### PR TITLE
[Bugfix] Pad sub-block FP8 tensor-parallel shards

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -95,7 +95,7 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             weight=layer.weight,
             weight_scale=weight_scale,
             workspace=layer.workspace,
-            size_n=layer.output_size_per_partition,
+            size_n=self.config.weight_shape[0],
             size_k=x.shape[-1],
             input_dtype=self.marlin_input_dtype,
             bias=bias,

--- a/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/marlin.py
@@ -96,7 +96,7 @@ class MarlinFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             weight_scale=weight_scale,
             workspace=layer.workspace,
             size_n=layer.output_size_per_partition,
-            size_k=layer.input_size_per_partition,
+            size_k=x.shape[-1],
             input_dtype=self.marlin_input_dtype,
             bias=bias,
         )

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -335,6 +335,7 @@ class RoutedExperts(PluggableLayer):
         shard_id: str,
         loaded_weight: torch.Tensor,
         tp_rank: int,
+        is_block_scale: bool = False,
     ):
         """
         Load grouped weight scales for group quantization or model weights
@@ -352,6 +353,7 @@ class RoutedExperts(PluggableLayer):
                 loaded_weight=loaded_weight,
                 expert_data=expert_data,
                 tp_rank=tp_rank,
+                is_block_scale=is_block_scale,
             )
         elif shard_id in ("w1", "w3"):
             self._load_w13(
@@ -360,6 +362,7 @@ class RoutedExperts(PluggableLayer):
                 loaded_weight=loaded_weight,
                 expert_data=expert_data,
                 tp_rank=tp_rank,
+                is_block_scale=is_block_scale,
             )
 
     def _load_per_channel_weight_scale(
@@ -464,6 +467,7 @@ class RoutedExperts(PluggableLayer):
         loaded_weight: torch.Tensor,
         tp_rank: int,
         load_full: bool = False,
+        is_block_scale: bool = False,
     ):
         # Index the loaded weight for tp sharding.
         # gate_up_proj: "MergedColumnParallel", so tp sharding on output_dim
@@ -479,9 +483,21 @@ class RoutedExperts(PluggableLayer):
             # size.  Compute the offset into the checkpoint weight using
             # the *unpadded* per-rank size so that every TP rank lands at
             # the correct slice.
-            tp_size = self.moe_config.moe_parallel_config.tp_size
-            loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
-            start_offset = loaded_per_rank * tp_rank
+            if is_block_scale:
+                block_sizes = self.weight_block_size
+                assert block_sizes is not None
+                block_size = block_sizes[0]
+                logical_size = self.moe_config.intermediate_size_per_partition_unpadded
+                assert logical_size is not None
+                start = tp_rank * logical_size
+                start_offset = start // block_size
+                loaded_per_rank = (
+                    start + logical_size + block_size - 1
+                ) // block_size - start_offset
+            else:
+                tp_size = self.moe_config.moe_parallel_config.tp_size
+                loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
+                start_offset = loaded_per_rank * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
                 # If there is no available weight to load for this TP rank
@@ -513,15 +529,28 @@ class RoutedExperts(PluggableLayer):
         shard_dim: int,
         loaded_weight: torch.Tensor,
         tp_rank: int,
+        is_block_scale: bool = False,
     ):
         # Index the loaded weight for tp sharding.
         # down_proj: "RowParallel" so tp sharding on input_dim
         # Only narrow if the loaded_weight is not a scalar (0-dim tensor).
         if loaded_weight.ndim > 0:
             # Same padding fix as _load_w13: use unpadded per-rank size.
-            tp_size = self.moe_config.moe_parallel_config.tp_size
-            loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
-            start_offset = loaded_per_rank * tp_rank
+            if is_block_scale:
+                block_sizes = self.weight_block_size
+                assert block_sizes is not None
+                block_size = block_sizes[1]
+                logical_size = self.moe_config.intermediate_size_per_partition_unpadded
+                assert logical_size is not None
+                start = tp_rank * logical_size
+                start_offset = start // block_size
+                loaded_per_rank = (
+                    start + logical_size + block_size - 1
+                ) // block_size - start_offset
+            else:
+                tp_size = self.moe_config.moe_parallel_config.tp_size
+                loaded_per_rank = loaded_weight.shape[shard_dim] // tp_size
+                start_offset = loaded_per_rank * tp_rank
             available = loaded_weight.shape[shard_dim] - start_offset
             if available <= 0:
                 # If there is no available weight to load for this TP rank
@@ -801,6 +830,8 @@ class RoutedExperts(PluggableLayer):
                     loaded_weight=loaded_weight,
                     expert_data=expert_data,
                     tp_rank=self.moe_config.tp_rank,
+                    is_block_scale=quant_method
+                    == FusedMoeWeightScaleSupported.BLOCK.value,
                 )
             elif quant_method == FusedMoeWeightScaleSupported.TENSOR.value:
                 self._load_per_tensor_weight_scale(

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -830,8 +830,12 @@ class RoutedExperts(PluggableLayer):
                     loaded_weight=loaded_weight,
                     expert_data=expert_data,
                     tp_rank=self.moe_config.tp_rank,
-                    is_block_scale=quant_method
-                    == FusedMoeWeightScaleSupported.BLOCK.value,
+                    is_block_scale=(
+                        quant_method == FusedMoeWeightScaleSupported.BLOCK.value
+                        and getattr(self, "weight_block_size", None) is not None
+                        and self.moe_config.intermediate_size_per_partition
+                        != self.moe_config.intermediate_size_per_partition_unpadded
+                    ),
                 )
             elif quant_method == FusedMoeWeightScaleSupported.TENSOR.value:
                 self._load_per_tensor_weight_scale(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -73,6 +74,7 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.model_executor.parameter import (
     BlockQuantScaleParameter,
+    ModelWeightParameter,
     PerTensorScaleParameter,
 )
 from vllm.model_executor.utils import (
@@ -84,6 +86,7 @@ from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
     is_deep_gemm_supported,
 )
+from vllm.utils.math_utils import round_up
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -240,6 +243,99 @@ class Fp8Config(QuantizationConfig):
         return cache_scale_mapper | QuantizationConfig.get_cache_scale_mapper()
 
 
+class _Fp8SubBlockWeightParameter(ModelWeightParameter):
+    """FP8 weight whose TP shard occupies part of a quantization block."""
+
+    def __init__(
+        self,
+        *,
+        logical_input_size: int,
+        logical_output_sizes: list[int],
+        padded_output_sizes: list[int],
+        **kwargs,
+    ):
+        self.logical_input_size = logical_input_size
+        self.logical_output_sizes = logical_output_sizes
+        self.padded_output_sizes = padded_output_sizes
+        super().__init__(**kwargs)
+
+    def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
+        dst = self.data.narrow(self.input_dim, 0, self.logical_input_size)
+        dst.copy_(
+            loaded_weight.narrow(
+                self.input_dim,
+                self.tp_rank * self.logical_input_size,
+                self.logical_input_size,
+            )
+        )
+
+    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
+        logical_size = self.logical_output_sizes[0]
+        dst = self.data.narrow(self.output_dim, 0, logical_size)
+        dst.copy_(
+            loaded_weight.narrow(
+                self.output_dim, self.tp_rank * logical_size, logical_size
+            )
+        )
+
+    def load_merged_column_weight(self, loaded_weight: torch.Tensor, **kwargs):
+        shard_id = self._shard_id_as_int(kwargs["shard_id"])
+        logical_size = self.logical_output_sizes[shard_id]
+        dst_offset = sum(self.padded_output_sizes[:shard_id])
+        dst = self.data.narrow(self.output_dim, dst_offset, logical_size)
+        dst.copy_(
+            loaded_weight.narrow(
+                self.output_dim, self.tp_rank * logical_size, logical_size
+            )
+        )
+
+
+class _Fp8SubBlockScaleParameter(BlockQuantScaleParameter):
+    """Block scale shared by TP shards that split one checkpoint block."""
+
+    def __init__(
+        self,
+        *,
+        logical_input_size: int,
+        logical_output_sizes: list[int],
+        padded_output_sizes: list[int],
+        block_n: int,
+        block_k: int,
+        **kwargs,
+    ):
+        self.logical_input_size = logical_input_size
+        self.logical_output_sizes = logical_output_sizes
+        self.padded_output_sizes = padded_output_sizes
+        self.block_n = block_n
+        self.block_k = block_k
+        super().__init__(**kwargs)
+
+    def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
+        src_offset = self.tp_rank * self.logical_input_size // self.block_k
+        self.data.copy_(
+            loaded_weight.narrow(self.input_dim, src_offset, self.data.shape[1])
+        )
+
+    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
+        logical_size = self.logical_output_sizes[0]
+        src_offset = self.tp_rank * logical_size // self.block_n
+        self.data.copy_(
+            loaded_weight.narrow(self.output_dim, src_offset, self.data.shape[0])
+        )
+
+    def load_merged_column_weight(self, loaded_weight: torch.Tensor, **kwargs):
+        shard_id = self._shard_id_as_int(kwargs["shard_id"])
+        logical_size = self.logical_output_sizes[shard_id]
+        dst_offset = sum(
+            size // self.block_n for size in self.padded_output_sizes[:shard_id]
+        )
+        dst_size = self.padded_output_sizes[shard_id] // self.block_n
+        src_offset = self.tp_rank * logical_size // self.block_n
+        self.data.narrow(self.output_dim, dst_offset, dst_size).copy_(
+            loaded_weight.narrow(self.output_dim, src_offset, dst_size)
+        )
+
+
 class Fp8LinearMethod(LinearMethodBase):
     """Linear method for FP8.
     Supports loading FP8 checkpoints with static weight scale and
