### PR TITLE
turboquant decode attetnion optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,30 @@ if(VLLM_GPU_LANG STREQUAL "HIP")
   target_compile_definitions(_C PRIVATE CUTLASS_ENABLE_DIRECT_CUDA_DRIVER_CALL=1)
 endif() # _C HIP endif
 
+if(VLLM_GPU_LANG STREQUAL "CUDA")
+  cuda_archs_loose_intersection(TURBOQUANT_ARCHS "8.0;9.0;10.0" "${CUDA_ARCHS}")
+  if(TURBOQUANT_ARCHS)
+    find_library(TURBOQUANT_TORCH_PYTHON_LIBRARY torch_python
+      PATHS "${TORCH_INSTALL_PREFIX}/lib"
+      NO_DEFAULT_PATH REQUIRED)
+    set(TURBOQUANT_SRC
+      "csrc/attention/turboquant/main.cpp"
+      "csrc/attention/turboquant/kernel.cu"
+      "csrc/attention/turboquant/mma_kernel.cu")
+    set_gencode_flags_for_srcs(
+      SRCS "${TURBOQUANT_SRC}"
+      CUDA_ARCHS "${TURBOQUANT_ARCHS}")
+    define_extension_target(
+      _turboquant_C
+      DESTINATION vllm
+      LANGUAGE CUDA
+      SOURCES ${TURBOQUANT_SRC}
+      COMPILE_FLAGS ${VLLM_GPU_FLAGS} --use_fast_math
+      LIBRARIES ${TURBOQUANT_TORCH_PYTHON_LIBRARY}
+      WITH_SOABI)
+  endif()
+endif()
+
 if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
   #
   # _C_stable_libtorch extension (ops registered via STABLE_TORCH_LIBRARY)

