### PR TITLE
[WIP][Model Runner V2] Enable adaptive verification for more attention backends

### DIFF
--- a/tests/models/inkling/test_contract_validation.py
+++ b/tests/models/inkling/test_contract_validation.py
@@ -57,15 +57,17 @@ def test_inkling_mtp_chain_norm_is_disabled_by_default():
 
 
 def test_inkling_supports_piecewise_cudagraphs():
+    # ALWAYS (varlen decode batches, needed by adaptive verification) must not
+    # downgrade a piecewise request.
     support = InklingSconvMetadataBuilder.get_cudagraph_support
-    assert support(None, None) == AttentionCGSupport.UNIFORM_BATCH
+    assert support(None, None) == AttentionCGSupport.ALWAYS
 
     compilation_config = CompilationConfig(
         cudagraph_mode=CUDAGraphMode.PIECEWISE,
         splitting_ops=[],
     )
     resolved_mode = compilation_config.resolve_cudagraph_mode_and_sizes(
-        AttentionCGSupport.UNIFORM_BATCH,
+        support(None, None),
         "InklingSconvBackend",
     )
 

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -201,22 +201,6 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
             return align_mla_chunked_context_workspace_size(vllm_config, workspace_size)
         return workspace_size
 
-    def _build_req_id_per_token(
-        self,
-        common_attn_metadata: "CommonAttentionMetadata",
-    ) -> torch.Tensor:
-        num_tokens = common_attn_metadata.num_actual_tokens
-        starts = np.asarray(common_attn_metadata.query_start_loc_cpu, dtype=np.int32)
-        seg_lengths = np.diff(starts)
-        req_id_per_token = np.repeat(
-            np.arange(seg_lengths.shape[0], dtype=np.int32), seg_lengths
-        )
-        self.req_id_per_token_buffer.fill_(0)
-        self.req_id_per_token_buffer[: req_id_per_token.shape[0]].copy_(
-            np_to_pinned_tensor(req_id_per_token), non_blocking=True
-        )
-        return self.req_id_per_token_buffer[:num_tokens]
-
     def _build_chunked_context_fields(
         self,
         common_attn_metadata: "CommonAttentionMetadata",
@@ -256,7 +240,12 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
         common_attn_metadata: "CommonAttentionMetadata",
         fast_build: bool = False,
     ) -> T:
-        req_id_per_token = self._build_req_id_per_token(common_attn_metadata)
+        # The sparse path indexes each token's top-k rows through its request's
+        # block table, so a wrong token->request mapping silently reads another
+        # request's KV.
+        req_id_per_token = common_attn_metadata.token_to_req_indices(
+            self.req_id_per_token_buffer
+        )
 
         num_decodes, num_prefills, num_decode_tokens, _ = split_decodes_and_prefills(
             common_attn_metadata,

--- a/vllm/models/inkling/nvidia/attention.py
+++ b/vllm/models/inkling/nvidia/attention.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from __future__ import annotations
 
-from typing import cast
+from typing import ClassVar, cast
 
 import torch
 from torch import nn
@@ -21,10 +21,11 @@ from vllm.utils.torch_utils import (
     canonicalize_singleton_dim_strides,
     kv_cache_dtype_str_to_dtype,
 )
-from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport
 from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionBackend,
     FlashAttentionMetadata,
+    FlashAttentionMetadataBuilder,
 )
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -63,6 +64,31 @@ class RelLogitsProj(nn.Module):
     def forward(self, r_out: torch.Tensor) -> torch.Tensor:
         # r_out: (T, num_heads, d_rel) -> (T, num_heads, rel_extent)
         return torch.einsum("thd,de->the", r_out, self.proj)
