### PR TITLE
[Attention][Spec Decode] Enable varlen Mamba2 decode for adaptive verification

### DIFF
--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -392,3 +392,81 @@ def test_causal_conv1d_varlen(
     )
     unpadded_out = out[:, : out_ref_tensor.shape[-1]]
     assert torch.allclose(unpadded_out, out_ref_tensor, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("itype", [torch.bfloat16])
+@pytest.mark.parametrize("silu_activation", [True])
+@pytest.mark.parametrize("has_bias", [True])
+@pytest.mark.parametrize("width", [4])
+@pytest.mark.parametrize("dim", [64, 2048])
+@pytest.mark.parametrize("q_lens_cfg", [[3, 1, 0, 4, 2], [1, 5, 5, 1], [2, 0, 0, 3]])
+def test_causal_conv1d_update_ragged_varlen(
+    q_lens_cfg, dim, width, has_bias, silu_activation, itype
+):
+    device = DEVICE
+    rtol, atol = 1e-2, 5e-2
+    set_random_seed(0)
+
+    batch_size = len(q_lens_cfg)
+    max_query_len = 5
+    assert max(q_lens_cfg) <= max_query_len
+    state_len = width - 1 + max_query_len
+    total_entries = 10 * batch_size
+
+    q_lens = torch.tensor(q_lens_cfg, dtype=torch.int32, device=device)
+    query_start_loc = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=device),
+            torch.cumsum(q_lens, dim=0, dtype=torch.int32),
+        ]
+    )
+    total_tokens = int(q_lens.sum())
+
+    x = torch.randn(total_tokens, dim, device=device, dtype=itype)
+    conv_state = torch.randn(
+        total_entries, state_len, dim, device=device, dtype=itype
+    ).transpose(1, 2)
+    weight = torch.randn(dim, width, device=device, dtype=itype)
+    bias = torch.randn(dim, device=device, dtype=itype) if has_bias else None
+    activation = None if not silu_activation else "silu"
+
+    conv_state_indices = (
+        torch.randperm(total_entries - 1, device=device)[:batch_size] + 1
+    ).to(torch.int32)
+    num_accepted_tokens = torch.randint(
+        1, max_query_len + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    conv_state_ref = conv_state.detach().clone()
+
+    out = causal_conv1d_update(
+        x.clone(),
+        conv_state,
+        weight,
+        bias,
+        activation=activation,
+        conv_state_indices=conv_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        query_start_loc=query_start_loc,
+        max_query_len=max_query_len,
+    )
+
+    for seq_idx in range(batch_size):
+        start = int(query_start_loc[seq_idx])
+        end = int(query_start_loc[seq_idx + 1])
+        entry = conv_state_indices[seq_idx : seq_idx + 1]
+        if start == end:
+            assert torch.equal(conv_state[entry], conv_state_ref[entry])
+            continue
+        out_ref = causal_conv1d_update(
+            x[start:end].clone(),
+            conv_state_ref,
+            weight,
+            bias,
+            activation=activation,
+            conv_state_indices=entry,
+            num_accepted_tokens=num_accepted_tokens[seq_idx : seq_idx + 1],
+            query_start_loc=query_start_loc.new_tensor([0, end - start]),
+            max_query_len=max_query_len,
+        )
+        assert torch.equal(conv_state[entry], conv_state_ref[entry])
+        assert torch.allclose(out[start:end], out_ref, rtol=rtol, atol=atol)

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import torch
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_current_vllm_config_or_none
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -100,6 +100,14 @@ class Mamba2AttentionBackend(AttentionBackend):
     @classmethod
     def is_ssm(cls) -> bool:
         return True
+
+    @classmethod
+    def supports_device_cpu_query_lens_mismatch(cls) -> bool:
+        # Decode kernels take device offsets; ReplaySSM plans off CPU counts.
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return True
+        return not vllm_config.cache_config.use_replayssm
 
 
 @dataclass

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -21,7 +21,7 @@ from vllm.v1.attention.backends.utils import (
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
 )
-from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.kv_cache_interface import KVCacheSpec, MambaSpec
 
 M = TypeVar("M", bound="BaseMambaAttentionMetadata")
 
@@ -200,6 +200,31 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
         if self.use_spec_decode:
             self.supports_update_block_table = False
+        self.use_varlen_decode_graphs = (
+            self.speculative_config is not None
+            and self.speculative_config.enable_adaptive_verification
+        )
+        if self.use_varlen_decode_graphs and self.use_replayssm:
+            raise ValueError(
+                "Adaptive verification requires device-side decode query "
+                "lengths, but ReplaySSM derives its decode write positions "
+                "from CPU token counts."
+            )
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: KVCacheSpec,
+    ) -> AttentionCGSupport:
+        speculative_config = vllm_config.speculative_config
+        if (
+            speculative_config is not None
+            and speculative_config.enable_adaptive_verification
+        ):
+            # Full graphs stay decode-only: the mode is FULL_AND_PIECEWISE.
+            return AttentionCGSupport.ALWAYS
+        return cls._cudagraph_support
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata
@@ -218,7 +243,9 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             "Make sure all cudagraph capture sizes <= max_num_seq."
         )
 
