### PR TITLE
[Bugfix][Frontend] Anthropic API: honor the `thinking` request parameter

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -1553,3 +1553,109 @@ class TestClientErrorResponses:
 
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json()["error"]["type"] == "BadRequestError"
+
+
+# ======================================================================
+# thinking configuration pass-through
+# ======================================================================
+
+
+class TestThinkingConfig:
+    def test_absent_thinking_leaves_reasoning_untouched(self):
+        """Requests without `thinking` must convert exactly as before."""
+        request = _make_request([{"role": "user", "content": "Hello"}])
+
+        result = _convert(request)
+        assert result.reasoning_effort is None
+        assert result.thinking_token_budget is None
+        assert result.include_reasoning is True
+
+    def test_disabled_clears_reasoning_effort(self):
+        """`disabled` maps to reasoning_effort="none", which is what clears
+        enable_thinking for templates that honor it."""
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            thinking={"type": "disabled"},
+        )
+
+        result = _convert(request)
+        assert result.reasoning_effort == "none"
+
+    def test_disabled_overrides_output_config_effort(self):
+        """`thinking` is applied after output_config so an explicit opt-out wins
+        over an inherited effort ceiling."""
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            output_config={"effort": "high"},
+            thinking={"type": "disabled"},
+        )
+
+        result = _convert(request)
+        assert result.reasoning_effort == "none"
+
+    def test_enabled_with_budget_sets_thinking_token_budget(self):
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            thinking={"type": "enabled", "budget_tokens": 2048},
+        )
+
+        result = _convert(request)
+        assert result.thinking_token_budget == 2048
+
+    def test_enabled_without_budget_pins_nothing(self):
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            thinking={"type": "enabled"},
+        )
+
+        result = _convert(request)
+        assert result.thinking_token_budget is None
+        assert result.reasoning_effort is None
+
+    def test_adaptive_pins_nothing_and_keeps_effort_ceiling(self):
+        """`adaptive` lets the model choose depth, so only the ceiling from
+        output_config.effort should survive."""
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            output_config={"effort": "low"},
+            thinking={"type": "adaptive"},
+        )
+
+        result = _convert(request)
+        assert result.reasoning_effort == "low"
+        assert result.thinking_token_budget is None
+
+    def test_display_omitted_suppresses_reasoning_in_response(self):
+        """`display` controls visibility only -- it must not touch depth."""
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            thinking={"type": "adaptive", "display": "omitted"},
+        )
+
+        result = _convert(request)
+        assert result.include_reasoning is False
+        assert result.reasoning_effort is None
+        assert result.thinking_token_budget is None
+
+    def test_display_summarized_keeps_reasoning_included(self):
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            thinking={"type": "adaptive", "display": "summarized"},
+        )
+
+        result = _convert(request)
+        assert result.include_reasoning is True
+
+    def test_claude_code_payload(self):
+        """The combination Claude Code sends on every request: an effort ceiling
+        plus adaptive thinking with reasoning display omitted."""
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            output_config={"effort": "high"},
+            thinking={"type": "adaptive", "display": "omitted"},
+        )
+
+        result = _convert(request)
+        assert result.reasoning_effort == "high"
+        assert result.include_reasoning is False
+        assert result.thinking_token_budget is None

--- a/tests/entrypoints/anthropic/test_protocol_exports.py
+++ b/tests/entrypoints/anthropic/test_protocol_exports.py
@@ -19,6 +19,7 @@ from vllm.entrypoints.anthropic.protocol import (
     AnthropicMessagesResponse,
     AnthropicOutputConfig,
     AnthropicStreamEvent,
+    AnthropicThinkingConfig,
     AnthropicUsage,
 )
 
@@ -35,6 +36,7 @@ SERVING_PROTOCOL_EXPORTS = (
     AnthropicMessagesResponse,
     AnthropicOutputConfig,
     AnthropicStreamEvent,
+    AnthropicThinkingConfig,
     AnthropicUsage,
 )
 

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -118,6 +118,18 @@ class AnthropicOutputConfig(BaseModel):
     format: AnthropicJsonOutputFormat | None = None
 
 