--- a/csrc/attention/turboquant/kernel.cu
+++ b/csrc/attention/turboquant/kernel.cu
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "kernel.h"
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <math_constants.h>
+
+__device__ __forceinline__ float shfl_xor_f(float x, int mask) {
+  return __shfl_xor_sync(0xffffffffu, x, mask);
+}
+
+__device__ __forceinline__ float warp_sum(float x) {
+#pragma unroll
+  for (int d = 16; d; d >>= 1) x += shfl_xor_f(x, d);
+  return x;
+}
+
+__device__ __forceinline__ float warp_max(float x) {
+#pragma unroll
+  for (int d = 16; d; d >>= 1) x = fmaxf(x, shfl_xor_f(x, d));
+  return x;
+}
+
+struct DynamicSplitPlan {
+  int splits;
+  int pps;
+};
+
+__device__ __forceinline__ DynamicSplitPlan
+make_dynamic_split_plan(int chunks, int max_splits, int one_wave) {
+  if (chunks <= 0) return {0, 1};
+  int splits = max_splits;
+  const int two_chunk_cap = chunks / 2 > 0 ? chunks / 2 : 1;
+  if (splits > two_chunk_cap) splits = two_chunk_cap;
+  const int four_chunk_cap = chunks / 4 > 0 ? chunks / 4 : 1;
+  const int warp_full_cap =
+      one_wave > four_chunk_cap ? one_wave : four_chunk_cap;
+  if (splits > warp_full_cap) splits = warp_full_cap;
+  const int pps = (chunks + splits - 1) / splits;
+  splits = (chunks + pps - 1) / pps;
+  return {splits, pps};
+}
+
+// Unnormalized Walsh-Hadamard transform of width D across one warp; each lane
+// holds D/32 contiguous elements. Butterfly stages over distinct index bits
+// commute, so intra-lane stages (low bits) followed by shuffle stages (lane
+// bits) reproduce the Sylvester Hadamard product exactly for D in {64,128,256}.
+template <int D>
+__device__ __forceinline__ void fwht(float (&x)[D / 32], int lane) {
+  constexpr int V = D / 32;
+#pragma unroll
+  for (int s = 1; s < V; s <<= 1) {
+#pragma unroll
+    for (int j = 0; j < V; ++j) {
+      if ((j & s) == 0) {
+        const float a = x[j] + x[j + s];
+        const float b = x[j] - x[j + s];
+        x[j] = a;
+        x[j + s] = b;
+      }
+    }
+  }
+#pragma unroll
+  for (int bit = 1; bit < 32; bit <<= 1) {
+#pragma unroll
+    for (int j = 0; j < V; ++j) {
+      const float y = shfl_xor_f(x[j], bit);
+      x[j] = (lane & bit) ? (y - x[j]) : (x[j] + y);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Decode: one CTA per (split, kvh*npacks, b). Each warp owns a logical
+// 32-token chunk, independent of the physical cache page template.
+// The q rotation (FWHT folding the normalized Hadamard and the D^-0.5 scale)
+// is fused: each CTA rotates its own head pack straight into shared memory.
+// ---------------------------------------------------------------------------
+template <int D, int PAGE_SIZE, int NP4, int ACTIVE_HEADS = NP4 * 4>
+__global__ void __launch_bounds__(128)
+    decode_kernel(const __nv_bfloat16* __restrict__ q,
+                  const uint8_t* __restrict__ kv_cache,
+                  const int* __restrict__ page_table,
+                  const int* __restrict__ seq_lens,
+                  const float* __restrict__ centroids,
+                  __nv_bfloat16* __restrict__ out, float* __restrict__ part_acc,
+                  float2* __restrict__ part_ml, const int HQ, const int HKV,
+                  const int page_table_stride, const int npacks,
+                  const int max_splits, const int one_wave) {
+  constexpr int PP = NP4 * 4;
+  constexpr int CODE_BYTES = D / 2;  // K4/V4 code bytes per token
+  constexpr int NV4 = D / 32;        // 16B K-code loads per token
+  constexpr int NWRD = D / 8;        // 4B K-code words per token
+  constexpr int VD = D / 32;         // V dims owned per lane
+  constexpr int VB = D / 64;         // V code bytes owned per lane
+  const int split = blockIdx.x;
+  const int kvh = blockIdx.y / npacks;
+  const int pack = blockIdx.y - kvh * npacks;
+  const int b = blockIdx.z;
+  const int G = HQ / HKV;
+  const int seq = seq_lens[b];
+  const int chunks_b = (seq + 31) >> 5;
+  const DynamicSplitPlan dynamic_plan =
+      make_dynamic_split_plan(chunks_b, max_splits, one_wave);
+  if (split >= dynamic_plan.splits) return;
+  const int chunk_lo = split * dynamic_plan.pps;
+  const int chunk_hi = min(chunk_lo + dynamic_plan.pps, chunks_b);
+
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  const int nw = blockDim.x >> 5;
+  const int h0 = kvh * G + pack * 8;
+  const int nvalid = min(ACTIVE_HEADS, G - pack * 8);
+
+  __shared__ float lut[16][32];
+  __shared__ float4 qs4[D][NP4];
+  __shared__ float4 wsm4[4][32][NP4];
+  __shared__ __align__(16) float comb_v[4][PP][D];
+  __shared__ float2 comb_ml[4][PP];
+  __shared__ float comb_w[PP][4];
+  __shared__ float2 comb_total_ml[PP];
+
+  for (int i = threadIdx.x; i < 512; i += blockDim.x)
+    lut[i >> 5][i & 31] = centroids[i >> 5];
+  if (nvalid < ACTIVE_HEADS) {
+    for (int i = threadIdx.x; i < ACTIVE_HEADS * D; i += blockDim.x) {
+      const int p = i / D;
+      const int d = i & (D - 1);
+      if (p >= nvalid) reinterpret_cast<float*>(&qs4[d][0])[p] = 0.0f;
+    }
+  }
+  for (int h = warp; h < nvalid; h += nw) {
+    float x[VD];
+    const __nv_bfloat16* src = q + ((size_t)b * HQ + h0 + h) * D + lane * VD;
+#pragma unroll
+    for (int j = 0; j < VD; ++j) x[j] = __bfloat162float(src[j]);
+    fwht<D>(x, lane);
+#pragma unroll
+    for (int j = 0; j < VD; ++j)
+      reinterpret_cast<float*>(&qs4[lane * VD + j][0])[h] = x[j] * (1.f / D);
+  }
+  __syncthreads();
+
+  float m[PP], ll[PP], zl[PP], A[PP][VD];
+#pragma unroll
+  for (int p = 0; p < ACTIVE_HEADS; ++p) {
+    m[p] = -CUDART_INF_F;
+    ll[p] = 0.0f;
+    zl[p] = 0.0f;
+#pragma unroll
+    for (int j = 0; j < VD; ++j) A[p][j] = 0.0f;
+  }
+
+  for (int chunk = chunk_lo + warp; chunk < chunk_hi; chunk += nw) {
+    const int token0 = chunk * 32;
+    const int pg0 = token0 / PAGE_SIZE;
+    const int row0 = token0 - pg0 * PAGE_SIZE;
+    const int blk0 = page_table[b * page_table_stride + pg0];
+    const size_t rec0 = (size_t)blk0 * HKV + kvh;
+    size_t rec1 = rec0;
+    if constexpr (PAGE_SIZE == 16) {
+      if (token0 + 16 < seq) {
+        const int blk1 = page_table[b * page_table_stride + pg0 + 1];
+        rec1 = (size_t)blk1 * HKV + kvh;
+      }
+    }
+    const size_t rec = (PAGE_SIZE == 16 && lane >= 16) ? rec1 : rec0;
+    const int row = (PAGE_SIZE == 16) ? (lane & 15) : (row0 + lane);
+    const uint8_t* record = kv_cache + rec * (PAGE_SIZE * (D + 6));
+    const uint4* kp =
+        reinterpret_cast<const uint4*>(record + (size_t)row * CODE_BYTES);
+    uint4 kv4[NV4];
+#pragma unroll
+    for (int i = 0; i < NV4; ++i) kv4[i] = kp[i];
+    const int ntok = min(32, seq - token0);
+    const float kn = __half2float(
+        *reinterpret_cast<const __half*>(record + PAGE_SIZE * D + row * 2));
+    const float vsc = __half2float(*reinterpret_cast<const __half*>(
+        record + PAGE_SIZE * (D + 2) + row * 2));
+    const float vzr = __half2float(*reinterpret_cast<const __half*>(
+        record + PAGE_SIZE * (D + 4) + row * 2));
+
+    // Two independent accumulator sets break the D/2-deep serial FMA
+    // dependency chains (n2 and per-head dots) in half.
+    float4 dot[NP4], dotb[NP4];
+#pragma unroll
+    for (int g = 0; g < NP4; ++g) {
+      dot[g] = make_float4(0.f, 0.f, 0.f, 0.f);
+      dotb[g] = make_float4(0.f, 0.f, 0.f, 0.f);
+    }
+    float n2 = 1e-16f, n2b = 0.f;
+
+    unsigned w32[NWRD];
+#pragma unroll
+    for (int i = 0; i < NV4; ++i) {
+      w32[4 * i + 0] = kv4[i].x;
+      w32[4 * i + 1] = kv4[i].y;
+      w32[4 * i + 2] = kv4[i].z;
+      w32[4 * i + 3] = kv4[i].w;
+    }
+#pragma unroll
+    for (int wi = 0; wi < NWRD; wi += 2) {
+      const unsigned wva = w32[wi];
+      const unsigned wvb = w32[wi + 1];
+#pragma unroll
+      for (int n = 0; n < 8; ++n) {
+        const float ca = lut[(wva >> (4 * n)) & 0xFu][lane];
+        n2 = fmaf(ca, ca, n2);
+#pragma unroll
+        for (int g = 0; g < NP4; ++g) {
+          const float4 qv = qs4[wi * 8 + n][g];
+          if (4 * g + 0 < ACTIVE_HEADS) dot[g].x = fmaf(ca, qv.x, dot[g].x);
+          if (4 * g + 1 < ACTIVE_HEADS) dot[g].y = fmaf(ca, qv.y, dot[g].y);
+          if (4 * g + 2 < ACTIVE_HEADS) dot[g].z = fmaf(ca, qv.z, dot[g].z);
+          if (4 * g + 3 < ACTIVE_HEADS) dot[g].w = fmaf(ca, qv.w, dot[g].w);
+        }
+      }
+#pragma unroll
+      for (int n = 0; n < 8; ++n) {
+        const float cb = lut[(wvb >> (4 * n)) & 0xFu][lane];
+        n2b = fmaf(cb, cb, n2b);
+#pragma unroll
+        for (int g = 0; g < NP4; ++g) {
+          const float4 qv = qs4[(wi + 1) * 8 + n][g];
+          if (4 * g + 0 < ACTIVE_HEADS) dotb[g].x = fmaf(cb, qv.x, dotb[g].x);
+          if (4 * g + 1 < ACTIVE_HEADS) dotb[g].y = fmaf(cb, qv.y, dotb[g].y);
+          if (4 * g + 2 < ACTIVE_HEADS) dotb[g].z = fmaf(cb, qv.z, dotb[g].z);
+          if (4 * g + 3 < ACTIVE_HEADS) dotb[g].w = fmaf(cb, qv.w, dotb[g].w);
+        }
+      }
+    }
+    n2 += n2b;
+#pragma unroll
+    for (int g = 0; g < NP4; ++g) {
+      dot[g].x += dotb[g].x;
+      dot[g].y += dotb[g].y;
+      dot[g].z += dotb[g].z;
+      dot[g].w += dotb[g].w;
+    }
+    const float mult = kn * rsqrtf(n2);
+    const bool tval = lane < ntok;
+    float sc[PP];
+#pragma unroll
+    for (int g = 0; g < NP4; ++g) {
+      sc[4 * g + 0] = tval ? dot[g].x * mult : -CUDART_INF_F;
+      sc[4 * g + 1] = tval ? dot[g].y * mult : -CUDART_INF_F;
+      sc[4 * g + 2] = tval ? dot[g].z * mult : -CUDART_INF_F;
+      sc[4 * g + 3] = tval ? dot[g].w * mult : -CUDART_INF_F;
+    }
+#pragma unroll
+    for (int p = 0; p < ACTIVE_HEADS; ++p) {
+      float pm = sc[p];
+#pragma unroll
+      for (int off = 16; off; off >>= 1)
+        pm = fmaxf(pm, __shfl_xor_sync(0xffffffffu, pm, off));
+      const float mn = fmaxf(m[p], pm);
+      const float alpha = __expf(m[p] - mn);
+      const float w = __expf(sc[p] - mn);
+      ll[p] = ll[p] * alpha + w;
+      zl[p] = zl[p] * alpha + w * vzr;
+      reinterpret_cast<float*>(&wsm4[warp][lane][0])[p] = w * vsc;
+#pragma unroll
+      for (int j = 0; j < VD; ++j) A[p][j] *= alpha;
+      m[p] = mn;
+    }
+    __syncwarp();
+    // V phase: lane owns dims VD*lane .. VD*lane+VD-1 (bytes VB*lane ..)
+#pragma unroll 4
+    for (int t = 0; t < 32; ++t) {
+      const size_t vrec = (PAGE_SIZE == 16 && t >= 16) ? rec1 : rec0;
+      const int vrow = (PAGE_SIZE == 16) ? (t & 15) : (row0 + t);
+      const uint8_t* vrecord = kv_cache + vrec * (PAGE_SIZE * (D + 6));
+      const uint8_t* vb = vrecord + PAGE_SIZE * CODE_BYTES +
+                          (size_t)vrow * CODE_BYTES + (size_t)lane * VB;
+      unsigned v;
+      if constexpr (VB == 1) {
+        v = *vb;
+      } else if constexpr (VB == 2) {
+        v = *reinterpret_cast<const unsigned short*>(vb);
+      } else {
+        v = *reinterpret_cast<const unsigned*>(vb);
+      }
+      float f[VD];
+#pragma unroll
+      for (int j = 0; j < VD; ++j)
+        f[j] =
+            __int_as_float(0x4B000000u | ((v >> (4 * j)) & 0xFu)) - 8388608.f;
+#pragma unroll
+      for (int g = 0; g < NP4; ++g) {
+        const float4 wt4 = wsm4[warp][t][g];
+        const float wt[4] = {wt4.x, wt4.y, wt4.z, wt4.w};
+#pragma unroll
+        for (int u = 0; u < 4; ++u) {
+          if (4 * g + u < ACTIVE_HEADS) {
+#pragma unroll
+            for (int j = 0; j < VD; ++j)
+              A[4 * g + u][j] = fmaf(wt[u], f[j], A[4 * g + u][j]);
+          }
+        }
+      }
+    }
+    __syncwarp();
+  }
+
+  // fold per-lane l/z partials, publish per-warp partials to smem
+#pragma unroll
+  for (int p = 0; p < ACTIVE_HEADS; ++p) {
+    float s0 = ll[p];
+    float s1 = zl[p];
+#pragma unroll
+    for (int off = 16; off; off >>= 1) {
+      s0 += __shfl_xor_sync(0xffffffffu, s0, off);
+      s1 += __shfl_xor_sync(0xffffffffu, s1, off);
+    }
+    if constexpr (VD == 2) {
+      reinterpret_cast<float2*>(&comb_v[warp][p][0])[lane] =
+          make_float2(A[p][0] + s1, A[p][1] + s1);
+    } else if constexpr (VD == 4) {
+      reinterpret_cast<float4*>(&comb_v[warp][p][0])[lane] =
+          make_float4(A[p][0] + s1, A[p][1] + s1, A[p][2] + s1, A[p][3] + s1);
+    } else {
+      float4* dst = reinterpret_cast<float4*>(&comb_v[warp][p][0]) + 2 * lane;
+      dst[0] =
+          make_float4(A[p][0] + s1, A[p][1] + s1, A[p][2] + s1, A[p][3] + s1);
+      dst[1] =
+          make_float4(A[p][4] + s1, A[p][5] + s1, A[p][6] + s1, A[p][7] + s1);
+    }
+    if (lane == 0) comb_ml[warp][p] = make_float2(m[p], s0);
+  }
+  __syncthreads();
+
+  // D=256 otherwise repeats the same cross-warp exponentials for every
+  // output dimension.  Compute the softmax merge weights once per head.
+  if constexpr (D == 256) {
+    if (threadIdx.x < nvalid) {
+      const int p = threadIdx.x;
+      float M = -CUDART_INF_F;
+      for (int w = 0; w < nw; ++w) M = fmaxf(M, comb_ml[w][p].x);
+      float L = 0.f;
+      for (int w = 0; w < nw; ++w) {
+        const float e = __expf(comb_ml[w][p].x - M);
+        comb_w[p][w] = e;
+        L = fmaf(e, comb_ml[w][p].y, L);
+      }
+      comb_total_ml[p] = make_float2(M, L);
+    }
+    __syncthreads();
+    for (int p = 0; p < nvalid; ++p) {
+      const float2 total = comb_total_ml[p];
+      for (int d = threadIdx.x; d < D; d += blockDim.x) {
+        float O = 0.f;
+        for (int w = 0; w < nw; ++w) O = fmaf(comb_w[p][w], comb_v[w][p][d], O);
+        if (max_splits == 1) {
+          out[((size_t)b * HQ + h0 + p) * D + d] =
+              __float2bfloat16(O / total.y);
+        } else {
+          const size_t idx = ((size_t)b * HQ + h0 + p) * max_splits + split;
+          part_acc[idx * D + d] = O;
+          if (d == 0) part_ml[idx] = total;
+        }
+      }
+    }
+  } else {
+    for (int p = 0; p < nvalid; ++p) {
+      for (int d = threadIdx.x; d < D; d += blockDim.x) {
+        float M = -CUDART_INF_F;
+        for (int w = 0; w < nw; ++w) M = fmaxf(M, comb_ml[w][p].x);
+        float L = 0.f;
+        float O = 0.f;
+        for (int w = 0; w < nw; ++w) {
+          const float2 mlw = comb_ml[w][p];
+          const float e = __expf(mlw.x - M);
+          L = fmaf(e, mlw.y, L);
+          O = fmaf(e, comb_v[w][p][d], O);
+        }
+        if (max_splits == 1) {
+          out[((size_t)b * HQ + h0 + p) * D + d] = __float2bfloat16(O / L);
+        } else {
+          const size_t idx = ((size_t)b * HQ + h0 + p) * max_splits + split;
+          part_acc[idx * D + d] = O;
+          if (d == 0) part_ml[idx] = make_float2(M, L);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Merge splits. grid B*HQ, block D (one thread per dim).
+// ---------------------------------------------------------------------------
+template <int D>
+__global__ void merge_kernel(const float* __restrict__ part_acc,
+                             const float2* __restrict__ part_ml,
+                             const int* __restrict__ seq_lens,
+                             __nv_bfloat16* __restrict__ out, const int HQ,
+                             const int max_splits, const int one_wave) {
+  const int bh = blockIdx.x;
+  const int b = bh / HQ;
+  const int seq = seq_lens[b];
+  const int chunks = (seq + 31) >> 5;
+  const DynamicSplitPlan dynamic_plan =
+      make_dynamic_split_plan(chunks, max_splits, one_wave);
+  const int nv = dynamic_plan.splits;
+  const int d = threadIdx.x;
+  const float* acc = part_acc + (size_t)bh * max_splits * D;
+  const float2* ml = part_ml + (size_t)bh * max_splits;
+  __shared__ float weights[256];
+  __shared__ float inv_l;
+  if (d < 32) {
+    float M = -CUDART_INF_F;
+    for (int s = d; s < nv; s += 32) M = fmaxf(M, ml[s].x);
+    M = warp_max(M);
+    float L = 0.f;
+    for (int s = d; s < nv; s += 32) {
+      const float e = __expf(ml[s].x - M);
+      weights[s] = e;
+      L = fmaf(e, ml[s].y, L);
+    }
+    L = warp_sum(L);
+    if (d == 0) inv_l = 1.f / L;
+  }
+  __syncthreads();
+  float O = 0.f;
+  for (int s = 0; s < nv; ++s) O = fmaf(weights[s], acc[s * D + d], O);
+  out[(size_t)bh * D + d] = __float2bfloat16(O * inv_l);
+}
+
+// ---------------------------------------------------------------------------
+template <int D>
+static void launch_simt(const void* q, const void* kv_cache,
+                        const void* page_table, const void* seq_lens,
+                        const void* rotation, const void* centroids, void* out,
+                        float* workspace, int B, int HQ, int HKV,
+                        int page_table_stride, int page_size,
+                        const DecodePlan& pl, cudaStream_t stream) {
+  (void)rotation;
+  float* part_acc = nullptr;
+  float2* part_ml = nullptr;
+  if (pl.splits > 1) {
+    part_acc = workspace;
+    part_ml =
+        reinterpret_cast<float2*>(part_acc + (size_t)B * HQ * pl.splits * D);
+  }
+
+  dim3 dgrid(pl.splits, HKV * pl.npacks, B);
+  const int threads = 32 * pl.nwarps;
+#define TQ_SIMT_LAUNCH(PS, HP, AH)                                       \
+  decode_kernel<D, PS, HP, AH><<<dgrid, threads, 0, stream>>>(           \
+      reinterpret_cast<const __nv_bfloat16*>(q),                         \
+      reinterpret_cast<const uint8_t*>(kv_cache),                        \
+      reinterpret_cast<const int*>(page_table),                          \
+      reinterpret_cast<const int*>(seq_lens),                            \
+      reinterpret_cast<const float*>(centroids),                         \
+      reinterpret_cast<__nv_bfloat16*>(out), part_acc, part_ml, HQ, HKV, \
+      page_table_stride, pl.npacks, pl.splits, pl.one_wave)
+
+  if (pl.np4 == 1) {
+    if (pl.G <= 2) {
+      switch (page_size) {
+        case 16:
+          TQ_SIMT_LAUNCH(16, 1, 2);
+          break;
+        case 32:
+          TQ_SIMT_LAUNCH(32, 1, 2);
+          break;
+        case 64:
+          TQ_SIMT_LAUNCH(64, 1, 2);
+          break;
+        default:
+          TQ_SIMT_LAUNCH(128, 1, 2);
+          break;
+      }
+    } else {
+      switch (page_size) {
+        case 16:
+          TQ_SIMT_LAUNCH(16, 1, 4);
+          break;
+        case 32:
+          TQ_SIMT_LAUNCH(32, 1, 4);
+          break;
+        case 64:
+          TQ_SIMT_LAUNCH(64, 1, 4);
+          break;
+        default:
+          TQ_SIMT_LAUNCH(128, 1, 4);
+          break;
+      }
+    }
+  } else {
+    switch (page_size) {
+      case 16:
+        TQ_SIMT_LAUNCH(16, 2, 8);
+        break;
+      case 32:
+        TQ_SIMT_LAUNCH(32, 2, 8);
+        break;
+      case 64:
+        TQ_SIMT_LAUNCH(64, 2, 8);
+        break;
+      default:
+        TQ_SIMT_LAUNCH(128, 2, 8);
+        break;
+    }
+  }
+#undef TQ_SIMT_LAUNCH
+
+  if (pl.splits > 1) {
+    merge_kernel<D><<<B * HQ, D, 0, stream>>>(
+        part_acc, part_ml, reinterpret_cast<const int*>(seq_lens),
+        reinterpret_cast<__nv_bfloat16*>(out), HQ, pl.splits, pl.one_wave);
+  }
+}
+
+void turboquant_decode_launch(const void* q, const void* kv_cache,
+                              const void* page_table, const void* seq_lens,
+                              const void* rotation, const void* centroids,
+                              void* out, float* workspace, int B, int HQ,
+                              int HKV, int page_table_stride, int page_size,
+                              int head_dim, const DecodePlan& pl,
+                              cudaStream_t stream) {
+  switch (head_dim) {
+    case 64:
+      launch_simt<64>(q, kv_cache, page_table, seq_lens, rotation, centroids,
+                      out, workspace, B, HQ, HKV, page_table_stride, page_size,
+                      pl, stream);
+      break;
+    case 128:
+      launch_simt<128>(q, kv_cache, page_table, seq_lens, rotation, centroids,
+                       out, workspace, B, HQ, HKV, page_table_stride, page_size,
+                       pl, stream);
+      break;
+    default:
+      launch_simt<256>(q, kv_cache, page_table, seq_lens, rotation, centroids,
+                       out, workspace, B, HQ, HKV, page_table_stride, page_size,
+                       pl, stream);
+      break;
+  }
+}

--- a/csrc/attention/turboquant/kernel.h
+++ b/csrc/attention/turboquant/kernel.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include <cuda_runtime.h>
+#include <cstdint>
+
+struct DecodePlan {
+  int G;
+  int npacks;
+  int np4;  // 1 -> pack of up to 4 heads, 2 -> up to 8
+  int splits;
+  int pps;     // logical 32-token chunks per split
+  int nwarps;  // warps per CTA (1..4)
+  int one_wave;
+};
+
+inline DecodePlan make_decode_plan(int B, int HQ, int HKV, int NP,
+                                   int page_size, int sm_count) {
+  DecodePlan pl;
+  pl.G = HQ / HKV;
+  pl.npacks = (pl.G + 7) / 8;
+  const int pmax = pl.G < 8 ? pl.G : 8;
+  pl.np4 = (pmax + 3) / 4;
+  const int base = B * HKV * pl.npacks;
+  const int nchunks = (NP * page_size + 31) / 32;
+  // Aim just under four resident CTAs per SM so the final wave remains
+  // populated without forcing an extra split solely for a small tail.
+  const int target = 4 * sm_count - sm_count / 8;
+  int desired = (target + base - 1) / base;
+  if (desired < 1) desired = 1;
+  int splits = desired;
+  if (splits > nchunks) splits = nchunks;
+  if (splits > 256) splits = 256;
+  // Use at least two 32-token warps per CTA when the allocated cache permits
+  // it; the policy is invariant to the physical page template.
+  const int two_chunk_cap = nchunks / 2 > 0 ? nchunks / 2 : 1;
+  if (splits > two_chunk_cap) splits = two_chunk_cap;
+  const int one_wave = (sm_count + base - 1) / base;
+  const int four_chunk_cap = nchunks / 4 > 0 ? nchunks / 4 : 1;
+  const int warp_full_cap =
+      one_wave > four_chunk_cap ? one_wave : four_chunk_cap;
+  if (splits > warp_full_cap) splits = warp_full_cap;
+  pl.pps = (nchunks + splits - 1) / splits;
+  pl.splits = (nchunks + pl.pps - 1) / pl.pps;
+  pl.nwarps = pl.pps < 4 ? pl.pps : 4;
+  pl.one_wave = one_wave;
+  return pl;
+}
+
+void turboquant_decode_launch(const void* q, const void* kv_cache,
+                              const void* page_table, const void* seq_lens,
+                              const void* rotation, const void* centroids,
+                              void* out, float* workspace, int B, int HQ,
+                              int HKV, int page_table_stride, int page_size,
+                              int head_dim, const DecodePlan& pl,
+                              cudaStream_t stream);
+#pragma once
+// SPDX-License-Identifier: Apache-2.0
+#pragma once

--- a/csrc/attention/turboquant/main.cpp
+++ b/csrc/attention/turboquant/main.cpp
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include "kernel.h"
+
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+extern "C" void turboquant_mma_decode_launch(
+    const void* q, const void* kv_cache, const int* pt, const int* sl,
+    const float* rot, const float* cen, void* out, void* part_o, void* part_ml,
+    int B, int HQ, int HKV, int page_table_stride, int page_size, int head_dim,
+    int splits, cudaStream_t stream);
+
+struct LaunchPlan {
+  bool use_mma;
+  int splits;
+  size_t workspace_bytes;
+};
+
+static int get_sm_count(int device) {
+  static int sm_counts[32] = {};
+  TORCH_CHECK(device >= 0 && device < 32, "invalid CUDA device index");
+  if (sm_counts[device] == 0) {
+    cudaDeviceGetAttribute(&sm_counts[device], cudaDevAttrMultiProcessorCount,
+                           device);
+  }
+  return sm_counts[device];
+}
+
+static LaunchPlan make_launch_plan(int B, int HQ, int HKV,
+                                   int page_table_stride, int page_size,
+                                   int head_dim, int max_seq_len,
+                                   int sm_count) {
+  const int G = HQ / HKV;
+  const int mma_npacks = (G + 15) / 16;
+  const int natural = B * HKV * mma_npacks;
+  const int ntiles64 = (max_seq_len + 63) / 64;
+  const bool populated_wide_pack =
+      G >= 4 && ntiles64 >= 1 &&
+      (natural >= sm_count || (G >= 6 && 3 * natural >= sm_count) ||
+       (G >= 7 && 5 * natural >= sm_count));
+  const int cap = std::max(1, std::min(64, ntiles64));
+  int mma_splits = 1;
+  double best = 1e30;
+  if (populated_wide_pack) {
+    for (int tiles_per_split = 1; tiles_per_split <= ntiles64;
+         ++tiles_per_split) {
+      const int s = (ntiles64 + tiles_per_split - 1) / tiles_per_split;
+      if (s > cap) continue;
+      const double bpsm = static_cast<double>(natural) * s / sm_count;
+      const double resident_waves = head_dim == 256 ? 2.0 : 3.0;
+      const double tail = std::max(std::ceil(bpsm), resident_waves) / bpsm;
+      const double merge =
+          s > 1
+              ? static_cast<double>(s) * HQ * 1050.0 /
+                    (static_cast<double>(max_seq_len) * HKV * (head_dim + 6.0))
+              : 0.0;
+      const double cost = tail * (1.0 + merge);
+      if (cost < best - 1e-12) {
+        best = cost;
+        mma_splits = s;
+      }
+      if (s == 1) break;
+    }
+  }
+
+  if (populated_wide_pack) {
+    const int64_t part_o_bytes = mma_splits > 1
+                                     ? static_cast<int64_t>(mma_splits) * B *
+                                           HQ * head_dim * sizeof(float)
+                                     : 0;
+    const int64_t part_ml_bytes =
+        mma_splits > 1
+            ? static_cast<int64_t>(mma_splits) * B * HQ * 2 * sizeof(float)
+            : 0;
+    return {true, mma_splits,
+            static_cast<size_t>(part_o_bytes + part_ml_bytes)};
+  }
+
+  const int logical_pages = (max_seq_len + page_size - 1) / page_size;
+  const DecodePlan plan =
+      make_decode_plan(B, HQ, HKV, std::min(logical_pages, page_table_stride),
+                       page_size, sm_count);
+  const int64_t workspace_floats =
+      plan.splits > 1
+          ? static_cast<int64_t>(B) * HQ * plan.splits * (head_dim + 2)
+          : 0;
+  return {false, plan.splits,
+          static_cast<size_t>(workspace_floats * sizeof(float))};
+}
+
+static int64_t workspace_size(int64_t B, int64_t HQ, int64_t HKV,
+                              int64_t page_table_stride, int64_t page_size,
+                              int64_t head_dim, int64_t max_seq_len,
+                              int64_t device) {
+  TORCH_CHECK(B > 0 && HQ > 0 && HKV > 0 && HQ % HKV == 0,
+              "TurboQuant decode dimensions are invalid");
+  TORCH_CHECK(page_table_stride > 0 && max_seq_len > 0 &&
+                  max_seq_len <= page_table_stride * page_size,
+              "TurboQuant page table dimensions are invalid");
+  TORCH_CHECK(
+      page_size == 16 || page_size == 32 || page_size == 64 || page_size == 128,
+      "TurboQuant page size must be one of {16, 32, 64, 128}");
+  TORCH_CHECK(head_dim == 64 || head_dim == 128 || head_dim == 256,
+              "TurboQuant head size must be one of {64, 128, 256}");
+  return static_cast<int64_t>(make_launch_plan(B, HQ, HKV, page_table_stride,
+                                               page_size, head_dim, max_seq_len,
+                                               get_sm_count(device))
+                                  .workspace_bytes);
+}
+
+static void run_with_workspace(torch::Tensor q, torch::Tensor kv_cache,
+                               torch::Tensor page_table, torch::Tensor seq_lens,
+                               torch::Tensor rotation, torch::Tensor centroids,
+                               torch::Tensor workspace, torch::Tensor out,
+                               int64_t page_size, int64_t max_seq_len) {
+  TORCH_CHECK(q.is_cuda() && q.is_contiguous() && q.dim() == 3,
+              "TurboQuant query must be a contiguous CUDA tensor");
+  const int head_dim = q.size(2);
+  TORCH_CHECK(q.scalar_type() == at::kBFloat16 &&
+                  (head_dim == 64 || head_dim == 128 || head_dim == 256),
+              "TurboQuant decode requires BF16 query with head size "
+              "64, 128, or 256");
+  TORCH_CHECK(kv_cache.is_cuda() && kv_cache.is_contiguous() &&
+                  kv_cache.scalar_type() == at::kByte && kv_cache.dim() == 4,
+              "TurboQuant cache must be a contiguous CUDA uint8 tensor");
+  TORCH_CHECK(
+      kv_cache.size(2) == 1 && kv_cache.size(3) == page_size * (head_dim + 6),
+      "TurboQuant cache record has an incompatible size");
+  TORCH_CHECK(page_table.is_cuda() && page_table.scalar_type() == at::kInt &&
+                  page_table.dim() == 2 && page_table.stride(1) == 1,
+              "TurboQuant page table must be a CUDA int32 row-major tensor");
+  TORCH_CHECK(
+      seq_lens.is_cuda() && seq_lens.is_contiguous() &&
+          seq_lens.scalar_type() == at::kInt && seq_lens.dim() == 1,
+      "TurboQuant sequence lengths must be a contiguous CUDA int32 tensor");
+  TORCH_CHECK(rotation.is_cuda() && rotation.is_contiguous() &&
+                  rotation.scalar_type() == at::kFloat && rotation.dim() == 2 &&
+                  rotation.size(0) == head_dim && rotation.size(1) == head_dim,
+              "TurboQuant rotation must be a contiguous CUDA float32 "
+              "[head_dim, head_dim] tensor");
+  TORCH_CHECK(centroids.is_cuda() && centroids.is_contiguous() &&
+                  centroids.scalar_type() == at::kFloat &&
+                  centroids.numel() == 16,
+              "TurboQuant centroids must be a contiguous CUDA float32 tensor");
+  TORCH_CHECK(workspace.is_cuda() && workspace.is_contiguous(),
+              "TurboQuant workspace must be a contiguous CUDA tensor");
+  TORCH_CHECK(out.is_cuda() && out.is_contiguous() &&
+                  out.scalar_type() == at::kBFloat16 &&
+                  out.sizes() == q.sizes(),
+              "TurboQuant output must match the query");
+  TORCH_CHECK(kv_cache.get_device() == q.get_device() &&
+                  page_table.get_device() == q.get_device() &&
+                  seq_lens.get_device() == q.get_device() &&
+                  rotation.get_device() == q.get_device() &&
+                  centroids.get_device() == q.get_device() &&
+                  workspace.get_device() == q.get_device() &&
+                  out.get_device() == q.get_device(),
+              "TurboQuant tensors must be on the same CUDA device");
+  TORCH_CHECK(
+      page_size == 16 || page_size == 32 || page_size == 64 || page_size == 128,
+      "TurboQuant page size must be one of {16, 32, 64, 128}");
+
+  const int B = q.size(0);
+  const int HQ = q.size(1);
+  const int HKV = kv_cache.size(1);
+  const int page_table_stride = page_table.stride(0);
+  TORCH_CHECK(B > 0 && HKV > 0 && HQ % HKV == 0 && page_table.size(0) == B &&
+                  seq_lens.size(0) == B,
+              "TurboQuant decode shapes are incompatible");
+  TORCH_CHECK(page_table.size(1) > 0 && max_seq_len > 0 &&
+                  max_seq_len <= page_table.size(1) * page_size,
+              "TurboQuant max sequence length exceeds the page table");
+
+  at::cuda::CUDAGuard device_guard(q.device());
+  int major = 0;
+  int minor = 0;
+  cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor,
+                         q.get_device());
+  cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor,
+                         q.get_device());
+  TORCH_CHECK(minor == 0 && (major == 8 || major == 9 || major == 10),
+              "TurboQuant optimized decode requires SM80, SM90, or SM100");
+  const LaunchPlan launch_plan =
+      make_launch_plan(B, HQ, HKV, page_table_stride, page_size, head_dim,
+                       max_seq_len, get_sm_count(q.get_device()));
+  const size_t workspace_bytes = workspace.numel() * workspace.element_size();
+  TORCH_CHECK(workspace_bytes >= launch_plan.workspace_bytes,
+              "TurboQuant caller workspace is too small");
+
+  char* base = static_cast<char*>(workspace.data_ptr());
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+  if (launch_plan.use_mma) {
+    const int64_t part_o_bytes =
+        launch_plan.splits > 1 ? static_cast<int64_t>(launch_plan.splits) * B *
+                                     HQ * head_dim * sizeof(float)
+                               : 0;
+    void* part_o = launch_plan.splits > 1 ? base : nullptr;
+    void* part_ml = launch_plan.splits > 1 ? base + part_o_bytes : nullptr;
+    turboquant_mma_decode_launch(
+        q.data_ptr(), kv_cache.data_ptr(), page_table.data_ptr<int>(),
+        seq_lens.data_ptr<int>(), rotation.data_ptr<float>(),
+        centroids.data_ptr<float>(), out.data_ptr(), part_o, part_ml, B, HQ,
+        HKV, page_table_stride, page_size, head_dim, launch_plan.splits,
+        stream);
+    return;
+  }
+
+  const int logical_pages = (max_seq_len + page_size - 1) / page_size;
+  const DecodePlan plan =
+      make_decode_plan(B, HQ, HKV, std::min(logical_pages, page_table_stride),
+                       page_size, get_sm_count(q.get_device()));
+  turboquant_decode_launch(
+      q.data_ptr(), kv_cache.data_ptr(), page_table.data_ptr(),
+      seq_lens.data_ptr(), rotation.data_ptr(), centroids.data_ptr(),
+      out.data_ptr(), reinterpret_cast<float*>(base), B, HQ, HKV,
+      page_table_stride, page_size, head_dim, plan, stream);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("workspace_size", &workspace_size);
+  m.def("run_with_workspace", &run_with_workspace);
+}

--- a/csrc/attention/turboquant/mma_kernel.cu
+++ b/csrc/attention/turboquant/mma_kernel.cu
@@ -1,0 +1,607 @@
+// SPDX-License-Identifier: Apache-2.0
+// TurboQuant K4V4-NC paged GQA decode, q_len=1, D in {64,128,256}, H100.
+//
+// Design:
+//  - decode kernel: block = (batch, kv_head, q_pack, split).
+//      * fused one-warp FWHT rotates the CTA's own q pack into smem fp16
+//        (folds the normalized Hadamard and D^-0.5; no separate rot kernel).
+//      * cp.async double-buffered loads of contiguous per-(page,head)
+//        PAGE_SIZE*(D/2)-byte code planes + 64B metadata rows.
+//      * K is dequantized register-direct into m16n8k16 B fragments inside
+//        the QK loop (shuffle LUT of the 16 centroids); no decoded-K smem
+//        plane exists, cutting ~2*D*64 bytes of shared memory per block.
+//      * V bytes -> half2 nibble dequant to padded smem (row stride 2D+16
+//        bytes -> conflict-free ldmatrix).
+//      * K row scale norm/centroid_norm folded into the score post-mma
+//        (per-token scalar), log2(e) folded in for exp2f softmax.
+//      * m16n8k16 tensor-core QK^T (warp-redundant, D/16 k-steps) and PV
+//        (D split across 4 warps -> D/4 dims each), FA2-style online softmax,
+//        C->A fragment reuse.
+//  - merge kernel: log-sum-exp combine of split partials.
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cstdint>
+
+namespace {
+
+constexpr float LOG2E = 1.4426950408889634f;
+
+// Compile-time shared-memory layout for a head dimension D.
+template <int D>
+struct TQLayout {
+  static constexpr int KV_STRIDE = 2 * D + 16;  // decoded row stride (pad 16B)
+  static constexpr int CODE_STRIDE = D / 2 + 16;  // code row stride (pad 16B)
+  static constexpr int P_STRIDE = 144;            // P staging row (128B + 16B)
+  static constexpr int OFF_Q = 0;
+  static constexpr int OFF_V = OFF_Q + 16 * KV_STRIDE;
+  static constexpr int OFF_CK = OFF_V + 64 * KV_STRIDE;
+  static constexpr int OFF_CV = OFF_CK + 2 * 64 * CODE_STRIDE;
+  static constexpr int OFF_NORM = OFF_CV + 2 * 64 * CODE_STRIDE;
+  static constexpr int OFF_SCALE = OFF_NORM + 2 * 64 * 2;
+  static constexpr int OFF_ZERO = OFF_SCALE + 2 * 64 * 2;
+  static constexpr int OFF_P = OFF_ZERO + 2 * 64 * 2;    // fp16 P [16][64]
+  static constexpr int OFF_RED = OFF_P + 16 * P_STRIDE;  // f32 [2][4w][16 rows]
+  static constexpr int OFF_R = OFF_RED + 512;
+  static constexpr int SMEM_BYTES = OFF_R + 64 * 4;
+};
+
+__device__ __forceinline__ uint32_t smem_u32(const void* p) {
+  return static_cast<uint32_t>(__cvta_generic_to_shared(p));
+}
+__device__ __forceinline__ void cp_async16(uint32_t dst, const void* src) {
+  asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n" ::"r"(dst),
+               "l"(src));
+}
+__device__ __forceinline__ void cp_commit() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+template <int N>
+__device__ __forceinline__ void cp_wait() {
+  asm volatile("cp.async.wait_group %0;\n" ::"n"(N));
+}
+__device__ __forceinline__ void ldmx4(uint32_t a, uint32_t& r0, uint32_t& r1,
+                                      uint32_t& r2, uint32_t& r3) {
+  asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+               : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3)
+               : "r"(a));
+}
+__device__ __forceinline__ void ldmx4t(uint32_t a, uint32_t& r0, uint32_t& r1,
+                                       uint32_t& r2, uint32_t& r3) {
+  asm volatile(
+      "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+      : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3)
+      : "r"(a));
+}
+__device__ __forceinline__ void mma16816(float* c, const uint32_t* a,
+                                         uint32_t b0, uint32_t b1) {
+  asm volatile(
+      "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+      "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+      : "+f"(c[0]), "+f"(c[1]), "+f"(c[2]), "+f"(c[3])
+      : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b0), "r"(b1));
+}
+__device__ __forceinline__ uint32_t pack_h2(float x, float y) {
+  __half2 h = __floats2half2_rn(x, y);
+  return *reinterpret_cast<uint32_t*>(&h);
+}
+
+template <int D>
+__device__ __forceinline__ void tq_fwht(float (&x)[D / 32], int lane) {
+  constexpr int V = D / 32;
+#pragma unroll
+  for (int s = 1; s < V; s <<= 1) {
+#pragma unroll
+    for (int j = 0; j < V; ++j) {
+      if ((j & s) == 0) {
+        const float a = x[j] + x[j + s];
+        const float b = x[j] - x[j + s];
+        x[j] = a;
+        x[j + s] = b;
+      }
+    }
+  }
+#pragma unroll
+  for (int bit = 1; bit < 32; bit <<= 1) {
+#pragma unroll
+    for (int j = 0; j < V; ++j) {
+      const float y = __shfl_xor_sync(0xffffffffu, x[j], bit);
+      x[j] = (lane & bit) ? (y - x[j]) : (x[j] + y);
+    }
+  }
+}
+
+template <int D, int PAGE_SIZE>
+__global__ void __launch_bounds__(128, (D >= 256) ? 2 : 3) tq_decode_kernel(
+    const __nv_bfloat16* __restrict__ qg, const uint8_t* __restrict__ kv_cache,
+    const int* __restrict__ page_table, const int* __restrict__ seq_lens,
+    const float* __restrict__ centroids, __nv_bfloat16* __restrict__ out,
+    float* __restrict__ part_o, float* __restrict__ part_ml, int B, int HQ,
+    int HKV, int G, int NPACKS, int SPLITS, int page_table_stride) {
+  using L = TQLayout<D>;
+  constexpr int CODE_BYTES = D / 2;  // K4/V4 code bytes per token
+  constexpr int CCH = D / 32;        // 16B cp.async chunks per code row
+  constexpr int QCH = D / 8;         // 16B chunks per fp16 q row
+  constexpr int KSTEPS = D / 16;     // QK^T k iterations
+  constexpr int KW = D / 16;         // 4B code words per half-row decoder
+  constexpr int NJ2 = D / 64;        // 16-dim PV column groups per warp
+  constexpr int NO = D / 32;         // n8 output blocks per warp
+  extern __shared__ uint8_t sm[];
+  const int tid = threadIdx.x;
+  const int lane = tid & 31;
+  const int warp = tid >> 5;
+
+  const int bx = blockIdx.x;
+  const int pack = bx % NPACKS;
+  const int kvh = (bx / NPACKS) % HKV;
+  const int b = bx / (NPACKS * HKV);
+  const int split = blockIdx.y;
+
+  const int seq = seq_lens[b];
+  const int ntiles_total = (seq + 63) >> 6;
+  const int tiles_per_split = (ntiles_total + SPLITS - 1) / SPLITS;
+  const int tile0 = split * tiles_per_split;
+  const int tile1 = min(ntiles_total, tile0 + tiles_per_split);
+
+  const int hp = min(16, G - pack * 16);
+  const int head0 = kvh * G + pack * 16;
+
+  if (tile0 >= tile1) {  // empty split: write neutral partials
+    if (part_o != nullptr) {
+      size_t obase = ((size_t)(split * B + b) * HQ + head0) * D;
+      for (int i = tid; i < hp * D; i += 128) part_o[obase + i] = 0.f;
+      size_t mlb = ((size_t)(split * B + b) * HQ + head0) * 2;
+      for (int i = tid; i < hp; i += 128) {
+        part_ml[mlb + 2 * i] = -1e30f;
+        part_ml[mlb + 2 * i + 1] = 0.f;
+      }
+    }
+    return;
+  }
+
+  const int ntiles = tile1 - tile0;
+  float* red = reinterpret_cast<float*>(sm + L::OFF_RED);
+  float* r_sm = reinterpret_cast<float*>(sm + L::OFF_R);
+  // lanes 0-15 hold the centroid table for shuffle-based dequant
+  const float my_c = centroids[lane & 15];
+  const __half* nsm = reinterpret_cast<const __half*>(sm + L::OFF_NORM);
+  const __half* ssm = reinterpret_cast<const __half*>(sm + L::OFF_SCALE);
+  const __half* zsm = reinterpret_cast<const __half*>(sm + L::OFF_ZERO);
+
+  auto issue_tile = [&](int t) {
+    if (t < ntiles) {
+      const int tile = tile0 + t;
+      const int buf = t & 1;
+      for (int i = tid; i < 64 * CCH; i += 128) {
+        const int dst_row = i / CCH;
+        const int ch = i % CCH;
+        const int token = min(tile * 64 + dst_row, seq - 1);
+        const int pg = token / PAGE_SIZE;
+        const int row = token - pg * PAGE_SIZE;
+        const int blk = page_table[b * page_table_stride + pg];
+        const size_t rec = (size_t)blk * HKV + kvh;
+        const uint8_t* record = kv_cache + rec * (PAGE_SIZE * (D + 6));
+        const size_t so = (size_t)row * CODE_BYTES + ch * 16;
+        const int doff =
+            dst_row * L::CODE_STRIDE + ch * 16 + buf * (64 * L::CODE_STRIDE);
+        cp_async16(smem_u32(sm + L::OFF_CK + doff), record + so);
+        cp_async16(smem_u32(sm + L::OFF_CV + doff),
+                   record + PAGE_SIZE * CODE_BYTES + so);
+      }
+      if (tid < 24) {
+        const int f = tid >> 3;
+        const int j = tid & 7;
+        const int token = min(tile * 64 + j * 8, ((seq - 1) >> 3) << 3);
+        const int pg = token / PAGE_SIZE;
+        const int row = token - pg * PAGE_SIZE;
+        const int blk = page_table[b * page_table_stride + pg];
+        const size_t rec = (size_t)blk * HKV + kvh;
+        const uint8_t* record = kv_cache + rec * (PAGE_SIZE * (D + 6));
+        const __half* srcp =
+            reinterpret_cast<const __half*>(record + PAGE_SIZE * (D + 2 * f));
+        const int off = ((f == 0)   ? L::OFF_NORM
+                         : (f == 1) ? L::OFF_SCALE
+                                    : L::OFF_ZERO) +
+                        buf * 128 + j * 16;
+        cp_async16(smem_u32(sm + off), srcp + row);
+      }
+    }
+    cp_commit();
+  };
+
+  issue_tile(0);
+  issue_tile(1);
+
+  // Fused q rotation: zero-pad rows >= hp, then FWHT the CTA's own heads
+  // (one warp per head, round-robin) straight into the fp16 q plane.
+  for (int i = tid; i < 16 * QCH; i += 128) {
+    const int row = i / QCH;
+    const int ch = i % QCH;
+    if (row >= hp)
+      *reinterpret_cast<uint4*>(sm + L::OFF_Q + row * L::KV_STRIDE + ch * 16) =
+          make_uint4(0u, 0u, 0u, 0u);
+  }
+  for (int h = warp; h < hp; h += 4) {
+    constexpr int V = D / 32;
+    float x[V];
+    const __nv_bfloat16* src = qg + ((size_t)b * HQ + head0 + h) * D + lane * V;
+#pragma unroll
+    for (int j = 0; j < V; ++j) x[j] = __bfloat162float(src[j]);
+    tq_fwht<D>(x, lane);
+    __half* dst =
+        reinterpret_cast<__half*>(sm + L::OFF_Q + h * L::KV_STRIDE) + lane * V;
+#pragma unroll
+    for (int j = 0; j < V; ++j) dst[j] = __float2half(x[j] * (1.f / D));
+  }
+  __syncthreads();
+
+  uint32_t qa[KSTEPS][4];
+  {
+    const int r = ((lane >> 3) & 1) * 8 + (lane & 7);
+    const uint32_t base =
+        smem_u32(sm + L::OFF_Q + r * L::KV_STRIDE + (lane >> 4) * 16);
+#pragma unroll
+    for (int ks = 0; ks < KSTEPS; ks++)
+      ldmx4(base + ks * 32, qa[ks][0], qa[ks][1], qa[ks][2], qa[ks][3]);
+  }
+
+  float O[NO][4];
+#pragma unroll
+  for (int j = 0; j < NO; j++)
+#pragma unroll
+    for (int e = 0; e < 4; e++) O[j][e] = 0.f;
+  float m0 = -1e30f, m1 = -1e30f, l0 = 0.f, l1 = 0.f;
+
+  const uint32_t vmat_base =
+      smem_u32(sm + L::OFF_V) +
+      (((lane >> 3) & 1) * 8 + (lane & 7)) * L::KV_STRIDE + warp * (D / 2) +
+      (lane >> 4) * 16;
+  const uint32_t pmat_base =
+      smem_u32(sm + L::OFF_P) +
+      (((lane >> 3) & 1) * 8 + (lane & 7)) * L::P_STRIDE + (lane >> 4) * 16;
+  const int r_local = lane >> 1;
+  const int hh = lane & 1;
+  const int drow = warp * 16 + r_local;
+  const int row0 = lane >> 2;
+  const int row1 = row0 + 8;
+  const int nA = lane >> 2;  // fragment n index (token within 8-group)
+  const int kb = lane & 3;   // fragment k byte selector
+
+  for (int t = 0; t < ntiles; t++) {
+    const int buf = t & 1;
+    cp_wait<1>();
+    __syncthreads();
+
+    {  // decode V half-row (D/4 code bytes -> D/2 dims)
+      const uint8_t* crow =
+          sm + L::OFF_CV + buf * (64 * L::CODE_STRIDE) + drow * L::CODE_STRIDE;
+      const __half2 s2 = __half2half2(ssm[buf * 64 + drow]);
+      const __half2 z2 = __half2half2(zsm[buf * 64 + drow]);
+      const __half2 c1024 = __float2half2_rn(1024.f);
+#pragma unroll
+      for (int i = 0; i < KW; i++) {
+        const int cst = hh * KW + ((i + 2 * r_local + 4 * hh) & (KW - 1));
+        const uint32_t code =
+            *reinterpret_cast<const uint32_t*>(crow + cst * 4);
+        uint32_t w[4];
+#pragma unroll
+        for (int e = 0; e < 4; e++) {
+          // fp16 bias trick: 0x6400|n == (half)(1024+n), exact for n in [0,15]
+          const uint32_t bt = code >> (8 * e);
+          uint32_t raw = 0x64006400u | (bt & 0xFu) | ((bt & 0xF0u) << 12);
+          __half2 hv = *reinterpret_cast<__half2*>(&raw);
+          hv = __hfma2(__hsub2(hv, c1024), s2, z2);
+          w[e] = *reinterpret_cast<uint32_t*>(&hv);
+        }
+        *reinterpret_cast<uint4*>(sm + L::OFF_V + drow * L::KV_STRIDE +
+                                  cst * 16) =
+            make_uint4(w[0], w[1], w[2], w[3]);
+      }
+    }
+    __syncthreads();
+
+    // QK^T: warp w owns tokens [16w, 16w+16). K is dequantized straight
+    // into B fragments from the staged code bytes (shuffle centroid LUT);
+    // per-lane csq partials cover dims {16ks+2kb, +1, +8, +9} over all ks.
+    float C[2][4];
+#pragma unroll
+    for (int j = 0; j < 2; j++)
+#pragma unroll
+      for (int e = 0; e < 4; e++) C[j][e] = 0.f;
+    float csq0 = 0.f, csq1 = 0.f;
+    {
+      const uint8_t* ckA = sm + L::OFF_CK + buf * (64 * L::CODE_STRIDE) +
+                           (warp * 16 + nA) * L::CODE_STRIDE;
+      const uint8_t* ckB = ckA + 8 * L::CODE_STRIDE;
+#pragma unroll
+      for (int ks = 0; ks < KSTEPS; ks++) {
+        const uint2 wA = *reinterpret_cast<const uint2*>(ckA + ks * 8);
+        const uint2 wB = *reinterpret_cast<const uint2*>(ckB + ks * 8);
+        const uint32_t bl0 = (wA.x >> (8 * kb)) & 0xFFu;
+        const uint32_t bh0 = (wA.y >> (8 * kb)) & 0xFFu;
+        const uint32_t bl1 = (wB.x >> (8 * kb)) & 0xFFu;
+        const uint32_t bh1 = (wB.y >> (8 * kb)) & 0xFFu;
+        const float c0 = __shfl_sync(0xffffffffu, my_c, bl0 & 0xFu);
+        const float c1 = __shfl_sync(0xffffffffu, my_c, bl0 >> 4);
+        const float c2 = __shfl_sync(0xffffffffu, my_c, bh0 & 0xFu);
+        const float c3 = __shfl_sync(0xffffffffu, my_c, bh0 >> 4);
+        const float c4 = __shfl_sync(0xffffffffu, my_c, bl1 & 0xFu);
+        const float c5 = __shfl_sync(0xffffffffu, my_c, bl1 >> 4);
+        const float c6 = __shfl_sync(0xffffffffu, my_c, bh1 & 0xFu);
+        const float c7 = __shfl_sync(0xffffffffu, my_c, bh1 >> 4);
+        csq0 = fmaf(c0, c0, csq0);
+        csq0 = fmaf(c1, c1, csq0);
+        csq0 = fmaf(c2, c2, csq0);
+        csq0 = fmaf(c3, c3, csq0);
+        csq1 = fmaf(c4, c4, csq1);
+        csq1 = fmaf(c5, c5, csq1);
+        csq1 = fmaf(c6, c6, csq1);
+        csq1 = fmaf(c7, c7, csq1);
+        const uint32_t b0 = pack_h2(c0, c1);
+        const uint32_t b1 = pack_h2(c2, c3);
+        const uint32_t b2 = pack_h2(c4, c5);
+        const uint32_t b3 = pack_h2(c6, c7);
+        mma16816(C[0], qa[ks], b0, b1);
+        mma16816(C[1], qa[ks], b2, b3);
+      }
+    }
+    csq0 += __shfl_xor_sync(0xffffffffu, csq0, 1);
+    csq0 += __shfl_xor_sync(0xffffffffu, csq0, 2);
+    csq1 += __shfl_xor_sync(0xffffffffu, csq1, 1);
+    csq1 += __shfl_xor_sync(0xffffffffu, csq1, 2);
+    if (kb == 0) {
+      const float n0 = __half2float(nsm[buf * 64 + warp * 16 + nA]);
+      const float n1 = __half2float(nsm[buf * 64 + warp * 16 + 8 + nA]);
+      r_sm[warp * 16 + nA] = n0 * rsqrtf(csq0 + 1e-16f) * LOG2E;
+      r_sm[warp * 16 + 8 + nA] = n1 * rsqrtf(csq1 + 1e-16f) * LOG2E;
+    }
+    __syncwarp();
+
+    const int token_base = (tile0 + t) * 64;
+    const int vcnt = min(seq, token_base + 64) - token_base;
+    float mx0 = -1e30f, mx1 = -1e30f;
+#pragma unroll
+    for (int j = 0; j < 2; j++) {
+      const int c0 = warp * 16 + j * 8 + 2 * (lane & 3);
+      const float2 rr = *reinterpret_cast<const float2*>(&r_sm[c0]);
+      C[j][0] = (c0 < vcnt) ? C[j][0] * rr.x : -1e30f;
+      C[j][1] = (c0 + 1 < vcnt) ? C[j][1] * rr.y : -1e30f;
+      C[j][2] = (c0 < vcnt) ? C[j][2] * rr.x : -1e30f;
+      C[j][3] = (c0 + 1 < vcnt) ? C[j][3] * rr.y : -1e30f;
+      mx0 = fmaxf(mx0, fmaxf(C[j][0], C[j][1]));
+      mx1 = fmaxf(mx1, fmaxf(C[j][2], C[j][3]));
+    }
+    mx0 = fmaxf(mx0, __shfl_xor_sync(0xffffffffu, mx0, 1));
+    mx0 = fmaxf(mx0, __shfl_xor_sync(0xffffffffu, mx0, 2));
+    mx1 = fmaxf(mx1, __shfl_xor_sync(0xffffffffu, mx1, 1));
+    mx1 = fmaxf(mx1, __shfl_xor_sync(0xffffffffu, mx1, 2));
+    if ((lane & 3) == 0) {
+      red[warp * 16 + row0] = mx0;
+      red[warp * 16 + row1] = mx1;
+    }
+    __syncthreads();
+    issue_tile(t + 2);  // all warps done with CK[buf]: safe to refill
+    const float mn0 = fmaxf(m0, fmaxf(fmaxf(red[row0], red[16 + row0]),
+                                      fmaxf(red[32 + row0], red[48 + row0])));
+    const float mn1 = fmaxf(m1, fmaxf(fmaxf(red[row1], red[16 + row1]),
+                                      fmaxf(red[32 + row1], red[48 + row1])));
+    const float a0 = exp2f(m0 - mn0);
+    const float a1 = exp2f(m1 - mn1);
+    m0 = mn0;
+    m1 = mn1;
+    float rs0 = 0.f, rs1 = 0.f;
+#pragma unroll
+    for (int j = 0; j < 2; j++) {
+      C[j][0] = exp2f(C[j][0] - mn0);
+      C[j][1] = exp2f(C[j][1] - mn0);
+      C[j][2] = exp2f(C[j][2] - mn1);
+      C[j][3] = exp2f(C[j][3] - mn1);
+      rs0 += C[j][0] + C[j][1];
+      rs1 += C[j][2] + C[j][3];
+    }
+    rs0 += __shfl_xor_sync(0xffffffffu, rs0, 1);
+    rs0 += __shfl_xor_sync(0xffffffffu, rs0, 2);
+    rs1 += __shfl_xor_sync(0xffffffffu, rs1, 1);
+    rs1 += __shfl_xor_sync(0xffffffffu, rs1, 2);
+    if ((lane & 3) == 0) {
+      red[64 + warp * 16 + row0] = rs0;
+      red[64 + warp * 16 + row1] = rs1;
+    }
+#pragma unroll
+    for (int j = 0; j < 2; j++) {
+      const int col = warp * 16 + j * 8 + 2 * (lane & 3);
+      *reinterpret_cast<uint32_t*>(sm + L::OFF_P + row0 * L::P_STRIDE +
+                                   col * 2) = pack_h2(C[j][0], C[j][1]);
+      *reinterpret_cast<uint32_t*>(sm + L::OFF_P + row1 * L::P_STRIDE +
+                                   col * 2) = pack_h2(C[j][2], C[j][3]);
+    }
+    __syncthreads();
+    l0 = l0 * a0 + ((red[64 + row0] + red[80 + row0]) +
+                    (red[96 + row0] + red[112 + row0]));
+    l1 = l1 * a1 + ((red[64 + row1] + red[80 + row1]) +
+                    (red[96 + row1] + red[112 + row1]));
+#pragma unroll
+    for (int jn = 0; jn < NO; jn++) {
+      O[jn][0] *= a0;
+      O[jn][1] *= a0;
+      O[jn][2] *= a1;
+      O[jn][3] *= a1;
+    }
+#pragma unroll
+    for (int ks = 0; ks < 4; ks++) {
+      uint32_t pa[4];
+      ldmx4(pmat_base + ks * 32, pa[0], pa[1], pa[2], pa[3]);
+#pragma unroll
+      for (int jn2 = 0; jn2 < NJ2; jn2++) {
+        uint32_t v0, v1, v2, v3;
+        ldmx4t(vmat_base + ks * (16 * L::KV_STRIDE) + jn2 * 32, v0, v1, v2, v3);
+        mma16816(O[2 * jn2], pa, v0, v1);
+        mma16816(O[2 * jn2 + 1], pa, v2, v3);
+      }
+    }
+  }
+
+  const int cbase = warp * (D / 4) + 2 * (lane & 3);
+  if (part_o == nullptr) {
+    const float inv0 = 1.f / l0;
+    const float inv1 = 1.f / l1;
+    if (row0 < hp) {
+      __nv_bfloat16* orow = out + ((size_t)b * HQ + head0 + row0) * D;
+#pragma unroll
+      for (int jn = 0; jn < NO; jn++) {
+        __nv_bfloat162 v =
+            __floats2bfloat162_rn(O[jn][0] * inv0, O[jn][1] * inv0);
+        *reinterpret_cast<uint32_t*>(orow + cbase + 8 * jn) =
+            *reinterpret_cast<uint32_t*>(&v);
+      }
+    }
+    if (row1 < hp) {
+      __nv_bfloat16* orow = out + ((size_t)b * HQ + head0 + row1) * D;
+#pragma unroll
+      for (int jn = 0; jn < NO; jn++) {
+        __nv_bfloat162 v =
+            __floats2bfloat162_rn(O[jn][2] * inv1, O[jn][3] * inv1);
+        *reinterpret_cast<uint32_t*>(orow + cbase + 8 * jn) =
+            *reinterpret_cast<uint32_t*>(&v);
+      }
+    }
+  } else {
+    const size_t base = (size_t)(split * B + b) * HQ + head0;
+    if (row0 < hp) {
+      float* po = part_o + (base + row0) * D;
+#pragma unroll
+      for (int jn = 0; jn < NO; jn++)
+        *reinterpret_cast<float2*>(po + cbase + 8 * jn) =
+            make_float2(O[jn][0], O[jn][1]);
+    }
+    if (row1 < hp) {
+      float* po = part_o + (base + row1) * D;
+#pragma unroll
+      for (int jn = 0; jn < NO; jn++)
+        *reinterpret_cast<float2*>(po + cbase + 8 * jn) =
+            make_float2(O[jn][2], O[jn][3]);
+    }
+    if (warp == 0 && (lane & 3) == 0) {
+      if (row0 < hp) {
+        part_ml[(base + row0) * 2] = m0;
+        part_ml[(base + row0) * 2 + 1] = l0;
+      }
+      if (row1 < hp) {
+        part_ml[(base + row1) * 2] = m1;
+        part_ml[(base + row1) * 2 + 1] = l1;
+      }
+    }
+  }
+}
+
+template <int D>
+__global__ void tq_merge_kernel(const float* __restrict__ part_o,
+                                const float* __restrict__ part_ml,
+                                __nv_bfloat16* __restrict__ out, int S,
+                                int BHQ) {
+  const int bh = blockIdx.x;
+  const int d = threadIdx.x;
+  float M = -1e30f, L = 0.f, acc = 0.f;
+  for (int s = 0; s < S; s++) {
+    const float m = part_ml[((size_t)s * BHQ + bh) * 2];
+    const float l = part_ml[((size_t)s * BHQ + bh) * 2 + 1];
+    if (l <= 0.f) continue;
+    const float o = part_o[((size_t)s * BHQ + bh) * D + d];
+    if (m > M) {
+      const float sc = exp2f(M - m);
+      acc *= sc;
+      L *= sc;
+      M = m;
+    }
+    const float w = exp2f(m - M);
+    acc += w * o;
+    L += w * l;
+  }
+  out[(size_t)bh * D + d] = __float2bfloat16(acc / L);
+}
+
+template <int D, int PAGE_SIZE>
+void launch_decode_page(const void* q, const void* kv_cache, const int* pt,
+                        const int* sl, const float* cen, void* out,
+                        void* part_o, void* part_ml, int B, int HQ, int HKV,
+                        int G, int npacks, int splits, int page_table_stride,
+                        cudaStream_t stream) {
+  static bool init = false;
+  if (!init) {
+    cudaFuncSetAttribute(tq_decode_kernel<D, PAGE_SIZE>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                         TQLayout<D>::SMEM_BYTES);
+    init = true;
+  }
+  dim3 grid(B * HKV * npacks, splits);
+  tq_decode_kernel<D, PAGE_SIZE>
+      <<<grid, 128, TQLayout<D>::SMEM_BYTES, stream>>>(
+          reinterpret_cast<const __nv_bfloat16*>(q),
+          reinterpret_cast<const uint8_t*>(kv_cache), pt, sl, cen,
+          reinterpret_cast<__nv_bfloat16*>(out),
+          reinterpret_cast<float*>(part_o), reinterpret_cast<float*>(part_ml),
+          B, HQ, HKV, G, npacks, splits, page_table_stride);
+}
+
+template <int D>
+void tq_launch_dim(const void* q, const void* kv_cache, const int* pt,
+                   const int* sl, const float* rot, const float* cen, void* out,
+                   void* part_o, void* part_ml, int B, int HQ, int HKV,
+                   int page_table_stride, int page_size, int splits,
+                   cudaStream_t stream) {
+  (void)rot;
+  const int G = HQ / HKV;
+  const int npacks = (G + 15) / 16;
+
+  switch (page_size) {
+    case 16:
+      launch_decode_page<D, 16>(q, kv_cache, pt, sl, cen, out, part_o, part_ml,
+                                B, HQ, HKV, G, npacks, splits,
+                                page_table_stride, stream);
+      break;
+    case 32:
+      launch_decode_page<D, 32>(q, kv_cache, pt, sl, cen, out, part_o, part_ml,
+                                B, HQ, HKV, G, npacks, splits,
+                                page_table_stride, stream);
+      break;
+    case 64:
+      launch_decode_page<D, 64>(q, kv_cache, pt, sl, cen, out, part_o, part_ml,
+                                B, HQ, HKV, G, npacks, splits,
+                                page_table_stride, stream);
+      break;
+    default:
+      launch_decode_page<D, 128>(q, kv_cache, pt, sl, cen, out, part_o, part_ml,
+                                 B, HQ, HKV, G, npacks, splits,
+                                 page_table_stride, stream);
+      break;
+  }
+
+  if (splits > 1)
+    tq_merge_kernel<D><<<B * HQ, D, 0, stream>>>(
+        reinterpret_cast<const float*>(part_o),
+        reinterpret_cast<const float*>(part_ml),
+        reinterpret_cast<__nv_bfloat16*>(out), splits, B * HQ);
+}
+
+}  // namespace
+
+extern "C" void turboquant_mma_decode_launch(
+    const void* q, const void* kv_cache, const int* pt, const int* sl,
+    const float* rot, const float* cen, void* out, void* part_o, void* part_ml,
+    int B, int HQ, int HKV, int page_table_stride, int page_size, int head_dim,
+    int splits, cudaStream_t stream) {
+  switch (head_dim) {
+    case 64:
+      tq_launch_dim<64>(q, kv_cache, pt, sl, rot, cen, out, part_o, part_ml, B,
+                        HQ, HKV, page_table_stride, page_size, splits, stream);
+      break;
+    case 128:
+      tq_launch_dim<128>(q, kv_cache, pt, sl, rot, cen, out, part_o, part_ml, B,
+                         HQ, HKV, page_table_stride, page_size, splits, stream);
+      break;
+    default:
+      tq_launch_dim<256>(q, kv_cache, pt, sl, rot, cen, out, part_o, part_ml, B,
+                         HQ, HKV, page_table_stride, page_size, splits, stream);
+      break;
+  }
+}

--- a/tests/quantization/test_turboquant.py
+++ b/tests/quantization/test_turboquant.py
@@ -309,6 +309,51 @@ class TestTurboQuantKVCacheSpec:
         expected_slot = TurboQuantConfig.from_cache_dtype(preset, 128).slot_size_aligned
         assert spec.state_content_bytes == expected_slot
 
+    @pytest.mark.parametrize("preset", ALL_PRESETS)
+    @pytest.mark.parametrize("block_size", [16, 32, 64, 128])
+    def test_backend_cache_shape_matches_page_layout(self, preset, block_size):
+        from vllm.v1.attention.backends.turboquant_attn import (
+            TurboQuantAttentionBackend,
+        )
+        from vllm.v1.kv_cache_interface import (
+            FullAttentionSpec,
+            KVCacheLayout,
+            compute_layer_kv_cache_shape_bytes,
+            get_kv_quant_mode,
+        )
+
+        num_blocks = 7
+        num_kv_heads = 3
+        head_dim = 128
+        cfg = TurboQuantConfig.from_cache_dtype(preset, head_dim)
+        spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_dim,
+            dtype=torch.uint8,
+            kv_quant_mode=get_kv_quant_mode(preset),
+        )
+        spec = TurboQuantAttentionBackend.customize_spec(spec)
+        shape = compute_layer_kv_cache_shape_bytes(spec, num_blocks)
+
+        assert shape == (
+            num_blocks,
+            num_kv_heads,
+            block_size,
+            cfg.slot_size_aligned,
+        )
+        assert TurboQuantAttentionBackend.supported_kv_cache_layouts() == (
+            KVCacheLayout.LBHNC,
+        )
+        cache = torch.empty(shape, dtype=torch.uint8)
+        page_view = cache.view(num_blocks, num_kv_heads, 1, -1)
+        assert page_view.shape == (
+            num_blocks,
+            num_kv_heads,
+            1,
+            block_size * cfg.slot_size_aligned,
+        )
+
 
 class TestTurboQuantWorkspaceReservation:
     @staticmethod
@@ -320,6 +365,7 @@ class TestTurboQuantWorkspaceReservation:
         max_model_len: int = 8192,
         dtype: torch.dtype = torch.float16,
         max_num_kv_splits: int = 4,
+        cache_dtype: str = "turboquant_3bit_nc",
     ):
         return SimpleNamespace(
             scheduler_config=SimpleNamespace(
@@ -339,6 +385,7 @@ class TestTurboQuantWorkspaceReservation:
             attention_config=SimpleNamespace(
                 tq_max_kv_splits_for_cuda_graph=max_num_kv_splits
             ),
+            cache_config=SimpleNamespace(cache_dtype=cache_dtype),
         )
 
     @staticmethod
@@ -375,6 +422,7 @@ class TestTurboQuantWorkspaceReservation:
             "is_workspace_manager_initialized",
             lambda: True,
         )
