### PR TITLE
[ROCm][Spec Decode] Add Aiter MLA decode support non-causal draft block

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_fp8_support.py
@@ -27,10 +27,15 @@ def reset_aiter_mla_support_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     import vllm._aiter_ops as aiter_ops
 
     monkeypatch.setattr(aiter_ops, "_AITER_MLA_SUPPORTS_FP8", None)
+    # if_aiter_supported wraps the functools.cache, so reach through to it.
+    aiter_ops.rocm_aiter_ops.mla_decode_supports_non_causal.__wrapped__.cache_clear()
 
 
 def _install_fake_aiter_modules(
-    monkeypatch: pytest.MonkeyPatch, *, supports_fp8: bool
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    supports_fp8: bool,
+    supports_causal: bool = False,
 ) -> None:
     aiter_mod: Any = types.ModuleType("aiter")
     mla_mod: Any = types.ModuleType("aiter.mla")
@@ -64,6 +69,14 @@ def _install_fake_aiter_modules(
             return None
 
         mla_decode_fwd = mla_decode_fwd_without_fp8
+
+    if supports_causal:
+        inner = mla_decode_fwd
+
+        def mla_decode_fwd_with_causal(*args, causal=True, **kwargs):
+            return inner(*args, **kwargs)
+
+        mla_decode_fwd = mla_decode_fwd_with_causal
 
     mla_mod.mla_decode_fwd = mla_decode_fwd
     aiter_mod.mla = mla_mod
@@ -135,3 +148,62 @@ def test_aiter_mla_fp8_support_result_is_cached(monkeypatch):
         assert _check_aiter_mla_fp8_support() is True
         assert _check_aiter_mla_fp8_support() is True
         assert signature_mock.call_count == 1
+
+
+@pytest.mark.parametrize("supports_causal", [True, False])
+def test_non_causal_probe_follows_the_installed_signature(monkeypatch, supports_causal):
+    """Builds without a ``causal`` argument are causal-only; asking one for a
+    non-causal block would return a causally masked result and say nothing."""
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    _install_fake_aiter_modules(
+        monkeypatch, supports_fp8=True, supports_causal=supports_causal
+    )
+    assert bool(rocm_aiter_ops.mla_decode_supports_non_causal()) is supports_causal
+
+
+def _install_callable_fake(monkeypatch) -> list:
+    """The shared fake above exists to be inspected, not called. The impl tests
+    need one that runs, so they bring their own."""
+    seen: list = []
+
+    def mla_decode_fwd(*args, causal=None, **kwargs):
+        seen.append(
+            {"causal": causal, **kwargs} if causal is not None else dict(kwargs)
+        )
+
+    mla_mod: Any = types.ModuleType("aiter.mla")
+    mla_mod.mla_decode_fwd = mla_decode_fwd
+    aiter_mod: Any = types.ModuleType("aiter")
+    aiter_mod.mla = mla_mod
+    monkeypatch.setitem(sys.modules, "aiter", aiter_mod)
+    monkeypatch.setitem(sys.modules, "aiter.mla", mla_mod)
+    return seen
+
+
+def _call_impl(causal: bool) -> None:
+    import torch
+
+    import vllm._aiter_ops as aiter_ops
+
+    aiter_ops._rocm_aiter_mla_decode_fwd_impl(
+        torch.zeros(2, 1, 8),
+        torch.zeros(2, 1, 1, 8),
+        torch.zeros(2, 1, 8),
+        torch.zeros(3, dtype=torch.int32),
+        1,
+        causal=causal,
+    )
+
+
+def test_a_causal_block_never_passes_the_argument(monkeypatch):
+    """Causal is the default, so builds without the argument keep working."""
+    seen = _install_callable_fake(monkeypatch)
+    _call_impl(causal=True)
+    assert "causal" not in seen[0]
+
+
+def test_a_non_causal_block_reaches_a_capable_build(monkeypatch):
+    seen = _install_callable_fake(monkeypatch)
+    _call_impl(causal=False)
+    assert seen[0]["causal"] is False

--- a/tests/v1/attention/test_rocm_aiter_mla_fp8_decode_routing.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_fp8_decode_routing.py
@@ -152,3 +152,22 @@ def test_pad_unpad_round_trip_preserves_head_order(num_heads):
 
     assert unpadded.shape == q.shape
     torch.testing.assert_close(unpadded, q)
+
+
+@pytest.mark.parametrize("kv_cache_dtype", ["fp8", "auto"])
+@pytest.mark.parametrize("num_heads", [8, 12, 16, 32])
+def test_a_non_causal_block_never_routes_to_gluon(
+    gluon_available, num_heads, kv_cache_dtype
+):
+    """Gluon masks the block causally with no way to turn it off, so a
+    non-causal block has to reach the padded asm decode -- at any head count
+    and either cache dtype. The fixture pins the arch gate, so a gfx942 host
+    cannot pass this for the wrong reason."""
+    assert not AiterMLAHelper.use_gluon_verify(
+        num_heads, 8, kv_cache_dtype, causal=False
+    )
+
+
+def test_a_causal_small_head_bf16_block_still_uses_gluon(gluon_available):
+    """The routing this backend already had must not move."""
+    assert AiterMLAHelper.use_gluon_verify(12, 8, "auto", causal=True)

--- a/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
@@ -528,3 +528,67 @@ def test_persistent_metadata_gate_without_gluon_build(
 
     assert metadata.has_persistent_metadata is expect_persistent
     assert get_mla_metadata_v1.called is expect_persistent
+
+
+def _build_non_causal(monkeypatch, *, num_heads, kv_cache_dtype, qlen, mtp_qlen):
+    """Drive _build_decode with causal=False and hand back the aiter mock."""
+    get_mla_metadata_v1 = mock.MagicMock()
+    monkeypatch.setitem(
+        sys.modules,
+        "aiter",
+        SimpleNamespace(get_mla_metadata_v1=get_mla_metadata_v1),
+    )
+    monkeypatch.setattr(
+        rocm_aiter_mla, "_expand_page_indices_kernel", _NoOpTritonKernel()
+    )
+    metadata = AiterMLAMetadataBuilder._build_decode(
+        _builder(
+            mtp_decode_qlen=mtp_qlen,
+            kv_cache_dtype=kv_cache_dtype,
+            num_heads=num_heads,
+        ),
+        block_table_tensor=torch.arange(16, dtype=torch.int32).view(2, 8),
+        seq_lens_device=torch.tensor([7, 5], dtype=torch.int32),
+        max_seq_len=7,
+        query_start_loc_cpu=torch.tensor([0, qlen, 2 * qlen], dtype=torch.int32),
+        query_start_loc_device=torch.tensor([0, qlen, 2 * qlen], dtype=torch.int32),
+        num_decode_tokens=2 * qlen,
+        dcp_tot_seq_lens_device=None,
+        causal=False,
+    )
+    return metadata, get_mla_metadata_v1
+
+
+def test_non_causal_build_hands_the_mask_to_aiter(monkeypatch):
+    """The schedule carries the mask, so is_causal must follow the block."""
+    metadata, get_mla_metadata_v1 = _build_non_causal(
+        monkeypatch, num_heads=12, kv_cache_dtype="auto", qlen=8, mtp_qlen=8
+    )
+    assert metadata.has_persistent_metadata
+    # 6th positional arg of get_mla_metadata_v1 is is_causal.
+    assert get_mla_metadata_v1.call_args.args[5] is False
+
+
+def test_a_bf16_padded_rank_past_qlen4_keeps_the_schedule_when_non_causal(monkeypatch):
+    """12 heads, bf16, qlen 8 is exactly the shape the old clause turned away;
+    a non-causal block has no causal staircase for the fold to drop."""
+    metadata, _ = _build_non_causal(
+        monkeypatch, num_heads=12, kv_cache_dtype="auto", qlen=8, mtp_qlen=8
+    )
+    assert metadata.has_persistent_metadata
+
+
+def test_a_two_token_fp8_block_is_refused(monkeypatch):
+    """aiter's fp8 dispatch has no non-causal fold for qlen 2."""
+    with pytest.raises(ValueError, match="2-token"):
+        _build_non_causal(
+            monkeypatch, num_heads=12, kv_cache_dtype="fp8", qlen=2, mtp_qlen=8
+        )
+
+
+def test_a_two_token_bf16_block_is_allowed(monkeypatch):
+    """The bf16 fold has no such hole, so the guard must not fire there."""
+    metadata, _ = _build_non_causal(
+        monkeypatch, num_heads=12, kv_cache_dtype="auto", qlen=2, mtp_qlen=8
+    )
+    assert metadata.has_persistent_metadata

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -565,6 +565,7 @@ def _rocm_aiter_mla_decode_fwd_impl(
     reduce_indptr: torch.Tensor | None = None,
     reduce_final_map: torch.Tensor | None = None,
     reduce_partial_map: torch.Tensor | None = None,
+    causal: bool = True,
 ) -> None:
     from aiter.mla import mla_decode_fwd
 
@@ -577,6 +578,11 @@ def _rocm_aiter_mla_decode_fwd_impl(
     if _check_aiter_mla_fp8_support():
         kwargs["q_scale"] = q_scale
         kwargs["kv_scale"] = kv_scale
+
+    # Leave the argument off when the block is causal, so builds without it
+    # keep working; backend selection is what refuses a non-causal block there.
+    if not causal:
+        kwargs["causal"] = False
 
     if work_meta_data is not None:
         assert work_indptr is not None, (
@@ -633,6 +639,7 @@ def _rocm_aiter_mla_decode_fwd_fake(
     reduce_indptr: torch.Tensor | None = None,
     reduce_final_map: torch.Tensor | None = None,
     reduce_partial_map: torch.Tensor | None = None,
+    causal: bool = True,
 ) -> None:
     pass
 
@@ -1897,6 +1904,21 @@ class rocm_aiter_ops:
 
     @classmethod
     @if_aiter_supported
+    @functools.cache
+    def mla_decode_supports_non_causal(cls) -> bool:
+        """Probe whether the installed aiter.mla.mla_decode_fwd accepts `causal`.
+
+        Added in aiter v0.1.20. Older builds are causal-only, so a non-causal
+        query block has no kernel there.
+        """
+        import inspect
+
+        from aiter.mla import mla_decode_fwd
+
+        return "causal" in inspect.signature(mla_decode_fwd).parameters
+
+    @classmethod
+    @if_aiter_supported
     def is_mha_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._MHA_ENABLED
 
@@ -2637,6 +2659,7 @@ class rocm_aiter_ops:
         reduce_indptr: torch.Tensor | None = None,
         reduce_final_map: torch.Tensor | None = None,
         reduce_partial_map: torch.Tensor | None = None,
+        causal: bool = True,
     ):
         torch.ops.vllm.rocm_aiter_mla_decode_fwd(
             q,
@@ -2657,6 +2680,7 @@ class rocm_aiter_ops:
             reduce_indptr=reduce_indptr,
             reduce_final_map=reduce_final_map,
             reduce_partial_map=reduce_partial_map,
+            causal=causal,
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2255,6 +2255,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        causal: bool = True,
     ) -> MLACommonDecodeMetadata:
         return MLACommonDecodeMetadata(
             block_table=block_table_tensor,
@@ -2414,6 +2415,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 query_start_loc_device=query_start_loc[: num_decodes + 1],
                 num_decode_tokens=num_decode_tokens,
                 dcp_tot_seq_lens_device=dcp_tot_seq_lens_device,
+                causal=not non_causal_decode,
             )
 
         attn_metadata = self.metadata_cls(

--- a/vllm/models/dots3_note/nvidia/attention.py
+++ b/vllm/models/dots3_note/nvidia/attention.py
@@ -339,8 +339,9 @@ class Dots3NoteMLAMetadataBuilder(TritonMLAMetadataBuilder):
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        causal: bool = True,
     ) -> Dots3NoteDecodeMetadata:
-        del max_seq_len, query_start_loc_device, num_decode_tokens
+        del max_seq_len, query_start_loc_device, num_decode_tokens, causal
         query_len = int(query_start_loc_cpu[1] - query_start_loc_cpu[0])
         return Dots3NoteDecodeMetadata(
             block_table=block_table_tensor,

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -203,6 +203,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        causal: bool = True,
     ) -> FlashAttnMLADecodeMetadata:
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         max_query_len = query_lens_cpu.max().item()

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -161,6 +161,7 @@ class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[FlashInferMLAMetadat
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        causal: bool = True,
     ) -> FlashInferMLADecodeMetadata:
         return FlashInferMLADecodeMetadata(
             block_table=block_table_tensor,

--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -167,6 +167,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        causal: bool = True,
     ) -> FlashMLADecodeMetadata:
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         # we use the max but all should be the same due to uniform length requirement

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -191,6 +191,12 @@ class AiterMLABackend(MLACommonBackend):
     def get_name() -> str:
         return "ROCM_AITER_MLA"
 
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        # A non-causal block is served by handing the mask to the asm decode,
+        # so the only thing to check is whether the installed aiter takes one.
+        return bool(rocm_aiter_ops.mla_decode_supports_non_causal())
+
     @staticmethod
     def get_impl_cls() -> type["AiterMLAImpl"]:
         return AiterMLAImpl
@@ -257,6 +263,9 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
     #  https://github.com/vllm-project/vllm/issues/22945
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+    # Served by passing the mask to the kernel; _build_decode turns away the
+    # shapes AITER has no non-causal kernel for.
+    supports_non_causal_multi_token_decode: ClassVar[bool] = True
 
     @staticmethod
     def _uniform_padded_mtp_qo_len(
@@ -628,6 +637,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
         dcp_tot_seq_lens_device: torch.Tensor | None,
+        causal: bool = True,
     ) -> AiterMLADecodeMetadata:
         device = self.device
         num_reqs = seq_lens_device.size(0)
@@ -744,19 +754,38 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 self.num_heads, max_qo_len, self._kv_cache_dtype_str
             )
             and not AiterMLAHelper.use_gluon_verify(
-                self.num_heads, max_qo_len, self._kv_cache_dtype_str
+                self.num_heads, max_qo_len, self._kv_cache_dtype_str, causal
             )
             # A padded rank has no bf16 persistent kernel past qlen 4 where the
             # gfx950 fold is absent; the non-persistent entry covers it. fp8
             # keeps the schedule -- its fold rejects non-persistent outright.
+            # A non-causal block keeps it too: what the fold drops past qlen 4
+            # is the block's causal staircase, which a non-causal block does
+            # not have, and the schedule is the only thing carrying its mask.
             and (
-                self.num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
+                not causal
+                or self.num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS
                 or max_qo_len <= AiterMLAHelper._ASM_PADDED_MAX_PS_QLEN
                 or is_quantized_kv_cache(self._kv_cache_dtype_str)
             )
             and max_qo_len >= 1
             and max_qo_len <= self._mtp_decode_qlen
         )
+        if (
+            not causal
+            and max_qo_len == 2
+            and is_quantized_kv_cache(self._kv_cache_dtype_str)
+        ):
+            # AITER's fp8 dispatch folds (gqa 16, qlen 3 or 4) onto the
+            # qseqlen-4 kernel but never lists 2, so the lookup would land on a
+            # causal-only entry -- and a missing kernel aborts the process
+            # rather than raising. The bf16 fold has no such hole. Drop this
+            # once the pinned AITER folds that length.
+            raise ValueError(
+                "AITER has no non-causal fp8 MLA kernel for a 2-token query "
+                "block. Pin the draft to TRITON_MLA for this speculative config."
+            )
+
         if use_persistent_metadata:
             from aiter import get_mla_metadata_v1
 
@@ -769,7 +798,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 paged_kv_last_page_len,
                 self._num_attention_heads,
                 1,
-                True,
+                causal,
                 self._mla_work_meta_data,
                 self._mla_work_info_set,
                 self._mla_work_indptr,
@@ -976,7 +1005,9 @@ class AiterMLAHelper:
         return m % num_heads == 0 and gluon_supported
 
     @staticmethod
-    def use_gluon_verify(num_heads: int, max_qo_len: int, kv_cache_dtype: str) -> bool:
+    def use_gluon_verify(
+        num_heads: int, max_qo_len: int, kv_cache_dtype: str, causal: bool = True
+    ) -> bool:
         """Whether a small-head multi-token verify is flattened onto Gluon.
 
         bf16 has no gqa<16, qseqlen>1 asm kernel, so the verify is flattened
@@ -985,6 +1016,11 @@ class AiterMLAHelper:
         asserts against. A predicate rather than inline in forward_mqa so the
         builder sees the same answer the impl acts on.
         """
+        if not causal:
+            # Gluon masks the block causally with no way to turn it off, so a
+            # non-causal block takes the padded asm decode whatever the head
+            # count -- padding is what gives it a kernel there.
+            return False
         if num_heads >= AiterMLAHelper._AITER_MIN_MLA_HEADS or max_qo_len <= 1:
             return False
         if is_quantized_kv_cache(kv_cache_dtype):
@@ -1280,7 +1316,10 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
         # builder -- which has to know whether the asm decode will run -- sees
         # the same answer as this branch.
         if AiterMLAHelper.use_gluon_verify(
-            self.num_heads, int(decode.max_qo_len), self.kv_cache_dtype
+            self.num_heads,
+            int(decode.max_qo_len),
+            self.kv_cache_dtype,
+            attn_metadata.causal,
         ):
             qlen = int(decode.max_qo_len)
             if type(q) is tuple:
@@ -1400,6 +1439,7 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
             decode.paged_kv_indptr,
             decode.paged_kv_indices,
             decode.paged_kv_last_page_len,
+            causal=attn_metadata.causal,
             **mla_kwargs,
         )
 


