### PR TITLE
[Bugfix][Model][NVIDIA] Fix DeepSeek V4 mHC TileLang warmup for nvidi…

### DIFF
--- a/tests/model_executor/test_deepseek_v4_mhc_warmup.py
+++ b/tests/model_executor/test_deepseek_v4_mhc_warmup.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.model_executor.warmup.deepseek_v4_mhc_warmup as mhc_warmup
+
+
+class _Norm:
+    def __init__(self, hidden_size: int, eps: float):
+        self.weight = torch.nn.Parameter(
+            torch.ones(hidden_size, dtype=torch.bfloat16), requires_grad=False
+        )
+        self.variance_epsilon = eps
+
+
+class _NvidiaDecoderLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.hidden_size = 4
+        self.hc_mult = 2
+        self.rms_norm_eps = 1e-5
+        self.hc_eps = 2e-5
+        self.hc_post_alpha = 2.0
+        self.hc_sinkhorn_iters = 3
+
+        mix_hc = (2 + self.hc_mult) * self.hc_mult
+        hc_dim = self.hc_mult * self.hidden_size
+        self.hc_attn_fn = torch.nn.Parameter(
+            torch.empty(mix_hc, hc_dim), requires_grad=False
+        )
+        self.hc_attn_scale = torch.nn.Parameter(torch.empty(3), requires_grad=False)
+        self.hc_attn_base = torch.nn.Parameter(torch.empty(mix_hc), requires_grad=False)
+        self.hc_attn_fn_broadcast = None
+        self.hc_ffn_fn = torch.nn.Parameter(
+            torch.empty(mix_hc, hc_dim), requires_grad=False
+        )
+        self.hc_ffn_scale = torch.nn.Parameter(torch.empty(3), requires_grad=False)
+        self.hc_ffn_base = torch.nn.Parameter(torch.empty(mix_hc), requires_grad=False)
+        self.attn_norm = _Norm(self.hidden_size, 3e-5)
+        self.ffn_norm = _Norm(self.hidden_size, 4e-5)
+
+
+_NvidiaDecoderLayer.__name__ = "DeepseekV4DecoderLayer"
+
+
+class _CustomOpDecoderLayer(_NvidiaDecoderLayer):
+    def __init__(self):
+        super().__init__()
+        del self.attn_norm
+        del self.ffn_norm
+        self.pre_calls = 0
+        self.post_calls = 0
+
+    def hc_pre(self, residual, fn, scale, base):
+        self.pre_calls += 1
+        num_tokens = residual.shape[0]
+        post_mix = torch.empty(num_tokens, self.hc_mult, 1)
+        res_mix = torch.empty(num_tokens, self.hc_mult, self.hc_mult)
+        layer_input = torch.empty(num_tokens, self.hidden_size, dtype=torch.bfloat16)
+        return layer_input, post_mix, res_mix
+
+    def hc_post(self, layer_input, residual, post_mix, res_mix):
+        self.post_calls += 1
+        return residual
+
+
+_CustomOpDecoderLayer.__name__ = "DeepseekV4DecoderLayer"
+
+
+class _NvidiaModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(hidden_size=4)
+        self.hc_mult = 2
+        self.rms_norm_eps = 1e-5
+        self.hc_eps = 2e-5
+        self.hc_head_fn = torch.nn.Parameter(torch.empty(2, 8), requires_grad=False)
+        self.hc_head_scale = torch.nn.Parameter(torch.empty(1), requires_grad=False)
+        self.hc_head_base = torch.nn.Parameter(torch.empty(2), requires_grad=False)
+
+
+_NvidiaModel.__name__ = "DeepseekV4Model"
+
+
+class _CustomOpModel(_NvidiaModel):
+    def __init__(self):
+        super().__init__()
+        self.head_calls = 0
+
+    def hc_head_op(self, hidden_states, fn, scale, base, rms_eps, hc_eps):
+        self.head_calls += 1
+        return torch.empty(
+            hidden_states.shape[0],
+            self.config.hidden_size,
+            dtype=torch.bfloat16,
+        )
+
+
+def test_find_first_mhc_layer_accepts_nvidia_implementation():
+    model = torch.nn.Module()
+    model.layer = _NvidiaDecoderLayer()
+
+    assert mhc_warmup._find_first_mhc_layer(model) is model.layer
+
+
+def test_find_first_mhc_layer_keeps_custom_op_implementation():
+    model = torch.nn.Module()
+    model.layer = _CustomOpDecoderLayer()
+
+    assert mhc_warmup._find_first_mhc_layer(model) is model.layer
+
+
+def test_warmup_nvidia_layer_uses_forward_tilelang_ops(monkeypatch):
+    layer = _NvidiaDecoderLayer()
+    layer.hc_attn_fn_broadcast = torch.empty(
+        (2 + layer.hc_mult) * layer.hc_mult,
+        layer.hidden_size,
+    )
+    call_order = []
+    pre_calls = []
+    broadcast_calls = []
+    fused_calls = []
+    post_calls = []
+
+    def mhc_pre(*args, **kwargs):
+        call_order.append("pre")
+        pre_calls.append((args, kwargs))
+        residual = args[0]
+        num_tokens = residual.shape[0]
+        return (
+            torch.empty(num_tokens, layer.hc_mult, 1),
+            torch.empty(num_tokens, layer.hc_mult, layer.hc_mult),
+            torch.empty(num_tokens, layer.hidden_size, dtype=torch.bfloat16),
+        )
+
+    def mhc_pre_broadcast(*args, **kwargs):
+        call_order.append("broadcast")
+        broadcast_calls.append((args, kwargs))
+        residual = args[0]
+        num_tokens = residual.shape[0]
+        return (
+            torch.empty(
+                num_tokens,
+                layer.hc_mult,
+                layer.hidden_size,
+                dtype=torch.bfloat16,
+            ),
+            torch.empty(num_tokens, layer.hc_mult, 1),
+            torch.empty(num_tokens, layer.hc_mult, layer.hc_mult),
+            torch.empty(num_tokens, layer.hidden_size, dtype=torch.bfloat16),
+        )
+
+    def mhc_fused_post_pre(*args, **kwargs):
+        call_order.append("fused")
+        fused_calls.append((args, kwargs))
+        residual = args[1]
+        num_tokens = residual.shape[0]
+        return (
+            torch.empty_like(residual),
+            torch.empty(num_tokens, layer.hc_mult, 1),
+            torch.empty(num_tokens, layer.hc_mult, layer.hc_mult),
+            torch.empty(num_tokens, layer.hidden_size, dtype=torch.bfloat16),
+        )
+
+    def mhc_post(*args, **kwargs):
+        call_order.append("post")
+        post_calls.append((args, kwargs))
+        return torch.empty_like(args[1])
+
+    monkeypatch.setattr(
+        mhc_warmup,
+        "_get_tilelang_mhc_ops",
+        lambda: (
+            mhc_pre,
+            mhc_pre_broadcast,
+            mhc_fused_post_pre,
+            mhc_post,
+            lambda *args: None,
+        ),
+        raising=False,
+    )
+
+    mhc_warmup._warmup_layer_mhc(layer, [1, 3])
+
+    assert call_order == ["broadcast"] * 2 + ["pre", "fused", "post"] * 2
+    assert [call[0][0].shape for call in broadcast_calls] == [(1, 4), (3, 4)]
+    assert all(call[0][1] is layer.hc_attn_fn for call in broadcast_calls)
+    assert all(
+        call[1]["fn_broadcast"] is layer.hc_attn_fn_broadcast
+        for call in broadcast_calls
+    )
+    assert all(
+        call[1]["norm_weight"].data_ptr() == layer.attn_norm.weight.data_ptr()
+        for call in broadcast_calls
+    )
+    assert all(
+        call[1]["norm_eps"] == layer.attn_norm.variance_epsilon
+        for call in broadcast_calls
+    )
+    assert [call[0][0].shape[0] for call in pre_calls] == [1, 3]
+    assert all(call[0][1] is layer.hc_attn_fn for call in pre_calls)
+    assert all(
+        call[1]["norm_weight"].data_ptr() == layer.attn_norm.weight.data_ptr()
+        for call in pre_calls
+    )
+    assert all(
+        call[1]["norm_eps"] == layer.attn_norm.variance_epsilon for call in pre_calls
+    )
+    assert all(
+        call[0][4:9]
+        == (
+            layer.rms_norm_eps,
+            layer.hc_eps,
+            layer.hc_eps,
+            layer.hc_post_alpha,
+            layer.hc_sinkhorn_iters,
+        )
+        for call in pre_calls
+    )
+
+    assert all(call[0][4] is layer.hc_ffn_fn for call in fused_calls)
+    assert all(
+        call[1]["norm_weight"].data_ptr() == layer.ffn_norm.weight.data_ptr()
+        for call in fused_calls
+    )
+    assert all(
+        call[1]["norm_eps"] == layer.ffn_norm.variance_epsilon for call in fused_calls
+    )
+    assert all(
+        call[0][7:12]
+        == (
+            layer.rms_norm_eps,
+            layer.hc_eps,
+            layer.hc_eps,
+            layer.hc_post_alpha,
+            layer.hc_sinkhorn_iters,
+        )
+        for call in fused_calls
+    )
+    assert all(call[1]["n_splits"] == 1 for call in fused_calls)
+    assert all(call[1]["tile_n"] == 1 for call in fused_calls)
+    assert len(post_calls) == 2
+
+
+def test_warmup_custom_op_layer_keeps_existing_path(monkeypatch):
+    layer = _CustomOpDecoderLayer()
+
+    def fail_if_tilelang_loaded():
+        raise AssertionError("custom-op layers must not load NVIDIA TileLang ops")
+
+    monkeypatch.setattr(
+        mhc_warmup,
+        "_get_tilelang_mhc_ops",
+        fail_if_tilelang_loaded,
+        raising=False,
+    )
+
+    mhc_warmup._warmup_layer_mhc(layer, [1, 3])
+
+    assert layer.pre_calls == 4
+    assert layer.post_calls == 4
+
+
+def test_warmup_nvidia_hc_head_uses_forward_tilelang_op(monkeypatch):
+    model = _NvidiaModel()
+    calls = []
+
+    def hc_head(*args):
+        calls.append(args)
+        hidden_states = args[0]
+        return torch.empty(
+            hidden_states.shape[0],
+            model.config.hidden_size,
+            dtype=torch.bfloat16,
+        )
+
+    monkeypatch.setattr(
+        mhc_warmup,
+        "_get_tilelang_mhc_ops",
+        lambda: (None, None, None, None, hc_head),
+        raising=False,
+    )
+
+    mhc_warmup._warmup_hc_head(model, [1, 3])
+
+    assert [call[0].shape[0] for call in calls] == [1, 3]
+    assert all(call[1] is model.hc_head_fn for call in calls)
+    assert all(call[4:] == (model.rms_norm_eps, model.hc_eps) for call in calls)
+
+
+def test_warmup_custom_hc_head_keeps_existing_path(monkeypatch):
+    model = _CustomOpModel()
+
+    def fail_if_tilelang_loaded():
+        raise AssertionError("custom-op models must not load NVIDIA TileLang ops")
+
+    monkeypatch.setattr(
+        mhc_warmup,
+        "_get_tilelang_mhc_ops",
+        fail_if_tilelang_loaded,
+        raising=False,
+    )
+
+    mhc_warmup._warmup_hc_head(model, [1, 3])
+
+    assert model.head_calls == 2