@@ -306,29 +402,73 @@ class Fp8LinearMethod(LinearMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
-        output_size_per_partition = sum(output_partition_sizes)
+        logical_input_size = input_size_per_partition
+        logical_output_sizes = output_partition_sizes
+        padded_input_size = logical_input_size
+        padded_output_sizes = logical_output_sizes
         weight_loader = extra_weight_attrs.get("weight_loader")
-        layer.logical_widths = output_partition_sizes
-        layer.input_size_per_partition = input_size_per_partition
-        layer.output_size_per_partition = output_size_per_partition
+        layer.logical_widths = logical_output_sizes
+        layer.input_size_per_partition = logical_input_size
+        layer.output_size_per_partition = sum(logical_output_sizes)
         layer.orig_dtype = params_dtype
         layer.weight_block_size = None
+        layer.fp8_sub_block_input_size = logical_input_size
+        layer.fp8_sub_block_output_sizes = logical_output_sizes
 
         if self.block_quant:
             assert self.weight_block_size is not None
             layer.weight_block_size = self.weight_block_size
+            block_n, block_k = self.weight_block_size
+            tp_size = getattr(layer, "tp_size", get_tensor_model_parallel_world_size())
+            is_row_parallel = tp_size > 1 and input_size == logical_input_size * tp_size
+            is_column_parallel = (
+                tp_size > 1 and output_size == sum(logical_output_sizes) * tp_size
+            )
+            if (
+                is_row_parallel
+                and logical_input_size < block_k
+                and block_k % logical_input_size == 0
+            ):
+                padded_input_size = block_k
+            if is_column_parallel:
+                padded_output_sizes = [
+                    block_n if size < block_n and block_n % size == 0 else size
+                    for size in logical_output_sizes
+                ]
             validate_fp8_block_shape(
                 layer,
                 input_size,
                 output_size,
-                input_size_per_partition,
-                output_partition_sizes,
+                padded_input_size,
+                padded_output_sizes,
                 self.weight_block_size,
             )
 
-        weight = create_fp8_weight_parameter(
-            output_size_per_partition, input_size_per_partition, weight_loader
+        use_sub_block_shard = (
+            padded_input_size != logical_input_size
+            or padded_output_sizes != logical_output_sizes
         )
+        layer.fp8_sub_block_input_size_padded = padded_input_size
+        layer.fp8_sub_block_output_sizes_padded = padded_output_sizes
+
+        if use_sub_block_shard:
+            weight = _Fp8SubBlockWeightParameter(
+                data=torch.zeros(
+                    sum(padded_output_sizes),
+                    padded_input_size,
+                    dtype=torch.float8_e4m3fn,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+                logical_input_size=logical_input_size,
+                logical_output_sizes=logical_output_sizes,
+                padded_output_sizes=padded_output_sizes,
+            )
+        else:
+            weight = create_fp8_weight_parameter(
+                sum(padded_output_sizes), padded_input_size, weight_loader
+            )
         layer.register_parameter("weight", weight)
 
         # WEIGHT SCALE
@@ -344,14 +484,38 @@ class Fp8LinearMethod(LinearMethodBase):
         else:
             assert not self.act_q_static
             assert self.weight_block_size is not None
-            scale = create_fp8_scale_parameter(
-                BlockQuantScaleParameter,
-                output_partition_sizes,
-                input_size_per_partition,
-                self.weight_block_size,
-                weight_loader,
-                scale_dtype=(torch.float8_e8m0fnu if self.is_scale_e8m0 else None),
-            )
+            if use_sub_block_shard:
+                block_n, block_k = self.weight_block_size
+                scale_dtype = (
+                    torch.float8_e8m0fnu if self.is_scale_e8m0 else torch.float32
+                )
+                scale = _Fp8SubBlockScaleParameter(
+                    data=torch.empty(
+                        (sum(padded_output_sizes) + block_n - 1) // block_n,
+                        (padded_input_size + block_k - 1) // block_k,
+                        dtype=scale_dtype,
+                    ),
+                    input_dim=1,
+                    output_dim=0,
+                    weight_loader=weight_loader,
+                    logical_input_size=logical_input_size,
+                    logical_output_sizes=logical_output_sizes,
+                    padded_output_sizes=padded_output_sizes,
+                    block_n=block_n,
+                    block_k=block_k,
+                )
+                if scale_dtype == torch.float32:
+                    scale[:] = torch.finfo(torch.float32).min
+                set_weight_attrs(scale, {"scale_type": "weight_scale"})
+            else:
+                scale = create_fp8_scale_parameter(
+                    BlockQuantScaleParameter,
+                    padded_output_sizes,
+                    padded_input_size,
+                    self.weight_block_size,
+                    weight_loader,
+                    scale_dtype=(torch.float8_e8m0fnu if self.is_scale_e8m0 else None),
+                )
             # The weight_scale_inv name is intentional for deepseekv3
             layer.register_parameter("weight_scale_inv", scale)
 
@@ -371,6 +535,10 @@ class Fp8LinearMethod(LinearMethodBase):
         )
 
         self.use_marlin = isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel)
+        if self.use_marlin and use_sub_block_shard:
+            # Marlin repack and apply read these as the packed dimensions.
+            layer.input_size_per_partition = padded_input_size
+            layer.output_size_per_partition = sum(padded_output_sizes)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if is_weights_pre_processed():
@@ -439,15 +607,55 @@ class Fp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        logical_input_size = getattr(layer, "fp8_sub_block_input_size", x.shape[-1])
+        padded_input_size = getattr(
+            layer, "fp8_sub_block_input_size_padded", logical_input_size
+        )
+        logical_output_sizes = getattr(
+            layer, "fp8_sub_block_output_sizes", layer.logical_widths
+        )
+        padded_output_sizes = getattr(
+            layer, "fp8_sub_block_output_sizes_padded", logical_output_sizes
+        )
+        if padded_input_size != logical_input_size:
+            x = torch.nn.functional.pad(x, (0, padded_input_size - logical_input_size))
+        if bias is not None and padded_output_sizes != logical_output_sizes:
+            bias = torch.cat(
+                [
+                    torch.nn.functional.pad(part, (0, padded - logical))
+                    for part, logical, padded in zip(
+                        torch.split(bias, logical_output_sizes),
+                        logical_output_sizes,
+                        padded_output_sizes,
+                    )
+                ]
+            )
+
+        def unpad_output(output: torch.Tensor) -> torch.Tensor:
+            if padded_output_sizes == logical_output_sizes:
+                return output
+            return torch.cat(
+                [
+                    part[..., :logical]
+                    for part, logical in zip(
+                        torch.split(output, padded_output_sizes, dim=-1),
+                        logical_output_sizes,
+                    )
+                ],
+                dim=-1,
+            )
+
         # if batch invariant mode is enabled, prefer direct FP8 path
         # we will use BF16 dequant when direct FP8 is not supported.
         if envs.VLLM_BATCH_INVARIANT:
             if self.block_quant:
                 assert self.weight_block_size is not None
-                return self.fp8_linear.apply_weights(
-                    layer,
-                    x,
-                    bias,
+                return unpad_output(
+                    self.fp8_linear.apply_weights(
+                        layer,
+                        x,
+                        bias,
+                    )
                 )
             else:
                 if isinstance(self.fp8_linear, CutlassFP8ScaledMMLinearKernel):
@@ -476,7 +684,7 @@ class Fp8LinearMethod(LinearMethodBase):
                         weight_bf16 = weight_fp8 * weight_scale
                 return torch.nn.functional.linear(x, weight_bf16.t(), bias)
 
-        return self.fp8_linear.apply_weights(layer, x, bias)
+        return unpad_output(self.fp8_linear.apply_weights(layer, x, bias))
 
 
 class Fp8MoEMethod(FusedMoEMethodBase):
@@ -555,6 +763,27 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             allow_vllm_cutlass=False,
         )
 
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size,
+            intermediate_size_per_partition,
+            act_dtype,
+            moe_parallel_config,
+        )
+        if self.block_quant:
+            assert self.weight_block_size is not None
+            alignment = math.lcm(*self.weight_block_size)
+            intermediate_size_per_partition = round_up(
+                intermediate_size_per_partition, alignment
+            )
+        return hidden_size, intermediate_size_per_partition
+
     def create_weights(
         self,
         layer: RoutedExperts,
@@ -596,7 +825,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         # WEIGHTS
         w13_weight = torch.nn.Parameter(
-            torch.empty(
+            torch.zeros(
                 num_experts,
                 self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
@@ -608,7 +837,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = torch.nn.Parameter(
-            torch.empty(
+            torch.zeros(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -250,9 +250,13 @@ class _Fp8SubBlockWeightParameter(ModelWeightParameter):
         self,
         *,
         logical_input_size: int,
+        logical_output_sizes: list[int],
+        padded_output_sizes: list[int],
         **kwargs,
     ):
         self.logical_input_size = logical_input_size
+        self.logical_output_sizes = logical_output_sizes
+        self.padded_output_sizes = padded_output_sizes
         super().__init__(**kwargs)
 
     def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
@@ -265,6 +269,28 @@ class _Fp8SubBlockWeightParameter(ModelWeightParameter):
             )
         )
 
+    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
+        if self.padded_output_sizes == self.logical_output_sizes:
+            return super().load_column_parallel_weight(loaded_weight)
+        logical_size = self.logical_output_sizes[0]
+        self.data.narrow(self.output_dim, 0, logical_size).copy_(
+            loaded_weight.narrow(
+                self.output_dim, self.tp_rank * logical_size, logical_size
+            )
+        )
+
+    def load_merged_column_weight(self, loaded_weight: torch.Tensor, **kwargs):
+        if self.padded_output_sizes == self.logical_output_sizes:
+            return super().load_merged_column_weight(loaded_weight, **kwargs)
+        shard_id = self._shard_id_as_int(kwargs["shard_id"])
+        logical_size = self.logical_output_sizes[shard_id]
+        dst_offset = sum(self.padded_output_sizes[:shard_id])
+        self.data.narrow(self.output_dim, dst_offset, logical_size).copy_(
+            loaded_weight.narrow(
+                self.output_dim, self.tp_rank * logical_size, logical_size
+            )
+        )
+
 
 class _Fp8SubBlockScaleParameter(BlockQuantScaleParameter):
     """Block scale shared by TP shards that split one checkpoint block."""
@@ -273,10 +299,16 @@ class _Fp8SubBlockScaleParameter(BlockQuantScaleParameter):
         self,
         *,
         logical_input_size: int,
+        logical_output_sizes: list[int],
+        padded_output_sizes: list[int],
+        block_n: int,
         block_k: int,
         **kwargs,
     ):
         self.logical_input_size = logical_input_size
+        self.logical_output_sizes = logical_output_sizes
+        self.padded_output_sizes = padded_output_sizes
+        self.block_n = block_n
         self.block_k = block_k
         super().__init__(**kwargs)
 
@@ -286,6 +318,31 @@ class _Fp8SubBlockScaleParameter(BlockQuantScaleParameter):
             loaded_weight.narrow(
                 self.input_dim, src_offset, self.data.shape[self.input_dim]
             )
+        )
+
+    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
+        if self.padded_output_sizes == self.logical_output_sizes:
+            return super().load_column_parallel_weight(loaded_weight)
+        logical_size = self.logical_output_sizes[0]
+        src_offset = self.tp_rank * logical_size // self.block_n
+        self.data.copy_(
+            loaded_weight.narrow(
+                self.output_dim, src_offset, self.data.shape[self.output_dim]
+            )
+        )
+
+    def load_merged_column_weight(self, loaded_weight: torch.Tensor, **kwargs):
+        if self.padded_output_sizes == self.logical_output_sizes:
+            return super().load_merged_column_weight(loaded_weight, **kwargs)
+        shard_id = self._shard_id_as_int(kwargs["shard_id"])
+        logical_size = self.logical_output_sizes[shard_id]
+        dst_offset = sum(
+            size // self.block_n for size in self.padded_output_sizes[:shard_id]
+        )
+        dst_size = self.padded_output_sizes[shard_id] // self.block_n
+        src_offset = self.tp_rank * logical_size // self.block_n
+        self.data.narrow(self.output_dim, dst_offset, dst_size).copy_(
+            loaded_weight.narrow(self.output_dim, src_offset, dst_size)
         )
 
 
@@ -356,11 +413,13 @@ class Fp8LinearMethod(LinearMethodBase):
         **extra_weight_attrs,
     ):
         logical_input_size = input_size_per_partition
+        logical_output_sizes = output_partition_sizes
         padded_input_size = logical_input_size
+        padded_output_sizes = logical_output_sizes
         weight_loader = extra_weight_attrs.get("weight_loader")
-        layer.logical_widths = output_partition_sizes
+        layer.logical_widths = logical_output_sizes
         layer.input_size_per_partition = logical_input_size
-        layer.output_size_per_partition = sum(output_partition_sizes)
+        layer.output_size_per_partition = sum(logical_output_sizes)
         layer.orig_dtype = params_dtype
         layer.weight_block_size = None
 
@@ -370,28 +429,48 @@ class Fp8LinearMethod(LinearMethodBase):
             block_n, block_k = self.weight_block_size
             tp_size = layer.tp_size
             is_row_parallel = tp_size > 1 and input_size == logical_input_size * tp_size
+            is_column_parallel = (
+                tp_size > 1 and output_size == sum(logical_output_sizes) * tp_size
+            )
             if (
                 is_row_parallel
                 and logical_input_size < block_k
                 and block_k % logical_input_size == 0
             ):
                 padded_input_size = block_k
+            if (
+                is_column_parallel
+                and not hasattr(layer, "num_kv_head_replicas")
+                and all(
+                    size % block_n == 0 or (size < block_n and block_n % size == 0)
+                    for size in logical_output_sizes
+                )
+            ):
+                padded_output_sizes = [
+                    block_n if size < block_n and block_n % size == 0 else size
+                    for size in logical_output_sizes
+                ]
             validate_fp8_block_shape(
                 layer,
                 input_size,
                 output_size,
                 padded_input_size,
-                output_partition_sizes,
+                padded_output_sizes,
                 self.weight_block_size,
             )
 
-        use_sub_block_shard = padded_input_size != logical_input_size
+        use_sub_block_shard = (
+            padded_input_size != logical_input_size
+            or padded_output_sizes != logical_output_sizes
+        )
         layer.fp8_sub_block_input_padding = padded_input_size - logical_input_size
+        self.logical_output_sizes = logical_output_sizes
+        self.padded_output_sizes = padded_output_sizes
 
         if use_sub_block_shard:
             weight = _Fp8SubBlockWeightParameter(
                 data=torch.zeros(
-                    sum(output_partition_sizes),
+                    sum(padded_output_sizes),
                     padded_input_size,
                     dtype=torch.float8_e4m3fn,
                 ),
@@ -399,10 +478,12 @@ class Fp8LinearMethod(LinearMethodBase):
                 output_dim=0,
                 weight_loader=weight_loader,
                 logical_input_size=logical_input_size,
+                logical_output_sizes=logical_output_sizes,
+                padded_output_sizes=padded_output_sizes,
             )
         else:
             weight = create_fp8_weight_parameter(
-                sum(output_partition_sizes), padded_input_size, weight_loader
+                sum(padded_output_sizes), padded_input_size, weight_loader
             )
         layer.register_parameter("weight", weight)
 
@@ -426,7 +507,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 )
                 scale = _Fp8SubBlockScaleParameter(
                     data=torch.empty(
-                        (sum(output_partition_sizes) + block_n - 1) // block_n,
+                        (sum(padded_output_sizes) + block_n - 1) // block_n,
                         (padded_input_size + block_k - 1) // block_k,
                         dtype=scale_dtype,
                     ),
@@ -434,6 +515,9 @@ class Fp8LinearMethod(LinearMethodBase):
                     output_dim=0,
                     weight_loader=weight_loader,
                     logical_input_size=logical_input_size,
+                    logical_output_sizes=logical_output_sizes,
+                    padded_output_sizes=padded_output_sizes,
+                    block_n=block_n,
                     block_k=block_k,
                 )
                 if scale_dtype == torch.float32:
