### PR TITLE
[CI] Raise MI300 multimodal standard 4 timeout

### DIFF
--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -80,7 +80,7 @@ steps:
       label: ":amd: (MI300) Multimodal Models (Standard) 4: other + whisper"
       dind: false
       device: mi300_1
-      timeout_in_minutes: 50
+      timeout_in_minutes: 60
       depends_on:
       - image-build-amd
 


### PR DESCRIPTION
## What changed

Raise the MI300 override for `Multimodal Models (Standard) 4: other + whisper` from 50 to 60 minutes.

## Why

Main builds #84629 and #84630 each timed out twice (original attempt and retry) at the 50-minute AMD override after completing the first three commands and entering the Whisper tail. Surrounding green runs took 45.6–48.5 minutes, so the existing budget had no variance or cleanup headroom.

## Validation

- `git diff --check`
- Parsed `.buildkite/test_areas/models_multimodal.yaml` with PyYAML and asserted the MI300 override is 60
- Exact-head normal diff-selected [Buildkite #84659](https://buildkite.com/vllm/ci/builds/84659) passed overall. Exact MI300 Standard 4 passed in 44m14s (exit 0), and H200 passed in 40m03s (exit 0), at `a05224bf5797a6b8a76bb5fd942cc999272ef451`.
- [#84657](https://buildkite.com/vllm/ci/builds/84657) produced no test signal because bootstrap rejected the generated AMD mirror key.

## Superseded

Closed in favor of #52976, which independently raises the same MI300 timeout to 70 minutes as part of broader AMD CI cleanup. At #52976's exact current head `1656b2782c31455fdfbb5e070749c891f21495c3`, [AMD CI #12250](https://buildkite.com/vllm/amd-ci/builds/12250) passed the exact MI300 Standard 4 job in 44m55s (exit 0); MI355 also passed in 32m23s.