### PR TITLE
[Perf][MoE] Share FlashInfer B12x MoE workspaces across layers

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -49,6 +49,10 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
         MoEActivation.RELU2_NO_MUL: "relu2",
     }
 
+    # Per-process (per-worker) buffers shared across layers; see
+    # _ensure_wrapper.
+    _shared_buffers: dict[tuple, tuple] = {}
+
     def __init__(
         self,
         moe_config: FusedMoEConfig,
@@ -239,6 +243,21 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
 
         from flashinfer.fused_moe import B12xMoEWrapper
 
+        # Workspaces are identical for every MoE layer and layers execute
+        # sequentially, so all layers share the buffers allocated by the
+        # first wrapper instead of paying the (large) per-layer cost.
+        key = (
+            self.global_num_experts,
+            self.topk,
+            self.hidden_dim,
+            self.intermediate_size_per_partition,
+            self.max_num_tokens,
+            self._activation_str,
+            torch.accelerator.current_device_index(),
+        )
+        shared = FlashInferB12xExperts._shared_buffers.get(key)
+        static_ws, dynamic_ws, output = shared if shared else (None, None, None)
+
         self._wrapper = B12xMoEWrapper(
             num_experts=self.global_num_experts,
             top_k=self.topk,
@@ -248,7 +267,16 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             max_num_tokens=self.max_num_tokens,
             num_local_experts=self.num_local_experts,
             activation=self._activation_str,
+            shared_static_workspace=static_ws,
+            shared_dynamic_workspace=dynamic_ws,
+            shared_output=output,
         )
+        if shared is None:
+            FlashInferB12xExperts._shared_buffers[key] = (
+                self._wrapper._static_workspace,
+                self._wrapper._dynamic_workspace,
+                self._wrapper._moe_output,
+            )
 
     def apply(
         self,


### PR DESCRIPTION
### What

Share the FlashInfer B12x MoE workspaces across layers within each worker process.

Today every MoE layer constructs its own `B12xMoEWrapper` with its own static workspace, dynamic workspace, and output buffer. For large-expert-count models this is a substantial per-layer GPU memory cost (e.g. ~640 MiB per layer on a 384-expert NVFP4 shape — 60+ GiB across layers). The workspaces are identically shaped for every layer and layers execute sequentially, so all layers can share the buffers allocated by the first wrapper.

### Dependency

**Depends on https://github.com/flashinfer-ai/flashinfer/pull/4603**, which adds the `shared_static_workspace` / `shared_dynamic_workspace` / `shared_output` parameters to `B12xMoEWrapper`. This PR is opened as a draft until that lands and the FlashInfer version pin is updated; with an older FlashInfer the new keyword arguments would raise `TypeError` at model init.

### Notes

- Sharing is keyed on `(global_num_experts, topk, hidden_dim, intermediate_size_per_partition, max_num_tokens, activation, device)`; layers with a different MoE config allocate their own buffers.
- No numerical change: the wrapper writes into the shared buffers on every call, and layers do not execute concurrently within a worker.
