### PR TITLE
[Core][Multimodal] Skip redundant placeholder scan when token match succeeds

### DIFF
--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -17,6 +17,7 @@ from vllm.multimodal.processing.processor import (
     PromptInsertion,
     PromptReplacement,
     _apply_matches,
+    _apply_token_matches_with_placeholders,
     apply_text_matches,
     apply_token_matches,
     find_mm_placeholders,
@@ -567,171 +568,309 @@ def test_find_update_text(
             assert new_prompt == expected
 
 
+FIND_UPDATE_TOKENS_TEST_CASES = [
+    # Tokenized test cases of `test_find_update_text`
+    # using the vocab of llava-hf/llava-v1.6-mistral-7b-hf
+    (
+        [1, 9833, 28747, 32000, 9833, 28747, 32000, 32000, 918],
+        {
+            # We use `<image>` before `Image:` to test matches that
+            # occur out of order
+            "pattern_1": [32000],
+            "pattern_2": [9833, 28747],
+            "pattern_3": [918],
+        },
+        {
+            # Test whether target is confused with replacement
+            "pattern_1": [32000, 32000],
+            # Test empty replacement
+            "pattern_2": [],
+            # Test dynamic replacement (beyond the form of `unit * count`)
+            "pattern_3": [1550, 918, 1550],
+        },
+        {
+            PromptInsertion: {
+                0: [1, 9833, 28747, 32000, 9833, 28747, 32000, 32000, 918],
+                1: [
+                    1,
+                    9833,
+                    28747,
+                    32000,
+                    32000,
+                    32000,
+                    9833,
+                    28747,
+                    32000,
+                    32000,
+                    918,
+                    1550,
+                    918,
+                    1550,
+                ],  # noqa: E501
+                2: [
+                    1,
+                    9833,
+                    28747,
+                    32000,
+                    32000,
+                    32000,
+                    32000,
+                    32000,
+                    9833,
+                    28747,
+                    32000,
+                    32000,
+                    918,
+                    1550,
+                    918,
+                    1550,
+                    1550,
+                    918,
+                    1550,
+                ],  # noqa: E501
+            },
+            PromptReplacement: {
+                0: [1, 9833, 28747, 32000, 9833, 28747, 32000, 32000, 918],
+                1: [1, 32000, 32000, 9833, 28747, 32000, 32000, 1550, 918, 1550],  # noqa: E501
+                2: [1, 32000, 32000, 32000, 32000, 32000, 1550, 918, 1550],
+            },
+        },
+    ),
+    # Test index targets
+    (
+        [],
+        {
+            "pattern_1": PromptIndexTargets.start(),
+            "pattern_2": PromptIndexTargets.prefix([32000]),
+            "pattern_3": PromptIndexTargets.end(),
+        },
+        {
+            "pattern_1": [-1],
+            "pattern_2": [-2],
+            "pattern_3": [-3],
+        },
+        {
+            PromptInsertion: {
+                0: [],
+                1: [-1, -3],
+                2: [-1, -1, -3, -3],
+            },
+            PromptReplacement: {
+                0: [],
+                1: [-1, -3],
+                2: [-1, -1, -3, -3],
+            },
+        },
+    ),
+    (
+        [32000],
+        {
+            "pattern_1": PromptIndexTargets.start(),
+            "pattern_2": PromptIndexTargets.prefix([32000]),
+            "pattern_3": PromptIndexTargets.end(),
+        },
+        {
+            "pattern_1": [-1],
+            "pattern_2": [-2],
+            "pattern_3": [-3],
+        },
+        {
+            PromptInsertion: {
+                0: [32000],
+                1: [-1, 32000, -2, -3],
+                2: [-1, -1, 32000, -2, -2, -3, -3],
+            },
+            PromptReplacement: {
+                0: [32000],
+                1: [-1, 32000, -2, -3],
+                2: [-1, -1, 32000, -2, -2, -3, -3],
+            },
+        },
+    ),
+    # Test different replacement per item
+    (
+        [32000, 32000, 32000],
+        {
+            "pattern_1": [32000],
+        },
+        {
+            "pattern_1": lambda idx: [-(idx + 1)],
+        },
+        {
+            PromptInsertion: {
+                0: [32000, 32000, 32000],
+                1: [32000, -1, 32000, 32000],
+                2: [32000, -1, -2, 32000, 32000],
+            },
+            PromptReplacement: {
+                0: [32000, 32000, 32000],
+                1: [-1, 32000, 32000],
+                2: [-1, -2, 32000],
+            },
+        },
+    ),
+    (
+        [32000, 32000, 32000],
+        {
+            "pattern_1": PromptIndexTargets.prefix([32000]),
+        },
+        {
+            "pattern_1": lambda idx: [-(idx + 1)],
+        },
+        {
+            PromptInsertion: {
+                0: [32000, 32000, 32000],
+                1: [32000, -1, 32000, 32000],
+                2: [32000, -1, -2, 32000, 32000],
+            },
+            PromptReplacement: {
+                0: [32000, 32000, 32000],
+                1: [32000, -1, 32000, 32000],
+                2: [32000, -1, -2, 32000, 32000],
+            },
+        },
+    ),
+]
+
+
+def _placeholder(modality, item_idx, start_idx, tokens):
+    return PlaceholderFeaturesInfo(
+        modality=modality,
+        item_idx=item_idx,
+        start_idx=start_idx,
+        tokens=tokens,
+        is_embed=None,
+    )
+
+
+FIND_UPDATE_TOKENS_PLACEHOLDER_EXPECTED = [
+    {
+        PromptInsertion: {
+            0: {},
+            1: {
+                "pattern_1": [_placeholder("pattern_1", 0, 4, [32000, 32000])],
+                "pattern_3": [_placeholder("pattern_3", 0, 11, [1550, 918, 1550])],
+            },
+            2: {
+                "pattern_1": [
+                    _placeholder("pattern_1", 0, 4, [32000, 32000]),
+                    _placeholder("pattern_1", 1, 6, [32000, 32000]),
+                ],
+                "pattern_3": [
+                    _placeholder("pattern_3", 0, 13, [1550, 918, 1550]),
+                    _placeholder("pattern_3", 1, 16, [1550, 918, 1550]),
+                ],
+            },
+        },
+        PromptReplacement: {
+            0: {},
+            1: {
+                "pattern_1": [_placeholder("pattern_1", 0, 1, [32000, 32000])],
+                "pattern_3": [_placeholder("pattern_3", 0, 7, [1550, 918, 1550])],
+            },
+            2: {},
+        },
+    },
+    {
+        PromptInsertion: {0: {}, 1: {}, 2: {}},
+        PromptReplacement: {0: {}, 1: {}, 2: {}},
+    },
+    {
+        PromptInsertion: {
+            0: {},
+            1: {
+                "pattern_1": [_placeholder("pattern_1", 0, 0, [-1])],
+                "pattern_2": [_placeholder("pattern_2", 0, 2, [-2])],
+                "pattern_3": [_placeholder("pattern_3", 0, 3, [-3])],
+            },
+            2: {
+                "pattern_1": [
+                    _placeholder("pattern_1", 0, 0, [-1]),
+                    _placeholder("pattern_1", 1, 1, [-1]),
+                ],
+                "pattern_2": [
+                    _placeholder("pattern_2", 0, 3, [-2]),
+                    _placeholder("pattern_2", 1, 4, [-2]),
+                ],
+                "pattern_3": [
+                    _placeholder("pattern_3", 0, 5, [-3]),
+                    _placeholder("pattern_3", 1, 6, [-3]),
+                ],
+            },
+        },
+        PromptReplacement: {
+            0: {},
+            1: {
+                "pattern_1": [_placeholder("pattern_1", 0, 0, [-1])],
+                "pattern_2": [_placeholder("pattern_2", 0, 2, [-2])],
+                "pattern_3": [_placeholder("pattern_3", 0, 3, [-3])],
+            },
+            2: {
+                "pattern_1": [
+                    _placeholder("pattern_1", 0, 0, [-1]),
+                    _placeholder("pattern_1", 1, 1, [-1]),
+                ],
+                "pattern_2": [
+                    _placeholder("pattern_2", 0, 3, [-2]),
+                    _placeholder("pattern_2", 1, 4, [-2]),
+                ],
+                "pattern_3": [
+                    _placeholder("pattern_3", 0, 5, [-3]),
+                    _placeholder("pattern_3", 1, 6, [-3]),
+                ],
+            },
+        },
+    },
+    {
+        PromptInsertion: {
+            0: {},
+            1: {"pattern_1": [_placeholder("pattern_1", 0, 1, [-1])]},
+            2: {
+                "pattern_1": [
+                    _placeholder("pattern_1", 0, 1, [-1]),
+                    _placeholder("pattern_1", 1, 2, [-2]),
+                ]
+            },
+        },
+        PromptReplacement: {
+            0: {},
+            1: {"pattern_1": [_placeholder("pattern_1", 0, 0, [-1])]},
+            2: {
+                "pattern_1": [
+                    _placeholder("pattern_1", 0, 0, [-1]),
+                    _placeholder("pattern_1", 1, 1, [-2]),
+                ]
+            },
+        },
+    },
+    {
+        PromptInsertion: {
+            0: {},
+            1: {"pattern_1": [_placeholder("pattern_1", 0, 1, [-1])]},
+            2: {
+                "pattern_1": [
+                    _placeholder("pattern_1", 0, 1, [-1]),
+                    _placeholder("pattern_1", 1, 2, [-2]),
+                ]
+            },
+        },
+        PromptReplacement: {
+            0: {},
+            1: {"pattern_1": [_placeholder("pattern_1", 0, 1, [-1])]},
+            2: {
+                "pattern_1": [
+                    _placeholder("pattern_1", 0, 1, [-1]),
+                    _placeholder("pattern_1", 1, 2, [-2]),
+                ]
+            },
+        },
+    },
+]
+
+
 @pytest.mark.parametrize(
     ("prompt", "target_by_key", "repl_by_key", "expected_by_update_type_mm_count"),  # noqa: E501
-    [
-        # Tokenized test cases of `test_find_update_text`
-        # using the vocab of llava-hf/llava-v1.6-mistral-7b-hf
-        (
-            [1, 9833, 28747, 32000, 9833, 28747, 32000, 32000, 918],
-            {
-                # We use `<image>` before `Image:` to test matches that
-                # occur out of order
-                "pattern_1": [32000],
-                "pattern_2": [9833, 28747],
-                "pattern_3": [918],
-            },
-            {
-                # Test whether target is confused with replacement
-                "pattern_1": [32000, 32000],
-                # Test empty replacement
-                "pattern_2": [],
-                # Test dynamic replacement (beyond the form of `unit * count`)
-                "pattern_3": [1550, 918, 1550],
-            },
-            {
-                PromptInsertion: {
-                    0: [1, 9833, 28747, 32000, 9833, 28747, 32000, 32000, 918],
-                    1: [
-                        1,
-                        9833,
-                        28747,
-                        32000,
-                        32000,
-                        32000,
-                        9833,
-                        28747,
-                        32000,
-                        32000,
-                        918,
-                        1550,
-                        918,
-                        1550,
-                    ],  # noqa: E501
-                    2: [
-                        1,
-                        9833,
-                        28747,
-                        32000,
-                        32000,
-                        32000,
-                        32000,
-                        32000,
-                        9833,
-                        28747,
-                        32000,
-                        32000,
-                        918,
-                        1550,
-                        918,
-                        1550,
-                        1550,
-                        918,
-                        1550,
-                    ],  # noqa: E501
-                },
-                PromptReplacement: {
-                    0: [1, 9833, 28747, 32000, 9833, 28747, 32000, 32000, 918],
-                    1: [1, 32000, 32000, 9833, 28747, 32000, 32000, 1550, 918, 1550],  # noqa: E501
-                    2: [1, 32000, 32000, 32000, 32000, 32000, 1550, 918, 1550],
-                },
-            },
-        ),
-        # Test index targets
-        (
-            [],
-            {
-                "pattern_1": PromptIndexTargets.start(),
-                "pattern_2": PromptIndexTargets.prefix([32000]),
-                "pattern_3": PromptIndexTargets.end(),
-            },
-            {
-                "pattern_1": [-1],
-                "pattern_2": [-2],
-                "pattern_3": [-3],
-            },
-            {
-                PromptInsertion: {
-                    0: [],
-                    1: [-1, -3],
-                    2: [-1, -1, -3, -3],
-                },
-                PromptReplacement: {
-                    0: [],
-                    1: [-1, -3],
-                    2: [-1, -1, -3, -3],
-                },
-            },
-        ),
-        (
-            [32000],
-            {
-                "pattern_1": PromptIndexTargets.start(),
-                "pattern_2": PromptIndexTargets.prefix([32000]),
-                "pattern_3": PromptIndexTargets.end(),
-            },
-            {
-                "pattern_1": [-1],
-                "pattern_2": [-2],
-                "pattern_3": [-3],
-            },
-            {
-                PromptInsertion: {
-                    0: [32000],
-                    1: [-1, 32000, -2, -3],
-                    2: [-1, -1, 32000, -2, -2, -3, -3],
-                },
-                PromptReplacement: {
-                    0: [32000],
-                    1: [-1, 32000, -2, -3],
-                    2: [-1, -1, 32000, -2, -2, -3, -3],
-                },
-            },
-        ),
-        # Test different replacement per item
-        (
-            [32000, 32000, 32000],
-            {
-                "pattern_1": [32000],
-            },
-            {
-                "pattern_1": lambda idx: [-(idx + 1)],
-            },
-            {
-                PromptInsertion: {
-                    0: [32000, 32000, 32000],
-                    1: [32000, -1, 32000, 32000],
-                    2: [32000, -1, -2, 32000, 32000],
-                },
-                PromptReplacement: {
-                    0: [32000, 32000, 32000],
-                    1: [-1, 32000, 32000],
-                    2: [-1, -2, 32000],
-                },
-            },
-        ),
-        (
-            [32000, 32000, 32000],
-            {
-                "pattern_1": PromptIndexTargets.prefix([32000]),
-            },
-            {
-                "pattern_1": lambda idx: [-(idx + 1)],
-            },
-            {
-                PromptInsertion: {
-                    0: [32000, 32000, 32000],
-                    1: [32000, -1, 32000, 32000],
-                    2: [32000, -1, -2, 32000, 32000],
-                },
-                PromptReplacement: {
-                    0: [32000, 32000, 32000],
-                    1: [32000, -1, 32000, 32000],
-                    2: [32000, -1, -2, 32000, 32000],
-                },
-            },
-        ),
-    ],
+    FIND_UPDATE_TOKENS_TEST_CASES,
 )
 def test_find_update_tokens(
     prompt,
@@ -767,6 +906,73 @@ def test_find_update_tokens(
 
             # Manually constructed results
             assert new_prompt == expected
+
+
+@pytest.mark.parametrize(
+    (
+        "prompt",
+        "target_by_key",
+        "repl_by_key",
+        "expected_by_update_type_mm_count",
+        "expected_placeholders_by_update_type_mm_count",
+    ),
+    [
+        (*case, placeholder_expected)
+        for case, placeholder_expected in zip(
+            FIND_UPDATE_TOKENS_TEST_CASES,
+            FIND_UPDATE_TOKENS_PLACEHOLDER_EXPECTED,
+            strict=True,
+        )
+    ],
+)
+def test_apply_token_matches_with_placeholders(
+    prompt,
+    target_by_key,
+    repl_by_key,
+    expected_by_update_type_mm_count,
+    expected_placeholders_by_update_type_mm_count,
+):
+    for update_type, expected_by_mm_count in expected_by_update_type_mm_count.items():
+        for mm_count, expected in expected_by_mm_count.items():
+            mm_prompt_updates = {
+                key: [
+                    [update_type(key, target, repl_by_key[key]).resolve(i)]
+                    for i in range(mm_count)
+                ]
+                for key, target in target_by_key.items()
+            }
+
+            new_prompt, result, placeholders = _apply_token_matches_with_placeholders(
+                prompt,
+                mm_prompt_updates,
+                tokenizer=None,
+            )
+
+            if any(
+                update_idx is None
+                for update_idxs in result.values()
+                for update_idx in update_idxs
+            ):
+                continue
+
+            expected_placeholders = expected_placeholders_by_update_type_mm_count[
+                update_type
+            ][mm_count]
+
+            # Only displayed on error
+            print("update_type:", update_type)
+            print("mm_count:", mm_count)
+            print("mm_prompt_updates:", mm_prompt_updates)
+            print("new_prompt:", new_prompt)
+            print("result:", result)
+            print("placeholders:", placeholders)
+
+            assert new_prompt == expected
+            assert {
+                modality: ph_list
+                for modality, ph_list in placeholders.items()
+                if ph_list
+            } == expected_placeholders
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -373,6 +373,40 @@ class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
 
         return token_ids, res
 
+    def _apply_token_matches_with_placeholders(
+        self,
+        token_ids: list[int],
+        mm_prompt_updates: MultiModalPromptUpdates,
+    ) -> tuple[
+        list[int],
+        MultiModalPromptUpdatesApplyResult,
+        Mapping[str, list[PlaceholderFeaturesInfo]],
+    ]:
+        new_token_ids, match_result = self._apply_token_matches(
+            token_ids,
+            mm_prompt_updates,
+        )
+
+        placeholders: dict[str, list[PlaceholderFeaturesInfo]] = {
+            modality: [] for modality in mm_prompt_updates
+        }
+
+        if all(
+            all(update_idx is not None for update_idx in update_idxs)
+            for update_idxs in match_result.values()
+        ):
+            placeholders = dict(
+                self._find_mm_placeholders(
+                    new_token_ids,
+                    self._matched_updates_from_result(
+                        mm_prompt_updates,
+                        match_result,
+                    ),
+                )
+            )
+
+        return new_token_ids, match_result, placeholders
+
     def _find_mm_placeholders(
         self,
         new_token_ids: list[int],

--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -391,6 +391,40 @@ class Gemma3nMultiModalProcessor(BaseMultiModalProcessor[Gemma3nProcessingInfo])
 
         return token_ids, res
 
+    def _apply_token_matches_with_placeholders(
+        self,
+        token_ids: list[int],
+        mm_prompt_updates: MultiModalPromptUpdates,
+    ) -> tuple[
+        list[int],
+        MultiModalPromptUpdatesApplyResult,
+        Mapping[str, list[PlaceholderFeaturesInfo]],
+    ]:
+        new_token_ids, match_result = self._apply_token_matches(
+            token_ids,
+            mm_prompt_updates,
+        )
+
+        placeholders: dict[str, list[PlaceholderFeaturesInfo]] = {
+            modality: [] for modality in mm_prompt_updates
+        }
+
+        if all(
+            all(update_idx is not None for update_idx in update_idxs)
+            for update_idxs in match_result.values()
+        ):
+            placeholders = dict(
+                self._find_mm_placeholders(
+                    new_token_ids,
+                    self._matched_updates_from_result(
+                        mm_prompt_updates,
+                        match_result,
+                    ),
+                )
+            )
+
+        return new_token_ids, match_result, placeholders
+
     def _find_mm_placeholders(
         self,
         new_token_ids: list[int],

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1755,24 +1755,37 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         """Apply multi-modal prompt updates to token IDs."""
         tokenizer = self.info.get_tokenizer()
 
-        new_token_ids, match_result, placeholders = (
-            _apply_token_matches_with_placeholders(
-                token_ids,
-                mm_prompt_updates,
-                tokenizer,
-            )
+        uses_base_token_matching = (
+            type(self)._apply_token_matches
+            is BaseMultiModalProcessor._apply_token_matches
+            and type(self)._find_mm_placeholders
+            is BaseMultiModalProcessor._find_mm_placeholders
         )
 
-        if all(
-            all(update_idx is not None for update_idx in update_idxs)
-            for update_idxs in match_result.values()
-        ):
-            placeholders = {
-                modality: modality_placeholders
-                for modality, modality_placeholders in placeholders.items()
-                if modality_placeholders
-            }
-            return new_token_ids, placeholders
+        if uses_base_token_matching:
+            new_token_ids, match_result, placeholders = (
+                _apply_token_matches_with_placeholders(
+                    token_ids,
+                    mm_prompt_updates,
+                    tokenizer,
+                )
+            )
+
+            if all(
+                all(update_idx is not None for update_idx in update_idxs)
+                for update_idxs in match_result.values()
+            ):
+                placeholders = {
+                    modality: modality_placeholders
+                    for modality, modality_placeholders in placeholders.items()
+                    if modality_placeholders
+                }
+                return new_token_ids, placeholders
+        else:
+            new_token_ids, match_result = self._apply_token_matches(
+                token_ids,
+                mm_prompt_updates,
+            )
 
         # If the search text does not represent a special token,
         # it may have different token IDs in the prompt, because
@@ -1784,12 +1797,16 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         # Since it is inefficient to search for all possible tokenizations
         # of the search text in the prompt, we instead perform string-based
         # updates on the decoded token IDs, then encode them back.
-        new_text, match_result = self._apply_text_matches(
-            _seq2text(tokenizer, token_ids, use_cache=False),
-            mm_prompt_updates,
-        )
+        if not all(
+            all(update_idx is not None for update_idx in update_idxs)
+            for update_idxs in match_result.values()
+        ):
+            new_text, match_result = self._apply_text_matches(
+                _seq2text(tokenizer, token_ids, use_cache=False),
+                mm_prompt_updates,
+            )
 
-        new_token_ids = _seq2tokens(tokenizer, new_text, use_cache=False)
+            new_token_ids = _seq2tokens(tokenizer, new_text, use_cache=False)
 
         matched_updates = defaultdict[str, list[Sequence[ResolvedPromptUpdate]]](list)
         for modality, update_idxs in match_result.items():

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -958,6 +958,64 @@ def apply_token_matches(
     return flatten_2d_lists(token_id_seqs), result
 
 
+def _apply_token_matches_with_placeholders(
+    token_ids: list[int],
+    mm_prompt_updates: "MultiModalPromptUpdates",
+    tokenizer: TokenizerLike | None,
+) -> tuple[
+    list[int],
+    "MultiModalPromptUpdatesApplyResult",
+    Mapping[str, list[PlaceholderFeaturesInfo]],
+]:
+    matched_updates, result = _plan_prompt_updates(
+        token_ids,
+        mm_prompt_updates,
+        tokenizer,
+    )
+    placeholders: dict[str, list[PlaceholderFeaturesInfo]] = {
+        modality: [] for modality in mm_prompt_updates
+    }
+
+    new_token_ids = list[int]()
+    prev_end_idx = 0
+    for matched_update in matched_updates:
+        update = matched_update.update
+        match = matched_update.match
+        matched_content = update.content.full
+
+        if update.mode == UpdateMode.INSERT:
+            end_idx_to_insert = match.end_idx
+        elif update.mode == UpdateMode.REPLACE:
+            end_idx_to_insert = match.start_idx
+        else:
+            assert_never(update.mode)
+
+        new_token_ids.extend(token_ids[prev_end_idx:end_idx_to_insert])
+        start_idx = len(new_token_ids)
+
+        tokens = _seq2tokens(tokenizer, matched_content)
+        if tokens:
+            content_is_embed = update.content.is_embed
+            if content_is_embed is not None:
+                content_is_embed = content_is_embed(tokenizer, matched_content)
+
+            placeholders[update.modality].append(
+                PlaceholderFeaturesInfo(
+                    modality=update.modality,
+                    item_idx=update.item_idx,
+                    start_idx=start_idx,
+                    tokens=tokens,
+                    is_embed=content_is_embed,
+                )
+            )
+            new_token_ids.extend(tokens)
+
+        prev_end_idx = match.end_idx
+
+    new_token_ids.extend(token_ids[prev_end_idx:])
+    return new_token_ids, result, placeholders
+
+
 def apply_text_matches(
     prompt: str,
     mm_prompt_updates: "MultiModalPromptUpdates",
@@ -1697,10 +1755,24 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         """Apply multi-modal prompt updates to token IDs."""
         tokenizer = self.info.get_tokenizer()
 
-        new_token_ids, match_result = self._apply_token_matches(
-            token_ids,
-            mm_prompt_updates,
+        new_token_ids, match_result, placeholders = (
+            _apply_token_matches_with_placeholders(
+                token_ids,
+                mm_prompt_updates,
+                tokenizer,
+            )
         )
+
+        if all(
+            all(update_idx is not None for update_idx in update_idxs)
+            for update_idxs in match_result.values()
+        ):
+            placeholders = {
+                modality: modality_placeholders
+                for modality, modality_placeholders in placeholders.items()
+                if modality_placeholders
+            }
+            return new_token_ids, placeholders
 
         # If the search text does not represent a special token,
         # it may have different token IDs in the prompt, because
@@ -1712,16 +1784,12 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         # Since it is inefficient to search for all possible tokenizations
         # of the search text in the prompt, we instead perform string-based
         # updates on the decoded token IDs, then encode them back.
-        if not all(
-            all(update_idx is not None for update_idx in update_idxs)
-            for update_idxs in match_result.values()
-        ):
-            new_text, match_result = self._apply_text_matches(
-                _seq2text(tokenizer, token_ids, use_cache=False),
-                mm_prompt_updates,
-            )
+        new_text, match_result = self._apply_text_matches(
+            _seq2text(tokenizer, token_ids, use_cache=False),
+            mm_prompt_updates,
+        )
 
-            new_token_ids = _seq2tokens(tokenizer, new_text, use_cache=False)
+        new_token_ids = _seq2tokens(tokenizer, new_text, use_cache=False)
 
         matched_updates = defaultdict[str, list[Sequence[ResolvedPromptUpdate]]](list)
         for modality, update_idxs in match_result.items():

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1729,6 +1729,22 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         tokenizer = self.info.get_tokenizer()
         return apply_token_matches(prompt, mm_prompt_updates, tokenizer)
 
+    def _apply_token_matches_with_placeholders(
+        self,
+        token_ids: list[int],
+        mm_prompt_updates: MultiModalPromptUpdates,
+    ) -> tuple[
+        list[int],
+        MultiModalPromptUpdatesApplyResult,
+        Mapping[str, list[PlaceholderFeaturesInfo]],
+    ]:
+        tokenizer = self.info.get_tokenizer()
+        return _apply_token_matches_with_placeholders(
+            token_ids,
+            mm_prompt_updates,
+            tokenizer,
+        )
+
     def _apply_text_matches(
         self,
         prompt: str,
@@ -1764,10 +1780,9 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
 
         if uses_base_token_matching:
             new_token_ids, match_result, placeholders = (
-                _apply_token_matches_with_placeholders(
+                self._apply_token_matches_with_placeholders(
                     token_ids,
                     mm_prompt_updates,
-                    tokenizer,
                 )
             )
 

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1763,66 +1763,11 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             prompt, mm_prompt_updates, tokenizer
         )
 
-    def _apply_prompt_updates(
+    def _matched_updates_from_result(
         self,
-        token_ids: list[int],
         mm_prompt_updates: MultiModalPromptUpdates,
-    ) -> tuple[list[int], Mapping[str, list[PlaceholderFeaturesInfo]]]:
-        """Apply multi-modal prompt updates to token IDs."""
-        tokenizer = self.info.get_tokenizer()
-
-        uses_base_token_matching = (
-            type(self)._apply_token_matches
-            is BaseMultiModalProcessor._apply_token_matches
-            and type(self)._find_mm_placeholders
-            is BaseMultiModalProcessor._find_mm_placeholders
-        )
-
-        if uses_base_token_matching:
-            new_token_ids, match_result, placeholders = (
-                self._apply_token_matches_with_placeholders(
-                    token_ids,
-                    mm_prompt_updates,
-                )
-            )
-
-            if all(
-                all(update_idx is not None for update_idx in update_idxs)
-                for update_idxs in match_result.values()
-            ):
-                placeholders = {
-                    modality: modality_placeholders
-                    for modality, modality_placeholders in placeholders.items()
-                    if modality_placeholders
-                }
-                return new_token_ids, placeholders
-        else:
-            new_token_ids, match_result = self._apply_token_matches(
-                token_ids,
-                mm_prompt_updates,
-            )
-
-        # If the search text does not represent a special token,
-        # it may have different token IDs in the prompt, because
-        # the tokens may go across the boundaries of the search text.
-        # ----
-        # e.g. when searching for "foo" in "food", if "food" itself makes
-        # up a token, then the token ID of "foo" will not appear at all
-        # ----
-        # Since it is inefficient to search for all possible tokenizations
-        # of the search text in the prompt, we instead perform string-based
-        # updates on the decoded token IDs, then encode them back.
-        if not all(
-            all(update_idx is not None for update_idx in update_idxs)
-            for update_idxs in match_result.values()
-        ):
-            new_text, match_result = self._apply_text_matches(
-                _seq2text(tokenizer, token_ids, use_cache=False),
-                mm_prompt_updates,
-            )
-
-            new_token_ids = _seq2tokens(tokenizer, new_text, use_cache=False)
-
+        match_result: MultiModalPromptUpdatesApplyResult,
+    ) -> dict[str, list[Sequence[ResolvedPromptUpdate]]]:
         matched_updates = defaultdict[str, list[Sequence[ResolvedPromptUpdate]]](list)
         for modality, update_idxs in match_result.items():
             for item_idx, update_idx in enumerate(update_idxs):
@@ -1835,9 +1780,54 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                     [mm_prompt_updates[modality][item_idx][update_idx]]
                 )
 
+        return dict(matched_updates)
+
+    def _apply_prompt_updates(
+        self,
+        token_ids: list[int],
+        mm_prompt_updates: MultiModalPromptUpdates,
+    ) -> tuple[list[int], Mapping[str, list[PlaceholderFeaturesInfo]]]:
+        """Apply multi-modal prompt updates to token IDs."""
+        tokenizer = self.info.get_tokenizer()
+
+        new_token_ids, match_result, placeholders = (
+            self._apply_token_matches_with_placeholders(
+                token_ids,
+                mm_prompt_updates,
+            )
+        )
+
+        if all(
+            all(update_idx is not None for update_idx in update_idxs)
+            for update_idxs in match_result.values()
+        ):
+            placeholders = {
+                modality: modality_placeholders
+                for modality, modality_placeholders in placeholders.items()
+                if modality_placeholders
+            }
+            return new_token_ids, placeholders
+
+        # If the search text does not represent a special token,
+        # it may have different token IDs in the prompt, because
+        # the tokens may go across the boundaries of the search text.
+        # ----
+        # e.g. when searching for "foo" in "food", if "food" itself makes
+        # up a token, then the token ID of "foo" will not appear at all
+        # ----
+        # Since it is inefficient to search for all possible tokenizations
+        # of the search text in the prompt, we instead perform string-based
+        # updates on the decoded token IDs, then encode them back.
+        new_text, match_result = self._apply_text_matches(
+            _seq2text(tokenizer, token_ids, use_cache=False),
+            mm_prompt_updates,
+        )
+
+        new_token_ids = _seq2tokens(tokenizer, new_text, use_cache=False)
+
         placeholders = self._find_mm_placeholders(
             new_token_ids,
-            dict(matched_updates),
+            self._matched_updates_from_result(mm_prompt_updates, match_result),
         )
 
         return new_token_ids, placeholders


### PR DESCRIPTION
## Purpose

CLOSE #52924

`_apply_prompt_updates` first calls `_apply_token_matches`. If any token match fails, it falls back to `_apply_text_matches`. The current code always calls `_find_mm_placeholders` after matching, even when all token matches succeed. This call scans for placeholders again through the following path: `_find_mm_placeholders` → `find_mm_placeholders` → `_iter_placeholders` → `prompt[start:end] == content_tokens`.

The table below shows the placeholder scan time at different image resolutions with 2,500 input text tokens:

| Function                      | 480p     | 720p     | 1080p     | 3k        |
| ----------------------------- | -------- | -------- | --------- | --------- |
| `_apply_prompt_updates`       | 5.126 ms | 9.542 ms | 23.728 ms | 75.347 ms |
| `_find_mm_placeholders`       | 4.556 ms | 8.950 ms | 23.074 ms | 74.241 ms |
| `find_mm_placeholders`        | 4.513 ms | 8.908 ms | 23.030 ms | 74.198 ms |
| `_iter_placeholders`          | 4.328 ms | 8.710 ms | 22.781 ms | 73.965 ms |
| slice compare                 | 2.934 ms | 7.150 ms | 20.977 ms | 71.419 ms |
| slice compare / total         | 57%      | 75%      | 88%       | 95%       |

Each function in the scan path takes almost as long as `_apply_prompt_updates`. This shows that placeholder scanning takes most of the total time. The `slice compare` row measures `prompt[start_idx:end_idx_full] == content_tokens_full`, which is the main bottleneck. As image resolution increases, this comparison grows from 2.934 ms to 71.419 ms and from 57% to 95% of the total `_apply_prompt_updates` time.

When all token matches succeed, token matching already knows each placeholder position. The code does not need to scan the prompt again. This PR collects placeholders during token matching and returns early when all matches succeed. It therefore skips `_find_mm_placeholders`. If any token match fails, the code still uses the existing text fallback path.

The following benchmarks compare `_apply_prompt_updates` before and after this change. The first benchmark fixes the image resolution and varies the input text length. The second fixes the input text length and varies the image resolution.

1. Input text length comparison (fixed image resolutions: 720p and 3k)

<table>
  <thead>
    <tr>
      <th rowspan="2">input text tokens</th>
      <th colspan="3">720p</th>
      <th colspan="3">3k</th>
    </tr>
    <tr>
      <th>baseline</th>
      <th>this PR</th>
      <th>speedup</th>
      <th>baseline</th>
      <th>this PR</th>
      <th>speedup</th>
    </tr>
  </thead>
  <tbody>
    <tr><td>10</td><td>0.646 ms</td><td>0.252 ms</td><td>2.6×</td><td>2.881 ms</td><td>0.995 ms</td><td>2.9×</td></tr>
    <tr><td>50</td><td>0.917 ms</td><td>0.268 ms</td><td>3.4×</td><td>3.468 ms</td><td>1.004 ms</td><td>3.5×</td></tr>
    <tr><td>100</td><td>1.226 ms</td><td>0.275 ms</td><td>4.5×</td><td>5.480 ms</td><td>1.020 ms</td><td>5.4×</td></tr>
    <tr><td>500</td><td>3.455 ms</td><td>0.342 ms</td><td>10.1×</td><td>18.694 ms</td><td>1.101 ms</td><td>17.0×</td></tr>
    <tr><td>1000</td><td>5.517 ms</td><td>0.424 ms</td><td>13.0×</td><td>33.501 ms</td><td>1.194 ms</td><td>28.1×</td></tr>
    <tr><td>2500</td><td>9.525 ms</td><td>0.685 ms</td><td>13.9×</td><td>75.249 ms</td><td>1.479 ms</td><td>50.9×</td></tr>
  </tbody>
</table>

2. Image resolution comparison (fixed input text length: 2,500 tokens)

| resolution | baseline  | this PR  | speedup |
| ---------- | --------- | -------- | ------- |
| 480p       | 5.126 ms  | 0.601 ms | 8.5×    |
| 720p       | 9.542 ms  | 0.725 ms | 13.2×   |
| 1080p      | 23.728 ms | 0.944 ms | 25.1×   |
| 3k         | 75.347 ms | 1.712 ms | 44.0×   |

As the input text grows, the speedup increases from 2.6× to 13.9× at 720p and from 2.9× to 50.9× at 3k. With 2,500 input text tokens, the optimized `_apply_prompt_updates` takes 0.601–1.712 ms across the tested image resolutions. This gives an 8.5×–44.0× speedup. Both benchmarks skip `_find_mm_placeholders` when all token matches succeed.

## Behavior

Token-matching path: the code returns early only when every token match succeeds across all modalities (`update_idx is not None`). The unit tests show that the new path produces the same `new_token_ids` as the old path for general token-matching cases. `_apply_token_matches_with_placeholders` collects placeholders directly and removes empty modality lists.

Text fallback path: if any token match fails, the code still calls `_apply_text_matches` and `_find_mm_placeholders`. This PR does not change the fallback path.

For typical `PromptReplacement` updates, direct collection and rescanning return the same placeholder positions. For `PromptInsertion`, inserted tokens may match adjacent tokens in the original prompt. A rescan can then select an earlier range that includes an original token. Direct collection records the exact range inserted by the update. The issue below tracks this case.

## Related work and performance

### Related issue

Related to [#52924](https://github.com/vllm-project/vllm/issues/52924).

This issue describes how `find_mm_placeholders` can return the wrong start position when tokens inserted by `PromptInsertion` overlap with adjacent tokens in the original prompt. This PR records the inserted token position directly. It does not treat an adjacent original token as part of the placeholder.

### Related PR

Merged PR [#51774](https://github.com/vllm-project/vllm/pull/51774) also improves multimodal prompt updates, but it targets a different bottleneck. This PR builds placeholders directly when all token matches succeed and skips the redundant `_find_mm_placeholders` scan. The results below measure this PR on top of #51774.

In the tables, `#51774` is the baseline after that PR merged. `#51774 + This PR` adds this PR.

1. **10,000 placeholders synthetic benchmark**

The setup matches #51774. It uses 1,000,000 input tokens and 10,000 image placeholders. Each placeholder expands to 50 tokens, so the updated prompt contains 1,490,000 tokens. This PR reduces average latency by 45.0%.

| Function | Version | Run 1 | Run 2 | Run 3 | **Average** |
| --- | --- | ---: | ---: | ---: | ---: |
| `_apply_prompt_updates` | #51774 | 466.451 ms | 462.842 ms | 462.278 ms | **463.857 ms** |
| `_apply_prompt_updates` | #51774 + This PR | 255.581 ms | 255.501 ms | 254.922 ms | **255.335 ms** |

2. **3k image with 2,500 input text tokens**

We measured 64 requests with one 1728×3072 image and 2,500 input text tokens. Average latency drops from 3.432 ms to 1.409 ms. Maximum latency drops from 13.749 ms to 1.481 ms, an 89.2% reduction. The new maximum is only 5.1% above the average. The standard deviation drops from 2.587 ms to 0.024 ms, which shows more stable latency.

| Function | Version | Requests | **Average** | **Maximum** | Std |
| --- | --- | ---: | ---: | ---: | ---: |
| `_apply_prompt_updates` | #51774 | 64 | **3.432 ms** | **13.749 ms** | 2.587 ms |
| `_apply_prompt_updates` | #51774 + This PR | 64 | **1.409 ms** | **1.481 ms** | 0.024 ms |

## Test Plan

This PR adds `test_apply_token_matches_with_placeholders`. The test reuses the five tokenized cases from `test_find_update_tokens` and covers:

- `PromptInsertion` and `PromptReplacement`;
- multimodal item counts of 0, 1, and 2;
- matching `new_token_ids` against manually constructed expected output when token matching succeeds;
- matching directly collected `PlaceholderFeaturesInfo` fields (`modality`, `item_idx`, `start_idx`, and `tokens`) against manually constructed expected output;
- keeping failed token matches on the existing text fallback path.

We also keep the refactored `test_find_update_tokens` to verify that existing token-update results do not change.
We run `test_apply_matches_many_shared_targets_scales_linearly` to verify that the new helper still uses the linearly scaling prompt-update planner.

```bash
pytest tests/multimodal/test_processing.py::test_apply_token_matches_with_placeholders \
    tests/multimodal/test_processing.py::test_find_update_tokens \
    tests/multimodal/test_processing.py::test_apply_matches_many_shared_targets_scales_linearly \
    -q
```

## Test Result

```text
11 passed, 2 warnings in 6.30s
```

