### PR TITLE
[Bugfix][Cosmos3-Edge] Reorder packed patches from block-major to raster before the vision tower

### DIFF
--- a/tests/models/multimodal/processing/test_cosmos3_edge.py
+++ b/tests/models/multimodal/processing/test_cosmos3_edge.py
@@ -4,9 +4,14 @@
 import os
 
 import pytest
+import torch
 
 from vllm.assets.video import VideoAsset
 from vllm.config import ModelConfig
+from vllm.model_executor.models.cosmos3_edge import (
+    blockmajor_to_raster,
+    patch_merging_by_param,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 
 from ....conftest import ImageTestAssets
@@ -111,3 +116,97 @@ def test_process_video(processor) -> None:
     )
 
     _assert_video_outputs(processor, processed)
+
+
+def _pack_blockmajor(grid_thw: list[list[int]], merge_size: int) -> torch.Tensor:
+    """Pack raster patch ids the way the processor's ``patchify()`` does.
+
+    Mirrors ``image_processing_cosmos3_edge.patchify``: reshape into
+    ``merge_size x merge_size`` blocks and emit block-major, per frame.
+    """
+    streams = []
+    offset = 0
+    for t, h, w in grid_thw:
+        for _ in range(t):
+            ids = torch.arange(offset, offset + h * w).reshape(h, w)
+            streams.append(
+                ids.reshape(h // merge_size, merge_size, w // merge_size, merge_size)
+                .permute(0, 2, 1, 3)
+                .reshape(-1)
+            )
+            offset += h * w
+    return torch.cat(streams)
+
+
+@pytest.mark.parametrize(
+    "grid_thw,merge_size",
+    [
+        # w // merge_size not in {1, merge_size}: the permutation is not
+        # self-inverse here, so a reversed direction cannot pass.
+        ([[1, 4, 6]], 2),
+        ([[1, 6, 10]], 2),
+        ([[1, 6, 9]], 3),
+        # multiple images and a multi-frame video in one packed batch
+        ([[1, 4, 6], [1, 6, 10]], 2),
+        ([[3, 4, 6]], 2),
+        ([[1, 4, 6], [2, 6, 10], [1, 4, 4]], 2),
+    ],
+)
+def test_blockmajor_to_raster_recovers_raster_order(
+    grid_thw: list[list[int]],
+    merge_size: int,
+) -> None:
+    """Reordering a block-major stream must yield raster order."""
+    spatial_shapes = torch.tensor(
+        [[h, w] for t, h, w in grid_thw for _ in range(t)],
+        dtype=torch.int64,
+    )
+    packed = _pack_blockmajor(grid_thw, merge_size).unsqueeze(-1).float()
+
+    reordered = blockmajor_to_raster(packed, spatial_shapes, merge_size)
+
+    expected = torch.arange(packed.shape[0], dtype=torch.float32).unsqueeze(-1)
+    assert torch.equal(reordered, expected)
+
+
+def test_blockmajor_to_raster_is_noop_without_merging() -> None:
+    packed = torch.randn(12, 3)
+    spatial_shapes = torch.tensor([[3, 4]], dtype=torch.int64)
+
+    assert blockmajor_to_raster(packed, spatial_shapes, 1) is packed
+
+
+def test_blockmajor_to_raster_rejects_patch_count_mismatch() -> None:
+    packed = torch.randn(20, 3)
+    spatial_shapes = torch.tensor([[4, 6]], dtype=torch.int64)
+
+    with pytest.raises(ValueError, match="do not match spatial_shapes"):
+        blockmajor_to_raster(packed, spatial_shapes, 2)
+
+
+@pytest.mark.parametrize("grid_thw", [[[1, 4, 6]], [[2, 6, 10], [1, 4, 4]]])
+def test_reorder_then_merge_matches_processor_block_order(
+    grid_thw: list[list[int]],
+) -> None:
+    """The projector must receive each 2x2 block as one contiguous group.
+
+    ``patch_merging_by_param`` on the reordered stream has to reproduce what a
+    plain reshape of the *un*-reordered block-major stream gives, which is what
+    HF's ``Cosmos3EdgePatchMerger`` consumes.
+    """
+    merge_size = 2
+    hidden_size = 8
+    spatial_shapes = torch.tensor(
+        [[h, w] for t, h, w in grid_thw for _ in range(t)],
+        dtype=torch.int64,
+    )
+    order = _pack_blockmajor(grid_thw, merge_size)
+    packed = torch.randn(order.shape[0], hidden_size)
+
+    reordered = blockmajor_to_raster(packed, spatial_shapes, merge_size)
+    merged = patch_merging_by_param(
+        reordered, torch.tensor(grid_thw, dtype=torch.int64), merge_size
+    )
+
+    expected = packed.reshape(-1, merge_size * merge_size * hidden_size)
+    assert torch.equal(merged, expected)

--- a/vllm/model_executor/models/cosmos3_edge.py
+++ b/vllm/model_executor/models/cosmos3_edge.py
@@ -59,6 +59,40 @@ from .vision import (
 )
 
 
+def blockmajor_to_raster(
+    pixel_values: torch.Tensor,
+    spatial_shapes: torch.Tensor,
+    merge_size: int,
+) -> torch.Tensor:
+    """Reorder packed patches from Cosmos block-major order to raster order.
+
+    Cosmos3-Edge's processors pack patches grouped by ``merge_size x
+    merge_size`` spatial blocks, while the packed positional embeddings and
+    ``patch_merging_by_param`` both index the stream row-major.
+    """
+    if merge_size == 1:
+        return pixel_values
+
+    shapes = spatial_shapes.tolist()
+    num_patches = sum(h * w for h, w in shapes)
+    if num_patches != pixel_values.shape[-2]:
+        raise ValueError(
+            "packed patches do not match spatial_shapes: "
+            f"got {pixel_values.shape[-2]}, expected {num_patches}."
+        )
+
+    indices: list[torch.Tensor] = []
+    offset = 0
+    for h, w in shapes:
+        index = torch.arange(h * w).reshape(
+            h // merge_size, w // merge_size, merge_size, merge_size
+        )
+        indices.append(index.transpose(1, 2).reshape(-1) + offset)
+        offset += h * w
+
+    return pixel_values.index_select(-2, torch.cat(indices).to(pixel_values.device))
+
+
 class Cosmos3EdgeVisionEncoder(Siglip2VisionTransformer):
     """Adapts Cosmos (T, H, W) metadata to vLLM packed SigLIP2."""
 
@@ -79,6 +113,15 @@ class Cosmos3EdgeVisionEncoder(Siglip2VisionTransformer):
             grid_thw_cpu[:, 0],
             dim=0,
         )