### PR DESCRIPTION
## Purpose

On ROCm a Kimi-K3 DSpark draft has to be pinned to TritonMLA:

```
--speculative-config '{"method":"dspark","model":"/draft",
                       "num_speculative_tokens":7,
                       "attention_backend":"TRITON_MLA"}'
```

The draft's query block is non-causal. On ROCm only TritonMLA sets `supports_non_causal_multi_token_decode`, so the pin.

TritonMLA and FlashInferMLA serve such a block by flattening it: one decode row per query token, every row reading the same committed KV. That is cheap for them because their kernels take a block table, so flattening is a `repeat_interleave`. AiterMLA's kernel takes a flat page-size-1 index list instead. Flattening there means rebuilding that list every forward -- roughly half a million entries at batch 8, block 8 and an 8k context.

**Fix: don't flatten. Pass the mask, which the kernel already accepts.**

`get_mla_metadata_v1` has always taken `is_causal`. aiter's `mla_decode_fwd` takes `causal` as of v0.1.20. vLLM hardcoded the first and never passed the second:

```python
get_mla_metadata_v1(..., self._num_attention_heads, 1, True, ...)  # <- the mask
```

Both now get the real value. Same one row per request, same index list.

Three pieces make that safe.

**Selection.** AiterMLA offers a non-causal block only if the installed `mla_decode_fwd` takes `causal`. Probed by signature, the same way this file already probes for fp8 scale support.

