### PR TITLE
[Bugfix][Kimi-K3] Convert developer role to system for updated K3 encoding rule

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -10,12 +10,12 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionReque
 from vllm.exceptions import VLLMValidationError
 from vllm.renderers.hf import (
     _consolidate_system_messages,
-    _convert_developer_to_system,
     _detect_content_format,
     _detect_developer_role_support,
     _get_hf_base_chat_template_params,
     _template_error_reason,
     _try_extract_ast,
+    convert_developer_to_system,
     resolve_chat_template,
     resolve_chat_template_content_format,
     resolve_chat_template_kwargs,
@@ -664,7 +664,7 @@ class TestConvertDeveloperToSystem:
             {"role": "developer", "content": "You are helpful."},
             {"role": "user", "content": "Hello"},
         ]
-        result = _convert_developer_to_system(conversation)
+        result = convert_developer_to_system(conversation)
         assert result[0]["role"] == "system"
         assert result[0]["content"] == "You are helpful."
         assert result[1]["role"] == "user"
@@ -677,7 +677,7 @@ class TestConvertDeveloperToSystem:
                 "tools": [{"type": "function"}],
             },
         ]
-        result = _convert_developer_to_system(conversation)
+        result = convert_developer_to_system(conversation)
         assert "tools" not in result[0]
 
     def test_no_developer_messages_unchanged(self):
@@ -685,7 +685,7 @@ class TestConvertDeveloperToSystem:
             {"role": "system", "content": "System prompt"},
             {"role": "user", "content": "Hello"},
         ]
-        result = _convert_developer_to_system(conversation)
+        result = convert_developer_to_system(conversation)
         assert result[0]["role"] == "system"
         assert result[1]["role"] == "user"
 
@@ -696,7 +696,7 @@ class TestConvertDeveloperToSystem:
             "tools": [{"type": "function"}],
         }
         conversation = [original]
-        _convert_developer_to_system(conversation)
+        convert_developer_to_system(conversation)
         assert original["role"] == "developer"
         assert "tools" in original
 

--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -680,6 +680,18 @@ class TestConvertDeveloperToSystem:
         result = convert_developer_to_system(conversation)
         assert "tools" not in result[0]
 