@@ -442,7 +526,7 @@ class Fp8LinearMethod(LinearMethodBase):
             else:
                 scale = create_fp8_scale_parameter(
                     BlockQuantScaleParameter,
-                    output_partition_sizes,
+                    padded_output_sizes,
                     padded_input_size,
                     self.weight_block_size,
                     weight_loader,
@@ -483,6 +567,13 @@ class Fp8LinearMethod(LinearMethodBase):
             return
 
         if self.use_marlin:
+            if (
+                layer.bias is not None
+                and self.padded_output_sizes != self.logical_output_sizes
+            ):
+                raise NotImplementedError(
+                    "FP8 Marlin does not support biased output sub-block TP shards."
+                )
             if not self.block_quant:
                 # Canonicalize to (K, N) for the kernel.
                 replace_parameter(layer, "weight", layer.weight.t())
@@ -538,13 +629,25 @@ class Fp8LinearMethod(LinearMethodBase):
         input_padding = layer.fp8_sub_block_input_padding
         if input_padding:
             x = torch.nn.functional.pad(x, (0, input_padding))
+        output_padding = self.padded_output_sizes != self.logical_output_sizes
+        if bias is not None and output_padding and not self.use_marlin:
+            bias = torch.cat(
+                [
+                    torch.nn.functional.pad(part, (0, padded - logical))
+                    for part, logical, padded in zip(
+                        torch.split(bias, self.logical_output_sizes),
+                        self.logical_output_sizes,
+                        self.padded_output_sizes,
+                    )
+                ]
+            )
 
         # if batch invariant mode is enabled, prefer direct FP8 path
         # we will use BF16 dequant when direct FP8 is not supported.
         if envs.VLLM_BATCH_INVARIANT:
             if self.block_quant:
                 assert self.weight_block_size is not None
-                return self.fp8_linear.apply_weights(layer, x, bias)
+                output = self.fp8_linear.apply_weights(layer, x, bias)
             else:
                 if isinstance(self.fp8_linear, CutlassFP8ScaledMMLinearKernel):
                     return self.fp8_linear.apply_weights(layer, x, bias)
@@ -571,8 +674,21 @@ class Fp8LinearMethod(LinearMethodBase):
                         # Fallback
                         weight_bf16 = weight_fp8 * weight_scale
                 return torch.nn.functional.linear(x, weight_bf16.t(), bias)
+        else:
+            output = self.fp8_linear.apply_weights(layer, x, bias)
 
-        return self.fp8_linear.apply_weights(layer, x, bias)
+        if output_padding:
+            output = torch.cat(
+                [
+                    part[..., :logical]
+                    for part, logical in zip(
+                        torch.split(output, self.padded_output_sizes, dim=-1),
+                        self.logical_output_sizes,
+                    )
+                ],
+                dim=-1,
+            )
+        return output
 
 
 class Fp8MoEMethod(FusedMoEMethodBase):

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -467,9 +467,6 @@ class Fp8LinearMethod(LinearMethodBase):
         )
 
         self.use_marlin = isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel)
