### PR TITLE
[Bugfix][Compilation] Guard empty splitting ops before early return

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -318,6 +318,29 @@ def test_splitting_ops_dynamic():
     assert config.compilation_config.cudagraph_mode == CUDAGraphMode.PIECEWISE
 
 
+@pytest.mark.parametrize(
+    ("cudagraph_mode", "expected_cudagraph_mode"),
+    [
+        (CUDAGraphMode.PIECEWISE, CUDAGraphMode.NONE),
+        (CUDAGraphMode.FULL_AND_PIECEWISE, CUDAGraphMode.FULL),
+    ],
+)
+def test_empty_splitting_ops_disable_piecewise_cudagraphs(
+    cudagraph_mode: CUDAGraphMode,
+    expected_cudagraph_mode: CUDAGraphMode,
+):
+    config = CompilationConfig(
+        mode=CompilationMode.NONE,
+        cudagraph_mode=cudagraph_mode,
+        splitting_ops=[],
+    )
+
+    config.set_splitting_ops_for_v1(all2all_backend="")
+
+    assert config.splitting_ops == []
+    assert config.cudagraph_mode == expected_cudagraph_mode
+
+
 def test_moe_splitting_ops_deepep_ht_inductor_partition():
     # Inductor partition case: user-provided splitting_ops should be
     # preserved and MoE ops should be appended for DeepEP HT with dp>1.

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1131,6 +1131,31 @@ class CompilationConfig:
         if self.cudagraph_capture_sizes:
             assert self.cudagraph_capture_sizes[-1] == self.max_cudagraph_capture_size
 
+    def _set_cudagraph_mode_for_empty_splitting_ops(self) -> None:
+        if (
+            self.cudagraph_mode == CUDAGraphMode.PIECEWISE
+            or self.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
+        ):
+            logger.warning_once("Using piecewise cudagraph with empty splitting_ops")
+        if self.cudagraph_mode == CUDAGraphMode.PIECEWISE:
+            logger.warning_once(
+                "Piecewise compilation with empty splitting_ops does not "
+                "contain piecewise cudagraph. Setting cudagraph_"
+                "mode to NONE. Hint: If you are using attention "
+                "backends that support cudagraph, consider manually "
+                "setting cudagraph_mode to FULL or FULL_DECODE_ONLY "
+                "to enable full cudagraphs."
+            )
+            self.cudagraph_mode = CUDAGraphMode.NONE
+        elif self.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
+            logger.warning_once(
+                "Piecewise compilation with empty splitting_ops does "
+                "not contain piecewise cudagraph. Setting "
+                "cudagraph_mode to FULL."
+            )
+            self.cudagraph_mode = CUDAGraphMode.FULL
+        self.splitting_ops = []
+
     def set_splitting_ops_for_v1(
         self, all2all_backend: str, data_parallel_size: int = 1
     ):
@@ -1139,6 +1164,8 @@ class CompilationConfig:
         if self.mode != CompilationMode.VLLM_COMPILE:
             if self.splitting_ops is None:
                 self.splitting_ops = []
+            if len(self.splitting_ops) == 0:
+                self._set_cudagraph_mode_for_empty_splitting_ops()
             return
 
         if self.pass_config.fuse_attn_quant and not self.use_inductor_graph_partition:
@@ -1185,31 +1212,7 @@ class CompilationConfig:
                     self.splitting_ops.append("vllm::unified_mla_kv_cache_update")
 
             elif len(self.splitting_ops) == 0:
-                if (
-                    self.cudagraph_mode == CUDAGraphMode.PIECEWISE
-                    or self.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
-                ):
-                    logger.warning_once(
-                        "Using piecewise cudagraph with empty splitting_ops"
-                    )
-                if self.cudagraph_mode == CUDAGraphMode.PIECEWISE:
-                    logger.warning_once(
-                        "Piecewise compilation with empty splitting_ops does not "
-                        "contain piecewise cudagraph. Setting cudagraph_"
-                        "mode to NONE. Hint: If you are using attention "
-                        "backends that support cudagraph, consider manually "
-                        "setting cudagraph_mode to FULL or FULL_DECODE_ONLY "
-                        "to enable full cudagraphs."
-                    )
-                    self.cudagraph_mode = CUDAGraphMode.NONE
-                elif self.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE:
-                    logger.warning_once(
-                        "Piecewise compilation with empty splitting_ops does "
-                        "not contain piecewise cudagraph. Setting "
-                        "cudagraph_mode to FULL."
-                    )
-                    self.cudagraph_mode = CUDAGraphMode.FULL
-                self.splitting_ops = []
+                self._set_cudagraph_mode_for_empty_splitting_ops()
 
         if (
             not self.use_inductor_graph_partition


### PR DESCRIPTION
## Summary

- Apply the empty `splitting_ops` cudagraph fallback before the early return for non-`VLLM_COMPILE` modes.
- Preserve the existing `VLLM_COMPILE` behavior while sharing the downgrade logic.
- Add regression coverage for `PIECEWISE -> NONE` and `FULL_AND_PIECEWISE -> FULL`.

Fixes #53030

## Why this is not duplicate work

I checked issue #53030 and searched open pull requests for `53030`, `empty splitting_ops`, and `piecewise cudagraph`. No open PR addresses this early-return guard. The related results are separate cudagraph/spec-decode or documentation changes, not this configuration fix.

## Tests

- `VLLM_TARGET_DEVICE=cpu VLLM_USE_PRECOMPILED=1 .venv/bin/python -m pytest tests/compile/test_config.py -q -k empty_splitting_ops_disable_piecewise_cudagraphs --maxfail=1` — 2 passed.
- `.venv/bin/ruff check vllm/config/compilation.py tests/compile/test_config.py` — passed.
- `.venv/bin/ruff format --check vllm/config/compilation.py tests/compile/test_config.py` — passed.
- `GOPROXY=https://goproxy.cn,direct .venv/bin/pre-commit run --files vllm/config/compilation.py tests/compile/test_config.py` — all applicable hooks passed.


## AI assistance

AI assistance was used to investigate the issue, implement the fix, and run the checks above. The human submitter must review every changed line and the test results before merging.
