### PR TITLE
nixl: skip importing NIXL on x86 CPUs without AVX to avoid UCX native…

### DIFF
--- a/tests/unit/test_nixl_utils_cpu_check.py
+++ b/tests/unit/test_nixl_utils_cpu_check.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import platform
+
+from vllm.distributed import nixl_utils as nu
+
+
+def test_cpu_no_avx_skips_nixl(monkeypatch):
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda path, *a, **k: io.StringIO("flags\t: fpu vme de\n"),
+    )
+    nu.__dict__.pop("NixlWrapper", None)
+    assert nu._load_nixl_attr("NixlWrapper") is None

--- a/vllm/distributed/nixl_utils.py
+++ b/vllm/distributed/nixl_utils.py
@@ -17,6 +17,26 @@ nixl_agent_config: Any
 nixlXferTelemetry: Any
 
 
+def _cpu_supports_avx() -> bool:
+    """True unless this x86 CPU lacks the 'avx' flag (conservative)."""
+    try:
+        import platform
+
+        machine = platform.machine().lower()
+    except Exception:
+        return True
+
+    if machine not in ("x86_64", "amd64", "i386", "i686"):
+        return True
+
+    try:
+        with open("/proc/cpuinfo", "r") as f:
+            data = f.read().lower()
+        return "avx" in data
+    except Exception:
+        return True
+
+
 def _maybe_set_ucx_rcache_limit() -> None:
     if "UCX_RCACHE_MAX_UNRELEASED" in os.environ:
         return
@@ -53,6 +73,15 @@ def _load_nixl_attr(name: str) -> Any:
         "nixl_agent_config": "nixl_agent_config",
         "nixlXferTelemetry": "nixlXferTelemetry",
     }[name]
+
+    # Avoid NIXL/UCX import on x86 CPUs without AVX (UCX aborts at init).
+    if not _cpu_supports_avx():
+        logger.warning_once(
+            "Detected x86 CPU without AVX; skipping NIXL import to avoid "
+            "a native UCX crash."
+        )
+        globals()[name] = None
+        return None
 
     _maybe_set_ucx_rcache_limit()
     try:


### PR DESCRIPTION
Fixes #52885

- **Root cause**: bundled NIXL/UCX native libs are imported at startup and abort the process on x86 CPUs without AVX.
- **Fix**: `_cpu_supports_avx()` checks /proc/cpuinfo (conservative); when AVX is missing, skip the NIXL import so vLLM runs without KV connectors.
- **Tests**: unit test simulating a non-AVX x86 CPU.
