### PR TITLE
[glm] [pcp] fuse norm rope with pcp cache gather

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -244,6 +244,7 @@ steps:
   commands:
     - pytest -v -s tests/distributed/test_context_parallel.py
     - pytest -v -s tests/distributed/test_nccl_symm_mem.py
+    - pytest -v -s tests/kernels/test_fused_deepseek_v32_norm_rope.py -k reuses_indexer_barrier
     - pytest -v -s tests/kernels/test_kimi_k3_gemm_rs.py
     - pytest -v -s tests/v1/distributed/test_dbo.py
     - pytest -v -s tests/distributed/test_mnnvl_alltoall.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,8 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     list(APPEND VLLM_STABLE_EXT_SRC
       "csrc/libtorch_stable/attention/dcp_utils/dcp_direct_a2a_lse_reduce.cu"
       "csrc/libtorch_stable/attention/dcp_utils/dcp_direct_kv_gather.cu"
-      "csrc/libtorch_stable/attention/dcp_utils/dcp_direct_q_gather.cu")
+      "csrc/libtorch_stable/attention/dcp_utils/dcp_direct_q_gather.cu"
+      "csrc/libtorch_stable/attention/pcp_utils/fused_norm_rope_pcp.cu")
 
     SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
 

--- a/csrc/libtorch_stable/attention/pcp_utils/fused_norm_rope_pcp.cu
+++ b/csrc/libtorch_stable/attention/pcp_utils/fused_norm_rope_pcp.cu
@@ -4,10 +4,12 @@
 // Sparse-MLA PCP cache preparation.
 //
 // The dispatch kernel keeps the local Q result local, but quantizes the K-side
-// tensors directly into their final FP8 representation and multicasts one
-// packed row per token through an NVLS symmetric-memory window:
+// tensors directly into their final cache representation and multicasts one
+// packed row per token through an NVLS symmetric-memory window. Static E4M3
+// stores a 576-byte FP8 MLA row; fp8_ds_mla stores a 656-byte row with tiled
+// NoPE scales and a BF16 RoPE tail. Sparse layers append:
 //
-//   [ MLA kv_c:512 | MLA k_pe:64 | indexer K:128 | indexer scale:4 | pad:12 ]
+//   [ MLA row | indexer K:128 | indexer scale:4 | pad:12 ]
 //
 // The combine kernel reads the acquired rank-major rows and scatters them into
 // the rank-local paged MLA and indexer caches.  Cache block mappings are local,
@@ -41,10 +43,50 @@ constexpr int kThreads = 256;
 constexpr int kKvLoraDim = 512;
 constexpr int kRopeDim = 64;
 constexpr int kIndexerDim = 128;
-constexpr int kMlaRowBytes = kKvLoraDim + kRopeDim;
-constexpr int kIndexerScaleOffset = kMlaRowBytes + kIndexerDim;
-constexpr int kPackedRowBytes = kIndexerScaleOffset + sizeof(uint4);
 constexpr float kFp8Max = 448.0f;
