### PR TITLE
[CI][Bugfix] Update distributed DP API server test path

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -31,14 +31,14 @@ steps:
   - vllm/v1/engine/
   - vllm/v1/worker/
   - tests/v1/distributed
-  - tests/entrypoints/openai/test_multi_api_servers.py
+  - tests/entrypoints/launchers/api_server/test_multi_api_servers.py
   commands:
   # https://github.com/NVIDIA/nccl/issues/1838
   - export NCCL_CUMEM_HOST_ENABLE=0
   - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_async_llm_dp.py
   - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_eagle_dp.py
   - TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py
-  - DP_SIZE=2 pytest -v -s entrypoints/openai/test_multi_api_servers.py
+  - DP_SIZE=2 pytest -v -s entrypoints/launchers/api_server/test_multi_api_servers.py
   mirror:
     amd:
       label: ":amd: (MI300) Distributed DP Basic"
@@ -56,7 +56,7 @@ steps:
       - vllm/v1/engine/
       - vllm/v1/worker/
       - tests/v1/distributed
-      - tests/entrypoints/openai/test_multi_api_servers.py
+      - tests/entrypoints/launchers/api_server/test_multi_api_servers.py
       - vllm/platforms/rocm.py
 
 - label: ":nvidia: (L4) Distributed Compile + RPC"


### PR DESCRIPTION
## Summary

Update the Distributed DP Basic test command and source-file dependencies after `test_multi_api_servers.py` moved from `tests/entrypoints/openai/` to `tests/entrypoints/launchers/api_server/` in #52131.

## Root cause

#52131 moved the test but left `.buildkite/test_areas/distributed.yaml` pointing at the old path. The L4 and mirrored MI300 jobs therefore complete their earlier DP tests, then fail before collecting the final test file.

Observed on merged main commit `eac636a7fa47` and subsequent main commits while this fix remains unmerged:

- Buildkite #84579: L4 Distributed DP Basic failed with `file or directory not found`
- Buildkite #84585: L4 and MI300 Distributed DP Basic failed identically
- Buildkite #84603: L4 and MI300 reproduced the same stale-path failure after this fix was validated but before it merged
- Buildkite #84608: L4 and MI300 reproduced the same stale-path failure again while the validated fix remained unmerged
- Buildkite #84633: L4 and MI300 reproduced the same stale-path failure
- Buildkite #84634: L4 and MI300 reproduced the same stale-path failure
- Buildkite #84644: L4 and MI300 reproduced the same stale-path failure
- Buildkite #84687 daily full run: L4 and MI300 reproduced the same stale-path failure after commands 1–4 passed; the MI300 automatic retry on a replacement node also passed commands 1–4 and failed identically at command 5
- Buildkite #84712: L4 and MI300 both passed commands 1–4, then command 5 invoked the removed `entrypoints/openai/test_multi_api_servers.py` path and exited 4; MI300 ran on `gpu9084`
- Buildkite #84699: MI300 passed commands 1–4, then command 5 invoked the same removed path and exited 4 on Kubernetes node `gpu9142`
- Buildkite #84721: L4 and MI300 both passed commands 1–4, then command 5 invoked the same removed path and exited 4
- PR #52131 exact-head Buildkite #84571 blocked both exact jobs, so this failure did not run before merge

## Duplicate-work check

Searched open PRs for #52131, `test_multi_api_servers distributed yaml`, and `distributed DP file not found launcher`; no open PR addresses this path correction.

## Validation

- `git diff --check`
- verified the old path is absent from `.buildkite/test_areas/distributed.yaml`
- verified `tests/entrypoints/launchers/api_server/test_multi_api_servers.py` exists
- parsed `.buildkite/test_areas/distributed.yaml` with PyYAML
- targeted Buildkite validation at exact head `fd9f28153488af11cd1605d08a28d163ab60b529`: [#84593](https://buildkite.com/vllm/ci/builds/84593) passed the L4 Distributed DP Basic job, including the corrected `test_multi_api_servers.py` path (2 passed); diff-selected [#84595](https://buildkite.com/vllm/ci/builds/84595) passed both exact jobs—L4 (2 passed) and MI300 (2 passed). The full diff-selected #84595 build is also terminal passed. Initial #84589 produced no test signal because bootstrap rejected an invalid separate AMD mirror key.

## Model evaluation

Not applicable. This changes only CI test paths and does not affect model behavior or output.

AI assistance was used to investigate the CI failure and prepare this change. The submitter reviewed every changed line and the validation evidence above.