### PR TITLE
[KV Connector] Add scheduler context for lazy block access

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -9,6 +9,7 @@ from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_events import BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
+    KVConnectorSchedulerContext,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
     connector as mooncake_store_connector,
@@ -88,6 +89,13 @@ def test_scheduler_role_initializes_store_scheduler_only():
     mock_worker.assert_not_called()
     assert connector.connector_scheduler is mock_scheduler.return_value
     assert connector.connector_worker is None
+    block_pool = MagicMock()
+
+    scheduler_context = KVConnectorSchedulerContext(block_pool, MagicMock())
+    connector.bind_scheduler_context(scheduler_context)
+    mock_scheduler.return_value.bind_scheduler_context.assert_called_once_with(
+        scheduler_context
+    )
 
 
 def test_worker_methods_delegate_to_store_worker():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -2,9 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorSchedulerContext,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     LoadSpec,
     MooncakeStoreWorkerMetadata,
@@ -14,7 +18,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler import (
     MooncakeStoreScheduler,
 )
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 
 
 def _make_bare_scheduler(
@@ -37,13 +43,45 @@ def _make_bare_scheduler(
     scheduler._unfinished_request_ids = {"req-0"}
     scheduler._unfinished_requests = {}
     scheduler._request_trackers = {}
-    scheduler._gpu_block_pool = BlockPool(
+    gpu_block_pool = BlockPool(
         num_gpu_blocks=64, enable_caching=True, hash_block_size=hash_block_size
     )
     scheduler._num_workers = 1
     scheduler._next_store_job_id = 0
     scheduler._pinned_saves = {}
+    scheduler._test_current_block_ids = {}
+    scheduler._test_scheduler_context_calls = []
+
+    def get_request_blocks(request_id: str) -> KVCacheBlocks:
+        scheduler._test_scheduler_context_calls.append(request_id)
+        block_ids = scheduler._test_current_block_ids[request_id]
+        return KVCacheBlocks(
+            tuple(
+                [gpu_block_pool.blocks[block_id] for block_id in group]
+                for group in block_ids
+            )
+        )
+
+    scheduler.bind_scheduler_context(
+        KVConnectorSchedulerContext(gpu_block_pool, get_request_blocks)
+    )
+    assert scheduler._scheduler_context is not None
+    assert scheduler._scheduler_context.gpu_block_pool is gpu_block_pool
     return scheduler
+
+
+def _get_gpu_block_pool(scheduler: MooncakeStoreScheduler) -> BlockPool:
+    assert scheduler._scheduler_context is not None
+    return scheduler._scheduler_context.gpu_block_pool
+
+
+def _set_unfinished_request(
+    scheduler: MooncakeStoreScheduler,
+    request: SimpleNamespace,
+    block_ids: tuple[list[int], ...],
+) -> None:
+    scheduler._unfinished_requests["req-0"] = request
+    scheduler._test_current_block_ids["req-0"] = block_ids
 
 
 def _make_scheduler_output(*, scheduled_spec_tokens: list[int] | None):
@@ -108,11 +146,23 @@ def _make_new_scheduler_output() -> SimpleNamespace:
     )
 
 
+def test_update_state_after_alloc_does_not_materialize_block_ids():
+    scheduler = _make_bare_scheduler()
+    request = SimpleNamespace(request_id="req-0")
+    blocks = MagicMock(spec=KVCacheBlocks)
+
+    scheduler.update_state_after_alloc(request, blocks, num_external_tokens=0)
+
+    blocks.get_block_ids.assert_not_called()
+    assert scheduler._unfinished_requests["req-0"] is request
+
+
 def test_scheduler_only_tracks_token_ids_for_kv_events():
     for enable_kv_events in (False, True):
         scheduler = _make_bare_scheduler()
         scheduler.enable_kv_events = enable_kv_events
-        scheduler._unfinished_requests["req-0"] = (
+        _set_unfinished_request(
+            scheduler,
             _make_new_scheduler_output().request,
             ([0, 1],),
         )
@@ -168,11 +218,10 @@ def _add_unfinished_request(
         block_hashes=block_hashes,
         num_output_placeholders=0,
     )
-    scheduler._unfinished_requests["req-0"] = (request, ([0, 1],))
+    _set_unfinished_request(scheduler, request, ([0, 1, 2],))
     scheduler._request_trackers["req-0"] = RequestTracker(
         req_id="req-0",
         token_len=44,
-        allocated_block_ids=([0, 1],),
         num_saved_tokens=32,
         token_ids=token_ids[:44],
         prefill_end_tokens=prefill_end_tokens,
@@ -197,7 +246,6 @@ def _setup_decode_request(
     )
     tracker = scheduler._request_trackers["req-0"]
     tracker.token_len = token_len
-    tracker.allocated_block_ids = ([0, 1, 2],)
     tracker.token_ids = token_ids[:token_len]
     return scheduler, tracker
 
@@ -219,10 +267,10 @@ def test_cached_request_with_spec_decode_does_not_save_scheduled_drafts():
     )
 
     assert meta.requests == []
+    assert scheduler._test_scheduler_context_calls == []
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.token_len == 44
     assert tracker.num_saved_tokens == 32
-    assert tracker.allocated_block_ids == ([0, 1, 2],)
 
 
 def test_cached_request_without_spec_decode_keeps_current_step_save_overlap():
@@ -259,7 +307,6 @@ def test_decode_tracking_is_skipped_by_default(kv_role):
     assert meta.requests == []
     assert tracker.token_len == 47
     assert tracker.num_saved_tokens == 32
-    assert tracker.allocated_block_ids == ([0, 1, 2],)
     assert tracker.token_ids == list(range(47))
 
 
@@ -275,7 +322,7 @@ def test_fresh_consumer_first_decode_save_can_backfill_missing_prompt():
     request.block_hashes = [b"h0", b"h1", b"h2"]
     request.all_token_ids = list(range(48))
     request.num_output_placeholders = 0
-    scheduler._unfinished_requests["req-0"] = (request, request.block_ids)
+    _set_unfinished_request(scheduler, request, request.block_ids)
 
     # The consumer does not save during prefill, so its first decode save must
     # still cover the prompt. The worker deduplicates prompt blocks already in
@@ -348,7 +395,6 @@ def test_preemption_resets_tracker():
 
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.token_len == 0
-    assert tracker.allocated_block_ids == ()
     assert tracker.num_saved_tokens == 0
     assert tracker.token_ids is None
     assert tracker.has_pending_offload is False
@@ -388,7 +434,7 @@ def _make_pending_load_unfinished_request(
         block_hashes=block_hashes,
         num_output_placeholders=0,
     )
-    scheduler._unfinished_requests["req-0"] = (request, block_ids)
+    _set_unfinished_request(scheduler, request, block_ids)
 
 
 def _make_pending_load_scheduler_output() -> SimpleNamespace:
@@ -437,6 +483,8 @@ def test_pending_load_does_not_co_queue_save():
     # Load is still issued as planned.
     assert req_meta.load_spec is not None
     assert req_meta.load_spec.can_load is True
+    assert req_meta.block_ids == ([0, 1, 2],)
+    assert scheduler._test_scheduler_context_calls == ["req-0"]
     # And the save watermark does not advance for a save that was never queued.
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
@@ -455,7 +503,7 @@ def _make_resumed_unfinished_request(
         num_computed_tokens=num_computed_tokens,
         num_output_placeholders=0,
     )
-    scheduler._unfinished_requests["req-0"] = (request, ([0, 1],))
+    _set_unfinished_request(scheduler, request, ([0, 1, 2],))
 
 
 def _make_resumed_scheduler_output(*, num_scheduled_tokens: int) -> SimpleNamespace:
@@ -504,6 +552,7 @@ def test_resumed_from_preemption_with_load_skips_save():
     assert req_meta.can_save is False
     assert req_meta.load_spec is not None
     assert req_meta.load_spec.can_load is True
+    assert req_meta.block_ids == ([0, 1, 2],)
     tracker = scheduler._request_trackers["req-0"]
     assert tracker.num_saved_tokens == 0
 
@@ -531,17 +580,8 @@ def test_resumed_from_preemption_without_load_still_saves():
     assert tracker.num_saved_tokens == 48
 
 
-def test_running_request_not_in_resumed_req_ids_appends_blocks():
-    """Regression: the replace-vs-append choice must follow the scheduler's
-    cached_reqs.resumed_req_ids, NOT connector-local preemption history.
-
-    A running request that is not resumed this step carries a *delta*
-    new_block_ids and must be APPENDED to the tracker's existing blocks.
-    Treating it as resumed would replace allocated_block_ids with just the
-    delta while token_len stays at the full computed length, so the store
-    path's block_ids[start // block_size] runs off the end (the
-    "list index out of range" / token_len >> len(block_ids) bug).
-    """
+def test_running_request_uses_authoritative_block_table():
+    """A running request's delta block update is not used as worker metadata."""
     scheduler = _make_bare_scheduler()
     _add_unfinished_request(
         scheduler,
@@ -555,20 +595,14 @@ def test_running_request_not_in_resumed_req_ids_appends_blocks():
 
     meta = scheduler.build_connector_meta(out)
 
-    tracker = scheduler._request_trackers["req-0"]
-    # Delta [2] appended to existing [0, 1] (decode path), not replaced by [2].
-    assert tracker.allocated_block_ids == ([0, 1, 2],)
-    # token_len stays covered by the block table: no store-path under-count.
-    blocks_held = sum(len(g) for g in tracker.allocated_block_ids)
-    assert tracker.token_len // scheduler._block_size <= blocks_held
     assert len(meta.requests) == 1
-    assert meta.requests[0].token_len_chunk == 48
+    req_meta = meta.requests[0]
+    assert req_meta.token_len_chunk == 48
+    assert req_meta.block_ids == ([0, 1, 2],)
+    assert scheduler._test_scheduler_context_calls == ["req-0"]
 
 
-def test_resumed_request_in_resumed_req_ids_replaces_blocks():
-    """A request the scheduler marks resumed gets the FULL block table in
-    new_block_ids and must REPLACE the tracker's blocks (not append), even if
-    a stale tracker from before preemption is still present."""
+def test_resumed_request_reinitializes_tracker_and_uses_current_blocks():
     scheduler = _make_bare_scheduler()
     _make_resumed_unfinished_request(
         scheduler,
@@ -576,24 +610,19 @@ def test_resumed_request_in_resumed_req_ids_replaces_blocks():
         block_hashes=[b"h0", b"h1", b"h2"],
         num_computed_tokens=0,
     )
-    # Stale pre-preemption tracker that must be overwritten, not appended to.
     scheduler._request_trackers["req-0"] = RequestTracker(
         req_id="req-0",
         token_len=99,
-        allocated_block_ids=([7, 8, 9],),
         num_saved_tokens=0,
     )
 
-    scheduler.build_connector_meta(
+    meta = scheduler.build_connector_meta(
         _make_resumed_scheduler_output(num_scheduled_tokens=48)
     )
 
     tracker = scheduler._request_trackers["req-0"]
-    # Replaced with the full table from new_block_ids, not appended to [7,8,9].
-    assert tracker.allocated_block_ids == ([0, 1, 2],)
     assert tracker.token_len == 48
-    blocks_held = sum(len(g) for g in tracker.allocated_block_ids)
-    assert tracker.token_len // scheduler._block_size <= blocks_held
+    assert meta.requests[0].block_ids == ([0, 1, 2],)
 
 
 # Focused tests for ReqMeta.from_request_tracker — the centralized guard that
@@ -607,7 +636,6 @@ def test_from_request_tracker_load_overrides_caller_skip_save():
     tracker = RequestTracker(
         req_id="req-0",
         token_len=48,
-        allocated_block_ids=([0, 1, 2],),
         num_saved_tokens=0,
     )
     load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=48, can_load=True)
@@ -632,7 +660,6 @@ def test_from_request_tracker_load_with_can_load_false_still_saves():
     tracker = RequestTracker(
         req_id="req-0",
         token_len=48,
-        allocated_block_ids=([0, 1, 2],),
         num_saved_tokens=0,
     )
     load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=48, can_load=False)
@@ -656,7 +683,6 @@ def test_from_request_tracker_no_load_saves_normally():
     tracker = RequestTracker(
         req_id="req-0",
         token_len=48,
-        allocated_block_ids=([0, 1, 2],),
         num_saved_tokens=0,
     )
 
@@ -876,11 +902,10 @@ def _add_pending_partial_tail_request(
         num_output_placeholders=0,
         num_prompt_tokens=12,
     )
-    scheduler._unfinished_requests["req-0"] = (request, block_ids)
+    _set_unfinished_request(scheduler, request, block_ids)
     scheduler._request_trackers["req-0"] = RequestTracker(
         req_id="req-0",
         token_len=num_tokens,
-        allocated_block_ids=block_ids,
         num_saved_tokens=0,
         token_ids=list(range(num_tokens)),
         prefill_end_tokens=num_tokens,
@@ -959,11 +984,10 @@ def test_resumed_partial_tail_attached_to_save_keeps_handoff_boundary():
         num_output_placeholders=0,
         num_prompt_tokens=36,
     )
-    scheduler._unfinished_requests["req-0"] = (request, ([0, 1],))
+    _set_unfinished_request(scheduler, request, ([0, 1, 2],))
     scheduler._request_trackers["req-0"] = RequestTracker(
         req_id="req-0",
         token_len=44,
-        allocated_block_ids=([0, 1],),
         num_saved_tokens=32,
         token_ids=list(range(44)),
         prefill_end_tokens=48,
@@ -994,18 +1018,44 @@ def test_partial_tail_cow_block_is_referenced_for_the_job():
         block_hashes=[b"h0", b"h1", b"h2"],
         block_ids=([0],),
     )
-    pool = scheduler._gpu_block_pool
+    pool = _get_gpu_block_pool(scheduler)
 
     meta = scheduler.build_connector_meta(out)
 
     store_job_id = meta.requests[0].store_job_id
-    # It leads the list, as in `pop_blocks_for_free`, so that the reversed free
-    # puts it last in eviction priority.
-    assert scheduler._pinned_saves[store_job_id][0] == [7, 0]
+    assert meta.requests[0].block_ids == ([NULL_BLOCK_ID],)
+    assert scheduler._pinned_saves[store_job_id][0] == [7]
+    assert pool.blocks[NULL_BLOCK_ID].ref_cnt == 0
     assert pool.blocks[7].ref_cnt == 1
 
     scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))
     assert pool.blocks[7].ref_cnt == 0
+
+
+def test_partial_tail_and_current_blocks_are_pinned_once():
+    scheduler = _make_bare_scheduler(hash_block_size=4, enable_partial_hash_hits=True)
+    out = _add_pending_partial_tail_request(
+        scheduler,
+        num_tokens=12,
+        block_hashes=[b"h0", b"h1", b"h2"],
+        block_ids=([7, NULL_BLOCK_ID], [7, 8]),
+    )
+    pool = _get_gpu_block_pool(scheduler)
+
+    meta = scheduler.build_connector_meta(out)
+
+    [req_meta] = meta.requests
+    assert req_meta.block_ids == ([7, NULL_BLOCK_ID], [7, 8])
+    store_job_id = req_meta.store_job_id
+    assert scheduler._pinned_saves[store_job_id][0] == [7, 8]
+    assert pool.blocks[NULL_BLOCK_ID].ref_cnt == 0
+    assert pool.blocks[7].ref_cnt == 1
+    assert pool.blocks[8].ref_cnt == 1
+
+    scheduler.update_connector_output(_make_worker_output({store_job_id: 1}))
+
+    assert pool.blocks[7].ref_cnt == 0
+    assert pool.blocks[8].ref_cnt == 0
 
 
 def test_store_job_blocks_are_released_once_every_rank_reports():
@@ -1021,7 +1071,7 @@ def test_store_job_blocks_are_released_once_every_rank_reports():
         block_hashes=[b"h0", b"h1", b"h2"],
         prefill_end_tokens=48,
     )
