### PR TITLE
[Core] Update PyTorch to 2.14.0 (torchvision 0.29.0, triton 3.8.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,8 @@ endif()
 # requirements.txt files and should be kept consistent.  The ROCm torch
 # versions are derived from docker/Dockerfile.rocm
 #
-set(TORCH_SUPPORTED_VERSION_CUDA "2.13.0")
-set(TORCH_SUPPORTED_VERSION_ROCM "2.13.0")
+set(TORCH_SUPPORTED_VERSION_CUDA "2.14.0")
+set(TORCH_SUPPORTED_VERSION_ROCM "2.14.0")
 # TORCH_NIGHTLY=1 builds run against unpinned nightly wheels, so the supported-
 # version check would always warn. Only treat it as a nightly build when the
 # value is exactly "1" (the bootstrap exports TORCH_NIGHTLY=0 by default, which

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "setuptools>=77.0.3,<81.0.0",
     "setuptools-scm>=8.0",
     "setuptools-rust>=1.9.0",
-    "torch == 2.13.0",
+    "torch == 2.14.0",
     "wheel",
     "jinja2",
 ]

--- a/requirements/build/cpu.txt
+++ b/requirements/build/cpu.txt
@@ -4,8 +4,8 @@ packaging>=24.2
 setuptools==77.0.3 # this version can reuse CMake build dir
 setuptools-scm>=8
 setuptools-rust>=1.9.0
-torch==2.13.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x" or platform_machine == "aarch64"
-torch==2.13.0; platform_system == "Darwin" or platform_machine == "ppc64le"  or platform_machine == "riscv64"
+torch==2.14.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x" or platform_machine == "aarch64"
+torch==2.14.0; platform_system == "Darwin" or platform_machine == "ppc64le"  or platform_machine == "riscv64"
 wheel
 jinja2>=3.1.6
 regex

--- a/requirements/build/cuda.txt
+++ b/requirements/build/cuda.txt
@@ -5,7 +5,7 @@ packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
 setuptools-rust>=1.9.0
-torch==2.13.0
+torch==2.14.0
 wheel
 jinja2>=3.1.6
 regex

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -6,8 +6,8 @@ setuptools==77.0.3 # this version can reuse CMake build dir
 numba == 0.65.0; platform_machine != "s390x" # Required for N-gram speculative decoding
 
 # Dependencies for CPUs
-torch==2.13.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x" or platform_machine == "aarch64"
-torch==2.13.0; platform_system == "Darwin" or platform_machine == "ppc64le" or platform_machine == "riscv64"
+torch==2.14.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x" or platform_machine == "aarch64"
+torch==2.14.0; platform_system == "Darwin" or platform_machine == "ppc64le" or platform_machine == "riscv64"
 
 # required for the image processor of minicpm-o-2_6, this must be updated alongside torch
 torchaudio; platform_machine != "s390x" and platform_machine != "riscv64"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -4,10 +4,10 @@
 numba == 0.65.0 # Required for N-gram speculative decoding
 
 # Dependencies for NVIDIA GPUs
-torch==2.13.0
-torchaudio==2.11.0
+torch==2.14.0
+torchaudio==2.12.0
 # These must be updated alongside torch
-torchvision==0.28.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+torchvision==0.29.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 torchcodec >= 0.14
 PyNvVideoCodec==2.0.4
 # FlashInfer should be updated together with the Dockerfile

--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -28,9 +28,9 @@ soundfile # required for audio tests
 jiwer # required for audio tests
 tblib # for pickling test exceptions
 timm >=1.0.17 # required for internvl and gemma3n-mm test
-torch==2.13.0
-torchaudio==2.11.0
-torchvision==0.28.0
+torch==2.14.0
+torchaudio==2.12.0
+torchvision==0.29.0
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
 mistral_common[image,audio] >= 1.11.6 # required for voxtral test

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r common.txt
 --extra-index-url=https://wheels.vllm.ai/xpu/
-triton==3.7.2+xpu
+triton==3.8.0+xpu
 
 ray>=2.9
 cmake>=3.26.1
@@ -14,7 +14,7 @@ jinja2>=3.1.6
 datasets # for benchmark scripts
 numba == 0.65.0 # Required for N-gram speculative decoding
 --extra-index-url=https://download.pytorch.org/whl/xpu
-torch==2.13.0
+torch==2.14.0
 torchaudio
 torchvision
 torchcodec >= 0.14 # Required for the torchcodec video decoding backend


### PR DESCRIPTION
Move the CUDA/CPU/XPU torch stack from 2.13.0 to 2.14.0 to pick up the stable-ABI `StableIValue -> std::string` host-memory-leak fix (pytorch/pytorch#190493). That fix only exists in the torch 2.14 line and was never backported to 2.13 (no v2.13.1; release/2.13 stopped at the 2.13.0 GA cut), so a torch patch bump cannot resolve it. Refs #52089, #50870.

DRAFT: blocked on torch 2.14.0 GA (currently v2.14.0-rc5). torchaudio 2.12.0 is provisional (no tag yet); compiled test lockfiles (requirements/test/*.txt), docker image digests, and the ROCm stack (separate cadence) still need updating once GA wheels are published.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

