### PR TITLE
[Bugfix][Attention] Fall back to native FlashInfer decode when XQA cannot serve a KV-cache group's head_dim

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -838,6 +838,23 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             if can_use_xqa_or_trtllm_gen_decode
             else None
         )
+        # The dedicated FlashInfer XQA API accepts head dimensions in
+        # [16, 256] that are divisible by 16. Some hybrid-attention models
+        # (for example Gemma 4) use XQA-compatible sliding-attention groups
+        # alongside global-attention groups with head_dim=512. Resolve the
+        # backend per KV-cache group so the eligible groups still use XQA and
+        # the wider groups fall back to native FlashInfer decode.
+        if (
+            self.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.XQA
+            and not (16 <= self.head_dim <= 256 and self.head_dim % 16 == 0)
+        ):
+            logger.warning_once(
+                "FlashInfer XQA decode does not support head_dim=%d; "
+                "reverting this KV-cache group to native FlashInfer decode.",
+                self.head_dim,
+            )
+            self.use_trtllm_decode_attention = False
+            self.flashinfer_trtllm_api_decode_kernel = None
         if (
             self.use_dcp
             and self.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.XQA


### PR DESCRIPTION
## Problem

Serving a hybrid-attention model with the FlashInfer TRTLLM/XQA decode path crashes at engine init:

```
ValueError: Invalid head_dim: 512, must be divisible by 16 and in range [16, 256]
```

raised from `profile_cudagraph_memory()` during `determine_available_memory()`.

The dedicated FlashInfer XQA decode API accepts head dimensions in `[16, 256]` that are divisible by 16. Gemma 4 is a hybrid-attention model that combines sliding-attention groups at `head_dim=256` with global-attention groups at `head_dim=512`. `FlashInferMetadataBuilder` resolves the decode kernel once, so a single group the XQA API cannot serve makes the server unstartable instead of degrading to a supported kernel.

This became reachable on SM12x via #49718, which enabled the dedicated XQA decode path there. The same crash occurs on any platform where XQA is selected for such a model.

## Fix

Resolve XQA eligibility per KV-cache group. When the resolved kernel is XQA and a group's `head_dim` falls outside the supported range, that group reverts to native FlashInfer decode and warns once. Eligible groups keep XQA. This mirrors the existing DCP guard immediately below in the same function.

## Reproducer

```bash
vllm serve nvidia/Gemma-4-26B-A4B-NVFP4 \
  --attention-backend FLASHINFER \
  --attention-config '{"use_trtllm_attention": true}' \
  --kv-cache-dtype fp8 --max-model-len 262144 --language-model-only
```

Before: `ValueError: Invalid head_dim: 512` at startup. After: the server starts, the log records the fallback, and the sliding-attention groups still run XQA.

## Testing

Hardware: RTX PRO 6000 Blackwell Max-Q (SM120), FlashInfer 0.6.16.post3.

Backend selection confirmed from the serve log, showing both kernels in use as intended:

```
AttentionBackendEnum.FLASHINFER
decode_backend=xqa
decode_backend=flashinfer-native
```

End-to-end benchmark at ISL 150k / OSL 4k / concurrency 1:

| config | output tok/s | ITL | request latency |
|---|---|---|---|
| `TRITON_ATTN` baseline | 35.25 | 22.04 ms | 113,463 ms |
| this change | 86.37 | 5.40 ms | 46,304 ms |

Lint: `pre-commit run --files vllm/v1/attention/backends/flashinfer.py` passes, including `mypy-3.10`.

No new unit test is included. The guard lives in `FlashInferMetadataBuilder.__init__`, and the sibling DCP guard directly below it is likewise untested. Happy to add coverage if reviewers prefer.

## Why this is not a duplicate

Searched open issues and PRs for XQA/head_dim, FlashInfer head_dim, and Gemma attention. #48162 routes backends at batch level, which is orthogonal to per-KV-cache-group kernel eligibility. No open PR addresses the head_dim gate.

## AI assistance

AI assistance (Claude) was used to diagnose the failure, locate the fix, and prepare this PR, as disclosed in the commit trailers.
