### PR TITLE
[Bugfix][Tool Parser] Strip thinking-only MiniCPM5 output

### DIFF
--- a/tests/tool_parsers/test_minicpm5xml_tool_parser.py
+++ b/tests/tool_parsers/test_minicpm5xml_tool_parser.py
@@ -512,6 +512,18 @@ def test_thinking_only_sentencepiece_normalized_in_content(
     assert "First, I need to check the weather." in out.content
 
 
+def test_thinking_only_output_not_leaked_into_content(parser: ToolParser) -> None:
+    # Thinking-only output (nothing after </think>) must not leak the raw
+    # reasoning text back as visible content.
+    request = make_request(make_tools_weather())
+    text = "Let me reason about the request.</think>"
+    out = parser.extract_tool_calls(text, request)
+    assert not out.tools_called
+    assert out.tool_calls == []
+    assert out.content == ""
+    assert "</think>" not in (out.content or "")
+
+
 def test_properties_wrapped_arguments(parser: ToolParser) -> None:
     tools = [
         _tool(

--- a/vllm/tool_parsers/minicpm5xml_tool_parser.py
+++ b/vllm/tool_parsers/minicpm5xml_tool_parser.py
@@ -75,8 +75,7 @@ def _strip_thinking_content(text: str) -> str:
     """Return only user-visible content after MiniCPM5 thinking, when present."""
     if "</think>" not in text:
         return text
-    visible = text.rsplit("</think>", 1)[-1].lstrip()
-    return visible if visible else text
+    return text.rsplit("</think>", 1)[-1].lstrip()
 
 
 def _streaming_args_snapshot(args_json: str, *, is_complete: bool) -> str:


### PR DESCRIPTION
`_strip_thinking_content` in `vllm/tool_parsers/minicpm5xml_tool_parser.py` returned the original text (including the raw `<think>...</think>` reasoning) whenever nothing followed `</think>`, because of the `return visible if visible else text` fallback. For a thinking-only model output this leaked the reasoning back as visible content. This PR returns the text after the final `</think>` unconditionally, so a thinking-only response yields empty content.

## Purpose

Fix reasoning leakage in the MiniCPM5 XML tool parser for thinking-only outputs.

When a MiniCPM5 response contains only reasoning that ends in `</think>` with no trailing content, `extract_tool_calls` (via `_strip_thinking_content`) previously returned the entire raw text — including the `<think>...</think>` block — as the assistant `content`. That surfaces internal reasoning to end users and can confuse downstream chat rendering.

The `if "</think>" not in text: return text` early-return already handles the "no marker" case, so the trailing `else text` fallback only fires when a `</think>` marker *is* present but nothing follows it. Dropping that fallback makes the function always return whatever follows the final `</think>` (an empty string for thinking-only output), which is consistent with the normal `reasoning</think>answer -> answer` behavior.

Before:
```python
def _strip_thinking_content(text: str) -> str:
    if "</think>" not in text:
        return text
    visible = text.rsplit("</think>", 1)[-1].lstrip()
    return visible if visible else text   # leaks the full text (incl. tags) when nothing follows </think>
```
After:
```python
def _strip_thinking_content(text: str) -> str:
    if "</think>" not in text:
        return text
    return text.rsplit("</think>", 1)[-1].lstrip()
```

## Test Plan

Added a unit test in `tests/tool_parsers/test_minicpm5xml_tool_parser.py`:

- `test_thinking_only_output_not_leaked_into_content`: feeds a thinking-only output (`"Let me reason about the request.</think>"`) to `extract_tool_calls` and asserts `tools_called is False`, `tool_calls == []`, `content == ""`, and that no `</think>` remains in the content.

Run:
```bash
pytest tests/tool_parsers/test_minicpm5xml_tool_parser.py -k thinking
```

## Test Result

- The new test exercises the thinking-only path and asserts empty, leak-free content.
- Existing behaviors are unaffected: `reasoning</think>answer` still returns `answer`, and outputs without a `</think>` marker pass through unchanged (covered by the existing `_strip_thinking_content` early return and the existing `test_thinking_only_sentencepiece_normalized_in_content` test).

Note: I was not able to run the full suite in my local environment; CI (once enabled by a maintainer) will run the complete test set.