### PR TITLE
[Model][EPLB] Add static expert maps for DeepSeek V4

### DIFF
--- a/docs/serving/expert_parallel_deployment.md
+++ b/docs/serving/expert_parallel_deployment.md
@@ -156,6 +156,7 @@ Configure EPLB with the `--eplb-config` argument, which accepts a JSON string. T
 | `use_async` | Use non-blocking EPLB for reduced latency overhead | `true` |
 | `policy` | The policy type for expert parallel load balancing | `"default"` |
 | `communicator` | Backend for expert weight transfers: `"torch_nccl"`, `"torch_gloo"`, `"pynccl"`, `"nixl"`,  or `null` (auto) | `null` |
+| `expert_map_path` | NVIDIA DSV4-only path to a static physical-to-logical expert map | `null` |
 
 For example:
 
@@ -175,6 +176,55 @@ vllm serve Qwen/Qwen3-30B-A3B \
             --eplb-config.num_redundant_experts 2 \
             --eplb-config.log_balancedness true
     ```
+
+### Static DSV4 expert placement
+
+On NVIDIA, DSV4 can apply a fixed expert placement while loading the checkpoint.
+Without redundant slots, set `expert_map_path` without `--enable-eplb`. The map
+reorders expert weights, router weights, router correction biases, and
+hash-router expert IDs before inference starts.
+
+The JSON file contains a physical-to-logical expert map. It can be one list
+shared by every DSV4 and MTP layer:
+
+```json
+[2, 0, 3, 1]
+```
+
+or one list per layer:
+
+```json
+[
+  [2, 0, 3, 1],
+  [1, 3, 0, 2]
+]
+```
+
+Every list must assign each logical expert at least once. Without redundant
+experts, this makes each list a permutation. For grouped routing in that mode,
+each physical group must contain all experts from exactly one logical group;
+whole groups and experts within a group may be reordered. When using a per-layer
+map with MTP or DSpark, include the draft layers after the target layers. Start
+the server with expert parallelism and the map path:
+
+```bash
+vllm serve deepseek-ai/DeepSeek-V4-Flash \
+  --tensor-parallel-size 8 \
+  --enable-expert-parallel \
+  --eplb-config '{"expert_map_path":"/path/to/expert-map.json"}'
+```
+
+For a map with repeated logical IDs, its width must equal the logical expert
+count plus `num_redundant_experts`. Enable EPLB so the router can select a fixed
+physical replica; the static map disables load recording and rearrangement:
+
+```bash
+vllm serve deepseek-ai/DeepSeek-V4-Flash \
+  --tensor-parallel-size 8 \
+  --enable-expert-parallel \
+  --enable-eplb \
+  --eplb-config '{"expert_map_path":"/path/to/expert-map.json","num_redundant_experts":8}'
+```
 
 ### Expert Distribution Formula
 

--- a/tests/models/test_deepseek_v4_expert_map.py
+++ b/tests/models/test_deepseek_v4_expert_map.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.distributed.eplb.eplb_state as eplb_state_module
+from vllm.config.parallel import EPLBConfig, ParallelConfig
+from vllm.distributed.eplb.eplb_state import EplbState
+from vllm.models.deepseek_v4.expert_map import (
+    get_expert_map_layer_index,
+    load_static_expert_map,
+    remap_expert_params_mapping,
+    remap_router_expert_ids,
+    remap_router_weight,
+)
+
+
+def test_get_expert_map_layer_index_ignores_expert_id():
+    name = "layers.0.ffn.experts.127.w1.weight_scale"
+
+    assert get_expert_map_layer_index(name) == 0
+
+
+def test_load_static_expert_map_shared_across_layers(tmp_path):
+    path = tmp_path / "expert-map.json"
+    path.write_text(json.dumps([2, 0, 3, 1]))
+
+    expert_map = load_static_expert_map(str(path), num_layers=2, num_experts=4)
+
+    torch.testing.assert_close(
+        expert_map,
+        torch.tensor(
+            [
+                [2, 0, 3, 1],
+                [2, 0, 3, 1],
+            ]
+        ),
+    )
+
+
+def test_load_static_expert_map_per_layer(tmp_path):
+    path = tmp_path / "expert-map.json"
+    path.write_text(json.dumps([[2, 0, 3, 1], [1, 3, 0, 2]]))
+
+    expert_map = load_static_expert_map(str(path), num_layers=2, num_experts=4)
+
+    torch.testing.assert_close(
+        expert_map,
+        torch.tensor(
+            [
+                [2, 0, 3, 1],
+                [1, 3, 0, 2],
+            ]
+        ),
+    )
+
+
+def test_load_static_expert_map_with_replicas(tmp_path):
+    path = tmp_path / "expert-map.json"
+    path.write_text(json.dumps([2, 0, 3, 1, 2, 1]))
+
+    expert_map = load_static_expert_map(
+        str(path),
+        num_layers=2,
+        num_experts=4,
+        num_physical_experts=6,
+    )
+
+    torch.testing.assert_close(
+        expert_map,
+        torch.tensor(
+            [
+                [2, 0, 3, 1, 2, 1],
+                [2, 0, 3, 1, 2, 1],
+            ]
+        ),
+    )
+
+
+def test_load_static_expert_map_preserves_router_groups(tmp_path):
+    path = tmp_path / "expert-map.json"
+    path.write_text(json.dumps([2, 3, 0, 1]))
+
+    expert_map = load_static_expert_map(
+        str(path), num_layers=1, num_experts=4, num_expert_groups=2
+    )
+
+    torch.testing.assert_close(expert_map, torch.tensor([[2, 3, 0, 1]]))
+
+    mixed_path = tmp_path / "mixed-expert-map.json"
+    mixed_path.write_text(json.dumps([0, 2, 1, 3]))
+    with pytest.raises(ValueError, match="mixes logical expert groups"):
+        load_static_expert_map(
+            str(mixed_path),
+            num_layers=1,
+            num_experts=4,
+            num_expert_groups=2,
+        )
+
+
+@pytest.mark.parametrize(
+    ("contents", "match"),
+    [
+        ([], "non-empty"),
+        ([0, 1, 2], "physical slots"),
+        ([0, 1, 2, 4], "assign every logical"),
+        ([0, 1, 1, 3], "assign every logical"),
+        ([0, True, 2, 3], "non-integer"),
+        ([[0, 1, 2, 3]] * 3, "either one shared"),
+    ],
+)
+def test_load_static_expert_map_rejects_invalid_maps(tmp_path, contents, match):
+    path = tmp_path / "expert-map.json"
+    path.write_text(json.dumps(contents))
+
+    with pytest.raises(ValueError, match=match):
+        load_static_expert_map(str(path), num_layers=2, num_experts=4)
+
+
+def test_static_expert_map_remaps_router_tensors():
+    physical_to_logical = torch.tensor([2, 0, 3, 1])
+    router_weight = torch.arange(12).view(4, 3)
+    correction_bias = torch.arange(4)
+    hash_expert_ids = torch.tensor([[0, 1], [2, 3]])
+
+    torch.testing.assert_close(
+        remap_router_weight(router_weight, physical_to_logical),
+        router_weight[[2, 0, 3, 1]],
+    )
+    torch.testing.assert_close(
+        remap_router_weight(correction_bias, physical_to_logical),
+        correction_bias[[2, 0, 3, 1]],
+    )
+    torch.testing.assert_close(
+        remap_router_expert_ids(hash_expert_ids, physical_to_logical),
+        torch.tensor([[1, 3], [0, 2]]),
+    )
+
+
+def test_static_expert_map_preserves_routed_output():
+    physical_to_logical = torch.tensor([2, 0, 3, 1])
+    hidden_states = torch.tensor([[1.0, 2.0], [3.0, -1.0]])
+    router_weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [2.0, 1.0], [-1.0, 3.0]])
+    expert_scale = torch.tensor([2.0, 3.0, 5.0, 7.0])
+
+    logical_ids = (hidden_states @ router_weight.T).argmax(dim=-1)
+    baseline_output = hidden_states * expert_scale[logical_ids, None]
+
+    static_router_weight = remap_router_weight(router_weight, physical_to_logical)
+    physical_ids = (hidden_states @ static_router_weight.T).argmax(dim=-1)
+    static_expert_scale = expert_scale[physical_to_logical]
+    static_output = hidden_states * static_expert_scale[physical_ids, None]
+
+    torch.testing.assert_close(static_output, baseline_output)
+
+
+def test_static_expert_map_remaps_fused_expert_checkpoint_names():
+    mapping = [
+        ("experts.w13_", "experts.0.w1.", 0, "w1"),
+        ("experts.w13_", "experts.1.w1.", 1, "w1"),
+        ("experts.w13_", "experts.2.w1.", 2, "w1"),
+    ]
+
+    remapped = remap_expert_params_mapping(mapping, torch.tensor([2, 0, 1]))
+
+    assert remapped == [
+        ("experts.w13_", "experts.2.w1.", 0, "w1"),
+        ("experts.w13_", "experts.0.w1.", 1, "w1"),
+        ("experts.w13_", "experts.1.w1.", 2, "w1"),
+    ]
+
+
+def test_static_expert_map_requires_expert_parallelism():
+    with pytest.raises(ValueError, match="enable_expert_parallel"):
+        ParallelConfig(eplb_config=EPLBConfig(expert_map_path="map.json"))
+
+
+def test_static_expert_map_allows_eplb_runtime_mapping():
+    config = ParallelConfig(
+        tensor_parallel_size=2,
+        enable_expert_parallel=True,
+        enable_eplb=True,
+        eplb_config=EPLBConfig(expert_map_path="map.json"),
+    )
+
+    assert config.enable_eplb
+
+
+def test_static_replicated_expert_map_requires_eplb_runtime_mapping():
+    with pytest.raises(ValueError, match="enable_eplb must be True"):
+        ParallelConfig(
+            tensor_parallel_size=2,
+            enable_expert_parallel=True,
+            eplb_config=EPLBConfig(expert_map_path="map.json", num_redundant_experts=2),
+        )
+
+
+def test_static_replicated_map_initializes_fixed_eplb_state(monkeypatch):
+    physical_to_logical = torch.tensor(
+        [
+            [2, 0, 3, 1, 2, 1],
+            [1, 3, 0, 2, 0, 3],
+        ]
+    )
+
+    class FakeModel:
+        num_moe_layers = 2
+        num_routed_experts = 4
+        num_redundant_experts = 2
+        num_physical_experts = 6
+        num_logical_experts = 4
+        num_expert_groups = 1
+        num_shared_experts = 0
+        num_local_physical_experts = 3
+        static_expert_map = physical_to_logical
+        moe_layers = []
+
+        def set_eplb_state(
+            self,
+            expert_load_view,
+            logical_to_physical_map,
+            logical_replica_count,
+        ):
+            self.logical_to_physical_map = logical_to_physical_map
+            self.logical_replica_count = logical_replica_count
+            self.expert_weights = [[torch.zeros(3, 1)] for _ in range(2)]
+
+    monkeypatch.setattr(eplb_state_module, "get_eplb_group", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        eplb_state_module, "create_eplb_communicator", lambda **_: object()
+    )
+    parallel_config = SimpleNamespace(
+        eplb_config=SimpleNamespace(
+            expert_map_path="map.json",
+            use_async=True,
+            window_size=2,
+            step_interval=4,
+            policy="default",
+            communicator="torch_nccl",
+        ),
+        num_ubatches=0,
+    )
+    model_config = SimpleNamespace(model="fake", compute_hash=lambda: "fake")
+    model = FakeModel()
+    state = EplbState(parallel_config, torch.device("cpu"))
+
+    state.add_model(model, model_config)
+
+    torch.testing.assert_close(
+        model.logical_replica_count,
+        torch.tensor([[1, 2, 2, 1], [2, 1, 1, 2]]),
+    )
+    torch.testing.assert_close(
+        model.logical_to_physical_map,
+        torch.tensor(
+            [
+                [[1, -1], [3, 5], [0, 4], [2, -1]],
+                [[2, 4], [0, -1], [3, -1], [1, 5]],
+            ]
+        ),
+    )
+    torch.testing.assert_close(
+        state.model_states["fake"].physical_to_logical_map,
+        physical_to_logical,
+    )
+    assert not state.is_async
+    state.step()

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -168,6 +168,79 @@ def test_deepseek_v4_mega_moe_weight_loader_uses_ep_expert_ownership():
     assert torch.count_nonzero(experts.w13_weight[1]) == 0
 
 
+def test_deepseek_v4_mega_moe_weight_loader_uses_static_expert_map():
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=4),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+    experts = DeepseekV4MegaMoEExperts(
+        vllm_config,
+        num_experts=4,
+        num_local_experts=2,
+        experts_start_idx=2,
+        top_k=2,
+        hidden_size=128,
+        intermediate_size=128,
+        physical_to_logical_map=torch.tensor([2, 0, 3, 1]),
+    )
+
+    expert_1 = torch.full((128, 64), 5, dtype=torch.uint8)
+    expert_3 = torch.full((128, 64), 9, dtype=torch.uint8)
+
+    assert experts.weight_loader(
+        experts.w13_weight,
+        expert_1,
+        "experts.w13_weight",
+        shard_id="w1",
+        expert_id=1,
+        return_success=True,
+    )
+    assert experts.weight_loader(
+        experts.w13_weight,
+        expert_3,
+        "experts.w13_weight",
+        shard_id="w1",
+        expert_id=3,
+        return_success=True,
+    )
+
+    assert torch.equal(experts.w13_weight[0, :128], expert_3)
+    assert torch.equal(experts.w13_weight[1, :128], expert_1)
+
+
+def test_deepseek_v4_mega_moe_weight_loader_populates_static_replicas():
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=4),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+    )
+    experts = DeepseekV4MegaMoEExperts(
+        vllm_config,
+        num_experts=6,
+        num_local_experts=3,
+        experts_start_idx=3,
+        top_k=2,
+        hidden_size=128,
+        intermediate_size=128,
+        num_logical_experts=4,
+        physical_to_logical_map=torch.tensor([0, 1, 2, 3, 2, 2]),
+    )
+
+    expert_2 = torch.full((128, 64), 7, dtype=torch.uint8)
+
+    assert experts.weight_loader(
+        experts.w13_weight,
+        expert_2,
+        "experts.w13_weight",
+        shard_id="w1",
+        expert_id=2,
+        return_success=True,
+    )
+
+    assert torch.count_nonzero(experts.w13_weight[0]) == 0
+    assert torch.equal(experts.w13_weight[1, :128], expert_2)
+    assert torch.equal(experts.w13_weight[2, :128], expert_2)
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="DeepSeek V4 MegaMoE fused input staging requires CUDA.",

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -72,6 +72,9 @@ class EPLBConfig:
     num_redundant_experts: int = Field(default=0, ge=0)
     """Number of redundant experts to use for expert parallelism."""
 
+    expert_map_path: str | None = None
+    """Path to a static DSV4 physical-to-logical expert map in JSON format."""
+
     log_balancedness: bool = False
     """
     Log the balancedness each step of expert parallelism.
@@ -489,6 +492,23 @@ class ParallelConfig:
             raise ValueError(
                 "numa_bind_nodes and numa_bind_cpus require numa_bind=True."
             )
+
+        static_expert_map = self.eplb_config.expert_map_path is not None
+        if static_expert_map:
+            if not self.enable_expert_parallel:
+                raise ValueError(
+                    "enable_expert_parallel must be True to use a static expert map."
+                )
+            if self.expert_placement_strategy != "linear":
+                raise ValueError(
+                    "A static expert map cannot be combined with a non-linear "
+                    "expert placement strategy."
+                )
+            if self.eplb_config.num_redundant_experts and not self.enable_eplb:
+                raise ValueError(
+                    "enable_eplb must be True when a static expert map contains "
+                    "redundant expert slots."
+                )
 
         if self.enable_eplb:
             if not current_platform.is_cuda_alike():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1108,6 +1108,17 @@ class VllmConfig:
 
             self.parallel_config.is_moe_model = self.model_config.is_moe
 
+            if self.parallel_config.eplb_config.expert_map_path is not None:
+                dsv4_architectures = {
+                    "DeepseekV4ForCausalLM",
+                    "DeepSeekV4MTPModel",
+                    "DSparkDraftModel",
+                }
+                if dsv4_architectures.isdisjoint(self.model_config.architectures):
+                    raise ValueError(
+                        "eplb_config.expert_map_path is supported only for DSV4."
+                    )
+
         if (
             self.model_config is not None
             and self.model_config.enable_return_routed_experts

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -286,6 +286,7 @@ class EplbState:
         """
         Background thread handling async transfers.
         """
+        self.is_static = parallel_config.eplb_config.expert_map_path is not None
         self.cuda_device_index: int | None = None
         """
         CUDA device index for the async EPLB worker thread.
@@ -360,18 +361,42 @@ class EplbState:
         Build the initial EPLB state.
         """
         self.validate_ep_configuration(model)
-        self.is_async = self.parallel_config.eplb_config.use_async
+        self.is_async = (
+            self.parallel_config.eplb_config.use_async and not self.is_static
+        )
 
-        physical_to_logical_map_list = (
-            EplbState.build_initial_global_physical_to_logical_map(
-                model.num_routed_experts,
-                model.num_redundant_experts,
+        static_map = getattr(model, "static_expert_map", None)
+        if self.is_static:
+            if static_map is None:
+                raise ValueError(
+                    "Static EPLB requires the model to expose its expert map."
+                )
+            expected_shape = (model.num_moe_layers, model.num_physical_experts)
+            if tuple(static_map.shape) != expected_shape:
+                raise ValueError(
+                    "Static EPLB expert map shape does not match the model: "
+                    f"{tuple(static_map.shape)} vs {expected_shape}."
+                )
+            physical_to_logical_map = static_map.to(
+                device=self.device, dtype=torch.long
             )
-        )
-        physical_to_logical_map = torch.tensor(
-            physical_to_logical_map_list,
-            device=self.device,
-        )
+            logical_to_physical_map, logical_replica_count = compute_logical_maps(
+                static_map.to(device="cpu", dtype=torch.long),
+                model.num_logical_experts,
+            )
+            logical_to_physical_map = logical_to_physical_map.to(self.device)
+            logical_replica_count = logical_replica_count.to(self.device)
+        else:
+            physical_to_logical_map_list = (
+                EplbState.build_initial_global_physical_to_logical_map(
+                    model.num_routed_experts,
+                    model.num_redundant_experts,
+                )
+            )
+            physical_to_logical_map = torch.tensor(
+                physical_to_logical_map_list,
+                device=self.device,
+            )
         # Assuming 8 GPUs per node, this supports up to
         # (1023 + 1) / 8 = 128 nodes for now.
         # TODO(rui): make this configurable
@@ -380,49 +405,41 @@ class EplbState:
             f"num_redundant_experts {model.num_redundant_experts} "
             f"must be less than or equal to {MAX_EXPERT_REDUNDANCY}"
         )
-        max_slots_per_logical_expert = MAX_EXPERT_REDUNDANCY + 1
-        logical_to_physical_map = torch.full(
-            (model.num_logical_experts, max_slots_per_logical_expert),
-            -1,
-            device=self.device,
-        )
-        logical_replica_count = torch.zeros(
-            (model.num_logical_experts,),
-            device=self.device,
-            dtype=torch.long,
-        )
+        if not self.is_static:
+            max_slots_per_logical_expert = MAX_EXPERT_REDUNDANCY + 1
+            logical_to_physical_map = torch.full(
+                (model.num_logical_experts, max_slots_per_logical_expert),
+                -1,
+                device=self.device,
+            )
+            logical_replica_count = torch.zeros(
+                (model.num_logical_experts,),
+                device=self.device,
+                dtype=torch.long,
+            )
 
-        for i in range(model.num_physical_experts):
-            logical_idx = physical_to_logical_map[i]
-            logical_to_physical_map[logical_idx, logical_replica_count[logical_idx]] = i
-            logical_replica_count[logical_idx] += 1
+            for i in range(model.num_physical_experts):
+                logical_idx = physical_to_logical_map[i]
+                logical_to_physical_map[
+                    logical_idx, logical_replica_count[logical_idx]
+                ] = i
+                logical_replica_count[logical_idx] += 1
 
-        # Duplicate initial mapping for all layers
-        physical_to_logical_map = (
-            physical_to_logical_map.unsqueeze(0)
-            .expand(
-                model.num_moe_layers,
-                -1,
+            physical_to_logical_map = (
+                physical_to_logical_map.unsqueeze(0)
+                .expand(model.num_moe_layers, -1)
+                .contiguous()
             )
-            .contiguous()
-        )
-        logical_to_physical_map = (
-            logical_to_physical_map.unsqueeze(0)
-            .expand(
-                model.num_moe_layers,
-                -1,
-                -1,
+            logical_to_physical_map = (
+                logical_to_physical_map.unsqueeze(0)
+                .expand(model.num_moe_layers, -1, -1)
+                .contiguous()
             )
-            .contiguous()
-        )
-        logical_replica_count = (
-            logical_replica_count.unsqueeze(0)
-            .expand(
-                model.num_moe_layers,
-                -1,
+            logical_replica_count = (
+                logical_replica_count.unsqueeze(0)
+                .expand(model.num_moe_layers, -1)
+                .contiguous()
             )
-            .contiguous()
-        )
 
         expert_load_pass = torch.zeros(
             (model.num_moe_layers, model.num_physical_experts),
@@ -464,6 +481,8 @@ class EplbState:
             logical_replica_count,
         )
         self._propagate_shared_tensors(model, num_unpadded_tokens_tensors)
+        if self.is_static and self.should_record_tensor is not None:
+            self.should_record_tensor.fill_(False)
         expert_buffer = [torch.empty_like(w) for w in model.expert_weights[0]]
 
         assert self.parallel_config.eplb_config.communicator is not None, (
@@ -550,6 +569,9 @@ class EplbState:
             - `max_tokens`: The maximum load across ranks.
             - `balancedness`: The ratio of average load to maximum load.
         """
+        if self.is_static:
+            return
+
         ep_group = get_ep_group().device_group
         if is_profile:
             self.rearrange(is_profile=True)

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -370,8 +370,13 @@ class DefaultModelLoader(BaseModelLoader):
         # When EPLB is enabled, redundant physical expert slots may map to
         # logical experts that belong to other ranks in the default partition.
         # The weight loader needs to see ALL logical expert weights so it can
-        # populate these redundant slots.  Skip the filter entirely.
-        if parallel_config.enable_eplb:
+        # populate these redundant slots. A static DSV4 map can likewise assign
+        # different logical experts to each rank on every layer. Skip the filter
+        # entirely in either case.
+        if (
+            parallel_config.enable_eplb
+            or parallel_config.eplb_config.expert_map_path is not None
+        ):
             return
 
         num_experts = model_config.get_num_experts()

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -182,6 +182,10 @@ class DeepseekV4MoE(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        if vllm_config.parallel_config.eplb_config.expert_map_path is not None:
+            raise NotImplementedError(
+                "Static DSV4 expert maps are currently supported only on NVIDIA."
+            )
         self.prefix = prefix
 
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)

--- a/vllm/models/deepseek_v4/expert_map.py
+++ b/vllm/models/deepseek_v4/expert_map.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from vllm.model_executor.models.utils import extract_layer_index
+
+
+def get_num_expert_map_layers(config: Any) -> int:
+    num_draft_layers = getattr(config, "num_nextn_predict_layers", None)
+    num_draft_layers = num_draft_layers or getattr(config, "n_mtp_layers", 0) or 0
+    return config.num_hidden_layers + num_draft_layers
+
+
+def get_expert_map_layer_index(weight_name: str) -> int:
+    """Extract the model layer index while ignoring checkpoint expert IDs."""
+    layer_name, separator, _ = weight_name.partition(".ffn.")
+    if not separator:
+        raise ValueError(f"DSV4 MoE weight name has no .ffn. component: {weight_name}")
+    return extract_layer_index(layer_name)
+
+
+@cache
+def load_static_expert_map(
+    path: str,
+    *,
+    num_layers: int,
+    num_experts: int,
+    num_physical_experts: int | None = None,
+    num_expert_groups: int = 1,
+) -> torch.Tensor:
+    """Load a DSV4 physical-to-logical expert map from JSON."""
+    try:
+        raw_map = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Failed to load DSV4 expert map from {path}: {exc}") from exc
+
+    if not isinstance(raw_map, list) or not raw_map:
+        raise ValueError("DSV4 expert map must be a non-empty JSON list.")
+
+    has_nested_list = any(isinstance(value, list) for value in raw_map)
+    if has_nested_list and not all(isinstance(value, list) for value in raw_map):
+        raise ValueError(
+            "DSV4 expert map must contain expert IDs or per-layer lists of IDs."
+        )
+    layer_maps = raw_map if has_nested_list else [raw_map]
+
+    if len(layer_maps) not in (1, num_layers):
+        raise ValueError(
+            "DSV4 expert map must define either one shared permutation or "
+            f"{num_layers} layer permutations, got {len(layer_maps)}."
+        )
+
+    if num_physical_experts is None:
+        num_physical_experts = num_experts
+    if num_physical_experts < num_experts:
+        raise ValueError(
+            "DSV4 num_physical_experts must be at least num_experts, got "
+            f"{num_physical_experts} and {num_experts}."
+        )
+
+    expected_experts = set(range(num_experts))
+    for layer_idx, layer_map in enumerate(layer_maps):
+        if not all(_is_int(expert_id) for expert_id in layer_map):
+            raise ValueError(
+                f"DSV4 expert map layer {layer_idx} contains a non-integer ID."
+            )
+        if len(layer_map) != num_physical_experts:
+            raise ValueError(
+                f"DSV4 expert map layer {layer_idx} must define "
+                f"{num_physical_experts} physical slots, got {len(layer_map)}."
+            )
+        actual_experts = set(layer_map)
+        if actual_experts != expected_experts:
+            missing = sorted(expected_experts - actual_experts)
+            invalid = sorted(actual_experts - expected_experts)
+            raise ValueError(
+                f"DSV4 expert map layer {layer_idx} must assign every logical "
+                f"expert ID in [0, {num_experts}); missing={missing}, "
+                f"invalid={invalid}."
+            )
+        if num_physical_experts == num_experts:
+            _validate_expert_groups(
+                layer_map,
+                layer_idx=layer_idx,
+                num_experts=num_experts,
+                num_expert_groups=num_expert_groups,
+            )
+
+    expert_map = torch.tensor(layer_maps, dtype=torch.long, device="cpu")
+    if len(layer_maps) == 1:
+        expert_map = expert_map.expand(num_layers, -1).contiguous()
+    return expert_map
+
+
+def remap_router_weight(
+    loaded_weight: torch.Tensor,
+    physical_to_logical_map: torch.Tensor,
+) -> torch.Tensor:
+    """Reorder an expert-indexed router tensor into physical expert order."""
+    if loaded_weight.shape[0] != physical_to_logical_map.numel():
+        raise ValueError(
+            "DSV4 router weight expert dimension does not match the expert map: "
+            f"{loaded_weight.shape[0]} vs {physical_to_logical_map.numel()}."
+        )
+    return loaded_weight.index_select(
+        0, physical_to_logical_map.to(device=loaded_weight.device)
+    )
+
+
+def remap_router_expert_ids(
+    loaded_weight: torch.Tensor,
+    physical_to_logical_map: torch.Tensor,
+) -> torch.Tensor:
+    """Translate logical expert IDs in a hash router to physical IDs."""
+    logical_to_physical_map = torch.empty_like(physical_to_logical_map)
+    logical_to_physical_map[physical_to_logical_map] = torch.arange(
+        physical_to_logical_map.numel(), dtype=torch.long
+    )
+    return logical_to_physical_map.to(device=loaded_weight.device)[
+        loaded_weight.long()
+    ].to(dtype=loaded_weight.dtype)
+
+
+def remap_expert_params_mapping(
+    mapping: list[tuple[str, str, int, str]],
+    physical_to_logical_map: torch.Tensor,
+) -> list[tuple[str, str, int, str]]:
+    """Point each physical expert slot at its mapped checkpoint expert."""
+    remapped = []
+    for param_name, weight_name, physical_id, shard_id in mapping:
+        logical_id = physical_to_logical_map[physical_id].item()
+        weight_name = weight_name.replace(
+            f"experts.{physical_id}.", f"experts.{logical_id}."
+        )
+        remapped.append((param_name, weight_name, physical_id, shard_id))
+    return remapped
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_expert_groups(
+    layer_map: list[int],
+    *,
+    layer_idx: int,
+    num_experts: int,
+    num_expert_groups: int,
+) -> None:
+    if num_expert_groups <= 0:
+        raise ValueError("DSV4 num_expert_groups must be greater than zero.")
+    if num_experts % num_expert_groups != 0:
+        raise ValueError(
+            f"DSV4 has {num_experts} experts, which is not divisible by "
+            f"{num_expert_groups} expert groups."
+        )
+
+    group_size = num_experts // num_expert_groups
+    for physical_group in range(num_expert_groups):
+        start = physical_group * group_size
+        logical_groups = {
+            expert_id // group_size
+            for expert_id in layer_map[start : start + group_size]
+        }
+        if len(logical_groups) != 1:
+            raise ValueError(
+                f"DSV4 expert map layer {layer_idx} mixes logical expert groups "
+                f"in physical group {physical_group}."
+            )

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -48,6 +48,14 @@ from vllm.models.common.ops.sequence_parallel import (
     sp_padding_mask,
     sp_shard,
 )
+from vllm.models.deepseek_v4.expert_map import (
+    get_expert_map_layer_index,
+    get_num_expert_map_layers,
+    load_static_expert_map,
+    remap_expert_params_mapping,
+    remap_router_expert_ids,
+    remap_router_weight,
+)
 
 from .model import (
     DeepseekV4DecoderLayer,
@@ -313,6 +321,23 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         self.draft_model_config = vllm_config.speculative_config.draft_model_config
         self.config = self.draft_model_config.hf_config
         self.quant_config = vllm_config.quant_config
+        parallel_config = vllm_config.parallel_config
+        eplb_config = parallel_config.eplb_config
+        self.enable_eplb = parallel_config.enable_eplb
+        expert_map_path = eplb_config.expert_map_path
+        self.static_expert_map = (
+            load_static_expert_map(
+                expert_map_path,
+                num_layers=get_num_expert_map_layers(self.config),
+                num_experts=self.config.n_routed_experts,
+                num_physical_experts=(
+                    self.config.n_routed_experts + eplb_config.num_redundant_experts
+                ),
+                num_expert_groups=getattr(self.config, "n_group", 1) or 1,
+            )
+            if expert_map_path is not None
+            else None
+        )
         self.pad_shared_expert = getattr(
             self.quant_config, "weight_block_size", None
         ) is not None and not _use_sequence_parallel(vllm_config)
@@ -403,8 +428,13 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                 ckpt_gate_proj_name="w1",
                 ckpt_down_proj_name="w2",
                 ckpt_up_proj_name="w3",
-                num_experts=self.config.n_routed_experts,
+                num_experts=(
+                    self.static_expert_map.shape[1]
+                    if self.static_expert_map is not None
+                    else self.config.n_routed_experts
+                ),
             )
+        static_expert_mappings: dict[int, list[tuple[str, str, int, str]]] = {}
         expert_scale_suffix = (
             ".weight_scale"
             if getattr(self.config, "expert_dtype", "fp4") == "fp4"
@@ -437,6 +467,19 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
             if "confidence_head." in name:
                 loaded_confidence_head = True
 
+            static_layer_map = None
+            if self.static_expert_map is not None and ".ffn." in name:
+                layer_idx = get_expert_map_layer_index(name)
+                static_layer_map = self.static_expert_map[layer_idx]
+                if not self.enable_eplb and name.endswith(
+                    (".ffn.gate.weight", ".ffn.gate.bias")
+                ):
+                    loaded_weight = remap_router_weight(loaded_weight, static_layer_map)
+                elif not self.enable_eplb and name.endswith(".ffn.gate.tid2eid"):
+                    loaded_weight = remap_router_expert_ids(
+                        loaded_weight, static_layer_map
+                    )
+
             # ``.scale`` -> per-method scale suffix.
             if name.endswith(".scale"):
                 suffix = (
@@ -459,7 +502,19 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                     and loaded_weight.dtype == torch.float8_e8m0fnu
                 ):
                     loaded_weight = loaded_weight.view(torch.uint8)
-                for param_name, weight_name, expert_id, shard_id in expert_mapping:
+                layer_expert_mapping = expert_mapping
+                if static_layer_map is not None and not use_mega_moe:
+                    if layer_idx not in static_expert_mappings:
+                        static_expert_mappings[layer_idx] = remap_expert_params_mapping(
+                            expert_mapping, static_layer_map
+                        )
+                    layer_expert_mapping = static_expert_mappings[layer_idx]
+                for (
+                    param_name,
+                    weight_name,
+                    expert_id,
+                    shard_id,
+                ) in layer_expert_mapping:
                     if weight_name not in name:
                         continue
                     name_mapped = name.replace(weight_name, param_name)

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -72,6 +72,14 @@ from vllm.models.common.ops.sequence_parallel import (
     sp_shard,
 )
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4.expert_map import (
+    get_expert_map_layer_index,
+    get_num_expert_map_layers,
+    load_static_expert_map,
+    remap_expert_params_mapping,
+    remap_router_expert_ids,
+    remap_router_weight,
+)
 from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
     DeepseekV4FlashInferMLAAttention,
     DeepseekV4FlashInferSM120Attention,
@@ -179,6 +187,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         intermediate_size: int,
         prefix: str = "",
         num_logical_experts: int | None = None,
+        physical_to_logical_map: torch.Tensor | None = None,
     ):
         super().__init__()
         self.prefix = prefix
@@ -195,6 +204,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         self.num_logical_experts = (
             num_logical_experts if num_logical_experts is not None else num_experts
         )
+        self.physical_to_logical_map = physical_to_logical_map
 
         self.eplb_state = EplbLayerState()
 
@@ -261,7 +271,12 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         """
         physical_ids: list[int] = []
         for p in range(self.experts_start_idx, self.experts_end_idx):
-            if p % self.num_logical_experts == expert_id:
+            logical_id = (
+                self.physical_to_logical_map[p].item()
+                if self.physical_to_logical_map is not None
+                else p % self.num_logical_experts
+            )
+            if logical_id == expert_id:
                 physical_ids.append(p - self.experts_start_idx)
         return physical_ids
 
@@ -533,6 +548,22 @@ class DeepseekV4MoE(nn.Module):
         quant_config = vllm_config.quant_config
         self.prefix = prefix
         self.use_sequence_parallel = use_sequence_parallel
+        parallel_config = vllm_config.parallel_config
+        eplb_config = parallel_config.eplb_config
+        expert_map_path = eplb_config.expert_map_path
+        if expert_map_path is None:
+            self.physical_to_logical_map = None
+        else:
+            layer_id = extract_layer_index(prefix)
+            self.physical_to_logical_map = load_static_expert_map(
+                expert_map_path,
+                num_layers=get_num_expert_map_layers(config),
+                num_experts=config.n_routed_experts,
+                num_physical_experts=(
+                    config.n_routed_experts + eplb_config.num_redundant_experts
+                ),
+                num_expert_groups=getattr(config, "n_group", 1) or 1,
+            )[layer_id]
         self.use_mega_moe = (
             vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
         )
@@ -655,6 +686,7 @@ class DeepseekV4MoE(nn.Module):
             hidden_size=config.hidden_size,
             intermediate_size=config.moe_intermediate_size,
             prefix=f"{prefix}.experts",
+            physical_to_logical_map=self.physical_to_logical_map,
         )
 
     def _init_fused_moe_experts(
@@ -993,6 +1025,22 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         self.config = config
         self.quant_config = quant_config
         self.parallel_config = vllm_config.parallel_config
+        expert_map_path = self.parallel_config.eplb_config.expert_map_path
+        num_physical_experts = (
+            config.n_routed_experts
+            + self.parallel_config.eplb_config.num_redundant_experts
+        )
+        self.static_expert_map = (
+            load_static_expert_map(
+                expert_map_path,
+                num_layers=get_num_expert_map_layers(config),
+                num_experts=config.n_routed_experts,
+                num_physical_experts=num_physical_experts,
+                num_expert_groups=getattr(config, "n_group", 1) or 1,
+            )
+            if expert_map_path is not None
+            else None
+        )
         self.use_mega_moe = (
             vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
         )
@@ -1210,8 +1258,15 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         head_rank_start = n_local_head * tp_rank
         head_rank_end = n_local_head * (tp_rank + 1)
 
-        # Pre-compute expert mapping ONCE.
-        expert_mapping = self.get_expert_mapping()
+        # Pre-compute the canonical expert mapping once. Static placement only
+        # changes which checkpoint expert populates each physical slot.
+        static_num_experts = (
+            self.static_expert_map.shape[1]
+            if self.static_expert_map is not None and not self.use_mega_moe
+            else None
+        )
+        expert_mapping = self.get_expert_mapping(static_num_experts)
+        static_expert_mappings: dict[int, list[tuple[str, str, int, str]]] = {}
 
         # Block-FP8 shared experts: pad the intermediate up to the TP-uniform
         # block count so the standard loaders below slice it evenly (trailing
@@ -1222,6 +1277,25 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         )
 
         for name, loaded_weight in weights:
+            static_layer_map = None
+            if self.static_expert_map is not None and ".ffn." in name:
+                layer_idx = get_expert_map_layer_index(name)
+                static_layer_map = self.static_expert_map[layer_idx]
+                if not self.parallel_config.enable_eplb and name.endswith(
+                    (
+                        ".ffn.gate.weight",
+                        ".ffn.gate.bias",
+                        ".ffn.gate.e_score_correction_bias",
+                    )
+                ):
+                    loaded_weight = remap_router_weight(loaded_weight, static_layer_map)
+                elif not self.parallel_config.enable_eplb and name.endswith(
+                    ".ffn.gate.tid2eid"
+                ):
+                    loaded_weight = remap_router_expert_ids(
+                        loaded_weight, static_layer_map
+                    )
+
             if pad_shared_expert and ".shared_experts." in name:
                 loaded_weight = self._pad_shared_expert_weight(
                     self.quant_config, name, loaded_weight
@@ -1252,7 +1326,16 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                         and loaded_weight.dtype == torch.float8_e8m0fnu
                     ):
                         loaded_weight = loaded_weight.view(torch.uint8)
-                    for mapping in expert_mapping:
+                    layer_expert_mapping = expert_mapping
+                    if static_layer_map is not None and not self.use_mega_moe:
+                        if layer_idx not in static_expert_mappings:
+                            static_expert_mappings[layer_idx] = (
+                                remap_expert_params_mapping(
+                                    expert_mapping, static_layer_map
+                                )
+                            )
+                        layer_expert_mapping = static_expert_mappings[layer_idx]
+                    for mapping in layer_expert_mapping:
                         param_name, weight_name, expert_id, expert_shard_id = mapping
                         if weight_name not in name:
                             continue
@@ -1325,7 +1408,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         pad_shape[dim] = pad
         return torch.cat([loaded_weight, loaded_weight.new_zeros(pad_shape)], dim=dim)
 
-    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+    def get_expert_mapping(
+        self, num_experts: int | None = None
+    ) -> list[tuple[str, str, int, str]]:
         first_layer = next(iter(islice(self.layers, self.start_layer, self.end_layer)))
         if first_layer.ffn.use_mega_moe:
             return make_deepseek_v4_expert_params_mapping(self.config.n_routed_experts)
@@ -1336,7 +1421,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             ckpt_gate_proj_name="w1",
             ckpt_down_proj_name="w2",
             ckpt_up_proj_name="w3",
-            num_experts=self.config.n_routed_experts,
+            num_experts=num_experts or self.config.n_routed_experts,
         )
 
     def finalize_mega_moe_weights(self) -> None:
@@ -1468,6 +1553,11 @@ class DeepseekV4ForCausalLM(
         )
 
         self.set_moe_parameters()
+        self.static_expert_map = (
+            self.model.static_expert_map[self.model.start_layer : self.model.end_layer]
+            if self.model.static_expert_map is not None
+            else None
+        )
 
     def set_moe_parameters(self) -> None:
         self.num_expert_groups = getattr(self.config, "n_group", 1)

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -55,6 +55,13 @@ from vllm.models.deepseek_v4.common.ops import (
     fused_mtp_input_rmsnorm,
     mtp_shared_head_rmsnorm,
 )
+from vllm.models.deepseek_v4.expert_map import (
+    get_num_expert_map_layers,
+    load_static_expert_map,
+    remap_expert_params_mapping,
+    remap_router_expert_ids,
+    remap_router_weight,
+)
 from vllm.sequence import IntermediateTensors
 
 from .model import (
@@ -284,6 +291,23 @@ class DeepSeekV4MTP(nn.Module):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
         self.quant_config = vllm_config.quant_config
+        parallel_config = vllm_config.parallel_config
+        eplb_config = parallel_config.eplb_config
+        self.enable_eplb = parallel_config.enable_eplb
+        expert_map_path = eplb_config.expert_map_path
+        self.static_expert_map = (
+            load_static_expert_map(
+                expert_map_path,
+                num_layers=get_num_expert_map_layers(self.config),
+                num_experts=self.config.n_routed_experts,
+                num_physical_experts=(
+                    self.config.n_routed_experts + eplb_config.num_redundant_experts
+                ),
+                num_expert_groups=getattr(self.config, "n_group", 1) or 1,
+            )
+            if expert_map_path is not None
+            else None
+        )
         self.pad_shared_expert = getattr(
             self.quant_config, "weight_block_size", None
         ) is not None and not _use_sequence_parallel(vllm_config)
@@ -361,7 +385,8 @@ class DeepSeekV4MTP(nn.Module):
 
         # Pre-compute expert mapping ONCE.
         first_layer = next(iter(self.model.layers.values()))
-        if first_layer.mtp_block.ffn.use_mega_moe:
+        use_mega_moe = first_layer.mtp_block.ffn.use_mega_moe
+        if use_mega_moe:
             expert_mapping = make_deepseek_v4_expert_params_mapping(
                 self.config.n_routed_experts
             )
@@ -371,8 +396,13 @@ class DeepSeekV4MTP(nn.Module):
                 ckpt_gate_proj_name="w1",
                 ckpt_down_proj_name="w2",
                 ckpt_up_proj_name="w3",
-                num_experts=self.config.n_routed_experts,
+                num_experts=(
+                    self.static_expert_map.shape[1]
+                    if self.static_expert_map is not None
+                    else self.config.n_routed_experts
+                ),
             )
+        static_expert_mappings: dict[int, list[tuple[str, str, int, str]]] = {}
 
         # FP8 experts register ``..._weight_scale_inv`` (block_quant) while
         # FP4/MXFP4 experts register ``..._weight_scale``. Choose the suffix
@@ -396,9 +426,26 @@ class DeepSeekV4MTP(nn.Module):
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is None:
                 continue
+            global_layer_idx = spec_layer
 
             name = _remap_weight_name(name)
             name = self._rewrite_spec_layer_name(spec_layer, name)
+
+            static_layer_map = None
+            if self.static_expert_map is not None and ".ffn." in name:
+                static_layer_map = self.static_expert_map[global_layer_idx]
+                if not self.enable_eplb and name.endswith(
+                    (
+                        ".ffn.gate.weight",
+                        ".ffn.gate.bias",
+                        ".ffn.gate.e_score_correction_bias",
+                    )
+                ):
+                    loaded_weight = remap_router_weight(loaded_weight, static_layer_map)
+                elif not self.enable_eplb and name.endswith(".ffn.gate.tid2eid"):
+                    loaded_weight = remap_router_expert_ids(
+                        loaded_weight, static_layer_map
+                    )
 
             if spec_layer != self.model.mtp_start_layer_idx and ".layers" not in name:
                 continue
@@ -438,7 +485,16 @@ class DeepSeekV4MTP(nn.Module):
                         and loaded_weight.dtype == torch.float8_e8m0fnu
                     ):
                         loaded_weight = loaded_weight.view(torch.uint8)
-                    for mapping in expert_mapping:
+                    layer_expert_mapping = expert_mapping
+                    if static_layer_map is not None and not use_mega_moe:
+                        if global_layer_idx not in static_expert_mappings:
+                            static_expert_mappings[global_layer_idx] = (
+                                remap_expert_params_mapping(
+                                    expert_mapping, static_layer_map
+                                )
+                            )
+                        layer_expert_mapping = static_expert_mappings[global_layer_idx]
+                    for mapping in layer_expert_mapping:
                         param_name, weight_name, expert_id, expert_shard_id = mapping
                         if weight_name not in name:
                             continue

--- a/vllm/models/deepseek_v4/xpu/model.py
+++ b/vllm/models/deepseek_v4/xpu/model.py
@@ -609,6 +609,10 @@ class DeepseekV4MoE(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        if vllm_config.parallel_config.eplb_config.expert_map_path is not None:
+            raise NotImplementedError(
+                "Static DSV4 expert maps are currently supported only on NVIDIA."
+            )
         self.prefix = prefix
         self.use_mega_moe = (
             vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"


### PR DESCRIPTION
## Purpose

Add static expert placement for DeepSeek V4. A precomputed JSON map assigns each physical expert slot to a logical expert for every MoE layer, and the checkpoint loader places expert weights directly into those slots. The same path also remaps DSV4 router weights, correction bias, and hash-routing IDs when runtime EPLB is not needed.

This supports both one-to-one permutations and replicated logical experts. Replicated maps use the fixed EPLB runtime mapping with `num_redundant_experts`; permutation-only maps can avoid runtime EPLB entirely.

## Duplicate-work check

This does not duplicate the two related open PRs:

- #41141 records load statistics and applies a generic offline schedule by rearranging already-loaded expert weights. This PR instead consumes an externally generated per-layer DSV4 physical-slot map and places weights during checkpoint loading, avoiding an initial distributed rearrangement. It also handles DSV4-specific router/hash tensors and the MegaMoE, MTP, and DSpark loaders.
- #34811 maps logical experts to EP ranks. It does not describe per-layer physical slots, replicas, or router tensor remapping.

The implementation is intentionally DSV4-specific rather than a replacement for either generic proposal.

## Changes

- Add `expert_map_path` to `EPLBConfig` and validate supported configurations.
- Parse and validate physical-to-logical JSON maps, including per-layer group-local placement and replicas.
- Load DSV4 expert weights directly according to the static map and remap router/correction/hash tensors where applicable.
- Support the NVIDIA base, MegaMoE, MTP, and DSpark checkpoint paths; fail explicitly on unsupported AMD and XPU paths.
- Initialize fixed EPLB state from replicated maps while disabling runtime recording and rebalancing.
- Document the JSON contract and serving configurations.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/models/test_deepseek_v4_expert_map.py \
  tests/models/test_deepseek_v4_mega_moe.py \
  tests/distributed/test_eplb_utils.py \
  tests/model_executor/model_loader/test_ep_weight_filter.py -q
# 71 passed, 15 warnings

.venv/bin/python -m pytest tests/distributed/test_eplb_algo.py -q
# 16 passed, 14 warnings

pre-commit run --from-ref origin/main --to-ref HEAD
# passed
```

## Model evaluation

Evaluated `deepseek-ai/DeepSeek-V4-Pro` revision `b5968e9190ef611bbf34a7229255be88a0e937c1` on 16 NVIDIA GB200 GPUs (TP1, DP/EP16) with the `deep_gemm_mega_moe` backend. The map was converted from the [SemiAnalysis EP16/384-slot configuration](https://raw.githubusercontent.com/SemiAnalysisAI/InferenceX/d029c0f7fb82f817850c78707491852fb53370e3/benchmarks/multi_node/srt-slurm-recipes/trtllm/deepseek-v4/agentx-gb300-20260811/eplb_confs/moe_load_balancer_gen_ep16_slots384.yaml), SHA256 `43c9a1a1a60a9f40455f6a96bff643cf6ed1a1b6a0f3d90615de5e97652631df` after JSON conversion.

GSM8K v3, 8-shot, full 1,319-example test set, greedy generation, maximum 2,048 generated tokens, maximum model length 8,192:

- Strict exact match: **96.2851%** (`1270/1319`)
- Flexible exact match: **96.2092%** (`1269/1319`)
- No empty responses or request failures

AI assistance was used to implement, test, evaluate, and prepare this change. The human submitter must review every changed line and understand and defend the implementation before marking this PR ready for review.
