### PR TITLE
[Bugfix][GDN] Reset speculative decode count for an empty draft schedule

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -239,6 +239,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 or num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item()
                 == 0
             ):
+                num_spec_decodes = 0
                 spec_sequence_masks = None
                 spec_sequence_masks_cpu = None
             else:


### PR DESCRIPTION
## Summary

Reset `num_spec_decodes` when speculative decoding is enabled but every scheduled draft-token count is zero.

PR #52078 correctly falls back to the regular-decode path in that case by clearing the speculative masks, but it leaves the previously counted speculative sequence total nonzero. The later metadata invariant then sees both regular and speculative decodes in the same batch and fails with:

```text
AssertionError: num_decodes: 2, num_spec_decodes: 2
```

This one-line fix keeps the count consistent with the cleared masks.

## Regression evidence

Nightly main Buildkite #84753 failed `models/kimi_k3/test_kda_metadata.py::test_kimi_k3_kda_metadata_matches_shared_gdn[no-scheduled-draft-tokens]` in the B200 Kimi K3 job. The exact Kimi K3 job was blocked in PR #52078's otherwise-green Buildkite #84686, so this configuration had no pre-merge signal.

- Failing main job: https://buildkite.com/vllm/ci/builds/84753#01a01dc2-e627-4c36-99ba-f860588fda26
- Suspected source: #52078

## Duplicate-work check

Searched open PRs for `52078`, `Kimi K3 GDN metadata`, and `num_decodes num_spec_decodes`; no open PR addresses this zero-draft count inconsistency. The related open GDN/KDA PRs concern different first-chunk, bounds, or mixed-batch behaviors.

## Validation

- `git diff --check` — passed
- `/home/ubuntu/vllm/.venv/bin/python -m compileall -q vllm/v1/attention/backends/gdn_attn.py` — passed
- Exact local pytest could not run because the available environment does not contain pytest/GPU test dependencies.
- Exact B200 Kimi K3 targeted Buildkite validation will be attached before review/merge.

Model evaluation is not applicable; this only corrects internal metadata bookkeeping for a zero-draft schedule.

## AI assistance

This patch and investigation were prepared with OpenAI Codex assistance. A human submitter must review and understand the one-line change and validation evidence before merge.