-    pool = scheduler._gpu_block_pool
+    pool = _get_gpu_block_pool(scheduler)
     assert scheduler.has_pending_push_work() is False
 
     meta = scheduler.build_connector_meta(

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -17,6 +17,7 @@ from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorRole
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
+    KVConnectorSchedulerContext,
     SupportsHMA,
     supports_hma,
 )
@@ -283,12 +284,12 @@ def test_multi_example_connector_consistency():
     events = get_connector_events()
     storage1_scheduler_events = _ignore_event_collection(events["storage1-SCHEDULER"])
     storage2_scheduler_events = _ignore_event_collection(events["storage2-SCHEDULER"])
-    # First event is bind_gpu_block_pool from initialization, then
+    # First event is bind_scheduler_context from initialization, then
     # set_xfer_handshake_metadata_pp_aware, then on_new_request when the request is
     # enqueued, then get_num_new_matched_tokens and update_state_after_alloc from
     # generate().
     assert storage1_scheduler_events[:6] == [
-        "bind_gpu_block_pool",
+        "bind_scheduler_context",
         "set_xfer_handshake_metadata_pp_aware",
         "on_new_request",
         "get_num_new_matched_tokens 0",
@@ -308,7 +309,7 @@ def test_multi_example_connector_consistency():
         "save_kv_layer",
     ]
     assert storage2_scheduler_events[:6] == [
-        "bind_gpu_block_pool",
+        "bind_scheduler_context",
         "set_xfer_handshake_metadata_pp_aware",
         "on_new_request",
         "get_num_new_matched_tokens 0",
@@ -887,6 +888,15 @@ Options:
   1. Add delegation in MultiConnector (preferred)
   2. Add to INHERITED_OK if the base implementation works correctly
 """)
+
+
+def test_multi_connector_forwards_scheduler_context(mc):
+    context = MagicMock(spec=KVConnectorSchedulerContext)
+
+    mc.bind_scheduler_context(context)
+
+    for connector in mc._connectors:
+        connector.bind_scheduler_context.assert_called_once_with(context)
 
 
 def test_multi_connector_prefer_cross_layer_blocks(mc):

--- a/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
+++ b/tests/v1/kv_connector/unit/test_scheduler_kv_connector_override.py
@@ -12,6 +12,7 @@ from vllm.distributed.kv_transfer.kv_connector.factory import (
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
+    KVConnectorSchedulerContext,
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import BlockHash
@@ -22,13 +23,26 @@ from vllm.v1.request import Request
 
 
 class DummyConnectorMetadata(KVConnectorMetadata):
-    def __init__(self, block_hashes_by_req: dict[str, list[BlockHash]]):
+    def __init__(
+        self,
+        block_hashes_by_req: dict[str, list[BlockHash]],
+        block_ids_by_req: dict[str, tuple[list[int], ...]],
+    ):
         self.block_hashes_by_req = block_hashes_by_req
+        self.block_ids_by_req = block_ids_by_req
 
 
 class DummyKVConnector(KVConnectorBase_V1):
     def __init__(self, vllm_config, role, kv_cache_config: KVCacheConfig):
         super().__init__(vllm_config, role, kv_cache_config)
+        self.scheduler_context: KVConnectorSchedulerContext | None = None
+        self.gpu_block_pool = None
+
+    def bind_scheduler_context(
+        self, scheduler_context: KVConnectorSchedulerContext
+    ) -> None:
+        self.scheduler_context = scheduler_context
+        self.gpu_block_pool = scheduler_context.gpu_block_pool
 
     def get_num_new_matched_tokens(
         self, request: Request, num_computed_tokens: int
@@ -47,8 +61,14 @@ class DummyKVConnector(KVConnectorBase_V1):
         assert block_hashes_by_req is not None, (
             "DummyKVConnector expected 'block_hashes_by_req' on scheduler_output"
         )
+        assert self.scheduler_context is not None
+        block_ids_by_req = {
+            req_id: self.scheduler_context.borrow_request_blocks(req_id).get_block_ids()
+            for req_id in scheduler_output.num_scheduled_tokens
+        }
         return DummyConnectorMetadata(
             block_hashes_by_req=block_hashes_by_req,
+            block_ids_by_req=block_ids_by_req,
         )
 
     def start_load_kv(self, kv_caches, finished_req_ids):
@@ -129,3 +149,13 @@ def test_connector_receives_block_hashes(_load_plugin):
             num_tokens // block_size
         )
         assert meta.block_hashes_by_req[req.request_id] == req.block_hashes
+
+    expected_block_ids = {
+        req.req_id: req.block_ids for req in output.scheduled_new_reqs
+    }
+    assert meta.block_ids_by_req == expected_block_ids
+    connector = scheduler.connector
+    assert isinstance(connector, DummyKVConnector)
+    assert connector.scheduler_context is not None
+    assert connector.gpu_block_pool is scheduler.kv_cache_manager.block_pool
+    assert connector.scheduler_context.gpu_block_pool is connector.gpu_block_pool

--- a/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
@@ -3,6 +3,7 @@
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorRole,
+    KVConnectorSchedulerContext,
     SupportsHMA,
     supports_hma,
 )
@@ -13,6 +14,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.decode_bench_connector import 
 __all__ = [
     "KVConnectorRole",
     "KVConnectorBase_V1",
+    "KVConnectorSchedulerContext",
     "supports_hma",
     "SupportsHMA",
     "DecodeBenchConnector",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -82,6 +82,31 @@ CopyBlocksOp = Callable[
 logger = init_logger(__name__)
 
 
+class KVConnectorSchedulerContext:
+    """Scheduler-owned KV-cache capabilities exposed to connectors."""
+
+    def __init__(
+        self,
+        gpu_block_pool: "BlockPool",
+        get_request_blocks: Callable[[str], "KVCacheBlocks"],
+    ) -> None:
+        self._gpu_block_pool = gpu_block_pool
+        self._get_request_blocks = get_request_blocks
+
+    @property
+    def gpu_block_pool(self) -> "BlockPool":
+        """Return the long-lived GPU block pool."""
+        return self._gpu_block_pool
+
+    def borrow_request_blocks(self, request_id: str) -> "KVCacheBlocks":
+        """Borrow current request blocks during metadata construction.
+
+        The returned view and its blocks are scheduler-owned. Connectors must
+        not mutate or retain them after ``build_connector_meta`` returns.
+        """
+        return self._get_request_blocks(request_id)
+
+
 class SupportsHMA(ABC):
     """
     The class that indicates the corresponding connector supports hybrid memory
@@ -461,14 +486,10 @@ class KVConnectorBase_V1(ABC):
     # Scheduler-side methods
     # ==============================
 
-    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
-        """
-        Bind the GPU block pool to the connector for per-GPU block status tracking.
-        For example, inc/dec ref counts, or iterate over the prefix cache blocks.
-
-        Args:
-            gpu_block_pool: the GPU block pool.
-        """
+    def bind_scheduler_context(
+        self, scheduler_context: KVConnectorSchedulerContext
+    ) -> None:
+        """Bind scheduler-owned KV-cache capabilities."""
         return
 
     @abstractmethod

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -26,6 +26,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    KVConnectorSchedulerContext,
     KVConnectorWorkerMetadata,
     SupportsHMA,
 )