+    def test_keeps_tools_key(self):
+        conversation = [
+            {
+                "role": "developer",
+                "content": "Instructions",
+                "tools": [{"type": "function"}],
+            },
+        ]
+        result = convert_developer_to_system(conversation, keep_tools=True)
+        assert result[0]["role"] == "system"
+        assert result[0]["tools"] == [{"type": "function"}]
+
     def test_no_developer_messages_unchanged(self):
         conversation = [
             {"role": "system", "content": "System prompt"},

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -507,7 +507,7 @@ def _detect_developer_role_support(chat_template: str) -> bool:
     return '"developer"' in chat_template or "'developer'" in chat_template
 
 
-def _convert_developer_to_system(
+def convert_developer_to_system(
     conversation: list[ConversationMessage],
     keep_tools: bool = False,
 ) -> list[ConversationMessage]:
@@ -812,7 +812,7 @@ def safe_apply_chat_template(
     if any(
         msg["role"] == "developer" for msg in conversation
     ) and not _detect_developer_role_support(chat_template):
-        conversation = _convert_developer_to_system(conversation)
+        conversation = convert_developer_to_system(conversation)
         conversation = _consolidate_system_messages(conversation)
         logger.info_once(
             "Chat template does not support the 'developer' message role. "

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -509,13 +509,15 @@ def _detect_developer_role_support(chat_template: str) -> bool:
 
 def _convert_developer_to_system(
     conversation: list[ConversationMessage],
+    keep_tools: bool = False,
 ) -> list[ConversationMessage]:
     converted: list[ConversationMessage] = []
     for msg in conversation:
         if msg["role"] == "developer":
             new_msg = dict(msg)
             new_msg["role"] = "system"
-            new_msg.pop("tools", None)
+            if not keep_tools:
+                new_msg.pop("tools", None)
             converted.append(new_msg)  # type: ignore[arg-type]
         else:
             converted.append(msg)

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -11,7 +11,7 @@ from vllm.entrypoints.chat_utils import (
 )
 from vllm.exceptions import VLLMValidationError
 from vllm.multimodal.media.connector import merge_media_io_kwargs
-from vllm.renderers.hf import _convert_developer_to_system
+from vllm.renderers.hf import convert_developer_to_system
 from vllm.tokenizers.hf import HfTokenizer
 from vllm.utils.async_utils import make_async
 
@@ -187,7 +187,7 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         )
 
         rendered_conversation = _normalize_k3_tool_messages(
-            _convert_developer_to_system(conversation, keep_tools=True)
+            convert_developer_to_system(conversation, keep_tools=True)
         )
         prompt = parse_dec_only_prompt(
             self._apply_chat_template(rendered_conversation, params)
@@ -213,7 +213,7 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         )
 
         rendered_conversation = _normalize_k3_tool_messages(
-            _convert_developer_to_system(conversation, keep_tools=True)
+            convert_developer_to_system(conversation, keep_tools=True)
         )
         token_ids = await self._apply_chat_template_async(rendered_conversation, params)
         prompt = parse_dec_only_prompt(token_ids)

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -11,6 +11,7 @@ from vllm.entrypoints.chat_utils import (
 )
 from vllm.exceptions import VLLMValidationError
 from vllm.multimodal.media.connector import merge_media_io_kwargs
+from vllm.renderers.hf import _convert_developer_to_system
 from vllm.tokenizers.hf import HfTokenizer
 from vllm.utils.async_utils import make_async
 
@@ -185,7 +186,9 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _convert_developer_to_system(conversation, keep_tools=True)
+        )
         prompt = parse_dec_only_prompt(
             self._apply_chat_template(rendered_conversation, params)
         )
@@ -209,7 +212,9 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _convert_developer_to_system(conversation, keep_tools=True)
+        )
         token_ids = await self._apply_chat_template_async(rendered_conversation, params)
         prompt = parse_dec_only_prompt(token_ids)
         if mm_data is not None:


### PR DESCRIPTION



## Purpose

Kimi K3 huggingface checkpoint [has just been updated](https://huggingface.co/moonshotai/Kimi-K3/commit/a590ce090cb049c93a33dfe8c208ec652aa20503), which now raises on unknown message roles. (see L698-701) While this chat template update fixes a silent role ignorance, newly introduced exception branch is backward-incompatible in terms of previous chat histories with `developer` role.

The `developer` role is included in the official OpenAI API schema, and we treat most other models with no designated `developer` role within chat template just convert `developer` role into `system`, e.g. [cohere](https://github.com/vllm-project/vllm/blob/7c8b68b9ce30c45ea17063cc040b2473e152fa7d/vllm/renderers/cohere.py#L275-L276), [inkling](https://github.com/vllm-project/vllm/blob/7c8b68b9ce30c45ea17063cc040b2473e152fa7d/vllm/renderers/inkling_encoding.py#L51-L52) and [general huggingface chat jinja template](https://github.com/vllm-project/vllm/blob/7c8b68b9ce30c45ea17063cc040b2473e152fa7d/vllm/renderers/hf.py#L461).

Thus we follow the same pattern and convert `developer` role to `system` for K3 as well. I just re-use the existing hf convert helper with newly introduced `keep_tools` kwargs due to the peculiarity of [Kimi K3 allowing tools in system role](https://huggingface.co/moonshotai/Kimi-K3/blob/main/encoding_k3.py#L652).

## Note

vllm-rs has already been covered the edge case, c.f. https://github.com/vllm-project/vllm/blob/9fd750f00de5ab8fa172c34e219b3345411e9a91/rust/src/chat/src/renderer/kimi_k3/encoding.rs#L155-L166

In that regard, this PR is a compatibility patch between vllm-python and vllm-rs kimi k3 renderer as well.

## Test Plan

New unit test added.

## Test Result

Pass all unit tests.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

