### PR TITLE
[ROCm][Perf] Fuse DSA indexer QK preprocessing with AITER

### DIFF
--- a/benchmarks/kernels/benchmark_indexer_qk_fusion.py
+++ b/benchmarks/kernels/benchmark_indexer_qk_fusion.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused vs unfused DSA indexer QK pre-processing on ROCm.
+
+The DSA indexer (DeepSeek-V3.2, GLM-5.x) runs five launches per layer per step:
+LayerNorm(k), RoPE(q, k), per-token-group fp8 quant of q, folding the q scale
+into the indexer weights, and the fp8 K quant + paged K-cache write. With
+VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION=1 one AITER kernel does all five.
+
+Usage:
+    python benchmarks/kernels/benchmark_indexer_qk_fusion.py
+    python benchmarks/kernels/benchmark_indexer_qk_fusion.py --num-tokens 1 8 64
+"""
+
+import argparse
+import functools
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import triton
+from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+    indexer_k_quant_and_cache_triton,
+)
+
+HEAD_DIM = 128
+ROPE_DIM = 64
+N_HEAD = 32
+MAX_POS = 65536
+QUANT_BLOCK = 128
+EPS = 1e-6
+SCALE_FMT = "ue8m0"
+WEIGHTS_SCALE = HEAD_DIM**-0.5 * N_HEAD**-0.5
+
+
+def _unfused(
+    q, k_raw, weights_raw, positions, cache, norm_w, norm_b, kv, slots, is_neox
+):
+    num_tokens = q.shape[0]
+    k = torch.nn.functional.layer_norm(
+        k_raw.float(), (HEAD_DIM,), norm_w.float(), norm_b.float(), EPS
+    ).to(q.dtype)
+    q = q.clone()
+    ops.rotary_embedding(
+        positions,
+        q[..., :ROPE_DIM],
+        k[..., :ROPE_DIM].unsqueeze(1),
+        ROPE_DIM,
+        cache,
+        is_neox,
+    )
+    q_fp8, q_scale = per_token_group_quant_fp8(
+        q.view(-1, HEAD_DIM), QUANT_BLOCK, column_major_scales=False, use_ue8m0=True
+    )
+    _ = weights_raw.float() * q_scale.view(num_tokens, N_HEAD) * WEIGHTS_SCALE
+    indexer_k_quant_and_cache_triton(k, kv, slots, QUANT_BLOCK, SCALE_FMT)
+
+
+def _fused(
+    q,
+    k_raw,
+    weights_raw,
+    positions,
+    cache,
+    norm_w,
+    norm_b,
+    kv,
+    slots,
+    q_out,
+    w_out,
+    is_neox,
+):
+    from aiter import indexer_qk_rope_quant_and_cache
+
+    half = ROPE_DIM // 2
+    indexer_qk_rope_quant_and_cache(
+        q,
+        q_out,
+        weights_raw,
+        w_out,
+        k_raw,
+        kv,
+        slots,
+        norm_w,
+        norm_b,
+        positions,
+        cache[:, :half],
+        cache[:, half:],
+        EPS,
+        QUANT_BLOCK,
+        SCALE_FMT,
+        WEIGHTS_SCALE,
+        preshuffle=kv.shape[1] > 1,
+        is_neox=is_neox,
+    )
+
+
+def _time_us(fn) -> float:
+    ms = triton.testing.do_bench(fn, warmup=25, rep=100)
+    return ms * 1000.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--num-tokens", type=int, nargs="+", default=[1, 8, 32, 64, 256, 1024]
+    )
+    parser.add_argument("--block-size", type=int, default=64)
+    parser.add_argument(
+        "--is-neox",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="RoPE layout. GLM-5.x sets indexer_rope_interleave, i.e. is_neox "
+        "False; DeepSeek-V3.2 leaves it at the NeoX default.",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=3,
+        help="Measure each point this many times and report the median. "
+        "Process-level state (kernel tuning caches, clocks) moves these numbers "
+        "more than do_bench's own variance does.",
+    )
+    args = parser.parse_args()
+
+    if not current_platform.is_rocm():
+        raise SystemExit("ROCm only")
+    fp8 = current_platform.fp8_dtype()
+    dev, dt = "cuda", torch.bfloat16
+
+    def median(runs: list[float]) -> tuple[float, float, float]:
+        ordered = sorted(runs)
+        return ordered[len(ordered) // 2], ordered[0], ordered[-1]
+
+    rows = []
+    for num_tokens in args.num_tokens:
+        num_blocks = (num_tokens + args.block_size - 1) // args.block_size + 2
+        q = torch.randn(num_tokens, N_HEAD, HEAD_DIM, device=dev, dtype=dt)
+        kw = torch.randn(num_tokens, HEAD_DIM + N_HEAD, device=dev, dtype=dt)
+        positions = torch.randint(
+            0, MAX_POS, (num_tokens,), device=dev, dtype=torch.int64
+        )
+        norm_w = torch.randn(HEAD_DIM, device=dev, dtype=dt)
+        norm_b = torch.randn(HEAD_DIM, device=dev, dtype=dt)
+        cache = torch.randn(MAX_POS, ROPE_DIM, device=dev, dtype=dt)
+        kv = torch.zeros(
+            num_blocks, args.block_size, HEAD_DIM + 4, dtype=fp8, device=dev
+        )
+        slots = torch.randperm(
+            num_blocks * args.block_size, device=dev, dtype=torch.int64
+        )[:num_tokens]
+        q_out = torch.zeros((num_tokens, N_HEAD, HEAD_DIM), dtype=fp8, device=dev)
+        w_out = torch.zeros((num_tokens, N_HEAD), dtype=torch.float32, device=dev)
+
+        unfused_fn = functools.partial(
+            _unfused,
+            q,
+            kw[:, :HEAD_DIM],
+            kw[:, HEAD_DIM:],
+            positions,
+            cache,
+            norm_w,
+            norm_b,
+            kv,
+            slots,
+            args.is_neox,
+        )
+        fused_fn = functools.partial(
+            _fused,
+            q,
+            kw[:, :HEAD_DIM],
+            kw[:, HEAD_DIM:],
+            positions,
+            cache,
+            norm_w,
+            norm_b,
+            kv,
+            slots,
+            q_out,
+            w_out,
+            args.is_neox,
+        )
+        unfused_runs = [_time_us(unfused_fn) for _ in range(args.repeat)]
+        fused_runs = [_time_us(fused_fn) for _ in range(args.repeat)]
+        rows.append((num_tokens, median(unfused_runs), median(fused_runs)))
+
+    print(
+        f"{'tokens':>8} {'unfused us':>12} {'fused us':>10} {'speedup':>9}"
+        f"   spread over {args.repeat} repeats"
+    )
+    for num_tokens, (u_med, u_lo, u_hi), (f_med, f_lo, f_hi) in rows:
+        print(
+            f"{num_tokens:>8} {u_med:>12.2f} {f_med:>10.2f} {u_med / f_med:>8.2f}x"
+            f"   unfused {u_lo:.1f}-{u_hi:.1f}, fused {f_lo:.1f}-{f_hi:.1f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/attention/test_rocm_aiter_indexer_qk_fusion.py
+++ b/tests/kernels/attention/test_rocm_aiter_indexer_qk_fusion.py
@@ -1,0 +1,379 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for the ROCm AITER fused DSA indexer QK path.
+
+Compares ``torch.ops.vllm.rocm_aiter_indexer_qk_rope_quant_and_cache`` against
+the unfused flow it replaces in ``Indexer.forward``
+(vllm/model_executor/models/deepseek_v2.py), built from the same primitives:
+
+    k = layer_norm(k, k_norm.weight, k_norm.bias, eps)
+    ops.rotary_embedding(positions, q[..., :64], k[..., :64], 64, cache, neox)
+    q_fp8, q_scale = per_token_group_quant_fp8(q, 128, use_ue8m0=True)
+    weights_out = weights * q_scale * softmax_scale * n_head_scale
+    indexer_k_quant_and_cache_triton(k, kv_cache, slot_mapping, 128, "ue8m0")
+
+The fused kernel folds the q scale into ``weights_out``, so the comparison is
+on the products the downstream MQA-logits kernels consume
+(``q_fp8 * weights_out``) and on the dequantized indexer K cache.
+
+The two paths cannot be bit-equal, and the difference is in the q scale, not in
+the RoPE: the kernel rounds the roped q through bf16 exactly as the unfused flow
+does, but derives a plain fp32 scale from it, while per_token_group_quant_fp8
+rounds that scale to a power of two (use_ue8m0=True). A different scale moves
+every element of the token by at most one fp8 code, in either direction, so
+asserting closeness to the unfused path would penalise whichever path happens to
+sit further from the truth. Both are instead scored against an fp64 golden of the
+same math, and the fused path must be no less accurate than the unfused one, with
+every element within one fp8 code of it.
+
+Speed is not asserted here: see benchmarks/kernels/benchmark_indexer_qk_fusion.py.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8,
+)
+from vllm.platforms import current_platform
+
+_SKIP_NON_MI3XX = True
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_mi3xx
+
+    _SKIP_NON_MI3XX = not on_mi3xx()
+
+pytestmark = [
+    pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific tests"),
+    pytest.mark.skipif(_SKIP_NON_MI3XX, reason="MI300/MI350 only (aiter CK kernel)"),
+]
+
+HEAD_DIM = 128
+ROPE_DIM = 64
+N_HEAD = 32
+MAX_POS = 65536
+QUANT_BLOCK = 128
+EPS = 1e-6
+SCALE_FMT = "ue8m0"
+WEIGHTS_SCALE = HEAD_DIM**-0.5 * N_HEAD**-0.5
+PREFIX = "model.layers.0.self_attn.indexer.k_cache"
+
+# fp8-e4m3 keeps 3 mantissa bits, so one code step is at most 12.5% of an
+# element: a value sitting on a quantization boundary flips to the neighbouring
+# code under any reordering of the RoPE/LayerNorm arithmetic.
+ONE_CODE_REL = 0.13
+# Slack on "no less accurate than unfused": both are fp8, so their errors
+# against the golden are dominated by the same quantization step.
+ACCURACY_SLACK = 1.10
+MAX_FP8_REL_L2 = 0.05
+
+
+def _require_aiter() -> None:
+    from vllm._aiter_ops import is_aiter_found_and_supported
+
+    if not is_aiter_found_and_supported():
+        pytest.skip("aiter is required for the fused indexer QK kernel")
+
+
+def _indexer_metadata(slot_mapping: torch.Tensor):
+    from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
+
+    num_tokens = int(slot_mapping.shape[0])
+    return DeepseekV32IndexerMetadata(
+        seq_lens=torch.tensor([num_tokens], device=slot_mapping.device),
+        max_seq_len=num_tokens,
+        slot_mapping=slot_mapping,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=1,
+        num_prefill_tokens=num_tokens,
+    )
+
+
+def _inputs(num_tokens: int, block_size: int, capacity: int | None = None):
+    capacity = capacity or num_tokens
+    num_blocks = (capacity + block_size - 1) // block_size + 2
+    dev, dt = "cuda", torch.bfloat16
+    return SimpleNamespace(
+        q=torch.randn(capacity, N_HEAD, HEAD_DIM, device=dev, dtype=dt),
+        kw=torch.randn(capacity, HEAD_DIM + N_HEAD, device=dev, dtype=dt),
+        positions=torch.randint(0, MAX_POS, (capacity,), device=dev, dtype=torch.int64),
+        slots=torch.randperm(num_blocks * block_size, device=dev, dtype=torch.int64)[
+            :num_tokens
+        ],
+        norm_weight=torch.randn(HEAD_DIM, device=dev, dtype=dt),
+        norm_bias=torch.randn(HEAD_DIM, device=dev, dtype=dt),
+        cos_sin_cache=torch.randn(MAX_POS, ROPE_DIM, device=dev, dtype=dt),
+        kv_cache=torch.zeros(
+            num_blocks,
+            block_size,
+            HEAD_DIM + 4,
+            dtype=current_platform.fp8_dtype(),
+            device=dev,
+        ),
+    )
+
+
+def _reference(t, kv_cache: torch.Tensor, is_neox: bool):
+    """The five launches the fused kernel replaces, in the same order."""
+    from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+        indexer_k_quant_and_cache_triton,
+    )
+
+    num_tokens = t.q.shape[0]
+    k = torch.nn.functional.layer_norm(
+        t.kw[:, :HEAD_DIM].float(),
+        (HEAD_DIM,),
+        t.norm_weight.float(),
+        t.norm_bias.float(),
+        EPS,
+    ).to(t.q.dtype)
+    q = t.q.clone()
+    ops.rotary_embedding(
+        t.positions,
+        q[..., :ROPE_DIM],
+        k[..., :ROPE_DIM].unsqueeze(1),
+        ROPE_DIM,
+        t.cos_sin_cache,
+        is_neox,
+    )
+    q_fp8, q_scale = per_token_group_quant_fp8(
+        q.view(-1, HEAD_DIM), QUANT_BLOCK, column_major_scales=False, use_ue8m0=True
+    )
+    weights = (
+        t.kw[:, HEAD_DIM:].float() * q_scale.view(num_tokens, N_HEAD) * WEIGHTS_SCALE
+    )
+    indexer_k_quant_and_cache_triton(k, kv_cache, t.slots, QUANT_BLOCK, SCALE_FMT)
+    return q_fp8.view(num_tokens, N_HEAD, HEAD_DIM), weights
+
+
+def _fused(t, kv_cache, is_neox, q_out=None, w_out=None, zero_outputs=False):
+    half = ROPE_DIM // 2
+    if q_out is None:
+        q_out = torch.zeros(
+            t.q.shape, dtype=current_platform.fp8_dtype(), device=t.q.device
+        )
+    if w_out is None:
+        w_out = torch.zeros(t.q.shape[:2], dtype=torch.float32, device=t.q.device)
+    torch.ops.vllm.rocm_aiter_indexer_qk_rope_quant_and_cache(
+        PREFIX,
+        kv_cache,
+        t.q,
+        t.kw[:, :HEAD_DIM],
+        t.kw[:, HEAD_DIM:],
+        t.positions,
+        t.cos_sin_cache[:, :half],
+        t.cos_sin_cache[:, half:],
+        t.norm_weight,
+        t.norm_bias,
+        q_out,
+        w_out,
+        EPS,
+        QUANT_BLOCK,
+        SCALE_FMT,
+        WEIGHTS_SCALE,
+        zero_outputs,
+        is_neox,
+    )
+    return q_out, w_out
+
+
+def _patch_context(monkeypatch, slot_mapping: torch.Tensor) -> None:
+    import vllm.v1.attention.ops.rocm_aiter_mla_sparse as mla_sparse
+
+    monkeypatch.setattr(
+        mla_sparse,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            attn_metadata={PREFIX: _indexer_metadata(slot_mapping)}
+        ),
+    )
+
+
+def _golden(t, is_neox: bool) -> tuple[torch.Tensor, torch.Tensor]:
+    """fp64 LayerNorm + RoPE: the same math with no intermediate rounding."""
+    half = ROPE_DIM // 2
+    k = torch.nn.functional.layer_norm(
+        t.kw[:, :HEAD_DIM].double(),
+        (HEAD_DIM,),
+        t.norm_weight.double(),
+        t.norm_bias.double(),
+        EPS,
+    )
+    cos = t.cos_sin_cache[t.positions, :half].double()
+    sin = t.cos_sin_cache[t.positions, half:].double()
+
+    def rope(x: torch.Tensor) -> torch.Tensor:
+        c, s_ = cos, sin
+        while c.dim() < x.dim():
+            c, s_ = c.unsqueeze(-2), s_.unsqueeze(-2)
+        pe, rest = x[..., :ROPE_DIM], x[..., ROPE_DIM:]
+        if is_neox:
+            x1, x2 = pe[..., :half], pe[..., half:]
+            roped = torch.cat([x1 * c - x2 * s_, x2 * c + x1 * s_], dim=-1)
+        else:
+            x1, x2 = pe[..., 0::2], pe[..., 1::2]
+            roped = torch.stack([x1 * c - x2 * s_, x2 * c + x1 * s_], dim=-1).flatten(
+                -2
+            )
+        return torch.cat([roped, rest], dim=-1)
+
+    return rope(t.q.double()), rope(k)
+
+
+def _rel_l2(got: torch.Tensor, golden: torch.Tensor) -> float:
+    return ((got.double() - golden).norm() / golden.norm().clamp(min=1e-12)).item()
+
+
+def _assert_no_less_accurate(
+    fused: torch.Tensor, unfused: torch.Tensor, golden: torch.Tensor, what: str
+) -> None:
+    err_fused, err_unfused = _rel_l2(fused, golden), _rel_l2(unfused, golden)
+    assert err_fused <= MAX_FP8_REL_L2, (
+        f"{what}: fused error vs fp64 golden {err_fused:.3e} exceeds fp8 granularity"
+    )
+    assert err_fused <= err_unfused * ACCURACY_SLACK, (
+        f"{what}: fused is less accurate than unfused "
+        f"({err_fused:.3e} vs {err_unfused:.3e})"
+    )
+    # And the two paths must still agree element-wise to within one fp8 code.
+    scale = torch.maximum(fused.abs(), unfused.abs())
+    live = scale > 1e-3 * unfused.abs().max()
+    rel = (fused - unfused).abs()[live] / scale[live]
+    worst = rel.max().item()
+    assert worst <= ONE_CODE_REL, (
+        f"{what}: {(rel > ONE_CODE_REL).sum().item()} of {rel.numel()} elements "
+        f"differ by more than one fp8 code (worst rel {worst:.4f})"
+    )
+
+
+def _dequant_cache(kv_cache: torch.Tensor, slots: torch.Tensor) -> torch.Tensor:
+    """Dequantize the rows `slots` point at, for either in-block layout."""
+    num_blocks, block_size = kv_cache.shape[0], kv_cache.shape[1]
+    flat = kv_cache.view(num_blocks, -1)
+    values = flat[:, : block_size * HEAD_DIM]
+    scales = flat[:, block_size * HEAD_DIM :].contiguous().view(torch.float32)
+    tile = 16
+    j = torch.arange(HEAD_DIM, device=kv_cache.device)
+    out = torch.empty(
+        (slots.shape[0], HEAD_DIM), dtype=torch.float32, device=kv_cache.device
+    )
+    for i, slot in enumerate(slots.tolist()):
+        block_id, off = slot // block_size, slot % block_size
+        if block_size == 1:
+            idx = off * HEAD_DIM + j
+        else:
+            # 16x16-tiled in-block layout, mirroring the writer's SHUFFLE path.
+            idx = (
+                (off // tile) * tile * HEAD_DIM
+                + (off % tile) * tile
+                + (j // tile) * tile * tile
+                + j % tile
+            )
+        out[i] = (
+            values[block_id, idx].view(kv_cache.dtype).float() * scales[block_id, off]
+        )
+    return out
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 32, 257, 1023])
+@pytest.mark.parametrize("block_size", [1, 64])
+@pytest.mark.parametrize("is_neox", [True, False])
+@torch.inference_mode()
+def test_fused_matches_unfused(monkeypatch, num_tokens, block_size, is_neox):
+    """One fused launch reproduces the five unfused launches it replaces."""
+    _require_aiter()
+    torch.manual_seed(0)
+    t = _inputs(num_tokens, block_size)
+    kv_ref = torch.zeros_like(t.kv_cache)
+
+    q_fp8_ref, weights_ref = _reference(t, kv_ref, is_neox)
+    _patch_context(monkeypatch, t.slots)
+    q_fp8, weights_out = _fused(t, t.kv_cache, is_neox)
+    q_golden, k_golden = _golden(t, is_neox)
+
+    # Scale-fold invariant: the kernel may split the scale between q_fp8 and
+    # weights_out differently, only the product reaches the logits kernels.
+    weights_raw = t.kw[:, HEAD_DIM:].double() * WEIGHTS_SCALE
+    _assert_no_less_accurate(
+        q_fp8.float() * weights_out.unsqueeze(-1),
+        q_fp8_ref.float() * weights_ref.unsqueeze(-1),
+        q_golden * weights_raw.unsqueeze(-1),
+        "q_fp8 * weights_out",
+    )
+    _assert_no_less_accurate(
+        _dequant_cache(t.kv_cache, t.slots),
+        _dequant_cache(kv_ref, t.slots),
+        k_golden,
+        "indexer K cache",
+    )
+
+
+@torch.inference_mode()
+def test_unowned_and_padded_rows_stay_zero(monkeypatch):
+    """Rows the kernel skips must read as zero, not as stale data.
+
+    The kernel early-returns on ``slot_mapping < 0`` - PAD_SLOT_ID marks both
+    CUDA-graph padding and, under context parallel, tokens this rank does not
+    own - and never touches rows past ``slot_mapping``. Decode reads
+    ``weights[:batch_size * next_n]``, which covers those rows, so they must be
+    zero for the padded logits they feed to stay finite.
+    """
+    _require_aiter()
+    torch.manual_seed(0)
+    num_tokens, capacity = 64, 96
+    t = _inputs(num_tokens, block_size=64, capacity=capacity)
+    t.slots[::4] = -1
+    before = t.kv_cache.view(torch.uint8).clone()
+
+    _patch_context(monkeypatch, t.slots)
+    q_fp8, weights_out = _fused(t, t.kv_cache, is_neox=True)
+
+    skipped = t.slots < 0
+    assert torch.all(q_fp8[:num_tokens][skipped].view(torch.uint8) == 0)
+    assert torch.all(weights_out[:num_tokens][skipped] == 0)
+    assert torch.all(q_fp8[num_tokens:].view(torch.uint8) == 0)
+    assert torch.all(weights_out[num_tokens:] == 0)
+    # Not vacuous: the owned rows were written, in both outputs and the cache.
+    assert not torch.all(q_fp8[:num_tokens][~skipped].view(torch.uint8) == 0)
+    assert not torch.equal(t.kv_cache.view(torch.uint8), before)
+
+
+@torch.inference_mode()
+def test_op_schema(monkeypatch):
+    """opcheck the custom op: fake impl for tracing, declared mutates_args."""
+    _require_aiter()
+    from tests.kernels.utils import opcheck
+
+    torch.manual_seed(0)
+    t = _inputs(num_tokens=8, block_size=64)
+    _patch_context(monkeypatch, t.slots)
+    half = ROPE_DIM // 2
+    opcheck(
+        torch.ops.vllm.rocm_aiter_indexer_qk_rope_quant_and_cache,
+        (
+            PREFIX,
+            t.kv_cache,
+            t.q,
+            t.kw[:, :HEAD_DIM],
+            t.kw[:, HEAD_DIM:],
+            t.positions,
+            t.cos_sin_cache[:, :half],
+            t.cos_sin_cache[:, half:],
+            t.norm_weight,
+            t.norm_bias,
+            torch.zeros(
+                t.q.shape, dtype=current_platform.fp8_dtype(), device=t.q.device
+            ),
+            torch.zeros(t.q.shape[:2], dtype=torch.float32, device=t.q.device),
+            EPS,
+            QUANT_BLOCK,
+            SCALE_FMT,
+            WEIGHTS_SCALE,
+            False,
+            True,
+        ),
+    )

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -14,6 +14,8 @@ from vllm.platforms import current_platform
 from vllm.utils.import_utils import PlaceholderModule
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+    rocm_aiter_indexer_qk_rope_quant_and_cache,
+    rocm_aiter_indexer_qk_rope_quant_and_cache_fake,
     rocm_aiter_sparse_attn_indexer,
     rocm_aiter_sparse_attn_indexer_fake,
 )
@@ -1685,6 +1687,7 @@ class rocm_aiter_ops:
     _FMOE_ENABLED = envs.VLLM_ROCM_USE_AITER_MOE
     _MLA_ENABLED = envs.VLLM_ROCM_USE_AITER_MLA
     _MHA_ENABLED = envs.VLLM_ROCM_USE_AITER_MHA
+    _INDEXER_QK_FUSION_ENABLED = envs.VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION
     _SHUFFLE_KV_CACHE_ENABLED = envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
     _TRITON_UNIFIED_ATTN_ENABLED = envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
     # TODO: Consolidate under _LINEAR_ENABLED
@@ -1718,6 +1721,7 @@ class rocm_aiter_ops:
         cls._FMOE_ENABLED = envs.VLLM_ROCM_USE_AITER_MOE
         cls._MLA_ENABLED = envs.VLLM_ROCM_USE_AITER_MLA
         cls._MHA_ENABLED = envs.VLLM_ROCM_USE_AITER_MHA
+        cls._INDEXER_QK_FUSION_ENABLED = envs.VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION
         cls._SHUFFLE_KV_CACHE_ENABLED = envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
         cls._TRITON_UNIFIED_ATTN_ENABLED = envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
         cls._FP8BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP8BMM
@@ -1831,6 +1835,11 @@ class rocm_aiter_ops:
     @if_aiter_supported
     def is_fused_moe_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._FMOE_ENABLED
+
+    @classmethod
+    @if_aiter_supported
+    def is_indexer_qk_fusion_enabled(cls) -> bool:
+        return cls._AITER_ENABLED and cls._INDEXER_QK_FUSION_ENABLED
 
     @classmethod
     @if_aiter_supported
@@ -2218,6 +2227,14 @@ class rocm_aiter_ops:
                 op_func=rocm_aiter_sparse_attn_indexer,
                 mutates_args=["topk_indices_buffer"],
                 fake_impl=rocm_aiter_sparse_attn_indexer_fake,
+                dispatch_key=current_platform.dispatch_key,
+            )
+
+            direct_register_custom_op(
+                op_name="rocm_aiter_indexer_qk_rope_quant_and_cache",
+                op_func=rocm_aiter_indexer_qk_rope_quant_and_cache,
+                mutates_args=["kv_cache", "q_fp8_out", "weights_out"],
+                fake_impl=rocm_aiter_indexer_qk_rope_quant_and_cache_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -774,6 +774,7 @@ class CompilationConfig:
         "vllm::olmo_hybrid_gdn_full_forward",
         "vllm::sparse_attn_indexer",
         "vllm::rocm_aiter_sparse_attn_indexer",
+        "vllm::rocm_aiter_indexer_qk_rope_quant_and_cache",
         "vllm::deepseek_v4_attention",
         "vllm::hpc_rope_norm_forward",
     ]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -142,6 +142,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_AITER_MLA_ASM_PADDING: Literal["auto", "gluon", "asm"] = "auto"
     VLLM_ROCM_USE_AITER_MHA: bool = True
+    VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION: bool = False
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
     VLLM_ROCM_USE_AITER_FP8BMM: bool = True
@@ -1299,6 +1300,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MHA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MHA", "True").lower() in ("true", "1")
+    ),
+    # Whether to use the aiter fused indexer QK kernel
+    # (indexer_qk_rope_quant_and_cache) on DeepSeek sparse attention models
+    # (DeepSeek-V3.2, GLM-5.x): fuses the indexer's Q/K RoPE, K LayerNorm,
+    # FP8 quantization and K-cache write into one launch. Needs
+    # VLLM_ROCM_USE_AITER=1 on gfx942/gfx950.
+    # By default is disabled.
+    "VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION", "False").lower()
+        in ("true", "1")
     ),
     # Whether to use aiter fp4 gemm asm.
     # By default is disabled.

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -37,6 +37,7 @@ from .deepseek_v2 import (
     DeepseekV2DecoderLayer,
     DeepseekV2MixtureOfExperts,
     DeepseekV2MoE,
+    IndexerQKFusionBuffers,
     _try_load_fp8_indexer_wk,
 )
 from .utils import (
@@ -90,8 +91,14 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
                 dtype=torch.int32,
                 device=self.device,
             )
+            # Each MTP layer is its own buffer root: it always re-zeros its
+            # pair instead of inheriting the target model's unwritten rows.
+            indexer_qk_fusion_buffers = IndexerQKFusionBuffers.maybe_build(
+                vllm_config, config, self.device
+            )
         else:
             topk_indices_buffer = None
+            indexer_qk_fusion_buffers = None
 
         self.shared_head = SharedHead(
             config=config, prefix=prefix, quant_config=quant_config
@@ -101,6 +108,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
             prefix,
             config=self.config,
             topk_indices_buffer=topk_indices_buffer,
+            indexer_qk_fusion_buffers=indexer_qk_fusion_buffers,
         )
 
     def forward(

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -82,6 +82,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     scaled_dequantize,
 )
 from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbeddingBase
 from vllm.model_executor.layers.sparse_attn_indexer import (
     SparseAttnIndexer,
     fused_indexer_q_rope_quant,
@@ -101,10 +102,14 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
-from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.utils.torch_utils import _encode_layer_name, direct_register_custom_op
 from vllm.v1.attention.backend import AttentionBackend, AttentionType
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerBackend,
+)
+from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+    get_indexer_rope_halves,
+    register_indexer_rope_halves,
 )
 from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
@@ -463,6 +468,7 @@ class DeepseekV2Attention(nn.Module):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         topk_indices_buffer: torch.Tensor | None = None,
+        indexer_qk_fusion_buffers: "IndexerQKFusionBuffers | None" = None,
         reduce_results: bool = True,
         prefix: str = "",
     ) -> None:
@@ -483,6 +489,9 @@ class DeepseekV2Attention(nn.Module):
         assert topk_indices_buffer is None, (
             "topk_indices_buffer is not \
         supported for DeepseekV2Attention"
+        )
+        assert indexer_qk_fusion_buffers is None, (
+            "indexer_qk_fusion_buffers is not supported for DeepseekV2Attention"
         )
 
         if self.q_lora_rank is not None:
@@ -664,6 +673,71 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         return DeepseekV32IndexerBackend
 
 
+class IndexerQKFusionBuffers:
+    """Model-shared q_fp8/weights output pair for the fused indexer QK kernel.
+
+    Allocated next to ``topk_indices_buffer`` and sized the same way, so the
+    address is stable before CUDA-graph capture. The first Indexer constructed
+    under the root claims the per-pass zero-fill; which rows stay unwritten
+    depends only on ``slot_mapping``, which every layer of a pass shares, so
+    zeroing once is enough. Takes the per-step fills from 2 per indexer layer
+    down to 2, plus the matching allocations.
+    """
+
+    def __init__(
+        self, capacity: int, n_heads: int, head_dim: int, device: torch.device
+    ):
+        # Zero-init is load-bearing: rows the kernel skips must read as zero.
+        self.q_fp8 = torch.zeros(
+            (capacity, n_heads, head_dim),
+            dtype=current_platform.fp8_dtype(),
+            device=device,
+        )
+        self.weights = torch.zeros(
+            (capacity, n_heads), dtype=torch.float32, device=device
+        )
+        self._zero_fill_owner: int | None = None
+
+    @classmethod
+    def maybe_build(
+        cls,
+        vllm_config: VllmConfig,
+        config: DeepseekV2Config | DeepseekV3Config,
+        device: torch.device,
+    ) -> "IndexerQKFusionBuffers | None":
+        # Every indexer rope is a RotaryEmbeddingBase subclass, so custom-op
+        # enablement stands in for the per-layer is_inplace_rope.
+        if not Indexer.can_use_aiter_qk_fusion(
+            vllm_config, config, RotaryEmbeddingBase.enabled()
+        ):
+            return None
+        return cls(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            config.index_n_heads,
+            config.index_head_dim,
+            device,
+        )
+
+    def claim_zero_fill(self, layer_index: int) -> bool:
+        """True only for the first caller, which owns the per-pass zero-fill.
+
+        The claimer must also be the first indexer to run under this root, or
+        the rows the kernel skips would keep the previous pass's values. Layers
+        that skip the indexer build none (deepseek_v2.py, `_skip_topk`), so
+        construction order is execution order; assert it, because the runtime
+        toggle at mla.py `not self.skip_topk` could break that in the future.
+        """
+        if self._zero_fill_owner is None:
+            self._zero_fill_owner = layer_index
+            return True
+        assert layer_index > self._zero_fill_owner, (
+            f"indexer at layer {layer_index} was built after the zero-fill "
+            f"owner at layer {self._zero_fill_owner}, so the owner may not run "
+            "first"
+        )
+        return False
+
+
 class Indexer(nn.Module):
     def __init__(
         self,
@@ -676,6 +750,7 @@ class Indexer(nn.Module):
         topk_indices_buffer: torch.Tensor | None,
         prefix: str = "",
         is_inplace_rope: bool = False,
+        indexer_qk_fusion_buffers: IndexerQKFusionBuffers | None = None,
     ):
         super().__init__()
         self.vllm_config = vllm_config
@@ -727,6 +802,16 @@ class Indexer(nn.Module):
         from vllm.v1.attention.backends.mla.indexer import get_max_prefill_buffer_size
 
         self.max_total_seq_len = get_max_prefill_buffer_size(vllm_config)
+        # The fused path writes the K cache itself; one predicate decides both
+        # the writer and the skip so they cannot disagree.
+        self.use_aiter_qk_fusion = self.can_use_aiter_qk_fusion(
+            vllm_config, config, is_inplace_rope
+        )
+        if self.use_aiter_qk_fusion:
+            logger.info_once(
+                "Fusing the DSA indexer QK pre-processing into "
+                "aiter.indexer_qk_rope_quant_and_cache"
+            )
         self.indexer_op = SparseAttnIndexer(
             self.k_cache,
             self.quant_block_size,
@@ -736,6 +821,16 @@ class Indexer(nn.Module):
             self.max_model_len,
             self.max_total_seq_len,
             self.topk_indices_buffer,
+            skip_k_cache_insert=self.use_aiter_qk_fusion,
+        )
+        self.indexer_qk_fusion_buffers = (
+            indexer_qk_fusion_buffers if self.use_aiter_qk_fusion else None
+        )
+        self.owns_qk_fusion_zero_fill = (
+            self.indexer_qk_fusion_buffers is not None
+            and self.indexer_qk_fusion_buffers.claim_zero_fill(
+                extract_layer_index(prefix)
+            )
         )
 
         self.is_inplace_rope = is_inplace_rope
@@ -748,13 +843,94 @@ class Indexer(nn.Module):
             and self.scale_fmt is not None
         )
 
+    @staticmethod
+    def can_use_aiter_qk_fusion(
+        vllm_config: VllmConfig,
+        config: DeepseekV2Config | DeepseekV3Config,
+        is_inplace_rope: bool,
+    ) -> bool:
+        """Whether the aiter fused indexer QK kernel serves this model.
+
+        Replaces the in-place-rope path, on the DSA shapes the kernel is built
+        for (head_dim 128, rope_dim 64) and on the gfx942/gfx950 parts aiter
+        ships its CK build for.
+
+        Context parallel must stay unfused: slot_mapping is PAD_SLOT_ID on
+        ranks that do not own a token, so the kernel would skip the row and
+        never write its query, which every rank needs to score its KV shard.
+        """
+        if not current_platform.is_rocm():
+            return False
+        from vllm.platforms.rocm import on_mi3xx
+
+        parallel_config = vllm_config.parallel_config
+        return bool(
+            rocm_aiter_ops.is_indexer_qk_fusion_enabled()
+            and on_mi3xx()
+            and is_inplace_rope
+            and getattr(config, "index_head_dim", None) == 128
+            and getattr(config, "qk_rope_head_dim", None) == 64
+            and parallel_config.decode_context_parallel_size == 1
+            and parallel_config.prefill_context_parallel_size == 1
+        )
+
     def forward(
         self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb
     ) -> torch.Tensor:
         q, _ = self.wq_b(qr)
         q = q.view(-1, self.n_head, self.head_dim)
 
-        if current_platform.is_rocm() and self.is_inplace_rope:
+        if self.use_aiter_qk_fusion:
+            # One GEMM, then split; the kernel reads both through their strides.
+            kw, _ = self.wk_weights_proj(hidden_states)
+            k = kw[:, : self.head_dim]
+            weights = kw[:, self.head_dim :]
+
+            kv_cache = self.k_cache.kv_cache
+            cos, sin = get_indexer_rope_halves(rotary_emb, q.dtype)
+
+            # Model-shared pair when one was handed down, a fresh zeroed pair
+            # otherwise; an init-time constant, so each layer traces one branch.
+            total = q.shape[0]
+            if self.indexer_qk_fusion_buffers is not None:
+                q_fp8 = self.indexer_qk_fusion_buffers.q_fp8
+                weights_out = self.indexer_qk_fusion_buffers.weights
+                zero_outputs = self.owns_qk_fusion_zero_fill
+            else:
+                q_fp8 = torch.zeros(
+                    (total, self.n_head, self.head_dim),
+                    dtype=current_platform.fp8_dtype(),
+                    device=q.device,
+                )
+                weights_out = torch.zeros(
+                    (total, self.n_head), dtype=torch.float32, device=q.device
+                )
+                zero_outputs = False
+
+            torch.ops.vllm.rocm_aiter_indexer_qk_rope_quant_and_cache(
+                _encode_layer_name(self.k_cache.prefix),
+                kv_cache,
+                q,
+                k,
+                weights,
+                positions,
+                cos,
+                sin,
+                # The aiter kernel reads the norm params in q's dtype.
+                self.k_norm.weight.to(q.dtype),
+                self.k_norm.bias.to(q.dtype),
+                q_fp8,
+                weights_out,
+                float(self.k_norm.eps),
+                self.quant_block_size,
+                self.scale_fmt,
+                float(self.softmax_scale * self.n_head_scale),
+                zero_outputs,
+                rotary_emb.is_neox_style,
+            )
+            # K cache already written; indexer_op skips its insert, `k` is unused.
+            return self.indexer_op(hidden_states, q_fp8[:total], k, weights_out[:total])
+        elif current_platform.is_rocm() and self.is_inplace_rope:
             # This path should works on all platform, will remove extra
             # branches in the future
             # This fast path relies on rotary_emb mutating q and k inplace.
@@ -1004,6 +1180,7 @@ class DeepseekV2MLAAttention(nn.Module):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         topk_indices_buffer: torch.Tensor | None = None,
+        indexer_qk_fusion_buffers: IndexerQKFusionBuffers | None = None,
         input_size: int | None = None,
         reduce_results: bool = True,
         non_causal_multi_token_decode: bool = False,
@@ -1168,7 +1345,10 @@ class DeepseekV2MLAAttention(nn.Module):
                 topk_indices_buffer,
                 f"{prefix}.indexer",
                 is_inplace_rope=self.indexer_rope_emb.enabled(),
+                indexer_qk_fusion_buffers=indexer_qk_fusion_buffers,
             )
+            if self.indexer.use_aiter_qk_fusion:
+                register_indexer_rope_halves(self.indexer_rope_emb)
         else:
             self.indexer_rope_emb = None
             self.indexer = None
@@ -1234,6 +1414,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         prefix: str,
         config: DeepseekV2Config | None = None,
         topk_indices_buffer: torch.Tensor | None = None,
+        indexer_qk_fusion_buffers: IndexerQKFusionBuffers | None = None,
     ) -> None:
         super().__init__()
 
@@ -1297,6 +1478,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
             topk_indices_buffer=topk_indices_buffer,
+            indexer_qk_fusion_buffers=indexer_qk_fusion_buffers,
             reduce_results=not self.use_sequence_parallel_moe,
         )
 
@@ -1419,8 +1601,12 @@ class DeepseekV2Model(nn.Module):
                 dtype=torch.int32,
                 device=self.device,
             )
+            indexer_qk_fusion_buffers = IndexerQKFusionBuffers.maybe_build(
+                vllm_config, config, self.device
+            )
         else:
             topk_indices_buffer = None
+            indexer_qk_fusion_buffers = None
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1437,6 +1623,7 @@ class DeepseekV2Model(nn.Module):
                 vllm_config=vllm_config,
                 prefix=prefix,
                 topk_indices_buffer=topk_indices_buffer,
+                indexer_qk_fusion_buffers=indexer_qk_fusion_buffers,
             ),
             prefix=f"{prefix}.layers",
         )

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1070,6 +1070,142 @@ def rocm_aiter_sparse_attn_indexer(
     return topk_indices_buffer
 
 
+# ``cos_sin_cache`` is ``cat((cos, sin), dim=-1)`` and constant after init, but
+# the kernel wants the halves separately. Splitting per forward would rewrite the
+# whole table once per layer per step; these views cost nothing, since the kernel
+# indexes by row stride and only needs the last dim contiguous.
+_INDEXER_ROPE_COS_ATTR = "aiter_indexer_rope_cos"
+_INDEXER_ROPE_SIN_ATTR = "aiter_indexer_rope_sin"
+
+
+def register_indexer_rope_halves(rope: torch.nn.Module) -> None:
+    cache = getattr(rope, "cos_sin_cache", None)
+    if not isinstance(cache, torch.Tensor) or cache.ndim != 2:
+        return
+    half = cache.shape[-1] // 2
+    rope.register_buffer(_INDEXER_ROPE_COS_ATTR, cache[:, :half], persistent=False)
+    rope.register_buffer(_INDEXER_ROPE_SIN_ATTR, cache[:, half:], persistent=False)
+
+
+def get_indexer_rope_halves(
+    rope: torch.nn.Module, dtype: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """cos/sin halves in ``dtype``, from the buffers registered at init.
+
+    The fallback covers a cache rebuilt or re-typed after registration.
+    """
+    cos = getattr(rope, _INDEXER_ROPE_COS_ATTR, None)
+    sin = getattr(rope, _INDEXER_ROPE_SIN_ATTR, None)
+    if cos is not None and sin is not None and cos.dtype == dtype:
+        return cos, sin
+    cache = rope.cos_sin_cache.to(dtype)
+    half = cache.shape[-1] // 2
+    return cache[:, :half], cache[:, half:]
+
+
+def rocm_aiter_indexer_qk_rope_quant_and_cache_fake(
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    positions: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_bias: torch.Tensor,
+    q_fp8_out: torch.Tensor,
+    weights_out: torch.Tensor,
+    epsilon: float,
+    quant_block_size: int,
+    scale_fmt: str,
+    weights_scale: float,
+    zero_outputs: bool,
+    is_neox: bool,
+) -> None:
+    return None
+
+
+def rocm_aiter_indexer_qk_rope_quant_and_cache(
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q: torch.Tensor,  # [num_tokens, n_heads, head_dim], raw post-wq_b
+    k: torch.Tensor,  # [num_tokens, head_dim], raw pre-norm/rope
+    weights: torch.Tensor,  # [num_tokens, n_heads], raw post-weights_proj
+    positions: torch.Tensor,  # [num_tokens]
+    cos: torch.Tensor,  # [max_position, rope_dim // 2]
+    sin: torch.Tensor,  # [max_position, rope_dim // 2]
+    norm_weight: torch.Tensor,  # [head_dim], q dtype
+    norm_bias: torch.Tensor,  # [head_dim], q dtype
+    q_fp8_out: torch.Tensor,  # [>= num_tokens, n_heads, head_dim] fp8, written
+    weights_out: torch.Tensor,  # [>= num_tokens, n_heads] fp32, written
+    epsilon: float,
+    quant_block_size: int,
+    scale_fmt: str,
+    weights_scale: float,
+    zero_outputs: bool,
+    is_neox: bool,
+) -> None:
+    """Run aiter's fused DSA indexer QK kernel into the caller's buffers.
+
+    One launch covers RoPE on q and k, LayerNorm on k, per-group FP8
+    quantization of both, the q scale folded into ``weights_out``, and the
+    paged indexer K-cache write.
+    """
+    from aiter import indexer_qk_rope_quant_and_cache
+
+    attn_metadata = get_forward_context().attn_metadata
+    # Profiling / dummy run: no slot_mapping, so nothing to write. The caller's
+    # buffers are already shaped, which is all tracing and profiling need.
+    if not isinstance(attn_metadata, dict):
+        return
+    from vllm.utils.torch_utils import _resolve_layer_name
+
+    k_cache_prefix = _resolve_layer_name(k_cache_prefix)
+    layer_attn_metadata = attn_metadata[k_cache_prefix]
+    assert isinstance(layer_attn_metadata, DeepseekV32IndexerMetadata)
+    slot_mapping = layer_attn_metadata.slot_mapping
+    num_tokens = slot_mapping.shape[0]
+
+    # Outputs cover one row per input token, CUDA-graph padding included: decode
+    # reads weights[:batch_size * next_n], which can exceed num_tokens. Rows the
+    # kernel skips must read as zero, so the padded logits they feed stay finite.
+    # Slice here, not in the caller, to keep the mutated args base tensors.
+    total = q.shape[0]
+    # The kernel indexes q/k/weights by slot_mapping row, so extra slots would
+    # read past their ends.
+    assert num_tokens <= total, (
+        f"slot_mapping has {num_tokens} rows but only {total} query rows"
+    )
+    q_fp8_out = q_fp8_out[:total]
+    weights_out = weights_out[:total]
+    if zero_outputs:
+        q_fp8_out.zero_()
+        weights_out.zero_()
+    indexer_qk_rope_quant_and_cache(
+        q[:num_tokens],
+        q_fp8_out[:num_tokens],
+        weights[:num_tokens],
+        weights_out[:num_tokens],
+        k[:num_tokens],
+        kv_cache,
+        slot_mapping,
+        norm_weight,
+        norm_bias,
+        positions[:num_tokens],
+        cos,
+        sin,
+        epsilon,
+        quant_block_size,
+        scale_fmt,
+        weights_scale,
+        # Same layout predicate the readers use: tiled in-block for
+        # block_size > 1, flat otherwise.
+        preshuffle=kv_cache.shape[1] > 1,
+        is_neox=is_neox,
+    )
+
+
 def _decode_e8m0_scales(scale: torch.Tensor) -> torch.Tensor:
     if scale.dtype == torch.float8_e8m0fnu:
         from vllm.model_executor.layers.quantization.utils.fp8_utils import (


### PR DESCRIPTION
## Purpose

Every DeepSeek-Sparse-Attention layer (DeepSeek-V3.2, GLM-5.x, and their MTP drafts) runs a lightweight indexer whose pre-processing costs five kernel launches per layer per step:

1. `LayerNorm` on `k`
2. RoPE on the leading rope dims of `q` and `k`
3. per-token-group FP8 quantization of `q`
4. a pointwise fold of the `q` scale into the indexer `weights`
5. FP8 quantization of `k` plus the paged indexer K-cache write

At decode sizes this is launch-bound: the cost barely moves with token count. AITER already ships a kernel that does all five in one launch (`indexer_qk_rope_quant_and_cache`). This PR wires it in behind a new, default-off env flag `VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION`.

The kernel writes the indexer K cache itself, so the sparse-attention indexer op skips its own insert (`skip_k_cache_insert`). Two data-movement optimizations ride along: the rope `cos_sin_cache` halves are registered once as strided views on the indexer's rotary embedding instead of being re-split every layer every step, and one zero-initialized `q_fp8`/`weights` output pair is shared by the indexer layers of a model (allocated next to `topk_indices_buffer` and sized the same way), with only the first indexer of a forward pass zero-filling it. The change is Python-only: the kernel is already in the AITER version the tree pins.

The fused path engages only when all of the following hold, and otherwise falls back silently to today's code:

- `VLLM_ROCM_USE_AITER=1` and `VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION=1`
- gfx942 / gfx950 (`on_mi3xx()`): AITER ships this kernel in its CK build, and the RDNA paths that `SparseAttnIndexer.forward_hip` now also serves have Triton-only AITER
- the in-place-RoPE indexer path, i.e. the `rotary_embedding` custom op is enabled
- DSA indexer shapes `index_head_dim == 128` and `qk_rope_head_dim == 64`
- no context parallelism (`decode_context_parallel_size == 1` and `prefill_context_parallel_size == 1`). The fused kernel is driven by `slot_mapping`, which is `PAD_SLOT_ID` on ranks that do not own a token, so those ranks would skip the row and never produce its quantized query — while every CP rank still needs the query to score its own KV shard.
## Related work

### #51315: same kernel, different integration scope

#51315 integrates the same AITER fused indexer kernel and is the direct overlapping effort. The shared core idea should land only once. This PR's material additional scope is:

- an explicit default-off feature gate;
- MI3XX, shape, in-place-RoPE, and context-parallel guards;
- graph-stable shared output buffers with one zero-fill per pass;
- defined zero values for skipped and padded rows;
- explicit MTP buffer ownership and wiring;
- one-time split RoPE buffer registration;
- broader correctness coverage, including skipped rows and custom-op schema;
- model-level validation across both checkpoint formats and MTP settings.

This PR is ready for maintainer comparison and coordination: maintainers can choose this implementation or carry the safety and integration pieces above into #51315. It should not be interpreted as a second independent fused-kernel feature.

### #51728: AITER dependency pin

Current vLLM main still pins AITER `v0.1.19`; #51728 proposes moving the pin to `v0.1.19.post2`. This PR does not duplicate that dependency update. The submitted code follows the currently pinned norm-parameter ABI. If the pin moves first, the fused call must follow the post2 FP32 norm-parameter contract and the op-level and model-accuracy tests must be rerun on that stack before merge.
## Test Plan

- **Image**: `vllm/vllm-openai-rocm:nightly-5a4c8d99242e9e069b604d0e9b969e77f7dd501d`.
- **8× MI355X (gfx950)** — GLM-5.2-FP8 and GLM-5.2-MXFP4: op test, kernel benchmark, coherence check, GSM8K (speculative decoding off and on), GPQA-Diamond, RULER/NIAH, serving throughput.
- **Serve configuration**: the official recipe for GLM-5.2, AMD selection (<https://recipes.vllm.ai/zai-org/GLM-5.2>), plus `--no-enable-prefix-caching` for the throughput sweep. Accuracy leaves prefix caching at its default, since GSM8K's few-shot prompts share prefixes; both arms are identical per workload.

**Serve — GLM-5.2-FP8.**

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
export VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION=1   # the flag this PR adds

vllm serve /models/GLM-5.2-FP8 --port $PORT \
  --kv-cache-dtype fp8_e4m3 --tensor-parallel-size 8 \
  --linear-backend aiter --moe-backend aiter \
  --tool-call-parser glm47 --enable-auto-tool-choice --reasoning-parser glm45 \
  --no-enable-prefix-caching        # throughput sweep only; accuracy keeps the default
```

**Serve — GLM-5.2-MXFP4.**

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
export VLLM_ROCM_USE_AITER_INDEXER_QK_FUSION=1
export VLLM_USE_V2_MODEL_RUNNER=1
export VLLM_ROCM_USE_AITER_FP8BMM=0
export VLLM_ROCM_USE_AITER_FP4BMM=0

vllm serve /models/GLM-5.2-MXFP4 --port $PORT \
  --kv-cache-dtype fp8_e4m3 --tensor-parallel-size 8 \
  --linear-backend aiter --moe-backend aiter \
  --tool-call-parser glm47 --enable-auto-tool-choice --reasoning-parser glm45 \
  --no-enable-prefix-caching --trust-remote-code
```

**Speculative decoding.** Append this to either serve command:

```bash
--speculative-config '{"method":"mtp","num_speculative_tokens":5}'
```

**Op test**

```bash
.venv/bin/python -m pytest \
  tests/kernels/attention/test_rocm_aiter_indexer_qk_fusion.py -v
```

**Kernel benchmark**

```bash
.venv/bin/python benchmarks/kernels/benchmark_indexer_qk_fusion.py --repeat 5
```

**Accuracy — coherence check.** One chat completion, to confirm the model is not producing garbage before spending hours on the rest.

```bash
curl -s http://127.0.0.1:$PORT/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "<model>", "messages": [{"role": "user", "content": "What is 17 times 23?"}],
  "temperature": 0.6, "top_p": 0.95, "max_tokens": 8192}'
```

**Accuracy — GSM8K**

```bash
lm_eval --model local-completions --tasks gsm8k \
  --model_args "model=<model>,base_url=http://127.0.0.1:$PORT/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,timeout=600"
```

**Accuracy — GPQA-Diamond**, 198 questions, zero-shot, against the running server:

```bash
.venv/bin/python -m sglang.test.run_eval --eval-name gpqa --model <model> \
  --host 127.0.0.1 --port $PORT --num-threads 32 --max-tokens 100000 \
  --temperature 1.0 --top-p 0.95 \
  --chat-template-kwargs '{"enable_thinking": true, "think_end_token": "</think>"}'
```

**Accuracy — RULER / NIAH**, 500 samples per context length, offline engine:

```bash
lm_eval --model vllm \
  --model_args 'pretrained=<model>,tensor_parallel_size=8,max_model_len=262144,gpu_memory_utilization=0.85,kv_cache_dtype=fp8,trust_remote_code=True,enable_thinking=True,think_end_token=</think>,max_gen_toks=8192,block_size=64' \
  --tasks niah_single_2 --metadata '{"max_seq_lengths":[65536,131072]}' \
  --batch_size auto --seed 1234 --log_samples --output_path ./niah
```

**Serving throughput**, for `CONC` in 4 8 16 32 64 128 256:

```bash
vllm bench serve --port $PORT --model <model> --dataset-name random \
  --random-input-len 8192 --random-output-len 1024 \
  --num-prompts $((3*CONC)) --max-concurrency $CONC \
  --num-warmups 8 --request-rate inf --ignore-eos \
  --percentile-metrics ttft,tpot,itl,e2el
```

**Lint**

```bash
uvx pre-commit run --files $(git diff --name-only HEAD~1 HEAD)
```

The op test scores the fused op and the unfused flow against an fp64 golden of the same math over 20 cases (`num_tokens` ∈ {1,7,32,257,1023} × `block_size` ∈ {1,64} × `is_neox` ∈ {True,False}): the fused path must be no less accurate than the unfused one, and the two must agree to within one fp8 code on every element above 1e-3 of the tensor maximum, for both `q_fp8 * weights_out` and the dequantized indexer K cache. Two further cases pin the rows the kernel skips to zero and `opcheck` the op's schema, for 22 in total.

## Test Result

**Current main rebase (2026-08-27)** — based on vLLM `fd57c4b7af`; the conflict-free rebase preserves the submitted patch exactly (`git range-diff`: equal). The full vLLM pre-commit set passes. The ROCm GPU results below remain from the original image and have not been rerun after this rebase.

**Op-level equivalence** — `22 passed` on 8× MI355X (gfx950).

**Kernel speed** — one indexer layer's pre-processing, median of `--repeat 5` at `block_size=64`, `n_head=32` (`index_n_heads` for both GLM-5.2 checkpoints) and the interleaved RoPE layout GLM-5.x selects, on 8× MI355X (gfx950):

| tokens | unfused | fused | speedup |
|---|---|---|---|
| 1 | 70.29 µs | 11.14 µs | **6.31×** |
| 8 | 74.10 µs | 11.31 µs | **6.55×** |
| 32 | 74.17 µs | 11.16 µs | **6.65×** |
| 64 | 74.51 µs | 11.17 µs | **6.67×** |
| 256 | 74.93 µs | 11.36 µs | **6.59×** |
| 1024 | 73.00 µs | 25.06 µs | **2.91×** |

**pre-commit** — all hooks pass (ruff check, ruff format, typos, markdownlint, mypy 3.10, SPDX headers, root lazy imports, forbidden imports, `torch.cuda` API check, configuration validation, …), exit code 0.

**Coherence check** — both arms answer 391 with a non-empty `content`, i.e. the model closed its thinking block and answered:

| Arm | `reasoning` | `content` | Answer |
|---|---|---|---|
| Before | 454 chars | 23 chars | `17 times 23 is **391**.` |
| After | 575 chars | 19 chars | `17 times 23 is 391.` |

**GSM8K (1319 questions, lm_eval `gsm8k`)**

8× MI355X, TP8. Reported as `strict-match` with lm_eval's standard error, `flexible-extract` in brackets.

| Model | MTP | Before | After |
|---|---|---|---|
| GLM-5.2-FP8 | off | **94.54%** ±0.63 (94.54%) | **94.16%** ±0.65 (94.31%) |
| GLM-5.2-FP8 | 5 tokens | **94.39%** ±0.63 (94.39%) | **94.39%** ±0.63 (94.39%) |
| GLM-5.2-MXFP4 | off | **93.10%** ±0.70 (93.10%) | **93.40%** ±0.68 (93.40%) |
| GLM-5.2-MXFP4 | 5 tokens | **94.01%** ±0.65 (94.01%) | **93.63%** ±0.67 (93.48%) |

**GPQA-Diamond (198 questions, zero-shot)**

| Model | Before | After |
|---|---|---|
| GLM-5.2-MXFP4 | **89.40%** | **91.90%** |

**RULER / NIAH (`niah_single_2`, 500 samples per length)**

| Model | Context | Before | After |
|---|---|---|---|
| GLM-5.2-MXFP4 | 65,536 | **100%** (500/500) | **100%** (500/500) |
| GLM-5.2-MXFP4 | 131,072 | **100%** (500/500) | **100%** (500/500) |

**Serving throughput, ISL 8192 / OSL 1024**

GLM-5.2-FP8, MTP off, 8× MI355X TP8:

| Conc | Out tok/s before | Out tok/s after | Δ | Mean TPOT ms |
|---|---|---|---|---|
| 4 | 154.6 | 157.2 | +1.66% | 24.8 → 24.3 |
| 8 | 273.2 | 278.3 | +1.84% | 27.4 → 26.8 |
| 16 | 461.2 | 469.9 | +1.88% | 31.5 → 30.9 |
| 32 | 700.2 | 705.2 | +0.72% | 41.0 → 40.8 |
| 64 | 989.9 | 995.2 | +0.54% | 57.9 → 57.1 |
| 128 | 1308.4 | 1311.7 | +0.25% | 85.8 → 86.0 |
| 256 | 1547.1 | 1547.8 | +0.05% | 144.2 → 144.0 |

GLM-5.2-MXFP4, MTP off, 8× MI355X TP8:

| Conc | Out tok/s before | Out tok/s after | Δ | Mean TPOT ms |
|---|---|---|---|---|
| 4 | 187.5 | 193.9 | +3.41% | 20.3 → 19.7 |
| 8 | 324.8 | 330.3 | +1.71% | 23.0 → 22.7 |
| 16 | 562.4 | 564.5 | +0.37% | 26.0 → 25.9 |
| 32 | 853.8 | 864.1 | +1.21% | 33.9 → 33.4 |
| 64 | 1249.8 | 1259.7 | +0.79% | 45.7 → 45.6 |
| 128 | 1642.5 | 1650.0 | +0.46% | 69.0 → 68.7 |
| 256 | 1975.0 | 1980.8 | +0.30% | 113.1 → 112.5 |

_Note: AI assistance was used to rebase, review, and prepare this contribution._

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described, including related work.
- [x] Test commands are provided.
- [x] Test and model evaluation results are provided with their tested base.
- [x] AI assistance is disclosed.
</details>