### PR TITLE
[SM100] Hdim 256 optimized

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,8 +38,8 @@ if(VLLM_FLASH_ATTN_SRC_DIR)
 else()
   FetchContent_Declare(
           vllm-flash-attn
-          GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG f3e1a4f74c99145c0717709860bf765de1703779
+          GIT_REPOSITORY https://github.com/simon-veitner-redhat/flash-attention.git
+          GIT_TAG a77403ce29508966313b60a365ea121615e23621
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -38,8 +38,8 @@ if(VLLM_FLASH_ATTN_SRC_DIR)
 else()
   FetchContent_Declare(
           vllm-flash-attn
-          GIT_REPOSITORY https://github.com/simon-veitner-redhat/flash-attention.git
-          GIT_TAG a77403ce29508966313b60a365ea121615e23621
+          GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
+          GIT_TAG 6bd7c7044074502c2f06679472fa876bf93b3612
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -39,7 +39,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 6bd7c7044074502c2f06679472fa876bf93b3612
+          GIT_TAG 4eb29359a51b4fe67c8c0f0c5e931236971aa492
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn

--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -127,6 +127,14 @@ Priority is **1 = highest** (tried first).
 > **†** FlashInfer Native is the regular FlashInfer path. XQA is the SM90 decode path exposed through FlashInfer's TRTLLM decode API. trtllm-gen is used on SM100 and supports sinks. Disable XQA/trtllm-gen via `--attention-config.use_trtllm_attention=0`.
 >
 > **\*** Specify the FlashAttention version via `--attention-config.flash_attn_version=2`, `3`, or `4`. Default is FA4 on SM100+ (Blackwell), FA3 on SM90 (Hopper), FA2 otherwise.
+>
+> On Blackwell, when the FlashAttention backend is selected, `head_size=256` is served
+> by a dedicated FA4 kernel that requires a KV cache block size of 128 (advertised
+> automatically, so it is picked as long as `--block-size` is not pinned) and does not
+> support logit soft capping, attention sinks, mm_prefix/R-SWA masking, DCP, or windowed
+> encoder attention. Those configurations transparently fall back to FA2. A pinned
+> `--block-size` that is not a multiple of 128 instead makes FlashAttention ineligible
+> for such models, which is an error if the backend was requested explicitly.
 
 ## MiniMax M3 Sparse Attention Backends
 

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from unittest.mock import patch
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -14,6 +15,7 @@ from vllm.config import (
 )
 from vllm.platforms import current_platform
 from vllm.platforms.cpu import CpuPlatform
+from vllm.platforms.interface import DeviceCapability
 
 if current_platform.is_cuda():
     from vllm.platforms.cuda import CudaPlatform
@@ -25,6 +27,7 @@ if current_platform.is_rocm():
 else:
     RocmPlatform = None
 
+from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import _cached_get_attn_backend, get_attn_backend
 
@@ -555,3 +558,178 @@ def test_flash_attn_accepts_handled_fp8_variants(
     # import order across earlier tests that patch vllm.platforms.current_platform.
     monkeypatch.setattr(fa_utils_mod.current_platform, "is_xpu", lambda: True)
     assert FlashAttentionBackend.supports_kv_cache_dtype(kv_cache_dtype)
+
+
+# FA4 dispatches head_size=256 on Blackwell to a dedicated 2-CTA kernel whose
+# feature set is far narrower than the generic FA4 forward. Every request shape
+# it cannot serve has to resolve to FA2 during selection, otherwise it becomes
+# an AssertionError at kernel-launch time.
+
+blackwell_only = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="FA4 is CUDA-only"
+)
+
+
+@contextmanager
+def _blackwell(vllm_config=None):
+    platform = MagicMock()
+    platform.is_xpu.return_value = False
+    platform.is_rocm.return_value = False
+    platform.get_device_capability.return_value = DeviceCapability(10, 0)
+    with (
+        patch("vllm.v1.attention.backends.fa_utils.current_platform", platform),
+        patch(
+            "vllm.vllm_flash_attn.flash_attn_interface.is_fa_version_supported",
+            return_value=True,
+        ),
+        patch("vllm.config.get_current_vllm_config_or_none", return_value=vllm_config),
+        patch(
+            "vllm.v1.attention.backends.flash_attn.get_current_vllm_config_or_none",
+            return_value=vllm_config,
+        ),
+    ):
+        yield
+
+
+def _hd256_config(
+    *, is_mm_prefix_lm=False, rswa_window=None, dcp_size=1, softcap=None, head_size=256
+):
+    vllm_config = MagicMock()
+    vllm_config.attention_config.flash_attn_version = None
+    vllm_config.model_config.is_mm_prefix_lm = is_mm_prefix_lm
+    vllm_config.model_config.rswa_window = rswa_window
+    vllm_config.model_config.hf_text_config.attn_logit_softcapping = softcap
+    vllm_config.model_config.get_head_size.return_value = head_size
+    vllm_config.parallel_config.decode_context_parallel_size = dcp_size
+    return vllm_config
+
+
+@blackwell_only
+@pytest.mark.parametrize(
+    "kwargs,config_kwargs,expected",
+    [
+        # Supported: the dedicated kernel serves this layer.
+        ({}, {}, 4),
+        # Callers that do not build the kernel's call shape must opt out.
+        ({"supports_fa4_hd256": False}, {}, 2),
+        # Per-layer features the kernel cannot express.
+        ({"has_sinks": True}, {}, 2),
+        ({"requires_softcap": True}, {}, 2),
+        # TMA paged KV with one page per 128-token tile. A larger multiple is
+        # split down to 128 by select_common_block_size, so it stays on FA4.
+        ({"kv_cache_block_size": 16}, {}, 2),
+        ({"kv_cache_block_size": 64}, {}, 2),
+        ({"kv_cache_block_size": 256}, {}, 4),
+        # Model-level configurations: mm_prefix and R-SWA need a CuTe-DSL
+        # mask_mod plus aux tensors, the DCP context call cannot page-align its
+        # block table, and Gemma-2 style soft capping is unsupported.
+        ({}, {"is_mm_prefix_lm": True}, 2),
+        ({}, {"rswa_window": 512}, 2),
+        ({}, {"dcp_size": 2}, 2),
+        ({}, {"softcap": 50.0}, 2),
+        # Only (256, 256) hits the dedicated kernel; every other head-dim
+        # combination keeps the generic FA4 forward and its 16-token pages.
+        ({"head_size": 128, "kv_cache_block_size": 16}, {}, 4),
+        ({"head_size": 192, "head_size_v": 128, "kv_cache_block_size": 16}, {}, 4),
+        ({"head_size": 256, "head_size_v": 128, "kv_cache_block_size": 16}, {}, 4),
+    ],
+)
+def test_fa4_hd256_fallback_matrix(kwargs, config_kwargs, expected):
+    from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
+
+    kwargs = {
+        "head_size": 256,
+        "kv_cache_block_size": 128,
+        "supports_fa4_hd256": True,
+        **kwargs,
+    }
+    with _blackwell(_hd256_config(head_size=kwargs["head_size"], **config_kwargs)):
+        assert get_flash_attn_version(**kwargs) == expected
+
+
+@blackwell_only
+@pytest.mark.parametrize(
+    "config_kwargs,expected",
+    [
+        ({}, 128),
+        # A model that falls back keeps the generic advertisement, so it does
+        # not pay a 128-token page (and lose --block-size < 128) for nothing.
+        ({"softcap": 50.0}, 16),
+        ({"head_size": 128}, 16),
+    ],
+)
+def test_fa4_hd256_block_size_advertisement(config_kwargs: dict, expected: int):
+    from vllm.v1.attention.backend import MultipleOf
+    from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
+
+    vllm_config = _hd256_config(**config_kwargs)
+    with _blackwell(vllm_config):
+        (size,) = FlashAttentionBackend.get_supported_kernel_block_sizes()
+        preferred = FlashAttentionBackend.get_preferred_block_size(16)
+    assert preferred == expected
+    if expected == 128:
+        assert size == 128
+    else:
+        assert isinstance(size, MultipleOf) and size.base == expected
+
+
+@blackwell_only
+def test_fa4_hd256_mm_prefix_deselects_flash_attn():
+    """mm_prefix hd256 models must not reach the kernel: FLASH_ATTN reports the
+    combination as unsupported and the selector falls through to FLEX."""
+    from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
+
+    with _blackwell(_hd256_config(is_mm_prefix_lm=True)):
+        assert (
+            FlashAttentionBackend.supports_combination(
+                head_size=256,
+                dtype=torch.bfloat16,
+                kv_cache_dtype=None,
+                block_size=128,
+                use_mla=False,
+                has_sink=False,
+                use_sparse=False,
+                use_mm_prefix=True,
+                device_capability=DeviceCapability(10, 0),
+            )
+            is not None
+        )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda()
+    or not current_platform.is_device_capability_family(100),
+    reason="requires a Blackwell GPU",
+)
+@pytest.mark.parametrize(
+    "attn_type,sliding_window,expected",
+    [
+        # Decoder attention always passes seqused_k, which is what the kernel
+        # needs for local attention, so a windowed decoder layer keeps FA4.
+        (AttentionType.DECODER, None, 4),
+        (AttentionType.DECODER, 512, 4),
+        # Encoder attention runs on dense cu_seqlens_k instead, and the kernel
+        # rejects local attention without seqused_q/seqused_k (e.g.
+        # google/embeddinggemma-300m: head_size=256, encoder-only, windowed).
+        (AttentionType.ENCODER_ONLY, None, 4),
+        (AttentionType.ENCODER_ONLY, 512, 2),
+    ],
+)
+def test_fa4_hd256_impl_selection(attn_type, sliding_window, expected):
+    from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
+
+    # Default block size (16), i.e. the state load_model() constructs impls in:
+    # Platform.update_block_size_for_backend() only runs afterwards.
+    with set_current_vllm_config(VllmConfig()):
+        impl = FlashAttentionImpl(
+            num_heads=8,
+            head_size=256,
+            scale=0.0625,
+            num_kv_heads=8,
+            alibi_slopes=None,
+            sliding_window=sliding_window,
+            kv_cache_dtype="auto",
+            attn_type=attn_type,
+        )
+    assert impl.vllm_flash_attn_version == expected
+    assert impl.fa4_hd256 == (expected == 4)

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -627,11 +627,14 @@ def _hd256_config(
         ({}, {"rswa_window": 512}, 2),
         ({}, {"dcp_size": 2}, 2),
         ({}, {"softcap": 50.0}, 2),
-        # Only (256, 256) hits the dedicated kernel; every other head-dim
-        # combination keeps the generic FA4 forward and its 16-token pages.
+        # Only (256, 256) hits the dedicated kernel; head-dim combinations FA4
+        # can serve keep the generic forward and its 16-token pages.
         ({"head_size": 128, "kv_cache_block_size": 16}, {}, 4),
         ({"head_size": 192, "head_size_v": 128, "kv_cache_block_size": 16}, {}, 4),
-        ({"head_size": 256, "head_size_v": 128, "kv_cache_block_size": 16}, {}, 4),
+        # (256, != 256) is not a shape FA4 can serve on SM100 (_validate_head_dims
+        # in flash_attn/cute/interface.py asserts), so the TMEM block gives FA2.
+        ({"head_size": 256, "head_size_v": 128, "kv_cache_block_size": 16}, {}, 2),
+        ({"head_size": 256, "head_size_v": 64}, {}, 2),
     ],
 )
 def test_fa4_hd256_fallback_matrix(kwargs, config_kwargs, expected):

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -592,7 +592,13 @@ def _blackwell(vllm_config=None):
 
 
 def _hd256_config(
-    *, is_mm_prefix_lm=False, rswa_window=None, dcp_size=1, softcap=None, head_size=256
+    *,
+    is_mm_prefix_lm=False,
+    rswa_window=None,
+    dcp_size=1,
+    softcap=None,
+    head_size=256,
+    cache_dtype="auto",
 ):
     vllm_config = MagicMock()
     vllm_config.attention_config.flash_attn_version = None
