### PR TITLE
[Feature][Spec Decode] Carry auxiliary state across PP stages

### DIFF
--- a/tests/distributed/test_pp_payload.py
+++ b/tests/distributed/test_pp_payload.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.distributed.pp_payload import (
+    AUX_HIDDEN_STATES_NAMESPACE,
+    PP_SIDECAR_PREFIX,
+    TOPK_INDICES_NAMESPACE,
+    PPForwardPayload,
+    merge_pp_aux_hidden_states,
+)
+from vllm.sequence import IntermediateTensors
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _intermediate(value: float) -> IntermediateTensors:
+    return IntermediateTensors(
+        {
+            "hidden_states": torch.full((2, 3), value, dtype=torch.float32),
+            "residual": torch.full((2, 3), -value, dtype=torch.float32),
+        }
+    )
+
+
+def test_pp_forward_payload_roundtrip_and_multihop():
+    aux_2 = torch.full((2, 3), 2.0)
+    aux_10 = torch.full((2, 3), 10.0)
+    topk_0 = torch.tensor([[0, 1], [2, 3]], dtype=torch.int32)
+    topk_1 = torch.tensor([[4, 5], [6, 7]], dtype=torch.int32)
+
+    rank_0 = PPForwardPayload(_intermediate(0))
+    rank_0.add_aux_hidden_states([2], [aux_2])
+    rank_0.set_topk_indices(topk_0)
+
+    rank_1_in = PPForwardPayload.from_intermediate_tensors(
+        rank_0.to_intermediate_tensors()
+    )
+    local_buffer = torch.empty_like(topk_0)
+    rank_1_in.copy_topk_indices_to(local_buffer, 2)
+    torch.testing.assert_close(local_buffer, topk_0)
+
+    rank_1_local = PPForwardPayload(_intermediate(1))
+    rank_1_local.add_aux_hidden_states([10], [aux_10])
+    rank_1_out = rank_1_in.carry(rank_1_local.to_intermediate_tensors())
+    rank_1_out.set_topk_indices(topk_1)
+
+    rank_2_in = PPForwardPayload.from_intermediate_tensors(
+        rank_1_out.to_intermediate_tensors()
+    )
+    torch.testing.assert_close(
+        rank_2_in.intermediate_tensors["hidden_states"],
+        torch.full((2, 3), 1.0),
+    )
+    aux_by_layer = rank_2_in.pop_aux_hidden_states()
+    assert aux_by_layer[2] is aux_2
+    assert aux_by_layer[10] is aux_10
+    assert rank_2_in.pop_topk_indices() is topk_1
+
+
+def test_merge_pp_aux_hidden_states_uses_configured_global_order():
+    aux_2 = torch.tensor([2])
+    aux_10 = torch.tensor([10])
+    aux_20 = torch.tensor([20])
+    payload = PPForwardPayload(_intermediate(0))
+    payload.add_aux_hidden_states([10, 2], [aux_10, aux_2])
+
+    merged = merge_pp_aux_hidden_states(payload, (2, 10, 20), [aux_20])
+
+    assert merged[0] is aux_2
+    assert merged[1] is aux_10
+    assert merged[2] is aux_20
+
+
+@pytest.mark.parametrize(
+    ("layer_ids", "local_states", "message"),
+    [
+        ((2, 2), [], "Duplicate aux hidden-state layer ids"),
+        ((2, 10), [], "last PP stage"),
+    ],
+)
+def test_merge_pp_aux_hidden_states_rejects_invalid_counts(
+    layer_ids: tuple[int, ...],
+    local_states: list[torch.Tensor],
+    message: str,
+):
+    with pytest.raises(ValueError, match=message):
+        merge_pp_aux_hidden_states(None, layer_ids, local_states)
+
+
+def test_pp_forward_payload_validates_topk_shape():
+    payload = PPForwardPayload(_intermediate(0))
+    payload.set_topk_indices(torch.zeros((2, 4), dtype=torch.int32))
+
+    with pytest.raises(ValueError, match="top-k indices shape"):
+        payload.copy_topk_indices_to(
+            torch.empty((2, 3), dtype=torch.int32), num_tokens=2
+        )
+
+
+def test_pp_forward_payload_sidecars_disable_implicit_tp_all_gather():
+    policy = PPForwardPayload.make_all_gather_policy({"residual": True})
+    aux_key = f"{PP_SIDECAR_PREFIX}{AUX_HIDDEN_STATES_NAMESPACE}/2"
+    topk_key = f"{PP_SIDECAR_PREFIX}{TOPK_INDICES_NAMESPACE}/buffer"
+
+    assert policy.get("residual", False)
+    assert policy.get("hidden_states", True)
+    assert not policy.get(aux_key, True)
+    assert not policy.get(topk_key, True)
+
+
+def test_pp_forward_payload_rejects_malformed_sidecar_key():
+    malformed_key = f"{PP_SIDECAR_PREFIX}missing_name"
+
+    with pytest.raises(ValueError, match="Malformed PP sidecar key"):
+        PPForwardPayload.from_intermediate_tensors(
+            IntermediateTensors({malformed_key: torch.tensor([1])})
+        )

