### PR TITLE
[Bugfix][CPU][RISC-V] Fix cross-compilation capability detection

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -16,6 +16,7 @@ endif()
 set(ENABLE_X86_ISA $ENV{VLLM_CPU_X86})
 set(ENABLE_ARM_BF16 $ENV{VLLM_CPU_ARM_BF16})
 set(ENABLE_ARM_I8MM $ENV{VLLM_CPU_ARM_I8MM})
+set(ENABLE_RVV_FP16 $ENV{VLLM_CPU_RVV_FP16})
 set(ENABLE_RVV_BF16 $ENV{VLLM_CPU_RVV_BF16})
 
 include_directories("${CMAKE_SOURCE_DIR}/csrc")
@@ -57,13 +58,21 @@ else()
     endif()
 endif()
 
-if (NOT MACOSX_FOUND)
+set(VLLM_RISCV_CROSSCOMPILING OFF)
+if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+    set(VLLM_RISCV_CROSSCOMPILING ON)
+endif()
+
+if (NOT MACOSX_FOUND AND NOT VLLM_RISCV_CROSSCOMPILING)
     execute_process(COMMAND cat /proc/cpuinfo
                     RESULT_VARIABLE CPUINFO_RET
                     OUTPUT_VARIABLE CPUINFO)
     if (NOT CPUINFO_RET EQUAL 0)
         message(FATAL_ERROR "Failed to check CPU features via /proc/cpuinfo")
     endif()
+elseif(VLLM_RISCV_CROSSCOMPILING)
+    message(STATUS
+        "Cross-compiling for RISC-V: skipping CPU feature detection from /proc/cpuinfo")
 endif()
 
 
@@ -99,15 +108,20 @@ if (MACOSX_FOUND AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     check_sysctl(hw.optional.arm.FEAT_BF16 ARM_BF16_FOUND)
     check_sysctl(hw.optional.arm.FEAT_I8MM ARM_I8MM_FOUND)
 else()
-    find_isa(${CPUINFO} "Power11" POWER11_FOUND)
-    find_isa(${CPUINFO} "POWER10" POWER10_FOUND)
-    find_isa(${CPUINFO} "POWER9" POWER9_FOUND)
-    find_isa(${CPUINFO} "asimd" ASIMD_FOUND) # Check for ARM NEON support
-    find_isa(${CPUINFO} "bf16" ARM_BF16_FOUND) # Check for ARM BF16 support
-    find_isa(${CPUINFO} "i8mm" ARM_I8MM_FOUND) # Check for ARM I8MM support
-    find_isa(${CPUINFO} "S390" S390_FOUND)
-    find_isa(${CPUINFO} "zvfhmin" RVV_FP16_FOUND) # Check for RISC-V Vector FP16 support
-    find_isa(${CPUINFO} "zvfbfmin" RVV_BF16_FOUND) # Check for RISC-V Vector BF16 support
+    if(VLLM_RISCV_CROSSCOMPILING)
+        set(RVV_FP16_FOUND OFF)
+        set(RVV_BF16_FOUND OFF)
+    else()
+        find_isa(${CPUINFO} "Power11" POWER11_FOUND)
+        find_isa(${CPUINFO} "POWER10" POWER10_FOUND)
+        find_isa(${CPUINFO} "POWER9" POWER9_FOUND)
+        find_isa(${CPUINFO} "asimd" ASIMD_FOUND) # Check for ARM NEON support
+        find_isa(${CPUINFO} "bf16" ARM_BF16_FOUND) # Check for ARM BF16 support
+        find_isa(${CPUINFO} "i8mm" ARM_I8MM_FOUND) # Check for ARM I8MM support
+        find_isa(${CPUINFO} "S390" S390_FOUND)
+        find_isa(${CPUINFO} "zvfhmin" RVV_FP16_FOUND) # Check for RISC-V Vector FP16 support
+        find_isa(${CPUINFO} "zvfbfmin" RVV_BF16_FOUND) # Check for RISC-V Vector BF16 support
+    endif()
 
     # Support cross-compilation by allowing override via environment variables
     if (ENABLE_ARM_BF16)
@@ -118,6 +132,10 @@ else()
         set(ARM_I8MM_FOUND ON)
         message(STATUS
             "ARM I8MM support enabled via VLLM_CPU_ARM_I8MM environment variable")
+    endif()
+    if (ENABLE_RVV_FP16)
+        set(RVV_FP16_FOUND ON)
+        message(STATUS "RVV FP16 support enabled via VLLM_CPU_RVV_FP16 environment variable")
     endif()
     # Some kernels (e.g. Bianbu on Spacemit X100) do not report zvfbfmin
     # in /proc/cpuinfo despite hardware support. VLLM_CPU_RVV_BF16=1
@@ -194,6 +212,13 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
         message(FATAL_ERROR
             "VLLM_RVV_VLEN must be zero or a positive integer; got '${VLLM_RVV_VLEN}'")
     endif()
+    if(VLLM_RISCV_CROSSCOMPILING AND DEFINED VLLM_RVV_VLEN AND
+            VLLM_RVV_VLEN EQUAL 0 AND
+            (RVV_FP16_FOUND OR RVV_BF16_FOUND))
+        message(FATAL_ERROR
+            "VLLM_RVV_VLEN=0 requests a scalar RISC-V build and cannot be "
+            "combined with VLLM_CPU_RVV_FP16=1 or VLLM_CPU_RVV_BF16=1.")
+    endif()
     # VLLM_RVV_VLEN selects the target VLEN. Auto-detected from /proc/cpuinfo
     # by default; set -DVLLM_RVV_VLEN=0 to force scalar RISC-V build.
     # Override with -DVLLM_RVV_VLEN=128 or -DVLLM_RVV_VLEN=256 for RVV.
@@ -230,6 +255,14 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
                 "  CMAKE_ARGS='-DVLLM_RVV_VLEN=128'   (for VLEN=128 hardware)\n"
                 "  CMAKE_ARGS='-DVLLM_RVV_VLEN=256'   (for VLEN=256 hardware, e.g. Spacemit X100)")
         endif()
