### PR TITLE
[ROCm][CI] Speed up `test_rocm_aiter_qk_norm_rope_kvcache_fusion`

### DIFF
--- a/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
@@ -40,8 +40,19 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.kv_cache_interface import AttentionSpec
 
+pytestmark = pytest.mark.skip_global_cleanup
+
 INDEX_SELECT_OP = torch.ops.aten.index.Tensor
 FP8_DTYPE = current_platform.fp8_dtype()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def module_global_cleanup():
+    # Cleanup once at the end of the module
+    from vllm.distributed import cleanup_dist_env_and_memory
+
+    yield
+    cleanup_dist_env_and_memory()
 
 
 class QKNormRoPEKVCacheTestModel(torch.nn.Module):
@@ -416,8 +427,7 @@ _FUSION_CONFIGS = [
         AttentionBackendEnum.ROCM_AITER_FA,
     ],
 )
-@pytest.mark.parametrize("num_tokens", [5, 16, 2048])
-@pytest.mark.parametrize("use_shuffle_kv_layout", ["1", "0"])
+@pytest.mark.parametrize("num_tokens", [5, 2048])
 @pytest.mark.parametrize(
     "kv_stride_order",
     # FA/unified use the 4D packed cache (num_blocks, num_kv_heads, block_size,
@@ -428,7 +438,7 @@ _FUSION_CONFIGS = [
 @pytest.mark.parametrize("block_size", [16, 32, 64])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("kv_cache_dtype", ["auto", "fp8"])
-@pytest.mark.parametrize("rms_norm_eps", [1e-5, 1e-6])
+@pytest.mark.parametrize("rms_norm_eps", [1e-6])
 @pytest.mark.parametrize("custom_op", ["+rotary_embedding", "+rms_norm"])
 @pytest.mark.skipif(
     not is_aiter_found_and_supported(),
@@ -443,7 +453,6 @@ def test_qk_norm_rope_kvcache_fusion(
     is_neox: bool,
     attn_backend: AttentionBackendEnum,
     enable_aiter_triton_rope: bool,
-    use_shuffle_kv_layout: str,
     kv_stride_order: tuple[int, ...],
     block_size: int,
     dtype: torch.dtype,
@@ -452,19 +461,6 @@ def test_qk_norm_rope_kvcache_fusion(
     custom_op: str,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    if (
-        attn_backend == AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN
-        and use_shuffle_kv_layout == "1"
-    ):
-        pytest.skip("ROCM_AITER_UNIFIED_ATTN is NHD-only; shuffle env is ignored")
-    if (
-        attn_backend == AttentionBackendEnum.ROCM_AITER_FA
-        and use_shuffle_kv_layout == "1"
-    ):
-        pytest.skip(
-            "ROCM_AITER_FA gates the qk_norm+rope+kvcache fusion off under shuffle "
-            "layout (defers to reshape_and_cache_shuffle_triton), so nothing fuses"
-        )
     _run_qk_norm_rope_kvcache_fusion_test(
         attn_backend=attn_backend,
         enable_aiter_triton_rope=enable_aiter_triton_rope,
@@ -475,7 +471,7 @@ def test_qk_norm_rope_kvcache_fusion(
         rotary_dim=rotary_dim,
         block_size=block_size,
         is_neox=is_neox,
-        use_shuffle_kv_layout=use_shuffle_kv_layout,
+        use_shuffle_kv_layout="0",
         kv_stride_order=kv_stride_order,
         dtype=dtype,
         kv_cache_dtype=kv_cache_dtype,

--- a/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
@@ -42,7 +42,13 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.kv_cache_interface import AttentionSpec
 
-pytestmark = pytest.mark.skip_global_cleanup
+pytestmark = [
+    pytest.mark.skip_global_cleanup,
+    pytest.mark.skipif(
+        not current_platform.is_rocm(),
+        reason="ROCm/AITER-only fusion test",
+    ),
+]
 
 INDEX_SELECT_OP = torch.ops.aten.index.Tensor
 FP8_DTYPE = current_platform.fp8_dtype()

--- a/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
@@ -2,9 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from importlib.metadata import version
 
 import pytest
 import torch
+from packaging.version import Version
 
 import vllm.config
 from tests.compile.backend import TestBackend
@@ -443,6 +445,16 @@ _FUSION_CONFIGS = [
 @pytest.mark.skipif(
     not is_aiter_found_and_supported(),
     reason="Only test on ROCm with AITER installed and supported",
+)
+# The fused_qk_norm_rope_cache kernel used by this test aborts on AITER < 0.1.20
+# (fused_qk_norm_rope_cache_quant.cu: "k_cache/v_cache must be contiguous within
+# a block")
+@pytest.mark.skipif(
+    not Version(version("amd_aiter")) >= Version("0.1.20"),
+    reason=(
+        "Requires AITER >= 0.1.20; older kernels abort on "
+        "fused_qk_norm_rope_cache (k_cache/v_cache contiguity)"
+    ),
 )
 def test_qk_norm_rope_kvcache_fusion(
     num_tokens: int,

--- a/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rocm_aiter_qk_norm_rope_kvcache_fusion.py
@@ -42,13 +42,13 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.kv_cache_interface import AttentionSpec
 
-pytestmark = [
-    pytest.mark.skip_global_cleanup,
-    pytest.mark.skipif(
-        not current_platform.is_rocm(),
-        reason="ROCm/AITER-only fusion test",
-    ),
-]
+pytestmark = pytest.mark.skip_global_cleanup
+
+if not is_aiter_found_and_supported():
+    pytest.skip(
+        "ROCm with supported AITER is required",
+        allow_module_level=True,
+    )
 
 INDEX_SELECT_OP = torch.ops.aten.index.Tensor
 FP8_DTYPE = current_platform.fp8_dtype()
@@ -448,10 +448,6 @@ _FUSION_CONFIGS = [
 @pytest.mark.parametrize("kv_cache_dtype", ["auto", "fp8"])
 @pytest.mark.parametrize("rms_norm_eps", [1e-6])
 @pytest.mark.parametrize("custom_op", ["+rotary_embedding", "+rms_norm"])
-@pytest.mark.skipif(
-    not is_aiter_found_and_supported(),
-    reason="Only test on ROCm with AITER installed and supported",
-)
 # The fused_qk_norm_rope_cache kernel used by this test aborts on AITER < 0.1.20
 # (fused_qk_norm_rope_cache_quant.cu: "k_cache/v_cache must be contiguous within
 # a block")


### PR DESCRIPTION

Currently, `test_rocm_aiter_qk_norm_rope_kvcache_fusion` takes 2.5+ hours due to the large number of parameterizations (1440). In this PR, I have trimmed the number of parameterizations down to 480, and I've also removed the per-test global cleanup in favor of a single cleanup at the end of the module. Now, the runtime for this test is about 6 minutes locally. 

I have completely removed the `use_shuffle_kv_layout` parameter since all nonzero cases were being skipped, so we only test with `use_shuffle_kv_layout=0`. I've also reduced `rms_norm_eps` to only one case, `1e-6`, as testing `1e-5` as well provides no practical benefit. Finally, I've chosen to reduce the set of parameters for `num_tokens` from `[5, 16, 2048]` to just `[5, 2048]`. 

This test still fails with AITER <0.1.20 due to an unrelated issue: https://buildkite.com/vllm/amd-ci/builds/12228/list?jid=01a0193f-ec85-4107-98f7-0f2b761abd39&tab=output#L1425