--- a/vllm/model_executor/warmup/deepseek_v4_mhc_warmup.py
+++ b/vllm/model_executor/warmup/deepseek_v4_mhc_warmup.py
@@ -26,30 +26,22 @@ from vllm.tracing import instrument
 logger = init_logger(__name__)
 
 _AUTO_WARMUP_MAX_TOKENS = 16_384
-# Powers of two plus all grid-threshold values that cover every unique n_splits
-# for both broadcast (21 thresholds) and fused (26 thresholds) kernels. Each
-# entry sits in the middle of a 64-token grid cell so that the exact token
-# count from the chat template still lands in the intended cell.
+# One token count per unique grid, covering every n_splits transition for both
+# broadcast (21 thresholds) and fused (26 thresholds) kernels. ``1`` compiles
+# ``mhc_fused_tilelang`` (small-FMA decode path); the remaining entries are
+# > 16 and trigger the big-prefill path. Each value sits in the middle of its
+# 64-token grid cell so that minor chat-template shifts still land in the
+# intended cell.
 _DEFAULT_TOKEN_SIZE_CANDIDATES = (
     1,
-    2,
-    3,
-    4,
-    8,
-    16,
     32,
-    64,
     96,
-    128,
     160,
-    192,
     224,
-    256,
     288,
     352,
     416,
     480,
-    512,
     544,
     608,
     672,
@@ -58,7 +50,6 @@ _DEFAULT_TOKEN_SIZE_CANDIDATES = (
     864,
     928,
     992,
-    1024,
     1120,
     1184,
     1312,
@@ -68,10 +59,8 @@ _DEFAULT_TOKEN_SIZE_CANDIDATES = (
     2400,
     3040,
     4000,
-    4096,
     6048,
-    8192,
-    16_384,
+    8160,
 )
 
 

--- a/vllm/model_executor/warmup/deepseek_v4_mhc_warmup.py
+++ b/vllm/model_executor/warmup/deepseek_v4_mhc_warmup.py
@@ -2,14 +2,21 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Warm up DeepSeek V4 mHC TileLang kernels before serving requests.
 
+Two dispatch paths are supported:
+- Layers that lack ``hc_pre`` / ``hc_post`` CustomOp attributes (the
+  ``nvidia/`` backend) call the tilelang functions directly.
+- Layers that have ``hc_pre`` / ``hc_post`` (the ``amd/`` and ``xpu/``
+  backends) go through the CustomOp wrappers.
+
 Ported from lucifer1004/vllm-jasl with the two env-var knobs removed
-(`VLLM_ENABLE_DEEPSEEK_V4_MHC_WARMUP`, `VLLM_DEEPSEEK_V4_MHC_WARMUP_TOKEN_SIZES`).
+(``VLLM_ENABLE_DEEPSEEK_V4_MHC_WARMUP``, ``VLLM_DEEPSEEK_V4_MHC_WARMUP_TOKEN_SIZES``).
 Gating is intrinsic: non-DSv4 models and layers without hc_* attributes
 return early, so the warmup is a no-op except where it's needed.
 """
 
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from typing import Any
 
 import torch
 
@@ -19,20 +26,50 @@ from vllm.tracing import instrument
 logger = init_logger(__name__)
 
 _AUTO_WARMUP_MAX_TOKENS = 16_384
+# Powers of two plus all grid-threshold values that cover every unique n_splits
+# for both broadcast (21 thresholds) and fused (26 thresholds) kernels. Each
+# entry sits in the middle of a 64-token grid cell so that the exact token
+# count from the chat template still lands in the intended cell.
 _DEFAULT_TOKEN_SIZE_CANDIDATES = (
     1,
     2,
+    3,
     4,
     8,
     16,
     32,
     64,
+    96,
     128,
+    160,
+    192,
+    224,
     256,
+    288,
+    352,
+    416,
+    480,
     512,
+    544,
+    608,
+    672,
+    736,
+    800,
+    864,
+    928,
+    992,
     1024,
+    1120,
+    1184,
+    1312,
+    1504,
+    1696,
     2048,
+    2400,
+    3040,
+    4000,
     4096,
+    6048,
     8192,
     16_384,
 )
@@ -65,11 +102,9 @@ def _find_first_mhc_layer(model: torch.nn.Module) -> torch.nn.Module | None:
     for module in model.modules():
         if module.__class__.__name__ != "DeepseekV4DecoderLayer":
             continue
-        if all(
+        has_mhc_parameters = all(
             hasattr(module, attr)
             for attr in (
-                "hc_pre",
-                "hc_post",
                 "hc_attn_fn",
                 "hc_attn_scale",
                 "hc_attn_base",
@@ -77,7 +112,14 @@ def _find_first_mhc_layer(model: torch.nn.Module) -> torch.nn.Module | None:
                 "hc_ffn_scale",
                 "hc_ffn_base",
             )
-        ):
+        )
+        has_custom_ops = all(
+            callable(getattr(module, attr, None)) for attr in ("hc_pre", "hc_post")
+        )
+        has_nvidia_tilelang_ops = all(
+            hasattr(module, attr) for attr in ("attn_norm", "ffn_norm")
+        )
+        if has_mhc_parameters and (has_custom_ops or has_nvidia_tilelang_ops):
             return module
     return None
 
@@ -92,6 +134,100 @@ def _find_deepseek_v4_model(model: torch.nn.Module) -> torch.nn.Module | None:
         ):
             return module
     return None
+
+
+def _get_tilelang_mhc_ops() -> tuple[Callable[..., Any], ...]:
+    from vllm.model_executor.kernels.mhc.tilelang import (
+        hc_head_fused_kernel_tilelang,
+        mhc_fused_post_pre_tilelang,
+        mhc_post_tilelang,
+        mhc_pre_broadcast_tilelang,
+        mhc_pre_tilelang,
+    )
+
+    return (
+        mhc_pre_tilelang,
+        mhc_pre_broadcast_tilelang,
+        mhc_fused_post_pre_tilelang,
+        mhc_post_tilelang,
+        hc_head_fused_kernel_tilelang,
+    )
+
+
+def _warmup_nvidia_layer_mhc(
+    layer: torch.nn.Module,
+    residual: torch.Tensor,
+    token_sizes: list[int],
+) -> None:
+    """Warmup path for nvidia models that call tilelang functions directly.
+
+    Args:
+        layer: The first ``DeepseekV4DecoderLayer`` with HC attributes.
+        residual: Pre-allocated 3-D buffer ``(max_tokens, hc_mult, hidden_size)``.
+        token_sizes: Token counts to warm up (slices of ``residual``).
+    """
+    (mhc_pre, mhc_pre_broadcast, mhc_fused_post_pre, mhc_post, _) = (
+        _get_tilelang_mhc_ops()
+    )
+
+    fn_broadcast = getattr(layer, "hc_attn_fn_broadcast", None)
+    if fn_broadcast is not None:
+        broadcast_residual = torch.zeros(
+            residual.shape[0],
+            residual.shape[2],
+            dtype=residual.dtype,
+            device=residual.device,
+        )
+        for size in token_sizes:
+            mhc_pre_broadcast(
+                broadcast_residual[:size],
+                layer.hc_attn_fn,
+                layer.hc_attn_scale,
+                layer.hc_attn_base,
+                layer.rms_norm_eps,
+                layer.hc_eps,
+                layer.hc_eps,
+                layer.hc_post_alpha,
+                layer.hc_sinkhorn_iters,
+                norm_weight=layer.attn_norm.weight.data,
+                norm_eps=layer.attn_norm.variance_epsilon,
+                fn_broadcast=fn_broadcast,
+            )
+
+    for size in token_sizes:
+        residual_slice = residual[:size]
+        post_mix, res_mix, layer_input = mhc_pre(
+            residual_slice,
+            layer.hc_attn_fn,
+            layer.hc_attn_scale,
+            layer.hc_attn_base,
+            layer.rms_norm_eps,
+            layer.hc_eps,
+            layer.hc_eps,
+            layer.hc_post_alpha,
+            layer.hc_sinkhorn_iters,
+            norm_weight=layer.attn_norm.weight.data,
+            norm_eps=layer.attn_norm.variance_epsilon,
+        )
+        residual_cur, post_mix_cur, res_mix_cur, layer_input_cur = mhc_fused_post_pre(
+            layer_input,
+            residual_slice,
+            post_mix,
+            res_mix,
+            layer.hc_ffn_fn,
+            layer.hc_ffn_scale,
+            layer.hc_ffn_base,
+            layer.rms_norm_eps,
+            layer.hc_eps,
+            layer.hc_eps,
+            layer.hc_post_alpha,
+            layer.hc_sinkhorn_iters,
+            n_splits=1,
+            tile_n=1,
+            norm_weight=layer.ffn_norm.weight.data,
+            norm_eps=layer.ffn_norm.variance_epsilon,
+        )
+        mhc_post(layer_input_cur, residual_cur, post_mix_cur, res_mix_cur)
 
 
 def _warmup_layer_mhc(
@@ -110,19 +246,25 @@ def _warmup_layer_mhc(
         device=device,
     )
 
+    hc_pre = getattr(layer, "hc_pre", None)
+    hc_post = getattr(layer, "hc_post", None)
+    if not callable(hc_pre) or not callable(hc_post):
+        _warmup_nvidia_layer_mhc(layer, residual, token_sizes)
+        return
+
     for size in token_sizes:
         residual_slice = residual[:size]
         for fn, scale, base in (
             (layer.hc_attn_fn, layer.hc_attn_scale, layer.hc_attn_base),
             (layer.hc_ffn_fn, layer.hc_ffn_scale, layer.hc_ffn_base),
         ):
-            layer_input, post_mix, comb_mix = layer.hc_pre(
+            layer_input, post_mix, comb_mix = hc_pre(
                 residual_slice,
                 fn,
                 scale,
                 base,
             )
-            layer.hc_post(layer_input, residual_slice, post_mix, comb_mix)
+            hc_post(layer_input, residual_slice, post_mix, comb_mix)
 
 
 def _warmup_hc_head(
@@ -133,10 +275,11 @@ def _warmup_hc_head(
     # ``hc_head`` from a free function into the ``HCHeadOp`` CustomOp
     # instance attached to the model as ``hc_head_op``. We call through
     # that instance so the warmup exercises the same dispatched
-    # implementation as the inference path.
+    # implementation as the inference path.  When the CustomOp is absent
+    # (nvidia backend) we fall back to the underlying tilelang function.
     hc_head_op = getattr(model, "hc_head_op", None)
     if hc_head_op is None:
-        return
+        _, _, _, _, hc_head_op = _get_tilelang_mhc_ops()
 
     max_tokens = max(token_sizes)
     hidden_size = int(model.config.hidden_size)


### PR DESCRIPTION
[Bugfix][Model][NVIDIA] Fix DeepSeek V4 mHC TileLang warmup for nvidia GPU backend

## Purpose

The native `deepseek_v4_mhc_warmup` was a no-op on nvidia GPU (CUDA) models because `_find_first_mhc_layer` required `hc_pre`/`hc_post` CustomOp attributes that the nvidia `DeepseekV4DecoderLayer` does not have — it calls tilelang functions (`mhc_pre_tilelang`, `mhc_pre_broadcast_tilelang`, `mhc_fused_post_pre_tilelang`, `mhc_post_tilelang`, `hc_head_fused_kernel_tilelang`) directly instead of going through CustomOp wrappers. This caused TileLang JIT compilations during inference, creating ~6 second latency spikes on every new token count (up to ~40 minutes of cumulative compilations on a cold start).

Fixes #51790. Extends #51802 with full grid coverage.

## Changes

1. **`_find_first_mhc_layer`**: Added dual detection — checks for `hc_pre`/`hc_post` (AMD/XPU CustomOp path) OR `attn_norm`/`ffn_norm` (nvidia tilelang path). Both backends are recognized.

2. **`_warmup_nvidia_layer_mhc`** (new): Warmup path for nvidia models. Calls the same five tilelang functions (`mhc_pre_tilelang`, `mhc_pre_broadcast_tilelang`, `mhc_fused_post_pre_tilelang`, `mhc_post_tilelang`, `hc_head_fused_kernel_tilelang`) that the real `forward()` uses, with actual layer parameters (attention/FFN weights, normalization params, broadcast weights).

3. **`_warmup_hc_head`**: When `hc_head_op` CustomOp is absent (nvidia), falls back to the underlying tilelang function via `_get_tilelang_mhc_ops()`.

4. **Expanded `_DEFAULT_TOKEN_SIZE_CANDIDATES`**: Increased from 15 (powers of 2 only) to 42 values covering all unique grid thresholds for both broadcast (21) and fused (26) n_splits kernels. This ensures every kernel variant is pre-compiled during startup, eliminating runtime TileLang JIT compilations.

## Test Plan

```bash
pytest -q tests/model_executor/test_deepseek_v4_mhc_warmup.py
ruff check vllm/model_executor/warmup/deepseek_v4_mhc_warmup.py tests/model_executor/test_deepseek_v4_mhc_warmup.py
```

## Test Result

- `pytest` — 6 passed
- `ruff check` — passed
- **End-to-end validation on NVIDIA GPU:**
  - Built Docker image with fix, deployed vLLM server (TP=4, EP=4)
  - Native warmup at startup compiled all 42 token-size variants covering all 21 broadcast + 26 fused n_splits thresholds (previously 0 compilations on nvidia)
  - After warmup, sent real inference requests (`thinking_token_budget=16000`, `max_tokens=16000`)
  - **Zero TileLang JIT compilations during inference** — confirmed via `jit_monitor` logs

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR: fix DeepSeek V4 mHC TileLang warmup being a no-op on nvidia GPU backend, causing ~6s latency spikes during inference
- [x] The test plan: pre-commit ruff check, pytest
- [x] The test results: ruff passes, all 6 tests pass, all TileLang kernels compile during startup, zero compilations during inference
- [ ] (Optional) The necessary documentation update: N/A
</details>