**Routing.** Gluon's mask is causal and cannot be turned off, so `use_gluon_verify` now returns False for any non-causal block. Such a block takes the padded asm decode instead. Padding the head count up is what gives it a kernel there -- the fp8 path already relies on that. This is also what lets a bf16 cache serve a non-causal block at all. Builder and impl call the same predicate, so they cannot disagree.

**Build.** One shape still reaches `_build_decode` and it raises: an fp8 2-token block. aiter's dispatch has no fold for that length, so the lookup lands on a causal-only kernel, and a missing kernel aborts the process rather than raising. ROCm/aiter#4872 adds the missing entry; once the pinned aiter carries it, this guard and its test can go. The bf16 fold has no such hole.

Outside ROCm, `_build_decode` gains a `causal` kwarg in `MLACommonMetadataBuilder`. The FlashAttn, FlashInfer, FlashMLA and Dots3Note overrides are signature-only updates. DCP is untouched; `supports_non_causal_multi_token_dcp` stays False.

vLLM pins aiter **v0.1.19** (`docker/Dockerfile.rocm_base`). That build has no `causal` argument, so **on the default image this PR is a no-op**: `supports_non_causal()` returns False, selection keeps handing the draft group to TritonMLA, and the recipe keeps its pin. It starts working once the pin moves.

