### PR TITLE
[CI][AMD] Bump torchao to v18 for Python 3.14

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2455,7 +2455,7 @@ steps:
   # https://github.com/pytorch/ao/issues/2919, we'll have to skip new torchao tests for now
   # we can only upgrade after this is resolved
   # TODO(jerryzh168): resolve the above comment
-  - uv pip install --system torchao==0.17.0
+  - uv pip install --system torchao==0.18.0
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 


### PR DESCRIPTION
## Purpose

Precursor to switching to Python 3.14.

## Test Plan

```bash
 uv pip install --system torchao==0.18.0 && \
  uv pip install --system conch-triton-kernels &&
  VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
```

## Test Result

Before:
```
AttributeError: 'typing.Union' object has no attribute '__module__'
and no __dict__ for setting new attributes. Did you mean: '__reduce__'?
```
After:
```
Success
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

