### PR TITLE
[CI] Add explicit Buildkite step keys to 7 keyless test-area steps

### DIFF
--- a/.buildkite/test_areas/docker.yaml
+++ b/.buildkite/test_areas/docker.yaml
@@ -3,6 +3,7 @@ depends_on:
   - image-build-cpu
 steps:
 - label: ":computer: (CPU) Docker Build Metadata"
+  key: docker-build-metadata
   timeout_in_minutes: 20
   device: cpu-small
   source_file_dependencies:

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -389,6 +389,7 @@ steps:
   - pytest -s -v evals/gsm8k/test_gsm8k_offloading.py -k "deepseek-v4-flash"
 
 - label: ":nvidia: (H200) MRCR Eval Small Models"
+  key: lm-eval-mrcr-small-models
   device: h200_35gb
   timeout_in_minutes: 25
   source_file_dependencies:

--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -3,6 +3,7 @@ depends_on:
   - image-build
 steps:
 - label: ":nvidia: (H200) Rust Frontend OpenAI Coverage"
+  key: rust-frontend-openai-coverage
   timeout_in_minutes: 30
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -38,6 +39,7 @@ steps:
   - pytest -v -s v1/sample/test_logprobs_e2e.py -k "test_prompt_logprobs_e2e_server"
 
 - label: ":nvidia: (H200) Rust Frontend Serve/Admin Coverage"
+  key: rust-frontend-serve-admin-coverage
   timeout_in_minutes: 25
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -67,6 +69,7 @@ steps:
   - pytest -v -s entrypoints/serve/tokenize/test_tokenization.py -k "not tokenizer_info"
 
 - label: ":nvidia: (H200) Rust Frontend Core Correctness"
+  key: rust-frontend-core-correctness
   timeout_in_minutes: 20
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -81,6 +84,7 @@ steps:
   - pytest -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
 
 - label: ":nvidia: (H200) Rust Frontend Tool Use"
+  key: rust-frontend-tool-use
   device: h200_35gb
   timeout_in_minutes: 25
   working_dir: "/vllm-workspace/tests"
@@ -96,6 +100,7 @@ steps:
   - pytest -v -s tool_use --ignore=tool_use/mistral --models llama3.2 -k "not test_response_format_with_tool_choice_required and not test_parallel_tool_calls_false and not test_tool_call_and_choice"
 
 - label: ":nvidia: (L4) Rust Frontend Distributed"
+  key: rust-frontend-distributed
   timeout_in_minutes: 25
   num_devices: 4
   working_dir: "/vllm-workspace/tests"


### PR DESCRIPTION
## Why

Steps without an explicit `key:` only get one derived from their label during group conversion in the ci-infra pipeline generator — which runs **after** test-area candidacy is computed for nightly trace enrollment (`read_steps_from_job_dir` collects `step.key` while keyless steps still have `key=None`). These 7 plain-pytest steps are therefore silently invisible to key-based CI automation, including the nightly trace-instrumentation enrollment.

## What

Adds explicit `key:` to the 7 affected steps — no label, command, dependency, timeout, or device changes:

- `.buildkite/test_areas/rust_frontend.yaml` (5): `rust-frontend-openai-coverage`, `rust-frontend-serve-admin-coverage`, `rust-frontend-core-correctness`, `rust-frontend-tool-use`, `rust-frontend-distributed` — following the `rust-frontend-*` convention from `rust_frontend_cargo.yaml`
- `.buildkite/test_areas/lm_eval.yaml` (1): `lm-eval-mrcr-small-models` — following the `lm-eval-*` convention
- `.buildkite/test_areas/docker.yaml` (1): `docker-build-metadata`

## Notes

- Adding `key:` changes the Buildkite step identity for these 7 steps (previously auto-derived from labels, e.g. `-nvidia--h200-mrcr-eval-small-models`). Label-keyed dashboards/automation are unaffected.
- **Nightly behavior change (render-verified):** this is not a cosmetic keying PR. On the first real main nightly after this merges, these 7 steps become newly trace-enrolled (5 kernel-set, 2 python-only): the traced inventory moves 123 → 130 and always-run 190 → 183, with per-key timeouts bumped by the tracing rule. Instrumentation is fail-closed — any collector failure marks the job unhealthy and keeps it in the always-run set — but reviewers should know this changes nightly behavior, not just step identity.

## Validation

Generator probe against this tree (ci-infra `configure_test_tracing` on `.buildkite/test_areas`): all 7 keys are visible at candidacy time and enroll as traced jobs under the nightly path — `docker-build-metadata` and `rust-frontend-distributed` as python-only, the other five as kernel-set; none fall to always-run.



## AI-assistance disclosure (per AGENTS.md)

- **AI assistance was used** in creating this change (drafted and verified by an AI agent working under human direction).
- **Not a duplicate:** no existing PR adds keys to these steps; motivated by the CI trace-enrollment work in vllm-project/ci-infra#469 (keyless steps are invisible to key-based automation).
- **Tests:** generator probe at this head — all 7 keys enroll under the nightly trace path (5 kernel-set, 2 python-only), none fall to always-run; key uniqueness verified across all 240 steps; no other diff. Bash/YAML unchanged besides the 7 added `key:` lines.
- **Model evaluation:** not applicable (CI metadata change; no output/accuracy/serving surface).