## Test Plan

```bash
pytest tests/v1/attention/test_rocm_aiter_mla_non_causal.py    # 15, CPU only
```

They stub `aiter.mla`, so both aiter generations can be exercised on one machine. The two `_build_decode` guards are covered in `test_rocm_aiter_mla_mtp_split.py`. That file already drives the method directly.

End to end on 8x MI355X, `/model` = Kimi-K3 and `/draft` its DSpark draft. Same server twice; the only difference is whether the draft is pinned:

```bash
vllm serve /model --served-model-name k3 \
  --tensor-parallel-size 8 --trust-remote-code \
  --kv-cache-dtype fp8 \
  --max-model-len 16384 --max-num-seqs 128 --max-num-batched-tokens 16384 \
  --gpu-memory-utilization 0.93 --block-size 128 --no-enable-prefix-caching \
  --load-format auto --mm-encoder-tp-mode data \
  --safetensors-load-strategy prefetch \
  --compilation-config '{"custom_ops":["+fused_rms_norm_gated"]}' \
  --speculative-config "$SPEC" --port 8000

# A -- what the recipe does today
SPEC='{"method":"dspark","model":"/draft","num_speculative_tokens":7,"attention_backend":"TRITON_MLA"}'
# B -- this PR: no pin, the draft picks AiterMLA
SPEC='{"method":"dspark","model":"/draft","num_speculative_tokens":7}'
```

