### PR TITLE
[Rust Frontend] Add Anthropic Messages API request surface and count_tokens (PR 1/3)

### DIFF
--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 mod abort_requests;
+pub(crate) mod anthropic;
 mod cache;
 mod collective_rpc;
 mod health;
@@ -83,6 +84,8 @@ fn build_router_with_options(
         .route("/v1/models", get(openai::list_models))
         .route("/v1/completions", post(openai::completions))
         .route("/v1/chat/completions", post(openai::chat_completions))
+        // Anthropic
+        .route("/v1/messages/count_tokens", post(anthropic::count_tokens))
         // vLLM specific endpoints
         .route("/tokenize", post(tokenize::tokenize))
         .route("/detokenize", post(tokenize::detokenize))

--- a/rust/src/server/src/routes/anthropic/convert.rs
+++ b/rust/src/server/src/routes/anthropic/convert.rs
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use serde_json::Value;
+use vllm_chat::{
+    AssistantContentBlock, AssistantToolCall, ChatContent, ChatContentPart,
+    ChatMessage as VllmChatMessage, ChatOptions, ChatRequest, ChatTool, ChatToolChoice,
+    GenerationPromptMode, ResolvedToolContext, SamplingParams,
+};
+use vllm_text::output::TextDecodeOptions;
+
+use super::types::{
+    AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicMessage, AnthropicRole,
+    AnthropicTool, AnthropicToolChoice, ImageSource, MessageContent, SystemPrompt, SystemTextBlock,
+    ToolResultContent,
+};
+use crate::error::{ApiError, bail_invalid_request, chat_submit_error};
+
+/// Claude Code attaches an attribution block whose per-request hash defeats
+/// prefix caching; Python strips it and so do we. The oracle has no named
+/// constant — it inlines this literal at every check site.
+const BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header";
+
+// ============================================================================
+// Oracle-mirrored conversions
+// ============================================================================
+// Each fn below maps 1:1 to a named method of the Python vLLM serving class,
+// listed in oracle definition order.
+
+/// Convert an Anthropic image source to a URL string.
+///
+/// Mirrors the Python vLLM `_convert_image_source_to_url`: `url` sources
+/// pass through (empty string when the URL is missing); everything else
+/// becomes a base64 data URI with `image/jpeg` as the fallback media type.
+pub(super) fn convert_image_source_to_url(source: &ImageSource) -> String {
+    if source.source_type.as_deref() == Some("url") {
+        return source.url.clone().unwrap_or_default();
+    }
+    let media_type = source.media_type.as_deref().unwrap_or("image/jpeg");
+    let data = source.data.as_deref().unwrap_or("");
+    format!("data:{media_type};base64,{data}")
+}
+
+/// Extract the effective text of one inline `role: system` message.
+///
+/// Mirrors the Python vLLM `_extract_system_text`: strings and text blocks
+/// pass through with billing headers stripped; `None` when nothing remains.
+fn extract_inline_system_text(content: &MessageContent) -> Option<String> {
+    let text = match content {
+        MessageContent::Text(text) => clean_system_text(text)?.to_string(),
+        MessageContent::Blocks(blocks) => {
+            let mut parts = String::new();
+            for block in blocks {
+                if let AnthropicContentBlock::Text { text } = block
+                    && !text.is_empty()
+                    && let Some(clean) = clean_system_text(text)
+                {
+                    parts.push_str(clean);
+                }
+            }
+            parts
+        }
+    };
+    (!text.is_empty()).then_some(text)
+}
+
+/// Lower the Anthropic system prompt plus conversation history into internal
+/// chat messages.
+///
+/// Mirrors the Python vLLM `_convert_messages`, folding in
+/// `_convert_system_message`: the leading system block (system prompt plus
+/// hoisted inline system messages) is built here rather than by the caller.
+///
+/// `merge_inline_system` mirrors Python's `_merge_inline_system` switch:
+/// when `true`, inline `role: system` messages are hoisted into the leading
+/// system block (for templates that reject mid-conversation system messages);
+/// when `false`, they stay at their original position to keep prefix-cache
+/// hits intact. Python chooses the flag per model via a startup template
+/// probe (`_detect_merge_inline_system`); PR 1 passes the conservative
+/// always-merge default from the route layer and defers the probe to PR 2.
+pub(super) fn convert_messages(
+    system: Option<SystemPrompt>,
+    messages: Vec<AnthropicMessage>,
+    merge_inline_system: bool,
+) -> Result<Vec<VllmChatMessage>, ApiError> {
+    let mut out = Vec::new();
+
+    let mut system_parts = String::new();
+    match &system {
+        Some(SystemPrompt::Text(text)) => system_parts.push_str(text),
+        Some(SystemPrompt::Blocks(blocks)) => {
+            system_parts.push_str(&system_text_from_blocks(blocks))
+        }
+        None => {}
+    }
+    if merge_inline_system {
+        for message in &messages {
+            if matches!(message.role, AnthropicRole::System)
+                && let Some(text) = extract_inline_system_text(&message.content)
+            {
+                system_parts.push_str(&text);
+            }
+        }
+    }
+    if !system_parts.is_empty() {
+        out.push(VllmChatMessage::system(system_parts));
+    }
+
+    for message in messages {
+        match message.role {
+            AnthropicRole::System => {
+                // Already hoisted above when merging; otherwise keep the
+                // message at its original position (billing headers stripped,
+                // dropped entirely if nothing remains).
+                if !merge_inline_system
+                    && let Some(text) = extract_inline_system_text(&message.content)
+                {
+                    out.push(VllmChatMessage::system(text));
+                }
+            }
+            AnthropicRole::User => convert_user_message(message.content, &mut out)?,
+            AnthropicRole::Assistant => convert_assistant_message(message.content, &mut out)?,
+        }
+    }
+
+    Ok(out)
+}
+
+/// Lower one `tool_result` block into a `ToolResponse` message plus an
+/// optional follow-up user message carrying any images.
+///
+/// Mirrors the Python vLLM `_convert_user_tool_result`: text parts join with
+/// `\n`; `tool_reference` entries inside the result are dropped (Python
+/// re-emits them as a second tool message in a shape the internal chat layer
+/// has no analog for).
+fn convert_user_tool_result(
+    tool_use_id: String,
+    content: Option<ToolResultContent>,
+    out: &mut Vec<VllmChatMessage>,
+) {
+    let mut image_urls: Vec<String> = Vec::new();
+    let text = match content {
+        None => String::new(),
+        Some(ToolResultContent::Text(text)) => text,
+        Some(ToolResultContent::Blocks(blocks)) => {
+            let mut text_parts: Vec<String> = Vec::new();
+            for block in blocks {
+                match block {
+                    AnthropicContentBlock::Text { text } => text_parts.push(text),
+                    AnthropicContentBlock::Image { source } => {
+                        let url = convert_image_source_to_url(&source);
+                        if !url.is_empty() {
+                            image_urls.push(url);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            text_parts.join("\n")
+        }
+    };
+
+    out.push(VllmChatMessage::tool_response(text, tool_use_id));
+
+    if !image_urls.is_empty() {
+        out.push(VllmChatMessage::user(ChatContent::Parts(
+            image_urls
+                .into_iter()
+                .map(|url| ChatContentPart::ImageUrl {
+                    image_url: url,
+                    detail: None,
+                    uuid: None,
+                })
+                .collect(),
+        )));
+    }
+}
+
+/// Map Anthropic tool choice onto the internal enum
+/// (`auto`→Auto, `any`→Required, `none`→None, `tool`→Function).
+///
+/// Mirrors the Python vLLM `_convert_tool_choice`: when tools are present
+/// without an explicit choice, Python defaults to `auto`. The
+/// `disable_parallel_tool_use` half of that method lives in
+/// [`parallel_tool_calls`].
+pub(super) fn convert_tool_choice(
+    tool_choice: Option<&AnthropicToolChoice>,
+    has_tools: bool,
+) -> Option<ChatToolChoice> {
+    match tool_choice {
+        Some(AnthropicToolChoice::Auto { .. }) => Some(ChatToolChoice::Auto),
+        Some(AnthropicToolChoice::Any { .. }) => Some(ChatToolChoice::Required),
+        Some(AnthropicToolChoice::None) => Some(ChatToolChoice::None),
+        Some(AnthropicToolChoice::Tool { name, .. }) => {
+            Some(ChatToolChoice::Function { name: name.clone() })
+        }
+        None if has_tools => Some(ChatToolChoice::Auto),
+        None => None,
+    }
+}
+
+/// Convert Anthropic tool definitions.
+///
+/// Mirrors the Python vLLM `_convert_tools`, plus the protocol validator's
+/// schema normalization: Python inserts `"type": "object"` into schemas that
+/// omit it at validation time; mirrored here so rendering sees the same
+/// schema.
+pub(super) fn convert_tools(tools: Option<Vec<AnthropicTool>>) -> Vec<ChatTool> {
+    tools
+        .unwrap_or_default()
+        .into_iter()
+        .map(|tool| {
+            let mut parameters = tool.input_schema;
+            if let Value::Object(map) = &mut parameters
+                && !map.contains_key("type")
+            {
+                map.insert("type".to_string(), Value::String("object".to_string()));
+            }
+            ChatTool {
+                name: tool.name,
+                description: tool.description,
+                parameters,
+                strict: tool.strict,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+// Logic the oracle inlines in its larger methods, or decomposes differently;
+// each doc comment names the Python method it lifts from.
+
+/// Drop billing-header text.
+///
+/// Lifts the `startswith` checks the oracle inlines in
+/// `_convert_system_message` and `_extract_system_text`.
+fn clean_system_text(text: &str) -> Option<&str> {
+    (!text.starts_with(BILLING_HEADER_PREFIX)).then_some(text)
+}
+
+/// Concatenate the text of block-form system content, skipping billing
+/// headers and empty blocks.
+///
+/// Lifts the block filter/join loop inlined in the Python vLLM
+/// `_convert_system_message`; Python joins with an empty separator.
+fn system_text_from_blocks(blocks: &[SystemTextBlock]) -> String {
+    blocks
+        .iter()
+        .filter(|block| block.block_type == "text" && !block.text.is_empty())
+        .filter_map(|block| clean_system_text(&block.text))
+        .collect()
+}
+
+/// Lower one user message.
+///
+/// Covers the user-role half of the Python vLLM `_convert_message_content` /
+/// `_convert_block` pair (Python dispatches per block type; we split per role
+/// instead). Tool results split out into `ToolResponse` messages (each
+/// followed by one image-carrying user message when the result contains
+/// images), emitted before the residual user content — matching the message
+/// ordering the Python converter produces. A user message whose blocks were
+/// fully consumed (or empty) is dropped, matching Python.
+fn convert_user_message(
+    content: MessageContent,
+    out: &mut Vec<VllmChatMessage>,
+) -> Result<(), ApiError> {
+    let blocks = match content {
+        MessageContent::Text(text) => {
+            out.push(VllmChatMessage::user(text));
+            return Ok(());
+        }
+        MessageContent::Blocks(blocks) => blocks,
+    };
+
+    let mut parts: Vec<ChatContentPart> = Vec::new();
+    for block in blocks {
+        match block {
+            AnthropicContentBlock::Text { text } => {
+                if !text.is_empty() {
+                    parts.push(ChatContentPart::text(text));
+                }
+            }
+            AnthropicContentBlock::Image { source } => parts.push(ChatContentPart::ImageUrl {
+                image_url: convert_image_source_to_url(&source),
+                detail: None,
+                uuid: None,
+            }),
+            AnthropicContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error: _,
+            } => convert_user_tool_result(tool_use_id, content, out),
+            // Accepted and dropped (opaque), matching Python.
+            AnthropicContentBlock::RedactedThinking { .. } => {}
+            // Standalone references are ignored, matching Python; references
+            // inside tool_result content are handled there.
+            AnthropicContentBlock::ToolReference { .. } => {}
+            AnthropicContentBlock::Thinking { .. } | AnthropicContentBlock::ToolUse { .. } => {
+                bail_invalid_request!(
+                    "thinking and tool_use blocks are only valid in assistant messages."
+                );
+            }
+        }
+    }
+
+    match parts.len() {
+        0 => {} // fully consumed by tool results (or empty): drop, matching Python
+        // Python collapses a single text part back to plain string content.
+        1 if matches!(parts[0], ChatContentPart::Text { .. }) => {
+            let Some(ChatContentPart::Text { text }) = parts.pop() else {
+                unreachable!("checked above");
+            };
+            out.push(VllmChatMessage::user(ChatContent::Text(text)));
+        }
+        _ => out.push(VllmChatMessage::user(ChatContent::Parts(parts))),
+    }
+    Ok(())
+}
+
+/// Lower one assistant message, preserving thinking/text/tool_use block order
+/// (Python concatenates all thinking into one `reasoning` field and appends
+/// tool calls after content; we keep the original interleaving).
+///
+/// Covers the assistant-role half of the Python vLLM
+/// `_convert_message_content` / `_convert_block` pair, including
+/// `_convert_tool_use_block`'s lowering of tool calls.
+fn convert_assistant_message(
+    content: MessageContent,
+    out: &mut Vec<VllmChatMessage>,
+) -> Result<(), ApiError> {
+    let blocks = match content {
+        MessageContent::Text(text) => {
+            out.push(VllmChatMessage::assistant_blocks(vec![
+                AssistantContentBlock::Text { text },
+            ]));
+            return Ok(());
+        }
+        MessageContent::Blocks(blocks) => blocks,
+    };
+
+    let mut assistant_blocks: Vec<AssistantContentBlock> = Vec::new();
+    for block in blocks {
+        match block {
+            AnthropicContentBlock::Thinking { thinking, .. } => {
+                // Input signatures are accepted and dropped; vLLM cannot
+                // verify them (#47753 open question covers the output side).
+                assistant_blocks.push(AssistantContentBlock::Reasoning { text: thinking });
+            }
+            AnthropicContentBlock::Text { text } => {
+                if !text.is_empty() {
+                    assistant_blocks.push(AssistantContentBlock::Text { text });
+                }
+            }
+            AnthropicContentBlock::ToolUse { id, name, input } => {
+                let arguments = serde_json::to_string(
+                    &input.unwrap_or_else(|| Value::Object(Default::default())),
+                )
+                .expect("JSON value serializes");
+                assistant_blocks.push(AssistantContentBlock::ToolCall(AssistantToolCall {
+                    id: id.unwrap_or_else(fabricate_tool_call_id),
+                    name,
+                    arguments,
+                }));
+            }
+            // Assistant-side tool_result is nonsensical but tolerated by
+            // Python, which renders it into the content via `str()` (Python
+            // repr); we render block content as JSON instead.
+            AnthropicContentBlock::ToolResult { content, .. } => {
+                let rendered = match content {
+                    None => String::new(),
+                    Some(ToolResultContent::Text(text)) => text,
+                    Some(ToolResultContent::Blocks(blocks)) => {
+                        serde_json::to_string(&blocks).expect("blocks serialize")
+                    }
+                };
+                assistant_blocks.push(AssistantContentBlock::Text {
+                    text: format!("Tool result: {rendered}"),
+                });
+            }
+            AnthropicContentBlock::RedactedThinking { .. }
+            | AnthropicContentBlock::ToolReference { .. } => {}
+            AnthropicContentBlock::Image { .. } => {
+                bail_invalid_request!("image blocks are not supported in assistant messages.");
+            }
+        }
+    }
+
+    if assistant_blocks.is_empty() {
+        bail_invalid_request!(
+            "Assistant messages must contain text, reasoning content, or tool_calls."
+        );
+    }
+    out.push(VllmChatMessage::assistant_blocks(assistant_blocks));
+    Ok(())
+}
+
+/// Fabricate a tool-call ID for `tool_use` blocks that arrive without one.
+///
+/// Covers the fallback inlined in the Python vLLM `_convert_tool_use_block`:
+/// Python uses `call_{int(time.time())}`, which collides when one response
+/// carries several tool_use blocks (#35667); we keep the UUID form the Rust
+/// stack already uses for generated tool calls.
+fn fabricate_tool_call_id() -> String {
+    format!("call_{}", uuid::Uuid::new_v4().simple())
+}
+
+/// Parallel tool use defaults to enabled; `disable_parallel_tool_use: true`
+/// switches it off.
+///
+/// Lifts the `parallel_tool_calls` assignment inlined in the Python vLLM
+/// `_convert_tool_choice` (`not disable_parallel_tool_use`).
+pub(super) fn parallel_tool_calls(tool_choice: Option<&AnthropicToolChoice>) -> bool {
+    let disable = match tool_choice {
+        Some(
+            AnthropicToolChoice::Auto {
+                disable_parallel_tool_use,
+            }
+            | AnthropicToolChoice::Any {
+                disable_parallel_tool_use,
+            }
+            | AnthropicToolChoice::Tool {
+                disable_parallel_tool_use,
+                ..
+            },
+        ) => disable_parallel_tool_use.unwrap_or(false),
+        Some(AnthropicToolChoice::None) | None => false,
+    };
+    !disable
+}
+
+/// Lower one `count_tokens` body into a [`ChatRequest`] for template
+/// rendering, following `tokenize`'s precedent: only fields that affect
+/// rendering are set; sampling and decode options stay at default because
+/// counting never generates.
+///
+/// Covers the request-preparation half of the Python vLLM `count_tokens`
+/// route (the prompt-shaping subset of `_convert_anthropic_to_openai_request`).
+pub(super) fn prepare_count_tokens_request(
+    request: AnthropicCountTokensRequest,
+    request_id: String,
+    merge_inline_system: bool,
+) -> Result<ChatRequest, ApiError> {
+    let has_tools = request.tools.is_some();
+    let parallel = parallel_tool_calls(request.tool_choice.as_ref());
+    let tool_choice = convert_tool_choice(request.tool_choice.as_ref(), has_tools);
+    let messages = convert_messages(request.system, request.messages, merge_inline_system)?;
+
+    let tool_context = ResolvedToolContext::new(
+        &messages,
+        convert_tools(request.tools),
+        tool_choice,
+        parallel,
+    )
+    .map_err(|error| chat_submit_error("failed to resolve request tools", error))?;
+
+    Ok(ChatRequest {
+        request_id,
+        messages,
+        sampling_params: SamplingParams::default(),
+        chat_options: ChatOptions {
+            generation_prompt_mode: GenerationPromptMode::StartNewAssistant,
+            chat_template: None,
+            reasoning_effort: None,
+            response_format: None,
+            template_kwargs: request.chat_template_kwargs.unwrap_or_default(),
+        },
+        tool_context,
+        decode_options: TextDecodeOptions::default(),
+        intermediate: false,
+        priority: 0,
+        documents: None,
+        cache_salt: None,
+        add_special_tokens: false,
+        data_parallel_rank: None,
+        session_id: None,
+        lora_request: None,
+    })
+}

--- a/rust/src/server/src/routes/anthropic/count_tokens.rs
+++ b/rust/src/server/src/routes/anthropic/count_tokens.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! `POST /v1/messages/count_tokens` (Anthropic Messages API).
+//!
+//! Mirrors the Python endpoint: the request is lowered through the same
+//! conversion path as `/v1/messages`, rendered and tokenized without engine
+//! submission (the `/tokenize` precedent), and the resulting prompt length is
+//! returned in Anthropic's `count_tokens` response shape. This exercises the
+//! entire request-conversion layer before any generation code exists (#47753).
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use thiserror_ext::AsReport as _;
+
+use super::convert::prepare_count_tokens_request;
+use super::error::{AnthropicApiError, AnthropicJson};
+use super::types::{
+    AnthropicContextManagement, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
+};
+use crate::error::{ApiError, chat_submit_error, server_error};
+use crate::state::AppState;
+use crate::utils::resolve_base_request_id;
+
+// ============================================================================
+// Oracle-mirrored route
+// ============================================================================
+
+/// Count prompt tokens for one Anthropic Messages request.
+///
+/// Mirrors the Python vLLM `count_tokens` (the api_router route plus the
+/// serving method of the same name); the route/impl split is Rust-only
+/// plumbing so every error takes the [`AnthropicApiError`] envelope.
+pub(crate) async fn count_tokens(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    AnthropicJson(body): AnthropicJson<AnthropicCountTokensRequest>,
+) -> Response {
+    match count_tokens_impl(&state, &headers, body).await {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => AnthropicApiError(error).into_response(),
+    }
+}
+
+/// Mirrors the flow of the Python vLLM serving `count_tokens`: convert the
+/// request, render without engine submission, and sum the prompt tokens
+/// (Python sums `prompt_token_ids` across engine inputs; PR 1's text-only
+/// path has exactly one). The render/tokenize steps follow the Rust
+/// `/tokenize` chat precedent.
+async fn count_tokens_impl(
+    state: &AppState,
+    headers: &HeaderMap,
+    body: AnthropicCountTokensRequest,
+) -> Result<AnthropicCountTokensResponse, ApiError> {
+    if !state.served_model_names().iter().any(|name| name == &body.model) {
+        return Err(ApiError::model_not_found(body.model));
+    }
+
+    let request_id = count_tokens_request_id(headers);
+    let chat_request = prepare_count_tokens_request(body, request_id, MERGE_INLINE_SYSTEM)?;
+    let text_request = state
+        .chat
+        .request_processor()
+        .prepare_for_tokenization(chat_request)
+        .await
+        // Unlike the `/tokenize` precedent, validation-shaped render failures
+        // (e.g. bad `chat_template_kwargs`) map to 400 here: Python's
+        // `count_tokens` surfaces them through the serving layer's
+        // `create_error_response`, which defaults to 400.
+        .map_err(|error| chat_submit_error("count_tokens failed", error))?;
+    let tokens = state
+        .chat
+        .text()
+        .request_processor()
+        .tokenize(text_request)
+        .map_err(|e| server_error!("count_tokens failed: {}", e.to_report_string()))?;
+
+    let input_tokens = tokens.len() as u64;
+    Ok(AnthropicCountTokensResponse {
+        input_tokens,
+        context_management: AnthropicContextManagement {
+            original_input_tokens: input_tokens,
+        },
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+// Pieces with no named Python counterpart on this route: the provisional
+// stand-in for the oracle's startup probe, and Rust-side request-ID plumbing.
+
+/// Whether inline `role: system` messages are hoisted into the leading system
+/// block.
+///
+/// Stands in for the Python vLLM `_detect_merge_inline_system` startup probe
+/// (rendering a probe conversation against the chat template per model); we
+/// ship its conservative fallback (always merge — what Python does when no
+/// template is available) and defer the probe to PR 2, since it needs
+/// renderer access at route-state construction time.
+const MERGE_INLINE_SYSTEM: bool = true;
+
+/// Match the `/tokenize` request-ID convention with an Anthropic prefix.
+///
+/// No Python counterpart on this route — request IDs come from FastAPI-side
+/// middleware there; the Rust stack threads them explicitly.
+fn count_tokens_request_id(headers: &HeaderMap) -> String {
+    let base = resolve_base_request_id(
+        headers.get("X-Request-Id").and_then(|value| value.to_str().ok()),
+        None,
+    );
+    format!("anthropic-count-{base}")
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, HeaderValue};
+
+    use super::count_tokens_request_id;
+
+    #[test]
+    fn count_tokens_request_id_prefers_x_request_id_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Request-Id", HeaderValue::from_static("client-req-1"));
+        assert_eq!(
+            count_tokens_request_id(&headers),
+            "anthropic-count-client-req-1"
+        );
+    }
+
+    #[test]
+    fn count_tokens_request_id_generates_uuid_when_header_missing() {
+        let headers = HeaderMap::new();
+        let id = count_tokens_request_id(&headers);
+        assert!(id.starts_with("anthropic-count-"));
+        assert_ne!(id, "anthropic-count-");
+    }
+}

--- a/rust/src/server/src/routes/anthropic/error.rs
+++ b/rust/src/server/src/routes/anthropic/error.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Anthropic error envelope over the shared [`ApiError`] family.
+
+use axum::Json;
+use axum::extract::{FromRequest, Request};
+use axum::response::{IntoResponse, Response};
+use serde::de::DeserializeOwned;
+use validator::Validate;
+
+use super::types::{AnthropicError, AnthropicErrorResponse};
+use crate::error::ApiError;
+use crate::routes::openai::utils::types::Normalizable;
+use crate::routes::openai::utils::validated_json::ValidatedJson;
+
+// ============================================================================
+// Oracle-mirrored error rendering
+// ============================================================================
+
+/// [`ApiError`] rendered in Anthropic's error envelope
+/// (`{"type": "error", "error": {"type", "message"}}`) instead of the OpenAI
+/// shape.
+///
+/// Mirrors the Python vLLM `translate_error_response` (api_router.py):
+/// message and HTTP status carry over from the internal error, while the
+/// error type maps to the Anthropic wire names (see [`anthropic_error_type`])
+/// rather than being forwarded verbatim.
+pub(crate) struct AnthropicApiError(pub ApiError);
+
+impl IntoResponse for AnthropicApiError {
+    fn into_response(self) -> Response {
+        let status = self.0.status_code();
+        let message = self.0.to_error_response().error.message;
+        let body = AnthropicErrorResponse {
+            response_type: "error",
+            error: AnthropicError {
+                error_type: anthropic_error_type(&self.0).to_string(),
+                message,
+            },
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+// Pieces with no named Python counterpart: a deliberate divergence from the
+// oracle's error-type forwarding, and extractor plumbing FastAPI provides
+// implicitly on the Python side.
+
+/// Anthropic wire error type for each [`ApiError`] class, following the real
+/// API's status↔type pairing: 400 `invalid_request_error`,
+/// 404 `not_found_error`, 500 `api_error`.
+///
+/// Deliberate divergence from the `type=response.error.type` forwarding in
+/// the Python vLLM `translate_error_response`, which leaks OpenAI-side
+/// exception class names onto the Anthropic wire.
+fn anthropic_error_type(error: &ApiError) -> &'static str {
+    match error {
+        ApiError::InvalidRequest { .. } | ApiError::JsonParseError { .. } => {
+            "invalid_request_error"
+        }
+        ApiError::ModelNotFound { .. } => "not_found_error",
+        ApiError::ServerError { .. } => "api_error",
+    }
+}
+
+/// [`ValidatedJson`] with rejections rendered in the Anthropic error envelope,
+/// so parse and validation failures on the Anthropic routes never leak the
+/// OpenAI error shape.
+///
+/// Covers the FastAPI plumbing the Python router leans on
+/// (`validate_json_request` dependency + pydantic rejection handling); the
+/// Rust stack needs the explicit extractor.
+pub(crate) struct AnthropicJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for AnthropicJson<T>
+where
+    T: DeserializeOwned + Validate + Normalizable + Send,
+    S: Send + Sync,
+{
+    type Rejection = AnthropicApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match ValidatedJson::<T>::from_request(req, state).await {
+            Ok(ValidatedJson(data)) => Ok(Self(data)),
+            Err(error) => Err(AnthropicApiError(error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn error_types_map_to_anthropic_wire_names() {
+        let cases = [
+            (
+                ApiError::InvalidRequest {
+                    message: "m".to_string(),
+                    param: None,
+                },
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+            ),
+            (
+                ApiError::JsonParseError {
+                    message: "m".to_string(),
+                },
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+            ),
+            (
+                ApiError::ModelNotFound {
+                    model: "m".to_string(),
+                },
+                StatusCode::NOT_FOUND,
+                "not_found_error",
+            ),
+            (
+                ApiError::ServerError {
+                    message: "m".to_string(),
+                },
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "api_error",
+            ),
+        ];
+        for (error, status, wire_type) in cases {
+            assert_eq!(error.status_code(), status);
+            assert_eq!(anthropic_error_type(&error), wire_type);
+        }
+    }
+}

--- a/rust/src/server/src/routes/anthropic/mod.rs
+++ b/rust/src/server/src/routes/anthropic/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+pub(crate) mod convert;
+pub(crate) mod count_tokens;
+pub(crate) mod error;
+pub(crate) mod types;
+
+pub(crate) use count_tokens::count_tokens;

--- a/rust/src/server/src/routes/anthropic/types.rs
+++ b/rust/src/server/src/routes/anthropic/types.rs
@@ -1,0 +1,732 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use validator::Validate;
+use vllm_chat::ReasoningEffort;
+
+use crate::routes::openai::utils::types::Normalizable;
+
+// ============================================================================
+// Requests
+// ============================================================================
+// Oracle-mirrored types first: each carries the exact name of a Python vLLM
+// protocol class and maps to it 1:1. Helper shapes follow in their own
+// section.
+
+/// Request body for `POST /v1/messages`.
+///
+/// Mirrors the Python vLLM `AnthropicMessagesRequest` class.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+#[allow(dead_code)] // constructed only by the /v1/messages serving path (PR 2 of 3, #47753)
+pub struct AnthropicMessagesRequest {
+    /// ID of the model to use.
+    #[validate(length(min = 1, message = "model is required"))]
+    pub model: String,
+
+    /// Ordered conversation history.
+    #[validate(length(min = 1, message = "messages must not be empty"))]
+    pub messages: Vec<AnthropicMessage>,
+
+    /// Maximum number of tokens to generate. Required by the Anthropic API.
+    #[validate(range(min = 1))]
+    pub max_tokens: u32,
+
+    /// System prompt: a plain string or a list of text blocks.
+    pub system: Option<SystemPrompt>,
+
+    /// Accepted and unused, matching Python.
+    pub metadata: Option<HashMap<String, Value>>,
+
+    /// Sequences where the API will stop generating further tokens.
+    pub stop_sequences: Option<Vec<String>>,
+
+    /// If set, server-sent events are streamed as they become available.
+    #[serde(default)]
+    pub stream: bool,
+
+    /// Sampling temperature.
+    pub temperature: Option<f32>,
+
+    /// Nucleus sampling parameter.
+    pub top_p: Option<f32>,
+
+    /// Top-k sampling parameter.
+    pub top_k: Option<u32>,
+
+    /// Client-side tools the model may call.
+    #[validate(custom(function = "validate_tools_input_schema"))]
+    pub tools: Option<Vec<AnthropicTool>>,
+
+    /// Controls which (if any) tool is called by the model.
+    pub tool_choice: Option<AnthropicToolChoice>,
+
+    /// Output configuration: structured-output format and reasoning effort.
+    pub output_config: Option<AnthropicOutputConfig>,
+
+    // -------- vLLM protocol extensions, parity with the Python endpoint ----
+    /// Salt for prefix cache isolation in multi-user environments.
+    #[validate(length(min = 1))]
+    pub cache_salt: Option<String>,
+
+    /// Additional keyword args passed to the chat template renderer.
+    pub chat_template_kwargs: Option<HashMap<String, Value>>,
+
+    /// KV transfer parameters for disaggregated serving.
+    pub kv_transfer_params: Option<HashMap<String, Value>>,
+
+    /// Encoder cache transfer parameters for disaggregated serving.
+    pub ec_transfer_params: Option<HashMap<String, Value>>,
+}
+
+/// Request body for `POST /v1/messages/count_tokens`: the prompt-shaping
+/// subset of [`AnthropicMessagesRequest`] (no sampling parameters).
+///
+/// Mirrors the Python vLLM `AnthropicCountTokensRequest` class.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+pub struct AnthropicCountTokensRequest {
+    #[validate(length(min = 1, message = "model is required"))]
+    pub model: String,
+    #[validate(length(min = 1, message = "messages must not be empty"))]
+    pub messages: Vec<AnthropicMessage>,
+    pub system: Option<SystemPrompt>,
+    #[validate(custom(function = "validate_tools_input_schema"))]
+    pub tools: Option<Vec<AnthropicTool>>,
+    pub tool_choice: Option<AnthropicToolChoice>,
+    pub chat_template_kwargs: Option<HashMap<String, Value>>,
+}
+
+/// Validates every tool's `input_schema` is a JSON object, matching Python's
+/// `validate_input_schema` ("input_schema must be a dictionary").
+fn validate_tools_input_schema(tools: &[AnthropicTool]) -> Result<(), validator::ValidationError> {
+    if tools.iter().any(|tool| !tool.input_schema.is_object()) {
+        return Err(validator::ValidationError::new(
+            "input_schema must be an object",
+        ));
+    }
+    Ok(())
+}
+
+/// One conversation message.
+///
+/// Mirrors the Python vLLM `AnthropicMessage` class.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AnthropicMessage {
+    pub role: AnthropicRole,
+    pub content: MessageContent,
+}
+
+/// Typed content blocks accepted on input.
+///
+/// Mirrors the Python vLLM `AnthropicContentBlock` class, which models every
+/// block kind as one all-optional record and coerces missing fields to empty
+/// strings; the fields required here are the ones the Anthropic spec marks
+/// required, so malformed blocks fail with 400 instead.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AnthropicContentBlock {
+    Text {
+        text: String,
+    },
+    Image {
+        source: ImageSource,
+    },
+    Thinking {
+        thinking: String,
+        /// Python fabricates a random `uuid4` hex here; whether to copy that
+        /// or omit the signature stays open on #47753.
+        signature: Option<String>,
+    },
+    /// Accepted and dropped (opaque), matching Python.
+    RedactedThinking {
+        data: String,
+    },
+    /// `id` and `input` are optional on input, matching Python; a missing ID
+    /// is fabricated in `convert.rs` using the UUID form (avoiding Python's
+    /// timestamp-collision bug, #35667).
+    ToolUse {
+        id: Option<String>,
+        name: String,
+        input: Option<Value>,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: Option<ToolResultContent>,
+        is_error: Option<bool>,
+    },
+    ToolReference {
+        tool_name: String,
+    },
+}
+
+/// One client-side tool definition.
+///
+/// Mirrors the Python vLLM `AnthropicTool` class; `defer_loading` is accepted
+/// and dropped, since the Rust chat layer has no analog for it.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AnthropicTool {
+    pub name: String,
+    pub description: Option<String>,
+    pub input_schema: Value,
+    pub strict: Option<bool>,
+}
+
+/// Anthropic tool choice: `auto` / `any` / `tool` / `none`.
+///
+/// Mirrors the Python vLLM `AnthropicToolChoice` class; the tagged enum makes
+/// `name` structurally required for `tool`, which Python enforces with a
+/// model validator instead.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum AnthropicToolChoice {
+    Auto {
+        disable_parallel_tool_use: Option<bool>,
+    },
+    Any {
+        disable_parallel_tool_use: Option<bool>,
+    },
+    Tool {
+        name: String,
+        disable_parallel_tool_use: Option<bool>,
+    },
+    None,
+}
+
+/// Output configuration carried by `output_config`.
+///
+/// Mirrors the Python vLLM `AnthropicOutputConfig` class.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[allow(dead_code)] // constructed only by the /v1/messages serving path (PR 2 of 3, #47753)
+pub struct AnthropicOutputConfig {
+    pub format: Option<OutputFormat>,
+    /// Lowered to `chat_options.reasoning_effort`.
+    pub effort: Option<Effort>,
+}
+
+// ---------------------------------------------------------------------------
+// Request helper shapes
+// ---------------------------------------------------------------------------
+// Shapes the Python protocol module inlines (unions, Literals, untyped
+// dicts), or named shapes it restructures; each doc comment points at the
+// form it lifts.
+
+/// `system` accepts either a plain string or a list of text blocks.
+///
+/// Lifts the inline `str | list` union on the Python request's `system`
+/// field. Python types the block list as `AnthropicContentBlock` and ignores
+/// non-text blocks at conversion time; only text blocks are meaningful in
+/// `system`, so the Rust type requires that shape (non-text system blocks
+/// fail with 400).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SystemPrompt {
+    Text(String),
+    Blocks(Vec<SystemTextBlock>),
+}
+
+/// One text block inside a block-form system prompt: the deliberate
+/// tightening of the oracle's all-purpose content block for the system
+/// position (see [`SystemPrompt`]).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SystemTextBlock {
+    /// Always `"text"`.
+    #[serde(rename = "type")]
+    pub block_type: String,
+    pub text: String,
+}
+
+/// Message roles accepted on input. `system` covers inline system messages
+/// (#44283); see `convert.rs` for how the merge flag is chosen.
+///
+/// Lifts Python's inline `Literal["user", "assistant", "system"]` annotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AnthropicRole {
+    User,
+    Assistant,
+    System,
+}
+
+/// Message content: shorthand string or a list of typed blocks.
+///
+/// Lifts the inline `str | list[AnthropicContentBlock]` union on the Python
+/// message's `content` field.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MessageContent {
+    Text(String),
+    Blocks(Vec<AnthropicContentBlock>),
+}
+
+/// Anthropic image source.
+///
+/// Lifts the source dict the oracle handles untyped. Kept loose (all fields
+/// optional) because the oracle's default semantics depend on missing
+/// fields: a missing `type` is treated as base64 and a missing media type
+/// defaults to `image/jpeg` (see `_convert_image_source_to_url`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ImageSource {
+    #[serde(rename = "type")]
+    pub source_type: Option<String>,
+    pub media_type: Option<String>,
+    pub data: Option<String>,
+    pub url: Option<String>,
+}
+
+/// `tool_result.content` accepts a shorthand string or nested blocks.
+///
+/// Lifts the inline `str | list` union the oracle reads off the tool_result
+/// block.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ToolResultContent {
+    Text(String),
+    Blocks(Vec<AnthropicContentBlock>),
+}
+
+/// Structured-output format selector.
+///
+/// Restructures the Python vLLM `AnthropicJsonOutputFormat` class as a
+/// tagged enum. Python names the attribute `json_schema` but takes `schema`
+/// on the wire via a pydantic alias (alias-only, so the wire name matches
+/// ours exactly); Python defaults `type` and tolerates a missing schema as a
+/// silent no-op, both required here per the Anthropic spec.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[allow(dead_code)] // constructed only by the /v1/messages serving path (PR 2 of 3, #47753)
+pub enum OutputFormat {
+    JsonSchema { schema: Value },
+}
+
+/// Reasoning effort accepted by the Anthropic endpoint.
+///
+/// Lifts the effort Literal the Python oracle inlines on its output-config
+/// field (`"low" | "medium" | "high" | "xhigh" | "max"`): a strict subset of
+/// the internal [`ReasoningEffort`], which additionally accepts `none` and
+/// `minimal` — both rejected here with 400, matching Python.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Effort {
+    Low,
+    Medium,
+    High,
+    XHigh,
+    Max,
+}
+
+impl From<Effort> for ReasoningEffort {
+    fn from(effort: Effort) -> Self {
+        match effort {
+            Effort::Low => Self::Low,
+            Effort::Medium => Self::Medium,
+            Effort::High => Self::High,
+            Effort::XHigh => Self::XHigh,
+            Effort::Max => Self::Max,
+        }
+    }
+}
+
+// ============================================================================
+// Responses
+// ============================================================================
+// Oracle-mirrored types first; response-side helper shapes follow.
+
+/// Non-streaming response body for `POST /v1/messages`.
+///
+/// Mirrors the Python vLLM `AnthropicMessagesResponse` class. Optional fields
+/// serialize as explicit `null`, matching the real Anthropic wire format (the
+/// Python route dumps with `exclude_none=True` and omits them instead); the
+/// usage cache fields are the exception (see [`AnthropicUsage`]).
+#[derive(Debug, Clone, Serialize)]
+#[allow(dead_code)] // constructed only by the /v1/messages serving path (PR 2 of 3, #47753)
+pub(super) struct AnthropicMessagesResponse {
+    pub id: String,
+    /// Always `"message"`.
+    #[serde(rename = "type")]
+    pub response_type: &'static str,
+    /// Always `"assistant"`.
+    pub role: &'static str,
+    pub model: String,
+    pub content: Vec<ResponseContentBlock>,
+    pub stop_reason: Option<StopReason>,
+    pub stop_sequence: Option<String>,
+    pub usage: AnthropicUsage,
+    // vLLM protocol extensions, matching the Python response fields.
+    pub kv_transfer_params: Option<Value>,
+    pub ec_transfer_params: Option<Value>,
+}
+
+/// Usage block. Mirrors the Python vLLM `AnthropicUsage` class; the two
+/// cache fields are omitted entirely (not `null`) unless
+/// `--enable-prompt-tokens-details` is set, matching Python's
+/// `_build_anthropic_usage`.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct AnthropicUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u64>,
+}
+
+/// Response body for `POST /v1/messages/count_tokens`.
+///
+/// Mirrors the Python vLLM `AnthropicCountTokensResponse` class, including
+/// its `context_management` envelope for response-shape parity.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct AnthropicCountTokensResponse {
+    pub input_tokens: u64,
+    pub context_management: AnthropicContextManagement,
+}
+
+/// Mirrors the Python vLLM `AnthropicContextManagement` class.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct AnthropicContextManagement {
+    pub original_input_tokens: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Response helper shapes
+// ---------------------------------------------------------------------------
+// Python reuses its all-purpose request records on output; the response side
+// emits dedicated strict shapes instead, since every field is under our
+// control.
+
+/// Content blocks emitted in responses, preserving thinking/text/tool_use
+/// ordering end to end (one of the fidelity wins over Python, #47753).
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[allow(dead_code)] // constructed only by the /v1/messages serving path (PR 2 of 3, #47753)
+pub(super) enum ResponseContentBlock {
+    Text {
+        text: String,
+    },
+    Thinking {
+        thinking: String,
+        /// Whether to fabricate a signature is an open question on #47753.
+        signature: Option<String>,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        /// Always present on the wire (`{}` when the model emitted no
+        /// arguments), unlike the tolerant request-side variant.
+        input: Value,
+    },
+}
+
+/// Anthropic stop reasons, lifting the stop-reason string literals the
+/// oracle emits inline. `Abort` / `Repetition` finish reasons have no analog
+/// and map to a `null` stop_reason pending the open question on #47753
+/// (matching Python's handling of unknown finish reasons).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // constructed only by the /v1/messages serving path (PR 2 of 3, #47753)
+pub(super) enum StopReason {
+    EndTurn,
+    MaxTokens,
+    StopSequence,
+    ToolUse,
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/// Anthropic error envelope: `{"type": "error", "error": {"type", "message"}}`.
+///
+/// Mirrors the Python vLLM `AnthropicErrorResponse` class.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct AnthropicErrorResponse {
+    /// Always `"error"`.
+    #[serde(rename = "type")]
+    pub response_type: &'static str,
+    pub error: AnthropicError,
+}
+
+/// Mirrors the Python vLLM `AnthropicError` class.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct AnthropicError {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+}
+
+// ---- trait impls required by ValidatedJson (see tokenize/types.rs) ----
+impl Normalizable for AnthropicMessagesRequest {} // default no-op normalize()
+impl Normalizable for AnthropicCountTokensRequest {}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use validator::Validate as _;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_minimal_request() {
+        let req: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":16,
+                "messages":[{"role":"user","content":"hello"}]}"#,
+        )
+        .unwrap();
+        req.validate().unwrap();
+        assert_eq!(req.max_tokens, 16);
+        assert!(!req.stream);
+        assert!(matches!(req.messages[0].role, AnthropicRole::User));
+        assert!(matches!(req.messages[0].content, MessageContent::Text(_)));
+    }
+
+    #[test]
+    fn validate_rejects_zero_max_tokens_and_empty_messages() {
+        let req: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":0,
+                "messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .unwrap();
+        assert!(req.validate().is_err());
+
+        let req: AnthropicMessagesRequest =
+            serde_json::from_str(r#"{"model":"m","max_tokens":1,"messages":[]}"#).unwrap();
+        assert!(req.validate().is_err());
+
+        // Empty model is rejected, matching Python's `validate_model`.
+        let req: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"","max_tokens":1,
+                "messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .unwrap();
+        assert!(req.validate().is_err());
+
+        let req: AnthropicCountTokensRequest =
+            serde_json::from_str(r#"{"model":"","messages":[{"role":"user","content":"hi"}]}"#)
+                .unwrap();
+        assert!(req.validate().is_err());
+
+        // Non-object input_schema is rejected, matching Python's
+        // `validate_input_schema`.
+        let req: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":1,
+                "messages":[{"role":"user","content":"hi"}],
+                "tools":[{"name":"t","input_schema":"not-an-object"}]}"#,
+        )
+        .unwrap();
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn unknown_fields_ignored() {
+        // Claude Code attaches cache_control to blocks and other extension
+        // fields at the top level; both must deserialize harmlessly, matching
+        // the pydantic behavior of the Python endpoint.
+        let req: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":1,"unknown_top_level":true,
+                "messages":[{"role":"user","content":[
+                  {"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}
+                ]}]}"#,
+        )
+        .unwrap();
+        let MessageContent::Blocks(blocks) = &req.messages[0].content else {
+            panic!("expected block content");
+        };
+        assert!(matches!(blocks[0], AnthropicContentBlock::Text { .. }));
+    }
+
+    #[test]
+    fn system_accepts_string_and_blocks() {
+        let string_form: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":1,"system":"be brief",
+                "messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .unwrap();
+        assert!(matches!(string_form.system, Some(SystemPrompt::Text(_))));
+
+        let block_form: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":1,
+                "system":[{"type":"text","text":"be brief"}],
+                "messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .unwrap();
+        let Some(SystemPrompt::Blocks(blocks)) = &block_form.system else {
+            panic!("expected block-form system prompt");
+        };
+        assert_eq!(blocks[0].text, "be brief");
+    }
+
+    #[test]
+    fn tool_result_accepts_string_and_block_content() {
+        let msg: AnthropicMessage = serde_json::from_str(
+            r#"{"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"toolu_1","content":"ok"},
+                {"type":"tool_result","tool_use_id":"toolu_2",
+                 "content":[{"type":"text","text":"42"}],"is_error":false}
+            ]}"#,
+        )
+        .unwrap();
+        let MessageContent::Blocks(blocks) = &msg.content else {
+            panic!("expected block content");
+        };
+        assert!(matches!(
+            &blocks[0],
+            AnthropicContentBlock::ToolResult { content: Some(ToolResultContent::Text(t)), .. } if t == "ok"
+        ));
+        assert!(matches!(
+            &blocks[1],
+            AnthropicContentBlock::ToolResult {
+                content: Some(ToolResultContent::Blocks(b)),
+                is_error: Some(false),
+                ..
+            } if b.len() == 1
+        ));
+    }
+
+    #[test]
+    fn assistant_history_round_trips_thinking_and_tool_use() {
+        let msg: AnthropicMessage = serde_json::from_str(
+            r#"{"role":"assistant","content":[
+                {"type":"thinking","thinking":"hm","signature":"sig"},
+                {"type":"text","text":"calling a tool"},
+                {"type":"tool_use","id":"toolu_1","name":"get_weather",
+                 "input":{"city":"Paris"}},
+                {"type":"redacted_thinking","data":"opaque"}
+            ]}"#,
+        )
+        .unwrap();
+        let MessageContent::Blocks(blocks) = &msg.content else {
+            panic!("expected block content");
+        };
+        assert!(matches!(&blocks[0],
+            AnthropicContentBlock::Thinking { signature: Some(s), .. } if s == "sig"));
+        assert!(matches!(&blocks[2],
+            AnthropicContentBlock::ToolUse { id: Some(id), input: Some(input), .. }
+                if id == "toolu_1" && input["city"] == "Paris"));
+        assert!(matches!(
+            &blocks[3],
+            AnthropicContentBlock::RedactedThinking { .. }
+        ));
+    }
+
+    #[test]
+    fn tool_choice_variants_deserialize() {
+        let parse = |s: &str| serde_json::from_str::<AnthropicToolChoice>(s).unwrap();
+        assert!(matches!(
+            parse(r#"{"type":"auto"}"#),
+            AnthropicToolChoice::Auto { .. }
+        ));
+        assert!(matches!(
+            parse(r#"{"type":"any","disable_parallel_tool_use":true}"#),
+            AnthropicToolChoice::Any {
+                disable_parallel_tool_use: Some(true)
+            }
+        ));
+        assert!(matches!(
+            parse(r#"{"type":"tool","name":"get_weather"}"#),
+            AnthropicToolChoice::Tool { name, .. } if name == "get_weather"
+        ));
+        assert!(matches!(
+            parse(r#"{"type":"none"}"#),
+            AnthropicToolChoice::None
+        ));
+    }
+
+    #[test]
+    fn response_serializes_nulls_explicitly_and_omits_cache_fields() {
+        // Anthropic wire format: stop_sequence is an explicit null; the usage
+        // cache fields are omitted entirely unless prompt-token details are
+        // enabled.
+        let response: AnthropicMessagesResponse = AnthropicMessagesResponse {
+            id: "msg_1".to_string(),
+            response_type: "message",
+            role: "assistant",
+            model: "m".to_string(),
+            content: vec![ResponseContentBlock::Text {
+                text: "hi".to_string(),
+            }],
+            stop_reason: Some(StopReason::EndTurn),
+            stop_sequence: None,
+            usage: AnthropicUsage {
+                input_tokens: 3,
+                output_tokens: 1,
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+            },
+            kv_transfer_params: None,
+            ec_transfer_params: None,
+        };
+        let json: Value = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["type"], "message");
+        assert_eq!(json["stop_reason"], "end_turn");
+        assert!(json.as_object().unwrap().contains_key("stop_sequence"));
+        assert!(json["stop_sequence"].is_null());
+        let usage = json["usage"].as_object().unwrap();
+        assert!(!usage.contains_key("cache_read_input_tokens"));
+
+        let error: AnthropicErrorResponse = AnthropicErrorResponse {
+            response_type: "error",
+            error: AnthropicError {
+                error_type: "invalid_request_error".to_string(),
+                message: "boom".to_string(),
+            },
+        };
+        let json: Value = serde_json::to_value(&error).unwrap();
+        assert_eq!(json["type"], "error");
+        assert_eq!(json["error"]["type"], "invalid_request_error");
+    }
+
+    #[test]
+    fn validate_rejects_empty_cache_salt() {
+        let req: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":1,"cache_salt":"",
+                "messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .unwrap();
+        assert!(req.validate().is_err());
+
+        let req: AnthropicMessagesRequest = serde_json::from_str(
+            r#"{"model":"m","max_tokens":1,"cache_salt":"tenant-abc",
+                "messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .unwrap();
+        req.validate().unwrap();
+    }
+
+    #[test]
+    fn tool_strict_and_tool_reference_deserialize() {
+        let tool: AnthropicTool = serde_json::from_str(
+            r#"{"name":"t","input_schema":{"type":"object"},
+                "strict":true,"defer_loading":false}"#,
+        )
+        .unwrap();
+        assert_eq!(tool.strict, Some(true));
+
+        let block: AnthropicContentBlock =
+            serde_json::from_str(r#"{"type":"tool_reference","tool_name":"web_search"}"#).unwrap();
+        assert!(matches!(
+            block,
+            AnthropicContentBlock::ToolReference { tool_name } if tool_name == "web_search"
+        ));
+    }
+
+    #[test]
+    fn output_config_effort_matches_python_literal() {
+        let parse = |s: &str| {
+            serde_json::from_str::<AnthropicOutputConfig>(&format!(r#"{{"effort":"{s}"}}"#))
+        };
+        for accepted in ["low", "medium", "high", "xhigh", "max"] {
+            parse(accepted).unwrap();
+        }
+        // Internal `ReasoningEffort` levels the Anthropic endpoint rejects,
+        // matching Python's effort Literal.
+        assert!(parse("none").is_err());
+        assert!(parse("minimal").is_err());
+    }
+}

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -6222,6 +6222,72 @@ async fn tokenize_completion_count_and_max_model_len() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
+async fn anthropic_count_tokens_returns_prompt_token_count() {
+    let mut app = test_app().await;
+
+    let (status, json) = post_json(
+        &mut app,
+        "/v1/messages/count_tokens",
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "be brief",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let input_tokens = json["input_tokens"].as_u64().expect("input_tokens");
+    assert!(input_tokens > 0);
+    assert_eq!(
+        json["context_management"]["original_input_tokens"],
+        json["input_tokens"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn anthropic_count_tokens_unknown_model_returns_anthropic_error() {
+    let mut app = test_app().await;
+
+    let (status, json) = post_json(
+        &mut app,
+        "/v1/messages/count_tokens",
+        json!({
+            "model": "does-not-exist",
+            "messages": [{"role": "user", "content": "hi"}],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["type"], "error");
+    assert_eq!(json["error"]["type"], "not_found_error");
+    assert!(json["error"]["message"].as_str().unwrap().contains("does-not-exist"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn anthropic_count_tokens_empty_messages_returns_anthropic_error() {
+    let mut app = test_app().await;
+
+    let (status, json) = post_json(
+        &mut app,
+        "/v1/messages/count_tokens",
+        json!({
+            "model": "Qwen/Qwen1.5-0.5B-Chat",
+            "messages": [],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["type"], "error");
+    assert_eq!(json["error"]["type"], "invalid_request_error");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
 async fn tokenize_chat_includes_generation_prompt_in_token_count() {
     let mut app = test_app().await;
     let messages = json!([{"role": "user", "content": "hi"}]);


### PR DESCRIPTION
Hi vLLM team, this is my first PR here, please kindly advise and critique, I will collaborate accordingly. Thank you!

## Purpose

Part of #47753 (Anthropic Messages API in the Rust frontend; roadmap item under #44280). This is **PR 1 of 3** per the RFC's plan: the request-side protocol surface plus the `/v1/messages/count_tokens` endpoint. PR 2 adds the `/v1/messages` non-streaming serving path; PR 3 adds streaming.

Suggested reading order:

- `routes/anthropic/types.rs` — request/response types for `MessagesRequest` and `CountTokensRequest`, content-block definitions, validation. Includes `cache_salt` (min-length validated, matching #46688), `ec_transfer_params`, and tool `strict` passthrough.
- `routes/anthropic/convert.rs` — lowering from Anthropic request shapes to the internal chat representation, ported case-by-case from the Python implementation's conversion tests (system merge, single-text-block collapse, image parts, tool_choice/tools mapping, tool_result shapes, billing-header stripping).
- `routes/anthropic/error.rs` — Anthropic-format error envelope (`AnthropicApiError`) adapting the existing `ApiError` with Anthropic wire error-type names, plus an `AnthropicJson` extractor wrapping `ValidatedJson` so no failure path leaks the OpenAI error shape.
- `routes/anthropic/count_tokens.rs` — the endpoint: check_model → prepare_for_tokenization → tokenize, with `x-request-id` handling.
- `routes.rs` / `routes/tests.rs` — route registration and mock-engine route tests.

**Type-design principle.** The Python implementation models the protocol as a few all-optional records and inlines its unions and Literals. The Rust side lifts each of those into a dedicated type — `SystemPrompt`, `MessageContent`, `ImageSource`, `ToolResultContent`, `Effort` have no `protocol.py` counterpart for exactly that reason — with the rule applied throughout: the request side is tolerant (Optional fields, unknown fields ignored, loose `ImageSource` preserving the oracle's missing-field default semantics), the response side is strict. Each source file is organized into an oracle-mirrored section (items carrying the exact name of a Python class or method, mapping 1:1) followed by a helpers section whose doc comments name the Python code they lift inline logic from.

The `/v1/messages`-only protocol types in `types.rs` (`AnthropicMessagesRequest`, `AnthropicOutputConfig`, `OutputFormat`, `AnthropicMessagesResponse`, `ResponseContentBlock`, `StopReason`) are reviewed here as part of the request surface but are only constructed by the PR 2 serving path; each carries `#[allow(dead_code)]` until then, since CI runs clippy with `-D warnings`.

## Design decisions and divergences from the Python implementation

1. **Assistant block order preserved**: mixed text/thinking/tool_use blocks in assistant history keep their original interleaving order rather than being regrouped by block type.
2. **Thinking blocks stay separate**: thinking content is carried as distinct blocks, not folded into adjacent text.
3. **Explicit-null response serialization**: optional response fields (`stop_reason`, `stop_sequence`, …) serialize as explicit `null`, matching the real Anthropic wire format; the Python route dumps with `exclude_none=True` and omits them. The usage cache fields are the deliberate exception (omitted unless prompt-token details are enabled, matching `_build_anthropic_usage`).
4. **Stricter required fields**: content blocks require the fields the Anthropic spec marks required, so malformed blocks fail with 400 instead of being coerced to empty strings; `defer_loading` on tools is accepted and dropped; `"stream": null` is rejected (Python accepts it); empty `messages` is rejected at the protocol layer; `output_config.format` requires both `type` and `schema`, where Python defaults the former and silently no-ops on a missing latter.
5. **Empty assistant messages and assistant image blocks are rejected** with 400, matching the Rust OpenAI routes; `thinking`/`tool_use` blocks in user messages likewise 400 instead of being silently accepted.
6. **`tool_reference` inside `tool_result` content is dropped** rather than converted (the internal chat layer has no analog for Python's second tool message).
7. **`tool_use` without an `id` gets a fabricated `call_<uuid>` id**; Python's `call_{int(time.time())}` fallback collides within one response (see #35667).
8. **Inline system handling**: the Python implementation auto-detects per model whether inline `role: system` messages must be hoisted into the leading system block, by rendering a probe conversation against the chat template at startup (`_detect_merge_inline_system`). PR 1 ships its conservative fallback (`MERGE_INLINE_SYSTEM = true` — what Python does when no template is available) and defers the probe to PR 2, which constructs route state with renderer access.
9. **Error envelope types follow the real API's status↔type pairing**: 400 `invalid_request_error`, 404 `not_found_error`, 500 `api_error`. The Python implementation forwards its OpenAI-side exception class names into the Anthropic envelope instead.
10. **No `validate.rs` in this PR**: the `stop_sequences` max-length check (`VLLM_MAX_STOP_STRINGS`) is deferred to PR 2's `messages.rs`, since `count_tokens` does not consume stop sequences; the existing `utils` stop validation is reused there.

## Test Plan

`cargo test --manifest-path rust/Cargo.toml -p vllm-server anthropic` — 30 tests: types deserialization/validation/serialization (explicit-null rule, unknown-field tolerance, `cache_salt` rejection, effort accepted-value set), conversion cases ported one-to-one from the Python implementation's conversion test suite as the behavioral oracle, the error-type mapping, request-id handling, and 3 mock-engine route tests (success, unknown model, empty messages) asserting the Anthropic error envelope end-to-end.

## Test Result

All 30 pass. `pre-commit run` green; `cargo fmt --check`, `cargo sort --workspace --check`, `cargo deny check bans`, and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` all clean locally.

## AI assistance disclosure

Per the [AI Assisted Contributions policy](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions): this PR includes AI-generated code (Claude, marked with `Co-authored-by` commit trailers). I have reviewed every changed line, validated behavior end-to-end against the Python implementation's tests, and run all relevant tests myself.