### PR TITLE
[Attention] Migrate FlashInfer MLA decode to unified API

### DIFF
--- a/tests/kernels/attention/test_flashinfer_mla_decode.py
+++ b/tests/kernels/attention/test_flashinfer_mla_decode.py
@@ -15,7 +15,16 @@ if not current_platform.has_device_capability(100):
         allow_module_level=True,
     )
 else:
-    from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+    from flashinfer.mla import batch_mla_paged_attention
+
+
+def test_flashinfer_mla_backend_imports_unified_public_api():
+    from flashinfer.mla import batch_mla_paged_attention as public_api
+
+    from vllm.v1.attention.backends.mla import flashinfer_mla as backend
+
+    assert backend.batch_mla_paged_attention is public_api
+
 
 # Deepseek R1 MLA config.
 NUM_HEADS = 128
@@ -103,7 +112,7 @@ def test_flashinfer_mla_decode(dtype: torch.dtype, bs: int, block_size: int):
     # where q_len_per_request is the MTP query length (=1 without MTP)
     q = q.unsqueeze(1)
 
-    out_ans = trtllm_batch_decode_with_kv_cache_mla(
+    out_ans = batch_mla_paged_attention(
         query=q,
         kv_cache=kv_cache.unsqueeze(1),
         workspace_buffer=workspace_buffer,
@@ -147,7 +156,7 @@ def test_flashinfer_mla_decode_workspace_supports_autotune():
     # Under the autotuner the CuteDSL tactic is instantiated with our workspace;
     # a uint8 buffer raises AssertionError here, an int8 buffer succeeds.
     with torch.inference_mode(), autotune(True):
-        trtllm_batch_decode_with_kv_cache_mla(
+        batch_mla_paged_attention(
             query=q.unsqueeze(1),
             kv_cache=kv_cache.unsqueeze(1),
             workspace_buffer=workspace_buffer,

--- a/tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py
+++ b/tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py
@@ -152,7 +152,7 @@ def test_flashinfer_mla_dense_decode_unified_slot_view():
     (inflated stride(0), non-zero storage offset) bit-identically to a
     contiguous per-layer cache."""
     try:
-        from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+        from flashinfer.mla import batch_mla_paged_attention
     except ImportError:
         pytest.skip("flashinfer is not available")
     from vllm.platforms import current_platform
@@ -197,7 +197,7 @@ def test_flashinfer_mla_dense_decode_unified_slot_view():
     scale = head_dim**-0.5
 
     def run(kv):
-        return trtllm_batch_decode_with_kv_cache_mla(
+        return batch_mla_paged_attention(
             query=q,
             kv_cache=kv,
             workspace_buffer=ws,
@@ -497,7 +497,7 @@ def test_flashinfer_mla_dense_fp8_decode_unified_slot_view():
     unified-slot block-major view bit-identically to a contiguous per-layer
     cache."""
     try:
-        from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+        from flashinfer.mla import batch_mla_paged_attention
     except ImportError:
         pytest.skip("flashinfer is not available")
     from vllm.platforms import current_platform
@@ -548,7 +548,7 @@ def test_flashinfer_mla_dense_fp8_decode_unified_slot_view():
     scale = head_dim**-0.5
 
     def run(kv):
-        return trtllm_batch_decode_with_kv_cache_mla(
+        return batch_mla_paged_attention(
             query=q,
             kv_cache=kv,
             workspace_buffer=ws,

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -903,7 +903,7 @@ def test_flashinfer_mla_dcp_multi_token_decode_uses_per_query_bounds(monkeypatch
 
     monkeypatch.setattr(
         flashinfer_mla_module,
-        "trtllm_batch_decode_with_kv_cache_mla",
+        "batch_mla_paged_attention",
         fake_decode,
     )
     monkeypatch.setattr(

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 import torch
-from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+from flashinfer.mla import batch_mla_paged_attention
 from flashinfer.utils import (
     get_device_sm_count,
     get_trtllm_gen_multi_ctas_kv_counter_bytes,
@@ -100,7 +100,7 @@ def _get_multi_ctas_kv_counter_buffer(
 
     trtllm-gen's multi-CTA-KV MLA decode kernel resets these semaphores to zero
     at the end of every launch, so the buffer only needs zeroing once. The
-    public ``trtllm_batch_decode_with_kv_cache_mla`` entry point builds a fresh
+    public ``batch_mla_paged_attention`` entry point builds a fresh
     runner per call, so without a caller-owned buffer it re-allocates and
     re-zeros this counter on every decode step (a tiny ``FillFunctor<uint8>``
     launch right before the FMHA). Owning it here and passing it in removes that
@@ -376,10 +376,8 @@ class FlashInferMLAImpl(MLACommonImpl[FlashInferMLAMetadata]):
         # trtllm-gen rejects MLA head counts it can't tile (e.g. 96);
         # fall back to cute-dsl for those.
         decode_backend = _select_mla_decode_backend(runtime_num_heads)
-        extra_kwargs = {}
-        if decode_backend:
-            extra_kwargs["backend"] = decode_backend
-        elif kv_c_and_k_pe_cache.shape[-2] in (32, 64):
+        multi_ctas_kv_counter_buffer = None
+        if decode_backend is None and kv_c_and_k_pe_cache.shape[-2] in (32, 64):
             # The auto path can dispatch to trtllm-gen, whose multi-CTA-KV decode
             # kernel self-resets its semaphore counter after each launch (so it
             # only needs zeroing once). Pass a persistent counter buffer to skip
@@ -393,10 +391,10 @@ class FlashInferMLAImpl(MLACommonImpl[FlashInferMLAMetadata]):
                     runtime_num_heads,
                     get_device_sm_count(q.device),
                 )
-            extra_kwargs["multi_ctas_kv_counter_buffer"] = (
-                _get_multi_ctas_kv_counter_buffer(self._mla_counter_bytes, q.device)
+            multi_ctas_kv_counter_buffer = _get_multi_ctas_kv_counter_buffer(
+                self._mla_counter_bytes, q.device
             )
-        kernel_out = trtllm_batch_decode_with_kv_cache_mla(
+        kernel_out = batch_mla_paged_attention(
             query=q,
             kv_cache=kv_c_and_k_pe_cache.unsqueeze(1),
             workspace_buffer=workspace_buffer,
@@ -408,8 +406,9 @@ class FlashInferMLAImpl(MLACommonImpl[FlashInferMLAMetadata]):
             max_seq_len=attn_metadata.max_seq_len,
             bmm1_scale=self.bmm1_scale,
             bmm2_scale=self.bmm2_scale,
+            backend=decode_backend or "auto",
             return_lse=return_lse,
-            **extra_kwargs,
+            multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
         )
         if return_lse:
             o, lse = kernel_out


### PR DESCRIPTION
## Purpose

Migrate the FlashInfer MLA decode backend to the unified public API introduced by [FlashInfer #4031](https://github.com/flashinfer-ai/flashinfer/pull/4031).

This replaces the legacy decode entry point with `flashinfer.mla.batch_mla_paged_attention`, while preserving vLLM's backend selection, return-LSE behavior, and persistent multi-CTA counter buffer. The affected kernel tests now exercise the same public API as production.

This is not duplicating an existing PR: open vLLM PRs were searched for the FlashInfer PR, the new API symbol, and unified MLA API terminology, with no matching migration found.

No model behavior or output change is intended, so model evaluation is not applicable. AI assistance was used under human direction to implement and validate this draft.

## Test Plan

- Run the focused FlashInfer MLA backend unit test.
- Run the FlashInfer MLA decode kernel tests on B200.
- Run the FlashInfer MLA dense cross-layer equivalence tests on B200.
- Run all configured pre-commit hooks for the changed files.

## Test Result

- `tests/v1/attention/test_mla_backends.py::test_flashinfer_mla_dcp_multi_token_decode_uses_per_query_bounds`: 1 passed.
- `tests/kernels/attention/test_flashinfer_mla_decode.py`: 10 passed.
- `tests/kernels/attention/test_mla_cross_layer_kernel_equivalence.py -k flashinfer_mla_dense`: 2 passed, 6 deselected.
- Changed-file pre-commit hooks: passed, including Ruff, formatting, mypy, import checks, SPDX checks, and repository policy checks.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (No documentation change is required for this internal API migration.)
</details>

