### PR TITLE
[CI/Build] Fix CPU platform pre-commit formatting

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -181,13 +181,16 @@ class CpuPlatform(Platform):
                 "otherwise the performance is not optimized."
             )
 
-        # Accelerated GDN (AMX tiles or AVX-512BF16 VDPBF16PS) requires float32 SSM state.
+        # Accelerated GDN (AMX tiles or AVX-512BF16 VDPBF16PS) requires
+        # float32 SSM state.
         if (
             torch.cpu._is_avx512_bf16_supported()
             and cache_config.mamba_ssm_cache_dtype != "float32"
         ):
             cache_config.mamba_ssm_cache_dtype = "float32"
-            logger.warning("Reset SSM cache type to float32 for accelerated GDN mamba attention.")
+            logger.warning(
+                "Reset SSM cache type to float32 for accelerated GDN mamba attention."
+            )
 
         # Lagecy setting
         env_key = "VLLM_CPU_KVCACHE_SPACE"


### PR DESCRIPTION
## Summary

- Wrap the accelerated GDN comment and warning in `vllm/platforms/cpu.py`.
- Restore a clean all-files pre-commit run on `main`.

## Root cause

PR #49688 added two lines longer than the repository's 88-character limit. The
all-files pre-commit workflow therefore failed `ruff-check` with E501 errors and
`ruff-format` modified the warning call.

## Validation

- `.venv/bin/pre-commit run ruff-check --all-files` — passed
- `.venv/bin/pre-commit run ruff-format --all-files` — passed
- Commit-time hooks, including mypy 3.10 and DCO sign-off — passed

No model evaluation is needed because this is formatting-only and does not
change runtime behavior.

## Duplicate check

No open PR matched searches for the exact warning text, `Accelerated GDN`, or
the `vllm/platforms/cpu.py` E501 failure.

## AI assistance

OpenAI Codex was used to inspect the CI failure, apply the formatting fix, run
validation, and prepare this PR. The human submitter reviewed the complete
single-file diff.
