### PR TITLE
[CI] Fail pre-commit outright when pre-run-check doesn't pass, instead of skipping it

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,9 +46,20 @@ jobs:
 
   pre-commit:
     needs: pre-run-check
-    if: always() && (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
+    if: always()
     runs-on: [self-hosted, linux, x64, vllm-runners]
     steps:
+    # pre-run-check gates untrusted PR code (this job's own .pre-commit-config.yaml)
+    # from running on self-hosted runners. Fail outright instead of skipping when
+    # it doesn't pass: a skipped conclusion reads as "passing" to both the
+    # branch-protection required check and ci-infra's pre-commit poller, so a
+    # skip here previously let unlinted PRs merge silently.
+    # Remaining steps use the default `if: success()` and are skipped automatically.
+    - name: Fail if pre-run-check did not pass
+      if: needs.pre-run-check.result == 'failure'
+      run: |
+        echo "::error::pre-commit did not run because pre-run-check failed. Ask a maintainer to add the 'ready' label, or see the pre-run-check job above for details."
+        exit 1
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:


### PR DESCRIPTION
## What

`pre-run-check` gates whether the `pre-commit` job is allowed to run (requires the `ready`/`verified` label, or the author having 4+ merged PRs). When it fails, `pre-commit` currently just doesn't run at all — its conclusion is `SKIPPED`, not `FAILURE`.

That's a real gap: both GitHub's own required-status-check evaluation and `ci-infra`'s Buildkite `github-github-pre-commit-check` poller treat a `skipped` conclusion as non-blocking. So a PR that never satisfies `pre-run-check` can merge with a diff that was never linted at all.

Concrete case: [#49688](https://github.com/vllm-project/vllm/pull/49688) merged this way and introduced real `ruff` `E501` violations in `vllm/platforms/cpu.py` that sat on `main` until a same-day follow-up ([#52981](https://github.com/vllm-project/vllm/pull/52981)) fixed them. It also caused an unrelated PR of mine to inherit a red `pre-commit` check, since the job runs `--all-files` against the whole tree — that's what led me to trace this down.

## Fix

Keep the trust boundary exactly as-is (untrusted `.pre-commit-config.yaml` still never executes without a maintainer signal) — just make an unmet gate produce a real `failure` conclusion instead of `skipped`, by adding one guard step that runs only when `pre-run-check` failed and exits non-zero. Every other step keeps its default `if: success()`, so they're automatically skipped without needing to touch them individually. No changes needed downstream — both the GitHub required-check gate and the Buildkite poller already correctly block on `failure`, they just never saw one.

## Test plan

- Validated the workflow YAML parses correctly and ran `pre-commit run --all-files --hook-stage manual` locally against this diff (includes the `actionlint`-backed "Lint GitHub Actions workflow files" hook) — passed.
- Traced the `if:`/`needs.<job>.result` semantics against GitHub Actions' documented defaults to confirm the skip-on-prior-failure behavior for the untouched steps.
- Have not been able to exercise the actual `pre-run-check`-fails branch against live GitHub Actions, since that requires a PR from a low-history author without the `ready`/`verified` label — happy to have a maintainer confirm on a test PR, or reason through it further if useful.

AI-assisted change (Claude Code) — I reviewed and understand every line of the diff and traced the root cause end-to-end via the GitHub API before proposing this.