### PR TITLE
[Model] Add FP8 quantization support for ModernBERT

### DIFF
--- a/tests/model_executor/test_modernbert_quantization.py
+++ b/tests/model_executor/test_modernbert_quantization.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+import pytest
+from torch import nn
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_modernbert_encoder_linears_receive_quant_config():
+    from vllm.model_executor.models.modernbert import ModernBertEncoderLayer
+
+    config = SimpleNamespace(
+        hidden_size=16,
+        intermediate_size=24,
+        num_attention_heads=4,
+        num_hidden_layers=1,
+        deterministic_flash_attn=False,
+        attention_bias=False,
+        layer_types=["full_attention"],
+        rope_parameters={
+            "full_attention": {
+                "rope_type": "default",
+                "rope_theta": 160_000.0,
+            }
+        },
+        max_position_embeddings=128,
+        mlp_bias=False,
+        hidden_activation="gelu",
+        norm_eps=1e-5,
+        norm_bias=False,
+    )
+    quant_config = Mock()
+    vllm_config = Mock()
+    vllm_config.model_config.hf_config = config
+    vllm_config.model_config.dtype = None
+    vllm_config.quant_config = quant_config
+
+    with (
+        patch(
+            "vllm.model_executor.models.modernbert."
+            "get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "vllm.model_executor.models.modernbert.QKVParallelLinear",
+            return_value=nn.Identity(),
+        ) as qkv_linear,
+        patch(
+            "vllm.model_executor.models.modernbert.MergedColumnParallelLinear",
+            return_value=nn.Identity(),
+        ) as merged_linear,
+        patch(
+            "vllm.model_executor.models.modernbert.RowParallelLinear",
+            side_effect=[nn.Identity(), nn.Identity()],
+        ) as row_linear,
+        patch(
+            "vllm.model_executor.models.modernbert.get_rope",
+            return_value=nn.Identity(),
+        ),
+        patch(
+            "vllm.model_executor.models.modernbert.EncoderOnlyAttention",
+            return_value=nn.Identity(),
+        ),
+    ):
+        ModernBertEncoderLayer(vllm_config, prefix="encoder")
+
+    qkv_linear.assert_called_once_with(
+        16,
+        4,
+        4,
+        bias=False,
+        quant_config=quant_config,
+        prefix="encoder.layers.0.attn.Wqkv",
+    )
+    merged_linear.assert_called_once_with(
+        16,
+        [24, 24],
+        bias=False,
+        quant_config=quant_config,
+        prefix="encoder.layers.0.mlp.Wi",
+    )
+    row_linear.assert_has_calls(
+        [
+            call(
+                16,
+                16,
+                bias=False,
+                quant_config=quant_config,
+                prefix="encoder.layers.0.attn.Wo",
+            ),
+            call(
+                24,
+                16,
+                bias=False,
+                quant_config=quant_config,
+                prefix="encoder.layers.0.mlp.Wo",
+            ),
+        ]
+    )

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -13,7 +13,11 @@ from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.model_executor.layers.attention import (
     EncoderOnlyAttention,
 )
-from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
 from vllm.model_executor.layers.pooler import DispatchPooler
 from vllm.model_executor.layers.pooler.activations import LambdaPoolerActivation
 from vllm.model_executor.layers.pooler.seqwise import (
@@ -22,6 +26,7 @@ from vllm.model_executor.layers.pooler.seqwise import (
     get_seq_pooling_method,
 )
 from vllm.model_executor.layers.pooler.tokwise import pooler_for_token_classify
+from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
@@ -68,6 +73,7 @@ class ModernBertAttention(nn.Module):
         layer_id: int | None = None,
         prefix: str = "",
         dtype: torch.dtype | None = None,
+        quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
         self.config = config
@@ -85,6 +91,7 @@ class ModernBertAttention(nn.Module):
             self.head_dim,
             self.num_heads,
             bias=config.attention_bias,
+            quant_config=quant_config,
             prefix=f"{prefix}.Wqkv",
         )
 
@@ -128,6 +135,7 @@ class ModernBertAttention(nn.Module):
             config.hidden_size,
             config.hidden_size,
             bias=config.attention_bias,
