### PR TITLE
Add multi-root sharding and aligned direct I/O to FS offloading

### DIFF
--- a/csrc/fs_io.cpp
+++ b/csrc/fs_io.cpp
@@ -7,6 +7,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -33,12 +34,23 @@ inline int ensure_parent_dirs(const std::string& path) {
   return ec ? ec.value() : 0;
 }
 
+inline bool can_use_o_direct(bool requested, const void* buffer, size_t size,
+                             size_t direct_io_alignment) {
+  if (!requested || kODirectFlag == 0 || direct_io_alignment == 0 ||
+      size % direct_io_alignment != 0) {
+    return false;
+  }
+  const auto address = reinterpret_cast<std::uintptr_t>(buffer);
+  return address % direct_io_alignment == 0;
+}
+
 // Core single-block store: src/size are raw pointer + byte count. Returns 0
 // on success, or the errno of the failing step on failure -- captured
 // before any subsequent cleanup call can overwrite it. On failure, the temp
 // file is removed.
 inline int _store_block(const char* tmp_path, const char* dest_path,
-                        const char* src, size_t size, bool use_o_direct) {
+                        const char* src, size_t size, bool use_o_direct,
+                        size_t direct_io_alignment) {
   if (access(dest_path, F_OK) == 0) {
     return 0;  // Already present.
   }
@@ -47,7 +59,10 @@ inline int _store_block(const char* tmp_path, const char* dest_path,
     return err;
   }
 
-  const int o_direct_flag = use_o_direct ? kODirectFlag : 0;
+  const int o_direct_flag =
+      can_use_o_direct(use_o_direct, src, size, direct_io_alignment)
+          ? kODirectFlag
+          : 0;
   const int fd = open(
       tmp_path, O_CREAT | O_EXCL | O_WRONLY | O_TRUNC | o_direct_flag, 0644);
   if (fd < 0) {
@@ -85,8 +100,10 @@ inline int _store_block(const char* tmp_path, const char* dest_path,
 // transient/ambiguous and leave the file untouched; a close failure after a
 // full read is harmless and does not fail the load.
 inline int _load_block(const char* source_path, char* dst, size_t size,
-                       bool use_o_direct) {
-  const int o_direct_flag = use_o_direct ? kODirectFlag : 0;
+                       bool use_o_direct, size_t direct_io_alignment) {
+  const bool direct_io =
+      can_use_o_direct(use_o_direct, dst, size, direct_io_alignment);
+  const int o_direct_flag = direct_io ? kODirectFlag : 0;
   const int fd = open(source_path, O_RDONLY | o_direct_flag, 0);
   if (fd < 0) {
     return errno;
@@ -199,16 +216,18 @@ static PyObject* batch_lookup(PyObject* /*self*/, PyObject* args) {
 /// @param use_o_direct bool – whether to open files with O_DIRECT
 ///                     (default True). Ignored where O_DIRECT is unsupported
 ///                     by the platform.
+/// @param direct_io_alignment int – validated direct-I/O alignment.
 /// @note Releases the GIL for the entire batch. Raises on first error.
 static PyObject* batch_store_block(PyObject* /*self*/, PyObject* args) {
   PyObject* tmp_paths_obj = nullptr;
   PyObject* dest_paths_obj = nullptr;
   PyObject* buffers_obj = nullptr;
   int use_o_direct = 1;
+  unsigned long long direct_io_alignment = 1;
 
-  if (!PyArg_ParseTuple(args, "O!O!O!|p", &PyList_Type, &tmp_paths_obj,
+  if (!PyArg_ParseTuple(args, "O!O!O!|pK", &PyList_Type, &tmp_paths_obj,
                         &PyList_Type, &dest_paths_obj, &PyList_Type,
-                        &buffers_obj, &use_o_direct)) {
+                        &buffers_obj, &use_o_direct, &direct_io_alignment)) {
     return nullptr;
   }
 
@@ -239,7 +258,8 @@ static PyObject* batch_store_block(PyObject* /*self*/, PyObject* args) {
       const char* buf = static_cast<const char*>(buffers[i].buf);
       const int err =
           _store_block(tmp_paths[i], dest_paths[i], buf,
-                       static_cast<size_t>(buffers[i].len), use_o_direct);
+                       static_cast<size_t>(buffers[i].len), use_o_direct,
+                       static_cast<size_t>(direct_io_alignment));
       if (err != 0) {
         failed_index = i;
         failure_errno = err;
@@ -268,14 +288,17 @@ static PyObject* batch_store_block(PyObject* /*self*/, PyObject* args) {
 /// @param use_o_direct bool – whether to open files with O_DIRECT
 ///                     (default True). Ignored where O_DIRECT is unsupported
 ///                     by the platform.
+/// @param direct_io_alignment int – validated direct-I/O alignment.
 /// @note Releases the GIL for the entire batch. Raises on first error.
 static PyObject* batch_load_block(PyObject* /*self*/, PyObject* args) {
   PyObject* source_paths_obj = nullptr;
   PyObject* buffers_obj = nullptr;
   int use_o_direct = 1;
+  unsigned long long direct_io_alignment = 1;
 
-  if (!PyArg_ParseTuple(args, "O!O!|p", &PyList_Type, &source_paths_obj,
-                        &PyList_Type, &buffers_obj, &use_o_direct)) {
+  if (!PyArg_ParseTuple(args, "O!O!|pK", &PyList_Type, &source_paths_obj,
+                        &PyList_Type, &buffers_obj, &use_o_direct,
+                        &direct_io_alignment)) {
     return nullptr;
   }
 
@@ -302,7 +325,7 @@ static PyObject* batch_load_block(PyObject* /*self*/, PyObject* args) {
       char* buf = static_cast<char*>(buffers[i].buf);
       const int err =
           _load_block(source_paths[i], buf, static_cast<size_t>(buffers[i].len),
-                      use_o_direct);
+                      use_o_direct, static_cast<size_t>(direct_io_alignment));
       if (err != 0) {
         failed_index = i;
         failure_errno = err;
@@ -345,14 +368,16 @@ static PyMethodDef fs_io_C_methods[] = {
     {"batch_store_block", batch_store_block, METH_VARARGS,
      "batch_store_block(tmp_paths: list[str], dest_paths: list[str],\n"
      "                  buffers: list[bytes-like],\n"
-     "                  use_o_direct: bool = True) -> None\n"
+     "                  use_o_direct: bool = True,\n"
+     "                  direct_io_alignment: int = 1) -> None\n"
      "\n"
      "Store a batch of blocks, each from its own buffer, to disk. Raises on "
      "first error."},
     {"batch_load_block", batch_load_block, METH_VARARGS,
      "batch_load_block(source_paths: list[str],\n"
      "                 buffers: list[writable bytes-like],\n"
-     "                 use_o_direct: bool = True) -> None\n"
+     "                 use_o_direct: bool = True,\n"
+     "                 direct_io_alignment: int = 1) -> None\n"
      "\n"
      "Load a batch of blocks from disk into corresponding buffers. "
      "Raises on first error."},

--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -124,7 +124,8 @@ The filesystem tier (`type: "fs"`) writes blocks to a filesystem directory.
 | Key | Required | Default | Notes |
 | --- | --- | --- | --- |
 | `type` | yes | — | Must be `fs`. |
-| `root_dir` | yes | — | Base directory; vLLM creates subdirectories beneath it (see [On-Disk Layout](#on-disk-layout)). |
+| `root_dir` | yes | — | Base directory, or an ordered comma-separated list of directories with `path_sharding: "by_block_hash"`; vLLM creates subdirectories beneath each one (see [On-Disk Layout](#on-disk-layout)). |
+| `path_sharding` | no | unspecified | Set to `by_block_hash` to distribute complete logical blocks deterministically across multiple `root_dir` paths. |
 | `n_read_threads` | no | `16` | Read-priority I/O threads (load path). |
 | `n_write_threads` | no | `16` | Write-priority I/O threads (store path). |
 | `enable_kv_events` | no | `false` | Publish `BlockStored` KV events (medium `FS`) for successfully stored blocks. Requires KV cache events to be enabled globally. |
@@ -132,9 +133,29 @@ The filesystem tier (`type: "fs"`) writes blocks to a filesystem directory.
 
 Each thread group prefers its own queue but pulls from the other when its primary queue is empty, so a write-heavy or read-heavy burst won't leave the off-priority queue waiting. Size the totals to your storage's effective concurrency.
 
+For whole-block path sharding, provide comma-separated roots and select the
+stable block-hash strategy:
+
+```json
+{
+  "type": "fs",
+  "root_dir": "/mnt/ps-1/kv,/mnt/ps-2/kv,/mnt/ps-3/kv,/mnt/ps-4/kv",
+  "path_sharding": "by_block_hash",
+  "n_read_threads": 64,
+  "n_write_threads": 64
+}
+```
+
+Each logical block remains one complete file containing every TP worker's KV
+region. Its content hash modulo the number of roots selects one root. Batches
+are grouped by selected root and submitted as parallel I/O tasks, allowing a
+single request containing many blocks to use multiple storage paths. Changing
+the number or order of roots changes the mapping and makes blocks under the old
+mapping unavailable until they are stored again.
+
 #### On-Disk Layout
 
-Under `root_dir`, vLLM creates a subdirectory `<model>_<digest>`, where `<model>` is the model name with `/` replaced by `_` (so HuggingFace IDs like `meta-llama/Llama-3-8B` don't nest), and `<digest>` is a short SHA256 prefix derived from the run configuration (model, block size, parallelism, dtype, etc.). Runs with the same configuration share the same subdirectory; runs with different configurations live side-by-side under the same `root_dir` without colliding.
+Under each `root_dir`, vLLM creates a subdirectory `<model>_<digest>`, where `<model>` is the model name with `/` replaced by `_` (so HuggingFace IDs like `meta-llama/Llama-3-8B` don't nest), and `<digest>` is a short SHA256 prefix derived from the run configuration (model, block size, parallelism, dtype, etc.). Runs with the same configuration share the same subdirectory; runs with different configurations live side-by-side under the same `root_dir` without colliding.
 
 Inside that subdirectory, blocks are sharded across hash-prefix subdirectories to limit directory fan-out:
 

--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -153,6 +153,14 @@ single request containing many blocks to use multiple storage paths. Changing
 the number or order of roots changes the mapping and makes blocks under the old
 mapping unavailable until they are stored again.
 
+The FS tier probes O_DIRECT support independently for each root with a
+page-sized transfer from a page-aligned buffer. Each read or write uses direct
+I/O only when that root passes the probe and the transfer size and host buffer
+address meet that validated alignment. An unaligned operation falls back to
+buffered I/O without changing other roots or operations. The `statvfs` block
+size is recorded for diagnostics but is not treated as a strict direct-I/O
+alignment because NFS can report its preferred transfer size there.
+
 #### On-Disk Layout
 
 Under each `root_dir`, vLLM creates a subdirectory `<model>_<digest>`, where `<model>` is the model name with `/` replaced by `_` (so HuggingFace IDs like `meta-llama/Llama-3-8B` don't nest), and `<digest>` is a short SHA256 prefix derived from the run configuration (model, block size, parallelism, dtype, etc.). Runs with the same configuration share the same subdirectory; runs with different configurations live side-by-side under the same `root_dir` without colliding.

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -40,7 +40,10 @@ from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
 from vllm.v1.kv_offload.tiering.fs.manager import (
     FileSystemTierManager,
 )
-from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+from vllm.v1.kv_offload.tiering.fs.thread_pool import (
+    DualQueueThreadPool,
+    JobState,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -273,6 +276,125 @@ def test_invalid_path_raises_at_construction():
         )
 
 
+def test_multiple_roots_require_block_hash_sharding(tmp_path):
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+
+    with pytest.raises(
+        ValueError,
+        match="multiple root_dir paths require path_sharding='by_block_hash'",
+    ):
+        FileSystemTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=memoryview(tensor.numpy()),
+            tier_type="fs",
+            root_dir=f"{tmp_path / 'root0'},{tmp_path / 'root1'}",
+        )
+
+
+@pytest.mark.parametrize("path_sharding", ["by_rank", "round_robin", ""])
+def test_unknown_path_sharding_rejected(tmp_path, path_sharding):
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+
+    with pytest.raises(ValueError, match="path_sharding must be omitted"):
+        FileSystemTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=memoryview(tensor.numpy()),
+            tier_type="fs",
+            root_dir=str(tmp_path),
+            path_sharding=path_sharding,
+        )
+
+
+def test_hash_sharding_requires_distinct_roots(tmp_path):
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+    root = str(tmp_path / "root0")
+
+    with pytest.raises(ValueError, match="root_dir paths must be distinct"):
+        FileSystemTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=memoryview(tensor.numpy()),
+            tier_type="fs",
+            root_dir=f"{root},{root}",
+            path_sharding="by_block_hash",
+        )
+
+
+@pytest.mark.parametrize("use_c_ext", [True, False])
+def test_block_hash_sharding_preserves_full_rows_and_root_affinity(
+    tmp_path, monkeypatch, use_c_ext
+):
+    import vllm.v1.kv_offload.tiering.fs.io as io_mod
+
+    if use_c_ext and not io_mod._HAS_FSIO_C:
+        pytest.skip("fs_io_C extension not built")
+    monkeypatch.setattr(io_mod, "_HAS_FSIO_C", use_c_ext)
+
+    tensor = _page_aligned_rand_tensor(_NUM_BLOCKS, _BLOCK_ELEMENTS)
+    roots = [tmp_path / f"root{idx}" for idx in range(4)]
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=memoryview(tensor.numpy()),
+        tier_type="fs",
+        root_dir=",".join(str(root) for root in roots),
+        path_sharding="by_block_hash",
+        n_read_threads=4,
+        n_write_threads=4,
+    )
+    try:
+        keys = [key(idx) for idx in range(4)]
+        expected = tensor[:4].clone()
+        tier.submit_store(make_job(1, keys, [0, 1, 2, 3]))
+        assert all(result.success for result in drain(tier))
+
+        for root_idx, block_key in enumerate(keys):
+            path = tier.get_file_name(block_key)
+            assert path.startswith(str(roots[root_idx]))
+            assert os.path.getsize(path) == tier._block_size
+            assert os.path.exists(tier.file_mappers[root_idx].get_config_file_path())
+
+        tensor[4:] = 0
+        tier.submit_load(make_job(2, keys, [4, 5, 6, 7], is_promotion=True))
+        assert all(result.success for result in drain(tier))
+        assert torch.equal(tensor[4:], expected)
+    finally:
+        tier.shutdown()
+
+
+def test_hash_sharded_load_reports_noncontiguous_successes(tmp_path):
+    tensor = _page_aligned_rand_tensor(_NUM_BLOCKS, _BLOCK_ELEMENTS)
+    roots = [tmp_path / f"root{idx}" for idx in range(4)]
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=memoryview(tensor.numpy()),
+        tier_type="fs",
+        root_dir=",".join(str(root) for root in roots),
+        path_sharding="by_block_hash",
+        n_read_threads=4,
+        n_write_threads=4,
+    )
+    try:
+        keys = [key(idx) for idx in range(4)]
+        tier.submit_store(make_job(1, keys, [0, 1, 2, 3]))
+        assert all(result.success for result in drain(tier))
+
+        ctx = ReqContext(req_id="hash-sharded-partial")
+        assert lookup_and_wait(tier, keys, ctx=ctx) == [LookupResult.HIT] * 4
+        os.unlink(tier.get_file_name(keys[2]))
+
+        tier.submit_load(make_job(2, keys, [4, 5, 6, 7], is_promotion=True))
+        results = drain(tier)
+        assert len(results) == 1 and not results[0].success
+        assert tuple(results[0].successful_keys) == (keys[0], keys[1], keys[3])
+        assert [tier.lookup(block_key, ctx) for block_key in keys] == [
+            LookupResult.HIT,
+            LookupResult.HIT,
+            LookupResult.MISS,
+            LookupResult.HIT,
+        ]
+    finally:
+        tier.shutdown()
+
+
 @pytest.mark.parametrize("locality", ["local", ""])
 def test_invalid_locality_raises_at_construction(tmp_path, locality):
     tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
@@ -463,6 +585,22 @@ def test_wait_idle_blocks_until_tasks_complete():
         gate.set()
         pool.shutdown(wait=True)
         waiter.join(timeout=5.0)
+
+
+def test_job_state_reports_parallel_wall_time_instead_of_sum():
+    state = JobState(job_id=1, n_tasks=2)
+    state.task_started(10.0)
+    state.task_started(11.0)
+
+    completed, success, transfer_time = state.task_done(True, 12.0)
+    assert not completed
+    assert success
+    assert transfer_time == 2.0
+
+    completed, success, transfer_time = state.task_done(True, 13.0)
+    assert completed
+    assert success
+    assert transfer_time == 3.0
 
 
 def test_batch_lookup_c_extension(tmp_path):

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -319,6 +319,33 @@ def test_hash_sharding_requires_distinct_roots(tmp_path):
         )
 
 
+def test_o_direct_capability_is_tracked_per_root(tmp_path, monkeypatch):
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+    roots = [tmp_path / "direct", tmp_path / "buffered"]
+    monkeypatch.setattr(
+        mgr_mod,
+        "probe_o_direct",
+        lambda directory: str(roots[0]) in directory,
+    )
+
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=memoryview(tensor.numpy()),
+        tier_type="fs",
+        root_dir=",".join(str(root) for root in roots),
+        path_sharding="by_block_hash",
+    )
+    try:
+        assert tier._o_direct_supported == [True, False]
+        assert tier._direct_io_alignments == [mmap.PAGESIZE, 0]
+        assert all(size > 0 for size in tier._filesystem_block_sizes)
+        assert tier._use_o_direct is False
+    finally:
+        tier.shutdown()
+
+
 @pytest.mark.parametrize("use_c_ext", [True, False])
 def test_block_hash_sharding_preserves_full_rows_and_root_affinity(
     tmp_path, monkeypatch, use_c_ext
@@ -565,6 +592,54 @@ def test_store_load_roundtrip_without_o_direct(tmp_path, monkeypatch):
             assert torch.allclose(tensor[bid], expected[i])
     finally:
         tier.shutdown()
+
+
+def test_o_direct_alignment_check_uses_size_and_buffer_address():
+    from vllm.v1.kv_offload.tiering.fs.io import O_DIRECT, _can_use_o_direct
+
+    if not O_DIRECT:
+        pytest.skip("O_DIRECT is unavailable on this platform")
+
+    tensor = _page_aligned_zero_tensor(1, _BLOCK_ELEMENTS)
+    view = memoryview(tensor.numpy()).cast("B")
+
+    assert _can_use_o_direct(view, len(view), mmap.PAGESIZE, True)
+    assert not _can_use_o_direct(view[:-1], len(view) - 1, mmap.PAGESIZE, True)
+    assert not _can_use_o_direct(view[1:], len(view) - 1, mmap.PAGESIZE, True)
+    assert not _can_use_o_direct(view, len(view), mmap.PAGESIZE, False)
+
+
+@pytest.mark.parametrize("use_c_ext", [True, False])
+def test_unaligned_direct_io_falls_back(tmp_path, monkeypatch, use_c_ext):
+    import vllm.v1.kv_offload.tiering.fs.io as io_mod
+
+    if use_c_ext and not io_mod._HAS_FSIO_C:
+        pytest.skip("fs_io_C extension not built")
+    monkeypatch.setattr(io_mod, "_HAS_FSIO_C", use_c_ext)
+
+    block_size = mmap.PAGESIZE + 1
+    source = bytearray(os.urandom(block_size))
+    destination = bytearray(block_size)
+    path = str(tmp_path / "unaligned.bin")
+
+    io_mod.batch_store_block(
+        [path],
+        memoryview(source),
+        [0],
+        block_size,
+        True,
+        mmap.PAGESIZE,
+    )
+    io_mod.batch_load_block(
+        [path],
+        memoryview(destination),
+        [0],
+        block_size,
+        True,
+        mmap.PAGESIZE,
+    )
+
+    assert destination == source
 
 
 def test_wait_idle_blocks_until_tasks_complete():

--- a/vllm/v1/kv_offload/tiering/fs/io.py
+++ b/vllm/v1/kv_offload/tiering/fs/io.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import contextlib
+import ctypes
 import logging
 import mmap
 import os
@@ -87,12 +88,34 @@ def _validate_offsets(view: memoryview, offsets: list[int], block_size: int) -> 
             )
 
 
+def _can_use_o_direct(
+    view: memoryview,
+    block_size: int,
+    direct_io_alignment: int,
+    use_o_direct: bool,
+) -> bool:
+    """Return whether this buffer and transfer satisfy O_DIRECT alignment."""
+    if (
+        not use_o_direct
+        or not O_DIRECT
+        or direct_io_alignment <= 0
+        or block_size % direct_io_alignment != 0
+    ):
+        return False
+    try:
+        address = ctypes.addressof(ctypes.c_char.from_buffer(view))
+    except (TypeError, BufferError):
+        return False
+    return address % direct_io_alignment == 0
+
+
 def _store_block(
     dest_path: str,
     buffer: memoryview,
     offset: int,
     block_size: int,
     use_o_direct: bool = True,
+    direct_io_alignment: int = 1,
 ) -> None:
     """
     Store callback: Writes to a temp file then atomically replaces the destination.
@@ -108,7 +131,11 @@ def _store_block(
     # Write block atomically. Cast to a flat byte view so the slice uses byte
     # indices; the raw memoryview may be multi-dimensional with itemsize > 1.
     view_slice = buffer.cast("B")[offset : offset + block_size]
-    o_direct = O_DIRECT if use_o_direct else 0
+    o_direct = (
+        O_DIRECT
+        if _can_use_o_direct(view_slice, block_size, direct_io_alignment, use_o_direct)
+        else 0
+    )
     try:
         fd = os.open(
             tmp_path,
@@ -138,13 +165,17 @@ def _load_block(
     offset: int,
     block_size: int,
     use_o_direct: bool = True,
+    direct_io_alignment: int = 1,
 ) -> None:
     """Read one KV block from disk; remove the file only on a provable short
     read (a too-short file is genuine corruption) and leave it untouched on any
     other error."""
     fd: int | None = None
     view_slice = view.cast("B")[offset : offset + block_size]
-    o_direct = O_DIRECT if use_o_direct else 0
+    use_direct_io = _can_use_o_direct(
+        view_slice, block_size, direct_io_alignment, use_o_direct
+    )
+    o_direct = O_DIRECT if use_direct_io else 0
 
     try:
         fd = os.open(source_path, os.O_RDONLY | o_direct)
@@ -171,6 +202,7 @@ def batch_store_block(
     offsets: list[int],
     block_size: int,
     use_o_direct: bool = True,
+    direct_io_alignment: int = 1,
 ) -> None:
     """
     Store a batch of KV blocks from a shared buffer to disk in one call.
@@ -184,10 +216,23 @@ def batch_store_block(
         view_B = view.cast("B")
         view_slices = [view_B[x : x + block_size] for x in offsets]
         tmp_paths = [p + _get_tmp_suffix() for p in paths]
-        return batch_store_block_C(tmp_paths, paths, view_slices, use_o_direct)
+        return batch_store_block_C(
+            tmp_paths,
+            paths,
+            view_slices,
+            use_o_direct,
+            direct_io_alignment,
+        )
     else:
         for path, offset in zip(paths, offsets):
-            _store_block(path, view, offset, block_size, use_o_direct)
+            _store_block(
+                path,
+                view,
+                offset,
+                block_size,
+                use_o_direct,
+                direct_io_alignment,
+            )
 
 
 def batch_load_block(
@@ -196,6 +241,7 @@ def batch_load_block(
     offsets: list[int],
     block_size: int,
     use_o_direct: bool = True,
+    direct_io_alignment: int = 1,
 ) -> None:
     """
     Load a batch of KV blocks from disk into a shared buffer in one call.
@@ -210,11 +256,23 @@ def batch_load_block(
     if _HAS_FSIO_C:
         view_B = view.cast("B")
         view_slices = [view_B[x : x + block_size] for x in offsets]
-        return batch_load_block_C(paths, view_slices, use_o_direct)
+        return batch_load_block_C(
+            paths,
+            view_slices,
+            use_o_direct,
+            direct_io_alignment,
+        )
     else:
         for i, (path, offset) in enumerate(zip(paths, offsets)):
             try:
-                _load_block(path, view, offset, block_size, use_o_direct)
+                _load_block(
+                    path,
+                    view,
+                    offset,
+                    block_size,
+                    use_o_direct,
+                    direct_io_alignment,
+                )
             except OSError as exc:
                 # Blocks 0..i-1 loaded fine; record the count for partial keep.
                 # The C path sets the same attribute via PyObject_SetAttrString.

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -38,6 +38,7 @@ from vllm.v1.kv_offload.base import (
     OffloadingEvent,
     OffloadKey,
     ReqContext,
+    get_offload_block_hash,
 )
 from vllm.v1.kv_offload.file_mapper import FileMapper
 from vllm.v1.kv_offload.tiering.async_lookup import AsyncLookupManager
@@ -76,7 +77,7 @@ class FsAsyncLookupManager(AsyncLookupManager):
     def batch_lookup(
         self, keys: list[OffloadKey], req_context: ReqContext
     ) -> Iterable[bool]:
-        paths = [self._tier.file_mapper.get_file_name(k) for k in keys]
+        paths = [self._tier.get_file_name(key) for key in keys]
         if _HAS_BATCH_LOOKUP_C:
             # C extension: GIL released for the entire faccessat() batch.
             return batch_lookup_C(paths)
@@ -117,6 +118,7 @@ class FileSystemTierManager(SecondaryTierManager):
         n_write_threads: int = 16,
         enable_kv_events: bool = False,
         locality: str | None = None,
+        path_sharding: str | None = None,
     ):
         """
         Args:
@@ -124,7 +126,8 @@ class FileSystemTierManager(SecondaryTierManager):
                 blocks_per_chunk.
             primary_kv_view: Memoryview of the primary tier's CPU KV cache.
             tier_type: Tier type identifier, set by SecondaryTierFactory.
-            root_dir: Root directory for block files.
+            root_dir: Root directory for block files, or an ordered,
+                comma-separated list of roots when path sharding is enabled.
             n_read_threads: Number of read-priority I/O threads.
             n_write_threads: Number of write-priority I/O threads.
             enable_kv_events: Emit BlockStored KV events for blocks
@@ -132,6 +135,9 @@ class FileSystemTierManager(SecondaryTierManager):
                 cache events are enabled globally (kv_events_config).
             locality: Whether this tier's storage is LOCAL or REMOTE relative
                 to the publishing vLLM instance.
+            path_sharding: Set to ``"by_block_hash"`` to map each complete
+                logical block to one of the configured roots using its stable
+                content hash.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
         self.locality = Locality(locality) if locality is not None else None
@@ -152,13 +158,10 @@ class FileSystemTierManager(SecondaryTierManager):
         # Keys of in-flight load (promotion) jobs, so a failed load can mark
         # its own cached lookup verdicts False (see get_finished_jobs).
         self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
-        # Per load job: how many blocks loaded before a failure (partial keep).
-        # Written by the pool worker inside the load task before it raises (so
-        # before task_done publishes the job); read on the scheduler thread in
-        # get_finished_jobs only for job ids the finished queue returned. Under
-        # the GIL that read cannot observe the finished job without the prior
-        # write, so no extra lock is needed (get_finished is itself lock-free).
-        self._load_progress: dict[JobId, int] = {}
+        # Per load job: whether each key completed before a task failed. This
+        # supports independent per-root batches whose successful keys need not
+        # form one prefix in the original job order.
+        self._load_success: dict[JobId, list[bool]] = {}
 
         # Extract block size from primary view
         assert primary_kv_view.strides is not None, (
@@ -166,33 +169,65 @@ class FileSystemTierManager(SecondaryTierManager):
         )
         self._block_size: int = primary_kv_view.strides[0]
 
-        # Opt in; FileMapper enables it only for a parallelism-invariant block.
-        self.file_mapper = FileMapper.from_offloading_spec(
-            root_dir=root_dir,
-            offloading_spec=offloading_spec,
-            blocks_per_file=offloading_spec.blocks_per_chunk,
-            parallel_agnostic=True,
-        )
+        raw_root_dirs = root_dir.split(",")
+        if not raw_root_dirs or any(not path.strip() for path in raw_root_dirs):
+            raise ValueError("root_dir must contain non-empty filesystem paths")
+        self._root_dirs = [path.strip() for path in raw_root_dirs]
+        if path_sharding not in (None, "by_block_hash"):
+            raise ValueError(
+                "path_sharding must be omitted or set to 'by_block_hash', got "
+                f"{path_sharding!r}"
+            )
+        if len(self._root_dirs) > 1 and path_sharding != "by_block_hash":
+            raise ValueError(
+                "multiple root_dir paths require path_sharding='by_block_hash'"
+            )
+        normalized_roots = [os.path.normpath(path) for path in self._root_dirs]
+        if len(set(normalized_roots)) != len(normalized_roots):
+            raise ValueError("root_dir paths must be distinct")
 
-        # Write config file
-        config_path = self.file_mapper.get_config_file_path()
-        os.makedirs(os.path.dirname(config_path), exist_ok=True)
-        if not os.path.exists(config_path):
-            with open(config_path, "w") as f:
-                json.dump(
-                    self.file_mapper.get_run_config(), f, indent=2, sort_keys=True
-                )
+        # Every mapper describes the existing complete-row block format. Only
+        # the root differs; the hash chooses exactly one mapper for each key.
+        self.file_mappers = [
+            FileMapper.from_offloading_spec(
+                root_dir=path,
+                offloading_spec=offloading_spec,
+                blocks_per_file=offloading_spec.blocks_per_chunk,
+                parallel_agnostic=True,
+            )
+            for path in self._root_dirs
+        ]
+        # Preserve the historical attribute for single-root users and tools.
+        self.file_mapper = self.file_mappers[0]
+
+        # Write the same full-row format config under every root.
+        config_paths = []
+        for mapper in self.file_mappers:
+            config_path = mapper.get_config_file_path()
+            config_paths.append(config_path)
+            os.makedirs(os.path.dirname(config_path), exist_ok=True)
+            if not os.path.exists(config_path):
+                with open(config_path, "w") as f:
+                    json.dump(mapper.get_run_config(), f, indent=2, sort_keys=True)
 
         # Prefer O_DIRECT to bypass the page cache, but fall back to buffered
         # I/O on filesystems that reject it (e.g. overlayfs, some NFS mounts)
-        # rather than failing every block.
-        self._use_o_direct = probe_o_direct(os.path.dirname(config_path))
+        # rather than failing every block. Keep one mode across all roots.
+        self._use_o_direct = all(
+            probe_o_direct(os.path.dirname(path)) for path in config_paths
+        )
         if not self._use_o_direct:
             logger.warning(
-                "O_DIRECT is not supported at '%s'; falling back to buffered "
-                "I/O for the '%s' KV offload tier.",
+                "O_DIRECT is not supported at one or more paths in '%s'; "
+                "falling back to buffered I/O for the '%s' KV offload tier.",
                 root_dir,
                 tier_type,
+            )
+
+        if len(self.file_mappers) > 1:
+            logger.info(
+                "Configured whole-block hash sharding across %d FS roots",
+                len(self.file_mappers),
             )
 
         self._pool = DualQueueThreadPool(
@@ -202,6 +237,14 @@ class FileSystemTierManager(SecondaryTierManager):
         )
 
         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
+
+    def _get_mapper_index(self, key: OffloadKey) -> int:
+        block_hash = get_offload_block_hash(key)
+        return int.from_bytes(block_hash, byteorder="big") % len(self.file_mappers)
+
+    def get_file_name(self, key: OffloadKey) -> str:
+        """Map a complete logical block to its deterministic storage root."""
+        return self.file_mappers[self._get_mapper_index(key)].get_file_name(key)
 
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
@@ -219,15 +262,28 @@ class FileSystemTierManager(SecondaryTierManager):
         keys = list(job_metadata.keys)
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = keys
-        task = functools.partial(
-            batch_store_block,
-            [self.file_mapper.get_file_name(key) for key in keys],
-            self._primary_kv_view,
-            [int(bid) * self._block_size for bid in job_metadata.block_ids],
-            self._block_size,
-            self._use_o_direct,
-        )
-        self._pool.enqueue_store(job_metadata.job_id, 1, [task])
+
+        paths_by_root: list[list[str]] = [[] for _ in self.file_mappers]
+        offsets_by_root: list[list[int]] = [[] for _ in self.file_mappers]
+        for key, block_id in zip(keys, job_metadata.block_ids):
+            root_idx = self._get_mapper_index(key)
+            paths_by_root[root_idx].append(
+                self.file_mappers[root_idx].get_file_name(key)
+            )
+            offsets_by_root[root_idx].append(int(block_id) * self._block_size)
+
+        tasks = [
+            functools.partial(
+                batch_store_block,
+                paths,
+                self._primary_kv_view,
+                offsets,
+                self._block_size,
+                self._use_o_direct,
+            )
+            for paths, offsets in zip(paths_by_root, offsets_by_root)
+        ]
+        self._pool.enqueue_store(job_metadata.job_id, len(tasks), tasks)
 
     @override
     def submit_load(self, job_metadata: TransferJob) -> None:
@@ -236,37 +292,58 @@ class FileSystemTierManager(SecondaryTierManager):
         # keys as a miss (see get_finished_jobs).
         keys = list(job_metadata.keys)
         self._load_job_keys[job_id] = keys
-        paths = [self.file_mapper.get_file_name(key) for key in keys]
-        offsets = [int(bid) * self._block_size for bid in job_metadata.block_ids]
+        self._load_success[job_id] = [False] * len(keys)
+        paths_by_root: list[list[str]] = [[] for _ in self.file_mappers]
+        offsets_by_root: list[list[int]] = [[] for _ in self.file_mappers]
+        indices_by_root: list[list[int]] = [[] for _ in self.file_mappers]
+        for key_idx, (key, block_id) in enumerate(zip(keys, job_metadata.block_ids)):
+            root_idx = self._get_mapper_index(key)
+            paths_by_root[root_idx].append(
+                self.file_mappers[root_idx].get_file_name(key)
+            )
+            offsets_by_root[root_idx].append(int(block_id) * self._block_size)
+            indices_by_root[root_idx].append(key_idx)
 
-        def load_task() -> None:
-            try:
-                batch_load_block(
-                    paths,
-                    self._primary_kv_view,
-                    offsets,
-                    self._block_size,
-                    self._use_o_direct,
-                )
-            except OSError as exc:
-                # Runs on the pool worker thread. Record how many blocks loaded
-                # before the failure so get_finished_jobs can keep them; this
-                # write precedes task_done, so the scheduler reads it safely
-                # under the GIL once the finished queue hands back this job.
-                num_succeeded = getattr(exc, "num_succeeded", 0)
-                self._load_progress[job_id] = num_succeeded
-                # Surfaces errno (e.g. EMFILE "Too many open files") for both
-                # the C and Python load paths.
-                logger.debug(
-                    "Load of %d blocks for job %s failed at block %d: %s",
-                    len(paths),
-                    job_id,
-                    num_succeeded,
-                    exc,
-                )
-                raise
+        tasks = []
+        for root_idx, (paths, offsets, key_indices) in enumerate(
+            zip(paths_by_root, offsets_by_root, indices_by_root)
+        ):
 
-        self._pool.enqueue_load(job_id, 1, [load_task])
+            def load_task(
+                root_idx: int = root_idx,
+                paths: list[str] = paths,
+                offsets: list[int] = offsets,
+                key_indices: list[int] = key_indices,
+            ) -> None:
+                try:
+                    batch_load_block(
+                        paths,
+                        self._primary_kv_view,
+                        offsets,
+                        self._block_size,
+                        self._use_o_direct,
+                    )
+                except Exception as exc:
+                    num_succeeded = getattr(exc, "num_succeeded", 0)
+                    for key_idx in key_indices[:num_succeeded]:
+                        self._load_success[job_id][key_idx] = True
+                    logger.debug(
+                        "Load of %d blocks for job %s root %d failed at "
+                        "root-local block %d: %s",
+                        len(paths),
+                        job_id,
+                        root_idx,
+                        num_succeeded,
+                        exc,
+                    )
+                    raise
+                else:
+                    for key_idx in key_indices:
+                        self._load_success[job_id][key_idx] = True
+
+            tasks.append(load_task)
+
+        self._pool.enqueue_load(job_id, len(tasks), tasks)
 
     @override
     def get_finished_jobs(self) -> Iterable[JobResult]:
@@ -286,14 +363,15 @@ class FileSystemTierManager(SecondaryTierManager):
                         )
                     )
             load_keys = self._load_job_keys.pop(job_id, None)
-            num_succeeded = self._load_progress.pop(job_id, 0)
+            load_success = self._load_success.pop(job_id, None)
             if load_keys is not None and not success:
-                # A batched load stops at the first bad block and reports how
-                # many loaded before it. Those earlier blocks are kept in the
-                # primary tier (reported via successful_keys); only this block
-                # and the ones after it are marked a miss and recomputed.
-                successful = load_keys[:num_succeeded]
-                failed = load_keys[num_succeeded:]
+                assert load_success is not None
+                successful = [
+                    key for key, loaded in zip(load_keys, load_success) if loaded
+                ]
+                failed = [
+                    key for key, loaded in zip(load_keys, load_success) if not loaded
+                ]
                 self._lookup_manager.mark_miss(failed)
                 results.append(
                     JobResult(

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -17,6 +17,7 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
 
 import functools
 import json
+import mmap
 import os
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, ClassVar
@@ -210,19 +211,49 @@ class FileSystemTierManager(SecondaryTierManager):
                 with open(config_path, "w") as f:
                     json.dump(mapper.get_run_config(), f, indent=2, sort_keys=True)
 
-        # Prefer O_DIRECT to bypass the page cache, but fall back to buffered
-        # I/O on filesystems that reject it (e.g. overlayfs, some NFS mounts)
-        # rather than failing every block. Keep one mode across all roots.
-        self._use_o_direct = all(
-            probe_o_direct(os.path.dirname(path)) for path in config_paths
-        )
-        if not self._use_o_direct:
-            logger.warning(
-                "O_DIRECT is not supported at one or more paths in '%s'; "
-                "falling back to buffered I/O for the '%s' KV offload tier.",
-                root_dir,
-                tier_type,
-            )
+        # Detect direct-I/O support and alignment independently for each root.
+        # The I/O layer also checks every transfer's size and buffer address;
+        # only an ineligible operation falls back to buffered I/O.
+        self._o_direct_supported: list[bool] = []
+        self._direct_io_alignments: list[int] = []
+        self._filesystem_block_sizes: list[int] = []
+        for root, config_path in zip(self._root_dirs, config_paths):
+            directory = os.path.dirname(config_path)
+            supported = probe_o_direct(directory)
+            try:
+                filesystem_block_size = os.statvfs(directory).f_bsize
+            except OSError as exc:
+                logger.warning(
+                    "Could not query filesystem block size for '%s': %s.",
+                    root,
+                    exc,
+                )
+                filesystem_block_size = 0
+            # probe_o_direct performs a page-sized transfer from a page-aligned
+            # mmap. Its success proves page alignment is valid. statvfs.f_bsize
+            # is informational here: NFS commonly reports its 1 MiB preferred
+            # transfer size rather than the kernel's strict O_DIRECT alignment.
+            direct_io_alignment = mmap.PAGESIZE if supported else 0
+            self._o_direct_supported.append(supported)
+            self._direct_io_alignments.append(direct_io_alignment)
+            self._filesystem_block_sizes.append(filesystem_block_size)
+            if not supported:
+                logger.warning(
+                    "O_DIRECT is unavailable at '%s'; operations on this "
+                    "root will use buffered I/O.",
+                    root,
+                )
+            else:
+                logger.info(
+                    "O_DIRECT enabled at '%s' with validated alignment %d "
+                    "bytes (statvfs block size %d bytes).",
+                    root,
+                    direct_io_alignment,
+                    filesystem_block_size,
+                )
+
+        # Preserve the historical aggregate attribute for callers and tests.
+        self._use_o_direct = all(self._o_direct_supported)
 
         if len(self.file_mappers) > 1:
             logger.info(
@@ -279,9 +310,15 @@ class FileSystemTierManager(SecondaryTierManager):
                 self._primary_kv_view,
                 offsets,
                 self._block_size,
-                self._use_o_direct,
+                o_direct_supported,
+                direct_io_alignment,
             )
-            for paths, offsets in zip(paths_by_root, offsets_by_root)
+            for paths, offsets, o_direct_supported, direct_io_alignment in zip(
+                paths_by_root,
+                offsets_by_root,
+                self._o_direct_supported,
+                self._direct_io_alignments,
+            )
         ]
         self._pool.enqueue_store(job_metadata.job_id, len(tasks), tasks)
 
@@ -305,8 +342,20 @@ class FileSystemTierManager(SecondaryTierManager):
             indices_by_root[root_idx].append(key_idx)
 
         tasks = []
-        for root_idx, (paths, offsets, key_indices) in enumerate(
-            zip(paths_by_root, offsets_by_root, indices_by_root)
+        for root_idx, (
+            paths,
+            offsets,
+            key_indices,
+            o_direct_supported,
+            direct_io_alignment,
+        ) in enumerate(
+            zip(
+                paths_by_root,
+                offsets_by_root,
+                indices_by_root,
+                self._o_direct_supported,
+                self._direct_io_alignments,
+            )
         ):
 
             def load_task(
@@ -314,6 +363,8 @@ class FileSystemTierManager(SecondaryTierManager):
                 paths: list[str] = paths,
                 offsets: list[int] = offsets,
                 key_indices: list[int] = key_indices,
+                o_direct_supported: bool = o_direct_supported,
+                direct_io_alignment: int = direct_io_alignment,
             ) -> None:
                 try:
                     batch_load_block(
@@ -321,7 +372,8 @@ class FileSystemTierManager(SecondaryTierManager):
                         self._primary_kv_view,
                         offsets,
                         self._block_size,
-                        self._use_o_direct,
+                        o_direct_supported,
+                        direct_io_alignment,
                     )
                 except Exception as exc:
                     num_succeeded = getattr(exc, "num_succeeded", 0)

--- a/vllm/v1/kv_offload/tiering/fs/thread_pool.py
+++ b/vllm/v1/kv_offload/tiering/fs/thread_pool.py
@@ -31,7 +31,7 @@ class JobState:
         "_n_tasks",
         "_completed",
         "_success",
-        "_transfer_time",
+        "_started_at",
         "_lock",
     )
 
@@ -40,23 +40,28 @@ class JobState:
         self._n_tasks = n_tasks
         self._completed = 0
         self._success = True
-        self._transfer_time = 0.0
+        self._started_at: float | None = None
         self._lock = threading.Lock()
 
     @property
     def job_id(self) -> JobId:
         return self._job_id
 
-    def task_done(
-        self, success: bool, transfer_time: float
-    ) -> tuple[bool, bool, float]:
-        """Returns if job completed and success flag"""
+    def task_started(self, started_at: float) -> None:
+        """Record when the first parallel task starts transferring data."""
+        with self._lock:
+            if self._started_at is None:
+                self._started_at = started_at
+
+    def task_done(self, success: bool, finished_at: float) -> tuple[bool, bool, float]:
+        """Return completion, success, and job-level transfer wall time."""
         with self._lock:
             self._completed += 1
-            self._transfer_time += transfer_time
             if not success:
                 self._success = False
-            return self._completed == self._n_tasks, self._success, self._transfer_time
+            assert self._started_at is not None
+            transfer_time = finished_at - self._started_at
+            return self._completed == self._n_tasks, self._success, transfer_time
 
 
 class DualQueueThreadPool:
@@ -176,18 +181,19 @@ class DualQueueThreadPool:
                 task, state = primary.popleft() if primary else secondary.popleft()
             try:
                 start_time = time.monotonic()
+                state.task_started(start_time)
                 task()
-                transfer_time = time.monotonic() - start_time
-                job_finished, success, total_time = state.task_done(True, transfer_time)
+                job_finished, success, total_time = state.task_done(
+                    True, time.monotonic()
+                )
             except Exception as exc:
-                transfer_time = time.monotonic() - start_time
                 logger.error(
                     "Job %s block I/O failed: %s",
                     state.job_id,
                     exc,
                 )
                 job_finished, success, total_time = state.task_done(
-                    False, transfer_time
+                    False, time.monotonic()
                 )
 
             if job_finished:


### PR DESCRIPTION
## Purpose

The filesystem KV offloading tier currently uses a single storage root and
assumes direct I/O can be selected for an entire batch. This change adds:

- Optional whole-block sharding across an ordered, comma-separated list of
  storage roots using `path_sharding: "by_block_hash"`.
- Deterministic placement based on the complete block hash. Each logical block
  remains one file containing all TP worker regions.
- Per-root batch grouping so independent storage paths can service a request in
  parallel while preserving the existing one-root behavior.
- Per-root O_DIRECT probing and per-operation alignment checks. Aligned
  operations use direct I/O; unaligned operations fall back to buffered I/O
  without disabling direct I/O for other roots or operations.
- Documentation for the new configuration, placement behavior, and remapping
  implications when root order or count changes.

## Performance

A local storage-hit TTFT comparison used the same H100 TP=4 server, model, and
request settings for both configurations:

```text
model: Qwen/Qwen3-Coder-30B-A3B-Instruct
input length: 128K tokens
output length: 1 token
concurrency: 1
```

| Configuration | Read 1 (ms) | Read 2 (ms) | Read 3 (ms) | Mean (ms) | Best (ms) |
| --- | ---: | ---: | ---: | ---: | ---: |
| Single filesystem root | 2105.3 | 1822.5 | 1904.6 | 1944.1 | 1822.5 |
| Four roots, block-hash sharding | 1259.8 | 1142.1 | 1033.5 | 1145.2 | 1033.5 |

The four-root configuration reduced mean storage-hit TTFT by **41.1%**. Mean
filesystem-to-CPU transfer time decreased from `1.404 s` to `0.671 s`
(`52.2%`). Every measured read retrieved all `126/126` requested blocks from
the filesystem tier and produced the expected physical NFS read-byte delta;
the samples were not GPU/CPU-tier hits or recomputation. These numbers are a
single-system result rather than a general performance guarantee.

## Test Plan

```bash
ruff format --check \
  vllm/v1/kv_offload/tiering/fs/manager.py \
  vllm/v1/kv_offload/tiering/fs/thread_pool.py \
  tests/v1/kv_offload/tiering/test_fs_tier.py

ruff check \
  vllm/v1/kv_offload/tiering/fs/manager.py \
  vllm/v1/kv_offload/tiering/fs/thread_pool.py \
  tests/v1/kv_offload/tiering/test_fs_tier.py

pytest -q tests/v1/kv_offload/tiering/test_fs_tier.py
```

The native extension was also rebuilt from source against CUDA 13 and H100
(`TORCH_CUDA_ARCH_LIST=9.0`, `CMAKE_CUDA_ARCHITECTURES=90`) using an editable
install, then the focused test suite was rerun against the rebuilt extension.

Runtime validation used four filesystem roots with TP=4 and a 128K-token
request. Three storage-hit reads each retrieved all 126 requested blocks from
the filesystem tier, with no short-I/O or backend errors.

## Test Result

- Ruff format: passed
- Ruff lint: passed
- `git diff --check`: passed
- Native CUDA/C++ build: passed
- Focused filesystem tier tests: `57 passed, 14 warnings in 13.29s`
- Loaded native extension exported the new `direct_io_alignment` argument