Drop `--kv-cache-dtype fp8` and run again for the bf16 numbers. That run also needs #50619, for an unrelated main-branch cudagraph defect in the target's causal verify.

Both were served against a v0.1.19 install with v0.1.20's MLA files copied in. That install reproduces a full v0.1.20 tree's kernel numbers bit for bit.

```bash
for C in 1 8; do
  vllm bench serve --backend openai-chat --endpoint /v1/chat/completions \
    --model k3 --tokenizer /model --trust-remote-code --port 8000 \
    --dataset-name random --random-input-len 1024 --random-output-len 128 \
    --ignore-eos --max-concurrency $C --num-prompts $((C == 1 ? 16 : 48))
done

lm_eval --model local-chat-completions \
  --model_args model=k3,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=32,tokenized_requests=False \
  --tasks gsm8k --num_fewshot 5 --batch_size 32 \
  --apply_chat_template --gen_kwargs temperature=0
```

## Test Result

Unit tests: **15 + 46 passed**.

Both runs land on `FULL_AND_PIECEWISE` with no cudagraph downgrade. Unpinning drops the second attention backend. So the gap below is the draft's backend and nothing else.

| draft backend | conc. | output throughput | mean TPOT |
|---|---|---|---|
| TritonMLA (pinned) | 1 | 68.44 tok/s | 13.23 ms |
| AiterMLA (this PR) | 1 | **76.32 tok/s** | **11.67 ms** |
| TritonMLA (pinned) | 8 | 294.57 tok/s | 23.32 ms |
| AiterMLA (this PR) | 8 | **324.44 tok/s** | **21.26 ms** |

