### PR TITLE
[ROCm][Quantization] Implement Fp8Config shared-expert FSE compatibility check

### DIFF
--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -15,6 +15,7 @@ import vllm.config as vllm_config_module
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.fused_moe import utils as fused_moe_utils
 from vllm.model_executor.layers.fused_moe.layer import determine_expert_counts
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
 from vllm.model_executor.layers.quantization.utils.config_utils import (
     is_shared_expert_quant_fse_compatible,
@@ -688,6 +689,98 @@ def test_quark_packed_layer_config_must_match_global_config() -> None:
         quant_config._find_matched_config(
             "model.layers.0.mlp.shared_expert.gate_up_proj", nn.Module()
         )
+
+
+def make_block_fp8_config(ignored_layers: list[str] | None = None) -> Fp8Config:
+    return Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        ignored_layers=ignored_layers,
+        weight_block_size=[128, 128],
+    )
+
+
+_FP8_SHARED_EXPERT_PROJECTIONS = [
+    "model.layers.0.mlp.shared_experts.gate_up_proj",
+    "model.layers.0.mlp.shared_experts.down_proj",
+]
+
+
+def test_fp8_shared_expert_fse_allows_uniformly_quantized_experts() -> None:
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        make_block_fp8_config(),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert compatible
+    assert reason is None
+
+
+def test_fp8_shared_expert_fse_ignores_non_expert_exclusions() -> None:
+    """Excluding layers that are not experts must not disable FSE."""
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        make_block_fp8_config(
+            [
+                "model.layers.0.input_layernorm",
+                "model.layers.0.mlp.gate",
+                "lm_head",
+            ]
+        ),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert compatible
+    assert reason is None
+
+
+def test_fp8_shared_expert_fse_allows_both_expert_groups_unquantized() -> None:
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        make_block_fp8_config(
+            ["model.layers.0.mlp.experts", *_FP8_SHARED_EXPERT_PROJECTIONS]
+        ),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert compatible
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    "ignored_layers",
+    [
+        pytest.param(_FP8_SHARED_EXPERT_PROJECTIONS, id="shared-experts-excluded"),
+        pytest.param(["model.layers.0.mlp.experts"], id="routed-experts-excluded"),
+        pytest.param(_FP8_SHARED_EXPERT_PROJECTIONS[:1], id="one-projection-excluded"),
+    ],
+)
+def test_fp8_shared_expert_fse_rejects_asymmetric_exclusions(
+    ignored_layers: list[str],
+) -> None:
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        make_block_fp8_config(ignored_layers),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert not compatible
+    assert reason == (
+        "FP8 uses different quantization configurations for routed and "
+        "shared experts at model.layers.0.mlp.shared_experts"
+    )
+
+
+def test_fp8_shared_expert_fse_requires_serialized_checkpoint() -> None:
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        Fp8Config(is_checkpoint_fp8_serialized=False),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert not compatible
+    assert reason == "FP8 FSE requires an fp8-serialized checkpoint"
 
 
 def test_non_quark_shared_expert_fse_is_incompatible() -> None:

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -32,6 +32,7 @@ def is_shared_expert_quant_fse_compatible(
     if quant_config is None:
         return True, None
 
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
     from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
     from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
 
@@ -143,6 +144,42 @@ def is_shared_expert_quant_fse_compatible(
             "Quark uses different quantization configurations for routed and "
             f"shared experts at {shared_expert_prefix}",
         )
+
+    # NOTE: must stay below the DeepseekV4FP8Config branch, which subclasses
+    # Fp8Config and needs its own MXFP4 handling.
+    if isinstance(quant_config, Fp8Config):
+        from vllm.model_executor.layers.quantization.utils.quant_utils import (
+            is_layer_skipped,
+        )
+
+        # Only fp8-serialized checkpoints have been validated with FSE.
+        if not quant_config.is_checkpoint_fp8_serialized:
+            return False, "FP8 FSE requires an fp8-serialized checkpoint"
+
+        # Fp8Config applies a single `weight_block_size` and `activation_scheme`
+        # to every layer it quantizes, so routed and shared experts share one
+        # quantization config as long as they are either both quantized or both
+        # listed in `ignored_layers`.
+        def is_fse_layer_skipped(prefix: str) -> bool:
+            return is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=quant_config.ignored_layers,
+                fused_mapping=quant_config.packed_modules_mapping,
+                match_mode=quant_config.ignored_layers_match_mode,
+            )
+
+        expert_skipped = is_fse_layer_skipped(expert_prefix)
+        if any(
+            is_fse_layer_skipped(f"{shared_expert_prefix}.{projection_name}")
+            != expert_skipped
+            for projection_name in projection_names
+        ):
+            return (
+                False,
+                "FP8 uses different quantization configurations for routed and "
+                f"shared experts at {shared_expert_prefix}",
+            )
+        return True, None
 
     # TODO: Extend FSE support detection to other quantization methods. Typically,
     # one would check that the experts and shared_experts use the same