+        # The processor packs patches block-major, but the packed positional
+        # embeddings and patch_merging_by_param both index this stream raster
+        # (row-major). Normalize once here so both see the order they assume.
+        pixel_values = blockmajor_to_raster(
+            pixel_values,
+            spatial_shapes,
+            self.config.spatial_merge_size,
+        )
+
         lengths_cpu = spatial_shapes.prod(dim=-1).to(torch.int32)
         lengths = lengths_cpu.to(
             device=pixel_values.device,


### PR DESCRIPTION
## Purpose

`Cosmos3EdgeImageProcessor` packs patches **block-major** (`patchify()` in
`transformers/.../image_processing_cosmos3_edge.py:143-166`, whose comment says so).
Two places in vLLM read that packed stream and both index it **raster (row-major)**:

- `lfm2_siglip2.py:147` — `resize_positional_embeddings_packed()` builds the table
  `reshape(embed_dim, height * width).transpose(0, 1)` and adds entry `i` to patch `i`.
  Correct for LFM2/SigLIP2, whose processor is raster; Cosmos3-Edge reuses this encoder.
- `cosmos3_edge.py:105-143` — `patch_merging_by_param()` does `view(t, h, w, hidden)` (`:131`).

So every patch gets another location's positional embedding and each merged token is
built from non-adjacent patches. Video is affected identically. It fails silently —
output stays fluent and patch/token counts are unchanged — and costs 50 points of
ChartQA accuracy.

The fix normalizes the stream to raster once at the encoder input
(`Cosmos3EdgeVisionEncoder.encode`), so both readers see the order they assume. The
merged-token output order is unchanged, so nothing downstream changes and no inverse
permutation is needed.

One thing to flag: #52229 (open) adds an `encoder_cudagraph_forward` that bypasses
`encode` and precomputes `pos_embeds` through the same raster-assuming function, so
from reading that diff it looks like the same reordering would be needed there too. I
haven't run it, so I may be missing something.

## Test Plan

Unit test added to `tests/models/multimodal/processing/test_cosmos3_edge.py` (CPU, no
weights), covering grids where the permutation is not self-inverse, multi-image and
multi-frame batches, and that merging the reordered stream reproduces what HF's patch
merger consumes. End-to-end on stock `nvidia/Cosmos3-Edge`, greedy, with the
reordering as the only variable:

```bash
# chat template = the checkpoint's, with enable_thinking defaulted to False, so the
# MCQ tasks get direct answers rather than reasoning traces
vllm serve nvidia/Cosmos3-Edge --enforce-eager --max-model-len 65536 \
  --tokenizer-mode hf --chat-template ./chat_template_nothink.jinja
python run.py --data ChartQA_TEST --base-url http://127.0.0.1:8000/v1 \
  --model cosmos3-edge-stock --temperature 0 --max-tokens 2048   # VLMEvalKit @09874c7
```

## Test Result

Unit test passes. 96.3% of patches were receiving the wrong positional embedding and
all 513 merged tokens were mis-grouped on a `38×54` grid; projector output vs HF
`transformers` goes from `cos 0.478` to `cos 0.9983`.

| benchmark | before | after | Cosmos 3 report |
|---|---|---|---|
| ChartQA_TEST (relaxed acc, n=2500) | 27.08 | **77.16** | not reported |
| AI2D_TEST (acc, n=3088) | 56.77 | 72.99 | 75.4 |

Both arms are the same build differing only in this patch, 0 inference failures.
`lmms-eval` independently gives 0.2444 → 0.7440 on ChartQA.

## AI assistance

Developed with AI assistance (investigation, patch drafting, this description).
I have reviewed every changed line.