+            quant_config=quant_config,
             prefix=f"{prefix}.Wo",
         )
 
@@ -146,22 +154,33 @@ class ModernBertAttention(nn.Module):
 
 
 class ModernBertMLP(nn.Module):
-    def __init__(self, config: ModernBertConfig, prefix: str = ""):
+    def __init__(
+        self,
+        config: ModernBertConfig,
+        prefix: str = "",
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         self.config = config
-        self.Wi = nn.Linear(
-            config.hidden_size, int(config.intermediate_size) * 2, bias=config.mlp_bias
+        self.Wi = MergedColumnParallelLinear(
+            config.hidden_size,
+            [int(config.intermediate_size)] * 2,
+            bias=config.mlp_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.Wi",
         )
         self.act = ACT2FN[config.hidden_activation]
         self.Wo = RowParallelLinear(
             config.intermediate_size,
             config.hidden_size,
             bias=config.mlp_bias,
+            quant_config=quant_config,
             prefix=f"{prefix}.Wo",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        input, gate = self.Wi(hidden_states).chunk(2, dim=-1)
+        input_gate, _ = self.Wi(hidden_states)
+        input, gate = input_gate.chunk(2, dim=-1)
         return self.Wo(self.act(input) * gate)[0]
 
 
@@ -172,6 +191,7 @@ class ModernBertLayer(nn.Module):
         prefix: str = "",
         layer_id: int | None = None,
         dtype: torch.dtype | None = None,
+        quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
         self.config = config
@@ -186,11 +206,16 @@ class ModernBertLayer(nn.Module):
             layer_id=layer_id,
             prefix=f"{prefix}.attn",
             dtype=dtype,
+            quant_config=quant_config,
         )
         self.mlp_norm = nn.LayerNorm(
             config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
         )
-        self.mlp = ModernBertMLP(config, prefix=f"{prefix}.mlp")
+        self.mlp = ModernBertMLP(
+            config,
+            prefix=f"{prefix}.mlp",
+            quant_config=quant_config,
+        )
 
     def forward(
         self,
@@ -211,6 +236,7 @@ class ModernBertEncoderLayer(nn.Module):
         super().__init__()
         config = vllm_config.model_config.hf_config
         dtype = vllm_config.model_config.dtype
+        quant_config = vllm_config.quant_config
         self.layers = nn.ModuleList(
             [
                 ModernBertLayer(
@@ -218,6 +244,7 @@ class ModernBertEncoderLayer(nn.Module):
                     layer_id=layer_id,
                     prefix=f"{prefix}.layers.{layer_id}",
                     dtype=dtype,
+                    quant_config=quant_config,
                 )
                 for layer_id in range(config.num_hidden_layers)
             ]


### PR DESCRIPTION
## Purpose

Fixes #47683.

ModernBERT did not pass `vllm_config.quant_config` to its encoder linear layers. As a result, loading an `llmcompressor` `FP8_DYNAMIC` checkpoint did not register the corresponding `weight_scale` parameters. Depending on the loader version, this either failed while loading the scales or silently produced non-finite embeddings.

This PR:

- threads `quant_config` through `ModernBertEncoderLayer -> ModernBertLayer -> ModernBertAttention / ModernBertMLP`;
- passes it to `Wqkv`, attention `Wo`, and MLP `Wo`;
- replaces the plain `nn.Linear` MLP `Wi` with `MergedColumnParallelLinear`;
- adds a focused regression test covering all four encoder projections.

`Wi` contains two fused logical projections. Using `MergedColumnParallelLinear` preserves their independent shard boundaries, while retaining the original `[input, gate]` output layout. Pooling heads, classifier heads, and embeddings are unchanged.

This does not duplicate an existing PR. An open-PR search for #47683 and for ModernBERT FP8 support found no matching implementation. #45535 changes embedding and tied-weight handling for WNA16 quantization and does not thread `quant_config` through the ModernBERT encoder linears.

## Test Plan

Run the focused constructor-wiring regression test:

```bash
.venv/bin/python -m pytest \
  tests/model_executor/test_modernbert_quantization.py -v
```

Run the relevant static checks:

```bash
pre-commit run ruff-check --files \
  vllm/model_executor/models/modernbert.py \
  tests/model_executor/test_modernbert_quantization.py

pre-commit run ruff-format --files \
  vllm/model_executor/models/modernbert.py \
  tests/model_executor/test_modernbert_quantization.py

pre-commit run mypy-3.12 --hook-stage manual --files \
  vllm/model_executor/models/modernbert.py \
  tests/model_executor/test_modernbert_quantization.py

git diff --check
```

Generate a W8A8 FP8 dynamic checkpoint with `llmcompressor==0.12.0` and
`compressed-tensors==0.17.1`:

```bash
.venv/bin/python - <<'PY'
from pathlib import Path

from transformers import AutoModel, AutoTokenizer

from llmcompressor import oneshot
from llmcompressor.modifiers.quantization import QuantizationModifier

model_id = "answerdotai/ModernBERT-base"
output_dir = Path("/tmp/ModernBERT-base-FP8-Dynamic")

model = AutoModel.from_pretrained(model_id, low_cpu_mem_usage=True)
tokenizer = AutoTokenizer.from_pretrained(model_id)
recipe = QuantizationModifier(targets="Linear", scheme="FP8_DYNAMIC")

oneshot(model=model, recipe=recipe, output_dir=output_dir)
tokenizer.save_pretrained(output_dir)
PY
```

Serve the FP8 checkpoint on an RTX 4090 and send embedding requests:

```bash
VLLM_USE_FLASHINFER_SAMPLER=0 .venv/bin/vllm serve \
  /tmp/ModernBERT-base-FP8-Dynamic \
  --runner pooling \
  --enforce-eager \
  --max-model-len 512 \
  --gpu-memory-utilization 0.3

curl http://127.0.0.1:8000/v1/embeddings \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "/tmp/ModernBERT-base-FP8-Dynamic",
    "input": [
      "hello world",
      "ModernBERT FP8 validation",
      "The quick brown fox jumps over the lazy dog."
    ]
  }'
```

Repeat the same requests against an unquantized `ModernBertModel` checkpoint created from `answerdotai/ModernBERT-base`, then compare output dimensions, finite values, L2 norms, cosine similarity, and maximum absolute difference.

## Test Result

Environment:

- GPU: NVIDIA GeForce RTX 4090, 24 GB
- Driver: 580.95.05
- PyTorch: 2.13.0+cu132
- Runtime `compressed-tensors`: 0.17.0
- Checkpoint `compressed-tensors`: 0.17.1

Results:

- Before the fix, the FP8 server returned HTTP 200 but all 768 embedding values were JSON `null` because the model output contained NaNs.
- After the fix, the generated checkpoint loaded successfully and exposed 88 `weight_scale` tensors: four per encoder layer across 22 layers. It exposed zero `input_scale` tensors, as expected for dynamic per-token activation
  quantization.
- vLLM selected `CutlassFP8ScaledMMLinearKernel` for `CompressedTensorsW8A8Fp8` on the RTX 4090.
- All three FP8 requests returned 768 finite values with L2 norm approximately 1.0.
- The unquantized ModernBERT path also loaded and returned finite, normalized embeddings.

FP8 versus unquantized output comparison:

| Input | Cosine similarity | Maximum absolute difference |
| --- | ---: | ---: |
| `hello world` | 0.994375 | 0.053796 |
| `ModernBERT FP8 validation` | 0.999963 | 0.003760 |
| `The quick brown fox jumps over the lazy dog.` | 0.998330 | 0.006787 |

Mean cosine similarity was 0.997556. This is a numerical smoke comparison, not a task-level accuracy benchmark. No throughput claim is made by this PR.

- Focused pytest: `1 passed`.
- `ruff-check`: passed.
- `ruff-format`: passed.
- Python 3.12 `mypy`: passed.
- `git diff --check`: passed.

No documentation update is required because this change extends quantization support for an already supported model architecture and does not add a new user-facing option.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR and the issue it resolves.
- [x] The test commands that were run.
- [x] The before/after and end-to-end test results.
- [x] Documentation impact was evaluated; no update is required.

</details>