+
+enum class MlaCacheLayout { kStaticE4M3, kFp8DsMla };
+
+constexpr int align_up_16(int value) { return (value + 15) & ~15; }
+
+template <int q_lora_dim, int kv_lora_dim, int rope_dim, int indexer_dim,
+          bool index_rope_interleave, MlaCacheLayout cache_layout>
+struct FusedNormRopeConfig {
+  static_assert(q_lora_dim % kThreads == 0);
+  static_assert(kv_lora_dim % 128 == 0);
+  static_assert(kv_lora_dim % 16 == 0);
+  static_assert(rope_dim % 16 == 0);
+  static_assert(indexer_dim % 16 == 0);
+
+  static constexpr int kQLoraDim = q_lora_dim;
+  static constexpr int kKvLoraDim = kv_lora_dim;
+  static constexpr int kRopeDim = rope_dim;
+  static constexpr int kIndexerDim = indexer_dim;
+  static constexpr bool kIndexRopeInterleave = index_rope_interleave;
+  static constexpr MlaCacheLayout kCacheLayout = cache_layout;
+  static constexpr int kMlaNumTiles = kv_lora_dim / 128;
+  static constexpr int kMlaScaleBytes = kMlaNumTiles * sizeof(float);
+  static constexpr int kMlaRopeBytes =
+      cache_layout == MlaCacheLayout::kFp8DsMla ? rope_dim * 2 : rope_dim;
+  static constexpr int kMlaRopeOffset =
+      cache_layout == MlaCacheLayout::kFp8DsMla ? kv_lora_dim + kMlaScaleBytes
+                                                : kv_lora_dim;
+  static constexpr int kMlaRowBytes = kMlaRopeOffset + kMlaRopeBytes;
+  static constexpr int kIndexerOffset = kMlaRowBytes;
+  static constexpr int kIndexerScaleOffset = kIndexerOffset + indexer_dim;
+  static constexpr int kPackedRowBytes =
+      align_up_16(kIndexerScaleOffset + sizeof(float));
+
+  static_assert(kMlaRowBytes % 16 == 0);
+  static_assert(kIndexerOffset % 16 == 0);
+  static_assert(cache_layout != MlaCacheLayout::kFp8DsMla || kMlaNumTiles == 4);
+};
+
+template <int q_lora_dim, bool index_rope_interleave,
+          MlaCacheLayout cache_layout>
+using DSV32FusedNormRopeConfig =
+    FusedNormRopeConfig<q_lora_dim, kKvLoraDim, kRopeDim, kIndexerDim,
+                        index_rope_interleave, cache_layout>;
 
 template <typename scalar_t>
 __device__ __forceinline__ float load_half(const scalar_t* ptr) {
@@ -147,6 +189,16 @@ __device__ __forceinline__ uint4 pack_fp8_16(const float* values,
   return output;
 }
 
+__device__ __forceinline__ uint4 pack_bfloat16_8(const float* values) {
+  uint4 output;
+  auto* output_values = reinterpret_cast<__nv_bfloat16*>(&output);
+#pragma unroll
+  for (int idx = 0; idx < 8; ++idx) {
+    output_values[idx] = __float2bfloat16(values[idx]);
+  }
+  return output;
+}
+
 // One CTA becomes the invocation leader.  It advances the epoch and publishes
 // it before any other CTA selects the double-buffer slot.  The last completed
 // CTA resets phase to zero, so the next stream-ordered invocation can elect a
@@ -171,7 +223,7 @@ __device__ __forceinline__ uint32_t establish_epoch(int32_t* phase,
   return *shared_epoch;
 }
 
-template <typename scalar_t, int q_lora_dim>
+template <typename scalar_t, typename Config>
 __global__ void fused_norm_rope_pcp_dispatch_kernel(
     const int64_t* __restrict__ positions, const scalar_t* __restrict__ q_c,
     int64_t q_stride, const scalar_t* __restrict__ q_weight, float q_eps,
@@ -193,9 +245,10 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
     int32_t* __restrict__ phase, int world_size, int rank, int max_local_tokens,
     int topk, int topk_stride, bool has_indexer) {
   __shared__ float reduce_scratch[8];
-  __shared__ float kv_values[kKvLoraDim];
-  __shared__ float k_pe_values[kRopeDim];
-  __shared__ float index_values[kIndexerDim];
+  __shared__ float kv_values[Config::kKvLoraDim];
+  __shared__ float k_pe_values[Config::kRopeDim];
+  __shared__ float index_values[Config::kIndexerDim];
+  __shared__ float mla_tile_scales[Config::kMlaNumTiles];
   __shared__ uint32_t active_epoch;
 
   int token = blockIdx.x;
@@ -205,23 +258,23 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
 
   // Q RMSNorm remains local.  Eight values per thread stay in registers across
   // the block reduction, avoiding an intermediate Q materialization.
-  float q_values[q_lora_dim / kThreads];
+  float q_values[Config::kQLoraDim / kThreads];
   float q_sum_sq = 0.0f;
 #pragma unroll
-  for (int idx = 0; idx < q_lora_dim / kThreads; ++idx) {
+  for (int idx = 0; idx < Config::kQLoraDim / kThreads; ++idx) {
     int dim = tid + idx * kThreads;
     float value = load_half(q_c + static_cast<int64_t>(token) * q_stride + dim);
     q_values[idx] = value;
     q_sum_sq += value * value;
   }
   float q_inv_rms = rsqrtf(block_sum(q_sum_sq, reduce_scratch) /
-                               static_cast<float>(q_lora_dim) +
+                               static_cast<float>(Config::kQLoraDim) +
                            q_eps);
 #pragma unroll
-  for (int idx = 0; idx < q_lora_dim / kThreads; ++idx) {
+  for (int idx = 0; idx < Config::kQLoraDim / kThreads; ++idx) {
     int dim = tid + idx * kThreads;
     float weight = load_half(q_weight + dim);
-    store_half(q_out + static_cast<int64_t>(token) * q_lora_dim + dim,
+    store_half(q_out + static_cast<int64_t>(token) * Config::kQLoraDim + dim,
                q_values[idx] * q_inv_rms * weight);
   }
 
@@ -229,7 +282,7 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
   // the final per-tensor FP8 pack.
   float kv_sum_sq = 0.0f;
 #pragma unroll
-  for (int idx = 0; idx < kKvLoraDim / kThreads; ++idx) {
+  for (int idx = 0; idx < Config::kKvLoraDim / kThreads; ++idx) {
     int dim = tid + idx * kThreads;
     float value =
         load_half(kv_c + static_cast<int64_t>(token) * kv_stride + dim);
@@ -237,10 +290,10 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
     kv_sum_sq += value * value;
   }
   float kv_inv_rms = rsqrtf(block_sum(kv_sum_sq, reduce_scratch) /
-                                static_cast<float>(kKvLoraDim) +
+                                static_cast<float>(Config::kKvLoraDim) +
                             kv_eps);
 #pragma unroll
-  for (int idx = 0; idx < kKvLoraDim / kThreads; ++idx) {
+  for (int idx = 0; idx < Config::kKvLoraDim / kThreads; ++idx) {
     int dim = tid + idx * kThreads;
     float weight = load_half(kv_weight + dim);
     kv_values[dim] = round_half<scalar_t>(kv_values[dim] * kv_inv_rms * weight);
@@ -249,14 +302,14 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
   }
 
   // This layout uses adjacent-pair (interleaved) RoPE for MLA K-pe.
-  if (tid < kRopeDim / 2) {
+  if (tid < Config::kRopeDim / 2) {
     int64_t position = positions[token];
     int64_t cos_sin_offset = position * k_pe_cos_sin_stride;
     float cosine = load_cos_sin<scalar_t>(k_pe_cos_sin, cos_sin_offset + tid,
                                           k_pe_cos_sin_is_float);
-    float sine = load_cos_sin<scalar_t>(k_pe_cos_sin,
-                                        cos_sin_offset + tid + kRopeDim / 2,
-                                        k_pe_cos_sin_is_float);
+    float sine = load_cos_sin<scalar_t>(
+        k_pe_cos_sin, cos_sin_offset + tid + Config::kRopeDim / 2,
+        k_pe_cos_sin_is_float);
     const scalar_t* row = k_pe + static_cast<int64_t>(token) * k_pe_stride;
     float x = load_half(row + 2 * tid);
     float y = load_half(row + 2 * tid + 1);
@@ -275,7 +328,7 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
   // Indexer K LayerNorm, interleaved RoPE, and UE8M0 FP8 quantization.
   float index_value = 0.0f;
   if (has_indexer) {
-    if (tid < kIndexerDim) {
+    if (tid < Config::kIndexerDim) {
       index_value = load_half(
           index_k + static_cast<int64_t>(token) * index_k_stride + tid);
     }
@@ -283,83 +336,148 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
   float index_scale = 1.0f;
   if (has_indexer) {
     float index_mean = block_sum(index_value, reduce_scratch) /
-                       static_cast<float>(kIndexerDim);
-    float centered = tid < kIndexerDim ? index_value - index_mean : 0.0f;
+                       static_cast<float>(Config::kIndexerDim);
+    float centered =
+        tid < Config::kIndexerDim ? index_value - index_mean : 0.0f;
     float index_variance = block_sum(centered * centered, reduce_scratch) /
-                           static_cast<float>(kIndexerDim);
-    if (tid < kIndexerDim) {
+                           static_cast<float>(Config::kIndexerDim);
+    if (tid < Config::kIndexerDim) {
       index_values[tid] =
           centered * rsqrtf(index_variance + index_eps) * index_weight[tid] +
           index_bias[tid];
     }
     __syncthreads();
-    if (tid < kRopeDim / 2) {
+    if (tid < Config::kRopeDim / 2) {
       int64_t position = positions[token];
       int64_t cos_sin_offset = position * index_cos_sin_stride;
       float cosine = load_cos_sin<scalar_t>(index_cos_sin, cos_sin_offset + tid,
                                             index_cos_sin_is_float);
-      float sine = load_cos_sin<scalar_t>(index_cos_sin,
-                                          cos_sin_offset + tid + kRopeDim / 2,
-                                          index_cos_sin_is_float);
-      float x = index_values[2 * tid];
-      float y = index_values[2 * tid + 1];
-      index_values[2 * tid] = x * cosine - y * sine;
-      index_values[2 * tid + 1] = y * cosine + x * sine;
+      float sine = load_cos_sin<scalar_t>(
+          index_cos_sin, cos_sin_offset + tid + Config::kRopeDim / 2,
+          index_cos_sin_is_float);
+      if constexpr (Config::kIndexRopeInterleave) {
+        float x = index_values[2 * tid];
+        float y = index_values[2 * tid + 1];
+        index_values[2 * tid] = x * cosine - y * sine;
+        index_values[2 * tid + 1] = y * cosine + x * sine;
+      } else {
+        float x = index_values[tid];
+        float y = index_values[tid + Config::kRopeDim / 2];
+        index_values[tid] = x * cosine - y * sine;
+        index_values[tid + Config::kRopeDim / 2] = y * cosine + x * sine;
+      }
     }
     __syncthreads();
-    if (tid < kIndexerDim) {
+    if (tid < Config::kIndexerDim) {
       index_values[tid] = round_half<scalar_t>(index_values[tid]);
     }
     __syncthreads();
-    float local_max = tid < kIndexerDim ? fabsf(index_values[tid]) : 0.0f;
+    float local_max =
+        tid < Config::kIndexerDim ? fabsf(index_values[tid]) : 0.0f;
     index_scale =
         fmaxf(block_max(local_max, reduce_scratch), 1.0e-4f) / kFp8Max;
     index_scale = exp2f(ceilf(log2f(index_scale)));
   }
 
-  int64_t slot_stride =
-      static_cast<int64_t>(world_size) * max_local_tokens * kPackedRowBytes;
-  int64_t row_offset =
-      static_cast<int64_t>(parity) * slot_stride +
-      (static_cast<int64_t>(rank) * max_local_tokens + token) * kPackedRowBytes;
+  int64_t slot_stride = static_cast<int64_t>(world_size) * max_local_tokens *
+                        Config::kPackedRowBytes;
+  int64_t row_offset = static_cast<int64_t>(parity) * slot_stride +
+                       (static_cast<int64_t>(rank) * max_local_tokens + token) *
+                           Config::kPackedRowBytes;
   auto* row_mc = reinterpret_cast<uint8_t*>(payload_mc) + row_offset;
 
-  // Quantize the rounded BF16 values directly into the symmetric payload.
-  if (tid < kKvLoraDim / 16) {
-    float values[16];
+  if constexpr (Config::kCacheLayout == MlaCacheLayout::kStaticE4M3) {
+    // Quantize the rounded input values with the cache's static scale.
+    if (tid < Config::kKvLoraDim / 16) {
+      float values[16];
 #pragma unroll
-    for (int idx = 0; idx < 16; ++idx) {
-      values[idx] = kv_values[tid * 16 + idx];
+      for (int idx = 0; idx < 16; ++idx) {
+        values[idx] = kv_values[tid * 16 + idx];
+      }
+      float inverse_scale = 1.0f / mla_k_scale[0];
+      multimem_store_16(reinterpret_cast<uint4*>(row_mc) + tid,
+                        pack_fp8_16(values, inverse_scale));
     }
-    float inverse_scale = 1.0f / mla_k_scale[0];
-    multimem_store_16(reinterpret_cast<uint4*>(row_mc) + tid,
-                      pack_fp8_16(values, inverse_scale));
-  }
-  if (tid < kRopeDim / 16) {
-    float values[16];
+    if (tid < Config::kRopeDim / 16) {
+      float values[16];
 #pragma unroll
-    for (int idx = 0; idx < 16; ++idx) {
-      values[idx] = k_pe_values[tid * 16 + idx];
+      for (int idx = 0; idx < 16; ++idx) {
+        values[idx] = k_pe_values[tid * 16 + idx];
+      }
+      float inverse_scale = 1.0f / mla_k_scale[0];
+      multimem_store_16(
+          reinterpret_cast<uint4*>(row_mc + Config::kMlaRopeOffset) + tid,
+          pack_fp8_16(values, inverse_scale));
     }
-    float inverse_scale = 1.0f / mla_k_scale[0];
-    multimem_store_16(reinterpret_cast<uint4*>(row_mc + kKvLoraDim) + tid,
-                      pack_fp8_16(values, inverse_scale));
+  } else {
+    // fp8_ds_mla uses one dynamic scale per 128-value NoPE tile and keeps
+    // the RoPE tail in BF16.
+    if (tid < 32) {
+#pragma unroll
+      for (int tile = 0; tile < Config::kMlaNumTiles; ++tile) {
+        float local_max = 0.0f;
+#pragma unroll
+        for (int idx = 0; idx < 4; ++idx) {
+          local_max = fmaxf(
+              local_max,
+              fabsf(kv_values[tile * 128 + tid + static_cast<int>(idx) * 32]));
+        }
+        float tile_max = warp_max(local_max);
+        if (tid == 0) {
+          mla_tile_scales[tile] =
+              fmaxf(tile_max * (1.0f / kFp8Max), 1.1754944e-38f);
+        }
+      }
+    }
+    __syncthreads();
+    if (tid < Config::kKvLoraDim / 16) {
+      float values[16];
+#pragma unroll
+      for (int idx = 0; idx < 16; ++idx) {
+        values[idx] = kv_values[tid * 16 + idx];
+      }
+      int tile = tid / (128 / 16);
+      multimem_store_16(reinterpret_cast<uint4*>(row_mc) + tid,
+                        pack_fp8_16(values, 1.0f / mla_tile_scales[tile]));
+    }
+    if (tid == 0) {
+      uint4 scales = {
+          __float_as_uint(mla_tile_scales[0]),
+          __float_as_uint(mla_tile_scales[1]),
+          __float_as_uint(mla_tile_scales[2]),
+          __float_as_uint(mla_tile_scales[3]),
+      };
+      multimem_store_16(reinterpret_cast<uint4*>(row_mc + Config::kKvLoraDim),
+                        scales);
+    }
+    if (tid < Config::kRopeDim / 8) {
+      float values[8];
+#pragma unroll
+      for (int idx = 0; idx < 8; ++idx) {
+        values[idx] = k_pe_values[tid * 8 + idx];
+      }
+      multimem_store_16(
+          reinterpret_cast<uint4*>(row_mc + Config::kMlaRopeOffset) + tid,
+          pack_bfloat16_8(values));
+    }
   }
   if (has_indexer) {
-    if (tid < kIndexerDim / 16) {
+    if (tid < Config::kIndexerDim / 16) {
       float values[16];
 #pragma unroll
       for (int idx = 0; idx < 16; ++idx) {
         values[idx] = index_values[tid * 16 + idx];
       }
-      multimem_store_16(reinterpret_cast<uint4*>(row_mc + kMlaRowBytes) + tid,
-                        pack_fp8_16(values, 1.0f / index_scale));
+      multimem_store_16(
+          reinterpret_cast<uint4*>(row_mc + Config::kIndexerOffset) + tid,
+          pack_fp8_16(values, 1.0f / index_scale));
     }
     if (tid == 0) {
       uint4 scale_and_padding = {0u, 0u, 0u, 0u};
       scale_and_padding.x = __float_as_uint(index_scale);
-      multimem_store_16(reinterpret_cast<uint4*>(row_mc + kIndexerScaleOffset),
-                        scale_and_padding);
+      multimem_store_16(
+          reinterpret_cast<uint4*>(row_mc + Config::kIndexerScaleOffset),
+          scale_and_padding);
     }
     for (int idx = tid; idx < topk; idx += blockDim.x) {
       topk_indices[static_cast<int64_t>(token) * topk_stride + idx] = -1;
@@ -390,6 +508,7 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
   atomicExch(phase, 0);
 }
 
+template <typename Config>
 __global__ void fused_norm_rope_pcp_combine_kernel(
     const uint8_t* __restrict__ received_payload,
     const int64_t* __restrict__ epoch,
@@ -420,7 +539,7 @@ __global__ void fused_norm_rope_pcp_combine_kernel(
   int64_t row_offset =
       (static_cast<int64_t>(parity) * world_size * max_local_tokens +
        static_cast<int64_t>(source) * max_local_tokens + source_token) *
-      kPackedRowBytes;
+      Config::kPackedRowBytes;
   const uint8_t* row = received_payload + row_offset;
 
   int64_t mla_slot = mla_slot_mapping[mapping_token];
@@ -429,7 +548,7 @@ __global__ void fused_norm_rope_pcp_combine_kernel(
     int64_t block_offset = mla_slot % cache_block_size;
     uint8_t* destination =
         mla_cache + block * mla_block_stride + block_offset * mla_token_stride;
-    for (int chunk = threadIdx.x; chunk < kMlaRowBytes / 16;
+    for (int chunk = threadIdx.x; chunk < Config::kMlaRowBytes / 16;
          chunk += blockDim.x) {
       reinterpret_cast<uint4*>(destination)[chunk] =
           reinterpret_cast<const uint4*>(row)[chunk];
@@ -442,17 +561,20 @@ __global__ void fused_norm_rope_pcp_combine_kernel(
       int64_t block = index_slot / cache_block_size;
       int64_t block_offset = index_slot % cache_block_size;
       uint8_t* block_base = index_cache + block * index_block_stride;
-      uint8_t* value_destination = block_base + block_offset * kIndexerDim;
-      for (int chunk = threadIdx.x; chunk < kIndexerDim / 16;
+      uint8_t* value_destination =
+          block_base + block_offset * Config::kIndexerDim;
+      for (int chunk = threadIdx.x; chunk < Config::kIndexerDim / 16;
            chunk += blockDim.x) {
         reinterpret_cast<uint4*>(value_destination)[chunk] =
-            reinterpret_cast<const uint4*>(row + kMlaRowBytes)[chunk];
+            reinterpret_cast<const uint4*>(row + Config::kIndexerOffset)[chunk];
       }
       if (threadIdx.x == 0) {
-        uint8_t* scale_destination =
-            block_base + cache_block_size * kIndexerDim + block_offset * 4;
+        uint8_t* scale_destination = block_base +
+                                     cache_block_size * Config::kIndexerDim +
+                                     block_offset * 4;
         *reinterpret_cast<uint32_t*>(scale_destination) =
-            *reinterpret_cast<const uint32_t*>(row + kIndexerScaleOffset);
+            *reinterpret_cast<const uint32_t*>(row +
+                                               Config::kIndexerScaleOffset);
       }
     }
   }
@@ -474,8 +596,8 @@ void fused_norm_rope_pcp_dispatch(
     torch::stable::Tensor& received_payload,
     torch::stable::Tensor& received_signal, torch::stable::Tensor& completion,
     torch::stable::Tensor& epoch, torch::stable::Tensor& phase,
-    int64_t world_size, int64_t rank, bool has_indexer, int64_t payload_mc_ptr,
-    int64_t signal_mc_ptr) {
+    int64_t world_size, int64_t rank, bool has_indexer, bool fp8_ds_mla,
+    bool index_rope_interleave, int64_t payload_mc_ptr, int64_t signal_mc_ptr) {
   using torch::headeronly::ScalarType;
   auto valid_rows = [](const torch::stable::Tensor& tensor, int64_t rows,
                        int64_t columns, ScalarType dtype) {
@@ -562,14 +684,22 @@ void fused_norm_rope_pcp_dispatch(
   }
   STD_TORCH_CHECK(world_size > 1 && rank >= 0 && rank < world_size,
                   "invalid PCP world_size/rank");
+  constexpr int kStaticPackedRowBytes =
+      DSV32FusedNormRopeConfig<1536, true,
+                               MlaCacheLayout::kStaticE4M3>::kPackedRowBytes;
+  constexpr int kDsMlaPackedRowBytes =
+      DSV32FusedNormRopeConfig<1536, true,
+                               MlaCacheLayout::kFp8DsMla>::kPackedRowBytes;
+  int expected_packed_row_bytes =
+      fp8_ds_mla ? kDsMlaPackedRowBytes : kStaticPackedRowBytes;
   STD_TORCH_CHECK(
       received_payload.is_cuda() && received_payload.is_contiguous() &&
           received_payload.scalar_type() == ScalarType::Byte &&
           received_payload.dim() == 4 && received_payload.size(0) == 2 &&
           received_payload.size(1) == world_size &&
-          received_payload.size(3) == kPackedRowBytes &&
+          received_payload.size(3) == expected_packed_row_bytes &&
           num_tokens <= received_payload.size(2),
-      "received_payload must be uint8 [2,W,max_local,720]");
+      "received_payload has the wrong PCP cache-layout row size");
   STD_TORCH_CHECK(
       received_signal.is_cuda() && received_signal.is_contiguous() &&
           received_signal.scalar_type() == ScalarType::Int &&
@@ -602,9 +732,9 @@ void fused_norm_rope_pcp_dispatch(
   int max_local_tokens = static_cast<int>(received_payload.size(2));
   int topk = static_cast<int>(topk_indices.size(1));
   int topk_stride = static_cast<int>(topk_indices.stride(0));
-  auto launch = [&]<int q_dim>() {
+  auto launch = [&]<typename Config>() {
     VLLM_STABLE_DISPATCH_HALF_TYPES(dtype, "fused_norm_rope_pcp_dispatch", [&] {
-      fused_norm_rope_pcp_dispatch_kernel<scalar_t, q_dim>
+      fused_norm_rope_pcp_dispatch_kernel<scalar_t, Config>
           <<<num_tokens, kThreads, 0, stream>>>(
               positions.const_data_ptr<int64_t>(),
               reinterpret_cast<const scalar_t*>(q_c.const_data_ptr()),
@@ -645,10 +775,31 @@ void fused_norm_rope_pcp_dispatch(
               has_indexer);
     });
   };
+  auto launch_q_dim = [&]<int q_dim>() {
+    if (fp8_ds_mla) {
+      if (index_rope_interleave) {
+        using Config =
+            DSV32FusedNormRopeConfig<q_dim, true, MlaCacheLayout::kFp8DsMla>;
+        launch.template operator()<Config>();
+      } else {
+        using Config =
+            DSV32FusedNormRopeConfig<q_dim, false, MlaCacheLayout::kFp8DsMla>;
+        launch.template operator()<Config>();
+      }
+    } else if (index_rope_interleave) {
+      using Config =
+          DSV32FusedNormRopeConfig<q_dim, true, MlaCacheLayout::kStaticE4M3>;
+      launch.template operator()<Config>();
+    } else {
+      using Config =
+          DSV32FusedNormRopeConfig<q_dim, false, MlaCacheLayout::kStaticE4M3>;
+      launch.template operator()<Config>();
+    }
+  };
   if (q_lora_dim == 1536) {
-    launch.template operator()<1536>();
+    launch_q_dim.template operator()<1536>();
   } else {
-    launch.template operator()<2048>();
+    launch_q_dim.template operator()<2048>();
   }
   check_cuda_launch("fused_norm_rope_pcp_dispatch");
 }
@@ -659,14 +810,23 @@ void fused_norm_rope_pcp_combine(
     const torch::stable::Tensor& mla_slot_mapping,
     const torch::stable::Tensor& index_slot_mapping,
     torch::stable::Tensor& mla_cache, torch::stable::Tensor& index_cache,
-    int64_t local_tokens, int64_t num_decode_tokens, bool has_indexer) {
+    int64_t local_tokens, int64_t num_decode_tokens, bool has_indexer,
+    bool fp8_ds_mla) {
   using torch::headeronly::ScalarType;
+  constexpr int kStaticPackedRowBytes =
+      DSV32FusedNormRopeConfig<1536, true,
+                               MlaCacheLayout::kStaticE4M3>::kPackedRowBytes;
+  constexpr int kDsMlaPackedRowBytes =
+      DSV32FusedNormRopeConfig<1536, true,
+                               MlaCacheLayout::kFp8DsMla>::kPackedRowBytes;
+  int expected_packed_row_bytes =
+      fp8_ds_mla ? kDsMlaPackedRowBytes : kStaticPackedRowBytes;
   STD_TORCH_CHECK(
       received_payload.is_cuda() && received_payload.is_contiguous() &&
           received_payload.scalar_type() == ScalarType::Byte &&
           received_payload.dim() == 4 && received_payload.size(0) == 2 &&
-          received_payload.size(3) == kPackedRowBytes,
-      "received_payload must be uint8 [2,W,max_local,720]");
+          received_payload.size(3) == expected_packed_row_bytes,
+      "received_payload has the wrong PCP cache-layout row size");
   int64_t world_size = received_payload.size(1);
   int64_t max_local_tokens = received_payload.size(2);
   STD_TORCH_CHECK(local_tokens > 0 && local_tokens <= max_local_tokens,
@@ -692,11 +852,15 @@ void fused_norm_rope_pcp_combine(
                       epoch.numel() == 1,
                   "epoch must be int64 [1]");
   auto mla_dtype = mla_cache.scalar_type();
+  int expected_mla_row_bytes = fp8_ds_mla ? 656 : 576;
+  bool valid_mla_dtype = fp8_ds_mla
+                             ? mla_dtype == ScalarType::Byte
+                             : mla_dtype == ScalarType::Byte ||
+                                   mla_dtype == ScalarType::Float8_e4m3fn;
   STD_TORCH_CHECK(mla_cache.is_cuda() && mla_cache.is_contiguous() &&
-                      (mla_dtype == ScalarType::Byte ||
-                       mla_dtype == ScalarType::Float8_e4m3fn) &&
-                      mla_cache.dim() == 3 && mla_cache.size(2) == kMlaRowBytes,
-                  "MLA cache must be contiguous byte/FP8 [B,block,576]");
+                      valid_mla_dtype && mla_cache.dim() == 3 &&
+                      mla_cache.size(2) == expected_mla_row_bytes,
+                  "MLA cache has the wrong dtype or cache-layout row size");
   if (has_indexer) {
     STD_TORCH_CHECK(index_cache.is_cuda() && index_cache.is_contiguous() &&
                         index_cache.scalar_type() == ScalarType::Byte &&
@@ -719,18 +883,29 @@ void fused_norm_rope_pcp_combine(
   cudaStream_t stream = get_current_cuda_stream(device);
   int blocks = static_cast<int>(
       num_decode_tokens + world_size * (local_tokens - num_decode_tokens));
-  fused_norm_rope_pcp_combine_kernel<<<blocks, 128, 0, stream>>>(
-      reinterpret_cast<const uint8_t*>(received_payload.const_data_ptr()),
-      epoch.const_data_ptr<int64_t>(),
-      mla_slot_mapping.const_data_ptr<int64_t>(),
-      index_slot_mapping.const_data_ptr<int64_t>(),
-      reinterpret_cast<uint8_t*>(mla_cache.mutable_data_ptr()),
-      mla_cache.stride(0), mla_cache.stride(1),
-      reinterpret_cast<uint8_t*>(index_cache.mutable_data_ptr()),
-      has_indexer ? index_cache.stride(0) : 0, static_cast<int>(world_size),
-      static_cast<int>(local_tokens), static_cast<int>(num_decode_tokens),
-      static_cast<int>(max_local_tokens), static_cast<int>(mla_cache.size(1)),
-      has_indexer);
+  auto launch = [&]<typename Config>() {
+    fused_norm_rope_pcp_combine_kernel<Config><<<blocks, 128, 0, stream>>>(
+        reinterpret_cast<const uint8_t*>(received_payload.const_data_ptr()),
+        epoch.const_data_ptr<int64_t>(),
+        mla_slot_mapping.const_data_ptr<int64_t>(),
+        index_slot_mapping.const_data_ptr<int64_t>(),
+        reinterpret_cast<uint8_t*>(mla_cache.mutable_data_ptr()),
+        mla_cache.stride(0), mla_cache.stride(1),
+        reinterpret_cast<uint8_t*>(index_cache.mutable_data_ptr()),
+        has_indexer ? index_cache.stride(0) : 0, static_cast<int>(world_size),
+        static_cast<int>(local_tokens), static_cast<int>(num_decode_tokens),
+        static_cast<int>(max_local_tokens), static_cast<int>(mla_cache.size(1)),
+        has_indexer);
+  };
+  if (fp8_ds_mla) {
+    using Config =
+        DSV32FusedNormRopeConfig<1536, true, MlaCacheLayout::kFp8DsMla>;
+    launch.template operator()<Config>();
+  } else {
+    using Config =
+        DSV32FusedNormRopeConfig<1536, true, MlaCacheLayout::kStaticE4M3>;
+    launch.template operator()<Config>();
+  }
   check_cuda_launch("fused_norm_rope_pcp_combine");
 }
 
@@ -754,7 +929,8 @@ void fused_norm_rope_pcp(
     const std::optional<torch::stable::Tensor>& index_slot_mapping,
     torch::stable::Tensor& mla_cache,
     std::optional<torch::stable::Tensor> index_cache, int64_t num_decode_tokens,
-    int64_t rank, int64_t payload_mc_ptr, int64_t signal_mc_ptr) {
+    int64_t rank, bool fp8_ds_mla, bool index_rope_interleave,
+    int64_t payload_mc_ptr, int64_t signal_mc_ptr) {
   bool has_indexer = index_k.has_value();
   STD_TORCH_CHECK(
       index_weight.has_value() == has_indexer &&
@@ -780,10 +956,12 @@ void fused_norm_rope_pcp(
       mla_k_scale, kv_eps, k_pe, k_pe_out, k_pe_cos_sin, index_k_arg,
       index_weight_arg, index_bias_arg, index_eps, index_cos_sin_arg,
       topk_indices, received_payload, received_signal, completion, epoch, phase,
-      world_size, rank, has_indexer, payload_mc_ptr, signal_mc_ptr);
-  fused_norm_rope_pcp_combine(
-      received_payload, epoch, mla_slot_mapping, index_slot_mapping_arg,
-      mla_cache, index_cache_arg, q_c.size(0), num_decode_tokens, has_indexer);
+      world_size, rank, has_indexer, fp8_ds_mla, index_rope_interleave,
+      payload_mc_ptr, signal_mc_ptr);
+  fused_norm_rope_pcp_combine(received_payload, epoch, mla_slot_mapping,
+                              index_slot_mapping_arg, mla_cache,
+                              index_cache_arg, q_c.size(0), num_decode_tokens,
+                              has_indexer, fp8_ds_mla);
 }
 
 }  // namespace
@@ -800,7 +978,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, fused_norm_rope_pcp_ops) {
       "Tensor! received_signal, Tensor! completion, Tensor! epoch, "
       "Tensor! phase, Tensor mla_slot_mapping, Tensor? index_slot_mapping, "
       "Tensor! mla_cache, Tensor!? index_cache, int num_decode_tokens, int "
-      "rank, "
+      "rank, bool fp8_ds_mla, bool index_rope_interleave, "
       "int payload_mc_ptr, int signal_mc_ptr) -> ()");
 }
 

--- a/csrc/libtorch_stable/attention/pcp_utils/fused_norm_rope_pcp.cu
+++ b/csrc/libtorch_stable/attention/pcp_utils/fused_norm_rope_pcp.cu
@@ -1,0 +1,810 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+//
+// Sparse-MLA PCP cache preparation.
+//
+// The dispatch kernel keeps the local Q result local, but quantizes the K-side
+// tensors directly into their final FP8 representation and multicasts one
+// packed row per token through an NVLS symmetric-memory window:
+//
+//   [ MLA kv_c:512 | MLA k_pe:64 | indexer K:128 | indexer scale:4 | pad:12 ]
+//
+// The combine kernel reads the acquired rank-major rows and scatters them into
+// the rank-local paged MLA and indexer caches.  Cache block mappings are local,
+// so the sender deliberately does not write remote paged-cache addresses.
+
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/headeronly/core/ScalarType.h>
+
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <optional>
+#include <string>
+
+#include "../../dispatch_utils.h"
+#include "../../type_convert.cuh"
+#include "../dcp_utils/dcp_direct_common.cuh"
+
+namespace {
+
+using vllm::direct_dcp::check_cuda_launch;
+using vllm::direct_dcp::multimem_store_16;
+using vllm::direct_dcp::multimem_store_release_system;
+using vllm::direct_dcp::wait_for_epoch;
+
+constexpr int kThreads = 256;
+constexpr int kKvLoraDim = 512;
+constexpr int kRopeDim = 64;
+constexpr int kIndexerDim = 128;
+constexpr int kMlaRowBytes = kKvLoraDim + kRopeDim;
+constexpr int kIndexerScaleOffset = kMlaRowBytes + kIndexerDim;
+constexpr int kPackedRowBytes = kIndexerScaleOffset + sizeof(uint4);
+constexpr float kFp8Max = 448.0f;
+
+template <typename scalar_t>
+__device__ __forceinline__ float load_half(const scalar_t* ptr) {
+  using Converter = vllm::_typeConvert<scalar_t>;
+  using device_t = typename Converter::hip_type;
+  return Converter::convert(*reinterpret_cast<const device_t*>(ptr));
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ void store_half(scalar_t* ptr, float value) {
+  using Converter = vllm::_typeConvert<scalar_t>;
+  using device_t = typename Converter::hip_type;
+  *reinterpret_cast<device_t*>(ptr) = Converter::convert(value);
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ float round_half(float value) {
+  using Converter = vllm::_typeConvert<scalar_t>;
+  using device_t = typename Converter::hip_type;
+  device_t rounded = Converter::convert(value);
+  return Converter::convert(rounded);
+}
+
+template <typename scalar_t>
+__device__ __forceinline__ float load_cos_sin(const void* ptr, int64_t offset,
+                                              bool is_float) {
+  if (is_float) {
+    return static_cast<const float*>(ptr)[offset];
+  }
+  return load_half(static_cast<const scalar_t*>(ptr) + offset);
+}
+
+__device__ __forceinline__ float warp_sum(float value) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value += __shfl_down_sync(0xffffffffu, value, offset);
+  }
+  return value;
+}
+
+__device__ __forceinline__ float warp_max(float value) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    value = fmaxf(value, __shfl_down_sync(0xffffffffu, value, offset));
+  }
+  return value;
+}
+
+__device__ __forceinline__ float block_sum(float value, float* scratch) {
+  int lane = threadIdx.x & 31;
+  int warp = threadIdx.x >> 5;
+  value = warp_sum(value);
+  if (lane == 0) {
+    scratch[warp] = value;
+  }
+  __syncthreads();
+  value = threadIdx.x < (blockDim.x >> 5) ? scratch[lane] : 0.0f;
+  if (warp == 0) {
+    value = warp_sum(value);
+    if (lane == 0) {
+      scratch[0] = value;
+    }
+  }
+  __syncthreads();
+  return scratch[0];
+}
+
+__device__ __forceinline__ float block_max(float value, float* scratch) {
+  int lane = threadIdx.x & 31;
+  int warp = threadIdx.x >> 5;
+  value = warp_max(value);
+  if (lane == 0) {
+    scratch[warp] = value;
+  }
+  __syncthreads();
+  value = threadIdx.x < (blockDim.x >> 5) ? scratch[lane] : 0.0f;
+  if (warp == 0) {
+    value = warp_max(value);
+    if (lane == 0) {
+      scratch[0] = value;
+    }
+  }
+  __syncthreads();
+  return scratch[0];
+}
+
+__device__ __forceinline__ uint4 pack_fp8_16(const float* values,
+                                             float inverse_scale) {
+  uint4 output;
+  auto* output_pairs = reinterpret_cast<__nv_fp8x2_storage_t*>(&output);
+#pragma unroll
+  for (int idx = 0; idx < 8; ++idx) {
+    float2 pair = make_float2(values[2 * idx] * inverse_scale,
+                              values[2 * idx + 1] * inverse_scale);
+    pair.x = fminf(fmaxf(pair.x, -kFp8Max), kFp8Max);
+    pair.y = fminf(fmaxf(pair.y, -kFp8Max), kFp8Max);
+    output_pairs[idx] =
+        __nv_cvt_float2_to_fp8x2(pair, __NV_SATFINITE, __NV_E4M3);
+  }
+  return output;
+}
+
+// One CTA becomes the invocation leader.  It advances the epoch and publishes
+// it before any other CTA selects the double-buffer slot.  The last completed
+// CTA resets phase to zero, so the next stream-ordered invocation can elect a
+// new leader without a separate epoch-increment launch.
+__device__ __forceinline__ uint32_t establish_epoch(int32_t* phase,
+                                                    int64_t* epoch,
+                                                    uint32_t* shared_epoch) {
+  if (threadIdx.x == 0) {
+    if (atomicCAS(phase, 0, 1) == 0) {
+      auto* epoch_u64 = reinterpret_cast<unsigned long long*>(epoch);
+      uint64_t next = atomicAdd(epoch_u64, 1ULL) + 1ULL;
+      *shared_epoch = static_cast<uint32_t>(next);
+      __threadfence();
+      atomicExch(phase, 2);
+    } else {
+      while (atomicAdd(phase, 0) != 2) {
+      }
+      *shared_epoch = static_cast<uint32_t>(*epoch);
+    }
+  }
+  __syncthreads();
+  return *shared_epoch;
+}
+
+template <typename scalar_t, int q_lora_dim>
+__global__ void fused_norm_rope_pcp_dispatch_kernel(
+    const int64_t* __restrict__ positions, const scalar_t* __restrict__ q_c,
+    int64_t q_stride, const scalar_t* __restrict__ q_weight, float q_eps,
+    scalar_t* __restrict__ q_out, const scalar_t* __restrict__ kv_c,
+    int64_t kv_stride, const scalar_t* __restrict__ kv_weight,
+    scalar_t* __restrict__ kv_out, int64_t kv_out_stride, float kv_eps,
+    const float* __restrict__ mla_k_scale, const scalar_t* __restrict__ k_pe,
+    int64_t k_pe_stride, scalar_t* __restrict__ k_pe_out,
+    int64_t k_pe_out_stride, const void* __restrict__ k_pe_cos_sin,
+    int64_t k_pe_cos_sin_stride, bool k_pe_cos_sin_is_float,
+    const scalar_t* __restrict__ index_k, int64_t index_k_stride,
+    const float* __restrict__ index_weight,
+    const float* __restrict__ index_bias, float index_eps,
+    const void* __restrict__ index_cos_sin, int64_t index_cos_sin_stride,
+    bool index_cos_sin_is_float, int32_t* __restrict__ topk_indices,
+    uint4* __restrict__ payload_mc, uint32_t* __restrict__ signal_mc,
+    const uint32_t* __restrict__ received_signal,
+    uint32_t* __restrict__ completion, int64_t* __restrict__ epoch,
+    int32_t* __restrict__ phase, int world_size, int rank, int max_local_tokens,
+    int topk, int topk_stride, bool has_indexer) {
+  __shared__ float reduce_scratch[8];
+  __shared__ float kv_values[kKvLoraDim];
+  __shared__ float k_pe_values[kRopeDim];
+  __shared__ float index_values[kIndexerDim];
+  __shared__ uint32_t active_epoch;
+
+  int token = blockIdx.x;
+  int tid = threadIdx.x;
+  uint32_t invocation = establish_epoch(phase, epoch, &active_epoch);
+  int parity = invocation & 1u;
+
+  // Q RMSNorm remains local.  Eight values per thread stay in registers across
+  // the block reduction, avoiding an intermediate Q materialization.
+  float q_values[q_lora_dim / kThreads];
+  float q_sum_sq = 0.0f;
+#pragma unroll
+  for (int idx = 0; idx < q_lora_dim / kThreads; ++idx) {
+    int dim = tid + idx * kThreads;
+    float value = load_half(q_c + static_cast<int64_t>(token) * q_stride + dim);
+    q_values[idx] = value;
+    q_sum_sq += value * value;
+  }
+  float q_inv_rms = rsqrtf(block_sum(q_sum_sq, reduce_scratch) /
+                               static_cast<float>(q_lora_dim) +
+                           q_eps);
+#pragma unroll
+  for (int idx = 0; idx < q_lora_dim / kThreads; ++idx) {
+    int dim = tid + idx * kThreads;
+    float weight = load_half(q_weight + dim);
+    store_half(q_out + static_cast<int64_t>(token) * q_lora_dim + dim,
+               q_values[idx] * q_inv_rms * weight);
+  }
+
+  // KV RMSNorm.  The normalized FP32 values remain in shared memory only until
+  // the final per-tensor FP8 pack.
+  float kv_sum_sq = 0.0f;
+#pragma unroll
+  for (int idx = 0; idx < kKvLoraDim / kThreads; ++idx) {
+    int dim = tid + idx * kThreads;
+    float value =
+        load_half(kv_c + static_cast<int64_t>(token) * kv_stride + dim);
+    kv_values[dim] = value;
+    kv_sum_sq += value * value;
+  }
+  float kv_inv_rms = rsqrtf(block_sum(kv_sum_sq, reduce_scratch) /
+                                static_cast<float>(kKvLoraDim) +
+                            kv_eps);
+#pragma unroll
+  for (int idx = 0; idx < kKvLoraDim / kThreads; ++idx) {
+    int dim = tid + idx * kThreads;
+    float weight = load_half(kv_weight + dim);
+    kv_values[dim] = round_half<scalar_t>(kv_values[dim] * kv_inv_rms * weight);
+    store_half(kv_out + static_cast<int64_t>(token) * kv_out_stride + dim,
+               kv_values[dim]);
+  }
+
+  // This layout uses adjacent-pair (interleaved) RoPE for MLA K-pe.
+  if (tid < kRopeDim / 2) {
+    int64_t position = positions[token];
+    int64_t cos_sin_offset = position * k_pe_cos_sin_stride;
+    float cosine = load_cos_sin<scalar_t>(k_pe_cos_sin, cos_sin_offset + tid,
+                                          k_pe_cos_sin_is_float);
+    float sine = load_cos_sin<scalar_t>(k_pe_cos_sin,
+                                        cos_sin_offset + tid + kRopeDim / 2,
+                                        k_pe_cos_sin_is_float);
+    const scalar_t* row = k_pe + static_cast<int64_t>(token) * k_pe_stride;
+    float x = load_half(row + 2 * tid);
+    float y = load_half(row + 2 * tid + 1);
+    k_pe_values[2 * tid] = round_half<scalar_t>(x * cosine - y * sine);
+    k_pe_values[2 * tid + 1] = round_half<scalar_t>(y * cosine + x * sine);
+    scalar_t* output_row =
+        k_pe_out + static_cast<int64_t>(token) * k_pe_out_stride;
+    store_half(output_row + 2 * tid, k_pe_values[2 * tid]);
+    store_half(output_row + 2 * tid + 1, k_pe_values[2 * tid + 1]);
+  }
+
+  // Shared layers skip all indexer reductions below.  Synchronize the KV and
+  // K-pe producers explicitly before either branch packs their shared rows.
+  __syncthreads();
+
+  // Indexer K LayerNorm, interleaved RoPE, and UE8M0 FP8 quantization.
+  float index_value = 0.0f;
+  if (has_indexer) {
+    if (tid < kIndexerDim) {
+      index_value = load_half(
+          index_k + static_cast<int64_t>(token) * index_k_stride + tid);
+    }
+  }
+  float index_scale = 1.0f;
+  if (has_indexer) {
+    float index_mean = block_sum(index_value, reduce_scratch) /
+                       static_cast<float>(kIndexerDim);
+    float centered = tid < kIndexerDim ? index_value - index_mean : 0.0f;
+    float index_variance = block_sum(centered * centered, reduce_scratch) /
+                           static_cast<float>(kIndexerDim);
+    if (tid < kIndexerDim) {
+      index_values[tid] =
+          centered * rsqrtf(index_variance + index_eps) * index_weight[tid] +
+          index_bias[tid];
+    }
+    __syncthreads();
+    if (tid < kRopeDim / 2) {
+      int64_t position = positions[token];
+      int64_t cos_sin_offset = position * index_cos_sin_stride;
+      float cosine = load_cos_sin<scalar_t>(index_cos_sin, cos_sin_offset + tid,
+                                            index_cos_sin_is_float);
+      float sine = load_cos_sin<scalar_t>(index_cos_sin,
+                                          cos_sin_offset + tid + kRopeDim / 2,
+                                          index_cos_sin_is_float);
+      float x = index_values[2 * tid];
+      float y = index_values[2 * tid + 1];
+      index_values[2 * tid] = x * cosine - y * sine;
+      index_values[2 * tid + 1] = y * cosine + x * sine;
+    }
+    __syncthreads();
+    if (tid < kIndexerDim) {
+      index_values[tid] = round_half<scalar_t>(index_values[tid]);
+    }
+    __syncthreads();
+    float local_max = tid < kIndexerDim ? fabsf(index_values[tid]) : 0.0f;
+    index_scale =
+        fmaxf(block_max(local_max, reduce_scratch), 1.0e-4f) / kFp8Max;
+    index_scale = exp2f(ceilf(log2f(index_scale)));
+  }
+
+  int64_t slot_stride =
+      static_cast<int64_t>(world_size) * max_local_tokens * kPackedRowBytes;
+  int64_t row_offset =
+      static_cast<int64_t>(parity) * slot_stride +
+      (static_cast<int64_t>(rank) * max_local_tokens + token) * kPackedRowBytes;
+  auto* row_mc = reinterpret_cast<uint8_t*>(payload_mc) + row_offset;
+
+  // Quantize the rounded BF16 values directly into the symmetric payload.
+  if (tid < kKvLoraDim / 16) {
+    float values[16];
+#pragma unroll
+    for (int idx = 0; idx < 16; ++idx) {
+      values[idx] = kv_values[tid * 16 + idx];
+    }
+    float inverse_scale = 1.0f / mla_k_scale[0];
+    multimem_store_16(reinterpret_cast<uint4*>(row_mc) + tid,
+                      pack_fp8_16(values, inverse_scale));
+  }
+  if (tid < kRopeDim / 16) {
+    float values[16];
+#pragma unroll
+    for (int idx = 0; idx < 16; ++idx) {
+      values[idx] = k_pe_values[tid * 16 + idx];
+    }
+    float inverse_scale = 1.0f / mla_k_scale[0];
+    multimem_store_16(reinterpret_cast<uint4*>(row_mc + kKvLoraDim) + tid,
+                      pack_fp8_16(values, inverse_scale));
+  }
+  if (has_indexer) {
+    if (tid < kIndexerDim / 16) {
+      float values[16];
+#pragma unroll
+      for (int idx = 0; idx < 16; ++idx) {
+        values[idx] = index_values[tid * 16 + idx];
+      }
+      multimem_store_16(reinterpret_cast<uint4*>(row_mc + kMlaRowBytes) + tid,
+                        pack_fp8_16(values, 1.0f / index_scale));
+    }
+    if (tid == 0) {
+      uint4 scale_and_padding = {0u, 0u, 0u, 0u};
+      scale_and_padding.x = __float_as_uint(index_scale);
+      multimem_store_16(reinterpret_cast<uint4*>(row_mc + kIndexerScaleOffset),
+                        scale_and_padding);
+    }
+    for (int idx = tid; idx < topk; idx += blockDim.x) {
+      topk_indices[static_cast<int64_t>(token) * topk_stride + idx] = -1;
+    }
+  }
+
+  __threadfence_system();
+  __syncthreads();
+  if (tid != 0) {
+    return;
+  }
+  uint32_t completed = atomicAdd(completion + parity, 1u);
+  if (completed + 1u != gridDim.x) {
+    return;
+  }
+  atomicExch(completion + parity, 0u);
+  multimem_store_release_system(signal_mc + parity * world_size + rank,
+                                invocation);
+  for (int source = 0; source < world_size; ++source) {
+    if (!wait_for_epoch(received_signal + parity * world_size + source,
+                        invocation)) {
+      printf("fused_norm_rope_pcp dispatch timeout source=%d epoch=%u\n",
+             source, invocation);
+      asm volatile("trap;");
+    }
+  }
+  __threadfence();
+  atomicExch(phase, 0);
+}
+
+__global__ void fused_norm_rope_pcp_combine_kernel(
+    const uint8_t* __restrict__ received_payload,
+    const int64_t* __restrict__ epoch,
+    const int64_t* __restrict__ mla_slot_mapping,
+    const int64_t* __restrict__ index_slot_mapping,
+    uint8_t* __restrict__ mla_cache, int64_t mla_block_stride,
+    int64_t mla_token_stride, uint8_t* __restrict__ index_cache,
+    int64_t index_block_stride, int world_size, int local_tokens,
+    int num_decode_tokens, int max_local_tokens, int cache_block_size,
+    bool has_indexer) {
+  int cache_token = blockIdx.x;
+  int source;
+  int source_token;
+  int mapping_token;
+  if (cache_token < num_decode_tokens) {
+    source = 0;
+    source_token = cache_token;
+    mapping_token = cache_token;
+  } else {
+    int local_prefill_tokens = local_tokens - num_decode_tokens;
+    int prefill_token = cache_token - num_decode_tokens;
+    source = prefill_token / local_prefill_tokens;
+    source_token =
+        num_decode_tokens + prefill_token - source * local_prefill_tokens;
+    mapping_token = source * local_tokens + source_token;
+  }
+  int parity = static_cast<uint32_t>(epoch[0]) & 1u;
+  int64_t row_offset =
+      (static_cast<int64_t>(parity) * world_size * max_local_tokens +
+       static_cast<int64_t>(source) * max_local_tokens + source_token) *
+      kPackedRowBytes;
+  const uint8_t* row = received_payload + row_offset;
+
+  int64_t mla_slot = mla_slot_mapping[mapping_token];
+  if (mla_slot >= 0) {
+    int64_t block = mla_slot / cache_block_size;
+    int64_t block_offset = mla_slot % cache_block_size;
+    uint8_t* destination =
+        mla_cache + block * mla_block_stride + block_offset * mla_token_stride;
+    for (int chunk = threadIdx.x; chunk < kMlaRowBytes / 16;
+         chunk += blockDim.x) {
+      reinterpret_cast<uint4*>(destination)[chunk] =
+          reinterpret_cast<const uint4*>(row)[chunk];
+    }
+  }
+
+  if (has_indexer) {
+    int64_t index_slot = index_slot_mapping[mapping_token];
+    if (index_slot >= 0) {
+      int64_t block = index_slot / cache_block_size;
+      int64_t block_offset = index_slot % cache_block_size;
+      uint8_t* block_base = index_cache + block * index_block_stride;
+      uint8_t* value_destination = block_base + block_offset * kIndexerDim;
+      for (int chunk = threadIdx.x; chunk < kIndexerDim / 16;
+           chunk += blockDim.x) {
+        reinterpret_cast<uint4*>(value_destination)[chunk] =
+            reinterpret_cast<const uint4*>(row + kMlaRowBytes)[chunk];
+      }
+      if (threadIdx.x == 0) {
+        uint8_t* scale_destination =
+            block_base + cache_block_size * kIndexerDim + block_offset * 4;
+        *reinterpret_cast<uint32_t*>(scale_destination) =
+            *reinterpret_cast<const uint32_t*>(row + kIndexerScaleOffset);
+      }
+    }
+  }
+}
+
+void fused_norm_rope_pcp_dispatch(
+    const torch::stable::Tensor& positions, const torch::stable::Tensor& q_c,
+    const torch::stable::Tensor& q_weight, double q_eps,
+    torch::stable::Tensor& q_out, const torch::stable::Tensor& kv_c,
+    const torch::stable::Tensor& kv_weight, torch::stable::Tensor& kv_out,
+    const torch::stable::Tensor& mla_k_scale, double kv_eps,
+    const torch::stable::Tensor& k_pe, torch::stable::Tensor& k_pe_out,
+    const torch::stable::Tensor& k_pe_cos_sin,
+    const torch::stable::Tensor& index_k,
+    const torch::stable::Tensor& index_weight,
+    const torch::stable::Tensor& index_bias, double index_eps,
+    const torch::stable::Tensor& index_cos_sin,
+    torch::stable::Tensor& topk_indices,
+    torch::stable::Tensor& received_payload,
+    torch::stable::Tensor& received_signal, torch::stable::Tensor& completion,
+    torch::stable::Tensor& epoch, torch::stable::Tensor& phase,
+    int64_t world_size, int64_t rank, bool has_indexer, int64_t payload_mc_ptr,
+    int64_t signal_mc_ptr) {
+  using torch::headeronly::ScalarType;
+  auto valid_rows = [](const torch::stable::Tensor& tensor, int64_t rows,
+                       int64_t columns, ScalarType dtype) {
+    return tensor.is_cuda() && tensor.dim() == 2 && tensor.size(0) == rows &&
+           tensor.size(1) == columns && tensor.stride(1) == 1 &&
+           tensor.scalar_type() == dtype;
+  };
+  STD_TORCH_CHECK(q_c.is_cuda() && q_c.dim() == 2 && q_c.stride(1) == 1,
+                  "q_c must be a row-contiguous CUDA matrix");
+  int64_t q_lora_dim = q_c.size(1);
+  STD_TORCH_CHECK(q_lora_dim == 1536 || q_lora_dim == 2048,
+                  "q_c width must be 1536 or 2048");
+  ScalarType dtype = q_c.scalar_type();
+  STD_TORCH_CHECK(dtype == ScalarType::Half || dtype == ScalarType::BFloat16,
+                  "fused_norm_rope_pcp only supports FP16/BF16 inputs");
+  int64_t num_tokens = q_c.size(0);
+  STD_TORCH_CHECK(num_tokens > 0, "fused_norm_rope_pcp requires tokens");
+  STD_TORCH_CHECK(valid_rows(kv_c, num_tokens, kKvLoraDim, dtype),
+                  "kv_c must be [T,512] with contiguous rows and the Q dtype");
+  STD_TORCH_CHECK(valid_rows(k_pe, num_tokens, kRopeDim, dtype),
+                  "k_pe must be [T,64] with contiguous rows and the Q dtype");
+  if (has_indexer) {
+    STD_TORCH_CHECK(
+        valid_rows(index_k, num_tokens, kIndexerDim, dtype),
+        "index_k must be [T,128] with contiguous rows and the Q dtype");
+  }
+  STD_TORCH_CHECK(q_weight.is_cuda() && q_weight.is_contiguous() &&
+                      q_weight.scalar_type() == dtype &&
+                      q_weight.numel() == q_lora_dim,
+                  "q_weight must match the Q width and dtype");
+  STD_TORCH_CHECK(kv_weight.is_cuda() && kv_weight.is_contiguous() &&
+                      kv_weight.scalar_type() == dtype &&
+                      kv_weight.numel() == kKvLoraDim,
+                  "kv_weight must be contiguous [512] with the Q dtype");
+  STD_TORCH_CHECK(mla_k_scale.is_cuda() && mla_k_scale.is_contiguous() &&
+                      mla_k_scale.scalar_type() == ScalarType::Float &&
+                      mla_k_scale.numel() == 1,
+                  "mla_k_scale must be one CUDA float32 value");
+  if (has_indexer) {
+    STD_TORCH_CHECK(index_weight.is_cuda() && index_weight.is_contiguous() &&
+                        index_weight.scalar_type() == ScalarType::Float &&
+                        index_weight.numel() == kIndexerDim &&
+                        index_bias.is_cuda() && index_bias.is_contiguous() &&
+                        index_bias.scalar_type() == ScalarType::Float &&
+                        index_bias.numel() == kIndexerDim,
+                    "indexer norm weight/bias must be CUDA float32 [128]");
+  }
+  STD_TORCH_CHECK(positions.is_cuda() && positions.is_contiguous() &&
+                      positions.scalar_type() == ScalarType::Long &&
+                      positions.numel() == num_tokens,
+                  "positions must be contiguous CUDA int64 [T]");
+  auto valid_cos_sin = [&](const torch::stable::Tensor& tensor) {
+    auto cache_dtype = tensor.scalar_type();
+    return tensor.is_cuda() && tensor.dim() == 2 &&
+           tensor.size(1) == kRopeDim && tensor.stride(1) == 1 &&
+           (cache_dtype == ScalarType::Float || cache_dtype == dtype);
+  };
+  STD_TORCH_CHECK(valid_cos_sin(k_pe_cos_sin),
+                  "K RoPE cache must be CUDA float32/input-dtype [P,64] "
+                  "with contiguous rows");
+  if (has_indexer) {
+    STD_TORCH_CHECK(valid_cos_sin(index_cos_sin),
+                    "index RoPE cache must be CUDA float32/input-dtype "
+                    "[P,64] with contiguous rows");
+  }
+  STD_TORCH_CHECK(q_out.is_cuda() && q_out.is_contiguous() &&
+                      q_out.scalar_type() == dtype && q_out.dim() == 2 &&
+                      q_out.size(0) == num_tokens &&
+                      q_out.size(1) == q_lora_dim,
+                  "q_out must match the Q shape and dtype");
+  STD_TORCH_CHECK(
+      valid_rows(kv_out, num_tokens, kKvLoraDim, dtype),
+      "kv_out must be [T,512] with contiguous rows and the Q dtype");
+  STD_TORCH_CHECK(
+      valid_rows(k_pe_out, num_tokens, kRopeDim, dtype),
+      "k_pe_out must be [T,64] with contiguous rows and the Q dtype");
+  if (has_indexer) {
+    STD_TORCH_CHECK(topk_indices.is_cuda() &&
+                        topk_indices.scalar_type() == ScalarType::Int &&
+                        topk_indices.dim() == 2 &&
+                        topk_indices.stride(1) == 1 &&
+                        topk_indices.size(0) >= num_tokens,
+                    "topk_indices must be row-contiguous CUDA int32 [>=T,K]");
+  }
+  STD_TORCH_CHECK(world_size > 1 && rank >= 0 && rank < world_size,
+                  "invalid PCP world_size/rank");
+  STD_TORCH_CHECK(
+      received_payload.is_cuda() && received_payload.is_contiguous() &&
+          received_payload.scalar_type() == ScalarType::Byte &&
+          received_payload.dim() == 4 && received_payload.size(0) == 2 &&
+          received_payload.size(1) == world_size &&
+          received_payload.size(3) == kPackedRowBytes &&
+          num_tokens <= received_payload.size(2),
+      "received_payload must be uint8 [2,W,max_local,720]");
+  STD_TORCH_CHECK(
+      received_signal.is_cuda() && received_signal.is_contiguous() &&
+          received_signal.scalar_type() == ScalarType::Int &&
+          received_signal.dim() == 2 && received_signal.size(0) == 2 &&
+          received_signal.size(1) == world_size,
+      "received_signal must be int32 [2,W]");
+  STD_TORCH_CHECK(completion.is_cuda() && completion.is_contiguous() &&
+                      completion.scalar_type() == ScalarType::Int &&
+                      completion.numel() == 2,
+                  "completion must be int32 [2]");
+  STD_TORCH_CHECK(epoch.is_cuda() && epoch.is_contiguous() &&
+                      epoch.scalar_type() == ScalarType::Long &&
+                      epoch.numel() == 1,
+                  "epoch must be int64 [1]");
+  STD_TORCH_CHECK(phase.is_cuda() && phase.is_contiguous() &&
+                      phase.scalar_type() == ScalarType::Int &&
+                      phase.numel() == 1,
+                  "phase must be int32 [1]");
+  STD_TORCH_CHECK(payload_mc_ptr != 0 && signal_mc_ptr != 0,
+                  "fused_norm_rope_pcp requires NVLS multicast pointers");
+  int device = q_c.get_device_index();
+  STD_TORCH_CHECK(
+      kv_c.get_device_index() == device && k_pe.get_device_index() == device &&
+          received_payload.get_device_index() == device &&
+          received_signal.get_device_index() == device,
+      "fused_norm_rope_pcp tensors must be on the same CUDA device");
+
+  const torch::stable::accelerator::DeviceGuard device_guard(device);
+  cudaStream_t stream = get_current_cuda_stream(device);
+  int max_local_tokens = static_cast<int>(received_payload.size(2));
+  int topk = static_cast<int>(topk_indices.size(1));
+  int topk_stride = static_cast<int>(topk_indices.stride(0));
+  auto launch = [&]<int q_dim>() {
+    VLLM_STABLE_DISPATCH_HALF_TYPES(dtype, "fused_norm_rope_pcp_dispatch", [&] {
+      fused_norm_rope_pcp_dispatch_kernel<scalar_t, q_dim>
+          <<<num_tokens, kThreads, 0, stream>>>(
+              positions.const_data_ptr<int64_t>(),
+              reinterpret_cast<const scalar_t*>(q_c.const_data_ptr()),
+              q_c.stride(0),
+              reinterpret_cast<const scalar_t*>(q_weight.const_data_ptr()),
+              static_cast<float>(q_eps),
+              reinterpret_cast<scalar_t*>(q_out.mutable_data_ptr()),
+              reinterpret_cast<const scalar_t*>(kv_c.const_data_ptr()),
+              kv_c.stride(0),
+              reinterpret_cast<const scalar_t*>(kv_weight.const_data_ptr()),
+              reinterpret_cast<scalar_t*>(kv_out.mutable_data_ptr()),
+              kv_out.stride(0), static_cast<float>(kv_eps),
+              mla_k_scale.const_data_ptr<float>(),
+              reinterpret_cast<const scalar_t*>(k_pe.const_data_ptr()),
+              k_pe.stride(0),
+              reinterpret_cast<scalar_t*>(k_pe_out.mutable_data_ptr()),
+              k_pe_out.stride(0), k_pe_cos_sin.const_data_ptr(),
+              k_pe_cos_sin.stride(0),
+              k_pe_cos_sin.scalar_type() == ScalarType::Float,
+              reinterpret_cast<const scalar_t*>(index_k.const_data_ptr()),
+              has_indexer ? index_k.stride(0) : 0,
+              index_weight.const_data_ptr<float>(),
+              index_bias.const_data_ptr<float>(), static_cast<float>(index_eps),
+              index_cos_sin.const_data_ptr(),
+              has_indexer ? index_cos_sin.stride(0) : 0,
+              has_indexer && index_cos_sin.scalar_type() == ScalarType::Float,
+              topk_indices.mutable_data_ptr<int32_t>(),
+              reinterpret_cast<uint4*>(static_cast<uintptr_t>(payload_mc_ptr)),
+              reinterpret_cast<uint32_t*>(
+                  static_cast<uintptr_t>(signal_mc_ptr)),
+              reinterpret_cast<const uint32_t*>(
+                  received_signal.const_data_ptr<int32_t>()),
+              reinterpret_cast<uint32_t*>(
+                  completion.mutable_data_ptr<int32_t>()),
+              epoch.mutable_data_ptr<int64_t>(),
+              phase.mutable_data_ptr<int32_t>(), static_cast<int>(world_size),
+              static_cast<int>(rank), max_local_tokens, topk, topk_stride,
+              has_indexer);
+    });
+  };
+  if (q_lora_dim == 1536) {
+    launch.template operator()<1536>();
+  } else {
+    launch.template operator()<2048>();
+  }
+  check_cuda_launch("fused_norm_rope_pcp_dispatch");
+}
+
+void fused_norm_rope_pcp_combine(
+    const torch::stable::Tensor& received_payload,
+    const torch::stable::Tensor& epoch,
+    const torch::stable::Tensor& mla_slot_mapping,
+    const torch::stable::Tensor& index_slot_mapping,
+    torch::stable::Tensor& mla_cache, torch::stable::Tensor& index_cache,
+    int64_t local_tokens, int64_t num_decode_tokens, bool has_indexer) {
+  using torch::headeronly::ScalarType;
+  STD_TORCH_CHECK(
+      received_payload.is_cuda() && received_payload.is_contiguous() &&
+          received_payload.scalar_type() == ScalarType::Byte &&
+          received_payload.dim() == 4 && received_payload.size(0) == 2 &&
+          received_payload.size(3) == kPackedRowBytes,
+      "received_payload must be uint8 [2,W,max_local,720]");
+  int64_t world_size = received_payload.size(1);
+  int64_t max_local_tokens = received_payload.size(2);
+  STD_TORCH_CHECK(local_tokens > 0 && local_tokens <= max_local_tokens,
+                  "invalid local token count");
+  STD_TORCH_CHECK(num_decode_tokens >= 0 && num_decode_tokens <= local_tokens,
+                  "invalid decode token count");
+  int64_t required_mapping_tokens = num_decode_tokens == local_tokens
+                                        ? num_decode_tokens
+                                        : world_size * local_tokens;
+  auto valid_mapping = [&](const torch::stable::Tensor& mapping) {
+    return mapping.is_cuda() && mapping.is_contiguous() &&
+           mapping.scalar_type() == ScalarType::Long &&
+           mapping.numel() >= required_mapping_tokens;
+  };
+  STD_TORCH_CHECK(valid_mapping(mla_slot_mapping),
+                  "MLA slot mapping is too short for the PCP token layout");
+  if (has_indexer) {
+    STD_TORCH_CHECK(valid_mapping(index_slot_mapping),
+                    "index slot mapping is too short for the PCP token layout");
+  }
+  STD_TORCH_CHECK(epoch.is_cuda() && epoch.is_contiguous() &&
+                      epoch.scalar_type() == ScalarType::Long &&
+                      epoch.numel() == 1,
+                  "epoch must be int64 [1]");
+  auto mla_dtype = mla_cache.scalar_type();
+  STD_TORCH_CHECK(mla_cache.is_cuda() && mla_cache.is_contiguous() &&
+                      (mla_dtype == ScalarType::Byte ||
+                       mla_dtype == ScalarType::Float8_e4m3fn) &&
+                      mla_cache.dim() == 3 && mla_cache.size(2) == kMlaRowBytes,
+                  "MLA cache must be contiguous byte/FP8 [B,block,576]");
+  if (has_indexer) {
+    STD_TORCH_CHECK(index_cache.is_cuda() && index_cache.is_contiguous() &&
+                        index_cache.scalar_type() == ScalarType::Byte &&
+                        index_cache.dim() == 3 &&
+                        index_cache.size(2) >= kIndexerDim + 4,
+                    "index cache must be contiguous uint8 [B,block,>=132]");
+    STD_TORCH_CHECK(mla_cache.size(1) == index_cache.size(1),
+                    "MLA and index caches must use the same block size");
+  }
+  int device = received_payload.get_device_index();
+  STD_TORCH_CHECK(
+      epoch.get_device_index() == device &&
+          mla_slot_mapping.get_device_index() == device &&
+          mla_cache.get_device_index() == device &&
+          (!has_indexer || (index_slot_mapping.get_device_index() == device &&
+                            index_cache.get_device_index() == device)),
+      "fused_norm_rope_pcp tensors must be on one device");
+
+  const torch::stable::accelerator::DeviceGuard device_guard(device);
+  cudaStream_t stream = get_current_cuda_stream(device);
+  int blocks = static_cast<int>(
+      num_decode_tokens + world_size * (local_tokens - num_decode_tokens));
+  fused_norm_rope_pcp_combine_kernel<<<blocks, 128, 0, stream>>>(
+      reinterpret_cast<const uint8_t*>(received_payload.const_data_ptr()),
+      epoch.const_data_ptr<int64_t>(),
+      mla_slot_mapping.const_data_ptr<int64_t>(),
+      index_slot_mapping.const_data_ptr<int64_t>(),
+      reinterpret_cast<uint8_t*>(mla_cache.mutable_data_ptr()),
+      mla_cache.stride(0), mla_cache.stride(1),
+      reinterpret_cast<uint8_t*>(index_cache.mutable_data_ptr()),
+      has_indexer ? index_cache.stride(0) : 0, static_cast<int>(world_size),
+      static_cast<int>(local_tokens), static_cast<int>(num_decode_tokens),
+      static_cast<int>(max_local_tokens), static_cast<int>(mla_cache.size(1)),
+      has_indexer);
+  check_cuda_launch("fused_norm_rope_pcp_combine");
+}
+
+void fused_norm_rope_pcp(
+    const torch::stable::Tensor& positions, const torch::stable::Tensor& q_c,
+    const torch::stable::Tensor& q_weight, double q_eps,
+    torch::stable::Tensor& q_out, const torch::stable::Tensor& kv_c,
+    const torch::stable::Tensor& kv_weight, torch::stable::Tensor& kv_out,
+    const torch::stable::Tensor& mla_k_scale, double kv_eps,
+    const torch::stable::Tensor& k_pe, torch::stable::Tensor& k_pe_out,
+    const torch::stable::Tensor& k_pe_cos_sin,
+    const std::optional<torch::stable::Tensor>& index_k,
+    const std::optional<torch::stable::Tensor>& index_weight,
+    const std::optional<torch::stable::Tensor>& index_bias, double index_eps,
+    const std::optional<torch::stable::Tensor>& index_cos_sin,
+    torch::stable::Tensor& topk_indices,
+    torch::stable::Tensor& received_payload,
+    torch::stable::Tensor& received_signal, torch::stable::Tensor& completion,
+    torch::stable::Tensor& epoch, torch::stable::Tensor& phase,
+    const torch::stable::Tensor& mla_slot_mapping,
+    const std::optional<torch::stable::Tensor>& index_slot_mapping,
+    torch::stable::Tensor& mla_cache,
+    std::optional<torch::stable::Tensor> index_cache, int64_t num_decode_tokens,
+    int64_t rank, int64_t payload_mc_ptr, int64_t signal_mc_ptr) {
+  bool has_indexer = index_k.has_value();
+  STD_TORCH_CHECK(
+      index_weight.has_value() == has_indexer &&
+          index_bias.has_value() == has_indexer &&
+          index_cos_sin.has_value() == has_indexer &&
+          index_slot_mapping.has_value() == has_indexer &&
+          index_cache.has_value() == has_indexer,
+      "indexer tensors must either all be present or all be absent");
+  STD_TORCH_CHECK(received_payload.dim() == 4,
+                  "received_payload must be rank four");
+
+  const auto& index_k_arg = has_indexer ? *index_k : q_c;
+  const auto& index_weight_arg = has_indexer ? *index_weight : mla_k_scale;
+  const auto& index_bias_arg = has_indexer ? *index_bias : mla_k_scale;
+  const auto& index_cos_sin_arg = has_indexer ? *index_cos_sin : k_pe_cos_sin;
+  const auto& index_slot_mapping_arg =
+      has_indexer ? *index_slot_mapping : mla_slot_mapping;
+  auto& index_cache_arg = has_indexer ? *index_cache : mla_cache;
+  int64_t world_size = received_payload.size(1);
+
+  fused_norm_rope_pcp_dispatch(
+      positions, q_c, q_weight, q_eps, q_out, kv_c, kv_weight, kv_out,
+      mla_k_scale, kv_eps, k_pe, k_pe_out, k_pe_cos_sin, index_k_arg,
+      index_weight_arg, index_bias_arg, index_eps, index_cos_sin_arg,
+      topk_indices, received_payload, received_signal, completion, epoch, phase,
+      world_size, rank, has_indexer, payload_mc_ptr, signal_mc_ptr);
+  fused_norm_rope_pcp_combine(
+      received_payload, epoch, mla_slot_mapping, index_slot_mapping_arg,
+      mla_cache, index_cache_arg, q_c.size(0), num_decode_tokens, has_indexer);
+}
+
+}  // namespace
+
+STABLE_TORCH_LIBRARY_FRAGMENT(_C, fused_norm_rope_pcp_ops) {
+  fused_norm_rope_pcp_ops.def(
+      "fused_norm_rope_pcp("
+      "Tensor positions, Tensor q_c, Tensor q_weight, float q_eps, "
+      "Tensor! q_out, Tensor kv_c, Tensor kv_weight, Tensor! kv_out, "
+      "Tensor mla_k_scale, float kv_eps, Tensor k_pe, Tensor! k_pe_out, "
+      "Tensor k_pe_cos_sin, Tensor? index_k, "
+      "Tensor? index_weight, Tensor? index_bias, float index_eps, "
+      "Tensor? index_cos_sin, Tensor! topk_indices, Tensor! received_payload, "
+      "Tensor! received_signal, Tensor! completion, Tensor! epoch, "
+      "Tensor! phase, Tensor mla_slot_mapping, Tensor? index_slot_mapping, "
+      "Tensor! mla_cache, Tensor!? index_cache, int num_decode_tokens, int "
+      "rank, "
+      "int payload_mc_ptr, int signal_mc_ptr) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, fused_norm_rope_pcp_ops) {
+  fused_norm_rope_pcp_ops.impl("fused_norm_rope_pcp",
+                               TORCH_BOX(&fused_norm_rope_pcp));
+}

--- a/csrc/libtorch_stable/attention/pcp_utils/fused_norm_rope_pcp.cu
+++ b/csrc/libtorch_stable/attention/pcp_utils/fused_norm_rope_pcp.cu
@@ -40,10 +40,19 @@ using vllm::direct_dcp::multimem_store_release_system;
 using vllm::direct_dcp::wait_for_epoch;
 
 constexpr int kThreads = 256;
+constexpr int kWarpSize = 32;
+constexpr int kReductionWarps = kThreads / kWarpSize;
+constexpr int kReductionResultSlot = kReductionWarps;
+constexpr int kCombineThreads = 128;
+constexpr int kCombineRowsPerBlock = kCombineThreads / kWarpSize;
 constexpr int kKvLoraDim = 512;
 constexpr int kRopeDim = 64;
 constexpr int kIndexerDim = 128;
 constexpr float kFp8Max = 448.0f;
+
+static_assert(kThreads % kWarpSize == 0);
+static_assert(kReductionWarps <= kWarpSize);
+static_assert(kCombineThreads % kWarpSize == 0);
 
 enum class MlaCacheLayout { kStaticE4M3, kFp8DsMla };
 
@@ -147,11 +156,11 @@ __device__ __forceinline__ float block_sum(float value, float* scratch) {
   if (warp == 0) {
     value = warp_sum(value);
     if (lane == 0) {
-      scratch[0] = value;
+      scratch[kReductionResultSlot] = value;
     }
   }
   __syncthreads();
-  return scratch[0];
+  return scratch[kReductionResultSlot];
 }
 
 __device__ __forceinline__ float block_max(float value, float* scratch) {
@@ -166,11 +175,11 @@ __device__ __forceinline__ float block_max(float value, float* scratch) {
   if (warp == 0) {
     value = warp_max(value);
     if (lane == 0) {
-      scratch[0] = value;
+      scratch[kReductionResultSlot] = value;
     }
   }
   __syncthreads();
-  return scratch[0];
+  return scratch[kReductionResultSlot];
 }
 
 __device__ __forceinline__ uint4 pack_fp8_16(const float* values,
@@ -228,11 +237,9 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
     const int64_t* __restrict__ positions, const scalar_t* __restrict__ q_c,
     int64_t q_stride, const scalar_t* __restrict__ q_weight, float q_eps,
     scalar_t* __restrict__ q_out, const scalar_t* __restrict__ kv_c,
-    int64_t kv_stride, const scalar_t* __restrict__ kv_weight,
-    scalar_t* __restrict__ kv_out, int64_t kv_out_stride, float kv_eps,
+    int64_t kv_stride, const scalar_t* __restrict__ kv_weight, float kv_eps,
     const float* __restrict__ mla_k_scale, const scalar_t* __restrict__ k_pe,
-    int64_t k_pe_stride, scalar_t* __restrict__ k_pe_out,
-    int64_t k_pe_out_stride, const void* __restrict__ k_pe_cos_sin,
+    int64_t k_pe_stride, const void* __restrict__ k_pe_cos_sin,
     int64_t k_pe_cos_sin_stride, bool k_pe_cos_sin_is_float,
     const scalar_t* __restrict__ index_k, int64_t index_k_stride,
     const float* __restrict__ index_weight,
@@ -244,7 +251,9 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
     uint32_t* __restrict__ completion, int64_t* __restrict__ epoch,
     int32_t* __restrict__ phase, int world_size, int rank, int max_local_tokens,
     int topk, int topk_stride, bool has_indexer) {
-  __shared__ float reduce_scratch[8];
+  // Keep the result separate from the per-warp partials so a subsequent
+  // reduction cannot overwrite it before every warp has consumed it.
+  __shared__ float reduce_scratch[kReductionWarps + 1];
   __shared__ float kv_values[Config::kKvLoraDim];
   __shared__ float k_pe_values[Config::kRopeDim];
   __shared__ float index_values[Config::kIndexerDim];
@@ -297,8 +306,6 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
     int dim = tid + idx * kThreads;
     float weight = load_half(kv_weight + dim);
     kv_values[dim] = round_half<scalar_t>(kv_values[dim] * kv_inv_rms * weight);
-    store_half(kv_out + static_cast<int64_t>(token) * kv_out_stride + dim,
-               kv_values[dim]);
   }
 
   // This layout uses adjacent-pair (interleaved) RoPE for MLA K-pe.
@@ -315,15 +322,13 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
     float y = load_half(row + 2 * tid + 1);
     k_pe_values[2 * tid] = round_half<scalar_t>(x * cosine - y * sine);
     k_pe_values[2 * tid + 1] = round_half<scalar_t>(y * cosine + x * sine);
-    scalar_t* output_row =
-        k_pe_out + static_cast<int64_t>(token) * k_pe_out_stride;
-    store_half(output_row + 2 * tid, k_pe_values[2 * tid]);
-    store_half(output_row + 2 * tid + 1, k_pe_values[2 * tid + 1]);
   }
 
-  // Shared layers skip all indexer reductions below.  Synchronize the KV and
-  // K-pe producers explicitly before either branch packs their shared rows.
-  __syncthreads();
+  // The first indexer reduction synchronizes the KV and K-pe producers.
+  // Shared layers need an explicit barrier before packing those rows.
+  if (!has_indexer) {
+    __syncthreads();
+  }
 
   // Indexer K LayerNorm, interleaved RoPE, and UE8M0 FP8 quantization.
   float index_value = 0.0f;
@@ -484,7 +489,12 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
     }
   }
 
-  __threadfence_system();
+  // Only warp 0 issues peer-visible multicast stores. Its system fences order
+  // those writes before thread 0 contributes to the completion counter; the
+  // CTA barrier keeps every local writer ordered before completion.
+  if (tid < kWarpSize) {
+    __threadfence_system();
+  }
   __syncthreads();
   if (tid != 0) {
     return;
@@ -508,6 +518,43 @@ __global__ void fused_norm_rope_pcp_dispatch_kernel(
   atomicExch(phase, 0);
 }
 
+#if CUDA_VERSION >= 12090
+// The q=2048 static-cache kernel otherwise uses 40 registers per thread on
+// Blackwell, limiting a 256-thread CTA to six resident blocks.  Cap only these
+// specializations at 32 registers; annotating the primary template also changes
+// register allocation for the other cache layouts.  CUDA 12.8 and older use the
+// ordinary implicit instantiations because __maxnreg__ was added in CUDA 12.9.
+// decltype avoids repeating the kernel's large parameter list here.
+using StaticQ2048InterleavedConfig =
+    DSV32FusedNormRopeConfig<2048, true, MlaCacheLayout::kStaticE4M3>;
+using StaticQ2048NeoXConfig =
+    DSV32FusedNormRopeConfig<2048, false, MlaCacheLayout::kStaticE4M3>;
+
+template __global__
+    __maxnreg__(32) decltype(fused_norm_rope_pcp_dispatch_kernel<
+                             torch::headeronly::Half,
+                             StaticQ2048InterleavedConfig>)
+        fused_norm_rope_pcp_dispatch_kernel<torch::headeronly::Half,
+                                            StaticQ2048InterleavedConfig>;
+template __global__
+    __maxnreg__(32) decltype(fused_norm_rope_pcp_dispatch_kernel<
+                             torch::headeronly::BFloat16,
+                             StaticQ2048InterleavedConfig>)
+        fused_norm_rope_pcp_dispatch_kernel<torch::headeronly::BFloat16,
+                                            StaticQ2048InterleavedConfig>;
+template __global__ __maxnreg__(
+    32) decltype(fused_norm_rope_pcp_dispatch_kernel<torch::headeronly::Half,
+                                                     StaticQ2048NeoXConfig>)
+    fused_norm_rope_pcp_dispatch_kernel<torch::headeronly::Half,
+                                        StaticQ2048NeoXConfig>;
+template __global__
+    __maxnreg__(32) decltype(fused_norm_rope_pcp_dispatch_kernel<
+                             torch::headeronly::BFloat16,
+                             StaticQ2048NeoXConfig>)
+        fused_norm_rope_pcp_dispatch_kernel<torch::headeronly::BFloat16,
+                                            StaticQ2048NeoXConfig>;
+#endif
+
 template <typename Config>
 __global__ void fused_norm_rope_pcp_combine_kernel(
     const uint8_t* __restrict__ received_payload,
@@ -519,7 +566,14 @@ __global__ void fused_norm_rope_pcp_combine_kernel(
     int64_t index_block_stride, int world_size, int local_tokens,
     int num_decode_tokens, int max_local_tokens, int cache_block_size,
     bool has_indexer) {
-  int cache_token = blockIdx.x;
+  int lane = threadIdx.x & (kWarpSize - 1);
+  int row_in_block = threadIdx.x / kWarpSize;
+  int cache_token = blockIdx.x * kCombineRowsPerBlock + row_in_block;
+  int num_cache_tokens =
+      num_decode_tokens + world_size * (local_tokens - num_decode_tokens);
+  if (cache_token >= num_cache_tokens) {
+    return;
+  }
   int source;
   int source_token;
   int mapping_token;
@@ -548,8 +602,8 @@ __global__ void fused_norm_rope_pcp_combine_kernel(
     int64_t block_offset = mla_slot % cache_block_size;
     uint8_t* destination =
         mla_cache + block * mla_block_stride + block_offset * mla_token_stride;
-    for (int chunk = threadIdx.x; chunk < Config::kMlaRowBytes / 16;
-         chunk += blockDim.x) {
+    for (int chunk = lane; chunk < Config::kMlaRowBytes / 16;
+         chunk += kWarpSize) {
       reinterpret_cast<uint4*>(destination)[chunk] =
           reinterpret_cast<const uint4*>(row)[chunk];
     }
@@ -563,12 +617,12 @@ __global__ void fused_norm_rope_pcp_combine_kernel(
       uint8_t* block_base = index_cache + block * index_block_stride;
       uint8_t* value_destination =
           block_base + block_offset * Config::kIndexerDim;
-      for (int chunk = threadIdx.x; chunk < Config::kIndexerDim / 16;
-           chunk += blockDim.x) {
+      for (int chunk = lane; chunk < Config::kIndexerDim / 16;
+           chunk += kWarpSize) {
         reinterpret_cast<uint4*>(value_destination)[chunk] =
             reinterpret_cast<const uint4*>(row + Config::kIndexerOffset)[chunk];
       }
-      if (threadIdx.x == 0) {
+      if (lane == 0) {
         uint8_t* scale_destination = block_base +
                                      cache_block_size * Config::kIndexerDim +
                                      block_offset * 4;
@@ -584,9 +638,9 @@ void fused_norm_rope_pcp_dispatch(
     const torch::stable::Tensor& positions, const torch::stable::Tensor& q_c,
     const torch::stable::Tensor& q_weight, double q_eps,
     torch::stable::Tensor& q_out, const torch::stable::Tensor& kv_c,
-    const torch::stable::Tensor& kv_weight, torch::stable::Tensor& kv_out,
+    const torch::stable::Tensor& kv_weight,
     const torch::stable::Tensor& mla_k_scale, double kv_eps,
-    const torch::stable::Tensor& k_pe, torch::stable::Tensor& k_pe_out,
+    const torch::stable::Tensor& k_pe,
     const torch::stable::Tensor& k_pe_cos_sin,
     const torch::stable::Tensor& index_k,
     const torch::stable::Tensor& index_weight,
@@ -668,12 +722,6 @@ void fused_norm_rope_pcp_dispatch(
                       q_out.size(0) == num_tokens &&
                       q_out.size(1) == q_lora_dim,
                   "q_out must match the Q shape and dtype");
-  STD_TORCH_CHECK(
-      valid_rows(kv_out, num_tokens, kKvLoraDim, dtype),
-      "kv_out must be [T,512] with contiguous rows and the Q dtype");
-  STD_TORCH_CHECK(
-      valid_rows(k_pe_out, num_tokens, kRopeDim, dtype),
-      "k_pe_out must be [T,64] with contiguous rows and the Q dtype");
   if (has_indexer) {
     STD_TORCH_CHECK(topk_indices.is_cuda() &&
                         topk_indices.scalar_type() == ScalarType::Int &&
@@ -745,13 +793,9 @@ void fused_norm_rope_pcp_dispatch(
               reinterpret_cast<const scalar_t*>(kv_c.const_data_ptr()),
               kv_c.stride(0),
               reinterpret_cast<const scalar_t*>(kv_weight.const_data_ptr()),
-              reinterpret_cast<scalar_t*>(kv_out.mutable_data_ptr()),
-              kv_out.stride(0), static_cast<float>(kv_eps),
-              mla_k_scale.const_data_ptr<float>(),
+              static_cast<float>(kv_eps), mla_k_scale.const_data_ptr<float>(),
               reinterpret_cast<const scalar_t*>(k_pe.const_data_ptr()),
-              k_pe.stride(0),
-              reinterpret_cast<scalar_t*>(k_pe_out.mutable_data_ptr()),
-              k_pe_out.stride(0), k_pe_cos_sin.const_data_ptr(),
+              k_pe.stride(0), k_pe_cos_sin.const_data_ptr(),
               k_pe_cos_sin.stride(0),
               k_pe_cos_sin.scalar_type() == ScalarType::Float,
               reinterpret_cast<const scalar_t*>(index_k.const_data_ptr()),
@@ -881,21 +925,24 @@ void fused_norm_rope_pcp_combine(
 
   const torch::stable::accelerator::DeviceGuard device_guard(device);
   cudaStream_t stream = get_current_cuda_stream(device);
-  int blocks = static_cast<int>(
+  int cache_rows = static_cast<int>(
       num_decode_tokens + world_size * (local_tokens - num_decode_tokens));
+  int blocks = (cache_rows + kCombineRowsPerBlock - 1) / kCombineRowsPerBlock;
   auto launch = [&]<typename Config>() {
-    fused_norm_rope_pcp_combine_kernel<Config><<<blocks, 128, 0, stream>>>(
-        reinterpret_cast<const uint8_t*>(received_payload.const_data_ptr()),
-        epoch.const_data_ptr<int64_t>(),
-        mla_slot_mapping.const_data_ptr<int64_t>(),
-        index_slot_mapping.const_data_ptr<int64_t>(),
-        reinterpret_cast<uint8_t*>(mla_cache.mutable_data_ptr()),
-        mla_cache.stride(0), mla_cache.stride(1),
-        reinterpret_cast<uint8_t*>(index_cache.mutable_data_ptr()),
-        has_indexer ? index_cache.stride(0) : 0, static_cast<int>(world_size),
-        static_cast<int>(local_tokens), static_cast<int>(num_decode_tokens),
-        static_cast<int>(max_local_tokens), static_cast<int>(mla_cache.size(1)),
-        has_indexer);
+    fused_norm_rope_pcp_combine_kernel<Config>
+        <<<blocks, kCombineThreads, 0, stream>>>(
+            reinterpret_cast<const uint8_t*>(received_payload.const_data_ptr()),
+            epoch.const_data_ptr<int64_t>(),
+            mla_slot_mapping.const_data_ptr<int64_t>(),
+            index_slot_mapping.const_data_ptr<int64_t>(),
+            reinterpret_cast<uint8_t*>(mla_cache.mutable_data_ptr()),
+            mla_cache.stride(0), mla_cache.stride(1),
+            reinterpret_cast<uint8_t*>(index_cache.mutable_data_ptr()),
+            has_indexer ? index_cache.stride(0) : 0,
+            static_cast<int>(world_size), static_cast<int>(local_tokens),
+            static_cast<int>(num_decode_tokens),
+            static_cast<int>(max_local_tokens),
+            static_cast<int>(mla_cache.size(1)), has_indexer);
   };
   if (fp8_ds_mla) {
     using Config =
@@ -913,9 +960,9 @@ void fused_norm_rope_pcp(
     const torch::stable::Tensor& positions, const torch::stable::Tensor& q_c,
     const torch::stable::Tensor& q_weight, double q_eps,
     torch::stable::Tensor& q_out, const torch::stable::Tensor& kv_c,
-    const torch::stable::Tensor& kv_weight, torch::stable::Tensor& kv_out,
+    const torch::stable::Tensor& kv_weight,
     const torch::stable::Tensor& mla_k_scale, double kv_eps,
-    const torch::stable::Tensor& k_pe, torch::stable::Tensor& k_pe_out,
+    const torch::stable::Tensor& k_pe,
     const torch::stable::Tensor& k_pe_cos_sin,
     const std::optional<torch::stable::Tensor>& index_k,
     const std::optional<torch::stable::Tensor>& index_weight,
@@ -952,12 +999,11 @@ void fused_norm_rope_pcp(
   int64_t world_size = received_payload.size(1);
 
   fused_norm_rope_pcp_dispatch(
-      positions, q_c, q_weight, q_eps, q_out, kv_c, kv_weight, kv_out,
-      mla_k_scale, kv_eps, k_pe, k_pe_out, k_pe_cos_sin, index_k_arg,
-      index_weight_arg, index_bias_arg, index_eps, index_cos_sin_arg,
-      topk_indices, received_payload, received_signal, completion, epoch, phase,
-      world_size, rank, has_indexer, fp8_ds_mla, index_rope_interleave,
-      payload_mc_ptr, signal_mc_ptr);
+      positions, q_c, q_weight, q_eps, q_out, kv_c, kv_weight, mla_k_scale,
+      kv_eps, k_pe, k_pe_cos_sin, index_k_arg, index_weight_arg, index_bias_arg,
+      index_eps, index_cos_sin_arg, topk_indices, received_payload,
+      received_signal, completion, epoch, phase, world_size, rank, has_indexer,
+      fp8_ds_mla, index_rope_interleave, payload_mc_ptr, signal_mc_ptr);
   fused_norm_rope_pcp_combine(received_payload, epoch, mla_slot_mapping,
                               index_slot_mapping_arg, mla_cache,
                               index_cache_arg, q_c.size(0), num_decode_tokens,
@@ -970,9 +1016,8 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, fused_norm_rope_pcp_ops) {
   fused_norm_rope_pcp_ops.def(
       "fused_norm_rope_pcp("
       "Tensor positions, Tensor q_c, Tensor q_weight, float q_eps, "
-      "Tensor! q_out, Tensor kv_c, Tensor kv_weight, Tensor! kv_out, "
-      "Tensor mla_k_scale, float kv_eps, Tensor k_pe, Tensor! k_pe_out, "
-      "Tensor k_pe_cos_sin, Tensor? index_k, "
+      "Tensor! q_out, Tensor kv_c, Tensor kv_weight, Tensor mla_k_scale, "
+      "float kv_eps, Tensor k_pe, Tensor k_pe_cos_sin, Tensor? index_k, "
       "Tensor? index_weight, Tensor? index_bias, float index_eps, "
       "Tensor? index_cos_sin, Tensor! topk_indices, Tensor! received_payload, "
       "Tensor! received_signal, Tensor! completion, Tensor! epoch, "

--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -26,9 +26,14 @@ rtol/atol=1e-2 (the tolerance the sibling deepseek_v4 fused-kernel test uses).
 
 import pytest
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
+from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.models.deepseek_v32.common import kernels as K
 from vllm.platforms import current_platform
+from vllm.utils.network_utils import get_open_port
+from vllm.utils.system_utils import update_environment_variables
 
 FP8 = torch.float8_e4m3fn
 FP8_MAX = 448.0
@@ -474,6 +479,215 @@ def test_fused_norm_rope_supports_large_token_count():
 
     rows = torch.tensor([0, num_tokens - 1], device=dev)
     assert_bf16(q_out[rows], rms_norm(q_c[rows], norm_w), "large-token q norm")
+
+
+def _all_gather_pcp_rows(local: torch.Tensor, world_size: int) -> torch.Tensor:
+    gathered = local.new_empty((world_size * local.shape[0], *local.shape[1:]))
+    dist.all_gather_into_tensor(gathered, local.contiguous())
+    return gathered
+
+
+def _fused_norm_rope_pcp_worker(
+    local_rank: int, world_size: int, master_port: int
+) -> None:
+    from vllm.v1.attention.ops.pcp import DirectPCPFusedNormRopeWorkspace
+
+    device = torch.device("cuda", local_rank)
+    torch.accelerator.set_device_index(device)
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(master_port),
+        }
+    )
+    dist.init_process_group("nccl")
+    try:
+        local_tokens = 3
+        num_decode_tokens = 1
+        cache_tokens = 5
+        dtype = torch.bfloat16
+        shared_generator = torch.Generator(device=device).manual_seed(1700)
+        local_generator = torch.Generator(device=device).manual_seed(1800 + local_rank)
+
+        def randn(shape: tuple[int, ...], generator: torch.Generator) -> torch.Tensor:
+            return torch.randn(shape, dtype=dtype, device=device, generator=generator)
+
+        q_c = randn((local_tokens, 1536), local_generator)
+        kv_c = randn((local_tokens, KV_LORA), local_generator)
+        k_pe = randn((local_tokens, ROPE_DIM), local_generator)
+        index_k = torch.zeros(
+            (local_tokens, INDEX_HEAD_DIM), dtype=dtype, device=device
+        )
+        index_k[:, :16] = 100
+        q_weight = randn((1536,), shared_generator)
+        kv_weight = randn((KV_LORA,), shared_generator)
+        index_weight = torch.ones(INDEX_HEAD_DIM, dtype=torch.float32, device=device)
+        index_bias = torch.zeros(INDEX_HEAD_DIM, dtype=torch.float32, device=device)
+        positions = torch.tensor(
+            [0, 1 + 2 * local_rank, 2 + 2 * local_rank],
+            dtype=torch.int64,
+            device=device,
+        )
+        cos_sin = make_cos_sin(cache_tokens, ROPE_DIM, device)
+        index_cos_sin = torch.zeros_like(cos_sin)
+        index_cos_sin[:, : ROPE_DIM // 2] = 1
+
+        for tensor in (q_c, kv_c, k_pe, index_k):
+            dist.broadcast(tensor[:num_decode_tokens], src=0)
+
+        consumed = torch.tensor([0, 1, 2, 4, 5], dtype=torch.int64, device=device)
+        slots = (torch.arange(cache_tokens, device=device) + local_rank) % cache_tokens
+        slot_mapping = torch.zeros(
+            world_size * local_tokens, dtype=torch.int64, device=device
+        )
+        slot_mapping[consumed] = slots
+
+        workspace = DirectPCPFusedNormRopeWorkspace(
+            dist.group.WORLD,
+            device,
+            local_tokens,
+            "fp8",
+            index_rope_interleave=True,
+        )
+        mla_scale = torch.tensor([0.25], dtype=torch.float32, device=device)
+
+        for has_indexer in (False, True, True):
+            mla_cache = torch.zeros(
+                (1, cache_tokens, KV_LORA + ROPE_DIM),
+                dtype=torch.uint8,
+                device=device,
+            )
+            index_cache = (
+                torch.zeros(
+                    (1, cache_tokens, INDEX_HEAD_DIM + 4),
+                    dtype=torch.uint8,
+                    device=device,
+                )
+                if has_indexer
+                else None
+            )
+            topk = torch.full((local_tokens, 17), 7, dtype=torch.int32, device=device)
+            q_out = workspace.forward(
+                positions=positions,
+                q_c=q_c,
+                q_weight=q_weight,
+                q_eps=EPS,
+                kv_c=kv_c,
+                kv_weight=kv_weight,
+                mla_k_scale=mla_scale,
+                kv_eps=EPS,
+                k_pe=k_pe,
+                k_pe_cos_sin=cos_sin,
+                index_k=index_k if has_indexer else None,
+                index_weight=index_weight if has_indexer else None,
+                index_bias=index_bias if has_indexer else None,
+                index_eps=EPS,
+                index_cos_sin=index_cos_sin if has_indexer else None,
+                topk_indices=topk,
+                mla_slot_mapping=slot_mapping,
+                index_slot_mapping=slot_mapping if has_indexer else None,
+                mla_cache=mla_cache,
+                index_cache=index_cache,
+                num_decode_tokens=num_decode_tokens,
+            )
+            torch.accelerator.synchronize()
+
+            assert_bf16(q_out, rms_norm(q_c, q_weight), "PCP Q norm")
+            kv_ref = rms_norm(kv_c, kv_weight).to(dtype)
+            k_pe_ref = rope(k_pe, positions, cos_sin, interleave=True).to(dtype)
+
+            gathered_mla = torch.cat(
+                (
+                    _all_gather_pcp_rows(kv_ref, world_size),
+                    _all_gather_pcp_rows(k_pe_ref, world_size),
+                ),
+                dim=-1,
+            )
+            expected_mla = torch.empty(
+                (cache_tokens, KV_LORA + ROPE_DIM), dtype=FP8, device=device
+            )
+            expected_mla[slots] = (gathered_mla[consumed].float() / mla_scale).to(FP8)
+            assert_fp8(
+                mla_cache.view(FP8).view_as(expected_mla),
+                expected_mla,
+                "PCP MLA cache",
+            )
+
+            if has_indexer:
+                assert index_cache is not None
+                local_index = rope(
+                    layer_norm(index_k, index_weight, index_bias),
+                    positions,
+                    index_cos_sin,
+                    interleave=True,
+                ).to(dtype)
+                local_values, local_scales = ue8m0_quant(local_index)
+                gathered_values = _all_gather_pcp_rows(local_values, world_size)
+                gathered_scales = _all_gather_pcp_rows(
+                    local_scales[:, None], world_size
+                )[:, 0]
+                expected_values = torch.empty(
+                    (cache_tokens, INDEX_HEAD_DIM), dtype=FP8, device=device
+                )
+                expected_scales = torch.empty(
+                    cache_tokens, dtype=torch.float32, device=device
+                )
+                expected_values[slots] = gathered_values[consumed]
+                expected_scales[slots] = gathered_scales[consumed]
+                flat_index_cache = index_cache.flatten()
+                value_bytes = cache_tokens * INDEX_HEAD_DIM
+                assert_fp8(
+                    flat_index_cache[:value_bytes].view(FP8).view_as(expected_values),
+                    expected_values,
+                    "PCP indexer cache",
+                )
+                torch.testing.assert_close(
+                    flat_index_cache[value_bytes:].view(torch.float32),
+                    expected_scales,
+                    rtol=0,
+                    atol=0,
+                )
+            assert (topk == (-1 if has_indexer else 7)).all()
+
+        assert int(workspace.epoch.item()) == 3
+        assert int(workspace.phase.item()) == 0
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed(num_gpus=2)
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="Fused PCP norm/RoPE requires Blackwell NVLS multicast",
+)
+def test_fused_norm_rope_pcp_reuses_indexer_barrier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Publish cache rows through the shared- and indexer-layer barriers."""
+    pytest.importorskip("torch.distributed._symmetric_memory")
+    from torch._C._autograd import DeviceType
+    from torch._C._distributed_c10d import _SymmetricMemory
+
+    world_size = 2
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip("Fused PCP norm/RoPE requires two GPUs")
+    if not _SymmetricMemory.has_multicast_support(DeviceType.CUDA, 0):
+        pytest.skip("Fused PCP norm/RoPE requires NVLS multicast")
+
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+    monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+    try:
+        mp.spawn(
+            _fused_norm_rope_pcp_worker,
+            args=(world_size, get_open_port()),
+            nprocs=world_size,
+        )
+    finally:
+        cleanup_dist_env_and_memory()
 
 
 # ── fused_q ──────────────────────────────────────────────────────────────────

--- a/tests/v1/attention/test_pcp.py
+++ b/tests/v1/attention/test_pcp.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+import torch
+
+import vllm.v1.attention.ops.pcp as pcp
+
+
+class _FakeGroupCoordinator:
+    device_group = None
+    world_size = 2
+
+
+def test_fused_workspace_cache_is_scoped_by_group(monkeypatch):
+    pcp._get_fused_pcp_norm_rope_workspace.cache_clear()
+    monkeypatch.setattr(pcp, "direct_cp_multicast_enabled", lambda *args: True)
+    workspace_a = object()
+    workspace_b = object()
+    init_workspace = MagicMock(side_effect=[workspace_a, workspace_b])
+    monkeypatch.setattr(
+        pcp,
+        "DirectPCPFusedNormRopeWorkspace",
+        init_workspace,
+    )
+    group_a = _FakeGroupCoordinator()
+    group_b = _FakeGroupCoordinator()
+    args = (torch.device("cpu"), 16, "fp8", False, 1)
+
+    try:
+        first = pcp._get_fused_pcp_norm_rope_workspace(group_a, *args)
+        reused = pcp._get_fused_pcp_norm_rope_workspace(group_a, *args)
+        isolated = pcp._get_fused_pcp_norm_rope_workspace(group_b, *args)
+    finally:
+        pcp._get_fused_pcp_norm_rope_workspace.cache_clear()
+
+    assert first is workspace_a
+    assert reused is workspace_a
+    assert isolated is workspace_b
+    assert init_workspace.call_count == 2

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -201,6 +201,7 @@ if TYPE_CHECKING:
     VLLM_USE_DIRECT_DCP_A2A: bool | None = None
     VLLM_USE_DIRECT_DCP_Q_GATHER: bool | None = None
     VLLM_USE_DIRECT_DCP_KV_GATHER: bool | None = None
+    VLLM_USE_FUSED_PCP_NORM_ROPE: bool | None = None
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -2120,6 +2121,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_USE_DIRECT_DCP_KV_GATHER": lambda: maybe_convert_bool(
         os.getenv("VLLM_USE_DIRECT_DCP_KV_GATHER")
+    ),
+    "VLLM_USE_FUSED_PCP_NORM_ROPE": lambda: maybe_convert_bool(
+        os.getenv("VLLM_USE_FUSED_PCP_NORM_ROPE")
     ),
     # Whether to enable dual cuda streams for LoRA computation
     # (used by both BaseLinearLayerWithLoRA and FusedMoEWithLoRA to

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -408,7 +408,7 @@ class DeepseekV32Attention(MLAAttention):
                 indexer_slot = slot_mapping.get(self.indexer.k_cache.prefix)
                 assert indexer_slot is not None
                 indexer_cache = self.indexer.k_cache.kv_cache
-            q_c, kv_c_out, k_pe_out = self._fused_pcp_norm_rope_workspace.forward(
+            q_c = self._fused_pcp_norm_rope_workspace.forward(
                 positions=positions,
                 q_c=q_c,
                 q_weight=self.q_a_layernorm.weight,
@@ -431,6 +431,8 @@ class DeepseekV32Attention(MLAAttention):
                 index_cache=indexer_cache,
                 num_decode_tokens=attn_metadata.num_decode_tokens,
             )
+            kv_c_out = None
+            k_pe_out = None
 
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -36,7 +36,9 @@ from vllm.models.deepseek_v32.common.kernels import fused_norm_rope, fused_q
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.ops.pcp import (
+    DirectPCPFusedNormRopeWorkspace,
     finalize_mla_pcp_decode,
+    get_fused_pcp_norm_rope_workspace,
     maybe_gather_mla_latent_cache_inputs,
 )
 
@@ -236,6 +238,14 @@ class DeepseekV32Attention(MLAAttention):
         self._fp8_kv_needs_view = fp8_attention and self.kv_cache_dtype != "fp8_ds_mla"
 
         self._index_rope_interleave = getattr(config, "indexer_rope_interleave", False)
+        self._fused_pcp_norm_rope_workspace: DirectPCPFusedNormRopeWorkspace | None = (
+            get_fused_pcp_norm_rope_workspace(
+                vllm_config,
+                config,
+                self.kv_cache_dtype,
+                next(kv_b_proj.parameters()).device,
+            )
+        )
 
         # Remaining MLA projections (registered on this module).
         self.fused_qkv_a_proj = DeepSeekV2FusedQkvAProjLinear(
@@ -315,6 +325,10 @@ class DeepseekV32Attention(MLAAttention):
         slot_mapping = forward_context.slot_mapping
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
+        use_fused_pcp_norm_rope = (
+            self._fused_pcp_norm_rope_workspace is not None
+            and attn_metadata is not None
+        )
 
         if self.indexer is not None and not self.skip_topk:
             has_indexer = True
@@ -323,7 +337,6 @@ class DeepseekV32Attention(MLAAttention):
             indexer_k_norm_eps = self.indexer.k_norm.eps
             indexer_k_rope_cos_sin_cache = self.indexer_rope_emb.cos_sin_cache
             indexer_k_cache = None if self.use_pcp else self.indexer.k_cache.kv_cache
-            index_k_out = torch.empty_like(index_k) if self.use_pcp else None
             indexer_softmax_scale = self.indexer.softmax_scale
             indexer_n_head_scale = self.indexer.n_head**-0.5
         else:
@@ -333,11 +346,12 @@ class DeepseekV32Attention(MLAAttention):
             indexer_k_norm_eps = 1e-6
             indexer_k_rope_cos_sin_cache = None
             indexer_k_cache = None
-            index_k_out = None
             indexer_softmax_scale = 0.0
             indexer_n_head_scale = 0.0
 
-        if attn_metadata is None or self.use_pcp:
+        if attn_metadata is None or (
+            self.use_pcp and self._fused_pcp_norm_rope_workspace is None
+        ):
             mla_kv_cache = None
             mla_k_scale = None
             indexer_k_cache = None
@@ -346,35 +360,77 @@ class DeepseekV32Attention(MLAAttention):
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
-        kv_c_out = torch.empty_like(kv_c) if self.use_pcp else None
-        k_pe_out = torch.empty_like(k_pe) if self.use_pcp else None
-        q_c = fused_norm_rope(
-            positions,
-            q_c,
-            self.q_a_layernorm.weight,
-            self.q_a_layernorm.variance_epsilon,
-            kv_c,
-            self.kv_a_layernorm.weight,
-            self.kv_a_layernorm.variance_epsilon,
-            k_pe,
-            self.rotary_emb.cos_sin_cache,
-            index_k,
-            indexer_k_norm_w,
-            indexer_k_norm_bias,
-            indexer_k_norm_eps,
-            indexer_k_rope_cos_sin_cache,
-            self.topk_indices_buffer,
-            slot_mapping=mla_slot,
-            indexer_k_cache=indexer_k_cache,
-            mla_kv_cache=mla_kv_cache,
-            mla_kv_cache_dtype=self.kv_cache_dtype,
-            mla_k_scale=mla_k_scale,
-            has_indexer=has_indexer,
-            index_rope_interleave=self._index_rope_interleave,
-            kv_c_out=kv_c_out,
-            k_pe_out=k_pe_out,
-            index_k_out=index_k_out,
-        )
+        if not use_fused_pcp_norm_rope:
+            index_k_out = (
+                torch.empty_like(index_k)
+                if self.use_pcp and index_k is not None
+                else None
+            )
+            kv_c_out = torch.empty_like(kv_c) if self.use_pcp else None
+            k_pe_out = torch.empty_like(k_pe) if self.use_pcp else None
+            q_c = fused_norm_rope(
+                positions,
+                q_c,
+                self.q_a_layernorm.weight,
+                self.q_a_layernorm.variance_epsilon,
+                kv_c,
+                self.kv_a_layernorm.weight,
+                self.kv_a_layernorm.variance_epsilon,
+                k_pe,
+                self.rotary_emb.cos_sin_cache,
+                index_k,
+                indexer_k_norm_w,
+                indexer_k_norm_bias,
+                indexer_k_norm_eps,
+                indexer_k_rope_cos_sin_cache,
+                self.topk_indices_buffer,
+                slot_mapping=mla_slot,
+                indexer_k_cache=indexer_k_cache,
+                mla_kv_cache=mla_kv_cache,
+                mla_kv_cache_dtype=self.kv_cache_dtype,
+                mla_k_scale=mla_k_scale,
+                has_indexer=has_indexer,
+                index_rope_interleave=self._index_rope_interleave,
+                kv_c_out=kv_c_out,
+                k_pe_out=k_pe_out,
+                index_k_out=index_k_out,
+            )
+        else:
+            index_k_out = None
+            assert self._fused_pcp_norm_rope_workspace is not None
+            assert attn_metadata is not None
+            assert mla_slot is not None
+            assert self._k_scale is not None
+            indexer_slot = None
+            indexer_cache = None
+            if has_indexer:
+                assert self.indexer is not None
+                indexer_slot = slot_mapping.get(self.indexer.k_cache.prefix)
+                assert indexer_slot is not None
+                indexer_cache = self.indexer.k_cache.kv_cache
+            q_c, kv_c_out, k_pe_out = self._fused_pcp_norm_rope_workspace.forward(
+                positions=positions,
+                q_c=q_c,
+                q_weight=self.q_a_layernorm.weight,
+                q_eps=self.q_a_layernorm.variance_epsilon,
+                kv_c=kv_c,
+                kv_weight=self.kv_a_layernorm.weight,
+                mla_k_scale=self._k_scale,
+                kv_eps=self.kv_a_layernorm.variance_epsilon,
+                k_pe=k_pe,
+                k_pe_cos_sin=self.rotary_emb.cos_sin_cache,
+                index_k=index_k,
+                index_weight=indexer_k_norm_w,
+                index_bias=indexer_k_norm_bias,
+                index_eps=indexer_k_norm_eps,
+                index_cos_sin=indexer_k_rope_cos_sin_cache,
+                topk_indices=self.topk_indices_buffer,
+                mla_slot_mapping=mla_slot,
+                index_slot_mapping=indexer_slot,
+                mla_cache=self.kv_cache,
+                index_cache=indexer_cache,
+                num_decode_tokens=attn_metadata.num_decode_tokens,
+            )
 
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
@@ -428,10 +484,11 @@ class DeepseekV32Attention(MLAAttention):
         mqa_q: torch.Tensor,
         output: torch.Tensor,
     ) -> None:
+        pcp_gather_cache = self.use_pcp and self._fused_pcp_norm_rope_workspace is None
         if self.indexer is not None and not self.skip_topk:
             assert index_q_fp8 is not None
             assert index_weights_out is not None
-            if self.use_pcp:
+            if pcp_gather_cache:
                 assert index_k is not None
             sparse_attn_indexer(
                 q_c,
@@ -448,7 +505,7 @@ class DeepseekV32Attention(MLAAttention):
                 self.indexer.max_model_len,
                 self.indexer.max_total_seq_len,
                 self.topk_indices_buffer,
-                skip_k_cache_insert=not self.use_pcp,
+                skip_k_cache_insert=not pcp_gather_cache,
                 use_pcp=self.use_pcp,
                 dense_mha_metadata_layer_name=self._dense_mha_metadata_layer_name,
                 dcp_rank=(
@@ -473,7 +530,7 @@ class DeepseekV32Attention(MLAAttention):
             return
         attn_metadata = cast("MLACommonMetadata", attn_metadata)
 
-        if self.use_pcp:
+        if pcp_gather_cache:
             assert kv_c is not None and k_pe is not None
             kv_for_cache, kpe_for_cache, cache_slot_mapping = (
                 maybe_gather_mla_latent_cache_inputs(

--- a/vllm/v1/attention/ops/pcp.py
+++ b/vllm/v1/attention/ops/pcp.py
@@ -113,7 +113,7 @@ class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
         mla_cache: torch.Tensor,
         index_cache: torch.Tensor | None,
         num_decode_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         local_tokens = q_c.shape[0]
         if local_tokens > self.max_local_tokens:
             raise ValueError(
@@ -130,8 +130,6 @@ class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
             raise ValueError(f"PCP ubatch {ubatch} exceeds {self.num_ubatches} slots")
         payload_multicast_ptr, signal_multicast_ptr = self.multicast_ptrs[ubatch]
         q_out = q_c.new_empty(q_c.shape)
-        kv_out = kv_c.new_empty(kv_c.shape)
-        k_pe_out = k_pe.new_empty(k_pe.shape)
         torch.ops._C.fused_norm_rope_pcp(
             positions,
             q_c,
@@ -140,11 +138,9 @@ class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
             q_out,
             kv_c,
             kv_weight,
-            kv_out,
             mla_k_scale,
             kv_eps,
             k_pe,
-            k_pe_out,
             k_pe_cos_sin,
             index_k,
             index_weight,
@@ -168,7 +164,7 @@ class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
             payload_multicast_ptr,
             signal_multicast_ptr,
         )
-        return q_out, kv_out, k_pe_out
+        return q_out
 
 
 @functools.cache

--- a/vllm/v1/attention/ops/pcp.py
+++ b/vllm/v1/attention/ops/pcp.py
@@ -33,17 +33,23 @@ class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
 
     Each rank contributes the same number of local tokens. Decode rows are
     replicated, while prefill rows are sequence-sharded. The dispatch kernel
-    writes FP8 payloads into the symmetric window, and the combine kernel
+    writes cache-ready payloads into the symmetric window, and the combine kernel
     scatters the unique rows into local paged caches.
     """
 
-    PACKED_ROW_BYTES = 720
+    PACKED_ROW_BYTES = {
+        "fp8": 720,
+        "fp8_e4m3": 720,
+        "fp8_ds_mla": 800,
+    }
 
     def __init__(
         self,
         group: ProcessGroup,
         device: torch.device,
         max_local_tokens: int,
+        kv_cache_dtype: str,
+        index_rope_interleave: bool,
         num_ubatches: int = 1,
     ) -> None:
         if group.size() <= 1:
@@ -54,13 +60,15 @@ class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
             raise ValueError("num_ubatches must be positive")
         super().__init__(group, device, num_ubatches)
         self.max_local_tokens = max_local_tokens
+        self.fp8_ds_mla = kv_cache_dtype == "fp8_ds_mla"
+        self.index_rope_interleave = index_rope_interleave
 
         payload_shape = (
             num_ubatches,
             2,
             self.world_size,
             max_local_tokens,
-            self.PACKED_ROW_BYTES,
+            self.PACKED_ROW_BYTES[kv_cache_dtype],
         )
         signal_shape = (num_ubatches, 2, self.world_size)
         self.received_payload, _ = self._allocate(payload_shape, torch.uint8)
@@ -155,6 +163,8 @@ class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
             index_cache,
             num_decode_tokens,
             self.rank,
+            self.fp8_ds_mla,
+            self.index_rope_interleave,
             payload_multicast_ptr,
             signal_multicast_ptr,
         )
@@ -166,6 +176,8 @@ def _get_fused_pcp_norm_rope_workspace(
     group: GroupCoordinator,
     device: torch.device,
     max_local_tokens: int,
+    kv_cache_dtype: str,
+    index_rope_interleave: bool,
     num_ubatches: int,
 ) -> DirectPCPFusedNormRopeWorkspace | None:
     if group.world_size <= 1 or not direct_cp_multicast_enabled(
@@ -178,6 +190,8 @@ def _get_fused_pcp_norm_rope_workspace(
         group.device_group,
         device,
         max_local_tokens,
+        kv_cache_dtype,
+        index_rope_interleave,
         num_ubatches,
     )
     logger.info_once("Using fused symmetric-memory PCP norm/RoPE cache dispatch.")
@@ -192,18 +206,19 @@ def get_fused_pcp_norm_rope_workspace(
 ) -> DirectPCPFusedNormRopeWorkspace | None:
     parallel_config = vllm_config.parallel_config
     if not (
-        kv_cache_dtype in ("fp8", "fp8_e4m3")
+        kv_cache_dtype in ("fp8", "fp8_e4m3", "fp8_ds_mla")
         and model_config.q_lora_rank in (1536, 2048)
         and model_config.kv_lora_rank == 512
         and model_config.qk_rope_head_dim == 64
         and getattr(model_config, "index_head_dim", None) == 128
-        and getattr(model_config, "indexer_rope_interleave", False)
     ):
         return None
     return _get_fused_pcp_norm_rope_workspace(
         get_pcp_group(),
         device,
         vllm_config.scheduler_config.max_num_batched_tokens,
+        kv_cache_dtype,
+        getattr(model_config, "indexer_rope_interleave", False),
         max(parallel_config.num_ubatches, 1),
     )
 

--- a/vllm/v1/attention/ops/pcp.py
+++ b/vllm/v1/attention/ops/pcp.py
@@ -1,11 +1,211 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Any
+
 import torch
 
+import vllm.envs as envs
+from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import (
     get_pcp_group,
     get_tp_group,
 )
+from vllm.logger import init_logger
+from vllm.v1.attention.ops.cp_common import (
+    DirectCPWorkspace,
+    direct_cp_multicast_enabled,
+)
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
+
+    from vllm.distributed.parallel_state import GroupCoordinator
+
+logger = init_logger(__name__)
+
+
+class DirectPCPFusedNormRopeWorkspace(DirectCPWorkspace):
+    """Persistent NVLS workspace for sparse-MLA PCP cache dispatch.
+
+    Each rank contributes the same number of local tokens. Decode rows are
+    replicated, while prefill rows are sequence-sharded. The dispatch kernel
+    writes FP8 payloads into the symmetric window, and the combine kernel
+    scatters the unique rows into local paged caches.
+    """
+
+    PACKED_ROW_BYTES = 720
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: torch.device,
+        max_local_tokens: int,
+        num_ubatches: int = 1,
+    ) -> None:
+        if group.size() <= 1:
+            raise ValueError("fused_norm_rope_pcp requires at least two ranks")
+        if max_local_tokens < 1:
+            raise ValueError("max_local_tokens must be positive")
+        if num_ubatches < 1:
+            raise ValueError("num_ubatches must be positive")
+        super().__init__(group, device, num_ubatches)
+        self.max_local_tokens = max_local_tokens
+
+        payload_shape = (
+            num_ubatches,
+            2,
+            self.world_size,
+            max_local_tokens,
+            self.PACKED_ROW_BYTES,
+        )
+        signal_shape = (num_ubatches, 2, self.world_size)
+        self.received_payload, _ = self._allocate(payload_shape, torch.uint8)
+        self.received_signal, _ = self._allocate(signal_shape, torch.int32)
+        payload_multicast_ptrs = self._multicast_ptrs(self.received_payload)
+        signal_multicast_ptrs = self._multicast_ptrs(self.received_signal)
+        self.multicast_ptrs = list(
+            zip(payload_multicast_ptrs, signal_multicast_ptrs, strict=True)
+        )
+        if not all(
+            payload_ptr and signal_ptr
+            for payload_ptr, signal_ptr in self.multicast_ptrs
+        ):
+            raise RuntimeError(
+                "fused_norm_rope_pcp requires NVLS symmetric-memory multicast"
+            )
+        self.completion = self.received_signal.new_zeros((num_ubatches, 2))
+        self.phase = self.received_signal.new_zeros((num_ubatches, 1))
+        torch.accelerator.synchronize()
+
+    def forward(
+        self,
+        *,
+        positions: torch.Tensor,
+        q_c: torch.Tensor,
+        q_weight: torch.Tensor,
+        q_eps: float,
+        kv_c: torch.Tensor,
+        kv_weight: torch.Tensor,
+        mla_k_scale: torch.Tensor,
+        kv_eps: float,
+        k_pe: torch.Tensor,
+        k_pe_cos_sin: torch.Tensor,
+        index_k: torch.Tensor | None,
+        index_weight: torch.Tensor | None,
+        index_bias: torch.Tensor | None,
+        index_eps: float,
+        index_cos_sin: torch.Tensor | None,
+        topk_indices: torch.Tensor,
+        mla_slot_mapping: torch.Tensor,
+        index_slot_mapping: torch.Tensor | None,
+        mla_cache: torch.Tensor,
+        index_cache: torch.Tensor | None,
+        num_decode_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        local_tokens = q_c.shape[0]
+        if local_tokens > self.max_local_tokens:
+            raise ValueError(
+                f"local tokens {local_tokens} exceed fused PCP capacity "
+                f"{self.max_local_tokens}"
+            )
+        if not 0 <= num_decode_tokens <= local_tokens:
+            raise ValueError(
+                f"invalid decode token count {num_decode_tokens} for "
+                f"{local_tokens} local tokens"
+            )
+        ubatch = dbo_current_ubatch_id()
+        if not 0 <= ubatch < self.num_ubatches:
+            raise ValueError(f"PCP ubatch {ubatch} exceeds {self.num_ubatches} slots")
+        payload_multicast_ptr, signal_multicast_ptr = self.multicast_ptrs[ubatch]
+        q_out = q_c.new_empty(q_c.shape)
+        kv_out = kv_c.new_empty(kv_c.shape)
+        k_pe_out = k_pe.new_empty(k_pe.shape)
+        torch.ops._C.fused_norm_rope_pcp(
+            positions,
+            q_c,
+            q_weight,
+            q_eps,
+            q_out,
+            kv_c,
+            kv_weight,
+            kv_out,
+            mla_k_scale,
+            kv_eps,
+            k_pe,
+            k_pe_out,
+            k_pe_cos_sin,
+            index_k,
+            index_weight,
+            index_bias,
+            index_eps,
+            index_cos_sin,
+            topk_indices,
+            self.received_payload[ubatch],
+            self.received_signal[ubatch],
+            self.completion[ubatch],
+            self.epoch[ubatch : ubatch + 1],
+            self.phase[ubatch],
+            mla_slot_mapping,
+            index_slot_mapping,
+            mla_cache,
+            index_cache,
+            num_decode_tokens,
+            self.rank,
+            payload_multicast_ptr,
+            signal_multicast_ptr,
+        )
+        return q_out, kv_out, k_pe_out
+
+
+@functools.cache
+def _get_fused_pcp_norm_rope_workspace(
+    group: GroupCoordinator,
+    device: torch.device,
+    max_local_tokens: int,
+    num_ubatches: int,
+) -> DirectPCPFusedNormRopeWorkspace | None:
+    if group.world_size <= 1 or not direct_cp_multicast_enabled(
+        group,
+        torch.uint8,
+        envs.VLLM_USE_FUSED_PCP_NORM_ROPE,
+    ):
+        return None
+    workspace = DirectPCPFusedNormRopeWorkspace(
+        group.device_group,
+        device,
+        max_local_tokens,
+        num_ubatches,
+    )
+    logger.info_once("Using fused symmetric-memory PCP norm/RoPE cache dispatch.")
+    return workspace
+
+
+def get_fused_pcp_norm_rope_workspace(
+    vllm_config: VllmConfig,
+    model_config: Any,
+    kv_cache_dtype: str,
+    device: torch.device,
+) -> DirectPCPFusedNormRopeWorkspace | None:
+    parallel_config = vllm_config.parallel_config
+    if not (
+        kv_cache_dtype in ("fp8", "fp8_e4m3")
+        and model_config.q_lora_rank in (1536, 2048)
+        and model_config.kv_lora_rank == 512
+        and model_config.qk_rope_head_dim == 64
+        and getattr(model_config, "index_head_dim", None) == 128
+        and getattr(model_config, "indexer_rope_interleave", False)
+    ):
+        return None
+    return _get_fused_pcp_norm_rope_workspace(
+        get_pcp_group(),
+        device,
+        vllm_config.scheduler_config.max_num_batched_tokens,
+        max(parallel_config.num_ubatches, 1),
+    )
 
 
 def _gather_prefill_cache_inputs(


### PR DESCRIPTION
## Summary

Fuse PCP Q/K preparation, cache quantization, and NVLS publication into one dispatch kernel plus one combine kernel for prefill, mixed, and decode batches.

* Old: bf16 norm/RoPE: output kv_c, k_pe, indexer_k → 3 all-gathers → quantize + cache-insertion 
* New: fused dispatch + NVLS multicast → local cache combine/scatter


### Dispatch

It launches one 256-thread CTA per local token and performs:

- Q RMSNorm, keeping Q local because each rank already holds the query rows it computes.
- KV RMSNorm.
- RoPE on `k_pe`.
- For sparse layers, indexer-K LayerNorm and RoPE.
- Packing directly into a cache-ready representation and NVLS multicast to every PCP rank.

For static E4M3, the fixed transport row is:

```text
| kv_c E4M3: 512 B | k_pe E4M3: 64 B | indexer K E4M3: 128 B | index scale FP32: 4 B | alignment: 12 B | = 720 B/token
```

For `fp8_ds_mla`, the fixed transport row is:

```text
| kv_c E4M3: 512 B | KV tile scales FP32: 16 B | k_pe BF16: 128 B | indexer K E4M3: 128 B | index scale FP32: 4 B | alignment: 12 B | = 800 B/token
```

Full workspace

```text
workspace[double_buffer_index][src rank][max_num_tokens][payload]
```

### Combine

The second kernel reads the received rank-major rows and scatters them into each rank's local paged caches:
- Prefill: tokens from every PCP rank are inserted.
- Decode: tokens are replicated, so they are inserted once from rank 0.

### Scope and limitations

- Requires CUDA and NVLS symmetric-memory multicast.
- Specialized for the GLM-5.2 / DeepSeek-V3.2 MLA dimensions above.
- Each rank retains a persistent double-buffered staging allocation of approximately `2 * num_ubatches * PCP_world_size * max_local_tokens * packed_row_bytes`.

## Performance

GLM-5.2 PCP8 on one 8×B300 node, TP1/PCP8/EP8, BF16 activations, static E4M3 KV cache, a 32K batched-token limit, and a 32K long-prefill threshold.

Default portable PCP pipeline (historical stage profile):

| Stage | Time |
| --- | ---: |
| Fused Q/K norm + K RoPE | 1.441 ms |
| Indexer-K all-gather | 2.064 ms |
| Indexer-K quantization/insertion | 0.423 ms |
| MLA `kv_c` all-gather | 11.044 ms |
| MLA `k_pe` all-gather | 2.349 ms |
| MLA quantization/insertion | 6.931 ms |
| **Total** | **24.252 ms** |

Final fused NVLS pipeline (latest two-run mean):

| Stage | Time |
| --- | ---: |
| Fused norm/RoPE + FP8 quantization + NVLS multicast | 8.228 ms |
| Cache combine/scatter | 0.898 ms |
| **Total** | **9.127 ms** |

Controlled current-stack full-forward A/B from the Kineto `execute_context_1(32768)_generation_0(0)` GPU annotation:

| Metric | Default portable PCP | Final fused NVLS | Change |
| --- | ---: | ---: | ---: |
| Mean across PCP ranks | 357.781 ms | 343.875 ms | **−3.89%** |
| Slowest PCP rank | 357.933 ms | 344.109 ms | **−3.86%** |

Each value is the arithmetic mean of two fresh-process runs. The portable baseline and pre-optimization fused path were measured in one current-stack ABBA; the final fused kernel was then measured in a second ABBA against that fused control. All runs used the same B300 node, model snapshot, source tree, eager-mode configuration, exact 32K input, warmup, and profiler procedure. The second ABBA measured the slowest-rank fused forward at 345.069 ms before these cache-overhead changes and 344.109 ms after them (−0.960 ms, −0.28%). "Default portable PCP" means the Triton fused norm/RoPE + PCP gather + cache-insert path.

## Relationship to existing work

- #52046 supplies the DeepSeek-V3.2 PCP gather-and-insert baseline now on `main`.
- #52839 moved the PCP attention helpers into `vllm/v1/attention/ops/pcp.py`; this branch is ported onto that layout.
- #52863 writes final rows directly into symmetric persistent cache replicas through P2P peer pointers.
- #49517 has the same replicated-KV-update goal using CUDA VMM peer mappings and direct peer stores.

This PR uses a different design from #52863/#49517: NVLS multicast into transient symmetric staging followed by a receiver-local paged-cache combine. It keeps cache tensors, allocation, and ownership ordinary and receiver-local, supports PCP2/4/8, and integrates with the common DeepSeek-V3.2 PCP path.

