### PR TITLE
[Bugfix] Recognize CephFS as a network FS for safetensors auto-prefetch

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -848,7 +848,7 @@ def safetensors_weights_iterator(
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
 
     fs_type = _get_fs_type(sorted_files)
-    is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
+    is_net_fs = fs_type in ("nfs", "nfs4", "lustre", "ceph")
     total_bytes = _get_checkpoints_size_bytes(sorted_files)
     avail_bytes = _get_available_ram_bytes()
     ram_threshold_pct = 90
@@ -880,14 +880,14 @@ def safetensors_weights_iterator(
         elif not is_net_fs and fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre). If you want to force "
+                "recognized network FS (NFS/Lustre/CephFS). If you want to force "
                 "prefetching, start vLLM with --safetensors-load-strategy=prefetch.",
                 fs_name,
             )
         elif not is_net_fs and not fits_in_ram:
             logger.info_once(
                 "Auto-prefetch is disabled because the filesystem (%s) is not a "
-                "recognized network FS (NFS/Lustre) and the checkpoint size "
+                "recognized network FS (NFS/Lustre/CephFS) and the checkpoint size "
                 "(%.2f GiB) exceeds %d%% of available RAM (%.2f GiB).",
                 fs_name,
                 total_bytes / 1024**3,


### PR DESCRIPTION
## Purpose

`safetensors_weights_iterator` auto-prefetches checkpoint files into the OS page
cache when the checkpoint sits on a network filesystem, which avoids
inefficient random reads over the wire. The detection is:

```python
is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
```

A kernel CephFS mount reports `ceph` in `/proc/mounts`, CephFS users never
get the auto-prefetch, and instead see:

> Auto-prefetch is disabled because the filesystem (CEPH) is not a recognized
> network FS (NFS/Lustre). If you want to force prefetching, start vLLM with
> --safetensors-load-strategy=prefetch.

CephFS has the same property that motivates the NFS/Lustre case: random reads
are expensive, and the sequential prefetch is far better suited to it.

This adds `ceph` to the list, and updates the log messages that enumerate
the recognized filesystems so they stay accurate.