@@ -38,7 +39,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
 from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
-from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -205,9 +205,11 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
             request, blocks, num_external_tokens
         )
 
-    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
+    def bind_scheduler_context(
+        self, scheduler_context: KVConnectorSchedulerContext
+    ) -> None:
         assert self.connector_scheduler is not None
-        self.connector_scheduler.bind_gpu_block_pool(gpu_block_pool)
+        self.connector_scheduler.bind_scheduler_context(scheduler_context)
 
     def has_pending_push_work(self) -> bool:
         assert self.connector_scheduler is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -316,7 +316,6 @@ class RequestTracker:
 
     req_id: str
     token_len: int
-    allocated_block_ids: tuple[list[int], ...]
     num_saved_tokens: int = 0
     token_ids: list[int] | None = None
     has_pending_offload: bool = False
@@ -327,28 +326,10 @@ class RequestTracker:
 
     def reset(self) -> None:
         self.token_len = 0
-        self.allocated_block_ids = ()
         self.num_saved_tokens = 0
         self.token_ids = None
         self.has_pending_offload = False
         self.prefill_end_tokens = 0
-
-    def update(
-        self,
-        new_block_ids: tuple[list[int], ...] | list[int],
-    ) -> None:
-        # Backward-compat: accept a single list (broadcast to single group).
-        if isinstance(new_block_ids, list):
-            new_block_ids = (new_block_ids,)
-        if len(new_block_ids) != len(self.allocated_block_ids):
-            raise ValueError(
-                f"Group count mismatch: tracker has "
-                f"{len(self.allocated_block_ids)} groups, update has "
-                f"{len(new_block_ids)}"
-            )
-        for existing, new in zip(self.allocated_block_ids, new_block_ids, strict=True):
-            if new:
-                existing.extend(new)
 
 
 @dataclass
