### PR TITLE
[Rust Frontend] Add Step3p5 tool parser

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -405,7 +405,7 @@ mod tests {
         )
         .unwrap_err();
 
-        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, hy_v4, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml, seed_oss)"].assert_eq(&error.to_report_string());
+        expect_test::expect!["tool parser `definitely_missing_tool_parser` is not registered (choose from: deepseek_v3, deepseek_v31, deepseek_v32, deepseek_v4, gemma4, glm45, glm47, granite4, hermes, hy_v3, hy_v4, inkling, internlm, kimi_k2, kimi_k3, llama3_json, llama4_json, minimax_m2, minimax_m3, mistral, phi4_mini_json, qwen3_coder, qwen3_xml, seed_oss, step3p5)"].assert_eq(&error.to_report_string());
     }
 
     #[test]

--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -10,7 +10,7 @@ pub use vllm_parser::tool::{
     Glm45MoeToolParser, Glm47MoeToolParser, Granite4ToolParser, HermesToolParser,
     Internlm2ToolParser, KimiK2ToolParser, Llama3JsonToolParser, MinimaxM2ToolParser,
     MinimaxM3ToolParser, MistralToolParser, Phi4MiniJsonToolParser, Qwen3CoderToolParser,
-    Qwen3XmlToolParser, SeedOssToolParser, ToolParser, ToolParserError,
+    Qwen3XmlToolParser, SeedOssToolParser, Step3p5ToolParser, ToolParser, ToolParserError,
 };
 
 use crate::parser::ParserFactory;
@@ -44,6 +44,7 @@ pub mod names {
     pub const QWEN3_CODER: &str = "qwen3_coder";
     pub const QWEN3_XML: &str = "qwen3_xml";
     pub const SEED_OSS: &str = "seed_oss";
+    pub const STEP3P5: &str = "step3p5";
 }
 
 /// Constructor signature for one registered tool parser implementation.