-        if self.use_marlin and use_sub_block_shard:
-            # Marlin repack and apply read this as the packed input dimension.
-            layer.input_size_per_partition = padded_input_size
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if is_weights_pre_processed():

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -250,13 +250,9 @@ class _Fp8SubBlockWeightParameter(ModelWeightParameter):
         self,
         *,
         logical_input_size: int,
-        logical_output_sizes: list[int],
-        padded_output_sizes: list[int],
         **kwargs,
     ):
         self.logical_input_size = logical_input_size
-        self.logical_output_sizes = logical_output_sizes
-        self.padded_output_sizes = padded_output_sizes
         super().__init__(**kwargs)
 
     def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
@@ -269,26 +265,6 @@ class _Fp8SubBlockWeightParameter(ModelWeightParameter):
             )
         )
 
-    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
-        logical_size = self.logical_output_sizes[0]
-        dst = self.data.narrow(self.output_dim, 0, logical_size)
-        dst.copy_(
-            loaded_weight.narrow(
-                self.output_dim, self.tp_rank * logical_size, logical_size
-            )
-        )
-
-    def load_merged_column_weight(self, loaded_weight: torch.Tensor, **kwargs):
-        shard_id = self._shard_id_as_int(kwargs["shard_id"])
-        logical_size = self.logical_output_sizes[shard_id]
-        dst_offset = sum(self.padded_output_sizes[:shard_id])
-        dst = self.data.narrow(self.output_dim, dst_offset, logical_size)
-        dst.copy_(
-            loaded_weight.narrow(
-                self.output_dim, self.tp_rank * logical_size, logical_size
-            )
-        )
-
 
 class _Fp8SubBlockScaleParameter(BlockQuantScaleParameter):
     """Block scale shared by TP shards that split one checkpoint block."""
