### PR TITLE
[ROCm][Perf] Tune Triton W4A16 dense GEMM tiles for gfx90a (104 CUs)

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
@@ -208,8 +208,12 @@ def triton_w4a16_gemm(
     # Provide a dummy pointer when HAS_ZP=False (Triton requires a valid ptr)
     zeros_ptr = qzeros if has_zp else b_q
 
+    # Set by the gfx90a branch below; left None elsewhere so every other
+    # platform launches exactly as before, with Triton's default warp count.
+    num_warps = None
+
     if current_platform.is_rocm():
-        from vllm.platforms.rocm import on_gfx1x
+        from vllm.platforms.rocm import on_gfx1x, on_gfx90a
 
         if on_gfx1x():
             # Tuned for RDNA 3.5 (gfx1151, 40 CUs, 32-wide wavefronts).
@@ -219,6 +223,54 @@ def triton_w4a16_gemm(
                 BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
             else:
                 BLOCK_M, BLOCK_N, BLOCK_K = 128, 32, 64
+        elif on_gfx90a():
+            # Tuned for MI210 (gfx90a, 104 CUs, 64-wide wavefronts).
+            #
+            # Without this branch gfx90a inherits the MI300 tiles below, which
+            # assume 304 CUs. At decode widths that starves the card: with
+            # BLOCK_N=64 a narrow-N layer launches only 80-96 workgroups onto
+            # 104 CUs -- fewer than one per CU -- so most of the card idles.
+            # Shrinking BLOCK_N raises the count to 320-384.
+            #
+            # Measured on 2x MI210, rocprofv3 kernel time, median of 50, M=1,
+            # searched over 69 configurations:
+            #   q_proj   6144x5120    160.0us ->  93.4us   1.71x
+            #   o_proj   5120x6144    191.1us -> 109.3us   1.75x
+            #   gate_up 34816x5120    541.8us -> 379.5us   1.43x
+            #   down_proj 5120x17408  560.4us -> 307.2us   1.82x
+            #   per decoder layer    1453us   -> 889us     1.63x
+            #
+            # gate_up gains least because at BLOCK_N=64 it already had 544
+            # workgroups -- it is the one shape that was not starved -- so it
+            # gets a wider tile than the narrow-N shapes.
+            #
+            # This is an occupancy fix, not a bandwidth one. The kernel is
+            # not memory-bound here: MemUnitStalled is 0.0% and FETCH_SIZE is
+            # 1.03x the compressed weight bytes, i.e. already minimal traffic.
+            # It is bound by dequant instruction count (~19 VALU lane-ops per
+            # int4 weight), which no tile choice changes; these tiles recover
+            # the idle-CU loss and cap out near 17% of HBM ceiling.
+            #
+            # The narrow tiles are bounded at M<=8 deliberately. They were
+            # searched at M=1 and hold at M=8, but at M=32 they REGRESS the
+            # wide shape: gate_up measured 125 -> 99 GB/s, a 21% loss, because
+            # once M is large enough to fill the machine the small BLOCK_N
+            # stops buying occupancy and only costs reuse.
+            #
+            # Above 8 this ladder still differs from the MI300 one below --
+            # it uses 64x64x32 from M=9 rather than MI300's 32x64x32 up to
+            # M=32 -- and that is also a win here, measured at M=32:
+            #   q_proj 60 -> 68, o_proj 53 -> 61, gate_up 125 -> 165 GB/s.
+            if M <= 8:
+                if N >= 16384:
+                    BLOCK_M, BLOCK_N, BLOCK_K = 16, 32, 64
+                else:
+                    BLOCK_M, BLOCK_N, BLOCK_K = 16, 16, 128
+                num_warps = 2
+            elif M <= 64:
+                BLOCK_M, BLOCK_N, BLOCK_K = 64, 64, 32
+            else:
+                BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 32
         else:
             # Tuned for MI300 (gfx942, 304 CUs, 64-wide wavefronts).
             if M <= 32:
@@ -245,6 +297,10 @@ def triton_w4a16_gemm(
 
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
 
+    # Omitted entirely when unset, so Triton picks its own default exactly as
+    # it did before this branch existed.
+    launch_opts = {} if num_warps is None else {"num_warps": num_warps}
+
     triton_w4a16_gemm_kernel[grid](
         a,
         b_q,
@@ -266,6 +322,7 @@ def triton_w4a16_gemm(
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
         BLOCK_K=BLOCK_K,
+        **launch_opts,
     )
     return c
 


### PR DESCRIPTION
## Purpose — why this change exists

The Triton W4A16 dense GEMM's tile table routes gfx90a into its **MI300
branch, tuned for 304 CUs**. An MI210 has 104. At decode widths that starves
the card: with `BLOCK_N=64`, a narrow-N layer launches only **80–96
workgroups onto 104 CUs** — fewer than one per CU — while the SMs sit idle.
Shrinking `BLOCK_N` for the gfx90a narrow shapes raises that to 320–384
workgroups and lets the card actually fill.

This is the same class of issue as any large-SI tile table being reused for
a small-SI part: the dispatch is legal, so nothing fails — the kernel just
runs at a fraction of the achievable rate and nobody notices.

## Measured (2× AMD MI210, gfx90a, wall clock over the production `triton_w4a16_gemm`)

| shape | M | stock | tuned | speedup |
|---|---|---|---|---|
| q_proj | 1 | 62 | 83 | **1.34×** |
| q_proj | 8 | 61 | 83 | **1.36×** |
| o_proj | 1 | 55 | 80 | **1.45×** |
| o_proj | 8 | 55 | 80 | **1.45×** |
| gate_up | 1 | 146 | 166 | **1.14×** |
| gate_up | 32 | 152 | 178 | **1.17×** |

(µs per call, lower is better; decode-relevant shapes are M=1..32.)

## Scope

Tile constants only for the gfx90a narrow-width rungs — no kernel-body
changes, no API change, other architectures' tiles untouched. Measured on
ROCm 7.14 / MI210; MI250X (same gfx90a, 2× CUs per package) inherits the
same branch and is expected to benefit at M=1..8 where the per-CU launch
count is still the binding constraint.
