### PR TITLE
[ROCm][CI] Skip unsupported gfx950 MoE parallel cases

### DIFF
--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -1886,6 +1886,12 @@ def test_moe_layer(
     if enable_eplb and not use_ep:
         pytest.skip("EPLB requires EP.")
 
+    if on_gfx950() and dp_size == 2 and tp_size == 1 and use_ep:
+        if backend in DEEPEP_BACKENDS:
+            pytest.skip(f"{backend} with DP2/EP is not supported on gfx950.")
+        if backend == "allgather_reducescatter" and enable_eplb:
+            pytest.skip("allgather_reducescatter with EPLB is not supported on gfx950.")
+
     if backend in DEEPEP_BACKENDS and not visible_devices_have_peer_access(world_size):
         pytest.skip("DeepEP backends require peer access between visible GPUs.")
 


### PR DESCRIPTION
## Summary

Skip exactly the three gfx950 DP2/EP parallel combinations that crash the new MI355 FusedMoE layer gate:

- `deepep_high_throughput` with DP2/EP
- `deepep_low_latency` with DP2/EP
- `allgather_reducescatter` with DP2/EP and EPLB enabled

The rest of the MI355 matrix remains enabled.

## Root cause

PR #41100 added `kernels-fusedmoe-layer-test-2-mi355`, but its final exact-head Buildkite #84438 blocked that exact job, so the new gate did not run before merge.

Daily main Buildkite #84687 is the first observed execution. The original and automatic retry ran on different MI355 Kubernetes nodes and failed the same three parametrizations with worker SIGSEGV/SIGABRT; the low-latency case also reports rocSHMEM `Unknown allocator type`. Both attempts otherwise completed 286 passed / 241 skipped.

The first validation patch incorrectly interpreted pytest's parameter-ID ordering and treated all three cases as EPLB-enabled. Exact-head Buildkite #84697 proved the distinction: it skipped the allgather+EPLB case, but the two DeepEP cases still failed with `enable_eplb=False` (286 passed / 242 skipped / 2 failed). Buildkite reported the overall build as passed because this optional job is soft-failing; the exact MI355 job itself failed and is not a green merge signal.

The revised guard matches the three observed outer parametrizations directly and leaves all other platform/backend/parallel combinations running.

## Duplicate-work check

Searched open PRs for `41100 in:body` and `MI355 FusedMoE`, plus open issues/PRs for the rocSHMEM allocator signature. No open change addresses this failure.

## Validation

- `uvx --from ruff==0.14.0 ruff check tests/kernels/moe/test_moe_layer.py`
- `uvx --from ruff==0.14.0 ruff format --check tests/kernels/moe/test_moe_layer.py`
- `uv run --no-project python -m compileall -q tests/kernels/moe/test_moe_layer.py`
- `git diff --check`
- Exact MI355 FusedMoE validation [#84697](https://buildkite.com/vllm/ci/builds/84697) at superseded head `f23e8c65b3c8d87c0dbfeea954539ee76cb35af5`: exact job failed (286 passed / 242 skipped / 2 failed), despite the optional build's overall `passed` state.
- Replacement exact MI355 validation [#84703](https://buildkite.com/vllm/ci/builds/84703) passed at current head `8f5c26220d935b1ef7be272b3b5be56d24ba6f91`. The exact MI355 job passed exit 0 in 8m27s with 286 passed / 244 skipped / 0 failed. Its log confirms the two DeepEP DP2/EP cases and the allgather+EPLB DP2/EP case were skipped while the retained matrix passed.

## Model evaluation

Not applicable. This changes only CI test gating and does not affect model behavior or output.

AI assistance was used to investigate the CI failure and prepare this change. The submitter reviewed every changed line and the validation evidence above.