@@ -297,42 +273,19 @@ class _Fp8SubBlockScaleParameter(BlockQuantScaleParameter):
         self,
         *,
         logical_input_size: int,
-        logical_output_sizes: list[int],
-        padded_output_sizes: list[int],
-        block_n: int,
         block_k: int,
         **kwargs,
     ):
         self.logical_input_size = logical_input_size
-        self.logical_output_sizes = logical_output_sizes
-        self.padded_output_sizes = padded_output_sizes
-        self.block_n = block_n
         self.block_k = block_k
         super().__init__(**kwargs)
 
     def load_row_parallel_weight(self, loaded_weight: torch.Tensor):
         src_offset = self.tp_rank * self.logical_input_size // self.block_k
         self.data.copy_(
-            loaded_weight.narrow(self.input_dim, src_offset, self.data.shape[1])
-        )
-
-    def load_column_parallel_weight(self, loaded_weight: torch.Tensor):
-        logical_size = self.logical_output_sizes[0]
-        src_offset = self.tp_rank * logical_size // self.block_n
-        self.data.copy_(
-            loaded_weight.narrow(self.output_dim, src_offset, self.data.shape[0])
-        )
-
-    def load_merged_column_weight(self, loaded_weight: torch.Tensor, **kwargs):
-        shard_id = self._shard_id_as_int(kwargs["shard_id"])
-        logical_size = self.logical_output_sizes[shard_id]
-        dst_offset = sum(
-            size // self.block_n for size in self.padded_output_sizes[:shard_id]
-        )
-        dst_size = self.padded_output_sizes[shard_id] // self.block_n
-        src_offset = self.tp_rank * logical_size // self.block_n
-        self.data.narrow(self.output_dim, dst_offset, dst_size).copy_(
-            loaded_weight.narrow(self.output_dim, src_offset, dst_size)
+            loaded_weight.narrow(
+                self.input_dim, src_offset, self.data.shape[self.input_dim]
+            )
         )
 
 
