### PR TITLE
[Kimi K3][Pref] Reuse internal checkpoint blocks for partial prefix caching

### DIFF
--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -392,3 +392,70 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+def test_causal_conv1d_exports_checkpoint_state_in_fwd_kernel():
+    device = DEVICE
+    set_random_seed(0)
+
+    dim = 64
+    width = 4
+    seqlens = [24, 24, 32]
+    query_start_loc = torch.tensor(
+        [0, *torch.tensor(seqlens).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    total_tokens = sum(seqlens)
+    x = torch.randn(total_tokens, dim, device=device).transpose(0, 1)
+    weight = torch.randn(dim, width, device=device)
+    conv_states = torch.randn(8, dim, width - 1, device=device)
+    conv_states_before = conv_states.clone()
+    state_indices = torch.tensor([1, 2, 3], dtype=torch.int32, device=device)
+    has_initial_state = torch.tensor([True, False, True], device=device)
+
+    # Export rows 0 and 2 at chunk boundaries; the null block disables row 1.
+    checkpoint_offsets = torch.tensor([16, 16, 24], dtype=torch.int32, device=device)
+    checkpoint_state_indices = torch.tensor(
+        [5, NULL_BLOCK_ID, 6], dtype=torch.int64, device=device
+    )
+
+    out = causal_conv1d_fn(
+        x,
+        weight,
+        bias=None,
+        conv_states=conv_states,
+        query_start_loc=query_start_loc,
+        cache_indices=state_indices,
+        has_initial_state=has_initial_state,
+        checkpoint_offsets=checkpoint_offsets,
+        checkpoint_state_indices=checkpoint_state_indices,
+        validate_data=True,
+    )
+
+    expected_out = []
+    start = 0
+    for row, seqlen in enumerate(seqlens):
+        x_seq = x[:, start : start + seqlen]
+        initial_state = (
+            conv_states_before[state_indices[row]].unsqueeze(0)
+            if has_initial_state[row]
+            else None
+        )
+        ref_out, _ = causal_conv1d_ref(
+            x_seq.unsqueeze(0),
+            weight,
+            initial_states=initial_state,
+        )
+        expected_out.append(ref_out.squeeze(0))
+        start += seqlen
+    torch.testing.assert_close(out, torch.cat(expected_out, dim=1))
+
+    for row, destination in ((0, 5), (2, 6)):
+        start = int(query_start_loc[row].item())
+        offset = int(checkpoint_offsets[row].item())
+        expected_checkpoint = x[:, start + offset - (width - 1) : start + offset]
+        torch.testing.assert_close(conv_states[destination], expected_checkpoint)
+
+    # A disabled row must not write to any extra checkpoint cache line.
+    torch.testing.assert_close(conv_states[7], conv_states_before[7])

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -88,6 +88,8 @@ def _make_builder(
     mamba_cache_mode: str = "none",
     use_recoverssm: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
+    mamba_block_size: int = BLOCK_SIZE,
+    prefix_match_unit: int | None = None,
 ) -> AttentionMetadataBuilder:
     vllm_config = create_vllm_config(
         model_name="Qwen/Qwen3.5-0.8B",
@@ -104,9 +106,10 @@ def _make_builder(
     vllm_config.cache_config.mamba_cache_mode = mamba_cache_mode
     vllm_config.cache_config.use_replayssm = use_recoverssm
     vllm_config.cache_config.use_kda_recoverssm = use_recoverssm
+    vllm_config.cache_config.prefix_match_unit = prefix_match_unit
     builder = builder_cls(
         kv_cache_spec=MambaSpec(
-            block_size=BLOCK_SIZE,
+            block_size=mamba_block_size,
             shapes=((16, 64),),
             dtypes=(torch.float16,),
             mamba_cache_mode=mamba_cache_mode,
@@ -147,6 +150,39 @@ def test_internal_checkpoint_metadata_targets_last_aligned_boundary():
     torch.testing.assert_close(
         actual.checkpoint.checkpoint_offsets,
         torch.tensor([48, 0], dtype=torch.int32, device=device),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_internal_checkpoint_metadata_targets_partial_hash_boundary():
+    device = torch.device("cuda")
+    batch = BatchSpec(seq_lens=[100], query_lens=[100])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, device, arange_block_indices=True
+    )
+    common_attn_metadata = common_attn_metadata.replace(
+        is_prefilling=torch.tensor([True]),
+        block_table_tensor=common_attn_metadata.block_table_tensor + 1,
+    )
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+        mamba_cache_mode="align",
+        num_prefill_checkpoint_blocks=1,
+        mamba_block_size=64,
+        prefix_match_unit=16,
+        device=device,
+    ).build(0, common_attn_metadata)
+
+    assert actual.checkpoint is not None
+    torch.testing.assert_close(
+        actual.checkpoint.state_indices,
+        torch.tensor([1], dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(
+        actual.checkpoint.checkpoint_offsets,
+        torch.tensor([96], dtype=torch.int32, device=device),
     )
 
 

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -78,6 +78,7 @@ def make_full_mamba_manager(
     num_blocks: int = 32,
     use_eagle: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
+    prefill_checkpoint_alignment: int = 1,
 ):
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,
@@ -100,6 +101,7 @@ def make_full_mamba_manager(
                     dtypes=(torch.float32,),
                     mamba_cache_mode="align",
                     num_prefill_checkpoint_blocks=num_prefill_checkpoint_blocks,
+                    prefill_checkpoint_alignment=prefill_checkpoint_alignment,
                 ),
             ),
         ],
@@ -517,6 +519,45 @@ def test_partial_hit_then_internal_checkpoint_uses_distinct_mamba_blocks():
     assert mamba_blocks[3].block_id == running_block_id
 
 
+def test_internal_checkpoint_uses_partial_hash_lifecycle():
+    hash_block_size = 2
+    mamba_block_size = 4
+    manager = make_full_mamba_manager(
+        dcp_world_size=1,
+        hash_block_size=hash_block_size,
+        full_block_size=hash_block_size,
+        mamba_block_size=mamba_block_size,
+        num_prefill_checkpoint_blocks=1,
+    )
+    request = make_request("producer", list(range(15)), hash_block_size, sha256)
+
+    new_blocks = manager.allocate_slots(request, request.num_tokens)
+
+    assert new_blocks is not None
+    mamba_blocks = manager.get_blocks(request.request_id).blocks[1]
+    checkpoint_idx = 2
+    checkpoint_block = mamba_blocks[checkpoint_idx]
+    running_block = mamba_blocks[checkpoint_idx + 1]
+    assert not checkpoint_block.is_null
+    assert not running_block.is_null
+    assert checkpoint_block is not running_block
+
+    # The internal block is exported at state@14, replacing its temporary
+    # full-block state@12 key while retaining #52789's req_to_blocks ownership.
+    partial_hash = request.block_hashes[14 // hash_block_size - 1]
+    partial_hit = manager.block_pool.get_cached_block(partial_hash, [1])
+    assert partial_hit is not None
+    assert partial_hit[0] is checkpoint_block
+    assert checkpoint_block.block_hash_num_tokens == 14
+    full_hash = request.block_hashes[12 // hash_block_size - 1]
+    assert manager.block_pool.get_cached_block(full_hash, [1]) is None
+
+    manager.free(request)
+    replay = make_request("replay", list(range(15)), hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(replay)
+    assert num_computed == 14
+
+
 def test_internal_checkpoint_requires_block_aligned_start():
     hash_block_size = 2
     mamba_block_size = 16
@@ -543,6 +584,27 @@ def test_internal_checkpoint_requires_block_aligned_start():
     assert mamba_blocks[checkpoint_block_idx].is_null
     assert not mamba_blocks[-1].is_null
     checkpoint_hash = request.block_hashes[48 // hash_block_size - 1]
+    assert manager.block_pool.get_cached_block(checkpoint_hash, [1]) is None
+
+
+def test_internal_checkpoint_requires_backend_aligned_offset():
+    hash_block_size = 2
+    mamba_block_size = 4
+    manager = make_full_mamba_manager(
+        dcp_world_size=1,
+        hash_block_size=hash_block_size,
+        full_block_size=hash_block_size,
+        mamba_block_size=mamba_block_size,
+        num_prefill_checkpoint_blocks=1,
+        prefill_checkpoint_alignment=4,
+    )
+    request = make_request("producer", list(range(15)), hash_block_size, sha256)
+
+    assert manager.allocate_slots(request, request.num_tokens) is not None
+
+    mamba_blocks = manager.get_blocks(request.request_id).blocks[1]
+    assert mamba_blocks[2].is_null
+    checkpoint_hash = request.block_hashes[14 // hash_block_size - 1]
     assert manager.block_pool.get_cached_block(checkpoint_hash, [1]) is None
 
 

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -31,6 +31,8 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     block_idx_last_scheduled_token,  # (batch,)
     initial_state_idx,  # (batch,)
     num_computed_tokens,  # (batch,)
+    checkpoint_offsets_ptr,  # (batch,)
+    checkpoint_state_indices_ptr,  # (batch,)
     o_ptr,  # (dim, seqlen) - actually pointing to x_ptr
     # Matrix dimensions
     dim: tl.constexpr,
@@ -56,6 +58,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     SILU_ACTIVATION: tl.constexpr,
     IS_APC_ENABLED: tl.constexpr,
     HAS_NULL_BLOCK: tl.constexpr,
+    HAS_CHECKPOINT: tl.constexpr,
     NP2_STATELEN: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -392,6 +395,44 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
             tl.debug_barrier()  #  NOTE: use this due to bug in Triton compiler
             tl.store(conv_states_ptrs_target, loaded_x, mask)
 
+    # At a chunk-aligned checkpoint boundary, col0..colN already contain the
+    # exact causal-convolution history immediately before the checkpoint token.
+    # Export it here to avoid reconstructing the state in a separate kernel.
+    if HAS_CHECKPOINT:
+        checkpoint_offset = tl.load(checkpoint_offsets_ptr + idx_seq)
+        checkpoint_state_coord = tl.load(checkpoint_state_indices_ptr + idx_seq).to(
+            tl.int64
+        )
+        store_checkpoint = (checkpoint_state_coord != null_block_id) & (
+            token_offset == checkpoint_offset
+        )
+        checkpoint_state_base = (
+            conv_states_ptr
+            + checkpoint_state_coord * stride_conv_state_seq
+            + idx_feats * stride_conv_state_dim
+        )
+        checkpoint_mask = store_checkpoint & (idx_feats < dim)
+        if KERNEL_WIDTH >= 2:
+            tl.store(checkpoint_state_base, col0, mask=checkpoint_mask)
+        if KERNEL_WIDTH >= 3:
+            tl.store(
+                checkpoint_state_base + stride_conv_state_tok,
+                col1,
+                mask=checkpoint_mask,
+            )
+        if KERNEL_WIDTH >= 4:
+            tl.store(
+                checkpoint_state_base + 2 * stride_conv_state_tok,
+                col2,
+                mask=checkpoint_mask,
+            )
+        if KERNEL_WIDTH >= 5:
+            tl.store(
+                checkpoint_state_base + 3 * stride_conv_state_tok,
+                col3,
+                mask=checkpoint_mask,
+            )
+
     if HAS_BIAS:
         bias = bias_ptr + idx_feats
         mask_bias = idx_feats < dim
@@ -496,6 +537,8 @@ def causal_conv1d_fn(
     block_size_to_align=0,
     metadata=None,
     validate_data=False,
+    checkpoint_offsets: torch.Tensor | None = None,
+    checkpoint_state_indices: torch.Tensor | None = None,
 ):
     """support varlen + continuous batching when x is 2D tensor
 
@@ -546,6 +589,12 @@ def causal_conv1d_fn(
         The number of tokens already completed for each sequence
     block_size_to_align: int
         The block size to align the cached states to
+    checkpoint_offsets: (batch,) int32
+        Optional per-sequence checkpoint offsets. Each valid offset must be
+        aligned to the kernel's BLOCK_M chunk size.
+    checkpoint_state_indices: (batch,) int64
+        Cache line receiving each sequence's checkpoint state. ``null_block_id``
+        disables checkpoint export for that sequence.
     out: same shape as `x`
     """
     if isinstance(activation, bool) and activation:
@@ -580,6 +629,12 @@ def causal_conv1d_fn(
     np2_statelen = triton.next_power_of_2(state_len)
 
     padded_batch = query_start_loc.size(0) - 1
+    has_checkpoint = checkpoint_offsets is not None
+    assert has_checkpoint == (checkpoint_state_indices is not None), (
+        "checkpoint offsets and state indices must be provided together"
+    )
+    if has_checkpoint:
+        assert conv_states is not None
     stride_x_dim = x.stride(0)
     stride_x_token = x.stride(1)
     stride_w_dim = weight.stride(0)
@@ -628,6 +683,15 @@ def causal_conv1d_fn(
             assert conv_states is not None, (
                 "ERROR: `has_initial_state` is used, which needs also `conv_states`"
             )
+        if has_checkpoint:
+            assert checkpoint_offsets is not None
+            assert checkpoint_state_indices is not None
+            assert checkpoint_offsets.size() == (padded_batch,)
+            assert checkpoint_state_indices.size() == (padded_batch,)
+            valid_checkpoint_offsets = checkpoint_offsets[
+                checkpoint_state_indices != null_block_id
+            ]
+            assert torch.all(valid_checkpoint_offsets % BLOCK_M == 0)
         assert weight.stride(1) == 1
         assert (dim, width) == weight.shape
         assert is_channel_last, "Need to run in channel-last layout"
@@ -724,6 +788,8 @@ def causal_conv1d_fn(
         block_idx_last_scheduled_token,
         initial_state_idx,
         num_computed_tokens,
+        checkpoint_offsets,
+        checkpoint_state_indices,
         out,
         # Matrix dimensions
         dim,
@@ -749,6 +815,7 @@ def causal_conv1d_fn(
         SILU_ACTIVATION=activation in ["silu", "swish"],
         IS_APC_ENABLED=block_idx_last_scheduled_token is not None,
         HAS_NULL_BLOCK=null_block_id is not None,
+        HAS_CHECKPOINT=has_checkpoint,
         NP2_STATELEN=np2_statelen,
         # launch_cooperative_grid=True
         BLOCK_M=BLOCK_M,

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -40,6 +40,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.parameter import BasevLLMParameter, BlockQuantScaleParameter
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.models.kimi_k3.nvidia.kda_metadata import (
+    FLASHKDA_CHUNK_SIZE,
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
 )
@@ -565,6 +566,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         return replace(
             spec,
             num_prefill_checkpoint_blocks=int(self.kda_prefill_backend == "flashkda"),
+            prefill_checkpoint_alignment=FLASHKDA_CHUNK_SIZE,
         )
 
     def forward(
@@ -816,9 +818,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                             else None
                         ),
                         checkpoint_state_indices=(
-                            checkpoint.state_indices
-                            if checkpoint is not None
-                            else None
+                            checkpoint.state_indices if checkpoint is not None else None
                         ),
                     ).transpose(0, 1)
 

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -234,29 +234,18 @@ def _flashkda_prefill(
 
 
 @triton.jit
-def _store_cache_checkpoints_kernel(
-    x_ptr,
-    conv_state_ptr,
+def _store_recurrent_cache_checkpoints_kernel(
     recurrent_checkpoint_ptr,
     recurrent_state_ptr,
-    query_start_loc_ptr,
     checkpoint_offsets_ptr,
     checkpoint_state_indices_ptr,
-    x_stride_0: tl.constexpr,
-    x_stride_1: tl.constexpr,
-    state_stride_0: tl.constexpr,
-    state_stride_1: tl.constexpr,
-    state_stride_2: tl.constexpr,
     checkpoint_stride_0: tl.constexpr,
     recurrent_state_stride_0: tl.constexpr,
     checkpoint_offset_stride: tl.constexpr,
-    STATE_LEN: tl.constexpr,
-    WIDTH: tl.constexpr,
     RECURRENT_ROW_SIZE: tl.constexpr,
     NULL_STATE_IDX: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    # store checkpoints to cache
     seq_idx = tl.program_id(0)
     cols = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     state_idx = tl.load(checkpoint_state_indices_ptr + seq_idx)
@@ -264,26 +253,6 @@ def _store_cache_checkpoints_kernel(
         checkpoint_offsets_ptr + seq_idx * checkpoint_offset_stride
     )
     valid_checkpoint = (state_idx != NULL_STATE_IDX) & (checkpoint_offset > 0)
-    valid_conv = (
-        (cols < WIDTH * STATE_LEN) & valid_checkpoint & (checkpoint_offset >= STATE_LEN)
-    )
-    width_idx = cols // STATE_LEN
-    history_idx = cols % STATE_LEN
-    checkpoint_end = tl.load(query_start_loc_ptr + seq_idx) + checkpoint_offset
-    token_idx = checkpoint_end - STATE_LEN + history_idx
-    values = tl.load(
-        x_ptr + token_idx * x_stride_0 + width_idx * x_stride_1,
-        mask=valid_conv,
-    )
-    tl.store(
-        conv_state_ptr
-        + state_idx * state_stride_0
-        + width_idx * state_stride_1
-        + history_idx * state_stride_2,
-        values,
-        mask=valid_conv,
-    )
-
     valid_recurrent = (cols < RECURRENT_ROW_SIZE) & valid_checkpoint
     recurrent = tl.load(
         recurrent_checkpoint_ptr + seq_idx * checkpoint_stride_0 + cols,
@@ -841,6 +810,16 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                         cache_indices=non_spec_state_indices_tensor,
                         query_start_loc=non_spec_query_start_loc,
                         metadata=m,
+                        checkpoint_offsets=(
+                            checkpoint.checkpoint_offsets
+                            if checkpoint is not None
+                            else None
+                        ),
+                        checkpoint_state_indices=(
+                            checkpoint.state_indices
+                            if checkpoint is not None
+                            else None
+                        ),
                     ).transpose(0, 1)
 
                 q_ns = _prefill_conv(q_ns, q_conv_state, q_conv_weight)
@@ -895,36 +874,21 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                         )
                         core_attn_out_non_spec = flashkda_out
                         last_recurrent_state = final_state
-                        state_len = conv_state.shape[-1]
-                        width = mixed_qkv_ns.shape[-1]
                         recurrent_row_size = checkpoint_state[0].numel()
                         block_size = 256
-                        _store_cache_checkpoints_kernel[
+                        _store_recurrent_cache_checkpoints_kernel[
                             (
                                 checkpoint_offsets.numel(),
-                                triton.cdiv(
-                                    max(width * state_len, recurrent_row_size),
-                                    block_size,
-                                ),
+                                triton.cdiv(recurrent_row_size, block_size),
                             )
                         ](
-                            mixed_qkv_ns,
-                            conv_state,
                             checkpoint_state,
                             recurrent_state,
-                            non_spec_query_start_loc,
                             checkpoint_offsets,
                             checkpoint.state_indices,
-                            mixed_qkv_ns.stride(0),
-                            mixed_qkv_ns.stride(1),
-                            conv_state.stride(0),
-                            conv_state.stride(1),
-                            conv_state.stride(2),
                             checkpoint_state.stride(0),
                             recurrent_state.stride(0),
                             checkpoint_offsets.stride(0),
-                            state_len,
-                            width,
                             recurrent_row_size,
                             NULL_BLOCK_ID,
                             block_size,

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -583,11 +583,18 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             query_lens = [all_query_lens[row] for row in request_rows]
             seq_lens = m.seq_lens_cpu_upper_bound.tolist()
             block_size = self.kv_cache_spec.block_size
+            checkpoint_granularity = (
+                self.vllm_config.cache_config.prefix_match_unit
+                or self.vllm_config.cache_config.block_size
+            )
             checkpoint_splits = []
             checkpoint_cols = []
             for row, query_len in zip(request_rows, query_lens):
                 seq_len = seq_lens[row]
-                offset = seq_len // block_size * block_size - (seq_len - query_len)
+                checkpoint_tokens = (
+                    (seq_len - 1) // checkpoint_granularity * checkpoint_granularity
+                )
+                offset = checkpoint_tokens - (seq_len - query_len)
                 # offset should be less than query_len
                 valid = (
                     seq_len % block_size != 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -330,7 +330,12 @@ class Scheduler(SchedulerInterface):
             and not self.use_eagle
             and all(
                 not isinstance(group.kv_cache_spec, MambaSpec)
-                or group.kv_cache_spec.num_prefill_checkpoint_blocks > 0
+                or (
+                    group.kv_cache_spec.num_prefill_checkpoint_blocks > 0
+                    and self.hash_block_size
+                    % group.kv_cache_spec.prefill_checkpoint_alignment
+                    == 0
+                )
                 for group in kv_cache_config.kv_cache_groups
             )
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1474,12 +1474,18 @@ class MambaManager(SingleTypeKVCacheManager):
         num_computed_tokens: int,
     ) -> bool:
         assert isinstance(self.kv_cache_spec, MambaSpec)
+        hash_block_size = self.block_pool.hash_block_size
+        checkpoint_tokens = (num_tokens - 1) // hash_block_size * hash_block_size
         checkpoint_idx = cdiv(num_tokens, self.block_size) - 2
         blocks = self.req_to_blocks[request_id]
         return (
             self.kv_cache_spec.num_prefill_checkpoint_blocks > 0
             and num_tokens % self.block_size != 0
             and num_computed_tokens % self.block_size == 0
+            and num_computed_tokens < checkpoint_tokens < num_tokens
+            and (checkpoint_tokens - num_computed_tokens)
+            % self.kv_cache_spec.prefill_checkpoint_alignment
+            == 0
             and checkpoint_idx >= 0
             and (checkpoint_idx >= len(blocks) or blocks[checkpoint_idx].is_null)
         )
@@ -1745,6 +1751,28 @@ class MambaManager(SingleTypeKVCacheManager):
             return None
         if num_tokens % self.block_size == 0:
             return None
+
+        # A backend-exported checkpoint occupies the otherwise-null slot just
+        # before the running state. Re-key that request-owned block at the
+        # finest reusable prefix boundary. Its allocation, eviction, and free
+        # path remain identical to a full-block checkpoint.
+        if self._num_checkpoint_blocks.get(request.request_id, 0):
+            checkpoint_tokens = (num_tokens - 1) // hash_block_size * hash_block_size
+            if checkpoint_tokens % self.block_size != 0:
+                checkpoint_idx = cdiv(num_tokens, self.block_size) - 2
+                blocks = self.req_to_blocks[request.request_id]
+                assert checkpoint_idx >= 0
+                checkpoint_block = blocks[checkpoint_idx]
+                partial_hash = self.block_pool.cache_partial_block(
+                    request=request,
+                    block=checkpoint_block,
+                    num_tokens=checkpoint_tokens,
+                    kv_cache_group_id=self.kv_cache_group_id,
+                    block_size=self.block_size,
+                )
+                if partial_hash is not None:
+                    return partial_hash
+
         if num_tokens % hash_block_size != 0:
             return None
         latest_prompt_hash_boundary = (

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -816,6 +816,7 @@ class MambaSpec(KVCacheSpec):
     mamba_cache_mode: str = "none"
     num_speculative_blocks: int = 0
     num_prefill_checkpoint_blocks: int = 0
+    prefill_checkpoint_alignment: int = 1
     num_heads: int = 1
     tokens_per_state: int = -1
 
@@ -869,6 +870,7 @@ class MambaSpec(KVCacheSpec):
             isinstance(spec, MambaSpec)
             and spec.num_speculative_blocks == self.num_speculative_blocks
             and spec.num_prefill_checkpoint_blocks == self.num_prefill_checkpoint_blocks
+            and spec.prefill_checkpoint_alignment == self.prefill_checkpoint_alignment
             for spec in kv_cache_specs.values()
         )
 


### PR DESCRIPTION
## Purpose

This PR is stacked on #52789 and extends its Kimi-K3 prefill checkpoint path to fine-grained partial prefix caching.

Main changes:

- Export the causal-conv checkpoint directly from the existing causal-conv forward kernel.
- Store recurrent checkpoints through the single FlashKDA prefill launch provided by the base PR.
- Re-key #52789's request-owned internal checkpoint block at the partial hash boundary (for example, 128 tokens), instead of introducing a separate checkpoint-block owner.
- Reuse the existing `req_to_blocks` allocation, prefix hash, eviction, and free lifecycle.
- Reject checkpoint allocation when the requested offset is not aligned for the backend, preventing an unwritten block from becoming cache-visible.

This is not a duplicate of #52789: that PR provides the internal full-block checkpoint infrastructure; this stacked PR makes the same block lifecycle work for partial prefix boundaries and removes the remaining separate causal-conv checkpoint reconstruction.

Speculative decoding remains governed by #52789. The checkpoint fast path is not enabled with EAGLE in this PR.

## Usage

No environment variable is required. The optimization is selected automatically when Kimi-K3 uses FlashKDA, prefix caching, and aligned Mamba cache mode.

```bash
vllm serve <model> \
  --kda-prefill-backend flashkda \
  --enable-prefix-caching \
  --mamba-cache-mode align \
  --prefix-match-unit 128
```

The required FlashKDA checkpoint support was merged in [FlashKDA#7](https://github.com/vllm-project/FlashKDA/pull/7).

## Performance

Setup:

- TP8 on 2 × 4 GB300
- Growing prefix from 120K to 164K tokens
- +2K tokens per round
- 8 concurrent streams
- Three runs per variant

| Variant | P50 TTFT | Improvement vs non-partial |
| --- | ---: | ---: |
| #52789, non-partial | 2,151.53 ms | Baseline |
| #52789, partial128 | 2,375.23 ms | -10.40% |
| This PR, non-partial | 2,141.67 ms | Baseline |
| **This PR, partial128** | **1,398.49 ms** | **34.70%** |

## Correctness and tests

Three consecutive full OCRBench runs with checkpoint mode and partial128:

- 89.4%
- 89.6%
- 89.3%
- Mean: 89.43%

Local regression after rebasing:

```bash
.venv/bin/python -m pytest -q \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py \
  tests/v1/core/test_mamba_align_chunk_split.py
# 70 passed

pre-commit run
# all hooks passed, including ruff, mypy, DCO, and config validation
```

CUDA-only causal-conv and KDA metadata tests are included for CI/GPU validation.

AI assistance was used to rebase the branch, implement the lifecycle refactor, and add tests. The human submitter must review and validate the final change.
