### PR TITLE
[Rust Frontend] Recover incomplete Kimi K3 calls at outer boundaries

### DIFF
--- a/rust/src/parser/src/unified/kimi_k3.rs
+++ b/rust/src/parser/src/unified/kimi_k3.rs
@@ -53,7 +53,9 @@ use self::structural_tag::KIMI_K3_STRUCTURAL_TAG_BUILDER;
 use super::{Result, UnifiedParser, UnifiedParserOutput, token_id};
 use crate::tool::{StructuralTagBuilder, Tool, ToolCallDelta};
 use crate::unified::parsing_failed;
-use crate::utils::{MarkerScanState, parse_buffered_event, safe_text_len_mul, take_until_marker};
+use crate::utils::{
+    MarkerScanState, parse_buffered_event, safe_text_len_mul, take_until_marker_mul,
+};
 
 const OPEN: &str = "<|open|>";
 const SEP: &str = "<|sep|>";
@@ -84,6 +86,7 @@ const REASONING_MARKERS: &[&str] = &[THINK_CLOSE, END_OF_MSG];
 const RESPONSE_MARKERS: &[&str] = &[RESPONSE_CLOSE, TOOLS_OPEN, MESSAGE_CLOSE, END_OF_MSG];
 const EPILOGUE_MARKERS: &[&str] = &[TOOLS_OPEN, MESSAGE_CLOSE, END_OF_MSG];
 const TOOLS_MARKERS: &[&str] = &[CALL_OPEN, TOOLS_CLOSE, MESSAGE_CLOSE, END_OF_MSG];
+const CALL_BODY_MARKERS: &[&str] = &[CALL_CLOSE, TOOLS_CLOSE, MESSAGE_CLOSE, END_OF_MSG];
 
 /// Channel tags are a couple of text tokens; longer `<|open|>…<|sep|>` spans in
 /// the prompt tail (attribute-bearing message opens, message bodies) never name
@@ -446,17 +449,23 @@ fn call_open_event(input: &mut KimiK3Input<'_>) -> ModalResult<KimiK3Event> {
     })
 }
 
