### PR TITLE
[ROCm][Quantization][MOE] Enable fused shared experts for block-quantized FP8

### DIFF
--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -738,18 +738,19 @@ def test_per_tensor_fp8_shared_expert_fse_is_incompatible() -> None:
     )
 
 
-def test_mxfp4_store_dtype_fp8_shared_expert_fse_is_incompatible() -> None:
-    """Routed experts become MXFP4 while the shared-expert linears stay FP8."""
+@pytest.mark.parametrize("store_dtype", ["mxfp4", "nvfp4"])
+def test_store_dtype_fp8_shared_expert_fse_is_incompatible(store_dtype: str) -> None:
+    """Any routed-expert storage override rules out fusing the shared expert."""
     compatible, reason = is_shared_expert_quant_fse_compatible(
-        _fp8_config(store_dtype="mxfp4"),
+        _fp8_config(store_dtype=store_dtype),
         "model.layers.0.mlp.experts",
         "model.layers.0.mlp.shared_experts",
     )
 
     assert not compatible
     assert reason == (
-        "FP8 stores routed experts as MXFP4 while shared experts at "
-        "model.layers.0.mlp.shared_experts remain FP8"
+        f"FP8 stores routed experts as {store_dtype}, which is not supported "
+        "for fused shared experts at model.layers.0.mlp.shared_experts"
     )
 
 

--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -15,6 +15,7 @@ import vllm.config as vllm_config_module
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.fused_moe import utils as fused_moe_utils
 from vllm.model_executor.layers.fused_moe.layer import determine_expert_counts
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
 from vllm.model_executor.layers.quantization.utils.config_utils import (
     is_shared_expert_quant_fse_compatible,
@@ -701,3 +702,134 @@ def test_non_quark_shared_expert_fse_is_incompatible() -> None:
     assert reason == (
         "shared-expert FSE quantization compatibility is not implemented for object"
     )
+
+
+def _fp8_config(**kwargs: Any) -> Fp8Config:
+    return Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        weight_block_size=[128, 128],
+        **kwargs,
+    )
+
+
+def test_block_fp8_shared_expert_fse_is_compatible() -> None:
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        _fp8_config(),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert compatible
+    assert reason is None
+
+
+def test_per_tensor_fp8_shared_expert_fse_is_incompatible() -> None:
+    """Per-tensor scales are 0-D, so the shared-expert chunker cannot slice them."""
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        Fp8Config(is_checkpoint_fp8_serialized=True, activation_scheme="dynamic"),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert not compatible
+    assert reason == (
+        "FP8 shared-expert FSE is only implemented for block-quantized checkpoints"
+    )
+
+
+def test_mxfp4_store_dtype_fp8_shared_expert_fse_is_incompatible() -> None:
+    """Routed experts become MXFP4 while the shared-expert linears stay FP8."""
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        _fp8_config(store_dtype="mxfp4"),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert not compatible
+    assert reason == (
+        "FP8 stores routed experts as MXFP4 while shared experts at "
+        "model.layers.0.mlp.shared_experts remain FP8"
+    )
+
+
+@pytest.mark.parametrize(
+    "ignored_layers",
+    [
+        ["model.layers.0.mlp.experts"],
+        ["model.layers.0.mlp.shared_experts.gate_up_proj"],
+        ["model.layers.0.mlp.shared_experts.down_proj"],
+    ],
+)
+def test_fp8_shared_expert_fse_rejects_asymmetric_ignored_layers(
+    ignored_layers: list[str],
+) -> None:
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        _fp8_config(ignored_layers=ignored_layers),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert not compatible
+    assert reason == (
+        "FP8 ignores routed and shared experts inconsistently at "
+        "model.layers.0.mlp.shared_experts"
+    )
+
+
+def test_fp8_shared_expert_fse_allows_symmetric_ignored_layers() -> None:
+    """Both sides unquantized is still a consistent scheme."""
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        _fp8_config(
+            ignored_layers=[
+                "model.layers.0.mlp.experts",
+                "model.layers.0.mlp.shared_experts.gate_up_proj",
+                "model.layers.0.mlp.shared_experts.down_proj",
+            ]
+        ),
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert compatible
+    assert reason is None
+
+
+def test_fp8_shared_expert_fse_expands_packed_projections() -> None:
+    """Both shards of a fused projection ignored is symmetric within that
+    projection, so the mismatch reported is against the routed experts."""
+    quant_config = _fp8_config(
+        ignored_layers=[
+            "model.layers.0.mlp.shared_experts.gate_proj",
+            "model.layers.0.mlp.shared_experts.up_proj",
+        ]
+    )
+    quant_config.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        quant_config,
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert not compatible
+    assert reason == (
+        "FP8 ignores routed and shared experts inconsistently at "
+        "model.layers.0.mlp.shared_experts"
+    )
+
+
+def test_fp8_shared_expert_fse_propagates_partial_shard_exclusion() -> None:
+    """Half a fused projection excluded is rejected by `is_layer_skipped`
+    itself, exactly as it is in `Fp8Config.get_quant_method`."""
+    quant_config = _fp8_config(
+        ignored_layers=["model.layers.0.mlp.shared_experts.gate_proj"]
+    )
+    quant_config.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+    with pytest.raises(ValueError, match="some but not all shards"):
+        is_shared_expert_quant_fse_compatible(
+            quant_config,
+            "model.layers.0.mlp.experts",
+            "model.layers.0.mlp.shared_experts",
+        )

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -32,7 +32,11 @@ def is_shared_expert_quant_fse_compatible(
     if quant_config is None:
         return True, None
 
+    from vllm.model_executor.layers.quantization.fp8 import Fp8Config
     from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        is_layer_skipped,
+    )
     from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
 
     if isinstance(quant_config, DeepseekV4FP8Config):
