### PR TITLE
[Bugfix] Fix int4_w4a16 benchmark tuning on CUDA

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -408,6 +408,29 @@ def get_configs_compute_bound(use_fp16, block_quant_shape) -> list[dict[str, int
     return configs
 
 
+def prune_cuda_wna16_search_space(
+    search_space: list[dict[str, int]],
+    num_valid_tokens: int,
+    num_experts: int,
+    group_size: int,
+) -> list[dict[str, int]]:
+    if not should_moe_wna16_use_cuda(
+        num_valid_tokens=num_valid_tokens,
+        group_size=group_size,
+        num_experts=num_experts,
+        bit=4,
+    ):
+        return search_space
+
+    return [
+        config
+        for config in search_space
+        if config["BLOCK_SIZE_M"] <= 64
+        and config["BLOCK_SIZE_K"] % group_size == 0
+        and config["BLOCK_SIZE_K"] // group_size in (1, 2, 4, 8)
+    ]
+
+
 def prune_rocm_search_space(
     num_tokens, shard_intermediate_size, hidden_size, search_space, is_fp16, topk
 ):
@@ -618,6 +641,14 @@ class BenchmarkWorker:
                 search_space,
                 is_fp16,
                 topk,
+            )
+        if use_int4_w4a16:
+            assert block_quant_shape is not None
+            search_space = prune_cuda_wna16_search_space(
+                search_space,
+                num_valid_tokens=num_tokens * topk,
+                num_experts=num_experts,
+                group_size=block_quant_shape[1],
             )
 
         need_device_guard = False

--- a/tests/kernels/moe/test_benchmark_moe.py
+++ b/tests/kernels/moe/test_benchmark_moe.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from benchmarks.kernels.benchmark_moe import prune_cuda_wna16_search_space
+
+
+def test_prune_cuda_wna16_search_space_filters_cuda_constraints(monkeypatch):
+    monkeypatch.setattr(
+        "benchmarks.kernels.benchmark_moe.should_moe_wna16_use_cuda",
+        lambda **kwargs: True,
+    )
+    search_space = [
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_K": 128},
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_K": 128},
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_K": 64},
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_K": 384},
+    ]
+
+    assert prune_cuda_wna16_search_space(
+        search_space,
+        num_valid_tokens=8,
+        num_experts=8,
+        group_size=128,
+    ) == [{"BLOCK_SIZE_M": 64, "BLOCK_SIZE_K": 128}]
+
+
+def test_prune_cuda_wna16_search_space_keeps_triton_search_space(monkeypatch):
+    monkeypatch.setattr(
+        "benchmarks.kernels.benchmark_moe.should_moe_wna16_use_cuda",
+        lambda **kwargs: False,
+    )
+    search_space = [
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_K": 64},
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_K": 128},
+    ]
+
+    assert (
+        prune_cuda_wna16_search_space(
+            search_space,
+            num_valid_tokens=64,
+            num_experts=8,
+            group_size=128,
+        )
+        is search_space
+    )


### PR DESCRIPTION
## Purpose

Fix #52845.

benchmark_moe.py --tune --dtype int4_w4a16 disables quantization-alignment filtering for the Triton GPTQ/AWQ path, but small CUDA batches dispatch to moe_wna16_gemm. The unfiltered search space can therefore pass configurations that violate the CUDA WNA16 constraints:

- BLOCK_SIZE_M <= 64
- BLOCK_SIZE_K % group_size == 0
- BLOCK_SIZE_K // group_size is one of 1, 2, 4, or 8

This change applies those constraints per batch only when should_moe_wna16_use_cuda(...) selects the CUDA WNA16 backend. Triton int4 tuning retains its existing search space.

No open PR matched issue #52845 or the benchmark_moe/int4_w4a16 area when checked.

AI assistance was used to develop this change. The human submitter is responsible for reviewing every changed line and validating the behavior end-to-end.

## Test Plan

- python -m pytest tests/kernels/moe/test_benchmark_moe.py -q --confcutdir=tests/kernels/moe
- pre-commit run --files benchmarks/kernels/benchmark_moe.py tests/kernels/moe/test_benchmark_moe.py
- python -m compileall -q benchmarks/kernels/benchmark_moe.py tests/kernels/moe/test_benchmark_moe.py
- git diff --check

## Test Result

- Regression tests: 2 passed.
- Applicable pre-commit hooks: passed. 
- Python compilation and whitespace checks: passed.
- Model evaluation: not applicable; this change only affects benchmark configuration filtering and does not change model outputs or serving behavior.