### PR TITLE
[XPU][MoE] Tune Triton fused MoE for Intel XPU

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.fused_moe.experts.triton_deep_gemm_moe import (
     TritonOrDeepGemmExperts,
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import *
+from vllm.platforms import current_platform
 from vllm.transformers_utils.config import get_config
 from vllm.triton_utils import triton
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -52,8 +53,8 @@ def clear_triton_cache():
     # Force Python garbage collection
     gc.collect()
 
-    # Clear CUDA memory cache
-    if torch.cuda.is_available():
+    # Clear accelerator memory cache
+    if torch.accelerator.is_available():
         torch.accelerator.empty_cache()
 
     # Try to clear Triton's runtime cache
@@ -257,7 +258,7 @@ def benchmark_config(
                     moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
                     in_dtype=init_dtype,
                     routing_method=RoutingMethodType.TopK,
-                    device="cuda",
+                    device=current_platform.device_type,
                 ),
             )
             deep_gemm_experts = mk.FusedMoEKernel(
@@ -303,9 +304,9 @@ def benchmark_config(
     run()
     torch.accelerator.synchronize()
 
-    # Capture 10 invocations with CUDA graph
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
+    # Capture 10 invocations with an accelerator graph
+    graph = torch.accelerator.Graph()
+    with graph:
         for _ in range(10):
             run()
     torch.accelerator.synchronize()
@@ -361,11 +362,33 @@ def get_rocm_tuning_space(use_fp16):
     return param_ranges
 
 
+def get_xpu_tuning_space(use_fp16):
+    # BLOCK_SIZE_N=32 and num_warps=32 never won; grf_mode=256 beat 128 on B70.
+    block_m_range = [16, 32, 64, 128, 256]
+    block_n_range = [64, 128]
+    block_k_range = [32, 64]
+    num_warps_range = [4, 8, 16]
+    group_m_range = [1, 8, 16]
+    num_stage_range = [3, 4]
+
+    return {
+        "BLOCK_SIZE_M": block_m_range,
+        "BLOCK_SIZE_N": block_n_range,
+        "BLOCK_SIZE_K": block_k_range,
+        "GROUP_SIZE_M": group_m_range,
+        "num_warps": num_warps_range,
+        "num_stages": num_stage_range,
+        "grf_mode": ["256"],
+    }
+
+
 def get_configs_compute_bound(use_fp16, block_quant_shape) -> list[dict[str, int]]:
     configs: list[BenchmarkConfig] = []
 
     if current_platform.is_rocm():
         param_ranges = get_rocm_tuning_space(use_fp16)
+    elif current_platform.is_xpu():
+        param_ranges = get_xpu_tuning_space(use_fp16)
     else:
         # Reduced search space for faster tuning.
         # TODO(woosuk): Increase the search space and use a performance model to
@@ -406,6 +429,14 @@ def get_configs_compute_bound(use_fp16, block_quant_shape) -> list[dict[str, int
             if not (n_aligned and k_aligned):
                 configs.remove(config)
     return configs
+
+
+def prune_xpu_search_space(num_tokens, search_space, topk, num_experts):
+    # Cap the tile by rows routed to one expert, not total rows: wider tiles
+    # just pad and are the slowest to compile.
+    rows_per_expert = (num_tokens * topk + num_experts - 1) // num_experts
+    max_block_m = max(16, triton.next_power_of_2(rows_per_expert))
+    return [c for c in search_space if c["BLOCK_SIZE_M"] <= max_block_m]
 
 
 def prune_rocm_search_space(
@@ -519,16 +550,15 @@ def merge_unique_dicts(list1, list2):
     return result
 
 
-@ray.remote(num_gpus=1)
 class BenchmarkWorker:
-    def __init__(self, seed: int) -> None:
-        torch.set_default_device("cuda")
+    def __init__(self, seed: int, use_ray: bool = True) -> None:
+        torch.set_default_device(current_platform.device_type)
         set_random_seed(seed)
         self.seed = seed
         # Get the device ID to allocate tensors and kernels
         # on the respective GPU. This is required for Ray to work
         # correctly with multi-GPU tuning on the ROCm platform.
-        self.device_id = int(ray.get_gpu_ids()[0])
+        self.device_id = int(ray.get_gpu_ids()[0]) if use_ray else 0
 
     def benchmark(
         self,
@@ -619,6 +649,10 @@ class BenchmarkWorker:
                 is_fp16,
                 topk,
             )
+        elif current_platform.is_xpu():
+            search_space = prune_xpu_search_space(
+                num_tokens, search_space, topk, num_experts
+            )
 
         need_device_guard = False
         if current_platform.is_rocm():
@@ -690,6 +724,7 @@ def sort_config(config: BenchmarkConfig) -> BenchmarkConfig:
             else {}
         ),
         **({"kpack": config["kpack"]} if "kpack" in config else {}),
+        **({"grf_mode": config["grf_mode"]} if "grf_mode" in config else {}),
         **({"SPLIT_K": config["SPLIT_K"]} if "SPLIT_K" in config else {}),
     }
 
@@ -959,20 +994,29 @@ def main(args: argparse.Namespace):
         os.environ["ROCR_VISIBLE_DEVICES"] = val
         del os.environ["HIP_VISIBLE_DEVICES"]
 
-    ray.init()
-    num_gpus = int(ray.available_resources()["GPU"])
-    workers = [BenchmarkWorker.remote(args.seed) for _ in range(num_gpus)]
+    if args.no_ray:
+        # Some accelerators (e.g. XPU) don't register Ray's "GPU" resource.
+        worker = BenchmarkWorker(args.seed, use_ray=False)
 
-    def _distribute(method: str, inputs: list[Any]) -> list[Any]:
-        outputs = []
-        worker_idx = 0
-        for input_args in inputs:
-            worker = workers[worker_idx]
+        def _distribute(method: str, inputs: list[Any]) -> list[Any]:
             worker_method = getattr(worker, method)
-            output = worker_method.remote(*input_args)
-            outputs.append(output)
-            worker_idx = (worker_idx + 1) % num_gpus
-        return ray.get(outputs)
+            return [worker_method(*input_args) for input_args in inputs]
+    else:
+        ray.init()
+        num_gpus = int(ray.available_resources()["GPU"])
+        remote_worker_cls = ray.remote(num_gpus=1)(BenchmarkWorker)
+        workers = [remote_worker_cls.remote(args.seed) for _ in range(num_gpus)]
+
+        def _distribute(method: str, inputs: list[Any]) -> list[Any]:
+            outputs = []
+            worker_idx = 0
+            for input_args in inputs:
+                worker = workers[worker_idx]
+                worker_method = getattr(worker, method)
+                output = worker_method.remote(*input_args)
+                outputs.append(output)
+                worker_idx = (worker_idx + 1) % num_gpus
+            return ray.get(outputs)
 
     if args.tune:
         # int4_w4a16 weights are uint8-packed, not fp16; treat like fp8 for
@@ -1082,6 +1126,13 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--batch-size", type=int, nargs="+", required=False)
     parser.add_argument("--tune", action="store_true")
+    parser.add_argument(
+        "--no-ray",
+        action="store_true",
+        help="Run in a single process instead of distributing over Ray actors. "
+        "Required on accelerators that do not register Ray's 'GPU' resource "
+        "(e.g. Intel XPU).",
+    )
     parser.add_argument("--trust-remote-code", action="store_true")
     parser.add_argument("--model-prefix", type=str, required=False)
     args = parser.parse_args()

--- a/vllm/model_executor/layers/fused_moe/configs/E=128,N=384,device_name=Intel(R)_Arc(TM)_Pro_B70_Graphics.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=128,N=384,device_name=Intel(R)_Arc(TM)_Pro_B70_Graphics.json
@@ -1,0 +1,164 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4,
+        "grf_mode": "256"
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4,
+        "grf_mode": "256"
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    }
+}

--- a/vllm/model_executor/layers/fused_moe/configs/E=64,N=1024,device_name=Intel(R)_Arc(TM)_Pro_B70_Graphics.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=64,N=1024,device_name=Intel(R)_Arc(TM)_Pro_B70_Graphics.json
@@ -1,0 +1,164 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 4,
+        "grf_mode": "256"
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 4,
+        "grf_mode": "256"
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4,
+        "grf_mode": "256"
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    }
+}