+        monkeypatch.setattr(turboquant_attn, "_turboquant_C", None)
 
         turboquant_attn.TurboQuantMetadataBuilder(
             kv_cache_spec=self._fake_kv_cache_spec(),
@@ -416,6 +464,7 @@ class TestTurboQuantWorkspaceReservation:
             "is_workspace_manager_initialized",
             lambda: True,
         )
+        monkeypatch.setattr(turboquant_attn, "_turboquant_C", None)
 
         turboquant_attn.TurboQuantMetadataBuilder(
             kv_cache_spec=self._fake_kv_cache_spec(),
@@ -431,6 +480,51 @@ class TestTurboQuantWorkspaceReservation:
                 ((16, 8), torch.float32),
             )
         ]
+
+    def test_metadata_builder_reserves_optimized_decode_workspace(self, monkeypatch):
+        from vllm.v1.attention.backends import turboquant_attn
+
+        workspace_calls = []
+        size_calls = []
+
+        class FakeWorkspaceManager:
+            def get_simultaneous(self, *shapes_and_dtypes):
+                workspace_calls.append(shapes_and_dtypes)
+
+        class FakeExtension:
+            @staticmethod
+            def workspace_size(*args):
+                size_calls.append(args)
+                return args[0] * 100
+
+        monkeypatch.setattr(
+            turboquant_attn,
+            "current_workspace_manager",
+            lambda: FakeWorkspaceManager(),
+        )
+        monkeypatch.setattr(
+            turboquant_attn,
+            "is_workspace_manager_initialized",
+            lambda: True,
+        )
+        monkeypatch.setattr(turboquant_attn, "_turboquant_C", FakeExtension())
+        monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: (9, 0))
+
+        turboquant_attn.TurboQuantMetadataBuilder(
+            kv_cache_spec=self._fake_kv_cache_spec(),
+            layer_names=["layers.0.self_attn.attn"],
+            vllm_config=self._fake_vllm_config(
+                dtype=torch.bfloat16,
+                cache_dtype="turboquant_4bit_nc",
+            ),
+            device=torch.device("cuda:0"),
+        )
+
+        assert len(size_calls) == 16
+        assert workspace_calls[1] == (
+            ((1600,), torch.uint8),
+            ((16, 8, 128), torch.bfloat16),
+        )
 
 
 # ============================================================================