@@ -90,7 +91,8 @@ impl ToolParserFactory {
             .register_parser::<Phi4MiniJsonToolParser>(names::PHI4_MINI_JSON)
             .register_parser::<Qwen3XmlToolParser>(names::QWEN3_XML)
             .register_parser::<Qwen3CoderToolParser>(names::QWEN3_CODER)
-            .register_parser::<SeedOssToolParser>(names::SEED_OSS);
+            .register_parser::<SeedOssToolParser>(names::SEED_OSS)
+            .register_parser::<Step3p5ToolParser>(names::STEP3P5);
 
         factory
             .register_pattern("mistral-", names::MISTRAL)
@@ -131,7 +133,10 @@ impl ToolParserFactory {
             .register_pattern("minimax", names::MINIMAX_M2)
             .register_pattern("mm-m2", names::MINIMAX_M2)
             .register_pattern("seed-oss", names::SEED_OSS)
-            .register_pattern("seedoss", names::SEED_OSS);
+            .register_pattern("seedoss", names::SEED_OSS)
+            .register_pattern("step-3p5", names::STEP3P5)
+            .register_pattern("step3p5", names::STEP3P5)
+            .register_pattern("step-3.5", names::STEP3P5);
 
         factory
     }

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -120,6 +120,27 @@ fn factory_new_resolves_default_patterns() {
     let factory = ToolParserFactory::new();
 
     assert_eq!(
+        factory.resolve_name_for_model("stepfun-ai/Step-3.5-Flash"),
+        Some(names::STEP3P5)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("stepfun-ai/step3p5"),
+        Some(names::STEP3P5)
+    );
+
+    assert_eq!(
+        factory.resolve_name_for_model("Qwen/Qwen3.5-0.8B"),
+        Some(names::QWEN3_CODER)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("Qwen/Qwen3-0.6B"),
+        Some(names::QWEN3_XML)
+    );
+    assert_eq!(
+        factory.resolve_name_for_model("Qwen/Qwen3-Coder-30B"),
+        Some(names::QWEN3_CODER)
+    );
+    assert_eq!(
         factory.resolve_name_for_model("meta-llama-4-maverick"),
         Some(names::LLAMA4_JSON)
     );

--- a/rust/src/chat/tests/roundtrip.rs
+++ b/rust/src/chat/tests/roundtrip.rs
@@ -390,7 +390,7 @@ roundtrip_tests! {
     glm47 => [reasoning_and_content, tool_call_mix],
     glm52 => [reasoning_and_content, tool_call_mix],
     seed_oss => [reasoning_and_content, tool_call_mix],
-    step3p5 => [reasoning_and_content],
+    step3p5 => [reasoning_and_content, tool_call_mix],
     nemotron_v3 => [reasoning_and_content],
     gemma4 => [tool_call_mix], // Gemma4 strips reasoning in history if there's no tool call
     kimi_k25 => [tool_call_mix], // Kimi K2.5 strips reasoning in history

--- a/rust/src/parser/src/tool/mod.rs
+++ b/rust/src/parser/src/tool/mod.rs
@@ -16,6 +16,7 @@ mod minimax_m3;
 mod parameters;
 mod qwen_coder;
 mod seed_oss;
+mod step3p5;
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_utils;
 use std::collections::{BTreeMap, btree_map};
@@ -36,6 +37,7 @@ pub use qwen_coder::Qwen3CoderToolParser;
 pub use seed_oss::SeedOssToolParser;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+pub use step3p5::Step3p5ToolParser;
 pub use xgrammar_structural_tag::builders::StructuralTagBuilder;
 
 use crate::utils;

--- a/rust/src/parser/src/tool/step3p5.rs
+++ b/rust/src/parser/src/tool/step3p5.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use winnow::combinator::{alt, seq};
+use winnow::prelude::*;
+use winnow::stream::Partial;
+use winnow::token::literal;
+
+use super::parameters::ToolSchemas;
+use super::utils::{MarkerScanState, parse_buffered_event, safe_text_len, take_until_marker};
+use super::{Result, Tool, ToolCallDelta, ToolParser, ToolParserOutput};
+
+const TOOL_CALL_START: &str = "<tool_call>";
+const TOOL_CALL_END: &str = "</tool_call>";
+const FUNCTION_START: &str = "<function=";
+const FUNCTION_END: &str = "</function>";
+const PARAMETER_START: &str = "<parameter=";
+const PARAMETER_END: &str = "</parameter>";
+
+type Input<'i> = Partial<&'i str>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Mode {
+    Text,
+    ToolCall { end_scan: MarkerScanState },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    Text(usize),
+    ToolCallStart,
+    ToolCallBody(String),
+}
+
+/// Tool parser for Step3.5 XML tool calls.
+pub struct Step3p5ToolParser {
+    buffer: String,
+    mode: Mode,
+    emitted_tool_count: usize,
+    tool_schemas: ToolSchemas,
+}
+
+impl Step3p5ToolParser {
+    fn new(tools: &[Tool]) -> Self {
+        Self {
+            buffer: String::new(),
+            mode: Mode::Text,
+            emitted_tool_count: 0,
+            tool_schemas: ToolSchemas::from_tools(tools),
+        }
+    }
+
+    fn apply_event(&mut self, event: Event, output: &mut ToolParserOutput) -> Result<()> {
+        match event {
+            Event::Text(len) => output.push_text(&self.buffer[..len]),
+            Event::ToolCallStart => {
+                self.mode = Mode::ToolCall {
+                    end_scan: MarkerScanState::default(),
+                };
+            }
+            Event::ToolCallBody(body) => {
+                let (name, params) = parse_tool_call_body(&body)?;
+                let arguments = self.tool_schemas.convert_params_with_schema(&name, params);
+                let arguments = serde_json::to_string(&arguments)
+                    .map_err(|error| parsing_failed!("failed to serialize arguments: {}", error))?;
+                output.push_call(ToolCallDelta {
+                    tool_index: self.emitted_tool_count,
+                    name: Some(name),
+                    arguments,
+                });
+                self.emitted_tool_count += 1;
+                self.mode = Mode::Text;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ToolParser for Step3p5ToolParser {
+    fn create(tools: &[Tool]) -> Result<Box<dyn ToolParser>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Box::new(Self::new(tools)))
+    }
+
+    fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
+        self.buffer.push_str(chunk);
+        while let Some((event, consumed_len)) = parse_buffered_event(&self.buffer, |input| {
+            parse_next_event(input, &mut self.mode)
+        })? {
+            self.apply_event(event, output)?;
+            self.buffer.drain(..consumed_len);
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<ToolParserOutput> {
+        let mut output = ToolParserOutput::default();
+        if !self.buffer.is_empty() {
+            match self.mode {
+                Mode::Text => output.push_text(&self.buffer),
+                Mode::ToolCall { .. } => {
+                    return Err(parsing_failed!("incomplete Step3p5 tool call"));
+                }
+            }
+        }
+        let _ = self.reset();
+        Ok(output)
+    }
+
+    fn reset(&mut self) -> String {
+        let buffered = match self.mode {
+            Mode::Text => std::mem::take(&mut self.buffer),
+            Mode::ToolCall { .. } => format!("{TOOL_CALL_START}{}", self.buffer),
+        };
+        self.mode = Mode::Text;
+        self.emitted_tool_count = 0;
+        self.buffer.clear();
+        buffered
+    }
+}
+
+fn parse_next_event(input: &mut Input<'_>, mode: &mut Mode) -> ModalResult<Event> {
+    match mode {
+        Mode::Text => alt((
+            literal(TOOL_CALL_START).value(Event::ToolCallStart),
+            safe_text_event,
+        ))
+        .parse_next(input),
+        Mode::ToolCall { end_scan } => seq!(
+            take_until_marker(TOOL_CALL_END, end_scan).map(str::to_string),
+            _: literal(TOOL_CALL_END),
+        )
+        .map(|(body,)| Event::ToolCallBody(body))
+        .parse_next(input),
+    }
+}
+
+fn safe_text_event(input: &mut Input<'_>) -> ModalResult<Event> {
+    safe_text_len(input, TOOL_CALL_START).map(Event::Text)
+}
+
+fn parse_tool_call_body(body: &str) -> Result<(String, Vec<(String, String)>)> {
+    let mut remaining = body.trim_start();
+    remaining = remaining
+        .strip_prefix(FUNCTION_START)
+        .ok_or_else(|| parsing_failed!("expected `{}`", FUNCTION_START))?;
+    let name_end = remaining
+        .find('>')
+        .ok_or_else(|| parsing_failed!("incomplete Step3p5 function tag"))?;
+    let name = remaining[..name_end].trim();
+    if name.is_empty() {
+        return Err(parsing_failed!("empty Step3p5 function name"));
+    }
+    remaining = &remaining[name_end + 1..];
+
+    let mut params = Vec::new();
+    loop {
+        remaining = remaining.trim_start();
+        if let Some(rest) = remaining.strip_prefix(FUNCTION_END) {
+            if !rest.trim().is_empty() {
+                return Err(parsing_failed!("unexpected text after Step3p5 function"));
+            }
+            return Ok((name.to_string(), params));
+        }
+
+        remaining = remaining
+            .strip_prefix(PARAMETER_START)
+            .ok_or_else(|| parsing_failed!("expected Step3p5 parameter or function end"))?;
+        let name_end = remaining
+            .find('>')
+            .ok_or_else(|| parsing_failed!("incomplete Step3p5 parameter tag"))?;
+        let parameter_name = remaining[..name_end].trim();
+        if parameter_name.is_empty() {
+            return Err(parsing_failed!("empty Step3p5 parameter name"));
+        }
+        remaining = &remaining[name_end + 1..];
+
+        let value_end = [
+            remaining.find(PARAMETER_END),
+            remaining.find(PARAMETER_START),
+            remaining.find(FUNCTION_END),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .ok_or_else(|| parsing_failed!("incomplete Step3p5 parameter value"))?;
+        params.push((
+            parameter_name.to_string(),
+            remaining[..value_end].trim().to_string(),
+        ));
+        remaining = &remaining[value_end..];
+        if remaining.starts_with(PARAMETER_END) {
+            remaining = &remaining[PARAMETER_END.len()..];
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+    use thiserror_ext::AsReport;
+
+    use super::Step3p5ToolParser;
+    use crate::tool::test_utils::{split_by_chars, test_tools};
+    use crate::tool::{ToolParser, ToolParserEvent, ToolParserOutput, ToolParserTestExt as _};
+
+    fn tool_call(name: &str, params: &[(&str, &str)]) -> String {
+        let params = params
+            .iter()
+            .map(|(key, value)| format!("<parameter={key}>\n{value}\n</parameter>"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("<tool_call>\n<function={name}>\n{params}\n</function>\n</tool_call>")
+    }
+
+    #[test]
+    fn preserves_text_without_tool_calls() {
+        let mut parser = Step3p5ToolParser::new(&test_tools());
+        let output = parser.parse_complete("Hello, world!").unwrap();
+        assert_eq!(output.normal_text(), "Hello, world!");
+        assert!(output.calls().is_empty());
+    }
+
+    #[test]
+    fn converts_parameters_using_tool_schema() {
+        let mut parser = Step3p5ToolParser::new(&test_tools());
+        let output = parser
+            .parse_complete(&tool_call(
+                "convert",
+                &[
+                    ("whole", "1.5"),
+                    ("flag", "true"),
+                    ("payload", r#"{"city":"Paris"}"#),
+                    ("items", "[1,2,3]"),
+                ],
+            ))
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&output.calls()[0].arguments).unwrap(),
+            json!({
+                "whole": 1.5,
+                "flag": true,
+                "payload": {"city": "Paris"},
+                "items": [1, 2, 3],
+            })
+        );
+    }
+
+    #[test]
+    fn streams_split_markers_and_mixed_content() {
+        let input = format!(
+            "hello{}middle{}done",
+            tool_call("get_weather", &[("city", "Shanghai"), ("days", "3")]),
+            tool_call("add", &[("x", "1"), ("y", "2")]),
+        );
+        let chunks = split_by_chars(&input, 3);
+        let mut parser = Step3p5ToolParser::new(&test_tools());
+        let mut streamed = ToolParserOutput::default();
+        for chunk in chunks {
+            parser.parse_into(chunk, &mut streamed).unwrap();
+        }
+        streamed.append(parser.finish().unwrap());
+
+        assert!(matches!(
+            streamed.events.as_slice(),
+            [
+                ToolParserEvent::Text(prefix),
+                ToolParserEvent::ToolCall(first),
+                ToolParserEvent::Text(middle),
+                ToolParserEvent::ToolCall(second),
+                ToolParserEvent::Text(suffix),
+            ] if prefix == "hello"
+                && first.tool_index == 0
+                && middle == "middle"
+                && second.tool_index == 1
+                && suffix == "done"
+        ));
+
+        let output = streamed.coalesce();
+        assert_eq!(output.normal_text(), "hellomiddledone");
+        assert_eq!(output.calls().len(), 2);
+        assert_eq!(output.calls()[0].name.as_deref(), Some("get_weather"));
+        assert_eq!(output.calls()[1].name.as_deref(), Some("add"));
+    }
+
+    #[test]
+    fn tolerates_missing_parameter_end() {
+        let input = "<tool_call><function=get_weather><parameter=city>Dallas\n\
+                     <parameter=state>TX</parameter></function></tool_call>";
+        let mut parser = Step3p5ToolParser::new(&test_tools());
+        let output = parser.parse_complete(input).unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&output.calls()[0].arguments).unwrap(),
+            json!({"city": "Dallas", "state": "TX"})
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_tool_call_at_finish() {
+        let mut parser = Step3p5ToolParser::new(&test_tools());
+        let input = "<tool_call><function=get_weather>";
+        parser.parse_chunk(input).unwrap();
+        assert_eq!(
+            parser.finish().unwrap_err().as_report().to_string(),
+            "tool parser parsing failed: incomplete Step3p5 tool call"
+        );
+        assert_eq!(parser.reset(), input);
+    }
+}


### PR DESCRIPTION
## Summary

- add a Rust `step3p5` tool parser for `<tool_call><function=...><parameter=...>` output
- convert parameter values with the selected tool's JSON schema, preserve ordered text/tool events, support multiple calls and arbitrary chunk boundaries, and tolerate a missing `</parameter>` before the next tag
- preserve the original `<tool_call>` prefix when recovering malformed or incomplete calls as plain text
- register the parser and Step-3.5 model patterns in the chat factory
- extend the existing Step3p5 roundtrip case with `tool_call_mix`

## Duplicate-work check

This does not duplicate an existing PR. I rechecked roadmap issue #44280 and open PRs immediately before submission. PR #46369 covers the separate `step3` format, while #51810 is a Python-side forced-tool-choice routing fix rather than a Rust tool parser.

## Testing

Passed:

```text
cargo fmt --manifest-path rust/Cargo.toml --all -- --check
cargo test --manifest-path rust/Cargo.toml -p vllm-parser --lib  # 435 passed
cargo test --manifest-path rust/Cargo.toml -p vllm-chat --lib  # 278 passed
cargo clippy --manifest-path rust/Cargo.toml -p vllm-parser -p vllm-chat --all-targets -- -D warnings
uv tool run pre-commit run --files <changed files>
```

The Step3p5 tokenizer roundtrip was also invoked locally, but model-file loading could not complete because the environment timed out connecting to Hugging Face. The existing Step3p5 reasoning roundtrip uses the same model artifact; CI can exercise the newly enabled `tool_call_mix` fixture with its normal model cache/network.

## Model evaluation

No model-generation evaluation was run because this change only parses already-generated assistant text and does not alter inference, sampling, or model execution. Parser behavior is covered by deterministic complete/streaming tests and the model-family roundtrip fixture.

## AI assistance

OpenAI Codex was used to assist with code exploration, implementation, and testing. The human submitter is responsible for reviewing every changed line and defending the change end-to-end.

Related: #44280