### PR DESCRIPTION
## Purpose

`is_shared_expert_quant_fse_compatible()` gates AITER fused shared experts (FSE) behind a
quantization compatibility check that currently implements only `QuarkConfig` and
`DeepseekV4FP8Config`. Every other quantization falls through to a catch-all rejection:

```
shared-expert FSE quantization compatibility is not implemented for Fp8Config
```

The practical effect is that models loading with the plain `Fp8Config` accept
`VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` and then silently run unfused. There is no error
and no non-zero exit, only one warning per MoE layer per rank buried in startup logs. On
GLM-5.2-FP8 (78 MoE layers, TP8) that is 600+ near-identical warning lines, and it is easy to
believe the flag took effect when it did not.

This PR implements the TODO that sits directly above the catch-all return:

```python
# TODO: Extend FSE support detection to other quantization methods. Typically,
# one would check that the experts and shared_experts use the same
# quantization config.
```

`Fp8Config` carries a single global `weight_block_size` and `activation_scheme` with no
per-layer overrides, so the only source of per-layer variation is `ignored_layers`. Routed and
shared experts therefore share a quantization config exactly when they are either both
quantized or both ignored. Skip status is resolved with `is_layer_skipped()` using the config's
own `packed_modules_mapping` and `ignored_layers_match_mode` — the same call
`Fp8Config.get_quant_method()` makes — so the check asks the quantization layer the question it
already asks itself rather than inventing a parallel rule.

The branch fails closed: any asymmetry between the routed and shared experts returns `False`
with a reason mirroring the existing Quark message. It is also restricted to fp8-serialized
checkpoints, since the online-quantization path has not been exercised. It is placed below the
`DeepseekV4FP8Config` branch, which subclasses `Fp8Config` and needs its own MXFP4 handling.

Other quantizations (compressed-tensors, GPTQ, AWQ, ModelOpt) still fall through the catch-all
and are unaffected.

## Test Plan

Unit:

```bash
pytest tests/model_executor/layers/test_fused_shared_expert.py -k fp8
```

Seven new cases extend the existing gate tests: uniformly quantized experts, non-expert
exclusions (layernorms, `mlp.gate`, `lm_head`) which must not disable FSE, both expert groups
ignored, three asymmetric-exclusion negative controls (shared excluded, routed excluded, one of
two projections excluded), and a non-serialized checkpoint.

End to end, `zai-org/GLM-5.2-FP8`, 8x MI325X (gfx942), TP8, `vllm bench serve` with random
131,072 input / 1,024 output, 20 prompts, seed 4, 2 warmups:

```bash
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 \
VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1 \
vllm serve zai-org/GLM-5.2-FP8 -tp 8 --block-size 64 --gpu-memory-utilization 0.83
```

## Test Result

Unit tests: 7 new cases pass with the change and all 7 fail without it. The 14 pre-existing
non-GPU cases in the same module continue to pass.

End to end the flag now takes effect: the per-layer `cannot be enabled` warning is gone, KV
cache size is unchanged at 2,240,512 tokens, AITER block-scale FP8 MoE kernels are selected
(`fmoe_bf16_blockscaleFp8_g1u1_vs_silu_*`), and output is correct on arithmetic, factual recall
and text completion prompts.

Output token throughput, FSE off vs on:

| Concurrency | off | on | change |
| --- | --- | --- | --- |
| 8 | 84.85 | 91.74 | +8.1% |
| 6 | 79.19 | 84.07 | +6.2% |
| 4 | 76.01 | 82.45 | +8.5% |
| 2 | 60.47 | 59.83 | −1.1% |

Latency, FSE off → on:

| Conc. | Mean TTFT (ms) | Mean TPOT (ms) | Mean E2EL (ms) |
| --- | --- | --- | --- |
| 8 | 31,173 → 28,759 (−7.7%) | 59.52 → 55.26 (−7.2%) | 92,061 → 85,285 (−7.4%) |
| 6 | 25,854 → 23,360 (−9.6%) | 46.38 → 44.23 (−4.6%) | 73,295 → 68,606 (−6.4%) |
| 4 | 22,814 → 20,321 (−10.9%) | 30.34 → 28.66 (−5.5%) | 53,852 → 49,642 (−7.8%) |
| 2 | 14,403 → 13,301 (−7.6%) | 19.02 → 20.45 (+7.5%) | 33,864 → 34,225 (+1.1%) |

TTFT improves at every concurrency because prefill always presents the fused grouped GEMM with
a large token batch. TPOT improves at concurrency 4 and above but regresses 7.5% at concurrency
2, where the decode batch is too small to amortize the fused kernel and a dedicated dense GEMM
for the single shared expert wins; there the prefill gain and decode loss roughly cancel. The
crossover lies between concurrency 2 and 4. Concurrency 2 was measured twice on separate days
with a server restart between, agreeing to within 0.05%, so these deltas are signal rather than
noise.