@@ -600,6 +606,7 @@ def _hd256_config(
     vllm_config.model_config.rswa_window = rswa_window
     vllm_config.model_config.hf_text_config.attn_logit_softcapping = softcap
     vllm_config.model_config.get_head_size.return_value = head_size
+    vllm_config.cache_config.cache_dtype = cache_dtype
     vllm_config.parallel_config.decode_context_parallel_size = dcp_size
     return vllm_config
 
@@ -627,6 +634,8 @@ def _hd256_config(
         ({}, {"rswa_window": 512}, 2),
         ({}, {"dcp_size": 2}, 2),
         ({}, {"softcap": 50.0}, 2),
+        # Quantized KV caches are not supported by the dedicated kernel.
+        ({}, {"cache_dtype": "fp8"}, 2),
         # Only (256, 256) hits the dedicated kernel; head-dim combinations FA4
         # can serve keep the generic forward and its 16-token pages.
         ({"head_size": 128, "kv_cache_block_size": 16}, {}, 4),
@@ -652,23 +661,35 @@ def test_fa4_hd256_fallback_matrix(kwargs, config_kwargs, expected):
 
 @blackwell_only
 @pytest.mark.parametrize(
-    "config_kwargs,expected",
+    "backend_name,config_kwargs,expected",
     [
-        ({}, 128),
+        ("FLASH_ATTN", {}, 128),
         # A model that falls back keeps the generic advertisement, so it does
         # not pay a 128-token page (and lose --block-size < 128) for nothing.
-        ({"softcap": 50.0}, 16),
-        ({"head_size": 128}, 16),
+        ("FLASH_ATTN", {"softcap": 50.0}, 16),
+        ("FLASH_ATTN", {"head_size": 128}, 16),
+        ("FLASH_ATTN", {"cache_dtype": "fp8"}, 16),
+        # DiffKV's (256, 128) shape uses generic FA4, not the dedicated kernel.
+        ("FLASH_ATTN_DIFFKV", {}, 16),
     ],
 )
-def test_fa4_hd256_block_size_advertisement(config_kwargs: dict, expected: int):
+def test_fa4_hd256_block_size_advertisement(
+    backend_name: str, config_kwargs: dict, expected: int
+):
     from vllm.v1.attention.backend import MultipleOf
     from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
+    from vllm.v1.attention.backends.flash_attn_diffkv import (
+        FlashAttentionDiffKVBackend,
+    )
 
+    backend = {
+        "FLASH_ATTN": FlashAttentionBackend,
+        "FLASH_ATTN_DIFFKV": FlashAttentionDiffKVBackend,
+    }[backend_name]
     vllm_config = _hd256_config(**config_kwargs)
     with _blackwell(vllm_config):
-        (size,) = FlashAttentionBackend.get_supported_kernel_block_sizes()
-        preferred = FlashAttentionBackend.get_preferred_block_size(16)
+        (size,) = backend.get_supported_kernel_block_sizes()
+        preferred = backend.get_preferred_block_size(16)
     assert preferred == expected
     if expected == 128:
         assert size == 128

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -560,11 +560,6 @@ def test_flash_attn_accepts_handled_fp8_variants(
     assert FlashAttentionBackend.supports_kv_cache_dtype(kv_cache_dtype)
 
 
-# FA4 dispatches head_size=256 on Blackwell to a dedicated 2-CTA kernel whose
-# feature set is far narrower than the generic FA4 forward. Every request shape
-# it cannot serve has to resolve to FA2 during selection, otherwise it becomes
-# an AssertionError at kernel-launch time.
-
 blackwell_only = pytest.mark.skipif(
     not current_platform.is_cuda(), reason="FA4 is CUDA-only"
 )
@@ -615,33 +610,21 @@ def _hd256_config(
 @pytest.mark.parametrize(
     "kwargs,config_kwargs,expected",
     [
-        # Supported: the dedicated kernel serves this layer.
         ({}, {}, 4),
-        # Callers that do not build the kernel's call shape must opt out.
         ({"supports_fa4_hd256": False}, {}, 2),
-        # Per-layer features the kernel cannot express.
         ({"has_sinks": True}, {}, 2),
         ({"requires_softcap": True}, {}, 2),
-        # TMA paged KV with one page per 128-token tile. A larger multiple is
-        # split down to 128 by select_common_block_size, so it stays on FA4.
+        # Larger block sizes normalize to 128.
         ({"kv_cache_block_size": 16}, {}, 2),
         ({"kv_cache_block_size": 64}, {}, 2),
         ({"kv_cache_block_size": 256}, {}, 4),
-        # Model-level configurations: mm_prefix and R-SWA need a CuTe-DSL
-        # mask_mod plus aux tensors, the DCP context call cannot page-align its
-        # block table, and Gemma-2 style soft capping is unsupported.
         ({}, {"is_mm_prefix_lm": True}, 2),
         ({}, {"rswa_window": 512}, 2),
         ({}, {"dcp_size": 2}, 2),
         ({}, {"softcap": 50.0}, 2),
-        # Quantized KV caches are not supported by the dedicated kernel.
         ({}, {"cache_dtype": "fp8"}, 2),
-        # Only (256, 256) hits the dedicated kernel; head-dim combinations FA4
-        # can serve keep the generic forward and its 16-token pages.
         ({"head_size": 128, "kv_cache_block_size": 16}, {}, 4),
         ({"head_size": 192, "head_size_v": 128, "kv_cache_block_size": 16}, {}, 4),
-        # (256, != 256) is not a shape FA4 can serve on SM100 (_validate_head_dims
-        # in flash_attn/cute/interface.py asserts), so the TMEM block gives FA2.
         ({"head_size": 256, "head_size_v": 128, "kv_cache_block_size": 16}, {}, 2),
         ({"head_size": 256, "head_size_v": 64}, {}, 2),
     ],
@@ -664,12 +647,9 @@ def test_fa4_hd256_fallback_matrix(kwargs, config_kwargs, expected):
     "backend_name,config_kwargs,expected",
     [
         ("FLASH_ATTN", {}, 128),
-        # A model that falls back keeps the generic advertisement, so it does
-        # not pay a 128-token page (and lose --block-size < 128) for nothing.
         ("FLASH_ATTN", {"softcap": 50.0}, 16),
         ("FLASH_ATTN", {"head_size": 128}, 16),
         ("FLASH_ATTN", {"cache_dtype": "fp8"}, 16),
-        # DiffKV's (256, 128) shape uses generic FA4, not the dedicated kernel.
         ("FLASH_ATTN_DIFFKV", {}, 16),
     ],
 )
@@ -699,8 +679,6 @@ def test_fa4_hd256_block_size_advertisement(
 
 @blackwell_only
 def test_fa4_hd256_mm_prefix_deselects_flash_attn():
-    """mm_prefix hd256 models must not reach the kernel: FLASH_ATTN reports the
-    combination as unsupported and the selector falls through to FLEX."""
     from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
 
     with _blackwell(_hd256_config(is_mm_prefix_lm=True)):
@@ -728,13 +706,9 @@ def test_fa4_hd256_mm_prefix_deselects_flash_attn():
 @pytest.mark.parametrize(
     "attn_type,sliding_window,expected",
     [
-        # Decoder attention always passes seqused_k, which is what the kernel
-        # needs for local attention, so a windowed decoder layer keeps FA4.
         (AttentionType.DECODER, None, 4),
         (AttentionType.DECODER, 512, 4),
-        # Encoder attention runs on dense cu_seqlens_k instead, and the kernel
-        # rejects local attention without seqused_q/seqused_k (e.g.
-        # google/embeddinggemma-300m: head_size=256, encoder-only, windowed).
+        # Local encoder attention lacks the required seqused tensors.
         (AttentionType.ENCODER_ONLY, None, 4),
         (AttentionType.ENCODER_ONLY, 512, 2),
     ],
@@ -742,8 +716,7 @@ def test_fa4_hd256_mm_prefix_deselects_flash_attn():
 def test_fa4_hd256_impl_selection(attn_type, sliding_window, expected):
     from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
-    # Default block size (16), i.e. the state load_model() constructs impls in:
-    # Platform.update_block_size_for_backend() only runs afterwards.
+    # Implementations are constructed before the platform updates the block size.
     with set_current_vllm_config(VllmConfig()):
         impl = FlashAttentionImpl(
             num_heads=8,

--- a/tests/kernels/attention/test_flash_attn.py
+++ b/tests/kernels/attention/test_flash_attn.py
@@ -215,3 +215,85 @@ def test_varlen_with_paged_kv(
         torch.testing.assert_close(output, ref_output, atol=atol, rtol=rtol),
         f"{torch.max(torch.abs(output - ref_output))}",
     )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="FA4 only has a dedicated head_size=256 kernel on Blackwell",
+)
+@pytest.mark.parametrize(
+    "seq_lens", [[(1, 1328), (5, 18), (129, 463)], [(1, 523), (1, 37), (1, 2011)]]
+)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("sliding_window", SLIDING_WINDOWS)
+@torch.inference_mode()
+def test_fa4_hd256_paged_call_shape(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    sliding_window: int | None,
+) -> None:
+    """Pin the call shape ``FlashAttentionImpl.forward`` builds for FA4's
+    dedicated Blackwell head_size=256 kernel: ``FA4_HD256_PAGE_SIZE``-token KV
+    pages, a page-aligned ``max_seqlen_k``, a block table sliced to exactly
+    ``max_seqlen_k // FA4_HD256_PAGE_SIZE`` columns whose over-hang holds
+    unrelated block ids, and no SplitKV.
+    """
+    from vllm.v1.attention.backends.fa_utils import FA4_HD256_PAGE_SIZE
+
+    if not is_fa_version_supported(4):
+        pytest.skip(f'FA4 unsupported: "{fa_version_unsupported_reason(4)}"')
+    torch.set_default_device("cuda")
+    set_random_seed(0)
+
+    head_size = 256
+    block_size = FA4_HD256_PAGE_SIZE
+    num_blocks = 2048
+    dtype = torch.bfloat16
+    num_query_heads, num_kv_heads = num_heads
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    max_kv_len = max(kv_lens)
+    window_size = (sliding_window - 1, 0) if sliding_window is not None else (-1, -1)
+    scale = head_size**-0.5
+
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    )
+    value_cache = torch.randn_like(key_cache)
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    num_pages = (max_kv_len + block_size - 1) // block_size
+    # The runtime block table is sized from max_model_len, not from the batch,
+    # so it is wider than max_seqlen_k // page needs.
+    block_tables = torch.randint(
+        0, num_blocks, (len(seq_lens), num_pages + 3), dtype=torch.int32
+    )
+
+    output = flash_attn_varlen_func(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=torch.tensor(kv_lens, dtype=torch.int32),
+        max_seqlen_q=max(query_lens),
+        max_seqlen_k=num_pages * block_size,
+        softmax_scale=scale,
+        causal=True,
+        window_size=window_size,
+        block_table=block_tables[:, :num_pages],
+        num_splits=1,
+        fa_version=4,
+    )
+    ref_output = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=block_tables,
+        scale=scale,
+        sliding_window=sliding_window,
+    )
+    torch.testing.assert_close(output, ref_output, atol=1.5e-2, rtol=1e-2)

--- a/tests/kernels/attention/test_flash_attn.py
+++ b/tests/kernels/attention/test_flash_attn.py
@@ -232,12 +232,7 @@ def test_fa4_hd256_paged_call_shape(
     num_heads: tuple[int, int],
     sliding_window: int | None,
 ) -> None:
-    """Pin the call shape ``FlashAttentionImpl.forward`` builds for FA4's
-    dedicated Blackwell head_size=256 kernel: ``FA4_HD256_PAGE_SIZE``-token KV
-    pages, a page-aligned ``max_seqlen_k``, a block table sliced to exactly
-    ``max_seqlen_k // FA4_HD256_PAGE_SIZE`` columns whose over-hang holds
-    unrelated block ids, and no SplitKV.
-    """
+    """Handles excess block-table columns with page-aligned ``max_seqlen_k``."""
     from vllm.v1.attention.backends.fa_utils import FA4_HD256_PAGE_SIZE
 
     if not is_fa_version_supported(4):
@@ -265,8 +260,6 @@ def test_fa4_hd256_paged_call_shape(
         dim=0, dtype=torch.int32
     )
     num_pages = (max_kv_len + block_size - 1) // block_size
-    # The runtime block table is sized from max_model_len, not from the batch,
-    # so it is wider than max_seqlen_k // page needs.
     block_tables = torch.randint(
         0, num_blocks, (len(seq_lens), num_pages + 3), dtype=torch.int32
     )

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -9,6 +9,11 @@ from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
+# FA4 serves (head_dim, head_dim_v) == (256, 256) on Blackwell with a dedicated
+# 2-CTA kernel (flash_attn/cute/sm100_hd256_2cta_fmha_forward.py) that reads
+# paged KV through TMA only, with exactly one page per 128-token tile.
+FA4_HD256_PAGE_SIZE = 128
+
 # Track whether upstream flash-attn is available on ROCm.
 # Set during module initialization and never modified afterwards.
 # This module-level flag avoids repeated import attempts and ensures
@@ -72,7 +77,9 @@ def get_flash_attn_version(
     head_size: int | None = None,
     head_size_v: int | None = None,
     has_sinks: bool = False,
-    requires_local_attention: bool = False,
+    requires_softcap: bool = False,
+    kv_cache_block_size: int | None = None,
+    supports_fa4_hd256: bool = False,
 ) -> int | None:
     if current_platform.is_xpu():
         return 2
@@ -169,17 +176,26 @@ def get_flash_attn_version(
             )
             fa_version = 2
 
-        if (
-            fa_version == 4
-            and device_capability.major >= 10
-            and head_size == 256
-            and requires_local_attention
-        ):
-            logger.warning_once(
-                "FA4 on Blackwell does not support local attention with "
-                "head_size=256, defaulting to FA version 2."
-            )
-            fa_version = 2
+        # FA4 routes head_size=256 on Blackwell to a dedicated kernel whose
+        # feature set is much narrower than the generic FA4 forward. Anything
+        # it cannot express has to resolve to FA2 *here*, at selection time,
+        # or it becomes an AssertionError at kernel-launch time.
+        if fa_version == 4 and uses_fa4_hd256_kernel(head_size, head_size_v):
+            if not supports_fa4_hd256:
+                # Opt-in: the kernel also needs a call shape only
+                # FlashAttentionBackend builds (see FA4_HD256_PAGE_SIZE).
+                fa_version = 2
+            elif (
+                reason := _fa4_hd256_fallback_reason(
+                    has_sinks, requires_softcap, kv_cache_block_size, vllm_config
+                )
+            ) is not None:
+                logger.warning_once(
+                    "FA4's Blackwell head_size=256 kernel does not support %s, "
+                    "defaulting to FA version 2.",
+                    reason,
+                )
+                fa_version = 2
 
         # FA4 on SM100 (Blackwell) has TMEM capacity limits that restrict
         # supported head dimensions to ≤128, with exceptions for 256 and 192/128 (MLA
@@ -212,6 +228,64 @@ def get_flash_attn_version(
         return None
 
 
+def uses_fa4_hd256_kernel(
+    head_size: int | None, head_size_v: int | None = None
+) -> bool:
+    """Whether FA4 would dispatch this layer to its dedicated hd256 kernel.
+
+    Mirrors ``use_dedicated_hd256_kernel`` in flash_attn/cute/interface.py:
+    ``arch // 10 in [10, 11] and head_dim == head_dim_v == 256``. head_size=256
+    with a different V head dim keeps using the generic FA4 forward.
+    """
+    if head_size != 256:
+        return False
+    if head_size_v is not None and head_size_v != 256:
+        return False
+    capability = current_platform.get_device_capability()
+    return capability is not None and capability.major in (10, 11)
+
+
+def _fa4_hd256_fallback_reason(
+    has_sinks: bool,
+    requires_softcap: bool,
+    kv_cache_block_size: int | None,
+    vllm_config: Any,
+) -> str | None:
+    """Feature of this layer that FA4's hd256 kernel cannot express, or None.
+
+    Only features are listed here. The kernel's remaining requirements are
+    call-shape ones that ``FlashAttentionImpl.forward`` satisfies directly, so
+    they are not fallback reasons; see ``FA4_HD256_PAGE_SIZE``.
+    """
+    model_config = vllm_config.model_config if vllm_config is not None else None
+    if has_sinks:
+        return "attention sinks"
+    if requires_softcap or (
+        # Model-level signal (Gemma-2), so the KV cache block size advertised
+        # for the model agrees with the version each of its layers selects.
+        model_config is not None
+        and getattr(model_config.hf_text_config, "attn_logit_softcapping", None)
+    ):
+        return "logits soft capping"
+    if kv_cache_block_size is not None and kv_cache_block_size % FA4_HD256_PAGE_SIZE:
+        # A larger multiple is fine: the KV cache group is then split into
+        # FA4_HD256_PAGE_SIZE-token kernel pages (select_common_block_size).
+        return f"a KV cache block size of {kv_cache_block_size}"
+    if model_config is not None:
+        if model_config.is_mm_prefix_lm:
+            return "mm_prefix bidirectional attention"
+        if model_config.rswa_window is not None:
+            return "R-SWA"
+    if (
+        vllm_config is not None
+        and vllm_config.parallel_config.decode_context_parallel_size > 1
+    ):
+        # The DCP context call reuses the unsliced block table with a
+        # max_dcp_context_kv_len that is not page aligned.
+        return "decode context parallelism"
+    return None
+
+
 def is_fa_version_supported(fa_version: int) -> bool:
     try:
         from vllm.vllm_flash_attn.flash_attn_interface import (
@@ -230,6 +304,9 @@ def flash_attn_supports_kv_cache_dtype(
     head_size: int | None = None,
     head_size_v: int | None = None,
     has_sinks: bool = False,
+    requires_softcap: bool = False,
+    kv_cache_block_size: int | None = None,
+    supports_fa4_hd256: bool = False,
 ) -> bool:
     if kv_cache_dtype == "fp8_e5m2":
         return False
@@ -240,6 +317,9 @@ def flash_attn_supports_kv_cache_dtype(
         head_size=head_size,
         head_size_v=head_size_v,
         has_sinks=has_sinks,
+        requires_softcap=requires_softcap,
+        kv_cache_block_size=kv_cache_block_size,
+        supports_fa4_hd256=supports_fa4_hd256,
     )
     return (fa_version == 3 and current_platform.is_device_capability_family(90)) or (
         fa_version == 4 and current_platform.is_device_capability_family(100)

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -206,7 +206,10 @@ def get_flash_attn_version(
             and device_capability.major >= 10
             and head_size is not None
             and head_size > 128
-            and not (head_size == 256 or (head_size == 192 and head_size_v == 128))
+            and not (
+                (head_size == 256 and head_size_v in (None, 256))
+                or (head_size == 192 and head_size_v == 128)
+            )
         ):
             logger.warning_once(
                 "FA4 on Blackwell does not support head_size=%d due to TMEM "
@@ -235,7 +238,9 @@ def uses_fa4_hd256_kernel(
 
     Mirrors ``use_dedicated_hd256_kernel`` in flash_attn/cute/interface.py:
     ``arch // 10 in [10, 11] and head_dim == head_dim_v == 256``. head_size=256
-    with a different V head dim keeps using the generic FA4 forward.
+    with a different V head dim is not a shape FA4 supports on SM100 at all
+    (``_validate_head_dims`` asserts on it); the TMEM block above resolves it
+    to FA2.
     """
     if head_size != 256:
         return False

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -72,6 +72,7 @@ def get_flash_attn_version(
     head_size: int | None = None,
     head_size_v: int | None = None,
     has_sinks: bool = False,
+    requires_local_attention: bool = False,
 ) -> int | None:
     if current_platform.is_xpu():
         return 2
@@ -168,26 +169,28 @@ def get_flash_attn_version(
             )
             fa_version = 2
 
-        # TODO: Restore the `requires_local_attention` restriction when FA4
-        # head-dim 256 is re-enabled.
-        if fa_version == 4 and device_capability.major >= 10 and head_size == 256:
+        if (
+            fa_version == 4
+            and device_capability.major >= 10
+            and head_size == 256
+            and requires_local_attention
+        ):
             logger.warning_once(
-                "FA4 on Blackwell is temporarily disabled for head_size=256, "
-                "defaulting to FA version 2."
+                "FA4 on Blackwell does not support local attention with "
+                "head_size=256, defaulting to FA version 2."
             )
             fa_version = 2
 
         # FA4 on SM100 (Blackwell) has TMEM capacity limits that restrict
-        # supported head dimensions to ≤128. The 192/128 MLA prefill case is
-        # supported; 256 is temporarily disabled until upstream supports the
-        # required features. Development of symmetric 192, 384, and 512 support
-        # is tracked in https://github.com/Dao-AILab/flash-attention/issues/2456
+        # supported head dimensions to ≤128, with exceptions for 256 and 192/128 (MLA
+        # prefill). Development of symmetric 192, 384, and 512 support is being tracked
+        # in https://github.com/Dao-AILab/flash-attention/issues/2456
         if (
             fa_version == 4
             and device_capability.major >= 10
             and head_size is not None
             and head_size > 128
-            and not (head_size == 192 and head_size_v == 128)
+            and not (head_size == 256 or (head_size == 192 and head_size_v == 128))
         ):
             logger.warning_once(
                 "FA4 on Blackwell does not support head_size=%d due to TMEM "

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -6,6 +6,7 @@ from typing import Any
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import is_quantized_kv_cache
 
 logger = init_logger(__name__)
 
@@ -263,6 +264,7 @@ def _fa4_hd256_fallback_reason(
     they are not fallback reasons; see ``FA4_HD256_PAGE_SIZE``.
     """
     model_config = vllm_config.model_config if vllm_config is not None else None
+    cache_config = vllm_config.cache_config if vllm_config is not None else None
     if has_sinks:
         return "attention sinks"
     if requires_softcap or (
@@ -272,6 +274,8 @@ def _fa4_hd256_fallback_reason(
         and getattr(model_config.hf_text_config, "attn_logit_softcapping", None)
     ):
         return "logits soft capping"
+    if cache_config is not None and is_quantized_kv_cache(cache_config.cache_dtype):
+        return f"quantized KV cache dtype {cache_config.cache_dtype}"
     if kv_cache_block_size is not None and kv_cache_block_size % FA4_HD256_PAGE_SIZE:
         # A larger multiple is fine: the KV cache group is then split into
         # FA4_HD256_PAGE_SIZE-token kernel pages (select_common_block_size).

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -10,9 +10,7 @@ from vllm.utils.torch_utils import is_quantized_kv_cache
 
 logger = init_logger(__name__)
 
-# FA4 serves (head_dim, head_dim_v) == (256, 256) on Blackwell with a dedicated
-# 2-CTA kernel (flash_attn/cute/sm100_hd256_2cta_fmha_forward.py) that reads
-# paged KV through TMA only, with exactly one page per 128-token tile.
+# The dedicated hd256 kernel requires one 128-token page per tile.
 FA4_HD256_PAGE_SIZE = 128
 
 # Track whether upstream flash-attn is available on ROCm.
@@ -177,14 +175,8 @@ def get_flash_attn_version(
             )
             fa_version = 2
 
-        # FA4 routes head_size=256 on Blackwell to a dedicated kernel whose
-        # feature set is much narrower than the generic FA4 forward. Anything
-        # it cannot express has to resolve to FA2 *here*, at selection time,
-        # or it becomes an AssertionError at kernel-launch time.
         if fa_version == 4 and uses_fa4_hd256_kernel(head_size, head_size_v):
             if not supports_fa4_hd256:
-                # Opt-in: the kernel also needs a call shape only
-                # FlashAttentionBackend builds (see FA4_HD256_PAGE_SIZE).
                 fa_version = 2
             elif (
                 reason := _fa4_hd256_fallback_reason(
@@ -198,10 +190,7 @@ def get_flash_attn_version(
                 )
                 fa_version = 2
 
-        # FA4 on SM100 (Blackwell) has TMEM capacity limits that restrict
-        # supported head dimensions to ≤128, with exceptions for 256 and 192/128 (MLA
-        # prefill). Development of symmetric 192, 384, and 512 support is being tracked
-        # in https://github.com/Dao-AILab/flash-attention/issues/2456
+        # FA4 head dimensions on Blackwell are limited by TMEM capacity.
         if (
             fa_version == 4
             and device_capability.major >= 10
@@ -235,14 +224,7 @@ def get_flash_attn_version(
 def uses_fa4_hd256_kernel(
     head_size: int | None, head_size_v: int | None = None
 ) -> bool:
-    """Whether FA4 would dispatch this layer to its dedicated hd256 kernel.
-
-    Mirrors ``use_dedicated_hd256_kernel`` in flash_attn/cute/interface.py:
-    ``arch // 10 in [10, 11] and head_dim == head_dim_v == 256``. head_size=256
-    with a different V head dim is not a shape FA4 supports on SM100 at all
-    (``_validate_head_dims`` asserts on it); the TMEM block above resolves it
-    to FA2.
-    """
+    """Return whether FA4 uses its dedicated hd256 kernel."""
     if head_size != 256:
         return False
     if head_size_v is not None and head_size_v != 256:
@@ -257,19 +239,12 @@ def _fa4_hd256_fallback_reason(
     kv_cache_block_size: int | None,
     vllm_config: Any,
 ) -> str | None:
-    """Feature of this layer that FA4's hd256 kernel cannot express, or None.
-
-    Only features are listed here. The kernel's remaining requirements are
-    call-shape ones that ``FlashAttentionImpl.forward`` satisfies directly, so
-    they are not fallback reasons; see ``FA4_HD256_PAGE_SIZE``.
-    """
     model_config = vllm_config.model_config if vllm_config is not None else None
     cache_config = vllm_config.cache_config if vllm_config is not None else None
     if has_sinks:
         return "attention sinks"
     if requires_softcap or (
-        # Model-level signal (Gemma-2), so the KV cache block size advertised
-        # for the model agrees with the version each of its layers selects.
+        # Keep model-level and per-layer version selection consistent.
         model_config is not None
         and getattr(model_config.hf_text_config, "attn_logit_softcapping", None)
     ):
@@ -277,8 +252,7 @@ def _fa4_hd256_fallback_reason(
     if cache_config is not None and is_quantized_kv_cache(cache_config.cache_dtype):
         return f"quantized KV cache dtype {cache_config.cache_dtype}"
     if kv_cache_block_size is not None and kv_cache_block_size % FA4_HD256_PAGE_SIZE:
-        # A larger multiple is fine: the KV cache group is then split into
-        # FA4_HD256_PAGE_SIZE-token kernel pages (select_common_block_size).
+        # Larger blocks are split into 128-token kernel pages.
         return f"a KV cache block size of {kv_cache_block_size}"
     if model_config is not None:
         if model_config.is_mm_prefix_lm:
@@ -289,8 +263,7 @@ def _fa4_hd256_fallback_reason(
         vllm_config is not None
         and vllm_config.parallel_config.decode_context_parallel_size > 1
     ):
-        # The DCP context call reuses the unsliced block table with a
-        # max_dcp_context_kv_len that is not page aligned.
+        # DCP reuses an unsliced block table with a non-page-aligned length.
         return "decode context parallelism"
     return None
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -96,7 +96,6 @@ class FlashAttentionBackend(AttentionBackend):
             return None
 
         head_size = vllm_config.model_config.get_head_size()
-        # No kv_cache_block_size: this call is what *decides* it.
         if (
             uses_fa4_hd256_kernel(head_size, cls.head_size_v)
             and get_flash_attn_version(
@@ -112,9 +111,7 @@ class FlashAttentionBackend(AttentionBackend):
     @classmethod
     def get_supported_kernel_block_sizes(cls) -> list[int | MultipleOf]:
         if block_size := cls._get_fa4_hd256_block_size():
-            # Sliding-window cache specs select the smallest advertised size.
-            # Report the kernel's exact page-size contract instead of the
-            # generic FlashAttention multiple-of-16 capability.
+            # Sliding-window specs select the smallest advertised size.
             return [block_size]
         return [MultipleOf(16)]
 
@@ -447,8 +444,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.aot_schedule = get_flash_attn_version() == 3
 
-        # FA4's dedicated Blackwell head_dim=256 kernel. self.block_size is
-        # this KV cache group's *actual* kernel page size.
         self.fa4_hd256 = uses_fa4_hd256_kernel(self.headdim) and (
             get_flash_attn_version(
                 head_size=self.headdim,
@@ -830,9 +825,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
         if self.fa4_hd256:
-            # The cascade path calls FA with the unsliced block table and a
-            # prefix length that is not page aligned, which the hd256 kernel
-            # rejects. Cascade is an optimization, so just turn it off.
+            # Cascade may use a non-page-aligned prefix length.
             return False
         return use_cascade_attention(*args, **kwargs)
 
@@ -882,8 +875,7 @@ class FlashAttentionImpl(AttentionImpl):
             AttentionType.ENCODER,
             AttentionType.ENCODER_ONLY,
         )
-        # No kv_cache_block_size: it is not final at impl construction time and
-        # the page size is enforced at spec/group level (select_common_block_size).
+        # The final KV cache block size is unavailable during construction.
         self.vllm_flash_attn_version = get_flash_attn_version(
             requires_alibi=alibi_slopes is not None,
             head_size=head_size,
@@ -891,16 +883,11 @@ class FlashAttentionImpl(AttentionImpl):
             requires_softcap=bool(self.logits_soft_cap),
             supports_fa4_hd256=True,
         )
-        # Requests routed to FA4's dedicated Blackwell head_dim=256 kernel need
-        # the call-shape adjustments made in forward() below.
         self.fa4_hd256 = self.vllm_flash_attn_version == 4 and uses_fa4_hd256_kernel(
             head_size
         )
         if self.fa4_hd256 and not uses_kv_cache and sliding_window is not None:
-            # That kernel implements local attention only alongside
-            # seqused_q/seqused_k. The KV cache path always passes seqused_k,
-            # but encoder attention runs on dense cu_seqlens_k (e.g.
-            # google/embeddinggemma-300m: head_size=256, encoder-only, windowed).
+            # The hd256 kernel requires seqused_k for local attention.
             logger.warning_once(
                 "FA4's Blackwell head_size=256 kernel does not support local "
                 "attention on encoder inputs, defaulting to FA version 2."
@@ -1165,9 +1152,8 @@ class FlashAttentionImpl(AttentionImpl):
 
                 num_splits = attn_metadata.max_num_splits
                 if self.fa4_hd256:
-                    # The kernel requires max_seqlen_k % page_size == 0, a block
-                    # table of exactly max_seqlen_k // page_size columns (the
-                    # over-hang is masked out by seqused_k), and no SplitKV.
+                    # hd256 requires page-aligned lengths, exact-width block
+                    # tables, and no SplitKV.
                     num_pages = cdiv(max_seqlen_k, FA4_HD256_PAGE_SIZE)
                     max_seqlen_k = num_pages * FA4_HD256_PAGE_SIZE
                     block_table = block_table[:, :num_pages]
@@ -1506,7 +1492,7 @@ class FlashAttentionImpl(AttentionImpl):
             else None,
             k_descale=layer._k_scale.expand(descale_shape),  # type: ignore[operator]
             v_descale=layer._v_scale.expand(descale_shape),  # type: ignore[operator]
-            # hd256: no SplitKV, so never let FA pick num_splits > 1.
+            # The hd256 kernel does not support SplitKV.
             num_splits=1 if self.batch_invariant_enabled or self.fa4_hd256 else 0,
             s_aux=self.sinks,
         )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -87,9 +87,10 @@ class FlashAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
     ]
+    head_size_v: int | None = None
 
-    @staticmethod
-    def _get_fa4_hd256_block_size() -> int | None:
+    @classmethod
+    def _get_fa4_hd256_block_size(cls) -> int | None:
         vllm_config = get_current_vllm_config_or_none()
         if vllm_config is None or vllm_config.model_config is None:
             return None
@@ -97,8 +98,12 @@ class FlashAttentionBackend(AttentionBackend):
         head_size = vllm_config.model_config.get_head_size()
         # No kv_cache_block_size: this call is what *decides* it.
         if (
-            uses_fa4_hd256_kernel(head_size)
-            and get_flash_attn_version(head_size=head_size, supports_fa4_hd256=True)
+            uses_fa4_hd256_kernel(head_size, cls.head_size_v)
+            and get_flash_attn_version(
+                head_size=head_size,
+                head_size_v=cls.head_size_v,
+                supports_fa4_hd256=True,
+            )
             == 4
         ):
             return FA4_HD256_PAGE_SIZE

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -24,11 +24,13 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.fa_utils import (
+    FA4_HD256_PAGE_SIZE,
     flash_attn_supports_kv_cache_dtype,
     flash_attn_supports_quant_query_input,
     get_flash_attn_version,
     is_fa_version_supported,
     is_flash_attn_varlen_func_available,
+    uses_fa4_hd256_kernel,
 )
 from vllm.v1.attention.backends.utils import (
     fill_mm_prefix_query_ranges,
@@ -87,13 +89,36 @@ class FlashAttentionBackend(AttentionBackend):
     ]
 
     @staticmethod
-    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+    def _get_fa4_hd256_block_size() -> int | None:
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None or vllm_config.model_config is None:
+            return None
+
+        head_size = vllm_config.model_config.get_head_size()
+        # No kv_cache_block_size: this call is what *decides* it.
+        if (
+            uses_fa4_hd256_kernel(head_size)
+            and get_flash_attn_version(head_size=head_size, supports_fa4_hd256=True)
+            == 4
+        ):
+            return FA4_HD256_PAGE_SIZE
+        return None
+
+    @classmethod
+    def get_supported_kernel_block_sizes(cls) -> list[int | MultipleOf]:
+        if block_size := cls._get_fa4_hd256_block_size():
+            # Sliding-window cache specs select the smallest advertised size.
+            # Report the kernel's exact page-size contract instead of the
+            # generic FlashAttention multiple-of-16 capability.
+            return [block_size]
         return [MultipleOf(16)]
 
     forward_includes_kv_cache_update: bool = False
 
     @classmethod
     def get_preferred_block_size(cls, default_block_size: int) -> int:
+        if block_size := cls._get_fa4_hd256_block_size():
+            return max(default_block_size, block_size)
         if current_platform.is_xpu():
             return max(default_block_size, 64)
         return super().get_preferred_block_size(default_block_size)
@@ -194,12 +219,20 @@ class FlashAttentionBackend(AttentionBackend):
                 head_size=head_size,
                 head_size_v=head_size,
                 has_sinks=has_sink,
+                kv_cache_block_size=block_size,
+                supports_fa4_hd256=True,
             )
         ):
             return "FP8 KV cache requires FA3 on SM90 or FA4 on SM100"
         if (
             use_mm_prefix
-            and get_flash_attn_version(head_size=head_size, has_sinks=has_sink) != 4
+            and get_flash_attn_version(
+                head_size=head_size,
+                has_sinks=has_sink,
+                kv_cache_block_size=block_size,
+                supports_fa4_hd256=True,
+            )
+            != 4
         ):
             return (
                 "mm_prefix (PrefixLM bidirectional attention) requires "
@@ -408,6 +441,17 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.aot_schedule = get_flash_attn_version() == 3
+
+        # FA4's dedicated Blackwell head_dim=256 kernel. self.block_size is
+        # this KV cache group's *actual* kernel page size.
+        self.fa4_hd256 = uses_fa4_hd256_kernel(self.headdim) and (
+            get_flash_attn_version(
+                head_size=self.headdim,
+                kv_cache_block_size=self.block_size,
+                supports_fa4_hd256=True,
+            )
+            == 4
+        )
 
         try:
             from vllm.distributed.parallel_state import get_dcp_group
@@ -780,6 +824,11 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         metadata.scheduler_metadata = self._store_scheduler_metadata(scheduler_metadata)
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
+        if self.fa4_hd256:
+            # The cascade path calls FA with the unsliced block table and a
+            # prefix length that is not page aligned, which the hd256 kernel
+            # rejects. Cascade is an optimization, so just turn it off.
+            return False
         return use_cascade_attention(*args, **kwargs)
 
 
@@ -823,12 +872,36 @@ class FlashAttentionImpl(AttentionImpl):
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
 
         self.attn_type = attn_type
+        vllm_config = get_current_vllm_config_or_none()
+        uses_kv_cache = attn_type not in (
+            AttentionType.ENCODER,
+            AttentionType.ENCODER_ONLY,
+        )
+        # No kv_cache_block_size: it is not final at impl construction time and
+        # the page size is enforced at spec/group level (select_common_block_size).
         self.vllm_flash_attn_version = get_flash_attn_version(
             requires_alibi=alibi_slopes is not None,
-            requires_local_attention=sliding_window is not None,
             head_size=head_size,
             has_sinks=sinks is not None,
+            requires_softcap=bool(self.logits_soft_cap),
+            supports_fa4_hd256=True,
         )
+        # Requests routed to FA4's dedicated Blackwell head_dim=256 kernel need
+        # the call-shape adjustments made in forward() below.
+        self.fa4_hd256 = self.vllm_flash_attn_version == 4 and uses_fa4_hd256_kernel(
+            head_size
+        )
+        if self.fa4_hd256 and not uses_kv_cache and sliding_window is not None:
+            # That kernel implements local attention only alongside
+            # seqused_q/seqused_k. The KV cache path always passes seqused_k,
+            # but encoder attention runs on dense cu_seqlens_k (e.g.
+            # google/embeddinggemma-300m: head_size=256, encoder-only, windowed).
+            logger.warning_once(
+                "FA4's Blackwell head_size=256 kernel does not support local "
+                "attention on encoder inputs, defaulting to FA version 2."
+            )
+            self.vllm_flash_attn_version = 2
+            self.fa4_hd256 = False
         logger.info_once(
             "Using FlashAttention version %s",
             self.vllm_flash_attn_version,
@@ -844,6 +917,8 @@ class FlashAttentionImpl(AttentionImpl):
             head_size=head_size,
             head_size_v=head_size,
             has_sinks=sinks is not None,
+            requires_softcap=bool(self.logits_soft_cap),
+            supports_fa4_hd256=True,
         ):
             raise NotImplementedError(
                 f"FlashAttention does not support {self.kv_cache_dtype}"
@@ -862,7 +937,6 @@ class FlashAttentionImpl(AttentionImpl):
 
         self.supports_quant_query_input = flash_attn_supports_quant_query_input()
 
-        vllm_config = get_current_vllm_config_or_none()
         dcp_a2a = (
             vllm_config is not None
             and vllm_config.parallel_config.decode_context_parallel_size > 1
@@ -1084,6 +1158,16 @@ class FlashAttentionImpl(AttentionImpl):
                     )
                     causal = not has_window
 
+                num_splits = attn_metadata.max_num_splits
+                if self.fa4_hd256:
+                    # The kernel requires max_seqlen_k % page_size == 0, a block
+                    # table of exactly max_seqlen_k // page_size columns (the
+                    # over-hang is masked out by seqused_k), and no SplitKV.
+                    num_pages = cdiv(max_seqlen_k, FA4_HD256_PAGE_SIZE)
+                    max_seqlen_k = num_pages * FA4_HD256_PAGE_SIZE
+                    block_table = block_table[:, :num_pages]
+                    num_splits = 1
+
                 flash_attn_varlen_func(
                     q=query[:num_actual_tokens],
                     k=key_cache,
@@ -1105,7 +1189,7 @@ class FlashAttentionImpl(AttentionImpl):
                     k_descale=k_descale,
                     v_descale=v_descale,
                     dynamic_causal=dynamic_causal,
-                    num_splits=attn_metadata.max_num_splits,
+                    num_splits=num_splits,
                     s_aux=self.sinks,
                     mask_mod=rswa_mask_mod_fn or mm_mask_mod,
                     aux_tensors=rswa_aux or mm_aux,
@@ -1417,7 +1501,8 @@ class FlashAttentionImpl(AttentionImpl):
             else None,
             k_descale=layer._k_scale.expand(descale_shape),  # type: ignore[operator]
             v_descale=layer._v_scale.expand(descale_shape),  # type: ignore[operator]
-            num_splits=1 if self.batch_invariant_enabled else 0,
+            # hd256: no SplitKV, so never let FA pick num_splits > 1.
+            num_splits=1 if self.batch_invariant_enabled or self.fa4_hd256 else 0,
             s_aux=self.sinks,
         )
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -825,6 +825,7 @@ class FlashAttentionImpl(AttentionImpl):
         self.attn_type = attn_type
         self.vllm_flash_attn_version = get_flash_attn_version(
             requires_alibi=alibi_slopes is not None,
+            requires_local_attention=sliding_window is not None,
             head_size=head_size,
             has_sinks=sinks is not None,
         )

--- a/vllm/v1/attention/backends/flash_attn_diffkv.py
+++ b/vllm/v1/attention/backends/flash_attn_diffkv.py
@@ -87,9 +87,6 @@ class FlashAttentionDiffKVImpl(FlashAttentionImpl):
             head_size_v=FlashAttentionDiffKVBackend.head_size_v,
             has_sinks=self.sinks is not None,
         )
-        # The dedicated hd256 kernel needs head_size_v == head_size == 256 and
-        # the call-shape fixups in FlashAttentionImpl.forward, which this
-        # subclass's KV path does not apply.
         self.fa4_hd256 = False
 
     def do_kv_cache_update(

--- a/vllm/v1/attention/backends/flash_attn_diffkv.py
+++ b/vllm/v1/attention/backends/flash_attn_diffkv.py
@@ -87,6 +87,10 @@ class FlashAttentionDiffKVImpl(FlashAttentionImpl):
             head_size_v=FlashAttentionDiffKVBackend.head_size_v,
             has_sinks=self.sinks is not None,
         )
+        # The dedicated hd256 kernel needs head_size_v == head_size == 256 and
+        # the call-shape fixups in FlashAttentionImpl.forward, which this
+        # subclass's KV path does not apply.
+        self.fa4_hd256 = False
 
     def do_kv_cache_update(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Re-enables FA4 for `head_size=256` on Blackwell, which was temporarily disabled in
https://github.com/vllm-project/vllm/pull/52050 because the SM100 2-CTA hd256 kernel rejected
`seqused_q/seqused_k` — something vLLM's decoder attention always supplies.

That gap is now closed upstream in https://github.com/vllm-project/flash-attention/pull/180,
which adds forward `seqused` support along with hd256 optimizations. This PR reverts #52050 and
integrates the kernel properly, with a fallback to FA2 for everything it cannot serve:

- The kernel reads paged KV through TMA only, with one page per 128-token tile, so the backend
  now advertises an exact KV cache block size of 128 for hd256. That 128 is chosen automatically
  when the user does not pin one; a user-pinned `--block-size` that is not a multiple of 128 makes
  FLASH_ATTN ineligible for hd256 (an error if the backend was requested explicitly).
- `forward()` page-aligns `max_seqlen_k` and slices the block table to match; the over-hang is
  masked out by `seqused_k`.
- The kernel has no SplitKV support, so `num_splits=1` is pinned for this path, and cascade
  attention is disabled.
- Selection falls back to FA2 for attention sinks, logits soft capping, mm_prefix, R-SWA and DCP.
  In practice Gemma-2 (soft capping) and multimodal Gemma-3 (mm_prefix) keep using FA2, while
  Gemma-1, text-only Gemma-3 and PaliGemma/ColPali get FA4.
- The hd256 kernel is opt-in (`supports_fa4_hd256`), so callers that do not build the required
  call shape — ViT/`mm_encoder_attention`, turboquant, MLA prefill — keep resolving to FA2.
- Only `(head_size=256, head_size_v=256)` uses this kernel; `(head_size=256, head_size_v=128)`
  still takes generic FA4, exactly as it did before #52050.

Sliding window on the decoder path is enabled again, since the kernel handles it; encoder inputs
(dense `cu_seqlens_k`, no `seqused_k`) still fall back to FA2.

## Test Plan

```bash
pytest tests/kernels/attention/test_attention_selector.py
pytest tests/kernels/attention/test_flash_attn.py -k fa4_hd256
pytest tests/kernels/attention/test_flash_attn.py

# reproducer from #52050
pytest tests/models/multimodal/pooling/test_colpali.py::test_colpali_multimodal_text_query_image_docs
```

## Test Result

On B200 (SM100):

```
tests/kernels/attention/test_attention_selector.py            52 passed, 10 skipped
tests/kernels/attention/test_flash_attn.py -k fa4_hd256        8 passed
```

---

AI assistance was used for the vLLM-side changes. I reviewed every changed line and ran the
tests reported above.