@@ -403,58 +356,42 @@ class Fp8LinearMethod(LinearMethodBase):
         **extra_weight_attrs,
     ):
         logical_input_size = input_size_per_partition
-        logical_output_sizes = output_partition_sizes
         padded_input_size = logical_input_size
-        padded_output_sizes = logical_output_sizes
         weight_loader = extra_weight_attrs.get("weight_loader")
-        layer.logical_widths = logical_output_sizes
+        layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = logical_input_size
-        layer.output_size_per_partition = sum(logical_output_sizes)
+        layer.output_size_per_partition = sum(output_partition_sizes)
         layer.orig_dtype = params_dtype
         layer.weight_block_size = None
-        layer.fp8_sub_block_input_size = logical_input_size
-        layer.fp8_sub_block_output_sizes = logical_output_sizes
 
         if self.block_quant:
             assert self.weight_block_size is not None
             layer.weight_block_size = self.weight_block_size
             block_n, block_k = self.weight_block_size
-            tp_size = getattr(layer, "tp_size", get_tensor_model_parallel_world_size())
+            tp_size = layer.tp_size
             is_row_parallel = tp_size > 1 and input_size == logical_input_size * tp_size
-            is_column_parallel = (
-                tp_size > 1 and output_size == sum(logical_output_sizes) * tp_size
-            )
             if (
                 is_row_parallel
                 and logical_input_size < block_k
                 and block_k % logical_input_size == 0
             ):
                 padded_input_size = block_k
-            if is_column_parallel:
-                padded_output_sizes = [
-                    block_n if size < block_n and block_n % size == 0 else size
-                    for size in logical_output_sizes
-                ]
             validate_fp8_block_shape(
                 layer,
                 input_size,
                 output_size,
                 padded_input_size,
-                padded_output_sizes,
+                output_partition_sizes,
                 self.weight_block_size,
             )
 