+class AnthropicThinkingConfig(BaseModel):
+    """Extended-thinking configuration.
+
+    ``display`` controls visibility only: reasoning still runs and is still
+    billed under every setting.
+    """
+
+    type: Literal["enabled", "disabled", "adaptive"] = "enabled"
+    budget_tokens: int | None = None
+    display: Literal["summarized", "omitted"] | None = None
+
+
 class AnthropicMessagesRequest(BaseModel):
     """Anthropic Messages API request"""
 
@@ -126,6 +138,7 @@ class AnthropicMessagesRequest(BaseModel):
     max_tokens: int
     metadata: dict[str, Any] | None = None
     output_config: AnthropicOutputConfig | None = None
+    thinking: AnthropicThinkingConfig | None = None
     stop_sequences: (
         Annotated[list[str], Field(max_length=envs.VLLM_MAX_STOP_STRINGS)] | None
     ) = None

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -27,6 +27,7 @@ from vllm.entrypoints.anthropic.protocol import (
     AnthropicMessagesResponse,
     AnthropicOutputConfig,
     AnthropicStreamEvent,
+    AnthropicThinkingConfig,
     AnthropicUsage,
 )
 from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
@@ -213,6 +214,7 @@ class AnthropicServingMessages(OpenAIServingChat):
         req = cls._build_base_request(anthropic_request, openai_messages)
         cls._handle_streaming_options(req, anthropic_request)
         cls._handle_output_config(req, anthropic_request)
+        cls._handle_thinking(req, anthropic_request)
         cls._convert_tool_choice(anthropic_request, req)
         cls._convert_tools(anthropic_request, req)
         return req
@@ -491,6 +493,30 @@ class AnthropicServingMessages(OpenAIServingChat):
             ec_transfer_params=anthropic_request.ec_transfer_params,
             chat_template_kwargs=anthropic_request.chat_template_kwargs,
         )
