### PR TITLE
[Bugfix][Spec Decode] Fix eagle draft sharing with a quantized lm_head

### DIFF
--- a/tests/v1/worker/test_gpu_spec_decode_eagle_utils.py
+++ b/tests/v1/worker/test_gpu_spec_decode_eagle_utils.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import _should_share
+
+
+class _UnquantizedHead(torch.nn.Module):
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight = torch.nn.Parameter(weight, requires_grad=False)
+
+
+class _QuantizedHead(torch.nn.Module):
+    """A head whose quant method packs the weights, leaving no `weight`."""
+
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.weight_packed = torch.nn.Parameter(
+            weight.to(torch.int8), requires_grad=False
+        )
+        self.weight_scale = torch.nn.Parameter(
+            torch.ones(weight.shape[0]), requires_grad=False
+        )
+
+
+def _eagle(has_own: bool = True):
+    return SimpleNamespace(has_own_lm_head=has_own)
+
+
+def test_quantized_draft_head_is_not_shared():
+    """A quantized draft head cannot be compared, so it must keep its own copy.
+
+    Reading `.weight` off a quantized ParallelLMHead raises AttributeError and
+    used to abort engine startup for eagle3 drafts with an int8 lm_head.
+    """
+    weight = torch.ones(4, 8)
+    shared = _should_share(
+        _eagle(), "has_own_lm_head", _QuantizedHead(weight), _UnquantizedHead(weight)
+    )
+    assert shared is False
+
+
+def test_quantized_target_head_is_not_shared():
+    weight = torch.ones(4, 8)
+    shared = _should_share(
+        _eagle(), "has_own_lm_head", _UnquantizedHead(weight), _QuantizedHead(weight)
+    )
+    assert shared is False
+
+
+def test_identical_unquantized_heads_are_shared():
+    weight = torch.ones(4, 8)
+    shared = _should_share(
+        _eagle(), "has_own_lm_head", _UnquantizedHead(weight), _UnquantizedHead(weight)
+    )
+    assert shared is True
+
+
+def test_distinct_unquantized_heads_are_not_shared():
+    shared = _should_share(
+        _eagle(),
+        "has_own_lm_head",
+        _UnquantizedHead(torch.ones(4, 8)),
+        _UnquantizedHead(torch.zeros(4, 8)),
+    )
+    assert shared is False
+
+
+def test_draft_without_own_head_is_shared():
+    """The draft carries no head of its own, so the target's is adopted."""
+    shared = _should_share(
+        _eagle(has_own=False),
+        "has_own_lm_head",
+        None,
+        _UnquantizedHead(torch.ones(4, 8)),
+    )
+    assert shared is True

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -16,13 +16,19 @@ def _should_share(eagle: nn.Module, flag: str, draft, target) -> bool:
         return True
     if target is None:
         return False
+    # A quantized layer registers packed weights (`weight_packed`, `qweight`,
+    # ...) instead of `weight`, so the two copies cannot be compared. Keep the
+    # draft's own copy rather than assuming it matches the target.
+    w = getattr(draft, "weight", None)
+    target_w = getattr(target, "weight", None)
+    if not isinstance(w, torch.Tensor) or not isinstance(target_w, torch.Tensor):
+        return False
     # torch.equal on GPU allocates a bool mask the size of the input.
     # Use the faster GPU path when there is plenty of headroom;
     # otherwise compare on CPU.
-    w = draft.weight
     if w.is_cuda and torch.accelerator.get_memory_info(w.device)[0] < w.numel() * 2:
-        return torch.equal(w.cpu(), target.weight.cpu())
-    return torch.equal(w, target.weight)
+        return torch.equal(w.cpu(), target_w.cpu())
+    return torch.equal(w, target_w)
 
 
 def get_target_lm_head(target_model: nn.Module, target_language_model: nn.Module):


### PR DESCRIPTION
## Purpose

`_should_share()` in `vllm/v1/worker/gpu/spec_decode/eagle/utils.py` reads `draft.weight` unconditionally to decide whether the draft can adopt the target's `lm_head`:

```python
w = draft.weight
if w.is_cuda and torch.accelerator.get_memory_info(w.device)[0] < w.numel() * 2:
    return torch.equal(w.cpu(), target.weight.cpu())
return torch.equal(w, target.weight)
```

A quantized `ParallelLMHead` registers packed weights (`weight_packed`, `qweight`, ...) and no `weight`, so this raises and aborts engine startup:

```
File "vllm/v1/worker/gpu/spec_decode/eagle/utils.py", line 22, in _should_share
  w = draft.weight
AttributeError: 'ParallelLMHead' object has no attribute 'weight'
```

This is a guard that already exists in V1 and was lost in the V2 rewrite. `LLMBaseProposer._maybe_share_lm_head` gates the same comparison on the attribute being present:

```python
elif (
    hasattr(target_language_model, "lm_head")
    and hasattr(target_language_model.lm_head, "weight")
    and hasattr(self.model.lm_head, "weight")
    and isinstance(target_language_model.lm_head.weight, torch.Tensor)
    and isinstance(self.model.lm_head.weight, torch.Tensor)
    and torch.equal(...)
):
    share_lm_head = True
else:
    # "Detected EAGLE model with distinct lm_head weights.
    #  Keeping separate lm_head weights from the target model."
```

When the attribute is missing, V1 falls through to the `else` and keeps the draft's own head. This PR restores that behaviour in the V2 helper.

## Why the draft keeps its own head

Not sharing is the correct answer, not merely the safe one. Without a plain `weight` on both sides there is no way to prove the two copies match, and adopting the target's head would silently change the draft's output.

For eagle3 drafts with a reduced `draft_vocab_size` the decision is unchanged: the shapes differ, so `torch.equal` already returned `False`. Those models get the same answer they did before — without raising.

The helper is shared, so this also covers the dflash and dspark drafters.

## Scope — please read

I could not find a public checkpoint that reproduces this. I scanned 880 eagle3/speculator repos and 429 quantized-target candidates on the Hub, reading safetensors tensor names; none carries a quantized `lm_head` or `embed_tokens`. The closest public eagle3 drafts (`nm-testing/Speculator-*-Eagle3-converted-*-quantized-w4a16`) quantize the transformer layers and leave `lm_head.weight` in place.

So this is a supported-but-uncommon configuration. Quantizing the `lm_head` is first-class in vLLM — `ParallelLMHead` takes a `quant_config`, and `CompressedTensorsConfig.get_quant_method` has a dedicated `isinstance(layer, ParallelLMHead)` branch — it is just rarely shipped. We hit it with internal compressed-tensors checkpoints that quantize the head (`lm_head.weight_packed` / `weight_scale` / `weight_shape`, no `lm_head.weight`), which made some of our models fail.

I am raising it because the V1/V2 divergence is a real inconsistency regardless of how many checkpoints exercise it today, not because of the number of users affected. Happy to publish a small reproducer checkpoint to the Hub if a maintainer wants one.

## Not a duplicate

Could not find any.

## Test plan

```
pytest tests/v1/worker/test_gpu_spec_decode_eagle_utils.py    # 5 passed
pytest tests/v1/worker/test_gpu_autoregressive_speculator.py  # 2 passed
```

Reverting the fix fails the two quantized-head cases with the exact `AttributeError` above; the three unquantized cases pass either way, confirming the sharing policy is unchanged.

End-to-end on gfx1151 with an internal `Qwen2.5-VL-7B-Instruct-AWQ` target and an eagle3 draft whose `lm_head` is int8 compressed-tensors.

`pre-commit` (ruff, mypy) clean.

AI assistance was used for this change.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

