### PR TITLE
[Bugfix][CPU] Guard unavailable WNA16 operator

### DIFF
--- a/tests/kernels/quantization/test_cpu_wna16_kernel_selection.py
+++ b/tests/kernels/quantization/test_cpu_wna16_kernel_selection.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+import vllm.model_executor.kernels.linear as linear_mod
+from vllm.model_executor.kernels.linear import (
+    CPUWNA16LinearKernel,
+    MPLinearLayerConfig,
+    ZentorchWNA16LinearKernel,
+    choose_mp_linear_kernel,
+)
+from vllm.model_executor.kernels.linear.mixed_precision import (
+    cpu as cpu_mod,
+)
+from vllm.model_executor.kernels.linear.mixed_precision import (
+    zentorch as zentorch_mod,
+)
+from vllm.platforms import CpuArchEnum, PlatformEnum
+from vllm.scalar_type import scalar_types
+
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
+
+
+def _config(
+    *, act_type: torch.dtype = torch.float16, has_g_idx: bool = False
+) -> MPLinearLayerConfig:
+    return MPLinearLayerConfig(
+        full_weight_shape=(128, 128),
+        partition_weight_shape=(128, 128),
+        weight_type=scalar_types.uint4,
+        act_type=act_type,
+        group_size=32,
+        zero_points=True,
+        has_g_idx=has_g_idx,
+    )
+
+
+def _set_cpu_platform(monkeypatch, architecture: CpuArchEnum, *, zen=False) -> None:
+    platform = SimpleNamespace(
+        _enum=PlatformEnum.CPU,
+        is_cpu=lambda: True,
+        is_zen_cpu=lambda: zen,
+        get_cpu_architecture=lambda: architecture,
+    )
+    monkeypatch.setattr(cpu_mod, "current_platform", platform)
+    monkeypatch.setattr(zentorch_mod, "current_platform", platform)
+    monkeypatch.setattr(linear_mod, "current_platform", platform)
+
+
+def _select_cpu_wna16(monkeypatch, config: MPLinearLayerConfig):
+    monkeypatch.setitem(
+        linear_mod._POSSIBLE_KERNELS,
+        PlatformEnum.CPU,
+        [CPUWNA16LinearKernel],
+    )
+    return choose_mp_linear_kernel(config, compute_capability=0)
+
+
+@pytest.mark.parametrize("operator_present", [False, True])
+def test_w4a16_requires_registered_operator(monkeypatch, operator_present):
+    _set_cpu_platform(monkeypatch, CpuArchEnum.X86)
+    monkeypatch.setattr(cpu_mod.envs, "VLLM_CPU_INT4_W4A8", False)
+    namespace = SimpleNamespace()
+    if operator_present:
+        namespace.cpu_gemm_wna16 = object()
+    with patch.object(cpu_mod.torch.ops, "_C", namespace):
+        if operator_present:
+            assert _select_cpu_wna16(monkeypatch, _config()) is CPUWNA16LinearKernel
+            return
+        with pytest.raises(ValueError, match="cpu_gemm_wna16 is not registered"):
+            _select_cpu_wna16(monkeypatch, _config())
+
+
+@pytest.mark.parametrize("has_g_idx", [False, True])
+def test_riscv_w4a8_only_bypasses_wna16_without_g_idx(monkeypatch, has_g_idx):
+    _set_cpu_platform(monkeypatch, CpuArchEnum.RISCV)
+    monkeypatch.setattr(cpu_mod.envs, "VLLM_CPU_INT4_W4A8", True)
+    monkeypatch.setattr(torch.cpu, "_is_amx_tile_supported", lambda: False)
+    with patch.object(cpu_mod.torch.ops, "_C", SimpleNamespace()):
+        config = _config(act_type=torch.bfloat16, has_g_idx=has_g_idx)
+        if not has_g_idx:
+            assert _select_cpu_wna16(monkeypatch, config) is CPUWNA16LinearKernel
+            return
+        with pytest.raises(ValueError, match="cpu_gemm_wna16 is not registered"):
+            _select_cpu_wna16(monkeypatch, config)
+
+
+def test_zentorch_uses_its_own_operator_gate(monkeypatch):
+    _set_cpu_platform(monkeypatch, CpuArchEnum.X86, zen=True)
+    monkeypatch.setattr(cpu_mod.envs, "VLLM_CPU_INT4_W4A8", False)
+    monkeypatch.setattr(zentorch_mod, "has_zentorch_op", lambda _: True)
+    with patch.object(cpu_mod.torch.ops, "_C", SimpleNamespace()):
+        assert ZentorchWNA16LinearKernel.can_implement(_config()) == (True, None)

