### PR TITLE
[Model] Remove unused DeepseekV32Indexer forward

### DIFF
--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -25,9 +25,6 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
-from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-    per_token_group_quant_fp8,
-)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.sparse_attn_indexer import (
     SparseAttnIndexer,
@@ -116,54 +113,6 @@ class DeepseekV32Indexer(nn.Module):
             self.max_total_seq_len,
             self.topk_indices_buffer,
         )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        qr: torch.Tensor,
-        positions: torch.Tensor,
-        rotary_emb: nn.Module,
-    ) -> torch.Tensor:
-        q, _ = self.wq_b(qr)
-        q = q.view(-1, self.n_head, self.head_dim)
-
-        q_pe, q_nope = torch.split(
-            q, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
-        )
-
-        kw, _ = self.wk_weights_proj(hidden_states)
-        k = kw[:, : self.head_dim]
-        weights = kw[:, self.head_dim :]
-
-        k = self.k_norm(k)
-        k_pe, k_nope = torch.split(
-            k, [self.rope_dim, self.head_dim - self.rope_dim], dim=-1
-        )
-
-        q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
-
-        q_pe = q_pe.reshape(-1, self.n_head, self.rope_dim)
-        k_pe = k_pe.reshape(-1, 1, self.rope_dim)
-
-        q = torch.cat([q_pe, q_nope], dim=-1)
-        k = torch.cat([k_pe.squeeze(-2), k_nope], dim=-1)
-
-        q = q.view(-1, self.head_dim)
-        q_fp8, q_scale = per_token_group_quant_fp8(
-            q,
-            self.quant_block_size,
-            column_major_scales=False,
-            use_ue8m0=self.scale_fmt is not None,
-        )
-        q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
-        q_scale = q_scale.view(-1, self.n_head, 1)
-
-        weights = (
-            weights.unsqueeze(-1) * q_scale * self.softmax_scale * self.n_head**-0.5
-        )
-        weights = weights.squeeze(-1)
-
-        return self.indexer_op(hidden_states, q_fp8, k, weights)
 
 
 class DeepseekV32Attention(MLAAttention):


### PR DESCRIPTION
## Summary

Remove the unused `DeepseekV32Indexer.forward()` implementation and its now-unused `per_token_group_quant_fp8` import. Keep `self.indexer_op` construction unchanged.

## Why

The NVIDIA non-compiled DSA path directly consumes the indexer's projections, normalization parameters, KV cache, and metadata from `DeepseekV32Attention.forward()`. It never invokes `DeepseekV32Indexer.forward()`. The ROCm path likewise performs these operations directly and uses its own attention-level indexer operation.

Keeping a second, unreachable implementation makes the actual execution path harder to follow and risks divergence as the inlined path evolves.

## Impact

No runtime behavior or model output changes. Parameter registration, checkpoint names, indexer KV-cache registration, and `self.indexer_op` construction are preserved.

## Duplicate-work check

Searched open PRs for `DeepseekV32Indexer forward`, `remove unused indexer forward`, and related terms. PR #39943 concerns multi-stream overlap in the legacy compiled MLA path and does not modify this class or file. No duplicate PR was found.

## Validation

- `.venv/bin/python -m compileall -q vllm/models/deepseek_v32/attention.py`
- `.venv/bin/pre-commit run --files vllm/models/deepseek_v32/attention.py` — all applicable hooks passed, including Ruff, mypy, typos, and repository policy checks
- `git diff --check`

Model evaluations were not run because this removes an unreachable method and does not alter the executed model path.

## AI assistance

AI assistance was used to trace callers, prepare the removal, run validation, and draft this PR. The human submitter must review and understand every changed line before marking the PR ready for review.
