### PR TITLE
[Bugfix] Reject shape-aliased prefills in uniform-decode classification

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1599,21 +1599,39 @@ def test_hybrid_cache_integration(default_vllm_config, dist_init):
     assert _is_req_state_block_table_match(runner, req_id)
 
 
+def _uniform_decode_runner(
+    num_computed_tokens: list[int], num_prompt_tokens: list[int]
+) -> SimpleNamespace:
+    """Minimal stand-in for the `self` used by _is_uniform_decode."""
+    return SimpleNamespace(
+        input_batch=SimpleNamespace(
+            num_computed_tokens_cpu=np.array(num_computed_tokens),
+            num_prompt_tokens=np.array(num_prompt_tokens),
+        )
+    )
+
+
 def test_is_uniform_decode() -> None:
+    # All requests past their prompt, i.e. genuinely decoding.
+    decode16 = _uniform_decode_runner([10] * 16, [8] * 16)
+    decode7 = _uniform_decode_runner([10] * 7, [8] * 7)
     # Normal
     assert GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
     )
     assert not GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=2,
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
     )
     assert not GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
@@ -1621,18 +1639,21 @@ def test_is_uniform_decode() -> None:
     )
     # Spec decoding
     assert GPUModelRunner._is_uniform_decode(
+        decode7,
         max_num_scheduled_tokens=5,
         uniform_decode_query_len=5,
         num_tokens=30,
         num_reqs=6,
     )
     assert not GPUModelRunner._is_uniform_decode(
+        decode7,
         max_num_scheduled_tokens=5,
         uniform_decode_query_len=4,
         num_tokens=30,
         num_reqs=6,
     )
     assert not GPUModelRunner._is_uniform_decode(
+        decode7,
         max_num_scheduled_tokens=5,
         uniform_decode_query_len=5,
         num_tokens=30,
@@ -1640,6 +1661,7 @@ def test_is_uniform_decode() -> None:
     )
     # Force uniform decode
     assert GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
@@ -1647,6 +1669,7 @@ def test_is_uniform_decode() -> None:
         force_uniform_decode=True,
     )
     assert GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=2,
         uniform_decode_query_len=1,
         num_tokens=16,
@@ -1654,6 +1677,7 @@ def test_is_uniform_decode() -> None:
         force_uniform_decode=True,
     )
     assert GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
@@ -1661,6 +1685,7 @@ def test_is_uniform_decode() -> None:
         force_uniform_decode=True,
     )
     assert not GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
@@ -1668,6 +1693,7 @@ def test_is_uniform_decode() -> None:
         force_uniform_decode=False,
     )
     assert not GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=2,
         uniform_decode_query_len=1,
         num_tokens=16,
@@ -1675,11 +1701,72 @@ def test_is_uniform_decode() -> None:
         force_uniform_decode=False,
     )
     assert not GPUModelRunner._is_uniform_decode(
+        decode16,
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=15,
         force_uniform_decode=False,
+    )
+
+
+def test_is_uniform_decode_rejects_shape_aliased_prefill() -> None:
+    # Regression test for https://github.com/vllm-project/vllm/issues/53051:
+    # with spec decode (num_spec_tokens=2, uniform_decode_query_len=3), a
+    # single 3-token prompt schedules exactly 3 = 3 * 1 tokens and aliases
+    # the uniform-decode shape. It must not be classified as uniform decode.
+    aliased_prefill = _uniform_decode_runner([0], [3])
+    assert not GPUModelRunner._is_uniform_decode(
+        aliased_prefill,
+        max_num_scheduled_tokens=3,
+        uniform_decode_query_len=3,
+        num_tokens=3,
+        num_reqs=1,
+    )
+    # Same shape, but the request is past its prompt: uniform decode.
+    decoding = _uniform_decode_runner([5], [3])
+    assert GPUModelRunner._is_uniform_decode(
+        decoding,
+        max_num_scheduled_tokens=3,
+        uniform_decode_query_len=3,
+        num_tokens=3,
+        num_reqs=1,
+    )
+    # Last chunk of a chunked prefill aliasing the shape is still a prefill.
+    chunked_prefill = _uniform_decode_runner([5], [8])
+    assert not GPUModelRunner._is_uniform_decode(
+        chunked_prefill,
+        max_num_scheduled_tokens=3,
+        uniform_decode_query_len=3,
+        num_tokens=3,
+        num_reqs=1,
+    )
+    # Mixed batch: one request decoding, one still in prefill.
+    mixed = _uniform_decode_runner([5, 0], [3, 3])
+    assert not GPUModelRunner._is_uniform_decode(
+        mixed,
+        max_num_scheduled_tokens=3,
+        uniform_decode_query_len=3,
+        num_tokens=6,
+        num_reqs=2,
+    )
+    # Without spec decode the same aliasing exists with 1-token prompts.
+    one_token_prompt = _uniform_decode_runner([0], [1])
+    assert not GPUModelRunner._is_uniform_decode(
+        one_token_prompt,
+        max_num_scheduled_tokens=1,
+        uniform_decode_query_len=1,
+        num_tokens=1,
+        num_reqs=1,
+    )
+    # force_uniform_decode (cudagraph capture) still overrides everything.
+    assert GPUModelRunner._is_uniform_decode(
+        aliased_prefill,
+        max_num_scheduled_tokens=3,
+        uniform_decode_query_len=3,
+        num_tokens=3,
+        num_reqs=1,
+        force_uniform_decode=True,
     )
 
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3985,8 +3985,8 @@ class GPUModelRunner(
             **model_kwargs,
         )
 