+    endif()
+    if(VLLM_RISCV_CROSSCOMPILING AND VLLM_RVV_VLEN AND
+            VLLM_RVV_VLEN GREATER 0 AND
+            NOT (RVV_FP16_FOUND OR RVV_BF16_FOUND))
+        message(FATAL_ERROR
+            "RISC-V cross-compilation with VLLM_RVV_VLEN>0 requires "
+            "explicit target capability information. Set "
+            "VLLM_CPU_RVV_FP16=1 or VLLM_CPU_RVV_BF16=1.")
     endif()
     if(VLLM_RVV_VLEN AND VLLM_RVV_VLEN GREATER 0)
         message(STATUS "RISC-V RVV VLEN=${VLLM_RVV_VLEN}")


### PR DESCRIPTION
## Purpose

Fix RISC-V target capability detection during cross-compilation.

Before this change, CMake reads the x86_64 build host’s `/proc/cpuinfo` when configuring a RISC-V target. The resulting host capability flags are then combined with the requested target VLEN. For example, `VLLM_RVV_VLEN=128` can configure successfully while silently generating a Scalar `-march=rv64gc` target.

This change:

- Skips host CPU capability detection when cross-compiling specifically for RISC-V.
- Adds `VLLM_CPU_RVV_FP16=1` as an explicit target capability override, matching the existing BF16 override.
- Requires explicit FP16 or BF16 target capability information when cross-compiling with `VLLM_RVV_VLEN>0`.
- Rejects contradictory Scalar VLEN and RVV capability settings.

Native RISC-V detection and the existing x86, Arm, Power, and s390x paths are unchanged.

This PR was split from the closed #50743. It is not duplicated by #47532, which prevents VLEN auto-detection from the build host but does not guard the earlier FP16/BF16 capability detection. It is also separate from #48487, which changes runtime attention ISA selection.

Open PR and issue searches using `RISC-V cross-compilation capability`, `VLLM_RVV_VLEN cross-compilation`, and `VLLM_CPU_RVV_FP16` found no other active implementation.

## Test Plan

The latest upstream baseline (`040700aaa6`) and the current PR head (`31e6729988`) were configured on an x86_64 Ubuntu 24.04 host using:

- GNU RISC-V cross compiler 14.2
- Python 3.12
- PyTorch 2.13.0+cpu
- CMake 3.28
- Ninja 1.11
- strace 6.8

