### PR TITLE
[Metrics] Expose NIXL compatibility hash in vllm:nixl_config_info metric

### DIFF
--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -71,6 +71,10 @@ class KVTransferConfig:
     'recompute': reschedule the request to recompute failed blocks
     'fail': immediately fail the request with an error finish reason (default)"""
 
+    compatibility_hash: str | None = field(default=None, init=False)
+    """Post-init compatibility hash from the KV connector (e.g. NIXL).
+    Set after KV cache initialization; not a user-facing parameter."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -1004,6 +1004,8 @@ class NixlBaseConnectorWorker:
             self.backend_name,
             transfer_mode=self._TRANSFER_MODE,
         )
+        assert self.vllm_config.kv_transfer_config is not None
+        self.vllm_config.kv_transfer_config.compatibility_hash = self.compat_hash
 
         if self.use_host_buffer:
             self.initialize_host_xfer_buffer(kv_caches=kv_caches)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -237,6 +237,33 @@ class NixlPromMetrics(KVConnectorPromMetrics):
             counter_nixl_num_kv_expired_reqs, self.per_engine_labelvalues
         )
 
+        config_labelnames = [
+            *labelnames,
+            "kv_connector",
+            "kv_role",
+            "compatibility_hash",
+        ]
+        self.gauge_nixl_config_info = self._gauge_cls(
+            name="vllm:nixl_config_info",
+            documentation="NIXL KV transfer configuration and compatibility hash.",
+            multiprocess_mode="mostrecent",
+            labelnames=config_labelnames,
+        )
+
+    def record_config_info(self, vllm_config: VllmConfig, engine_idx: int = 0) -> None:
+        kv_transfer_config = vllm_config.kv_transfer_config
+        label_values = list(self.per_engine_labelvalues[engine_idx])
+        label_values.extend(
+            [
+                kv_transfer_config.kv_connector if kv_transfer_config else "none",
+                kv_transfer_config.kv_role if kv_transfer_config else "none",
+                (kv_transfer_config.compatibility_hash or "unknown")
+                if kv_transfer_config
+                else "unknown",
+            ]
+        )
+        self.gauge_nixl_config_info.labels(*label_values).set(1)
+
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         for prom_obj, list_item_key in zip(
             [

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -102,6 +102,7 @@ class EngineCoreReadyResponse:
     weight_transfer_backend: str | None = None
     enable_sleep_mode: bool = False
     supports_draft_weight_updates: bool = False
+    kv_connector_compatibility_hash: str | None = None
 
 
 class EngineCoreRequest(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -344,6 +344,14 @@ class EngineCore:
         if not envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
             self.model_executor.compile_or_warm_up_model()
 
+        if vllm_config.kv_transfer_config is not None:
+            hashes: list[str | None] = self.collective_rpc(
+                "get_kv_connector_compatibility_hash"
+            )
+            non_none = [h for h in hashes if h is not None]
+            if non_none:
+                vllm_config.kv_transfer_config.compatibility_hash = non_none[0]
+
         elapsed = time.time() - start
         compile_time = vllm_config.compilation_config.compilation_time
         encoder_compile_time = vllm_config.compilation_config.encoder_compilation_time
@@ -1682,6 +1690,11 @@ class EngineCoreProc(EngineCore):
             enable_sleep_mode=self.vllm_config.model_config.enable_sleep_mode,
             supports_draft_weight_updates=(
                 self.model_executor.supports_draft_weight_updates()
+            ),
+            kv_connector_compatibility_hash=(
+                self.vllm_config.kv_transfer_config.compatibility_hash
+                if self.vllm_config.kv_transfer_config is not None
+                else None
             ),
         )
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -771,6 +771,14 @@ class MPClient(EngineCoreClient):
             else response.kv_cache_max_concurrency
         )
 
+        if (
+            response.kv_connector_compatibility_hash is not None
+            and vllm_config.kv_transfer_config is not None
+        ):
+            vllm_config.kv_transfer_config.compatibility_hash = (
+                response.kv_connector_compatibility_hash
+            )
+
         # In external DP LB mode, the coordinator address that the
         # front-end procs connect to is obtained by each engine via it's
         # initial handshake with the rank 0 front-end.

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1280,6 +1280,16 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
 
+        if (
+            self.kv_connector_prom is not None
+            and self.kv_connector_prom.prom_metrics is not None
+            and hasattr(self.kv_connector_prom.prom_metrics, "record_config_info")
+        ):
+            for engine_idx in self.engine_indexes:
+                self.kv_connector_prom.prom_metrics.record_config_info(
+                    self.vllm_config, engine_idx
+                )
+
 
 def build_buckets(mantissa_lst: list[int], max_value: int) -> list[int]:
     """

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -652,6 +652,11 @@ class Worker(WorkerBase):
         tp_rank = get_tp_group().rank_in_group
         return {(pp_rank, tp_rank): metadata}
 
+    def get_kv_connector_compatibility_hash(self) -> str | None:
+        if self.vllm_config.kv_transfer_config is None:
+            return None
+        return self.vllm_config.kv_transfer_config.compatibility_hash
+
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()
 


### PR DESCRIPTION
Adds a new Prometheus gauge `vllm:nixl_config_info` that exposes the NIXL KV connector compatibility hash as a label, enabling external schedulers/routers to route requests only to prefill/decode pod pairs with matching configs during rolling upgrades.

## Purpose

In disaggregated prefill/decode deployments, rolling upgrades can create a window where pods running different model configurations coexist. KV cache transfer between incompatible pods will fail. Today the compatibility hash is only exchanged during the NIXL handshake between workers — external schedulers have no visibility into it.

This PR surfaces the existing `compute_nixl_compatibility_hash()` value as a Prometheus metric label so that routers (e.g. llm-d-router) can pre-filter endpoints by compatibility *before* scheduling, rather than discovering mismatches at transfer time.

**Changes:**
- Plumb the compatibility hash from the NIXL connector worker → `VllmConfig` → `EngineCoreReadyResponse` → frontend `PrometheusStatLogger`
- Add `vllm:nixl_config_info` gauge with labels: `model_name`, `engine`, `kv_connector`, `kv_role`, `compatibility_hash`
- Add `get_kv_connector_compatibility_hash()` worker RPC to collect the hash after KV cache initialization

The metric is only emitted when the NIXL connector is active; no overhead for non-disaggregated deployments.

## Test Plan

Tested end-to-end on a live disaggregated P/D cluster (3 prefill + 3 decode replicas, Qwen3-0.6B, NIXL connector with `kv_role=kv_both`):

1. Verified the metric is exposed on vLLM pod metrics endpoints:
```
$ curl -sk https://localhost:8000/metrics | grep nixl_config
# HELP vllm:nixl_config_info NIXL KV transfer configuration and compatibility hash.
# TYPE vllm:nixl_config_info gauge
vllm:nixl_config_info{compatibility_hash="5fc56ef3...",engine="0",kv_connector="NixlConnector",kv_role="kv_both",model_name="Qwen/Qwen3-0.6B"} 1.0
```

2. Verified the hash changes when dtype is changed (bfloat16 → float16), confirming the metric reflects the underlying `compute_nixl_compatibility_hash()` output.

3. When integrated with an llm-d-router compatibility-screener plugin that reads this metric to filter endpoints by hash. Ran a 16,000-request benchmark during a rolling dtype change:
   - **Without screener (baseline):** 14,593 errors (91% failure rate) — KV transfer failures from incompatible P/D pairing
   - **With screener reading this metric:** 0 errors

## Test Result
Metric is visible, and can be used by routers (like llm-d) to enable rolling upgrades without routing requests to incompatible P / D pods.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>