### PR TITLE
[ROCm] Disable AITER FP8/FP4 BMM for MLA by default

### DIFF
--- a/tests/kernels/quantization/test_rocm_fp8.py
+++ b/tests/kernels/quantization/test_rocm_fp8.py
@@ -30,7 +30,7 @@ fp8_only = pytest.mark.skipif(
 
 ENV_DEFAULTS = {
     "VLLM_ROCM_FP8_PADDING": True,
-    "VLLM_ROCM_USE_AITER_FP8BMM": True,
+    "VLLM_ROCM_USE_AITER_FP8BMM": False,
     "VLLM_ROCM_FP8_MFMA_PAGE_ATTN": False,
 }
 

--- a/tests/kernels/quantization/test_rocm_mxfp4.py
+++ b/tests/kernels/quantization/test_rocm_mxfp4.py
@@ -148,7 +148,7 @@ def test_fp4_env_defaults():
     import vllm.envs as envs
 
     assert envs.VLLM_ROCM_USE_AITER_FP4_ASM_GEMM is False
-    assert envs.VLLM_ROCM_USE_AITER_FP4BMM is True
+    assert envs.VLLM_ROCM_USE_AITER_FP4BMM is False
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -147,11 +147,45 @@ def test_quark_excluded_mla_projection_denies_bmm_requantization(prefix):
     assert not _is_mla_bmm_requantization_allowed(kv_b_proj)
 
 
-def test_quark_dynamic_mla_projection_allows_bmm_requantization(monkeypatch):
+def _quark_config_from_checkpoint(model_type: str, exclude: list[str]) -> QuarkConfig:
+    """Build a QuarkConfig the way vLLM does at config construction time.
+
+    ``maybe_update_config`` is the gate that opts DeepSeek-V3-family fp4
+    checkpoints into dynamic MXFP4 re-quantization of *excluded* attention
+    projections; every other checkpoint keeps the exclusion.
+    """
+    quant_config = {
+        "exclude": exclude,
+        "global_quant_config": {"weight": {"dtype": "fp4"}},
+    }
+    config = QuarkConfig(quant_config)
+    config.maybe_update_config(
+        "dummy-model",
+        hf_config=SimpleNamespace(
+            model_type=model_type, quantization_config=quant_config
+        ),
+    )
+    return config
+
+
+@pytest.mark.parametrize(
+    ("model_type", "allows_requantization"),
+    [
+        # amd/DeepSeek-R1-0528-MXFP4 excludes kv_b_proj on every layer but
+        # deliberately opts into dynamic MXFP4, so re-quantization stays on.
+        pytest.param("deepseek_v3", True, id="deepseek-v3-fp4-opts-in"),
+        # amd/GLM-5.2-MXFP4 excludes kv_b_proj without opting in, so the
+        # checkpoint's exclusion must be honored.
+        pytest.param("glm_moe_dsa", False, id="non-deepseek-honors-exclude"),
+    ],
+)
+def test_dynamic_mxfp4_option_decides_excluded_mla_projection(
+    monkeypatch, model_type, allows_requantization
+):
     prefix = "model.layers.3.self_attn.kv_b_proj"
-    quant_config = QuarkConfig({"exclude": [prefix]})
-    quant_config.dynamic_mxfp4_quant = True
+    quant_config = _quark_config_from_checkpoint(model_type, [prefix])
     monkeypatch.setattr(quant_config, "get_scheme", lambda **_: object())
+
     linear = LinearBase.__new__(LinearBase)
     quant_method = quant_config.get_quant_method(linear, prefix)
     kv_b_proj = SimpleNamespace(
@@ -159,8 +193,11 @@ def test_quark_dynamic_mla_projection_allows_bmm_requantization(monkeypatch):
         quant_method=quant_method,
     )
 
-    assert isinstance(quant_method, QuarkLinearMethod)
-    assert _is_mla_bmm_requantization_allowed(kv_b_proj)
+    expected_cls = (
+        QuarkLinearMethod if allows_requantization else UnquantizedLinearMethod
+    )
+    assert isinstance(quant_method, expected_cls)
+    assert _is_mla_bmm_requantization_allowed(kv_b_proj) is allows_requantization
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -27,7 +27,16 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     QueryLenSupport,
     _DecodeConcatQuantFP8,
+    _is_mla_bmm_requantization_allowed,
     build_mla_chunked_context_metadata,
+)
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization.quark.quark import (
+    QuarkConfig,
+    QuarkLinearMethod,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.platforms import current_platform
@@ -92,6 +101,66 @@ def test_mla_kv_cache_spec_uses_layer_cache_dtype(
     assert spec.kv_quant_mode == expected_quant_mode
     if cache_dtype == "fp8_ds_mla":
         assert spec.page_size_bytes == 64 * 656
+
+
+@pytest.mark.parametrize(
+    ("quant_config", "quant_method", "expected"),
+    [
+        pytest.param(None, UnquantizedLinearMethod(), True, id="fully-bf16"),
+        pytest.param(
+            object(),
+            UnquantizedLinearMethod(),
+            False,
+            id="explicitly-unquantized",
+        ),
+        pytest.param(object(), object(), True, id="quantized"),
+    ],
+)
+def test_mla_bmm_requantization_respects_linear_precision_provenance(
+    quant_config, quant_method, expected
+):
+    kv_b_proj = SimpleNamespace(
+        quant_config=quant_config,
+        quant_method=quant_method,
+    )
+
+    assert _is_mla_bmm_requantization_allowed(kv_b_proj) is expected
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "model.layers.3.self_attn.kv_b_proj",
+        "model.layers.78.self_attn.kv_b_proj",
+    ],
+)
+def test_quark_excluded_mla_projection_denies_bmm_requantization(prefix):
+    quant_config = QuarkConfig({"exclude": [prefix]})
+    linear = LinearBase.__new__(LinearBase)
+    quant_method = quant_config.get_quant_method(linear, prefix)
+    kv_b_proj = SimpleNamespace(
+        quant_config=quant_config,
+        quant_method=quant_method,
+    )
+
+    assert isinstance(quant_method, UnquantizedLinearMethod)
+    assert not _is_mla_bmm_requantization_allowed(kv_b_proj)
+
+
+def test_quark_dynamic_mla_projection_allows_bmm_requantization(monkeypatch):
+    prefix = "model.layers.3.self_attn.kv_b_proj"
+    quant_config = QuarkConfig({"exclude": [prefix]})
+    quant_config.dynamic_mxfp4_quant = True
+    monkeypatch.setattr(quant_config, "get_scheme", lambda **_: object())
+    linear = LinearBase.__new__(LinearBase)
+    quant_method = quant_config.get_quant_method(linear, prefix)
+    kv_b_proj = SimpleNamespace(
+        quant_config=quant_config,
+        quant_method=quant_method,
+    )
+
+    assert isinstance(quant_method, QuarkLinearMethod)
+    assert _is_mla_bmm_requantization_allowed(kv_b_proj)
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -27,16 +27,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     QueryLenSupport,
     _DecodeConcatQuantFP8,
