### PR TITLE
docs: add AMD ROCm Windows community runtime to GPU install note

### DIFF
--- a/docs/getting_started/installation/gpu.md
+++ b/docs/getting_started/installation/gpu.md
@@ -28,7 +28,7 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 - Python: 3.10 -- 3.13
 
 !!! note
-    vLLM does not support Windows natively. To run vLLM on Windows, you can use the Windows Subsystem for Linux (WSL) with a compatible Linux distribution, or use some community-maintained forks, e.g. [https://github.com/SystemPanic/vllm-windows](https://github.com/SystemPanic/vllm-windows).
+    vLLM does not support Windows natively. To run vLLM on Windows, you can use the Windows Subsystem for Linux (WSL) with a compatible Linux distribution, or use some community-maintained forks, e.g. [https://github.com/SystemPanic/vllm-windows](https://github.com/SystemPanic/vllm-windows) for NVIDIA GPUs and [https://github.com/sebastianmechno-sys/vllm-rocm-windows-rdna2](https://github.com/sebastianmechno-sys/vllm-rocm-windows-rdna2) for AMD Radeon RX 6000-series (RDNA2) GPUs (native ROCm runtime, no WSL2).
 
 === "NVIDIA CUDA"
 


### PR DESCRIPTION
## Purpose

The GPU installation note already points Windows users to community-maintained forks (SystemPanic/vllm-windows, NVIDIA-focused). This PR adds the AMD Radeon RX 6000-series (RDNA2) native ROCm runtime as a second example, so AMD users on Windows have a documented path without WSL2.

The referenced project runs vLLM 0.19.1 + ROCm 7.15 (TheRock) natively on Windows 11 with a one-click installer: verified 25.97 TFLOPS FP16 (rocBLAS) and 59-62 tok/s (Qwen3.5-4B AWQ 4-bit) on an RX 6750 XT (gfx1031); RX 6800 (gfx1030) works via HSA_OVERRIDE_GFX_VERSION=10.3.1.

## Why this is not a duplicate

- #47476 ("DOC: clarify Windows support in quickstart prerequisites") only modifies `docs/getting_started/quickstart.md` and clarifies that Windows is unsupported; it does not list community options.
- No open PR touches the community-forks example on `docs/getting_started/installation/gpu.md`.
- This adds new, factual content (an AMD/ROCm Windows option where none is currently documented), following the existing precedent of the SystemPanic fork mention.

## Tests

- Documentation-only change; no code tests apply.
- The markdown is a single sentence addition inside the existing `!!! note` admonition on `gpu.md`; verified rendering and link syntax manually.

## AI assistance disclosure

This change was prepared with AI assistance (opencode). The human submitter (repo owner, esseba-dev) has reviewed the single changed line and the referenced project end-to-end, and can defend the change. Benchmark numbers come from the linked project's own verified testing.