--- a/vllm/distributed/pp_payload.py
+++ b/vllm/distributed/pp_payload.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Optional tensors carried alongside pipeline-parallel model activations."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import TypeVar, overload
+
+import torch
+
+from vllm.sequence import IntermediateTensors
+
+PP_SIDECAR_PREFIX = "__vllm_pp_sidecar__/"
+AUX_HIDDEN_STATES_NAMESPACE = "aux_hidden_states"
+TOPK_INDICES_NAMESPACE = "topk_indices"
+TOPK_INDICES_NAME = "buffer"
+
+_T = TypeVar("_T")
+
+
+class _SidecarAllGatherPolicy(dict[str, bool]):
+    """Keep sidecars on their matching TP lane during PP communication."""
+
+    @overload
+    def get(self, key: str, default: None = None, /) -> bool | None: ...
+
+    @overload
+    def get(self, key: str, default: bool, /) -> bool: ...
+
+    @overload
+    def get(self, key: str, default: _T, /) -> bool | _T: ...
+
+    def get(self, key: str, default: _T | None = None, /) -> bool | _T | None:
+        if key.startswith(PP_SIDECAR_PREFIX) and key not in self:
+            return False
+        return super().get(key, default)
+
+
+@dataclass
+class PPForwardPayload:
+    """Model activations and optional sidecars for one PP microbatch.
+
+    Sidecars use the existing PP tensor-dict transport, but are kept outside
+    the next stage's model inputs. This lets features carry tensors across
+    several PP stages without changing each model's intermediate tensor schema.
+    """
+
+    intermediate_tensors: IntermediateTensors
+    sidecars: dict[tuple[str, str], torch.Tensor] = field(default_factory=dict)
+
+    @staticmethod
+    def _wire_key(namespace: str, name: str) -> str:
+        if not namespace or not name or "/" in namespace or "/" in name:
+            raise ValueError(
+                "PP sidecar namespace and name must be non-empty and cannot "
+                f"contain '/': {(namespace, name)!r}"
+            )
+        return f"{PP_SIDECAR_PREFIX}{namespace}/{name}"
+
+    @classmethod
+    def from_intermediate_tensors(
+        cls, intermediate_tensors: IntermediateTensors
+    ) -> "PPForwardPayload":
+        model_tensors: dict[str, torch.Tensor] = {}
+        sidecars: dict[tuple[str, str], torch.Tensor] = {}
+        for key, tensor in intermediate_tensors.tensors.items():
+            if not key.startswith(PP_SIDECAR_PREFIX):
+                model_tensors[key] = tensor
+                continue
+
+            parts = key.removeprefix(PP_SIDECAR_PREFIX).split("/")
+            if len(parts) != 2 or not all(parts):
+                raise ValueError(f"Malformed PP sidecar key: {key!r}")
+            sidecar_key = (parts[0], parts[1])
+            if sidecar_key in sidecars:
+                raise ValueError(f"Duplicate PP sidecar: {sidecar_key!r}")
+            sidecars[sidecar_key] = tensor
+        return cls(IntermediateTensors(model_tensors), sidecars)
+
+    def to_intermediate_tensors(self) -> IntermediateTensors:
+        tensors = dict(self.intermediate_tensors.tensors)
+        for (namespace, name), tensor in self.sidecars.items():
+            key = self._wire_key(namespace, name)
+            if key in tensors:
+                raise ValueError(f"Duplicate PP tensor key: {key!r}")
+            tensors[key] = tensor
+        return IntermediateTensors(tensors)
+
+    def add_tensor(
+        self,
+        namespace: str,
+        name: str,
+        tensor: torch.Tensor,
+        *,
+        replace: bool = False,
+    ) -> None:
+        self._wire_key(namespace, name)
+        key = (namespace, name)
+        if key in self.sidecars and not replace:
+            raise ValueError(f"Duplicate PP sidecar: {key!r}")
+        self.sidecars[key] = tensor
+
+    def pop_tensor(
+        self, namespace: str, name: str, default: _T | None = None
+    ) -> torch.Tensor | _T | None:
+        return self.sidecars.pop((namespace, name), default)
+
+    def carry(self, next_stage_tensors: IntermediateTensors) -> "PPForwardPayload":
+        output = self.from_intermediate_tensors(next_stage_tensors)
+        for (namespace, name), tensor in self.sidecars.items():
+            output.add_tensor(namespace, name, tensor)
+        return output
+
+    def discard_intermediate_tensors(self) -> None:
+        self.intermediate_tensors = IntermediateTensors({})
+
+    def add_aux_hidden_states(
+        self, layer_ids: Sequence[int], hidden_states: Sequence[torch.Tensor]
+    ) -> None:
+        if len(layer_ids) != len(hidden_states):
+            raise ValueError(
+                "Aux hidden-state layer and tensor counts differ: "
+                f"{len(layer_ids)} != {len(hidden_states)}"
+            )
+        for layer_id, hidden_state in zip(layer_ids, hidden_states):
+            if layer_id < 0:
+                raise ValueError(
+                    f"Aux hidden-state layer id must be non-negative: {layer_id}"
+                )
+            self.add_tensor(AUX_HIDDEN_STATES_NAMESPACE, str(layer_id), hidden_state)
+
+    def pop_aux_hidden_states(self) -> dict[int, torch.Tensor]:
+        result: dict[int, torch.Tensor] = {}
+        for namespace, name in list(self.sidecars):
+            if namespace != AUX_HIDDEN_STATES_NAMESPACE:
+                continue
+            try:
+                layer_id = int(name)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid aux hidden-state layer id: {name!r}"
+                ) from exc
+            if str(layer_id) != name or layer_id < 0:
+                raise ValueError(f"Invalid aux hidden-state layer id: {name!r}")
+            result[layer_id] = self.sidecars.pop((namespace, name))
+        return result
+
+    def set_topk_indices(self, tensor: torch.Tensor) -> None:
+        self.add_tensor(
+            TOPK_INDICES_NAMESPACE,
+            TOPK_INDICES_NAME,
+            tensor,
+            replace=True,
+        )
+
+    def pop_topk_indices(self) -> torch.Tensor | None:
+        tensor = self.pop_tensor(TOPK_INDICES_NAMESPACE, TOPK_INDICES_NAME)
+        assert tensor is None or isinstance(tensor, torch.Tensor)
+        return tensor
+
+    def copy_topk_indices_to(
+        self, topk_indices_buffer: torch.Tensor, num_tokens: int
+    ) -> None:
+        topk_indices = self.pop_topk_indices()
+        if topk_indices is None:
+            return
+        expected_shape = topk_indices_buffer[:num_tokens].shape
+        if topk_indices.shape != expected_shape:
+            raise ValueError(
+                "PP top-k indices shape does not match the local buffer: "
+                f"{tuple(topk_indices.shape)} != {tuple(expected_shape)}"
+            )
+        topk_indices_buffer[:num_tokens].copy_(topk_indices)
+
+    @staticmethod
+    def make_all_gather_policy(
+        overrides: dict[str, bool] | None = None,
+    ) -> dict[str, bool]:
+        return _SidecarAllGatherPolicy(overrides or {})
+
+
+def add_pp_aux_hidden_states(
+    intermediate_tensors: IntermediateTensors,
+    layer_ids: Sequence[int],
+    hidden_states: Sequence[torch.Tensor],
+) -> IntermediateTensors:
+    """Attach locally produced aux states to a model's PP output."""
+
+    payload = PPForwardPayload.from_intermediate_tensors(intermediate_tensors)
+    payload.add_aux_hidden_states(layer_ids, hidden_states)
+    return payload.to_intermediate_tensors()
+
+
+def merge_pp_aux_hidden_states(
+    payload: PPForwardPayload | None,
+    layer_ids: Sequence[int],
+    local_hidden_states: Sequence[torch.Tensor],
+) -> list[torch.Tensor]:
+    """Merge received and local aux states in configured global-layer order."""
+
+    if len(layer_ids) != len(set(layer_ids)):
+        raise ValueError(f"Duplicate aux hidden-state layer ids: {layer_ids}")
+
+    hidden_states_by_layer = {} if payload is None else payload.pop_aux_hidden_states()
+    unexpected = set(hidden_states_by_layer).difference(layer_ids)
+    if unexpected:
+        raise ValueError(
+            f"Received aux hidden states for unconfigured layers: {sorted(unexpected)}"
+        )
+
+    local_layer_ids = [
+        layer_id for layer_id in layer_ids if layer_id not in hidden_states_by_layer
+    ]
+    if len(local_layer_ids) != len(local_hidden_states):
+        raise ValueError(
+            "Local aux hidden-state count does not match layers owned by the "
+            f"last PP stage: {len(local_hidden_states)} != {len(local_layer_ids)}"
+        )
+    hidden_states_by_layer.update(zip(local_layer_ids, local_hidden_states))
+
+    missing = [
+        layer_id for layer_id in layer_ids if layer_id not in hidden_states_by_layer
+    ]
+    if missing:
+        raise ValueError(f"Missing aux hidden states for layers: {missing}")
+    return [hidden_states_by_layer[layer_id] for layer_id in layer_ids]

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -45,6 +45,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.distributed.pp_payload import add_pp_aux_hidden_states
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import (
@@ -1497,6 +1498,7 @@ class DeepseekV2Model(nn.Module):
             llama_4_scaling = None
 
         aux_hidden_states = []
+        aux_hidden_state_layer_ids: list[int] = []
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
@@ -1520,13 +1522,17 @@ class DeepseekV2Model(nn.Module):
                     )
                     aux_hidden_state = aux_hidden_state[: positions.shape[0]]
                 aux_hidden_states.append(aux_hidden_state)
