### PR TITLE
[Bugfix][KV Cache] Reject stale partial hashes after full-block promotion

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
@@ -4,6 +4,7 @@
 from collections.abc import Callable
 
 import pytest
+import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
@@ -18,6 +19,8 @@ from vllm.v1.core.kv_cache_utils import (
     hash_block_tokens,
     init_none_hash,
 )
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec
 from vllm.v1.request import Request
 
 pytestmark = pytest.mark.cpu_test
@@ -459,4 +462,129 @@ def test_partial_block_promotes_to_direct_full_block_hash(dcp_world_size: int):
         kv_cache_group_id=kv_cache_group_id,
     )
     assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
+def test_cache_partial_block_does_not_resurrect_stale_hash_after_promotion(
+    dcp_world_size: int,
+):
+    """Regression for #49125: the pool must reject a smaller partial key after
+    the same block has been promoted to a full-block hash.
+    """
+    hash_block_size = 2
+    block_size = 6 * dcp_world_size
+    kv_cache_group_id = 0
+    partial_num_tokens = 2 * block_size - hash_block_size
+    token_ids = list(range(partial_num_tokens))
+    req = make_request("0", token_ids, hash_block_size, sha256)
+    pool = BlockPool(
+        num_gpu_blocks=3,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+        enable_kv_cache_events=True,
+    )
+    blocks = pool.get_new_blocks(2)
+
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=block_size,
+        kv_cache_group_id=kv_cache_group_id,
+    )
+    partial_hash = boundary_hash(req, hash_block_size, partial_num_tokens)
+    assert pool.cache_partial_block(
+        request=req,
+        block=blocks[1],
+        num_tokens=partial_num_tokens,
+        kv_cache_group_id=kv_cache_group_id,
+        block_size=block_size,
+    )
+    pool.take_events()
+
+    req.append_output_token_ids(list(range(partial_num_tokens, 2 * block_size)))
+    full_hashes = BlockHashListWithBlockSize(
+        req.block_hashes, hash_block_size, block_size
+    )
+    promoted_full_hash = full_hashes[1]
+    pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=1,
+        num_full_blocks=2,
+        block_size=block_size,
+        kv_cache_group_id=kv_cache_group_id,
+    )
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+    pool.take_events()
+
+    stale = pool.cache_partial_block(
+        request=req,
+        block=blocks[1],
+        num_tokens=partial_num_tokens,
+        kv_cache_group_id=kv_cache_group_id,
+        block_size=block_size,
+    )
+    assert stale is None
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+    assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [blocks[1]]
+    assert pool.take_events() == []
+
+
+@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
+def test_cache_blocks_does_not_resurrect_stale_partial_hash_after_promotion(
+    dcp_world_size: int,
+):
+    """Regression for #49125 via FullAttentionManager.cache_blocks.
+
+    _cache_partial_tail_block keeps using the prompt-end boundary after
+    decode fills the block, so cache_blocks must not resurrect that hash.
+    """
+    hash_block_size = 2
+    block_size = 6 * dcp_world_size
+    kv_cache_group_id = 0
+    prompt_token_ids = list(range(10 * dcp_world_size))
+    req = make_request("R", prompt_token_ids, hash_block_size, sha256)
+
+    pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    manager = FullAttentionManager(
+        kv_cache_spec=FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        ),
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=kv_cache_group_id,
+        scheduler_block_size=block_size,
+    )
+    manager.req_to_blocks[req.request_id] = pool.get_new_blocks(2)
+
+    manager.cache_blocks(req, num_tokens=len(prompt_token_ids))
+    partial_hash = boundary_hash(req, hash_block_size, len(prompt_token_ids))
+    block1 = manager.req_to_blocks[req.request_id][1]
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) == [block1]
+
+    tokens_to_fill = block_size - (len(prompt_token_ids) % block_size)
+    for i in range(tokens_to_fill):
+        req.append_output_token_ids([100 + i])
+        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
+
+    full_hashes = BlockHashListWithBlockSize(
+        req.block_hashes, hash_block_size, block_size
+    )
+    promoted_full_hash = full_hashes[1]
+    assert pool.get_cached_block(promoted_full_hash, [kv_cache_group_id]) == [block1]
+    assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None
+
+    for i in range(tokens_to_fill, tokens_to_fill + 3):
+        req.append_output_token_ids([200 + i])
+        manager.cache_blocks(req, num_tokens=len(prompt_token_ids) + i + 1)
     assert pool.get_cached_block(partial_hash, [kv_cache_group_id]) is None

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -492,23 +492,32 @@ class BlockPool:
         block_hash_with_group_id = make_block_hash_with_group_id(
             block_hash, kv_cache_group_id
         )