-    _is_mla_bmm_requantization_allowed,
     build_mla_chunked_context_metadata,
-)
-from vllm.model_executor.layers.linear import (
-    LinearBase,
-    UnquantizedLinearMethod,
-)
-from vllm.model_executor.layers.quantization.quark.quark import (
-    QuarkConfig,
-    QuarkLinearMethod,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.platforms import current_platform
@@ -101,103 +92,6 @@ def test_mla_kv_cache_spec_uses_layer_cache_dtype(
     assert spec.kv_quant_mode == expected_quant_mode
     if cache_dtype == "fp8_ds_mla":
         assert spec.page_size_bytes == 64 * 656
-
-
-@pytest.mark.parametrize(
-    ("quant_config", "quant_method", "expected"),
-    [
-        pytest.param(None, UnquantizedLinearMethod(), True, id="fully-bf16"),
-        pytest.param(
-            object(),
-            UnquantizedLinearMethod(),
-            False,
-            id="explicitly-unquantized",
-        ),
-        pytest.param(object(), object(), True, id="quantized"),
-    ],
-)
-def test_mla_bmm_requantization_respects_linear_precision_provenance(
-    quant_config, quant_method, expected
-):
-    kv_b_proj = SimpleNamespace(
-        quant_config=quant_config,
-        quant_method=quant_method,
-    )
-
-    assert _is_mla_bmm_requantization_allowed(kv_b_proj) is expected
-
-
-@pytest.mark.parametrize(
-    "prefix",
-    [
-        "model.layers.3.self_attn.kv_b_proj",
-        "model.layers.78.self_attn.kv_b_proj",
-    ],
-)
-def test_quark_excluded_mla_projection_denies_bmm_requantization(prefix):
-    quant_config = QuarkConfig({"exclude": [prefix]})
-    linear = LinearBase.__new__(LinearBase)
-    quant_method = quant_config.get_quant_method(linear, prefix)
-    kv_b_proj = SimpleNamespace(
-        quant_config=quant_config,
-        quant_method=quant_method,
-    )
-
-    assert isinstance(quant_method, UnquantizedLinearMethod)
-    assert not _is_mla_bmm_requantization_allowed(kv_b_proj)
-
-
-def _quark_config_from_checkpoint(model_type: str, exclude: list[str]) -> QuarkConfig:
-    """Build a QuarkConfig the way vLLM does at config construction time.
-
-    ``maybe_update_config`` is the gate that opts DeepSeek-V3-family fp4
-    checkpoints into dynamic MXFP4 re-quantization of *excluded* attention
-    projections; every other checkpoint keeps the exclusion.
-    """
-    quant_config = {
-        "exclude": exclude,
-        "global_quant_config": {"weight": {"dtype": "fp4"}},
-    }
-    config = QuarkConfig(quant_config)
-    config.maybe_update_config(
-        "dummy-model",
-        hf_config=SimpleNamespace(
-            model_type=model_type, quantization_config=quant_config
-        ),
-    )
-    return config
-
-
-@pytest.mark.parametrize(
-    ("model_type", "allows_requantization"),
-    [
-        # amd/DeepSeek-R1-0528-MXFP4 excludes kv_b_proj on every layer but
-        # deliberately opts into dynamic MXFP4, so re-quantization stays on.
-        pytest.param("deepseek_v3", True, id="deepseek-v3-fp4-opts-in"),
-        # amd/GLM-5.2-MXFP4 excludes kv_b_proj without opting in, so the
-        # checkpoint's exclusion must be honored.
-        pytest.param("glm_moe_dsa", False, id="non-deepseek-honors-exclude"),
-    ],
-)
-def test_dynamic_mxfp4_option_decides_excluded_mla_projection(
-    monkeypatch, model_type, allows_requantization
-):
-    prefix = "model.layers.3.self_attn.kv_b_proj"
-    quant_config = _quark_config_from_checkpoint(model_type, [prefix])
-    monkeypatch.setattr(quant_config, "get_scheme", lambda **_: object())
-
-    linear = LinearBase.__new__(LinearBase)
-    quant_method = quant_config.get_quant_method(linear, prefix)
-    kv_b_proj = SimpleNamespace(
-        quant_config=quant_config,
-        quant_method=quant_method,
-    )
-
-    expected_cls = (
-        QuarkLinearMethod if allows_requantization else UnquantizedLinearMethod
-    )
-    assert isinstance(quant_method, expected_cls)
-    assert _is_mla_bmm_requantization_allowed(kv_b_proj) is allows_requantization
 
 
 @pytest.mark.cpu_test

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -145,8 +145,8 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
-    VLLM_ROCM_USE_AITER_FP8BMM: bool = True
-    VLLM_ROCM_USE_AITER_FP4BMM: bool = True
+    VLLM_ROCM_USE_AITER_FP8BMM: bool = False
+    VLLM_ROCM_USE_AITER_FP4BMM: bool = False
     VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION: bool = False
     VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: bool = False
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
@@ -1313,15 +1313,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ROCM_USE_AITER_TRITON_ROPE": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_TRITON_ROPE", "False").lower() in ("true", "1")
     ),