+                aux_hidden_state_layer_ids.append(idx)
             hidden_states, residual = layer(
                 positions, hidden_states, residual, llama_4_scaling
             )
 
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
+            output = IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
+            )
+            return add_pp_aux_hidden_states(
+                output, aux_hidden_state_layer_ids, aux_hidden_states
             )
 
         if hidden_states.shape[0] != positions.shape[0]:
@@ -1539,6 +1545,7 @@ class DeepseekV2Model(nn.Module):
 
         if self.end_layer in self.aux_hidden_state_layers:
             aux_hidden_states.append(hidden_states + residual)
+            aux_hidden_state_layer_ids.append(self.end_layer)
 
         hidden_states, _ = self.norm(hidden_states, residual)
         if len(aux_hidden_states) > 0:

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1508,10 +1508,13 @@ class EagleModelMixin:
         layer_idx: int,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
+        layer_ids: list[int] | None = None,
     ) -> list[torch.Tensor]:
         if layer_idx in self.aux_hidden_state_layers:
             value = hidden_states + residual if residual is not None else hidden_states
             aux_hidden_states.append(value)
+            if layer_ids is not None:
+                layer_ids.append(layer_idx)
         return aux_hidden_states
 
 

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -36,6 +36,7 @@ from transformers import Qwen2Config
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.distributed.pp_payload import add_pp_aux_hidden_states
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import (
     Attention,
@@ -412,18 +413,35 @@ class Qwen2Model(nn.Module, EagleModelMixin):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        aux_hidden_states: list[torch.Tensor] = []
+        aux_hidden_state_layer_ids: list[int] = []
+        if get_pp_group().is_first_rank:
+            self._maybe_add_hidden_state(
+                aux_hidden_states,
+                0,
+                hidden_states,
+                residual,
+                aux_hidden_state_layer_ids,
+            )
         for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(
-                aux_hidden_states, idx + 1, hidden_states, residual
+                aux_hidden_states,
+                idx + 1,
+                hidden_states,
+                residual,
+                aux_hidden_state_layer_ids,
             )
 
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
+            output = IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
+            )
+            return add_pp_aux_hidden_states(
+                output, aux_hidden_state_layer_ids, aux_hidden_states
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -39,6 +39,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
+from vllm.distributed.pp_payload import add_pp_aux_hidden_states
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import Attention
@@ -493,21 +494,35 @@ class Qwen3MoeModel(nn.Module, EagleModelMixin):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        aux_hidden_states = self._maybe_add_hidden_state(
-            [], self.start_layer, hidden_states, residual
-        )
+        aux_hidden_states: list[torch.Tensor] = []
+        aux_hidden_state_layer_ids: list[int] = []
+        if get_pp_group().is_first_rank:
+            self._maybe_add_hidden_state(
+                aux_hidden_states,
+                self.start_layer,
+                hidden_states,
+                residual,
+                aux_hidden_state_layer_ids,
+            )
         for layer_idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(
-                aux_hidden_states, layer_idx + 1, hidden_states, residual
+                aux_hidden_states,
+                layer_idx + 1,
+                hidden_states,
+                residual,
+                aux_hidden_state_layer_ids,
             )
 
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
+            output = IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
+            )
+            return add_pp_aux_hidden_states(
+                output, aux_hidden_state_layer_ids, aux_hidden_states
             )
         hidden_states, _ = self.norm(hidden_states, residual)
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -558,9 +558,12 @@ class ModelCudaGraphManager(CudaGraphManager):
 
                 if self.is_last_pp_rank:
                     # Last PP rank (common case).
