### PR TITLE
Fix response_format strict=false for Chat Completions and Responses API

### DIFF
--- a/tests/entrypoints/openai/test_response_format.py
+++ b/tests/entrypoints/openai/test_response_format.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for response_format handling shared by the chat APIs.
+
+``strict=false`` asks for schema adherence without a guarantee, so no grammar
+constraint is applied while the schema is still forwarded to the renderer.
+``strict=true`` and an absent ``strict`` keep guided decoding. Responses
+``text.format`` reaches renderers in the same shape as the Chat Completions
+``response_format``.
+"""
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+_WEATHER_SCHEMA = {
+    "type": "object",
+    "properties": {"city": {"type": "string"}},
+    "required": ["city"],
+    "additionalProperties": False,
+}
+
+_ABSENT = object()
+
+
+def _build_chat_request(**kwargs) -> ChatCompletionRequest:
+    defaults = dict(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    defaults.update(kwargs)
+    return ChatCompletionRequest(**defaults)
+
+
+def _build_responses_request(**kwargs) -> ResponsesRequest:
+    defaults = dict(
+        model="test-model",
+        input=[{"role": "user", "content": "Hello"}],
+    )
+    defaults.update(kwargs)
+    return ResponsesRequest(**defaults)
+
+
+def _chat_json_schema_request(strict=_ABSENT) -> ChatCompletionRequest:
+    json_schema: dict = {"name": "weather", "schema": _WEATHER_SCHEMA}
+    if strict is not _ABSENT:
+        json_schema["strict"] = strict
+    return _build_chat_request(
+        response_format={"type": "json_schema", "json_schema": json_schema}
+    )
+
+
+def _responses_json_schema_request(strict=_ABSENT) -> ResponsesRequest:
+    fmt: dict = {
+        "type": "json_schema",
+        "name": "weather",
+        "schema": _WEATHER_SCHEMA,
+    }
+    if strict is not _ABSENT:
+        fmt["strict"] = strict
+    return _build_responses_request(text={"format": fmt})
+
+
+def _guided_json(structured_outputs) -> dict | None:
+    if structured_outputs is None:
+        return None
+    return structured_outputs.json
+
+
+class TestChatCompletionStrict:
+    def _guided_json(self, request: ChatCompletionRequest) -> dict | None:
+        params = request.to_sampling_params(max_tokens=100, default_sampling_params={})
+        return _guided_json(params.structured_outputs)
+
+    def test_strict_false_disables_guided_decoding(self):
+        assert self._guided_json(_chat_json_schema_request(strict=False)) is None
+
+    def test_strict_true_keeps_guided_decoding(self):
+        assert self._guided_json(_chat_json_schema_request(strict=True)) == (
+            _WEATHER_SCHEMA
+        )
+
+    def test_strict_absent_keeps_guided_decoding(self):
+        assert self._guided_json(_chat_json_schema_request()) == _WEATHER_SCHEMA
+
+    def test_strict_false_keeps_existing_structured_outputs(self):
+        request = _build_chat_request(
+            structured_outputs={"choice": ["a", "b"]},
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "weather",
+                    "schema": _WEATHER_SCHEMA,
+                    "strict": False,
+                },
+            },
+        )
+        params = request.to_sampling_params(max_tokens=100, default_sampling_params={})
+        assert params.structured_outputs is not None
+        assert params.structured_outputs.json is None
+        assert params.structured_outputs.choice == ["a", "b"]
+
+    def test_strict_false_still_forwards_schema_to_renderer(self):
+        params = _chat_json_schema_request(strict=False).build_chat_params(None, "auto")
+        assert params.response_format is not None
+        assert params.response_format.json_schema is not None
+        assert params.response_format.json_schema.json_schema == _WEATHER_SCHEMA
+        assert params.response_format.json_schema.strict is False
+
+
+class TestResponsesStrict:
+    def _guided_json(self, request: ResponsesRequest) -> dict | None:
+        params = request.to_sampling_params(default_max_tokens=100)
+        return _guided_json(params.structured_outputs)
+
+    def test_strict_false_disables_guided_decoding(self):
+        assert self._guided_json(_responses_json_schema_request(strict=False)) is None
+
+    def test_strict_true_keeps_guided_decoding(self):
+        assert self._guided_json(_responses_json_schema_request(strict=True)) == (
+            _WEATHER_SCHEMA
+        )
+
+    def test_strict_absent_keeps_guided_decoding(self):
+        assert self._guided_json(_responses_json_schema_request()) == _WEATHER_SCHEMA
+
+
+class TestResponsesResponseFormatForwarding:
+    def _responses_chat_params(self, **kwargs):
+        return _build_responses_request(**kwargs).build_chat_params(None, "auto")
+
+    @pytest.mark.parametrize("strict", [True, False, _ABSENT])
+    def test_json_schema_matches_chat_completions(self, strict):
+        chat = _chat_json_schema_request(strict=strict).build_chat_params(None, "auto")
+        responses = _responses_json_schema_request(strict=strict).build_chat_params(
+            None, "auto"
+        )
+        assert responses.response_format is not None
+        assert responses.response_format == chat.response_format
+
+    @pytest.mark.parametrize("format_type", ["json_object", "text"])
+    def test_schemaless_format_matches_chat_completions(self, format_type):
+        chat = _build_chat_request(
+            response_format={"type": format_type}
+        ).build_chat_params(None, "auto")
+        responses = self._responses_chat_params(text={"format": {"type": format_type}})
+        assert responses.response_format is not None
+        assert responses.response_format == chat.response_format
+
+    def test_no_text_format_not_forwarded(self):
+        assert self._responses_chat_params().response_format is None
+        assert self._responses_chat_params(text={}).response_format is None

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -195,6 +195,8 @@ def structured_outputs_from_response_format(
     elif response_format.type == "json_schema":
         json_schema = response_format.json_schema
         assert json_schema is not None
+        if json_schema.strict is False:
+            return structured_outputs
         overrides = {"json": json_schema.json_schema}
     else:
         assert isinstance(

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -60,7 +60,12 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
 )
-from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel, StopParam
+from vllm.entrypoints.openai.engine.protocol import (
+    JsonSchemaResponseFormat,
+    OpenAIBaseModel,
+    ResponseFormat,
+    StopParam,
+)
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.renderers import ChatParams, TokenizeParams, merge_kwargs
@@ -116,6 +121,25 @@ def serialize_messages(msgs):
     Serializes multiple messages
     """
     return [serialize_message(msg) for msg in msgs] if msgs else None