-    # Whether to use aiter triton fp8 bmm kernel
-    # By default is enabled.
+    # Whether to use aiter triton fp8 bmm kernel for MLA kv_b_proj.
+    # By default is disabled: it re-quantizes the projection weights online,
+    # regardless of the precision the checkpoint asked for.
     "VLLM_ROCM_USE_AITER_FP8BMM": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_FP8BMM", "True").lower() in ("true", "1")
+        os.getenv("VLLM_ROCM_USE_AITER_FP8BMM", "False").lower() in ("true", "1")
     ),
-    # Whether to use aiter triton fp4 bmm kernel
-    # By default is enabled.
+    # Whether to use aiter triton fp4 bmm kernel for MLA kv_b_proj.
+    # By default is disabled, for the same reason as the fp8 variant above.
     "VLLM_ROCM_USE_AITER_FP4BMM": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_FP4BMM", "True").lower() in ("true", "1")
+        os.getenv("VLLM_ROCM_USE_AITER_FP4BMM", "False").lower() in ("true", "1")
     ),
     # Use AITER triton unified attention for V1 attention
     "VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION": lambda: (

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -245,6 +245,7 @@ from vllm.model_executor.layers.attention.kv_transfer_utils import (
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
@@ -308,6 +309,16 @@ from vllm.v1.kv_cache_interface import (
 logger = init_logger(__name__)
 
 _FP8_DTYPE = current_platform.fp8_dtype()
+
+
+def _is_mla_bmm_requantization_allowed(kv_b_proj: torch.nn.Module) -> bool:
+    """Whether online BMM weight quantization preserves checkpoint precision."""
+    return not (
+        getattr(kv_b_proj, "quant_config", None) is not None
+        and isinstance(
+            getattr(kv_b_proj, "quant_method", None), UnquantizedLinearMethod
+        )
+    )
 
 
 def _detect_output_quant_key(
@@ -617,11 +628,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 use_pcp=self.use_pcp,
             )
 
-        self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
+        allow_bmm_requantization = _is_mla_bmm_requantization_allowed(self.kv_b_proj)
+        self.is_aiter_triton_fp8_bmm_enabled = (
+            rocm_aiter_ops.is_fp8bmm_enabled() and allow_bmm_requantization
+        )
 
         # If kv_b_proj_weight is unquantized, quantize it to mxfp4 if supported
         self.is_aiter_triton_fp4_bmm_enabled = (
             rocm_aiter_ops.is_fp4bmm_enabled()
+            and allow_bmm_requantization
             and hasattr(self.kv_b_proj, "weight")
             and self.kv_b_proj.weight.dtype == torch.bfloat16
         )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -629,6 +629,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
 
         allow_bmm_requantization = _is_mla_bmm_requantization_allowed(self.kv_b_proj)
+        if not allow_bmm_requantization and (
+            rocm_aiter_ops.is_fp8bmm_enabled() or rocm_aiter_ops.is_fp4bmm_enabled()
+        ):
+            logger.info_once(
+                "Skipping AITER FP8/FP4 BMM online re-quantization for MLA "
+                "kv_b_proj: the checkpoint's quantization config explicitly "
+                "leaves this projection unquantized."
+            )
         self.is_aiter_triton_fp8_bmm_enabled = (
             rocm_aiter_ops.is_fp8bmm_enabled() and allow_bmm_requantization
         )
@@ -3055,7 +3063,10 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         self.indexer = indexer
         self.q_pad_num_heads = q_pad_num_heads
         self.supports_quant_query_input = True
-        self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
+        self.is_aiter_triton_fp8_bmm_enabled = (
+            rocm_aiter_ops.is_fp8bmm_enabled()
+            and _is_mla_bmm_requantization_allowed(kv_b_proj)
+        )
 
         # Use flashinfer's optimized concat_mla_k kernel when available.
         # The kernel is optimized for DeepSeek V3 dimensions:

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -245,7 +245,6 @@ from vllm.model_executor.layers.attention.kv_transfer_utils import (
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
-    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
@@ -309,16 +308,6 @@ from vllm.v1.kv_cache_interface import (
 logger = init_logger(__name__)
 
 _FP8_DTYPE = current_platform.fp8_dtype()
-
-
-def _is_mla_bmm_requantization_allowed(kv_b_proj: torch.nn.Module) -> bool:
-    """Whether online BMM weight quantization preserves checkpoint precision."""
-    return not (
-        getattr(kv_b_proj, "quant_config", None) is not None
-        and isinstance(
-            getattr(kv_b_proj, "quant_method", None), UnquantizedLinearMethod
-        )
-    )
 
 
 def _detect_output_quant_key(
@@ -628,23 +617,16 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 use_pcp=self.use_pcp,
             )
 
-        allow_bmm_requantization = _is_mla_bmm_requantization_allowed(self.kv_b_proj)
-        if not allow_bmm_requantization and (
-            rocm_aiter_ops.is_fp8bmm_enabled() or rocm_aiter_ops.is_fp4bmm_enabled()
-        ):
-            logger.info_once(
-                "Skipping AITER FP8/FP4 BMM online re-quantization for MLA "
-                "kv_b_proj: the checkpoint's quantization config explicitly "
-                "leaves this projection unquantized."
-            )
-        self.is_aiter_triton_fp8_bmm_enabled = (
-            rocm_aiter_ops.is_fp8bmm_enabled() and allow_bmm_requantization
-        )
+        # TODO(ROCm): both BMM kernels re-quantize kv_b_proj online, ignoring
+        # the precision the checkpoint asked for, so they now default to off.
+        # Turning them back on needs long-context accuracy validation, and the
+        # per-layer decision belongs in --quantization-config.targets rather
+        # than in this layer.
+        self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
 
         # If kv_b_proj_weight is unquantized, quantize it to mxfp4 if supported
         self.is_aiter_triton_fp4_bmm_enabled = (
             rocm_aiter_ops.is_fp4bmm_enabled()
-            and allow_bmm_requantization
             and hasattr(self.kv_b_proj, "weight")
             and self.kv_b_proj.weight.dtype == torch.bfloat16
         )
@@ -3063,10 +3045,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         self.indexer = indexer
         self.q_pad_num_heads = q_pad_num_heads
         self.supports_quant_query_input = True
-        self.is_aiter_triton_fp8_bmm_enabled = (
-            rocm_aiter_ops.is_fp8bmm_enabled()
-            and _is_mla_bmm_requantization_allowed(kv_b_proj)
-        )
+        self.is_aiter_triton_fp8_bmm_enabled = rocm_aiter_ops.is_fp8bmm_enabled()
 
         # Use flashinfer's optimized concat_mla_k kernel when available.
         # The kernel is optimized for DeepSeek V3 dimensions:


### PR DESCRIPTION
## Purpose

Fixes background issue [#52833](https://github.com/vllm-project/vllm/issues/52833)

`VLLM_ROCM_USE_AITER_FP8BMM` and `VLLM_ROCM_USE_AITER_FP4BMM` both default to `True`. Once `VLLM_ROCM_USE_AITER=1` is set, MLA `kv_b_proj` weights are re-quantized online regardless of the precision the checkpoint asked for, and there is no per-model opt-out.

`kv_b_proj` holds `[W_UK; W_UV]`, which decompress the latent KV cache on every read, so the perturbation applies to the whole KV history rather than to a single GEMM. That is why the damage shows up first in long context — exactly the
regime where these defaults have not been validated.

Two data points:

- #48051 measures ~11% error per attention layer from this path, accumulating into repetition loops.
- On `amd/GLM-5.2-MXFP4`, MTP acceptance rate goes 0% -> 58.5% when the re-quantization is skipped (#52833).

This PR flips both defaults to `False`. Accuracy over speed until the kernels are validated in long context. Anyone who wants them still gets them with `VLLM_ROCM_USE_AITER_FP8BMM=1` / `VLLM_ROCM_USE_AITER_FP4BMM=1`.

## Changes

- `vllm/envs.py`: both dataclass annotations and both `os.getenv` defaults flip `True` -> `False`; the two "By default is enabled" comments now say what the flags do and why they are off.
- `tests/kernels/quantization/test_rocm_fp8.py`: `ENV_DEFAULTS` pins the new `VLLM_ROCM_USE_AITER_FP8BMM` default.
- `tests/kernels/quantization/test_rocm_mxfp4.py`: `test_fp4_env_defaults` likewise.

## Test Plan

- tests/kernels/quantization/test_rocm_fp8.py
- tests/kernels/quantization/test_rocm_mxfp4.py

## Test Result

Passed.

--end--

=======================================
History for ones who may be interested
=======================================
## Purpose

Fixes issue [#52833](https://github.com/vllm-project/vllm/issues/52833)

This PR replaces [#48051](https://github.com/vllm-project/vllm/pull/48051)’s model-name guard with the generic rule:
```python
kv_b_proj.quant_config is not None
and isinstance(kv_b_proj.quant_method, UnquantizedLinearMethod)
```

When that condition is true, both AITER FP4BMM and FP8BMM re-quantization are disabled for the projection and MLA uses the existing BF16 BMM path.

The behavior remains unchanged for:
- fully BF16 models, where **quant_config** is null;
- projections with a real quantized method; and
- DeepSeek-V3-family Quark checkpoints whose intentional dynamic MXFP4
  attention path selects **QuarkLinearMethod**.

The current dispatch treats a BF16 weight as sufficient evidence that this online re-quantization is safe. That is not true for quantized checkpoints which explicitly exclude **kv_b_proj** to preserve it in high precision.

## Test Plan

### focused unit tests

```bash
python -m pytest tests/v1/attention/test_mla_backends.py
```

### gfx950 model validation

```bash
export VLLM_USE_V2_MODEL_RUNNER=0
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_FP4BMM=1
export VLLM_ROCM_USE_AITER_FP8BMM=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1

serve_args=(
  /home/xuebwang/models/amd/GLM-5.2-MXFP4
  --port 8000
  --kv-cache-dtype fp8_e4m3
  --trust-remote-code
  --tensor-parallel-size 8
  --enable-expert-parallel
  --linear-backend aiter
  --moe-backend aiter
  --tool-call-parser glm47
  --enable-auto-tool-choice
  --reasoning-parser glm45
  --max-model-len 262144
  --max-num-seqs 2
  --gpu-memory-utilization 0.80
  --speculative-config '{"method":"mtp","num_speculative_tokens":5}'
)
vllm serve "${serve_args[@]}"
```

## Test Result

```text
Mean acceptance length: 3.92
Accepted: 193
Drafted: 330
Avg Draft acceptance rate: 58.5%
Per-position acceptance rate: 0.909, 0.727, 0.545, 0.424, 0.318
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