-                    if self.use_aux_hidden_state_outputs:
+                    if self.use_aux_hidden_state_outputs and isinstance(
+                        model_output, tuple
+                    ):
                         hidden_states, aux_hidden_states = model_output
                     else:
+                        assert isinstance(model_output, torch.Tensor)
                         hidden_states = model_output
                         aux_hidden_states = []
                     if self.hidden_states is None:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -35,6 +35,10 @@ from vllm.distributed.parallel_state import (
     get_dcp_group,
     get_pp_group,
 )
+from vllm.distributed.pp_payload import (
+    PPForwardPayload,
+    merge_pp_aux_hidden_states,
+)
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
@@ -136,6 +140,9 @@ from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
 )
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     set_eagle3_aux_hidden_state_layers,
+)
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import (
+    get_target_topk_indices_buffer,
 )
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
     RejectionSampler,
@@ -242,6 +249,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Speculative decoding.
         self.speculator = None
         self.use_aux_hidden_state_outputs = False
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
+        self.pp_topk_indices_buffer: torch.Tensor | None = None
         self.num_speculative_steps = vllm_config.num_speculative_tokens
         if self.speculative_config is not None:
             if self.is_last_pp_rank:
@@ -250,11 +259,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if self.speculative_config.method in ("eagle3", "dflash", "dspark"):
                 # Drafting may require auxiliary hidden states from target model outputs
                 self.use_aux_hidden_state_outputs = True
