### PR TITLE
[ROCm][MoE] Pack UE8M0 scales directly in Triton silu_mul_quant

### DIFF
--- a/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
+++ b/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
@@ -150,7 +150,7 @@ def pack_scales(x: torch.Tensor, tokens_per_expert: torch.Tensor) -> torch.Tenso
 
     # Add i32_padding here so we can view it as a i32 tensor later on.
     i32_padding = round_up(G, 4) - G
-    ref_s_i8 = torch.empty((E, T, G + i32_padding), dtype=torch.uint8, device=DEVICE)
+    ref_s_i8 = torch.zeros((E, T, G + i32_padding), dtype=torch.uint8, device=DEVICE)
     for e in range(E):
         nt = tokens_per_expert[e].item()
         ref_s_i8[e, :nt, :G] = x[e, :nt].view(torch.int32) >> 23
@@ -229,6 +229,9 @@ def test_silu_mul_fp8_quant_deep_gemm(E: int, T: int, H: int, fp8_type: torch.dt
         dtype=torch.int32,
         device=DEVICE,
     )
+    tokens_per_expert[0] = T
+    if E > 1:
+        tokens_per_expert[1] = 0
 
     # Input tensor of shape (E, T, 2*H)
     y = token_random(E, T, 2 * H, tokens_per_expert)
@@ -286,6 +289,11 @@ def test_silu_mul_fp8_quant_deep_gemm(E: int, T: int, H: int, fp8_type: torch.dt
         )
         assert y_s.dtype == expected_scale_dtype
         assert ref_y_s.dtype == expected_scale_dtype
+        if scale_fmt == DeepGemmQuantScaleFMT.UE8M0:
+            G = H // group_size
+            packed_G = cdiv(G, 4)
+            assert y_s.shape == (E, T, packed_G)
+            assert y_s.stride() == (T * packed_G, 1, T)
 
         for e in range(E):
             nt = tokens_per_expert[e].item()
@@ -308,10 +316,9 @@ def test_silu_mul_fp8_quant_deep_gemm(E: int, T: int, H: int, fp8_type: torch.dt
                 )
 
             if scale_fmt == DeepGemmQuantScaleFMT.UE8M0:
-                G = H // group_size
                 y_s_sliced = as_uint8(y_s[e])
                 ref_s_sliced = as_uint8(ref_y_s[e])
-                torch.testing.assert_close(y_s_sliced[:nt, :G], ref_s_sliced[:nt, :G])
+                torch.testing.assert_close(y_s_sliced, ref_s_sliced)
                 if dg_scales is not None:
                     dg_sliced = as_uint8(dg_scales[e])
                     torch.testing.assert_close(y_s_sliced[:nt, :G], dg_sliced[:nt, :G])

