### PR TITLE
[Model] Let `QKVParallelLinear` de-interleave fused QKV weights

### DIFF
--- a/tests/model_executor/layers/test_qkv_parallel_linear.py
+++ b/tests/model_executor/layers/test_qkv_parallel_linear.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for weight loading in `QKVParallelLinear`."""
+
+import contextlib
+import os
+import tempfile
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed import (
+    cleanup_dist_env_and_memory,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.model_executor.layers.linear import QKVParallelLinear
+
+HIDDEN_SIZE = 64
+HEAD_SIZE = 8
+
+
+@pytest.fixture
+def single_rank_dist():
+    fd, temp_file = tempfile.mkstemp()
+    os.close(fd)
+    try:
+        with set_current_vllm_config(VllmConfig()):
+            init_distributed_environment(
+                world_size=1,
+                rank=0,
+                distributed_init_method=f"file://{temp_file}",
+                local_rank=0,
+                backend="gloo",
+            )
+            initialize_model_parallel(1, 1)
+            yield
+        cleanup_dist_env_and_memory()
+    finally:
+        # FileStore may already have removed the file it was given.
+        with contextlib.suppress(OSError):
+            os.unlink(temp_file)
+
+
+def interleave(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, num_kv_heads: int):
+    """Fuse [Q|K|V] into the per-KV-group interleaved layout found on disk."""
+    trailing = q.shape[1:]
+    groups = [t.reshape(num_kv_heads, -1, HEAD_SIZE, *trailing) for t in (q, k, v)]
+    return torch.cat(groups, dim=1).reshape(-1, *trailing)
+
+
+@pytest.mark.parametrize("num_heads,num_kv_heads", [(8, 8), (8, 2), (8, 1)])
+@pytest.mark.parametrize("is_bias", [False, True])
+def test_fused_qkv_interleaved_weight_loader(
+    single_rank_dist, num_heads: int, num_kv_heads: int, is_bias: bool
+):
+    """An interleaved fused checkpoint loads to the same [Q|K|V] as split weights."""
+    shape = () if is_bias else (HIDDEN_SIZE,)
+    q = torch.randn(num_heads * HEAD_SIZE, *shape)
+    k = torch.randn(num_kv_heads * HEAD_SIZE, *shape)
+    v = torch.randn(num_kv_heads * HEAD_SIZE, *shape)
+
+    layer = QKVParallelLinear(
+        HIDDEN_SIZE,
+        HEAD_SIZE,
+        num_heads,
+        num_kv_heads,
+        bias=True,
+        params_dtype=torch.float32,
+        fused_qkv_interleaved=True,
+    )
+    param = layer.bias if is_bias else layer.weight
+    layer.weight_loader(param, interleave(q, k, v, num_kv_heads))
+
+    assert torch.equal(param.data, torch.cat((q, k, v)))

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -994,6 +994,9 @@ class QKVParallelLinear(ColumnParallelLinear):
                         (e.g. model.layers.0.qkv_proj)
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
+        v_head_size: size of each attention value head.
+            If None, assume v_head_size = head_size.
+        fused_qkv_interleaved: If true, QKV weights are fused and interleaved on disk.
     """
 
     def __init__(
@@ -1011,10 +1014,12 @@ class QKVParallelLinear(ColumnParallelLinear):
         return_bias: bool = True,
         disable_tp: bool = False,
         v_head_size: int | None = None,
+        fused_qkv_interleaved: bool = False,
     ):
         self.hidden_size = hidden_size
         self.head_size = head_size
         self.v_head_size = v_head_size if v_head_size is not None else head_size
+        self.fused_qkv_interleaved = fused_qkv_interleaved
         self.total_num_heads = total_num_heads
         if total_num_kv_heads is None:
             total_num_kv_heads = total_num_heads
@@ -1075,6 +1080,29 @@ class QKVParallelLinear(ColumnParallelLinear):
         }
         return shard_size_mapping.get(loaded_shard_id)
 
