### PR TITLE
[ROCm][Perf] Perf improvement for DSv4 on ROCm

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -19,10 +19,21 @@ from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.v1.worker.workspace import current_workspace_manager
 
 if current_platform.is_rocm():
+    from aiter.ops.topk import top_k_per_row_decode as _aiter_top_k_per_row_decode
+    from aiter.ops.triton.gemm.batched.batched_gemm_bf16 import (
+        batched_gemm_bf16 as _aiter_batched_gemm_bf16,
+    )
+
     from vllm.platforms.rocm import _ON_GFX942, _ON_GFX950
 else:
     _ON_GFX942 = False
     _ON_GFX950 = False
+    _aiter_top_k_per_row_decode = None
+    _aiter_batched_gemm_bf16 = None
+
+# log2(e): folded into qk_scale so the decode softmax can use tl.exp2 instead
+# of tl.exp. AMD hardware executes exp2 faster than natural exp.
+_LOG2E = 1.4426950408889634
 
 
 @triton.jit
@@ -882,7 +893,7 @@ def rocm_aiter_sparse_attn_indexer(
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
         num_rows = logits.shape[0]
 
-        torch.ops._C.top_k_per_row_decode(
+        _aiter_top_k_per_row_decode(
             logits,
             next_n,
             decode_metadata.seq_lens,
@@ -1075,11 +1086,20 @@ def rocm_inv_rope_einsum(
     o_ref = _fused_inverse_rope_gptj(
         o, positions, rotary_emb.cos_sin_cache, rope_head_dim
     )
-    o_ref = o_ref.view(o.shape[0], n_local_groups, -1)
+    num_tokens = o_ref.shape[0]
+    o_ref = o_ref.view(num_tokens, n_local_groups, -1)
 
     wo_a_weight = _get_cached_wo_a_bf16(
         wo_a, n_local_groups, o_lora_rank, o_ref.shape[-1]
     )
+
+    if _aiter_batched_gemm_bf16 is not None and num_tokens <= 32:
+        # aiter Triton batched GEMM: tuned for small T (decode regime).
+        # Accepts non-contiguous inputs via strides; no .contiguous() needed.
+        return _aiter_batched_gemm_bf16(
+            o_ref.transpose(0, 1),
+            wo_a_weight,
+        ).transpose(0, 1)
 
     return torch.einsum("tgd,grd->tgr", o_ref, wo_a_weight)
 
@@ -1408,7 +1428,8 @@ def _sparse_attn_decode_ragged_kernel(
     extra_num_rows,
     main_block_size,
     extra_block_size,
-    scale,
+    qk_scale,
+    log2e,
     num_heads,
     HAS_ATTN_SINK: tl.constexpr,
     HAS_EXTRA: tl.constexpr,
@@ -1499,13 +1520,13 @@ def _sparse_attn_decode_ragged_kernel(
         k_rope = tl.where(k_rope == k_rope, k_rope, zero_rope)
 
         scores = tl.dot(q_nope, tl.trans(k_nope)) + tl.dot(q_rope, tl.trans(k_rope))
-        scores *= scale
+        scores *= qk_scale
         scores = tl.where(head_mask[:, None] & valid[None, :], scores, neg_large)
 
         m_block = tl.max(scores, axis=1)
         m_new = tl.maximum(m_i, m_block)
-        alpha = tl.exp(m_i - m_new)
-        p = tl.exp(scores - m_new[:, None])
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
         p = tl.where(head_mask[:, None] & valid[None, :], p, 0.0)
         l_new = l_i * alpha + tl.sum(p, axis=1)
 
@@ -1570,13 +1591,13 @@ def _sparse_attn_decode_ragged_kernel(
                 q_rope,
                 tl.trans(k_rope),
             )
-            scores *= scale
+            scores *= qk_scale
             scores = tl.where(head_mask[:, None] & valid[None, :], scores, neg_large)
 
             m_block = tl.max(scores, axis=1)
             m_new = tl.maximum(m_i, m_block)
-            alpha = tl.exp(m_i - m_new)
-            p = tl.exp(scores - m_new[:, None])
+            alpha = tl.exp2(m_i - m_new)
+            p = tl.exp2(scores - m_new[:, None])
             p = tl.where(head_mask[:, None] & valid[None, :], p, 0.0)
             l_new = l_i * alpha + tl.sum(p, axis=1)
 
@@ -1589,9 +1610,10 @@ def _sparse_attn_decode_ragged_kernel(
         sink = tl.load(
             attn_sink_ptr + head_offsets, mask=head_mask, other=neg_large
         ).to(tl.float32)
-        m_final = tl.maximum(m_i, sink)
-        alpha = tl.exp(m_i - m_final)
-        l_final = l_i * alpha + tl.exp(sink - m_final)
+        sink_log2 = sink * log2e
+        m_final = tl.maximum(m_i, sink_log2)
+        alpha = tl.exp2(m_i - m_final)
+        l_final = l_i * alpha + tl.exp2(sink_log2 - m_final)
         denom = tl.maximum(l_final, 1.0e-30)
         out_nope = tl.where(
             l_final[:, None] > 0.0,
@@ -1648,7 +1670,8 @@ def _sparse_attn_decode_partial_kernel(
     extra_num_rows,
     main_block_size,
     extra_block_size,
-    scale,
+    qk_scale,
+    log2e,
     num_heads,
     HAS_EXTRA: tl.constexpr,
     NOPE_DIM: tl.constexpr,
@@ -1749,13 +1772,13 @@ def _sparse_attn_decode_partial_kernel(
         k_rope = tl.where(k_rope == k_rope, k_rope, zero_rope)
 
         scores = tl.dot(q_nope, tl.trans(k_nope)) + tl.dot(q_rope, tl.trans(k_rope))
-        scores *= scale
+        scores *= qk_scale
         scores = tl.where(head_mask[:, None] & valid[None, :], scores, neg_large)
 
         m_block = tl.max(scores, axis=1)
         m_new = tl.maximum(m_i, m_block)
-        alpha = tl.exp(m_i - m_new)
-        p = tl.exp(scores - m_new[:, None])
+        alpha = tl.exp2(m_i - m_new)
+        p = tl.exp2(scores - m_new[:, None])
         p = tl.where(head_mask[:, None] & valid[None, :], p, 0.0)
         l_new = l_i * alpha + tl.sum(p, axis=1)
 
@@ -1823,13 +1846,13 @@ def _sparse_attn_decode_partial_kernel(
                 q_rope,
                 tl.trans(k_rope),
             )
-            scores *= scale
+            scores *= qk_scale
             scores = tl.where(head_mask[:, None] & valid[None, :], scores, neg_large)
 
             m_block = tl.max(scores, axis=1)
             m_new = tl.maximum(m_i, m_block)
-            alpha = tl.exp(m_i - m_new)
-            p = tl.exp(scores - m_new[:, None])
+            alpha = tl.exp2(m_i - m_new)
+            p = tl.exp2(scores - m_new[:, None])
             p = tl.where(head_mask[:, None] & valid[None, :], p, 0.0)
             l_new = l_i * alpha + tl.sum(p, axis=1)
 
@@ -2276,6 +2299,7 @@ def _sparse_attn_decode_reduce_kernel(
     pa_stride0,
     pa_stride_s,
     pa_stride_h,
+    log2e,
     num_heads,
     HAS_ATTN_SINK: tl.constexpr,
     ADAPTIVE_SPLITS: tl.constexpr,
@@ -2321,18 +2345,19 @@ def _sparse_attn_decode_reduce_kernel(
 
     m_comb = tl.max(m_all, axis=0)  # [H]
     if HAS_ATTN_SINK:
-        sink = tl.load(
+        sink_raw = tl.load(
             attn_sink_ptr + head_offsets, mask=head_mask, other=neg_large
         ).to(tl.float32)
-        m_final = tl.maximum(m_comb, sink)
+        sink_log2 = sink_raw * log2e
+        m_final = tl.maximum(m_comb, sink_log2)
     else:
         m_final = m_comb
 
-    w_all = tl.exp(m_all - m_final[None, :])  # [S, H]
+    w_all = tl.exp2(m_all - m_final[None, :])  # [S, H]
     w_all = tl.where(load_mask, w_all, 0.0)
     l_final = tl.sum(w_all * l_all, axis=0)  # [H]
     if HAS_ATTN_SINK:
-        l_final = l_final + tl.exp(sink - m_final)
+        l_final = l_final + tl.exp2(sink_log2 - m_final)
     denom = tl.maximum(l_final, 1.0e-30)
 
     # Phase 2: weighted sum of the per-split accumulators. The combine weight
@@ -2346,7 +2371,7 @@ def _sparse_attn_decode_reduce_kernel(
             mask=head_mask,
             other=neg_large,
         )
-        w_s = tl.exp(m_s - m_final)
+        w_s = tl.exp2(m_s - m_final)
         if ADAPTIVE_SPLITS:
             active_split = m_s > neg_large
             w_s = tl.where(head_mask & active_split, w_s, 0.0)
@@ -2697,6 +2722,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
         extra_indptr = torch.zeros(num_queries + 1, device=q.device, dtype=torch.int32)
 
     block_h = 16
+
     if out is None:
         out = torch.empty_like(q, dtype=torch.bfloat16)
     else:
@@ -2711,6 +2737,8 @@ def _rocm_sparse_attn_decode_ragged_triton(
     nope_block = triton.next_power_of_2(nope_head_dim)
     comb_dim = nope_head_dim + rope_head_dim
     is_fnuz = current_platform.is_fp8_fnuz()
+
+    qk_scale = float(scale) * _LOG2E
 
     if not (_ON_GFX942 or _ON_GFX950):  # Fallback path for un-tuned architectures.
         block_k = 16 if head_dim >= 256 else 32
@@ -2734,7 +2762,8 @@ def _rocm_sparse_attn_decode_ragged_triton(
             extra_cache.shape[0] * extra_cache.shape[1],
             main_cache.shape[1],
             extra_cache.shape[1],
-            scale,
+            qk_scale,
+            _LOG2E,
             num_heads,
             HAS_ATTN_SINK=has_attn_sink,
             HAS_EXTRA=has_extra,
@@ -2750,10 +2779,10 @@ def _rocm_sparse_attn_decode_ragged_triton(
         return out
 
     block_k = 32  # KV tokens walked per split-K iteration. Tuned on gfx950.
+    inv_q = 1.0 / max(1, num_queries)
+    avg_main_len = main_indices.numel() * inv_q
+    avg_extra_len = (extra_indices.numel() * inv_q) if has_extra else 0.0
     if _ON_GFX950:
-        inv_q = 1.0 / max(1, num_queries)
-        avg_main_len = main_indices.numel() * inv_q
-        avg_extra_len = (extra_indices.numel() * inv_q) if has_extra else 0.0
         num_splits = _decode_gfx950_num_splits(
             num_queries,
             heads_blocks,
@@ -2762,11 +2791,6 @@ def _rocm_sparse_attn_decode_ragged_triton(
             block_k,
         )
     else:
-        # Average per-query segment lengths, read sync-free from the ragged
-        # index sizes, let the split heuristic avoid over-splitting.
-        inv_q = 1.0 / max(1, num_queries)
-        avg_main_len = main_indices.numel() * inv_q
-        avg_extra_len = (extra_indices.numel() * inv_q) if has_extra else 0.0
         num_splits = _decode_num_splits(
             num_queries, heads_blocks, avg_main_len, avg_extra_len, block_k
         )
@@ -2855,7 +2879,8 @@ def _rocm_sparse_attn_decode_ragged_triton(
             extra_cache.shape[0] * extra_cache.shape[1],
             main_cache.shape[1],
             extra_cache.shape[1],
-            scale,
+            qk_scale,
+            _LOG2E,
             num_heads,
             HAS_EXTRA=has_extra,
             NOPE_DIM=nope_head_dim,
@@ -2887,6 +2912,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
         part_acc.stride(0),
         part_acc.stride(1),
         part_acc.stride(2),
+        _LOG2E,
         num_heads,
         HAS_ATTN_SINK=has_attn_sink,
         ADAPTIVE_SPLITS=adaptive_splits,


### PR DESCRIPTION
## Purpose
This PR is to improve the perf of DSv4 on ROCm. 
Changes include:
1. Use AITER topk decode to replace vLLM's own compiled extension (torch.ops._C.top_k_per_row_decode);
2. Use AITER batched_gemm_bf16 to replace torch.einsum in rocm_inv_rope_einsum for small decode batches(T <= 32);
3. Replaces tl.exp with tl.exp2 which ROCm platform has native instruction support;

For MRV1, the perf for different settings (concurrency=[1, 4, 16, 64], ISL=8K, OSL=1K) has ~5% improvement on TPOT.