### PR TITLE
[Bugfix][Security] Guard _load_ov2_processor with resolve_trust_remote_code

### DIFF
--- a/vllm/model_executor/models/llava_onevision2.py
+++ b/vllm/model_executor/models/llava_onevision2.py
@@ -39,7 +39,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from PIL import Image
 from transformers import AutoProcessor, AutoTokenizer, BatchFeature
-from transformers.dynamic_module_utils import get_class_from_dynamic_module
+from transformers.dynamic_module_utils import (
+    get_class_from_dynamic_module,
+    resolve_trust_remote_code,
+)
 from transformers.models.qwen2_vl import Qwen2VLImageProcessor
 from transformers.models.qwen2_vl.image_processing_qwen2_vl import smart_resize
 
@@ -129,17 +132,22 @@ def _load_ov2_processor(
     path = convert_model_repo_to_path(model)
     revision = revision or "main"
 
+    resolve_trust_remote_code(
+        trust_remote_code,
+        model,
+        has_local_code=False,
+        has_remote_code=True,
+    )
+
     processor_cls = get_class_from_dynamic_module(
         "processing_llava_onevision2.LlavaOnevision2Processor",
         path,
         revision=revision,
-        trust_remote_code=trust_remote_code,
     )
     video_processor_cls = get_class_from_dynamic_module(
         "video_processing_llava_onevision2.LlavaOnevision2VideoProcessor",
         path,
         revision=revision,
-        trust_remote_code=trust_remote_code,
     )
 
     # Slow Qwen2VLImageProcessor mirrors the remote processor (the Fast variant


### PR DESCRIPTION
## Summary

- `_load_ov2_processor` passed `trust_remote_code` to `get_class_from_dynamic_module`, but that transformers function has no such parameter — the value was silently swallowed by `**kwargs` and discarded. This meant attacker-supplied processing modules executed even with `trust_remote_code=False`.
- Adds a `resolve_trust_remote_code` gate before the `get_class_from_dynamic_module` calls, matching the established safe pattern in `minicpmv.py:599` and `try_get_class_from_dynamic_module`.
- When `trust_remote_code=False`, `resolve_trust_remote_code` now raises `ValueError` and blocks the load before any remote code is imported.

## Test plan

- [ ] Verify `trust_remote_code=True` still loads LlavaOnevision2 processor normally (no functional change).
- [ ] Verify `trust_remote_code=False` with a model containing remote processor code raises `ValueError` and blocks execution.
- [ ] Pre-commit hooks pass cleanly on the changed file.

Signed-off-by: Juan Perez de Algaba Diaz <jperezde@redhat.com>

Made with [Cursor](https://cursor.com)