-        assert m.max_query_len == 1 + self.num_spec_tokens  # decode-only
+        assert self.use_varlen_decode_graphs or (
+            m.max_query_len == 1 + self.num_spec_tokens
+        )  # decode-only
 
         num_accepted_tokens = None
         if self.num_spec_tokens > 0:


### PR DESCRIPTION
## Purpose

- Resolves #51868: adaptive verification needs Mamba decode batches with per-request query lengths
- Audit: the Mamba2 decode kernels already handle ragged batches from device offsets, so this is wiring only
- Flip `supports_device_cpu_query_lens_mismatch` on Mamba2; ReplaySSM still opts out
- Report `AttentionCGSupport.ALWAYS` and accept ragged capture when adaptive verification is on
- Guard: ReplaySSM + adaptive verification fails fast at init
- Not a duplicate: no open PR touches Mamba varlen decode

## Test Plan

- `pytest tests/kernels/mamba/test_causal_conv1d.py` with new ragged-varlen test + uniform regression (L4)
- SSU ragged coverage already exists upstream
- Kernel perf: ragged/trimmed vs uniform-padded at Nemotron-H shapes (B200)

## Test Result

- 146 passed, 0 failed

| batch | max_q | case | tokens | conv_us | ssu_us | total_us | vs uniform |
|---|---|---|---|---|---|---|---|
| 8 | 8 | uniform | 64 | 37.8 | 90.1 | 127.9 | 1.00 |
| 8 | 8 | ragged q~U[1,8] | 42 | 36.2 | 89.5 | 125.7 | 0.98 |
| 8 | 8 | trimmed to 1 | 8 | 35.2 | 83.0 | 118.2 | 0.92 |
| 32 | 4 | uniform | 128 | 36.0 | 186.4 | 222.4 | 1.00 |
| 32 | 4 | ragged q~U[1,4] | 83 | 35.9 | 141.2 | 177.1 | 0.80 |
| 32 | 4 | trimmed to 1 | 32 | 36.0 | 90.3 | 126.4 | 0.57 |
| 32 | 8 | uniform | 256 | 35.2 | 334.9 | 370.0 | 1.00 |
| 32 | 8 | ragged q~U[1,8] | 151 | 35.1 | 227.7 | 262.7 | 0.71 |
| 32 | 8 | trimmed to 1 | 32 | 36.5 | 89.4 | 125.9 | 0.34 |
| 128 | 8 | uniform | 1024 | 33.8 | 1296.8 | 1330.5 | 1.00 |
| 128 | 8 | ragged q~U[1,8] | 596 | 33.9 | 866.1 | 900.0 | 0.68 |
| 128 | 8 | trimmed to 1 | 128 | 36.1 | 286.9 | 323.0 | 0.24 |

- No fixed varlen overhead (unlike #52157): trimmed batches cut SSU time token-linearly
- Adaptive E2E blocked on a public drafter with a confidence head (same as #52157)

AI assistance (Claude Code) was used; every changed line was reviewed by the submitter.

---
