### PR TITLE
[Bugfix] Fix ncclCommQueryProperties heap overflow with NCCL >= 2.31

### DIFF
--- a/vllm/distributed/device_communicators/pynccl_wrapper.py
+++ b/vllm/distributed/device_communicators/pynccl_wrapper.py
@@ -51,8 +51,15 @@ class ncclUniqueId(ctypes.Structure):
     _fields_ = [("internal", ctypes.c_byte * 128)]
 
 
-# NCCL 2.30+ ncclCommProperties_t. Only fields through ginType are read;
-# trailing fields keep the layout aligned with NCCL's versioned structure.
+# Mirror of NCCL's versioned ncclCommProperties_t (nccl_device/core.h,
+# v2.31.2-1, 144 bytes). ncclCommQueryProperties fills fields gated by the
+# version the caller declares in props.version, not by props.size, so never
+# declare a version newer than this layout: clamp to
+# NCCL_COMM_PROPERTIES_LAYOUT_VERSION. To use fields added in a newer NCCL,
+# extend the layout and bump the constant.
+NCCL_COMM_PROPERTIES_LAYOUT_VERSION = 23102  # NCCL_VERSION(2, 31, 2)
+
+
 class ncclCommProperties(ctypes.Structure):
     _fields_ = [
         ("size", ctypes.c_size_t),
@@ -68,6 +75,12 @@ class ncclCommProperties(ctypes.Structure):
         ("nLsaTeams", ctypes.c_int),
         ("hostRmaSupport", ctypes.c_bool),
         ("railedGinType", ctypes.c_int),
+        # Filled only when the declared version is >= NCCL_VERSION(2, 31, 0).
+        ("commHash", ctypes.c_uint64),
+        ("ginMinStride", ctypes.c_int),
+        ("ginConnectionType", ctypes.c_int),
+        ("ginSupport", ctypes.c_bool * 64),
+        ("devCommRuntimeVersionSize", ctypes.c_size_t),
     ]
 
 

--- a/vllm/utils/nccl.py
+++ b/vllm/utils/nccl.py
@@ -86,6 +86,7 @@ def find_nccl_library_paths() -> list[str] | None:
 def query_nccl_gin_type(group: torch.distributed.ProcessGroup) -> int | None:
     """Return the GIN type for an initialized group, or ``None`` on failure."""
     from vllm.distributed.device_communicators.pynccl_wrapper import (
+        NCCL_COMM_PROPERTIES_LAYOUT_VERSION,
         NCCLLibrary,
         ncclCommProperties,
     )
@@ -114,7 +115,9 @@ def query_nccl_gin_type(group: torch.distributed.ProcessGroup) -> int | None:
         ctypes.memset(ctypes.addressof(props), 0, ctypes.sizeof(props))
         props.size = ctypes.sizeof(props)
         props.magic = 0xCAFEBEEF
-        props.version = nccl.ncclGetRawVersion()
+        props.version = min(
+            nccl.ncclGetRawVersion(), NCCL_COMM_PROPERTIES_LAYOUT_VERSION
+        )
         result = query_fn(ctypes.c_void_p(comm_ptr), ctypes.byref(props))
     except Exception:
         logger.warning("Failed to query NCCL communicator properties", exc_info=True)


### PR DESCRIPTION
This PR is for fixing host heap corruption (flaky SIGSEGV) when running vLLM with NCCL >= 2.31, seen in multi-node expert-parallel serving (vLLM + DeepEP).

`ncclCommQueryProperties` fills the `ncclCommProperties` struct based on the version the caller declares in `props.version`. It never reads `props.size`. C callers get this right through `NCCL_COMM_PROPERTIES_INITIALIZER`, which declares the `NCCL_VERSION_CODE` of the headers the application was compiled against, i.e. the layout its buffer actually has. vLLM instead declared the runtime library version (`ncclGetRawVersion()`) while its ctypes struct only mirrored the NCCL 2.30 layout (56 bytes). NCCL 2.31 grew the struct to 144 bytes (`commHash`, `ginMinStride`, `ginConnectionType`, `ginSupport[64]`, `devCommRuntimeVersionSize`) behind a `props->version >= NCCL_VERSION(2, 31, 0)` gate, so with a 2.31 library vLLM passes the gate and NCCL writes 88 bytes past the end of the buffer. The corruption surfaces later as flaky SIGSEGV or glibc heap errors in unrelated code, once per worker process.

This PR extends the ctypes struct to the NCCL 2.31 layout as shipped in v2.31.2-1 (144 bytes, offsets verified against its `nccl_device/core.h`) and clamps the declared `props.version` to the version of the headers the layout was taken from (`NCCL_COMM_PROPERTIES_LAYOUT_VERSION = 23102`), matching the C initializer semantics. The clamp is what prevents this bug class from recurring: when a future NCCL adds fields behind a newer gate, the declared version will not pass that gate, so NCCL will not write fields the buffer does not have. Older NCCL libraries are unaffected because the declared version never exceeds the runtime version.