--- a/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
@@ -17,7 +17,25 @@ from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 _CPUWNA16_SUPPORTED_QUANT_TYPES = (scalar_types.uint4, scalar_types.uint4b8)
 
 
+def _uses_w4a8(c: MPLinearLayerConfig) -> bool:
+    return (
+        envs.VLLM_CPU_INT4_W4A8
+        and not c.has_g_idx
+        and c.act_type == torch.bfloat16
+        and (
+            torch.cpu._is_amx_tile_supported()
+            or current_platform.get_cpu_architecture() == CpuArchEnum.RISCV
+        )
+    )
+
+
+def _has_cpu_gemm_wna16() -> bool:
+    return hasattr(torch.ops._C, "cpu_gemm_wna16")
+
+
 class CPUWNA16LinearKernel(MPLinearKernel):
+    requires_cpu_gemm_wna16 = True
+
     @classmethod
     def get_min_capability(cls) -> int:
         return -1
@@ -54,6 +72,16 @@ class CPUWNA16LinearKernel(MPLinearKernel):
                 False,
                 f"Output size ({c.partition_weight_shape[1]}) not supported by "
                 "CPUWNA16, supported sizes are multiples of 32",
+            )
+
+        if (
+            cls.requires_cpu_gemm_wna16
+            and not _uses_w4a8(c)
+            and not _has_cpu_gemm_wna16()
+        ):
+            return (
+                False,
+                "cpu_gemm_wna16 is not registered in the loaded CPU extension",
             )
 
         return True, None
@@ -168,14 +196,7 @@ class CPUWNA16LinearKernel(MPLinearKernel):
             if zp.output_dim == 0:
                 zp.data = zp.t().contiguous()
 
-        supports_amx = torch.cpu._is_amx_tile_supported()
-        supports_riscv = current_platform.get_cpu_architecture() == CpuArchEnum.RISCV
-        layer.use_w4a8 = (
-            envs.VLLM_CPU_INT4_W4A8
-            and not self.config.has_g_idx
-            and self.config.act_type == torch.bfloat16
-            and (supports_amx or supports_riscv)
-        )
+        layer.use_w4a8 = _uses_w4a8(self.config)
         # layer.use_w4a8 = False
         # AWQ format will be converted to GPTQ format in `AutoAWQMarlinLinearMethod`
         if layer.use_w4a8:

--- a/vllm/model_executor/kernels/linear/mixed_precision/zentorch.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/zentorch.py
@@ -36,6 +36,8 @@ def _import_unpack_from_int32():
 class ZentorchWNA16LinearKernel(CPUWNA16LinearKernel):
     """W4A16 GPTQ kernel backed by ``torch.ops.zentorch.zentorch_woq_linear``."""
 
+    requires_cpu_gemm_wna16 = False
+
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
         ok, reason = super().can_implement(c)


### PR DESCRIPTION
## Purpose

Fix CPU WNA16 kernel selection when the loaded CPU extension does not register `_C::cpu_gemm_wna16`.

`CPUWNA16LinearKernel.can_implement()` previously validated the platform, quantization type, group size, and tensor shape, but did not verify that the operator used by `apply_weights()` was available. A Scalar RISC-V build omits `cpu_wna16.cpp`, so the selector could accept W4A16 or W4A8 with `g_idx` and fail later when the missing operator was called.

