### PR TITLE
[Bugfix][MoE] Tune FlashInfer experts to scheduler token limit

### DIFF
--- a/tests/kernels/moe/test_flashinfer_moe.py
+++ b/tests/kernels/moe/test_flashinfer_moe.py
@@ -72,6 +72,7 @@ def test_flashinfer_swigluoai_params_are_forwarded(activation, monkeypatch):
         moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
         in_dtype=torch.bfloat16,
         routing_method=RoutingMethodType.TopK,
+        max_num_tokens=16_384,
     )
     quant_config = FusedMoEQuantConfig.make(
         gemm1_alpha=1.702,
@@ -110,6 +111,7 @@ def test_flashinfer_swigluoai_params_are_forwarded(activation, monkeypatch):
 
     assert experts._supports_activation(activation)
     assert call_args["activation_type"] == ActivationType.Swiglu
+    assert call_args["tune_max_num_tokens"] == 16_384
     for name, value in (
         ("swiglu_alpha", 1.702),
         ("swiglu_beta", 1.0),

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
+from vllm.model_executor.layers.fused_moe.utils import fi_moe_largest_bucket
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     activation_to_flashinfer_type,
 )
@@ -388,6 +389,7 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             use_deepseek_fp8_block_scale=self.use_deepseek_fp8_block_scale,
             use_mxfp8_act_scaling=use_mxfp8_act_scaling,
             use_w4_group_scaling=use_w4_group_scaling,
+            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
@@ -219,6 +219,7 @@ class TrtLlmBf16ExpertsModular(TrtLlmBf16ExpertsBase, mk.FusedMoEExpertsModular)
             weight_layout=WeightLayout.BlockMajorK,
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
+            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
         # FlashInfer's BF16 routed wrapper does not expose an output= argument.
         output.copy_(result[0] if isinstance(result, list) else result)

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_lora_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_lora_moe.py
@@ -39,6 +39,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
 from vllm.model_executor.layers.fused_moe.utils import (
+    fi_moe_largest_bucket,
     trtllm_moe_pack_topk_ids_weights,
 )
 from vllm.platforms import current_platform
@@ -549,6 +550,7 @@ class TrtLlmBf16LoRAExperts(_TrtLlmLoRAExpertsBase):
             routing_method_type=self.routing_method_type,
             do_finalize=do_finalize,
             output=output if do_finalize else None,
+            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
         if not do_finalize:
             # [gemm2_output, expert_weights, expanded_idx, gemm1_activation]

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxint4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxint4_moe.py
@@ -11,6 +11,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.utils import fi_moe_largest_bucket
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kInt4Static32,
@@ -169,6 +170,7 @@ class TrtLlmMxint4ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
             e_score_correction_bias=e_score_correction_bias,
             routing_method_type=self.routing_method,
             routing_replay_out=routing_replay_out,
+            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
         self._maybe_dispatch_routing_replay(
             routing_replay_out, num_tokens=hidden_states.shape[0]

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
@@ -191,6 +191,7 @@ def flashinfer_trtllm_mxint4_moe(
     e_score_correction_bias: torch.Tensor | None = None,
     routing_method_type: int | None = None,
     routing_replay_out: torch.Tensor | None = None,
+    tune_max_num_tokens: int = 8192,
 ) -> torch.Tensor:
     """
     Apply FlashInfer TensorRT-LLM MxInt4 MoE kernel.
@@ -211,6 +212,7 @@ def flashinfer_trtllm_mxint4_moe(
         topk_group: Top-k within groups (default: None -> 0)
         e_score_correction_bias: Optional routing bias. dtype: bfloat16
         routing_method_type: FlashInfer RoutingMethodType enum value
+        tune_max_num_tokens: Maximum token count covered by autotuning.
 
     Returns:
         Output tensor from MoE layer. dtype: same as x (bfloat16)
@@ -262,7 +264,7 @@ def flashinfer_trtllm_mxint4_moe(
         enable_pdl=None,
         do_finalize=True,
         output=None,
-        tune_max_num_tokens=8192,
+        tune_max_num_tokens=tune_max_num_tokens,
         routing_replay_out=routing_replay_out,
     )
     if isinstance(out, (tuple, list)):


### PR DESCRIPTION
## Summary

- pass vLLM's parallel-aware maximum token bucket to FlashInfer CUTLASS experts
- fix the same omitted or hardcoded bound in modular BF16, BF16 LoRA, and MXINT4 expert paths
- cover the CUTLASS forwarding behavior with a focused regression assertion

## Root cause

These expert paths let FlashInfer use its default `tune_max_num_tokens=8192`, even when vLLM's effective MoE input bound was larger. As a result, startup autotuning stopped at 8,192 tokens and larger prefill batches reused a tactic selected for the smaller bucket.

The other FlashInfer TRT-LLM expert implementations already use `fi_moe_largest_bucket(self.moe_config)`, which accounts for both `max_num_tokens` and the data-parallel factor while preserving 8,192 as the minimum tuning range. This change applies the same bound consistently to the remaining paths.

## Duplicate-work check

I checked issue #41306 and searched open PRs for `41306 in:body`, `FlashInfer CUTLASS MoE autotune`, and `tune_max_num_tokens FlashInfer`. No open PR addresses this omission.

This follows up on #46838, which removed the unrelated CUDA graph capture size as the tuning bound, and #47427, which introduced the shared parallel-aware helper but did not update every expert path.

## Evaluation

The motivating B300 dummy-load run used `--max-num-batched-tokens 16384`, but both FP8 and BF16 FlashInfer routed-MoE autotune caches contained 21 buckets ending at 8,192. This draft fixes that coverage mismatch; an end-to-end post-change performance rerun is still pending.

Validation completed:

- commit-time pre-commit suite: passed, including Ruff, formatting, mypy, SPDX, import, and configuration checks
- `python -m pytest tests/kernels/moe/test_flashinfer_moe.py -k params_are_forwarded -q`: 2 passed with FlashInfer 0.6.17
- `python -m pytest tests/kernels/moe/test_trtllm_bf16_moe.py -q`: 3 passed with FlashInfer 0.6.18.dev20260807
- focused MXINT4 wrapper test: 1 passed with FlashInfer 0.6.18.dev20260807
- mocked BF16 LoRA invocation: confirmed `tune_max_num_tokens=16384` is forwarded

The pinned-0.6.17 BF16 suite rerun was interrupted during its cold native JIT build and should be completed before marking this ready for review.

## AI assistance

Codex was used to investigate, implement, validate, and draft this change. The human submitter must review every changed line and complete the remaining validation before marking the PR ready.

Related: #41306
