### PR TITLE
[Revert] Restore test-only FP8 Marlin selection

### DIFF
--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -371,10 +371,6 @@ def test_fusion_rmsnorm_quant(
             use_aiter_fusion=False,
             use_aiter_quant=False,
         )
-        if any(
-            type(layer.kernel) is not force_kernel for layer in model.fp8_linear_layers
-        ):
-            pytest.skip(f"{force_kernel.__name__} is not supported on this platform")
 
         backend, _ = _run_fusion_test(
             model, fusion_pass, vllm_config, dtype, hidden_size, num_tokens

--- a/tests/compile/passes/test_mla_attn_quant_fusion.py
+++ b/tests/compile/passes/test_mla_attn_quant_fusion.py
@@ -481,12 +481,6 @@ def test_mla_attention_quant_pattern(
             device=device,
             vllm_config=vllm_config_unfused,
         )
-        if (
-            model_class is TestMLAAttentionFp8GroupQuantPatternModel
-            and type(model_unfused.block_fp8_linear.kernel)
-            is not CutlassFp8BlockScaledMMKernel
-        ):
-            pytest.skip("CUTLASS FP8 block kernel is not supported on this platform")
         model_unfused = model_unfused.to(device)
         # HACK: See #131044
         result_unfused_0 = model_unfused(q, kv_c_normed, k_pe)  # noqa: F841

--- a/tests/evals/gsm8k/configs/moe-refactor/Llama-4-Scout-Fp8-ModelOpt-marlin.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Llama-4-Scout-Fp8-ModelOpt-marlin.yaml
@@ -2,4 +2,6 @@ model_name: "nvidia/Llama-4-Scout-17B-16E-Instruct-FP8"
 accuracy_threshold: 0.92
 num_questions: 1319
 num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --linear-backend marlin --moe-backend marlin"
+server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2"
+env:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-Fp8-AutoFp8-marlin.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-Fp8-AutoFp8-marlin.yaml
@@ -2,4 +2,6 @@ model_name: "Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8"
 accuracy_threshold: 0.88
 num_questions: 1319
 num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --linear-backend marlin --moe-backend marlin"
+server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2"
+env:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-Fp8-CT-Block-marlin.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-Fp8-CT-Block-marlin.yaml
@@ -2,4 +2,6 @@ model_name: "RedHatAI/Qwen3-30B-A3B-FP8-block"
 accuracy_threshold: 0.85
 num_questions: 1319
 num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --linear-backend marlin --moe-backend marlin"
+server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2"
+env:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-Fp8-CT-Channel-marlin.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-Fp8-CT-Channel-marlin.yaml
@@ -2,4 +2,6 @@ model_name: "RedHatAI/Qwen3-30B-A3B-FP8-dynamic"
 accuracy_threshold: 0.85
 num_questions: 1319
 num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --linear-backend marlin --moe-backend marlin"
+server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2"
+env:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-CT-marlin.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-CT-marlin.yaml
@@ -2,4 +2,6 @@ model_name: "RedHatAI/Qwen3-30B-A3B-NVFP4"
 accuracy_threshold: 0.88
 num_questions: 1319
 num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --linear-backend marlin --moe-backend marlin"
+server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2"
+env:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-ModelOpt-marlin.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/Qwen3-30B-A3B-NvFp4-ModelOpt-marlin.yaml
@@ -2,4 +2,6 @@ model_name: "nvidia/Qwen3-30B-A3B-NVFP4"
 accuracy_threshold: 0.88
 num_questions: 1319
 num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2 --linear-backend marlin --moe-backend marlin"
+server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2"
+env:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -64,12 +64,10 @@ def test_model_load_and_run(
     if use_rocm_aiter:
         monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
 
-    kwargs = {}
     if force_marlin:
-        kwargs["linear_backend"] = "marlin"
-        kwargs["moe_backend"] = "marlin"
+        monkeypatch.setenv("VLLM_TEST_FORCE_FP8_MARLIN", "1")
 
-    with vllm_runner(model_id, enforce_eager=True, **kwargs) as llm:
+    with vllm_runner(model_id, enforce_eager=True) as llm:
         # note: this does not test accuracy, just that we can run through
         # see lm-eval tests for accuracy
         outputs = llm.generate_greedy(["Hello my name is"], max_tokens=4)
@@ -100,10 +98,8 @@ def test_online_quantization(
     # `LLM.apply_model` requires pickling a function.
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
-    kwargs = {}
     if force_marlin:
-        kwargs["linear_backend"] = "marlin"
-        kwargs["moe_backend"] = "marlin"
+        monkeypatch.setenv("VLLM_TEST_FORCE_FP8_MARLIN", "1")
 
     model_dtype = "auto"
     if kv_cache_dtype == "fp8" and current_platform.is_device_capability_family(90):
@@ -116,7 +112,6 @@ def test_online_quantization(
         dtype=model_dtype,
         enforce_eager=True,
         kv_cache_dtype=kv_cache_dtype,
-        **kwargs,
     ) as llm:
 
         def check_model(model):
@@ -345,7 +340,7 @@ def test_scaled_fp8_quant(dtype) -> None:
 @pytest.mark.parametrize("method_cls", [Fp8LinearMethod, Fp8MoEMethod])
 # FP8 weight reloading does not support online quantization
 @pytest.mark.parametrize("is_checkpoint_fp8_serialized", [True])  # skip False
-@pytest.mark.parametrize("weight_block_size", [None, [128, 128]])
+@pytest.mark.parametrize("weight_block_size", [None, [1, 1]])
 # any postprocessing that is applied to the weights such as padding and repacking
 # (excluding device sharding) must also be applied to the reloaded weights
 #
@@ -376,8 +371,6 @@ def test_fp8_reloading(
 
     # Set model config as model_config.dtype is required in Fp8LinearMethod.
     default_vllm_config.model_config = ModelConfig()
-    default_vllm_config.kernel_config.moe_backend = "triton"
-    layer_size = 128 if weight_block_size is not None else 1
     with torch.device(f"{DEVICE_TYPE}:0"):
         config = Fp8Config(
             is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
@@ -385,14 +378,14 @@ def test_fp8_reloading(
         )
 
         if method_cls is Fp8LinearMethod:
-            layer = torch.nn.Linear(layer_size, layer_size)
+            layer = torch.nn.Linear(1, 1)
             method = method_cls(config)
             method.create_weights(
                 layer=layer,
-                input_size_per_partition=layer_size,
-                output_partition_sizes=[layer_size],
-                input_size=layer_size,
-                output_size=layer_size,
+                input_size_per_partition=1,
+                output_partition_sizes=[1],
+                input_size=1,
+                output_size=1,
                 params_dtype=torch.bfloat16,
                 weight_loader=default_weight_loader,
             )
@@ -402,16 +395,16 @@ def test_fp8_reloading(
             layer = FusedMoEFactory(
                 num_experts=1,
                 top_k=1,
-                hidden_size=layer_size,
-                intermediate_size=layer_size,
+                hidden_size=1,
+                intermediate_size=1,
             )
             layer = layer.routed_experts
             method = method_cls(config, layer)
             method.create_weights(
                 layer=layer,
                 num_experts=1,
-                hidden_size=layer_size,
-                intermediate_size_per_partition=layer_size,
+                hidden_size=1,
+                intermediate_size_per_partition=1,
                 params_dtype=torch.bfloat16,
                 weight_loader=default_weight_loader,
             )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2339,10 +2339,6 @@ class TestFP8Layer(torch.nn.Module):
         force_kernel: type[_KernelT] | None = None,
     ):
         super().__init__()
-        self.input_size_per_partition = weight_shape[1]
-        self.output_size_per_partition = weight_shape[0]
-        self.logical_widths = [self.output_size_per_partition]
-        self.orig_dtype = input_dtype
         act_scale_desc = activation_quant_key.scale
         weight_scale_desc = weight_quant_key.scale
         is_block_wise = act_scale_desc.group_shape.is_per_group()
@@ -2350,12 +2346,11 @@ class TestFP8Layer(torch.nn.Module):
             block_size = weight_scale_desc.group_shape.col
             weight_scale_shape = weight_shape[0] // block_size
             self.weight_scale_inv = torch.rand(
-                (weight_scale_shape, weight_scale_shape),
-                dtype=torch.float32,
-                device=device,
+                (weight_scale_shape, weight_scale_shape), dtype=torch.float32
             )
-            self.weight = torch.rand(weight_shape, device=device).to(dtype=FP8_DTYPE)
+            self.weight = torch.rand(weight_shape).to(dtype=FP8_DTYPE)
             self.input_scale = None
+            self.weight_scale = None
             self.weight_block_size = [block_size, block_size]
             if transpose_weights:
                 self.weight = self.weight.t()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1099,6 +1099,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.environ.get("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "0").strip().lower()
         in ("1", "true")
     ),
+    # If set, forces FP8 Marlin to be used for FP8 quantization regardless
+    # of the hardware support for FP8 compute.
+    "VLLM_TEST_FORCE_FP8_MARLIN": lambda: (
+        os.environ.get("VLLM_TEST_FORCE_FP8_MARLIN", "0").strip().lower()
+        in ("1", "true")
+    ),
     "VLLM_TEST_FORCE_LOAD_FORMAT": lambda: os.getenv(
         "VLLM_TEST_FORCE_LOAD_FORMAT", "dummy"
     ),

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -394,12 +394,12 @@ _POSSIBLE_INT8_KERNELS: dict[PlatformEnum, list[type[Int8ScaledMMLinearKernel]]]
 # in priority/performance order (when available)
 _POSSIBLE_FP8_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]]] = {
     PlatformEnum.CUDA: [
+        MarlinFP8ScaledMMLinearKernel,
         FlashInferFP8ScaledMMLinearKernel,
         CutlassFP8ScaledMMLinearKernel,
         B12xTensorFP8ScaledMMLinearKernel,
         PerTensorTorchFP8ScaledMMLinearKernel,
         ChannelWiseTorchFP8ScaledMMLinearKernel,
-        MarlinFP8ScaledMMLinearKernel,
         HummingFP8ScaledMMLinearKernel,
     ],
     PlatformEnum.ROCM: [
@@ -434,8 +434,8 @@ _POSSIBLE_FP8_BLOCK_KERNELS: dict[
         CutlassFp8BlockScaledMMKernel,
         B12xFp8BlockScaledMMKernel,
         MarlinFP8ScaledMMLinearKernel,
-        HummingFP8ScaledMMLinearKernel,
         TritonFp8BlockScaledMMKernel,
+        HummingFP8ScaledMMLinearKernel,
         BlockWiseTorchFP8ScaledMMLinearKernel,
     ],
     PlatformEnum.ROCM: [

--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -43,6 +43,18 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             return False, "FP8 Marlin requires compute capability 7.5 or higher"
         if envs.VLLM_BATCH_INVARIANT:
             return False, "FP8 Marlin not supported for batch invariant execution."
+        if (
+            compute_capability is not None
+            and compute_capability >= 89
+            and not envs.VLLM_TEST_FORCE_FP8_MARLIN
+        ):
+            return (
+                False,
+                (
+                    "To apply FP8 Marlin on high-capability GPUs, please set "
+                    "VLLM_TEST_FORCE_FP8_MARLIN=1"
+                ),
+            )
         return True, None
 
     @classmethod

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -370,6 +370,13 @@ def select_fp8_moe_backend(
                 backend, config, weight_key, activation_key, activation_format
             )
 
+    # Handle explicit MARLIN FP8 configuration.
+    if envs.VLLM_TEST_FORCE_FP8_MARLIN:
+        backend = Fp8MoeBackend.MARLIN
+        return _return_or_raise(
+            backend, config, weight_key, activation_key, activation_format
+        )
+
     # Handle explicit AITER FP8 configuration.
     if envs.is_set("VLLM_ROCM_USE_AITER") or envs.is_set("VLLM_ROCM_USE_AITER_MOE"):
         skip_aiter_moe = (

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 import torch
 
+import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
@@ -268,6 +269,12 @@ def select_nvfp4_moe_backend(
             )
         return _return_or_raise(
             requested_backend, config, weight_key, activation_key, activation_format
+        )
+
+    if envs.VLLM_TEST_FORCE_FP8_MARLIN:
+        backend = NvFp4MoeBackend.MARLIN
+        return _return_or_raise(
+            backend, config, weight_key, activation_key, activation_format
         )
 
     # Select kernels in order of backend.


### PR DESCRIPTION
## Summary

Reverts #52182 (`bca7bea2405127bd5291bb6fffa679bdcd8f6dd9`) in full, with only a parenthesized diagnostic string to satisfy the current Ruff rule set.

## Why

Nightly [Buildkite #84555](https://buildkite.com/vllm/ci/builds/84555) failed `MoE Refactor Integration TEMPORARY` on the H100 configuration `Qwen3-30B-A3B-Fp8-CT-Block-marlin`.

Both tensor-parallel workers crash during model loading because the forced Marlin linear backend accesses `QKVParallelLinear.weight_scale_inv`, while this projection exposes `weight_scale`.

The previous nightly [#84376](https://buildkite.com/vllm/ci/builds/84376) passed this exact H100 job. The only intervening commit that changed both the failing model-eval config and `scaled_mm/marlin.py` was #52182. It replaced the test-only `VLLM_TEST_FORCE_FP8_MARLIN=1` path with global `--linear-backend marlin --moe-backend marlin`, which forces the incompatible Marlin linear path onto the QKV projection.

## PR CI coverage

[PR #52182 exact-head Buildkite #84229](https://buildkite.com/vllm/ci/builds/84229) passed overall, but `MoE Refactor Integration Test (H100 - TEMPORARY)` was blocked. The exact failing test did not run before merge.

## Validation

- `uvx ruff check` on all changed Python files: passed
- `git diff --cached --check` before commit: passed
- [Exact H100 MoE Refactor targeted Buildkite #84570](https://buildkite.com/vllm/ci/builds/84570): passed at exact head `fe30af71ea2a5fcc1e03dab6b3c3495ed10e26f0`
  - The formerly failing `Qwen3-30B-A3B-Fp8-CT-Block-marlin` configuration passed.
  - The complete selected GSM8K inventory passed: 12 passed / 0 failed in 47m14s.

## Model evaluation

No separate local model evaluation was run. Targeted #84570 ran the exact H100 GSM8K integration inventory at the PR head and passed all 12 configurations, including the regression case.

## Duplicate-work check

Searched open issues and pull requests for `weight_scale_inv QKVParallelLinear marlin`, `#52182`, and Marlin backend regressions. No open duplicate fix or revert was found. Issue #42803 concerns a separate MiMoV2 fused-QKV checkpoint sharding bug and does not address this backend-selection failure.

AI assistance was used to investigate CI logs, identify the regression boundary, prepare the rollback, and draft this description. The submitter reviewed the changed scope and owns the result.