### PR TITLE
[Core] Separate DSpark scheduler input budgets

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1304,6 +1304,38 @@ def test_draft_slots_budgeted_per_scheduled_request(tmp_path, monkeypatch):
     assert scheduler.schedule().num_scheduled_tokens == {"0": 10, "1": 4}
 
 
+@pytest.mark.parametrize(
+    ("num_requests", "num_tokens", "expected"),
+    [
+        (2, 8, {"0": 8, "1": 8}),
+        (5, 1, {"0": 1, "1": 1, "2": 1, "3": 1}),
+    ],
+)
+def test_dspark_uses_separate_draft_input_budget(
+    tmp_path, monkeypatch, num_requests, num_tokens, expected
+):
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    (tmp_path / "config.json").write_text(
+        '{"architectures": ["OPTForCausalLM"], "model_type": "opt"}'
+    )
+    scheduler = create_scheduler(
+        model=str(tmp_path),
+        max_num_seqs=16,
+        max_num_batched_tokens=16,
+        num_speculative_tokens=4,
+        parallel_drafting=True,
+        skip_tokenizer_init=True,
+    )
+    speculative_config = scheduler.vllm_config.speculative_config
+    assert speculative_config is not None
+    speculative_config.method = "dspark"
+
+    for request in create_requests(num_requests=num_requests, num_tokens=num_tokens):
+        scheduler.add_request(request)
+
+    assert scheduler.schedule().num_scheduled_tokens == expected
+
+
 # Note - these test cases mirror some of those in test_rejection_sampler.py
 @pytest.mark.parametrize(
     "spec_tokens,output_tokens,expected",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -496,8 +496,16 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens: dict[str, int] = {}
         token_budget = self.max_num_scheduled_tokens
         spec = self.vllm_config.speculative_config
-        draft_slots = spec.max_num_new_slots_for_drafting if spec is not None else 0
+        dspark_draft_tokens = (
+            spec.num_speculative_tokens if spec is not None and spec.use_dspark() else 0
+        )
+        draft_slots = (
+            spec.max_num_new_slots_for_drafting
+            if spec is not None and not spec.use_dspark()
+            else 0
+        )
         input_budget = self.scheduler_config.max_num_batched_tokens
+        draft_input_budget = input_budget
         if self._pause_state == PauseState.PAUSED_ALL:
             # Do not schedule any requests when paused.
             token_budget = 0
@@ -525,7 +533,7 @@ class Scheduler(SchedulerInterface):
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
-            if input_budget <= draft_slots:
+            if input_budget <= draft_slots or draft_input_budget < dspark_draft_tokens:
                 break
 
             if (
@@ -662,6 +670,7 @@ class Scheduler(SchedulerInterface):
                             restored = num_scheduled_tokens.pop(preempted_req_id)
                             token_budget += restored
                             input_budget += restored + draft_slots
+                            draft_input_budget += dspark_draft_tokens
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -700,6 +709,7 @@ class Scheduler(SchedulerInterface):
             num_scheduled_tokens[request_id] = num_new_tokens
             token_budget -= num_new_tokens
             input_budget -= num_new_tokens + draft_slots
+            draft_input_budget -= dspark_draft_tokens
             req_index += 1
 
             # Speculative decode related.
@@ -750,7 +760,10 @@ class Scheduler(SchedulerInterface):
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if input_budget <= draft_slots:
+                if (
+                    input_budget <= draft_slots
+                    or draft_input_budget < dspark_draft_tokens
+                ):
                     break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
                 # in `running` but still hold a model-runner request slot.
@@ -1133,6 +1146,7 @@ class Scheduler(SchedulerInterface):
                 num_scheduled_tokens[request_id] = num_new_tokens
                 token_budget -= num_new_tokens
                 input_budget -= num_new_tokens + draft_slots
+                draft_input_budget -= dspark_draft_tokens
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 if pad_spec_decode:
@@ -1173,6 +1187,7 @@ class Scheduler(SchedulerInterface):
 
         assert token_budget >= 0
         assert input_budget >= 0
+        assert draft_input_budget >= 0
         assert len(self.running) <= self.max_num_running_reqs
         # Since some requests in the RUNNING queue may not be scheduled in
         # this step, the total number of scheduled requests can be smaller than


### PR DESCRIPTION

## Purpose

Fixes #52922.

The scheduler combined DSpark target tokens and fixed draft-query tokens in one input budget even though they run in separate stages. Track a separate DSpark draft-input budget so each stage can use the configured batch capacity without exceeding it.

This does not duplicate an open PR. Searches for #52922 and for DSpark scheduling found no open PR addressing this accounting bug.

Credit to @slippersss for reporting the bug and providing the minimal scheduling example.

AI assistance was used to investigate, implement, test, and write this change. The human submitter must review every changed line and reproduce the tests before submission.

## Test Plan

- Add a scheduler regression test for two 8-token prefills with a 16-token target budget and four DSpark query tokens per request.
- Check that the independent draft budget still limits five one-token requests to four admitted requests.
- Run the full core scheduler test file.
- Run pre-commit on both changed files.

## Test Result

Tested on Linux with Python 3.12.13. The node has eight NVIDIA A40 GPUs, but the scheduler tests used the CPU backend.

- Regression test without the fix: 1 failed, 1 passed. The second prefill received 2 tokens instead of 8.
- Focused tests with the fix: 3 passed.
- `tests/v1/core/test_scheduler.py`: 149 passed.
- Pre-commit on both changed files: passed.

No DSpark model was loaded, and no GPU end-to-end generation was run. The exact-commit precompiled editable wheel was unavailable, so tests ran from the local source tree with pinned dependencies.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

