### PR TITLE
[Bugfix] Prevent stale partial prefix-cache hash resurrection after full-block promotion

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -19,8 +19,8 @@ from vllm.v1.core.kv_cache_utils import (
     hash_block_tokens,
     init_none_hash,
 )
-from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, MambaManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec
 from vllm.v1.request import Request
 
 pytestmark = pytest.mark.cpu_test
@@ -429,6 +429,7 @@ def test_partial_block_promotes_to_direct_full_block_hash(dcp_world_size: int):
         num_gpu_blocks=3,
         enable_caching=True,
         hash_block_size=hash_block_size,
+        enable_kv_cache_events=True,
     )
     blocks = pool.get_new_blocks(2)
 
@@ -467,181 +468,8 @@ def test_partial_block_promotes_to_direct_full_block_hash(dcp_world_size: int):
     )
     assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
     assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
-
-
-@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
-def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
-    dcp_world_size: int,
-):
-    """Regression test for partial-hash resurrection after full-block promotion.
-
-    When a request's prompt ends inside a block, _cache_partial_tail_block
-    registers a partial hash for that boundary.  Once decode fills the block
-    completely, cache_full_blocks promotes it to a full-block hash and removes
-    the partial entry.  _cache_partial_tail_block must then skip re-inserting
-    the now-superseded partial hash on every subsequent cache_blocks call,
-    because boundary_tokens is derived from the fixed num_prompt_tokens and
-    does not change across decode steps.
-
-    The cache map and the KV-cache event stream are both checked: a fix that
-    keeps get_cached_block clean but still emits BlockStored for the retired
-    partial hash would leave external KV-aware routers with the contradictory
-    view this bug is actually reported for.
-    """
-    hash_block_size = 2
-    block_size = 6 * dcp_world_size
-    kv_cache_group_id = 0
-
-    # Prompt: 10 tokens, ends 4 tokens into block 1 (partial tail).
-    prompt_token_ids = list(range(10 * dcp_world_size))
-    req = make_request("R", prompt_token_ids, hash_block_size, sha256)
-
-    pool = BlockPool(
-        num_gpu_blocks=4,
-        enable_caching=True,
-        hash_block_size=hash_block_size,
-        enable_kv_cache_events=True,
-    )
-    spec = FullAttentionSpec(
-        block_size=block_size,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-    )
-    manager = FullAttentionManager(
-        kv_cache_spec=spec,
-        block_pool=pool,
-        enable_caching=True,
-        kv_cache_group_id=kv_cache_group_id,
-        scheduler_block_size=block_size,
-    )
-    manager.req_to_blocks[req.request_id] = pool.get_new_blocks(2)
-
-    # Prefill: registers the partial hash for the prompt boundary and
-    # announces it to KV-cache-event subscribers.
-    manager.cache_blocks(req, num_tokens=len(prompt_token_ids))
-    partial_hash = boundary_hash(req, hash_block_size, len(prompt_token_ids))
-    stale_event_hash = kv_cache_utils.maybe_convert_block_hash(partial_hash)
-    block1 = manager.req_to_blocks[req.request_id][1]
-    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) == [block1]
-    assert any(
-        isinstance(e, BlockStored) and stale_event_hash in e.block_hashes
-        for e in pool.take_events()
-    ), "prefill must announce the partial boundary hash"
-
-    # Decode: fill block 1 to completion, triggering promotion.
-    tokens_to_fill = block_size - (len(prompt_token_ids) % block_size)
-    for i in range(tokens_to_fill):
-        req.append_output_token_ids([100 + i])
-        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
-    promotion_events = pool.take_events()
-
-    # After promotion the stale partial hash must not be live in the cache.
-    full_hashes = BlockHashListWithBlockSize(
-        req.block_hashes, hash_block_size, block_size
-    )
-    promoted_full_hash = full_hashes[1]
-    assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [block1], (
-        "promoted full-block hash must be cached"
-    )
-    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None, (
-        "stale partial hash must not be resurrected after promotion"
-    )
-
-    # ...and the event stream must agree with the cache map. Promotion
-    # announces the partial hash as removed, so nothing may re-announce it as
-    # stored afterwards.
-    removed_at = [
-        i
-        for i, e in enumerate(promotion_events)
-        if isinstance(e, BlockRemoved) and stale_event_hash in e.block_hashes
-    ]
-    assert removed_at, "promotion must announce the partial hash as removed"
-    assert not any(
-        isinstance(e, BlockStored) and stale_event_hash in e.block_hashes
-        for e in promotion_events[removed_at[-1] :]
-    ), "stale partial hash must not be re-announced as stored after promotion"
-
-    # Additional decode steps must not re-insert the stale entry either, in
-    # the cache map or on the event stream.
-    for i in range(tokens_to_fill, tokens_to_fill + 3):
-        req.append_output_token_ids([200 + i])
-        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
-    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None, (
-        "stale partial hash must stay absent on subsequent decode steps"
-    )
-    assert pool.take_events() == [], (
-        "decode inside an already-promoted block must emit no further events"
-    )
-
-
-@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
-def test_cache_partial_block_refuses_boundary_the_block_has_outgrown(
-    dcp_world_size: int,
-):
-    """The pool itself must refuse a partial entry a promoted block outgrew.
-
-    test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion
-    covers the caller that actually makes this mistake in production.  This
-    test pins the invariant at the insert site instead, so it holds for any
-    future caller of cache_partial_block: once a block carries a hash covering
-    at least as many tokens as the incoming boundary, that boundary has been
-    superseded and re-registering it is never correct.
-
-    Refusal is reported by returning None -- the same contract as a null block
-    -- because callers such as MambaManager._cache_partial_tail_block key
-    follow-up bookkeeping off the returned hash and must not record a partial
-    entry that was never inserted.
-    """
-    hash_block_size = 2
-    block_size = 6 * dcp_world_size
-    kv_cache_group_id = 0
-    partial_num_tokens = 2 * block_size - hash_block_size
-    token_ids = list(range(partial_num_tokens))
-    req = make_request("0", token_ids, hash_block_size, sha256)
-    pool = BlockPool(
-        num_gpu_blocks=3,
-        enable_caching=True,
-        hash_block_size=hash_block_size,
-        enable_kv_cache_events=True,
-    )
-    blocks = pool.get_new_blocks(2)
-
-    pool.cache_full_blocks(
-        request=req,
-        blocks=blocks,
-        num_cached_blocks=0,
-        num_full_blocks=1,
-        block_size=block_size,
-        kv_cache_group_id=kv_cache_group_id,
-    )
-    partial_hash = boundary_hash(req, hash_block_size, partial_num_tokens)
-    assert pool.cache_partial_block(
-        request=req,
-        block=blocks[1],
-        num_tokens=partial_num_tokens,
-        kv_cache_group_id=kv_cache_group_id,
-        block_size=block_size,
-    )
-    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) == [blocks[1]]
-
-    # Fill the block and promote it past the partial boundary.
-    req.append_output_token_ids(list(range(partial_num_tokens, 2 * block_size)))
-    full_hashes = BlockHashListWithBlockSize(
-        req.block_hashes, hash_block_size, block_size
-    )
-    promoted_full_hash = full_hashes[1]
-    pool.cache_full_blocks(
-        request=req,
-        blocks=blocks,
-        num_cached_blocks=1,
-        num_full_blocks=2,
-        block_size=block_size,
-        kv_cache_group_id=kv_cache_group_id,
-    )
     pool.take_events()
 
