### PR TITLE
[Kernel][Perf] Support DSpark K=8 in fused GDN MTP decode

### DIFF
--- a/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
+++ b/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
@@ -88,7 +88,8 @@ constexpr int kWarps = kThreads / 32;
 constexpr int kChunkV = 32;
 constexpr int kNumChunks = kDimV / kChunkV;
 constexpr int kRowsPerWarp = kChunkV / kWarps;
-constexpr int kMaxMtpTokens = 8;
+// Target verification includes the sampled token, so MTP K=8 needs 9 slots.
+constexpr int kMaxMtpTokens = kWarps + 1;
 constexpr int kDtBiasFloat32 = 0;
 constexpr int kDtBiasBFloat16 = 1;
 constexpr int kDtBiasFloat16 = 2;
@@ -146,7 +147,7 @@ __device__ __forceinline__ Sum2 warp_reduce_sum_pair(float x, float y) {
   return {x, y};
 }
 
-template <typename StateT, int ValueHeadsPerKeyHead>
+template <typename StateT, int ValueHeadsPerKeyHead, int MaxTokens>
 __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
     const __nv_bfloat16* __restrict__ mixed_qkv,
     const __nv_bfloat16* __restrict__ a, const __nv_bfloat16* __restrict__ b,
@@ -175,7 +176,7 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
       accepted > 0 && accepted <= state_indices_width
           ? state_indices[request * state_indices_width + accepted - 1]
           : 0;
-  if (source_slot <= 0 || num_tokens > kMaxMtpTokens) {
+  if (source_slot <= 0 || num_tokens > MaxTokens) {
     for (int linear = tid; linear < num_tokens * kDimV; linear += kThreads) {
       const int token = bos + linear / kDimV;
       const int value = linear % kDimV;
@@ -188,12 +189,12 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
 
   const int key_head = value_head / ValueHeadsPerKeyHead;
   __shared__ StateT shared_state[2][kChunkV][kDimK];
-  __shared__ float shared_q[kMaxMtpTokens][kDimK];
-  __shared__ float shared_k[kMaxMtpTokens][kDimK];
-  __shared__ __nv_bfloat16 shared_v[kMaxMtpTokens][kDimV];
-  __shared__ __nv_bfloat16 shared_out[kMaxMtpTokens][kDimV];
-  __shared__ float shared_decay[kMaxMtpTokens];
-  __shared__ float shared_beta[kMaxMtpTokens];
+  __shared__ float shared_q[MaxTokens][kDimK];
+  __shared__ float shared_k[MaxTokens][kDimK];
+  __shared__ __nv_bfloat16 shared_v[MaxTokens][kDimV];
+  __shared__ __nv_bfloat16 shared_out[MaxTokens][kDimV];
+  __shared__ float shared_decay[MaxTokens];
+  __shared__ float shared_beta[MaxTokens];
 
   StateT* source_state =
       state + static_cast<int64_t>(source_slot) * strides.state_slot +
@@ -201,8 +202,7 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
   copy_state_chunk<StateT, kChunkV, kDimK, 2>(&shared_state[0][0][0],
                                               source_state, 0, tid, kThreads);
 
-  if (warp < num_tokens) {
-    const int t = warp;
+  for (int t = warp; t < num_tokens; t += kWarps) {
     const int token = bos + t;
     const int64_t mixed_base = static_cast<int64_t>(token) * strides.mixed_row;
     float q_values[4];
@@ -242,6 +242,9 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
                                                            dt_bias_type));
       shared_decay[t] = __expf(g);
       shared_beta[t] = sigmoid_fast(b_value);
+    }
+    if constexpr (MaxTokens <= kWarps) {
+      break;
     }
   }
   __syncthreads();
@@ -337,8 +340,7 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
   }
   __syncthreads();
 
-  if (warp < num_tokens) {
-    const int t = warp;
+  for (int t = warp; t < num_tokens; t += kWarps) {
     float output_values[4];
     float sum_square = 0.0f;
 #pragma unroll
@@ -367,10 +369,13 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
       out[out_offset] =
           __float2bfloat16(output_values[i] * rstd * weight * gate);
     }
+    if constexpr (MaxTokens <= kWarps) {
+      break;
+    }
   }
 }
 
-template <typename StateT, int ValueHeadsPerKeyHead>
+template <typename StateT, int ValueHeadsPerKeyHead, int MaxTokens>
 void launch_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a_log,
     torch::stable::Tensor const& dt_bias,
