### PR TITLE
[CI][Bugfix] Use a prompt that survives offload-resume rounding in mamba offload test

### DIFF
--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -574,7 +574,15 @@ def test_mamba_cpu_offload_boundary(
     )
 
     _PROMPT_SIZE: int = block_size * 2
-    _PROMPT_TEXT = "Hi. Give me a set of trivia questions and their answers "
+    # Cold prefill and offload-resume are not bit-exact (selective_scan_fn over
+    # the whole prompt vs selective_state_update for the recomputed token), so
+    # exact-text equality only holds while the rounding difference never flips a
+    # greedy argmax. Use a long, highly predictable prompt: it needs no "...."
+    # padding and keeps top-1 ahead of top-2 by >2.8 logprobs at every step.
+    _PROMPT_TEXT = (
+        "The cat sat on the mat. The cat sat on the mat. The cat sat on the mat. "
+        "The cat sat on the mat. The cat sat on the mat. The cat sat on the mat. "
+    )
 
     # build prompt ids to match prompt_size
     tokenizer = llm.get_tokenizer()


### PR DESCRIPTION
## Summary

`test_mamba_cpu_offload_boundary` asserts that text generated with CPU KV-offload is identical to the same prompt generated cold. Those two paths are not bit-exact, so the assertion holds only by luck of the prompt, and the current prompt stopped being lucky on the torch 2.14 / triton 3.8 pin (tracked in pytorch/pytorch#193431).

Per layer, the two paths call different kernels:

| path | calls |
|---|---|
| cold | `causal_conv1d_fn` `(4096, 33)` then `selective_scan_fn` `(4096, 33)`, `has_initial_state=False` |
| resume | `causal_conv1d_update` `(1, 4096)` then `selective_state_update`, with `conv_state_indices` set |

The cold path scans the whole prompt; the resume path reloads the offloaded state and runs the decode-style update for the single recomputed token. They round differently, and the SSM recurrence amplifies it to **~0.8% mean relative error** at the last prompt token by layer 47, on **torch 2.13 as well as 2.14** (47 of 48 layers differ on both). Whether that flips a greedy argmax inside the 128-token window is prompt-dependent.

Screening 12 prompts through the failing case (`all`, `block-mid-prompt`) on both channels:

| prompt | torch 2.13 | torch 2.14 |
|---|---|---|
| `Hi. Give me a set of trivia questions and their answers ` (current) | pass | **FAIL** |
| `The quick brown fox jumps over the lazy dog repeatedly ` | **FAIL** | **FAIL** |
| `To be or not to be, that is the question posed by Hamlet ` | **FAIL** | pass |
| other 9 | pass | pass |

Two prompts fail on torch 2.13 and a different pair fails on 2.14, so neither channel is the "correct" baseline. Roughly 1 prompt in 4 trips this.

This PR switches `_PROMPT_TEXT` to one that holds on both channels and documents the constraint so it is not changed casually. It deliberately keeps the `cold == cpu` assertion rather than pinning golden outputs, which would be GPU- and pin-specific.

Note this is a test fix, not a correctness fix. Making the paths bit-identical would require the resume path to recompute through the same kernel and shape as the cold path, which defeats resuming from stored state. `VLLM_BATCH_INVARIANT=1` would address it but currently raises `VLLM batch_invariant mode is not supported for MAMBA1_ATTN`.

## Not a duplicate

Checked open PRs for `test_offloading_connector`, "mamba cpu offload boundary", and `193431 in:body`. The only open PR touching this file is #50087 (per-request store strategy hook), whose diff contains no reference to `test_mamba_cpu_offload_boundary` or `_PROMPT_TEXT`. No open PR addresses this failure.

## Test plan

Ran the full test on both torch channels using the CI images for commit `6accb779`, same vLLM code, only the torch/triton channel differing, on an NVIDIA H100:

```
cd /vllm-workspace/tests && python3 -m pytest -q \
  v1/kv_connector/unit/test_offloading_connector.py::test_mamba_cpu_offload_boundary
```

| image | torch / triton | before | after |
|---|---|---|---|
| `vllm-ci-postmerge-repo:6accb779…` | 2.13.0+cu130 / 3.7.1 | 2 passed | **2 passed** |
| `vllm-ci-postmerge-repo:6accb779…-torch-nightly` | 2.14.0.dev20260810+cu130 / 3.8.0 | 1 failed, 1 passed | **2 passed** |

Lint: `ruff check` and `ruff format --check` (v0.14.0, the pinned version) both clean on the changed file.

## Model evaluation

Not applicable: this changes only a test prompt, no library code, so no model output or serving behaviour changes.

## AI assistance

AI assistance (Claude) was used for the investigation and to prepare this change.
