### PR TITLE
[XPU][CI] downgrade sentencepiece

### DIFF
--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -808,7 +808,7 @@ scipy==1.18.0
     #   sentence-transformers
 sentence-transformers==5.7.0
     # via mteb
-sentencepiece==0.2.2
+sentencepiece==0.2.1
     # via -r requirements/test/../common.txt
 sentry-sdk==2.68.0
     # via fastapi-cloud-cli


### PR DESCRIPTION
**CI issue**: https://buildkite.com/vllm/intel-ci/builds/9299/canvas?jid=01a0189b-4b3a-4327-a6c2-6b2e193ad366&tab=output

**Root cause**: The `tokenizer.model` file for InternVL2-2B contains a `\x00` token, which is incompatible with newer versions of sentencepiece.

**Fix**: Downgrade sentencepiece

**Issue to sentencepiece**: https://github.com/google/sentencepiece/issues/1308