--- a/vllm/model_executor/layers/fused_moe/configs/E=64,N=512,device_name=Intel(R)_Arc(TM)_Pro_B70_Graphics.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=64,N=512,device_name=Intel(R)_Arc(TM)_Pro_B70_Graphics.json
@@ -1,0 +1,56 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3,
+        "grf_mode": "256"
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 16,
+        "num_stages": 3,
+        "grf_mode": "256"
+    }
+}


### PR DESCRIPTION
## Purpose

The Triton fused MoE kernel runs on Intel XPU but had no tuned configs, so it
always fell back to `get_default_config()`. This PR enables XPU tuning in
`benchmark_moe.py` and adds Intel Arc Pro B70 configs.

## Changes

- Replace hardcoded CUDA graph/device/cache calls with
  `torch.accelerator` / `current_platform`.
- Add `--no-ray` for accelerators that do not register Ray's `"GPU"` resource.
- Add an XPU search space and prune `BLOCK_SIZE_M` by rows per expert.
- Preserve XPU's `grf_mode` in serialized configs.
- Ship `E=64,N=1024`, `E=64,N=512`, and `E=128,N=384` configs. The other
  shapes below are additional validation and are not in this revision.

## Results

Intel Arc Pro B70, bf16. Baseline is Triton's built-in heuristic; tuned uses
the generated JSON. Full per-batch sweeps (18 sizes) are available for the
three shapes below; geometric-mean speedups are 1.86x (`E=64,N=1024`),
1.91x (`E=64,N=512`), and 1.92x (`E=60,N=1408`).