@@ -395,7 +400,7 @@ void launch_gdn_decode_post_conv_mtp(
       get_current_cuda_stream(mixed_qkv.get_device_index());
   const int num_requests = static_cast<int>(state_indices.size(0));
   const dim3 grid(num_requests, num_value_heads);
-  gdn_decode_post_conv_mtp_kernel<StateT, ValueHeadsPerKeyHead>
+  gdn_decode_post_conv_mtp_kernel<StateT, ValueHeadsPerKeyHead, MaxTokens>
       <<<grid, kThreads, 0, stream>>>(
           static_cast<const __nv_bfloat16*>(mixed_qkv.data_ptr()), a, b,
           static_cast<const float*>(a_log.data_ptr()), dt_bias.data_ptr(),
@@ -491,7 +496,7 @@ void fused_gdn_decode_post_conv_mtp(
   STD_TORCH_CHECK(state_indices.dim() == 2 && state_indices.size(0) > 0 &&
                       state_indices.size(1) > 0 &&
                       state_indices.size(1) <= kMaxMtpTokens,
-                  "state_indices must have shape [N, S] with 1 <= S <= 8");
+                  "state_indices must have shape [N, S] with 1 <= S <= 9");
   const int num_requests = static_cast<int>(state_indices.size(0));
   STD_TORCH_CHECK(
       cu_seqlens.dim() == 1 && cu_seqlens.numel() == num_requests + 1,
@@ -547,18 +552,28 @@ void fused_gdn_decode_post_conv_mtp(
   const auto* b_ptr = static_cast<const __nv_bfloat16*>(b.data_ptr());
   const auto* output_gate_ptr =
       static_cast<const __nv_bfloat16*>(output_gate.data_ptr());
-  const auto launch = [&]<typename StateT, int ValueHeadsPerKeyHead>() {
-    launch_gdn_decode_post_conv_mtp<StateT, ValueHeadsPerKeyHead>(
+  const auto launch = [&]<typename StateT, int ValueHeadsPerKeyHead,
+                          int MaxTokens>() {
+    launch_gdn_decode_post_conv_mtp<StateT, ValueHeadsPerKeyHead, MaxTokens>(
         mixed_qkv, a_log, dt_bias, state_indices, cu_seqlens,
         num_accepted_tokens, state, norm_weight, out, a_ptr, b_ptr,
         output_gate_ptr, num_key_heads, num_value_heads, scale, norm_eps,
         strides);
   };
+  const auto dispatch_token_width = [&]<typename StateT,
+                                        int ValueHeadsPerKeyHead>() {
+    if (state_indices.size(1) <= kWarps) {
+      launch.template operator()<StateT, ValueHeadsPerKeyHead, kWarps>();
+    } else {
+      launch.template operator()<StateT, ValueHeadsPerKeyHead, kMaxMtpTokens>();
+    }
+  };
   const auto dispatch_state_type = [&]<int ValueHeadsPerKeyHead>() {
     if (state_scalar_type == ScalarType::Float) {
-      launch.template operator()<float, ValueHeadsPerKeyHead>();
+      dispatch_token_width.template operator()<float, ValueHeadsPerKeyHead>();
     } else {
-      launch.template operator()<__nv_bfloat16, ValueHeadsPerKeyHead>();
+      dispatch_token_width
+          .template operator()<__nv_bfloat16, ValueHeadsPerKeyHead>();
     }
   };
   switch (value_heads_per_key_head) {

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -77,7 +77,7 @@ class _TestGatedNorm:
         )
 
 
-def _make_vllm_config():
+def _make_vllm_config(num_spec: int = NUM_SPEC):
     config = create_vllm_config(
         model_name="Qwen/Qwen3.5-0.8B",
         block_size=BLOCK_SIZE,
@@ -86,7 +86,7 @@ def _make_vllm_config():
     config.additional_config = {"gdn_prefill_backend": "cutedsl"}
     config.cache_config.mamba_cache_mode = "none"
     config.speculative_config = SpeculativeConfig(
-        method="ngram", num_speculative_tokens=NUM_SPEC
+        method="ngram", num_speculative_tokens=num_spec
     )
     return config
 
@@ -181,6 +181,42 @@ def test_fused_mtp_head_ratio_guard(num_v_heads: int, expected: bool) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "state_width,expected",
+    [
+        pytest.param(8, True, id="width8"),
+        pytest.param(9, True, id="width9-dspark-k8"),
+        pytest.param(10, False, id="width10"),
+    ],
+)
+def test_fused_mtp_token_width_guard(state_width: int, expected: bool) -> None:
+    if not hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp"):
+        pytest.skip("fused GDN decode MTP op is not built")
+
+    layer = types.SimpleNamespace(
+        num_k_heads=2,
+        num_v_heads=4,
+        kv_cache=(None, torch.empty(1, dtype=torch.float32, device="cuda")),
+        gdn_decode_kernel="cuda",
+    )
+    attn_metadata = types.SimpleNamespace(
+        spec_state_indices_tensor=torch.ones(
+            1, state_width, dtype=torch.int32, device="cuda"
+        ),
+        spec_sequence_masks=object(),
+        num_decodes=0,
+        num_spec_decodes=1,
+    )
+
+    assert (
+        QwenGatedDeltaNetAttention._can_use_fused_gdn_mtp_decode(
+            cast(QwenGatedDeltaNetAttention, layer),
+            cast(GDNAttentionMetadata, attn_metadata),
+        )
+        is expected
+    )
+
+
 @torch.inference_mode()
 def test_fused_forward_uses_packed_entrypoint() -> None:
     """Fused mode keeps projected QKVZ and BA packed through the model op."""
@@ -236,22 +272,32 @@ def test_fused_forward_uses_packed_entrypoint() -> None:
 
 
 @pytest.mark.parametrize(
-    "seq_lens,query_lens,draft_tokens,expected_fused_calls",
+    "num_spec,seq_lens,query_lens,draft_tokens,expected_fused_calls",
     [
-        pytest.param([128], [SPEC_TOKENS], [NUM_SPEC], 1, id="pure-mtp"),
+        pytest.param(NUM_SPEC, [128], [SPEC_TOKENS], [NUM_SPEC], 1, id="pure-mtp"),
         pytest.param(
+            NUM_SPEC,
             [128, 96],
             [SPEC_TOKENS, 64],
             [NUM_SPEC, -1],
             0,
             id="mixed-mtp-falls-back",
         ),
-        pytest.param([96], [64], [-1], 0, id="pure-prefill"),
-        pytest.param([128], [1], [-1], 0, id="pure-decode"),
+        pytest.param(NUM_SPEC, [96], [64], [-1], 0, id="pure-prefill"),
+        pytest.param(NUM_SPEC, [128], [1], [-1], 0, id="pure-decode"),
+        pytest.param(
+            8,
+            [128],
+            [9],
+            [8],
+            1,
+            id="pure-width9-target-verification",
+        ),
     ],
 )
 @torch.inference_mode()
 def test_fused_model_path_matches_reference(
+    num_spec: int,
     seq_lens: list[int],
     query_lens: list[int],
     draft_tokens: list[int],
@@ -260,13 +306,13 @@ def test_fused_model_path_matches_reference(
     """Fused MTP and its mixed/prefill/decode fallbacks match the reference."""
     torch.manual_seed(1)
     device = torch.device("cuda")
-    vllm_config = _make_vllm_config()
+    vllm_config = _make_vllm_config(num_spec)
     builder = GDNAttentionMetadataBuilder(
         kv_cache_spec=MambaSpec(
             block_size=BLOCK_SIZE,
             shapes=((16, 64),),
             dtypes=(torch.float16,),
-            num_speculative_blocks=NUM_SPEC,
+            num_speculative_blocks=num_spec,
         ),
         layer_names=[PREFIX],
         vllm_config=vllm_config,
@@ -276,6 +322,20 @@ def test_fused_model_path_matches_reference(
     common = create_common_attn_metadata(
         batch, BLOCK_SIZE, device, arange_block_indices=True
     )
+    # The generic attention fixture sizes block tables from sequence length.
+    # Production Mamba allocation reserves one state slot per verification token.
+    missing_state_slots = num_spec + 1 - common.block_table_tensor.size(1)
+    if missing_state_slots > 0:
+        next_block = int(common.block_table_tensor.max().item()) + 1
+        extra_blocks = torch.arange(
+            next_block,
+            next_block + batch.batch_size * missing_state_slots,
+            dtype=common.block_table_tensor.dtype,
+            device=device,
+        ).view(batch.batch_size, missing_state_slots)
+        common.block_table_tensor = torch.cat(
+            (common.block_table_tensor, extra_blocks), dim=1
+        )
     common.block_table_tensor.add_(1)
     with set_current_vllm_config(vllm_config):
         metadata = builder.build(
@@ -298,7 +358,7 @@ def test_fused_model_path_matches_reference(
     pool_size = max(int(indices.max().item()) for indices in state_indices) + 1
     conv_state_shape, temporal_state_shape = (
         MambaStateShapeCalculator.gated_delta_net_state_shape(
-            1, H, HV, K, V, CONV_KERNEL, NUM_SPEC
+            1, H, HV, K, V, CONV_KERNEL, num_spec
         )
     )
     conv_state_seed = 0.05 * torch.randn(

--- a/tests/kernels/test_fused_gdn_post_conv.py
+++ b/tests/kernels/test_fused_gdn_post_conv.py
@@ -250,6 +250,22 @@ def test_fused_post_conv_l0():
             id="ratio2-tp4-max-fp32",
         ),
         pytest.param(
+            2,
+            1,
+            (9, 7, 0),
+            torch.float32,
+            torch.bfloat16,
+            id="ratio2-tp1-dspark-width9-fp32",
+        ),
+        pytest.param(
+            2,
+            1,
+            (9,),
+            torch.bfloat16,
+            torch.float32,
+            id="ratio2-tp1-dspark-width9-bf16",
+        ),
+        pytest.param(
             3,
             2,
             (4, 2, 0),

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -86,7 +86,7 @@ if GDN_AITER_TRITON_AVAILABLE:
 
 logger = init_logger(__name__)
 
-MAX_FUSED_GDN_MTP_TOKENS = 8
+MAX_FUSED_GDN_MTP_TOKENS = 9
 FUSED_GDN_STATE_DTYPES = (torch.float32, torch.bfloat16)
 
 


### PR DESCRIPTION
## Purpose

#52539 enabled the production Qwen GDN head ratios, but the fused MTP
post-convolution kernel accepted at most eight verification tokens.
Qwen3.6 DSpark K=8 verifies `K + 1 = 9` tokens, so all 30 GDN layers
otherwise fall back to the Triton sequence.

This PR adds a width-9 specialization while preserving the existing
`MaxTokens=8` specialization for older widths. The public operator ABI and
build configuration are unchanged.

## Test Plan

```bash
python -m pytest -q tests/kernels/test_fused_gdn_post_conv.py
python -m pytest -q tests/kernels/mamba/test_gdn_fused_mtp.py
python -m pytest -q \
  'tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_dspark.py::test_dspark_correctness_and_acceptance_rate[qwen3.6-speculators]'
pre-commit run --files \
  csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/kernels/test_fused_gdn_post_conv.py \
  tests/kernels/mamba/test_gdn_fused_mtp.py
```

## Test Results

- Low-level post-convolution tests: **77 passed**.
- GDN MTP model-path tests: **16 passed**.
- Pre-commit on all four changed files: **passed**.
- Official 200-question NVFP4 DSpark test: **passed**; GSM8K accuracy
  `0.875`, acceptance rate `0.454`, acceptance length `4.630`.

### Full-model generation

The official `Qwen/Qwen3.6-35B-A3B-FP8` target and
`RedHatAI/Qwen3.6-35B-A3B-speculator.dspark` draft were tested at TP1 in
eager mode with greedy 64-token generation, three warmup rounds, and 15
measured ABBA rounds within one model load:

| Batch | Full-model generation speedup | TPOT speedup | Generation / TPOT wins |
|---:|---:|---:|---:|
| 1 | **1.121x** | **1.135x** | 15/15 / 15/15 |
| 4 | **1.119x** | **1.130x** | 15/15 / 15/15 |

`Full-model generation` is synchronized elapsed time for one complete
offline `LLM.generate` call over the full batch, including prefill and
decode; model loading, warmup, arm switching, probes, metrics, and
HTTP/network serving are excluded. At B4 it is full-batch completion time.
The table reports the median of 15 paired fallback/fused ratios.

Non-timed probes confirmed that all 30 GDN layers saw width nine: the fused
arm used CUDA on every eligible call and the fallback arm used it on none.
All 300 measured requests had identical prompt IDs, output IDs, and
speculative work across arms, with zero cached tokens. B2/B8/B16 timings
were excluded because speculative work differed, although output IDs
matched.

### Kernel boundary

Fixed-input Qwen3.6 TP1 width-9 benchmarks used 60 paired ABBA samples per
batch and mode; ranges below cover B1/B4/B16/B64:

| GPU | Eager paired-median range | CUDA Graph paired-median range | Outcomes |
|---|---:|---:|---:|
| RTX PRO 6000 Blackwell (SM120) | **1.017x-1.644x** | **1.009x-1.359x** | 479 wins, 1 tie, 0 losses |
| NVIDIA H20 (SM90a) | **1.442x-1.918x** | **1.423x-1.789x** | 479 wins, 1 tie, 0 losses |

Maximum width-9 output/full-state relative L2 was
`4.174e-5 / 5.521e-8` on the RTX PRO 6000 and
`3.37e-5 / 5.48e-8` on H20 at the production FP32-state geometry. For
tested widths up to eight, outputs and full state were bitwise equal to
base, and audited `MaxTokens=8` device code was byte-identical.

These are custom out-of-tree kernel-boundary measurements. The H20 audit
did not use a Qwen3.6 DSpark checkpoint and makes no model-level or serving
end-to-end claim.

