### PR TITLE
[Bugfix][ROCm][Disagg] Honor pinned remote_dp_rank for WideEP child-pod notify

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -688,6 +688,18 @@ class MoRIIOConnectorScheduler:
                 assert request.kv_transfer_params is not None, (
                     "kv_transfer_params should not be None"
                 )
+                extra = self.kv_transfer_config.kv_connector_extra_config
+                if extra.get("remote_hosts") and not request.kv_transfer_params.get(
+                    "remote_hosts"
+                ):
+                    request.kv_transfer_params["remote_hosts"] = extra["remote_hosts"]
+                if extra.get("remote_dp_size_local") not in (
+                    None,
+                    "",
+                ) and not request.kv_transfer_params.get("remote_dp_size_local"):
+                    request.kv_transfer_params["remote_dp_size_local"] = extra[
+                        "remote_dp_size_local"
+                    ]
 
                 remote_dp_rank = request.kv_transfer_params.get("remote_dp_rank", 0)
 
@@ -726,10 +738,15 @@ class MoRIIOConnectorScheduler:
 
                 # Only the owning rank originates notify (exactly-once).
                 # Priority: is_request_leader > remote_dp_rank_override > _is_kv_master
+                # Honor a router-pinned remote_dp_rank even without override;
+                # child-pod ranks are not _is_kv_master and would otherwise skip notify.
                 _leader_flag = request.kv_transfer_params.get("is_request_leader")
                 if _leader_flag is not None:
                     _should_notify = bool(_leader_flag)
-                elif request.kv_transfer_params.get("remote_dp_rank_override"):
+                elif (
+                    request.kv_transfer_params.get("remote_dp_rank_override")
+                    or "remote_dp_rank" in request.kv_transfer_params
+                ):
                     _should_notify = self._global_dp_rank == remote_dp_rank
                 else:
                     _should_notify = self._is_kv_master


### PR DESCRIPTION
## Purpose

WideEP **2P2D DP16** MoRIIO **WRITE** GSM8K stalls at `num_concurrent` when requests land on child-pod ranks (DP 8–15).

The toy proxy pins `remote_dp_rank` and `X-data-parallel-rank`, but does not set `remote_dp_rank_override`. Decode `update_state_after_alloc` then falls back to `_is_kv_master` (`pod_index == 0`), so only the first pod sends `remote_blocks`. Prefill child ranks wait until `defer_timeout` (`remote blocks never arrived`).

Notify host/port also come from `request_id`, which embeds only the master-pod ZMQ address. If `remote_hosts` / `remote_dp_size_local` are omitted on the request, child-rank notify lands on the master IP with an unfolded port.

## Changes

`vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py` (`update_state_after_alloc` WRITE notify):

- Copy `remote_hosts` / `remote_dp_size_local` from `kv_connector_extra_config` when the router omits them.
- Treat a present `remote_dp_rank` as a pin even without `remote_dp_rank_override`: notify iff `global_dp_rank == remote_dp_rank`.

No other connector, engine, or harness changes.

## Test Plan

MoRIIO **2P2D WideEP DP16** (`xP=2 yD=2`), `ROUTER_TYPE=proxy`, `RUN_AFTER_HEALTH=accuracy`, image `vllm/vllm-openai-rocm:nightly`.

Child nodes use `--data-parallel-start-rank 8 --headless`. Decode extra_config `remote_hosts` is the two prefill pod IPs; prefill extra_config `remote_hosts` is the two decode pod IPs. `remote_dp_size_local` is `8`.

### DeepSeek-V3 — 2P2D WideEP DP16

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MLA=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_RMSNORM=1
export VLLM_ROCM_USE_AITER_PAGED_ATTN=0
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0
export VLLM_USE_AITER_TRITON_SILU_MUL=0
export VLLM_ROCM_USE_AITER_FP8BMM=false
```

```bash
# PREFILL — master (node0, DP ranks 0–7)
vllm serve /data/models2/DeepSeek-V3 \
    --host $PREFILL_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend mori_high_throughput \
    --api-server-count=8 \
    --trust-remote-code \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --max-model-len 65536 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","handshake_port":"6301","notify_port":"61005",
      "transfer_timeout":300,"defer_timeout":600,
      "remote_hosts":["'$DECODE_IP'","'$DECODE_CHILD_IP'"],
      "local_hosts":["'$PREFILL_IP'","'$PREFILL_CHILD_IP'"],
      "remote_dp_size_local":"8"}}'
```

```bash
# PREFILL — child (node1, headless, DP ranks 8–15)
vllm serve /data/models2/DeepSeek-V3 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend mori_high_throughput \
    --trust-remote-code \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --max-model-len 65536 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","handshake_port":"6301","notify_port":"61005",
      "transfer_timeout":300,"defer_timeout":600,
      "remote_hosts":["'$DECODE_IP'","'$DECODE_CHILD_IP'"],
      "local_hosts":["'$PREFILL_IP'","'$PREFILL_CHILD_IP'"],
      "remote_dp_size_local":"8"}}'
```

```bash
# DECODE — master (node2, DP ranks 0–7)
vllm serve /data/models2/DeepSeek-V3 \
    --host $DECODE_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend mori_low_latency \
    --api-server-count=8 \
    --trust-remote-code \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.75 \
    --enforce-eager \
    --max-model-len 65536 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","handshake_port":"7301","notify_port":"62005",
      "transfer_timeout":300,"defer_timeout":600,
      "remote_hosts":["'$PREFILL_IP'","'$PREFILL_CHILD_IP'"],
      "local_hosts":["'$DECODE_IP'","'$DECODE_CHILD_IP'"],
      "remote_dp_size_local":"8"}}'
```

```bash
# DECODE — child (node3, headless, DP ranks 8–15)
vllm serve /data/models2/DeepSeek-V3 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend mori_low_latency \
    --trust-remote-code \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.75 \
    --enforce-eager \
    --max-model-len 65536 \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","handshake_port":"7301","notify_port":"62005",
      "transfer_timeout":300,"defer_timeout":600,
      "remote_hosts":["'$PREFILL_IP'","'$PREFILL_CHILD_IP'"],
      "local_hosts":["'$DECODE_IP'","'$DECODE_CHILD_IP'"],
      "remote_dp_size_local":"8"}}'
```

### GSM8K evaluation

```bash
lm_eval --model local-completions \
    --tasks gsm8k \
    --model_args "model=/data/models2/DeepSeek-V3,base_url=http://127.0.0.1:10001/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True,timeout=7200" \
    --limit 250
```

## Test Result

Verified on `vllm/vllm-openai-rocm:nightly`. GSM8K flexible-extract, threshold 0.85.

| Config | Without this fix | With this fix |
|---|---|---|
| DSV3 2P2D WideEP GSM8K | stall at **64/250** (`remote blocks never arrived` on DP 8–15) | **0.956** (PASS) |