This change:

- checks the loaded extension with the established `hasattr(torch.ops._C, ...)` capability-probe pattern;
- fails closed when `cpu_gemm_wna16` is unavailable;
- shares the W4A8 eligibility predicate between kernel selection and weight processing;
- preserves RISC-V/AMX W4A8 without `g_idx`, which uses the independently registered INT4 operators; and
- preserves Zentorch selection because it has its own operator gate.

The missing-operator condition was reproduced on Scalar RISC-V, but the fix is based on the capabilities of the loaded CPU extension rather than a hard-coded architecture check.

Duplicate checks against open vLLM issues and PRs found no other change addressing this missing-operator gate.

AI assistance was used for analysis, implementation, and testing. I reviewed every changed line and the reported results.

## Test Plan

Run the focused kernel-selection regression tests on x86 Linux:

```bash
.venv/bin/python -m pytest \
  tests/kernels/quantization/test_cpu_wna16_kernel_selection.py -vv
```

On native RISC-V hardware, load the real Scalar vLLM CPU extension, inspect its registered operators, and call the actual `CPUWNA16LinearKernel.can_implement()` implementation for:

1. W4A16 with FP16 activations;
2. W4A8 with BF16 activations and no `g_idx`; and
3. W4A8 with BF16 activations and `g_idx`.

The native probe supplies the platform and configuration inputs but does not mock the Torch dispatcher or the tested kernel-selection implementation.

Run the source checks:

```bash
pre-commit run --files \
  vllm/model_executor/kernels/linear/mixed_precision/cpu.py \
  vllm/model_executor/kernels/linear/mixed_precision/zentorch.py \
  tests/kernels/quantization/test_cpu_wna16_kernel_selection.py

git diff --check
```

## Test Result

### Native RISC-V capability probe

The probe ran on a SpacemiT K1 (`riscv64`, VLEN 256) with Python 3.12, RISE PyTorch 2.13.0+cpu, and a Scalar vLLM CPU extension.

The real Torch dispatcher reported:

```text
cpu_gemm_wna16=False
int4_scaled_mm_cpu=True
convert_weight_packed_scale_zp=True
```

Using the same extension before and after the fix produced:

| Configuration | Before | Current PR |
|---|---|---|
| W4A16, FP16 | accepted | rejected: `cpu_gemm_wna16 is not registered` |
| W4A8, BF16, no `g_idx` | accepted | accepted |
| W4A8, BF16, with `g_idx` | accepted | rejected: `cpu_gemm_wna16 is not registered` |

This confirms that the unavailable WNA16 path is rejected while the independently supported RISC-V W4A8 path remains selectable.

### Focused pytest

The same regression test was run against the pre-fix source and the current PR on x86_64 Linux with Python 3.12 and PyTorch 2.13.0+cpu:

| Revision | Result |
|---|---|
| Pre-fix | 2 failed, 3 passed |
| Current PR | 5 passed |

The two pre-fix failures reproduce the intended regression: W4A16 without the registered operator was accepted, and RISC-V W4A8 with `g_idx` was accepted even though it falls back to the missing WNA16 operator.

The three preserved cases verify that W4A16 remains selectable when the operator exists, RISC-V W4A8 without `g_idx` remains selectable, and Zentorch continues to use its independent operator gate.

The focused pytest was also attempted on the K1, but collection stopped before running assertions because the available RISE PyTorch wheel raised an unrelated internal `torch._inductor` generic-type error:

```text
TypeError: Too few arguments for torch._inductor.codegen.common.CSE;
actual 1, expected 2
```

This RISC-V pytest attempt is not reported as passing; native behavior is covered by the real-extension capability probe above.

The following checks pass:

```text
pre-commit run --files ...: PASS
git diff --check: PASS
```

Model evaluation was not run because this change only prevents selection of an unavailable kernel and does not modify the numerical behavior of any executable kernel.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