-        use_sub_block_shard = (
-            padded_input_size != logical_input_size
-            or padded_output_sizes != logical_output_sizes
-        )
-        layer.fp8_sub_block_input_size_padded = padded_input_size
-        layer.fp8_sub_block_output_sizes_padded = padded_output_sizes
+        use_sub_block_shard = padded_input_size != logical_input_size
+        layer.fp8_sub_block_input_padding = padded_input_size - logical_input_size
 
         if use_sub_block_shard:
             weight = _Fp8SubBlockWeightParameter(
                 data=torch.zeros(
-                    sum(padded_output_sizes),
+                    sum(output_partition_sizes),
                     padded_input_size,
                     dtype=torch.float8_e4m3fn,
                 ),
@@ -462,12 +399,10 @@ class Fp8LinearMethod(LinearMethodBase):
                 output_dim=0,
                 weight_loader=weight_loader,
                 logical_input_size=logical_input_size,
-                logical_output_sizes=logical_output_sizes,
-                padded_output_sizes=padded_output_sizes,
             )
         else:
             weight = create_fp8_weight_parameter(
-                sum(padded_output_sizes), padded_input_size, weight_loader
+                sum(output_partition_sizes), padded_input_size, weight_loader
             )
         layer.register_parameter("weight", weight)
 
@@ -491,7 +426,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 )
                 scale = _Fp8SubBlockScaleParameter(
                     data=torch.empty(
-                        (sum(padded_output_sizes) + block_n - 1) // block_n,
+                        (sum(output_partition_sizes) + block_n - 1) // block_n,
                         (padded_input_size + block_k - 1) // block_k,
                         dtype=scale_dtype,
                     ),
@@ -499,9 +434,6 @@ class Fp8LinearMethod(LinearMethodBase):
                     output_dim=0,
                     weight_loader=weight_loader,
                     logical_input_size=logical_input_size,
-                    logical_output_sizes=logical_output_sizes,
-                    padded_output_sizes=padded_output_sizes,
-                    block_n=block_n,
                     block_k=block_k,
                 )
                 if scale_dtype == torch.float32:
