### PR TITLE
[Distributed] Enable FlashInfer all-reduce by default

### DIFF
--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -58,7 +58,10 @@ class CudaCommunicator(DeviceCommunicatorBase):
 
             use_custom_allreduce = _ENABLE_CUSTOM_ALL_REDUCE
             use_torch_symm_mem = envs.VLLM_ALLREDUCE_USE_SYMM_MEM
-            use_flashinfer_allreduce = envs.VLLM_ALLREDUCE_USE_FLASHINFER
+            # FlashInfer all-reduce does not provide a fixed reduction order.
+            use_flashinfer_allreduce = (
+                envs.VLLM_ALLREDUCE_USE_FLASHINFER and not envs.VLLM_BATCH_INVARIANT
+            )
             use_aiter_allreduce = use_custom_allreduce and bool(
                 rocm_aiter_ops.is_custom_all_reduce_enabled()
             )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -260,7 +260,7 @@ if TYPE_CHECKING:
     VLLM_HAS_FLASHINFER_CUBIN: bool = False
     VLLM_ROCM_FP8_MFMA_PAGE_ATTN: bool = False
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
-    VLLM_ALLREDUCE_USE_FLASHINFER: bool = False
+    VLLM_ALLREDUCE_USE_FLASHINFER: bool = True
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_ENABLE_STARTUP_PLAN: bool = False
     VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS: set[str] = set()
@@ -1857,7 +1857,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Whether to use FlashInfer allreduce
     "VLLM_ALLREDUCE_USE_FLASHINFER": lambda: bool(
-        int(os.getenv("VLLM_ALLREDUCE_USE_FLASHINFER", "0"))
+        int(os.getenv("VLLM_ALLREDUCE_USE_FLASHINFER", "1"))
     ),
     # Experimental: use this to enable MCP tool calling for non harmony models
     "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT": lambda: bool(


### PR DESCRIPTION
## Purpose

Enable the existing FlashInfer all-reduce backend by default for tensor-parallel
CUDA groups. The existing platform, world-size, tensor-shape, and workspace
guards remain in place, so unsupported calls continue through the normal
all-reduce fallback chain.

`VLLM_ALLREDUCE_USE_FLASHINFER=0` remains available as an explicit opt-out.
FlashInfer all-reduce is always excluded when `VLLM_BATCH_INVARIANT=1` because
it does not provide the fixed reduction order that batch invariance requires.

## Duplicate-work check

No issue number was provided, so the issue-number lookup was not applicable. I
searched open PRs for `FlashInfer All Reduce`, `FlashInfer allreduce`,
`VLLM_ALLREDUCE_USE_FLASHINFER`, and `FlashInfer default allreduce`.

The related open PRs cover benchmark initialization (#40970), MNNVL workspace
capacity (#50932), topology fallback (#48075), and batch-invariant fused
all-reduce behavior (#51292). #50505 includes the same communicator exclusion
as part of a broader redesign of batch-invariant custom all-reduce; this PR
only carries the guard required to make the default flip safe. None of these
PRs changes this environment variable's default.

## Tests

```bash
.venv/bin/python -m pytest tests/test_envs.py -q
# 56 passed

.venv/bin/python -m pytest \
  'tests/distributed/test_comm_ops.py::test_multi_process_tensor_parallel[test_target0-2]' -v
# 1 passed on 2x NVIDIA GB200

VLLM_BATCH_INVARIANT=1 .venv/bin/python -m pytest \
  'tests/distributed/test_comm_ops.py::test_multi_process_tensor_parallel[test_target0-2]' -v -s
# 1 passed on 2x NVIDIA GB200

.venv/bin/pre-commit run --files \
  vllm/envs.py \
  vllm/distributed/device_communicators/cuda_communicator.py
# all applicable hooks passed
```

## Model evaluation

Ran `facebook/opt-125m` with TP=2, FP16, eager mode, greedy decoding, and the
prompt `The capital of France is` on 2x NVIDIA GB200:

- Unset/default: logs selected `FLASHINFER` and initialized the `mnnvl`
  workspace; token IDs were `[5, 812, 9, 5, 1515, 3497, 4, 50118]`.
- `VLLM_ALLREDUCE_USE_FLASHINFER=0`: logs excluded `FLASHINFER`; token IDs were
  identical.
- `VLLM_BATCH_INVARIANT=1 VLLM_ALLREDUCE_USE_FLASHINFER=1`: logs selected only
  `PYNCCL`; token IDs were identical.

No performance benchmark was run.

## AI assistance

OpenAI Codex assisted with implementation, tests, validation, and drafting this
description. This is a draft PR; the human submitter must review every changed
line and confirm they understand and can defend the change before marking it
ready for review.
