### PR TITLE
[Bugfix] Load reasoning parser plugins before headless engine config

### DIFF
--- a/tests/entrypoints/cli/test_serve.py
+++ b/tests/entrypoints/cli/test_serve.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the ``vllm serve`` CLI subcommand."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.entrypoints.cli.serve import run_headless
+
+
+class _StopAfterEngineConfig(Exception):
+    pass
+
+
+def test_headless_imports_reasoning_parser_plugin_before_engine_config():
+    plugin_path = "/tmp/custom_reasoning_parser.py"
+    args = argparse.Namespace(
+        api_server_count=0,
+        reasoning_parser_plugin=plugin_path,
+    )
+    engine_args = MagicMock()
+
+    with (
+        patch(
+            "vllm.entrypoints.cli.serve.vllm.AsyncEngineArgs.from_cli_args",
+            return_value=engine_args,
+        ),
+        patch(
+            "vllm.reasoning.ReasoningParserManager.import_reasoning_parser"
+        ) as import_plugin,
+    ):
+
+        def create_engine_config(**kwargs):
+            import_plugin.assert_called_once_with(plugin_path)
+            raise _StopAfterEngineConfig
+
+        engine_args.create_engine_config.side_effect = create_engine_config
+
+        with pytest.raises(_StopAfterEngineConfig):
+            run_headless(args)

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -15,6 +15,7 @@ from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_se
 from vllm.entrypoints.openai.dp_supervisor import run_dp_supervisor
 from vllm.entrypoints.serve.utils.api_utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
+from vllm.reasoning import ReasoningParserManager
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.network_utils import get_tcp_uri
@@ -175,6 +176,9 @@ def cmd_init() -> list[CLISubcommand]:
 def run_headless(args: argparse.Namespace):
     if args.api_server_count > 1:
         raise ValueError("api_server_count can't be set in headless mode")
+
+    if args.reasoning_parser_plugin and len(args.reasoning_parser_plugin) > 3:
+        ReasoningParserManager.import_reasoning_parser(args.reasoning_parser_plugin)
 
     # Create the EngineConfig.
     engine_args = vllm.AsyncEngineArgs.from_cli_args(args)


### PR DESCRIPTION
## Purpose

Fixes #53072.

Headless serving currently constructs the engine config before loading `--reasoning-parser-plugin`. `VllmConfig` resolves the requested parser during config initialization, so a custom parser raises `KeyError` before its module has a chance to register itself.

This change loads the plugin before `AsyncEngineArgs.from_cli_args` and `create_engine_config`, matching the existing API server startup order. It also adds a regression test that checks the import has happened when engine config construction begins.

I searched the open vLLM pull requests by issue number and relevant keywords and found no duplicate implementation. No documentation update is needed because this restores the existing CLI option in headless mode.

Codex assisted with investigation and drafting. I reviewed and understand every changed line and ran the validation below locally.

## Test Plan

- Run the new headless CLI regression test together with the related CLI suites.
- Run the repository pre-commit hooks against both changed files.

## Test Result

Before the fix, the new regression test fails because the plugin import call count is zero when engine config construction starts.

After the fix:

```text
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest -q tests/entrypoints/cli/test_serve.py tests/entrypoints/launchers/test_launch_cli.py tests/entrypoints/openai/test_cli_args.py
43 passed, 16 warnings in 10.76s
```

```text
.venv/bin/pre-commit run --files vllm/entrypoints/cli/serve.py tests/entrypoints/cli/test_serve.py
All applicable hooks passed.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan, including the commands used.
- [x] The test results, including before/after behavior.
- [x] Documentation impact was considered; no update is required for this bug fix.
</details>

