### PR TITLE
[Model] Default quantized GLM KV cache to FP8 on NVIDIA

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -264,6 +264,33 @@ def test_dsa_models_select_matching_mtp(model_type, expected_architecture):
 
 
 @pytest.mark.parametrize(
+    ("is_cuda", "quantization", "cache_dtype", "expected"),
+    [
+        pytest.param(True, "fp8", "auto", "fp8", id="fp8-model"),
+        pytest.param(True, "modelopt_fp4", "auto", "fp8", id="nvfp4-model"),
+        pytest.param(True, "fp8", "bfloat16", "bfloat16", id="explicit-override"),
+        pytest.param(False, "fp8", "auto", "auto", id="non-nvidia"),
+        pytest.param(True, None, "auto", "auto", id="bf16-model"),
+    ],
+)
+def test_glm52_defaults_to_fp8_kv_cache_on_nvidia(
+    monkeypatch, is_cuda, quantization, cache_dtype, expected
+):
+    from vllm.model_executor.models.config import MODELS_CONFIG_MAP
+    from vllm.platforms import current_platform
+
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: is_cuda)
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(quantization=quantization),
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype),
+    )
+
+    MODELS_CONFIG_MAP["GlmMoeDsaForCausalLM"].verify_and_update_config(config)
+
+    assert config.cache_config.cache_dtype == expected
+
+
+@pytest.mark.parametrize(
     ("use_v2_model_runner", "expected_capture_sizes"),
     [
         (False, [4, 8, 12, 16]),

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -89,9 +89,9 @@ class CacheConfig:
     """Data type for kv cache storage. If "auto", will use model data type.
     CUDA 11.8+ supports fp8 (=fp8_e4m3) and fp8_e5m2. ROCm (AMD GPU) supports
     fp8 (=fp8_e4m3). Intel Gaudi (HPU) supports fp8 (using fp8_inc).
-    Some models (namely DeepSeekV3.2) default to fp8, set to bfloat16 to use
-    bfloat16 instead, this is an invalid option for models that do not default
-    to fp8.
+    Some models (namely DeepSeekV3.2 and quantized GLM-5.2 models on NVIDIA GPUs)
+    default to fp8. Set to bfloat16 to use bfloat16 instead; this is an invalid
+    option for models that do not default to fp8.
     "nvfp4_4over6" uses the NVFP4 layout and selects between max/6 and max/4
     scales per 16 values by minimizing squared reconstruction error.
     """

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -40,6 +40,22 @@ class DeepseekV32ForCausalLM(VerifyAndUpdateConfig):
             logger.info("Using bfloat16 kv-cache for DeepSeekV3.2")
 
 
+class GlmMoeDsaForCausalLM(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        from vllm.platforms import current_platform
+
+        cache_config = vllm_config.cache_config
+        quantization = vllm_config.model_config.quantization
+        if (
+            current_platform.is_cuda()
+            and quantization in {"fp8", "modelopt_fp4"}
+            and cache_config.cache_dtype == "auto"
+        ):
+            cache_config.cache_dtype = "fp8"
+            logger.info("Using FP8 KV cache for quantized GLM models on NVIDIA GPUs")
+
+
 class Ernie4_5_VLMoeForConditionalGenerationConfig(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
@@ -913,6 +929,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "Gemma4ForCausalLM": Gemma4Config,
     "Gemma4ForConditionalGeneration": Gemma4Config,
     "Gemma4UnifiedForConditionalGeneration": Gemma4Config,
+    "GlmMoeDsaForCausalLM": GlmMoeDsaForCausalLM,
     "GptOssForCausalLM": GptOssForCausalLMConfig,
     "LongcatFlashNgramForCausalLM": LongcatFlashNgramForCausalLMConfig,
     "GteModel": SnowflakeGteNewModelConfig,


### PR DESCRIPTION
## Summary

- Default the KV cache to FP8 for `GlmMoeDsaForCausalLM` checkpoints using
  `fp8` or `modelopt_fp4` quantization on NVIDIA GPUs.
- Apply the default only when `--kv-cache-dtype` remains `auto`; explicit
  cache dtype choices are preserved.
- Keep non-NVIDIA platforms and unquantized GLM checkpoints unchanged.

This lets both GLM-5.2-FP8 and GLM-5.2-NVFP4 use the intended FP8 KV cache
without requiring an extra launch flag.

## Duplicate-work check

I searched open PRs for `GLM 5.2 FP8 KV cache` and `GLM KV cache default`.
No open PR implements this default. In particular, #51915 targets ROCm
GLM-5.2 MXFP4 model enablement/correctness, while #51724 targets W4A16 DSA;
neither changes the NVIDIA KV-cache default.

## Tests

- `.venv/bin/python -m pytest tests/test_config.py -k glm52_defaults_to_fp8_kv_cache_on_nvidia -q`
  - `5 passed, 201 deselected`
- `.venv/bin/pre-commit run --files vllm/model_executor/models/config.py vllm/config/cache.py tests/test_config.py`
  - all applicable hooks passed
- `.venv/bin/python -m pytest tests/test_config.py -q`
  - `204 passed`; one unrelated existing failure in
    `test_draft_model_enables_async_scheduling_by_default` because MRV2 rejects
    the `draft_model` speculative method

## Model evaluations

Both evaluations omitted `--kv-cache-dtype`; startup resolved
`kv_cache_dtype=fp8` from the new default. The completion requests included the
required `model` field via an evaluation-only compatibility adjustment that is
not part of this PR.

### GLM-5.2-NVFP4

Server:

```bash
vllm serve nvidia/GLM-5.2-NVFP4 \
  --enforce-eager \
  --max-model-len 4096 \
  --max-num-batched-tokens 32768 \
  --safetensors-load-strategy prefetch \
  --moe-backend flashinfer_cutlass \
  --prefill-context-parallel-size 4 \
  --enable-expert-parallel \
  --trust-remote-code \
  --disable-uvicorn-access-log \
  --port 39985 \
  --seed 0
```

GSM8K 5-shot, 1,319 questions: accuracy `0.9371`, invalid rate `0.0010`,
latency `318.6s`, throughput `4.1 questions/s`.

### GLM-5.2-FP8

Ran through Slurm on two GB200 nodes with TP8 and expert parallelism. Node 0
served the API and node 1 used `--headless`; both used the same distributed
arguments below with their respective `--node-rank`:

```bash
vllm serve zai-org/GLM-5.2-FP8 \
  --enforce-eager \
  --max-model-len 4096 \
  --max-num-batched-tokens 32768 \
  --moe-backend deep_gemm \
  --tensor-parallel-size 8 \
  --enable-expert-parallel \
  --distributed-executor-backend mp \
  --nnodes 2 \
  --node-rank "$SLURM_PROCID" \
  --master-addr "$MASTER_ADDR" \
  --master-port 29652 \
  --trust-remote-code \
  --disable-uvicorn-access-log \
  --port 8100
```

Startup allocated 69.67 GiB of FP8 KV cache per GPU (1,568,256 tokens).
GSM8K 5-shot, 1,319 questions: accuracy `0.93935`, invalid rate `0.0`, latency
`423.4s`, throughput `3.12 questions/s`.

## AI assistance

OpenAI Codex was used to implement and test this change. This draft remains
pending the submitter's line-by-line review before it is marked ready.
