### PR TITLE
[Bugfix][ROCm] Fix num_tokens inflation for 2-D (M-RoPE) positions from the MTP drafter

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/base.py
+++ b/vllm/model_executor/layers/rotary_embedding/base.py
@@ -168,6 +168,14 @@ class RotaryEmbedding(RotaryEmbeddingBase):
         is_neox_style: bool,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """A PyTorch-native implementation of forward()."""
+        # M-RoPE positions can arrive as (3, N) -- e.g. from the MTP drafter
+        # of a multimodal model -- where 3 is the number of rope dimensions,
+        # not tokens. Flattening first inflated num_tokens to 3N and produced
+        # an invalid query view (query.view(3N, -1, head_size)). For text
+        # tokens all rope dimensions carry identical positions, so take the
+        # last row; full multimodal input needs a dedicated path.
+        if positions.dim() == 2:
+            positions = positions[-1]
         positions = positions.flatten()
         num_tokens = positions.shape[0]
         cos_sin = cos_sin_cache.index_select(0, positions)


### PR DESCRIPTION
## The fix

`RotaryEmbedding.forward_static` flattens `positions` **before** deriving
`num_tokens`. When positions arrive 2-D — `(3, N)`, as the MTP drafter of a
multimodal model passes them, where 3 is the number of rope dimensions, not
tokens — `flatten()` makes `num_tokens = 3N` and the next line
`query.view(num_tokens, -1, head_size)` fails on a query that holds N tokens.

This makes speculative decoding (MTP) completely unusable on multimodal
M-RoPE checkpoints in this code path, and the failure is actively misleading:

- **under torch.compile** it surfaces as a dynamo fake-tensor error —
  `TorchRuntimeError: RuntimeError when making fake tensor call ... call_method
  view ... shape '[3*s18, -1, 256]' is invalid for input of size 2048*s47` —
  which reads as a compiler/quantization problem and sends debugging in the
  wrong direction (int8/compressed-tensors combinations were suspected for
  two days before the rope was isolated);
- **in eager** it is concrete: `shape '[6144, -1, 256]' is invalid for input
  of size 4194304` — 6144 = 3 × 2048, the rope-dim inflation.

## Repro

Multimodal M-RoPE checkpoint with an MTP head (e.g. the official
`Qwen/Qwen3.6-35B-A3B`, a `Qwen3_5MoeForConditionalGeneration` VLM whose
text config carries `mtp_num_hidden_layers: 1`), served with:

```
vllm serve <model> --tensor-parallel-size 2 \
  --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}'
```

→ engine init fails at `determine_available_memory` with either error above.
Without `--speculative-config` the same model serves fine (the drafter is
what passes 2-D positions).

## The change

Take the last rope row when `positions` is 2-D. For **text** tokens all rope
dimensions carry identical positions, so this is exact; genuine multimodal
(vision) input needs a dedicated path and is out of scope here — flagged in
the code comment.

## Measured (2× AMD MI210, gfx90a, TP=2)

| config (Qwen3.6-35B-A3B) | before | after |
|---|---|---|
| any MTP config | engine init crash | serves |
| W8A8 + MTP n=3 | — | 139.8 tok/s decode (vs 59.2 non-spec, 2.4×) |
| bf16 + MTP n=3 | — | 155.0 tok/s decode (vs 74.4 non-spec, 2.1×) |

Gate v2 divergence probes and reference-free ground-truth checks pass on the
fixed path (outputs change vs non-speculative as expected for speculation).
