### PR TITLE
[Bugfix][KVConnector] Drop unexpected send completions in MultiConnector

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -1142,3 +1142,49 @@ def test_multi_connector_mixed_hma_disables_hybrid_kv_cache(monkeypatch):
             assert mc._all_support_hma is False
         finally:
             llm.llm_engine.engine_core.shutdown()
+
+
+# A send completion is only valid when a request finished with async saves
+# outstanding; anything else would make the vllm scheduler free/delete the
+# request out from under an in-flight recv (or hit its asserts).
+
+
+def _finish_request(mc: MultiConnector, req_id: str, async_save: bool = False) -> None:
+    """Simulate the scheduler aborting/finishing a request."""
+    request = MagicMock()
+    request.request_id = req_id
+    for c in mc._connectors:
+        c.request_finished.return_value = (async_save, None)
+    mc.request_finished(request, [])
+
+
+def _deliver_sends(mc: MultiConnector, *req_ids: str) -> set[str] | None:
+    output = KVConnectorOutput(finished_sending=set(req_ids))
+    mc.update_connector_output(output)
+    return output.finished_sending
+
+
+def test_send_completion_after_finish_with_async_save(mc):
+    """A request finished with async saves outstanding gets exactly one send
+    completion through (the scheduler's deferred free); duplicates drop."""
+    _finish_request(mc, "req-1", async_save=True)
+    assert _deliver_sends(mc, "req-1") == {"req-1"}
+    assert _deliver_sends(mc, "req-1") == set()
+
+
+def test_send_completion_without_pending_save_dropped(mc):
+    """Send completions are dropped for unknown, live, and
+    finished-without-saves requests alike (e.g. the nixl echo produced when
+    an aborted PD request's decode side cleans up)."""
+    assert _deliver_sends(mc, "ghost") == set()
+
+    _finish_request(mc, "req-1")  # no async save outstanding
+    assert _deliver_sends(mc, "req-1") == set()
+
+
+def test_recv_completions_pass_through(mc):
+    """Recv completions are not filtered."""
+    _finish_request(mc, "req-1")
+    output = KVConnectorOutput(finished_recving={"req-1", "req-2"})
+    mc.update_connector_output(output)
+    assert output.finished_recving == {"req-1", "req-2"}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -197,6 +197,11 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         # load the request from (if any).
         self._requests_to_connector: dict[str, int] = {}
 
+        # Req_ids of requests that finished with async saves outstanding;
+        # their merged send completion is expected once more (the scheduler
+        # defers freeing their blocks until it arrives).
+        self._finished_awaiting_send: set[str] = set()
+
         # Keeps track of *additional* remaining async saves (beyond 1) to be
         # finished per request. Not needed for async loads since we only allow
         # a single connector to load.
@@ -455,6 +460,26 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             # restore kv_connector_worker_meta
             connector_output.kv_connector_worker_meta = multi_connector_worker_meta
 
+        # A send completion is only valid for a finished request whose async
+        # saves are still outstanding (the scheduler defers freeing it until
+        # the completion arrives). Anything else (e.g. the nixl echo produced
+        # when an aborted PD request's decode side cleans up, with no save
+        # ever registered) would make the scheduler free/delete the request
+        # out from under an in-flight recv, so it is dropped.
+        if connector_output.finished_sending:
+            filtered_sending: set[str] = set()
+            for req_id in connector_output.finished_sending:
+                if req_id in self._finished_awaiting_send:
+                    self._finished_awaiting_send.discard(req_id)
+                    filtered_sending.add(req_id)
+                else:
+                    logger.warning(
+                        "Dropping unexpected finished_sending completion for "
+                        "request %s (no async save was outstanding).",
+                        req_id,
+                    )
+            connector_output.finished_sending = filtered_sending
+
     def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
         """
         Get the KVConnector handshake metadata from sub-connectors.
@@ -510,6 +535,8 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             self._extra_async_saves[request.request_id] = async_saves - 1
 
         self._requests_to_connector.pop(request.request_id, None)
+        if async_saves > 0:
+            self._finished_awaiting_send.add(request.request_id)
 
         return async_saves > 0, kv_txfer_params
 


### PR DESCRIPTION
## Purpose

Fix #46240 for the `MultiConnector` path: a PD request aborted while its async KV load is still in flight receives a `finished_sending` completion it never registered, which makes the scheduler delete the request out from under the in-flight load — the load's later `finished_recving` then hits `assert req_id in self.requests` and kills EngineCore.

**Root cause.** With `MultiConnector(NixlConnector producer + MooncakeStoreConnector load_async)` on the prefill side:

1. A PD request is computing on prefill while an async Mooncake load (prefix-cache fetch) for the same request is still in flight.
2. The request is aborted. The decode side's abort cleanup notifies the prefill (nixl pull mode), producing a `finished_sending` completion for the request — but the prefill never registered a save for it. It is a phantom.
3. The scheduler's send loop treats the first completion it sees as authoritative and frees/deletes the request on the phantom send.
4. When the in-flight load's `finished_recving` arrives, `assert req_id in self.requests` fires and kills EngineCore.

Production incident on 2026-08-18; reproduced without fault injection on a GB300 cluster with the exact production config under repeated Mooncake load failures plus client aborts.

**Fix.** The scheduler-side `MultiConnector` now expects a send completion only for requests that finished with async saves outstanding (the deferred-free contract) and drops the rest with a warning. The recv path is unchanged.

Scope is deliberately minimal: it covers the `MultiConnector` + nixl pull producer path from the incident. The phantom notification itself can also occur in pure nixl PD; tagging it at the connector level is a complementary follow-up.

**Why this layer:** #46304 checks completions against scheduler state, but the phantom send here passes scheduler-side existence checks — the request is still live when it arrives. `MultiConnector` is the layer that knows no save was ever registered for the request, so the filter belongs here.

## Reproduction

Deterministic and GPU-free: the new unit tests below fail on main.

E2E (timing-dependent): prefill with `MultiConnector(NixlConnector(kv_producer) + MooncakeStoreConnector(kv_both, load_async))`, decode with `NixlConnector(kv_consumer)`, then generate Mooncake load failures (e.g. restart the Mooncake store under load so loads fail/retry and pile up) while clients abort requests. The abort must land while a request's Mooncake load is still in flight. Within a few minutes of load + abort storm, the prefill EngineCore dies on `assert req_id in self.requests`.

## Test Plan

GPU-free (mocked connectors, no engine):

```
pytest tests/v1/kv_connector/unit/test_multi_connector.py \
  -k "send_completion or recv_completions_pass" -v
```

## Test Result

On the base commit (`0ecc284790`), the new tests fail — they monitor exactly this bug:

```
FAILED test_multi_connector.py::test_send_completion_after_finish_with_async_save
FAILED test_multi_connector.py::test_send_completion_without_pending_save_dropped
```

With this PR, all pass; the regression guard `test_recv_completions_pass_through` (recv path untouched) passes both before and after. The rest of `test_multi_connector.py` is unchanged (23 passed, 1 skipped; `test_multi_example_connector_consistency` fails identically on the base commit — pre-existing, unrelated).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
