### PR TITLE
[Performance][Model] Fuse GLM indexer attention projections

### DIFF
--- a/tests/models/deepseek_v32/test_indexer_linear_fusion.py
+++ b/tests/models/deepseek_v32/test_indexer_linear_fusion.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm.model_executor.models.deepseek_v2 as deepseek_v2
+import vllm.model_executor.parameter as parameter
+import vllm.models.deepseek_v32.attention as attention
+from vllm.model_executor.models.deepseek_v2 import DeepSeekV2FusedQkvAProjLinear
+
+
+def _mock_tp(monkeypatch, rank: int, size: int) -> None:
+    monkeypatch.setattr(attention, "get_tensor_model_parallel_rank", lambda: rank)
+    monkeypatch.setattr(attention, "get_tensor_model_parallel_world_size", lambda: size)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(parameter, "get_tensor_model_parallel_world_size", lambda: 1)
+
+
+def test_fused_q_indexer_projection_loads_mixed_tp_weights(monkeypatch) -> None:
+    _mock_tp(monkeypatch, rank=2, size=4)
+    layer = attention.DeepseekV32FusedQIndexerProjLinear(
+        input_size=8,
+        q_output_size=12,
+        indexer_output_size=4,
+        prefix="self_attn.q_b_proj",
+    )
+    params = {"self_attn.q_b_proj.weight": layer.weight}
+    q_weight = torch.arange(96, dtype=torch.float32).view(12, 8)
+    indexer_weight = torch.arange(32, dtype=torch.float32).view(4, 8) + 1000
+
+    attention.try_load_fused_indexer_projection(
+        "self_attn.q_b_proj.weight", q_weight, params
+    )
+    attention.try_load_fused_indexer_projection(
+        "self_attn.indexer.wq_b.weight", indexer_weight, params
+    )
+
+    expected_weight = torch.cat((q_weight[6:9], indexer_weight))
+    torch.testing.assert_close(layer.weight, expected_weight)
+    inputs = torch.randn(2, 8)
+    torch.testing.assert_close(layer(inputs)[0], inputs @ expected_weight.T)
+
+
+def test_fused_qkv_a_projection_loads_indexer_weights(monkeypatch) -> None:
+    _mock_tp(monkeypatch, rank=0, size=1)
+    layer = DeepSeekV2FusedQkvAProjLinear(8, [4, 3, 2, 1])
+    params = {"self_attn.fused_qkv_a_proj.weight": layer.weight}
+    q_weight = torch.randn(4, 8)
+    kv_weight = torch.randn(3, 8)
+    wk_weight = torch.randn(2, 8)
+    score_weight = torch.randn(1, 8)
+
+    layer.weight.weight_loader(layer.weight, q_weight, 0)
+    layer.weight.weight_loader(layer.weight, kv_weight, 1)
+
+    attention.try_load_fused_indexer_projection(
+        "self_attn.indexer.wk.weight", wk_weight, params
+    )
+    attention.try_load_fused_indexer_projection(
+        "self_attn.indexer.weights_proj.weight", score_weight, params
+    )
+
+    expected_weight = torch.cat((q_weight, kv_weight, wk_weight, score_weight))
+    torch.testing.assert_close(layer.weight, expected_weight)
+    inputs = torch.randn(2, 8)
+    torch.testing.assert_close(layer(inputs)[0], inputs @ expected_weight.T)
+
+
+def test_fp8_indexer_wk_loader_targets_fused_qkv_a(monkeypatch) -> None:
+    _mock_tp(monkeypatch, rank=0, size=1)
+    layer = DeepSeekV2FusedQkvAProjLinear(8, [4, 3, 2, 1])
+    target_name = "self_attn.fused_qkv_a_proj.weight"
+    params = {target_name: layer.weight}
+    loaded_params: set[str] = set()
+    pending: dict = {}
+    weight = torch.randn(2, 8).to(torch.float8_e4m3fn)
+    scale = torch.ones(2)
+    monkeypatch.setattr(
+        deepseek_v2,
+        "scaled_dequantize",
+        lambda weight, *args, **kwargs: weight.to(torch.bfloat16),
+    )
+
+    for name, tensor in (
+        ("self_attn.indexer.wk.weight", weight),
+        ("self_attn.indexer.wk.weight_scale_inv", scale),
+    ):
+        assert deepseek_v2._try_load_fp8_indexer_wk(
+            name, tensor, pending, params, loaded_params, set()
+        )
+
+    torch.testing.assert_close(layer.weight[7:9], weight.float())
+    assert loaded_params == {target_name}

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -844,8 +844,8 @@ def _try_load_fp8_indexer_wk(
     We fuse the WK and weights_proj projections, but in some checkpoints WK is stored
     in FP8 with a separate weight_scale_inv, while weights_proj is stored in BF16.
     Upcasting to BF16 during loading enables the fusion. This function loads the FP8 WK
-    weights and scale, and when both are available, dequantizes to BF16 and stores into
-    the fused wk_weights_proj.weight parameter.
+    weights and scale, and when both are available, dequantizes to BF16 and stores it in
+    the projection containing the indexer WK weight.
     """
     if "indexer.wk." not in name or "wk_weights" in name:
         return False  # Weight is not an isolated WK weight for the indexer, ignore.
@@ -855,7 +855,6 @@ def _try_load_fp8_indexer_wk(
         return False  # WK is not in FP8 format, ignore.
     # Buffer this tensor (weight or scale) until both have arrived.
     layer_prefix = name.rsplit(".wk.", 1)[0]  # e.g. "model.layers.0.self_attn.indexer"
-    fused_name = f"{layer_prefix}.wk_weights_proj.weight"
     if any(
         name.startswith(missing_layer_name)
         for missing_layer_name in pp_missing_layer_names
@@ -882,9 +881,15 @@ def _try_load_fp8_indexer_wk(
         out_dtype=torch.bfloat16,
     )
 
-    # Load the dequantized weight into shard 0 of the fused buffer.
+    fused_name = f"{layer_prefix}.wk_weights_proj.weight"
+    shard_id = 0
+    if fused_name not in params_dict:
+        attention_prefix = layer_prefix.rsplit(".indexer", 1)[0]
+        fused_name = f"{attention_prefix}.fused_qkv_a_proj.weight"
+        shard_id = 2
+
     param = params_dict[fused_name]
-    param.weight_loader(param, weight_bf16, 0)
+    param.weight_loader(param, weight_bf16, shard_id)
     loaded_params.add(fused_name)
     return True
 

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -8,7 +8,10 @@ from transformers import DeepseekV2Config, DeepseekV3Config
 
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, VllmConfig
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
@@ -20,9 +23,11 @@ from vllm.model_executor.layers.attention.pcp import (
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
+    LinearBase,
     MergedColumnParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
@@ -39,6 +44,7 @@ from vllm.model_executor.models.deepseek_v2 import (
     yarn_get_mscale,
 )
 from vllm.model_executor.models.utils import extract_layer_index
+from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.models.deepseek_v32.common.kernels import fused_norm_rope, fused_q
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_quantized_kv_cache
@@ -47,8 +53,113 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
 
 
+class DeepseekV32FusedQIndexerProjLinear(MergedColumnParallelLinear):
+    """Fuse TP-sharded MLA Q with replicated indexer Q in one local GEMM."""
+
+    def __init__(
+        self,
+        input_size: int,
+        q_output_size: int,
+        indexer_output_size: int,
+        prefix: str,
+    ) -> None:
+        self.q_tp_rank = get_tensor_model_parallel_rank()
+        self.q_tp_size = get_tensor_model_parallel_world_size()
+        assert q_output_size % self.q_tp_size == 0
+        self.q_output_size = q_output_size
+        self.q_output_size_per_partition = q_output_size // self.q_tp_size
+        super().__init__(
+            input_size,
+            [self.q_output_size_per_partition, indexer_output_size],
+            bias=False,
+            quant_config=None,
+            disable_tp=True,
+            prefix=prefix,
+        )
+
+    def _slice_q_weight(
+        self,
+        param: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None,
+    ) -> torch.Tensor:
+        output_dim = getattr(param, "output_dim", None)
+        if loaded_shard_id == 0 and output_dim is not None:
+            loaded_size = loaded_weight.shape[output_dim]
+            if loaded_size == self.q_output_size:
+                loaded_weight = loaded_weight.narrow(
+                    output_dim,
+                    self.q_tp_rank * self.q_output_size_per_partition,
+                    self.q_output_size_per_partition,
+                )
+            else:
+                assert loaded_size == self.q_output_size_per_partition
+        return loaded_weight
+
+    def weight_loader(
+        self,
+        param: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        loaded_weight = self._slice_q_weight(param, loaded_weight, loaded_shard_id)
+        super().weight_loader(param, loaded_weight, loaded_shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: BasevLLMParameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        loaded_weight = self._slice_q_weight(param, loaded_weight, loaded_shard_id)
+        super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
+
+
+def _uses_unquantized_method(layer: LinearBase) -> bool:
+    return type(layer.quant_method) is UnquantizedLinearMethod
+
+
+def try_load_fused_indexer_projection(
+    name: str,
+    loaded_weight: torch.Tensor,
+    params_dict: dict[str, torch.nn.Parameter],
+) -> str | None:
+    if name.endswith(".q_b_proj.weight"):
+        target_name = name
+        shard_id = 0
+    elif ".indexer.wq_b." in name:
+        target_name = name.replace(".indexer.wq_b.", ".q_b_proj.")
+        shard_id = 1
+    elif ".indexer.wk." in name:
+        target_name = name.replace(".indexer.wk.", ".fused_qkv_a_proj.")
+        shard_id = 2
+    elif ".indexer.weights_proj." in name:
+        target_name = name.replace(".indexer.weights_proj.", ".fused_qkv_a_proj.")
+        shard_id = 3
+    else:
+        return None
+
+    param = params_dict.get(target_name)
+    if param is None:
+        return None
+    layer = getattr(param.weight_loader, "__self__", None)  # type: ignore[attr-defined]
+    if shard_id < 2:
+        if not isinstance(layer, DeepseekV32FusedQIndexerProjLinear):
+            return None
+    elif not (
+        isinstance(layer, DeepSeekV2FusedQkvAProjLinear)
+        and len(layer.output_sizes) == 4
+    ):
+        return None
+
+    param.weight_loader(param, loaded_weight, shard_id)  # type: ignore[attr-defined]
+    return target_name
+
+
 class DeepseekV32Indexer(nn.Module):
     indexer_cache_cls = DeepseekV32IndexerCache
+    wq_b: ReplicatedLinear | None
+    wk_weights_proj: MergedColumnParallelLinear | None
 
     def __init__(
         self,
@@ -124,6 +235,8 @@ class DeepseekV32Indexer(nn.Module):
         positions: torch.Tensor,
         rotary_emb: nn.Module,
     ) -> torch.Tensor:
+        assert self.wq_b is not None
+        assert self.wk_weights_proj is not None
         q, _ = self.wq_b(qr)
         q = q.view(-1, self.n_head, self.head_dim)
 
@@ -303,6 +416,56 @@ class DeepseekV32Attention(MLAAttention):
             quant_config=quant_config,
             prefix=f"{prefix}.q_b_proj",
         )
+
+        can_fuse_indexer_projections = (
+            indexer is not None
+            and config.model_type == "glm_moe_dsa"
+            and not is_mtp_layer
+            and vllm_config.lora_config is None
+            and current_platform.is_cuda()
+            and not current_platform.is_device_capability((10, 3))
+        )
+        self._fuse_qkv_a_indexer = False
+        self._fuse_q_b_indexer = False
+        if can_fuse_indexer_projections:
+            assert indexer is not None
+            wk_weights_proj = indexer.wk_weights_proj
+            if (
+                wk_weights_proj is not None
+                and _uses_unquantized_method(self.fused_qkv_a_proj)
+                and _uses_unquantized_method(wk_weights_proj)
+                and self.fused_qkv_a_proj.params_dtype == wk_weights_proj.params_dtype
+            ):
+                self._fuse_qkv_a_indexer = True
+                self.fused_qkv_a_proj = DeepSeekV2FusedQkvAProjLinear(
+                    hidden_size,
+                    [
+                        q_lora_rank,
+                        kv_lora_rank + qk_rope_head_dim,
+                        indexer.head_dim,
+                        indexer.n_head,
+                    ],
+                    quant_config=None,
+                    prefix=f"{prefix}.fused_qkv_a_proj",
+                )
+                indexer.wk_weights_proj = None
+
+            wq_b = indexer.wq_b
+            if (
+                wq_b is not None
+                and _uses_unquantized_method(self.q_b_proj)
+                and _uses_unquantized_method(wq_b)
+                and self.q_b_proj.params_dtype == wq_b.params_dtype
+            ):
+                self._fuse_q_b_indexer = True
+                self.q_b_proj = DeepseekV32FusedQIndexerProjLinear(
+                    q_lora_rank,
+                    num_heads * qk_head_dim,
+                    indexer.n_head * indexer.head_dim,
+                    prefix=f"{prefix}.q_b_proj",
+                )
+                indexer.wq_b = None
+
         self.kv_a_layernorm = RMSNorm(kv_lora_rank, eps=config.rms_norm_eps)
 
         self.o_proj = RowParallelLinear(
@@ -335,14 +498,29 @@ class DeepseekV32Attention(MLAAttention):
     ) -> torch.Tensor:
         # Captured: A-projections (+ indexer A-GEMM on indexer layers).
         qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
-        q_c, kv_c, k_pe = qkv_lora.split(
-            [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
-        )
+        if self._fuse_qkv_a_indexer:
+            assert self.indexer is not None
+            q_c, kv_c, k_pe, index_k, index_weights = qkv_lora.split(
+                [
+                    self.q_lora_rank,
+                    self.kv_lora_rank,
+                    self.qk_rope_head_dim,
+                    self.indexer.head_dim,
+                    self.indexer.n_head,
+                ],
+                dim=-1,
+            )
+        else:
+            q_c, kv_c, k_pe = qkv_lora.split(
+                [self.q_lora_rank, self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
 
         if self.indexer is not None and not self.skip_topk:
-            kw = self.indexer.wk_weights_proj(hidden_states)[0]
-            index_k = kw[:, : self.indexer.head_dim]
-            index_weights = kw[:, self.indexer.head_dim :]
+            if not self._fuse_qkv_a_indexer:
+                assert self.indexer.wk_weights_proj is not None
+                kw = self.indexer.wk_weights_proj(hidden_states)[0]
+                index_k = kw[:, : self.indexer.head_dim]
+                index_weights = kw[:, self.indexer.head_dim :]
         else:
             index_k = None
             index_weights = None
@@ -427,15 +605,29 @@ class DeepseekV32Attention(MLAAttention):
             index_k_out=index_k_out,
         )
 
-        q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
-        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        ql_nope = torch.bmm(q_nope.transpose(0, 1), self.W_UK_T).transpose(0, 1)
-
-        if self.indexer is not None and not self.skip_topk:
-            index_q = self.indexer.wq_b(q_c)[0]
+        q_proj = self.q_b_proj(q_c)[0]
+        if self._fuse_q_b_indexer:
+            assert self.indexer is not None
+            q, index_q = q_proj.split(
+                [
+                    self.num_local_heads * self.qk_head_dim,
+                    self.indexer.n_head * self.indexer.head_dim,
+                ],
+                dim=-1,
+            )
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
-            index_q = None
+            q = q_proj
+            if self.indexer is not None and not self.skip_topk:
+                assert self.indexer.wq_b is not None
+                index_q = self.indexer.wq_b(q_c)[0]
+                index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
+            else:
+                index_q = None
+
+        q = q.view(-1, self.num_local_heads, self.qk_head_dim)
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        ql_nope = torch.bmm(q_nope.transpose(0, 1), self.W_UK_T).transpose(0, 1)
 
         index_q_fp8, index_weights_out, mqa_q = fused_q(
             positions,

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -44,7 +44,10 @@ from vllm.models.common.ops.sequence_parallel import (
     sp_reduce_scatter,
     sp_shard,
 )
-from vllm.models.deepseek_v32.attention import DeepseekV32Attention
+from vllm.models.deepseek_v32.attention import (
+    DeepseekV32Attention,
+    try_load_fused_indexer_projection,
+)
 from vllm.sequence import IntermediateTensors
 
 from .glm52_low_latency_gemm import enable_glm52_low_latency_gemm
@@ -349,6 +352,12 @@ class DeepseekV32Model(torch.nn.Module):
                 loaded_params,
                 pp_missing_layer_names,
             ):
+                continue
+            fused_name = try_load_fused_indexer_projection(
+                name, loaded_weight, params_dict
+            )
+            if fused_name is not None:
+                loaded_params.add(fused_name)
                 continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:


### PR DESCRIPTION
## Summary

Fuse two pairs of GLM-5.2 sparse-indexer projections when they consume the same activation and use compatible unquantized BF16 linear methods:

- pack indexer `wk` and `weights_proj` into the attention `fused_qkv_a_proj`
- pack indexer `wq_b` into the attention `q_b_proj`

The fusion is limited to CUDA GLM indexer layers without LoRA or MTP. The checkpoint loader continues to accept the original parameter names and handles the existing FP8-indexer-`wk` checkpoint layout by dequantizing it into the appropriate fused shard.

## Why

The indexer projections currently launch separate GEMMs beside attention projections that consume the same tensors. Packing compatible weights removes two GEMM launches per indexer layer while retaining the existing tensor-parallel layout and checkpoint format.

## Impact

This reduces decode TPOT for GLM-5.2 NVFP4 at TP4. The fusion is enabled only when both participating linears use the same unquantized method and parameter dtype; other quantization configurations keep the existing path.

Focused tests cover:

- loading a TP-sharded attention Q weight together with replicated indexer Q
- loading indexer K and score weights into the fused QKV-A projection
- routing an FP8 indexer K checkpoint through dequantization into the fused parameter
- numerical projection output from the packed weights

## Performance

Measured on Slurm node `gb200-rack1-03` with GLM-5.2 NVFP4, TP4, dummy weights, FlashInfer autotune disabled, max concurrency 1, 128 input tokens, 128 output tokens, 2 warmup requests, and 20 measured requests.

| | Baseline | Fused | Change |
|---|---:|---:|---:|
| Mean TPOT | 7.1569 ms | 7.0201 ms | -1.91% |
| Decode TPS (`1000 / mean TPOT`) | 139.73 | 142.45 | +1.95% |
| Completed / failed | 20 / 0 | 20 / 0 | — |

Decode used the full CUDA graph at batch size 1. Although piecewise CUDA graphs were enabled, the 128-token prefill exceeded the captured sizes `[1, 2]`, so TTFT did not use a piecewise CUDA graph. TTFT is excluded from the decode-TPS numbers above.

The benchmark compared baseline `425d3934f4` with fused `ad7efb59f2`; the fusion diff is carried here as `0e23c8eb0f` after splitting it from the unrelated dead-code change.

## Duplicate-work check

Searched open PRs for `GLM indexer`, `indexer linear fusion`, `GLM indexer projection fusion`, and `wk_weights_proj`. PR #39943 overlaps indexer and attention GEMMs using a side stream but does not pack these same-input projections into single GEMMs. Other open indexer PRs target kernels, ROCm paths, sparse-index remapping, or logits precision.

PR #53021 removes the unused `DeepseekV32Indexer.forward()`; that already-open change was deliberately excluded from this PR.

## Validation

- `.venv/bin/python -m pytest tests/models/deepseek_v32/test_indexer_linear_fusion.py -v` — 3 passed
- `.venv/bin/pre-commit run --files tests/models/deepseek_v32/test_indexer_linear_fusion.py vllm/model_executor/models/deepseek_v2.py vllm/models/deepseek_v32/attention.py vllm/models/deepseek_v32/nvidia/model.py` — all applicable hooks passed, including Ruff, mypy, typos, and repository policy checks
- `git diff --check origin/main...HEAD` — passed
- GLM-5.2 NVFP4 TP4 dummy-weight serving benchmark described above — 20/20 requests completed for both revisions

No accuracy evaluation was run because the requested benchmark used dummy weights. Numerical equivalence of the fused projections is covered by the focused tests.

## AI assistance

AI assistance was used to trace the executed projection paths, implement the fusion and loader routing, add focused tests, run validation and benchmarking, and draft this PR. The human submitter must review and understand every changed line and the benchmark methodology before marking the PR ready for review.