+        incoming_num_tokens = num_hash_blocks * self.hash_block_size
         already_cached = block.block_hash == block_hash_with_group_id or (
             self.cached_block_hash_to_block.contain(
                 block_hash_with_group_id, block.block_id
             )
         )
+        # After full-block promotion the primary hash covers more tokens than
+        # this partial boundary. Do not re-insert the superseded key.
+        if (
+            not already_cached
+            and block.block_hash_num_tokens is not None
+            and block.block_hash_num_tokens >= incoming_num_tokens
+        ):
+            return None
         if (
             not already_cached
             and block.block_hash is not None
             and block.block_hash_num_tokens is not None
-            and block.block_hash_num_tokens < num_hash_blocks * self.hash_block_size
+            and block.block_hash_num_tokens < incoming_num_tokens
         ):
             removed_hashes = self._remove_cached_block_hashes(block)
             self._emit_block_removed_events(removed_hashes)
         self._insert_block_hash(
             block_hash_with_group_id,
             block,
-            num_tokens=num_hash_blocks * self.hash_block_size,
+            num_tokens=incoming_num_tokens,
         )
         if self.enable_kv_cache_events and not already_cached:
             parent_hash, block_start = self._get_partial_block_parent_hash_and_start(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -812,9 +812,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
+        target_block = blocks[block_idx]
+        if (
+            target_block.block_hash_num_tokens is not None
+            and target_block.block_hash_num_tokens >= boundary_tokens
+        ):
+            return
         self.block_pool.cache_partial_block(
             request=request,
-            block=blocks[block_idx],
+            block=target_block,
             num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,


### PR DESCRIPTION
## Purpose

Fixes #49125.

When a prompt ends inside a cache block, `cache_partial_block` registers a partial prefix-cache hash. After decode fills that block, `cache_full_blocks` promotes it and removes the partial key. The next `cache_blocks()` call still asks to re-register the old prompt-tail boundary, so the stale hash is inserted as a secondary lookup key. Prefix lookup and KV events then see a hash the server had already discarded.

## Approach

This is not a duplicate of #52972, which only early-returns in `FullAttentionManager._cache_partial_tail_block`.

This PR enforces the invariant at the insert site:

- `BlockPool.cache_partial_block` no-ops when the block already has a hash covering at least as many tokens as the incoming partial (the growth path 8→10 tokens is unchanged).
- `FullAttentionManager._cache_partial_tail_block` still skips a promoted tail so decode steps do not keep calling into the pool.

The pool guard also covers any other `cache_partial_block` caller, and it does not emit a spurious `BlockStored` for the stale key.

## Test Plan

```bash
pytest tests/v1/core/prefix_cache/test_partial_prefix_cache_primitives.py
```

## Test Result

20 passed, including:

- pool-level: `cache_partial_block` after promotion returns `None`, stale lookup stays empty, no extra KV events
- manager-level: `cache_blocks` after filling the tail does not resurrect the prompt-boundary hash, including later decode steps

Reverting the production change fails those new tests.

No accuracy eval: this is a deterministic cache-index bug.