-                if self.use_pp:
-                    raise ValueError(
-                        f"{self.speculative_config.method} with pipeline parallel "
-                        "is not supported."
-                    )
 
         # Draft tokens propagation - for spec-dec + struct outputs.
         self.draft_tokens_handler = DraftTokensHandler(self.device)
@@ -372,7 +376,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
             if self.use_aux_hidden_state_outputs:
                 assert self.speculative_config is not None
-                set_eagle3_aux_hidden_state_layers(self.model, self.speculative_config)
+                self.aux_hidden_state_layers = set_eagle3_aux_hidden_state_layers(
+                    self.model, self.speculative_config
+                )
+            if self.use_pp and self.speculative_config is not None:
+                self.pp_topk_indices_buffer = get_target_topk_indices_buffer(self.model)
             if isinstance(self.speculator, DraftModelSpeculator):
                 with use_workspace_lane(self._draft_workspace_lane):
                     self.speculator.load_model(self.model)
@@ -1593,6 +1601,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 ec_connector_output,
             )
 
+        incoming_pp_payload: PPForwardPayload | None = None
         model_inputs = {
             "input_ids": input_ids,
             "positions": input_batch.positions,
@@ -1610,13 +1619,21 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # Prepare the intermediate tensors.
             assert intermediate_tensors is not None
             assert self.intermediate_tensors is not None
+            incoming_pp_payload = PPForwardPayload.from_intermediate_tensors(
+                intermediate_tensors
+            )
             n = input_batch.num_tokens_after_padding
             new_tensors = {
                 k: v[:n]
                 if dummy_run
-                else v[:n].copy_(intermediate_tensors.tensors[k][:n])
+                else v[:n].copy_(
+                    incoming_pp_payload.intermediate_tensors.tensors[k][:n]
+                )
                 for k, v in self.intermediate_tensors.tensors.items()
             }
+            if self.pp_topk_indices_buffer is not None:
+                incoming_pp_payload.copy_topk_indices_to(self.pp_topk_indices_buffer, n)
+            incoming_pp_payload.discard_intermediate_tensors()
             model_inputs["intermediate_tensors"] = IntermediateTensors(new_tensors)
             del intermediate_tensors
 
@@ -1670,8 +1687,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         if self.is_last_pp_rank:
             if self.use_aux_hidden_state_outputs:
-                assert isinstance(model_output, tuple)
-                hidden_states, aux_hidden_states = model_output
+                if isinstance(model_output, tuple):
+                    hidden_states, aux_hidden_states = model_output
+                else:
+                    assert isinstance(model_output, torch.Tensor)
+                    hidden_states = model_output
+                    aux_hidden_states = []
+                if self.use_pp:
+                    aux_hidden_states = merge_pp_aux_hidden_states(
+                        incoming_pp_payload,
+                        self.aux_hidden_state_layers,
+                        aux_hidden_states,
+                    )
             else:
                 assert isinstance(model_output, torch.Tensor)
                 hidden_states = model_output
@@ -1681,7 +1708,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             assert isinstance(model_output, IntermediateTensors)
             hidden_states = None
             aux_hidden_states = None
-            output_intermediate_tensors = model_output
+            output_payload = PPForwardPayload.from_intermediate_tensors(model_output)
+            if incoming_pp_payload is not None:
+                output_payload = incoming_pp_payload.carry(
+                    output_payload.to_intermediate_tensors()
+                )
+            if self.pp_topk_indices_buffer is not None:
+                output_payload.set_topk_indices(
+                    self.pp_topk_indices_buffer[: input_batch.num_tokens_after_padding]
+                )
+            output_intermediate_tensors = output_payload.to_intermediate_tensors()
 
         routed_experts = None
         if not dummy_run and (capturer := self.routed_experts_capturer) is not None:

--- a/vllm/v1/worker/gpu/spec_decode/eagle/eagle3_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/eagle3_utils.py
@@ -14,7 +14,7 @@ logger = init_logger(__name__)
 def set_eagle3_aux_hidden_state_layers(
     model: nn.Module,
     spec_config: SpeculativeConfig,
-) -> None:
+) -> tuple[int, ...]:
     if not supports_eagle3(model):
         raise RuntimeError("Model does not support EAGLE3 interface")
     # mypy may infer the class-level overload for supports_eagle3.
