### PR TITLE
[Bugfix] CacheInfo.hit_ratio to return float when total is 0

### DIFF
--- a/tests/utils_/test_cache.py
+++ b/tests/utils_/test_cache.py
@@ -127,6 +127,21 @@ def test_lru_cache():
     assert 6 in cache
 
 
+def test_cache_info_hit_ratio():
+    # No queries yet: ratio should be a float 0.0, not int 0, to match the
+    # `-> float` return type of the property.
+    empty_info = CacheInfo(hits=0, total=0)
+    assert empty_info.hit_ratio == 0.0
+    assert isinstance(empty_info.hit_ratio, float)
+
+    # Regular case: ratio is computed as hits / total.
+    partial_info = CacheInfo(hits=1, total=4)
+    assert partial_info.hit_ratio == 0.25
+
+    full_info = CacheInfo(hits=3, total=3)
+    assert full_info.hit_ratio == 1.0
+
+
 def test_lru_cache_put_if_fits():
     cache = LRUCache(10, getsizeof=lambda x: x)
 

--- a/vllm/utils/cache.py
+++ b/vllm/utils/cache.py
@@ -37,7 +37,7 @@ class CacheInfo(NamedTuple):
     @property
     def hit_ratio(self) -> float:
         if self.total == 0:
-            return 0
+            return 0.0
 
         return self.hits / self.total
 


### PR DESCRIPTION
CacheInfo.hit_ratio is annotated as -> float, but the total == 0 branch returned the int 0 instead of 0.0. Add coverage for the property, which previously had no dedicated tests.

## Purpose
CacheInfo.hit_ratio (in vllm/utils/cache.py) is annotated as returning float, but the total == 0 branch returned the bare int 0 instead of 0.0. This is a small type-correctness bug: the property's contract says float, and callers relying on the annotation (e.g. for further arithmetic or serialization) could get an int instead. Separately, hit_ratio had no dedicated test coverage at all — not even the normal hits / total path was tested, only indirectly via CacheInfo equality checks in test_lru_cache.

This PR:

Changes the total == 0 branch to return 0.0 so the return value always matches the declared -> float type.
Adds test_cache_info_hit_ratio in tests/utils_/test_cache.py, covering the zero-total case (asserting both the value and that it's a float), a partial hit ratio, and a full hit ratio.

No behavior change for any existing caller (0 == 0.0 in Python), so this is a low-risk, test-covered cleanup.

## Test Plan
Ran the utils cache unit tests directly:

``` python -m pytest tests/utils_/test_cache.py -v```

Also checked lint/format on the changed files:

```
ruff check vllm/utils/cache.py tests/utils_/test_cache.py
ruff format --check vllm/utils/cache.py tests/utils_/test_cache.py
```
## Test Result
```
tests/utils_/test_cache.py::test_lru_cache PASSED
tests/utils_/test_cache.py::test_cache_info_hit_ratio PASSED
```

<img width="1051" height="328" alt="Screenshot 2026-08-20 at 09 19 55" src="https://github.com/user-attachments/assets/f4f86deb-2bee-4ecb-b97a-b58171bb21dc" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

## AI assistance
This PR was drafted with AI assistance (Claude). I reviewed all the changed lines and ran the tests myself before submitting.

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