@@ -143,6 +147,45 @@ def is_shared_expert_quant_fse_compatible(
             "Quark uses different quantization configurations for routed and "
             f"shared experts at {shared_expert_prefix}",
         )
+
+    if isinstance(quant_config, Fp8Config):
+        if quant_config.store_dtype == "mxfp4":
+            return (
+                False,
+                "FP8 stores routed experts as MXFP4 while shared experts at "
+                f"{shared_expert_prefix} remain FP8",
+            )
+
+        # Serialized per-tensor checkpoints store 0-D or size-1 scales, which
+        # the shared-expert weight chunker cannot slice into the appended expert
+        # slots; online FP8 is simply untested. Both lack a weight block size.
+        if quant_config.weight_block_size is None:
+            return (
+                False,
+                "FP8 shared-expert FSE is only implemented for block-quantized "
+                "checkpoints",
+            )
+
+        def is_ignored(layer_name: str) -> bool:
+            return is_layer_skipped(
+                prefix=layer_name,
+                ignored_layers=quant_config.ignored_layers,
+                fused_mapping=quant_config.packed_modules_mapping,
+                match_mode=quant_config.ignored_layers_match_mode,
+            )
+
+        expert_ignored = is_ignored(expert_prefix)
+        if any(
+            is_ignored(f"{shared_expert_prefix}.{projection_name}") != expert_ignored
+            for projection_name in projection_names
+        ):
+            return (
+                False,
+                "FP8 ignores routed and shared experts inconsistently at "
+                f"{shared_expert_prefix}",
+            )
+
+        return True, None
 
     # TODO: Extend FSE support detection to other quantization methods. Typically,
     # one would check that the experts and shared_experts use the same

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -149,11 +149,12 @@ def is_shared_expert_quant_fse_compatible(
         )
 
     if isinstance(quant_config, Fp8Config):
-        if quant_config.store_dtype == "mxfp4":
+        if quant_config.store_dtype is not None:
             return (
                 False,
-                "FP8 stores routed experts as MXFP4 while shared experts at "
-                f"{shared_expert_prefix} remain FP8",
+                f"FP8 stores routed experts as {quant_config.store_dtype}, which "
+                f"is not supported for fused shared experts at "
+                f"{shared_expert_prefix}",
             )
 
         # Serialized per-tensor checkpoints store 0-D or size-1 scales, which


### PR DESCRIPTION
## Purpose

**To enable fp8 models such as DeepSeek-R1-0528 ("n_shared_experts": 1, "quant_method": "fp8")**

