### PR TITLE
Add separate post-thinking sampling parameters

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -258,6 +258,56 @@ To use this feature:
 
 If `thinking_token_budget` is not specified, no explicit reasoning limit is applied beyond normal generation constraints such as `max_tokens`.
 
+## Post-thinking sampling
+
+Some reasoning models (for example Qwen3.8) need higher temperature while thinking so they do not loop, then a lower temperature after `</think>` so the final answer stays coherent.
+
+`post_thinking` is an optional overlay of sampling knobs used while the request is **not** inside an open think block. Unset overlay fields inherit the primary sampling parameters.
+
+Requires `--reasoning-parser` (same gate as `thinking_token_budget`). vLLM decides the phase from the last reasoning start/end token IDs in the prompt plus generated tokens:
+
+- inside an open think block → primary `temperature` / `top_p` / `top_k` / `min_p` / penalties
+- otherwise (including thinking disabled, or after `</think>`) → `post_thinking`
+- if thinking re-opens, the primary knobs are restored
+
+The switch is applied on the next engine step after the think-end token is committed. With speculative decoding or async scheduling that can be one speculative window later (a few tokens). That boundary lag does not affect long thinking or answer phases.
+
+GPU workers only (Model Runner V1 and V2). TPU / XPU / CPU keep the primary knobs for the whole request.
+
+### Server default
+
+```bash
+vllm serve Qwen/Qwen3-0.6B \
+    --reasoning-parser qwen3 \
+    --override-generation-config '{"temperature":1.0,"post_thinking":{"temperature":0.4,"top_p":0.95,"top_k":20}}'
+```
+
+### Online request
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "9.11 and 9.8, which is greater?"}],
+    "temperature": 1.0,
+    "post_thinking": {"temperature": 0.4, "top_p": 0.95, "top_k": 20}
+  }'
+```
+
+### Offline inference
+
+```python
+from vllm import LLM, SamplingParams
+from vllm.sampling_params import PostThinkingParams
+
+llm = LLM(model="Qwen/Qwen3-0.6B", reasoning_parser="qwen3")
+sampling_params = SamplingParams(
+    temperature=1.0,
+    post_thinking=PostThinkingParams(temperature=0.4, top_p=0.95, top_k=20),
+)
+```
+
 `--reasoning-config` accepts a JSON object corresponding to  
 [ReasoningConfig][vllm.config.ReasoningConfig] with the following fields:
 

--- a/rust/src/engine-core-client/src/protocol/sampling.rs
+++ b/rust/src/engine-core-client/src/protocol/sampling.rs
@@ -20,6 +20,22 @@ fn default_temperature() -> f32 {
     1.0
 }
 
+/// Sampling knobs applied after the model exits a thinking block.
+///
+/// Mirrors Python's `PostThinkingParams`. Unset fields inherit the primary
+/// `EngineCoreSamplingParams` values.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct PostThinkingParams {
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub top_k: Option<u32>,
+    pub min_p: Option<f32>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub repetition_penalty: Option<f32>,
+}
+
 fn default_max_tokens() -> u32 {
     16
 }
@@ -86,6 +102,10 @@ pub struct EngineCoreSamplingParams {
     /// reaching this DTO, so only non-negative values are sent. Enforced
     /// engine-side (and only when a reasoning parser is configured).
     pub thinking_token_budget: Option<u64>,
+    /// Optional sampling knobs used while the request is not inside a think
+    /// block. Unset fields inherit the primary values. Requires a configured
+    /// reasoning parser.
+    pub post_thinking: Option<PostThinkingParams>,
     /// Number of log probabilities to return per generated token.
     ///
     /// `None` disables sample logprobs. `-1` requests the full vocabulary.
@@ -161,6 +181,7 @@ impl EngineCoreSamplingParams {
             max_tokens: 65536,
             min_tokens: 0,
             thinking_token_budget: None,
+            post_thinking: None,
             logprobs: None,
             prompt_logprobs: None,
             min_p: 0.0,

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2664,6 +2664,7 @@ fn python_msgpack_fixtures_match_rust_encoding() {
             max_tokens: 16,
             min_tokens: 0,
             thinking_token_budget: None,
+            post_thinking: None,
             logprobs: None,
             prompt_logprobs: None,
             min_p: 0.0,

--- a/rust/src/server/src/routes/openai/chat_completions/convert.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/convert.rs
@@ -149,6 +149,7 @@ pub(super) fn prepare_chat_request(
             max_tokens: request.max_completion_tokens,
             min_tokens: request.min_tokens,
             thinking_token_budget: request.thinking_token_budget,
+            post_thinking: request.post_thinking,
             logprobs: request.logprobs.then_some(top_logprobs),
             prompt_logprobs,
             min_p: request.min_p,
@@ -753,6 +754,34 @@ mod tests {
         assert_eq!(prepare(Some(64)), Some(64));
         assert_eq!(prepare(Some(-1)), Some(-1));
         assert_eq!(prepare(None), None);
+    }
+
+    #[test]
+    fn prepare_chat_request_passes_through_post_thinking() {
+        use vllm_engine_core_client::protocol::sampling::PostThinkingParams;
+
+        let prepared = prepare_chat_request(
+            ChatCompletionRequest {
+                post_thinking: Some(PostThinkingParams {
+                    temperature: Some(0.4),
+                    top_p: Some(0.95),
+                    top_k: Some(20),
+                    ..PostThinkingParams::default()
+                }),
+                ..base_request()
+            },
+            &served(&["Qwen/Qwen1.5-0.5B-Chat"]),
+            ResolvedRequestContext::default(),
+        )
+        .expect("request is valid");
+        let overlay = prepared
+            .chat_request
+            .sampling_params
+            .post_thinking
+            .expect("post_thinking forwarded");
+        assert_eq!(overlay.temperature, Some(0.4));
+        assert_eq!(overlay.top_p, Some(0.95));
+        assert_eq!(overlay.top_k, Some(20));
     }
 
     #[test]

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -9,7 +9,9 @@ use serde_json::Value;
 use serde_with::SerializeDisplay;
 use validator::Validate;
 use vllm_chat::ReasoningEffort;
-use vllm_engine_core_client::protocol::sampling::RepetitionDetectionParams;
+use vllm_engine_core_client::protocol::sampling::{
+    PostThinkingParams, RepetitionDetectionParams,
+};
 
 use crate::routes::openai::utils::structured_outputs::ResponseFormat;
 use crate::routes::openai::utils::types::{
@@ -174,6 +176,12 @@ pub struct ChatCompletionRequest {
     /// to "no budget").
     pub thinking_token_budget: Option<i64>,
 
+    /// Sampling knobs to use after the model exits the thinking block.
+    /// Unset fields inherit the primary sampling parameters. Requires a
+    /// configured reasoning parser.
+    #[serde(default)]
+    pub post_thinking: Option<PostThinkingParams>,
+
     /// Whether to include reasoning content in the response
     #[serde(default = "default_true")]
     pub include_reasoning: bool,
@@ -274,6 +282,7 @@ impl Default for ChatCompletionRequest {
             tool_choice: None,
             reasoning_effort: None,
             thinking_token_budget: None,
+            post_thinking: None,
             include_reasoning: true,
             parallel_tool_calls: None,
             user: None,

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -122,6 +122,7 @@ pub(super) fn prepare_completion_request(
             max_tokens,
             min_tokens: request.min_tokens,
             thinking_token_budget: request.thinking_token_budget,
+            post_thinking: request.post_thinking,
             logprobs,
             prompt_logprobs,
             min_p: request.min_p,

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -6,7 +6,9 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use validator::Validate;
-use vllm_engine_core_client::protocol::sampling::RepetitionDetectionParams;
+use vllm_engine_core_client::protocol::sampling::{
+    PostThinkingParams, RepetitionDetectionParams,
+};
 use vllm_text::Prompt;
 
 use crate::routes::openai::utils::types::{
@@ -157,6 +159,12 @@ pub struct CompletionRequest {
     /// `-1` for unlimited (mirroring the Python frontend, which normalizes `-1`
     /// to "no budget").
     pub thinking_token_budget: Option<i64>,
+
+    /// Sampling knobs to use after the model exits the thinking block.
+    /// Unset fields inherit the primary sampling parameters. Requires a
+    /// configured reasoning parser.
+    #[serde(default)]
+    pub post_thinking: Option<PostThinkingParams>,
 
     /// Request scheduling priority (lower means earlier; default 0)
     pub priority: Option<i32>,

--- a/rust/src/text/src/backend/hf/config.rs
+++ b/rust/src/text/src/backend/hf/config.rs
@@ -116,6 +116,8 @@ pub(super) struct GenerationConfig {
     pub min_p: Option<f32>,
     pub repetition_penalty: Option<f32>,
     pub max_new_tokens: Option<u32>,
+    pub post_thinking:
+        Option<vllm_engine_core_client::protocol::sampling::PostThinkingParams>,
 }
 
 /// Deserialize vLLM-compatible `top_k` values from generation configs.

--- a/rust/src/text/src/backend/hf/mod.rs
+++ b/rust/src/text/src/backend/hf/mod.rs
@@ -178,6 +178,7 @@ fn build_sampling_hints(
         default_min_p: sampling_config.and_then(|config| config.min_p),
         default_repetition_penalty: sampling_config.and_then(|config| config.repetition_penalty),
         default_max_tokens: sampling_config.and_then(|config| config.max_new_tokens),
+        default_post_thinking: self.generation_config.post_thinking.clone(),
     }
 }
 

--- a/rust/src/text/src/backend/mod.rs
+++ b/rust/src/text/src/backend/mod.rs
@@ -65,6 +65,8 @@ pub struct SamplingHints {
     pub default_min_p: Option<f32>,
     pub default_repetition_penalty: Option<f32>,
     pub default_max_tokens: Option<u32>,
+    pub default_post_thinking:
+        Option<vllm_engine_core_client::protocol::sampling::PostThinkingParams>,
 }
 
 /// Effective bounds used to validate and lower sampling requests.

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -85,6 +85,7 @@ pub fn lower_sampling_params(
         default_min_p,
         default_repetition_penalty,
         default_max_tokens,
+        default_post_thinking,
     }: SamplingHints,
     sampling_limits: SamplingLimits,
     prompt_len: u32,
@@ -98,6 +99,7 @@ pub fn lower_sampling_params(
         max_tokens,
         min_tokens,
         thinking_token_budget,
+        post_thinking,
         logprobs,
         prompt_logprobs,
         min_p,
@@ -148,6 +150,7 @@ pub fn lower_sampling_params(
         });
     }
     let thinking_token_budget = normalize_thinking_token_budget(thinking_token_budget)?;
+    let post_thinking = post_thinking.or(default_post_thinking);
     let frequency_penalty = frequency_penalty.unwrap_or(0.0);
     let presence_penalty = presence_penalty.unwrap_or(0.0);
 
@@ -170,6 +173,7 @@ pub fn lower_sampling_params(
         max_tokens,
         min_tokens,
         thinking_token_budget,
+        post_thinking,
         logprobs,
         prompt_logprobs,
         min_p,
@@ -349,6 +353,7 @@ mod tests {
             default_min_p: None,
             default_repetition_penalty: None,
             default_max_tokens: None,
+            default_post_thinking: None,
         }
     }
 
@@ -376,6 +381,7 @@ mod tests {
                 default_min_p: None,
                 default_repetition_penalty: None,
                 default_max_tokens: None,
+                default_post_thinking: None,
             },
             sampling_limits,
             3,
@@ -411,6 +417,27 @@ mod tests {
             lower(Some(-2)),
             Err(Error::InvalidThinkingTokenBudget)
         ));
+    }
+
+    #[test]
+    fn lower_sampling_params_forwards_post_thinking() {
+        use vllm_engine_core_client::protocol::sampling::PostThinkingParams;
+
+        let params = lower_sampling_params_with_limits(
+            SamplingParams {
+                post_thinking: Some(PostThinkingParams {
+                    temperature: Some(0.4),
+                    top_k: Some(20),
+                    ..PostThinkingParams::default()
+                }),
+                ..SamplingParams::default()
+            },
+            sample_sampling_limits(),
+        )
+        .unwrap();
+        let overlay = params.post_thinking.expect("post_thinking forwarded");
+        assert_eq!(overlay.temperature, Some(0.4));
+        assert_eq!(overlay.top_k, Some(20));
     }
 
     #[test]
@@ -622,6 +649,7 @@ mod tests {
                 max_tokens: 999997,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                post_thinking: None,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -676,6 +704,7 @@ mod tests {
                 max_tokens: 999997,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                post_thinking: None,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -815,6 +844,7 @@ mod tests {
                 default_min_p: None,
                 default_repetition_penalty: None,
                 default_max_tokens: None,
+                default_post_thinking: None,
             }
         "#]]
         .assert_debug_eq(&hints);
@@ -843,6 +873,7 @@ mod tests {
                 max_tokens: 40957,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                post_thinking: None,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -891,6 +922,7 @@ mod tests {
                 default_min_p: None,
                 default_repetition_penalty: None,
                 default_max_tokens: None,
+                default_post_thinking: None,
             },
             sample_sampling_limits(),
             3,
@@ -907,6 +939,7 @@ mod tests {
                 max_tokens: 999997,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                post_thinking: None,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.0,
@@ -963,6 +996,7 @@ mod tests {
                 default_min_p: Some(0.1),
                 default_repetition_penalty: Some(1.2),
                 default_max_tokens: Some(128),
+                default_post_thinking: None,
             },
             sample_sampling_limits(),
             3,
@@ -979,6 +1013,7 @@ mod tests {
                 max_tokens: 32,
                 min_tokens: 2,
                 thinking_token_budget: None,
+                post_thinking: None,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.1,
@@ -1021,6 +1056,7 @@ mod tests {
                 default_min_p: None,
                 default_repetition_penalty: None,
                 default_max_tokens: None,
+                default_post_thinking: None,
             },
             SamplingLimits {
                 max_logprobs: -1,
@@ -1213,6 +1249,7 @@ mod tests {
                 default_min_p: Some(0.1),
                 default_repetition_penalty: Some(1.2),
                 default_max_tokens: Some(128),
+                default_post_thinking: None,
             },
             sample_sampling_limits(),
             3,
@@ -1229,6 +1266,7 @@ mod tests {
                 max_tokens: 128,
                 min_tokens: 0,
                 thinking_token_budget: None,
+                post_thinking: None,
                 logprobs: None,
                 prompt_logprobs: None,
                 min_p: 0.1,

--- a/rust/src/text/src/request.rs
+++ b/rust/src/text/src/request.rs
@@ -9,7 +9,9 @@ use serde_json::Value;
 use vllm_engine_core_client::protocol::lora::LoraRequest;
 use vllm_engine_core_client::protocol::multimodal::MmFeatures;
 use vllm_engine_core_client::protocol::request::ReasoningParserKwargs;
-use vllm_engine_core_client::protocol::sampling::RepetitionDetectionParams;
+use vllm_engine_core_client::protocol::sampling::{
+    PostThinkingParams, RepetitionDetectionParams,
+};
 use vllm_engine_core_client::protocol::structured_outputs::StructuredOutputsParams;
 
 use crate::error::{Error, Result};
@@ -67,6 +69,9 @@ pub struct SamplingParams {
     /// here; `-1` is normalized to `None` (and other negatives rejected) during
     /// lowering (see `lower_sampling_params`).
     pub thinking_token_budget: Option<i64>,
+    /// Sampling knobs to use after the model exits the thinking block.
+    /// Unset fields inherit the primary sampling parameters.
+    pub post_thinking: Option<PostThinkingParams>,
     /// Number of log probabilities to return per generated token.
     ///
     /// `None` disables sample logprobs. `-1` requests the full vocabulary.
@@ -131,6 +136,7 @@ impl Default for SamplingParams {
             max_tokens: None,
             min_tokens: None,
             thinking_token_budget: None,
+            post_thinking: None,
             logprobs: None,
             prompt_logprobs: None,
             min_p: None,

--- a/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py
+++ b/tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py
@@ -74,3 +74,46 @@ def test_completion_request_accepts_minus_one_as_unlimited():
         }
     )
     assert request.thinking_token_budget is None
+
+
+def test_chat_completion_request_post_thinking_to_sampling_params():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hello"}],
+            "temperature": 1.0,
+            "post_thinking": {"temperature": 0.4, "top_p": 0.95, "top_k": 20},
+        }
+    )
+    params = request.to_sampling_params(max_tokens=16, default_sampling_params={})
+    assert params.temperature == 1.0
+    assert params.post_thinking is not None
+    assert params.post_thinking.temperature == 0.4
+    assert params.post_thinking.top_p == 0.95
+    assert params.post_thinking.top_k == 20
+
+
+def test_chat_completion_request_inherits_server_default_post_thinking():
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+    )
+    params = request.to_sampling_params(
+        max_tokens=16,
+        default_sampling_params={"post_thinking": {"temperature": 0.4}},
+    )
+    assert params.post_thinking is not None
+    assert params.post_thinking.temperature == 0.4
+
+
+def test_chat_completion_request_rejects_invalid_post_thinking_temperature():
+    with pytest.raises(VLLMValidationError, match="temperature"):
+        ChatCompletionRequest.model_validate(
+            {
+                "model": "qwen",
+                "messages": [{"role": "user", "content": "hello"}],
+                "post_thinking": {"temperature": 3.5},
+            }
+        )

--- a/tests/samplers/test_post_thinking.py
+++ b/tests/samplers/test_post_thinking.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import (
+    PostThinkingParams,
+    SamplingParams,
+    tokens_in_reasoning,
+)
+
+
+def test_resolve_sampling_knobs_inherits_unset_overlay_fields():
+    params = SamplingParams(
+        temperature=1.0,
+        top_p=1.0,
+        top_k=0,
+        min_p=0.0,
+        post_thinking=PostThinkingParams(temperature=0.4),
+    )
+    thinking = params.resolve_sampling_knobs(in_reasoning=True)
+    assert thinking.temperature == 1.0
+    assert thinking.top_p == 1.0
+    assert thinking.top_k == 0
+
+    answer = params.resolve_sampling_knobs(in_reasoning=False)
+    assert answer.temperature == 0.4
+    assert answer.top_p == 1.0
+    assert answer.top_k == 0
+
+
+def test_resolve_sampling_knobs_without_overlay_is_primary():
+    params = SamplingParams(temperature=0.7, top_p=0.9, top_k=20)
+    knobs = params.resolve_sampling_knobs(in_reasoning=False)
+    assert knobs.temperature == 0.7
+    assert knobs.top_p == 0.9
+    assert knobs.top_k == 20
+
+
+def test_post_thinking_from_optional_dict():
+    params = SamplingParams.from_optional(
+        temperature=1.0, post_thinking={"temperature": 0.4, "top_k": 20}
+    )
+    assert params.post_thinking is not None
+    assert params.post_thinking.temperature == 0.4
+    assert params.post_thinking.top_k == 20
+
+
+def test_post_thinking_rejects_invalid_temperature():
+    with pytest.raises(VLLMValidationError, match="temperature"):
+        PostThinkingParams(temperature=-0.1)
+
+
+def test_tokens_in_reasoning_uses_last_start_vs_last_end():
+    start, end = [10], [11]
+    assert tokens_in_reasoning([1, 10, 2, 3], start, end)
+    assert not tokens_in_reasoning([1, 10, 2, 11, 3], start, end)
+    assert tokens_in_reasoning([1, 10, 2, 11, 10, 4], start, end)
+    assert not tokens_in_reasoning([1, 2, 3], start, end)
+    assert not tokens_in_reasoning([], start, end)

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import PostThinkingParams, SamplingParams
 from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.pool.metadata import PoolingMetadata
 from vllm.v1.sample.logits_processor import LogitsProcessors
@@ -511,3 +511,52 @@ def test_pooling_metadata_token_id_buffers(
         assert metadata.get_prompt_token_ids_cpu()[0].tolist() == req.prompt_token_ids
     else:
         assert metadata.prompt_token_ids_cpu is None
+
+
+class _MockReasoningConfig:
+    enabled = True
+    reasoning_start_token_ids = [10]
+    reasoning_end_token_ids = [11]
+    natural_reasoning_end_token_ids = [11]
+
+
+def test_post_thinking_overlay_switches_after_think_end():
+    input_batch = InputBatch(
+        max_num_reqs=1,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        device=torch.device("cpu"),
+        vocab_size=VOCAB_SIZE,
+        block_sizes=[16],
+        kernel_block_sizes=[16],
+        max_num_blocks_per_req=[4],
+        reasoning_config=_MockReasoningConfig(),
+    )
+    req = CachedRequestState(
+        req_id="req0",
+        prompt_token_ids=[1, 10, 2],
+        sampling_params=SamplingParams(
+            temperature=1.0,
+            top_p=1.0,
+            top_k=0,
+            max_tokens=16,
+            post_thinking=PostThinkingParams(temperature=0.4, top_p=0.95, top_k=20),
+        ),
+        pooling_params=None,
+        mm_features=[],
+        block_ids=([],),
+        generator=None,
+        num_computed_tokens=0,
+        output_token_ids=[],
+    )
+    req_index = input_batch.add_request(req)
+    input_batch.refresh_metadata()
+    assert input_batch.temperature_cpu[req_index] == 1.0
+
+    req.output_token_ids.append(11)
+    input_batch.token_ids_cpu[req_index, 3] = 11
+    input_batch.num_tokens_no_spec[req_index] = 4
+    input_batch.refresh_metadata()
+    assert input_batch.temperature_cpu[req_index] == pytest.approx(0.4)
+    assert input_batch.top_p_cpu[req_index] == pytest.approx(0.95)
+    assert input_batch.top_k_cpu[req_index] == 20

--- a/tests/v1/worker/test_gpu_thinking_budget.py
+++ b/tests/v1/worker/test_gpu_thinking_budget.py
@@ -11,7 +11,7 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import PostThinkingParams, SamplingParams
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
 from vllm.v1.worker.gpu.states import RequestState
@@ -299,3 +299,27 @@ def test_v2_thinking_budget_continues_end_prefix_from_prompt():
 
     assert out[0, END_B] == pytest.approx(1.0e9)
     assert out[0, END_A] == 0
+
+
+def test_v2_post_thinking_observe_tokens_flips_temperature():
+    from vllm.v1.worker.gpu.sample.states import SamplingStates
+
+    states = SamplingStates(
+        max_num_reqs=4,
+        vocab_size=VOCAB_SIZE,
+        reasoning_start_token_ids=[START],
+        reasoning_end_token_ids=[END],
+    )
+    params = SamplingParams(
+        temperature=1.0,
+        max_tokens=16,
+        post_thinking=PostThinkingParams(temperature=0.4, top_p=0.95, top_k=20),
+    )
+    states.add_request(3, params, token_ids=[1, START, 7])
+    assert states.temperature.np[3] == pytest.approx(1.0)
+    assert states.observe_tokens(3, [END])
+    assert states.temperature.np[3] == pytest.approx(0.4)
+    assert states.top_p.np[3] == pytest.approx(0.95)
+    assert states.top_k.np[3] == 20
+    assert states.observe_tokens(3, [START])
+    assert states.temperature.np[3] == pytest.approx(1.0)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1741,6 +1741,7 @@ class ModelConfig:
             "top_p",
             "min_p",
             "max_new_tokens",
+            "post_thinking",
         ]
         if any(p in config for p in available_params):
             diff_sampling_param = {

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -44,6 +44,7 @@ from vllm.logprobs import Logprob
 from vllm.renderers import ChatParams, TokenizeParams, merge_kwargs
 from vllm.sampling_params import (
     BeamSearchParams,
+    PostThinkingParams,
     RepetitionDetectionParams,
     RequestOutputKind,
     SamplingParams,
@@ -256,6 +257,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
         ),
     )
     thinking_token_budget: ThinkingTokenBudget = None
+    post_thinking: PostThinkingParams | None = None
     include_reasoning: bool = True
     parallel_tool_calls: bool | None = True
 
@@ -685,8 +687,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_p = default_sampling_params.get(
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
+        if (post_thinking := self.post_thinking) is None:
+            post_thinking = default_sampling_params.get("post_thinking")
 
-        # Merge server-default stop_token_ids (e.g., model-specific tokens
+        # Merge server-default stop_token_ids (e.g., model-specific tokens)
         # like </call> for gpt-oss) with any request-specified ones
         stop_token_ids = self.stop_token_ids
         default_stop_ids = default_sampling_params.get("stop_token_ids")
@@ -742,6 +746,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             logit_bias=self.logit_bias,
             bad_words=self.bad_words,
             thinking_token_budget=self.thinking_token_budget,
+            post_thinking=post_thinking,
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -27,6 +27,7 @@ from vllm.logprobs import Logprob
 from vllm.renderers import TokenizeParams
 from vllm.sampling_params import (
     BeamSearchParams,
+    PostThinkingParams,
     RepetitionDetectionParams,
     RequestOutputKind,
     SamplingParams,
@@ -247,6 +248,14 @@ class CompletionRequest(OpenAIBaseModel):
             "-1 means unlimited (treated as unset)."
         ),
     )
+    post_thinking: PostThinkingParams | None = Field(
+        default=None,
+        description=(
+            "Sampling knobs to use after the model exits the thinking block. "
+            "Unset fields inherit the primary sampling parameters. Requires "
+            "--reasoning-parser."
+        ),
+    )
 
     stream_interval: Annotated[int, Field(ge=1)] | None = Field(
         default=None,
@@ -340,8 +349,10 @@ class CompletionRequest(OpenAIBaseModel):
             min_p = default_sampling_params.get(
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
+        if (post_thinking := self.post_thinking) is None:
+            post_thinking = default_sampling_params.get("post_thinking")
 
-        # Merge server-default stop_token_ids (e.g., model-specific tokens
+        # Merge server-default stop_token_ids (e.g., model-specific tokens)
         # like </call> for gpt-oss) with any request-specified ones
         stop_token_ids = self.stop_token_ids
         default_stop_ids = default_sampling_params.get("stop_token_ids")
@@ -399,6 +410,7 @@ class CompletionRequest(OpenAIBaseModel):
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
             thinking_token_budget=self.thinking_token_budget,
+            post_thinking=post_thinking,
             routed_experts_prompt_start=self.routed_experts_prompt_start,
         )
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -5,10 +5,11 @@
 import copy
 import json as json_mod
 import math
+from collections.abc import Sequence
 from dataclasses import field
 from enum import Enum, IntEnum
 from functools import cached_property
-from typing import Annotated, Any
+from typing import Annotated, Any, NamedTuple
 
 import msgspec
 from pydantic import BeforeValidator
@@ -75,6 +76,182 @@ ThinkingTokenBudget = Annotated[
     int | None,
     BeforeValidator(validate_thinking_token_budget),
 ]
+
+
+class SamplingKnobs(NamedTuple):
+    """Resolved sampling knobs for one decode step."""
+
+    temperature: float
+    top_p: float
+    top_k: int
+    min_p: float
+    presence_penalty: float
+    frequency_penalty: float
+    repetition_penalty: float
+
+
+def last_subsequence_index(haystack: Sequence[int], needle: Sequence[int]) -> int:
+    """Return the last start index of ``needle`` in ``haystack``, or -1."""
+    if not needle:
+        return -1
+    n = len(needle)
+    if n > len(haystack):
+        return -1
+    for i in range(len(haystack) - n, -1, -1):
+        if list(haystack[i : i + n]) == list(needle):
+            return i
+    return -1
+
+
+def tokens_in_reasoning(
+    token_ids: Sequence[int],
+    start_ids: Sequence[int],
+    end_ids: Sequence[int],
+) -> bool:
+    """True when the last think-start is after the last think-end."""
+    if not start_ids or not end_ids:
+        return False
+    return last_subsequence_index(token_ids, start_ids) > last_subsequence_index(
+        token_ids, end_ids
+    )
+
+
+def _validate_optional_temperature(temperature: float | None) -> float | None:
+    if temperature is None:
+        return None
+    if not math.isfinite(temperature):
+        raise VLLMValidationError(
+            f"temperature must be a finite number, got {temperature}.",
+            parameter="temperature",
+            value=temperature,
+        )
+    if temperature < 0.0:
+        raise VLLMValidationError(
+            f"temperature must be non-negative, got {temperature}.",
+            parameter="temperature",
+            value=temperature,
+        )
+    if temperature > 2.0:
+        raise VLLMValidationError(
+            f"temperature must be in [0, 2], got {temperature}.",
+            parameter="temperature",
+            value=temperature,
+        )
+    if 0 < temperature < _MAX_TEMP:
+        logger.warning(
+            "temperature %s is less than %s, which may cause numerical "
+            "errors nan or inf in tensors. We have maxed it out to %s.",
+            temperature,
+            _MAX_TEMP,
+            _MAX_TEMP,
+        )
+        return _MAX_TEMP
+    return temperature
+
+
+def _validate_optional_top_p(top_p: float | None) -> None:
+    if top_p is None:
+        return
+    if not 0.0 < top_p <= 1.0:
+        raise VLLMValidationError(
+            f"top_p must be in (0, 1], got {top_p}.",
+            parameter="top_p",
+            value=top_p,
+        )
+
+
+def _validate_optional_top_k(top_k: int | None) -> None:
+    if top_k is None:
+        return
+    if top_k < -1:
+        raise VLLMValidationError(
+            f"top_k must be 0 (disable), or at least 1, got {top_k}."
+        )
+    if not isinstance(top_k, int):
+        raise VLLMValidationError(f"top_k must be an integer, got {type(top_k).__name__}")
+
+
+def _validate_optional_min_p(min_p: float | None) -> None:
+    if min_p is None:
+        return
+    if not 0.0 <= min_p <= 1.0:
+        raise VLLMValidationError(f"min_p must be in [0, 1], got {min_p}.")
+
+
+def _validate_optional_presence_penalty(presence_penalty: float | None) -> None:
+    if presence_penalty is None:
+        return
+    if not -2.0 <= presence_penalty <= 2.0:
+        raise VLLMValidationError(
+            f"presence_penalty must be in [-2, 2], got {presence_penalty}."
+        )
+
+
+def _validate_optional_frequency_penalty(frequency_penalty: float | None) -> None:
+    if frequency_penalty is None:
+        return
+    if not -2.0 <= frequency_penalty <= 2.0:
+        raise VLLMValidationError(
+            f"frequency_penalty must be in [-2, 2], got {frequency_penalty}."
+        )
+
+
+def _validate_optional_repetition_penalty(repetition_penalty: float | None) -> None:
+    if repetition_penalty is None:
+        return
+    if not math.isfinite(repetition_penalty):
+        raise VLLMValidationError(
+            "repetition_penalty must be a finite number, "
+            f"got {repetition_penalty}."
+        )
+    if repetition_penalty <= 0.0:
+        raise VLLMValidationError(
+            "repetition_penalty must be greater than zero, got "
+            f"{repetition_penalty}."
+        )
+
+
+@dataclass
+class PostThinkingParams:
+    """Sampling knobs to use while the request is not inside a think block.
+
+    Unset fields inherit the corresponding primary ``SamplingParams`` value.
+    Requires a configured reasoning parser.
+    """
+
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    min_p: float | None = None
+    presence_penalty: float | None = None
+    frequency_penalty: float | None = None
+    repetition_penalty: float | None = None
+
+    def __post_init__(self) -> None:
+        self.temperature = _validate_optional_temperature(self.temperature)
+        _validate_optional_top_p(self.top_p)
+        _validate_optional_top_k(self.top_k)
+        _validate_optional_min_p(self.min_p)
+        _validate_optional_presence_penalty(self.presence_penalty)
+        _validate_optional_frequency_penalty(self.frequency_penalty)
+        _validate_optional_repetition_penalty(self.repetition_penalty)
+
+    @classmethod
+    def from_optional(
+        cls, value: "PostThinkingParams | dict[str, Any] | None"
+    ) -> "PostThinkingParams | None":
+        if value is None:
+            return None
+        if isinstance(value, PostThinkingParams):
+            return value
+        if isinstance(value, dict):
+            return cls(**value)
+        raise VLLMValidationError(
+            "post_thinking must be an object of sampling knobs "
+            f"(temperature, top_p, top_k, min_p, ...), got {type(value).__name__}.",
+            parameter="post_thinking",
+            value=value,
+        )
 
 
 class SamplingType(IntEnum):
@@ -357,6 +534,11 @@ class SamplingParams(
     thinking_token_budget: int | None = None
     """Maximum number of tokens allowed for thinking operations."""
 
+    post_thinking: PostThinkingParams | None = None
+    """Optional sampling knobs used while the request is not inside a think
+    block. Unset fields inherit the primary SamplingParams values. Requires a
+    configured reasoning parser."""
+
     repetition_detection: RepetitionDetectionParams | None = None
     """Parameters for detecting repetitive N-gram patterns in output tokens.
     If such repetition is detected, generation will be ended early. LLMs can
@@ -393,6 +575,7 @@ class SamplingParams(
         stop_token_ids: list[int] | None = None,
         bad_words: list[str] | None = None,
         thinking_token_budget: int | None = None,
+        post_thinking: PostThinkingParams | dict[str, Any] | None = None,
         include_stop_str_in_output: bool = False,
         ignore_eos: bool = False,
         max_tokens: int | None = 16,
@@ -458,6 +641,7 @@ class SamplingParams(
             stop_token_ids=stop_token_ids,
             bad_words=bad_words,
             thinking_token_budget=thinking_token_budget,
+            post_thinking=PostThinkingParams.from_optional(post_thinking),
             include_stop_str_in_output=include_stop_str_in_output,
             ignore_eos=ignore_eos,
             max_tokens=max_tokens,
@@ -497,6 +681,7 @@ class SamplingParams(
         self.thinking_token_budget = validate_thinking_token_budget(
             self.thinking_token_budget
         )
+        self.post_thinking = PostThinkingParams.from_optional(self.post_thinking)
 
         if self.stop is None:
             self.stop = []
@@ -740,6 +925,37 @@ class SamplingParams(
                 parameter="bad_words",
                 value=self.bad_words,
             )
+
+    def resolve_sampling_knobs(self, in_reasoning: bool) -> SamplingKnobs:
+        """Return the knobs that apply for the current reasoning phase."""
+        if in_reasoning or self.post_thinking is None:
+            return SamplingKnobs(
+                temperature=self.temperature,
+                top_p=self.top_p,
+                top_k=self.top_k,
+                min_p=self.min_p,
+                presence_penalty=self.presence_penalty,
+                frequency_penalty=self.frequency_penalty,
+                repetition_penalty=self.repetition_penalty,
+            )
+        overlay = self.post_thinking
+        return SamplingKnobs(
+            temperature=self.temperature
+            if overlay.temperature is None
+            else overlay.temperature,
+            top_p=self.top_p if overlay.top_p is None else overlay.top_p,
+            top_k=self.top_k if overlay.top_k is None else overlay.top_k,
+            min_p=self.min_p if overlay.min_p is None else overlay.min_p,
+            presence_penalty=self.presence_penalty
+            if overlay.presence_penalty is None
+            else overlay.presence_penalty,
+            frequency_penalty=self.frequency_penalty
+            if overlay.frequency_penalty is None
+            else overlay.frequency_penalty,
+            repetition_penalty=self.repetition_penalty
+            if overlay.repetition_penalty is None
+            else overlay.repetition_penalty,
+        )
 
     @cached_property
     def sampling_type(self) -> SamplingType:
@@ -1211,6 +1427,7 @@ class SamplingParams(
             f"stop_token_ids={self.stop_token_ids}, "
             f"bad_words={self.bad_words}, "
             f"thinking_token_budget={self.thinking_token_budget}, "
+            f"post_thinking={self.post_thinking}, "
             f"include_stop_str_in_output={self.include_stop_str_in_output}, "
             f"ignore_eos={self.ignore_eos}, "
             f"max_tokens={self.max_tokens}, "

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -130,6 +130,15 @@ class InputProcessor:
                     "enabled. Start the engine with --enable-trace-replay "
                     "to use it."
                 )
+            if params.post_thinking is not None and (
+                    self.vllm_config.reasoning_config is None
+                    or not self.vllm_config.reasoning_config.enabled
+            ):
+                raise VLLMValidationError(
+                    "post_thinking is set but reasoning_config is "
+                    "not configured. Please set --reasoning-parser "
+                    "and/or --reasoning-config to use post_thinking."
+                )
         elif isinstance(params, PoolingParams):
             supported_pooling_tasks = [
                 task for task in supported_tasks if task in POOLING_TASKS

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -51,6 +51,27 @@ class MinPLogitsProcessor(LogitsProcessor):
     def get_min_p_by_index(self, index: int) -> float:
         return float(self.min_p_cpu[index])
 
+    def set_min_p(self, index: int, min_p: float) -> bool:
+        """Update min_p for a live request. Returns True if the value changed."""
+        min_p_before = self.min_p_cpu[index]
+        if min_p_before == min_p:
+            return False
+        self.min_p_cpu[index] = min_p
+        if min_p and not min_p_before:
+            self.min_p_count += 1
+        elif not min_p and min_p_before:
+            self.min_p_count -= 1
+        if self.min_p_count:
+            size = self.min_p.shape[0] if self.min_p.numel() else index + 1
+            size = max(size, index + 1)
+            self.min_p = self.min_p_device[:size]
+            if self.use_double_tensor:
+                self.min_p.copy_(self.min_p_cpu_tensor[:size], non_blocking=True)
+            self.min_p.unsqueeze_(1)
+        else:
+            self.min_p = self.min_p_device[:0]
+        return True
+
     def update_state(self, batch_update: BatchUpdate | None):
         if not batch_update:
             return

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -122,6 +122,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         copy_stream: torch.cuda.Stream,
         check_ep_fault: bool = False,
         routed_experts: RoutedExpertsTensors | None = None,
+        on_tokens_ready: Callable[[list[str], list[list[int]]], None] | None = None,
     ):
         # NOTE(woosuk): We must retain references to the GPU tensors,
         # as the copy operations are performed on a different CUDA stream than
@@ -130,6 +131,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.sampler_output = sampler_output
         self.num_sampled_tokens = num_sampled_tokens
         self.routed_experts = routed_experts
+        self.on_tokens_ready = on_tokens_ready
         # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
         self.copy_event = torch.cuda.Event(blocking=True)
         self._has_fault: torch.Tensor | None = None
@@ -176,6 +178,10 @@ class AsyncOutput(AsyncModelRunnerOutput):
         for token_ids, num_tokens in zip(sampled_token_ids, num_sampled_tokens):
             del token_ids[num_tokens:]
         self.model_runner_output.sampled_token_ids = sampled_token_ids
+        if self.on_tokens_ready is not None:
+            self.on_tokens_ready(
+                self.model_runner_output.req_ids, sampled_token_ids
+            )
 
         if self.sampling_mask_tensors is not None:
             self.model_runner_output.sampling_masks = (

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1020,7 +1020,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if self.is_last_pp_rank and new_req_data.sampling_params is not None:
                 assert self.sampler is not None
                 self.sampler.add_request(
-                    req_index, prompt_len, new_req_data.sampling_params
+                    req_index,
+                    prompt_len,
+                    new_req_data.sampling_params,
+                    prefill_token_ids=new_req_data.prefill_token_ids,
                 )
                 assert self.prompt_logprobs_worker is not None
                 self.prompt_logprobs_worker.add_request(
@@ -1848,6 +1851,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             copy_stream=self.output_copy_stream,
             check_ep_fault=self.check_ep_fault,
             routed_experts=routed_experts,
+            on_tokens_ready=self.sampler.observe_sampled_tokens,
         )
 
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None

--- a/vllm/v1/worker/gpu/sample/penalties.py
+++ b/vllm/v1/worker/gpu/sample/penalties.py
@@ -53,6 +53,22 @@ class PenaltiesState:
         if do_penalty:
             self._new_penalties_reqs.append(req_idx)
 
+    def update_knobs(
+        self,
+        req_idx: int,
+        repetition_penalty: float,
+        frequency_penalty: float,
+        presence_penalty: float,
+    ) -> None:
+        self.repetition_penalty.np[req_idx] = repetition_penalty
+        self.frequency_penalty.np[req_idx] = frequency_penalty
+        self.presence_penalty.np[req_idx] = presence_penalty
+        self.use_penalty[req_idx] = (
+            repetition_penalty != 1.0
+            or frequency_penalty != 0.0
+            or presence_penalty != 0.0
+        )
+
     def apply_staged_writes(self) -> None:
         if self._new_penalties_reqs:
             idx_mapping = async_tensor_h2d(

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -49,7 +49,18 @@ class Sampler:
         self.use_fp64_gumbel = use_fp64_gumbel
 
         self.req_states = req_states
-        self.sampling_states = SamplingStates(max_num_reqs, vocab_size)
+        start_ids: list[int] = []
+        end_ids: list[int] = []
+        if reasoning_config is not None and reasoning_config.enabled:
+            start_ids = reasoning_config.reasoning_start_token_ids or []
+            end_ids = (
+                reasoning_config.natural_reasoning_end_token_ids
+                or reasoning_config.reasoning_end_token_ids
+                or []
+            )
+        self.sampling_states = SamplingStates(
+            max_num_reqs, vocab_size, start_ids, end_ids
+        )
         self.penalties_state = PenaltiesState(req_states)
         self.logit_bias_state = LogitBiasState(max_num_reqs, device)
         self.bad_words_state = BadWordsState(req_states)
@@ -66,10 +77,24 @@ class Sampler:
         )
 
     def add_request(
-        self, req_idx: int, prompt_len: int, sampling_params: SamplingParams
+        self,
+        req_idx: int,
+        prompt_len: int,
+        sampling_params: SamplingParams,
+        prefill_token_ids: list[int] | None = None,
     ) -> None:
-        self.sampling_states.add_request(req_idx, sampling_params)
+        self.sampling_states.add_request(req_idx, sampling_params, prefill_token_ids)
         self.penalties_state.add_request(req_idx, sampling_params)
+        if sampling_params.post_thinking is not None:
+            knobs = sampling_params.resolve_sampling_knobs(
+                bool(self.sampling_states.in_reasoning[req_idx])
+            )
+            self.penalties_state.update_knobs(
+                req_idx,
+                knobs.repetition_penalty,
+                knobs.frequency_penalty,
+                knobs.presence_penalty,
+            )
         self.logit_bias_state.add_request(req_idx, prompt_len, sampling_params)
         self.bad_words_state.add_request(req_idx, sampling_params)
         self.logprob_token_ids_state.add_request(req_idx, sampling_params)
@@ -80,18 +105,40 @@ class Sampler:
         states = self.sampling_states
         temperature = states.temperature.np[req_idx]
         self.needs_logits_processing[req_idx] = (
-            self.logit_bias_state.use_logit_bias[req_idx]
-            or self.penalties_state.use_penalty[req_idx]
-            or self.bad_words_state.num_bad_words.np[req_idx] > 0
-            or (
-                self.thinking_budget_state.enabled
-                and self.thinking_budget_state.use_thinking_budget[req_idx]
-            )
-            or (temperature != 0.0 and temperature != 1.0)
-            or states.min_p.np[req_idx] != 0.0
-            or states.top_k.np[req_idx] != states.vocab_size
-            or states.top_p.np[req_idx] != 1.0
+                self.logit_bias_state.use_logit_bias[req_idx]
+                or self.penalties_state.use_penalty[req_idx]
+                or self.bad_words_state.num_bad_words.np[req_idx] > 0
+                or (
+                        self.thinking_budget_state.enabled
+                        and self.thinking_budget_state.use_thinking_budget[req_idx]
+                )
+                or (temperature != 0.0 and temperature != 1.0)
+                or states.min_p.np[req_idx] != 0.0
+                or states.top_k.np[req_idx] != states.vocab_size
+                or states.top_p.np[req_idx] != 1.0
         )
+
+    def observe_sampled_tokens(
+        self, req_ids: list[str], sampled_token_ids: list[list[int]]
+    ) -> None:
+        for req_id, tokens in zip(req_ids, sampled_token_ids):
+            req_idx = self.req_states.req_id_to_index.get(req_id)
+            if req_idx is None:
+                continue
+            if not self.sampling_states.observe_tokens(req_idx, tokens):
+                continue
+            params = self.sampling_states.post_thinking_params.get(req_idx)
+            if params is None:
+                continue
+            knobs = params.resolve_sampling_knobs(
+                bool(self.sampling_states.in_reasoning[req_idx])
+            )
+            self.penalties_state.update_knobs(
+                req_idx,
+                knobs.repetition_penalty,
+                knobs.frequency_penalty,
+                knobs.presence_penalty,
+            )
 
     def apply_staged_writes(self) -> None:
         self.sampling_states.apply_staged_writes()
@@ -215,6 +262,9 @@ class Sampler:
         expanded_local_pos: torch.Tensor,
         skip_top_k_top_p: bool = False,
     ) -> torch.Tensor:
+        if self.sampling_states.knobs_dirty:
+            self.apply_staged_writes()
+            self.sampling_states.knobs_dirty = False
         if not np.any(self.needs_logits_processing[idx_mapping_np]):
             return logits
 

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -3,7 +3,9 @@
 import numpy as np
 import torch
 
-from vllm.sampling_params import SamplingParams
+from collections.abc import Sequence
+
+from vllm.sampling_params import SamplingKnobs, SamplingParams, tokens_in_reasoning
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor
 from vllm.v1.worker.gpu.sample.gumbel import apply_temperature
@@ -15,9 +17,17 @@ _NP_INT64_MAX = np.iinfo(np.int64).max
 
 
 class SamplingStates:
-    def __init__(self, max_num_reqs: int, vocab_size: int):
+    def __init__(
+        self,
+        max_num_reqs: int,
+        vocab_size: int,
+        reasoning_start_token_ids: Sequence[int] | None = None,
+        reasoning_end_token_ids: Sequence[int] | None = None,
+    ):
         self.max_num_reqs = max_num_reqs
         self.vocab_size = vocab_size
+        self.reasoning_start_token_ids = list(reasoning_start_token_ids or [])
+        self.reasoning_end_token_ids = list(reasoning_end_token_ids or [])
 
         self.temperature = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
         self.top_k = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
@@ -38,15 +48,17 @@ class SamplingStates:
         # -1 means no logprobs are requested.
         self.num_logprobs.fill(NO_LOGPROBS)
 
-    def add_request(self, req_idx: int, sampling_params: SamplingParams) -> None:
-        self.temperature.np[req_idx] = sampling_params.temperature
-        self.top_p.np[req_idx] = sampling_params.top_p
-        top_k = sampling_params.top_k
-        if top_k <= 0 or top_k > self.vocab_size:
-            top_k = self.vocab_size
-        self.top_k.np[req_idx] = top_k
-        self.min_p.np[req_idx] = sampling_params.min_p
+        self.post_thinking_params: dict[int, SamplingParams] = {}
+        self.in_reasoning = np.ones(max_num_reqs, dtype=bool)
+        self._marker_window: dict[int, list[int]] = {}
+        self.knobs_dirty = False
 
+    def add_request(
+        self,
+        req_idx: int,
+        sampling_params: SamplingParams,
+        token_ids: Sequence[int] | None = None,
+    ) -> None:
         seed = sampling_params.seed
         self.seeds_set[req_idx] = seed is not None
         if seed is None:
@@ -59,6 +71,72 @@ class SamplingStates:
         elif num_logprobs == -1:
             num_logprobs = self.vocab_size
         self.num_logprobs[req_idx] = num_logprobs
+
+        in_reasoning = True
+        if sampling_params.post_thinking is not None:
+            self.post_thinking_params[req_idx] = sampling_params
+            ids = list(token_ids or [])
+            in_reasoning = tokens_in_reasoning(
+                ids, self.reasoning_start_token_ids, self.reasoning_end_token_ids
+            )
+            overlap = self._marker_overlap()
+            self._marker_window[req_idx] = ids[-overlap:] if overlap else []
+        else:
+            self.post_thinking_params.pop(req_idx, None)
+            self._marker_window.pop(req_idx, None)
+        self.in_reasoning[req_idx] = in_reasoning
+        self._write_knobs(
+            req_idx, sampling_params.resolve_sampling_knobs(in_reasoning)
+        )
+
+    def observe_tokens(self, req_idx: int, new_token_ids: Sequence[int]) -> bool:
+        """Update in-reasoning state from newly sampled tokens.
+
+        Returns True when the active overlay changed.
+        """
+        params = self.post_thinking_params.get(req_idx)
+        if params is None or not new_token_ids:
+            return False
+        overlap = self._marker_overlap()
+        prev = self._marker_window.get(req_idx, [])
+        window = prev[-overlap:] + list(new_token_ids)
+        self._marker_window[req_idx] = window[-max(overlap, 1) :]
+        in_reasoning = self._in_reasoning_from_window(
+            window, bool(self.in_reasoning[req_idx])
+        )
+        if in_reasoning == bool(self.in_reasoning[req_idx]):
+            return False
+        self.in_reasoning[req_idx] = in_reasoning
+        self._write_knobs(req_idx, params.resolve_sampling_knobs(in_reasoning))
+        self.knobs_dirty = True
+        return True
+
+    def _marker_overlap(self) -> int:
+        return max(
+            len(self.reasoning_start_token_ids),
+            len(self.reasoning_end_token_ids),
+            1,
+        )
+
+    def _in_reasoning_from_window(
+        self, window: Sequence[int], current: bool
+    ) -> bool:
+        from vllm.sampling_params import last_subsequence_index
+
+        last_start = last_subsequence_index(window, self.reasoning_start_token_ids)
+        last_end = last_subsequence_index(window, self.reasoning_end_token_ids)
+        if last_start < 0 and last_end < 0:
+            return current
+        return last_start > last_end
+
+    def _write_knobs(self, req_idx: int, knobs: SamplingKnobs) -> None:
+        self.temperature.np[req_idx] = knobs.temperature
+        self.top_p.np[req_idx] = knobs.top_p
+        top_k = knobs.top_k
+        if top_k <= 0 or top_k > self.vocab_size:
+            top_k = self.vocab_size
+        self.top_k.np[req_idx] = top_k
+        self.min_p.np[req_idx] = knobs.min_p
 
     def apply_staged_writes(self) -> None:
         self.temperature.copy_to_uva()

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -12,7 +12,12 @@ from vllm.config.reasoning import ReasoningConfig
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
-from vllm.sampling_params import SamplingParams, SamplingType
+from vllm.sampling_params import (
+    SamplingKnobs,
+    SamplingParams,
+    tokens_in_reasoning,
+)
+from vllm.v1.sample.logits_processor.builtin import MinPLogitsProcessor
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.utils.collection_utils import swap_dict_values
 from vllm.utils.torch_utils import PIN_MEMORY
@@ -117,6 +122,20 @@ class InputBatch:
             PIN_MEMORY,
         )
         self.thinking_token_budget_reqs: set[str] = set()
+        if reasoning_config is not None and reasoning_config.enabled:
+            self.reasoning_start_token_ids = (
+                reasoning_config.reasoning_start_token_ids or []
+            )
+            self.reasoning_end_token_ids = (
+                reasoning_config.natural_reasoning_end_token_ids
+                or reasoning_config.reasoning_end_token_ids
+                or []
+            )
+        else:
+            self.reasoning_start_token_ids: list[int] = []
+            self.reasoning_end_token_ids: list[int] = []
+        self.post_thinking_params: dict[str, SamplingParams] = {}
+        self.post_thinking_in_reasoning: dict[str, bool] = {}
         self.is_pooling_model = is_pooling_model
         self.max_num_reqs = max_num_reqs
         self.max_model_len = max_model_len
@@ -398,34 +417,21 @@ class InputBatch:
         self.block_table.add_row(request.block_ids, req_index)
 
         if sampling_params := request.sampling_params:
-            if sampling_params.sampling_type == SamplingType.GREEDY:
-                # Should avoid division by zero later when apply_temperature.
-                self.temperature_cpu[req_index] = 0.0
-                self.greedy_reqs.add(req_id)
-            else:
-                self.temperature_cpu[req_index] = sampling_params.temperature
-                self.random_reqs.add(req_id)
-
-            self.top_p_cpu[req_index] = sampling_params.top_p
-            if sampling_params.top_p < 1:
-                self.top_p_reqs.add(req_id)
-            top_k = sampling_params.top_k
-            if 0 < top_k < self.vocab_size:
-                self.top_k_reqs.add(req_id)
-            else:
-                top_k = self.vocab_size
-            self.top_k_cpu[req_index] = top_k
-            self.frequency_penalties_cpu[req_index] = sampling_params.frequency_penalty
-            if sampling_params.frequency_penalty != 0.0:
-                self.frequency_penalties_reqs.add(req_id)
-            self.presence_penalties_cpu[req_index] = sampling_params.presence_penalty
-            if sampling_params.presence_penalty != 0.0:
-                self.presence_penalties_reqs.add(req_id)
-            self.repetition_penalties_cpu[req_index] = (
-                sampling_params.repetition_penalty
+            in_reasoning = True
+            if sampling_params.post_thinking is not None:
+                self.post_thinking_params[req_id] = sampling_params
+                prompt_ids = request.prompt_token_ids or []
+                in_reasoning = tokens_in_reasoning(
+                    [*prompt_ids, *request.output_token_ids],
+                    self.reasoning_start_token_ids,
+                    self.reasoning_end_token_ids,
+                )
+                self.post_thinking_in_reasoning[req_id] = in_reasoning
+            self._apply_sampling_knobs(
+                req_id,
+                req_index,
+                sampling_params.resolve_sampling_knobs(in_reasoning),
             )
-            if sampling_params.repetition_penalty != 1.0:
-                self.repetition_penalties_reqs.add(req_id)
 
             # NOTE(woosuk): self.generators should not include the requests that
             # do not have their own generator.
@@ -579,6 +585,8 @@ class InputBatch:
             self.allowed_token_ids_mask_cpu_tensor[req_index].fill_(False)
         self.bad_words_token_ids.pop(req_index, None)
         self.thinking_token_budget_reqs.discard(req_id)
+        self.post_thinking_params.pop(req_id, None)
+        self.post_thinking_in_reasoning.pop(req_id, None)
         return req_index
 
     def swap_states(self, i1: int, i2: int) -> None:
@@ -835,6 +843,121 @@ class InputBatch:
         del self.req_output_token_ids[num_reqs:]
         del self.spec_token_ids[num_reqs:]
 
+    def _apply_sampling_knobs(
+        self, req_id: str, req_index: int, knobs: SamplingKnobs
+    ) -> bool:
+        """Write resolved sampling knobs for a request. Return True if changed."""
+        changed = False
+        if knobs.temperature < 1e-5:
+            if req_id in self.random_reqs or req_id not in self.greedy_reqs:
+                self.random_reqs.discard(req_id)
+                self.greedy_reqs.add(req_id)
+                changed = True
+            if self.temperature_cpu[req_index] != 0.0:
+                # Avoid division by zero later when apply_temperature.
+                self.temperature_cpu[req_index] = 0.0
+                changed = True
+        else:
+            if req_id in self.greedy_reqs or req_id not in self.random_reqs:
+                self.greedy_reqs.discard(req_id)
+                self.random_reqs.add(req_id)
+                changed = True
+            if self.temperature_cpu[req_index] != knobs.temperature:
+                self.temperature_cpu[req_index] = knobs.temperature
+                changed = True
+
+        if self.top_p_cpu[req_index] != knobs.top_p:
+            self.top_p_cpu[req_index] = knobs.top_p
+            changed = True
+        if knobs.top_p < 1:
+            if req_id not in self.top_p_reqs:
+                self.top_p_reqs.add(req_id)
+                changed = True
+        elif req_id in self.top_p_reqs:
+            self.top_p_reqs.discard(req_id)
+            changed = True
+
+        top_k = knobs.top_k
+        if not (0 < top_k < self.vocab_size):
+            top_k = self.vocab_size
+        if self.top_k_cpu[req_index] != top_k:
+            self.top_k_cpu[req_index] = top_k
+            changed = True
+        if 0 < knobs.top_k < self.vocab_size:
+            if req_id not in self.top_k_reqs:
+                self.top_k_reqs.add(req_id)
+                changed = True
+        elif req_id in self.top_k_reqs:
+            self.top_k_reqs.discard(req_id)
+            changed = True
+
+        if self.frequency_penalties_cpu[req_index] != knobs.frequency_penalty:
+            self.frequency_penalties_cpu[req_index] = knobs.frequency_penalty
+            changed = True
+        if knobs.frequency_penalty != 0.0:
+            if req_id not in self.frequency_penalties_reqs:
+                self.frequency_penalties_reqs.add(req_id)
+                changed = True
+        elif req_id in self.frequency_penalties_reqs:
+            self.frequency_penalties_reqs.discard(req_id)
+            changed = True
+
+        if self.presence_penalties_cpu[req_index] != knobs.presence_penalty:
+            self.presence_penalties_cpu[req_index] = knobs.presence_penalty
+            changed = True
+        if knobs.presence_penalty != 0.0:
+            if req_id not in self.presence_penalties_reqs:
+                self.presence_penalties_reqs.add(req_id)
+                changed = True
+        elif req_id in self.presence_penalties_reqs:
+            self.presence_penalties_reqs.discard(req_id)
+            changed = True
+
+        if self.repetition_penalties_cpu[req_index] != knobs.repetition_penalty:
+            self.repetition_penalties_cpu[req_index] = knobs.repetition_penalty
+            changed = True
+        if knobs.repetition_penalty != 1.0:
+            if req_id not in self.repetition_penalties_reqs:
+                self.repetition_penalties_reqs.add(req_id)
+                changed = True
+        elif req_id in self.repetition_penalties_reqs:
+            self.repetition_penalties_reqs.discard(req_id)
+            changed = True
+
+        if self._set_min_p(req_index, knobs.min_p):
+            changed = True
+        return changed
+
+    def _set_min_p(self, req_index: int, min_p: float) -> bool:
+        for proc in self.logitsprocs.all:
+            if isinstance(proc, MinPLogitsProcessor):
+                return proc.set_min_p(req_index, min_p)
+        return False
+
+    def _sync_post_thinking_overlays(self) -> bool:
+        if not self.post_thinking_params:
+            return False
+        changed = False
+        for req_id, params in self.post_thinking_params.items():
+            req_index = self.req_id_to_index.get(req_id)
+            if req_index is None:
+                continue
+            num_tokens = int(self.num_tokens_no_spec[req_index])
+            token_ids = self.token_ids_cpu[req_index, :num_tokens]
+            in_reasoning = tokens_in_reasoning(
+                token_ids,
+                self.reasoning_start_token_ids,
+                self.reasoning_end_token_ids,
+            )
+            if self.post_thinking_in_reasoning.get(req_id) == in_reasoning:
+                continue
+            self.post_thinking_in_reasoning[req_id] = in_reasoning
+            if self._apply_sampling_knobs(
+                req_id, req_index, params.resolve_sampling_knobs(in_reasoning)
+            ):
+                changed = True
+        return changed
+
     def refresh_metadata(self):
         """Apply any batch updates to sampling metadata."""
 
@@ -847,12 +970,13 @@ class InputBatch:
         # For non-pooling models - generate and apply logitsprocs update;
         # reset batch update tracking.
         # Update sampling metadata if batch state is changed.
+        overlay_changed = self._sync_post_thinking_overlays()
         batch_update = self.batch_update_builder.get_and_reset(self.num_reqs)
         if self.thinking_budget_state_holder is not None and batch_update:
             self.thinking_budget_state_holder.sync_batch(batch_update)
         for logit_proc in self.logitsprocs.all:
             logit_proc.update_state(batch_update)
-        if batch_update:
+        if batch_update or overlay_changed:
             self.sampling_metadata = self._make_sampling_metadata()
 
     def _make_sampling_metadata(self) -> SamplingMetadata:


### PR DESCRIPTION
## Summary

This PR adds support for using a separate set of sampling parameters after a model finishes its `<think>...</think>` reasoning block.

The primary motivation is models such as **Qwen 3.8 27B**, where the optimal sampling parameters for reasoning differ substantially from the optimal parameters for the final answer.

In testing, Qwen 3.8 27B benefits from a relatively high temperature (`~0.9–1.0`) during reasoning. Lower temperatures can cause the reasoning process to become repetitive or enter loops. However, keeping that same temperature after `</think>` noticeably reduces the reliability and precision of the final response, including normal chat output and tool calls.

This PR allows those two phases to use different sampling configurations.

For example:

```json
{
  "temperature": 0.9,
  "top_p": 0.95,
  "top_k": 20,
  "post_thinking": {
    "temperature": 0.2,
    "top_p": 0.95,
    "top_k": 20
  }
}
```

With this configuration:

* while inside an open `<think>` block, the normal sampling parameters are used;
* after `</think>`, the `post_thinking` sampling parameters are used;
* if a model opens another `<think>` block later in the same generation, sampling switches back to the primary parameters;
* fields omitted from `post_thinking` inherit their values from the primary sampling configuration.

This makes it possible to use sampling parameters appropriate for exploratory reasoning without carrying that randomness into the final answer.

## Motivation

Reasoning models do not necessarily benefit from a single sampling configuration throughout the entire generated sequence.

For Qwen 3.8 27B specifically, I have found the following configuration to work well:

* **Thinking:** `temperature=0.9`
* **Final output:** `temperature=0.2`

The higher temperature keeps the reasoning process healthy and avoids repetitive reasoning loops, while the lower temperature after `</think>` produces substantially cleaner and more reliable final output.

Using `temperature=0.9` for the entire response allows reasoning to work correctly, but makes the final answer more error-prone.

Using `temperature=0.2` for the entire response improves the final answer, but can negatively affect the reasoning process.

Allowing the sampler to change state at the reasoning boundary provides the benefits of both.

Initial testing with Qwen 3.8 27B shows significantly fewer errors in generated answers while preserving the behavior of the thinking section.

## API

The PR adds a `post_thinking` sampling configuration.

Example generation configuration:

```json
{
  "temperature": 0.9,
  "top_p": 0.95,
  "top_k": 20,
  "min_p": 0,
  "post_thinking": {
    "temperature": 0.2,
    "top_p": 0.95,
    "top_k": 20
  }
}
```

Any parameter not explicitly provided under `post_thinking` inherits the corresponding primary sampling parameter.

For example:

```json
{
  "temperature": 0.9,
  "top_p": 0.95,
  "top_k": 20,
  "post_thinking": {
    "temperature": 0.2
  }
}
```

is effectively equivalent to:

```json
{
  "temperature": 0.9,
  "top_p": 0.95,
  "top_k": 20,
  "post_thinking": {
    "temperature": 0.2,
    "top_p": 0.95,
    "top_k": 20
  }
}
```

## Sampling behavior

The sampler tracks whether generation is currently inside a reasoning block.

Conceptually:

```text
<think>
    primary sampling parameters
