### PR TITLE
[CI][Docker] Pin manylinux2_28-builder:cuda13.0 to the release/2.13 image

### DIFF
--- a/.buildkite/image_build/image_build_torch_nightly.sh
+++ b/.buildkite/image_build/image_build_torch_nightly.sh
@@ -48,7 +48,7 @@ echo "Image not found, proceeding with build..."
 # --- CUDA 13.0 for nightly builds ---
 # Nightly CI uses CUDA 13.0 while regular CI stays on CUDA 12.9
 NIGHTLY_CUDA_VERSION="13.0.2"
-NIGHTLY_BUILD_BASE_IMAGE="pytorch/manylinux2_28-builder:cuda13.0"
+NIGHTLY_BUILD_BASE_IMAGE="pytorch/manylinux2_28-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359"
 NIGHTLY_FINAL_BASE_IMAGE="nvidia/cuda:${NIGHTLY_CUDA_VERSION}-base-ubuntu22.04"
 
 echo "--- :docker: Building torch nightly image (CUDA ${NIGHTLY_CUDA_VERSION})"

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -47,7 +47,7 @@ steps:
         agents:
           queue: cpu_queue_release
         commands:
-          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=13.0.2 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_X86}\" --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
+          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=13.0.2 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_X86}\" --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
           - "bash .buildkite/scripts/upload-nightly-wheels.sh"
@@ -234,7 +234,7 @@ steps:
               --build-arg CUDA_VERSION=13.0.2 \
               --build-arg torch_cuda_arch_list="${CUDA_ARCH_X86}" \
               --build-arg INSTALL_KV_CONNECTORS=true \
-              --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0 \
+              --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 \
               --target vllm-openai \
               --progress plain \
               -f docker/Dockerfile .
@@ -334,7 +334,7 @@ steps:
               --build-arg GDRCOPY_OS_VERSION=Ubuntu24_04 \
               --build-arg torch_cuda_arch_list="${CUDA_ARCH_X86}" \
               --build-arg INSTALL_KV_CONNECTORS=true \
-              --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0 \
+              --build-arg BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 \
               --target vllm-openai \
               --progress plain \
               -f docker/Dockerfile .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ ARG NCCL_VERSION=2.30.7
 # docker build --build-arg BUILD_BASE_IMAGE=registry.acme.org/mirror/pytorch/manylinux2_28-builder:cuda13.0
 
 # Build wheels against the same glibc floor as PyTorch's published wheels.
-ARG BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0
+ARG BUILD_BASE_IMAGE=pytorch/manylinux2_28-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359
 # Using cuda base image with minimal dependencies necessary for JIT compilation (FlashInfer, DeepGEMM, EP kernels)
 ARG FINAL_BASE_IMAGE=nvidia/cuda:${CUDA_VERSION}-base-ubuntu${UBUNTU_VERSION}
 

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -14,7 +14,7 @@
       "default": "2.30.7"
     },
     "BUILD_BASE_IMAGE": {
-      "default": "pytorch/manylinux2_28-builder:cuda13.0"
+      "default": "pytorch/manylinux2_28-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359"
     },
     "FINAL_BASE_IMAGE": {
       "default": "nvidia/cuda:13.0.3-base-ubuntu24.04"


### PR DESCRIPTION
## Purpose

`BUILD_BASE_IMAGE` currently tracks the floating tag `pytorch/manylinux2_28-builder:cuda13.0`. That tag is rebuilt upstream, so the compiler, glibc and CUDA toolchain underneath every CUDA 13.0 wheel build can change without a single vLLM commit. The practical cost is attribution: the same vLLM SHA can build one day and fail the next, and bisecting vLLM will never find the cause because nothing in vLLM changed.

This pins it to `cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359` — the exact image PyTorch's own `release/2.13` branch uses in `.github/workflows/generated-linux-binary-manywheel-nightly.yml` (commit `78e737ad`, 2026-06-26). So vLLM builds against an immutable toolchain that is known-good because it is the one a shipped PyTorch release was built with.

## Changes

Five references to the bare x86 CUDA 13.0 tag:

| File | What |
|---|---|
| `docker/Dockerfile` | `ARG BUILD_BASE_IMAGE` default |
| `docker/versions.json` | regenerated with `tools/generate_versions_json.py` (not hand-edited) |
| `.buildkite/image_build/image_build_torch_nightly.sh` | `NIGHTLY_BUILD_BASE_IMAGE` |
| `.buildkite/release-pipeline.yaml` | x86 nightly wheel build + two `vllm-openai` image builds |

## Deliberately not changed

- **`manylinuxaarch64-builder:cuda13.0`** (arm64 build, GH200 test script, docs) and **`manylinux2_28-builder:cuda12.9`** — different images. Pinning them is worth doing, but each needs its own known-good tag chosen the same way; I did not want to guess at those in this PR.
- The `registry.acme.org/mirror/...` example comment in `docker/Dockerfile`, which documents repository renaming for private mirrors. Pinning it there would make the example about something else.

## Test Plan

- `docker/versions.json` was regenerated by the repo's own generator rather than edited by hand; the one-line diff confirms no other drift.
- CI on this PR exercises the pinned image directly: any CUDA 13.0 x86 build step that succeeds is evidence the tag resolves and builds.

## Test Result

Pending CI.

## Note

Worth deciding as a policy question, not just for this PR: whether vLLM wants to track the floating tag deliberately (early warning of upstream toolchain changes, at the cost of unattributable breakage) or pin and bump on purpose. This PR takes the second position for the x86 CUDA 13.0 path only. If maintainers prefer the first, the same argument says the pin should at least be applied on release branches.
