### PR TITLE
[Bugfix][CPU][RISC-V] Return zero below exp clamp bound

### DIFF
--- a/csrc/cpu/cpu_types_riscv_impl.hpp
+++ b/csrc/cpu/cpu_types_riscv_impl.hpp
@@ -513,6 +513,8 @@ struct FP32Vec8 : public Vec<FP32Vec8> {
     // Matches the clamping strategy used by x86 AVX-512 and ARM NEON.
     constexpr float exp_lo = -87.3365447505f;  // ln(FLT_MIN)
     constexpr float exp_hi = 88.7228391117f;   // ln(FLT_MAX)
+    rvv_mask_f32x8_t low_mask = RVVIB(__riscv_vmflt_vf_f32, LMUL_256, BOOL_256)(
+        reg, exp_lo, VEC_ELEM_NUM);
     fixed_fp32x8_t x = RVVI(__riscv_vfmin_vf_f32, LMUL_256)(
         RVVI(__riscv_vfmax_vf_f32, LMUL_256)(reg, exp_lo, VEC_ELEM_NUM), exp_hi,
         VEC_ELEM_NUM);
@@ -554,8 +556,12 @@ struct FP32Vec8 : public Vec<FP32Vec8> {
     fixed_fp32x8_t scale = RVVI4(__riscv_vreinterpret_v_i32, LMUL_256, _f32,
                                  LMUL_256)(exponent_bits);
 
-    return FP32Vec8(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, scale, VEC_ELEM_NUM));
+    fixed_fp32x8_t result =
+        RVVI(__riscv_vfmul_vv_f32, LMUL_256)(poly, scale, VEC_ELEM_NUM);
+    fixed_fp32x8_t zeros =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_256)(0.0f, VEC_ELEM_NUM);
+    return FP32Vec8(RVVI(__riscv_vmerge_vvm_f32, LMUL_256)(
+        result, zeros, low_mask, VEC_ELEM_NUM));
   }
 
   FP32Vec8 tanh() const {
@@ -783,6 +789,8 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
     // Matches the clamping strategy used by x86 AVX-512 and ARM NEON.
     constexpr float exp_lo = -87.3365447505f;  // ln(FLT_MIN)
     constexpr float exp_hi = 88.7228391117f;   // ln(FLT_MAX)
+    rvv_mask_f32x16_t low_mask = RVVIB(__riscv_vmflt_vf_f32, LMUL_512,
+                                       BOOL_512)(reg, exp_lo, VEC_ELEM_NUM);
     fixed_fp32x16_t x = RVVI(__riscv_vfmin_vf_f32, LMUL_512)(
         RVVI(__riscv_vfmax_vf_f32, LMUL_512)(reg, exp_lo, VEC_ELEM_NUM), exp_hi,
         VEC_ELEM_NUM);
@@ -822,8 +830,12 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
         RVVI4(__riscv_vreinterpret_v_i32, LMUL_512, _f32, LMUL_512)(
             RVVI(__riscv_vsll_vx_i32, LMUL_512)(biased_exp, 23, VEC_ELEM_NUM));
 
-    return FP32Vec16(
-        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, scale, VEC_ELEM_NUM));
+    fixed_fp32x16_t result =
+        RVVI(__riscv_vfmul_vv_f32, LMUL_512)(poly, scale, VEC_ELEM_NUM);
+    fixed_fp32x16_t zeros =
+        RVVI(__riscv_vfmv_v_f_f32, LMUL_512)(0.0f, VEC_ELEM_NUM);
+    return FP32Vec16(RVVI(__riscv_vmerge_vvm_f32, LMUL_512)(
+        result, zeros, low_mask, VEC_ELEM_NUM));
   }
 
   FP32Vec16 tanh() const {


### PR DESCRIPTION
## Purpose

Fix the lower-bound behavior of the RISC-V RVV FP32 fast-exp implementation.

`FP32Vec8::exp()` and `FP32Vec16::exp()` clamp their inputs to `ln(FLT_MIN)` before evaluating the polynomial approximation. Before this change, every input strictly below that bound—including `-inf` values written by the CPU attention mask—was evaluated at the bound and returned `FLT_MIN` instead of positive zero.

This change records a strict `input < ln(FLT_MIN)` mask before clamping and merges `+0.0f` into those lanes after the existing polynomial calculation. This follows the lower-bound policy used by the x86 AVX-512 attention fast-exp implementation.

The strict comparison preserves the existing boundary behavior:

- Inputs strictly below `ln(FLT_MIN)`, including `-inf`, return `+0.0f`.
- An input exactly equal to `ln(FLT_MIN)` still returns `FLT_MIN`.
- Ordinary finite inputs and the upper-bound behavior are unchanged.
- The existing NaN behavior is unchanged.

The fix applies to both `FP32Vec8` and `FP32Vec16`.

Duplicate checks against open vLLM issues and PRs found no competing fix for this RISC-V lower-bound behavior. #42900 is a transcendental-function performance change, while #47983 changes float-to-integer rounding; neither changes the result below the exp clamp bound.

AI assistance was used for analysis, implementation, and hardware validation. I reviewed every changed line and the reported results.

## Test Plan

On a native SpacemiT K1 system (`riscv64`, runtime VLEN 256), compile a focused harness that includes the production RISC-V CPU type header and directly calls the actual `FP32Vec8::exp()` and `FP32Vec16::exp()` implementations.

Run the harness against an upstream baseline and the patched candidate at both `-O2` and `-O3` with:

```text
-std=c++20
-march=rv64gcv_zvfh_zvl256b
-mrvv-vector-bits=zvl
-mabi=lp64d
```

The inputs cover `-inf`, the adjacent float below the lower bound, the exact lower bound, the adjacent float above it, ordinary finite values, the upper bound, `+inf`, and NaN.

Build and install the complete CPU extension for both revisions with GCC 14.2, RISE PyTorch 2.13.0+cpu, and `VLLM_RVV_VLEN=256`:

```bash
FETCHCONTENT_SOURCE_DIR_ONEDNN=<onednn-source> \
cmake -S . -B <rvv-build-dir> -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 \
  -DVLLM_TARGET_DEVICE=cpu \
  -DVLLM_RVV_VLEN=256 \
  -DVLLM_PYTHON_EXECUTABLE=<torch-2.13-venv>/bin/python \
  -DCMAKE_INSTALL_PREFIX=<install-dir>

cmake --build <rvv-build-dir> --target install --parallel 2
```

Using each generated `_C.abi3.so`, invoke the real `cpu_attention_with_kv_cache` operator with identical tensors. The focused regression input places `2**126` in a causally masked value position so that the incorrect `FLT_MIN` weight becomes observable.

Run the source checks:

```bash
pre-commit run clang-format \
  --files csrc/cpu/cpu_types_riscv_impl.hpp

pre-commit run typos \
  --files csrc/cpu/cpu_types_riscv_impl.hpp

git diff --check
```

## Test Result

The tests were run on:

```text
CPU: Spacemit X60
Architecture: riscv64
Runtime VLEN: 256 bits
Compiler: GCC 14.2
Python: 3.12
PyTorch: RISE PyTorch 2.13.0+cpu
```

The production-header harness passed for both vector classes and both optimization levels:

| Input | Upstream baseline | Patched candidate |
|---|---|---|
| `-inf` | `0x00800000` (`FLT_MIN`) | `0x00000000` (`+0.0f`) |
| Adjacent float below `exp_lo` | `FLT_MIN` | `+0.0f` |
| Exactly `exp_lo` | `FLT_MIN` | `FLT_MIN` |
| Remaining controls | Existing result | Bit-identical |

Both the upstream baseline and patched candidate completed the full RVV CPU extension build and install target. The candidate result was:

```text
CMake configuration: PASS
RVV target: rv64gcv_zvfh_zvl256b
Full build/install target: PASS
_C.abi3.so link: PASS
RISC-V ELF artifact: generated
```

The same real attention operator and input tensors produced:

| Case | First-query output |
|---|---|
| Upstream baseline | All 64 elements were `1.0`; `q0_nonzero=64` |
| Patched candidate | All 64 elements were `+0.0`; `q0_nonzero=0` |

Both operator probes exited successfully. This reproduces the defect and verifies the fix through the production `cpu_attention_with_kv_cache` path, rather than only through an isolated polynomial approximation.

The `2**126` value is an intentional diagnostic amplifier because `FLT_MIN * 2**126 == 1`. It demonstrates that a masked lane is not strictly excluded before the fix; it does not claim a measurable accuracy impact for ordinary model inputs.

A normal extension import with the RISE PyTorch wheel was also attempted but stopped at the pre-existing unresolved `sbgemm_` symbol in the FLA/OpenBLAS path. The focused comparison used the same lazy-loading method for both artifacts to reach the already-linked CPU attention operator. This PR does not modify the FLA or OpenBLAS paths, and the normal import is not reported as passing.

Model evaluation was not run because the unrelated `sbgemm_` platform-library issue prevents a normal extension load and no model was cached on the K1. The real CPU-attention operator comparison above is the targeted integration result for the changed implementation.

The hardware run used the rebased candidate `95f5efd8`. The branch was subsequently rebased over six additional upstream commits to the current head `91b56fe5`. `git range-diff` confirms that the PR patch is unchanged, the changed header has the same Git blob, and none of those upstream commits modifies the changed file.

The source checks pass:

```text
clang-format: PASS
typos: PASS
git diff --check: PASS
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

