### PR TITLE
Support serving a model from a subfolder of its repo

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1935,6 +1935,50 @@ def test_renderer_num_workers_with_mm_cache():
     assert config.renderer_num_workers == 1
 
 
+# A tiny public fixture: a 2-layer target at the repo root and a 1-layer draft
+# under DFlash/. The differing layer count is what makes the assertions below
+# distinguish "read the subfolder's config" from "read the root's config".
+SUBFOLDER_FIXTURE = "poolside/spec-decoding-subfolder-fixture"
+
+
+def test_speculative_config_subfolder_reads_the_draft_config():
+    """A draft bundled in a subfolder must load its own config, not the root's.
+
+    Without `subfolder` the repository root's config.json is used, which for a
+    bundled draft belongs to a different model (the target), so the draft is
+    built with the wrong architecture and shape.
+    """
+    target_model_config = ModelConfig(SUBFOLDER_FIXTURE)
+    speculative_config = SpeculativeConfig(
+        model=SUBFOLDER_FIXTURE,
+        subfolder="DFlash",
+        num_speculative_tokens=1,
+        target_model_config=target_model_config,
+        target_parallel_config=ParallelConfig(),
+    )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert draft_model_config.subfolder == "DFlash"
+    # The draft has 1 layer; the target at the repo root has 2.
+    assert draft_model_config.hf_config.num_hidden_layers == 1
+    assert target_model_config.hf_config.num_hidden_layers == 2
+
+
+def test_speculative_config_without_subfolder_reads_the_root_config():
+    """Control: omitting `subfolder` keeps the previous behaviour."""
+    target_model_config = ModelConfig(SUBFOLDER_FIXTURE)
+    speculative_config = SpeculativeConfig(
+        model=SUBFOLDER_FIXTURE,
+        num_speculative_tokens=1,
+        target_model_config=target_model_config,
+        target_parallel_config=ParallelConfig(),
+    )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert draft_model_config.subfolder is None
+    assert draft_model_config.hf_config.num_hidden_layers == 2
+
+
 def test_eagle_draft_model_config():
     """Test that EagleDraft model config is correctly set."""
     target_model_config = ModelConfig(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -198,6 +198,10 @@ class ModelConfig:
     revision: str | None = None
     """The specific model version to use. It can be a branch name, a tag name,
     or a commit id. If unspecified, will use the default version."""
+    subfolder: str | None = None
+    """The subfolder within the model repository or directory that holds the
+    weights. A Hub repo id may contain at most one `/`, so `org/repo/subdir`
+    cannot be expressed as an id."""
     code_revision: str | None = None
     """The specific revision to use for the model code on the Hugging Face Hub.
     It can be a branch name, a tag name, or a commit id. If unspecified, will
@@ -614,6 +618,9 @@ class ModelConfig:
             hf_overrides_kw=hf_overrides_kw,
             hf_overrides_fn=hf_overrides_fn,
             token=self.hf_token,
+            # The config must come from the same place as the weights: the
+            # repo root usually holds a different model's config.json.
+            **({"subfolder": self.subfolder} if self.subfolder else {}),
         )
         self.hf_config = hf_config
         if dict_overrides:

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -94,6 +94,9 @@ class SpeculativeConfig:
     model: str | None = None
     """The name of the draft model, eagle head, or additional weights, if
     provided."""
+    subfolder: str | None = None
+    """The subfolder within `model` that holds the draft weights, for a draft
+    bundled inside its target's repository rather than published separately."""
     method: SpeculativeMethod | None = None
     """The name of the speculative method to use. If users provide and set the
     `model` param, the speculative method type will be detected automatically
@@ -898,6 +901,7 @@ class SpeculativeConfig:
                     )
                 self.draft_model_config = ModelConfig(
                     model=self.model,
+                    subfolder=self.subfolder,
                     runner="draft",
                     tokenizer=(
                         self.model

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -326,6 +326,7 @@ class DefaultModelLoader(BaseModelLoader):
         primary_weights = DefaultModelLoader.Source(
             model_config.model,
             model_config.revision,
+            subfolder=model_config.subfolder,
             prefix="",
             fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", True),
             allow_patterns_overrides=getattr(model, "allow_patterns_overrides", None),
@@ -342,7 +343,7 @@ class DefaultModelLoader(BaseModelLoader):
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(
             model_name_or_path=model_config.model,
-            subfolder=None,
+            subfolder=model_config.subfolder,
             revision=model_config.revision,
             fall_back_to_pt=True,
             allow_patterns_overrides=None,


### PR DESCRIPTION



## Purpose
We've received lots of feedback that storing the DFlashes separately from the base model is confusing. Typically speaking, we list models like this:

```
poolside/Laguna-S-2.1-NVFP4
poolside/Laguna-S-2.1-DFlash-NVFP4
```

Since really they're not separate models, it makes sense to instead be able to bundle them in one place:

```
poolside/Laguna-S-2.1-NVFP4
poolside/Laguna-S-2.1-NVFP4/DFlash
```

This PR enables this sort of bundling. We also plan to upstream this to SGLang & TRT-LLM too ie this is not just a vLLM-specific change. 

Happily, vLLM pretty much already supports this out of the box: there just needs to be some subfolder plumbing. 

## Test Plan
We made a small bundled model of this form available [here](https://huggingface.co/poolside/spec-decoding-subfolder-fixture). We are happy to incorporate this into the CI if necessary, but we did some manual testing in the meantime & it seems to work well.

## Test Result


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

