### PR TITLE
Add NIXL side channel advertize address for NAT'd deployments

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -67,6 +67,10 @@ class NixlBaseConnectorScheduler:
         self.engine_id: EngineId = engine_id
         self.kv_cache_config = kv_cache_config
         self.side_channel_host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
+        self.side_channel_advertize_host = (
+            envs.VLLM_NIXL_SIDE_CHANNEL_ADVERTIZE_HOST
+            or self.side_channel_host
+        )
         self.side_channel_port = (
             envs.VLLM_NIXL_SIDE_CHANNEL_PORT
             + vllm_config.parallel_config.data_parallel_index

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -272,7 +272,7 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
             remote_block_ids=block_ids,
             remote_engine_id=self.engine_id,
             remote_request_id=request.request_id,
-            remote_host=self.side_channel_host,
+            remote_host=self.side_channel_advertize_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             remote_num_tokens=remote_num_tokens,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -180,7 +180,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         self._push_pending_registrations[request.request_id] = {
             "request_id": request.request_id,
             "decode_engine_id": self.engine_id,
-            "decode_host": self.side_channel_host,
+            "decode_host": self.side_channel_advertize_host,
             "decode_port": self.side_channel_port,
             "decode_tp_size": (self.vllm_config.parallel_config.tensor_parallel_size),
             "local_block_ids": local_block_ids,
@@ -287,7 +287,7 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             remote_block_ids=block_ids,
             remote_engine_id=self.engine_id,
             remote_request_id=request.request_id,
-            remote_host=self.side_channel_host,
+            remote_host=self.side_channel_advertize_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -223,6 +223,7 @@ if TYPE_CHECKING:
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
     VLLM_DISABLE_REQUEST_ID_RANDOMIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
+    VLLM_NIXL_SIDE_CHANNEL_ADVERTIZE_HOST: str | None = None
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
     VLLM_P2P_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_P2P_SIDE_CHANNEL_PORT: int = 5710
@@ -1654,6 +1655,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # IP address used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_HOST": lambda: os.getenv(
         "VLLM_NIXL_SIDE_CHANNEL_HOST", "localhost"
+    ),
+    "VLLM_NIXL_SIDE_CHANNEL_ADVERTIZE_HOST": lambda: os.getenv(
+        "VLLM_NIXL_SIDE_CHANNEL_ADVERTIZE_HOST"
     ),
     # Port used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_PORT": lambda: int(


### PR DESCRIPTION



## Purpose
VLLM_NIXL_SIDE_CHANNEL_HOST is currently used both to bind a NIXL connector instance's local ZMQ metadata handshake listener and as the address advertized to remote peers. There are not always the same address. A producer may need to bind to a local or internal address while being reached by remote peers at a different address. This causes disaggregated P/D serving across two independently administered sites with at least one site using NAT'd OpenStack cloud to fail. Adding a VLLM_NIXL_SIDE_CHANNEL_ADVERTIZE_HOST can separate these two needs. 

## Test Plan
Testing this with prefill server at ACCESS JetStream2 (Indiana University data center) and decode server at CloudLab University of Utah).

## Test Result
**Before this fix**, decode's ZMQ metadata handshake against prefill consistently failed with "zmq.error.Again", with "remote_host": "localhost" visible in the failure context. Error message: 
[distributed/.../nixl/base_worker.py:933] NIXL transfer failure: handshake_failed | Context: {'failure_type': 'handshake_failed', 'request_id': 'cmpl-23c48056-34fc-43fe-aaa7-426c9f953482-0-b5301f64', 'engine_id': 'a56e21d3-56dd-42f5-9398-8ba696988a85', 'remote_engine_id': '47c9c929-8e63-460d-a89c-d1b0010ea088', 'remote_request_id': 'cmpl-23c48056-34fc-43fe-aaa7-426c9f953482-0-9d20b39c', **'remote_host': 'localhost',** 'remote_port': 5559, 'num_local_blocks': 4, 'num_remote_blocks': 4, 'local_block_ids_sample': [1, 2]}

**After this fix**, setting VLLM_NIXL_SIDE_CHANNEL_HOST=0.0.0.0 (bind) and VLLM_NIXL_SIDE_CHANNEL_ADVERTIZE_HOST=<public_IP> , the error is fixed: the metadata handshake roundtrip dropped from a 5s timeout failure to ~0.16s success, with the public IP now showing up correctly in the handshake payload ("remote_host": <public IP>)

.....,  'e5c907ed-a5a7-4b05-85e2-fcd507bbac7f', 'remote_request_id': 'cmpl-93c8ca93-183d-431f-bd12-546c50a83532-0-b4a296ad', **'remote_host': '149.165.172.72',** 'remote_port': 5559, 'num_local_blocks': 4, 'num_remote_blocks': 4, 'local_block_ids_sample': [1, 2]}
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