@@ -30,6 +30,7 @@ def set_eagle3_aux_hidden_state_layers(
         aux_layers = eagle3_model.get_eagle3_default_aux_hidden_state_layers()
         logger.info("Using Eagle3 auxiliary layers from model: %s", aux_layers)
     eagle3_model.set_aux_hidden_state_layers(aux_layers)
+    return aux_layers
 
 
 def get_eagle3_aux_layers_from_config(

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -33,6 +33,21 @@ def get_target_lm_head(target_model: nn.Module, target_language_model: nn.Module
     )
 
 
+def get_target_model_inner(target_model: nn.Module) -> nn.Module:
+    target_language_model = (
+        target_model.get_language_model()
+        if hasattr(target_model, "get_language_model")
+        else target_model
+    )
+    return getattr(target_language_model, "model", target_language_model)
+
+
+def get_target_topk_indices_buffer(
+    target_model: nn.Module,
+) -> torch.Tensor | None:
+    return getattr(get_target_model_inner(target_model), "topk_indices_buffer", None)
+
+
 def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Module:
     from vllm.compilation.backends import set_model_tag
 
@@ -57,7 +72,7 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
         if hasattr(target_model, "get_language_model")
         else target_model
     )
-    target_inner = target_language_model.model
+    target_inner = get_target_model_inner(target_model)
     draft_inner = eagle_model.model
 
     # Skip embedding sharing under PP — each rank owns its own embedding.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -46,6 +46,7 @@ from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
 )
