### PR TITLE
[Perf][Spec Decode] Fuse target temperature in rejection sampler

### DIFF
--- a/benchmarks/kernels/benchmark_rejection_sampler_temperature.py
+++ b/benchmarks/kernels/benchmark_rejection_sampler_temperature.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from functools import partial
+
+import torch
+
+from vllm.triton_utils import triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.worker.gpu.sample.gumbel import apply_temperature
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+    rejection_sample,
+)
+
+
+def make_inputs(
+    batch_size: int,
+    num_speculative_steps: int,
+    vocab_size: int,
+    temperature: float,
+    dtype: torch.dtype,
+    with_draft_logits: bool,
+) -> dict[str, torch.Tensor]:
+    device = "cuda"
+    num_logits = batch_size * (num_speculative_steps + 1)
+    target_logits = torch.randn(num_logits, vocab_size, dtype=dtype, device=device)
+    draft_sampled = torch.randint(
+        vocab_size,
+        (batch_size, num_speculative_steps + 1),
+        dtype=torch.int64,
+        device=device,
+    )
+    draft_sampled[:, 0] = 0
+    idx_mapping = torch.arange(batch_size, dtype=torch.int32, device=device)
+    expanded_idx_mapping = idx_mapping.repeat_interleave(num_speculative_steps + 1)
+    expanded_local_pos = torch.arange(
+        num_speculative_steps + 1, dtype=torch.int32, device=device
+    ).repeat(batch_size)
+
+    inputs = {
+        "target_logits": target_logits,
+        "draft_sampled": draft_sampled.flatten(),
+        "cu_num_logits": torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+        * (num_speculative_steps + 1),
+        "pos": torch.arange(num_logits, dtype=torch.int32, device=device),
+        "idx_mapping": idx_mapping,
+        "expanded_idx_mapping": expanded_idx_mapping,
+        "expanded_local_pos": expanded_local_pos,
+        "temperature": torch.full(
+            (batch_size,), temperature, dtype=torch.float32, device=device
+        ),
+        "seed": torch.arange(batch_size, dtype=torch.int64, device=device),
+    }
+    if with_draft_logits:
+        inputs["draft_logits"] = torch.randn(
+            batch_size,
+            num_speculative_steps,
+            vocab_size,
+            dtype=dtype,
+            device=device,
+        )
+    return inputs
+
+
+def run_baseline(
+    inputs: dict[str, torch.Tensor], num_speculative_steps: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    processed_logits = torch.empty_like(
+        inputs["target_logits"], dtype=torch.float32
+    ).copy_(inputs["target_logits"])
+    apply_temperature(
+        processed_logits,
+        inputs["expanded_idx_mapping"],
+        inputs["temperature"],
+    )
+    return rejection_sample(
+        target_logits=processed_logits,
+        draft_logits=inputs.get("draft_logits"),
+        num_speculative_steps=num_speculative_steps,
+        **{
+            key: value
+            for key, value in inputs.items()
+            if key not in ("target_logits", "draft_logits")
+        },
+    )
+
+
+def run_fused(
+    inputs: dict[str, torch.Tensor], num_speculative_steps: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return rejection_sample(
+        target_logits=inputs["target_logits"],
+        draft_logits=inputs.get("draft_logits"),
+        num_speculative_steps=num_speculative_steps,
+        apply_target_temperature=True,
+        **{
+            key: value
+            for key, value in inputs.items()
+            if key not in ("target_logits", "draft_logits")
+        },
+    )
+
+
+def assert_outputs_equal(
+    baseline: tuple[torch.Tensor, torch.Tensor],
+    fused: tuple[torch.Tensor, torch.Tensor],
+    num_speculative_steps: int,
+) -> None:
+    baseline_sampled, baseline_num_sampled = baseline
+    fused_sampled, fused_num_sampled = fused
+    torch.testing.assert_close(fused_num_sampled, baseline_num_sampled, rtol=0, atol=0)
+    steps = torch.arange(
+        num_speculative_steps + 1, device=baseline_sampled.device
+    ).unsqueeze(0)
+    valid = steps < baseline_num_sampled.unsqueeze(1)
+    torch.testing.assert_close(
+        fused_sampled[valid], baseline_sampled[valid], rtol=0, atol=0
+    )
+
+
+def measure_peak_memory(callable_) -> int:
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    allocated = torch.cuda.memory_allocated()
+    output = callable_()
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated() - allocated
+    del output
+    return peak
+
+
+def main(args) -> None:
+    dtype = getattr(torch, args.dtype)
+    print(
+        "batch  rows  baseline_ms  fused_ms  speedup  "
+        "baseline_peak_MiB  fused_peak_MiB  saved_MiB"
+    )
+    for batch_size in args.batch_sizes:
+        inputs = make_inputs(
+            batch_size,
+            args.num_speculative_steps,
+            args.vocab_size,
+            args.temperature,
+            dtype,
+            args.with_draft_logits,
+        )
+        baseline_call = partial(run_baseline, inputs, args.num_speculative_steps)
+        fused_call = partial(run_fused, inputs, args.num_speculative_steps)
+
+        baseline_output = baseline_call()
+        fused_output = fused_call()
+        torch.cuda.synchronize()
+        assert_outputs_equal(baseline_output, fused_output, args.num_speculative_steps)
+        del baseline_output, fused_output
+
+        baseline_ms = triton.testing.do_bench(
+            baseline_call, warmup=args.warmup_ms, rep=args.rep_ms
+        )
+        fused_ms = triton.testing.do_bench(
+            fused_call, warmup=args.warmup_ms, rep=args.rep_ms
+        )
+        baseline_peak = measure_peak_memory(baseline_call)
+        fused_peak = measure_peak_memory(fused_call)
+        mib = 1024**2
+        print(
+            f"{batch_size:5d}  {batch_size * (args.num_speculative_steps + 1):4d}  "
+            f"{baseline_ms:11.3f}  {fused_ms:8.3f}  "
+            f"{baseline_ms / fused_ms:7.3f}x  "
+            f"{baseline_peak / mib:17.1f}  {fused_peak / mib:14.1f}  "
+            f"{(baseline_peak - fused_peak) / mib:9.1f}"
+        )
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(
+        description="Benchmark in-kernel target temperature for rejection sampling."
+    )
+    parser.add_argument("--batch-sizes", type=int, nargs="+", default=[1, 8, 32, 128])
+    parser.add_argument("--num-speculative-steps", type=int, default=4)
+    parser.add_argument("--vocab-size", type=int, default=151936)
+    parser.add_argument("--temperature", type=float, default=0.6)
+    parser.add_argument(
+        "--dtype", choices=["float32", "float16", "bfloat16"], default="bfloat16"
+    )
+    parser.add_argument("--with-draft-logits", action="store_true")
+    parser.add_argument("--warmup-ms", type=int, default=100)
+    parser.add_argument("--rep-ms", type=int, default=500)
+    main(parser.parse_args())

--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
+++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
@@ -140,17 +140,22 @@ def _assert_distribution_match(
 
 
 @pytest.mark.parametrize(
-    "num_speculative_steps,temperature",
+    "num_speculative_steps,temperature,apply_target_temperature",
     [
-        (1, 0.6),
-        (3, 0.6),
-        (1, 1.0),
-        (3, 1.0),
+        (1, 0.6, False),
+        (3, 0.6, False),
+        (1, 1.0, False),
+        (3, 1.0, False),
+        (1, 0.6, True),
+        (3, 0.6, True),
     ],
 )
 @pytest.mark.parametrize("draft_logits_dtype", [torch.float32, torch.bfloat16])
 def test_stochastic_rejection_sample(
-    num_speculative_steps: int, temperature: float, draft_logits_dtype: torch.dtype
+    num_speculative_steps: int,
+    temperature: float,
+    apply_target_temperature: bool,
+    draft_logits_dtype: torch.dtype,
 ):
     """
     Verify that rejection sampling produces the target distribution.
@@ -168,13 +173,14 @@ def test_stochastic_rejection_sample(
     device = "cuda"
     num_trials = 10 * VOCAB_SIZE
 
-    target_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+    raw_target_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+    target_logits_1d = raw_target_logits_1d
     draft_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32).to(
         draft_logits_dtype
     )
 
-    if temperature > 0:
-        target_logits_1d /= temperature
+    if temperature > 0 and not apply_target_temperature:
+        target_logits_1d = target_logits_1d / temperature
 
     inputs = _build_rejection_sample_inputs(
         target_logits_1d,
@@ -185,10 +191,15 @@ def test_stochastic_rejection_sample(
     )
 
     sampled, num_sampled = rejection_sample(
-        **inputs, num_speculative_steps=num_speculative_steps
+        **inputs,
+        num_speculative_steps=num_speculative_steps,
+        apply_target_temperature=apply_target_temperature,
     )
 
-    target_probs = torch.softmax(target_logits_1d, dim=0)
+    processed_target_logits_1d = raw_target_logits_1d
+    if temperature > 0:
+        processed_target_logits_1d = processed_target_logits_1d / temperature
+    target_probs = torch.softmax(processed_target_logits_1d, dim=0)
     for pos in range(num_speculative_steps + 1):
         accepted_mask = num_sampled >= pos + 1
         _assert_distribution_match(
@@ -289,6 +300,168 @@ def test_gumbel_drafted_rejection_sample_is_unbiased(num_speculative_steps: int)
         _assert_distribution_match(
             sampled[accepted_mask, pos], target_probs, device, label=f"position {pos}"
         )
+@pytest.mark.parametrize("target_dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("has_draft_logits", [True, False])
+@pytest.mark.parametrize("use_block_verification", [True, False])
+def test_in_kernel_target_temperature_matches_preprocessing(
+    target_dtype: torch.dtype,
+    has_draft_logits: bool,
+    use_block_verification: bool,
+):
+    torch.manual_seed(42)
+    device = "cuda"
+    num_trials = 64
+    num_speculative_steps = 3
+    temperature = 0.6
+
+    raw_target_logits_1d = torch.randn(
+        VOCAB_SIZE, device=device, dtype=torch.float32
+    ).to(target_dtype)
+    processed_target_logits_1d = raw_target_logits_1d.float() / temperature
+    draft_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.bfloat16)
+    processed_inputs = _build_rejection_sample_inputs(
+        processed_target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+    raw_inputs = dict(processed_inputs)
+    raw_inputs["target_logits"] = (
+        raw_target_logits_1d.unsqueeze(0)
+        .expand(num_trials * (num_speculative_steps + 1), -1)
+        .contiguous()
+    )
+    if not has_draft_logits:
+        processed_inputs["draft_logits"] = None
+        raw_inputs["draft_logits"] = None
+
+    expected = rejection_sample(
+        **processed_inputs,
+        num_speculative_steps=num_speculative_steps,
+        use_block_verification=use_block_verification,
+    )
+    actual = rejection_sample(
+        **raw_inputs,
+        num_speculative_steps=num_speculative_steps,
+        use_block_verification=use_block_verification,
+        apply_target_temperature=True,
+    )
+
+    assert torch.equal(actual[1], expected[1])
+    steps = torch.arange(num_speculative_steps + 1, device=device).unsqueeze(0)
+    valid = steps < expected[1].unsqueeze(1)
+    assert torch.equal(actual[0][valid], expected[0][valid])
+
+
+def test_in_kernel_target_temperature_supports_mixed_requests():
+    torch.manual_seed(42)
+    device = "cuda"
+    num_trials = 6
+    num_speculative_steps = 2
+    num_logits = num_trials * (num_speculative_steps + 1)
+    temperatures = torch.tensor(
+        [0.0, 0.6, 1.0, 0.8, 0.0, 1.0], dtype=torch.float32, device=device
+    )
+    idx_mapping = torch.arange(num_trials, dtype=torch.int32, device=device)
+    expanded_idx_mapping = idx_mapping.repeat_interleave(num_speculative_steps + 1)
+    expanded_local_pos = torch.arange(
+        num_speculative_steps + 1, dtype=torch.int32, device=device
+    ).repeat(num_trials)
+    row_temperatures = temperatures[expanded_idx_mapping.long()]
+
+    raw_target_logits = torch.randn(
+        num_logits, VOCAB_SIZE, dtype=torch.bfloat16, device=device
+    )
+    processed_target_logits = raw_target_logits.float()
+    scaled_rows = (row_temperatures != 0.0) & (row_temperatures != 1.0)
+    processed_target_logits[scaled_rows] /= row_temperatures[scaled_rows, None]
+    draft_sampled = torch.randint(
+        VOCAB_SIZE, (num_logits,), dtype=torch.int64, device=device
+    )
+    cu_num_logits = torch.arange(num_trials + 1, dtype=torch.int32, device=device) * (
+        num_speculative_steps + 1
+    )
+    pos = torch.arange(num_logits, dtype=torch.int32, device=device)
+    seed = torch.arange(num_trials, dtype=torch.int64, device=device)
+    common_inputs = dict(
+        draft_logits=None,
+        draft_sampled=draft_sampled,
+        cu_num_logits=cu_num_logits,
+        pos=pos,
+        idx_mapping=idx_mapping,
+        expanded_idx_mapping=expanded_idx_mapping,
+        expanded_local_pos=expanded_local_pos,
+        temperature=temperatures,
+        seed=seed,
+        num_speculative_steps=num_speculative_steps,
+    )
+
+    expected = rejection_sample(target_logits=processed_target_logits, **common_inputs)
+    actual = rejection_sample(
+        target_logits=raw_target_logits,
+        apply_target_temperature=True,
+        **common_inputs,
+    )
+
+    assert torch.equal(actual[1], expected[1])
+    steps = torch.arange(num_speculative_steps + 1, device=device).unsqueeze(0)
+    valid = steps < expected[1].unsqueeze(1)
+    assert torch.equal(actual[0][valid], expected[0][valid])
+
+
+def test_in_kernel_target_temperature_stress_matches_preprocessing():
+    torch.manual_seed(42)
+    device = "cuda"
+    num_trials = 8192
+    num_speculative_steps = 1
+    temperature = 0.6
+
+    num_logits = num_trials * (num_speculative_steps + 1)
+    raw_target_logits = torch.randn(
+        num_logits, VOCAB_SIZE, device=device, dtype=torch.bfloat16
+    )
+    draft_sampled = torch.randint(
+        VOCAB_SIZE,
+        (num_trials, num_speculative_steps + 1),
+        dtype=torch.int64,
+        device=device,
+    )
+    draft_sampled[:, 0] = 0
+    idx_mapping = torch.arange(num_trials, dtype=torch.int32, device=device)
+    common_inputs = dict(
+        draft_logits=None,
+        draft_sampled=draft_sampled.flatten(),
+        cu_num_logits=torch.arange(num_trials + 1, dtype=torch.int32, device=device)
+        * (num_speculative_steps + 1),
+        pos=torch.arange(num_logits, dtype=torch.int32, device=device),
+        idx_mapping=idx_mapping,
+        expanded_idx_mapping=idx_mapping.repeat_interleave(num_speculative_steps + 1),
+        expanded_local_pos=torch.arange(
+            num_speculative_steps + 1, dtype=torch.int32, device=device
+        ).repeat(num_trials),
+        temperature=torch.full(
+            (num_trials,), temperature, dtype=torch.float32, device=device
+        ),
+        seed=torch.arange(num_trials, dtype=torch.int64, device=device),
+    )
+
+    expected = rejection_sample(
+        target_logits=raw_target_logits.float() / temperature,
+        **common_inputs,
+        num_speculative_steps=num_speculative_steps,
+    )
+    actual = rejection_sample(
+        target_logits=raw_target_logits,
+        **common_inputs,
+        num_speculative_steps=num_speculative_steps,
+        apply_target_temperature=True,
+    )
+
+    assert torch.equal(actual[1], expected[1])
+    steps = torch.arange(num_speculative_steps + 1, device=device).unsqueeze(0)
+    valid = steps < expected[1].unsqueeze(1)
+    assert torch.equal(actual[0][valid], expected[0][valid])
 
 
 @pytest.mark.parametrize("num_speculative_steps", [1, 3])

--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
+++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
@@ -300,25 +300,36 @@ def test_gumbel_drafted_rejection_sample_is_unbiased(num_speculative_steps: int)
         _assert_distribution_match(
             sampled[accepted_mask, pos], target_probs, device, label=f"position {pos}"
         )
-@pytest.mark.parametrize("target_dtype", [torch.float32, torch.bfloat16])
+
+
+@pytest.mark.parametrize(
+    ("target_dtype", "vocab_size", "num_trials"),
+    [
+        (torch.float32, VOCAB_SIZE, 64),
+        (torch.float16, VOCAB_SIZE, 64),
+        (torch.bfloat16, VOCAB_SIZE, 64),
+        (torch.bfloat16, 8193, 4),
+    ],
+)
 @pytest.mark.parametrize("has_draft_logits", [True, False])
-@pytest.mark.parametrize("use_block_verification", [True, False])
+@pytest.mark.parametrize("verification_mode", ["standard", "block", "synthetic"])
 def test_in_kernel_target_temperature_matches_preprocessing(
     target_dtype: torch.dtype,
+    vocab_size: int,
+    num_trials: int,
     has_draft_logits: bool,
-    use_block_verification: bool,
+    verification_mode: str,
 ):
     torch.manual_seed(42)
     device = "cuda"
-    num_trials = 64
     num_speculative_steps = 3
     temperature = 0.6
 
     raw_target_logits_1d = torch.randn(
-        VOCAB_SIZE, device=device, dtype=torch.float32
+        vocab_size, device=device, dtype=torch.float32
     ).to(target_dtype)
     processed_target_logits_1d = raw_target_logits_1d.float() / temperature
-    draft_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.bfloat16)
+    draft_logits_1d = torch.randn(vocab_size, device=device, dtype=torch.bfloat16)
     processed_inputs = _build_rejection_sample_inputs(
         processed_target_logits_1d,
         draft_logits_1d,
@@ -336,16 +347,24 @@ def test_in_kernel_target_temperature_matches_preprocessing(
         processed_inputs["draft_logits"] = None
         raw_inputs["draft_logits"] = None
 
+    verification_kwargs = {}
+    if verification_mode == "block":
+        verification_kwargs["use_block_verification"] = True
+    elif verification_mode == "synthetic":
+        verification_kwargs["synthetic_conditional_rates"] = torch.full(
+            (num_speculative_steps,), 0.5, dtype=torch.float32, device=device
+        )
+
     expected = rejection_sample(
         **processed_inputs,
         num_speculative_steps=num_speculative_steps,
-        use_block_verification=use_block_verification,
+        **verification_kwargs,
     )
     actual = rejection_sample(
         **raw_inputs,
         num_speculative_steps=num_speculative_steps,
-        use_block_verification=use_block_verification,
         apply_target_temperature=True,
+        **verification_kwargs,
     )
 
     assert torch.equal(actual[1], expected[1])
@@ -402,60 +421,6 @@ def test_in_kernel_target_temperature_supports_mixed_requests():
         target_logits=raw_target_logits,
         apply_target_temperature=True,
         **common_inputs,
-    )
-
-    assert torch.equal(actual[1], expected[1])
-    steps = torch.arange(num_speculative_steps + 1, device=device).unsqueeze(0)
-    valid = steps < expected[1].unsqueeze(1)
-    assert torch.equal(actual[0][valid], expected[0][valid])
-
-
-def test_in_kernel_target_temperature_stress_matches_preprocessing():
-    torch.manual_seed(42)
-    device = "cuda"
-    num_trials = 8192
-    num_speculative_steps = 1
-    temperature = 0.6
-
-    num_logits = num_trials * (num_speculative_steps + 1)
-    raw_target_logits = torch.randn(
-        num_logits, VOCAB_SIZE, device=device, dtype=torch.bfloat16
-    )
-    draft_sampled = torch.randint(
-        VOCAB_SIZE,
-        (num_trials, num_speculative_steps + 1),
-        dtype=torch.int64,
-        device=device,
-    )
-    draft_sampled[:, 0] = 0
-    idx_mapping = torch.arange(num_trials, dtype=torch.int32, device=device)
-    common_inputs = dict(
-        draft_logits=None,
-        draft_sampled=draft_sampled.flatten(),
-        cu_num_logits=torch.arange(num_trials + 1, dtype=torch.int32, device=device)
-        * (num_speculative_steps + 1),
-        pos=torch.arange(num_logits, dtype=torch.int32, device=device),
-        idx_mapping=idx_mapping,
-        expanded_idx_mapping=idx_mapping.repeat_interleave(num_speculative_steps + 1),
-        expanded_local_pos=torch.arange(
-            num_speculative_steps + 1, dtype=torch.int32, device=device
-        ).repeat(num_trials),
-        temperature=torch.full(
-            (num_trials,), temperature, dtype=torch.float32, device=device
-        ),
-        seed=torch.arange(num_trials, dtype=torch.int64, device=device),
-    )
-
-    expected = rejection_sample(
-        target_logits=raw_target_logits.float() / temperature,
-        **common_inputs,
-        num_speculative_steps=num_speculative_steps,
-    )
-    actual = rejection_sample(
-        target_logits=raw_target_logits,
-        **common_inputs,
-        num_speculative_steps=num_speculative_steps,
-        apply_target_temperature=True,
     )
 
     assert torch.equal(actual[1], expected[1])

--- a/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
@@ -10,10 +10,54 @@ import torch
 
 from vllm.config.model import PROCESSED_LOGPROBS_MODES, LogprobsMode
 from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
     RejectionSampler,
     _iter_request_chunks,
 )
+
+
+@pytest.mark.parametrize(
+    (
+        "logprobs_mode",
+        "max_num_logprobs",
+        "active_flags",
+        "temperatures",
+        "expected",
+    ),
+    [
+        ("raw_logprobs", NO_LOGPROBS, [False, False], [0.6, 0.6], True),
+        ("raw_logprobs", 2, [False, False], [0.6, 0.6], True),
+        ("processed_logprobs", NO_LOGPROBS, [False, False], [0.6, 0.6], True),
+        ("processed_logprobs", 2, [False, False], [0.6, 0.6], False),
+        ("raw_logprobs", NO_LOGPROBS, [False, True], [0.6, 0.6], False),
+        ("raw_logprobs", NO_LOGPROBS, [False, False], [0.0, 1.0], False),
+        ("raw_logprobs", NO_LOGPROBS, [False, False], [0.0, 0.6], True),
+    ],
+)
+def test_target_temperature_fusion_eligibility(
+    logprobs_mode: str,
+    max_num_logprobs: int,
+    active_flags: list[bool],
+    temperatures: list[float],
+    expected: bool,
+):
+    rejection_sampler = object.__new__(RejectionSampler)
+    all_flags = np.array([True, *active_flags, True], dtype=bool)
+    rejection_sampler.sampler = SimpleNamespace(
+        logprobs_mode=logprobs_mode,
+        needs_non_temperature_logits_processing=all_flags,
+        sampling_states=SimpleNamespace(
+            temperature=SimpleNamespace(np=np.array([1.0, *temperatures, 1.0]))
+        ),
+    )
+
+    assert (
+        rejection_sampler._should_apply_target_temperature(
+            np.array([1, 2], dtype=np.int32), max_num_logprobs
+        )
+        is expected
+    )
 
 
 def test_iter_request_chunks_preserves_request_boundaries():

--- a/tests/v1/worker/test_gpu_sampler_flags.py
+++ b/tests/v1/worker/test_gpu_sampler_flags.py
@@ -42,32 +42,45 @@ def _make_sampler() -> Sampler:
 
 
 @pytest.mark.parametrize(
-    ("sampling_params", "expected"),
+    ("sampling_params", "expected", "expected_non_temperature"),
     [
-        pytest.param(SamplingParams(), False, id="defaults"),
-        pytest.param(SamplingParams(temperature=0.0), False, id="greedy"),
+        pytest.param(SamplingParams(), False, False, id="defaults"),
+        pytest.param(SamplingParams(temperature=0.0), False, False, id="greedy"),
         pytest.param(
-            SamplingParams(thinking_token_budget=3), True, id="thinking-budget"
+            SamplingParams(thinking_token_budget=3),
+            True,
+            True,
+            id="thinking-budget",
         ),
-        pytest.param(SamplingParams(logit_bias={1: 1.0}), True, id="logit-bias"),
-        pytest.param(SamplingParams(frequency_penalty=0.1), True, id="penalty"),
-        pytest.param(SamplingParams(_bad_words_token_ids=[[1]]), True, id="bad-words"),
-        pytest.param(SamplingParams(temperature=0.7), True, id="temperature"),
-        pytest.param(SamplingParams(min_p=0.1), True, id="min-p"),
-        pytest.param(SamplingParams(top_k=10), True, id="top-k"),
-        pytest.param(SamplingParams(top_p=0.9), True, id="top-p"),
+        pytest.param(SamplingParams(logit_bias={1: 1.0}), True, True, id="logit-bias"),
+        pytest.param(SamplingParams(frequency_penalty=0.1), True, True, id="penalty"),
         pytest.param(
-            SamplingParams.for_sampler_warmup(), True, id="all-logits-processors"
+            SamplingParams(_bad_words_token_ids=[[1]]), True, True, id="bad-words"
+        ),
+        pytest.param(SamplingParams(temperature=0.7), True, False, id="temperature"),
+        pytest.param(SamplingParams(min_p=0.1), True, True, id="min-p"),
+        pytest.param(SamplingParams(top_k=10), True, True, id="top-k"),
+        pytest.param(SamplingParams(top_p=0.9), True, True, id="top-p"),
+        pytest.param(
+            SamplingParams.for_sampler_warmup(),
+            True,
+            True,
+            id="all-logits-processors",
         ),
     ],
 )
 def test_logits_processing_cache_matches_request_features(
-    sampling_params: SamplingParams, expected: bool
+    sampling_params: SamplingParams,
+    expected: bool,
+    expected_non_temperature: bool,
 ):
     sampler = _make_sampler()
     sampler.add_request(3, prompt_len=1, sampling_params=sampling_params)
 
     assert sampler.needs_logits_processing[3] == expected
+    assert (
+        sampler.needs_non_temperature_logits_processing[3] == expected_non_temperature
+    )
 
 
 def test_logits_processing_cache_is_overwritten_when_slot_is_reused():
@@ -76,6 +89,7 @@ def test_logits_processing_cache_is_overwritten_when_slot_is_reused():
     sampler.add_request(3, 1, SamplingParams())
 
     assert not sampler.needs_logits_processing[3]
+    assert not sampler.needs_non_temperature_logits_processing[3]
 
 
 def test_logits_processing_cache_only_checks_active_requests():
@@ -88,3 +102,5 @@ def test_logits_processing_cache_only_checks_active_requests():
 
     assert not np.any(sampler.needs_logits_processing[sampling_only])
     assert np.any(sampler.needs_logits_processing[with_processing])
+    assert not np.any(sampler.needs_non_temperature_logits_processing[sampling_only])
+    assert np.any(sampler.needs_non_temperature_logits_processing[with_processing])

--- a/tests/v1/worker/test_gpu_warmup_blocks.py
+++ b/tests/v1/worker/test_gpu_warmup_blocks.py
@@ -130,6 +130,18 @@ class _StepRecorder:
         return None
 
 
+class _SamplerRecorder:
+    def __init__(self) -> None:
+        self.requests = []
+        self.applied_staged_writes = 0
+
+    def add_request(self, req_idx, prompt_len, sampling_params) -> None:
+        self.requests.append((req_idx, prompt_len, sampling_params))
+
+    def apply_staged_writes(self) -> None:
+        self.applied_staged_writes += 1
+
+
 def _assert_covers_lookahead(
     steps: list[tuple[list[int], int, int]], num_lookahead_tokens: int
 ) -> None:
@@ -158,6 +170,29 @@ def test_warmup_kernels_reserves_lookahead_blocks(num_spec_steps, extra_lookahea
     )
 
     _assert_covers_lookahead(recorder.steps, num_lookahead_tokens)
+
+
+def test_warmup_kernels_exercises_temperature_only_rejection_path():
+    runner = _make_runner([_attention_group()], NUM_SPEC_STEPS)
+    sampler = _SamplerRecorder()
+    runner.rejection_sampler = object()
+    runner.sampler = sampler
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={f"_warmup_{i}_": i for i in range(runner.max_num_reqs)}
+    )
+    recorder = _StepRecorder()
+
+    warmup_kernels(runner, recorder.execute_model, recorder.sample_tokens)
+
+    assert sampler.applied_staged_writes == 1
+    assert len(sampler.requests) == runner.max_num_reqs
+    for req_idx, prompt_len, sampling_params in sampler.requests:
+        assert req_idx in range(runner.max_num_reqs)
+        assert prompt_len == runner.decode_query_len + 1
+        assert sampling_params.temperature == 0.9
+        assert sampling_params.top_p == 1.0
+        assert sampling_params.top_k == 0
+        assert sampling_params.min_p == 0.0
 
 
 def test_mixed_warmup_reserves_lookahead_blocks():

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -59,6 +59,9 @@ class Sampler:
             TraceReplayState(req_states) if enable_trace_replay else None
         )
         self.needs_logits_processing = np.zeros(max_num_reqs, dtype=bool)
+        self.needs_non_temperature_logits_processing = np.zeros(
+            max_num_reqs, dtype=bool
+        )
         self.num_speculative_tokens = num_speculative_tokens
         self.return_sampling_mask = return_sampling_mask
         self.use_flashinfer = (
@@ -79,7 +82,7 @@ class Sampler:
 
         states = self.sampling_states
         temperature = states.temperature.np[req_idx]
-        self.needs_logits_processing[req_idx] = (
+        needs_non_temperature_processing = (
             self.logit_bias_state.use_logit_bias[req_idx]
             or self.penalties_state.use_penalty[req_idx]
             or self.bad_words_state.num_bad_words.np[req_idx] > 0
@@ -87,10 +90,15 @@ class Sampler:
                 self.thinking_budget_state.enabled
                 and self.thinking_budget_state.use_thinking_budget[req_idx]
             )
-            or (temperature != 0.0 and temperature != 1.0)
             or states.min_p.np[req_idx] != 0.0
             or states.top_k.np[req_idx] != states.vocab_size
             or states.top_p.np[req_idx] != 1.0
+        )
+        self.needs_non_temperature_logits_processing[req_idx] = (
+            needs_non_temperature_processing
+        )
+        self.needs_logits_processing[req_idx] = needs_non_temperature_processing or (
+            temperature != 0.0 and temperature != 1.0
         )
 
     def apply_staged_writes(self) -> None:

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -23,11 +23,10 @@ from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
     rejection_sample,
 )
 
-# Cap on the FP32 target-logits buffer materialized by apply_sampling_params.
-# TODO(mgoin): Chunking is a workaround. The rejection kernels already upcast
-# per vocab block on load and apply ops like temperature and gumbel, so folding
-# sampling-param application into those kernels would remove this buffer and
-# its traffic entirely.
+# Cap on the FP32 target-logits buffer materialized by non-temperature sampling
+# parameters. Temperature-only requests apply it inside the rejection kernels.
+# TODO(mgoin): Fold the remaining sampling parameters into the rejection kernels
+# to remove this buffer and its traffic entirely.
 MAX_CHUNK_BYTES = 2**30  # 1GB
 _FP32_BYTES = 4
 
@@ -97,6 +96,22 @@ class RejectionSampler:
         elif rejection_sample_method == "block":
             self.use_block_verification = True
 
+    def _should_apply_target_temperature(
+        self, idx_mapping_np: np.ndarray, max_num_logprobs: int
+    ) -> bool:
+        needs_processed_logprobs = (
+            max_num_logprobs != NO_LOGPROBS
+            and self.sampler.logprobs_mode in PROCESSED_LOGPROBS_MODES
+        )
+        temperature = self.sampler.sampling_states.temperature.np[idx_mapping_np]
+        return bool(
+            not needs_processed_logprobs
+            and not np.any(
+                self.sampler.needs_non_temperature_logits_processing[idx_mapping_np]
+            )
+            and np.any((temperature != 0.0) & (temperature != 1.0))
+        )
+
     def _get_logprobs_tensors(
         self,
         sampled: torch.Tensor,
@@ -152,16 +167,20 @@ class RejectionSampler:
         idx_mapping_np: np.ndarray,
         expanded_idx_mapping: torch.Tensor,
         expanded_local_pos: torch.Tensor,
+        apply_target_temperature: bool,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        processed_logits = self.sampler.apply_sampling_params(
-            logits,
-            expanded_idx_mapping,
-            idx_mapping,
-            idx_mapping_np,
-            pos,
-            draft_sampled,
-            expanded_local_pos,
-        )
+        if apply_target_temperature:
+            processed_logits = logits
+        else:
+            processed_logits = self.sampler.apply_sampling_params(
+                logits,
+                expanded_idx_mapping,
+                idx_mapping,
+                idx_mapping_np,
+                pos,
+                draft_sampled,
+                expanded_local_pos,
+            )
         sampled, num_sampled = rejection_sample(
             processed_logits,
             draft_logits,
@@ -177,6 +196,7 @@ class RejectionSampler:
             self.synthetic_conditional_rates,
             use_fp64=self.sampler.use_fp64_gumbel,
             use_block_verification=self.use_block_verification,
+            apply_target_temperature=apply_target_temperature,
         )
         return processed_logits, sampled, num_sampled
 
@@ -189,6 +209,7 @@ class RejectionSampler:
         pos: torch.Tensor,
         max_chunk_logits: int,
         max_num_logprobs: int,
+        apply_target_temperature: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor, LogprobsTensors | None]:
         cu_num_logits_np = input_batch.cu_num_logits_np
         use_processed_logits = self.sampler.logprobs_mode in PROCESSED_LOGPROBS_MODES
@@ -224,6 +245,7 @@ class RejectionSampler:
                 input_batch.idx_mapping_np[start:end],
                 input_batch.expanded_idx_mapping[lo:hi],
                 input_batch.expanded_local_pos[lo:hi],
+                apply_target_temperature,
             )
             chunk_logprobs = self._get_logprobs_tensors(
                 sampled,
@@ -273,7 +295,14 @@ class RejectionSampler:
         max_num_logprobs = self.sampler.sampling_states.max_num_logprobs(
             input_batch.idx_mapping_np
         )
-        chunk_logit_limit = get_max_chunk_logits(logits.shape[1])
+        apply_target_temperature = self._should_apply_target_temperature(
+            input_batch.idx_mapping_np, max_num_logprobs
+        )
+        chunk_logit_limit = (
+            logits.shape[0]
+            if apply_target_temperature
+            else get_max_chunk_logits(logits.shape[1])
+        )
         sampled, num_sampled, logprobs_tensors = self._verify_in_chunks(
             logits,
             input_batch,
@@ -282,6 +311,7 @@ class RejectionSampler:
             pos,
             chunk_logit_limit,
             max_num_logprobs,
+            apply_target_temperature,
         )
 
         num_sampled, num_rejected = get_num_sampled_and_rejected(

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -18,6 +18,17 @@ def _compute_max_and_sumexp(logits):
 
 
 @triton.jit
+def _maybe_apply_target_temperature(
+    logits,
+    temperature,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
+):
+    if APPLY_TARGET_TEMPERATURE and temperature != 0.0 and temperature != 1.0:
+        logits = logits / temperature
+    return logits
+
+
+@triton.jit
 def _compute_global_logsumexp(
     local_max_ptr,
     local_max_stride,
@@ -57,8 +68,10 @@ def _compute_global_residual_mass(
     target_local_sumexp_stride,
     draft_token,
     logit_idx,
+    temp,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     if HAS_DRAFT_LOGITS:
@@ -86,6 +99,9 @@ def _compute_global_residual_mass(
         target_logit = tl.load(
             target_logits_ptr + logit_idx * target_logits_stride + draft_token,
         ).to(tl.float32)
+        target_logit = _maybe_apply_target_temperature(
+            target_logit, temp, APPLY_TARGET_TEMPERATURE
+        )
         m_b = tl.exp(target_logit - target_lse)
         return prefix_joint_ratio * (1.0 - m_b)
 
@@ -142,6 +158,7 @@ def _compute_global_logprobs_and_logsumexp(
     draft_local_sumexp_stride,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     target_logit = tl.load(
@@ -149,6 +166,9 @@ def _compute_global_logprobs_and_logsumexp(
         mask=mask,
         other=float("-inf"),
     ).to(tl.float32)
+    target_logit = _maybe_apply_target_temperature(
+        target_logit, temp, APPLY_TARGET_TEMPERATURE
+    )
     target_lse = _compute_global_logsumexp(
         target_local_max_ptr,
         target_local_max_stride,
@@ -222,6 +242,7 @@ def _compute_local_logits_stats_kernel(
     vocab_size,
     num_speculative_steps,
     BLOCK_SIZE: tl.constexpr,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     logit_idx = tl.program_id(0).to(tl.int64)
@@ -245,6 +266,9 @@ def _compute_local_logits_stats_kernel(
             mask=mask,
             other=float("-inf"),
         ).to(tl.float32)
+        target_logits = _maybe_apply_target_temperature(
+            target_logits, temp, APPLY_TARGET_TEMPERATURE
+        )
         value, idx = tl.max(target_logits, axis=0, return_indices=True)
         token_id = block_idx * BLOCK_SIZE + idx
         tl.store(
@@ -264,6 +288,9 @@ def _compute_local_logits_stats_kernel(
             mask=mask,
             other=float("-inf"),
         ).to(tl.float32)
+        target_logits = _maybe_apply_target_temperature(
+            target_logits, temp, APPLY_TARGET_TEMPERATURE
+        )
         target_max, target_sumexp = _compute_max_and_sumexp(target_logits)
         tl.store(
             target_local_max_ptr + logit_idx * target_local_max_stride + block_idx,
@@ -335,6 +362,7 @@ def _compute_cumulative_log_p_kernel(
     temp_ptr,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
@@ -376,6 +404,7 @@ def _compute_cumulative_log_p_kernel(
                     draft_local_sumexp_stride,
                     vocab_num_blocks,
                     PADDED_VOCAB_NUM_BLOCKS,
+                    APPLY_TARGET_TEMPERATURE,
                     HAS_DRAFT_LOGITS,
                 )
             )
@@ -422,6 +451,7 @@ def _compute_local_residual_mass_kernel(
     vocab_num_blocks,
     BLOCK_SIZE: tl.constexpr,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
 ):
     logit_idx = tl.program_id(0).to(tl.int64)
     draft_step_idx = tl.load(expanded_local_pos_ptr + logit_idx)
@@ -466,6 +496,7 @@ def _compute_local_residual_mass_kernel(
         draft_local_sumexp_stride,
         vocab_num_blocks,
         PADDED_VOCAB_NUM_BLOCKS,
+        APPLY_TARGET_TEMPERATURE,
         True,  # HAS_DRAFT_LOGITS
     )
 
@@ -534,6 +565,7 @@ def _rejection_kernel(
     local_residual_mass_stride,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
     SYNTHETIC_MODE: tl.constexpr,
     USE_BLOCK_VERIFICATION: tl.constexpr,
@@ -615,8 +647,10 @@ def _rejection_kernel(
                         target_local_sumexp_stride,
                         next_draft_token,
                         logit_idx + 1,
+                        temp,
                         vocab_num_blocks,
                         PADDED_VOCAB_NUM_BLOCKS,
+                        APPLY_TARGET_TEMPERATURE,
                         HAS_DRAFT_LOGITS,
                     )
                     denom = residual_mass + 1.0 - prefix_joint_ratio
@@ -650,6 +684,7 @@ def _rejection_kernel(
                         draft_local_sumexp_stride,
                         vocab_num_blocks,
                         PADDED_VOCAB_NUM_BLOCKS,
+                        APPLY_TARGET_TEMPERATURE,
                         HAS_DRAFT_LOGITS,
                     )
                 )
@@ -729,6 +764,7 @@ def _resample_kernel(
     cumulative_log_p_ptr,
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
+    APPLY_TARGET_TEMPERATURE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
     USE_FP64: tl.constexpr,
     USE_BLOCK_VERIFICATION: tl.constexpr,
@@ -762,6 +798,9 @@ def _resample_kernel(
         mask=mask,
         other=float("-inf"),
     ).to(tl.float32)
+    target_logits = _maybe_apply_target_temperature(
+        target_logits, temp, APPLY_TARGET_TEMPERATURE
+    )
 
     # Compute the residual logits to resample the rejected token from.
     if is_bonus or not is_valid_rejected_draft:
@@ -947,6 +986,7 @@ def rejection_sample(
     synthetic_conditional_rates: torch.Tensor | None = None,
     use_fp64: bool = False,
     use_block_verification: bool = False,
+    apply_target_temperature: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert target_logits.ndim == 2 and target_logits.stride(-1) == 1
     assert draft_logits is None or (
@@ -1006,6 +1046,7 @@ def rejection_sample(
         vocab_size,
         num_speculative_steps,
         BLOCK_SIZE=VOCAB_BLOCK_SIZE,
+        APPLY_TARGET_TEMPERATURE=apply_target_temperature,
         HAS_DRAFT_LOGITS=has_draft_logits,
     )
 
@@ -1041,6 +1082,7 @@ def rejection_sample(
             temperature,
             vocab_num_blocks,
             PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+            APPLY_TARGET_TEMPERATURE=apply_target_temperature,
             HAS_DRAFT_LOGITS=has_draft_logits,
             num_warps=1,
         )
@@ -1079,6 +1121,7 @@ def rejection_sample(
                 vocab_num_blocks,
                 BLOCK_SIZE=VOCAB_BLOCK_SIZE,
                 PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+                APPLY_TARGET_TEMPERATURE=apply_target_temperature,
             )
         else:
             local_residual_mass = None
@@ -1127,6 +1170,7 @@ def rejection_sample(
         local_residual_mass.stride(0) if local_residual_mass is not None else 0,
         vocab_num_blocks,
         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+        APPLY_TARGET_TEMPERATURE=apply_target_temperature,
         HAS_DRAFT_LOGITS=has_draft_logits,
         SYNTHETIC_MODE=synthetic_conditional_rates is not None,
         USE_BLOCK_VERIFICATION=use_block_verification,
@@ -1167,6 +1211,7 @@ def rejection_sample(
         cumulative_log_p,
         vocab_size,
         BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
+        APPLY_TARGET_TEMPERATURE=apply_target_temperature,
         HAS_DRAFT_LOGITS=has_draft_logits,
         USE_FP64=use_fp64,
         USE_BLOCK_VERIFICATION=use_block_verification,

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -222,7 +222,7 @@ def warmup_kernels(
     # Upper bound on the decode steps built in `decode_steps` below.
     num_decode_steps = 1
     if not model_runner.is_pooling_model:
-        num_decode_steps = 5 if num_spec_steps > 0 else 3
+        num_decode_steps = 6 if num_spec_steps > 0 else 3
     # Size the block allocation for the worst case: every request advancing
     # decode_query_len tokens on every decode step.
     decode_len = prompt_len + num_decode_steps * decode_query_len
@@ -408,6 +408,23 @@ def warmup_kernels(
 
         for step_indices, step_spec_flags in decode_steps:
             _run_decode_step(step_indices, step_spec_flags)
+
+        if use_spec_decode:
+            # Finish with temperature-only requests to compile the rejection
+            # sampler's fused-temperature variants.
+            if (
+                model_runner.is_last_pp_rank
+                and getattr(model_runner, "rejection_sampler", None) is not None
+            ):
+                assert model_runner.sampler is not None
+                temperature_only_params = SamplingParams(temperature=0.9)
+                for req_id in req_ids:
+                    req_idx = model_runner.req_states.req_id_to_index[req_id]
+                    model_runner.sampler.add_request(
+                        req_idx, prompt_len, temperature_only_params
+                    )
+                model_runner.sampler.apply_staged_writes()
+            _run_decode_step(all_indices, [True] * num_reqs)
 
     # Clean up - process finish_req_ids.
     cleanup_output = SchedulerOutput.make_empty()


### PR DESCRIPTION
## Summary

Fuse target-temperature scaling into the MRV2 rejection-sampling kernels for temperature-only requests. This avoids materializing an FP32 target-logits buffer and removes chunking on this path.

Requests using other logits processors or processed logprobs keep the existing fallback. Startup warmup compiles the fused variants to avoid first-request JIT compilation.

## Results

L40S, BF16 target logits, vocabulary 151936, speculative K=4:

| Batch | 1 | 8 | 32 | 128 |
|---:|---:|---:|---:|---:|
| One-hot draft | 1.57x | 2.41x | 4.17x | 6.89x |
| Full draft logits | 1.49x | 1.94x | 2.85x | 4.56x |

At batch 128, peak temporary allocation decreased from 371.4 MiB to 0.5 MiB (370.9 MiB saved).

Two five-round Qwen3.5-9B end-to-end comparisons (ngram K=4, 128 prompts, 64 output tokens) remained within run-to-run noise: -0.66% and +0.99%. These are rejection-sampler gains; no end-to-end throughput improvement is claimed.

A fresh Triton-cache run confirmed that the fused rejection-sampler kernels do not compile during inference after startup warmup.

After rebasing onto `680e2177`, an L20 rerun produced:

| Batch | 1 | 8 | 32 | 128 |
|---:|---:|---:|---:|---:|
| One-hot draft | 1.654x | 2.407x | 3.786x | 6.307x |
| Full draft logits | 1.554x | 1.881x | 2.705x | 4.315x |

The batch-128 temporary allocation again decreased from 371.4 MiB to 0.5 MiB. A Qwen3.5-9B single-GPU smoke run with ngram K=4 and temperature 0.7 completed four 32-token generations. Its inference-time JIT warnings were limited to unrelated Qwen Mamba/GDN kernels; no rejection-sampler kernel compiled during inference.

## Tests

```bash
.venv/bin/python -m pytest -q \
  tests/v1/spec_decode/test_rejection_sampler_utils.py \
  tests/v1/worker/test_gpu_rejection_sampler_chunking.py \
  tests/v1/worker/test_gpu_sampler_flags.py \
  tests/v1/worker/test_gpu_rejection_sampler_i64.py \
  tests/v1/worker/test_gpu_warmup_blocks.py \
  tests/v1/worker/test_gpu_gumbel_sample.py::test_drafting_uses_a_separate_noise_stream
# 128 passed

uv run --no-sync ruff check $(git diff --name-only origin/main...HEAD -- '*.py')
uv run --no-sync ruff format --check $(git diff --name-only origin/main...HEAD -- '*.py')
```

Coverage includes FP32/FP16/BF16 target logits, one-hot/full draft logits, standard/block/synthetic verification, mixed temperatures, multi-block vocabularies, fallback paths, and the independent draft/target Gumbel noise streams introduced by #54282.

Benchmark commands:

```bash
.venv/bin/python benchmarks/kernels/benchmark_rejection_sampler_temperature.py \
  --batch-sizes 1 8 32 128 --warmup-ms 100 --rep-ms 300
.venv/bin/python benchmarks/kernels/benchmark_rejection_sampler_temperature.py \
  --batch-sizes 1 8 32 128 --warmup-ms 100 --rep-ms 300 --with-draft-logits
```

## Related work and duplicate check

#53630 is a broader head-dtype verifier redesign and subsumes this temperature path. This PR intentionally remains a smaller incremental fast path: only temperature-only requests bypass the FP32 canvas, while processors and processed-logprob paths keep the existing FP32 behavior. It therefore introduces no penalty write-back precision trade-off and can land independently. If maintainers prefer the broader redesign, or if #53630 lands first, this PR can be closed as superseded.

#41258 and #45369 target the legacy sampler. #48928 targets FlashInfer AIR top-p sampling, while this fast path excludes top-p.