-    @staticmethod
     def _is_uniform_decode(
+        self,
         max_num_scheduled_tokens: int,
         uniform_decode_query_len: int,
         num_tokens: int,
@@ -3997,13 +3997,28 @@ class GPUModelRunner(
         Checks if it's a decode batch with same amount scheduled tokens
         across all requests.
         """
-        return (
+        if force_uniform_decode is not None:
+            return force_uniform_decode
+        if not (
+            max_num_scheduled_tokens == uniform_decode_query_len
+            and num_tokens == max_num_scheduled_tokens * num_reqs
+        ):
+            return False
+        # The shape check alone can misclassify prefills: with spec decode
+        # (uniform_decode_query_len = 1 + num_spec_tokens), any batch of
+        # prompts scheduled with exactly uniform_decode_query_len tokens per
+        # request aliases the uniform-decode shape. Dispatching such a
+        # prefill into a cudagraph captured for uniform decode replays stale
+        # capture-time metadata for backends with persistent buffers (e.g.
+        # GDN), silently skipping prefill state writes and corrupting output
+        # (https://github.com/vllm-project/vllm/issues/53051). A batch is
+        # only uniform decode if every request is already past its prompt.
+        input_batch = self.input_batch
+        return bool(
             (
-                (max_num_scheduled_tokens == uniform_decode_query_len)
-                and (num_tokens == max_num_scheduled_tokens * num_reqs)
-            )
-            if force_uniform_decode is None
-            else force_uniform_decode
+                input_batch.num_computed_tokens_cpu[:num_reqs]
+                >= input_batch.num_prompt_tokens[:num_reqs]
+            ).all()
         )
 
     def _allow_microbatching(


### PR DESCRIPTION
## Purpose

FIX #53051 (same root cause as #49918)

With spec decode enabled, `GPUModelRunner._is_uniform_decode` classifies batches by shape only. A prefill whose scheduled tokens equal `uniform_decode_query_len (= 1 + num_spec_tokens)` per request — e.g. a single (k+1)-token prompt — aliases the uniform-decode shape and is dispatched into the FULL cudagraph captured for spec decode. For attention backends with persistent metadata buffers (e.g. GDN / hybrid recurrent models), those buffers are only refreshed on the decode path, so the replay uses stale capture-time state indices (NULL block 0); the kernels' null-block guards silently skip all recurrent-state writes, the request's state stays zero forever, and output is deterministic garbage (details and measured evidence in #53051).

This PR makes `_is_uniform_decode` additionally require that every request in the batch is already past its prompt (`num_computed_tokens >= num_prompt_tokens`), so any batch still containing prefill tokens falls back to the mixed prefill-decode path. The `force_uniform_decode` override used for cudagraph capture is preserved unchanged.

**Relationship to #47123:** that PR addresses the same root cause by computing `force_uniform_decode=False` in `execute_model` when a hybrid model's batch contains context requests. This PR is an alternative that fixes the classification at its source instead: the diff is smaller (no new caller-side state), it applies to all models rather than only `is_hybrid` (the q_len==1 aliasing of 1-token prompts exists without spec decode too), and the per-request check also covers chunked-prefill last chunks and mixed batches uniformly. If maintainers prefer the approach in #47123, I'm happy to close this one in its favor.

## Test Plan

- `pytest tests/v1/worker/test_gpu_model_runner.py -k uniform_decode`
  - existing `test_is_uniform_decode` cases preserved (adapted to the method now reading `self.input_batch`)
  - new `test_is_uniform_decode_rejects_shape_aliased_prefill`: aliased (k+1)-token prompt, chunked-prefill last chunk, mixed decode+prefill batch, 1-token prompt without spec decode, and the `force_uniform_decode` capture override
- The new regression test fails against the pre-fix shape-only logic and passes with the fix.

## Test Result

Unit tests pass. End-to-end, the same per-request check (as a hot patch on v0.27.1, ROCm gfx1151, Qwen3.6-35B-A3B GDN hybrid, MTP k=2, `FULL_AND_PIECEWISE`) was validated in the deployment from #53051:

- the aliased 3-token prompt's output recovers to byte-identical with the eager reference (previously deterministic garbage)
- GDN state-write signature during the aliased prefill restored from draft-only `{10}` to full `{1, 4, 7, 10}`
- spec-decode acceptance rate on subsequent traffic recovers 12% → 79%
- no regression in decode throughput or 100k-token long-context gates

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
