### PR TITLE
fix(find_mm_placeholders): prefer inserted occurrences for PromptInse…

### DIFF
--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -900,6 +900,24 @@ def test_find_mm_placeholders(
     assert result == expected
 
 
+def test_find_mm_placeholders_insertion_overlap():
+    prompt = [1, 32000, 32000, 32000]
+    mm_prompt_updates = {
+        "pattern": [
+            [PromptInsertion("pattern", [32000], [32000, 32000]).resolve(0)]
+        ]
+    }
+
+    result = find_mm_placeholders(prompt, mm_prompt_updates, tokenizer=None)
+
+    assert "pattern" in result
+    infos = result["pattern"]
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.start_idx == 2
+    assert info.tokens == [32000, 32000]
+
+
 @pytest.mark.parametrize("model_id", ["llava-hf/llava-v1.6-mistral-7b-hf"])
 @pytest.mark.parametrize(
     ("num_images", "limit", "is_valid"),

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1047,11 +1047,24 @@ def _iter_placeholders(
             if content_len_full == 0 or end_idx_full > prompt_len:
                 continue
 
-            # Check the first token before comparing the full slice
+                # Check the first token before comparing the full slice
             if (
                 first_token == content_tokens_full[0]
                 and prompt[start_idx:end_idx_full] == content_tokens_full
             ):
+                if update.mode == UpdateMode.INSERT and not isinstance(
+                    update.target, PromptIndex
+                ):
+                    try:
+                        target_tokens = _seq2tokens(tokenizer, update.target)
+                    except Exception:
+                        target_tokens = None
+
+                    if target_tokens:
+                        tlen = len(target_tokens)
+                        if start_idx < tlen or prompt[start_idx - tlen : start_idx] != target_tokens:  # noqa: E203
+                            continue
+
                 content = update.content
                 content_is_embed = content.is_embed
                 if content_is_embed is not None:


### PR DESCRIPTION
Fixes #52924

- **Root cause**: `_iter_placeholders` could report an earlier occurrence that includes original prompt tokens when the tokens inserted by `PromptInsertion` are identical to existing tokens.
- **Fix**: for INSERT updates, prefer matches that immediately follow the update's target tokens; skip occurrences whose left context doesn't match the target.
- **Tests**: added a case where inserted tokens overlap with identical prompt tokens.