@@ -357,6 +338,7 @@ class ReqMeta:
 
     req_id: str
     token_len_chunk: int
+    # Populated from the scheduler context immediately before worker dispatch.
     block_ids: tuple[list[int], ...]
     block_hashes: list[BlockHash]
 
@@ -432,7 +414,7 @@ class ReqMeta:
         return ReqMeta(
             req_id=tracker.req_id,
             token_len_chunk=num_tokens_to_save,
-            block_ids=tracker.allocated_block_ids,
+            block_ids=(),
             can_save=not skip_save,
             load_spec=load_spec,
             block_hashes=block_hashes,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -8,6 +8,7 @@
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
+    KVConnectorSchedulerContext,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
     partial_hash_hits_enabled,
@@ -23,9 +24,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.worker import (
     LookupKeyClient,
 )
 from vllm.logger import init_logger
-from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+from vllm.v1.core.kv_cache_utils import KVCacheBlock, resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.outputs import KVConnectorOutput
@@ -81,17 +82,19 @@ class MooncakeStoreScheduler:
         # Per-request state
         self.load_specs: dict[str, LoadSpec] = {}  # to be loaded
         self._request_trackers: dict[str, RequestTracker] = {}  # scheduled new requests
-        self._unfinished_requests: dict[str, tuple[Request, tuple[list[int], ...]]] = {}
+        self._unfinished_requests: dict[str, Request] = {}
         self._unfinished_request_ids: set[str] = set()
 
-        self._gpu_block_pool: BlockPool | None = None
+        self._scheduler_context: KVConnectorSchedulerContext | None = None
         self._num_workers = vllm_config.parallel_config.world_size
         self._next_store_job_id = 0
         # store_job_id -> (referenced block ids, ranks yet to report completion)
         self._pinned_saves: dict[int, tuple[list[int], int]] = {}
 
-    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
-        self._gpu_block_pool = gpu_block_pool
+    def bind_scheduler_context(
+        self, scheduler_context: KVConnectorSchedulerContext
+    ) -> None:
+        self._scheduler_context = scheduler_context
 
     def get_num_new_matched_tokens(
         self,
@@ -155,11 +158,7 @@ class MooncakeStoreScheduler:
         num_external_tokens: int,
     ):
         """Update state after block allocation."""
-        local_block_ids: tuple[list[int], ...] = ()
-        if num_external_tokens > 0:
-            local_block_ids = blocks.get_block_ids()
-
-        self._unfinished_requests[request.request_id] = (request, local_block_ids)
+        self._unfinished_requests[request.request_id] = request
         self._unfinished_request_ids.add(request.request_id)
 
         if request.request_id not in self.load_specs:
@@ -217,21 +216,12 @@ class MooncakeStoreScheduler:
                 + scheduler_output.num_scheduled_tokens[request.req_id]
             )
             assert request.req_id in self._unfinished_requests
