### PR TITLE
[Kimi K3][Kernel] Fuse MoonViT Q/K complex RoPE

### DIFF
--- a/benchmarks/kernels/benchmark_vision_rope.py
+++ b/benchmarks/kernels/benchmark_vision_rope.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark MoonViT's packed-QKV complex RoPE implementations."""
+
+import torch
+
+from vllm.benchmarks.lib.utils import default_vllm_config
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+from vllm.model_executor.layers.rotary_embedding.vision import (
+    apply_fused_qk_complex_rope,
+)
+from vllm.triton_utils import triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+def get_benchmark(
+    num_heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: str,
+):
+    token_counts = [256, 1024, 4096, 16384]
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["num_tokens"],
+            x_vals=token_counts,
+            line_arg="provider",
+            line_vals=["existing", "fused"],
+            line_names=["Existing ApplyRotaryEmb x2", "Fused Q/K complex RoPE"],
+            styles=[("blue", "-"), ("red", "-")],
+            ylabel="us",
+            plot_name=f"moonvit-vision-rope-h{num_heads}-d{head_dim}-{dtype}",
+            args={},
+        )
+    )
+    @default_vllm_config()
+    def benchmark(num_tokens: int, provider: str):
+        qkv = torch.randn(
+            num_tokens,
+            3,
+            num_heads,
+            head_dim,
+            dtype=dtype,
+            device=device,
+        )
+        query, key, _ = torch.unbind(qkv, dim=1)
+        angles = torch.randn(num_tokens, head_dim // 2, device=device)
+        freqs_cis = torch.polar(torch.ones_like(angles), angles)
+        apply_rotary_emb = ApplyRotaryEmb(
+            enforce_enable=True,
+            is_neox_style=False,
+            enable_fp32_compute=True,
+        )
+
+        if provider == "existing":
+
+            def run():
+                rope_cos = freqs_cis.real.contiguous()
+                rope_sin = freqs_cis.imag.contiguous()
+                return (
+                    apply_rotary_emb.forward_cuda(query, rope_cos, rope_sin),
+                    apply_rotary_emb.forward_cuda(key, rope_cos, rope_sin),
+                )
+
+        else:
+
+            def run():
+                return apply_fused_qk_complex_rope(query, key, freqs_cis)
+
+        quantiles = [0.5, 0.2, 0.8]
+        ms, min_ms, max_ms = triton.testing.do_bench(run, quantiles=quantiles)
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(
+        description="Benchmark MoonViT packed-QKV complex RoPE."
+    )
+    parser.add_argument("--num-heads", type=int, default=12)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument(
+        "--dtype",
+        choices=["bfloat16", "float16"],
+        default="bfloat16",
+    )
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--save-path", default="./configs/vision_rope/")
+    args = parser.parse_args()
+
+    benchmark = get_benchmark(
+        args.num_heads,
+        args.head_dim,
+        getattr(torch, args.dtype),
+        args.device,
+    )
+    benchmark.run(print_data=True, save_path=args.save_path)

--- a/tests/kernels/core/test_vision_rope.py
+++ b/tests/kernels/core/test_vision_rope.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for fused vision rotary embeddings."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.rotary_embedding.vision import (
+    apply_fused_qk_complex_rope,
+    can_use_fused_qk_complex_rope,
+)
+from vllm.platforms import current_platform
+
+
+def _complex_rope_reference(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    x_complex = torch.view_as_complex(x.float().reshape(*x.shape[:-1], -1, 2))
+    output = torch.view_as_real(x_complex * freqs_cis.unsqueeze(-2)).flatten(-2)
+    return output.to(x.dtype)
+
+
+def _make_packed_inputs(
+    num_tokens: int,
+    num_heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    qkv = torch.randn(
+        num_tokens,
+        3,
+        num_heads,
+        head_dim,
+        dtype=dtype,
+        device="cuda",
+    )
+    query, key, _ = torch.unbind(qkv, dim=1)
+    angles = torch.randn(num_tokens, head_dim // 2, device="cuda")
+    freqs_cis = torch.polar(torch.ones_like(angles), angles)
+    return qkv, query, key, freqs_cis
+
+
+requires_sm90 = pytest.mark.skipif(
+    not (current_platform.is_cuda() and current_platform.has_device_capability(90)),
+    reason="The fused vision RoPE kernel requires NVIDIA SM90 or newer.",
+)
+
+
+@requires_sm90
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("num_tokens", [1, 257, 4096])
+def test_fused_qk_complex_rope_matches_reference(
+    dtype: torch.dtype,
+    num_tokens: int,
+) -> None:
+    """The fused path matches FP32 complex multiplication for packed QKV."""
+    torch.manual_seed(0)
+    _, query, key, freqs_cis = _make_packed_inputs(
+        num_tokens, num_heads=12, head_dim=128, dtype=dtype
+    )
+
+    assert query.stride(0) == 3 * query.shape[1] * query.shape[2]
+    query_out, key_out = apply_fused_qk_complex_rope(query, key, freqs_cis)
+
+    atol = 2 * torch.finfo(dtype).eps
+    torch.testing.assert_close(
+        query_out,
+        _complex_rope_reference(query, freqs_cis),
+        atol=atol,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        key_out,
+        _complex_rope_reference(key, freqs_cis),
+        atol=atol,
+        rtol=0,
+    )
+    assert query_out.is_contiguous()
+    assert key_out.is_contiguous()
+
+
+@requires_sm90
+def test_fused_qk_complex_rope_cuda_graph_replay() -> None:
+    """Captured execution reads updated packed-QKV inputs on replay."""
+    qkv, query, key, freqs_cis = _make_packed_inputs(
+        257, num_heads=12, head_dim=128, dtype=torch.bfloat16
+    )
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        apply_fused_qk_complex_rope(query, key, freqs_cis)
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        query_out, key_out = apply_fused_qk_complex_rope(query, key, freqs_cis)
+
+    qkv.copy_(torch.randn_like(qkv))
+    graph.replay()
+
+    atol = 2 * torch.finfo(query.dtype).eps
+    torch.testing.assert_close(
+        query_out,
+        _complex_rope_reference(query, freqs_cis),
+        atol=atol,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        key_out,
+        _complex_rope_reference(key, freqs_cis),
+        atol=atol,
+        rtol=0,
+    )
+
+
+def test_fused_qk_complex_rope_rejects_unsupported_inputs() -> None:
+    query = torch.empty(2, 4, 8, dtype=torch.float32)
+    key = torch.empty_like(query)
+    freqs_cis = torch.empty(2, 4, dtype=torch.complex64)
+
+    assert not can_use_fused_qk_complex_rope(query, key, freqs_cis)
+    with pytest.raises(ValueError, match="Unsupported fused vision RoPE inputs"):
+        apply_fused_qk_complex_rope(query, key, freqs_cis)

--- a/vllm/model_executor/layers/rotary_embedding/vision.py
+++ b/vllm/model_executor/layers/rotary_embedding/vision.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused rotary embeddings for vision attention."""
+
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/kernels/ops/attention/vision_rope.py
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit(do_not_specialize=["num_pairs"])
+def _fused_qk_complex_rope_kernel(
+    q_ptr,
+    k_ptr,
+    freqs_ptr,
+    q_out_ptr,
+    k_out_ptr,
+    num_pairs,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    k_stride_token: tl.constexpr,
+    k_stride_head: tl.constexpr,
+    k_stride_dim: tl.constexpr,
+    freq_stride_token: tl.constexpr,
+    freq_stride_pair: tl.constexpr,
+    freq_stride_complex: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    pair_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = pair_offsets < num_pairs
+    pairs_per_head = head_dim // 2
+    row = pair_offsets // pairs_per_head
+    pair = pair_offsets - row * pairs_per_head
+    token = row // num_heads
+    head = row - token * num_heads
+
+    q_base = token * q_stride_token + head * q_stride_head
+    q_base += pair * 2 * q_stride_dim
+    k_base = token * k_stride_token + head * k_stride_head
+    k_base += pair * 2 * k_stride_dim
+    freq_base = token * freq_stride_token + pair * freq_stride_pair
+
+    cos = tl.load(freqs_ptr + freq_base, mask=mask).to(tl.float32)
+    sin = tl.load(freqs_ptr + freq_base + freq_stride_complex, mask=mask).to(tl.float32)
+    q_real = tl.load(q_ptr + q_base, mask=mask).to(tl.float32)
+    q_imag = tl.load(q_ptr + q_base + q_stride_dim, mask=mask).to(tl.float32)
+    k_real = tl.load(k_ptr + k_base, mask=mask).to(tl.float32)
+    k_imag = tl.load(k_ptr + k_base + k_stride_dim, mask=mask).to(tl.float32)
+
+    out_base = row * head_dim + pair * 2
+    q_real_cos = q_real * cos
+    q_imag_sin = q_imag * sin
+    k_real_cos = k_real * cos
+    k_imag_sin = k_imag * sin
+    tl.store(
+        q_out_ptr + out_base,
+        q_real_cos - q_imag_sin,
+        mask=mask,
+    )
+    tl.store(
+        q_out_ptr + out_base + 1,
+        q_imag * cos + q_real * sin,
+        mask=mask,
+    )
+    tl.store(
+        k_out_ptr + out_base,
+        k_real_cos - k_imag_sin,
+        mask=mask,
+    )
+    tl.store(
+        k_out_ptr + out_base + 1,
+        k_imag * cos + k_real * sin,
+        mask=mask,
+    )
+
+
+def can_use_fused_qk_complex_rope(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> bool:
+    """Return whether the fused vision RoPE kernel supports the inputs."""
+    if not current_platform.is_cuda():
+        return False
+    if not (
+        query.is_cuda
+        and key.is_cuda
+        and freqs_cis.is_cuda
+        and query.device == key.device == freqs_cis.device
+    ):
+        return False
+    if query.dtype != key.dtype or query.dtype not in (
+        torch.bfloat16,
+        torch.float16,
+    ):
+        return False
+    if query.shape != key.shape or query.ndim != 3:
+        return False
+    if freqs_cis.dtype != torch.complex64 or query.numel() == 0 or query.shape[-1] % 2:
+        return False
+    if freqs_cis.shape != (query.shape[0], query.shape[-1] // 2):
+        return False
+    device_id = query.device.index or 0
+    return current_platform.has_device_capability(90, device_id=device_id)
+
+
+def apply_fused_qk_complex_rope(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Rotate strided Q/K views together and return contiguous outputs."""
+    if not can_use_fused_qk_complex_rope(query, key, freqs_cis):
+        raise ValueError(
+            "Unsupported fused vision RoPE inputs: "
+            f"query={query.shape}/{query.dtype}/{query.device}, "
+            f"key={key.shape}/{key.dtype}/{key.device}, "
+            f"freqs={freqs_cis.shape}/{freqs_cis.dtype}/{freqs_cis.device}"
+        )
+
+    query_out = torch.empty_like(query, memory_format=torch.contiguous_format)
+    key_out = torch.empty_like(key, memory_format=torch.contiguous_format)
+    freqs = torch.view_as_real(freqs_cis)
+
+    block_size = 128
+    num_pairs = query.numel() // 2
+    _fused_qk_complex_rope_kernel[(triton.cdiv(num_pairs, block_size),)](
+        query,
+        key,
+        freqs,
+        query_out,
+        key_out,
+        num_pairs,
+        query.shape[1],
+        query.shape[2],
+        query.stride(0),
+        query.stride(1),
+        query.stride(2),
+        key.stride(0),
+        key.stride(1),
+        key.stride(2),
+        freqs.stride(0),
+        freqs.stride(1),
+        freqs.stride(2),
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return query_out, key_out

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -30,6 +30,10 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+from vllm.model_executor.layers.rotary_embedding.vision import (
+    apply_fused_qk_complex_rope,
+    can_use_fused_qk_complex_rope,
+)
 from vllm.model_executor.models.utils import maybe_prefix
 from vllm.model_executor.models.vision import (
     is_vit_use_data_parallel,
@@ -463,10 +467,13 @@ class MoonViTEncoderLayer(nn.Module):
 
         _apply_rope_input_validation(xq, rope_freqs_cis)
         _apply_rope_input_validation(xk, rope_freqs_cis)
-        rope_cos = rope_freqs_cis.real.contiguous()
-        rope_sin = rope_freqs_cis.imag.contiguous()
-        xq = self.apply_rotary_emb(xq, rope_cos, rope_sin)
-        xk = self.apply_rotary_emb(xk, rope_cos, rope_sin)
+        if can_use_fused_qk_complex_rope(xq, xk, rope_freqs_cis):
+            xq, xk = apply_fused_qk_complex_rope(xq, xk, rope_freqs_cis)
+        else:
+            rope_cos = rope_freqs_cis.real.contiguous()
+            rope_sin = rope_freqs_cis.imag.contiguous()
+            xq = self.apply_rotary_emb(xq, rope_cos, rope_sin)
+            xk = self.apply_rotary_emb(xk, rope_cos, rope_sin)
 
         if max_seqlen is None:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()


### PR DESCRIPTION
## Purpose

MoonViT currently materializes the real and imaginary RoPE components in every
encoder layer and invokes `ApplyRotaryEmb` separately for the strided Q and K
views of its packed QKV projection. This PR adds an SM90+ Triton path that:

- reads the packed-QKV Q/K views directly;
- rotates Q and K in one kernel and produces the same contiguous output layout;
- keeps the token count as a runtime argument to avoid recompilation for random
  image sizes; and
- falls back to the existing implementation for unsupported devices, dtypes,
  shapes, and empty inputs.

The kernel is adapted from SGLang's fused vision RoPE implementation, while its
arithmetic order follows vLLM's current interleaved RoPE path.

This is not a duplicate of an existing open PR. Searches for `MoonViT RoPE`,
`Kimi vision RoPE`, `fused QK complex RoPE`, and `kimi_k25_vit` found no PR
implementing this kernel. #53011 addresses eager `torch.compile` cache behavior,
and #40600 targets full ViT CUDA graphs; neither fuses Q/K complex RoPE.

AI assistance (OpenAI Codex) was used for implementation and testing. The human
submitter must review every changed line and be able to defend the change before
this draft is marked ready for review.

## Test Plan

1. Run pre-commit hooks on all changed files.
2. Compare BF16/FP16 fused results against FP32 complex-multiply references for
   Kimi K3's packed-QKV layout and dynamic token counts.
3. Capture and replay the fused path with a CUDA graph after changing inputs.
4. Benchmark the exact current MoonViT boundary (`ApplyRotaryEmb` twice,
   including real/imag materialization) against the fused path on B200.
5. Before marking ready, run a trained Kimi K3 multimodal end-to-end comparison.

## Test Result

Local hooks:

```text
.venv/bin/pre-commit run --files \
  vllm/model_executor/layers/rotary_embedding/vision.py \
  vllm/model_executor/models/kimi_k25_vit.py \
  tests/kernels/core/test_vision_rope.py \
  benchmarks/kernels/benchmark_vision_rope.py

All hooks passed, including ruff, formatting, mypy, SPDX, and forbidden-import
checks.
```

B200 kernel tests in the vLLM nightly container:

```text
/workspace/.venv/bin/python -m pytest /workspace/test_vision_rope.py -q
8 passed, 14 warnings in 17.87s
```

The tests cover BF16 and FP16, 1/257/4096 tokens, packed QKV strides,
contiguous outputs, unsupported-input rejection, and CUDA graph replay. In a
direct BF16 comparison with the existing vLLM path, the maximum difference was
one BF16 ULP (`0.0078125`), affecting `0.00152%` of elements.

B200 BF16 microbenchmark, 12 heads and head dimension 128:

| Tokens | Existing Q/K RoPE | Fused Q/K RoPE | Speedup |
| ---: | ---: | ---: | ---: |
| 256 | 150.02 us | 11.81 us | 12.7x |
| 1,024 | 150.75 us | 12.06 us | 12.5x |
| 4,096 | 151.15 us | 20.48 us | 7.4x |
| 16,384 | 302.11 us | 57.31 us | 5.3x |

A 27-layer random-weight MoonViT run using Kimi K3's vision geometry produced
finite outputs with cosine similarity `0.999912` between the existing and fused
paths. This is a numerical stress test, not a trained-model evaluation.

Trained Kimi K3 multimodal end-to-end serving/evaluation has **not** been run
yet. This PR remains a draft until that result and human line-by-line review are
complete.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The available test and benchmark results.
- [x] No documentation update is required for this internal kernel optimization.

</details>