The cross-compilation toolchain file was:

```cmake
set(CMAKE_SYSTEM_NAME Linux)
set(CMAKE_SYSTEM_PROCESSOR riscv64)
set(CMAKE_C_COMPILER riscv64-linux-gnu-gcc-14)
set(CMAKE_CXX_COMPILER riscv64-linux-gnu-g++-14)
set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
```

Each case used a fresh CMake build directory. The FP16 case was configured with:

```bash
env -u CMAKE_ARGS -u VLLM_CPU_RVV_BF16 \
  VLLM_CPU_RVV_FP16=1 \
  VLLM_TARGET_DEVICE=cpu \
  cmake -S . -B <build-dir> -G Ninja \
    -DVLLM_TARGET_DEVICE=cpu \
    -DVLLM_PYTHON_EXECUTABLE=<python> \
    -DCMAKE_TOOLCHAIN_FILE=<riscv-toolchain.cmake> \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
    -DVLLM_RVV_VLEN=128
```

The same configuration was repeated with the capability overrides unset or with `VLLM_CPU_RVV_BF16=1`, and with VLEN set to `0`, `128`, `-1`, or omitted as required by each case.

`strace` was used to distinguish vLLM’s explicit `cat /proc/cpuinfo` probe from any `/proc/cpuinfo` access performed by Python or PyTorch initialization.

Finally, the RISC-V flags were extracted from the patched `compile_commands.json` and used to compile a minimal object containing real `__riscv_*` FP16 intrinsics:

```bash
riscv64-linux-gnu-gcc-14 \
  -march=rv64gcv_zvfh_zvl128b \
  -mrvv-vector-bits=zvl \
  -mabi=lp64d \
  -c <rvv-fp16-probe.c> \
  -o <rvv-fp16-probe.o>

readelf -A <rvv-fp16-probe.o>
```

## Test Result

The before/after configuration results were:

| Configuration | Upstream baseline | PR head |
| --- | --- | --- |
| `VLEN=0`, no capability override | Success; `-march=rv64gc` | Success; `-march=rv64gc` |
| `VLEN=128`, no capability override | Incorrectly succeeds with `-march=rv64gc` | Rejected; explicit target capability required |
| `VLEN=128`, `FP16=1` | Override ignored; `-march=rv64gc` | Success; `-march=rv64gcv_zvfh_zvl128b` |
| `VLEN=128`, `BF16=1` | Success with the BF16 RVV target | Success with the BF16 RVV target |

Additional patched-input validation:

| Configuration | Result |
| --- | --- |
| `VLEN=0`, `FP16=1` | Rejected as a Scalar/RVV conflict |
| `VLEN=-1` | Rejected by the non-negative VLEN constraint |
| `FP16=1`, VLEN omitted | Rejected with a request for an explicit VLEN |
| Native x86_64 configuration | Success |

On the upstream baseline, `strace` captured the vLLM CMake capability probe executing:

```text
execve("/usr/bin/cat", ["cat", "/proc/cpuinfo"], ...) = 0
```

On the patched configuration, that `cat /proc/cpuinfo` execution was absent and CMake reported:

```text
Cross-compiling for RISC-V: skipping CPU feature detection from /proc/cpuinfo
RVV FP16 support enabled via VLLM_CPU_RVV_FP16 environment variable
RISC-V RVV VLEN=128
```

Two remaining `/proc/cpuinfo` opens were traced to Python processes launched while locating PyTorch; they were not made by the vLLM capability gate.

The Scalar and RVV FP16 compiler probes both passed. `readelf -A` on the RVV object reported the expected `v1p0`, `zvfh1p0`, and `zvl128b1p0` attributes.

The following source checks also passed:

```text
pre-commit run --files cmake/cpu_extension.cmake
git diff --check upstream/main...HEAD
```

A complete vLLM RISC-V target was not cross-built. This validation covers CMake target selection and verifies that the generated Scalar and RVV FP16 flags are accepted by the target compiler.

Model evaluation was not run because this change only affects build-time target configuration and does not modify model execution or output.

AI assistance was used for analysis, implementation, and test execution. I reviewed every changed line and the reported test results.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

