### PR TITLE
fix(dflash-speculator): guard capture() log on needs_capture() (#53031)

### DIFF
--- a/tests/v1/spec_decode/test_dflash_speculator_capture.py
+++ b/tests/v1/spec_decode/test_dflash_speculator_capture.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for ``DFlashSpeculator.capture()`` (#53031).
+
+The ``DFlashSpeculator.capture()`` log line ``"Capturing model for ... speculator"``
+is the only externally visible signal for whether the drafter is captured.
+Before the fix it printed unconditionally, so the line also appeared when
+``init_cudagraph_manager`` resolved to ``CUDAGraphMode.NONE`` and the
+capture loop ended up doing nothing. The fix guards the log on
+``query_cudagraph_manager.needs_capture()`` and returns early when
+nothing should be captured.
+
+These tests inject a mock ``DFlashSpeculator`` so they can run on CPU
+without a real CUDA graph setup.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+
+
+def _make_speculator(needs_capture: bool) -> SimpleNamespace:
+    """Build a hand-rolled stand-in for ``DFlashSpeculator`` that only
+    exposes the attributes touched by ``capture()``.
+
+    We bypass ``__init__`` because it requires a real ``VllmConfig`` and
+    CUDA device. The class method under test (``capture``) reads exactly
+    the attributes populated below, so the test is hermetic.
+    """
+    fake = SimpleNamespace(
+        _speculator_name="DFlashTest",
+        sample_indices=MagicMock(),
+        sample_pos=MagicMock(),
+        sample_idx_mapping=MagicMock(),
+        _generate_draft=lambda *a, **k: None,
+        input_buffers=MagicMock(),
+        block_tables=MagicMock(),
+        attn_groups=MagicMock(),
+        kv_cache_config=MagicMock(),
+        max_model_len=1024,
+        _group_causal=False,
+    )
+    manager = MagicMock()
+    manager.needs_capture.return_value = needs_capture
+    fake.query_cudagraph_manager = manager
+    return fake
+
+
+def test_capture_skips_log_and_call_when_nothing_to_capture(caplog) -> None:
+    """``needs_capture() == False`` ⇒ no log, no capture() call."""
+    import logging
+
+    speculator = _make_speculator(needs_capture=False)
+
+    with caplog.at_level(logging.INFO, logger="vllm"):
+        DFlashSpeculator.capture(speculator)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any("Capturing model" in m for m in msgs), (
+        f"unexpected capture log when needs_capture=False: {msgs!r}"
+    )
+    speculator.query_cudagraph_manager.capture.assert_not_called()
+
+
+def test_capture_logs_and_runs_when_needed(caplog) -> None:
+    """``needs_capture() == True`` ⇒ log line and capture() call both fire."""
+    import logging
+
+    speculator = _make_speculator(needs_capture=True)
+
+    with caplog.at_level(logging.INFO, logger="vllm"):
+        DFlashSpeculator.capture(speculator)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("Capturing model" in m and "DFlashTest" in m for m in msgs), (
+        f"expected capture log when needs_capture=True: {msgs!r}"
+    )
+    speculator.query_cudagraph_manager.capture.assert_called_once()

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -138,12 +138,19 @@ class DFlashSpeculator(DraftModelSpeculator):
         )
 
     def capture(self) -> None:
+        # DFlash skips CUDA-graph capture in some configurations (draft
+        # attention does not support full cudagraphs, etc.). The log line
+        # below is the only externally visible signal for whether the
+        # drafter is captured, so guard it on needs_capture() to avoid
+        # logging "Capturing model ..." when nothing is captured. See #53031.
+        assert self.query_cudagraph_manager is not None
+        if not self.query_cudagraph_manager.needs_capture():
+            return
         logger.info("Capturing model for %s speculator...", self._speculator_name)
         # Padded sample rows must not scatter into a live request during capture.
         self.sample_indices.zero_()
         self.sample_pos.zero_()
         self.sample_idx_mapping.fill_(-1)
-        assert self.query_cudagraph_manager is not None
         self.query_cudagraph_manager.capture(
             self._generate_draft,
             self.input_buffers,


### PR DESCRIPTION
## Bugfix

Fixes [#53031](https://github.com/vllm-project/vllm/issues/53031) — `DFlashSpeculator.capture()` logged "Capturing model for ... speculator" unconditionally, even when `init_cudagraph_manager` resolved to `CUDAGraphMode.NONE` and the capture loop did nothing.

That line is the only externally visible signal for whether the drafter is captured, so an unconditional log made the drafter-capture state unobservable from outside the process.

## Reproducer

Run any DFlash setup where draft attention does not support full cudagraphs (e.g. uniform batch < `AttentionCGSupport.UNIFORM_BATCH`, or runner decode mode not `FULL`). Inspect the worker log: the "Capturing model ..." line prints once per worker even though the discoverer returned early on `if not (self.cudagraph_mode and capture_sizes)` and `_capture_descs` stayed empty.

## Fix

Mirror the model runner's existing guard pattern at `vllm/v1/worker/gpu/model_runner.py`:

```python
def capture(self) -> None:
+    assert self.query_cudagraph_manager is not None
+    if not self.query_cudagraph_manager.needs_capture():
+        return
     logger.info("Capturing model for %s speculator...", self._speculator_name)
     ...
```

`needs_capture()` already exists on the manager (returns `len(self._capture_descs) > 0`). The early-return matches the model runner pattern exactly, so the only operator-visible difference is that the log line becomes an accurate proxy for "something was actually captured".

The reporter proposed this exact diff in the bug report — submitting it as a PR with a regression test so future changes can't quietly regress.

## Files

| File | Change |
| --- | --- |
| `vllm/v1/worker/gpu/spec_decode/dflash/speculator.py` | 3 new lines: assert + early-return + comment. Reorder so the log message lives after the guard. |
| `tests/v1/spec_decode/test_dflash_speculator_capture.py` | CPU-only regression test (mock-based). Verifies (a) `needs_capture=False` ⇒ no log + no `capture()` call, (b) `needs_capture=True` ⇒ log + `capture()` call as before. |

Diff: `+87 / -1`, 2 files.

## Risk

Behavioural change is limited to the log surface. The `assert` was already correct (asserts a stronger precondition than the existing code used); the early-return was the gap. No data-flow or API changes. The full capture path is unchanged when there *is* something to capture.

## Local verification

- `pytest tests/v1/spec_decode/test_dflash_speculator_capture.py -v` — 2 tests pass.
- Test follows the existing `SimpleNamespace` + `unittest.mock.MagicMock` pattern from `tests/v1/spec_decode/test_dflash_prepare_inputs.py` so it stays hermetic. CPU-only because `DFlashSpeculator.__init__` requires a real `VllmConfig`; the `capture()` method itself only reads attributes, so the mock-based harness is clean.

## Notes for maintainers

- Marked `fix(...)` rather than `feat(...)` because it changes an *observable log* rather than adds new functionality.
- The `needs_capture()` API predates this PR and is already imported by the model runner, so no new cross-file surface area is introduced.
- Followed the same review momentum: the reporter's quoted diff maps 1:1 to the source change; the test file is the only addition.