+    def _deinterleave_fused_qkv(
+        self, loaded_weight: torch.Tensor, output_dim: int = 0
+    ) -> torch.Tensor:
+        """De-interleave a per-KV-group fused qkv weight/bias to [Q|K|V].
+
+        The on-disk layout groups each KV head's query heads, key and value
+        together: ``[q_0..q_{g-1}, k, v]`` repeated per KV head, where
+        ``g = total_num_heads // total_num_kv_heads``. This reorders it to the
+        block-contiguous ``[Q_all | K_all | V_all]`` that the fused split below
+        expects. Assumes a uniform head size across q/k/v.
+        """
+        groups = self.total_num_heads // self.total_num_kv_heads
+        shape = loaded_weight.shape
+        lead, trail = shape[:output_dim], shape[output_dim + 1 :]
+        loaded_weight = loaded_weight.view(
+            *lead, self.total_num_kv_heads, groups + 2, -1, *trail
+        )
+        shards = [
+            loaded_weight.narrow(output_dim + 1, *span)
+            for span in ((0, groups), (groups, 1), (groups + 1, 1))
+        ]
+        return torch.cat([s.reshape(*lead, -1, *trail) for s in shards], dim=output_dim)
+
     def _load_fused_module_from_checkpoint(
         self, param: BasevLLMParameter, loaded_weight: torch.Tensor
     ):
