### PR TITLE
[CI/Build] Extract helper for -static-global-template-stub CUDA flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,20 +679,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
         set_gencode_flags_for_srcs(
           SRCS "${MARLIN_TEMPLATE_KERNEL_SRC}"
           CUDA_ARCHS "${MARLIN_ARCHS}")
-        if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-          set_source_files_properties(${MARLIN_TEMPLATE_KERNEL_SRC}
-            PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-        endif()
+        disable_static_global_template_stub(SRCS ${MARLIN_TEMPLATE_KERNEL_SRC})
         list(APPEND VLLM_STABLE_EXT_SRC ${MARLIN_TEMPLATE_KERNEL_SRC})
 
         file(GLOB MARLIN_TEMPLATE_BF16_KERNEL_SRC "csrc/libtorch_stable/quantization/marlin/sm80_kernel_*_bfloat16.cu")
         set_gencode_flags_for_srcs(
           SRCS "${MARLIN_TEMPLATE_BF16_KERNEL_SRC}"
           CUDA_ARCHS "${MARLIN_BF16_ARCHS}")
-        if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-          set_source_files_properties(${MARLIN_TEMPLATE_BF16_KERNEL_SRC}
-            PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-        endif()
+        disable_static_global_template_stub(SRCS ${MARLIN_TEMPLATE_BF16_KERNEL_SRC})
         list(APPEND VLLM_STABLE_EXT_SRC ${MARLIN_TEMPLATE_BF16_KERNEL_SRC})
       endif()
 
@@ -701,10 +695,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
         set_gencode_flags_for_srcs(
           SRCS "${MARLIN_TEMPLATE_SM75_KERNEL_SRC}"
           CUDA_ARCHS "${MARLIN_SM75_ARCHS}")
-        if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-          set_source_files_properties(${MARLIN_TEMPLATE_SM75_KERNEL_SRC}
-            PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-        endif()
+        disable_static_global_template_stub(SRCS ${MARLIN_TEMPLATE_SM75_KERNEL_SRC})
         list(APPEND VLLM_STABLE_EXT_SRC ${MARLIN_TEMPLATE_SM75_KERNEL_SRC})
       endif()
 
@@ -713,10 +704,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
         set_gencode_flags_for_srcs(
           SRCS "${MARLIN_TEMPLATE_FP8_KERNEL_SRC}"
           CUDA_ARCHS "${MARLIN_FP8_ARCHS}")
-        if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-          set_source_files_properties(${MARLIN_TEMPLATE_FP8_KERNEL_SRC}
-            PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-        endif()
+        disable_static_global_template_stub(SRCS ${MARLIN_TEMPLATE_FP8_KERNEL_SRC})
         list(APPEND VLLM_STABLE_EXT_SRC ${MARLIN_TEMPLATE_FP8_KERNEL_SRC})
       endif()
 
@@ -728,10 +716,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
       set_gencode_flags_for_srcs(
         SRCS "${MARLIN_SRCS}"
         CUDA_ARCHS "${MARLIN_OTHER_ARCHS}")
-      if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-        set_source_files_properties(${MARLIN_SRCS}
-          PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-      endif()
+      disable_static_global_template_stub(SRCS ${MARLIN_SRCS})
       list(APPEND VLLM_STABLE_EXT_SRC "${MARLIN_SRCS}")
 
       message(STATUS "Building Marlin kernels for archs: ${MARLIN_OTHER_ARCHS}")
@@ -1371,10 +1356,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       set_gencode_flags_for_srcs(
         SRCS "${MARLIN_MOE_SRC}"
         CUDA_ARCHS "${MARLIN_MOE_ARCHS}")
-      if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-        set_source_files_properties(${MARLIN_MOE_SRC}
-          PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-      endif()
+      disable_static_global_template_stub(SRCS ${MARLIN_MOE_SRC})
       list(APPEND VLLM_MOE_EXT_SRC ${MARLIN_MOE_SRC})
     endif()
 
@@ -1383,10 +1365,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       set_gencode_flags_for_srcs(
         SRCS "${MARLIN_MOE_SM75_SRC}"
         CUDA_ARCHS "${MARLIN_MOE_SM75_ARCHS}")
-      if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-        set_source_files_properties(${MARLIN_MOE_SM75_SRC}
-          PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-      endif()
+      disable_static_global_template_stub(SRCS ${MARLIN_MOE_SM75_SRC})
       list(APPEND VLLM_MOE_EXT_SRC ${MARLIN_MOE_SM75_SRC})
     endif()
 
@@ -1395,10 +1374,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       set_gencode_flags_for_srcs(
         SRCS "${MARLIN_MOE_FP8_SRC}"
         CUDA_ARCHS "${MARLIN_MOE_FP8_ARCHS}")
-      if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-        set_source_files_properties(${MARLIN_MOE_FP8_SRC}
-          PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-      endif()
+      disable_static_global_template_stub(SRCS ${MARLIN_MOE_FP8_SRC})
       list(APPEND VLLM_MOE_EXT_SRC ${MARLIN_MOE_FP8_SRC})
     endif()
 
@@ -1406,10 +1382,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     set_gencode_flags_for_srcs(
       SRCS "${MARLIN_MOE_OTHER_SRC}"
       CUDA_ARCHS "${MARLIN_MOE_OTHER_ARCHS}")
-    if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
-      set_source_files_properties(${MARLIN_MOE_OTHER_SRC}
-        PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
-    endif()
+    disable_static_global_template_stub(SRCS ${MARLIN_MOE_OTHER_SRC})
     list(APPEND VLLM_MOE_EXT_SRC "${MARLIN_MOE_OTHER_SRC}")
 
     message(STATUS "Building Marlin MOE kernels for archs: ${MARLIN_MOE_OTHER_ARCHS}")

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -659,3 +659,17 @@ function (define_extension_target MOD_NAME)
 
   install(TARGETS ${MOD_NAME} LIBRARY DESTINATION ${ARG_DESTINATION} COMPONENT ${MOD_NAME})
 endfunction()
+
+# Disable the CUDA 12.8+ static global template stub for heavily templated
+# kernel sources that don't need it.
+#
+# Usage:
+#   disable_static_global_template_stub(SRCS ${MY_KERNEL_SOURCES})
+#
+function(disable_static_global_template_stub)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "" "SRCS")
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
+    set_source_files_properties(${ARG_SRCS}
+      PROPERTIES COMPILE_FLAGS "-static-global-template-stub=false")
+  endif()
+endfunction()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -660,8 +660,11 @@ function (define_extension_target MOD_NAME)
   install(TARGETS ${MOD_NAME} LIBRARY DESTINATION ${ARG_DESTINATION} COMPONENT ${MOD_NAME})
 endfunction()
 
-# Disable the CUDA 12.8+ static global template stub for heavily templated
-# kernel sources that don't need it.
+#
+# For source files that use CUDA global function templates, disable the
+# static global template stub that CUDA 12.8+ generates by default.
+# This avoids link-time bloat/errors from un-instantiated __global__
+# template stubs in heavily-templated kernels (e.g. Marlin).
 #
 # Usage:
 #   disable_static_global_template_stub(SRCS ${MY_KERNEL_SOURCES})

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -660,11 +660,8 @@ function (define_extension_target MOD_NAME)
   install(TARGETS ${MOD_NAME} LIBRARY DESTINATION ${ARG_DESTINATION} COMPONENT ${MOD_NAME})
 endfunction()
 
-#
-# For source files that use CUDA global function templates, disable the
-# static global template stub that CUDA 12.8+ generates by default.
-# This avoids link-time bloat/errors from un-instantiated __global__
-# template stubs in heavily-templated kernels (e.g. Marlin).
+# Disable the CUDA 12.8+ static global template stub for heavily templated
+# kernel sources that don't need it.
 #
 # Usage:
 #   disable_static_global_template_stub(SRCS ${MY_KERNEL_SOURCES})


### PR DESCRIPTION
Move the repeated CUDA 12.8+ version-guarded
set_source_files_properties(..., "-static-global-template-stub=false")
pattern into a reusable function in cmake/utils.cmake.

## Purpose

Part of #9129. The same 3-line if/set_source_files_properties/endif block was copy-pasted 9 times across Marlin kernel definitions in CMakeLists.txt. This PR extracts it into a `disable_static_global_template_stub(SRCS ...)` function in `cmake/utils.cmake`.

No functional change.

## Test Plan

- Confirmed zero remaining inline occurrences of the pattern in CMakeLists.txt
- Build-tested with CUDA >= 12.8 to verify the flag still appears on all 9 Marlin source groups via `cmake --build . -- VERBOSE=1`

## Test Result

Compiler flags identical before and after.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