+from vllm.distributed.pp_payload import PPForwardPayload
 from vllm.distributed.weight_transfer import (
     WeightTransferEngine,
     WeightTransferEngineFactory,
@@ -1062,7 +1063,7 @@ class Worker(WorkerBase):
         intermediate_tensors = None
         forward_pass = scheduler_output.total_num_scheduled_tokens > 0
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
-        all_gather_tensors = {}
+        all_gather_tensors = PPForwardPayload.make_all_gather_policy()
         compilation_config = self.vllm_config.compilation_config
         parallel_config = self.vllm_config.parallel_config
 
@@ -1089,11 +1090,9 @@ class Worker(WorkerBase):
                     use_cascade_attn=False,  # TODO(lucas): Handle cascade attention
                 )
             )
-            all_gather_tensors = {
-                "residual": not is_residual_scattered_for_sp(
-                    self.vllm_config, batch_desc.num_tokens
-                )
-            }
+            all_gather_tensors["residual"] = not is_residual_scattered_for_sp(
+                self.vllm_config, batch_desc.num_tokens
+            )
 
         if forward_pass and not get_pp_group().is_first_rank:
             tensor_dict, comm_handles, comm_postprocess = (


### PR DESCRIPTION
## Purpose

Enable speculative decoders to carry target-model side inputs through Model Runner V2 pipeline stages using the existing IntermediateTensors transport.

- Add a namespaced PP sidecar payload without introducing another collective.
- Carry auxiliary hidden states by global layer id and merge them in configured order before draft execution.
- Carry the active top-k index-buffer slice on the matching TP lane, copy it into each local target buffer before forward, and forward the latest contents to the next PP stage.
- Enable auxiliary-state PP output for Qwen2/Qwen3, Qwen3 MoE, and DeepSeek model families.
- Preserve full CUDA graph behavior when the last PP stage owns no auxiliary layers.

This is a stacked change and depends on #52295 for sampled and draft token synchronization across PP ranks.

## Test Plan

- Run the new CPU unit tests for sidecar wire encoding, multi-hop forwarding, global aux-layer ordering, top-k replacement and shape validation, and TP all-gather policy.
- Run Ruff lint and format checks on all changed files.
- Import all modified model and runner modules in the vLLM development environment.
- Run PP speculative-decoding end-to-end tests together with #52295 on GPU hardware before marking ready.

## Test Result

```text
$ python -m pytest -q tests/distributed/test_pp_payload.py
.......                                                                  [100%]
7 passed, 1 warning in 0.03s

$ ruff check <changed files>
All checks passed!

$ ruff format --check <changed files>
11 files already formatted
```

The warning is from the source worktree not having a generated vllm._version module. Module import checks passed. GPU end-to-end validation remains pending on the stacked branch.