### PR TITLE
[Model][Llama] Support hidden_act variants in gated MLP

### DIFF
--- a/tests/model_executor/test_llama_hidden_act.py
+++ b/tests/model_executor/test_llama_hidden_act.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for LlamaMLP resolving `hidden_act` through the activation registry.
+
+The reference computation mirrors how `transformers` applies the configured
+activation in `LlamaMLP`: `down_proj(ACT2FN[hidden_act](gate_proj(x)) * up_proj(x))`.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.models.llama import LlamaMLP
+
+HIDDEN_SIZE = 16
+INTERMEDIATE_SIZE = 32
+
+# Reference definitions of the supported gate activations, matching the
+# semantics of `transformers.activations.ACT2FN` for the same config names.
+REFERENCE_ACT_FNS = {
+    "gelu": F.gelu,
+    "gelu_pytorch_tanh": lambda x: F.gelu(x, approximate="tanh"),
+    "silu": F.silu,
+    "swish": F.silu,
+}
+
+
+def _make_mlp(hidden_act: str, seed: int = 0) -> LlamaMLP:
+    mlp = LlamaMLP(
+        hidden_size=HIDDEN_SIZE,
+        intermediate_size=INTERMEDIATE_SIZE,
+        hidden_act=hidden_act,
+    )
+    # Give the (otherwise uninitialized) projection weights deterministic,
+    # finite values so outputs can be compared numerically.
+    generator = torch.Generator().manual_seed(seed)
+    for param in mlp.parameters():
+        param.data.normal_(mean=0.0, std=0.1, generator=generator)
+    return mlp
+
+
+@pytest.mark.parametrize("activation_name", sorted(REFERENCE_ACT_FNS))
+def test_llama_mlp_matches_reference_hidden_act(
+    activation_name: str,
+    default_vllm_config,
+    dist_init,
+) -> None:
+    """LlamaMLP must apply the activation selected by `hidden_act`, i.e.
+    compute `down_proj(act(gate) * up)` like the transformers implementation."""
+    mlp = _make_mlp(activation_name)
+    x = torch.randn(3, HIDDEN_SIZE, generator=torch.Generator().manual_seed(1))
+
+    gate_up = x @ mlp.gate_up_proj.weight.T
+    gate, up = gate_up.chunk(2, dim=-1)
+    expected = (REFERENCE_ACT_FNS[activation_name](gate) * up) @ mlp.down_proj.weight.T
+
+    torch.testing.assert_close(mlp(x), expected)
+
+
+def test_llama_mlp_rejects_unknown_hidden_act(
+    default_vllm_config,
+    dist_init,
+) -> None:
+    with pytest.raises(ValueError, match="Unsupported activation"):
+        _make_mlp("not_a_real_activation")
+
+
+def test_llama_mlp_rejects_incompatible_operand_layout(
+    default_vllm_config,
+    dist_init,
+) -> None:
+    """`swigluoai` is in the activation-and-mul registry, but SwigluOAIAndMul
+    reads the gate and up operands interleaved rather than as the concatenated
+    halves produced by this MLP's fused gate_up_proj. It must be rejected
+    rather than silently computing the wrong result."""
+    with pytest.raises(ValueError, match="Unsupported activation"):
+        _make_mlp("swigluoai")

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -35,7 +35,7 @@ from transformers import LlamaConfig
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
-from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.activation import get_act_and_mul_fn
 from vllm.model_executor.layers.attention import (
     Attention,
     EncoderOnlyAttention,
@@ -76,6 +76,10 @@ from .utils import (
     maybe_prefix,
 )
 
+# ACT2FN names whose fused activation-and-mul op uses the concatenated
+# [gate | up] layout of gate_up_proj; SwigluOAIAndMul expects interleaved.
+_SUPPORTED_HIDDEN_ACTS = frozenset({"gelu", "gelu_pytorch_tanh", "silu", "swish"})
+
 
 class LlamaMLP(nn.Module):
     def __init__(
@@ -107,11 +111,12 @@ class LlamaMLP(nn.Module):
             disable_tp=disable_tp,
             prefix=f"{prefix}.down_proj",
         )
-        if hidden_act != "silu":
+        if hidden_act not in _SUPPORTED_HIDDEN_ACTS:
             raise ValueError(
-                f"Unsupported activation: {hidden_act}. Only silu is supported for now."
+                f"Unsupported activation: {hidden_act}. Supported activations "
+                f"are: {sorted(_SUPPORTED_HIDDEN_ACTS)}."
             )
-        self.act_fn = SiluAndMul()
+        self.act_fn = get_act_and_mul_fn(hidden_act)
 
     def forward(self, x):
         x, _ = self.gate_up_proj(x)


### PR DESCRIPTION
## Purpose

This applies the generalization that #40588 (merged) made for Gemma3/Gemma4 to the
Llama family: resolve the gated-MLP activation from the checkpoint config instead of
hard-coding one activation and rejecting every other config value.

vLLM's Llama implementation is narrower than the `LlamaForCausalLM` config contract
it consumes. Transformers' `LlamaMLP` selects the gate activation from the config —
`self.act_fn = ACT2FN[config.hidden_act]`
([modeling_llama.py#L172](https://github.com/huggingface/transformers/blob/decba1d2ea4ed3cbf0495d1828abad4b2dba1846/src/transformers/models/llama/modeling_llama.py#L172))
— so a `LlamaForCausalLM` checkpoint may legitimately carry a non-default
`hidden_act`. vLLM reads the same field, passes it into its `LlamaMLP`, then rejects
everything except `silu`. Such checkpoints are otherwise identical to stock Llama
(same `gate_proj`/`up_proj`/`down_proj` names, shapes and TP partitioning), so
activation selection is the only thing that needs to change.

### Scope

This does not open the MLP to the whole activation-and-mul registry. The accepted set
is the `ACT2FN` names backed by a fused activation-and-multiply kernel whose operand
layout matches this MLP:

```python
_SUPPORTED_HIDDEN_ACTS = frozenset({"gelu", "gelu_pytorch_tanh", "silu", "swish"})
```

`LlamaMLP` fuses `gate_proj`/`up_proj` into one `MergedColumnParallelLinear`, so the
activation must read concatenated halves (`x[..., :d]`, `x[..., d:]`). `swigluoai` is
excluded because `SwigluOAIAndMul` reads its operands interleaved and would compute
silently wrong results here rather than fail — there is a test asserting it stays
rejected. `geglu` is excluded because it is not recognized by `ACT2FN`, so
Transformers' `LlamaMLP` would reject it. Anything outside the set still raises
`ValueError` at load time.

`silu` resolves to the same default-constructed `SiluAndMul()` as before, so the
mainline path is unchanged. Activations needing a per-model parameter (`fatrelu`) or
with no gated kernel in vLLM (`relu`, `relu2`, `mish`) remain unsupported. Only
`llama.py` is touched to keep the diff reviewable; the same hard-coded check exists
in several other model files and can follow separately.

### Why this is not duplicating an existing PR

`gh pr list --repo vllm-project/vllm --state open --search` for `llama hidden_act`,
`llama activation` and `act_and_mul llama` returns no open PR addressing Llama
activation-variant support; the nearest hits (#51415, #46864) are activation/quant
*fusion* work. The equivalent Gemma3/Gemma4 change (#40588) is already merged and
this PR follows its structure.

## Test Plan

`tests/model_executor/test_llama_hidden_act.py`, modelled on
`test_gemma_hidden_act.py` from #40588 but asserting numerical equivalence rather
than module types: each supported name reproduces the reference
`down_proj(act(gate) * up)` built from the matching `ACT2FN` semantics (the `silu`
case is the regression guard, its reference being exactly what the previous
hard-coded implementation computed); an unknown name raises `ValueError`; and
`swigluoai` raises `ValueError`.

Plus a model-level check against a public checkpoint carrying `hidden_act: "gelu"` —
`Harshatheeswar/babylama-activation_gelu` (rev `3bf2d713`,
`architectures: ["LlamaForCausalLM"]`, 12 layers, hidden 768, ffn 3072).

## Test Result

The host used has no usable GPU, so all runs below are CPU/fp32 against a
`VLLM_TARGET_DEVICE=empty` editable install, with a local-only pytest plugin
(`local_c_stub`, not in this PR) supplying schema-only stand-ins for the compiled
`_C` activation ops, switching `dist_init` from `nccl` to `gloo`, and running
`process_weights_after_loading` after MLP construction for the CPU linear path:

```bash
CUDA_VISIBLE_DEVICES="" VLLM_TARGET_DEVICE=cpu PYTHONPATH=<dir with local_c_stub.py> \
  <venv>/bin/python -m pytest tests/model_executor/test_llama_hidden_act.py -v -p local_c_stub
# 6 passed in 22.92s
```

I have not run the plain `.venv/bin/python -m pytest
tests/model_executor/test_llama_hidden_act.py -v` on a GPU host. The test file itself
contains none of that scaffolding, and as a control the already-merged
`test_gemma_hidden_act.py` passes 10/10 under the same harness.

**Model evaluation** — vLLM's `LlamaMLP` vs the `transformers` implementation on that
checkpoint's own weights and real per-layer MLP inputs (3 prompts x 12 layers = 36
comparisons, fp32): **max abs diff `3.58e-07`, mean `4.27e-08`**, against a max
reference magnitude of `2.09e+00` — equal within fp32 rounding. On the same config,
before this change `LlamaMLP` raises `ValueError: Unsupported activation: gelu. Only
silu is supported for now.`; after it, it builds with `act_fn=GeluAndMul`. The
activation is not cosmetic here: substituting `silu` for the configured `gelu` on the
same weights shifts the layer-0 output by mean `3.03e-02` (max `1.34e-01`) against a
mean output magnitude of `1.70e-01`.

**Not covered:** the CUDA fused-kernel paths (`forward_cuda`) for the newly reachable
activations, and end-to-end engine/serving output. The `silu` path is
construction-identical to the previous code, so mainline Llama serving is unchanged
by construction. CUDA and end-to-end coverage remain pending upstream CI.

## AI assistance

This change was developed with AI assistance (Claude): surveying the activation
registry and the operand layouts of its entries, drafting the patch and the test, and
producing the runs reported above. The `ACT2FN` membership and the `SwigluOAIAndMul`
operand-layout constraint were each checked against the `transformers` and vLLM
sources rather than assumed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