| batch | OLMoE E=64,N=1024 tp=1 | OLMoE E=64,N=512 tp=2 | Qwen1.5-MoE E=60,N=1408 tp=1 |
|---:|---:|---:|---:|
| 1 | 1.41x | 1.21x | 1.23x |
| 8 | 1.75x | — | 1.79x |
| 32 | 1.81x | — | 1.85x |
| 128 | 3.02x | 2.78x | 3.11x |
| 512 | 1.44x | 1.39x | 1.33x |
| 2048 | 2.82x | 2.59x | 3.36x |
| 4096 | 2.65x | 2.36x | 2.98x |

(Full 18-row sweeps per shape available on request / in commit history.)

`E=64,N=704` (DeepSeek-V2-Lite) and `E=128,N=384` (Qwen3-30B-A3B /
Qwen3-Coder tp=2) passed fp32-reference validation (rel_l2 ~4.1e-3) but
per-batch kernel numbers were not retained; only aggregate/e2e results are
reported for them below.

At tp=4, Qwen3-Coder's local shape is `E=128,N=192` (not shipped in this
revision): all 18 tuned configs passed fp32 validation
(`rel_l2=3.82e-3..4.20e-3`), with microkernel latency down 43.73% mean /
43.34% median vs the heuristic (aggregate only, no per-batch table).

### End-to-end

All rows use explicit `--moe-backend triton`, comparing Triton's built-in
heuristic (baseline) with the tuned shape-specific JSON config. Workload is
512 input tokens, 128 output tokens, 32 prompts, unless noted otherwise:

| model | shape | TP | baseline | tuned | speedup |
|---|---|---:|---:|---:|---:|
| `allenai/OLMoE-1B-7B-0924` | `E=64,N=1024` | 1 | 3022.8 tok/s | 4146.4 tok/s | 1.37x |
| `allenai/OLMoE-1B-7B-0924` | `E=64,N=512` | 2 | 2731.8 tok/s | 3084.2 tok/s | 1.13x |
| `Qwen/Qwen1.5-MoE-A2.7B` | `E=60,N=1408` | 1 | 652.5 tok/s | 697.9 tok/s | 1.070x |
| `deepseek-ai/DeepSeek-V2-Lite` | `E=64,N=704` | 2 | 739.1 tok/s | 756.4 tok/s | 1.023x |
| `Qwen/Qwen3-Coder-30B-A3B-Instruct` | `E=128,N=192` | 4 | 1980.3 tok/s | 2061.1 tok/s | 1.041x |

Qwen1.5-MoE used 12 samples/arm (p=7.4e-07); DeepSeek used 4 samples/arm
(p=0.0022); Qwen3-Coder used 6 samples/arm, balanced order, fresh engines
(+4.10% mean, 95% bootstrap CI [+3.09%, +5.88%]).
## Test plan

- Tune on XPU with `benchmark_moe.py --model <model> --tp-size <tp> --no-ray --tune`.
- Verify every generated winner against an fp32 reference.
- Confirm serving with `--moe-backend triton` loads the exact JSON.
- Compare heuristic and tuned Triton with identical workloads and fresh engines.
- Keep CUDA/ROCm behavior unchanged; XPU pruning is guarded by
  `current_platform.is_xpu()`.