@@ -1087,6 +1115,10 @@ class QKVParallelLinear(ColumnParallelLinear):
         An example of a model with these fused layers:
         https://huggingface.co/microsoft/Phi-3-mini-4k-instruct
         """
+        if self.fused_qkv_interleaved:
+            loaded_weight = self._deinterleave_fused_qkv(
+                loaded_weight, getattr(param, "output_dim", 0)
+            )
         shard_offsets = [
             # (shard_id, shard_offset, shard_size)
             ("q", 0, self.total_num_heads * self.head_size),
@@ -1194,6 +1226,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                 assert param_data.shape == loaded_weight.shape
                 param_data.copy_(loaded_weight)
                 return
+            if self.fused_qkv_interleaved:
+                loaded_weight = self._deinterleave_fused_qkv(loaded_weight, output_dim)
             shard_offsets = [
                 # (shard_id, shard_offset, shard_size)
                 ("q", 0, self.total_num_heads * self.head_size),

--- a/vllm/model_executor/models/bloom.py
+++ b/vllm/model_executor/models/bloom.py
@@ -107,6 +107,7 @@ class BloomAttention(nn.Module):
             bias=True,
             quant_config=quant_config,
             prefix=f"{prefix}.query_key_value",
+            fused_qkv_interleaved=True,
         )
         self.dense = RowParallelLinear(
             self.hidden_size,
@@ -294,24 +295,6 @@ class BloomModel(nn.Module):
             return IntermediateTensors({"hidden_states": hidden_states})
         hidden_states = self.ln_f(hidden_states)
         return hidden_states
-
-    def _repack_qkv(
-        self, weights: Iterable[tuple[str, torch.Tensor]]
-    ) -> Iterable[tuple[str, torch.Tensor]]:
-        # BLOOM's fused QKV is laid out as (num_heads * 3 * head_size) on its
-        # output dim (0), while vLLM expects (3 * num_heads * head_size).
-        num_heads = self.config.num_attention_heads
-        for name, loaded_weight in weights:
-            if "query_key_value" in name:
-                shape = loaded_weight.shape
-                loaded_weight = loaded_weight.view((num_heads, 3, -1) + shape[1:])
-                loaded_weight = loaded_weight.transpose(0, 1)
-                loaded_weight = loaded_weight.reshape(shape)
-            yield name, loaded_weight
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
-        return loader.load_weights(self._repack_qkv(weights))
 
 
 class BloomForCausalLM(nn.Module, SupportsPP, SupportsQuant):

--- a/vllm/model_executor/models/falcon.py
+++ b/vllm/model_executor/models/falcon.py
@@ -52,14 +52,12 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.falcon import RWConfig
 
 from .interfaces import SupportsPP
 from .utils import (
     AutoWeightsLoader,
-    is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
@@ -138,6 +136,7 @@ class FalconAttention(nn.Module):
             skip_bias_add=True,
             quant_config=quant_config,
             prefix=f"{prefix}.query_key_value",
+            fused_qkv_interleaved=True,
         )
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
@@ -420,61 +419,6 @@ class FalconModel(nn.Module):
             return IntermediateTensors({"hidden_states": hidden_states})
         hidden_states = self.ln_f(hidden_states)
         return hidden_states
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        total_num_heads = self.config.num_attention_heads
-        if self.config.new_decoder_architecture:
-            total_num_kv_heads = self.config.num_kv_heads
-        elif self.config.multi_query:
-            total_num_kv_heads = 1
-        else:
-            total_num_kv_heads = total_num_heads
-        num_query_heads_per_kv_head = total_num_heads // total_num_kv_heads
-        params_dict = dict(self.named_parameters(remove_duplicate=False))
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            # Skip loading extra bias for GPTQ models.
-            if name.endswith(".bias") and name not in params_dict:
-                continue
-            if is_pp_missing_parameter(name, self):
-                continue
-            param = params_dict[name]
-            if "query_key_value" in name:
-                output_dim = getattr(param, "output_dim", None)
-                loaded_weight_shape = loaded_weight.shape
-                if output_dim is not None:
-                    loaded_weight = loaded_weight.view(
-                        loaded_weight_shape[:output_dim]
-                        + (total_num_kv_heads, num_query_heads_per_kv_head + 2, -1)
-                        + loaded_weight_shape[output_dim + 1 :]
-                    )
-                    wq = loaded_weight.narrow(
-                        output_dim + 1, 0, num_query_heads_per_kv_head
-                    ).reshape(
-                        *loaded_weight_shape[:output_dim],
-                        -1,
-                        *loaded_weight_shape[output_dim + 1 :],
-                    )
-                    wk = loaded_weight.narrow(
-                        output_dim + 1, num_query_heads_per_kv_head, 1
-                    ).reshape(
-                        *loaded_weight_shape[:output_dim],
-                        -1,
-                        *loaded_weight_shape[output_dim + 1 :],
-                    )
-                    wv = loaded_weight.narrow(
-                        output_dim + 1, num_query_heads_per_kv_head + 1, 1
-                    ).reshape(
-                        *loaded_weight_shape[:output_dim],
-                        -1,
-                        *loaded_weight_shape[output_dim + 1 :],
-                    )
-                    loaded_weight = torch.cat([wq, wk, wv], dim=output_dim)
-
-            weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
 
 
 class FalconForCausalLM(nn.Module, SupportsPP):

--- a/vllm/model_executor/models/gpt_neox.py
+++ b/vllm/model_executor/models/gpt_neox.py
@@ -79,6 +79,7 @@ class GPTNeoXAttention(nn.Module):
             bias=self.bias,
             quant_config=quant_config,
             prefix=f"{prefix}.query_key_value",
+            fused_qkv_interleaved=True,
         )
         self.dense = RowParallelLinear(
             config.hidden_size,
@@ -247,25 +248,11 @@ class GPTNeoXModel(nn.Module):
         hidden_states = self.final_layer_norm(hidden_states)
         return hidden_states
 
-    def _repack_qkv(
-        self, weights: Iterable[tuple[str, torch.Tensor]]
-    ) -> Iterable[tuple[str, torch.Tensor]]:
-        # GPT-NeoX's fused QKV is laid out as (num_heads * 3 * head_size) on
-        # its output dim (0), while vLLM expects (3 * num_heads * head_size).
-        num_heads = self.config.num_attention_heads
-        for name, loaded_weight in weights:
-            if "query_key_value" in name:
-                shape = loaded_weight.shape
-                loaded_weight = loaded_weight.view((num_heads, 3, -1) + shape[1:])
-                loaded_weight = loaded_weight.transpose(0, 1)
-                loaded_weight = loaded_weight.reshape(shape)
-            yield name, loaded_weight
-
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(
             self, skip_substrs=["attention.bias", "attention.masked_bias"]
         )
-        return loader.load_weights(self._repack_qkv(weights))
+        return loader.load_weights(weights)
 
 
 class GPTNeoXForCausalLM(nn.Module, SupportsPP):


### PR DESCRIPTION
Part of #48972, extracted from #49038.

Several models store their fused QKV projection interleaved per KV group on disk (`[q_0..q_{g-1}, k, v]` repeated per KV head) rather than block contiguous (`[Q|K|V]`). Each of them re-implemented the same reordering in `load_weights`.

This adds `fused_qkv_interleaved` to `QKVParallelLinear`, so the layer de-interleaves the weight itself in the two paths that handle a checkpoint that is already fused (`_load_fused_module_from_checkpoint`, and `weight_loader` with `loaded_shard_id=None`). The de-interleave respects the parameter's `output_dim`, preserving Falcon's handling of quantised checkpoints where the output dim is 1.

Bloom, Falcon and GPT-NeoX now set the flag and drop their bespoke repacking. For Falcon that removes the entire hand written `FalconModel.load_weights`, since the rest of it duplicated `AutoWeightsLoader`:

- the GPTQ extra bias skip is already covered by `AutoWeightsLoader.load_weights`, which appends `.bias` to `ignore_unexpected_suffixes`
- the `is_pp_missing_parameter` check is already covered by `_load_module` returning early for `PPMissingLayer`/`StageMissingLayer`
- the `getattr(param, "weight_loader", default_weight_loader)` dispatch is already `_load_param`

`BloomModel.load_weights` is removed for the same reason: once `_repack_qkv` is gone it is a bare `AutoWeightsLoader(self)` wrapper, which is what the parent's recursion does anyway. `GPTNeoXModel.load_weights` stays because it still carries `skip_substrs`, which is #53106's territory.

### Not a duplicate

The only open PR touching this is #49038, which is mine and which this is extracted from. #49038 is large and mixes this with the `autoload_weights` infrastructure; splitting it out lets the QKV change be reviewed and land on its own. I will rebase #49038 on top of this. A search for other open PRs touching Falcon/Bloom/GPT-NeoX weight loading or `QKVParallelLinear` turned up nothing overlapping.

### Testing

New unit test asserting an interleaved fused checkpoint loads to the same `[Q|K|V]` as separate Q/K/V weights, over MHA/GQA/MQA head counts and over both weight and bias:

```
$ pytest tests/model_executor/layers/test_qkv_parallel_linear.py -q
6 passed
```

The test discriminates: flipping `fused_qkv_interleaved` to `False` fails 4 of the 6 cases (the two MQA cases are no-ops by construction, since one KV head means the interleaved layout already equals `[Q|K|V]`).

The new `_deinterleave_fused_qkv` was also checked to be bit-exact against both removed implementations (`torch.equal`) across MHA/GQA/MQA shapes, 2-D weights with `output_dim` 0 and 1, and 1-D biases.

Each affected architecture was then built on CPU and driven through its real `load_weights` with a synthetic HF-layout checkpoint, asserting every parameter is consumed and that the fused QKV tensors land exactly as `torch.cat([q, k, v])`:

| Model | Config | Result |
| --- | --- | --- |
| `tiiuae/falcon-rw-1b` | MHA, 32 heads | 27/27 params, qkv exact |
| `tiiuae/falcon-7b` | MQA, 71 heads / 1 KV head | 16/16 params, qkv exact |
| `tiiuae/falcon-40b` | new decoder arch, 128 heads / 8 KV heads | 20/20 params, qkv exact |
| `bigscience/bloom-560m` | 16 heads | 29/29 params, qkv weight + bias exact |
| `EleutherAI/pythia-70m` | 8 heads | 28/28 params, qkv weight + bias exact |

That covers all three Falcon branches the deleted code special cased.

### Model evaluation

Correctness here is a bit-exact tensor layout property, and it is verified above against the exact code being removed, on every affected architecture. End to end generation evals have not been run yet as I do not have GPU hardware to hand right now; I will post results for Bloom, Falcon and GPT-NeoX before merge.

### AI assistance

AI assistance was used for this change. I have reviewed every changed line and understand and stand behind the change.