+
+
+def text_config_to_response_format(
+    text: ResponseTextConfig | None,
+) -> ResponseFormat | None:
+    if text is None or text.format is None:
+        return None
+    fmt = text.format
+    if fmt.type == "json_schema":
+        return ResponseFormat(
+            type="json_schema",
+            json_schema=JsonSchemaResponseFormat(
+                name=fmt.name,
+                description=fmt.description,
+                schema=fmt.schema_,
+                strict=fmt.strict,
+            ),
+        )
+    return ResponseFormat(type=fmt.type)
 
 
 class ResponseRawMessageAndToken(OpenAIBaseModel):
@@ -347,6 +371,7 @@ class ResponsesRequest(OpenAIBaseModel):
             ),
             media_io_kwargs=self.media_io_kwargs,
             tool_choice=self.tool_choice if self.tools else None,
+            response_format=text_config_to_response_format(self.text),
         )
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:
@@ -381,6 +406,7 @@ class ResponsesRequest(OpenAIBaseModel):
         if (
             response_format.type == "json_schema"
             and response_format.schema_ is not None
+            and response_format.strict is not False
         ):
             return StructuredOutputsParams(
                 json=response_format.schema_  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary

`response_format` affects two independent stages of a request:

1. **Prompt rendering** — the renderer embeds the schema as an instruction in the prompt (input side), so the model knows what format is expected.
2. **Constrained generation** — a grammar engine restricts which tokens can be produced so the output is guaranteed to match the schema (output side).

`json_schema.strict=false` means "prompt instruction only": the schema should still be rendered into the prompt, but no grammar constraint should be applied to generation, and the output is not guaranteed to match the schema.

**Chat Completions**
- Bug: `structured_outputs_from_response_format()` always applied a grammar constraint for `json_schema`, even when `strict=false`.
- Fix: return early when `json_schema.strict` is `False`, so no grammar override is applied and any existing `structured_outputs` on the request is preserved. Prompt rendering was already correct (`response_format` reaches renderers via `build_chat_params()`).

**Responses API**
- Bug: `build_chat_params()` never forwarded `text.format` into `ChatParams.response_format`, so renderers (e.g. Kimi K3) never saw the schema in the prompt at all, regardless of `strict`.
- Fix: add `text_config_to_response_format()` to convert the flat Responses `text.format` into the nested `ResponseFormat` shape that renderers expect (the same internal type Chat Completions already populates), and pass it through `build_chat_params()`.
- Bug: `extract_structured_outputs()` ignored `strict=false` and always applied a grammar constraint when a schema was present.
- Fix: skip the grammar constraint when `text.format.strict` is `False`.

## Test plan

- [x] `pytest tests/entrypoints/openai/test_response_format.py -q` (14 passed)
- [x] pre-commit: ruff-check, ruff-format, typos, check-spdx-header on changed files