@@ -667,15 +761,375 @@ class TestHadamardRotation:
 # ============================================================================
 
 
+def _pack_tq_codes(codes: torch.Tensor, bits: int) -> torch.Tensor:
+    codes = codes.to(torch.int32)
+    if bits == 4:
+        return (codes[..., 0::2] | (codes[..., 1::2] << 4)).to(torch.uint8)
+    groups = codes.reshape(*codes.shape[:-1], -1, 8)
+    shifts = torch.arange(0, 24, 3, device=codes.device, dtype=torch.int32)
+    packed = torch.sum(groups << shifts, dim=-1)
+    return (
+        torch.stack(
+            [packed & 0xFF, (packed >> 8) & 0xFF, (packed >> 16) & 0xFF],
+            dim=-1,
+        )
+        .flatten(-2)
+        .to(torch.uint8)
+    )
+
+
+def _reference_turboquant_store(
+    key,
+    value,
+    slot_mapping,
+    rotation,
+    midpoints,
+    config,
+    block_size,
+    num_blocks,
+    fill_value=0xA5,
+):
+    num_tokens, num_heads, head_dim = key.shape
+    cache = torch.full(
+        (
+            num_blocks,
+            num_heads,
+            1,
+            block_size * config.slot_size_aligned,
+        ),
+        fill_value,
+        device=key.device,
+        dtype=torch.uint8,
+    )
+    written = torch.zeros_like(cache, dtype=torch.bool)
+
+    if config.key_fp8:
+        if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9):
+            pytest.skip("FP8 byte reference requires native e4m3fn conversion")
+        key_data = key.float().to(torch.float8_e4m3fn).view(torch.uint8)
+        key_data_bytes = head_dim
+        key_norm = None
+        key_norm_bytes = 0
+    else:
+        key_fp32 = key.float()
+        key_norm = torch.linalg.vector_norm(key_fp32, dim=-1, keepdim=True)
+        rotated = (key_fp32 / (key_norm + 1e-8)) @ rotation
+        key_codes = torch.bucketize(rotated, midpoints, right=True)
+        key_data = _pack_tq_codes(key_codes, config.key_mse_bits)
+        key_data_bytes = math.ceil(head_dim * config.key_mse_bits / 8)
+        key_norm = key_norm.to(torch.float16).contiguous().view(torch.uint8)
+        key_norm_bytes = 2
+
+    value_fp32 = value.float()
+    value_min = value_fp32.amin(dim=-1, keepdim=True)
+    value_max = value_fp32.amax(dim=-1, keepdim=True)
+    levels = 2**config.effective_value_quant_bits - 1
+    value_scale = ((value_max - value_min) / levels).clamp_min(1e-8)
+    value_codes = (
+        ((value_fp32 - value_min) / value_scale + 0.5).to(torch.int32).clamp_(0, levels)
+    )
+    value_data = _pack_tq_codes(value_codes, config.effective_value_quant_bits)
+    value_scale = value_scale.to(torch.float16).contiguous().view(torch.uint8)
+    value_zero = value_min.to(torch.float16).contiguous().view(torch.uint8)
+    value_data_bytes = math.ceil(head_dim * config.effective_value_quant_bits / 8)
+
+    for token_idx in range(num_tokens):
+        slot = int(slot_mapping[token_idx])
+        if slot < 0:
+            continue
+        block_idx, position = divmod(slot, block_size)
+        for head_idx in range(num_heads):
+            record = cache[block_idx, head_idx, 0]
+            record_mask = written[block_idx, head_idx, 0]
+            key_base = position * key_data_bytes
+            value_plane = block_size * key_data_bytes
+            value_base = value_plane + position * value_data_bytes
+            norm_plane = value_plane + block_size * value_data_bytes
+            scale_plane = norm_plane + block_size * key_norm_bytes
+            zero_plane = scale_plane + block_size * 2
+
+            record[key_base : key_base + key_data_bytes] = key_data[token_idx, head_idx]
+            record_mask[key_base : key_base + key_data_bytes] = True
+            record[value_base : value_base + value_data_bytes] = value_data[
+                token_idx, head_idx
+            ]
+            record_mask[value_base : value_base + value_data_bytes] = True
+            if key_norm is not None:
+                norm_base = norm_plane + position * 2
+                record[norm_base : norm_base + 2] = key_norm[token_idx, head_idx]
+                record_mask[norm_base : norm_base + 2] = True
+            scale_base = scale_plane + position * 2
+            zero_base = zero_plane + position * 2
+            record[scale_base : scale_base + 2] = value_scale[token_idx, head_idx]
+            record[zero_base : zero_base + 2] = value_zero[token_idx, head_idx]
+            record_mask[scale_base : scale_base + 2] = True
+            record_mask[zero_base : zero_base + 2] = True
+    return cache, written
+
+
 @pytest.mark.skipif(not GPGPU_AVAILABLE, reason="GPGPU not available")
 class TestStoreDecodeRoundTrip:
     """End-to-end: store KV into TQ cache, decode, compare vs fp16 ref."""
 
