### PR TITLE
Add MTP support for Nemotron VL models

### DIFF
--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -414,6 +414,10 @@ class NemotronHMTP(nn.Module, SupportsPP):
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
+            # MTP weights are nested in "language_model."
+            # in Multimodal Nemotron-H checkpoints.
+            name = name.removeprefix("language_model.")
+
             # Only process MTP weights - skip all non-MTP weights
             if not name.startswith("mtp.") and "embeddings" not in name:
                 continue

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -216,7 +216,7 @@ class NemotronHMultiTokenPredictor(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
 
         self.config = config
         self.vocab_size = config.vocab_size
@@ -322,7 +322,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         self.vllm_config = vllm_config
         self.config = config
         self.quant_config = vllm_config.quant_config

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1403,6 +1403,10 @@ class SpecDecodeBaseProposer:
                 self.model.config.image_token_index = (
                     target_model.config.media_placeholder_token_id
                 )
+            elif self.get_model_name(target_model) == "NemotronH_Nano_VL_V2":
+                self.model.config.image_token_index = (
+                    target_model.config.img_context_token_id
+                )
             else:
                 self.model.config.image_token_index = (
                     target_model.config.image_token_index


### PR DESCRIPTION
## Purpose

Follow-up to #52929.

This PR adds MTP support for Nemotron VL models.

Without this change, `vllm serve` on a `NemotronH_Omni_Reasoning_V3` checkpoint with
`--speculative_config.method mtp` fails at engine init:

```
AttributeError: 'NemotronH_Omni_Reasoning_V3_Config' object has no attribute 'num_hidden_layers'
```

`num_hidden_layers` exists under the "llm_config" for multi-modal models (such as Nemotron-3-Nano-Omni).

Adding attribute `'image_token_index'` was also required.

And finally, a fix in `NemotronHMTP.load_weights` was required to properly load MTP weights (a silent bug if not fixed).

## Test Plan

Nemotron VL model produces valid output with
`--speculative_config.method mtp --speculative_config.num_speculative_tokens N`

GSM8K eval for Nemotron-3-Super (NVFP4, with/without MTP).

Basic functionality test for Nemotron-3-Nano-Omni (does not have MTP, so shouldn't be affected by this change - but tested anyway for extra caution).

## Test Result

PR fixes the issue and does not break other Nemotron-3 models.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

