### PR TITLE
[ROCm][Perf] Kimi-K3 Mixed-dtype Biased Grouped Top-k

### DIFF
--- a/tests/kernels/moe/test_rocm_aiter_topk.py
+++ b/tests/kernels/moe/test_rocm_aiter_topk.py
@@ -29,6 +29,8 @@ aiter_available = importlib.util.find_spec("aiter") is not None
 if not aiter_available:
     pytest.skip("These tests require AITER to run.", allow_module_level=True)
 
+import aiter  # noqa: E402
+
 
 def test_rocm_aiter_biased_grouped_topk_custom_op_registration():
     """Test that the custom op is correctly registered."""
@@ -48,7 +50,22 @@ def test_rocm_aiter_grouped_topk_custom_op_registration():
     assert callable(torch.ops.vllm.rocm_aiter_grouped_topk)
 
 
-def test_rocm_aiter_biased_grouped_topk_torch_compile_compatibility():
+@pytest.mark.parametrize(
+    "correction_bias_dtype",
+    [
+        torch.bfloat16,
+        pytest.param(
+            torch.float32,
+            marks=pytest.mark.skipif(
+                not hasattr(aiter, "biased_grouped_topk_mixed_dtype"),
+                reason="AITER mixed-dtype biased grouped top-k is unavailable",
+            ),
+        ),
+    ],
+)
+def test_rocm_aiter_biased_grouped_topk_torch_compile_compatibility(
+    correction_bias_dtype: torch.dtype,
+):
     """Test that the op can be used with torch.compile."""
     # Create test tensors
     token = 64
@@ -61,7 +78,7 @@ def test_rocm_aiter_biased_grouped_topk_torch_compile_compatibility():
 
     gating_output = torch.randn((token, expert), dtype=torch.bfloat16, device="cuda")
     e_score_correction_bias = torch.randn(
-        (expert,), dtype=torch.bfloat16, device="cuda"
+        (expert,), dtype=correction_bias_dtype, device="cuda"
     )
 
     device = gating_output.device

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -423,9 +423,12 @@ def _rocm_aiter_biased_grouped_topk_impl(
     need_renorm: bool,
     routed_scaling_factor: float = 1.0,  # mul to topk_weights
 ) -> None:
-    from aiter import biased_grouped_topk
+    import aiter
 
-    biased_grouped_topk(
+    topk_op = aiter.biased_grouped_topk
+    if gating_output.dtype != correction_bias.dtype:
+        topk_op = aiter.biased_grouped_topk_mixed_dtype
+    topk_op(
         gating_output,
         correction_bias,
         topk_weights,
@@ -1873,6 +1876,13 @@ class rocm_aiter_ops:
 
     @classmethod
     @if_aiter_supported
+    def mixed_dtype_biased_topk_available(cls) -> bool:
+        import aiter
+
+        return callable(getattr(aiter, "biased_grouped_topk_mixed_dtype", None))
+
+    @classmethod
+    @if_aiter_supported
     def fuse_sigmoid_in_kernel(cls, aiter_topK_meta_data: object) -> bool:
         """Whether fused shared-expert sigmoid in the topk kernel is usable.
 
@@ -2544,7 +2554,12 @@ class rocm_aiter_ops:
         need_renorm: bool,
         routed_scaling_factor: float = 1.0,
     ) -> None:
-        if correction_bias.dtype != gating_output.dtype:
+        supports_mixed_dtype = (
+            gating_output.dtype == torch.bfloat16
+            and correction_bias.dtype == torch.float32
+            and rocm_aiter_ops.mixed_dtype_biased_topk_available()
+        )
+        if correction_bias.dtype != gating_output.dtype and not supports_mixed_dtype:
             correction_bias = correction_bias.to(gating_output.dtype)
         torch.ops.vllm.rocm_aiter_biased_grouped_topk(
             gating_output,

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -7,6 +7,7 @@ from typing import Any
 import torch
 from torch import nn
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (
     get_pp_group,
@@ -69,6 +70,9 @@ from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
 
 logger = init_logger(__name__)
+
+# BF16 router GEMM crossover on gfx950 (MI355X).
+_MAX_BF16_ROUTER_GEMM_TOKENS = 16
 
 
 class KimiMLP(nn.Module):
@@ -208,16 +212,23 @@ class KimiMoE(nn.Module):
             config.activation_situ_linear_beta if config.hidden_act == "situ" else None
         )
 
-        # Route with fp32 logits for numerically stable expert selection.
+        use_mixed_dtype_topk = bool(
+            config.num_expert_group == 1
+            and config.topk_group == 1
+            and config.moe_router_activation_func == "sigmoid"
+            and rocm_aiter_ops.is_fused_moe_enabled()
+            and rocm_aiter_ops.mixed_dtype_biased_topk_available()
+        )
+        self.use_mixed_dtype_topk = use_mixed_dtype_topk
         self.gate = GateLinear(
             input_size=hidden_size,
             output_size=num_experts,
             bias=False,
-            out_dtype=torch.float32,
+            out_dtype=(torch.bfloat16 if use_mixed_dtype_topk else torch.float32),
             prefix=f"{prefix}.gate",
         )
 
-        # Preserve FP32 checkpoint values and match FP32 router logits.
+        # The mixed-dtype AITER kernel consumes the checkpoint bias in FP32.
         self.gate.e_score_correction_bias = nn.Parameter(
             torch.empty(num_experts, dtype=torch.float32)
         )
@@ -308,7 +319,14 @@ class KimiMoE(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
-        router_logits, _ = self.gate(hidden_states)
+        if self.use_mixed_dtype_topk and num_tokens > _MAX_BF16_ROUTER_GEMM_TOKENS:
+            router_logits = torch.mm(
+                hidden_states,
+                self.gate.weight.T,
+                out_dtype=torch.float32,
+            )
+        else:
+            router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )


### PR DESCRIPTION
## Purpose
Previously, the router GEMM produced BF16 logits that were converted to FP32 by a separate copy kernel before grouped top-k. This added an extra kernel launch to the decode path.

<img width="1100" height="151" alt="Screenshot 2026-08-19 at 2 16 10 PM" src="https://github.com/user-attachments/assets/e5745263-fe68-4539-8c9d-90ee1a84d5e7" />

Aiter doesn't currently support BF16 router logits, but once [this PR ](https://github.com/ROCm/aiter/pull/4845) lands, we will be able to pass the router logits directly without conversions.

Perf results are presented below
<img width="2250" height="1530" alt="latest-changes-vs-main-concurrency-1-16" src="https://github.com/user-attachments/assets/2bd895fa-c614-47d6-ae6e-215be0e96cdb" />



## Test Plan
lm_eval
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