-/// Parse the buffered call body through `<|close|>call<|sep|>` into a
-/// completed call.
+/// Parse the buffered call body through its close marker or an outer boundary.
 fn call_body_event(
     input: &mut KimiK3Input<'_>,
     scan: &mut MarkerScanState,
 ) -> ModalResult<KimiK3Event> {
-    let (body,) = seq!(
-        take_until_marker(CALL_CLOSE, scan),
-        _: literal(CALL_CLOSE),
-    )
-    .parse_next(input)?;
+    let (body, marker_index) = take_until_marker_mul(CALL_BODY_MARKERS, scan).parse_next(input)?;
+    let marker = CALL_BODY_MARKERS[marker_index];
+    literal(marker).parse_next(input)?;
+
+    if marker == TOOLS_CLOSE {
+        return Ok(KimiK3Event::ToolsClose);
+    }
+    if marker == MESSAGE_CLOSE || marker == END_OF_MSG {
+        return Ok(KimiK3Event::MessageEnd);
+    }
+
+    debug_assert_eq!(marker, CALL_CLOSE);
     let arguments = parse_call_arguments(body)?;
 
     Ok(KimiK3Event::CallComplete { arguments })
@@ -574,8 +583,8 @@ mod tests {
     use vllm_tokenizer::test_utils::TestTokenizer;
 
     use super::{
-        END_OF_MSG, KimiK3UnifiedParser, OPEN, RESPONSE_CLOSE, RESPONSE_OPEN, SEP, THINK_CLOSE,
-        THINK_OPEN, TOOLS_CLOSE, TOOLS_OPEN,
+        CALL_CLOSE, END_OF_MSG, KimiK3UnifiedParser, MESSAGE_CLOSE, OPEN, RESPONSE_CLOSE,
+        RESPONSE_OPEN, SEP, THINK_CLOSE, THINK_OPEN, TOOLS_CLOSE, TOOLS_OPEN,
     };
     use crate::tool::ToolCallDelta;
     use crate::unified::{
@@ -1040,6 +1049,50 @@ mod tests {
 
         assert_eq!(output.normal_text(), "answer");
         assert_eq!(output.calls().len(), 1);
+    }
+
+    #[test]
+    fn kimi_k3_outer_boundary_aborts_incomplete_call() {
+        let complete_call = call(
+            "tool=\"complete\" index=\"1\"",
+            &arg("value", "string", "kept"),
+        );
+
+        for boundary in [TOOLS_CLOSE, MESSAGE_CLOSE, END_OF_MSG] {
+            let message_close = if boundary == TOOLS_CLOSE {
+                MESSAGE_CLOSE
+            } else {
+                ""
+            };
+            let text = format!(
+                "{TOOLS_OPEN}{complete_call}\
+                 {OPEN}call tool=\"incomplete\" index=\"2\"{SEP}\
+                 {OPEN}argument key=\"value\" type=\"string\"{SEP}discarded\
+                 {boundary}{CALL_CLOSE}{message_close}{RESPONSE_OPEN}fabricated"
+            );
+
+            for size in [text.chars().count(), 1, 3, 7] {
+                let chunks = char_chunks(&text, size);
+                let chunk_refs: Vec<&str> = chunks.iter().map(String::as_str).collect();
+                let output = collect_stream(&mut test_parser(), &chunk_refs);
+                let calls = output.calls();
+
+                assert_eq!(calls.len(), 1, "boundary {boundary}, chunk size {size}");
+                assert_eq!(
+                    calls[0].name.as_deref(),
+                    Some("complete"),
+                    "boundary {boundary}, chunk size {size}"
+                );
+                assert_eq!(
+                    calls[0].arguments, r#"{"value":"kept"}"#,
+                    "boundary {boundary}, chunk size {size}"
+                );
+                assert!(
+                    output.normal_text().is_empty(),
+                    "boundary {boundary}, chunk size {size}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/rust/src/parser/src/utils.rs
+++ b/rust/src/parser/src/utils.rs
@@ -109,8 +109,9 @@ fn find_slice_mul(text: &str, markers: &[&str]) -> Option<usize> {
     range.map(|range| range.start)
 }
 
-/// Streaming scan state for a buffered marker search [`take_until_marker`],
-/// so that we don't have to rescan the whole buffered prefix when resuming.
+/// Streaming scan state for buffered marker searches such as
+/// [`take_until_marker`] and [`take_until_marker_mul`], so that we don't have
+/// to rescan the whole buffered prefix when resuming.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MarkerScanState {
     scan_start: usize,
@@ -138,15 +139,29 @@ pub fn take_until_marker<'i, 'a>(
     marker: &'a str,
     state: &'a mut MarkerScanState,
 ) -> impl Parser<Partial<&'i str>, &'i str, ErrMode<ContextError>> + 'a {
-    move |input: &mut Partial<&'i str>| take_until_marker_(input, marker, state)
+    move |input: &mut Partial<&'i str>| {
+        take_until_marker_mul_(input, &[marker], state).map(|(body, _)| body)
+    }
 }
 
-fn take_until_marker_<'i>(
+/// Parse text until the earliest of `markers`, resuming from the last safe scan checkpoint.
+///
+/// Returns the slice before the marker and the matched marker's index, leaving
+/// the marker itself for the caller to consume.
+pub fn take_until_marker_mul<'i, 'a>(
+    markers: &'a [&'a str],
+    state: &'a mut MarkerScanState,
+) -> impl Parser<Partial<&'i str>, (&'i str, usize), ErrMode<ContextError>> + 'a {
+    move |input: &mut Partial<&'i str>| take_until_marker_mul_(input, markers, state)
+}
+
+fn take_until_marker_mul_<'i>(
     input: &mut Partial<&'i str>,
-    marker: &str,
+    markers: &[&str],
     state: &mut MarkerScanState,
-) -> ModalResult<&'i str> {
-    debug_assert!(!marker.is_empty());
+) -> ModalResult<(&'i str, usize)> {
+    debug_assert!(!markers.is_empty());
+    debug_assert!(markers.iter().all(|marker| !marker.is_empty()));
 
     let text = **input;
     if text.is_empty() {
@@ -156,15 +171,19 @@ fn take_until_marker_<'i>(
     // Normal updates store a char boundary; this keeps stale or misused state from panicking.
     let scan_start = floor_char_boundary(text, state.scan_start);
 
-    if let Some(offset) = text[scan_start..].find(marker) {
+    if let Some(offset) = find_slice_mul(&text[scan_start..], markers) {
         let marker_start = scan_start + offset;
+        let marker_index = markers
+            .iter()
+            .position(|marker| text[marker_start..].starts_with(*marker))
+            .expect("matched marker must be present");
         let body = &text[..marker_start];
         input.next_slice(marker_start);
         state.reset();
-        return Ok(body);
+        return Ok((body, marker_index));
     }
 
-    let keep_len = partial_prefix_len(text, marker);
+    let keep_len = markers.iter().map(|marker| partial_prefix_len(text, marker)).max().unwrap_or(0);
     state.scan_start = text.len() - keep_len;
     incomplete()
 }
@@ -428,7 +447,7 @@ mod tests {
     use super::{
         JsonObjectScanState, JsonStringScanState, MarkerScanState, json_str, parse_buffered_event,
         partial_prefix_len, safe_text_len, safe_text_len_mul, take_json_object, take_json_string,
-        take_until_marker,
+        take_until_marker, take_until_marker_mul,
     };
 
     #[test]
@@ -563,6 +582,27 @@ mod tests {
 
         assert_eq!(body, "body");
         assert_eq!(*input, "</tool_call>tail");
+        assert_eq!(state, MarkerScanState::default());
+    }
+
+    #[test]
+    fn take_until_marker_mul_resumes_and_reports_the_earliest_marker() {
+        let markers = ["</call>", "</tools>", "<eom>"];
+        let mut state = MarkerScanState::default();
+        let mut input = Partial::new("body</too");
+
+        let error = take_until_marker_mul(&markers, &mut state).parse_next(&mut input).unwrap_err();
+
+        assert!(matches!(error, ErrMode::Incomplete(_)));
+        assert_eq!(state.scan_start, "body".len());
+
+        let mut input = Partial::new("body</tools>ignored</call>");
+        let (body, marker_index) =
+            take_until_marker_mul(&markers, &mut state).parse_next(&mut input).unwrap();
+
+        assert_eq!(body, "body");
+        assert_eq!(marker_index, 1);
+        assert_eq!(*input, "</tools>ignored</call>");
         assert_eq!(state, MarkerScanState::default());
     }
 


### PR DESCRIPTION
## Purpose

> [!NOTE]
> Since this is more of a heuristic recovery for malformed model output, we probably shouldn’t merge this unless we find more reports about the issue.

Kimi K3's unified parser previously waited only for `<|close|>call<|sep|>` while inside a tool call. When a malformed generation reached an outer tools or message boundary first, the parser buffered the outer trailer as call arguments and failed with `invalid Kimi K3 call body`.

This change scans the call close and the three authoritative outer boundaries together. A call close completes the call as before; a tools close discards the current incomplete call and enters the epilogue; a message close or end-of-message discards it and terminates parsing. Tool calls completed before the malformed call remain available.

The shared buffered-marker utility now supports multiple markers while retaining its incremental scan checkpoint, so large call bodies continue to scan only newly appended input.

AI assistance: OpenAI Codex assisted with implementation and test design. This draft remains for human line-by-line review before readiness.

## Test Plan

```bash
cd rust
cargo nextest run -p vllm-parser
cargo nextest run -p vllm-parser kimi_k3
cargo clippy -p vllm-parser --all-targets -- -D warnings
cargo fmt --all --check
git diff --check
```

The regression covers `TOOLS_CLOSE`, `MESSAGE_CLOSE`, and `END_OF_MSG` arriving before a later call close, with whole-input and 1/3/7-character streaming chunks. It also verifies that a previously completed call is preserved and post-boundary fabricated content stays suppressed.

## Test Result

- Before the fix, the regression failed with `invalid Kimi K3 call body` after the parser included the outer tools boundary in the incomplete call body.
- After the fix, all 418 `vllm-parser` tests pass.
- All 33 focused Kimi K3 tests pass.
- Clippy with `-D warnings`, rustfmt, and `git diff --check` pass.
- Model evaluation: the repository has no Kimi K3 parser evaluation entry. The malformed XTML sequence is covered with deterministic streaming regression cases.
