### PR TITLE
[Bugfix] hadacore: issue cp.async.wait_group on the partial-chunk warp

### DIFF
--- a/csrc/libtorch_stable/quantization/hadamard/hadacore/hadamard_transform_cuda.cu
+++ b/csrc/libtorch_stable/quantization/hadamard/hadacore/hadamard_transform_cuda.cu
@@ -118,7 +118,8 @@ hadamard_transform_kernel(b16* a, b16* out, int total_num_chunks) {
     int64_t threadid = threadIdx.x % 32;
     extern __shared__ b32 bfrag_arr[]; // num_chunks * warps_per_block * 128
     int64_t real_num_chunks = ((blockid + 1) * num_chunks) > total_num_chunks ? (total_num_chunks - (blockid * num_chunks)) : num_chunks;
-    int64_t diff_num_chunks = real_num_chunks - num_chunks;
+    // Non-negative: a negative index misses every case in the switch below.
+    int64_t diff_num_chunks = llabs(real_num_chunks - num_chunks);
 
     b32* a_start_ptr = (b32*) (a + blockid * num_chunks * 256); // offset a to where this warp starts
     b32* out_start_ptr = (b32*) (out + blockid * num_chunks * 256);
@@ -135,6 +136,11 @@ hadamard_transform_kernel(b16* a, b16* out, int total_num_chunks) {
 
     #pragma unroll
     for (int64_t k = 0; k < num_chunks; k++) {
+        if constexpr(enable_mask) {
+            // Prefetching these would read past the end of the tensor.
+            if (k >= real_num_chunks)
+                break;
+        }
         size_t shared_ptr = __cvta_generic_to_shared(b_frag_ptr);
         #if (__CUDA_ARCH__ >= 900) // SM90
             asm volatile(
@@ -350,6 +356,8 @@ hadamard_transform_kernel(b16* a, b16* out, int total_num_chunks) {
                 #define SWITCH_WAIT_ASYNC_LOAD_GROUP(i) case i: asm volatile("cp.async.wait_group %0;\n" :: "n"(num_chunks - i - 1)); break;
                 if constexpr(enable_mask) {
                     switch(k + diff_num_chunks) {
+                        // An unmatched index must not skip the barrier.
+                        default: asm volatile("cp.async.wait_group 0;\n"); break;
                         SWITCH_WAIT_ASYNC_LOAD_GROUP(0)
                         SWITCH_WAIT_ASYNC_LOAD_GROUP(1)
                         SWITCH_WAIT_ASYNC_LOAD_GROUP(2)

--- a/tests/kernels/quantization/test_hadacore.py
+++ b/tests/kernels/quantization/test_hadacore.py
@@ -20,9 +20,44 @@ if current_platform.is_rocm():
 @pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("hidden_dim", [2**n for n in range(10)])
 def test_hadacore(batch_size, hidden_dim, dtype=torch.bfloat16, device="cuda"):
-    x = torch.eye(hidden_dim, dtype=dtype, device=device)
+    # Rank 3 covers the reshape round trip the INT4 KV cache caller relies on.
+    x = torch.eye(hidden_dim, dtype=dtype, device=device).repeat(batch_size, 1, 1)
     hadamard = deterministic_hadamard_matrix(
         hidden_dim, dtype=torch.float64, device="cuda"
+    ) / math.sqrt(hidden_dim)
+
+    y = ops.hadacore_transform(x.clone())
+    y_true = (x.to(hadamard.dtype) @ hadamard.T).to(y.dtype)
+    assert torch.allclose(y, y_true)
+
+    y = ops.hadacore_transform(y)
+    assert torch.allclose(y, x)
+
+
+# Only an odd 256-element chunk count reaches the partial-chunk warp.  One
+# case per hadamard size, since each is a separate kernel instantiation.
+@pytest.mark.parametrize(
+    "num_rows,hidden_dim",
+    [
+        (42, 64),  # 2688 -> padded 2816 -> 11 chunks, odd
+        (24, 32),  # 768 -> 3 chunks, odd
+        (6, 128),  # 768 -> 3 chunks, odd
+        (3, 256),  # 768 -> 3 chunks, odd
+        (8, 64),  # 512 -> 2 chunks, even (control)
+    ],
+)
+def test_hadacore_partial_chunk(
+    num_rows, hidden_dim, dtype=torch.bfloat16, device="cuda"
+):
+    """Row counts that leave a warp holding a partial chunk must still transform.
+
+    hadacore splits work into 256-element chunks, 2 chunks per warp.  An odd
+    chunk count leaves the last warp with one real chunk, which takes a
+    separate masked code path.
+    """
+    x = torch.eye(hidden_dim, dtype=dtype, device=device)[:num_rows]
+    hadamard = deterministic_hadamard_matrix(
+        hidden_dim, dtype=torch.float64, device=device
     ) / math.sqrt(hidden_dim)
 
     y = ops.hadacore_transform(x.clone())


### PR DESCRIPTION
## Fixes #53086

The nibble ordering and zero-point packing named in the issue are both fine. The defect is a layer down, in `hadacore_transform`, which `single_rht` calls on the INT4 write path.

### The bug

`hadamard_transform_kernel` hands each warp two 256-element chunks. When the chunk count is odd the last warp gets one, and takes a separate code path:

```cpp
int64_t diff_num_chunks = real_num_chunks - num_chunks;   // 1 - 2 = -1
```

Used as `switch(k + diff_num_chunks)` over cases `0..31`, with no `default:`. Nothing matches, so no `cp.async.wait_group` runs and the warp reads shared memory before its copy arrives. A full warp gets `2 - 2 = 0` and lands on the right case regardless, which is why this survived until a warp came up short.

The prefetch loop always issues `num_chunks` copies, so the same warp also fetches 512 bytes past the end of the tensor. Stores were already guarded, so nothing was written out of bounds.

### The fix

- `llabs` on the delta, so the index is never negative. Not `abs`, which binds to the `int` overload and truncates an `int64_t`.
- A `default:` arm issuing `wait_group 0`. An unmatched index must not silently skip a barrier.
- The `k >= real_num_chunks` guard the consumer loop already uses, applied to the prefetch loop.

### Why these shapes

`reshape_and_cache_int4` runs the RHT over `[num_tokens, num_kv_heads, head_size]`. An odd `num_tokens * num_kv_heads * head_size / 256` is what reaches the broken path, and that picks out exactly the three failing cases of the 18 (INT8 and FP8 skip the RHT).

### Tests

I ran the file on an sm_89 card and got 25 passed. To exercise the kernel on its own I compiled it standalone with a `default:` arm that records whether the switch matched anything. Before the fix it matched nothing on every odd chunk count; afterwards it matches every time. memcheck on 28x64 went from 33 errors to zero.

### What CI needs to check

The added case does not discriminate on sm_89: the old kernel returns correct results here even at 4097 blocks with dense input, so it passes with and without the fix on my hardware. Requesting an sm_90 run to confirm the wrong-value path.

### Housekeeping

Not a duplicate. The other open hadacore PRs are #43462 (wrapper, line 796) and #33589 (ABI migration); this is inside the kernel at 121, 136 and 358.

Upstream `meta-pytorch/applied-ai` has both defects, so a resync reintroduces them. Happy to send the fix there.


