### PR TITLE
[Bugfix][Core] Ignore stale KV-transfer completions for aborted requests

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4762,6 +4762,45 @@ def test_abort_request_finished_recving():
     assert not scheduler.finished_recving_kv_req_ids
 
 
+def test_stale_kv_xfer_completion_for_aborted_request():
+    scheduler = create_scheduler(use_kv_connector=True)
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+    request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={},
+        total_num_scheduled_tokens=0,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    def xfer_finished() -> ModelRunnerOutput:
+        return ModelRunnerOutput(
+            req_ids=[],
+            req_id_to_index={},
+            kv_connector_output=KVConnectorOutput(
+                finished_recving={request.request_id},
+            ),
+        )
+
+    # First completion lands normally, then the client disconnects and the
+    # request is aborted and freed.
+    scheduler.update_from_output(scheduler_output, xfer_finished())
+    scheduler.finish_requests((request.request_id,), RequestStatus.FINISHED_ABORTED)
+    assert request.request_id not in scheduler.requests
+
+    # A duplicate/late completion for the same transfer must be ignored
+    # instead of tripping the assert.
+    scheduler.update_from_output(scheduler_output, xfer_finished())
+    assert request.request_id not in scheduler.requests
+
+
 def test_delayed_kv_connector_free_keeps_scheduler_active():
     scheduler = create_scheduler(use_kv_connector=True)
     queued_request, request = create_requests(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2816,8 +2816,14 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                # The request was aborted or finished while its KV receive
+                # was in flight; its blocks were already freed.
+                logger.warning(
+                    "Ignoring stale KV-receive completion for request %s", req_id
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
@@ -2825,7 +2831,13 @@ class Scheduler(SchedulerInterface):
                 self._free_blocks(self.requests[req_id])
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            req = self.requests.get(req_id)
+            if req is None:
+                # Same as above: stale completion for an aborted request.
+                logger.warning(
+                    "Ignoring stale KV-send completion for request %s", req_id
+                )
+                continue
             self._free_blocks(self.requests[req_id])
 
     def _update_requests_with_invalid_blocks(


### PR DESCRIPTION
### What

`_update_from_kv_xfer_finished` asserted `req_id in self.requests` for every `finished_recving` / `finished_sending` event. If a request is aborted (e.g. client disconnect) while its KV transfer is still in flight, the late or duplicate completion event trips the assert and crashes the engine core.

Downgrade to a warning and skip the event: the request's blocks were already freed by the abort path.

### Reproduction

Disaggregated prefill/decode (e.g. Mooncake connector): abort a request that is `WAITING_FOR_REMOTE_KVS` while the pull is in flight; when the transfer completes, the scheduler assert fires.

### Tests

- `test_stale_kv_xfer_completion_for_aborted_request`: complete a receive, abort the request, deliver a duplicate completion — must be ignored.
- Full `tests/v1/core/test_scheduler.py` passes (148 tests).
