### PR TITLE
[Bugfix][Quantization][MoE] Normalise an unset group_size on the compressed-tensors WNA16 MoE path

### DIFF
--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -366,3 +366,110 @@ def test_xpu_platform_supports_moe_wna16():
         pytest.skip("vllm_xpu_kernels not importable outside an XPU stack")
 
     assert "moe_wna16" in XPUPlatform.supported_quantization
+
+
+def _channelwise_int4_args() -> QuantizationArgs:
+    """A per-channel int4 checkpoint, which leaves ``group_size`` unset."""
+    args = QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.INT,
+        strategy=QuantizationStrategy.CHANNEL,
+        symmetric=True,
+        dynamic=False,
+    )
+    assert args.group_size is None, "premise: CHANNEL leaves group_size unset"
+    return args
+
+
+@pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="check_moe_marlin_supports_config rejects every config on ROCm",
+)
+@pytest.mark.parametrize("backend", [WNA16MoEBackend.MARLIN, WNA16MoEBackend.TRITON])
+def test_wna16_oracle_accepts_unset_group_size(backend):
+    """Both backends must *accept* a per-channel config, not just survive it.
+
+    -1 is a supported Marlin group size and the shapes below pass the Marlin
+    tiling checks, while Triton never reads group_size for QuantizationArgs.
+    A reason string from either backend would mean the unset group_size cost
+    the layer its preferred kernel instead of raising TypeError.
+    """
+    from tests.kernels.moe.utils import make_dummy_moe_config
+
+    # hidden_dim % 128 and intermediate % 64 must hold, or the Marlin shape
+    # check rejects the config before group_size is ever read.
+    reason = _backend_incompatibility_reason(
+        backend=backend,
+        moe_config=make_dummy_moe_config(
+            num_experts=2, hidden_dim=256, intermediate_size=512
+        ),
+        quant_config=_channelwise_int4_args(),
+        may_have_zp=False,
+        may_have_bias=False,
+        allow_tile_padding=True,
+    )
+
+    assert reason is None
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Marlin is only a candidate WNA16 MoE backend on CUDA; elsewhere "
+    "__init__ takes the non-Marlin branch, which rejects channelwise",
+)
+def test_compressed_tensors_wna16_moe_marlin_prep_with_unset_group_size():
+    """Load a per-channel checkpoint through the Marlin path end to end.
+
+    ``__init__`` and Marlin weight prep read ``group_size`` independently, so
+    both have to normalise the unset value. The post-repack shapes prove prep
+    ran with the Marlin K/N rather than merely returning something.
+    """
+    from tests.kernels.moe.utils import make_dummy_moe_config
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16 import (  # noqa: E501
+        CompressedTensorsWNA16MoEMethod,
+    )
+
+    num_experts, hidden_size, intermediate_size = 2, 256, 512
+    moe_config = make_dummy_moe_config(
+        num_experts=num_experts,
+        hidden_dim=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    moe_config.moe_backend = "marlin"
+
+    method = CompressedTensorsWNA16MoEMethod(_channelwise_int4_args(), None, moe_config)
+    assert method.wna16_backend == WNA16MoEBackend.MARLIN
+    assert method.group_size == -1
+
+    layer = torch.nn.Module()
+    layer.intermediate_size_per_partition = intermediate_size
+    layer._expert_routing_tables = lambda: (None, None, None)
+    method.create_weights(
+        layer,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size_per_partition=intermediate_size,
+        intermediate_size_full=intermediate_size,
+        params_dtype=torch.bfloat16,
+    )
+    layer.cuda()
+    for parameter in layer.parameters():
+        parameter.data.zero_()
+
+    method.process_weights_after_loading(layer)
+
+    # gptq_marlin_moe_repack packs to (size_k // 16, size_n * 2) for int4; w13
+    # is repacked with size_k=hidden_size, size_n=2*intermediate_size, and w2
+    # the other way round. Channelwise keeps one scale group per channel.
+    assert layer.w13_weight_packed.shape == (
+        num_experts,
+        hidden_size // 16,
+        4 * intermediate_size,
+    )
+    assert layer.w2_weight_packed.shape == (
+        num_experts,
+        intermediate_size // 16,
+        2 * hidden_size,
+    )
+    assert layer.w13_weight_scale.shape == (num_experts, 1, 2 * intermediate_size)
+    assert layer.w2_weight_scale.shape == (num_experts, 1, hidden_size)

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -160,7 +160,11 @@ def _backend_incompatibility_reason(
         WNA16MoEBackend.BATCHED_MARLIN,
     ):
         if isinstance(quant_config, (AutoAWQConfig, AutoGPTQConfig, QuantizationArgs)):
-            group_size = quant_config.group_size
+            # QuantizationArgs leaves group_size unset for per-channel
+            # strategies; -1 is the in-tree encoding for that.
+            group_size = (
+                -1 if quant_config.group_size is None else quant_config.group_size
+            )
         else:
             return "Marlin not supported for this layer"
 
@@ -1509,7 +1513,9 @@ def convert_to_wna16_moe_kernel_format(
         elif isinstance(quant_config, QuantizationArgs):
             num_bits = quant_config.num_bits
             pack_factor = 32 // quant_config.num_bits
-            group_size = quant_config.group_size
+            group_size = (
+                -1 if quant_config.group_size is None else quant_config.group_size
+            )
             actorder = quant_config.actorder
         else:
             raise TypeError(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -70,7 +70,11 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         self.num_bits = weight_quant.num_bits
         self.packed_factor = Fraction(32, weight_quant.num_bits)
         self.strategy = weight_quant.strategy
-        self.group_size = weight_quant.group_size
+        # Per-channel strategies leave group_size unset; -1 is the in-tree
+        # encoding for that, as in CompressedTensorsWNA16 and siblings.
+        self.group_size = (
+            -1 if weight_quant.group_size is None else weight_quant.group_size
+        )
         self.actorder = weight_quant.actorder
 
         # Extract quant_type and create weight key for oracle selection


### PR DESCRIPTION
Fixes #52713.

## Bug

`compressed-tensors` leaves `group_size` unset (`None`) for channel-strategy weights, and three sites compare it against an `int`:

| site | on `origin/main` |
|---|---|
| `oracle/int_wna16.py:163` | feeds the Marlin probe → `marlin_utils.py:378` `group_size <= 0` |
| `oracle/int_wna16.py:1512` | weight prep re-reads `weight_quant.group_size` |
| `compressed_tensors_moe_wna16.py:73` | `self.group_size = weight_quant.group_size`, unnormalised |

The first raise happens inside `_backend_incompatibility_reason`, whose contract is to *return* a reason string, so backend selection aborts instead of rejecting Marlin and trying the next candidate.

Regression from #44570 (`454ea5b526`), which moved the probe into the oracle and dropped the `group_size = weight_quant.group_size or -1` that `get_moe_method` used to apply.

## Fix

Normalise `None` → `-1` at those three of the four `QuantizationArgs.group_size` reads. (The fourth, `:1116` in the Humming schema, is unreachable with `None`: the `strategy == "group"` assert at `compressed_tensors_moe_wna16.py:134` fires first.)

## Affected checkpoints

Configs fetched 2026-08-20, both int4 `pack-quantized` with experts quantized and `group_size: null, strategy: channel`:
[RedHatAI/Mixtral-8x22B-v0.1-quantized.w4a16](https://huggingface.co/RedHatAI/Mixtral-8x22B-v0.1-quantized.w4a16) (hidden 6144, intermediate 16384) and [lokeshe09/gemma-4-26B-A4B-it-INT4-W4A16-channelwise](https://huggingface.co/lokeshe09/gemma-4-26B-A4B-it-INT4-W4A16-channelwise) (hidden 2816, moe_intermediate 704, 128 experts).

## Test

`pytest tests/quantization/test_moe_wna16.py -k "unset_group_size or marlin_prep_with_unset"`

Two tests, one per read path. Controlled A/B, 2026-08-21 — same image and same test file on both sides, only the three production hunks applied via `patch -p1`:

| platform | image | unpatched | patched |
|---|---|---|---|
| NVIDIA L40S (sm89) | stock `vllm/vllm-openai:v0.27.0` | 2 failed, 1 passed | 3 passed |
| Intel Arc Pro B70 | stock `vllm-release-repo:3ee2df303-xpu` | 1 failed, 1 passed, 1 skipped | 2 passed, 1 skipped |

Node IDs that flip: `test_wna16_oracle_accepts_unset_group_size[MARLIN]` on both platforms, and `test_compressed_tensors_wna16_moe_marlin_prep_with_unset_group_size` on CUDA (skipped on XPU, where `__init__` takes the non-Marlin branch). `[TRITON]` passes in both arms — it is the control showing the config is otherwise valid. Unpatched failure is `TypeError: '<=' not supported between instances of 'NoneType' and 'int'` at `marlin_utils.py:378`; `marlin_utils.py` is byte-identical at v0.27.0 and `origin/main` (blob `3658761d6f`), so the v0.27.0 result transfers.

The Marlin case is skipped on ROCm: `check_moe_marlin_supports_config` returns `False` on its first line there (`marlin_utils.py:368`), so asserting `reason is None` would fail `pytest -v -s quantization/` on MI300 (`.buildkite/test-amd.yaml:2489`).

Whole-file runs, both platforms, before and after: no pre-existing test changes state. The five `create_weights_uses_ceil_packed_shapes` / `humming_kernel` failures visible on the v0.27.0 image are image drift — that release predates main's 3/5/6/7-bit support — confirmed by a control run of `origin/main`'s own test file on the same image.

`pre-commit run --files tests/quantization/test_moe_wna16.py` green including `mypy-3.10`; ruff 0.14.0 clean.

## Gaps

- No model-level load of either checkpoint. The two tests cover the three read sites and nothing more.
- No sm90 or sm100 row; the CUDA arm is Ada sm89.
- For channelwise configs the fix changes the selected backend from crash to MARLIN, so weight prep and every forward run newly-reached code. An accuracy run is owed; not measured.

Duplicate-work check: no open PR covers this; nearest is #44563 (`moe_wna16` `BLOCK_SIZE_K` tile arithmetic), which does not touch the `None` comparison. AI assistance was used (Claude Code); every changed line reviewed, both table rows produced on the named hardware on 2026-08-21.
