### PR TITLE
[Bugfix][Frontend] Support Prometheus name[] metric filtering

### DIFF
--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -31,6 +31,22 @@ Then query the endpoint to get the latest metrics from the server:
     ...
     ```
 
+## Filtering Metrics
+
+The endpoint accepts repeated `name[]` query parameters to return only selected
+metric samples:
+
+```bash
+curl -sG http://localhost:8000/metrics \
+  --data-urlencode 'name[]=vllm:num_requests_waiting' \
+  --data-urlencode 'name[]=vllm:prompt_tokens_total'
+```
+
+The values must be sample names. Counters use the `_total` suffix. Histograms
+must request the desired `_bucket`, `_sum`, or `_count` samples individually.
+Requests without `name[]` continue to return all metrics, while unknown names
+return no metric samples with a `200 OK` response.
+
 The following metrics are exposed:
 
 ## General Metrics

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,7 +17,7 @@ starlette >= 1.0.1 # CVE-2026-48710: Host header injection in < 1.0.1
 aiohttp >= 3.13.3
 openai >= 2.0.0  # For Responses API with reasoning content
 pydantic >= 2.12.0
-prometheus_client >= 0.18.0
+prometheus_client >= 0.25.0  # Multiprocess restricted registry support
 pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 8.0.0 # v8 unblocks starlette >= 1.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer

--- a/requirements/test/cpu.txt
+++ b/requirements/test/cpu.txt
@@ -713,7 +713,7 @@ portalocker==2.10.1
     # via sacrebleu
 pqdm==0.2.0
     # via -r requirements/test/cuda.in
-prometheus-client==0.22.0
+prometheus-client==0.25.0
     # via
     #   -r requirements/test/../common.txt
     #   opentelemetry-exporter-prometheus

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -799,7 +799,7 @@ portalocker==2.10.1
     # via sacrebleu
 pqdm==0.2.0
     # via -r requirements/test/cuda.in
-prometheus-client==0.22.0
+prometheus-client==0.25.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -772,7 +772,7 @@ portalocker==3.2.0
     # via sacrebleu
 pqdm==0.2.0
     # via -r requirements/test/rocm.in
-prometheus-client==0.24.1
+prometheus-client==0.25.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/tests/entrypoints/serve/exception_handling/test_http_status_metrics.py
+++ b/tests/entrypoints/serve/exception_handling/test_http_status_metrics.py
@@ -62,12 +62,10 @@ def app(registry):
     """
     import vllm.entrypoints.serve.instrumentator.metrics as metrics_mod
 
-    original = metrics_mod.get_prometheus_registry
-    metrics_mod.get_prometheus_registry = lambda: registry
-    try:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+        monkeypatch.setattr(metrics_mod, "get_prometheus_registry", lambda: registry)
         app = build_app(_build_args(), supported_tasks=())
-    finally:
-        metrics_mod.get_prometheus_registry = original
 
     @app.get("/raise_http_exception_400")
     async def raise_http_exception_400():

--- a/tests/entrypoints/serve/instrumentator/test_metrics_filter.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics_filter.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import multiprocessing
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from prometheus_client import (
+    CONTENT_TYPE_PLAIN_0_0_4,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+
+from vllm.entrypoints.serve.instrumentator import metrics as metrics_endpoint
+from vllm.v1.metrics import prometheus
+
+
+class _LateCollector:
+    def __init__(self):
+        self.metrics = []
+
+    def collect(self):
+        yield from self.metrics
+
+
+def _record_multiprocess_http_metric():
+    registry = CollectorRegistry()
+    Counter(
+        "http_requests",
+        "Total number of requests by method, status and handler.",
+        labelnames=["method", "status", "handler"],
+        registry=registry,
+    ).labels("GET", "2xx", "/test").inc()
+
+
+@pytest.fixture
+def single_process_metrics_client(monkeypatch) -> Iterator[TestClient]:
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+    registry = CollectorRegistry(auto_describe=True)
+    monkeypatch.setattr(prometheus, "REGISTRY", registry)
+
+    Gauge(
+        "vllm:num_requests_waiting",
+        "Number of requests waiting to be processed.",
+        registry=registry,
+    ).set(2)
+    Counter(
+        "vllm:tokens",
+        "Number of processed tokens.",
+        registry=registry,
+    ).inc(10)
+    Gauge(
+        "vllm:unrequested",
+        "Metric that should not be returned.",
+        registry=registry,
+    ).set(3)
+    Histogram(
+        "vllm:request_latency_seconds",
+        "Request latency.",
+        buckets=(0.5, 1.0, 2.0),
+        registry=registry,
+    ).observe(0.75)
+
+    app = FastAPI()
+    metrics_endpoint.attach_router(app)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"status": "ok"}
+
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def multiprocess_metrics_client(monkeypatch, tmp_path) -> Iterator[TestClient]:
+    collector = _LateCollector()
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        prometheus.multiprocess,
+        "MultiProcessCollector",
+        lambda registry: registry.register(collector),
+    )
+
+    registry = prometheus.get_prometheus_registry()
+    monkeypatch.setattr(metrics_endpoint, "get_prometheus_registry", lambda: registry)
+
+    app = FastAPI()
+    metrics_endpoint.attach_router(app)
+    http_requests = CounterMetricFamily(
+        "http_requests",
+        "Total number of requests by method, status and handler.",
+        labels=["method", "status", "handler"],
+    )
+    http_requests.add_metric(["GET", "2xx", "/test"], 1)
+    collector.metrics = [
+        GaugeMetricFamily(
+            "vllm:num_requests_waiting",
+            "Number of requests waiting to be processed.",
+            value=2,
+        ),
+        CounterMetricFamily(
+            "vllm:tokens",
+            "Number of processed tokens.",
+            value=10,
+            created=1,
+        ),
+        GaugeMetricFamily(
+            "vllm:unrequested",
+            "Metric that should not be returned.",
+            value=3,
+        ),
+        http_requests,
+    ]
+
+    with TestClient(app) as client:
+        yield client
+
+
+def test_single_process_unfiltered_metrics_remain_available(
+    single_process_metrics_client,
+):
+    single_process_metrics_client.get("/test")
+    response = single_process_metrics_client.get("/metrics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == CONTENT_TYPE_PLAIN_0_0_4
+    assert "content-encoding" not in response.headers
+    assert "vllm:num_requests_waiting 2.0" in response.text
+    assert "vllm:unrequested 3.0" in response.text
+    assert "http_requests_total{" in response.text
+
+
+def test_single_process_name_parameters_filter_metrics(single_process_metrics_client):
+    response = single_process_metrics_client.get(
+        "/metrics",
+        params=[
+            ("name[]", "vllm:num_requests_waiting"),
+            ("name[]", "vllm:tokens_total"),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert "vllm:num_requests_waiting 2.0" in response.text
+    assert "vllm:tokens_total 10.0" in response.text
+    assert "vllm:tokens_created" not in response.text
+    assert "vllm:unrequested" not in response.text
+
+
+@pytest.mark.parametrize("method", ["HEAD", "POST", "PUT", "OPTIONS"])
+def test_metrics_preserves_existing_non_get_behavior(
+    single_process_metrics_client, method
+):
+    response = single_process_metrics_client.request(method, "/metrics")
+
+    assert response.status_code == 200
+
+
+def test_histogram_family_name_does_not_select_samples(
+    single_process_metrics_client,
+):
+    response = single_process_metrics_client.get(
+        "/metrics", params=[("name[]", "vllm:request_latency_seconds")]
+    )
+
+    assert response.status_code == 200
+    assert response.content == b""
+
+
+def test_histogram_sample_names_can_be_filtered(single_process_metrics_client):
+    response = single_process_metrics_client.get(
+        "/metrics",
+        params=[
+            ("name[]", "vllm:request_latency_seconds_bucket"),
+            ("name[]", "vllm:request_latency_seconds_sum"),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert "vllm:request_latency_seconds_bucket{" in response.text
+    assert "vllm:request_latency_seconds_sum " in response.text
+    assert "vllm:request_latency_seconds_count " not in response.text
+
+
+def test_openmetrics_content_negotiation(single_process_metrics_client):
+    response = single_process_metrics_client.get(
+        "/metrics",
+        headers={"Accept": "application/openmetrics-text; version=1.0.0"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(
+        "application/openmetrics-text; version=1.0.0"
+    )
+    assert response.text.endswith("# EOF\n")
+
+
+def test_name_parameter_filters_late_registered_metrics(
+    multiprocess_metrics_client,
+):
+    response = multiprocess_metrics_client.get(
+        "/metrics",
+        params=[
+            ("name[]", "vllm:num_requests_waiting"),
+            ("name[]", "vllm:tokens_total"),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert "vllm:num_requests_waiting 2.0" in response.text
+    assert "vllm:tokens_total 10.0" in response.text
+    assert "vllm:tokens_created" not in response.text
+    assert "vllm:unrequested" not in response.text
+
+
+def test_throwaway_registry_metrics_are_collected_from_mmap(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    process = multiprocessing.get_context("spawn").Process(
+        target=_record_multiprocess_http_metric
+    )
+    process.start()
+    process.join(timeout=30)
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        pytest.fail("Prometheus metric writer process did not exit")
+    assert process.exitcode == 0
+
+    registry = CollectorRegistry(support_collectors_without_names=True)
+    prometheus.multiprocess.MultiProcessCollector(registry)
+    output = generate_latest(
+        registry.restricted_registry(["http_requests_total"])
+    ).decode()
+
+    assert output.count("# HELP http_requests_total ") == 1
+    assert output.count("# TYPE http_requests_total counter") == 1
+    assert output.count("http_requests_total{") == 1
+
+
+def test_unknown_metric_name_returns_empty_response(multiprocess_metrics_client):
+    response = multiprocess_metrics_client.get(
+        "/metrics", params=[("name[]", "vllm:does_not_exist")]
+    )
+
+    assert response.status_code == 200
+    assert response.content == b""
+
+
+def test_multiprocess_http_metric_is_emitted_once(multiprocess_metrics_client):
+    response = multiprocess_metrics_client.get(
+        "/metrics", params=[("name[]", "http_requests_total")]
+    )
+
+    assert response.status_code == 200
+    assert response.text.count("# HELP http_requests_total ") == 1
+    assert response.text.count("# TYPE http_requests_total counter") == 1
+    assert response.text.count("http_requests_total{") == 1

--- a/vllm/entrypoints/serve/instrumentator/metrics.py
+++ b/vllm/entrypoints/serve/instrumentator/metrics.py
@@ -2,16 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
-import prometheus_client
 import regex as re
-from fastapi import FastAPI, Response
+from fastapi import FastAPI
 from prometheus_client import make_asgi_app
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator import routing as _pfi_routing
 from starlette.routing import Match, Mount
 from starlette.types import Scope
 
-from vllm.v1.metrics.prometheus import get_prometheus_registry
+from vllm.v1.metrics.prometheus import (
+    get_prometheus_instrumentator_registry,
+    get_prometheus_registry,
+)
 
 
 def _patch_instrumentator_route_walk() -> None:
@@ -49,19 +51,12 @@ def _patch_instrumentator_route_walk() -> None:
 _patch_instrumentator_route_walk()
 
 
-class PrometheusResponse(Response):
-    media_type = prometheus_client.CONTENT_TYPE_LATEST
-
-
 def attach_router(app: FastAPI):
     """Mount prometheus metrics to a FastAPI app."""
 
     registry = get_prometheus_registry()
+    instrumentator_registry = get_prometheus_instrumentator_registry(registry)
 
-    # `response_class=PrometheusResponse` is needed to return an HTTP response
-    # with header "Content-Type: text/plain; version=0.0.4; charset=utf-8"
-    # instead of the default "application/json" which is incorrect.
-    # See https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/163#issue-1296092364
     Instrumentator(
         excluded_handlers=[
             "/metrics",
@@ -71,11 +66,13 @@ def attach_router(app: FastAPI):
             "/version",
             "/server_info",
         ],
-        registry=registry,
-    ).add().instrument(app).expose(app, response_class=PrometheusResponse)
+        registry=instrumentator_registry,
+    ).add().instrument(app)
 
-    # Add prometheus asgi middleware to route /metrics requests
-    metrics_route = Mount("/metrics", make_asgi_app(registry=registry))
+    # Keep the previous uncompressed response behavior. Filtering and content
+    # negotiation are still handled by prometheus_client.
+    prometheus_app = make_asgi_app(registry=registry, disable_compression=True)
+    metrics_route = Mount("/metrics", prometheus_app)
 
     # Workaround for 307 Redirect for /metrics
     metrics_route.path_regex = re.compile("^/metrics(?P<path>.*)$")

--- a/vllm/v1/metrics/prometheus.py
+++ b/vllm/v1/metrics/prometheus.py
@@ -36,6 +36,20 @@ def setup_multiprocess_prometheus():
         )
 
 
+def get_prometheus_instrumentator_registry(
+    scrape_registry: CollectorRegistry,
+) -> CollectorRegistry:
+    """Return the registry used by Instrumentator's HTTP collectors.
+
+    In multiprocess mode, metric values are written to mmap files and collected
+    by ``MultiProcessCollector``. Registering the local collectors in the
+    scrape registry as well would emit duplicate metric families.
+    """
+    if os.getenv("PROMETHEUS_MULTIPROC_DIR") is not None:
+        return CollectorRegistry()
+    return scrape_registry
+
+
 def get_prometheus_registry() -> CollectorRegistry:
     """Get the appropriate prometheus registry based on multiprocessing
     configuration.
@@ -45,7 +59,7 @@ def get_prometheus_registry() -> CollectorRegistry:
     """
     if os.getenv("PROMETHEUS_MULTIPROC_DIR") is not None:
         logger.debug("Using multiprocess registry for prometheus metrics")
-        registry = CollectorRegistry()
+        registry = CollectorRegistry(support_collectors_without_names=True)
         multiprocess.MultiProcessCollector(registry)
         return registry
 


### PR DESCRIPTION
<!--
Suggested title:
[Bugfix][Frontend] Support Prometheus name[] metric filtering

Before updating the PR:
1. Re-run the listed commands on the final commit.
2. Check the Test Result checklist item only after the results still match.
-->

<!-- markdownlint-disable -->
## Purpose

Fixes #53140.

The Instrumentator exposition route currently shadows the Prometheus ASGI
mount, so `/metrics` ignores the `name[]` query parameter supported by
`prometheus_client` and always returns the complete payload.

The route change also needs a multiprocess registry split. Otherwise the local
Instrumentator collectors and `MultiProcessCollector` emit the same HTTP metric
families, including duplicate `HELP` and `TYPE` lines. Prometheus rejects that
exposition instead of ingesting the scrape.

This PR:

- Raises the minimum `prometheus_client` version to 0.25.0, the first release
  with restricted-registry support for collectors whose names are discovered
  at scrape time.
- Serves `/metrics` through `prometheus_client.make_asgi_app()` instead of the
  shadowing Instrumentator exposition route.
- Supports repeated `name[]` query parameters while preserving the unfiltered
  metric families and sample values.
- Preserves the upstream exact-sample semantics, so requesting a counter's
  `_total` sample does not implicitly include its `_created` sample.
- Preserves the existing HTTP method behavior and uncompressed responses while retaining standard Accept format negotiation.
- Uses separate Instrumentator and scrape registries in multiprocess mode so
  HTTP metrics are written to the multiprocess mmap files without also being
  emitted by local collectors.
- Documents sample-name filtering, including counter and histogram suffixes.
- Adds regression coverage for single-process and multiprocess filtering,
  methods, content types, histograms, actual mmap collection, late-discovered
  metrics, and duplicate HTTP metric families.

Requests without `name[]` continue to expose all metrics. Restricted
multiprocess scrapes still read and merge every mmap file; the savings are in
exposition encoding, response size, network transfer, and client-side parsing,
not collection.

The CPU, CUDA, and ROCm uv-compiled requirement files were regenerated for the
new floor. XPU already resolves `prometheus_client` 0.26.0.

Duplicate-work check: before opening #53140 and this PR, searches of existing
and historical issues and open PRs for Prometheus metric filtering, `name[]`,
and restricted registries found no matching work.

Model evaluation is not applicable because this change only affects the
Prometheus HTTP endpoint and does not affect model output, accuracy, or
inference behavior.

AI assistance disclosure: GitHub Copilot CLI assisted with the implementation
and PR preparation. The human submitter reviewed every changed line,
understands the implementation, and is responsible for validating the behavior
end to end.

## Test Plan

Run the focused regression tests:

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/serve/instrumentator/test_metrics_filter.py \
  tests/entrypoints/serve/exception_handling/test_http_status_metrics.py \
  -v
```

Run targeted lint and formatting checks:

```bash
.venv/bin/ruff check \
  vllm/entrypoints/serve/instrumentator/metrics.py \
  vllm/v1/metrics/prometheus.py \
  tests/entrypoints/serve/instrumentator/test_metrics_filter.py \
  tests/entrypoints/serve/exception_handling/test_http_status_metrics.py

.venv/bin/ruff format --check \
  vllm/entrypoints/serve/instrumentator/metrics.py \
  vllm/v1/metrics/prometheus.py \
  tests/entrypoints/serve/instrumentator/test_metrics_filter.py \
  tests/entrypoints/serve/exception_handling/test_http_status_metrics.py
```

Verify the installed dependency set:

```bash
uv pip check
```

Verify the patch contains no whitespace errors:

```bash
git diff --check upstream/main...
```

## Test Result

- Focused pytest result: `25 passed in 6.21s`
- Ruff check result: `All checks passed!`
- Ruff format result: `4 files already formatted`
- Dependency check result: `All installed packages are compatible`
- Git diff check result: `Passed`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
