### PR TITLE
[Bugfix][Perf] Let speculative decode use the 3D split-KV attention path

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -75,6 +75,7 @@ class TritonAttentionMetadata:
     slot_mapping: torch.Tensor
 
     seq_threshold_3D: int
+    max_q_len_3D: int
     num_par_softmax_segments: int
     softmax_segm_output: torch.Tensor
     softmax_segm_max: torch.Tensor
@@ -153,11 +154,33 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
                 key=lambda x: abs(x - self.seq_threshold_3D),
             )
 
+        # Largest query length the 3D (split-KV) path may serve. The kernel
+        # and ``reduce_segments`` index the ``softmax_segm_*`` scratch per
+        # *query row*, so the scratch must cover ``query_len`` rows per
+        # sequence, not one. Size it by how many query rows still count as a
+        # decode -- 1 without speculation, and the spec-decode query width
+        # with it -- which excludes true prefill in a way that
+        # ``max_seqlen_q > 1`` could not.
+        self.max_q_len_3D = 1
+        speculative_config = self.vllm_config.speculative_config
+        if (
+            speculative_config is not None
+            and speculative_config.num_speculative_tokens is not None
+        ):
+            self.max_q_len_3D = (
+                1
+                + (2 if speculative_config.parallel_drafting else 1)
+                * speculative_config.num_speculative_tokens
+            )
+
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
+        # Scratch is indexed per query row: seq_threshold_3D sequences each
+        # contributing up to max_q_len_3D rows.
+        num_segm_rows = self.seq_threshold_3D * self.max_q_len_3D
         self.softmax_segm_output = torch.empty(
             (
-                self.seq_threshold_3D,
+                num_segm_rows,
                 self.num_heads_q,
                 self.num_par_softmax_segments,
                 headdim_padded,
@@ -166,12 +189,12 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             device=device,
         )
         self.softmax_segm_max = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (num_segm_rows, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
         self.softmax_segm_expsum = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (num_segm_rows, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
@@ -243,6 +266,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             suffix_kv_lens=suffix_kv_lens,
             prefix_scheduler_metadata=prefix_scheduler_metadata,
             seq_threshold_3D=self.seq_threshold_3D,
+            max_q_len_3D=self.max_q_len_3D,
             num_par_softmax_segments=self.num_par_softmax_segments,
             softmax_segm_output=self.softmax_segm_output,
             softmax_segm_max=self.softmax_segm_max,
@@ -700,6 +724,7 @@ class TritonAttentionImpl(AttentionImpl):
         block_table = attn_metadata.block_table
 
         seq_threshold_3D = attn_metadata.seq_threshold_3D
+        max_q_len_3D = attn_metadata.max_q_len_3D
         num_par_softmax_segments = attn_metadata.num_par_softmax_segments
         softmax_segm_output = attn_metadata.softmax_segm_output
         softmax_segm_max = attn_metadata.softmax_segm_max
@@ -727,6 +752,7 @@ class TritonAttentionImpl(AttentionImpl):
             k_descale=k_descale,
             v_descale=v_descale,
             seq_threshold_3D=seq_threshold_3D,
+            max_q_len_3D=max_q_len_3D,
             num_par_softmax_segments=num_par_softmax_segments,
             softmax_segm_output=softmax_segm_output,
             softmax_segm_max=softmax_segm_max,

--- a/vllm/v1/attention/backends/triton_attn_diffkv.py
+++ b/vllm/v1/attention/backends/triton_attn_diffkv.py
@@ -57,7 +57,7 @@ class TritonAttentionDiffKVMetadataBuilder(TritonAttentionMetadataBuilder):
         head_size_v_padded = next_power_of_2(head_size_v)
         self.softmax_segm_output = torch.empty(
             (
-                self.seq_threshold_3D,
+                self.seq_threshold_3D * self.max_q_len_3D,
                 self.num_heads_q,
                 self.num_par_softmax_segments,
                 head_size_v_padded,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -817,6 +817,7 @@ def unified_attention(
     k_descale,
     v_descale,
     seq_threshold_3D=None,
+    max_q_len_3D=1,
     num_par_softmax_segments=None,
     softmax_segm_output=None,
     softmax_segm_max=None,
@@ -1037,15 +1038,38 @@ def unified_attention(
     # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
     # 2. The batch includes at least one prefill request, or
     # 3. The number of sequences exceeds the configured threshold, or
-    # 4. Batch invariance is enabled
+    # 4. The scratch cannot cover this batch's query rows, or
+    # 5. Batch invariance is enabled
+    #
+    # (2) is a *capacity* constraint, not a prefill-specific one: the kernel
+    # and ``reduce_segments`` index ``softmax_segm_*`` per query row
+    # (``segm_output[token, head, segm_idx, :]``), so the scratch must have a
+    # row for every query token in the batch. ``max_q_len_3D`` is how many
+    # query rows per sequence the caller sized that scratch for -- 1 for plain
+    # decode, ``1 + num_speculative_tokens`` under speculative decoding.
+    # Gating on it rather than on ``max_seqlen_q > 1`` keeps true prefill on
+    # the 2D path (prefill's query length far exceeds any decode threshold,
+    # and split-KV would not help it anyway) while letting speculative decode
+    # keep the 3D path it was previously and unintentionally excluded from.
+    #
+    # (4) is the exact scratch bound. ``max_seqlen_q <= max_q_len_3D`` alone
+    # is not sufficient: the scratch holds ``seq_threshold_3D * max_q_len_3D``
+    # rows, and a batch of ``num_seqs`` sequences uses ``q.shape[0]`` of them,
+    # so check the row count that is actually consumed.
+    max_segm_rows = (
+        0
+        if (softmax_segm_max is None or seq_threshold_3D is None)
+        else seq_threshold_3D * max_q_len_3D
+    )
     use_3d = not (
         seq_threshold_3D is None
         or num_par_softmax_segments is None
         or softmax_segm_output is None
         or softmax_segm_max is None
         or softmax_segm_expsum is None
-        or max_seqlen_q > 1
+        or max_seqlen_q > max_q_len_3D
         or num_seqs > seq_threshold_3D
+        or q.shape[0] > max_segm_rows
         or is_batch_invariant
     )
 


### PR DESCRIPTION
## Purpose

Fixes #48076. The 3D split-KV path is disabled whenever `max_seqlen_q > 1`, but the real constraint is that `softmax_segm_*` is allocated per sequence and indexed per query row, so this sizes the scratch per query row and gates on that width instead — letting speculative decode use split-KV rather than falling back to 2D.

## Test Plan

```bash
pytest tests/kernels/attention/test_triton_unified_attention.py -v
```

## Test Result

1584 passed with no new failures (the 290 `use_td` failures are pre-existing and reproduce identically on `main`). A guard-region probe forcing the 3D path at `query_len=2` shows the current per-sequence sizing writing out of bounds — 32768 floats past the end at batch 33, 1048576 at batch 64 — and zero once the scratch is sized per query row. Kernel time improves 2.6x–8.9x, scaling with KV length (8.9x at KV=32768, batch 1), and without speculation `max_q_len_3D == 1`, so every gating decision and the scratch size are unchanged.