-            request_tuple = self._unfinished_requests.get(request.req_id)
-            request_real = request_tuple[0]  # type: ignore[index]
-
-            if isinstance(request.block_ids, tuple):
-                # Multi-group: preserve per-group structure.
-                unfolded_block_ids = tuple(b.copy() for b in request.block_ids)
-            else:
-                # Single-group legacy: list[int] -> 1-tuple.
-                unfolded_block_ids = (request.block_ids.copy(),)
+            request_real = self._unfinished_requests[request.req_id]
 
             prefill_tokens = _new_req_prefill_tokens(request)
             request_tracker = RequestTracker(
                 req_id=request.req_id,
                 token_len=num_tokens_to_compute,
-                allocated_block_ids=unfolded_block_ids,
                 num_saved_tokens=0,
                 token_ids=(
                     prefill_tokens[:num_tokens_to_compute]
@@ -265,13 +255,8 @@ class MooncakeStoreScheduler:
                     # Resumed after preemption
                     if not new_block_ids:
                         continue
-                    if isinstance(new_block_ids, tuple):
-                        new_block_ids = tuple(b.copy() for b in new_block_ids)
-                    else:
-                        new_block_ids = (new_block_ids.copy(),)
                     load_spec = self.load_specs.pop(req_id, None)
-                    request_tuple = self._unfinished_requests.get(req_id)
-                    request_real = request_tuple[0]  # type: ignore[index]
+                    request_real = self._unfinished_requests[req_id]
                     num_tokens_to_compute = (
                         request_real.num_computed_tokens
                         + scheduler_output.num_scheduled_tokens[req_id]
@@ -282,7 +267,6 @@ class MooncakeStoreScheduler:
                     request_tracker = RequestTracker(
                         req_id=req_id,
                         token_len=num_tokens_to_compute,
-                        allocated_block_ids=new_block_ids,
                         num_saved_tokens=0,
                         token_ids=(
                             prefill_tokens[:num_tokens_to_compute]
@@ -312,9 +296,8 @@ class MooncakeStoreScheduler:
                         continue
 
                     num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
-                    req_tuple = self._unfinished_requests.get(req_id)
-                    if req_tuple:
-                        unfinished_req = req_tuple[0]
+                    unfinished_req = self._unfinished_requests.get(req_id)
+                    if unfinished_req is not None:
                         num_current_tokens = request_tracker.token_len
                         new_token_ids = unfinished_req.all_token_ids[
                             num_current_tokens : num_current_tokens + num_new_tokens
@@ -326,11 +309,6 @@ class MooncakeStoreScheduler:
                         raise ValueError(
                             f"Request {req_id} is not in _unfinished_requests"
                         )
-                    # A block is usually allocated before the step that fills
-                    # it, so reaching a save boundary does not imply that this
-                    # step has new block ids.
-                    if new_block_ids:
-                        request_tracker.update(new_block_ids)
                     if is_consumer and not is_decode:
                         continue
 
@@ -347,10 +325,7 @@ class MooncakeStoreScheduler:
 
         # Handle requests with pending load specs not yet scheduled
         request_ids = [req.req_id for req in scheduler_output.scheduled_new_reqs]
-        for request_id, (
-            unfinished_req,
-            block_ids,
-        ) in self._unfinished_requests.items():
+        for request_id, unfinished_req in self._unfinished_requests.items():
             if request_id not in request_ids and request_id not in cached_reqs.req_ids:
                 load_spec = self.load_specs.pop(request_id, None)
                 if not load_spec:
@@ -359,7 +334,6 @@ class MooncakeStoreScheduler:
                 request_tracker = RequestTracker(
                     req_id=request_id,
                     token_len=num_tokens_to_compute,
-                    allocated_block_ids=block_ids,
                     num_saved_tokens=0,
                 )
                 self._request_trackers[request_id] = request_tracker
@@ -391,8 +365,8 @@ class MooncakeStoreScheduler:
                             tracker.has_pending_offload = True
             for req_id, groups in pending.items():
                 tracker = self._request_trackers.get(req_id)
-                req_tuple = self._unfinished_requests.get(req_id)
-                if tracker is None or req_tuple is None:
+                unfinished_req = self._unfinished_requests.get(req_id)
+                if tracker is None or unfinished_req is None:
                     # Request finished/preempted within this step; its blocks
                     # are going away, so the offload is conservatively dropped.
                     logger.debug("Dropping partial-tail offload for request %s", req_id)
@@ -403,57 +377,73 @@ class MooncakeStoreScheduler:
                     ReqMeta(
                         req_id=req_id,
                         token_len_chunk=0,
-                        block_ids=tracker.allocated_block_ids,
-                        block_hashes=req_tuple[0].block_hashes,
+                        block_ids=(),
+                        block_hashes=unfinished_req.block_hashes,
                         can_save=True,
                         num_prompt_tokens=tracker.prefill_end_tokens,
                         partial_tail_offloads=groups,
                     )
                 )
 
-        self._reference_save_blocks(meta)
+        self._prepare_request_blocks(meta)
         return meta
 
-    def _reference_save_blocks(self, meta: MooncakeStoreConnectorMetadata) -> None:
-        """Take a GPU block reference for every store job this step emits.
+    def _prepare_request_blocks(self, meta: MooncakeStoreConnectorMetadata) -> None:
+        """Populate worker block IDs and reference blocks used by store jobs.
 
         The worker DMAs out of these blocks after the step that scheduled them,
         so a reference keeps them out of the free queue even once the request
         itself is freed, until every rank reports the job done.
         """
-        pool = self._gpu_block_pool
+        scheduler_context = self._scheduler_context
         for req_meta in meta.requests:
-            if not req_meta.can_save:
-                continue
-            assert pool is not None, (
-                "GPU block pool must be bound before any store job is emitted"
+            assert scheduler_context is not None, (
+                "Scheduler context must be bound before connector metadata is emitted"
             )
+            current_groups = scheduler_context.borrow_request_blocks(
+                req_meta.req_id
+            ).blocks
+
+            if not req_meta.can_save:
+                req_meta.block_ids = tuple(
+                    [block.block_id for block in blocks] for blocks in current_groups
+                )
+                continue
+
+            pool = scheduler_context.gpu_block_pool
             req_meta.store_job_id = store_job_id = self._next_store_job_id
             self._next_store_job_id += 1
-            block_ids: list[int] = []
+            blocks_by_id: dict[int, KVCacheBlock] = {}
             if req_meta.partial_tail_offloads:
-                # A partial-tail CoW block is deliberately kept out of the
-                # request's block table, so it is absent from `block_ids` even
-                # though the worker DMAs out of it just as asynchronously.
-                # It leads the list, as in `pop_blocks_for_free`.
-                block_ids += [bid for _, bid, _ in req_meta.partial_tail_offloads]
-            # Every allocated block is referenced, not just the ones covering
-            # this job's token range: a rank resumes from its own last
-            # successful offset, which lags the scheduler's whenever a save was
-            # skipped or failed, so it may read anywhere below the range.
-            block_ids += [bid for group in req_meta.block_ids for bid in group]
+                for _, block_id, _ in req_meta.partial_tail_offloads:
+                    assert block_id != NULL_BLOCK_ID, (
+                        "A null block cannot back a partial-tail offload"
+                    )
+                    blocks_by_id.setdefault(block_id, pool.blocks[block_id])
+
+            worker_block_ids: list[list[int]] = []
+            for blocks in current_groups:
+                worker_block_ids.append([block.block_id for block in blocks])
+                for block in blocks:
+                    if block.block_id != NULL_BLOCK_ID:
+                        blocks_by_id.setdefault(block.block_id, block)
+            req_meta.block_ids = tuple(worker_block_ids)
+
+            block_ids = list(blocks_by_id)
+            assert NULL_BLOCK_ID not in block_ids
             if not block_ids:
                 continue
             self._pinned_saves[store_job_id] = (block_ids, self._num_workers)
-            pool.touch([pool.blocks[bid] for bid in block_ids])
+            pool.touch(list(blocks_by_id.values()))
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Drop the block references of store jobs every rank has finished."""
         meta = connector_output.kv_connector_worker_meta
         if not isinstance(meta, MooncakeStoreWorkerMetadata):
             return
-        pool = self._gpu_block_pool
-        assert pool is not None
+        scheduler_context = self._scheduler_context
+        assert scheduler_context is not None
+        pool = scheduler_context.gpu_block_pool
         for store_job_id, count in meta.completed_saves.items():
             pinned = self._pinned_saves.get(store_job_id)
             if pinned is None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -17,6 +17,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
     KVConnectorRole,
+    KVConnectorSchedulerContext,
     KVConnectorWorkerMetadata,
     SupportsHMA,
 )
@@ -34,7 +35,6 @@ from vllm.v1.outputs import KVConnectorOutput
 if TYPE_CHECKING:
     from vllm.distributed.kv_events import KVCacheEvent
     from vllm.forward_context import ForwardContext
-    from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -256,9 +256,11 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         for c in self._connectors:
             c.register_kv_caches(kv_caches)
 
-    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
+    def bind_scheduler_context(
+        self, scheduler_context: KVConnectorSchedulerContext
+    ) -> None:
         for c in self._connectors:
-            c.bind_gpu_block_pool(gpu_block_pool)
+            c.bind_scheduler_context(scheduler_context)
 
     # We must override the base class method here because we need to bind
     # the metadata to each connector in the order of the connectors in the

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -13,6 +13,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    KVConnectorSchedulerContext,
     SupportsHMA,
 )
 from vllm.logger import init_logger
@@ -31,7 +32,6 @@ from vllm.v1.simple_kv_offload.worker import (
 if TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
     from vllm.v1.attention.backend import AttentionMetadata
-    from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -228,9 +228,11 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
 
     # --- Scheduler-side methods ---
 
-    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
+    def bind_scheduler_context(
+        self, scheduler_context: KVConnectorSchedulerContext
+    ) -> None:
         if self.scheduler_manager is not None:
-            self.scheduler_manager.bind_gpu_block_pool(gpu_block_pool)
+            self.scheduler_manager.bind_gpu_block_pool(scheduler_context.gpu_block_pool)
 
     def get_num_new_matched_tokens(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -20,6 +20,7 @@ from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorBase_V1,
     KVConnectorRole,
+    KVConnectorSchedulerContext,
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
@@ -291,10 +292,15 @@ class Scheduler(SchedulerInterface):
             metrics_collector=self.kv_metrics_collector,
             watermark=self.scheduler_config.watermark,
         )
-        # Bind GPU block pool to the KV connector. This must happen after
-        # kv_cache_manager is constructed so block_pool is available.
+        # Bind scheduler-owned KV-cache capabilities after the manager and its
+        # block pool are available.
         if self.connector is not None:
-            self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
+            self.connector.bind_scheduler_context(
+                KVConnectorSchedulerContext(
+                    self.kv_cache_manager.block_pool,
+                    self.kv_cache_manager.get_blocks,
+                )
+            )
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.use_v2_model_runner = vllm_config.use_v2_model_runner


### PR DESCRIPTION
## Summary

- add a narrow `KVConnectorSchedulerContext` that exposes the GPU block pool and temporary access to current request blocks
- bind the context once during scheduler initialization and forward it through `MultiConnector` and `SimpleCPUOffloadConnector`
- make Mooncake borrow current blocks only when it emits save/load metadata, while serializing block IDs and collecting unique blocks to pin in one pass
- remove Mooncake `RequestTracker.allocated_block_ids` and the old connector-level `bind_gpu_block_pool()` API

## Performance

Connectors that do not use the context have no scheduler hot-path work; they receive one context object during initialization. Mooncake no longer snapshots or incrementally maintains request block IDs. It borrows scheduler-owned block lists only for emitted metadata jobs, serializes all KV groups, skips null blocks for pinning, and deduplicates blocks shared with partial-tail offloads.

## Relationship to #51358

This is prerequisite groundwork for #51358. It separates the scheduler/connector ownership boundary and lazy Mooncake block access from the Mamba boundary-state expansion and worker batching in that PR.

## Duplicate work

I searched open vLLM PRs for KV connector scheduler context and request-block borrowing work and found no PR implementing this interface or Mooncake migration.

## Tests

- `/home/yifanqiao/vllm/.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py -q` — 33 passed
- `pre-commit run ruff-check --files <changed files>` — passed
- `pre-commit run mypy-3.12 --hook-stage manual --files <changed production files>` — passed
- commit-time pre-commit hooks, including ruff, mypy, forbidden imports, and sign-off checks — passed
- Mooncake connector, MultiConnector, and scheduler override suites were attempted but could not collect in this CPU environment because the compiled FlashAttention CUDA extension is unavailable

No model evaluation is needed because this change does not affect model outputs or accuracy.

## AI assistance

AI assistance was used for code exploration, implementation, test updates, and review. The human submitter reviewed the changes and is responsible for the final contribution.