+
+
+class InklingAttentionMetadataBuilder(FlashAttentionMetadataBuilder):
+    """FlashAttention metadata for Inkling's own varlen rel-attention kernel.
+
+    The kernel reads its per-request bounds from the device ``query_start_loc``
+    and ``seq_lens``; the host-side ``max_query_len`` and ``num_actual_tokens``
+    only size the launch, and both stay upper bounds when adaptive verification
+    trims drafts on device. Varlen decode batches are therefore capture-safe,
+    unlike the FlashAttention decode kernel this metadata is shared with.
+    """
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
+
+
+class InklingAttentionBackend(FlashAttentionBackend):
+    """FlashAttention KV-cache layout and metadata, Inkling's cudagraph support."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "INKLING_FA4_REL"
+
+    @staticmethod
+    def get_builder_cls() -> type[InklingAttentionMetadataBuilder]:
+        return InklingAttentionMetadataBuilder
 
 
 class InklingAttention(nn.Module, AttentionLayerBase):
@@ -175,7 +201,7 @@ class InklingAttention(nn.Module, AttentionLayerBase):
         self.kv_cache = torch.tensor([])  # replaced by bind_kv_cache
 
     def get_attn_backend(self) -> type[AttentionBackend]:
-        return FlashAttentionBackend
+        return InklingAttentionBackend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         block_size = vllm_config.cache_config.block_size

--- a/vllm/models/inkling/nvidia/sconv_swa_attn.py
+++ b/vllm/models/inkling/nvidia/sconv_swa_attn.py
@@ -49,7 +49,10 @@ class InklingSconvMetadata(AttentionMetadata):
 
 
 class InklingSconvMetadataBuilder(AttentionMetadataBuilder[InklingSconvMetadata]):
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    # Per-token seq_idx/query_start are searched from the device query_start_loc,
+    # and the tokens adaptive verification trims carry PAD slots the conv skips,
+    # so varlen decode batches replay correctly from a capture.
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -380,7 +380,7 @@ def _maybe_symmetrize_window(
 
 
 class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetadata]):
-    # FA3:
+    # FA3/FA4:
     # Supports full cudagraphs for all cases.
     #
     # FA2:
@@ -398,9 +398,13 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
     # to FULL_AND_PIECEWISE.
     # TODO(luka, lucas): audit FA2 as part of:
     #  https://github.com/vllm-project/vllm/issues/22945
+    # FA3 and FA4 both capture cleanly for mixed prefill-decode and for varlen
+    # decode; only FA2 needs the UNIFORM_BATCH fallback the comment above
+    # describes. FA4 builds no AOT scheduler metadata at all (aot_schedule is
+    # gated on version == 3), so there is nothing for a captured graph to stale.
     _cudagraph_support = (
         AttentionCGSupport.ALWAYS
-        if get_flash_attn_version() == 3
+        if get_flash_attn_version() in (3, 4)
         else AttentionCGSupport.UNIFORM_BATCH
     )
     supports_update_block_table: bool = True

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -113,7 +113,10 @@ class FlashAttnMLAMetadata(MLACommonMetadata[FlashAttnMLADecodeMetadata]):
 
 
 class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]):
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    # Per-request bounds reach the kernel via the device query_start_loc and
+    # seq_lens, so varlen decode batches replay correctly under capture;
+    # max_query_len only sizes the launch and stays a valid upper bound.
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.VARLEN
     reorder_batch_threshold: int = 512  # process small prefills with decode pathway
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -269,7 +269,12 @@ class FlashInferMLASparseMetadataBuilder(
     """Builder for FlashInfer MLA Sparse attention metadata."""
 
     metadata_cls = FlashInferMLASparseMetadata
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    # Decode launches one kernel row per query token (q_len_per_request=1),
+    # each carrying its own top-k index row, and the per-row bounds are all
+    # device-derived from req_id_per_token and the seq_lens the index conversion
+    # returns. No host scalar reaches the decode launch, so varlen decode
+    # batches replay correctly from a capture.
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
 
     def __init__(
         self,


### PR DESCRIPTION
# Benchmarks
## Speed-Bench 1K/2K, # Prompts=512, Concurrency=64, Temp=1, Top-p=0.95
### nvidia/GLM-5.2-NVFP4 + Inferact/GLM-5.2-DSpark 16, 4xGB200
| Metric | Baseline | Adaptive Verification (DSpark) | Δ % |
|---|---|---|---|
| Request throughput (req/s) | 0.83 | 2.32 | +179.52% |
| Output token throughput (tok/s) | 1588.78 | 4508.91 | +183.80% |
| Benchmark duration (s) | 620.21 | 220.50 | -64.45% |
| Median TPOT (ms) | 38.95 | 13.00 | -66.62% |
| Median TTFT (ms) | 561.50 | 240.35 | -57.20% |
| Acceptance length | 4.35 | 3.76 | -13.56% |
| Acceptance rate (%) | 20.92 | 17.24 | -17.59% |
| **Per-position acceptance (%)** | | | |
| Position 0 | 71.23 | 69.67 | -2.19% |
| Position 1 | 51.70 | 46.42 | -10.21% |
| Position 2 | 39.04 | 31.79 | -18.57% |
| Position 3 | 30.51 | 23.45 | -23.14% |
| Position 4 | 24.37 | 18.18 | -25.40% |
| Position 5 | 20.00 | 14.94 | -25.30% |
| Position 6 | 16.85 | 12.56 | -25.46% |
| Position 7 | 14.41 | 10.79 | -25.12% |
| Position 8 | 12.46 | 9.38 | -24.72% |
| Position 9 | 10.94 | 8.17 | -25.32% |
| Position 10 | 9.64 | 7.14 | -25.93% |
| Position 11 | 8.56 | 6.20 | -27.57% |
| Position 12 | 7.58 | 5.37 | -29.16% |
| Position 13 | 6.67 | 4.65 | -30.28% |
| Position 14 | 5.82 | 3.95 | -32.13% |
| Position 15 | 4.98 | 3.25 | -34.74% |

### MiMo V2.5 Pro + DFlash 8 (using #52228), 4xGB200
| Metric | Baseline | Acceptance Estimator | Δ % |
|---|---|---|---|
| Request throughput (req/s) | 2.96 | 3.49 | +17.91% |
| Output token throughput (tok/s) | 4271.69 | 4978.08 | +16.54% |
| Median TPOT (ms) | 13.22 | 11.47 | -13.24% |
| Median TTFT (ms) | 165.39 | 141.57 | -14.40% |
| Acceptance length | 3.46 | 3.15 | -8.96% |
| **Per-position acceptance (%)** | | | |
| Position 0 | 71.58 | 70.37 | -1.69% |
| Position 1 | 50.17 | 44.95 | -10.40% |
| Position 2 | 36.50 | 30.55 | -16.30% |
| Position 3 | 27.65 | 22.29 | -19.39% |
| Position 4 | 21.29 | 16.91 | -20.57% |
| Position 5 | 16.51 | 12.96 | -21.50% |
| Position 6 | 12.64 | 9.89 | -21.76% |
| Position 7 | 9.29 | 7.07 | -23.90% |

### Kimi-K2.5 + DFlash 8 (using #52228), 8xH200
| Metric | Baseline | Acceptance Estimator | Δ % |
|---|---|---|---|
| Request throughput (req/s) | 1.33 | 1.79 | +34.59% |
| Output token throughput (tok/s) | 2566.08 | 3455.55 | +34.66% |
| Total token throughput (tok/s) | 3908.33 | 5258.44 | +34.54% |
| Median TPOT (ms) | 24.17 | 17.72 | -26.69% |
| Median TTFT (ms) | 312.06 | 216.26 | -30.70% |
| Acceptance length | 3.74 | 3.14 | -16.04% |
| **Per-position acceptance (%)** | | | |
| Position 0 | 78.30 | 77.26 | -1.33% |
| Position 1 | 57.03 | 52.50 | -7.94% |
| Position 2 | 41.68 | 36.53 | -12.36% |
| Position 3 | 31.07 | 26.74 | -13.94% |
| Position 4 | 23.54 | 20.50 | -12.91% |
| Position 5 | 18.02 | 0.00 | -100.00% |
| Position 6 | 13.99 | 0.00 | -100.00% |
| Position 7 | 10.80 | 0.00 | -100.00% |