### PR TITLE
docs: Add troubleshooting note for Qwen3-VL FP8 hang on Blackwell (#46619)

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -692,6 +692,9 @@ Some models are supported only via the [Transformers modeling backend](#transfor
     The official `openbmb/MiniCPM-V-2` doesn't work yet, so we need to use a fork (`HwwwH/MiniCPM-V-2`) for now.
     For more details, please see: <https://github.com/vllm-project/vllm/pull/4087#issuecomment-2250397630>
 
+!!! note
+    For `Qwen3-VL` and `Qwen3-VL-MOE`, running FP8 models on Blackwell GPUs (e.g., RTX 5080) with vLLM versions prior to v0.24.0 may cause the engine to silently hang during generation due to DeepGEMM kernel compilation deadlocks. To resolve this issue, please upgrade to vLLM v0.25.0 or newer. Alternatively, set the environment variable `VLLM_USE_DEEP_GEMM=0` as a workaround.
+    
 #### Transcription
 
 Speech2Text models trained specifically for Automatic Speech Recognition.


### PR DESCRIPTION
## Description
This PR updates the `supported_models.md` documentation to include a troubleshooting note for `Qwen3-VL` FP8 models running on Blackwell GPUs (e.g., RTX 5080). 

As reported, versions prior to v0.24.0 may silently hang during generation due to DeepGEMM kernel compilation deadlocks. This note informs users of the issue and documents the recommended fix (upgrading to v0.25.0+) or the environment variable workaround (`VLLM_USE_DEEP_GEMM=0`), saving future users from debugging this silent deadlock.

Fixes #46619

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the contributing guidelines.