+
+    @classmethod
+    def _handle_thinking(
+        cls,
+        req: ChatCompletionRequest,
+        anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest,
+    ) -> None:
+        """Handle extended-thinking configuration"""
+        if isinstance(anthropic_request, AnthropicCountTokensRequest):
+            return
+        thinking: AnthropicThinkingConfig | None = anthropic_request.thinking
+        if thinking is None:
+            return
+
+        if thinking.type == "disabled":
+            # "none" is what clears enable_thinking for templates that honor it.
+            req.reasoning_effort = "none"
+        elif thinking.type == "enabled" and thinking.budget_tokens is not None:
+            req.thinking_token_budget = thinking.budget_tokens
+        # "adaptive" pins nothing: the model chooses depth beneath the ceiling
+        # already set from output_config.effort.
+
+        if thinking.display == "omitted":
+            req.include_reasoning = False
 
     @classmethod
     def _handle_output_config(


### PR DESCRIPTION
## AI
Claude Code, Opus 5 was part of this change including writing this PR, overseen and validated with human.

## Purpose
`AnthropicMessagesRequest` never declared a `thinking` field, so the documented Anthropic request
parameter was silently discarded — the model sets no Pydantic `extra` policy, so the default
`extra="ignore"` drops it without an error. Clients asking for disabled thinking, a token budget, or
omitted reasoning display were answered as though they had asked for nothing, at whatever
`output_config.effort` implied.

This is user-visible: Claude Code sends `{"type": "adaptive", "display": "omitted"}` on every
request. Both instructions were dropped, so every request reasoned at the effort ceiling *and*
streamed the reasoning back. On a DeepSeek-V4-Flash-0731 deployment an ordinary coding question
produced 2237 reasoning events over 151 seconds without a single visible output token — the client
gave up before the model finished thinking.

This adds `AnthropicThinkingConfig` and maps it onto reasoning controls `ChatCompletionRequest`
already exposes:

| `thinking` | maps to |
|---|---|
| `{"type": "disabled"}` | `reasoning_effort = "none"` |
| `{"type": "enabled", "budget_tokens": N}` | `thinking_token_budget = N` |
| `{"display": "omitted"}` | `include_reasoning = False` |
| `{"type": "adaptive"}` | nothing pinned — the model chooses depth |

Two design points worth reviewer attention:

- **`adaptive` deliberately pins nothing.** Per Anthropic's API, `output_config.effort` is the
  ceiling and `adaptive` lets the model choose depth beneath it. No frontend-side action makes a
  model adaptive, so the correct behaviour is to avoid forcing a static value.
- **`display` maps to `include_reasoning`, not to any depth control.** It governs visibility only —
  reasoning still runs and is still billed — so it must not be conflated with effort.

`_handle_thinking` runs *after* `_handle_output_config` so an explicit `thinking` overrides the
effort-derived default rather than being overwritten by it.

## Test Plan

Frontend-only change, so the Python-only dev install is enough — no CUDA rebuild, no GPU:

```bash
uv venv .venv --python 3.12
VLLM_USE_PRECOMPILED=1 uv pip install -e .
uv pip install pytest pytest-asyncio httpx tblib   # tblib is required by tests/conftest.py

# New unit tests
.venv/bin/python -m pytest -q \
  tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -k TestThinkingConfig

# Affected files in full, as a regression check
.venv/bin/python -m pytest -q \
  tests/entrypoints/anthropic/test_anthropic_messages_conversion.py \
  tests/entrypoints/anthropic/test_protocol_exports.py
```

`TestThinkingConfig` covers nine conversion cases:

| Case | Asserts |
|---|---|
| `thinking` absent | `reasoning_effort is None`, `thinking_token_budget is None`, `include_reasoning is True` (regression guard) |
| `{"type": "disabled"}` | `reasoning_effort == "none"` |
| `disabled` + `output_config.effort="high"` | `reasoning_effort == "none"` — ordering: `thinking` beats the ceiling |
| `{"type": "enabled", "budget_tokens": 2048}` | `thinking_token_budget == 2048` |
| `{"type": "enabled"}` without a budget | nothing pinned |
| `{"type": "adaptive"}` + `effort="low"` | `reasoning_effort == "low"`, budget unset |
| `{"display": "omitted"}` | `include_reasoning is False`, depth untouched |
| `{"display": "summarized"}` | `include_reasoning is True` |
| `effort="high"` + `adaptive` + `omitted` | the exact payload Claude Code sends |

End-to-end against a served model with a reasoning parser
(`--reasoning-parser deepseek_v4 --tool-call-parser deepseek_v4 --enable-auto-tool-choice`):

```bash
curl -s localhost:8000/v1/messages -H 'content-type: application/json' -d '{
  "model": "'"$MODEL"'", "max_tokens": 800,
  "thinking": {"type": "disabled"},
  "messages": [{"role": "user", "content": "Explain why sourcing an untrusted config file is risky."}]
}' | jq '[.content[] | select(.type=="thinking") | .thinking | length]'
# expected after this change: [] (or [0]); before: a non-empty reasoning block
```

## Test Result

Unit tests:

```
$ pytest -q tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -k TestThinkingConfig
.........                                                                [100%]
9 passed, 55 deselected in 2.97s

$ pytest -q tests/entrypoints/anthropic/test_anthropic_messages_conversion.py \
          tests/entrypoints/anthropic/test_protocol_exports.py
..................................................................       [100%]
66 passed in 13.66s
```

The remaining tests under `tests/entrypoints/anthropic/` (`test_messages.py`, 7 tests) error at
fixture setup on this machine with `DeviceConfig` unable to detect a device — they boot a real model
server and need a GPU. Unrelated to this change; they fail before any of it executes.

Lint: `ruff-check`, `ruff-format`, `check-spdx-header` and `typos` all pass via `pre-commit run`.

End-to-end on `DeepSeek-V4-Flash-0731`, TP=2, `deepseek_v4` reasoning parser, reasoning-block length
in the response:

| Request | Before | After |
|---|---|---|
| no `thinking` field | 149 chars | 149 — unchanged |
| `{"type": "disabled"}` | **3058** (silently ignored) | **0**, content returned |
| `{"type": "adaptive", "display": "omitted"}` | reasoning streamed | **0** returned, `stop_reason: end_turn` |
| `{"type": "adaptive"}` | pinned to the ceiling | 641 chars, nothing pinned |

`thinking_token_budget` is rejected by the V2 model runner on current builds ("not yet supported by
the V2 model runner"), so the `budget_tokens` branch is covered at the conversion layer rather than
end-to-end.

## Impact

No behaviour change for requests that omit `thinking`: the field defaults to `None` and the handler
returns immediately, so `output_config.effort` remains the only input to reasoning configuration for
existing callers. The `thinking`-absent unit test guards this.