-    # Re-registering the outgrown boundary must be refused outright.
     assert (
         pool.cache_partial_block(
             request=req,
@@ -651,101 +479,23 @@ def test_cache_partial_block_refuses_boundary_the_block_has_outgrown(
             block_size=block_size,
         )
         is None
-    ), "a boundary the block has outgrown must not be registered"
-    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None, (
-        "the outgrown boundary must not become reachable again"
     )
-    assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [
-        blocks[1]
-    ], "the promoted full-block hash must be left intact"
-    assert blocks[1].block_hash_num_tokens == 2 * block_size, (
-        "the refused call must not shorten the block's recorded coverage"
-    )
-    assert pool.take_events() == [], "a refused registration must emit no events"
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+    assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
+    assert blocks[1].block_hash_num_tokens == 2 * block_size
+    assert pool.take_events() == []
 
 
-@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
-def test_cache_partial_block_still_grows_a_partial_entry_forward(
-    dcp_world_size: int,
-):
-    """The refusal must not catch a partial entry legitimately growing.
-
-    The guard keys on ">= incoming", so the 8 -> 10 token growth path inside a
-    single block -- where the block's existing hash covers *fewer* tokens --
-    must still retire the shorter key and register the longer one.
-    """
-    hash_block_size = 2
-    block_size = 6 * dcp_world_size
+def test_cache_blocks_does_not_resurrect_partial_hash_after_promotion():
+    hash_block_size, block_size = 2, 6
     kv_cache_group_id = 0
-    shorter_num_tokens = block_size + hash_block_size
-    longer_num_tokens = block_size + 2 * hash_block_size
-    token_ids = list(range(longer_num_tokens))
-    req = make_request("0", token_ids, hash_block_size, sha256)
-    pool = BlockPool(
-        num_gpu_blocks=3,
-        enable_caching=True,
-        hash_block_size=hash_block_size,
-    )
-    blocks = pool.get_new_blocks(2)
-
-    pool.cache_full_blocks(
-        request=req,
-        blocks=blocks,
-        num_cached_blocks=0,
-        num_full_blocks=1,
-        block_size=block_size,
-        kv_cache_group_id=kv_cache_group_id,
-    )
-    shorter_hash = boundary_hash(req, hash_block_size, shorter_num_tokens)
-    longer_hash = boundary_hash(req, hash_block_size, longer_num_tokens)
-
-    assert pool.cache_partial_block(
-        request=req,
-        block=blocks[1],
-        num_tokens=shorter_num_tokens,
-        kv_cache_group_id=kv_cache_group_id,
-        block_size=block_size,
-    )
-    assert pool.get_cached_block(shorter_hash, [kv_cache_group_id]) == [blocks[1]]
-
-    assert pool.cache_partial_block(
-        request=req,
-        block=blocks[1],
-        num_tokens=longer_num_tokens,
-        kv_cache_group_id=kv_cache_group_id,
-        block_size=block_size,
-    ), "growing a partial entry forward inside its block must still be allowed"
-    assert pool.get_cached_block(longer_hash, [kv_cache_group_id]) == [blocks[1]]
-    assert pool.get_cached_block(shorter_hash, [kv_cache_group_id]) is None, (
-        "the superseded shorter boundary must be retired"
-    )
-
-
-@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
-def test_promoted_tail_stops_calling_into_the_pool_each_decode_step(
-    dcp_world_size: int,
-):
-    """The caller-side guard is an optimisation; pin what it actually buys.
-
-    BlockPool.cache_partial_block already refuses an outgrown boundary, so
-    correctness does not depend on the check in _cache_partial_tail_block --
-    dropping it leaves every other test in this file green.  What it buys is
-    that steady-state decode inside a promoted block stops re-deriving the
-    partial hash and calling into the pool once per step, forever, only to
-    have the call refused.  Without an assertion on the call count that
-    property is invisible and a future refactor would silently drop it.
-    """
-    hash_block_size = 2
-    block_size = 6 * dcp_world_size
-    kv_cache_group_id = 0
-
-    prompt_token_ids = list(range(10 * dcp_world_size))
+    prompt_token_ids = list(range(10))
     req = make_request("R", prompt_token_ids, hash_block_size, sha256)
-
     pool = BlockPool(
         num_gpu_blocks=4,
         enable_caching=True,
         hash_block_size=hash_block_size,
+        enable_kv_cache_events=True,
     )
     spec = FullAttentionSpec(
         block_size=block_size,
@@ -762,147 +512,36 @@ def test_promoted_tail_stops_calling_into_the_pool_each_decode_step(
     )
     manager.req_to_blocks[req.request_id] = pool.get_new_blocks(2)
 
-    calls = 0
-    original = pool.cache_partial_block
-
-    def counting_cache_partial_block(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        return original(*args, **kwargs)
-
-    pool.cache_partial_block = counting_cache_partial_block
-
     manager.cache_blocks(req, num_tokens=len(prompt_token_ids))
-    assert calls == 1, "the prompt boundary itself must be registered once"
-
-    # Fill the tail block to completion, promoting it.
-    tokens_to_fill = block_size - (len(prompt_token_ids) % block_size)
-    for i in range(tokens_to_fill):
-        req.append_output_token_ids([100 + i])
-        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
-
-    # Steady-state decode inside the promoted block: no further pool calls.
-    calls_after_promotion = calls
-    for i in range(tokens_to_fill, tokens_to_fill + 5):
-        req.append_output_token_ids([200 + i])
-        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
-    assert calls == calls_after_promotion, (
-        "decode inside an already-promoted block must not call into the pool"
+    partial_hash = boundary_hash(req, hash_block_size, len(prompt_token_ids))
+    event_hash = kv_cache_utils.maybe_convert_block_hash(partial_hash)
+    block1 = manager.req_to_blocks[req.request_id][1]
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) == [block1]
+    assert any(
+        isinstance(event, BlockStored) and event_hash in event.block_hashes
+        for event in pool.take_events()
     )
 
+    for token_id in range(10, 12):
+        req.append_output_token_ids([token_id])
+        manager.cache_blocks(req, num_tokens=token_id + 1)
+    events = pool.take_events()
 
-def _mamba_align_manager(
-    hash_block_size: int, block_size: int
-) -> tuple[BlockPool, MambaManager]:
-    spec = MambaSpec(
-        shapes=((8,),),
-        dtypes=(torch.float32,),
-        block_size=block_size,
-        mamba_cache_mode="align",
-        num_speculative_blocks=0,
+    promoted_hash = BlockHashListWithBlockSize(
+        req.block_hashes, hash_block_size, block_size
+    )[1]
+    assert pool.get_cached_block(promoted_hash, [kv_cache_group_id]) == [block1]
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+    assert any(
+        isinstance(event, BlockRemoved) and event_hash in event.block_hashes
+        for event in events
     )
-    pool = BlockPool(
-        num_gpu_blocks=8,
-        enable_caching=True,
-        hash_block_size=hash_block_size,
-        enable_kv_cache_events=True,
+    assert not any(
+        isinstance(event, BlockStored) and event_hash in event.block_hashes
+        for event in events
     )
-    manager = MambaManager(
-        kv_cache_spec=spec,
-        block_pool=pool,
-        enable_caching=True,
-        kv_cache_group_id=0,
-        scheduler_block_size=block_size,
-    )
-    return pool, manager
 
-
-def test_mamba_partial_tail_registers_the_boundary_when_it_is_not_superseded():
-    """Positive control for the refusal test below.
-
-    On an un-promoted tail block MambaManager._cache_partial_tail_block still
-    registers the boundary and records all three pieces of follow-up
-    bookkeeping, the last of which hands the CoW block to a KV connector for
-    partial-tail offload.  Without this the refusal test could pass vacuously.
-    """
-    hash_block_size, block_size = 2, 6
-    kv_cache_group_id = 0
-    pool, manager = _mamba_align_manager(hash_block_size, block_size)
-
-    # 10 prompt tokens: block 0 is full, block 1 holds tokens 6..9, and the
-    # last prompt hash boundary is 10 -- inside block 1.
-    req = make_request("0", list(range(10)), hash_block_size, sha256)
-    blocks = pool.get_new_blocks(2)
-    manager.req_to_blocks[req.request_id] = blocks
-
-    partial_hash = manager._cache_partial_tail_block(req, num_tokens=10)
-
-    assert partial_hash is not None
-    assert pool.get_cached_block(
-        boundary_hash(req, hash_block_size, 10), [kv_cache_group_id]
-    ) == [blocks[1]]
-    assert manager._partial_hit_reqs[req.request_id] == (1, blocks[1])
-    assert manager.num_cached_block[req.request_id] == 1
-    assert manager._producer_partial_tail_reqs[req.request_id] == (blocks[1], 10)
-
-
-def test_mamba_partial_tail_skips_all_bookkeeping_when_the_boundary_is_superseded():
-    """The Mamba caller must treat a superseded boundary as "nothing happened".
-
-    cache_partial_block now has two reasons to return None -- null block, and a
-    boundary the block has outgrown.  MambaManager._cache_partial_tail_block
-    keys three updates off that value, and the third,
-    _producer_partial_tail_reqs, is what makes allocate_new_blocks hand the CoW
-    block to a KV connector for offload under the *boundary* sub-hash.
-
-    Skipping it is the only correct behaviour: the pool has just refused to
-    publish that key locally, and the block records coverage of a later
-    boundary, so offloading it would advertise a superseded key to an external
-    store backed by the wrong state.  That is the same corruption this module's
-    other tests pin, one surface further out.
-
-    This state is not reachable from MambaManager on its own -- its
-    ``num_tokens != latest_prompt_hash_boundary`` guard fires the boundary
-    exactly once, so a block it targets is never already promoted past it.  The
-    promotion is therefore forced out of band here, to pin the contract for any
-    future caller rather than to reproduce a live bug.
-    """
-    hash_block_size, block_size = 2, 6
-    kv_cache_group_id = 0
-    pool, manager = _mamba_align_manager(hash_block_size, block_size)
-
-    req = make_request("0", list(range(10)), hash_block_size, sha256)
-    blocks = pool.get_new_blocks(2)
-    manager.req_to_blocks[req.request_id] = blocks
-
-    # Force the tail block past the boundary: a 12-token request promotes both
-    # blocks, so block 1 carries a full-block hash covering 12 >= 10 tokens.
-    promoter = make_request("1", list(range(12)), hash_block_size, sha256)
-    pool.cache_full_blocks(
-        request=promoter,
-        blocks=blocks,
-        num_cached_blocks=0,
-        num_full_blocks=2,
-        block_size=block_size,
-        kv_cache_group_id=kv_cache_group_id,
-    )
-    assert blocks[1].block_hash_num_tokens == 12
-    pool.take_events()
-
-    assert manager._cache_partial_tail_block(req, num_tokens=10) is None
-
-    # None of the three updates may happen, and nothing may be published --
-    # not in the cache map, not on the event stream.
-    assert req.request_id not in manager._partial_hit_reqs
-    assert req.request_id not in manager.num_cached_block
-    assert req.request_id not in manager._producer_partial_tail_reqs
-    assert (
-        pool.get_cached_block(
-            boundary_hash(req, hash_block_size, 10), [kv_cache_group_id]
-        )
-        is None
-    )
+    req.append_output_token_ids([12])
+    manager.cache_blocks(req, num_tokens=13)
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
     assert pool.take_events() == []
-    assert blocks[1].block_hash_num_tokens == 12, (
-        "the refusal must not shorten the block's recorded coverage"
-    )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -4,6 +4,7 @@
 from collections.abc import Callable
 
 import pytest
+import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
@@ -18,6 +19,8 @@ from vllm.v1.core.kv_cache_utils import (
     hash_block_tokens,
     init_none_hash,
 )
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec
 from vllm.v1.request import Request
 
 pytestmark = pytest.mark.cpu_test
@@ -464,3 +467,78 @@ def test_partial_block_promotes_to_direct_full_block_hash(dcp_world_size: int):
     )
     assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
     assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
+def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
+    dcp_world_size: int,
+):
+    """Regression test for partial-hash resurrection after full-block promotion.
+
+    When a request's prompt ends inside a block, _cache_partial_tail_block
+    registers a partial hash for that boundary.  Once decode fills the block
+    completely, cache_full_blocks promotes it to a full-block hash and removes
+    the partial entry.  _cache_partial_tail_block must then skip re-inserting
+    the now-superseded partial hash on every subsequent cache_blocks call,
+    because boundary_tokens is derived from the fixed num_prompt_tokens and
+    does not change across decode steps.
+    """
+    hash_block_size = 2
+    block_size = 6 * dcp_world_size
+    kv_cache_group_id = 0
+
+    # Prompt: 10 tokens, ends 4 tokens into block 1 (partial tail).
+    prompt_token_ids = list(range(10 * dcp_world_size))
+    req = make_request("R", prompt_token_ids, hash_block_size, sha256)
+
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    manager = FullAttentionManager(
+        kv_cache_spec=spec,
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=kv_cache_group_id,
+        scheduler_block_size=block_size,
+    )
+    manager.req_to_blocks[req.request_id] = pool.get_new_blocks(2)
+
+    # Prefill: registers partial hash for the prompt boundary.
+    manager.cache_blocks(req, num_tokens=len(prompt_token_ids))
+    partial_hash = boundary_hash(req, hash_block_size, len(prompt_token_ids))
+    block1 = manager.req_to_blocks[req.request_id][1]
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) == [block1]
+
+    # Decode: fill block 1 to completion, triggering promotion.
+    tokens_to_fill = block_size - (len(prompt_token_ids) % block_size)
+    for i in range(tokens_to_fill):
+        req.append_output_token_ids([100 + i])
+        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
+
+    # After promotion the stale partial hash must not be live in the cache.
+    full_hashes = BlockHashListWithBlockSize(
+        req.block_hashes, hash_block_size, block_size
+    )
+    promoted_full_hash = full_hashes[1]
+    assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [block1], (
+        "promoted full-block hash must be cached"
+    )
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None, (
+        "stale partial hash must not be resurrected after promotion"
+    )
+
+    # Additional decode steps must not re-insert the stale entry either.
+    for i in range(tokens_to_fill, tokens_to_fill + 3):
+        req.append_output_token_ids([200 + i])
+        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None, (
+        "stale partial hash must stay absent on subsequent decode steps"
+    )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -19,8 +19,8 @@ from vllm.v1.core.kv_cache_utils import (
     hash_block_tokens,
     init_none_hash,
 )
-from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
-from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager, MambaManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
 from vllm.v1.request import Request
 
 pytestmark = pytest.mark.cpu_test
@@ -788,4 +788,121 @@ def test_promoted_tail_stops_calling_into_the_pool_each_decode_step(
         manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
     assert calls == calls_after_promotion, (
         "decode inside an already-promoted block must not call into the pool"
+    )
+
+
+def _mamba_align_manager(
+    hash_block_size: int, block_size: int
+) -> tuple[BlockPool, MambaManager]:
+    spec = MambaSpec(
+        shapes=((8,),),
+        dtypes=(torch.float32,),
+        block_size=block_size,
+        mamba_cache_mode="align",
+        num_speculative_blocks=0,
+    )
+    pool = BlockPool(
+        num_gpu_blocks=8,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        enable_kv_cache_events=True,
+    )
+    manager = MambaManager(
+        kv_cache_spec=spec,
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+    return pool, manager
+
+
+def test_mamba_partial_tail_registers_the_boundary_when_it_is_not_superseded():
+    """Positive control for the refusal test below.
+
+    On an un-promoted tail block MambaManager._cache_partial_tail_block still
+    registers the boundary and records all three pieces of follow-up
+    bookkeeping, the last of which hands the CoW block to a KV connector for
+    partial-tail offload.  Without this the refusal test could pass vacuously.
+    """
+    hash_block_size, block_size = 2, 6
+    kv_cache_group_id = 0
+    pool, manager = _mamba_align_manager(hash_block_size, block_size)
+
+    # 10 prompt tokens: block 0 is full, block 1 holds tokens 6..9, and the
+    # last prompt hash boundary is 10 -- inside block 1.
+    req = make_request("0", list(range(10)), hash_block_size, sha256)
+    blocks = pool.get_new_blocks(2)
+    manager.req_to_blocks[req.request_id] = blocks
+
+    partial_hash = manager._cache_partial_tail_block(req, num_tokens=10)
+
+    assert partial_hash is not None
+    assert pool.get_cached_block(
+        boundary_hash(req, hash_block_size, 10), [kv_cache_group_id]
+    ) == [blocks[1]]
+    assert manager._partial_hit_reqs[req.request_id] == (1, blocks[1])
+    assert manager.num_cached_block[req.request_id] == 1
+    assert manager._producer_partial_tail_reqs[req.request_id] == (blocks[1], 10)
+
+
+def test_mamba_partial_tail_skips_all_bookkeeping_when_the_boundary_is_superseded():
+    """The Mamba caller must treat a superseded boundary as "nothing happened".
+
+    cache_partial_block now has two reasons to return None -- null block, and a
+    boundary the block has outgrown.  MambaManager._cache_partial_tail_block
+    keys three updates off that value, and the third,
+    _producer_partial_tail_reqs, is what makes allocate_new_blocks hand the CoW
+    block to a KV connector for offload under the *boundary* sub-hash.
+
+    Skipping it is the only correct behaviour: the pool has just refused to
+    publish that key locally, and the block records coverage of a later
+    boundary, so offloading it would advertise a superseded key to an external
+    store backed by the wrong state.  That is the same corruption this module's
+    other tests pin, one surface further out.
+
+    This state is not reachable from MambaManager on its own -- its
+    ``num_tokens != latest_prompt_hash_boundary`` guard fires the boundary
+    exactly once, so a block it targets is never already promoted past it.  The
+    promotion is therefore forced out of band here, to pin the contract for any
+    future caller rather than to reproduce a live bug.
+    """
+    hash_block_size, block_size = 2, 6
+    kv_cache_group_id = 0
+    pool, manager = _mamba_align_manager(hash_block_size, block_size)
+
+    req = make_request("0", list(range(10)), hash_block_size, sha256)
+    blocks = pool.get_new_blocks(2)
+    manager.req_to_blocks[req.request_id] = blocks
+
+    # Force the tail block past the boundary: a 12-token request promotes both
+    # blocks, so block 1 carries a full-block hash covering 12 >= 10 tokens.
+    promoter = make_request("1", list(range(12)), hash_block_size, sha256)
+    pool.cache_full_blocks(
+        request=promoter,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=kv_cache_group_id,
+    )
+    assert blocks[1].block_hash_num_tokens == 12
+    pool.take_events()
+
+    assert manager._cache_partial_tail_block(req, num_tokens=10) is None
+
+    # None of the three updates may happen, and nothing may be published --
+    # not in the cache map, not on the event stream.
+    assert req.request_id not in manager._partial_hit_reqs
+    assert req.request_id not in manager.num_cached_block
+    assert req.request_id not in manager._producer_partial_tail_reqs
+    assert (
+        pool.get_cached_block(
+            boundary_hash(req, hash_block_size, 10), [kv_cache_group_id]
+        )
+        is None
+    )
+    assert pool.take_events() == []
+    assert blocks[1].block_hash_num_tokens == 12, (
+        "the refusal must not shorten the block's recorded coverage"
     )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -573,3 +573,219 @@ def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
     assert pool.take_events() == [], (
         "decode inside an already-promoted block must emit no further events"
     )
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
+def test_cache_partial_block_refuses_boundary_the_block_has_outgrown(
+    dcp_world_size: int,
+):
+    """The pool itself must refuse a partial entry a promoted block outgrew.
+
+    test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion
+    covers the caller that actually makes this mistake in production.  This
+    test pins the invariant at the insert site instead, so it holds for any
+    future caller of cache_partial_block: once a block carries a hash covering
+    at least as many tokens as the incoming boundary, that boundary has been
+    superseded and re-registering it is never correct.
+
+    Refusal is reported by returning None -- the same contract as a null block
+    -- because callers such as MambaManager._cache_partial_tail_block key
+    follow-up bookkeeping off the returned hash and must not record a partial
+    entry that was never inserted.
+    """
+    hash_block_size = 2
+    block_size = 6 * dcp_world_size
+    kv_cache_group_id = 0
+    partial_num_tokens = 2 * block_size - hash_block_size
+    token_ids = list(range(partial_num_tokens))
+    req = make_request("0", token_ids, hash_block_size, sha256)
+    pool = BlockPool(
+        num_gpu_blocks=3,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        enable_kv_cache_events=True,
+    )
+    blocks = pool.get_new_blocks(2)
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=block_size,
+        kv_cache_group_id=kv_cache_group_id,
+    )
+    partial_hash = boundary_hash(req, hash_block_size, partial_num_tokens)
+    assert pool.cache_partial_block(
+        request=req,
+        block=blocks[1],
+        num_tokens=partial_num_tokens,
+        kv_cache_group_id=kv_cache_group_id,
+        block_size=block_size,
+    )
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) == [blocks[1]]
+
+    # Fill the block and promote it past the partial boundary.
+    req.append_output_token_ids(list(range(partial_num_tokens, 2 * block_size)))
+    full_hashes = BlockHashListWithBlockSize(
+        req.block_hashes, hash_block_size, block_size
+    )
+    promoted_full_hash = full_hashes[1]
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=1,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=kv_cache_group_id,
+    )
+    pool.take_events()
+
+    # Re-registering the outgrown boundary must be refused outright.
+    assert (
+        pool.cache_partial_block(
+            request=req,
+            block=blocks[1],
+            num_tokens=partial_num_tokens,
+            kv_cache_group_id=kv_cache_group_id,
+            block_size=block_size,
+        )
+        is None
+    ), "a boundary the block has outgrown must not be registered"
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None, (
+        "the outgrown boundary must not become reachable again"
+    )
+    assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [
+        blocks[1]
+    ], "the promoted full-block hash must be left intact"
+    assert blocks[1].block_hash_num_tokens == 2 * block_size, (
+        "the refused call must not shorten the block's recorded coverage"
+    )
+    assert pool.take_events() == [], "a refused registration must emit no events"
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
+def test_cache_partial_block_still_grows_a_partial_entry_forward(
+    dcp_world_size: int,
+):
+    """The refusal must not catch a partial entry legitimately growing.
+
+    The guard keys on ">= incoming", so the 8 -> 10 token growth path inside a
+    single block -- where the block's existing hash covers *fewer* tokens --
+    must still retire the shorter key and register the longer one.
+    """
+    hash_block_size = 2
+    block_size = 6 * dcp_world_size
+    kv_cache_group_id = 0
+    shorter_num_tokens = block_size + hash_block_size
+    longer_num_tokens = block_size + 2 * hash_block_size
+    token_ids = list(range(longer_num_tokens))
+    req = make_request("0", token_ids, hash_block_size, sha256)
+    pool = BlockPool(
+        num_gpu_blocks=3,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    blocks = pool.get_new_blocks(2)
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=block_size,
+        kv_cache_group_id=kv_cache_group_id,
+    )
+    shorter_hash = boundary_hash(req, hash_block_size, shorter_num_tokens)
+    longer_hash = boundary_hash(req, hash_block_size, longer_num_tokens)
+
+    assert pool.cache_partial_block(
+        request=req,
+        block=blocks[1],
+        num_tokens=shorter_num_tokens,
+        kv_cache_group_id=kv_cache_group_id,
+        block_size=block_size,
+    )
+    assert pool.get_cached_block(shorter_hash, [kv_cache_group_id]) == [blocks[1]]
+
+    assert pool.cache_partial_block(
+        request=req,
+        block=blocks[1],
+        num_tokens=longer_num_tokens,
+        kv_cache_group_id=kv_cache_group_id,
+        block_size=block_size,
+    ), "growing a partial entry forward inside its block must still be allowed"
+    assert pool.get_cached_block(longer_hash, [kv_cache_group_id]) == [blocks[1]]
+    assert pool.get_cached_block(shorter_hash, [kv_cache_group_id]) is None, (
+        "the superseded shorter boundary must be retired"
+    )
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
+def test_promoted_tail_stops_calling_into_the_pool_each_decode_step(
+    dcp_world_size: int,
+):
+    """The caller-side guard is an optimisation; pin what it actually buys.
+
+    BlockPool.cache_partial_block already refuses an outgrown boundary, so
+    correctness does not depend on the check in _cache_partial_tail_block --
+    dropping it leaves every other test in this file green.  What it buys is
+    that steady-state decode inside a promoted block stops re-deriving the
+    partial hash and calling into the pool once per step, forever, only to
+    have the call refused.  Without an assertion on the call count that
+    property is invisible and a future refactor would silently drop it.
+    """
+    hash_block_size = 2
+    block_size = 6 * dcp_world_size
+    kv_cache_group_id = 0
+
+    prompt_token_ids = list(range(10 * dcp_world_size))
+    req = make_request("R", prompt_token_ids, hash_block_size, sha256)
+
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    manager = FullAttentionManager(
+        kv_cache_spec=spec,
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=kv_cache_group_id,
+        scheduler_block_size=block_size,
+    )
+    manager.req_to_blocks[req.request_id] = pool.get_new_blocks(2)
+
+    calls = 0
+    original = pool.cache_partial_block
+
+    def counting_cache_partial_block(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    pool.cache_partial_block = counting_cache_partial_block
+
+    manager.cache_blocks(req, num_tokens=len(prompt_token_ids))
+    assert calls == 1, "the prompt boundary itself must be registered once"
+
+    # Fill the tail block to completion, promoting it.
+    tokens_to_fill = block_size - (len(prompt_token_ids) % block_size)
+    for i in range(tokens_to_fill):
+        req.append_output_token_ids([100 + i])
+        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
+
+    # Steady-state decode inside the promoted block: no further pool calls.
+    calls_after_promotion = calls
+    for i in range(tokens_to_fill, tokens_to_fill + 5):
+        req.append_output_token_ids([200 + i])
+        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
+    assert calls == calls_after_promotion, (
+        "decode inside an already-promoted block must not call into the pool"
+    )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -482,6 +482,11 @@ def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
     the now-superseded partial hash on every subsequent cache_blocks call,
     because boundary_tokens is derived from the fixed num_prompt_tokens and
     does not change across decode steps.
+
+    The cache map and the KV-cache event stream are both checked: a fix that
+    keeps get_cached_block clean but still emits BlockStored for the retired
+    partial hash would leave external KV-aware routers with the contradictory
+    view this bug is actually reported for.
     """
     hash_block_size = 2
     block_size = 6 * dcp_world_size
@@ -495,6 +500,7 @@ def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
         num_gpu_blocks=4,
         enable_caching=True,
         hash_block_size=hash_block_size,
+        enable_kv_cache_events=True,
     )
     spec = FullAttentionSpec(
         block_size=block_size,
@@ -511,17 +517,24 @@ def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
     )
     manager.req_to_blocks[req.request_id] = pool.get_new_blocks(2)
 
-    # Prefill: registers partial hash for the prompt boundary.
+    # Prefill: registers the partial hash for the prompt boundary and
+    # announces it to KV-cache-event subscribers.
     manager.cache_blocks(req, num_tokens=len(prompt_token_ids))
     partial_hash = boundary_hash(req, hash_block_size, len(prompt_token_ids))
+    stale_event_hash = kv_cache_utils.maybe_convert_block_hash(partial_hash)
     block1 = manager.req_to_blocks[req.request_id][1]
     assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) == [block1]
+    assert any(
+        isinstance(e, BlockStored) and stale_event_hash in e.block_hashes
+        for e in pool.take_events()
+    ), "prefill must announce the partial boundary hash"
 
     # Decode: fill block 1 to completion, triggering promotion.
     tokens_to_fill = block_size - (len(prompt_token_ids) % block_size)
     for i in range(tokens_to_fill):
         req.append_output_token_ids([100 + i])
         manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
+    promotion_events = pool.take_events()
 
     # After promotion the stale partial hash must not be live in the cache.
     full_hashes = BlockHashListWithBlockSize(
@@ -535,10 +548,28 @@ def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
         "stale partial hash must not be resurrected after promotion"
     )
 
-    # Additional decode steps must not re-insert the stale entry either.
+    # ...and the event stream must agree with the cache map. Promotion
+    # announces the partial hash as removed, so nothing may re-announce it as
+    # stored afterwards.
+    removed_at = [
+        i
+        for i, e in enumerate(promotion_events)
+        if isinstance(e, BlockRemoved) and stale_event_hash in e.block_hashes
+    ]
+    assert removed_at, "promotion must announce the partial hash as removed"
+    assert not any(
+        isinstance(e, BlockStored) and stale_event_hash in e.block_hashes
+        for e in promotion_events[removed_at[-1] :]
+    ), "stale partial hash must not be re-announced as stored after promotion"
+
+    # Additional decode steps must not re-insert the stale entry either, in
+    # the cache map or on the event stream.
     for i in range(tokens_to_fill, tokens_to_fill + 3):
         req.append_output_token_ids([200 + i])
         manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
     assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None, (
         "stale partial hash must stay absent on subsequent decode steps"
+    )
+    assert pool.take_events() == [], (
+        "decode inside an already-promoted block must emit no further events"
     )

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -498,6 +498,13 @@ class BlockPool:
                 block_hash_with_group_id, block.block_id
             )
         )
+        # Note the direction of the comparison: this only retires hashes that
+        # cover *fewer* tokens than the entry being registered, i.e. a partial
+        # entry growing forward within its block. It deliberately does not fire
+        # when the block already carries a longer hash -- that case is a caller
+        # trying to register a boundary the block has already outgrown, and the
+        # caller is responsible for not making that call at all. See
+        # FullAttentionManager._cache_partial_tail_block.
         if (
             not already_cached
             and block.block_hash is not None

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -479,8 +479,14 @@ class BlockPool:
                 entry is partial within the owning cache block.
 
         Returns:
-            The hash key with group ID if a partial entry can be registered;
-            otherwise ``None`` for null blocks.
+            The hash key with group ID if a partial entry was registered.
+            ``None`` if the entry was refused: either ``block`` is a null
+            block, or ``block`` already carries a hash covering at least
+            ``num_tokens``, which means this boundary has been superseded
+            (see the promotion note below). Callers that key follow-up
+            bookkeeping off this value -- e.g.
+            ``MambaManager._cache_partial_tail_block`` -- must treat both
+            refusals the same way: nothing was registered.
         """
         if block.is_null:
             return None
@@ -493,30 +499,44 @@ class BlockPool:
         block_hash_with_group_id = make_block_hash_with_group_id(
             block_hash, kv_cache_group_id
         )
+        incoming_num_tokens = num_hash_blocks * self.hash_block_size
         already_cached = block.block_hash == block_hash_with_group_id or (
             self.cached_block_hash_to_block.contain(
                 block_hash_with_group_id, block.block_id
             )
         )
-        # Note the direction of the comparison: this only retires hashes that
-        # cover *fewer* tokens than the entry being registered, i.e. a partial
-        # entry growing forward within its block. It deliberately does not fire
-        # when the block already carries a longer hash -- that case is a caller
-        # trying to register a boundary the block has already outgrown, and the
-        # caller is responsible for not making that call at all. See
-        # FullAttentionManager._cache_partial_tail_block.
+        # The two branches below split on the direction of the comparison
+        # between the hash the block already carries and the one being
+        # registered, and they are not symmetric.
+        #
+        # Existing hash covers *fewer* tokens: a partial entry is growing
+        # forward inside its block (8 -> 10 tokens). The shorter key is
+        # genuinely superseded, so retire it and register the longer one.
+        #
+        # Existing hash covers *at least as many* tokens: the block has been
+        # promoted past this boundary -- cache_full_blocks already removed the
+        # partial key and announced it as BlockRemoved. Re-registering here
+        # would resurrect a retired key in cached_block_hash_to_block and emit
+        # a contradictory BlockStored for a hash the server has already told
+        # subscribers is gone. Refuse instead.
+        if (
+            not already_cached
+            and block.block_hash_num_tokens is not None
+            and block.block_hash_num_tokens >= incoming_num_tokens
+        ):
+            return None
         if (
             not already_cached
             and block.block_hash is not None
             and block.block_hash_num_tokens is not None
-            and block.block_hash_num_tokens < num_hash_blocks * self.hash_block_size
+            and block.block_hash_num_tokens < incoming_num_tokens
         ):
             removed_hashes = self._remove_cached_block_hashes(block)
             self._emit_block_removed_events(removed_hashes)
         self._insert_block_hash(
             block_hash_with_group_id,
             block,
-            num_tokens=num_hash_blocks * self.hash_block_size,
+            num_tokens=incoming_num_tokens,
         )
         if self.enable_kv_cache_events and not already_cached:
             parent_hash, block_start = self._get_partial_block_parent_hash_and_start(

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -479,14 +479,8 @@ class BlockPool:
                 entry is partial within the owning cache block.
 
         Returns:
-            The hash key with group ID if a partial entry was registered.
-            ``None`` if the entry was refused: either ``block`` is a null
-            block, or ``block`` already carries a hash covering at least
-            ``num_tokens``, which means this boundary has been superseded
-            (see the promotion note below). Callers that key follow-up
-            bookkeeping off this value -- e.g.
-            ``MambaManager._cache_partial_tail_block`` -- must treat both
-            refusals the same way: nothing was registered.
+            The hash key with group ID, or ``None`` for a null block or a
+            boundary superseded by the block's current hash.
         """
         if block.is_null:
             return None
@@ -505,20 +499,8 @@ class BlockPool:
                 block_hash_with_group_id, block.block_id
             )
         )
-        # The two branches below split on the direction of the comparison
-        # between the hash the block already carries and the one being
-        # registered, and they are not symmetric.
-        #
-        # Existing hash covers *fewer* tokens: a partial entry is growing
-        # forward inside its block (8 -> 10 tokens). The shorter key is
-        # genuinely superseded, so retire it and register the longer one.
-        #
-        # Existing hash covers *at least as many* tokens: the block has been
-        # promoted past this boundary -- cache_full_blocks already removed the
-        # partial key and announced it as BlockRemoved. Re-registering here
-        # would resurrect a retired key in cached_block_hash_to_block and emit
-        # a contradictory BlockStored for a hash the server has already told
-        # subscribers is gone. Refuse instead.
+        # Do not resurrect a shorter boundary removed during full-block
+        # promotion. Forward growth is handled by the removal branch below.
         if (
             not already_cached
             and block.block_hash_num_tokens is not None

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -835,10 +835,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
-        # If this block has already been promoted to a full-block hash that
-        # covers at least as many tokens as the partial boundary, skip
-        # re-registering the stale partial entry (it was already superseded
-        # by the promotion and re-inserting it corrupts the cache index).
+        # boundary_tokens is derived from the fixed request.num_prompt_tokens,
+        # so this method re-fires on every decode step for the lifetime of the
+        # request -- including after cache_full_blocks has promoted the block
+        # past the boundary. Skip those calls once the block's own hash already
+        # covers the boundary. BlockPool.cache_partial_block refuses the same
+        # case, so this is belt-and-braces for correctness; what it adds is
+        # keeping the steady-state decode path out of the pool entirely rather
+        # than re-deriving the partial hash every step only to have it refused.
         target_block = blocks[block_idx]
         if (
             target_block.block_hash_num_tokens is not None

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -847,7 +847,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             return
         self.block_pool.cache_partial_block(
             request=request,
-            block=blocks[block_idx],
+            block=target_block,
             num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -835,14 +835,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
-        # boundary_tokens is derived from the fixed request.num_prompt_tokens,
-        # so this method re-fires on every decode step for the lifetime of the
-        # request -- including after cache_full_blocks has promoted the block
-        # past the boundary. Skip those calls once the block's own hash already
-        # covers the boundary. BlockPool.cache_partial_block refuses the same
-        # case, so this is belt-and-braces for correctness; what it adds is
-        # keeping the steady-state decode path out of the pool entirely rather
-        # than re-deriving the partial hash every step only to have it refused.
+        # This fixed prompt boundary is revisited on every decode step. Avoid
+        # re-entering the pool once the block already covers it; the pool also
+        # enforces this invariant.
         target_block = blocks[block_idx]
         if (
             target_block.block_hash_num_tokens is not None

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -835,6 +835,16 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
+        # If this block has already been promoted to a full-block hash that
+        # covers at least as many tokens as the partial boundary, skip
+        # re-registering the stale partial entry (it was already superseded
+        # by the promotion and re-inserting it corrupts the cache index).
+        target_block = blocks[block_idx]
+        if (
+            target_block.block_hash_num_tokens is not None
+            and target_block.block_hash_num_tokens >= boundary_tokens
+        ):
+            return
         self.block_pool.cache_partial_block(
             request=request,
             block=blocks[block_idx],


### PR DESCRIPTION
## Purpose

Prevent a superseded partial prefix-cache hash from being re-registered after
its owning block is promoted to a full-block hash.

Fixes #49125.

## Root cause

`FullAttentionManager._cache_partial_tail_block` runs on every
`cache_blocks()` call with a boundary derived from the fixed
`request.num_prompt_tokens`. After `cache_full_blocks` promotes the tail block,
the partial key has been removed, so the old `already_cached` check does not
recognize it. The stale call then inserts the retired key again and emits a new
`BlockStored` event after its `BlockRemoved` event.

## Fix

- `BlockPool.cache_partial_block` refuses an incoming partial boundary already
  covered by the block's current hash. This is the correctness invariant for
  all callers and prevents both cache-index resurrection and contradictory KV
  events.
- `FullAttentionManager._cache_partial_tail_block` skips the pool call once the
  target block already covers the fixed prompt boundary. This avoids repeating
  the rejected work on every decode step.

Legitimate forward growth of a partial entry, such as 8 to 10 tokens, remains
unchanged.

## Mamba caller behavior

`cache_partial_block` can now return `None` for a superseded boundary as well as
for a null block. `MambaManager._cache_partial_tail_block` intentionally skips
its partial-hit and producer/offload bookkeeping when nothing was registered.
Offloading under a key the pool refused would advertise a superseded boundary
to an external store.

This superseded-boundary state is not reachable through Mamba's current normal
call path: its prompt-boundary guard fires once, and full-block caching does not
promote the tail it targets. Existing Mamba partial-tail and offload tests cover
the normal path.

## Duplicate-work check

- #49145 attempted the caller-side fix but was closed with unresolved conflicts
  and no maintainer review.
- #53158 opened on 2026-08-20, one day after this PR, and addresses the same
  issue. This PR now includes the pool invariant, manager fast path, and
  cache-map/KV-event regression coverage. The two PRs should be consolidated
  so only one implementation lands.

## Tests

- Extended `test_partial_block_promotes_to_direct_full_block_hash` to verify
  that the pool refuses re-registration after promotion without changing the
  promoted hash or emitting events.
- Added `test_cache_blocks_does_not_resurrect_partial_hash_after_promotion` to
  exercise prefill, decode-time promotion, the cache map, the KV-event stream,
  and a subsequent decode step through `FullAttentionManager.cache_blocks`.
- The existing partial-replacement test covers valid forward growth.

```bash
PYTHONPATH=tests:. .venv/bin/python -m pytest \
  tests/v1/core/prefix_cache/ \
  tests/v1/core/test_single_type_kv_cache_manager.py \
  -x -q
# 74 passed

.venv/bin/pre-commit run --files \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py \
  vllm/v1/core/block_pool.py \
  vllm/v1/core/single_type_kv_cache_manager.py
# all hooks passed
```

No model evaluation was run because this is a deterministic cache-index and
KV-event bookkeeping bug covered directly by CPU regression tests.

## AI assistance

This PR was developed with AI assistance from Claude and OpenAI Codex. The
human author remains responsible for reviewing, understanding, and owning the
final diff end-to-end.