--- a/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
@@ -59,7 +59,7 @@ def _silu_mul_fp8_quant_deep_gemm(
     # Pointers ------------------------------------------------------------
     input_ptr,  # 16-bit activations (E, T, 2*H)
     y_q_ptr,  # fp8 quantized activations (E, T, H)
-    y_s_ptr,  # 16-bit scales (E, T, G)
+    y_s_ptr,  # fp32 or packed UE8M0 scales
     counts_ptr,  # int32 num tokens per expert (E)
     # Sizes ---------------------------------------------------------------
     H: tl.constexpr,  # hidden dimension (per output)
@@ -83,6 +83,7 @@ def _silu_mul_fp8_quant_deep_gemm(
     fp8_min: tl.constexpr,
     fp8_max: tl.constexpr,
     ceil_ue8m0: tl.constexpr,
+    packed_ue8m0: tl.constexpr,
     # Meta ---------------------------------------------------------------
     BLOCK: tl.constexpr,
     NUM_STAGES: tl.constexpr,
@@ -108,7 +109,6 @@ def _silu_mul_fp8_quant_deep_gemm(
     base_up_offset = base_input_offset + H * stride_i_h + cols * stride_i_h
     base_yq_offset = e * stride_yq_e + g * GROUP_SIZE * stride_yq_h + cols * stride_yq_h
     base_ys_offset = e * stride_ys_e + g * stride_ys_g
-
     for t in tl.range(0, n_tokens, num_stages=NUM_STAGES):
         gate = tl.load(
             input_ptr + base_gate_offset + t * stride_i_t, mask=mask, other=0.0
@@ -128,7 +128,16 @@ def _silu_mul_fp8_quant_deep_gemm(
         y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
 
         tl.store(y_q_ptr + base_yq_offset + t * stride_yq_t, y_q, mask=mask)
-        tl.store(y_s_ptr + base_ys_offset + t * stride_ys_t, y_s)
+        if packed_ue8m0:
+            # Each int32 stores four consecutive group-scale exponent bytes.
+            y_s_u8_ptr = y_s_ptr.to(tl.pointer_type(tl.uint8))
+            packed_offset = (
+                e * stride_ys_e + (g // 4) * stride_ys_g + t * stride_ys_t
+            ) * 4 + g % 4
+            scale_bits = y_s.to(tl.int32, bitcast=True)
+            tl.store(y_s_u8_ptr + packed_offset, (scale_bits >> 23).to(tl.uint8))
+        else:
+            tl.store(y_s_ptr + base_ys_offset + t * stride_ys_t, y_s)
 
 
 def persistent_masked_m_silu_mul_quant(
@@ -220,21 +229,7 @@ def persistent_masked_m_silu_mul_quant(
         # Triton fallback for ROCm and XPU -- the C++ kernel is guarded by
         # #ifndef USE_ROCM in activation_kernels.cu.
         # https://github.com/ROCm/aiter/issues/2420
-        # For UE8M0 (int32 packed scales), compute with float32 scales
-        # first, then pack afterwards.
         is_packed_ue8m0 = quant_scale_fmt == DeepGemmQuantScaleFMT.UE8M0
-        if is_packed_ue8m0:
-            f32_shape, f32_strides, _ = scales_shape_stride_dtype(
-                E, T, G, DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0
-            )
-            y_s_f32 = torch.empty_strided(
-                f32_shape,
-                f32_strides,
-                dtype=torch.float32,
-                device=y.device,
-            )
-        else:
-            y_s_f32 = y_s
 
         stride_cnt_e = tokens_per_expert.stride()[0]
 
@@ -252,11 +247,11 @@ def persistent_masked_m_silu_mul_quant(
                 "_silu_mul_fp8_quant_deep_gemm Triton fallback does not "
                 f"support {y_s.dtype} scales. Only torch.float32 supported."
             )
-        f32_strides = y_s_f32.stride()
+        ys_strides = y_s.stride()
         _silu_mul_fp8_quant_deep_gemm[grid](
             y,
             y_q,
-            y_s_f32,
+            y_s,
             tokens_per_expert,
             H,
             group_size,
@@ -266,35 +261,19 @@ def persistent_masked_m_silu_mul_quant(
             stride_yq_e,
             stride_yq_t,
             stride_yq_h,
-            f32_strides[0],
-            f32_strides[1],
-            f32_strides[2],
+            ys_strides[0],
+            ys_strides[1],
+            ys_strides[2],
             stride_cnt_e,
             eps,
             fp8_min,
             fp8_max,
             ceil_ue8m0,
+            is_packed_ue8m0,
             BLOCK=group_size,
             NUM_STAGES=4,
             num_warps=1,
         )
-
-        if is_packed_ue8m0:
-            # Pack float32 scales into int32 UE8M0 format:
-            # extract exponent bits (bits 30:23) from float32.
-            E_dim, T_dim, G_dim = y_s_f32.shape
-            y_s_cont = y_s_f32.contiguous()
-            i32_pad = round_up(G_dim, 4) - G_dim
-            y_s_u8 = (y_s_cont.view(torch.int32) >> 23).to(torch.uint8)
-            if i32_pad > 0:
-                y_s_u8 = torch.nn.functional.pad(y_s_u8, (0, i32_pad))
-            # y_s has shape (E, T, G//4) with stride (T*G//4, 1, T)
-            packed = y_s_u8.view(torch.int32)
-            # Copy with matching strides
-            for e_idx in range(E_dim):
-                nt = tokens_per_expert[e_idx].item()
-                if nt > 0:
-                    y_s[e_idx, :nt].copy_(packed[e_idx, :nt])
 
     return y_q, y_s
 


### PR DESCRIPTION
This PR follows up on the review of #37835. The fallback added there writes scales to a temporary FP32 tensor, packs them with PyTorch operations, and then copies them one expert at a time. This change stores each UE8M0 exponent byte directly from the Triton kernel and removes that post-processing path. The packed shape, strides, byte values, padding, and unused rows stay unchanged.

I benchmarked the full forced-UE8M0 operator on a gfx950 ROCm GPU using BF16 inputs and a group size of 128. The workloads cover DeepSeek-style EP1, EP8, and EP16 shapes with decode-like 8-route and balanced 2,048-route distributions, plus a padded `G=6` case.

| Case | E | T | H | Active routes | Base steady (us) | PR steady (us) | Speedup | Base isolated (us) | PR isolated (us) | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| DeepSeek-style EP1, decode | 256 | 256 | 2048 | 8 | 772.26 | 21.34 | 36.18x | 773.39 | 31.52 | 24.54x |
| DeepSeek-style EP1, balanced | 256 | 256 | 2048 | 2,048 | 4,628.73 | 21.25 | 217.86x | 4,609.07 | 36.97 | 124.67x |
| DeepSeek-style EP8, decode | 32 | 2,048 | 2048 | 8 | 246.18 | 21.20 | 11.61x | 248.93 | 29.84 | 8.34x |
| DeepSeek-style EP8, balanced | 32 | 2,048 | 2048 | 2,048 | 609.14 | 31.95 | 19.07x | 620.10 | 55.51 | 11.17x |
| DeepSeek-style EP16, decode | 16 | 4,096 | 2048 | 8 | 208.88 | 21.08 | 9.91x | 215.67 | 29.56 | 7.30x |
| DeepSeek-style EP16, balanced | 16 | 4,096 | 2048 | 2,048 | 358.83 | 53.71 | 6.68x | 368.43 | 76.97 | 4.79x |
| Padded `G=6`, decode | 16 | 2,048 | 768 | 8 | 221.09 | 21.34 | 10.36x | 218.88 | 29.85 | 7.33x |
| Padded `G=6`, balanced | 16 | 2,048 | 768 | 2,048 | 369.58 | 52.79 | 7.00x | 369.82 | 76.83 | 4.81x |

- **Tests:** `HIP_VISIBLE_DEVICES=1 .venv/bin/python -m pytest -q tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py -x` passed all 23 cases. The tests compare the complete packed output, including padding and unused rows. An additional 800-launch stress run was bit-exact, and pre-commit passed on the changed files.
- **Benchmark setup:** I compared base commit `17dbd42930` with this working tree on gfx950 using BF16 inputs, group size 128, four rotating datasets, 20 warmups, 100 bundles of 20 calls, and 100 synchronized single calls. The table reports median host wall time for the full operator, including output allocation and the old packing and copy work.
- **Control:** The unchanged FLOAT32_CEIL_UE8M0 path stayed within 2.2% of the base revision across the same shapes.