### PR TITLE
[CI/Build][ROCm] Keep the CUDA-only kernel tests out of the ROCm run

### DIFF
--- a/tests/kernels/test_fp32_router_gemm.py
+++ b/tests/kernels/test_fp32_router_gemm.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 from vllm._custom_ops import fp32_router_gemm
+from vllm.platforms import current_platform
 
 # (hidden_size, num_experts)
 SHAPES = [(3072, 256), (6144, 128), (6144, 256)]
@@ -26,8 +27,10 @@ ATOL_BF16 = 2e-2  # bf16 activation has lower precision
 
 
 def _requires_sm90():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
+    # ROCm reports a CUDA-like device capability (gfx950 -> (9, 5)), which would
+    # pass the SM90 check below for a kernel that is only built for CUDA.
+    if not current_platform.is_cuda():
+        pytest.skip("fp32_router_gemm is built for CUDA only")
     major, minor = torch.cuda.get_device_capability()
     if major * 10 + minor < 90:
         pytest.skip(f"fp32_router_gemm requires SM90+, got SM{major}{minor}")

--- a/tests/kernels/test_kimi_k3_gemm_rs.py
+++ b/tests/kernels/test_kimi_k3_gemm_rs.py
@@ -12,7 +12,6 @@ from vllm.distributed.parallel_state import (
     init_distributed_environment,
     initialize_model_parallel,
 )
-from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs import GemmRS
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_open_port
 from vllm.utils.system_utils import update_environment_variables
@@ -70,6 +69,11 @@ def _assert_valid_rows_close(
 
 
 def _worker(local_rank: int, world_size: int, master_port: int) -> None:
+    # This module pulls in cute_dsl, which is unavailable off CUDA, so importing
+    # it at module level would fail collection. Import it where it is used, as
+    # `kda.py` does.
+    from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs import GemmRS
+
     device = torch.device("cuda", local_rank)
     torch.accelerator.set_device_index(device)
     update_environment_variables(


### PR DESCRIPTION
The test belongs to the Kernels Root Misc Test group, which AMD CI does not run yet.
This fix should land before the PR that enables that group (https://github.com/vllm-project/vllm/pull/50519).


## Purpose

Two tests in the kernels root misc group reach for CUDA-only code on ROCm.

`test_fp32_router_gemm` guards itself with `torch.cuda.is_available()`, which is
true for a ROCm build, and then reads the device capability. gfx950 reports
`(9, 5)`, so it clears the SM90 check and every case goes on to call a kernel
that is only built for CUDA. Gating on `current_platform.is_cuda()` keeps the
SM90 check for CUDA and skips everywhere else.

`test_kimi_k3_gemm_rs` imports the cute_dsl `GemmRS` wrapper at module level.
That import pulls in cutlass, which is not there off CUDA, so collection of the
file fails and takes the whole pytest run down with it - the file's own
`is_device_capability_family(100)` skip never gets a chance to run. Importing
`GemmRS` inside the worker, the way `vllm/models/kimi_k3/nvidia/ops/kda.py`
already does, leaves collection alone.

## Test Plan

```
pytest tests/kernels/test_fp32_router_gemm.py tests/kernels/test_kimi_k3_gemm_rs.py
```

## Test Result

On MI355 (gfx950, ROCm 7.2.3), before the change, the collection failure ends
the run before the other file is touched:

```
ImportError while importing test module 'tests/kernels/test_kimi_k3_gemm_rs.py'.
E   ModuleNotFoundError: No module named 'cutlass'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

Running `test_fp32_router_gemm` on its own then fails every case with

```
AttributeError: '_OpNamespace' '_C' object has no attribute 'fp32_router_gemm'
218 failed, 17 warnings in 69.44s
```

With the change, both files come out clean:

```
219 skipped, 17 warnings in 74.59s
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

