### PR TITLE
[Bugfix] Allocate packed outputs in fused_q_kv_rmsnorm so q_b_proj keeps its low-latency GEMM path at decode

### DIFF
--- a/tests/kernels/core/test_fused_q_kv_rmsnorm.py
+++ b/tests/kernels/core/test_fused_q_kv_rmsnorm.py
@@ -51,6 +51,37 @@ def test_fused_q_kv_rmsnorm_correctness(num_tokens: int, dtype: torch.dtype):
     torch.testing.assert_close(kv_out, kv_ref, **tol)
 
 
+@pytest.mark.parametrize("num_tokens", [1, 16])
+def test_fused_q_kv_rmsnorm_outputs_are_packed(num_tokens: int):
+    """Regression guard: the outputs must be packed row-major even when the
+    inputs are column slices of a wider fused-projection buffer.
+
+    empty_like preserves the strides of size-1 dims, so with num_tokens == 1
+    a [1, q_size] slice of a [1, q_size + kv_size] buffer used to produce a
+    qr_out with row stride q_size + kv_size. Downstream dispatchers that
+    require packed row-major inputs then reject the tensor and silently fall
+    back to a slower GEMM path on every decode step."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    q_size, kv_size = 192, 576
+    fused = torch.randn(num_tokens, q_size + kv_size, dtype=dtype, device=device)
+    qr, kv = fused.split([q_size, kv_size], dim=-1)
+    qw = torch.randn(q_size, dtype=dtype, device=device)
+    kvw = torch.randn(kv_size, dtype=dtype, device=device)
+    eps = 1e-6
+
+    qr_out, kv_out = fused_q_kv_rmsnorm(qr, kv, qw, kvw, eps)
+
+    assert qr_out.stride() == (q_size, 1)
+    assert kv_out.stride() == (kv_size, 1)
+
+    qr_ref = _ref_rmsnorm(qr, qw, eps)
+    kv_ref = _ref_rmsnorm(kv, kvw, eps)
+    tol = dict(rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(qr_out, qr_ref, **tol)
+    torch.testing.assert_close(kv_out, kv_ref, **tol)
+
+
 @pytest.mark.parametrize("num_tokens", [65535, 65536, 131072])
 def test_fused_q_kv_rmsnorm_launches_past_grid_y_cap(num_tokens: int):
     """Regression guard: grid used to be (2, num_tokens), hitting CUDA's

--- a/vllm/models/common/ops/fused_qk_rmsnorm.py
+++ b/vllm/models/common/ops/fused_qk_rmsnorm.py
@@ -77,8 +77,15 @@ def fused_q_kv_rmsnorm(
     q_size = qr.shape[1]
     kv_size = kv.shape[1]
     num_tokens = qr.shape[0]
-    qr_out = torch.empty_like(qr)
-    kv_out = torch.empty_like(kv)
+    # Allocate packed outputs rather than empty_like: qr/kv are typically
+    # column slices of a fused qkv_a projection, and for num_tokens == 1
+    # empty_like preserves the parent's row stride (torch keeps strides of
+    # size-1 dims), e.g. (2112, 1) for a [1, 1536] q slice. Downstream
+    # dispatchers that require packed row-major inputs (e.g. the Kimi-K3
+    # low-latency GEMM's _is_packed_row_major check) then reject the tensor
+    # and silently fall back to cuBLAS on every decode step.
+    qr_out = torch.empty(qr.shape, dtype=qr.dtype, device=qr.device)
+    kv_out = torch.empty(kv.shape, dtype=kv.dtype, device=kv.device)
     if num_tokens == 0:
         return qr_out, kv_out
 


### PR DESCRIPTION
## Purpose

Fix a silent performance bug: `fused_q_kv_rmsnorm` allocates its outputs with `torch.empty_like(qr)`, but `qr`/`kv` are column slices of the fused `qkv_a` projection output. PyTorch preserves the strides of size-1 dims, so at `num_tokens == 1` (single-sequence decode) `empty_like` returns a tensor carrying the **parent buffer's row stride** — e.g. `(2112, 1)` for a `[1, 1536]` `q_c` slice:

```python
>>> qkv = torch.empty(1, 2112)
>>> q = qkv[:, :1536]
>>> torch.empty_like(q).stride()
(2112, 1)   # is_contiguous() is True, but not packed row-major
```

The Kimi-K3 low-latency GEMM dispatch (`low_latency_gemm._is_packed_row_major`, which requires `stride == (shape[1], 1)`) then rejects `q_c`, and `q_b_proj` silently falls back to `F.linear` → cuBLAS on **every decode step**, even though `(2304, 1536)` is listed in `KIMI_K3_PROJECTIONS`. `num_tokens >= 2` happens to produce packed strides, so only decode is affected — which is why this never showed up in prefill or batched benchmarks.

The fallback is not just a missed fusion. On one SM103 machine (148 SMs) the cuBLAS heuristic picks `nvjet_sm103_tst_16x64_64x16_2x1_v_bz_TNN` at ~10.9 µs/call for this `[1,1536]×[1536,2304]` GEMM, vs 4.5 µs (in-graph) for the intended `dsv3_fused_a` kernel — ~150 µs per decode step across Kimi-K3's 24 MLA layers at TP8. On another SM103 machine (152 SMs) the heuristic happens to land on a faster kernel (~3.1 µs), so the cost of this bug is machine-dependent and easy to miss.

Fix: allocate packed row-major outputs explicitly. Packed outputs are strictly better for every downstream consumer of these tensors.

## Test Plan

```bash
pytest tests/kernels/core/test_fused_q_kv_rmsnorm.py
```

Adds `test_fused_q_kv_rmsnorm_outputs_are_packed`, which feeds column slices of a fused buffer (the real call pattern from `mla.py`) at `num_tokens ∈ {1, 16}` and asserts packed output strides plus numerical correctness. The `num_tokens == 1` case fails before this change (`stride (768, 1) != (192, 1)`) and passes after.

End-to-end A/B on Kimi-K3, TP8, single 8×GPU SM103 node (`--kv-cache-dtype fp8`, isl 128 / osl 32, torch-profiled serving, identical config except this one file):

## Test Result

Unit tests: 13 passed (8 correctness, 3 grid-cap, 2 new packed-stride).

Serving A/B (decode-step stats over 31 steps, per-rank torch traces):

| metric (concurrency 1) | before | after |
|---|---|---|
| decode step wall p50 | 9.251 ms | **9.075 ms (−1.9%)** |
| TPOT | 9.54 ms | 9.36 ms |
| q_b_proj kernel | `nvjet_…_16x64_64x16_2x1` 10.87 µs ×24/step | `fused_a_gemm_kernel<1,2304,1536>` 4.48 µs ×24/step |
| gemm-group exclusive time | — | −148.5 µs/step |

Concurrency 16 (control, bug does not trigger at `num_tokens >= 2`): step wall p50 16.054 → 16.035 ms — unchanged within noise, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