+    @pytest.mark.parametrize("preset", ALL_PRESETS)
+    @pytest.mark.parametrize("head_dim", [64, 128, 256])
+    @pytest.mark.parametrize("input_dtype", [torch.float16, torch.bfloat16])
+    def test_store_matches_reference_all_modes(self, preset, head_dim, input_dtype):
+        from vllm.model_executor.layers.quantization.turboquant.centroids import (
+            solve_lloyd_max,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_decode import (
+            triton_turboquant_decode_attention,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        device = torch.device(DEVICE_TYPE)
+        config = TurboQuantConfig.from_cache_dtype(preset, head_dim)
+        rotation = _build_hadamard(head_dim, DEVICE_TYPE)
+        centroids, _ = solve_lloyd_max(head_dim, config.centroid_bits)
+        centroids = centroids.to(device=device, dtype=torch.float32)
+        midpoints = (centroids[:-1] + centroids[1:]) / 2
+        num_tokens, num_heads, block_size, num_blocks = 4, 2, 32, 2
+        torch.manual_seed(20260818)
+        key = torch.randn(
+            num_tokens,
+            num_heads,
+            head_dim,
+            device=device,
+            dtype=input_dtype,
+        )
+        value = torch.randn_like(key) * 0.25
+        slots = torch.arange(num_tokens, device=device, dtype=torch.int64)
+        expected, written = _reference_turboquant_store(
+            key,
+            value,
+            slots,
+            rotation,
+            midpoints,
+            config,
+            block_size,
+            num_blocks,
+        )
+        actual = torch.full_like(expected, 0xA5)
+        triton_turboquant_store(
+            key,
+            value,
+            actual,
+            slots,
+            rotation,
+            midpoints,
+            mse_bits=config.key_mse_bits,
+            key_packed_size=config.key_packed_size,
+            value_quant_bits=config.effective_value_quant_bits,
+            key_fp8=config.key_fp8,
+        )
+
+        assert torch.equal(actual[~written], expected[~written])
+        byte_diff = (actual[written] != expected[written]).float().mean().item()
+        if config.key_fp8:
+            assert byte_diff == 0
+        else:
+            assert byte_diff < 0.05
+
+        query = torch.randn(1, num_heads, head_dim, device=device, dtype=input_dtype)
+        block_table = torch.tensor([[0]], device=device, dtype=torch.int32)
+        seq_lens = torch.tensor([num_tokens], device=device, dtype=torch.int32)
+
+        def decode(cache):
+            return triton_turboquant_decode_attention(
+                query,
+                cache,
+                block_table,
+                seq_lens,
+                rotation,
+                centroids,
+                scale=1 / math.sqrt(head_dim),
+                mse_bits=config.key_mse_bits,
+                key_packed_size=config.key_packed_size,
+                value_quant_bits=config.effective_value_quant_bits,
+                key_fp8=config.key_fp8,
+                norm_correction=config.norm_correction,
+                PiT=rotation,
+                max_num_kv_splits=4,
+            )
+
+        torch.testing.assert_close(decode(actual), decode(expected), rtol=0, atol=0.005)
+
+    @pytest.mark.parametrize("preset", ALL_PRESETS)
+    @pytest.mark.parametrize(
+        ("num_heads", "block_size"),
+        [(1, 16), (2, 32), (4, 64), (8, 128), (16, 16), (32, 128)],
+    )
+    def test_store_page_field_abi(self, preset, num_heads, block_size):
+        from vllm.model_executor.layers.quantization.turboquant.centroids import (
+            solve_lloyd_max,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        device = torch.device(DEVICE_TYPE)
+        head_dim = 128
+        config = TurboQuantConfig.from_cache_dtype(preset, head_dim)
+        rotation = _build_hadamard(head_dim, DEVICE_TYPE)
+        centroids, _ = solve_lloyd_max(head_dim, config.centroid_bits)
+        centroids = centroids.to(device=device, dtype=torch.float32)
+        midpoints = (centroids[:-1] + centroids[1:]) / 2
+        slots = torch.tensor(
+            [block_size - 1, block_size, -1], device=device, dtype=torch.int64
+        )
+        torch.manual_seed(20260818)
+        key = torch.randn(
+            3,
+            num_heads,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        value = torch.randn_like(key)
+        expected, written = _reference_turboquant_store(
+            key,
+            value,
+            slots,
+            rotation,
+            midpoints,
+            config,
+            block_size,
+            2,
+        )
+        actual = torch.full_like(expected, 0xA5)
+        triton_turboquant_store(
+            key,
+            value,
+            actual,
+            slots,
+            rotation,
+            midpoints,
+            mse_bits=config.key_mse_bits,
+            key_packed_size=config.key_packed_size,
+            value_quant_bits=config.effective_value_quant_bits,
+            key_fp8=config.key_fp8,
+        )
+
+        assert torch.equal(actual[~written], expected[~written])
+        assert (actual[written] != expected[written]).float().mean() < 0.05
+
     @pytest.mark.parametrize(
         "preset",
-        ["turboquant_k8v4", "turboquant_4bit_nc"],
+        ["turboquant_4bit_nc", "turboquant_k3v4_nc", "turboquant_3bit_nc"],
     )
-    def test_single_token_roundtrip(self, preset):
+    @pytest.mark.parametrize("head_dim", [64, 128, 256])
+    @pytest.mark.parametrize(("num_tokens", "num_heads"), [(128, 2), (16, 16), (8, 32)])
+    def test_store_m16_matches_reference(self, preset, head_dim, num_tokens, num_heads):
+        from vllm.model_executor.layers.quantization.turboquant.centroids import (
+            solve_lloyd_max,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        device = torch.device(DEVICE_TYPE)
+        block_size = 32
+        config = TurboQuantConfig.from_cache_dtype(preset, head_dim)
+        rotation = _build_hadamard(head_dim, DEVICE_TYPE)
+        centroids, _ = solve_lloyd_max(head_dim, config.centroid_bits)
+        centroids = centroids.to(device=device, dtype=torch.float32)
+        midpoints = (centroids[:-1] + centroids[1:]) / 2
+        slots = torch.arange(num_tokens, device=device, dtype=torch.int64)
+        torch.manual_seed(20260818)
+        key = torch.randn(
+            num_tokens,
+            num_heads,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        value = torch.randn_like(key)
+        expected, written = _reference_turboquant_store(
+            key,
+            value,
+            slots,
+            rotation,
+            midpoints,
+            config,
+            block_size,
+            4,
+        )
+        actual = torch.full_like(expected, 0xA5)
+        triton_turboquant_store(
+            key,
+            value,
+            actual,
+            slots,
+            rotation,
+            midpoints,
+            mse_bits=config.key_mse_bits,
+            key_packed_size=config.key_packed_size,
+            value_quant_bits=config.effective_value_quant_bits,
+        )
+        assert torch.equal(actual[~written], expected[~written])
+        assert (actual[written] != expected[written]).float().mean() < 0.05
+
+    @pytest.mark.parametrize("preset", ALL_PRESETS)
+    @pytest.mark.parametrize("head_dim", [64, 128, 256])
+    def test_store_cudagraph_replay(self, preset, head_dim):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA graph requires CUDA")
+        from vllm.model_executor.layers.quantization.turboquant.centroids import (
+            solve_lloyd_max,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        config = TurboQuantConfig.from_cache_dtype(preset, head_dim)
+        rotation = _build_hadamard(head_dim, "cuda")
+        centroids, _ = solve_lloyd_max(head_dim, config.centroid_bits)
+        centroids = centroids.to(device="cuda", dtype=torch.float32)
+        midpoints = (centroids[:-1] + centroids[1:]) / 2
+        key = torch.randn(4, 2, head_dim, device="cuda", dtype=torch.bfloat16)
+        value = torch.randn_like(key)
+        slots = torch.arange(4, device="cuda", dtype=torch.int64)
+        cache_shape = (
+            1,
+            2,
+            1,
+            16 * config.slot_size_aligned,
+        )
+        graph_cache = torch.zeros(cache_shape, device="cuda", dtype=torch.uint8)
+        eager_cache = torch.zeros_like(graph_cache)
+
+        def store(cache):
+            triton_turboquant_store(
+                key,
+                value,
+                cache,
+                slots,
+                rotation,
+                midpoints,
+                mse_bits=config.key_mse_bits,
+                key_packed_size=config.key_packed_size,
+                value_quant_bits=config.effective_value_quant_bits,
+                key_fp8=config.key_fp8,
+            )
+
+        store(graph_cache)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            store(graph_cache)
+        key.normal_()
+        value.normal_()
+        graph_cache.zero_()
+        eager_cache.zero_()
+        graph.replay()
+        store(eager_cache)
+        assert torch.equal(graph_cache, eager_cache)
+
+    @pytest.mark.parametrize("preset", ALL_PRESETS)
+    @pytest.mark.parametrize("block_size", [16, 32, 64, 128])
+    def test_single_token_roundtrip(self, preset, block_size):
         """Store 1 token, decode with query=key, check attention output.
 
         For a single token with query=key, attention output should equal
@@ -697,7 +1151,6 @@ class TestStoreDecodeRoundTrip:
         Hk = 4  # num_kv_heads
         Hq = 4  # num_q_heads (no GQA for simplicity)
         B = 1  # single token
-        block_size = 16
         num_blocks = 1
 
         device = torch.device(DEVICE_TYPE)
@@ -719,12 +1172,11 @@ class TestStoreDecodeRoundTrip:
         value = torch.randn(B, Hk, D, device=device, dtype=torch.float16)
 
         # Allocate KV cache
-        padded_slot = cfg.slot_size_aligned
         kv_cache = torch.zeros(
             num_blocks,
-            block_size,
             Hk,
-            padded_slot,
+            1,
+            block_size * cfg.slot_size_aligned,
             device=device,
             dtype=torch.uint8,
         )
@@ -780,3 +1232,556 @@ class TestStoreDecodeRoundTrip:
             assert cos_sim > threshold, (
                 f"Preset {preset} head {h}: cosine_sim={cos_sim:.4f} < {threshold}"
             )
+
+    @pytest.mark.parametrize("preset", ALL_PRESETS)
+    @pytest.mark.parametrize("block_size", [16, 32, 64, 128])
+    def test_cross_page_uniform_attention(self, preset, block_size):
+        from vllm.v1.attention.ops.triton_turboquant_decode import (
+            _tq_full_dequant_kv,
+            _use_fp8_e4b15,
+            triton_turboquant_decode_attention,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        device = torch.device(DEVICE_TYPE)
+        head_dim = 128
+        num_heads = 1
+        seq_len = block_size + 1
+        cfg = TurboQuantConfig.from_cache_dtype(preset, head_dim)
+        rotation = torch.eye(head_dim, device=device, dtype=torch.float32)
+        centroids, _ = solve_lloyd_max(head_dim, cfg.centroid_bits)
+        centroids = centroids.to(device=device, dtype=torch.float32)
+        sorted_centroids, _ = centroids.sort()
+        midpoints = (sorted_centroids[:-1] + sorted_centroids[1:]) / 2
+
+        key = torch.zeros(
+            seq_len, num_heads, head_dim, device=device, dtype=torch.float16
+        )
+        token_values = torch.arange(seq_len, device=device, dtype=torch.float16)
+        value_pattern = torch.arange(
+            head_dim, device=device, dtype=torch.float16
+        ).remainder(8)
+        value = token_values[:, None, None] + value_pattern[None, None, :]
+        cache_shape = (3, num_heads, 1, block_size * cfg.slot_size_aligned)
+        kv_cache = torch.zeros(cache_shape, device=device, dtype=torch.uint8)
+        slot_mapping = torch.cat(
+            [
+                torch.arange(
+                    2 * block_size,
+                    3 * block_size,
+                    device=device,
+                    dtype=torch.int32,
+                ),
+                torch.tensor([0], device=device, dtype=torch.int32),
+            ]
+        )
+        triton_turboquant_store(
+            key,
+            value,
+            kv_cache,
+            slot_mapping,
+            rotation,
+            midpoints,
+            mse_bits=cfg.key_mse_bits,
+            key_packed_size=cfg.key_packed_size,
+            value_quant_bits=cfg.effective_value_quant_bits,
+            key_fp8=cfg.key_fp8,
+        )
+
+        query = torch.zeros(1, num_heads, head_dim, device=device, dtype=torch.float16)
+        block_table = torch.tensor([[2, 0]], device=device, dtype=torch.int32)
+        output = triton_turboquant_decode_attention(
+            query=query,
+            kv_cache=kv_cache,
+            block_table=block_table,
+            seq_lens=torch.tensor([seq_len], device=device, dtype=torch.int32),
+            Pi=rotation,
+            centroids=centroids,
+            scale=1.0 / math.sqrt(head_dim),
+            mse_bits=cfg.key_mse_bits,
+            key_packed_size=cfg.key_packed_size,
+            value_quant_bits=cfg.effective_value_quant_bits,
+            key_fp8=cfg.key_fp8,
+            norm_correction=cfg.norm_correction,
+            PiT=rotation,
+            max_num_kv_splits=4,
+        )
+
+        assert torch.allclose(
+            output,
+            block_size / 2 + value_pattern[None, None, :],
+            atol=0.25,
+            rtol=0,
+        )
+
+        key_out = torch.empty(
+            1, num_heads, seq_len, head_dim, device=device, dtype=torch.float16
+        )
+        value_out = torch.empty_like(key_out)
+        _tq_full_dequant_kv[(seq_len, num_heads)](
+            kv_cache,
+            block_table,
+            centroids,
+            key_out,
+            value_out,
+            key_out.stride(0),
+            key_out.stride(1),
+            key_out.stride(2),
+            value_out.stride(0),
+            value_out.stride(1),
+            value_out.stride(2),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            1,
+            HEAD_DIM=head_dim,
+            BLOCK_SIZE=block_size,
+            NUM_KV_HEADS=num_heads,
+            KEY_DATA_BYTES=(
+                head_dim if cfg.key_fp8 else math.ceil(head_dim * cfg.key_mse_bits / 8)
+            ),
+            KEY_NORM_BYTES=0 if cfg.key_fp8 else 2,
+            VQB=cfg.effective_value_quant_bits,
+            VAL_DATA_BYTES=math.ceil(head_dim * cfg.effective_value_quant_bits / 8),
+            MSE_BITS=cfg.key_mse_bits,
+            KEY_FP8=1 if cfg.key_fp8 else 0,
+            BLOCK_D=128,
+            NORM_CORRECTION=1 if cfg.norm_correction else 0,
+            FP8_E4B15=_use_fp8_e4b15(device.index or 0),
+            num_warps=4,
+        )
+        expected_values = (
+            token_values[None, None, :, None] + value_pattern[None, None, None, :]
+        )
+        assert torch.count_nonzero(key_out) == 0
+        assert torch.allclose(value_out, expected_values, atol=0.25, rtol=0)
+
+    def test_d256_long_context_uses_optimized_decode(self, monkeypatch):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA is required")
+        from vllm.v1.attention.backends import turboquant_attn
+
+        calls = []
+
+        class FakeExtension:
+            @staticmethod
+            def workspace_size(*args):
+                calls.append(("workspace_size", args))
+                return 1
+
+            @staticmethod
+            def run_with_workspace(*args):
+                calls.append(("run_with_workspace", args[-2:]))
+                args[7].zero_()
+
+        class FakeWorkspaceManager:
+            def get_simultaneous(self, *shapes_and_dtypes):
+                return tuple(
+                    torch.empty(shape, device="cuda", dtype=dtype)
+                    for shape, dtype in shapes_and_dtypes
+                )
+
+        def fail_fallback(*args, **kwargs):
+            pytest.fail("D256 long context fell back to production Triton")
+
+        monkeypatch.setattr(turboquant_attn, "_turboquant_C", FakeExtension())
+        monkeypatch.setattr(
+            turboquant_attn, "is_workspace_manager_initialized", lambda: True
+        )
+        monkeypatch.setattr(
+            turboquant_attn,
+            "current_workspace_manager",
+            lambda: FakeWorkspaceManager(),
+        )
+        monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: (9, 0))
+        monkeypatch.setattr(
+            turboquant_attn, "triton_turboquant_decode_attention", fail_fallback
+        )
+
+        head_dim = 256
+        num_heads = 12
+        num_kv_heads = 2
+        page_size = 16
+        max_seq_len = 65536
+        config = TurboQuantConfig.from_cache_dtype("turboquant_4bit_nc", head_dim)
+        impl = turboquant_attn.TurboQuantAttentionImpl.__new__(
+            turboquant_attn.TurboQuantAttentionImpl
+        )
+        impl.num_heads = num_heads
+        impl.num_kv_heads = num_kv_heads
+        impl.head_size = head_dim
+        impl.scale = head_dim**-0.5
+        impl.tq_config = config
+        impl.alibi_slopes = None
+        impl.sliding_window = None
+        impl.logits_soft_cap = None
+
+        query = torch.randn(1, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+        kv_cache = torch.zeros(
+            1,
+            num_kv_heads,
+            1,
+            page_size * config.slot_size_aligned,
+            device="cuda",
+            dtype=torch.uint8,
+        )
+        block_table = torch.zeros(
+            1, max_seq_len // page_size, device="cuda", dtype=torch.int32
+        )
+        seq_lens = torch.tensor([max_seq_len], device="cuda", dtype=torch.int32)
+        metadata = turboquant_attn.TurboQuantMetadata(
+            seq_lens=seq_lens,
+            slot_mapping=torch.empty(0, device="cuda", dtype=torch.int64),
+            block_table=block_table,
+            query_start_loc=torch.tensor([0, 1], device="cuda", dtype=torch.int32),
+            num_actual_tokens=1,
+            max_query_len=1,
+            max_seq_len=max_seq_len,
+            num_decodes=1,
+            num_decode_tokens=1,
+        )
+        rotation = torch.eye(head_dim, device="cuda", dtype=torch.float32)
+        centroids = torch.zeros(16, device="cuda", dtype=torch.float32)
+
+        output = impl._decode_attention(query, kv_cache, metadata, rotation, centroids)
+
+        assert output.shape == query.shape
+        assert [name for name, _ in calls] == [
+            "workspace_size",
+            "run_with_workspace",
+        ]
+        assert calls[0][1][5:7] == (head_dim, max_seq_len)
+
+    @pytest.mark.parametrize(
+        ("num_heads", "num_kv_heads"),
+        [
+            pytest.param(32, 32, id="mha_g1"),
+            pytest.param(16, 8, id="gqa_g2"),
+            pytest.param(24, 8, id="gqa_g3"),
+            pytest.param(32, 8, id="qwen3_8b_g4"),
+            pytest.param(40, 8, id="qwen3_14b_g5"),
+            pytest.param(12, 2, id="gqa_g6"),
+            pytest.param(56, 8, id="gqa_g7"),
+            pytest.param(64, 8, id="gqa_g8"),
+            pytest.param(32, 4, id="qwen3_30b_a3b_g8"),
+            pytest.param(72, 8, id="gqa_g9"),
+            pytest.param(128, 8, id="gqa_g16"),
+            pytest.param(32, 1, id="mqa_g32"),
+        ],
+    )
+    @pytest.mark.parametrize("head_dim", [64, 128, 256])
+    @pytest.mark.parametrize("block_size", [16, 32, 64, 128])
+    def test_optimized_decode_matches_triton_across_page_boundary(
+        self,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        block_size,
+        **kwargs,
+    ):
+        use_graph = kwargs.pop("use_graph", False)
+        assert not kwargs
+        if not current_platform.is_cuda():
+            pytest.skip("TurboQuant optimized decode requires CUDA")
+        if torch.cuda.get_device_capability() not in {(8, 0), (9, 0), (10, 0)}:
+            pytest.skip("TurboQuant optimized decode requires SM80, SM90, or SM100")
+        try:
+            from vllm import _turboquant_C
+        except ImportError:
+            pytest.skip("TurboQuant optimized decode extension is unavailable")
+        from vllm.v1.attention.ops.triton_turboquant_decode import (
+            triton_turboquant_decode_attention,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        device = torch.device(DEVICE_TYPE)
+        batch_size = 3
+        seq_lens_list = [1, block_size, block_size + 1]
+        config = TurboQuantConfig.from_cache_dtype("turboquant_4bit_nc", head_dim)
+        rotation = _build_hadamard(head_dim, DEVICE_TYPE)
+        centroids, _ = solve_lloyd_max(head_dim, config.centroid_bits)
+        centroids = centroids.to(device=device, dtype=torch.float32)
+        midpoints = (centroids[:-1] + centroids[1:]) / 2
+        block_table = torch.tensor(
+            [[4, 1, -1, -1], [0, 5, -1, -1], [3, 2, -1, -1]],
+            device=device,
+            dtype=torch.int32,
+        )
+        slot_mapping = torch.tensor(
+            [
+                int(block_table[batch_idx, token_idx // block_size]) * block_size
+                + token_idx % block_size
+                for batch_idx, seq_len in enumerate(seq_lens_list)
+                for token_idx in range(seq_len)
+            ],
+            device=device,
+            dtype=torch.int64,
+        )
+        torch.manual_seed(20260817)
+        key = torch.randn(
+            len(slot_mapping),
+            num_kv_heads,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        value = torch.randn_like(key) * 0.25
+        query = torch.randn(
+            batch_size,
+            num_heads,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        kv_cache = torch.zeros(
+            6,
+            num_kv_heads,
+            1,
+            block_size * config.slot_size_aligned,
+            device=device,
+            dtype=torch.uint8,
+        )
+        seq_lens = torch.tensor(seq_lens_list, device=device, dtype=torch.int32)
+        allocated_max_seq_len = block_table.shape[1] * block_size
+        triton_turboquant_store(
+            key,
+            value,
+            kv_cache,
+            slot_mapping,
+            rotation,
+            midpoints,
+            mse_bits=config.key_mse_bits,
+            key_packed_size=config.key_packed_size,
+            value_quant_bits=config.effective_value_quant_bits,
+        )
+        reference = triton_turboquant_decode_attention(
+            query,
+            kv_cache,
+            block_table,
+            seq_lens,
+            rotation,
+            centroids,
+            scale=1 / math.sqrt(head_dim),
+            mse_bits=config.key_mse_bits,
+            key_packed_size=config.key_packed_size,
+            value_quant_bits=config.effective_value_quant_bits,
+            norm_correction=True,
+            PiT=rotation,
+            max_num_kv_splits=16,
+        )
+        workspace_size = _turboquant_C.workspace_size(
+            batch_size,
+            num_heads,
+            num_kv_heads,
+            block_table.stride(0),
+            block_size,
+            head_dim,
+            allocated_max_seq_len,
+            device.index or 0,
+        )
+        workspace = torch.empty(workspace_size, device=device, dtype=torch.uint8)
+        actual = torch.empty_like(query)
+        if use_graph:
+            _turboquant_C.run_with_workspace(
+                query,
+                kv_cache,
+                block_table,
+                seq_lens,
+                rotation,
+                centroids,
+                workspace,
+                actual,
+                block_size,
+                allocated_max_seq_len,
+            )
+            graph_block_table = torch.zeros_like(block_table)
+            graph_seq_lens = torch.ones_like(seq_lens)
+            graph = torch.cuda.CUDAGraph()
+            torch.accelerator.synchronize()
+            with torch.cuda.graph(graph):
+                _turboquant_C.run_with_workspace(
+                    query,
+                    kv_cache,
+                    graph_block_table,
+                    graph_seq_lens,
+                    rotation,
+                    centroids,
+                    workspace,
+                    actual,
+                    block_size,
+                    allocated_max_seq_len,
+                )
+            graph_block_table.copy_(block_table)
+            graph_seq_lens.copy_(seq_lens)
+            graph.replay()
+            first_replay = actual.clone()
+            graph.replay()
+            assert torch.equal(actual, first_replay)
+        else:
+            _turboquant_C.run_with_workspace(
+                query,
+                kv_cache,
+                block_table,
+                seq_lens,
+                rotation,
+                centroids,
+                workspace,
+                actual,
+                block_size,
+                allocated_max_seq_len,
+            )
+
+        torch.testing.assert_close(actual, reference, rtol=0, atol=0.01)
+        cosine = torch.nn.functional.cosine_similarity(
+            actual.float().flatten(1), reference.float().flatten(1), dim=1
+        )
+        assert cosine.min() > 0.99999
+
+    @pytest.mark.parametrize("head_dim", [64, 128, 256])
+    @pytest.mark.parametrize("block_size", [16, 32, 64, 128])
+    def test_optimized_decode_cudagraph_replays_live_metadata(
+        self, head_dim, block_size
+    ):
+        self.test_optimized_decode_matches_triton_across_page_boundary(
+            num_heads=32,
+            num_kv_heads=8,
+            head_dim=head_dim,
+            block_size=block_size,
+            use_graph=True,
+        )
+
+    def test_optimized_decode_dynamic_splits_match_tight_plan(self):
+        if not current_platform.is_cuda():
+            pytest.skip("TurboQuant optimized decode requires CUDA")
+        if torch.cuda.get_device_capability() not in {(8, 0), (9, 0), (10, 0)}:
+            pytest.skip("TurboQuant optimized decode requires SM80, SM90, or SM100")
+        try:
+            from vllm import _turboquant_C
+        except ImportError:
+            pytest.skip("TurboQuant optimized decode extension is unavailable")
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        device = torch.device(DEVICE_TYPE)
+        head_dim = 128
+        num_heads = 16
+        num_kv_heads = 8
+        block_size = 32
+        seq_len = 4096
+        allocated_max_seq_len = 40960
+        num_blocks = seq_len // block_size
+        config = TurboQuantConfig.from_cache_dtype("turboquant_4bit_nc", head_dim)
+        rotation = _build_hadamard(head_dim, DEVICE_TYPE)
+        centroids, _ = solve_lloyd_max(head_dim, config.centroid_bits)
+        centroids = centroids.to(device=device, dtype=torch.float32)
+        midpoints = (centroids[:-1] + centroids[1:]) / 2
+        torch.manual_seed(20260819)
+        key = torch.randn(
+            seq_len,
+            num_kv_heads,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        value = torch.randn_like(key) * 0.25
+        kv_cache = torch.zeros(
+            num_blocks,
+            num_kv_heads,
+            1,
+            block_size * config.slot_size_aligned,
+            device=device,
+            dtype=torch.uint8,
+        )
+        triton_turboquant_store(
+            key,
+            value,
+            kv_cache,
+            torch.arange(seq_len, device=device, dtype=torch.int64),
+            rotation,
+            midpoints,
+            mse_bits=config.key_mse_bits,
+            key_packed_size=config.key_packed_size,
+            value_quant_bits=config.effective_value_quant_bits,
+        )
+        block_table = torch.full(
+            (1, allocated_max_seq_len // block_size),
+            -1,
+            device=device,
+            dtype=torch.int32,
+        )
+        block_table[0, :num_blocks] = torch.arange(
+            num_blocks, device=device, dtype=torch.int32
+        )
+        query = torch.randn(
+            1,
+            num_heads,
+            head_dim,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        workspace = torch.empty(
+            _turboquant_C.workspace_size(
+                1,
+                num_heads,
+                num_kv_heads,
+                block_table.stride(0),
+                block_size,
+                head_dim,
+                allocated_max_seq_len,
+                device.index or 0,
+            ),
+            device=device,
+            dtype=torch.uint8,
+        )
+        output = torch.empty_like(query)
+        graph_seq_lens = torch.ones(1, device=device, dtype=torch.int32)
+        _turboquant_C.run_with_workspace(
+            query,
+            kv_cache,
+            block_table,
+            graph_seq_lens,
+            rotation,
+            centroids,
+            workspace,
+            output,
+            block_size,
+            allocated_max_seq_len,
+        )
+        graph = torch.cuda.CUDAGraph()
+        torch.accelerator.synchronize()
+        with torch.cuda.graph(graph):
+            _turboquant_C.run_with_workspace(
+                query,
+                kv_cache,
+                block_table,
+                graph_seq_lens,
+                rotation,
+                centroids,
+                workspace,
+                output,
+                block_size,
+                allocated_max_seq_len,
+            )
+
+        for live_seq_len in (4096, 2048):
+            graph_seq_lens.fill_(live_seq_len)
+            graph.replay()
+            graph_output = output.clone()
+            tight_output = torch.empty_like(query)
+            _turboquant_C.run_with_workspace(
+                query,
+                kv_cache,
+                block_table,
+                graph_seq_lens,
+                rotation,
+                centroids,
+                workspace,
+                tight_output,
+                block_size,
+                live_seq_len,
+            )
+            assert torch.equal(graph_output, tight_output)

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -7,13 +7,14 @@ Prefill: Standard scaled dot-product attention on uncompressed K/V,
 Decode:  Compute TQ attention scores from compressed cache,
          unpack FP16 values, softmax + weighted sum.
 
-Cache layout (no leading 2 dimension):
-  (num_blocks, block_size, num_kv_heads, slot_size)
-  where slot_size = key_packed_size + value_fp16_size
+Framework cache layout (no leading 2 dimension):
+  (num_blocks, num_kv_heads, block_size, slot_size)
 
-Per-head per-position slot layout:
-  [key_packed (kps bytes) | value_fp16 (D*2 bytes)]
-  For turboquant_k3v4_nc head_dim=256: [100 bytes key | 512 bytes value] = 612
+Kernel-facing zero-copy view:
+  (num_blocks, num_kv_heads, 1, page_record_size)
+
+Per-head page record layout:
+  [key data | value data | key norms | value scales | value zeros | padding]
 """
 
 import contextlib
@@ -24,6 +25,11 @@ from typing import Any, ClassVar
 
 import torch
 import torch.nn.functional as F
+
+try:
+    from vllm import _turboquant_C  # type: ignore[attr-defined]
+except ImportError:
+    _turboquant_C = None
 
 from vllm.config import get_current_vllm_config
 from vllm.config.cache import CacheDType
@@ -82,6 +88,7 @@ if _HAS_FLASH_ATTN:
 # kernel can read them efficiently. This avoids O(cached_len) dequant work
 # per continuation, eliminating the O(N²/chunk_size) collapse at long context.
 _CONTINUATION_DECODE_THRESHOLD = 128
+_OPTIMIZED_DECODE_CAPABILITIES = {(8, 0), (9, 0), (10, 0)}
 
 
 def _soa_imports():
@@ -158,7 +165,7 @@ class TurboQuantAttentionBackend(AttentionBackend):
 
     @classmethod
     def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
-        return (KVCacheLayout.LBNHC,)
+        return (KVCacheLayout.LBHNC,)
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
@@ -246,6 +253,37 @@ class TurboQuantMetadataBuilder(AttentionMetadataBuilder[TurboQuantMetadata]):
             ((max_num_reqs, num_heads), torch.float32),
         )
 
+        cache_dtype = self.vllm_config.cache_config.cache_dtype
+        if (
+            _turboquant_C is not None
+            and cache_dtype == "turboquant_4bit_nc"
+            and model_config.dtype == torch.bfloat16
+            and head_size in {64, 128, 256}
+            and torch.cuda.get_device_capability(self.device)
+            in _OPTIMIZED_DECODE_CAPABILITIES
+        ):
+            block_size = self.kv_cache_spec.block_size
+            max_model_len = model_config.max_model_len
+            page_table_stride = math.ceil(max_model_len / block_size)
+            device_index = self.device.index or 0
+            workspace_bytes = max(
+                _turboquant_C.workspace_size(
+                    batch_size,
+                    num_heads,
+                    num_kv_heads,
+                    page_table_stride,
+                    block_size,
+                    head_size,
+                    max_model_len,
+                    device_index,
+                )
+                for batch_size in range(1, max_num_reqs + 1)
+            )
+            current_workspace_manager().get_simultaneous(
+                ((workspace_bytes,), torch.uint8),
+                ((max_num_reqs, num_heads, head_size), model_config.dtype),
+            )
+
         reserve_continuation_prefill = (
             scheduler_config.enable_chunked_prefill
             and scheduler_config.max_num_batched_tokens > _CONTINUATION_DECODE_THRESHOLD
@@ -331,6 +369,9 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
         self.num_kv_groups = num_heads // self.num_kv_heads
         self.kv_cache_dtype = kv_cache_dtype
+        self.alibi_slopes = alibi_slopes
+        self.sliding_window = sliding_window
+        self.logits_soft_cap = logits_soft_cap
 
         from vllm.model_executor.layers.quantization.turboquant.config import (
             TurboQuantConfig,
@@ -518,8 +559,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
 
         k = key[:N].view(N, self.num_kv_heads, self.head_size)
         v = value[:N].view(N, self.num_kv_heads, self.head_size)
-        # (B, H, N, C) -> (B, N, H, C) for TQ kernels
-        kv_cache = kv_cache.transpose(1, 2)
+        kv_cache = kv_cache.view(kv_cache.shape[0], kv_cache.shape[1], 1, -1)
         self._store_kv(k, v, kv_cache, slot_mapping, layer)
 
     def forward(
@@ -547,14 +587,12 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         if attn_metadata is None:
             return output.fill_(0)
 
-        # (B, H, N, C) -> (B, N, H, C) for TQ kernels
-        kv_cache = kv_cache.transpose(1, 2)
-
         # Slice to actual tokens
         N = attn_metadata.num_actual_tokens
         if N <= 0:
             return output.fill_(0)
 
+        kv_cache = kv_cache.view(kv_cache.shape[0], kv_cache.shape[1], 1, -1)
         q = query[:N].view(N, self.num_heads, self.head_size)
 
         # Get TQ buffers, ensure on device (one-time migration).
@@ -678,7 +716,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         self,
         key: torch.Tensor,  # (N, Hk, D)
         value: torch.Tensor,  # (N, Hk, D)
-        kv_cache: torch.Tensor,  # (num_blocks, block_size, Hk, slot_size)
+        kv_cache: torch.Tensor,  # (num_blocks, Hk, 1, page_record_size)
         slot_mapping: torch.Tensor,
         layer: Any,
     ):
@@ -725,7 +763,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         query: torch.Tensor,  # (N, Hq, D)
         key: torch.Tensor,  # (N, Hk, D)
         value: torch.Tensor,  # (N, Hk, D)
-        kv_cache: torch.Tensor,  # (num_blocks, block_size, Hk, slot_size)
+        kv_cache: torch.Tensor,  # (num_blocks, Hk, 1, page_record_size)
         attn_metadata: TurboQuantMetadata,
         Pi: torch.Tensor,
         centroids: torch.Tensor,
@@ -910,7 +948,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         query: torch.Tensor,  # (q_len, Hq, D)
         key_chunk: torch.Tensor,  # (q_len, Hk, D)
         val_chunk: torch.Tensor,  # (q_len, Hk, D)
-        kv_cache: torch.Tensor,  # (num_blocks, block_size, Hk, slot_size)
+        kv_cache: torch.Tensor,  # (num_blocks, Hk, 1, page_record_size)
         block_table: torch.Tensor,  # (1, max_num_blocks)
         cached_len: int,
         seq_len: int,
@@ -925,7 +963,14 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         q_len, Hq, D = query.shape
         Hk = key_chunk.shape[1]
         device = query.device
-        block_size = kv_cache.shape[1]
+        record_size = kv_cache.shape[-1]
+        slot_size = self.tq_config.slot_size_aligned
+        if record_size % slot_size:
+            raise ValueError(
+                "TurboQuant page record size must be divisible by its "
+                f"per-token payload: {record_size=} {slot_size=}"
+            )
+        block_size = record_size // slot_size
         BLOCK_D = triton.next_power_of_2(D)
 
         mse_bytes = self._mse_bytes
@@ -1011,13 +1056,12 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
                 v_cached.stride(2),
                 kv_cache.stride(0),
                 kv_cache.stride(1),
-                kv_cache.stride(2),
                 block_table.stride(0),
                 HEAD_DIM=D,
                 BLOCK_SIZE=block_size,
                 NUM_KV_HEADS=Hk,
-                MSE_BYTES=mse_bytes,
-                KPS=self.tq_config.key_packed_size,
+                KEY_DATA_BYTES=self._mse_bytes,
+                KEY_NORM_BYTES=0 if self.tq_config.key_fp8 else 2,
                 VQB=self.tq_config.effective_value_quant_bits,
                 VAL_DATA_BYTES=val_data_bytes,
                 MSE_BITS=self.tq_config.key_mse_bits,
@@ -1101,13 +1145,50 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
     def _decode_attention(
         self,
         query: torch.Tensor,  # (B, Hq, D)
-        kv_cache: torch.Tensor,  # (num_blocks, block_size, Hk, slot_size)
+        kv_cache: torch.Tensor,  # (num_blocks, Hk, 1, page_record_size)
         attn_metadata: TurboQuantMetadata,
         Pi: torch.Tensor,
         centroids: torch.Tensor,
         PiT: torch.Tensor | None = None,
         layer: torch.nn.Module | None = None,
     ) -> torch.Tensor:
+        if self._can_use_optimized_decode(query, kv_cache, attn_metadata):
+            assert _turboquant_C is not None
+            B, Hq, D = query.shape
+            record_size = kv_cache.shape[-1]
+            page_size = record_size // self.tq_config.slot_size_aligned
+            page_table_stride = attn_metadata.block_table.stride(0)
+            max_seq_len = attn_metadata.max_seq_len
+            if torch.cuda.is_current_stream_capturing():
+                max_seq_len = attn_metadata.block_table.shape[1] * page_size
+            workspace_bytes = _turboquant_C.workspace_size(
+                B,
+                Hq,
+                self.num_kv_heads,
+                page_table_stride,
+                page_size,
+                D,
+                max_seq_len,
+                query.device.index or 0,
+            )
+            workspace, output = current_workspace_manager().get_simultaneous(
+                ((workspace_bytes,), torch.uint8),
+                ((B, Hq, D), query.dtype),
+            )
+            _turboquant_C.run_with_workspace(
+                query,
+                kv_cache,
+                attn_metadata.block_table,
+                attn_metadata.seq_lens,
+                Pi,
+                centroids,
+                workspace,
+                output,
+                page_size,
+                max_seq_len,
+            )
+            return output
+
         # Acquire shared decode scratch buffers from WorkspaceManager.
         # Layers execute sequentially so one set of buffers is sufficient.
         # Falls back to kernel-internal allocation if workspace unavailable.
@@ -1241,3 +1322,50 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
                 f"SoA decode does not support kwargs {sorted(dropped)}"
             )
         return soa_decode(**{k: v for k, v in kwargs.items() if k in accepted})
+
+    def _can_use_optimized_decode(
+        self,
+        query: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: TurboQuantMetadata,
+    ) -> bool:
+        if (
+            _turboquant_C is None
+            or not is_workspace_manager_initialized()
+            or not query.is_cuda
+            or query.dtype != torch.bfloat16
+            or self.head_size not in {64, 128, 256}
+            or query.shape[2] != self.head_size
+            or self.tq_config.key_mse_bits != 4
+            or self.tq_config.effective_value_quant_bits != 4
+            or not self.tq_config.norm_correction
+            or self.tq_config.key_fp8
+            or not math.isclose(self.scale, 1 / math.sqrt(self.head_size))
+            or self.alibi_slopes is not None
+            or self.sliding_window is not None
+            or self.logits_soft_cap not in (None, 0.0)
+            or not query.is_contiguous()
+            or not kv_cache.is_contiguous()
+            or kv_cache.dtype != torch.uint8
+            or not attn_metadata.block_table.is_cuda
+            or attn_metadata.block_table.dtype != torch.int32
+            or attn_metadata.block_table.stride(1) != 1
+            or not attn_metadata.seq_lens.is_cuda
+            or attn_metadata.seq_lens.dtype != torch.int32
+            or not attn_metadata.seq_lens.is_contiguous()
+            or attn_metadata.max_seq_len <= 0
+            or torch.cuda.get_device_capability(query.device)
+            not in _OPTIMIZED_DECODE_CAPABILITIES
+        ):
+            return False
+        record_size = kv_cache.shape[-1]
+        slot_size = self.tq_config.slot_size_aligned
+        if record_size % slot_size:
+            return False
+        page_size = record_size // slot_size
+        return page_size in {
+            16,
+            32,
+            64,
+            128,
+        }

--- a/vllm/v1/attention/ops/flydsl_turboquant_decode.py
+++ b/vllm/v1/attention/ops/flydsl_turboquant_decode.py
@@ -558,7 +558,7 @@ def _reduce_partitions(
 # -- Public launcher ----------------------------------------------------------
 def flydsl_turboquant_decode_attention(
     query: torch.Tensor,  # [B, Hq, D] bf16/fp16
-    kv_cache: torch.Tensor,  # [num_blocks, BS, Hk, slot_size_aligned]
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, 1, page_record_size]
     block_table: torch.Tensor,  # [B, max_blocks_per_seq] int32
     seq_lens: torch.Tensor,  # [B] int32
     Pi: torch.Tensor,  # [D, D] fp32
@@ -595,7 +595,7 @@ def flydsl_turboquant_decode_attention(
     Sinks are NYI and silently ignored if set. norm_correction is honored
     implicitly via the pre-folded stored K-norm (see footer comment).
     """
-    del mid_o_buf, lse_buf, key_packed_size, value_packed_size
+    del mid_o_buf, lse_buf
     if not is_flydsl_available():
         raise RuntimeError(
             "FlyDSL decode requested but FlyDSL is not available (needs gfx950 "
@@ -608,8 +608,17 @@ def flydsl_turboquant_decode_attention(
     )
 
     B, Hq, D = query.shape
-    Hk = kv_cache.shape[2]
-    block_size = kv_cache.shape[1]
+    Hk = kv_cache.shape[1]
+    slot_size = key_packed_size + value_packed_size
+    slot_size += slot_size % 2
+    record_size = kv_cache.shape[-1]
+    if kv_cache.ndim != 4 or kv_cache.shape[2] != 1 or record_size % slot_size:
+        raise ValueError(
+            "TurboQuant cache must have shape "
+            "[num_blocks, num_kv_heads, 1, page_record_size] with a page "
+            "record divisible by the per-token payload"
+        )
+    block_size = record_size // slot_size
     QG = Hq // Hk
     assert D == _TQ_MOD.HEAD_SIZE
     assert block_size in (16, 32), (

--- a/vllm/v1/attention/ops/triton_turboquant_decode.py
+++ b/vllm/v1/attention/ops/triton_turboquant_decode.py
@@ -45,7 +45,7 @@ def _tq_decode_stage1(
     # Precomputed query projection
     Q_rot_ptr,  # [B, Hq, D] float32
     # Compressed KV cache (combined K+V)
-    KV_cache_ptr,  # [num_blocks, block_size, Hk, padded_slot] uint8
+    KV_cache_ptr,  # [num_blocks, Hk, 1, page_record_size] uint8
     # Block table and sequence info
     Block_table_ptr,  # [B, max_num_blocks] int32
     Seq_lens_ptr,  # [B] int32
@@ -57,7 +57,6 @@ def _tq_decode_stage1(
     stride_qb,
     stride_qh,  # Q strides: [B, Hq, D]
     stride_cache_block,
-    stride_cache_pos,
     stride_cache_head,  # KV cache
     stride_bt_b,  # block_table stride per batch
     stride_mid_b,
@@ -71,8 +70,8 @@ def _tq_decode_stage1(
     KV_GROUP_SIZE: tl.constexpr,  # Hq // Hk
     # TQ layout constants
     MSE_BITS: tl.constexpr,  # 3 or 4
-    MSE_BYTES: tl.constexpr,  # ceil(D * mse_bits / 8)
-    KPS: tl.constexpr,  # key_packed_size
+    KEY_DATA_BYTES: tl.constexpr,
+    KEY_NORM_BYTES: tl.constexpr,
     VQB: tl.constexpr,  # value_quant_bits (4 or 8=FP8)
     VAL_DATA_BYTES: tl.constexpr,  # ceil(D * vqb / 8) or D for FP8
     # Score constants
@@ -145,17 +144,26 @@ def _tq_decode_stage1(
             other=0,
         ).to(tl.int64)
 
-        slot_bases = (
+        record_bases = (
             block_nums * stride_cache_block
-            + page_off.to(tl.int64) * stride_cache_pos
             + tl.cast(kv_head, tl.int64) * stride_cache_head
         )
+        page_off_i64 = page_off.to(tl.int64)
+        key_data_bases = record_bases + page_off_i64 * KEY_DATA_BYTES
+        value_data_plane = record_bases + BLOCK_SIZE * KEY_DATA_BYTES
+        value_data_bases = value_data_plane + page_off_i64 * VAL_DATA_BYTES
+        key_norm_plane = value_data_plane + BLOCK_SIZE * VAL_DATA_BYTES
+        key_norm_bases = key_norm_plane + page_off_i64 * KEY_NORM_BYTES
+        value_scale_plane = key_norm_plane + BLOCK_SIZE * KEY_NORM_BYTES
+        value_scale_bases = value_scale_plane + page_off_i64 * 2
+        value_zero_plane = value_scale_plane + BLOCK_SIZE * 2
+        value_zero_bases = value_zero_plane + page_off_i64 * 2
 
         # ============================================================
         # COMPUTE ATTENTION SCORES: [BLOCK_KV]
         # ============================================================
         if KEY_FP8:
-            k_addrs = slot_bases[:, None] + d_offs[None, :]
+            k_addrs = key_data_bases[:, None] + d_offs[None, :]
             k_raw = tl.load(
                 KV_cache_ptr + k_addrs,
                 mask=kv_mask[:, None] & d_mask[None, :],
@@ -175,7 +183,7 @@ def _tq_decode_stage1(
             scores = tl.where(kv_mask, scores, -float("inf"))
         else:
             # MSE unpack + norms
-            mse_addrs0 = slot_bases[:, None] + mse_byte_idx[None, :]
+            mse_addrs0 = key_data_bases[:, None] + mse_byte_idx[None, :]
             mse_raw0 = tl.load(
                 KV_cache_ptr + mse_addrs0,
                 mask=kv_mask[:, None] & d_mask[None, :],
@@ -210,12 +218,11 @@ def _tq_decode_stage1(
                 axis=1,
             )
 
-            # Load norms (fp16 -> fp32): norms are at MSE_BYTES offset
-            norm_bases = slot_bases + MSE_BYTES
-            n_lo = tl.load(KV_cache_ptr + norm_bases, mask=kv_mask, other=0).to(
+            # Load norms (fp16 -> fp32)
+            n_lo = tl.load(KV_cache_ptr + key_norm_bases, mask=kv_mask, other=0).to(
                 tl.uint16
             )
-            n_hi = tl.load(KV_cache_ptr + norm_bases + 1, mask=kv_mask, other=0).to(
+            n_hi = tl.load(KV_cache_ptr + key_norm_bases + 1, mask=kv_mask, other=0).to(
                 tl.uint16
             )
             vec_norms = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
@@ -233,10 +240,8 @@ def _tq_decode_stage1(
         # ============================================================
         # VALUE LOAD + DEQUANTIZE: [BLOCK_KV, BLOCK_D]
         # ============================================================
-        val_bases = slot_bases + KPS
-
         if VQB == 3:
-            val_addrs0 = val_bases[:, None] + val_byte_idx[None, :]
+            val_addrs0 = value_data_bases[:, None] + val_byte_idx[None, :]
             val_raw0 = tl.load(
                 KV_cache_ptr + val_addrs0,
                 mask=kv_mask[:, None] & d_mask[None, :],
@@ -250,28 +255,27 @@ def _tq_decode_stage1(
             raw16 = val_raw0 | (val_raw1 << 8)
             v_idx = ((raw16 >> val_bit_shift[None, :]) & 0x7).to(tl.float32)
 
-            sc_bases = val_bases + VAL_DATA_BYTES
-            sc_lo = tl.load(KV_cache_ptr + sc_bases, mask=kv_mask, other=0).to(
+            sc_lo = tl.load(KV_cache_ptr + value_scale_bases, mask=kv_mask, other=0).to(
                 tl.uint16
             )
-            sc_hi = tl.load(KV_cache_ptr + sc_bases + 1, mask=kv_mask, other=0).to(
-                tl.uint16
-            )
+            sc_hi = tl.load(
+                KV_cache_ptr + value_scale_bases + 1, mask=kv_mask, other=0
+            ).to(tl.uint16)
             v_scales = (
                 (sc_lo | (sc_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
             )
-            zr_lo = tl.load(KV_cache_ptr + sc_bases + 2, mask=kv_mask, other=0).to(
+            zr_lo = tl.load(KV_cache_ptr + value_zero_bases, mask=kv_mask, other=0).to(
                 tl.uint16
             )
-            zr_hi = tl.load(KV_cache_ptr + sc_bases + 3, mask=kv_mask, other=0).to(
-                tl.uint16
-            )
+            zr_hi = tl.load(
+                KV_cache_ptr + value_zero_bases + 1, mask=kv_mask, other=0
+            ).to(tl.uint16)
             v_zeros = (zr_lo | (zr_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
             values = v_idx * v_scales[:, None] + v_zeros[:, None]
         else:  # VQB == 4
             vb_idx = d_offs // 2
             vb_shift = (d_offs % 2) * 4
-            val_addrs = val_bases[:, None] + vb_idx[None, :]
+            val_addrs = value_data_bases[:, None] + vb_idx[None, :]
             val_raw = tl.load(
                 KV_cache_ptr + val_addrs,
                 mask=kv_mask[:, None] & d_mask[None, :],
@@ -279,22 +283,21 @@ def _tq_decode_stage1(
             ).to(tl.int32)
             v_idx = ((val_raw >> vb_shift[None, :]) & 0xF).to(tl.float32)
 
-            sc_bases = val_bases + VAL_DATA_BYTES
-            sc_lo = tl.load(KV_cache_ptr + sc_bases, mask=kv_mask, other=0).to(
+            sc_lo = tl.load(KV_cache_ptr + value_scale_bases, mask=kv_mask, other=0).to(
                 tl.uint16
             )
-            sc_hi = tl.load(KV_cache_ptr + sc_bases + 1, mask=kv_mask, other=0).to(
-                tl.uint16
-            )
+            sc_hi = tl.load(
+                KV_cache_ptr + value_scale_bases + 1, mask=kv_mask, other=0
+            ).to(tl.uint16)
             v_scales = (
                 (sc_lo | (sc_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
             )
-            zr_lo = tl.load(KV_cache_ptr + sc_bases + 2, mask=kv_mask, other=0).to(
+            zr_lo = tl.load(KV_cache_ptr + value_zero_bases, mask=kv_mask, other=0).to(
                 tl.uint16
             )
-            zr_hi = tl.load(KV_cache_ptr + sc_bases + 3, mask=kv_mask, other=0).to(
-                tl.uint16
-            )
+            zr_hi = tl.load(
+                KV_cache_ptr + value_zero_bases + 1, mask=kv_mask, other=0
+            ).to(tl.uint16)
             v_zeros = (zr_lo | (zr_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
             values = v_idx * v_scales[:, None] + v_zeros[:, None]
 
@@ -332,14 +335,13 @@ def _tq_full_dequant_kv(
     stride_vo_h,
     stride_vo_s,
     stride_cache_block,
-    stride_cache_pos,
     stride_cache_head,
     stride_bt_b,
     HEAD_DIM: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     NUM_KV_HEADS: tl.constexpr,
-    MSE_BYTES: tl.constexpr,
-    KPS: tl.constexpr,
+    KEY_DATA_BYTES: tl.constexpr,
+    KEY_NORM_BYTES: tl.constexpr,
     VQB: tl.constexpr,
     VAL_DATA_BYTES: tl.constexpr,
     MSE_BITS: tl.constexpr,
@@ -357,11 +359,19 @@ def _tq_full_dequant_kv(
     page_idx = pos // BLOCK_SIZE
     page_off = pos % BLOCK_SIZE
     block_num = tl.load(Block_table_ptr + bid * stride_bt_b + page_idx).to(tl.int64)
-    slot_base = (
-        block_num * stride_cache_block
-        + tl.cast(page_off, tl.int64) * stride_cache_pos
-        + tl.cast(hid, tl.int64) * stride_cache_head
+    record_base = (
+        block_num * stride_cache_block + tl.cast(hid, tl.int64) * stride_cache_head
     )
+    page_off_i64 = tl.cast(page_off, tl.int64)
+    key_data_base = record_base + page_off_i64 * KEY_DATA_BYTES
+    value_data_plane = record_base + BLOCK_SIZE * KEY_DATA_BYTES
+    value_data_base = value_data_plane + page_off_i64 * VAL_DATA_BYTES
+    key_norm_plane = value_data_plane + BLOCK_SIZE * VAL_DATA_BYTES
+    key_norm_base = key_norm_plane + page_off_i64 * KEY_NORM_BYTES
+    value_scale_plane = key_norm_plane + BLOCK_SIZE * KEY_NORM_BYTES
+    value_scale_base = value_scale_plane + page_off_i64 * 2
+    value_zero_plane = value_scale_plane + BLOCK_SIZE * 2
+    value_zero_base = value_zero_plane + page_off_i64 * 2
 
     d_offs = tl.arange(0, BLOCK_D)
     d_mask = d_offs < HEAD_DIM
@@ -369,7 +379,7 @@ def _tq_full_dequant_kv(
     # === K dequant ===
     ko_base = bid * stride_ko_b + hid * stride_ko_h + pos * stride_ko_s
     if KEY_FP8:
-        k_raw = tl.load(KV_cache_ptr + slot_base + d_offs, mask=d_mask, other=0)
+        k_raw = tl.load(KV_cache_ptr + key_data_base + d_offs, mask=d_mask, other=0)
         if FP8_E4B15:
             k_recon = k_raw.to(tl.float8e4b15, bitcast=True).to(tl.float32)
         else:
@@ -383,10 +393,10 @@ def _tq_full_dequant_kv(
         mse_umask = (1 << MSE_BITS) - 1
 
         mse_raw0 = tl.load(
-            KV_cache_ptr + slot_base + mse_byte_idx, mask=d_mask, other=0
+            KV_cache_ptr + key_data_base + mse_byte_idx, mask=d_mask, other=0
         ).to(tl.int32)
         mse_raw1 = tl.load(
-            KV_cache_ptr + slot_base + mse_byte_idx + 1, mask=d_mask, other=0
+            KV_cache_ptr + key_data_base + mse_byte_idx + 1, mask=d_mask, other=0
         ).to(tl.int32)
         raw16_key = mse_raw0 | (mse_raw1 << 8)
         mse_idx = (raw16_key >> mse_bit_shift) & mse_umask
@@ -399,31 +409,27 @@ def _tq_full_dequant_kv(
             c_inv_norm = 1.0 / tl.sqrt(c_norm_sq + 1e-16)
             k_mse = k_mse * c_inv_norm
 
-        # Norms at MSE_BYTES offset (no QJL bytes)
-        norm_base = slot_base + MSE_BYTES
-        n_lo = tl.load(KV_cache_ptr + norm_base).to(tl.uint16)
-        n_hi = tl.load(KV_cache_ptr + norm_base + 1).to(tl.uint16)
+        n_lo = tl.load(KV_cache_ptr + key_norm_base).to(tl.uint16)
+        n_hi = tl.load(KV_cache_ptr + key_norm_base + 1).to(tl.uint16)
         vec_norm = (n_lo | (n_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
 
         k_recon = vec_norm * k_mse
         tl.store(K_out_ptr + ko_base + d_offs, k_recon.to(tl.float16), mask=d_mask)
 
     # === V dequant ===
-    val_base = slot_base + KPS
     if VQB == 4:
         vb_idx = d_offs // 2
         vb_shift = (d_offs % 2) * 4
-        val_raw = tl.load(KV_cache_ptr + val_base + vb_idx, mask=d_mask, other=0).to(
-            tl.int32
-        )
+        val_raw = tl.load(
+            KV_cache_ptr + value_data_base + vb_idx, mask=d_mask, other=0
+        ).to(tl.int32)
         v_idx = ((val_raw >> vb_shift) & 0xF).to(tl.float32)
 
-        sc_base = val_base + VAL_DATA_BYTES
-        sc_lo = tl.load(KV_cache_ptr + sc_base).to(tl.uint16)
-        sc_hi = tl.load(KV_cache_ptr + sc_base + 1).to(tl.uint16)
+        sc_lo = tl.load(KV_cache_ptr + value_scale_base).to(tl.uint16)
+        sc_hi = tl.load(KV_cache_ptr + value_scale_base + 1).to(tl.uint16)
         v_scale = (sc_lo | (sc_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
-        zr_lo = tl.load(KV_cache_ptr + sc_base + 2).to(tl.uint16)
-        zr_hi = tl.load(KV_cache_ptr + sc_base + 3).to(tl.uint16)
+        zr_lo = tl.load(KV_cache_ptr + value_zero_base).to(tl.uint16)
+        zr_hi = tl.load(KV_cache_ptr + value_zero_base + 1).to(tl.uint16)
         v_zero = (zr_lo | (zr_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
         v_vals = v_idx * v_scale + v_zero
     elif VQB == 3:
@@ -432,20 +438,21 @@ def _tq_full_dequant_kv(
         val_byte_idx = val_bit_off // 8
         val_bit_shift = val_bit_off % 8
         val_raw0 = tl.load(
-            KV_cache_ptr + val_base + val_byte_idx, mask=d_mask, other=0
+            KV_cache_ptr + value_data_base + val_byte_idx, mask=d_mask, other=0
         ).to(tl.int32)
         val_raw1 = tl.load(
-            KV_cache_ptr + val_base + val_byte_idx + 1, mask=d_mask, other=0
+            KV_cache_ptr + value_data_base + val_byte_idx + 1,
+            mask=d_mask,
+            other=0,
         ).to(tl.int32)
         raw16_val = val_raw0 | (val_raw1 << 8)
         v_idx = ((raw16_val >> val_bit_shift) & 0x7).to(tl.float32)
 
-        sc_base = val_base + VAL_DATA_BYTES
-        sc_lo = tl.load(KV_cache_ptr + sc_base).to(tl.uint16)
-        sc_hi = tl.load(KV_cache_ptr + sc_base + 1).to(tl.uint16)
+        sc_lo = tl.load(KV_cache_ptr + value_scale_base).to(tl.uint16)
+        sc_hi = tl.load(KV_cache_ptr + value_scale_base + 1).to(tl.uint16)
         v_scale = (sc_lo | (sc_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
-        zr_lo = tl.load(KV_cache_ptr + sc_base + 2).to(tl.uint16)
-        zr_hi = tl.load(KV_cache_ptr + sc_base + 3).to(tl.uint16)
+        zr_lo = tl.load(KV_cache_ptr + value_zero_base).to(tl.uint16)
+        zr_hi = tl.load(KV_cache_ptr + value_zero_base + 1).to(tl.uint16)
         v_zero = (zr_lo | (zr_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
         v_vals = v_idx * v_scale + v_zero
     else:
@@ -485,7 +492,7 @@ def _get_layout(D, mse_bits, value_quant_bits, key_packed_size):
 
 def triton_turboquant_decode_attention(
     query: torch.Tensor,  # [B, Hq, D] — original query
-    kv_cache: torch.Tensor,  # [num_blocks, block_size, Hk, padded_slot] uint8
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, 1, page_record_size] uint8
     block_table: torch.Tensor,  # [B, max_num_blocks] int32
     seq_lens: torch.Tensor,  # [B] int32
     Pi: torch.Tensor,  # [D, D] float32
@@ -509,12 +516,24 @@ def triton_turboquant_decode_attention(
     Returns: output tensor [B, Hq, D] in query's dtype.
     """
     B, Hq, D = query.shape
-    Hk = kv_cache.shape[2]
-    block_size = kv_cache.shape[1]
+    if kv_cache.ndim != 4 or kv_cache.shape[2] != 1:
+        raise ValueError(
+            "TurboQuant cache must have shape "
+            "[num_blocks, num_kv_heads, 1, page_record_size]"
+        )
+    Hk = kv_cache.shape[1]
+    cfg = _get_layout(D, mse_bits, value_quant_bits, key_packed_size)
+    per_token_bytes = key_packed_size + cfg["val_data_bytes"] + 4
+    aligned_token_bytes = per_token_bytes + per_token_bytes % 2
+    record_size = kv_cache.shape[-1]
+    if record_size % aligned_token_bytes:
+        raise ValueError(
+            "TurboQuant page record is not divisible by its per-token payload: "
+            f"{record_size=} {aligned_token_bytes=}"
+        )
+    block_size = record_size // aligned_token_bytes
     kv_group_size = Hq // Hk
     device = query.device
-
-    cfg = _get_layout(D, mse_bits, value_quant_bits, key_packed_size)
 
     # Compute q_rot = q @ Pi.T (rotated query for MSE key scoring)
     # FP8 path: pass query directly (float16); kernel casts inline.
@@ -562,7 +581,6 @@ def triton_turboquant_decode_attention(
         q_rot.stride(1),
         kv_cache.stride(0),
         kv_cache.stride(1),
-        kv_cache.stride(2),
         block_table.stride(0),
         mid_o.stride(0),
         mid_o.stride(1),
@@ -573,8 +591,8 @@ def triton_turboquant_decode_attention(
         NUM_KV_SPLITS=NUM_KV_SPLITS,
         KV_GROUP_SIZE=kv_group_size,
         MSE_BITS=mse_bits,
-        MSE_BYTES=cfg["mse_bytes"],
-        KPS=key_packed_size,
+        KEY_DATA_BYTES=D if key_fp8 else cfg["mse_bytes"],
+        KEY_NORM_BYTES=0 if key_fp8 else 2,
         VQB=value_quant_bits,
         VAL_DATA_BYTES=cfg["val_data_bytes"],
         ATTN_SCALE=scale,

--- a/vllm/v1/attention/ops/triton_turboquant_store.py
+++ b/vllm/v1/attention/ops/triton_turboquant_store.py
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Fused Triton kernels for TurboQuant KV store.
 
-Two kernels:
+Three kernels:
 1. _tq_fused_store_fp8: FP8 key scatter + value uniform quantization.
-2. _tq_fused_store_mse: Fused binary-search bucketize + MSE index
-   packing + value quantization.
+2. _tq_fused_store_mse_m1: Fused MSE store for small token-head counts.
+3. _tq_fused_store_mse_m16: Batched MSE store for larger token-head counts.
 
 The launcher `triton_turboquant_store` selects the appropriate kernel.
 """
@@ -27,11 +27,12 @@ def _store_quantized_value(
     Value_ptr,
     KV_cache_ptr,
     base,  # pid * D offset into Value_ptr
-    slot_base,  # byte offset into KV_cache_ptr for this slot+head
+    value_data_base,
+    value_scale_base,
+    value_zero_base,
     d_offs,  # tl.arange(0, BLOCK_D)
     d_mask,  # d_offs < D
     D: tl.constexpr,
-    KPS: tl.constexpr,
     VQB: tl.constexpr,
     VAL_DATA_BYTES: tl.constexpr,
     BLOCK_D: tl.constexpr,
@@ -39,7 +40,6 @@ def _store_quantized_value(
     BLOCK_GRP: tl.constexpr,
 ):
     """Uniform quantization of values to VQB bits, pack, and store with scale/zero."""
-    val_cache_offset = KPS
 
     if VQB == 3:
         val_vec = tl.load(Value_ptr + base + d_offs, mask=d_mask, other=0.0).to(
@@ -63,36 +63,27 @@ def _store_quantized_value(
         b1 = ((packed_24 >> 8) & 0xFF).to(tl.uint8)
         b2 = ((packed_24 >> 16) & 0xFF).to(tl.uint8)
         tl.store(
-            KV_cache_ptr + slot_base + val_cache_offset + grp_offs * 3,
+            KV_cache_ptr + value_data_base + grp_offs * 3,
             b0,
             mask=grp_mask,
         )
         tl.store(
-            KV_cache_ptr + slot_base + val_cache_offset + grp_offs * 3 + 1,
+            KV_cache_ptr + value_data_base + grp_offs * 3 + 1,
             b1,
             mask=grp_mask,
         )
         tl.store(
-            KV_cache_ptr + slot_base + val_cache_offset + grp_offs * 3 + 2,
+            KV_cache_ptr + value_data_base + grp_offs * 3 + 2,
             b2,
             mask=grp_mask,
         )
 
-        sc_offset = val_cache_offset + VAL_DATA_BYTES
-        sc_f16 = v_scale.to(tl.float16)
-        sc_u16 = sc_f16.to(tl.uint16, bitcast=True)
-        tl.store(KV_cache_ptr + slot_base + sc_offset, (sc_u16 & 0xFF).to(tl.uint8))
-        tl.store(
-            KV_cache_ptr + slot_base + sc_offset + 1,
-            ((sc_u16 >> 8) & 0xFF).to(tl.uint8),
-        )
-        zr_f16 = val_min.to(tl.float16)
-        zr_u16 = zr_f16.to(tl.uint16, bitcast=True)
-        tl.store(KV_cache_ptr + slot_base + sc_offset + 2, (zr_u16 & 0xFF).to(tl.uint8))
-        tl.store(
-            KV_cache_ptr + slot_base + sc_offset + 3,
-            ((zr_u16 >> 8) & 0xFF).to(tl.uint8),
-        )
+        sc_u16 = v_scale.to(tl.float16).to(tl.uint16, bitcast=True)
+        zr_u16 = val_min.to(tl.float16).to(tl.uint16, bitcast=True)
+        sc_ptr = (KV_cache_ptr + value_scale_base).to(tl.pointer_type(tl.uint16))
+        zr_ptr = (KV_cache_ptr + value_zero_base).to(tl.pointer_type(tl.uint16))
+        tl.store(sc_ptr, sc_u16)
+        tl.store(zr_ptr, zr_u16)
 
     else:  # VQB == 4
         val_vec = tl.load(Value_ptr + base + d_offs, mask=d_mask, other=0.0).to(
@@ -114,26 +105,17 @@ def _store_quantized_value(
         val_offs = tl.arange(0, BLOCK_D // 2)
         val_mask = val_offs < VAL_DATA_BYTES
         tl.store(
-            KV_cache_ptr + slot_base + val_cache_offset + val_offs,
+            KV_cache_ptr + value_data_base + val_offs,
             packed_val,
             mask=val_mask,
         )
 
-        sc_offset = val_cache_offset + VAL_DATA_BYTES
-        sc_f16 = v_scale.to(tl.float16)
-        sc_u16 = sc_f16.to(tl.uint16, bitcast=True)
-        tl.store(KV_cache_ptr + slot_base + sc_offset, (sc_u16 & 0xFF).to(tl.uint8))
-        tl.store(
-            KV_cache_ptr + slot_base + sc_offset + 1,
-            ((sc_u16 >> 8) & 0xFF).to(tl.uint8),
-        )
-        zr_f16 = val_min.to(tl.float16)
-        zr_u16 = zr_f16.to(tl.uint16, bitcast=True)
-        tl.store(KV_cache_ptr + slot_base + sc_offset + 2, (zr_u16 & 0xFF).to(tl.uint8))
-        tl.store(
-            KV_cache_ptr + slot_base + sc_offset + 3,
-            ((zr_u16 >> 8) & 0xFF).to(tl.uint8),
-        )
+        sc_u16 = v_scale.to(tl.float16).to(tl.uint16, bitcast=True)
+        zr_u16 = val_min.to(tl.float16).to(tl.uint16, bitcast=True)
+        sc_ptr = (KV_cache_ptr + value_scale_base).to(tl.pointer_type(tl.uint16))
+        zr_ptr = (KV_cache_ptr + value_zero_base).to(tl.pointer_type(tl.uint16))
+        tl.store(sc_ptr, sc_u16)
+        tl.store(zr_ptr, zr_u16)
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -149,15 +131,12 @@ def _tq_fused_store_fp8(
     Slot_mapping_ptr,  # [N] int32 — per-token slot indices
     # Cache strides (for computing byte offsets)
     stride_cache_block: tl.constexpr,
-    stride_cache_pos: tl.constexpr,
     stride_cache_head: tl.constexpr,
     # Dimensions
     D: tl.constexpr,
     H: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     BLOCK_D: tl.constexpr,
-    # TQ layout
-    KPS: tl.constexpr,
     # Value quantization
     VQB: tl.constexpr,
     VAL_DATA_BYTES: tl.constexpr,
@@ -177,11 +156,14 @@ def _tq_fused_store_fp8(
     blk = (slot // BLOCK_SIZE).to(tl.int64)
     off = (slot % BLOCK_SIZE).to(tl.int64)
     head_idx_i64 = tl.cast(head_idx, tl.int64)
-    slot_base = (
-        blk * stride_cache_block
-        + off * stride_cache_pos
-        + head_idx_i64 * stride_cache_head
-    )
+    record_base = blk * stride_cache_block + head_idx_i64 * stride_cache_head
+    key_data_base = record_base + off * D
+    value_data_plane = record_base + BLOCK_SIZE * D
+    value_scale_plane = value_data_plane + BLOCK_SIZE * VAL_DATA_BYTES
+    value_zero_plane = value_scale_plane + BLOCK_SIZE * 2
+    value_data_base = value_data_plane + off * VAL_DATA_BYTES
+    value_scale_base = value_scale_plane + off * 2
+    value_zero_base = value_zero_plane + off * 2
 
     base = pid * D
 
@@ -191,18 +173,19 @@ def _tq_fused_store_fp8(
     k_vals = tl.load(Key_ptr + base + d_offs, mask=d_mask, other=0.0).to(tl.float32)
     k_fp8 = k_vals.to(tl.float8e4b15) if FP8_E4B15 else k_vals.to(tl.float8e4nv)
     k_bytes = k_fp8.to(tl.uint8, bitcast=True)
-    tl.store(KV_cache_ptr + slot_base + d_offs, k_bytes, mask=d_mask)
+    tl.store(KV_cache_ptr + key_data_base + d_offs, k_bytes, mask=d_mask)
 
     # ── VALUE QUANTIZE + PACK ───────────────────────────────────────
     _store_quantized_value(
         Value_ptr,
         KV_cache_ptr,
         base,
-        slot_base,
+        value_data_base,
+        value_scale_base,
+        value_zero_base,
         d_offs,
         d_mask,
         D=D,
-        KPS=KPS,
         VQB=VQB,
         VAL_DATA_BYTES=VAL_DATA_BYTES,
         BLOCK_D=BLOCK_D,
@@ -212,49 +195,32 @@ def _tq_fused_store_fp8(
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# Fused MSE store: bucketize + MSE index pack + norm store + value pack
-# (eliminates 4 PyTorch kernel launches per layer vs pack-only kernel)
+# Fused MSE store: normalize + rotate + bucketize + pack + metadata store
 # ═══════════════════════════════════════════════════════════════════════
 
 
 @triton.jit
-def _tq_fused_store_mse(
-    # Post-rotation inputs
-    Y_ptr,  # [NH, D] float32 — rotated normalized keys (x_hat @ PiT)
-    Norms_ptr,  # [NH] float32 — key vector norms (||k||)
-    Value_ptr,  # [NH, D] float32 — raw values
-    # Quantization tables
-    Midpoints_ptr,  # [n_centroids-1] float32
-    # Cache and indexing
-    KV_cache_ptr,  # [total_bytes] uint8 (flattened view)
-    Slot_mapping_ptr,  # [N] int32 — per-token slot indices
-    # Cache strides
+def _tq_fused_store_mse_m1(
+    Key_ptr,
+    Value_ptr,
+    PiT_mma_ptr,
+    Midpoints_ptr,
+    KV_cache_ptr,
+    Slot_mapping_ptr,
     stride_cache_block: tl.constexpr,
-    stride_cache_pos: tl.constexpr,
     stride_cache_head: tl.constexpr,
-    # Dimensions
     D: tl.constexpr,
     H: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     BLOCK_D: tl.constexpr,
-    # TQ layout
     MSE_BYTES: tl.constexpr,
-    KPS: tl.constexpr,
-    # Value quantization
     VQB: tl.constexpr,
     VAL_DATA_BYTES: tl.constexpr,
-    # Packing block sizes
-    BLOCK_VAL: tl.constexpr,
-    # MSE params
     MSE_BITS: tl.constexpr,
     N_CENTROIDS: tl.constexpr,
-    BLOCK_GRP: tl.constexpr = 16,
+    BLOCK_GRP: tl.constexpr,
+    M_PAD: tl.constexpr = 16,
 ):
-    """Fused MSE quantize + pack + store.
-
-    Performs binary-search bucketize, MSE index packing, norm storage,
-    and value quantization in one kernel.
-    """
     pid = tl.program_id(0)
     token_idx = pid // H
     head_idx = pid % H
@@ -262,84 +228,314 @@ def _tq_fused_store_mse(
     slot = tl.load(Slot_mapping_ptr + token_idx)
     if slot < 0:
         return
-    blk = (slot // BLOCK_SIZE).to(tl.int64)
-    off = (slot % BLOCK_SIZE).to(tl.int64)
-    head_idx_i64 = tl.cast(head_idx, tl.int64)
-    slot_base = (
-        blk * stride_cache_block
-        + off * stride_cache_pos
-        + head_idx_i64 * stride_cache_head
+    block_idx = (slot // BLOCK_SIZE).to(tl.int64)
+    position = (slot % BLOCK_SIZE).to(tl.int64)
+    record_base = (
+        block_idx * stride_cache_block + tl.cast(head_idx, tl.int64) * stride_cache_head
     )
+    key_data_base = record_base + position * MSE_BYTES
+    value_data_plane = record_base + BLOCK_SIZE * MSE_BYTES
+    key_norm_plane = value_data_plane + BLOCK_SIZE * VAL_DATA_BYTES
+    value_scale_plane = key_norm_plane + BLOCK_SIZE * 2
+    value_zero_plane = value_scale_plane + BLOCK_SIZE * 2
+    value_data_base = value_data_plane + position * VAL_DATA_BYTES
+    key_norm_base = key_norm_plane + position * 2
+    value_scale_base = value_scale_plane + position * 2
+    value_zero_base = value_zero_plane + position * 2
 
-    base = pid * D
     d_offs = tl.arange(0, BLOCK_D)
     d_mask = d_offs < D
+    input_base = pid * D
+    key = tl.load(Key_ptr + input_base + d_offs, mask=d_mask, other=0.0)
+    value = tl.load(Value_ptr + input_base + d_offs, mask=d_mask, other=0.0)
 
-    # ── 1. BINARY SEARCH BUCKETIZE ───────────────────────────────────
-    # Midpoints are sorted (N_CENTROIDS-1 values); binary search finds
-    # insertion point in MSE_BITS iterations vs N_CENTROIDS-1 for linear.
-    y_vec = tl.load(Y_ptr + base + d_offs, mask=d_mask, other=0.0)
+    key_fp32 = key.to(tl.float32)
+    norm = tl.sqrt(tl.sum(tl.where(d_mask, key_fp32 * key_fp32, 0.0)))
+    normalized = key_fp32 / (norm + 1e-8)
+    rows = tl.arange(0, M_PAD)
+    normalized_2d = tl.where(
+        (rows[:, None] == 0) & d_mask[None, :],
+        normalized[None, :],
+        0.0,
+    ).to(tl.float16)
+    pit = tl.load(
+        PiT_mma_ptr + d_offs[:, None] * D + d_offs[None, :],
+        mask=d_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )
+    rotated = tl.sum(tl.dot(normalized_2d, pit), axis=0)
+
     lo = tl.zeros([BLOCK_D], dtype=tl.int32)
     hi = tl.full([BLOCK_D], N_CENTROIDS - 1, dtype=tl.int32)
     for _ in range(MSE_BITS):
         mid = (lo + hi) >> 1
-        # Clamp to valid midpoint index [0, N_CENTROIDS-2] for load safety;
-        # the search result (lo) is still correct since converged lanes
-        # don't change.
-        safe_mid = tl.minimum(mid, N_CENTROIDS - 2)
-        mid_val = tl.load(Midpoints_ptr + safe_mid, mask=d_mask, other=0.0)
-        lo = tl.where(y_vec >= mid_val, mid + 1, lo)
-        hi = tl.where(y_vec >= mid_val, hi, mid)
-    idx = tl.minimum(lo, N_CENTROIDS - 1)
+        midpoint = tl.load(
+            Midpoints_ptr + tl.minimum(mid, N_CENTROIDS - 2),
+            mask=d_mask,
+            other=0.0,
+        )
+        ge = rotated >= midpoint
+        lo = tl.where(ge, mid + 1, lo)
+        hi = tl.where(ge, hi, mid)
+    key_idx = tl.minimum(lo, N_CENTROIDS - 1)
 
-    # ── 2. PACK MSE INDICES from register idx ─────────────────────────
     if MSE_BITS == 4:
-        idx_pairs = tl.reshape(idx, [BLOCK_D // 2, 2])
-        shifts_4 = tl.arange(0, 2) * 4
-        packed = tl.sum((idx_pairs & 0xF) << shifts_4[None, :], axis=1).to(tl.uint8)
-        mse_offs = tl.arange(0, BLOCK_D // 2)
-        mse_mask = mse_offs < MSE_BYTES
-        tl.store(KV_cache_ptr + slot_base + mse_offs, packed, mask=mse_mask)
+        key_pairs = tl.reshape(key_idx, [BLOCK_D // 2, 2])
+        shifts = tl.arange(0, 2) * 4
+        key_packed = tl.sum((key_pairs & 0xF) << shifts[None, :], axis=1).to(tl.uint8)
+        key_offs = tl.arange(0, BLOCK_D // 2)
+        tl.store(
+            KV_cache_ptr + key_data_base + key_offs,
+            key_packed,
+            mask=key_offs < MSE_BYTES,
+        )
+    else:
+        groups = tl.arange(0, BLOCK_GRP)
+        group_mask = groups < (D // 8)
+        key_groups = tl.reshape(key_idx, [BLOCK_GRP, 8])
+        packed = tl.sum((key_groups & 0x7) << (tl.arange(0, 8) * 3)[None, :], axis=1)
+        tl.store(
+            KV_cache_ptr + key_data_base + groups * 3,
+            (packed & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + key_data_base + groups * 3 + 1,
+            ((packed >> 8) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + key_data_base + groups * 3 + 2,
+            ((packed >> 16) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
 
-    elif MSE_BITS == 3:
-        grp_offs = tl.arange(0, BLOCK_GRP)
-        grp_mask = grp_offs < (D // 8)
-        idx_grp = tl.reshape(idx, [BLOCK_GRP, 8])
-        shifts_3 = tl.arange(0, 8) * 3
-        packed_24 = tl.sum((idx_grp & 0x7) << shifts_3[None, :], axis=1)
-        b0 = (packed_24 & 0xFF).to(tl.uint8)
-        b1 = ((packed_24 >> 8) & 0xFF).to(tl.uint8)
-        b2 = ((packed_24 >> 16) & 0xFF).to(tl.uint8)
-        tl.store(KV_cache_ptr + slot_base + grp_offs * 3, b0, mask=grp_mask)
-        tl.store(KV_cache_ptr + slot_base + grp_offs * 3 + 1, b1, mask=grp_mask)
-        tl.store(KV_cache_ptr + slot_base + grp_offs * 3 + 2, b2, mask=grp_mask)
+    norm_u16 = norm.to(tl.float16).to(tl.uint16, bitcast=True)
+    norm_ptr = (KV_cache_ptr + key_norm_base).to(tl.pointer_type(tl.uint16))
+    tl.store(norm_ptr, norm_u16)
 
-    # ── 3. STORE vec_norm (fp16, 2 bytes) ─────────────────────────────
-    norm_offset = MSE_BYTES
-
-    vn_f16 = tl.load(Norms_ptr + pid).to(tl.float16)
-    vn_u16 = vn_f16.to(tl.uint16, bitcast=True)
-    tl.store(KV_cache_ptr + slot_base + norm_offset, (vn_u16 & 0xFF).to(tl.uint8))
-    tl.store(
-        KV_cache_ptr + slot_base + norm_offset + 1, ((vn_u16 >> 8) & 0xFF).to(tl.uint8)
+    value_fp32 = value.to(tl.float32)
+    value_min = tl.min(tl.where(d_mask, value_fp32, float("inf")), axis=0)
+    value_max = tl.max(tl.where(d_mask, value_fp32, -float("inf")), axis=0)
+    levels = 7.0 if VQB == 3 else 15.0
+    value_scale = tl.maximum((value_max - value_min) / levels, 1e-8)
+    value_idx = tl.minimum(
+        tl.maximum(((value_fp32 - value_min) / value_scale + 0.5).to(tl.int32), 0),
+        7 if VQB == 3 else 15,
     )
 
-    # ── 4. VALUE QUANTIZE + PACK ──────────────────────────────────────
-    _store_quantized_value(
-        Value_ptr,
-        KV_cache_ptr,
-        base,
-        slot_base,
-        d_offs,
-        d_mask,
-        D=D,
-        KPS=KPS,
-        VQB=VQB,
-        VAL_DATA_BYTES=VAL_DATA_BYTES,
-        BLOCK_D=BLOCK_D,
-        BLOCK_VAL=BLOCK_VAL,
-        BLOCK_GRP=BLOCK_GRP,
+    if VQB == 4:
+        value_pairs = tl.reshape(value_idx, [BLOCK_D // 2, 2])
+        shifts = tl.arange(0, 2) * 4
+        value_packed = tl.sum((value_pairs & 0xF) << shifts[None, :], axis=1).to(
+            tl.uint8
+        )
+        value_offs = tl.arange(0, BLOCK_D // 2)
+        tl.store(
+            KV_cache_ptr + value_data_base + value_offs,
+            value_packed,
+            mask=value_offs < VAL_DATA_BYTES,
+        )
+    else:
+        groups = tl.arange(0, BLOCK_GRP)
+        group_mask = groups < (D // 8)
+        value_groups = tl.reshape(value_idx, [BLOCK_GRP, 8])
+        packed = tl.sum(value_groups << (tl.arange(0, 8) * 3)[None, :], axis=1)
+        tl.store(
+            KV_cache_ptr + value_data_base + groups * 3,
+            (packed & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + value_data_base + groups * 3 + 1,
+            ((packed >> 8) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + value_data_base + groups * 3 + 2,
+            ((packed >> 16) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+
+    scale_u16 = value_scale.to(tl.float16).to(tl.uint16, bitcast=True)
+    zero_u16 = value_min.to(tl.float16).to(tl.uint16, bitcast=True)
+    scale_ptr = (KV_cache_ptr + value_scale_base).to(tl.pointer_type(tl.uint16))
+    zero_ptr = (KV_cache_ptr + value_zero_base).to(tl.pointer_type(tl.uint16))
+    tl.store(scale_ptr, scale_u16)
+    tl.store(zero_ptr, zero_u16)
+
+
+@triton.jit
+def _tq_fused_store_mse_m16(
+    Key_ptr,
+    Value_ptr,
+    PiT_mma_ptr,
+    Midpoints_ptr,
+    KV_cache_ptr,
+    Slot_mapping_ptr,
+    stride_cache_block: tl.constexpr,
+    stride_cache_head: tl.constexpr,
+    NH,
+    D: tl.constexpr,
+    H: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    VQB: tl.constexpr,
+    VAL_DATA_BYTES: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+    BLOCK_GRP: tl.constexpr,
+    BLOCK_M: tl.constexpr = 16,
+):
+    pid = tl.program_id(0)
+    rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    row_mask = rows < NH
+    token_idx = rows // H
+    head_idx = rows % H
+    slots = tl.load(Slot_mapping_ptr + token_idx, mask=row_mask, other=-1)
+    store_mask = row_mask & (slots >= 0)
+
+    block_idx = (slots // BLOCK_SIZE).to(tl.int64)
+    position = (slots % BLOCK_SIZE).to(tl.int64)
+    record_base = (
+        block_idx * stride_cache_block + head_idx.to(tl.int64) * stride_cache_head
     )
+    key_data_base = record_base + position * MSE_BYTES
+    value_data_plane = record_base + BLOCK_SIZE * MSE_BYTES
+    key_norm_plane = value_data_plane + BLOCK_SIZE * VAL_DATA_BYTES
+    value_scale_plane = key_norm_plane + BLOCK_SIZE * 2
+    value_zero_plane = value_scale_plane + BLOCK_SIZE * 2
+    value_data_base = value_data_plane + position * VAL_DATA_BYTES
+    key_norm_base = key_norm_plane + position * 2
+    value_scale_base = value_scale_plane + position * 2
+    value_zero_base = value_zero_plane + position * 2
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    input_offsets = rows[:, None] * D + d_offs[None, :]
+    input_mask = store_mask[:, None] & d_mask[None, :]
+    key = tl.load(Key_ptr + input_offsets, mask=input_mask, other=0.0)
+    value = tl.load(Value_ptr + input_offsets, mask=input_mask, other=0.0)
+
+    key_fp32 = key.to(tl.float32)
+    norm = tl.sqrt(tl.sum(tl.where(input_mask, key_fp32 * key_fp32, 0.0), axis=1))
+    normalized = (key_fp32 / (norm[:, None] + 1e-8)).to(tl.float16)
+    pit = tl.load(
+        PiT_mma_ptr + d_offs[:, None] * D + d_offs[None, :],
+        mask=d_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )
+    rotated = tl.dot(normalized, pit)
+
+    lo = tl.zeros([BLOCK_M, BLOCK_D], dtype=tl.int32)
+    hi = tl.full([BLOCK_M, BLOCK_D], N_CENTROIDS - 1, dtype=tl.int32)
+    for _ in range(MSE_BITS):
+        mid = (lo + hi) >> 1
+        midpoint = tl.load(
+            Midpoints_ptr + tl.minimum(mid, N_CENTROIDS - 2),
+            mask=input_mask,
+            other=0.0,
+        )
+        ge = rotated >= midpoint
+        lo = tl.where(ge, mid + 1, lo)
+        hi = tl.where(ge, hi, mid)
+    key_idx = tl.minimum(lo, N_CENTROIDS - 1)
+
+    if MSE_BITS == 4:
+        key_pairs = tl.reshape(key_idx, [BLOCK_M, BLOCK_D // 2, 2])
+        shifts = tl.arange(0, 2) * 4
+        key_packed = tl.sum((key_pairs & 0xF) << shifts[None, None, :], axis=2).to(
+            tl.uint8
+        )
+        key_offs = tl.arange(0, BLOCK_D // 2)
+        tl.store(
+            KV_cache_ptr + key_data_base[:, None] + key_offs[None, :],
+            key_packed,
+            mask=store_mask[:, None] & (key_offs[None, :] < MSE_BYTES),
+        )
+    else:
+        groups = tl.arange(0, BLOCK_GRP)
+        group_mask = store_mask[:, None] & (groups[None, :] < (D // 8))
+        key_groups = tl.reshape(key_idx, [BLOCK_M, BLOCK_GRP, 8])
+        packed = tl.sum(
+            (key_groups & 0x7) << (tl.arange(0, 8) * 3)[None, None, :],
+            axis=2,
+        )
+        tl.store(
+            KV_cache_ptr + key_data_base[:, None] + groups[None, :] * 3,
+            (packed & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + key_data_base[:, None] + groups[None, :] * 3 + 1,
+            ((packed >> 8) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + key_data_base[:, None] + groups[None, :] * 3 + 2,
+            ((packed >> 16) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+
+    norm_u16 = norm.to(tl.float16).to(tl.uint16, bitcast=True)
+    norm_ptr = (KV_cache_ptr + key_norm_base).to(tl.pointer_type(tl.uint16))
+    tl.store(norm_ptr, norm_u16, mask=store_mask)
+
+    value_fp32 = value.to(tl.float32)
+    value_min = tl.min(tl.where(input_mask, value_fp32, float("inf")), axis=1)
+    value_max = tl.max(tl.where(input_mask, value_fp32, -float("inf")), axis=1)
+    levels = 7.0 if VQB == 3 else 15.0
+    value_scale = tl.maximum((value_max - value_min) / levels, 1e-8)
+    value_idx = tl.minimum(
+        tl.maximum(
+            ((value_fp32 - value_min[:, None]) / value_scale[:, None] + 0.5).to(
+                tl.int32
+            ),
+            0,
+        ),
+        7 if VQB == 3 else 15,
+    )
+
+    if VQB == 4:
+        value_pairs = tl.reshape(value_idx, [BLOCK_M, BLOCK_D // 2, 2])
+        shifts = tl.arange(0, 2) * 4
+        value_packed = tl.sum((value_pairs & 0xF) << shifts[None, None, :], axis=2).to(
+            tl.uint8
+        )
+        value_offs = tl.arange(0, BLOCK_D // 2)
+        tl.store(
+            KV_cache_ptr + value_data_base[:, None] + value_offs[None, :],
+            value_packed,
+            mask=store_mask[:, None] & (value_offs[None, :] < VAL_DATA_BYTES),
+        )
+    else:
+        groups = tl.arange(0, BLOCK_GRP)
+        group_mask = store_mask[:, None] & (groups[None, :] < (D // 8))
+        value_groups = tl.reshape(value_idx, [BLOCK_M, BLOCK_GRP, 8])
+        packed = tl.sum(value_groups << (tl.arange(0, 8) * 3)[None, None, :], axis=2)
+        tl.store(
+            KV_cache_ptr + value_data_base[:, None] + groups[None, :] * 3,
+            (packed & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + value_data_base[:, None] + groups[None, :] * 3 + 1,
+            ((packed >> 8) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+        tl.store(
+            KV_cache_ptr + value_data_base[:, None] + groups[None, :] * 3 + 2,
+            ((packed >> 16) & 0xFF).to(tl.uint8),
+            mask=group_mask,
+        )
+
+    scale_u16 = value_scale.to(tl.float16).to(tl.uint16, bitcast=True)
+    zero_u16 = value_min.to(tl.float16).to(tl.uint16, bitcast=True)
+    scale_ptr = (KV_cache_ptr + value_scale_base).to(tl.pointer_type(tl.uint16))
+    zero_ptr = (KV_cache_ptr + value_zero_base).to(tl.pointer_type(tl.uint16))
+    tl.store(scale_ptr, scale_u16, mask=store_mask)
+    tl.store(zero_ptr, zero_u16, mask=store_mask)
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -347,10 +543,26 @@ def _tq_fused_store_mse(
 # ═══════════════════════════════════════════════════════════════════════
 
 
+_PIT_MMA_CACHE: dict[tuple[int, int, tuple[int, ...]], torch.Tensor] = {}
+_BLOCK_M_THRESHOLD = 256
+_BLOCK_M = 16
+
+
+def _get_pit_mma(PiT: torch.Tensor) -> torch.Tensor:
+    if PiT.dtype == torch.float16:
+        return PiT.contiguous()
+    key = (PiT.data_ptr(), PiT.device.index or 0, tuple(PiT.shape))
+    cached = _PIT_MMA_CACHE.get(key)
+    if cached is None or cached.device != PiT.device:
+        cached = PiT.to(torch.float16).contiguous()
+        _PIT_MMA_CACHE[key] = cached
+    return cached
+
+
 def triton_turboquant_store(
     key: torch.Tensor,  # [N, H, D] — raw keys (post-RoPE)
     value: torch.Tensor,  # [N, H, D] — raw values
-    kv_cache: torch.Tensor,  # [num_blocks, block_size, Hk, padded_slot] uint8
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, 1, page_record_size] uint8
     slot_mapping: torch.Tensor,  # [N] int32
     PiT: torch.Tensor,  # [D, D] float32
     midpoints: torch.Tensor,  # [n_centroids-1] float32
@@ -362,19 +574,35 @@ def triton_turboquant_store(
     """Launch TQ store kernel (FP8 or MSE path)."""
     N, H, D = key.shape
     NH = N * H
-    block_size = kv_cache.shape[1]
     BLOCK_D = triton.next_power_of_2(D)
     mse_bytes = math.ceil(D * mse_bits / 8)
     n_centroids = 2**mse_bits
 
     val_data_bytes = math.ceil(D * value_quant_bits / 8)
+    per_token_bytes = key_packed_size + val_data_bytes + 4
+    aligned_token_bytes = per_token_bytes + per_token_bytes % 2
+    record_size = kv_cache.shape[-1]
+    if kv_cache.ndim != 4 or kv_cache.shape[2] != 1:
+        raise ValueError(
+            "TurboQuant cache must have shape "
+            "[num_blocks, num_kv_heads, 1, page_record_size]"
+        )
+    if kv_cache.shape[1] != H:
+        raise ValueError(
+            f"TurboQuant cache has {kv_cache.shape[1]} heads, expected {H}"
+        )
+    if record_size % aligned_token_bytes:
+        raise ValueError(
+            "TurboQuant page record is not divisible by its per-token payload: "
+            f"{record_size=} {aligned_token_bytes=}"
+        )
+    block_size = record_size // aligned_token_bytes
 
     BLOCK_VAL = triton.next_power_of_2(val_data_bytes)
 
     # Cache strides (element_size=1 for uint8, so stride in bytes = stride())
     stride_block = kv_cache.stride(0)
-    stride_pos = kv_cache.stride(1)
-    stride_head = kv_cache.stride(2)
+    stride_head = kv_cache.stride(1)
 
     block_grp = triton.next_power_of_2(D // 8) if D >= 8 else 1
 
@@ -392,13 +620,11 @@ def triton_turboquant_store(
             kv_cache,
             slot_mapping,
             stride_cache_block=stride_block,
-            stride_cache_pos=stride_pos,
             stride_cache_head=stride_head,
             D=D,
             H=H,
             BLOCK_SIZE=block_size,
             BLOCK_D=BLOCK_D,
-            KPS=key_packed_size,
             VQB=value_quant_bits,
             VAL_DATA_BYTES=val_data_bytes,
             BLOCK_VAL=BLOCK_VAL,
@@ -409,39 +635,54 @@ def triton_turboquant_store(
         )
         return
 
-    # ── MSE PATH: external GEMM + fused bucketize/pack kernel ──
-    # Normalize + rotation GEMM externally (cuBLAS is faster than in-kernel)
-    k_flat = key.float().reshape(NH, D)
-    norms = k_flat.norm(dim=1, keepdim=True)
-    x_hat = k_flat / (norms + 1e-8)
-    y = x_hat @ PiT
-
-    v_flat = value.float().reshape(NH, D)
-
-    # Fused kernel: bucketize + MSE index pack + norm store + value pack
-    grid = (NH,)
-    _tq_fused_store_mse[grid](
-        y,
-        norms.squeeze(1),
-        v_flat,
-        midpoints,
-        kv_cache,
-        slot_mapping,
-        stride_cache_block=stride_block,
-        stride_cache_pos=stride_pos,
-        stride_cache_head=stride_head,
-        D=D,
-        H=H,
-        BLOCK_SIZE=block_size,
-        BLOCK_D=BLOCK_D,
-        MSE_BYTES=mse_bytes,
-        KPS=key_packed_size,
-        VQB=value_quant_bits,
-        VAL_DATA_BYTES=val_data_bytes,
-        BLOCK_VAL=BLOCK_VAL,
-        MSE_BITS=mse_bits,
-        N_CENTROIDS=n_centroids,
-        BLOCK_GRP=block_grp,
-        num_warps=4,
-        num_stages=1,
-    )
+    k_flat = key.reshape(NH, D).contiguous()
+    v_flat = value.reshape(NH, D).contiguous()
+    pit_mma = _get_pit_mma(PiT)
+    if NH < _BLOCK_M_THRESHOLD:
+        _tq_fused_store_mse_m1[(NH,)](
+            k_flat,
+            v_flat,
+            pit_mma,
+            midpoints,
+            kv_cache,
+            slot_mapping,
+            stride_cache_block=stride_block,
+            stride_cache_head=stride_head,
+            D=D,
+            H=H,
+            BLOCK_SIZE=block_size,
+            BLOCK_D=BLOCK_D,
+            MSE_BYTES=mse_bytes,
+            VQB=value_quant_bits,
+            VAL_DATA_BYTES=val_data_bytes,
+            MSE_BITS=mse_bits,
+            N_CENTROIDS=n_centroids,
+            BLOCK_GRP=block_grp,
+            num_warps=4,
+            num_stages=1,
+        )
+    else:
+        _tq_fused_store_mse_m16[(triton.cdiv(NH, _BLOCK_M),)](
+            k_flat,
+            v_flat,
+            pit_mma,
+            midpoints,
+            kv_cache,
+            slot_mapping,
+            stride_cache_block=stride_block,
+            stride_cache_head=stride_head,
+            NH=NH,
+            D=D,
+            H=H,
+            BLOCK_SIZE=block_size,
+            BLOCK_D=BLOCK_D,
+            MSE_BYTES=mse_bytes,
+            VQB=value_quant_bits,
+            VAL_DATA_BYTES=val_data_bytes,
+            MSE_BITS=mse_bits,
+            N_CENTROIDS=n_centroids,
+            BLOCK_GRP=block_grp,
+            BLOCK_M=_BLOCK_M,
+            num_warps=4,
+            num_stages=3,
+        )

--- a/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_decode.py
+++ b/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_decode.py
@@ -484,7 +484,7 @@ def _get_layout(D, mse_bits, value_quant_bits, key_packed_size):
 
 def triton_turboquant_decode_attention(
     query: torch.Tensor,  # [B, Hq, D] — original query
-    kv_cache: torch.Tensor,  # [num_blocks, block_size, Hk, padded_slot] uint8
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, 1, page_record_size] uint8
     block_table: torch.Tensor,  # [B, max_num_blocks] int32
     seq_lens: torch.Tensor,  # [B] int32
     Pi: torch.Tensor,  # [D, D] float32
@@ -509,12 +509,24 @@ def triton_turboquant_decode_attention(
     Returns: output tensor [B, Hq, D] in query's dtype.
     """
     B, Hq, D = query.shape
-    Hk = kv_cache.shape[2]
-    block_size = kv_cache.shape[1]
+    cfg = _get_layout(D, mse_bits, value_quant_bits, key_packed_size)
+    Hk = kv_cache.shape[1]
+    per_token_bytes = key_packed_size + cfg["val_data_bytes"] + 4
+    aligned_token_bytes = per_token_bytes + per_token_bytes % 2
+    record_size = kv_cache.shape[-1]
+    if kv_cache.ndim != 4 or kv_cache.shape[2] != 1:
+        raise ValueError(
+            "TurboQuant cache must have shape "
+            "[num_blocks, num_kv_heads, 1, page_record_size]"
+        )
+    if record_size % aligned_token_bytes:
+        raise ValueError(
+            "TurboQuant page record is not divisible by its per-token payload: "
+            f"{record_size=} {aligned_token_bytes=}"
+        )
+    block_size = record_size // aligned_token_bytes
     kv_group_size = Hq // Hk
     device = query.device
-
-    cfg = _get_layout(D, mse_bits, value_quant_bits, key_packed_size)
 
     # Opt#3 SoA layout constants (derived locally; match store-side values).
     key_data_bytes = D if key_fp8 else cfg["mse_bytes"]

--- a/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_decode_v2.py
+++ b/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_decode_v2.py
@@ -514,16 +514,27 @@ def triton_turboquant_decode_attention_v2(
     graph across both versions.
     """
     B, Hq, D = query.shape
-    Hk = kv_cache.shape[2]
-    block_size = kv_cache.shape[1]
-    padded_slot = kv_cache.shape[3]
+    cfg = _get_layout(D, mse_bits, value_quant_bits, key_packed_size)
+    Hk = kv_cache.shape[1]
+    per_token_bytes = key_packed_size + cfg["val_data_bytes"] + 4
+    padded_slot = per_token_bytes + per_token_bytes % 2
+    record_size = kv_cache.shape[-1]
+    if kv_cache.ndim != 4 or kv_cache.shape[2] != 1:
+        raise ValueError(
+            "TurboQuant cache must have shape "
+            "[num_blocks, num_kv_heads, 1, page_record_size]"
+        )
+    if record_size % padded_slot:
+        raise ValueError(
+            "TurboQuant page record is not divisible by its per-token payload: "
+            f"{record_size=} {padded_slot=}"
+        )
+    block_size = record_size // padded_slot
     max_num_blocks = block_table.shape[1]
     n_centroids = centroids.shape[0]
     kv_group_size = Hq // Hk
     device = query.device
     del max_seq_len  # no longer used: splits is fixed via max_num_kv_splits
-
-    cfg = _get_layout(D, mse_bits, value_quant_bits, key_packed_size)
 
     # Opt#3 SoA layout constants (match store-side computation).
     key_data_bytes = D if key_fp8 else cfg["mse_bytes"]

--- a/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_store.py
+++ b/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_store.py
@@ -381,7 +381,7 @@ def _tq_fused_store_mse(
 def triton_turboquant_store(
     key: torch.Tensor,  # [N, H, D] — raw keys (post-RoPE)
     value: torch.Tensor,  # [N, H, D] — raw values
-    kv_cache: torch.Tensor,  # [num_blocks, block_size, Hk, padded_slot] uint8
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, 1, page_record_size] uint8
     slot_mapping: torch.Tensor,  # [N] int32
     PiT: torch.Tensor,  # [D, D] float32
     midpoints: torch.Tensor,  # [n_centroids-1] float32
@@ -409,12 +409,29 @@ def triton_turboquant_store(
         )
     N, H, D = key.shape
     NH = N * H
-    block_size = kv_cache.shape[1]
     BLOCK_D = triton.next_power_of_2(D)
     mse_bytes = math.ceil(D * mse_bits / 8)
     n_centroids = 2**mse_bits
 
     val_data_bytes = math.ceil(D * value_quant_bits / 8)
+    per_token_bytes = key_packed_size + val_data_bytes + 4
+    aligned_token_bytes = per_token_bytes + per_token_bytes % 2
+    record_size = kv_cache.shape[-1]
+    if kv_cache.ndim != 4 or kv_cache.shape[2] != 1:
+        raise ValueError(
+            "TurboQuant cache must have shape "
+            "[num_blocks, num_kv_heads, 1, page_record_size]"
+        )
+    if kv_cache.shape[1] != H:
+        raise ValueError(
+            f"TurboQuant cache has {kv_cache.shape[1]} heads, expected {H}"
+        )
+    if record_size % aligned_token_bytes:
+        raise ValueError(
+            "TurboQuant page record is not divisible by its per-token payload: "
+            f"{record_size=} {aligned_token_bytes=}"
+        )
+    block_size = record_size // aligned_token_bytes
 
     BLOCK_VAL = triton.next_power_of_2(val_data_bytes)
 

--- a/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_unified_attention.py
+++ b/vllm/v1/attention/ops/turboquant_soa/triton_turboquant_unified_attention.py
@@ -893,7 +893,7 @@ def _get_pit_in_query_dtype(PiT: torch.Tensor, qdtype: torch.dtype) -> torch.Ten
 
 def triton_turboquant_unified_attention(
     query: torch.Tensor,  # [num_tokens, Hq, D] - fp16/bf16
-    kv_cache: torch.Tensor,  # [num_blocks, block_size, Hk, padded_slot] uint8
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, 1, page_record_size] uint8
     block_table: torch.Tensor,  # [num_seqs, max_num_blocks] int32
     seq_lens: torch.Tensor,  # [num_seqs] int32
     query_start_loc: torch.Tensor,  # [num_seqs+1] int32
@@ -903,7 +903,7 @@ def triton_turboquant_unified_attention(
     mse_bits: int,
     key_packed_size: int,
     value_quant_bits: int,
-    value_packed_size: int,  # unused; kept for signature parity with v2
+    value_packed_size: int,
     key_fp8: bool = False,
     norm_correction: bool = False,
     PiT: torch.Tensor | None = None,
@@ -946,14 +946,22 @@ def triton_turboquant_unified_attention(
     """
     assert query.dim() == 3, f"query must be [N, Hq, D], got {query.shape}"
     num_tokens, Hq, D = query.shape
-    Hk = kv_cache.shape[2]
-    block_size = kv_cache.shape[1]
+    Hk = kv_cache.shape[1]
+    slot_size = key_packed_size + value_packed_size
+    slot_size += slot_size % 2
+    record_size = kv_cache.shape[-1]
+    if kv_cache.ndim != 4 or kv_cache.shape[2] != 1 or record_size % slot_size:
+        raise ValueError(
+            "TurboQuant cache must have shape "
+            "[num_blocks, num_kv_heads, 1, page_record_size] with a page "
+            "record divisible by the per-token payload"
+        )
+    block_size = record_size // slot_size
     kv_group_size = Hq // Hk
     num_seqs = int(query_start_loc.shape[0] - 1)
     device = query.device
 
     cfg = _get_layout(D, mse_bits, value_quant_bits)
-    _ = value_packed_size  # unused
 
     # Q-rotation strategy:
     #   * FP8-key path: no rotation at all (keys stored as fp8, no codebook).


### PR DESCRIPTION
## Purpose
This work optimizes the TurboQuant decode path in vLLM while preserving compressed KV-cache semantics. It introduces three related changes:

1. A page-local KV-cache ABI shared by cache store, decode, dequantization, and continuation-prefill paths.
2. Fused store kernels that quantize, pack, and write directly to the new ABI without an intermediate layout conversion.
3. An optimized fused decode-attention operator.

## Support matrix

The new page-local ABI is fully integrated across the TurboQuant cache lifecycle. All cache producers and consumers—including the MSE and FP8 store paths, decode attention, full dequantization, and continuation-prefill—use the same layout. The runtime contains neither a legacy-layout branch nor an ABI conversion operator.

The table below describes only the coverage of the optimized decode-attention operator:

| Capability | Supported range |
|---|---|
| Attention | Full causal self-attention, `q_len = 1` |
| Query/output dtype | BF16 |
| Head dimension | 64, 128, 256 |
| Head geometry | MHA and GQA |
| Page size | 16, 32, 64, 128 |
| Cache preset | K4V4-NC |
| Attention scale | `1 / sqrt(head_dim)` |
| Execution mode | Eager and CUDA Graph |
| GPU | NVIDIA Ampere / Hopper / Blackwell |

Unsupported fast-path configurations continue to use the existing compressed TurboQuant implementation.