### PR TITLE
[Bugfix][CPU][RISC-V] Use explicit RNE for FP16 narrowing

### DIFF
--- a/csrc/cpu/cpu_types_riscv_impl.hpp
+++ b/csrc/cpu/cpu_types_riscv_impl.hpp
@@ -963,10 +963,12 @@ inline void storeFP32<c10::Half>(float v, c10::Half* ptr) {
 }
 
 inline FP16Vec16::FP16Vec16(const FP32Vec16& v) {
-  reg = RVVI(__riscv_vfncvt_f_f_w_f16, LMUL_256)(v.reg, VEC_ELEM_NUM);
+  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_256, _rm)(v.reg, __RISCV_FRM_RNE,
+                                                       VEC_ELEM_NUM);
 }
 inline FP16Vec8::FP16Vec8(const FP32Vec8& v) {
-  reg = RVVI(__riscv_vfncvt_f_f_w_f16, LMUL_128)(v.reg, VEC_ELEM_NUM);
+  reg = RVVI3(__riscv_vfncvt_f_f_w_f16, LMUL_128, _rm)(v.reg, __RISCV_FRM_RNE,
+                                                       VEC_ELEM_NUM);
 }
 inline FP32Vec16::FP32Vec16(const FP16Vec16& v) {
   reg = RVVI(__riscv_vfwcvt_f_f_v_f32, LMUL_512)(v.reg, VEC_ELEM_NUM);


### PR DESCRIPTION
## Purpose

Fix RISC-V FP32-to-FP16 narrowing depending on the caller's floating-point rounding mode.

`FP16Vec8` and `FP16Vec16` used the dynamic-rounding form of `vfncvt.f.f.w`, so callers using RTZ, RDN, or RUP could receive different FP16 values. This change uses the explicit RNE intrinsic, matching the x86 and scalar implementations while preserving the caller's `frm` value.

This was split from closed PR #50743. Duplicate searches for `RISC-V FP16 rounding` and `vfncvt RNE` found no overlapping open issue or PR. PR #47983 changes separate float-to-integer conversions.

## Test Plan

Tested before and after the fix on a SpacemiT K1 RISC-V system with RVV 1.0, VLEN=256, GCC 14.2, Python 3.12, and RISE PyTorch 2.13.0+cpu.

A focused harness including the production `cpu_types_riscv.hpp` tested `FP16Vec8` and `FP16Vec16` at `-O2` and `-O3 -DNDEBUG`. It covered RNE, RTZ, RDN, and RUP through both direct `frm` access and `std::fesetround`, comparing the results with software and explicit-RNE RVV references.

The relevant compiler flags were:

```bash
/usr/bin/g++-14 -std=c++20 -O2 \
  -march=rv64gcv_zvfh_zvl256b \
  -mrvv-vector-bits=zvl -mabi=lp64d

/usr/bin/g++-14 -std=c++20 -O3 -DNDEBUG \
  -march=rv64gcv_zvfh_zvl256b \
  -mrvv-vector-bits=zvl -mabi=lp64d
```

The CPU extension was built and installed with:

```bash
cmake -S . -B <build-dir> -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 \
  -DVLLM_TARGET_DEVICE=cpu \
  -DVLLM_RVV_VLEN=256 \
  -DVLLM_PYTHON_EXECUTABLE=<venv>/bin/python \
  -DCMAKE_INSTALL_PREFIX=<source-dir>

cmake --build <build-dir> --target install --parallel 2
```

A fresh baseline build was followed by a current-head incremental rebuild using the same CMake cache, following the documented incremental build workflow. The rebuilt extension was also exercised through the real `torch.ops._C.rotary_embedding` operator under all four rounding modes.

## Test Result

| Test | Before | Current head |
|---|---|---|
| Production-header harness, `-O2` | 12/16 cases failed; 52/192 lanes differed from RNE | 16/16 passed; 0/192 mismatches |
| Production-header harness, `-O3 -DNDEBUG` | 12/16 cases failed; 52/192 lanes differed from RNE | 16/16 passed; 0/192 mismatches |
| `rotary_embedding` FP16 result | RTZ/RDN produced `0x3e01`; RNE/RUP produced `0x3e02` | All four modes produced the expected RNE result `0x3e02` |
| RVV CPU extension | Fresh full build and install passed | Affected objects rebuilt; `_C.abi3.so` relink and install passed |

The caller's `frm` value was preserved in every harness and operator case. Disassembly also confirmed that the current implementation selects RNE and restores the original rounding mode.

The following local checks passed:

```text
pre-commit run --files csrc/cpu/cpu_types_riscv_impl.hpp
git diff --check
```

A model evaluation could not be completed in the available environment. A normal load of the current `_C.abi3.so` stops at an unresolved `sbgemm_` symbol: the existing FLA object references this symbol, while the OpenBLAS library bundled with the RISE PyTorch wheel does not export it. The same environment limitation applies before and after this change, and this PR does not modify the FLA or OpenBLAS paths.

The focused `rotary_embedding` comparison used lazy symbol resolution so that this unrelated operator could be exercised; it is not reported as a successful full model runtime.

AI assistance was used for analysis and test automation. I reviewed every changed line and the reported test results.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