</think>

post_thinking sampling parameters
```

The state transitions are:

```text
<think>     -> primary sampler
</think>    -> post_thinking sampler
<think>     -> primary sampler
```

The final transition is not expected to be relevant for Qwen 3.8 27B, but supporting it keeps the behavior consistent if a model produces multiple reasoning sections.

The `post_thinking` configuration applies to everything following the reasoning block, including:

* normal assistant content;
* structured output;
* tool calls;
* other generated content after `</think>`.

If `post_thinking` is not supplied, generation behaves exactly as it does today.

## Server configuration

The feature can be configured as a server default through the generation config.

Recommended/tested Qwen 3.8 27B configuration:

```bash
vllm serve Qwen/Qwen3.8-27B-FP8 \
  --override-generation-config '{
    "temperature": 0.9,
    "top_p": 0.95,
    "top_k": 20,
    "min_p": 0,
    "post_thinking": {
      "temperature": 0.2,
      "top_p": 0.95,
      "top_k": 20
    }
  }'
```

The important difference here is the temperature transition from `0.9` during reasoning to `0.2` after reasoning completes.

## Per-request configuration

It can also be specified on individual requests:

```python
client.chat.completions.create(
    model="qwen/qwen3.8-27B",
    messages=[
        {"role": "user", "content": "..."}
    ],
    temperature=0.9,
    extra_body={
        "post_thinking": {
            "temperature": 0.2,
            "top_p": 0.95,
            "top_k": 20,
        },
    },
)
```

This allows applications to tune the two phases independently without changing server-wide defaults.

## Backward compatibility

The feature is opt-in.

When `post_thinking` is not specified, sampling behavior remains unchanged.

Existing requests, generation configurations, and model behavior should therefore continue to work as before.

## Results

So far I have primarily tested this with **Qwen 3.8 27B**.

The initial results are encouraging:

* reasoning behavior remains effectively unchanged;
* reasoning loops remain avoided with the higher thinking temperature;
* final answers contain noticeably fewer errors;
* final output is more deterministic and coherent;
* tool-call generation benefits from the lower post-thinking sampling temperature.

More systematic evaluation would be useful, particularly across additional reasoning models.

## Why implement this in vLLM?

It is possible for a client to approximate this behavior by stopping generation after `</think>` and issuing another request with different sampling parameters.

However, doing so introduces unnecessary complexity and can interfere with normal continuous generation, request state, KV-cache reuse, tool-call generation, streaming, and model-specific chat templates.

The reasoning boundary already exists within a single generation. Allowing the sampler configuration to change at that boundary lets vLLM support this use case directly without splitting one logical model turn into multiple requests.

## Reference implementation

The current implementation is available here:

```text
https://github.com/mdierolf/vllm-fork/tree/feat/post_thinking_sample_settings
```

This is still a work in progress, and I am interested in feedback on both the API shape and where the state transition should live within vLLM's sampling architecture.