On top of PR [#51695](https://github.com/vllm-project/vllm/pull/51695).

PR #51695 (`88b2bff2c63`) centralised the "may this model fuse its shared experts into the routed grouped GEMM?" decision into `is_shared_expert_quant_fse_compatible`. That helper implements `None`, `DeepseekV4FP8Config` and `QuarkConfig`, and closes with a TODO plus a generic fallback for everything else.

`Fp8Config` therefore lands in the fallback. On ROCm with `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`, a block-quantized FP8 checkpoint (DeepSeek-V3/R1 and friends) now reports
```
shared-expert FSE quantization compatibility is not implemented for Fp8Config
```

is logged as `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS is enabled but cannot be enabled: ...` (`vllm/model_executor/layers/fused_moe/utils.py:85-90`, duplicated at `vllm/models/deepseek_v4/amd/model.py:239-245` and
`vllm/models/minimax_m3/amd/model.py:386-392`) and falls back to running the shared expert as separate linears. This is not a silent failure -- it warns -- but before #51695 `deepseek_v2.py` gated fused shared experts on the env var alone, with no quantization check, so this configuration did take the fused path.

This PR fills that TODO for `Fp8Config`, restoring the fused path for the case that is actually safe, and rejecting the cases that are not.

## What changes

Three gates, then compatible.

### Gate 1 -- `store_dtype == "mxfp4"` (`config_utils.py:152-157`)
This gate is defensive. Folding an FP8 shared expert into MXFP4 expert slots is exactly the storage-format mismatch this helper exists to catch.

### Gate 2 -- `weight_block_size is None` (`config_utils.py:161-166`)

Fused shared experts are enabled only for block-quantized FP8. Two distinct populations are rejected here:

- **Serialized per-tensor checkpoints.** Their scales are 0-D (AutoFP8) or size-1 (compressed-tensors) -- On a 0-D tensor that is an `IndexError`; on a size-1 tensor with `n_shared_experts > 1` the following divisibility assert (`deepseek_v2.py:1689-1692`) fails instead. Reporting these compatible would turn a model that loads today into a load-time crash.
- **Online (non-serialized) FP8.** No scale tensors exist in the checkpoint, so nothing crashes -- this half is rejected because it is untested, not because broken.

### Gate 3 -- asymmetric `ignored_layers` (`config_utils.py:169-185`)

`ignored_layers` + `ignored_layers_match_mode` is the **only** per-layer discriminator on `Fp8Config`; the whole class body (`fp8.py:92-236`) has no `layer_quant_config` / `targets` / `overrides`, and every other field (`activation_scheme`, `weight_block_size`, `is_checkpoint_fp8_serialized`, `use_deep_gemm`) is model-global and so cannot differ between routed and shared experts by construction. Once ignore-status agrees, both sides are driven by the same config object and reach the same FP8 scheme.

## Unit Test Plan & Result

### Plan

7 new test functions (9 parametrized cases) in `tests/model_executor/layers/test_fused_shared_expert.py`, modelled on the existing Quark compatibility tests in the same file:

| test | asserts |
|---|---|
| `test_block_fp8_shared_expert_fse_is_compatible` | block FP8 -> `(True, None)` |
| `test_per_tensor_fp8_shared_expert_fse_is_incompatible` | gate 2 |
| `test_mxfp4_store_dtype_fp8_shared_expert_fse_is_incompatible` | gate 1 |
| `test_fp8_shared_expert_fse_rejects_asymmetric_ignored_layers` | gate 3, parametrized over routed-only / gate_up-only / down-only |
| `test_fp8_shared_expert_fse_allows_symmetric_ignored_layers` | symmetric exclusion -> compatible |
| `test_fp8_shared_expert_fse_expands_packed_projections` | `packed_modules_mapping` fused-shard expansion |
| `test_fp8_shared_expert_fse_propagates_partial_shard_exclusion` | limitation 4 above |

### Results

Passed

## End-to-end Test Plan & Result (negative -> positive)

### Plan

Two arms:
- **negative** = unmodified `upstream/main`
- **positive** = the same tree plus this PR changes

DeepSeek-R1-0528 is used to run the end-to-end validation:
- Checkpoint: **`DeepSeek-R1-0528`**, unmodified, all 61 layers. Its `quantization_config` is `{"quant_method": "fp8", "activation_scheme": "dynamic", "fmt": "e4m3", "weight_block_size": [128, 128]}` with `n_shared_experts: 1`, `n_routed_experts: 256` and `first_k_dense_replace: 3`, so layers 3..60 -- 58 layers -- are MoE layers with a shared expert. It resolves to plain `Fp8Config`: not `QuarkConfig`, not `CompressedTensorsConfig`, and not `DeepseekV4FP8Config`. That is exactly the config class that had no branch, and it is the class every stock DeepSeek-V3/R1 FP8 release lands on.
- Hardware/env: 8x MI325X (gfx942, 256 GiB), TP8, torch 2.11. 
- Environments: `VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1 VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`.

### Results

#### GSM8K

| | negative (`upstream/main`) | positive (this PR) |
|---|---|---|
| `"cannot be enabled"` warnings | **464** (58 MoE layers x 8 ranks) | **0** |
| fused shared experts | declined everywhere | active everywhere |
| **GSM8K accuracy** | **0.9568** (1262/1319) | **0.9538** (1258/1319) |
| invalid responses | 0.000 | 0.000 |
| output tokens/s | 2352.7 | 2503.6 (+6.4%) |
| questions/s | 24.23 | 26.04 (+7.5%) |

#### Throughput (non-eager)

5 timed repeats per batch size, median reported:

| batch | negative (`upstream/main`) | positive (this PR) | delta |
|---|---|---|---|
| 1 | 90.9 tok/s | 103.2 tok/s | +13.5% |
| 16 | 985.7 tok/s | 1153.8 tok/s | +17.1% |
| 64 | 2799.6 tok/s | 3222.8 tok/s | +15.1% |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

