### PR TITLE
[Bugfix] Fix int4 MoE tuner crash on the CUDA wna16 path

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -620,6 +620,30 @@ class BenchmarkWorker:
                 topk,
             )
 
+        if use_int4_w4a16 and block_quant_shape is not None:
+            # The CUDA moe_wna16 kernel is selected for small batches and
+            # asserts tile constraints the generic search space violates
+            # (BLOCK_SIZE_M <= 64, BLOCK_SIZE_K a {1,2,4,8} multiple of
+            # group_size, K divisible by BLOCK_SIZE_K). Restrict the space to
+            # configs that kernel accepts whenever it will be the one used.
+            from vllm.model_executor.layers.fused_moe.fused_moe import (
+                should_moe_wna16_use_cuda,
+            )
+
+            group_size = block_quant_shape[1]
+            if should_moe_wna16_use_cuda(
+                num_tokens * topk, group_size, num_experts, 4
+            ):
+                k_dims = (hidden_size, shard_intermediate_size // 2)
+                search_space = [
+                    config
+                    for config in search_space
+                    if config["BLOCK_SIZE_M"] <= 64
+                    and config["BLOCK_SIZE_K"] % group_size == 0
+                    and (config["BLOCK_SIZE_K"] // group_size) in (1, 2, 4, 8)
+                    and all(k % config["BLOCK_SIZE_K"] == 0 for k in k_dims)
+                ]
+
         need_device_guard = False
         if current_platform.is_rocm():
             visible_device = os.environ.get("ROCR_VISIBLE_DEVICES", None)


### PR DESCRIPTION
Fixes #52845.

`benchmark_moe.py --tune --dtype int4_w4a16` aborts on the first config on NVIDIA.

The tuner skips block-shape filtering for int4 because the Triton `gptq_awq` kernel accepts any `BLOCK_SIZE_K`. But dispatch also selects the CUDA `moe_wna16_gemm` kernel for small batches, and that one asserts `BLOCK_SIZE_K % group_size == 0`, `BLOCK_SIZE_M <= 64`, and `BLOCK_SIZE_K / group_size ∈ {1,2,4,8}`.

This restricts the search space to configs that kernel accepts, and only for the batch sizes where `should_moe_wna16_use_cuda()` is true — the Triton path keeps the full space.

## Test

```bash
python benchmarks/kernels/benchmark_moe.py \
  --model Qwen/Qwen3-30B-A3B-GPTQ-Int4 --tp-size 1 \
  --dtype int4_w4a16 --tune --batch-size 1 8 32
```

Before: `RuntimeError: moe_wna16_gemm ... BLOCK_SIZE_K must divisible by group_size` on config 1/1920.
After: completes and writes `E=128,N=768,device_name=NVIDIA_GeForce_RTX_5080,dtype=int4_w4a16.json`.

Verified on an RTX 5080 (sm_120), vLLM 0.27.1, torch 2.13.0+cu130.
