### PR TITLE
[Bugfix][Kernel] Fix int32 overflow in LoRA Triton kernel pointer arithmetic

### DIFF
--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -646,3 +646,84 @@ def test_add_lora_fused_moe_early_exit(device):
     assert torch.equal(y, y_snapshot), (
         "add_lora_fused_moe modified output tensor despite no_lora_flag_cpu=True"
     )
+
+
+@pytest.mark.parametrize("op_type", ["shrink", "expand"])
+@pytest.mark.parametrize("device", DEVICES)
+def test_kernels_large_token_count(op_type: str, device: str):
+    """
+    Guards against int32 overflow in the LoRA kernels' pointer arithmetic:
+    once a token index times the row stride reaches 2**31 elements, the
+    offset used to wrap, causing illegal memory accesses in lora_expand and
+    silently wrong results in lora_shrink.
+    See https://github.com/vllm-project/vllm/issues/53028.
+    """
+    if current_platform.get_device_total_memory() < 12 * 1024**3:
+        pytest.skip("needs ~12 GiB of device memory")
+
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+    set_random_seed(0)
+
+    # Smallest shapes past the overflow boundary:
+    # (num_tokens - 1) * hidden_size * nslices >= 2**31.
+    num_tokens = 174764
+    hidden_size = 6144
+    nslices = 2
+    rank = 16
+    dtype = torch.bfloat16
+
+    token_lora_mapping = torch.zeros(num_tokens, dtype=torch.int32, device=device)
+    lora_meta = LoRAKernelMeta.make(
+        max_loras=1, max_num_tokens=num_tokens, device=device
+    )
+    lora_meta.prepare_tensors(token_lora_mapping)
+    meta_args = lora_meta.meta_args(token_nums=num_tokens, specialize_active_lora=False)
+
+    # Verifying every row would need another multi-GiB reference tensor, so
+    # check a sample of rows including the last one (the largest offsets).
+    check_rows = torch.tensor(
+        [0, num_tokens // 2, num_tokens - 1], dtype=torch.long, device=device
+    )
+
+    if op_type == "expand":
+        inputs = torch.rand((nslices, num_tokens, rank), dtype=dtype) / rank
+        lora_weights = [
+            torch.rand((1, hidden_size, rank), dtype=dtype) / rank
+            for _ in range(nslices)
+        ]
+        out = torch.zeros((num_tokens, hidden_size * nslices), dtype=dtype)
+        with _dict_lock:
+            _LORA_B_PTR_DICT.clear()
+            triton_ops.lora_expand(
+                inputs,
+                lora_weights,
+                out,
+                *meta_args,
+                offset_start=0,
+                add_inputs=False,
+            )
+        ref = torch.cat(
+            [inputs[s, check_rows] @ lora_weights[s][0].T for s in range(nslices)],
+            dim=1,
+        )
+        assert_close(out[check_rows], ref)
+    else:
+        inputs = (
+            torch.rand((num_tokens, hidden_size * nslices), dtype=dtype) / hidden_size
+        )
+        lora_weights = [
+            torch.rand((1, rank, hidden_size * nslices), dtype=dtype)
+            for _ in range(nslices)
+        ]
+        out = torch.zeros((nslices, num_tokens, rank), dtype=torch.float32)
+        with _dict_lock:
+            _LORA_A_PTR_DICT.clear()
+            triton_ops.lora_shrink(inputs, lora_weights, out, *meta_args, scaling=1.0)
+        ref = torch.stack(
+            [
+                inputs[check_rows].float() @ lora_weights[s][0].float().T
+                for s in range(nslices)
+            ]
+        )
+        assert_close(out[:, check_rows], ref)

--- a/vllm/lora/ops/triton_ops/lora_expand_fp8_op.py
+++ b/vllm/lora/ops/triton_ops/lora_expand_fp8_op.py
@@ -101,10 +101,12 @@ def _lora_expand_kernel_fp8(
     pid_m = pid_mn % cta_m_num
     pid_n = (pid_mn // cta_m_num) % cta_n_num
 
-    slice_id = tl.program_id(axis=1)
+    # slice_id, lora_id and ram index into pointer arithmetic; keep them int64
+    # so products with strides cannot overflow int32 for large token counts.
+    slice_id = tl.program_id(axis=1).to(tl.int64)
     lora_idx = tl.program_id(axis=2)
 
-    lora_id = tl.load(lora_ids + lora_idx)
+    lora_id = tl.load(lora_ids + lora_idx).to(tl.int64)
     if lora_id == -1:
         return
 
@@ -126,7 +128,7 @@ def _lora_expand_kernel_fp8(
     )
 
     offset_m = tl.arange(0, BLOCK_M) % cta_m_len
-    ram = tl.load(cta_lora_seq_indices + offset_m)
+    ram = tl.load(cta_lora_seq_indices + offset_m).to(tl.int64)
 
     do_expand_kernel_fp8(
         pid_n,

--- a/vllm/lora/ops/triton_ops/lora_expand_op.py
+++ b/vllm/lora/ops/triton_ops/lora_expand_op.py
@@ -60,10 +60,12 @@ def _lora_expand_kernel(
     pid_m = pid_mn % cta_m_num
     pid_n = (pid_mn // cta_m_num) % cta_n_num
 
-    slice_id = tl.program_id(axis=1)
+    # slice_id, lora_id and ram index into pointer arithmetic; keep them int64
+    # so products with strides cannot overflow int32 for large token counts.
+    slice_id = tl.program_id(axis=1).to(tl.int64)
     lora_idx = tl.program_id(axis=2)
 
-    lora_id = tl.load(lora_ids + lora_idx)
+    lora_id = tl.load(lora_ids + lora_idx).to(tl.int64)
     if lora_id == -1:
         # Early exit for the no-lora case.
         return
@@ -94,7 +96,7 @@ def _lora_expand_kernel(
 
     # Load all relevant row indices.
     offset_m = tl.arange(0, BLOCK_M) % cta_m_len
-    ram = tl.load(cta_lora_seq_indices + offset_m)
+    ram = tl.load(cta_lora_seq_indices + offset_m).to(tl.int64)
 
     do_expand_kernel(
         pid_n,

--- a/vllm/lora/ops/triton_ops/lora_shrink_fp8_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_fp8_op.py
@@ -143,10 +143,12 @@ def _lora_shrink_kernel_fp8(
     pid_m = first_pid_m + ((pid_m_n % num_pid_in_group) % group_size_m)
     pid_n = (pid_m_n % num_pid_in_group) // group_size_m
 
-    slice_id = tl.program_id(axis=1)
+    # slice_id, lora_id and ram index into pointer arithmetic; keep them int64
+    # so products with strides cannot overflow int32 for large token counts.
+    slice_id = tl.program_id(axis=1).to(tl.int64)
     lora_idx = tl.program_id(axis=2)
 
-    lora_id = tl.load(lora_ids + lora_idx)
+    lora_id = tl.load(lora_ids + lora_idx).to(tl.int64)
     if lora_id == -1:
         # Early exit for the no-lora case.
         return
@@ -169,7 +171,7 @@ def _lora_shrink_kernel_fp8(
 
     # Load all relevant row indices.
     offset_m = tl.arange(0, BLOCK_M) % cta_m_len
-    ram = tl.load(cta_lora_seq_indices + offset_m)
+    ram = tl.load(cta_lora_seq_indices + offset_m).to(tl.int64)
 
     do_shrink_kernel_fp8(
         pid_n,

--- a/vllm/lora/ops/triton_ops/lora_shrink_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_op.py
@@ -67,10 +67,12 @@ def _lora_shrink_kernel(
     pid_m = first_pid_m + ((pid_m_n % num_pid_in_group) % group_size_m)
     pid_n = (pid_m_n % num_pid_in_group) // group_size_m
 
-    slice_id = tl.program_id(axis=1)
+    # slice_id, lora_id and ram index into pointer arithmetic; keep them int64
+    # so products with strides cannot overflow int32 for large token counts.
+    slice_id = tl.program_id(axis=1).to(tl.int64)
     lora_idx = tl.program_id(axis=2)
 
-    lora_id = tl.load(lora_ids + lora_idx)
+    lora_id = tl.load(lora_ids + lora_idx).to(tl.int64)
     if lora_id == -1:
         # Early exit for the no-lora case.
         return
@@ -92,7 +94,7 @@ def _lora_shrink_kernel(
     )
     # Load all relevant row indices.
     offset_m = tl.arange(0, BLOCK_M) % cta_m_len
-    ram = tl.load(cta_lora_seq_indices + offset_m)
+    ram = tl.load(cta_lora_seq_indices + offset_m).to(tl.int64)
 
     do_shrink_kernel(
         pid_n,


### PR DESCRIPTION
## Purpose

Fix #53028: with `enable_lora=True` and a long `max_model_len`, engine init dies in the profile run with `RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered` in `_lora_expand_kernel`. Likely also addresses #48862 (`lora_shrink`, sibling kernel in the same op family).

**Root cause.** In the punica Triton kernels, the token row indices `ram` (int32, from `tl.load`), `slice_id` (`tl.program_id`) and `lora_id` are multiplied by strides in pointer arithmetic. Once such a product reaches 2**31, the int32 offset wraps negative:

- `lora_expand`: the output pointer `out_ptr + ram * output_d0_stride` lands far below the tensor → illegal memory access;
- `lora_shrink`: the *input* pointer `input_ptr + ram * input_d0_stride` (stride = hidden_size) reads the wrong memory → **silently wrong LoRA outputs**, no crash.

**Fix.** Cast `slice_id`, `lora_id` and `ram` to int64 at their definition sites in `_lora_expand_kernel` / `_lora_shrink_kernel` and their FP8 variants. Every downstream stride product (`a_ptr`, `b_ptr`, `c_ptr`, the FP8 per-token/per-adapter scale pointers, and the `slice_id * d0_stride` slice base offsets) is then computed in 64-bit. This follows the convention already used in `fused_moe_lora_op.py` (`offs = tl.arange(0, BLOCK_M).to(tl.int64)`).

### Not a duplicate of #39585

#39585 (open since April, inactive) casts `ram` at 4 of the use sites — only the output `c_ptr` of each kernel. It does not cover:

- `lora_shrink`'s input pointer `a_ptr` — the largest product in that kernel and the one that silently corrupts results (reproduced below);
- the FP8 kernels' scale pointers;
- the `slice_id * d0_stride` / `lora_d0_stride * lora_index` scalar base offsets (same overflow class; reachable with many slices / many adapters at high rank).

Its review thread already flagged the missing sites. Casting at the three definition sites covers all of them with fewer changes.

## Test Plan

- New regression test: `pytest tests/lora/test_punica_ops.py -k large_token_count` — smallest shape past the boundary (`num_tokens = 174764`, 2 slices × `hidden_size` 6144, rank 16, i.e. `(num_tokens - 1) * 12288 ≥ 2**31`), validates sampled rows (including the last row, which carries the largest offset) against a torch reference. Peak device memory ~5 GiB; skips on devices with < 12 GiB.
- Standalone boundary sweep (87383 / 174763 / 174764 / 175000 / 200000 tokens × {expand, shrink}) driving `torch.ops.vllm.lora_expand` / `lora_shrink` directly with `CUDA_LAUNCH_BLOCKING=1`.
- Full existing suites: `pytest tests/lora/test_punica_ops.py tests/lora/test_punica_ops_fp8.py`.

## Test Result

RTX 5880 Ada (SM89, 48 GB), vLLM 0.27.1 kernel files (identical to main for these ops), torch 2.13 + triton 3.7.1.

Before (unpatched):

| num_tokens | lora_expand | lora_shrink |
|---|---|---|
| ≤ 174763 | ok | ok |
| ≥ 174764 | `Triton Error [CUDA]: an illegal memory access was encountered` (same stack as #53028) | **silently wrong results** (100% mismatch on verified rows) |

New regression test on unpatched kernels: `1 failed` (shrink mismatch; the expand variant crashes the process).

After (this PR):

- Boundary sweep: all 10 combinations pass with numerics verified against the torch reference.
- `tests/lora/test_punica_ops.py`: **4275 passed** (incl. the 2 new), `tests/lora/test_punica_ops_fp8.py`: **1944 passed**.

Note on thresholds: on this setup the wrap happens at an element offset of 2**31 (`num_tokens = 174764` for a 12288-element row); #53028 reports the byte-level boundary (87383) on RTX PRO 6000 / H100 — the same int32 wrap, scaled differently by the backend. The int64 cast removes both.

## AI assistance disclosure

This PR was developed with AI assistance (Claude Code): issue analysis, the patch, the standalone repro and the regression test. The submitter reviewed every changed line and ran the tests above. Duplicate-work check: #39585 is the only related open PR; the difference is explained above and in a comment on #53028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