That is 11.5% at concurrency 1 and 10.1% at 8.

A bf16 cache reaches 84.16 tok/s at concurrency 1 and 331.66 at 8, TPOT 10.45 ms and 20.76 ms.

Accuracy, full GSM8K test set (1319 questions), 5-shot, greedy, fp8 KV:

| | flexible-extract | strict-match |
|---|---|---|
| TritonMLA (pinned), fp8 | 0.9644 ± 0.0051 | 0.9636 ± 0.0052 |
| AiterMLA (this PR), fp8 | 0.9613 ± 0.0053 | 0.9606 ± 0.0054 |
| AiterMLA (this PR), bf16 | 0.9644 ± 0.0051 | 0.9636 ± 0.0052 |

At the kernel, checked with ad-hoc scripts rather than in-tree tests:

With an fp8 cache and 16 heads, `causal=False` lands 7.1e-03 from a non-causal reference. Against a causal one it sits 6.3e-02 away at block 4 and 9.1e-02 at block 8. So it runs the mask that was asked for. Four identical query rows come back identical, spread 0.0.

With a bf16 cache the padded asm decode holds 3.5e-04 to 5.6e-04. That is across 8, 12, 16, 24 and 32 heads, and block lengths 1 through 16. fp8 covers 1 and 3 through 16.

---

Written with AI assistance (Claude Code); the commit carries `Co-authored-by: Claude`. I reviewed every changed line and ran the tests above myself.