@@ -510,7 +442,7 @@ class Fp8LinearMethod(LinearMethodBase):
             else:
                 scale = create_fp8_scale_parameter(
                     BlockQuantScaleParameter,
-                    padded_output_sizes,
+                    output_partition_sizes,
                     padded_input_size,
                     self.weight_block_size,
                     weight_loader,
@@ -536,9 +468,8 @@ class Fp8LinearMethod(LinearMethodBase):
 
         self.use_marlin = isinstance(self.fp8_linear, MarlinFP8ScaledMMLinearKernel)
         if self.use_marlin and use_sub_block_shard:
-            # Marlin repack and apply read these as the packed dimensions.
+            # Marlin repack and apply read this as the packed input dimension.
             layer.input_size_per_partition = padded_input_size
-            layer.output_size_per_partition = sum(padded_output_sizes)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if is_weights_pre_processed():
@@ -607,56 +538,16 @@ class Fp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        logical_input_size = getattr(layer, "fp8_sub_block_input_size", x.shape[-1])
-        padded_input_size = getattr(
-            layer, "fp8_sub_block_input_size_padded", logical_input_size
-        )
-        logical_output_sizes = getattr(
-            layer, "fp8_sub_block_output_sizes", layer.logical_widths
-        )
-        padded_output_sizes = getattr(
-            layer, "fp8_sub_block_output_sizes_padded", logical_output_sizes
-        )
-        if padded_input_size != logical_input_size:
-            x = torch.nn.functional.pad(x, (0, padded_input_size - logical_input_size))
-        if bias is not None and padded_output_sizes != logical_output_sizes:
-            bias = torch.cat(
-                [
-                    torch.nn.functional.pad(part, (0, padded - logical))
-                    for part, logical, padded in zip(
-                        torch.split(bias, logical_output_sizes),
-                        logical_output_sizes,
-                        padded_output_sizes,
-                    )
-                ]
-            )
-
-        def unpad_output(output: torch.Tensor) -> torch.Tensor:
-            if padded_output_sizes == logical_output_sizes:
-                return output
-            return torch.cat(
-                [
-                    part[..., :logical]
-                    for part, logical in zip(
-                        torch.split(output, padded_output_sizes, dim=-1),
-                        logical_output_sizes,
-                    )
-                ],
-                dim=-1,
-            )
+        input_padding = layer.fp8_sub_block_input_padding
+        if input_padding:
+            x = torch.nn.functional.pad(x, (0, input_padding))
 
         # if batch invariant mode is enabled, prefer direct FP8 path
         # we will use BF16 dequant when direct FP8 is not supported.
         if envs.VLLM_BATCH_INVARIANT:
             if self.block_quant:
                 assert self.weight_block_size is not None
-                return unpad_output(
-                    self.fp8_linear.apply_weights(
-                        layer,
-                        x,
-                        bias,
-                    )
-                )
+                return self.fp8_linear.apply_weights(layer, x, bias)
             else:
                 if isinstance(self.fp8_linear, CutlassFP8ScaledMMLinearKernel):
                     return self.fp8_linear.apply_weights(layer, x, bias)
@@ -684,7 +575,7 @@ class Fp8LinearMethod(LinearMethodBase):
                         weight_bf16 = weight_fp8 * weight_scale
                 return torch.nn.functional.linear(x, weight_bf16.t(), bias)
 
-        return unpad_output(self.fp8_linear.apply_weights(layer, x, bias))
+        return self.fp8_linear.apply_weights(layer, x, bias)
 
 
 class Fp8MoEMethod(FusedMoEMethodBase):
@@ -778,10 +669,18 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
         if self.block_quant:
             assert self.weight_block_size is not None
-            alignment = math.lcm(*self.weight_block_size)
-            intermediate_size_per_partition = round_up(
-                intermediate_size_per_partition, alignment
-            )
+            if all(
+                intermediate_size_per_partition % block_size == 0
+                or (
+                    intermediate_size_per_partition < block_size
+                    and block_size % intermediate_size_per_partition == 0
+                )
+                for block_size in self.weight_block_size
+            ):
+                alignment = math.lcm(*self.weight_block_size)
+                intermediate_size_per_partition = round_up(
+                    intermediate_size_per_partition, alignment
+                )
         return hidden_size, intermediate_size_per_partition
 
     def create_weights(
@@ -824,8 +723,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     block_n, block_k = moe_block_shape
 
         # WEIGHTS
+        weight_factory = (
+            torch.zeros
+            if intermediate_size_per_partition
+            != self.moe.intermediate_size_per_partition_unpadded
+            else torch.empty
+        )
         w13_weight = torch.nn.Parameter(
-            torch.zeros(
+            weight_factory(
                 num_experts,
                 self.moe.w13_num_shards * intermediate_size_per_partition,
                 hidden_size,
@@ -837,7 +742,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w2_weight = torch.nn.Parameter(
-            torch.zeros(
+            weight_factory(
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -117,7 +117,8 @@ def prepare_fp8_layer_for_marlin(
         raise RuntimeError("Marlin W8A8 is not supported.")
 
     part_size_n = layer.output_size_per_partition
-    part_size_k = layer.input_size_per_partition
+    # Weight storage can be wider than the logical row-parallel shard.
+    part_size_k = layer.weight.shape[0 if size_k_first else 1]
     weight_block_size = getattr(layer, "weight_block_size", None)
     group_size = -1 if weight_block_size is None else weight_block_size[1]
     padded_n, padded_k = marlin_padded_nk(part_size_n, part_size_k, group_size)

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -116,8 +116,7 @@ def prepare_fp8_layer_for_marlin(
     if input_dtype is not None and input_dtype.itemsize == 1:
         raise RuntimeError("Marlin W8A8 is not supported.")
 
-    part_size_n = layer.output_size_per_partition
-    # Weight storage can be wider than the logical row-parallel shard.
+    part_size_n = layer.weight.shape[1 if size_k_first else 0]
     part_size_k = layer.weight.shape[0 if size_k_first else 1]
     weight_block_size = getattr(layer, "weight_block_size", None)
     group_size = -1 if weight_block_size is None else weight_block_size[1]


### PR DESCRIPTION
## Purpose

Serving `Qwen/Qwen3.6-35B-A3B-FP8` on one H100 node with tensor
parallelism 8 fails during model initialization. Tensor parallelism produces a
rank-local shared-expert width of 64, while the checkpoint uses 128-element FP8
quantization blocks:

```text
ValueError: Weight input_size_per_partition = 64 is not divisible by
weight quantization block_k = 128.
```

Padding only the row-parallel K shard exposes the corresponding merged-column N
problem. With Marlin forced, weight loading advances to the scale loader and
then fails because it still uses the unpadded rank-local output layout:

```text
RuntimeError: start (4) + length (1) exceeds dimension size (4).
```

This change pads rank-local block-FP8 weight and scale shards on both dimensions
to the quantization-block boundary. It preserves logical checkpoint and output
dimensions while exposing padded physical dimensions to the linear kernel. It
also loads the correct scale tile when multiple tensor-parallel ranks share one
checkpoint scale block.

## Test Plan

Run on one H100 node with eight GPUs using automatic backend selection:

```bash
vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
  --served-model-name Qwen/Qwen3.6-35B-A3B-FP8 \
  --tensor-parallel-size 8 \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.9 \
  --block-size 128 \
  --max-num-seqs 1024 \
  --max-model-len 2200 \
  --max-num-batched-tokens 8192 \
  --no-enable-prefix-caching
```

Run the same model with the Marlin linear and MoE backends forced:

```bash
VLLM_TEST_FORCE_FP8_MARLIN=1 vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
  --served-model-name Qwen/Qwen3.6-35B-A3B-FP8 \
  --tensor-parallel-size 8 \
  --trust-remote-code \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.9 \
  --block-size 128 \
  --max-num-seqs 1024 \
  --max-model-len 2200 \
  --max-num-batched-tokens 8192 \
  --no-enable-prefix-caching \
  --linear-backend marlin \
  --moe-backend marlin
```

## Test Result

Before this change, the automatic command fails while constructing the shared
expert:

```text
File ".../vllm/model_executor/layers/linear.py", line 1613, in __init__
  self.quant_method.create_weights(
File ".../vllm/model_executor/layers/quantization/fp8.py", line 343, in
create_weights
  validate_fp8_block_shape(
File ".../vllm/model_executor/layers/quantization/utils/fp8_utils.py",
line 1224, in validate_fp8_block_shape
  raise ValueError(
ValueError: Weight input_size_per_partition = 64 is not divisible by
weight quantization block_k = 128.
```

With only K padding applied, the forced-Marlin command selects Marlin and then
fails in the merged-column scale loader:

```text
Selected MarlinFP8ScaledMMLinearKernel for Fp8LinearMethod
Using MARLIN Fp8 MoE backend
File ".../vllm/model_executor/layers/linear.py", line 938, in weight_loader_v2
  param.load_merged_column_weight(
File ".../vllm/model_executor/parameter.py", line 172, in
load_merged_column_weight
  loaded_weight = loaded_weight.narrow(
RuntimeError: start (4) + length (1) exceeds dimension size (4).
```

After the complete K-and-N change, automatic selection succeeds:

```text
Model loading took 8.24 GiB memory and 48.100638 seconds
Available KV cache memory: 58.65 GiB
GPU KV cache size: 6,034,914 tokens
Server is ready
```

It captured all required CUDA graphs and completed all nine workloads from
concurrency 1 through 256, including 768/768 successful requests at concurrency
256.

The forced-Marlin path also succeeds end to end:

```text
Selected MarlinFP8ScaledMMLinearKernel for Fp8LinearMethod
Using MARLIN Fp8 MoE backend
Loading weights took 15.72 seconds
Model loading took 8.38 GiB memory and 17.972281 seconds
torch.compile took 32.79 s in total
Available KV cache memory: 57.06 GiB
GPU KV cache size: 5,876,200 tokens
Graph capturing finished in 19 secs, took 1.01 GiB
Model is ready. Have 0 prefills and 1 decodes.
Server is healthy - starting benchmark
Benchmark completed successfully
```

It completed every workload from concurrency 1 through 64. The concurrency-64
run completed 192/192 requests with 177,076 input and 177,040 output tokens.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is required.
</details>
