### PR TITLE
[Core][Model] Add experimental Recirculation support

### DIFF
--- a/benchmarks/benchmark_recirculation.py
+++ b/benchmarks/benchmark_recirculation.py
@@ -309,7 +309,7 @@ def run(args: argparse.Namespace, window_data: dict[str, Any]) -> dict[str, Any]
         gpu_memory_utilization=args.gpu_memory_utilization,
         max_model_len=args.max_model_len,
         max_num_seqs=1,
-        enforce_eager=True,
+        enforce_eager=args.enforce_eager,
         enable_prefix_caching=False,
         long_prefill_token_threshold=args.long_prefill_token_threshold,
         hf_overrides=hf_overrides,
@@ -356,6 +356,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
     parser.add_argument("--dtype", default="bfloat16")
     parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Disable torch.compile and CUDA graphs for debugging.",
+    )
     parser.add_argument("--decode-tokens", type=int, default=64)
     parser.add_argument("--source-layer", type=int, default=11)
     parser.add_argument("--destination-layer", type=int, default=4)
@@ -387,7 +392,7 @@ def main() -> None:
             "seed": args.seed,
             "max_model_len": args.max_model_len,
             "max_num_seqs": 1,
-            "enforce_eager": True,
+            "enforce_eager": args.enforce_eager,
             "speculative_decoding": False,
             "prefix_caching": False,
             "long_prefill_token_threshold": args.long_prefill_token_threshold,

--- a/benchmarks/benchmark_recirculation.py
+++ b/benchmarks/benchmark_recirculation.py
@@ -297,6 +297,7 @@ def run(args: argparse.Namespace, window_data: dict[str, Any]) -> dict[str, Any]
                 "destination_layer": args.destination_layer,
                 "alpha": args.alpha,
                 "ramp_tokens": args.ramp_tokens,
+                "wavefront": args.wavefront,
             }
         }
     start = time.perf_counter()
@@ -366,6 +367,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--destination-layer", type=int, default=4)
     parser.add_argument("--alpha", type=float, default=0.15)
     parser.add_argument("--ramp-tokens", type=int, default=10)
+    parser.add_argument(
+        "--wavefront",
+        action="store_true",
+        help="Batch the previous recurrent token with the current upper stack.",
+    )
     parser.add_argument("--device-index", type=int, default=0)
     parser.add_argument("--performance-only", action="store_true")
     args = parser.parse_args()
@@ -373,6 +379,10 @@ def parse_args() -> argparse.Namespace:
         parser.error("--window-size must equal --max-model-len")
     if not 0 < args.decode_tokens < args.max_model_len:
         parser.error("--decode-tokens must be between 1 and max-model-len - 1")
+    if args.wavefront and args.mode != "recirculation":
+        parser.error("--wavefront requires --mode recirculation")
+    if args.wavefront and args.long_prefill_token_threshold != 1:
+        parser.error("--wavefront requires --long-prefill-token-threshold 1")
     return args
 
 
@@ -406,6 +416,7 @@ def main() -> None:
                     "alpha": args.alpha,
                     "beta": None,
                     "ramp_tokens": args.ramp_tokens,
+                    "wavefront": args.wavefront,
                 }
             ),
         },

--- a/benchmarks/benchmark_recirculation.py
+++ b/benchmarks/benchmark_recirculation.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.metadata
 import json
 import math
+import os
 import platform
 import subprocess
 import threading
@@ -15,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+DEFAULT_MODEL = "google/gemma-3-1b-pt"
 DEFAULT_MODEL_REVISION = "fcf18a2a879aab110ca39f8bffbccd5d49d8eb29"
 DEFAULT_DATASET_REVISION = "1588ec454efa1a09f29cd18ddd04fe05fc8653a2"
 
@@ -122,30 +124,67 @@ def load_or_build_windows(args: argparse.Namespace) -> dict[str, Any]:
 
 class PeakGpuMemory:
     def __init__(self, device_index: int) -> None:
-        import pynvml
-
-        self._pynvml = pynvml
-        pynvml.nvmlInit()
-        self._handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
-        memory = pynvml.nvmlDeviceGetMemoryInfo(self._handle)
-        self.start_bytes = memory.used
-        self.peak_bytes = memory.used
-        self.total_bytes = memory.total
-        self.name = pynvml.nvmlDeviceGetName(self._handle)
-        self.driver = pynvml.nvmlSystemGetDriverVersion()
+        self.device_index = device_index
+        self._pynvml = self._load_pynvml()
         self._stopped = threading.Event()
-        self._thread = threading.Thread(target=self._poll, daemon=True)
+        self._thread: threading.Thread | None = None
+        if self._pynvml is not None:
+            self.source = "nvml"
+            self._pynvml.nvmlInit()
+            self._handle = self._pynvml.nvmlDeviceGetHandleByIndex(device_index)
+            memory = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+            self.start_bytes = memory.used
+            self.peak_bytes = memory.used
+            self.total_bytes = memory.total
+            self.name = self._pynvml.nvmlDeviceGetName(self._handle)
+            self.driver = self._pynvml.nvmlSystemGetDriverVersion()
+            self._thread = threading.Thread(target=self._poll, daemon=True)
+            return
+
+        import torch
+
+        if not torch.accelerator.is_available():
+            raise RuntimeError("GPU memory measurement requires an accelerator")
+        self.source = "torch"
+        self._torch = torch
+        device_module = torch.get_device_module(torch.accelerator.current_accelerator())
+        properties = device_module.get_device_properties(device_index)
+        self.start_bytes = torch.accelerator.memory_allocated(device_index)
+        self.peak_bytes = self.start_bytes
+        self.total_bytes = properties.total_memory
+        self.name = properties.name
+        self.driver = None
+
+    @staticmethod
+    def _load_pynvml() -> Any | None:
+        try:
+            import pynvml
+        except ModuleNotFoundError:
+            return None
+        return pynvml
 
     def _poll(self) -> None:
+        assert self._pynvml is not None
         while not self._stopped.wait(0.01):
             used = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle).used
             self.peak_bytes = max(self.peak_bytes, used)
 
     def __enter__(self) -> "PeakGpuMemory":
-        self._thread.start()
+        if self._thread is not None:
+            self._thread.start()
+        else:
+            self._torch.accelerator.reset_peak_memory_stats(self.device_index)
         return self
 
     def __exit__(self, *exc_info: object) -> None:
+        if self._thread is None:
+            self._torch.accelerator.synchronize(self.device_index)
+            self.peak_bytes = max(
+                self.peak_bytes,
+                self._torch.accelerator.max_memory_allocated(self.device_index),
+            )
+            return
+        assert self._pynvml is not None
         self._stopped.set()
         self._thread.join()
         used = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle).used
@@ -286,20 +325,30 @@ def environment_metadata() -> dict[str, Any]:
     }
 
 
+def build_recirculation_config(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "source_layer": args.source_layer,
+        "destination_layer": args.destination_layer,
+        "alpha": args.alpha,
+        "beta": args.beta,
+        "ramp_tokens": args.ramp_tokens,
+        "wavefront": args.wavefront,
+    }
+
+
 def run(args: argparse.Namespace, window_data: dict[str, Any]) -> dict[str, Any]:
+    # Recirculation currently selects the V1 runner. Keep the baseline on the
+    # same runner and avoid a separate engine process so comparisons exercise
+    # the same execution path (and work on systems without CUDA UVA support).
+    os.environ.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
+    os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
+
     from vllm import LLM
 
     hf_overrides = None
     if args.mode == "recirculation":
-        hf_overrides = {
-            "recirculation_config": {
-                "source_layer": args.source_layer,
-                "destination_layer": args.destination_layer,
-                "alpha": args.alpha,
-                "ramp_tokens": args.ramp_tokens,
-                "wavefront": args.wavefront,
-            }
-        }
+        hf_overrides = {"recirculation_config": build_recirculation_config(args)}
     start = time.perf_counter()
     llm = LLM(
         model=args.model,
@@ -345,8 +394,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--windows-file", type=Path, required=True)
     parser.add_argument("--num-windows", type=int, default=16)
     parser.add_argument("--window-size", type=int, default=1024)
-    parser.add_argument("--model", default="google/gemma-3-1b-pt")
-    parser.add_argument("--model-revision", default=DEFAULT_MODEL_REVISION)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--model-revision",
+        help="Checkpoint revision; defaults to the pinned Gemma 3 1B revision only.",
+    )
     parser.add_argument("--dataset", default="allenai/c4")
     parser.add_argument("--dataset-config", default="en")
     parser.add_argument("--dataset-revision", default=DEFAULT_DATASET_REVISION)
@@ -366,6 +418,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--source-layer", type=int, default=11)
     parser.add_argument("--destination-layer", type=int, default=4)
     parser.add_argument("--alpha", type=float, default=0.15)
+    parser.add_argument("--beta", type=float)
     parser.add_argument("--ramp-tokens", type=int, default=10)
     parser.add_argument(
         "--wavefront",
@@ -375,6 +428,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--device-index", type=int, default=0)
     parser.add_argument("--performance-only", action="store_true")
     args = parser.parse_args()
+    if args.model_revision is None and args.model == DEFAULT_MODEL:
+        args.model_revision = DEFAULT_MODEL_REVISION
     if args.window_size != args.max_model_len:
         parser.error("--window-size must equal --max-model-len")
     if not 0 < args.decode_tokens < args.max_model_len:
@@ -408,16 +463,7 @@ def main() -> None:
             "long_prefill_token_threshold": args.long_prefill_token_threshold,
             "gpu_memory_utilization": args.gpu_memory_utilization,
             "recirculation_config": (
-                None
-                if args.mode == "baseline"
-                else {
-                    "source_layer": args.source_layer,
-                    "destination_layer": args.destination_layer,
-                    "alpha": args.alpha,
-                    "beta": None,
-                    "ramp_tokens": args.ramp_tokens,
-                    "wavefront": args.wavefront,
-                }
+                None if args.mode == "baseline" else build_recirculation_config(args)
             ),
         },
         "window_spec": {
@@ -428,6 +474,7 @@ def main() -> None:
         "window_hashes": [window["sha256"] for window in window_data["windows"]],
         "environment": environment_metadata(),
         "gpu": {
+            "memory_measurement_source": gpu_memory.source,
             "name": gpu_memory.name,
             "driver": gpu_memory.driver,
             "total_bytes": gpu_memory.total_bytes,

--- a/benchmarks/benchmark_recirculation.py
+++ b/benchmarks/benchmark_recirculation.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Evaluate fixed Recirculation with reproducible token windows."""
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import platform
+import subprocess
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODEL_REVISION = "fcf18a2a879aab110ca39f8bffbccd5d49d8eb29"
+DEFAULT_DATASET_REVISION = "1588ec454efa1a09f29cd18ddd04fe05fc8653a2"
+
+
+def sha256_json(value: Any) -> str:
+    payload = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_windows(args: argparse.Namespace) -> dict[str, Any]:
+    from datasets import load_dataset
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model,
+        revision=args.model_revision,
+    )
+    dataset = load_dataset(
+        args.dataset,
+        args.dataset_config,
+        split=args.dataset_split,
+        revision=args.dataset_revision,
+        streaming=True,
+    )
+    windows = []
+    for document_index, row in enumerate(dataset):
+        token_ids = tokenizer.encode(
+            row[args.dataset_text_column],
+            add_special_tokens=False,
+        )
+        for token_offset in range(
+            0, len(token_ids) - args.window_size + 1, args.window_size
+        ):
+            window = token_ids[token_offset : token_offset + args.window_size]
+            windows.append(
+                {
+                    "document_index": document_index,
+                    "token_offset": token_offset,
+                    "token_ids": window,
+                    "sha256": sha256_json(window),
+                }
+            )
+            if len(windows) == args.num_windows:
+                break
+        if len(windows) == args.num_windows:
+            break
+    if len(windows) != args.num_windows:
+        raise RuntimeError(
+            f"Found only {len(windows)} full windows; requested {args.num_windows}"
+        )
+    return {
+        "format_version": 1,
+        "dataset": {
+            "name": args.dataset,
+            "config": args.dataset_config,
+            "revision": args.dataset_revision,
+            "split": args.dataset_split,
+            "text_column": args.dataset_text_column,
+        },
+        "tokenizer": {
+            "name": args.model,
+            "revision": args.model_revision,
+        },
+        "construction": {
+            "window_size": args.window_size,
+            "add_special_tokens": False,
+            "selection": (
+                "dataset order; non-overlapping full windows within each document; "
+                "incomplete tails skipped"
+            ),
+        },
+        "windows": windows,
+    }
+
+
+def load_or_build_windows(args: argparse.Namespace) -> dict[str, Any]:
+    path = args.windows_file
+    if path.exists():
+        data = json.loads(path.read_text())
+        expected = {
+            "name": args.dataset,
+            "config": args.dataset_config,
+            "revision": args.dataset_revision,
+            "split": args.dataset_split,
+            "text_column": args.dataset_text_column,
+        }
+        matches = (
+            data.get("dataset") == expected
+            and data.get("tokenizer")
+            == {"name": args.model, "revision": args.model_revision}
+            and data.get("construction", {}).get("window_size") == args.window_size
+        )
+        if matches and len(data.get("windows", [])) >= args.num_windows:
+            for window in data["windows"][: args.num_windows]:
+                if sha256_json(window["token_ids"]) != window["sha256"]:
+                    raise ValueError(f"Corrupt window cache: {path}")
+            data["windows"] = data["windows"][: args.num_windows]
+            return data
+
+    data = build_windows(args)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+    return data
+
+
+class PeakGpuMemory:
+    def __init__(self, device_index: int) -> None:
+        import pynvml
+
+        self._pynvml = pynvml
+        pynvml.nvmlInit()
+        self._handle = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+        memory = pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+        self.start_bytes = memory.used
+        self.peak_bytes = memory.used
+        self.total_bytes = memory.total
+        self.name = pynvml.nvmlDeviceGetName(self._handle)
+        self.driver = pynvml.nvmlSystemGetDriverVersion()
+        self._stopped = threading.Event()
+        self._thread = threading.Thread(target=self._poll, daemon=True)
+
+    def _poll(self) -> None:
+        while not self._stopped.wait(0.01):
+            used = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle).used
+            self.peak_bytes = max(self.peak_bytes, used)
+
+    def __enter__(self) -> "PeakGpuMemory":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._stopped.set()
+        self._thread.join()
+        used = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle).used
+        self.peak_bytes = max(self.peak_bytes, used)
+        self._pynvml.nvmlShutdown()
+
+
+def chosen_prompt_nll(output: Any) -> float:
+    if output.prompt_logprobs is None or output.prompt_token_ids is None:
+        raise RuntimeError("vLLM did not return requested prompt logprobs")
+    nll = 0.0
+    for token_id, entries in zip(
+        output.prompt_token_ids[1:], output.prompt_logprobs[1:]
+    ):
+        if entries is None or token_id not in entries:
+            raise RuntimeError(f"Missing prompt logprob for token {token_id}")
+        nll -= entries[token_id].logprob
+    return nll
+
+
+def score_window(llm: Any, token_ids: list[int], seed: int) -> dict[str, float]:
+    from vllm import SamplingParams
+
+    prompt_token_ids = token_ids[:-1]
+    final_target = token_ids[-1]
+    params = SamplingParams(
+        temperature=0.0,
+        max_tokens=1,
+        seed=seed,
+        prompt_logprobs=0,
+        logprobs=1,
+        logprob_token_ids=[final_target],
+        ignore_eos=True,
+    )
+    start = time.perf_counter()
+    output = llm.generate(
+        [{"prompt_token_ids": prompt_token_ids}],
+        params,
+        use_tqdm=False,
+    )[0]
+    elapsed = time.perf_counter() - start
+    completion_logprobs = output.outputs[0].logprobs
+    if not completion_logprobs or final_target not in completion_logprobs[0]:
+        raise RuntimeError(f"Missing final target logprob for token {final_target}")
+    nll = chosen_prompt_nll(output) - completion_logprobs[0][final_target].logprob
+    prefill_latency = output.metrics.first_token_latency if output.metrics else elapsed
+    return {
+        "negative_log_likelihood": nll,
+        "elapsed_s": elapsed,
+        "prefill_latency_s": prefill_latency,
+    }
+
+
+def score_windows(llm: Any, windows: list[dict[str, Any]], seed: int) -> dict[str, Any]:
+    scores = []
+    for index, window in enumerate(windows, 1):
+        score = score_window(llm, window["token_ids"], seed)
+        scores.append(score)
+        print(
+            f"window {index}/{len(windows)}: "
+            f"nll={score['negative_log_likelihood']:.6f}, "
+            f"elapsed={score['elapsed_s']:.3f}s",
+            flush=True,
+        )
+    total_nll = sum(score["negative_log_likelihood"] for score in scores)
+    scored_tokens = sum(len(window["token_ids"]) - 1 for window in windows)
+    return {
+        "num_windows": len(windows),
+        "scored_tokens": scored_tokens,
+        "negative_log_likelihood": total_nll,
+        "mean_negative_log_likelihood": total_nll / scored_tokens,
+        "perplexity": math.exp(total_nll / scored_tokens),
+        "elapsed_s": sum(score["elapsed_s"] for score in scores),
+        "mean_prefill_latency_s": sum(score["prefill_latency_s"] for score in scores)
+        / len(scores),
+        "per_window": scores,
+    }
+
+
+def measure_decode(
+    llm: Any,
+    token_ids: list[int],
+    max_model_len: int,
+    decode_tokens: int,
+    seed: int,
+) -> dict[str, Any]:
+    from vllm import SamplingParams
+
+    prompt_tokens = max_model_len - decode_tokens
+    prompt_token_ids = token_ids[:prompt_tokens]
+    params = SamplingParams(
+        temperature=0.0,
+        max_tokens=decode_tokens,
+        seed=seed,
+        ignore_eos=True,
+    )
+    start = time.perf_counter()
+    output = llm.generate(
+        [{"prompt_token_ids": prompt_token_ids}],
+        params,
+        use_tqdm=False,
+    )[0]
+    elapsed = time.perf_counter() - start
+    output_tokens = len(output.outputs[0].token_ids)
+    metrics = output.metrics
+    decode_elapsed = metrics.last_token_ts - metrics.first_token_ts if metrics else 0.0
+    measured_decode_tokens = max(output_tokens - 1, 0)
+    return {
+        "prompt_tokens": len(prompt_token_ids),
+        "output_tokens": output_tokens,
+        "elapsed_s": elapsed,
+        "prefill_latency_s": metrics.first_token_latency if metrics else None,
+        "decode_elapsed_s": decode_elapsed,
+        "decode_throughput_tokens_per_s": (
+            measured_decode_tokens / decode_elapsed if decode_elapsed > 0 else None
+        ),
+        "output_text": output.outputs[0].text,
+        "output_token_ids": list(output.outputs[0].token_ids),
+    }
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def environment_metadata() -> dict[str, Any]:
+    import torch
+
+    return {
+        "git_commit": git_output("rev-parse", "HEAD"),
+        "git_status_short": git_output("status", "--short"),
+        "python": platform.python_version(),
+        "vllm": importlib.metadata.version("vllm"),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "transformers": importlib.metadata.version("transformers"),
+        "datasets": importlib.metadata.version("datasets"),
+    }
+
+
+def run(args: argparse.Namespace, window_data: dict[str, Any]) -> dict[str, Any]:
+    from vllm import LLM
+
+    hf_overrides = None
+    if args.mode == "recirculation":
+        hf_overrides = {
+            "recirculation_config": {
+                "source_layer": args.source_layer,
+                "destination_layer": args.destination_layer,
+                "alpha": args.alpha,
+                "ramp_tokens": args.ramp_tokens,
+            }
+        }
+    start = time.perf_counter()
+    llm = LLM(
+        model=args.model,
+        revision=args.model_revision,
+        tokenizer_revision=args.model_revision,
+        dtype=args.dtype,
+        seed=args.seed,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.max_model_len,
+        max_num_seqs=1,
+        enforce_eager=True,
+        enable_prefix_caching=False,
+        long_prefill_token_threshold=args.long_prefill_token_threshold,
+        hf_overrides=hf_overrides,
+        disable_log_stats=False,
+    )
+    load_s = time.perf_counter() - start
+    try:
+        windows = window_data["windows"]
+        quality = (
+            None if args.performance_only else score_windows(llm, windows, args.seed)
+        )
+        performance = measure_decode(
+            llm,
+            windows[0]["token_ids"],
+            args.max_model_len,
+            args.decode_tokens,
+            args.seed,
+        )
+        return {
+            "model_load_s": load_s,
+            "quality": quality,
+            "performance": performance,
+        }
+    finally:
+        llm.llm_engine.engine_core.shutdown()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("baseline", "recirculation"), required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--windows-file", type=Path, required=True)
+    parser.add_argument("--num-windows", type=int, default=16)
+    parser.add_argument("--window-size", type=int, default=1024)
+    parser.add_argument("--model", default="google/gemma-3-1b-pt")
+    parser.add_argument("--model-revision", default=DEFAULT_MODEL_REVISION)
+    parser.add_argument("--dataset", default="allenai/c4")
+    parser.add_argument("--dataset-config", default="en")
+    parser.add_argument("--dataset-revision", default=DEFAULT_DATASET_REVISION)
+    parser.add_argument("--dataset-split", default="validation")
+    parser.add_argument("--dataset-text-column", default="text")
+    parser.add_argument("--max-model-len", type=int, default=1024)
+    parser.add_argument("--long-prefill-token-threshold", type=int, default=1)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.8)
+    parser.add_argument("--dtype", default="bfloat16")
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--decode-tokens", type=int, default=64)
+    parser.add_argument("--source-layer", type=int, default=11)
+    parser.add_argument("--destination-layer", type=int, default=4)
+    parser.add_argument("--alpha", type=float, default=0.15)
+    parser.add_argument("--ramp-tokens", type=int, default=10)
+    parser.add_argument("--device-index", type=int, default=0)
+    parser.add_argument("--performance-only", action="store_true")
+    args = parser.parse_args()
+    if args.window_size != args.max_model_len:
+        parser.error("--window-size must equal --max-model-len")
+    if not 0 < args.decode_tokens < args.max_model_len:
+        parser.error("--decode-tokens must be between 1 and max-model-len - 1")
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    window_data = load_or_build_windows(args)
+    started = time.perf_counter()
+    with PeakGpuMemory(args.device_index) as gpu_memory:
+        measurements = run(args, window_data)
+    result = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "mode": args.mode,
+        "configuration": {
+            "model": args.model,
+            "model_revision": args.model_revision,
+            "dtype": args.dtype,
+            "seed": args.seed,
+            "max_model_len": args.max_model_len,
+            "max_num_seqs": 1,
+            "enforce_eager": True,
+            "speculative_decoding": False,
+            "prefix_caching": False,
+            "long_prefill_token_threshold": args.long_prefill_token_threshold,
+            "gpu_memory_utilization": args.gpu_memory_utilization,
+            "recirculation_config": (
+                None
+                if args.mode == "baseline"
+                else {
+                    "source_layer": args.source_layer,
+                    "destination_layer": args.destination_layer,
+                    "alpha": args.alpha,
+                    "beta": None,
+                    "ramp_tokens": args.ramp_tokens,
+                }
+            ),
+        },
+        "window_spec": {
+            key: value for key, value in window_data.items() if key != "windows"
+        },
+        "window_file": str(args.windows_file),
+        "window_file_sha256": sha256_json(window_data),
+        "window_hashes": [window["sha256"] for window in window_data["windows"]],
+        "environment": environment_metadata(),
+        "gpu": {
+            "name": gpu_memory.name,
+            "driver": gpu_memory.driver,
+            "total_bytes": gpu_memory.total_bytes,
+            "start_used_bytes": gpu_memory.start_bytes,
+            "peak_used_bytes": gpu_memory.peak_bytes,
+            "peak_delta_bytes": gpu_memory.peak_bytes - gpu_memory.start_bytes,
+        },
+        "total_elapsed_s": time.perf_counter() - started,
+        **measurements,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/validate_recirculation_adapters.py
+++ b/benchmarks/validate_recirculation_adapters.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU-smoke Recirculation adapters with tiny local dummy models.
+
+This benchmark downloads no model weights or tokenizers. It generates a small
+four-layer Hugging Face configuration in a temporary directory, asks vLLM to
+initialize random weights, and runs token-ID generation through the real engine.
+"""
+
+import argparse
+import json
+import os
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
+os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+os.environ.setdefault("VLLM_USE_FLASHINFER_SAMPLER", "0")
+os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
+
+import torch
+from transformers import (
+    DeepseekV3Config,
+    Glm4MoeLiteConfig,
+    GptOssConfig,
+    Llama4TextConfig,
+    LlamaConfig,
+    MixtralConfig,
+    PretrainedConfig,
+    Qwen3Config,
+)
+from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+from vllm.transformers_utils.configs.minimax_m3 import MiniMaxM3TextConfig
+from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5TextConfig
+from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeTextConfig
+from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
+from vllm.transformers_utils.configs.step3p5 import Step3p5Config
+
+ConfigBuilder = Callable[[], PretrainedConfig]
+
+
+def deepseek_v3_config() -> PretrainedConfig:
+    return DeepseekV3Config(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        moe_intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        n_shared_experts=1,
+        n_routed_experts=4,
+        kv_lora_rank=512,
+        q_lora_rank=None,
+        qk_rope_head_dim=64,
+        qk_nope_head_dim=128,
+        v_head_dim=128,
+        n_group=1,
+        topk_group=1,
+        num_experts_per_tok=2,
+        first_k_dense_replace=1,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+
+
+def qwen3_config() -> PretrainedConfig:
+    return Qwen3Config(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+
+
+def mixtral_config() -> PretrainedConfig:
+    return MixtralConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=128,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        tie_word_embeddings=False,
+    )
+
+
+def llama4_config() -> PretrainedConfig:
+    return Llama4TextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=128,
+        intermediate_size_mlp=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        num_local_experts=4,
+        num_experts_per_tok=1,
+        attention_chunk_size=64,
+        attn_temperature_tuning=False,
+        tie_word_embeddings=False,
+    )
+
+
+def gemma4_config() -> PretrainedConfig:
+    return Gemma4TextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        global_head_dim=32,
+        num_global_key_value_heads=2,
+        max_position_embeddings=128,
+        sliding_window=64,
+        layer_types=["sliding_attention"] * 3 + ["full_attention"],
+        hidden_size_per_layer_input=0,
+        vocab_size_per_layer_input=256,
+        enable_moe_block=True,
+        num_experts=4,
+        top_k_experts=2,
+        moe_intermediate_size=128,
+        tie_word_embeddings=False,
+    )
+
+
+def gpt_oss_config() -> PretrainedConfig:
+    return GptOssConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=128,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        sliding_window=64,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        tie_word_embeddings=False,
+    )
+
+
+def qwen3_5_config() -> PretrainedConfig:
+    return Qwen3_5TextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_num_key_heads=4,
+        linear_num_value_heads=4,
+        layer_types=["linear_attention"] * 3 + ["full_attention"],
+        tie_word_embeddings=False,
+    )
+
+
+def qwen3_5_moe_config() -> PretrainedConfig:
+    return Qwen3_5MoeTextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_num_key_heads=4,
+        linear_num_value_heads=4,
+        layer_types=["linear_attention"] * 3 + ["full_attention"],
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=64,
+        shared_expert_intermediate_size=64,
+        tie_word_embeddings=False,
+    )
+
+
+def qwen3_next_config() -> PretrainedConfig:
+    return Qwen3NextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_num_key_heads=4,
+        linear_num_value_heads=4,
+        layer_types=["linear_attention"] * 3 + ["full_attention"],
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=64,
+        shared_expert_intermediate_size=64,
+        tie_word_embeddings=False,
+    )
+
+
+def minimax_m3_config() -> PretrainedConfig:
+    return MiniMaxM3TextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=64,
+        dense_intermediate_size=256,
+        shared_intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=128,
+        max_position_embeddings=128,
+        rotary_dim=64,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        moe_layer_freq=[0, 1, 1, 1],
+        sparse_attention_config={},
+        tie_word_embeddings=False,
+    )
+
+
+def glm4_moe_lite_config() -> PretrainedConfig:
+    config = Glm4MoeLiteConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        moe_intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        n_shared_experts=1,
+        n_routed_experts=4,
+        kv_lora_rank=512,
+        q_lora_rank=None,
+        qk_rope_head_dim=64,
+        qk_nope_head_dim=192,
+        v_head_dim=256,
+        num_experts_per_tok=2,
+        max_position_embeddings=128,
+        mlp_layer_types=["dense", "sparse", "sparse", "sparse"],
+        tie_word_embeddings=False,
+    )
+    config.first_k_dense_replace = 1
+    config.moe_layer_freq = 1
+    return config
+
+
+def mimo_v2_config() -> PretrainedConfig:
+    config = LlamaConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        hidden_act="silu",
+        tie_word_embeddings=False,
+    )
+    config.layernorm_epsilon = 1e-6
+    config.hybrid_layer_pattern = [0, 0, 0, 0]
+    config.attention_bias = False
+    config.moe_layer_freq = [0, 1, 1, 1]
+    config.n_routed_experts = 4
+    config.num_experts_per_tok = 2
+    config.moe_intermediate_size = 64
+    config.norm_topk_prob = True
+    config.n_group = 1
+    config.topk_group = 1
+    return config
+
+
+def step3p5_config() -> PretrainedConfig:
+    return Step3p5Config(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_attention_groups=2,
+        head_dim=32,
+        max_seq_len=128,
+        max_position_embeddings=128,
+        moe_intermediate_size=64,
+        moe_num_experts=4,
+        moe_top_k=2,
+        share_expert_dim=64,
+        tie_word_embeddings=False,
+    )
+
+
+FAMILIES: dict[str, tuple[str, ConfigBuilder, bool]] = {
+    "deepseek-v3": ("DeepseekV3ForCausalLM", deepseek_v3_config, False),
+    "gemma4": ("Gemma4ForCausalLM", gemma4_config, True),
+    "glm4-moe-lite": (
+        "Glm4MoeLiteForCausalLM",
+        glm4_moe_lite_config,
+        False,
+    ),
+    "gpt-oss": ("GptOssForCausalLM", gpt_oss_config, False),
+    "llama4": ("Llama4ForCausalLM", llama4_config, True),
+    "minimax-m3": (
+        "MiniMaxM3SparseForCausalLM",
+        minimax_m3_config,
+        False,
+    ),
+    "mimo-v2": ("MiMoV2ForCausalLM", mimo_v2_config, True),
+    "mixtral": ("MixtralForCausalLM", mixtral_config, True),
+    "qwen3": ("Qwen3ForCausalLM", qwen3_config, True),
+    "qwen3.5": ("Qwen3_5ForCausalLM", qwen3_5_config, False),
+    "qwen3.5-moe": (
+        "Qwen3_5MoeForCausalLM",
+        qwen3_5_moe_config,
+        False,
+    ),
+    "qwen3-next": ("Qwen3NextForCausalLM", qwen3_next_config, False),
+    "step3.5": ("Step3p5ForCausalLM", step3p5_config, True),
+}
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    from vllm import LLM, SamplingParams
+
+    architecture, build_config, supports_wavefront = FAMILIES[args.family]
+    wavefront = args.mode == "wavefront"
+    if wavefront and not supports_wavefront:
+        raise ValueError(f"{args.family} only supports serial Recirculation")
+
+    config = build_config()
+    config.architectures = [architecture]
+    config.recirculation_config = {
+        "source_layer": 2,
+        "destination_layer": 1,
+        "alpha": 0.15,
+        "wavefront": wavefront,
+    }
+
+    torch.accelerator.reset_peak_memory_stats()
+    started = time.perf_counter()
+    with tempfile.TemporaryDirectory(prefix=f"recirculation-{args.family}-") as path:
+        config.save_pretrained(path)
+        llm = LLM(
+            model=path,
+            load_format="dummy",
+            skip_tokenizer_init=True,
+            dtype="bfloat16",
+            max_model_len=64,
+            max_num_seqs=1,
+            max_num_batched_tokens=64,
+            long_prefill_token_threshold=1,
+            enable_prefix_caching=False,
+            enforce_eager=not args.compile,
+            gpu_memory_utilization=0.25,
+            kv_cache_memory_bytes=args.kv_cache_mib * 1024 * 1024,
+        )
+        try:
+            output = llm.generate(
+                [{"prompt_token_ids": list(range(1, 9))}],
+                SamplingParams(temperature=0.0, max_tokens=8, ignore_eos=True),
+                use_tqdm=False,
+            )[0]
+            token_ids = list(output.outputs[0].token_ids)
+        finally:
+            llm.llm_engine.engine_core.shutdown()
+
+    return {
+        "family": args.family,
+        "architecture": architecture,
+        "mode": args.mode,
+        "compiled": args.compile,
+        "load_format": "dummy",
+        "weights_downloaded": False,
+        "num_layers": 4,
+        "hidden_size": 128,
+        "kv_cache_mib": args.kv_cache_mib,
+        "peak_torch_gpu_mib": torch.accelerator.max_memory_allocated() / (1024 * 1024),
+        "elapsed_s": time.perf_counter() - started,
+        "output_token_ids": token_ids,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--family", choices=sorted(FAMILIES), required=True)
+    parser.add_argument("--mode", choices=("serial", "wavefront"), required=True)
+    parser.add_argument("--compile", action="store_true")
+    parser.add_argument("--kv-cache-mib", type=int, default=128)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = run(args)
+    payload = json.dumps(result, indent=2) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload)
+    print(payload, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/validate_recirculation_adapters.py
+++ b/benchmarks/validate_recirculation_adapters.py
@@ -24,13 +24,19 @@ os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
 import torch
 from transformers import (
     DeepseekV3Config,
+    Gemma3TextConfig,
+    Glm4MoeConfig,
     Glm4MoeLiteConfig,
     GptOssConfig,
     Llama4TextConfig,
     LlamaConfig,
+    MiniMaxM2Config,
+    MistralConfig,
     MixtralConfig,
     PretrainedConfig,
+    Qwen2Config,
     Qwen3Config,
+    Qwen3MoeConfig,
 )
 from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
 
@@ -41,6 +47,65 @@ from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.transformers_utils.configs.step3p5 import Step3p5Config
 
 ConfigBuilder = Callable[[], PretrainedConfig]
+
+
+def gemma3_config() -> PretrainedConfig:
+    return Gemma3TextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        query_pre_attn_scalar=32,
+        max_position_embeddings=128,
+        sliding_window=64,
+        layer_types=["sliding_attention"] * 3 + ["full_attention"],
+        tie_word_embeddings=False,
+    )
+
+
+def llama_config() -> PretrainedConfig:
+    return LlamaConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+
+
+def mistral_config() -> PretrainedConfig:
+    return MistralConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        max_position_embeddings=128,
+        sliding_window=64,
+        tie_word_embeddings=False,
+    )
+
+
+def qwen2_config() -> PretrainedConfig:
+    return Qwen2Config(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
 
 
 def deepseek_v3_config() -> PretrainedConfig:
@@ -78,6 +143,22 @@ def qwen3_config() -> PretrainedConfig:
         num_key_value_heads=2,
         head_dim=32,
         max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+
+
+def qwen3_moe_config() -> PretrainedConfig:
+    return Qwen3MoeConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=64,
         tie_word_embeddings=False,
     )
 
@@ -246,6 +327,52 @@ def minimax_m3_config() -> PretrainedConfig:
     )
 
 
+def minimax_m2_config() -> PretrainedConfig:
+    config = MiniMaxM2Config(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        head_dim=128,
+        max_position_embeddings=128,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        bos_token_id=None,
+        eos_token_id=None,
+        tie_word_embeddings=False,
+    )
+    # Current checkpoint configs include this field, but the corresponding
+    # Transformers config class does not expose it yet.
+    config.rotary_dim = 64
+    config.scoring_func = "sigmoid"
+    config.use_routing_bias = True
+    return config
+
+
+def glm4_moe_config() -> PretrainedConfig:
+    config = Glm4MoeConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        moe_intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        n_shared_experts=1,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        first_k_dense_replace=1,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+    # The vLLM implementation follows newer checkpoints that persist an
+    # explicit head_dim, while the installed Transformers config derives it.
+    config.head_dim = 32
+    return config
+
+
 def glm4_moe_lite_config() -> PretrainedConfig:
     config = Glm4MoeLiteConfig(
         vocab_size=256,
@@ -319,22 +446,29 @@ def step3p5_config() -> PretrainedConfig:
 
 FAMILIES: dict[str, tuple[str, ConfigBuilder, bool]] = {
     "deepseek-v3": ("DeepseekV3ForCausalLM", deepseek_v3_config, False),
+    "gemma3": ("Gemma3ForCausalLM", gemma3_config, True),
     "gemma4": ("Gemma4ForCausalLM", gemma4_config, True),
+    "glm4-moe": ("Glm4MoeForCausalLM", glm4_moe_config, True),
     "glm4-moe-lite": (
         "Glm4MoeLiteForCausalLM",
         glm4_moe_lite_config,
         False,
     ),
     "gpt-oss": ("GptOssForCausalLM", gpt_oss_config, False),
+    "llama": ("LlamaForCausalLM", llama_config, True),
     "llama4": ("Llama4ForCausalLM", llama4_config, True),
+    "minimax-m2": ("MiniMaxM2ForCausalLM", minimax_m2_config, True),
     "minimax-m3": (
         "MiniMaxM3SparseForCausalLM",
         minimax_m3_config,
         False,
     ),
     "mimo-v2": ("MiMoV2ForCausalLM", mimo_v2_config, True),
+    "mistral": ("MistralForCausalLM", mistral_config, True),
     "mixtral": ("MixtralForCausalLM", mixtral_config, True),
+    "qwen2": ("Qwen2ForCausalLM", qwen2_config, True),
     "qwen3": ("Qwen3ForCausalLM", qwen3_config, True),
+    "qwen3-moe": ("Qwen3MoeForCausalLM", qwen3_moe_config, True),
     "qwen3.5": ("Qwen3_5ForCausalLM", qwen3_5_config, False),
     "qwen3.5-moe": (
         "Qwen3_5MoeForCausalLM",
@@ -350,18 +484,21 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     from vllm import LLM, SamplingParams
 
     architecture, build_config, supports_wavefront = FAMILIES[args.family]
+    recirculation = args.mode != "baseline"
     wavefront = args.mode == "wavefront"
     if wavefront and not supports_wavefront:
         raise ValueError(f"{args.family} only supports serial Recirculation")
 
     config = build_config()
     config.architectures = [architecture]
-    config.recirculation_config = {
-        "source_layer": 2,
-        "destination_layer": 1,
-        "alpha": 0.15,
-        "wavefront": wavefront,
-    }
+    if recirculation:
+        config.recirculation_config = {
+            "source_layer": 2,
+            "destination_layer": 1,
+            "alpha": 0.0 if args.mode == "no-op" else 0.15,
+            "ramp_tokens": args.ramp_tokens,
+            "wavefront": wavefront,
+        }
 
     torch.accelerator.reset_peak_memory_stats()
     started = time.perf_counter()
@@ -380,14 +517,27 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             enforce_eager=not args.compile,
             gpu_memory_utilization=0.25,
             kv_cache_memory_bytes=args.kv_cache_mib * 1024 * 1024,
+            seed=args.seed,
         )
         try:
             output = llm.generate(
                 [{"prompt_token_ids": list(range(1, 9))}],
-                SamplingParams(temperature=0.0, max_tokens=8, ignore_eos=True),
+                SamplingParams(
+                    temperature=0.0,
+                    max_tokens=8,
+                    logprobs=1,
+                    ignore_eos=True,
+                ),
                 use_tqdm=False,
             )[0]
             token_ids = list(output.outputs[0].token_ids)
+            token_logprobs = [
+                entries[token_id].logprob
+                for token_id, entries in zip(
+                    token_ids,
+                    output.outputs[0].logprobs or [],
+                )
+            ]
         finally:
             llm.llm_engine.engine_core.shutdown()
 
@@ -401,18 +551,27 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "num_layers": 4,
         "hidden_size": 128,
         "kv_cache_mib": args.kv_cache_mib,
+        "seed": args.seed,
+        "ramp_tokens": args.ramp_tokens,
         "peak_torch_gpu_mib": torch.accelerator.max_memory_allocated() / (1024 * 1024),
         "elapsed_s": time.perf_counter() - started,
         "output_token_ids": token_ids,
+        "output_token_logprobs": token_logprobs,
     }
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--family", choices=sorted(FAMILIES), required=True)
-    parser.add_argument("--mode", choices=("serial", "wavefront"), required=True)
+    parser.add_argument(
+        "--mode",
+        choices=("baseline", "no-op", "serial", "wavefront"),
+        required=True,
+    )
     parser.add_argument("--compile", action="store_true")
     parser.add_argument("--kv-cache-mib", type=int, default=128)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--ramp-tokens", type=int, default=0)
     parser.add_argument("--output", type=Path)
     return parser.parse_args()
 

--- a/docs/features/recirculation.md
+++ b/docs/features/recirculation.md
@@ -83,8 +83,28 @@ uv pip install 'datasets>=3.3.0,<=3.6.0'
 
 Use `--num-windows 50` for a larger sample. For a normal-scheduler baseline
 performance measurement, add `--long-prefill-token-threshold 0
---performance-only`. The exact runs default to one sequence, eager BF16,
-`max_model_len=1024`, no prefix caching, and no speculative decoding.
+--performance-only`. The exact runs default to one sequence, compiled BF16,
+`max_model_len=1024`, no prefix caching, and no speculative decoding. Add
+`--enforce-eager` only when debugging; it disables torch.compile and CUDA graphs
+and can be substantially slower.
+
+For faster approximate prefill, increase `--long-prefill-token-threshold` to
+the desired Recirculation block size. For example:
+
+```bash
+.venv/bin/python benchmarks/benchmark_recirculation.py \
+  --mode recirculation \
+  --long-prefill-token-threshold 16 \
+  --windows-file results/recirculation-windows.json \
+  --output results/recirculation-block16.json
+```
+
+A threshold of `1` is exact tokenwise Recirculation. Values greater than `1`
+process that many prefill tokens together: the first-pass logits within each
+block do not depend on that block's recirculated cache, so this is an explicit
+quality-throughput tradeoff rather than an exact optimization. Autoregressive
+decode remains tokenwise. Sweep block sizes on the target workload instead of
+assuming one value is universally optimal.
 
 ## Current restrictions
 

--- a/docs/features/recirculation.md
+++ b/docs/features/recirculation.md
@@ -44,10 +44,26 @@ the `SupportsRecirculation` interface and use a shared residual-decoder
 execution mixin. This keeps scheduling behavior common while allowing a model
 family to override its layer execution with a specialized implementation.
 
-The reviewed adapters currently cover text-only Gemma 3, the native Llama
-implementation and its direct architecture aliases, and Mistral. An
-unreviewed subclass does not inherit support automatically and fails during
-model loading when Recirculation is requested.
+The reviewed text adapters cover the following residual-decoder families:
+
+| Execution | Families |
+| --- | --- |
+| Serial and wavefront | Gemma 3, Gemma 4, Llama and direct aliases, Llama 4, Mistral, Mixtral, Qwen 2, Qwen 3, Qwen 3 MoE, GLM-4 MoE, MiniMax-M2, MiMo-V2, Step-3.5 |
+| Serial only | DeepSeek V2/V3/V3.2, GLM-4.7-Flash, GPT-OSS, MiniMax-M3, Qwen3-Next, Qwen 3.5 dense and MoE |
+
+Serial-only status is deliberate when the architecture uses an attention
+backend that cannot consume the engine's two-token FlashAttention wavefront,
+or a recurrent state that needs a pre-block snapshot. Qwen3-Next and Qwen 3.5
+snapshot the active convolution and GDN state slots before the normal upper
+stack, then restore those slots before the recirculated rerun. This prevents a
+second in-place recurrent update from incorrectly consuming the current
+token's already-updated state.
+
+An unreviewed subclass does not inherit support automatically and fails during
+model loading when Recirculation is requested. DeepSeek-V4 is intentionally
+not opted in: its multi-stream hyperconnection state does not expose the
+standard residual boundary assumed by this algorithm. Diffusion and other
+non-causal models are also rejected.
 
 ## Wavefront execution
 
@@ -99,6 +115,32 @@ from the normal pass, and the recirculated cache affects later blocks.
 For exact tokenwise evaluation, set `--long-prefill-token-threshold 1` and do
 not enable speculative decoding. For throughput experiments, increase the
 threshold to sweep the block size and measure the quality-throughput tradeoff.
+
+## No-download adapter validation
+
+`benchmarks/validate_recirculation_adapters.py` creates a four-layer local
+configuration, initializes dummy weights, skips tokenizer initialization, and
+runs token-ID generation through the real GPU engine. It does not download
+model weights or tokenizers. Run each family in a fresh process, for example:
+
+```bash
+.venv/bin/python benchmarks/validate_recirculation_adapters.py \
+  --family qwen3.5-moe --mode serial \
+  --output results/qwen3.5-moe-recirculation.json
+
+.venv/bin/python benchmarks/validate_recirculation_adapters.py \
+  --family gemma4 --mode wavefront \
+  --output results/gemma4-recirculation.json
+
+.venv/bin/python benchmarks/validate_recirculation_adapters.py \
+  --family qwen3 --mode wavefront --compile \
+  --output results/qwen3-compiled-recirculation.json
+```
+
+This is an integration smoke for adapter signatures, attention/MoE kernels,
+cache allocation, recurrent-state handling, and generation. Random dummy
+weights cannot establish model quality; use the perplexity harness with real
+weights when storage and hardware permit.
 
 ## Reproducible evaluation
 
@@ -152,10 +194,20 @@ assuming one value is universally optimal.
 
 ## Current restrictions
 
-- Reviewed adapters currently cover text-only Gemma 3, Llama, and Mistral
-  implementations. Multimodal wrappers are not yet supported.
+- Multimodal wrappers, DeepSeek-V4 hyperconnections, and non-causal diffusion
+  backbones are not supported.
 - Pipeline parallelism is not supported.
+- Model Runner V2 does not yet implement Recirculation. Recirculation selects
+  Model Runner V1 automatically; explicitly setting
+  `VLLM_USE_V2_MODEL_RUNNER=1` is rejected.
 - Only fixed scalar coefficients and source norm matching are implemented.
+- Qwen3-Next and Qwen 3.5 reject speculative decoding and sequence-parallel
+  MoE execution. Their recurrent-state adapter is serial only.
+- MiniMax-M3 currently requires tensor-parallel size 1. Its sparse-attention
+  backend is serial only.
+- Gemma 4 YOCO fast prefill is unsupported. Gemma 4 per-layer embeddings are
+  serial only because the engine does not retain the previous token's
+  per-layer input stack for a wavefront.
 - Wavefront execution currently requires one sequence, one scheduled token per
   step, FlashAttention, no prefix caching or speculative decoding, and no data,
   decode-context, sequence, or pipeline parallelism.

--- a/docs/features/recirculation.md
+++ b/docs/features/recirculation.md
@@ -1,0 +1,62 @@
+# Recirculation
+
+!!! warning
+    Recirculation support is experimental. The current implementation is a
+    correctness-first, serial implementation for text-only Gemma 3 models.
+
+[Recirculation](https://arxiv.org/abs/2608.17981) feeds a norm-matched deep
+residual-stream activation back into a shallower layer. vLLM returns the logits
+from the token block's normal pass, then reruns the layers above the destination
+with the mixed residual. The rerun overwrites the block's upper-layer KV cache,
+so later tokens attend to the recirculated representations.
+
+Enable fixed recirculation through `--hf-overrides`. For Gemma 3 1B PT, the
+paper's perplexity configuration is:
+
+```bash
+vllm serve google/gemma-3-1b-pt \
+  --hf-overrides '{
+    "recirculation_config": {
+      "source_layer": 11,
+      "destination_layer": 4,
+      "alpha": 0.15,
+      "ramp_tokens": 10
+    }
+  }' \
+  --long-prefill-token-threshold 1
+```
+
+When `beta` is omitted, vLLM uses the convex coefficient
+`beta = 1 - alpha`. The ramp scales `alpha` from zero to its configured value
+over the first `ramp_tokens` positions and adjusts the convex `beta`
+accordingly.
+
+The paper reports the following fixed configurations for its pretrained-model
+perplexity evaluation:
+
+| Model | Source | Destination | Alpha | Beta | Ramp tokens |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Gemma 3 1B PT | 11 | 4 | 0.15 | `1 - alpha` | 10 |
+| Gemma 3 4B PT | 18 | 9 | 0.15 | 1.0 | 0 |
+| Gemma 3 12B PT | 35 | 16 | 0.15 | 1.0 | 0 |
+
+Set `"beta": 1.0` explicitly for the non-convex 4B and 12B configurations.
+
+## Exact and blockwise execution
+
+Each forward call recirculates the scheduled tokens as one block. A one-token
+block implements the paper's tokenwise recurrence. Larger prefill chunks use
+the blockwise approximation proposed in the paper: logits within a block come
+from the normal pass, and the recirculated cache affects later blocks.
+
+For exact tokenwise evaluation, set `--long-prefill-token-threshold 1` and do
+not enable speculative decoding. For throughput experiments, increase the
+threshold to sweep the block size and measure the quality-throughput tradeoff.
+
+## Current restrictions
+
+- Only `Gemma3ForCausalLM` is supported. Multimodal Gemma 3 models are not.
+- Pipeline parallelism is not supported.
+- Only fixed scalar coefficients and source norm matching are implemented.
+- Layers above the destination run serially a second time. Wavefront execution
+  that overlaps the normal and recirculated stacks is not yet implemented.

--- a/docs/features/recirculation.md
+++ b/docs/features/recirculation.md
@@ -1,9 +1,9 @@
 # Recirculation
 
 !!! warning
-    Recirculation support is experimental. The serial implementation supports
-    text-only Gemma 3 models; the optimized wavefront path has the additional
-    restrictions listed below.
+    Recirculation support is experimental. Compatible model implementations
+    must opt in to the engine capability; the optimized wavefront path has the
+    additional restrictions listed below.
 
 [Recirculation](https://arxiv.org/abs/2608.17981) feeds a norm-matched deep
 residual-stream activation back into a shallower layer. vLLM returns the logits
@@ -35,6 +35,19 @@ accordingly.
 An identity configuration with `alpha = 0` and `beta` omitted or set to `1`
 disables Recirculation. It therefore agrees exactly with the baseline and does
 not incur a redundant upper-layer pass.
+
+## Model capability
+
+The scheduler, recurrent-state buffers, KV-slot remapping, and CUDA-graph
+specialization are engine-level features. Model implementations opt in through
+the `SupportsRecirculation` interface and use a shared residual-decoder
+execution mixin. This keeps scheduling behavior common while allowing a model
+family to override its layer execution with a specialized implementation.
+
+The reviewed adapters currently cover text-only Gemma 3, the native Llama
+implementation and its direct architecture aliases, and Mistral. An
+unreviewed subclass does not inherit support automatically and fails during
+model loading when Recirculation is requested.
 
 ## Wavefront execution
 
@@ -139,7 +152,8 @@ assuming one value is universally optimal.
 
 ## Current restrictions
 
-- Only `Gemma3ForCausalLM` is supported. Multimodal Gemma 3 models are not.
+- Reviewed adapters currently cover text-only Gemma 3, Llama, and Mistral
+  implementations. Multimodal wrappers are not yet supported.
 - Pipeline parallelism is not supported.
 - Only fixed scalar coefficients and source norm matching are implemented.
 - Wavefront execution currently requires one sequence, one scheduled token per

--- a/docs/features/recirculation.md
+++ b/docs/features/recirculation.md
@@ -142,6 +142,73 @@ cache allocation, recurrent-state handling, and generation. Random dummy
 weights cannot establish model quality; use the perplexity harness with real
 weights when storage and hardware permit.
 
+The validator accepts `baseline`, `no-op`, `serial`, and `wavefront` modes.
+Use the same `--seed` across separate processes to compare generated token IDs
+and selected-token log probabilities. Pass `--ramp-tokens 10` to exercise
+position-dependent mixing, including MRoPE text positions.
+
+## RTX 3080 validation snapshot
+
+The following results were collected on an NVIDIA GeForce RTX 3080 10 GB after
+rebasing onto `main` on August 20, 2026. The dummy-model runs use four layers,
+BF16, random weights, seed 1234, eight decode tokens, and no downloaded weights
+or tokenizer. Their elapsed times include process startup and JIT work, so they
+are compatibility evidence rather than performance measurements.
+
+For the compiled Gemma 3 dummy model, no-op output was bit-identical to the
+baseline. Serial and wavefront generated the same token IDs; their maximum
+selected-token log-probability difference was `1.235e-4`, consistent with BF16
+execution-order differences.
+
+| Mode | Token IDs | Log-probability sum | Peak PyTorch GPU MiB | Elapsed s |
+| --- | --- | ---: | ---: | ---: |
+| Baseline | 8 x 227 | -44.174433 | 145.590 | 25.386 |
+| No-op | 8 x 227 | -44.174433 | 145.590 | 6.997 |
+| Serial | 8 x 227 | -44.168809 | 145.594 | 12.571 |
+| Wavefront | 8 x 227 | -44.169186 | 145.584 | 15.139 |
+
+Every documented adapter also completed generation through the real GPU
+engine. `ramp=10` was used for both MRoPE Qwen 3.5 adapters.
+
+| Family | Mode | Ramp | Result |
+| --- | --- | ---: | --- |
+| DeepSeek V3 | Serial | 0 | Pass |
+| Gemma 3 | Wavefront, compiled | 0 | Pass |
+| Gemma 4 | Wavefront | 0 | Pass |
+| GLM-4 MoE | Wavefront | 0 | Pass |
+| GLM-4 MoE Lite | Serial | 0 | Pass |
+| GPT-OSS | Serial | 0 | Pass |
+| Llama | Wavefront | 0 | Pass |
+| Llama 4 | Wavefront | 0 | Pass |
+| MiMo-V2 | Wavefront | 0 | Pass |
+| MiniMax-M2 | Wavefront | 0 | Pass |
+| MiniMax-M3 | Serial | 0 | Pass |
+| Mistral | Wavefront | 0 | Pass |
+| Mixtral | Wavefront | 0 | Pass |
+| Qwen 2 | Wavefront | 0 | Pass |
+| Qwen 3 | Wavefront | 0 | Pass |
+| Qwen 3 MoE | Wavefront | 0 | Pass |
+| Qwen3-Next | Serial | 0 | Pass |
+| Qwen 3.5 | Serial | 10 | Pass |
+| Qwen 3.5 MoE | Serial | 10 | Pass |
+| Step-3.5 | Wavefront | 0 | Pass |
+
+MiniMax-M3 sparse attention was disabled in its tiny fixture, so this validates
+its residual/MoE adapter but not that optional custom sparse-attention kernel.
+
+A real-weight, compiled Gemma 3 1B PT comparison used the same 16 fixed C4
+windows (16,368 scored tokens) for both modes:
+
+| Mode | Perplexity | Mean prefill latency s | Decode tokens/s | Peak GPU delta GiB |
+| --- | ---: | ---: | ---: | ---: |
+| Baseline | 19.1576 | 7.9496 | 194.97 | 7.661 |
+| Wavefront | 16.9613 | 8.4007 | 181.90 | 7.593 |
+
+For this small sample, wavefront reduced perplexity by 11.46%, increased mean
+prefill latency by 5.67%, and reduced decode throughput by 6.70%. Treat the
+quality delta as promising validation rather than a statistically complete
+model evaluation.
+
 ## Reproducible evaluation
 
 `benchmarks/benchmark_recirculation.py` scores deterministic, pre-tokenized
@@ -165,6 +232,24 @@ uv pip install 'datasets>=3.3.0,<=3.6.0'
   --wavefront \
   --windows-file results/recirculation-windows.json \
   --output results/recirculation-wavefront.json
+```
+
+The harness keeps baseline and Recirculation on Model Runner V1 for a fair
+comparison. Peak memory uses `nvidia-ml-py` when available and otherwise falls
+back to PyTorch accelerator peak-memory statistics.
+
+For the paper's Gemma 3 4B configuration, select the model explicitly and pass
+the non-convex beta. Revisions are model-specific; omit `--model-revision` to
+use the repository default or provide a checkpoint revision explicitly.
+
+```bash
+.venv/bin/python benchmarks/benchmark_recirculation.py \
+  --mode recirculation \
+  --model google/gemma-3-4b-pt \
+  --source-layer 18 --destination-layer 9 \
+  --alpha 0.15 --beta 1.0 --ramp-tokens 0 \
+  --windows-file results/gemma-3-4b-windows.json \
+  --output results/gemma-3-4b-recirculation.json
 ```
 
 Use `--num-windows 50` for a larger sample. For a normal-scheduler baseline
@@ -201,8 +286,12 @@ assuming one value is universally optimal.
   Model Runner V1 automatically; explicitly setting
   `VLLM_USE_V2_MODEL_RUNNER=1` is rejected.
 - Only fixed scalar coefficients and source norm matching are implemented.
-- Qwen3-Next and Qwen 3.5 reject speculative decoding and sequence-parallel
-  MoE execution. Their recurrent-state adapter is serial only.
+- All Recirculation execution rejects speculative decoding, EAGLE/DFlash
+  auxiliary hidden-state extraction, and other speculative configurations.
+  Defining recurrence over draft-token blocks and auxiliary states requires a
+  separate design. Qwen3-Next and Qwen 3.5 additionally reject
+  sequence-parallel MoE execution; their recurrent-state adapter is serial
+  only.
 - MiniMax-M3 currently requires tensor-parallel size 1. Its sparse-attention
   backend is serial only.
 - Gemma 4 YOCO fast prefill is unsupported. Gemma 4 per-layer embeddings are

--- a/docs/features/recirculation.md
+++ b/docs/features/recirculation.md
@@ -31,6 +31,10 @@ When `beta` is omitted, vLLM uses the convex coefficient
 over the first `ramp_tokens` positions and adjusts the convex `beta`
 accordingly.
 
+An identity configuration with `alpha = 0` and `beta` omitted or set to `1`
+disables Recirculation. It therefore agrees exactly with the baseline and does
+not incur a redundant upper-layer pass.
+
 The paper reports the following fixed configurations for its pretrained-model
 perplexity evaluation:
 
@@ -52,6 +56,35 @@ from the normal pass, and the recirculated cache affects later blocks.
 For exact tokenwise evaluation, set `--long-prefill-token-threshold 1` and do
 not enable speculative decoding. For throughput experiments, increase the
 threshold to sweep the block size and measure the quality-throughput tradeoff.
+
+## Reproducible evaluation
+
+`benchmarks/benchmark_recirculation.py` scores deterministic, pre-tokenized
+1024-token C4 windows. It excludes the first token in each independent window,
+reports token-weighted negative log-likelihood and perplexity, and records
+latency, decode throughput, peak GPU memory, revisions, and window hashes.
+
+Install the optional dataset dependency, then reuse the same window file for
+both quality runs:
+
+```bash
+uv pip install 'datasets>=3.3.0,<=3.6.0'
+
+.venv/bin/python benchmarks/benchmark_recirculation.py \
+  --mode baseline \
+  --windows-file results/recirculation-windows.json \
+  --output results/baseline-exact.json
+
+.venv/bin/python benchmarks/benchmark_recirculation.py \
+  --mode recirculation \
+  --windows-file results/recirculation-windows.json \
+  --output results/recirculation-exact.json
+```
+
+Use `--num-windows 50` for a larger sample. For a normal-scheduler baseline
+performance measurement, add `--long-prefill-token-threshold 0
+--performance-only`. The exact runs default to one sequence, eager BF16,
+`max_model_len=1024`, no prefix caching, and no speculative decoding.
 
 ## Current restrictions
 

--- a/docs/features/recirculation.md
+++ b/docs/features/recirculation.md
@@ -1,8 +1,9 @@
 # Recirculation
 
 !!! warning
-    Recirculation support is experimental. The current implementation is a
-    correctness-first, serial implementation for text-only Gemma 3 models.
+    Recirculation support is experimental. The serial implementation supports
+    text-only Gemma 3 models; the optimized wavefront path has the additional
+    restrictions listed below.
 
 [Recirculation](https://arxiv.org/abs/2608.17981) feeds a norm-matched deep
 residual-stream activation back into a shallower layer. vLLM returns the logits
@@ -34,6 +35,35 @@ accordingly.
 An identity configuration with `alpha = 0` and `beta` omitted or set to `1`
 disables Recirculation. It therefore agrees exactly with the baseline and does
 not incur a redundant upper-layer pass.
+
+## Wavefront execution
+
+Set `"wavefront": true` to execute exact tokenwise Recirculation as a
+two-token wavefront. After the first-token warmup, the layers above the
+destination process the previous token's recurrent state and the current
+token's normal state in one layer call. Each upper attention layer first
+overwrites the previous token's KV entry, so the current token attends to the
+same recurrent cache that the serial implementation would have produced.
+
+```bash
+vllm serve google/gemma-3-1b-pt \
+  --hf-overrides '{
+    "recirculation_config": {
+      "source_layer": 11,
+      "destination_layer": 4,
+      "alpha": 0.15,
+      "ramp_tokens": 10,
+      "wavefront": true
+    }
+  }' \
+  --max-num-seqs 1 \
+  --long-prefill-token-threshold 1 \
+  --no-enable-prefix-caching
+```
+
+Wavefront mode captures a dedicated one-token CUDA graph whose upper stack has
+the internal two-token batch. Torch compilation remains enabled unless
+`--enforce-eager` is also set.
 
 The paper reports the following fixed configurations for its pretrained-model
 perplexity evaluation:
@@ -77,8 +107,9 @@ uv pip install 'datasets>=3.3.0,<=3.6.0'
 
 .venv/bin/python benchmarks/benchmark_recirculation.py \
   --mode recirculation \
+  --wavefront \
   --windows-file results/recirculation-windows.json \
-  --output results/recirculation-exact.json
+  --output results/recirculation-wavefront.json
 ```
 
 Use `--num-windows 50` for a larger sample. For a normal-scheduler baseline
@@ -111,5 +142,7 @@ assuming one value is universally optimal.
 - Only `Gemma3ForCausalLM` is supported. Multimodal Gemma 3 models are not.
 - Pipeline parallelism is not supported.
 - Only fixed scalar coefficients and source norm matching are implemented.
-- Layers above the destination run serially a second time. Wavefront execution
-  that overlaps the normal and recirculated stacks is not yet implemented.
+- Wavefront execution currently requires one sequence, one scheduled token per
+  step, FlashAttention, no prefix caching or speculative decoding, and no data,
+  decode-context, sequence, or pipeline parallelism.
+- Serial execution remains available when `"wavefront"` is omitted or false.

--- a/tests/benchmarks/test_recirculation.py
+++ b/tests/benchmarks/test_recirculation.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from benchmarks.benchmark_recirculation import (
+    DEFAULT_MODEL_REVISION,
+    PeakGpuMemory,
+    build_recirculation_config,
+    parse_args,
+)
+from benchmarks.validate_recirculation_adapters import FAMILIES
+
+EXPECTED_FAMILIES = {
+    "deepseek-v3",
+    "gemma3",
+    "gemma4",
+    "glm4-moe",
+    "glm4-moe-lite",
+    "gpt-oss",
+    "llama",
+    "llama4",
+    "mimo-v2",
+    "minimax-m2",
+    "minimax-m3",
+    "mistral",
+    "mixtral",
+    "qwen2",
+    "qwen3",
+    "qwen3-moe",
+    "qwen3-next",
+    "qwen3.5",
+    "qwen3.5-moe",
+    "step3.5",
+}
+
+
+def test_benchmark_accepts_model_specific_revision_and_beta(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_recirculation.py",
+            "--mode",
+            "recirculation",
+            "--output",
+            "result.json",
+            "--windows-file",
+            "windows.json",
+            "--model",
+            "google/gemma-3-4b-pt",
+            "--beta",
+            "1.0",
+        ],
+    )
+
+    args = parse_args()
+
+    assert args.model_revision is None
+    assert build_recirculation_config(args)["beta"] == 1.0
+
+
+def test_benchmark_pins_only_default_gemma_revision(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_recirculation.py",
+            "--mode",
+            "baseline",
+            "--output",
+            "result.json",
+            "--windows-file",
+            "windows.json",
+        ],
+    )
+
+    assert parse_args().model_revision == DEFAULT_MODEL_REVISION
+
+
+def test_gpu_memory_monitor_falls_back_to_torch(monkeypatch) -> None:
+    properties = SimpleNamespace(total_memory=1000, name="test accelerator")
+    device_module = SimpleNamespace(get_device_properties=lambda index: properties)
+    monkeypatch.setattr(PeakGpuMemory, "_load_pynvml", staticmethod(lambda: None))
+    monkeypatch.setattr(torch.accelerator, "is_available", lambda: True)
+    monkeypatch.setattr(torch.accelerator, "current_accelerator", lambda: "cuda")
+    monkeypatch.setattr(torch.accelerator, "memory_allocated", lambda index: 10)
+    monkeypatch.setattr(
+        torch.accelerator, "reset_peak_memory_stats", lambda index: None
+    )
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda index: None)
+    monkeypatch.setattr(torch.accelerator, "max_memory_allocated", lambda index: 25)
+    monkeypatch.setattr(torch, "get_device_module", lambda device: device_module)
+
+    with PeakGpuMemory(0) as monitor:
+        pass
+
+    assert monitor.source == "torch"
+    assert monitor.start_bytes == 10
+    assert monitor.peak_bytes == 25
+    assert monitor.total_bytes == 1000
+
+
+def test_adapter_validation_covers_every_documented_family() -> None:
+    assert FAMILIES.keys() == EXPECTED_FAMILIES
+
+
+@pytest.mark.parametrize("family", sorted(EXPECTED_FAMILIES))
+def test_adapter_validation_uses_tiny_local_config(family: str) -> None:
+    architecture, build_config, _ = FAMILIES[family]
+
+    config = build_config()
+
+    assert architecture
+    assert config.num_hidden_layers == 4
+    assert config.vocab_size == 256

--- a/tests/model_executor/test_gemma3_recirculation.py
+++ b/tests/model_executor/test_gemma3_recirculation.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.models.gemma3 import Gemma3Model
+from vllm.model_executor.models.recirculation import RecirculationConfig
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_recirculation_mix_matches_destination_norm() -> None:
+    config = RecirculationConfig(
+        source_layer=2,
+        destination_layer=0,
+        alpha=0.25,
+    )
+    source = torch.tensor([[3.0, 4.0]])
+    destination = torch.tensor([[0.0, 10.0]])
+
+    mixed = config.mix(source, destination, torch.tensor([8]))
+
+    torch.testing.assert_close(mixed, torch.tensor([[1.5, 9.5]]))
+
+
+def test_recirculation_mix_ramps_convex_coefficients_by_position() -> None:
+    config = RecirculationConfig(
+        source_layer=2,
+        destination_layer=0,
+        alpha=0.2,
+        ramp_tokens=10,
+    )
+    source = torch.tensor([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
+    destination = torch.tensor([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]])
+
+    mixed = config.mix(source, destination, torch.tensor([0, 5, 10]))
+
+    expected = torch.tensor([[0.0, 1.0], [0.1, 0.9], [0.2, 0.8]])
+    torch.testing.assert_close(mixed, expected)
+
+
+def test_recirculation_mix_supports_nonconvex_beta() -> None:
+    config = RecirculationConfig(
+        source_layer=2,
+        destination_layer=0,
+        alpha=0.2,
+        beta=1.0,
+    )
+    source = torch.tensor([[1.0, 0.0]])
+    destination = torch.tensor([[0.0, 1.0]])
+
+    mixed = config.mix(source, destination, torch.tensor([4]))
+
+    torch.testing.assert_close(mixed, torch.tensor([[0.2, 1.0]]))
+
+
+@pytest.mark.parametrize(
+    "raw_config",
+    [
+        {"source_layer": 2, "destination_layer": 2},
+        {"source_layer": 3, "destination_layer": 0},
+        {"source_layer": 2, "destination_layer": 0, "alpha": 1.1},
+        {"source_layer": 2, "destination_layer": 0, "ramp_tokens": -1},
+        {"source_layer": 2, "destination_layer": 0, "unexpected": True},
+    ],
+)
+def test_recirculation_config_rejects_invalid_values(raw_config: dict) -> None:
+    hf_config = SimpleNamespace(
+        num_hidden_layers=3,
+        recirculation_config=raw_config,
+    )
+
+    with pytest.raises(ValueError):
+        RecirculationConfig.from_hf_config(hf_config)
+
+
+class _AdditiveLayer(nn.Module):
+    def __init__(self, layer_idx: int, calls: list[int]) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.calls = calls
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self.calls.append(self.layer_idx)
+        residual = hidden_states if residual is None else hidden_states + residual
+        hidden_states = torch.full_like(residual, self.layer_idx + 1)
+        return hidden_states, residual
+
+
+class _FinalNorm(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return hidden_states + residual, residual
+
+
+def test_gemma3_returns_first_pass_and_recirculates_upper_layers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    monkeypatch.setattr(
+        "vllm.model_executor.models.gemma3.get_pp_group", lambda: pp_group
+    )
+    calls: list[int] = []
+    model = Gemma3Model.__new__(Gemma3Model)
+    nn.Module.__init__(model)
+    model.start_layer = 0
+    model.end_layer = 3
+    model.layers = nn.ModuleList([_AdditiveLayer(i, calls) for i in range(3)])
+    model.norm = _FinalNorm()
+    model.recirculation_config = RecirculationConfig(
+        source_layer=1,
+        destination_layer=0,
+        alpha=0.2,
+    )
+
+    output = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        inputs_embeds=torch.zeros(1, 2),
+    )
+
+    torch.testing.assert_close(output, torch.full((1, 2), 6.0))
+    assert calls == [0, 1, 2, 1, 2]

--- a/tests/model_executor/test_gemma3_recirculation.py
+++ b/tests/model_executor/test_gemma3_recirculation.py
@@ -58,6 +58,21 @@ def test_recirculation_mix_supports_nonconvex_beta() -> None:
     torch.testing.assert_close(mixed, torch.tensor([[0.2, 1.0]]))
 
 
+@pytest.mark.parametrize("beta", [None, 1.0])
+def test_recirculation_config_disables_identity_mix(beta: float | None) -> None:
+    hf_config = SimpleNamespace(
+        num_hidden_layers=3,
+        recirculation_config={
+            "source_layer": 2,
+            "destination_layer": 0,
+            "alpha": 0.0,
+            "beta": beta,
+        },
+    )
+
+    assert RecirculationConfig.from_hf_config(hf_config) is None
+
+
 @pytest.mark.parametrize(
     "raw_config",
     [
@@ -94,6 +109,8 @@ class _AdditiveLayer(nn.Module):
         self.calls.append(self.layer_idx)
         residual = hidden_states if residual is None else hidden_states + residual
         hidden_states = torch.full_like(residual, self.layer_idx + 1)
+        if (kv_cache := kwargs.get("kv_cache")) is not None:
+            kv_cache[self.layer_idx] = (hidden_states + residual).clone()
         return hidden_states, residual
 
 
@@ -133,4 +150,44 @@ def test_gemma3_returns_first_pass_and_recirculates_upper_layers(
     )
 
     torch.testing.assert_close(output, torch.full((1, 2), 6.0))
+    assert calls == [0, 1, 2, 1, 2]
+
+
+def test_gemma3_recirculation_overwrites_only_upper_layer_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    monkeypatch.setattr(
+        "vllm.model_executor.models.gemma3.get_pp_group", lambda: pp_group
+    )
+    calls: list[int] = []
+    model = Gemma3Model.__new__(Gemma3Model)
+    nn.Module.__init__(model)
+    model.start_layer = 0
+    model.end_layer = 3
+    model.layers = nn.ModuleList([_AdditiveLayer(i, calls) for i in range(3)])
+    model.norm = _FinalNorm()
+    model.recirculation_config = RecirculationConfig(
+        source_layer=1,
+        destination_layer=0,
+        alpha=0.2,
+    )
+    kv_cache: dict[int, torch.Tensor] = {}
+
+    output = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        inputs_embeds=torch.tensor([[1.0, 0.0]]),
+        kv_cache=kv_cache,
+    )
+
+    destination = torch.tensor([[2.0, 1.0]])
+    source = torch.tensor([[4.0, 3.0]])
+    recirculated = model.recirculation_config.mix(
+        source, destination, torch.tensor([0])
+    )
+    torch.testing.assert_close(output, torch.tensor([[7.0, 6.0]]))
+    torch.testing.assert_close(kv_cache[0], destination)
+    torch.testing.assert_close(kv_cache[1], recirculated + 2.0)
+    torch.testing.assert_close(kv_cache[2], recirculated + 5.0)
     assert calls == [0, 1, 2, 1, 2]

--- a/tests/model_executor/test_gemma3_recirculation.py
+++ b/tests/model_executor/test_gemma3_recirculation.py
@@ -80,6 +80,7 @@ def test_recirculation_config_disables_identity_mix(beta: float | None) -> None:
         {"source_layer": 3, "destination_layer": 0},
         {"source_layer": 2, "destination_layer": 0, "alpha": 1.1},
         {"source_layer": 2, "destination_layer": 0, "ramp_tokens": -1},
+        {"source_layer": 2, "destination_layer": 0, "wavefront": 1},
         {"source_layer": 2, "destination_layer": 0, "unexpected": True},
     ],
 )
@@ -191,3 +192,67 @@ def test_gemma3_recirculation_overwrites_only_upper_layer_cache(
     torch.testing.assert_close(kv_cache[1], recirculated + 2.0)
     torch.testing.assert_close(kv_cache[2], recirculated + 5.0)
     assert calls == [0, 1, 2, 1, 2]
+
+
+def _make_wavefront_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Gemma3Model, list[int]]:
+    pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    monkeypatch.setattr(
+        "vllm.model_executor.models.gemma3.get_pp_group", lambda: pp_group
+    )
+    calls: list[int] = []
+    model = Gemma3Model.__new__(Gemma3Model)
+    nn.Module.__init__(model)
+    model.start_layer = 0
+    model.end_layer = 3
+    model.layers = nn.ModuleList([_AdditiveLayer(i, calls) for i in range(3)])
+    model.norm = _FinalNorm()
+    model.recirculation_config = RecirculationConfig(
+        source_layer=1,
+        destination_layer=0,
+        alpha=0.2,
+        wavefront=True,
+    )
+    return model, calls
+
+
+def test_gemma3_wavefront_warms_up_without_rerunning_upper_layers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model, calls = _make_wavefront_model(monkeypatch)
+
+    output = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        inputs_embeds=torch.zeros(1, 2),
+        recirculation_wavefront_warmup=True,
+    )
+
+    torch.testing.assert_close(output[0:1], torch.full((1, 2), 6.0))
+    torch.testing.assert_close(output[1:2], torch.ones(1, 2))
+    assert calls == [0, 1, 2]
+
+
+def test_gemma3_wavefront_batches_previous_and_current_upper_stacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model, calls = _make_wavefront_model(monkeypatch)
+    kv_cache: dict[int, torch.Tensor] = {}
+
+    output = model.forward(
+        input_ids=None,
+        positions=torch.tensor([1]),
+        inputs_embeds=torch.ones(1, 2),
+        recirculation_wavefront_warmup=False,
+        recirculation_wavefront_positions=torch.tensor([0, 1]),
+        recirculation_wavefront_pending=torch.ones(1, 2),
+        kv_cache=kv_cache,
+    )
+
+    torch.testing.assert_close(output[0:1], torch.full((1, 2), 7.0))
+    torch.testing.assert_close(output[1:2], torch.full((1, 2), 2.0))
+    assert kv_cache[0].shape[0] == 1
+    assert kv_cache[1].shape[0] == 2
+    assert kv_cache[2].shape[0] == 2
+    assert calls == [0, 1, 2]

--- a/tests/model_executor/test_gemma3_recirculation.py
+++ b/tests/model_executor/test_gemma3_recirculation.py
@@ -43,6 +43,26 @@ def test_recirculation_mix_ramps_convex_coefficients_by_position() -> None:
     torch.testing.assert_close(mixed, expected)
 
 
+def test_recirculation_mix_uses_first_mrope_position_row() -> None:
+    config = RecirculationConfig(
+        source_layer=2,
+        destination_layer=0,
+        alpha=0.2,
+        ramp_tokens=10,
+    )
+    source = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+    destination = torch.tensor([[0.0, 1.0], [0.0, 1.0]])
+    positions = torch.tensor([[5, 10], [50, 60], [70, 80]])
+
+    mixed = config.mix(source, destination, positions)
+
+    assert mixed.shape == source.shape
+    torch.testing.assert_close(
+        mixed,
+        torch.tensor([[0.1, 0.9], [0.2, 0.8]]),
+    )
+
+
 def test_recirculation_mix_supports_nonconvex_beta() -> None:
     config = RecirculationConfig(
         source_layer=2,
@@ -194,6 +214,30 @@ def test_gemma3_recirculation_overwrites_only_upper_layer_cache(
     assert calls == [0, 1, 2, 1, 2]
 
 
+def test_identity_config_uses_baseline_stack_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model, calls = _make_wavefront_model(monkeypatch)
+    hf_config = SimpleNamespace(
+        num_hidden_layers=3,
+        recirculation_config={
+            "source_layer": 1,
+            "destination_layer": 0,
+            "alpha": 0.0,
+        },
+    )
+    model.recirculation_config = RecirculationConfig.from_hf_config(hf_config)
+
+    output = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        inputs_embeds=torch.zeros(1, 2),
+    )
+
+    torch.testing.assert_close(output, torch.full((1, 2), 6.0))
+    assert calls == [0, 1, 2]
+
+
 def _make_wavefront_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[Gemma3Model, list[int]]:
@@ -256,3 +300,71 @@ def test_gemma3_wavefront_batches_previous_and_current_upper_stacks(
     assert kv_cache[1].shape[0] == 2
     assert kv_cache[2].shape[0] == 2
     assert calls == [0, 1, 2]
+
+
+def test_serial_and_wavefront_match_outputs_and_effective_upper_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serial, _ = _make_wavefront_model(monkeypatch)
+    serial.recirculation_config = RecirculationConfig(
+        source_layer=1,
+        destination_layer=0,
+        alpha=0.2,
+    )
+    wavefront, _ = _make_wavefront_model(monkeypatch)
+    serial_cache: dict[int, torch.Tensor] = {}
+    wavefront_cache: dict[int, torch.Tensor] = {}
+    inputs = [
+        torch.tensor([[1.0, 0.0]]),
+        torch.tensor([[0.0, 1.0]]),
+        torch.tensor([[2.0, 1.0]]),
+    ]
+
+    serial.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        inputs_embeds=inputs[0],
+        kv_cache=serial_cache,
+    )
+    serial_output = serial.forward(
+        input_ids=None,
+        positions=torch.tensor([1]),
+        inputs_embeds=inputs[1],
+        kv_cache=serial_cache,
+    )
+    serial_upper_cache = {
+        layer_idx: serial_cache[layer_idx].clone() for layer_idx in (1, 2)
+    }
+
+    warmup = wavefront.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        inputs_embeds=inputs[0],
+        recirculation_wavefront_warmup=True,
+        kv_cache=wavefront_cache,
+    )
+    wavefront_output = wavefront.forward(
+        input_ids=None,
+        positions=torch.tensor([1]),
+        inputs_embeds=inputs[1],
+        recirculation_wavefront_warmup=False,
+        recirculation_wavefront_positions=torch.tensor([0, 1]),
+        recirculation_wavefront_pending=warmup[1:],
+        kv_cache=wavefront_cache,
+    )
+    wavefront.forward(
+        input_ids=None,
+        positions=torch.tensor([2]),
+        inputs_embeds=inputs[2],
+        recirculation_wavefront_warmup=False,
+        recirculation_wavefront_positions=torch.tensor([1, 2]),
+        recirculation_wavefront_pending=wavefront_output[1:],
+        kv_cache=wavefront_cache,
+    )
+
+    torch.testing.assert_close(wavefront_output[:1], serial_output)
+    for layer_idx in (1, 2):
+        torch.testing.assert_close(
+            wavefront_cache[layer_idx][0:1],
+            serial_upper_cache[layer_idx],
+        )

--- a/tests/model_executor/test_recirculation.py
+++ b/tests/model_executor/test_recirculation.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.models.interfaces import supports_recirculation
+from vllm.model_executor.models.llama import LlamaForCausalLM, LlamaModel
+from vllm.model_executor.models.mistral import MistralModel
+from vllm.model_executor.models.recirculation import RecirculationConfig
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class _AdditiveLayer(nn.Module):
+    def __init__(self, layer_idx: int, calls: list[int]) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.calls = calls
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self.calls.append(self.layer_idx)
+        residual = hidden_states if residual is None else hidden_states + residual
+        return torch.full_like(residual, self.layer_idx + 1), residual
+
+
+class _FinalNorm(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, None]:
+        assert residual is not None
+        return hidden_states + residual, None
+
+
+def _make_llama_model(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: type[LlamaModel] = LlamaModel,
+) -> tuple[LlamaModel, list[int]]:
+    pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    monkeypatch.setattr(
+        "vllm.model_executor.models.llama.get_pp_group", lambda: pp_group
+    )
+    calls: list[int] = []
+    model = cast(LlamaModel, object.__new__(model_type))
+    nn.Module.__init__(model)
+    model.start_layer = 0
+    model.end_layer = 3
+    model.layers = nn.ModuleList([_AdditiveLayer(i, calls) for i in range(3)])
+    model.norm = _FinalNorm()
+    model.recirculation_config = RecirculationConfig(
+        source_layer=1,
+        destination_layer=0,
+        alpha=0.2,
+        wavefront=True,
+    )
+    return model, calls
+
+
+def test_llama_uses_shared_wavefront_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model, calls = _make_llama_model(monkeypatch)
+
+    output = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=torch.zeros(1, 2),
+        recirculation_wavefront_warmup=True,
+    )
+
+    torch.testing.assert_close(output[0:1], torch.full((1, 2), 6.0))
+    torch.testing.assert_close(output[1:2], torch.ones(1, 2))
+    assert calls == [0, 1, 2]
+
+
+def test_llama_top_level_advertises_engine_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model, _ = _make_llama_model(monkeypatch)
+    causal_lm = LlamaForCausalLM.__new__(LlamaForCausalLM)
+    nn.Module.__init__(causal_lm)
+    causal_lm.model = model
+
+    assert supports_recirculation(causal_lm)
+
+
+def test_mistral_delegates_to_shared_wavefront_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model, calls = _make_llama_model(monkeypatch, MistralModel)
+
+    output = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=torch.zeros(1, 2),
+        t_cond=None,
+        recirculation_wavefront_warmup=True,
+    )
+
+    torch.testing.assert_close(output[0:1], torch.full((1, 2), 6.0))
+    torch.testing.assert_close(output[1:2], torch.ones(1, 2))
+    assert calls == [0, 1, 2]
+
+
+def test_unvalidated_llama_subclass_does_not_inherit_adapter() -> None:
+    class UnvalidatedLlamaModel(LlamaModel):
+        pass
+
+    model = UnvalidatedLlamaModel.__new__(UnvalidatedLlamaModel)
+
+    assert not model.has_recirculation_adapter()
+
+
+def test_engine_capability_rejects_incomplete_forward() -> None:
+    class IncompleteModel:
+        supports_recirculation = True
+
+        def forward(
+            self, input_ids: torch.Tensor, positions: torch.Tensor
+        ) -> torch.Tensor:
+            return input_ids
+
+    assert not supports_recirculation(IncompleteModel())

--- a/tests/model_executor/test_recirculation.py
+++ b/tests/model_executor/test_recirculation.py
@@ -8,10 +8,32 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.model_executor.models.deepseek_v2 import DeepseekV2Model
+from vllm.model_executor.models.gemma4 import Gemma4Model
+from vllm.model_executor.models.glm4_moe import Glm4MoeModel
+from vllm.model_executor.models.glm4_moe_lite import Glm4MoeLiteModel
+from vllm.model_executor.models.gpt_oss import GptOssModel
 from vllm.model_executor.models.interfaces import supports_recirculation
 from vllm.model_executor.models.llama import LlamaForCausalLM, LlamaModel
+from vllm.model_executor.models.llama4 import Llama4Model
+from vllm.model_executor.models.mimo_v2 import MiMoV2Model
+from vllm.model_executor.models.minimax_m2 import MiniMaxM2Model
 from vllm.model_executor.models.mistral import MistralModel
-from vllm.model_executor.models.recirculation import RecirculationConfig
+from vllm.model_executor.models.mixtral import MixtralModel
+from vllm.model_executor.models.qwen2 import Qwen2Model
+from vllm.model_executor.models.qwen3 import Qwen3Model
+from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+from vllm.model_executor.models.qwen3_moe import Qwen3MoeModel
+from vllm.model_executor.models.qwen3_next import (
+    Qwen3NextDecoderLayer,
+    Qwen3NextModel,
+)
+from vllm.model_executor.models.recirculation import (
+    RecirculationConfig,
+    RecirculationDecoderMixin,
+)
+from vllm.model_executor.models.step3p5 import Step3p5Model
+from vllm.models.minimax_m3.nvidia.model import MiniMaxM3Model
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -135,3 +157,115 @@ def test_engine_capability_rejects_incomplete_forward() -> None:
             return input_ids
 
     assert not supports_recirculation(IncompleteModel())
+
+
+@pytest.mark.parametrize(
+    ("model_type", "adapter", "wavefront"),
+    [
+        (DeepseekV2Model, "deepseek_moe", False),
+        (Gemma4Model, "gemma4", True),
+        (Glm4MoeModel, "glm4_moe", True),
+        (Glm4MoeLiteModel, "glm4_moe_lite", False),
+        (GptOssModel, "gpt_oss_moe", False),
+        (Llama4Model, "llama4_moe", True),
+        (MiniMaxM2Model, "minimax_m2_moe", True),
+        (MiniMaxM3Model, "minimax_m3_sparse_moe", False),
+        (MiMoV2Model, "mimo_v2_moe", True),
+        (MixtralModel, "mixtral", True),
+        (Qwen2Model, "qwen2", True),
+        (Qwen3Model, "qwen3", True),
+        (Qwen3MoeModel, "qwen3_moe", True),
+        (Qwen3NextModel, "qwen3_next_hybrid", False),
+        (Qwen3_5Model, "qwen3_5_hybrid", False),
+        (Step3p5Model, "step3p5_moe", True),
+    ],
+)
+def test_reviewed_family_capabilities(
+    model_type: type[RecirculationDecoderMixin],
+    adapter: str,
+    wavefront: bool,
+) -> None:
+    model = cast(RecirculationDecoderMixin, object.__new__(model_type))
+    if isinstance(model, Gemma4Model):
+        model.hidden_size_per_layer_input = 0
+
+    capabilities = model.get_recirculation_capabilities()
+
+    assert capabilities is not None
+    assert capabilities.adapter == adapter
+    assert capabilities.serial
+    assert capabilities.wavefront is wavefront
+
+
+def test_gemma4_per_layer_embeddings_are_serial_only() -> None:
+    model = cast(Gemma4Model, object.__new__(Gemma4Model))
+    model.hidden_size_per_layer_input = 16
+
+    capabilities = model.get_recirculation_capabilities()
+
+    assert capabilities is not None
+    assert capabilities.serial
+    assert not capabilities.wavefront
+
+
+def test_nested_text_config_is_used_for_recirculation() -> None:
+    text_config = SimpleNamespace(
+        num_hidden_layers=4,
+        recirculation_config={
+            "source_layer": 2,
+            "destination_layer": 1,
+            "alpha": 0.1,
+        },
+    )
+    wrapper_config = SimpleNamespace(get_text_config=lambda: text_config)
+
+    config = RecirculationConfig.from_hf_config(wrapper_config)
+
+    assert config is not None
+    assert config.source_layer == 2
+    assert config.destination_layer == 1
+
+
+def test_qwen_next_restores_active_gdn_state_before_rerun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLinearAttention(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.prefix = "model.layers.0.linear_attn"
+            self.kv_cache = (
+                torch.arange(12, dtype=torch.float32).reshape(3, 4),
+                torch.arange(18, dtype=torch.float32).reshape(3, 2, 3),
+            )
+
+    layer = cast(Qwen3NextDecoderLayer, object.__new__(Qwen3NextDecoderLayer))
+    nn.Module.__init__(layer)
+    layer.linear_attn = FakeLinearAttention()
+    model = cast(Qwen3NextModel, object.__new__(Qwen3NextModel))
+    nn.Module.__init__(model)
+    model.layers = nn.ModuleList([layer])
+    metadata = SimpleNamespace(
+        spec_sequence_masks=None,
+        non_spec_state_indices_tensor=torch.tensor([2, 0], dtype=torch.int64),
+        num_prefills=1,
+        num_decodes=1,
+    )
+    context = SimpleNamespace(attn_metadata={"model.layers.0.linear_attn": metadata})
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_next.get_forward_context",
+        lambda: context,
+    )
+
+    snapshot = model._capture_recirculation_layer_state(0)
+    untouched = tuple(state[1].clone() for state in layer.linear_attn.kv_cache)
+    for state in layer.linear_attn.kv_cache:
+        state.add_(100)
+    model._restore_recirculation_layer_state(0, snapshot)
+
+    assert snapshot is not None
+    state_indices, captured = snapshot
+    for cache, saved, untouched_row in zip(
+        layer.linear_attn.kv_cache, captured, untouched
+    ):
+        torch.testing.assert_close(cache.index_select(0, state_indices), saved)
+        torch.testing.assert_close(cache[1], untouched_row + 100)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,8 +131,15 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
 def test_recirculation_forces_v1_model_runner(monkeypatch):
     config = SimpleNamespace(
         model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(recirculation_config={"source_layer": 2})
-        )
+            hf_config=SimpleNamespace(
+                num_hidden_layers=4,
+                recirculation_config={
+                    "source_layer": 2,
+                    "destination_layer": 1,
+                },
+            )
+        ),
+        speculative_config=None,
     )
     config._recirculation_requested = lambda: VllmConfig._recirculation_requested(
         config
@@ -147,6 +154,42 @@ def test_recirculation_forces_v1_model_runner(monkeypatch):
 
     config.model_config.hf_config.recirculation_config.update(alpha=0.0)
     assert VllmConfig.use_v2_model_runner.fget(config)
+
+
+def test_invalid_identity_recirculation_config_cannot_bypass_validation() -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                num_hidden_layers=4,
+                recirculation_config={"source_layer": 2, "alpha": 0.0},
+            )
+        )
+    )
+
+    with pytest.raises(ValueError, match="destination_layer"):
+        VllmConfig._recirculation_requested(config)
+
+
+def test_recirculation_rejects_all_speculative_methods(monkeypatch) -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                num_hidden_layers=4,
+                recirculation_config={
+                    "source_layer": 2,
+                    "destination_layer": 1,
+                },
+            )
+        ),
+        speculative_config=SimpleNamespace(method="extract_hidden_states"),
+    )
+    config._recirculation_requested = lambda: VllmConfig._recirculation_requested(
+        config
+    )
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+
+    with pytest.raises(ValueError, match="auxiliary hidden-state extraction"):
+        VllmConfig.use_v2_model_runner.fget(config)
 
 
 def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -128,6 +128,27 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
     assert envs.VLLM_USE_V2_MODEL_RUNNER is expected
 
 
+def test_recirculation_forces_v1_model_runner(monkeypatch):
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(recirculation_config={"source_layer": 2})
+        )
+    )
+    config._recirculation_requested = lambda: VllmConfig._recirculation_requested(
+        config
+    )
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+
+    assert not VllmConfig.use_v2_model_runner.fget(config)
+
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    with pytest.raises(ValueError, match="VLLM_USE_V2_MODEL_RUNNER=0"):
+        VllmConfig.use_v2_model_runner.fget(config)
+
+    config.model_config.hf_config.recirculation_config.update(alpha=0.0)
+    assert VllmConfig.use_v2_model_runner.fget(config)
+
+
 def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
     """ROCm keeps DeepSeek V3.2 and V4 on their compiled MRV1 paths."""
     from vllm.config.vllm import (

--- a/tests/transformers_utils/test_minimax_m3_config.py
+++ b/tests/transformers_utils/test_minimax_m3_config.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+
+from vllm.transformers_utils.config import get_config
+from vllm.transformers_utils.configs import MiniMaxM3TextConfig
+
+
+def test_load_local_minimax_m3_text_config(tmp_path: Path):
+    config = MiniMaxM3TextConfig(
+        num_hidden_layers=4,
+        moe_layer_freq=[0, 0, 0, 1],
+        sparse_attention_config={},
+    )
+    config.save_pretrained(tmp_path)
+
+    loaded = get_config(tmp_path, trust_remote_code=False)
+
+    assert isinstance(loaded, MiniMaxM3TextConfig)
+    assert loaded.num_hidden_layers == 4
+    assert loaded.moe_layer_freq == [0, 0, 0, 1]

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -38,6 +38,7 @@ from vllm.config.parallel import EPLBConfig, ParallelConfig
 from vllm.config.pooler import PoolerConfig
 from vllm.config.profiler import ProfilerConfig
 from vllm.config.reasoning import ReasoningConfig
+from vllm.config.recirculation import RecirculationConfig
 from vllm.config.scheduler import SchedulerConfig
 from vllm.config.speculative import SpeculativeConfig
 from vllm.config.speech_to_text import SpeechToTextConfig, SpeechToTextParams
@@ -114,6 +115,8 @@ __all__ = [
     "PoolerConfig",
     # From vllm.config.reasoning
     "ReasoningConfig",
+    # From vllm.config.recirculation
+    "RecirculationConfig",
     # From vllm.config.scheduler
     "SchedulerConfig",
     # From vllm.config.speculative

--- a/vllm/config/recirculation.py
+++ b/vllm/config/recirculation.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True)
+class RecirculationConfig:
+    """Fixed-coefficient residual-stream recirculation configuration."""
+
+    source_layer: int
+    destination_layer: int
+    alpha: float = 0.15
+    beta: float | None = None
+    ramp_tokens: int = 0
+    wavefront: bool = False
+
+    @staticmethod
+    def _get_text_config(hf_config: object) -> object:
+        get_text_config = getattr(hf_config, "get_text_config", None)
+        if callable(get_text_config):
+            return get_text_config()
+        return hf_config
+
+    @classmethod
+    def from_hf_config(cls, hf_config: object) -> "RecirculationConfig | None":
+        text_config = cls._get_text_config(hf_config)
+        raw_config = getattr(hf_config, "recirculation_config", None)
+        if raw_config is None and text_config is not hf_config:
+            raw_config = getattr(text_config, "recirculation_config", None)
+        if raw_config is None:
+            return None
+        if not isinstance(raw_config, dict):
+            raise ValueError("recirculation_config must be a dictionary")
+
+        valid_keys = {
+            "source_layer",
+            "destination_layer",
+            "alpha",
+            "beta",
+            "ramp_tokens",
+            "wavefront",
+        }
+        unknown_keys = raw_config.keys() - valid_keys
+        if unknown_keys:
+            unknown = ", ".join(sorted(unknown_keys))
+            raise ValueError(f"Unknown recirculation_config fields: {unknown}")
+
+        missing_keys = {"source_layer", "destination_layer"} - raw_config.keys()
+        if missing_keys:
+            missing = ", ".join(sorted(missing_keys))
+            raise ValueError(f"Missing recirculation_config fields: {missing}")
+
+        config = cls(
+            source_layer=raw_config["source_layer"],
+            destination_layer=raw_config["destination_layer"],
+            alpha=raw_config.get("alpha", 0.15),
+            beta=raw_config.get("beta"),
+            ramp_tokens=raw_config.get("ramp_tokens", 0),
+            wavefront=raw_config.get("wavefront", False),
+        )
+        num_hidden_layers = getattr(text_config, "num_hidden_layers", None)
+        if isinstance(num_hidden_layers, bool) or not isinstance(
+            num_hidden_layers, int
+        ):
+            raise ValueError("num_hidden_layers must be an integer")
+        config.validate(num_hidden_layers)
+        if config.alpha == 0.0 and config.beta in (None, 1.0):
+            return None
+        return config
+
+    def validate(self, num_hidden_layers: int) -> None:
+        for name, value in (
+            ("source_layer", self.source_layer),
+            ("destination_layer", self.destination_layer),
+            ("ramp_tokens", self.ramp_tokens),
+        ):
+            if type(value) is not int:
+                raise ValueError(f"{name} must be an integer")
+
+        if not 0 <= self.destination_layer < self.source_layer < num_hidden_layers:
+            raise ValueError(
+                "recirculation layers must satisfy 0 <= destination_layer < "
+                "source_layer < num_hidden_layers"
+            )
+        if self.ramp_tokens < 0:
+            raise ValueError("ramp_tokens must be non-negative")
+        if type(self.wavefront) is not bool:
+            raise ValueError("wavefront must be a boolean")
+
+        self._validate_coefficient("alpha", self.alpha)
+        if self.beta is not None:
+            self._validate_coefficient("beta", self.beta)
+
+    @staticmethod
+    def _validate_coefficient(name: str, value: Any) -> None:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ValueError(f"{name} must be a real number")
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(f"{name} must be between 0 and 1")
+
+    def mix(
+        self,
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Mix a norm-matched source residual into the destination residual."""
+        source_float = source.float()
+        destination_float = destination.float()
+        source_norm = torch.linalg.vector_norm(
+            source_float, dim=-1, keepdim=True
+        ).clamp_min(torch.finfo(torch.float32).tiny)
+        destination_norm = torch.linalg.vector_norm(
+            destination_float, dim=-1, keepdim=True
+        )
+        normalized_source = source_float * (destination_norm / source_norm)
+
+        alpha: float | torch.Tensor = self.alpha
+        if self.ramp_tokens:
+            if positions.ndim == 2:
+                positions = positions[0]
+            if positions.ndim != 1 or positions.shape[0] != source.shape[0]:
+                raise ValueError(
+                    "Recirculation positions must have shape [tokens] or "
+                    "[dimensions, tokens]"
+                )
+            ramp = positions.to(dtype=torch.float32).clamp(max=self.ramp_tokens)
+            alpha = (ramp / self.ramp_tokens).unsqueeze(-1) * self.alpha
+        beta = 1.0 - alpha if self.beta is None else self.beta
+        mixed = beta * destination_float + alpha * normalized_source
+        return mixed.to(dtype=destination.dtype)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -46,6 +46,7 @@ from .offload import OffloadConfig
 from .parallel import ParallelConfig
 from .profiler import ProfilerConfig
 from .reasoning import ReasoningConfig
+from .recirculation import RecirculationConfig
 from .scheduler import SchedulerConfig
 from .speculative import EagleModelTypes, NgramGPUTypes, SpeculativeConfig
 from .structured_outputs import StructuredOutputsConfig
@@ -649,6 +650,11 @@ class VllmConfig:
     def use_v2_model_runner(self) -> bool:
         use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
         recirculation_requested = self._recirculation_requested()
+        if recirculation_requested and self.speculative_config is not None:
+            raise ValueError(
+                "Recirculation does not support speculative decoding or "
+                "auxiliary hidden-state extraction"
+            )
         if use_v2_model_runner is not None:
             if use_v2_model_runner and recirculation_requested:
                 raise ValueError(
@@ -705,19 +711,8 @@ class VllmConfig:
     def _recirculation_requested(self) -> bool:
         if self.model_config is None:
             return False
-        hf_config = self.model_config.hf_config
-        raw_config = getattr(hf_config, "recirculation_config", None)
-        get_text_config = getattr(hf_config, "get_text_config", None)
-        if raw_config is None and callable(get_text_config):
-            text_config = get_text_config()
-            raw_config = getattr(text_config, "recirculation_config", None)
-        if raw_config is None:
-            return False
-        if not isinstance(raw_config, dict):
-            return True
-        return not (
-            raw_config.get("alpha", 0.15) == 0.0
-            and raw_config.get("beta") in (None, 1.0)
+        return (
+            RecirculationConfig.from_hf_config(self.model_config.hf_config) is not None
         )
 
     def _dflash_needs_multi_kv_group(self) -> bool:
@@ -1135,6 +1130,12 @@ class VllmConfig:
             logger.info_once("Performance mode set to '%s'.", self.performance_mode)
 
         self.try_verify_and_update_config()
+
+        if self._recirculation_requested() and self.speculative_config is not None:
+            raise ValueError(
+                "Recirculation does not support speculative decoding or "
+                "auxiliary hidden-state extraction"
+            )
 
         if self.model_config is not None:
             self.model_config.verify_with_parallel_config(self.parallel_config)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -648,8 +648,17 @@ class VllmConfig:
     @property
     def use_v2_model_runner(self) -> bool:
         use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER
+        recirculation_requested = self._recirculation_requested()
         if use_v2_model_runner is not None:
+            if use_v2_model_runner and recirculation_requested:
+                raise ValueError(
+                    "Recirculation is not implemented by Model Runner V2; "
+                    "set VLLM_USE_V2_MODEL_RUNNER=0"
+                )
             return use_v2_model_runner
+
+        if recirculation_requested:
+            return False
 
         # PCP runtime support is implemented only by the V2 model runner.
         if self.parallel_config.prefill_context_parallel_size > 1:
@@ -692,6 +701,24 @@ class VllmConfig:
             return False
 
         return True
+
+    def _recirculation_requested(self) -> bool:
+        if self.model_config is None:
+            return False
+        hf_config = self.model_config.hf_config
+        raw_config = getattr(hf_config, "recirculation_config", None)
+        get_text_config = getattr(hf_config, "get_text_config", None)
+        if raw_config is None and callable(get_text_config):
+            text_config = get_text_config()
+            raw_config = getattr(text_config, "recirculation_config", None)
+        if raw_config is None:
+            return False
+        if not isinstance(raw_config, dict):
+            return True
+        return not (
+            raw_config.get("alpha", 0.15) == 0.0
+            and raw_config.get("beta") in (None, 1.0)
+        )
 
     def _dflash_needs_multi_kv_group(self) -> bool:
         """Whether a DFlash draft mixes sliding-window and full attention."""

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -8,13 +8,16 @@ from .interfaces import (
     SupportsMultiModal,
     SupportsMultiModalEmbeddings,
     SupportsPP,
+    SupportsRecirculation,
     SupportsTranscription,
+    get_recirculation_capabilities,
     has_inner_state,
     supports_lora,
     supports_mrope,
     supports_multimodal,
     supports_multimodal_embeddings,
     supports_pp,
+    supports_recirculation,
     supports_transcription,
 )
 from .interfaces_base import (
@@ -43,6 +46,9 @@ __all__ = [
     "supports_mrope",
     "SupportsPP",
     "supports_pp",
+    "SupportsRecirculation",
+    "supports_recirculation",
+    "get_recirculation_capabilities",
     "SupportsTranscription",
     "supports_transcription",
 ]

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -114,7 +114,9 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsRecirculation,
 )
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     PPMissingLayer,
     get_pp_missing_layer_names,
@@ -1387,7 +1389,11 @@ class DeepseekV2DecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class DeepseekV2Model(nn.Module):
+class DeepseekV2Model(RecirculationDecoderMixin, nn.Module):
+    recirculation_capabilities = RecirculationCapabilities(
+        adapter="deepseek_moe",
+        wavefront=False,
+    )
     fall_back_to_pt_during_load = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -1429,6 +1435,13 @@ class DeepseekV2Model(nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
+        if self.recirculation_config is not None and any(
+            layer.use_sequence_parallel_moe for layer in self.layers
+        ):
+            raise ValueError(
+                "Recirculation does not support sequence-parallel DeepSeek models"
+            )
 
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
@@ -1459,12 +1472,45 @@ class DeepseekV2Model(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
+    def _get_llama_4_scaling(
+        self,
+        positions: torch.Tensor,
+    ) -> torch.Tensor | None:
+        llama_4_scaling_config = getattr(self.config, "llama_4_scaling", None)
+        if llama_4_scaling_config is None:
+            return None
+        return _get_llama_4_scaling(
+            original_max_position_embeddings=llama_4_scaling_config[
+                "original_max_position_embeddings"
+            ],
+            scaling_beta=llama_4_scaling_config["beta"],
+            positions=positions,
+        )
+
+    def _forward_recirculation_layer(
+        self,
+        layer_idx: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **layer_kwargs: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.layers[layer_idx](
+            positions,
+            hidden_states,
+            residual,
+            self._get_llama_4_scaling(positions),
+        )
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -1483,18 +1529,17 @@ class DeepseekV2Model(nn.Module):
             residual = intermediate_tensors["residual"]
 
         # Compute llama 4 scaling once per forward pass if enabled
-        llama_4_scaling_config = getattr(self.config, "llama_4_scaling", None)
-        llama_4_scaling: torch.Tensor | None
-        if llama_4_scaling_config is not None:
-            llama_4_scaling = _get_llama_4_scaling(
-                original_max_position_embeddings=llama_4_scaling_config[
-                    "original_max_position_embeddings"
-                ],
-                scaling_beta=llama_4_scaling_config["beta"],
-                positions=positions,
+        llama_4_scaling = self._get_llama_4_scaling(positions)
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
             )
-        else:
-            llama_4_scaling = None
 
         aux_hidden_states = []
         for idx, layer in enumerate(
@@ -1830,6 +1875,7 @@ class DeepseekV2ForCausalLM(
     SupportsLoRA,
     SupportsEagle,
     SupportsEagle3,
+    SupportsRecirculation,
 ):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
@@ -1916,15 +1962,31 @@ class DeepseekV2ForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -289,7 +289,14 @@ class Gemma3DecoderLayer(nn.Module):
         return hidden_states, residual
 
 
-@support_torch_compile
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": 0,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
 class Gemma3Model(nn.Module):
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
@@ -355,6 +362,9 @@ class Gemma3Model(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
@@ -367,6 +377,21 @@ class Gemma3Model(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if (
+            self.recirculation_config is not None
+            and self.recirculation_config.wavefront
+            and recirculation_wavefront_warmup is not None
+        ):
+            return self._forward_recirculation_wavefront(
+                positions=positions,
+                hidden_states=hidden_states,
+                residual=residual,
+                warmup=recirculation_wavefront_warmup,
+                wavefront_positions=recirculation_wavefront_positions,
+                wavefront_pending=recirculation_wavefront_pending,
+                **kwargs,
+            )
 
         destination_states = None
         source_states = None
@@ -405,6 +430,68 @@ class Gemma3Model(nn.Module):
                     **kwargs,
                 )
         return hidden_states
+
+    def _forward_recirculation_wavefront(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        warmup: bool,
+        wavefront_positions: torch.Tensor | None,
+        wavefront_pending: torch.Tensor | None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Run the normal and previous-token recurrent upper stacks together."""
+        config = self.recirculation_config
+        assert config is not None and config.wavefront
+        assert positions.shape[0] == 1
+
+        destination_states = None
+        source_states = None
+        if warmup:
+            for layer_idx in range(self.start_layer, self.end_layer):
+                hidden_states, residual = self.layers[layer_idx](
+                    positions,
+                    hidden_states,
+                    residual,
+                    **kwargs,
+                )
+                if layer_idx == config.destination_layer:
+                    destination_states = hidden_states + residual
+                if layer_idx == config.source_layer:
+                    source_states = hidden_states + residual
+            hidden_states, _ = self.norm(hidden_states, residual)
+        else:
+            assert wavefront_positions is not None
+            assert wavefront_positions.shape[0] == 2
+            assert wavefront_pending is not None
+            assert wavefront_pending.shape == hidden_states.shape
+            for layer_idx in range(self.start_layer, config.destination_layer + 1):
+                hidden_states, residual = self.layers[layer_idx](
+                    positions,
+                    hidden_states,
+                    residual,
+                    **kwargs,
+                )
+
+            destination_states = hidden_states + residual
+            hidden_states = torch.cat((wavefront_pending, destination_states), dim=0)
+            residual = None
+            for layer_idx in range(config.destination_layer + 1, self.end_layer):
+                hidden_states, residual = self.layers[layer_idx](
+                    wavefront_positions,
+                    hidden_states,
+                    residual,
+                    **kwargs,
+                )
+                if layer_idx == config.source_layer:
+                    source_states = (hidden_states + residual)[1:]
+            hidden_states, _ = self.norm(hidden_states, residual)
+            hidden_states = hidden_states[1:]
+
+        assert destination_states is not None and source_states is not None
+        next_pending = config.mix(source_states, destination_states, positions)
+        return torch.cat((hidden_states, next_pending), dim=0)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -46,8 +46,8 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
-from .interfaces import SupportsLoRA, SupportsPP
-from .recirculation import RecirculationConfig
+from .interfaces import SupportsLoRA, SupportsPP, SupportsRecirculation
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
@@ -297,7 +297,8 @@ class Gemma3DecoderLayer(nn.Module):
         "inputs_embeds": 0,
     }
 )
-class Gemma3Model(nn.Module):
+class Gemma3Model(RecirculationDecoderMixin, nn.Module):
+    recirculation_capabilities = RecirculationCapabilities(adapter="gemma3")
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)
@@ -316,12 +317,6 @@ class Gemma3Model(nn.Module):
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
-        self.recirculation_config = RecirculationConfig.from_hf_config(config)
-        if self.recirculation_config is not None and not getattr(
-            config, "is_causal", True
-        ):
-            raise ValueError("Recirculation requires causal attention")
-
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
@@ -335,10 +330,7 @@ class Gemma3Model(nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
-        if self.recirculation_config is not None and (
-            self.start_layer != 0 or self.end_layer != config.num_hidden_layers
-        ):
-            raise ValueError("Recirculation does not support pipeline parallelism")
+        self._init_recirculation(config, self.start_layer, self.end_layer)
         self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         # Normalize the embedding by sqrt(hidden_size)
@@ -378,23 +370,17 @@ class Gemma3Model(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        if (
-            self.recirculation_config is not None
-            and self.recirculation_config.wavefront
-            and recirculation_wavefront_warmup is not None
-        ):
-            return self._forward_recirculation_wavefront(
-                positions=positions,
-                hidden_states=hidden_states,
-                residual=residual,
-                warmup=recirculation_wavefront_warmup,
-                wavefront_positions=recirculation_wavefront_positions,
-                wavefront_pending=recirculation_wavefront_pending,
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
                 **kwargs,
             )
 
-        destination_states = None
-        source_states = None
         for layer_idx in range(self.start_layer, self.end_layer):
             layer = self.layers[layer_idx]
             hidden_states, residual = layer(
@@ -403,102 +389,19 @@ class Gemma3Model(nn.Module):
                 residual,
                 **kwargs,
             )
-            if self.recirculation_config is not None:
-                if layer_idx == self.recirculation_config.destination_layer:
-                    destination_states = hidden_states + residual
-                if layer_idx == self.recirculation_config.source_layer:
-                    source_states = hidden_states + residual
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
-
-        if self.recirculation_config is not None:
-            assert destination_states is not None and source_states is not None
-            recirculated_states = self.recirculation_config.mix(
-                source_states, destination_states, positions
-            )
-            recirculated_residual = None
-            for layer_idx in range(
-                self.recirculation_config.destination_layer + 1, self.end_layer
-            ):
-                recirculated_states, recirculated_residual = self.layers[layer_idx](
-                    positions,
-                    recirculated_states,
-                    recirculated_residual,
-                    **kwargs,
-                )
         return hidden_states
-
-    def _forward_recirculation_wavefront(
-        self,
-        positions: torch.Tensor,
-        hidden_states: torch.Tensor,
-        residual: torch.Tensor | None,
-        warmup: bool,
-        wavefront_positions: torch.Tensor | None,
-        wavefront_pending: torch.Tensor | None,
-        **kwargs,
-    ) -> torch.Tensor:
-        """Run the normal and previous-token recurrent upper stacks together."""
-        config = self.recirculation_config
-        assert config is not None and config.wavefront
-        assert positions.shape[0] == 1
-
-        destination_states = None
-        source_states = None
-        if warmup:
-            for layer_idx in range(self.start_layer, self.end_layer):
-                hidden_states, residual = self.layers[layer_idx](
-                    positions,
-                    hidden_states,
-                    residual,
-                    **kwargs,
-                )
-                if layer_idx == config.destination_layer:
-                    destination_states = hidden_states + residual
-                if layer_idx == config.source_layer:
-                    source_states = hidden_states + residual
-            hidden_states, _ = self.norm(hidden_states, residual)
-        else:
-            assert wavefront_positions is not None
-            assert wavefront_positions.shape[0] == 2
-            assert wavefront_pending is not None
-            assert wavefront_pending.shape == hidden_states.shape
-            for layer_idx in range(self.start_layer, config.destination_layer + 1):
-                hidden_states, residual = self.layers[layer_idx](
-                    positions,
-                    hidden_states,
-                    residual,
-                    **kwargs,
-                )
-
-            destination_states = hidden_states + residual
-            hidden_states = torch.cat((wavefront_pending, destination_states), dim=0)
-            residual = None
-            for layer_idx in range(config.destination_layer + 1, self.end_layer):
-                hidden_states, residual = self.layers[layer_idx](
-                    wavefront_positions,
-                    hidden_states,
-                    residual,
-                    **kwargs,
-                )
-                if layer_idx == config.source_layer:
-                    source_states = (hidden_states + residual)[1:]
-            hidden_states, _ = self.norm(hidden_states, residual)
-            hidden_states = hidden_states[1:]
-
-        assert destination_states is not None and source_states is not None
-        next_pending = config.mix(source_states, destination_states, positions)
-        return torch.cat((hidden_states, next_pending), dim=0)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
-class Gemma3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class Gemma3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsRecirculation):
     hf_to_vllm_mapper = Gemma3Model.hf_to_vllm_mapper
     packed_modules_mapping = {
         "qkv_proj": [
@@ -541,6 +444,13 @@ class Gemma3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
+
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
 
     def forward(
         self,

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections.abc import Iterable
-from itertools import islice
 
 import torch
 from torch import nn
@@ -48,6 +47,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
 from .interfaces import SupportsLoRA, SupportsPP
+from .recirculation import RecirculationConfig
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
@@ -309,6 +309,11 @@ class Gemma3Model(nn.Module):
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
+        self.recirculation_config = RecirculationConfig.from_hf_config(config)
+        if self.recirculation_config is not None and not getattr(
+            config, "is_causal", True
+        ):
+            raise ValueError("Recirculation requires causal attention")
 
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
@@ -323,6 +328,10 @@ class Gemma3Model(nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
+        if self.recirculation_config is not None and (
+            self.start_layer != 0 or self.end_layer != config.num_hidden_layers
+        ):
+            raise ValueError("Recirculation does not support pipeline parallelism")
         self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
         # Normalize the embedding by sqrt(hidden_size)
@@ -358,18 +367,43 @@ class Gemma3Model(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
-        for layer in islice(self.layers, self.start_layer, self.end_layer):
+
+        destination_states = None
+        source_states = None
+        for layer_idx in range(self.start_layer, self.end_layer):
+            layer = self.layers[layer_idx]
             hidden_states, residual = layer(
                 positions,
                 hidden_states,
                 residual,
                 **kwargs,
             )
+            if self.recirculation_config is not None:
+                if layer_idx == self.recirculation_config.destination_layer:
+                    destination_states = hidden_states + residual
+                if layer_idx == self.recirculation_config.source_layer:
+                    source_states = hidden_states + residual
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if self.recirculation_config is not None:
+            assert destination_states is not None and source_states is not None
+            recirculated_states = self.recirculation_config.mix(
+                source_states, destination_states, positions
+            )
+            recirculated_residual = None
+            for layer_idx in range(
+                self.recirculation_config.destination_layer + 1, self.end_layer
+            ):
+                recirculated_states, recirculated_residual = self.layers[layer_idx](
+                    positions,
+                    recirculated_states,
+                    recirculated_residual,
+                    **kwargs,
+                )
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -73,6 +73,12 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsRecirculation,
+)
+from .recirculation import (
+    RecirculationCapabilities,
+    RecirculationConfig,
+    RecirculationDecoderMixin,
 )
 from .utils import (
     AutoWeightsLoader,
@@ -946,7 +952,9 @@ class Gemma4CrossDecoderLayers(nn.Module):
 @support_torch_compile(
     enable_if=lambda vllm_config: not vllm_config.cache_config.kv_sharing_fast_prefill
 )
-class Gemma4Model(nn.Module, EagleModelMixin):
+class Gemma4Model(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(adapter="gemma4")
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = _get_text_config(vllm_config.model_config.hf_config)
@@ -1092,6 +1100,11 @@ class Gemma4Model(nn.Module, EagleModelMixin):
             )
 
         self.fast_prefill_enabled = cache_config.kv_sharing_fast_prefill
+        self._init_recirculation(
+            vllm_config.model_config.hf_config,
+            self.start_layer,
+            self.end_layer,
+        )
 
         if self.fast_prefill_enabled:
             # Allocate static buffers for CUDAGraph
@@ -1153,6 +1166,46 @@ class Gemma4Model(nn.Module, EagleModelMixin):
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.self_decoder.embed_input_ids(input_ids)
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        capabilities = super().get_recirculation_capabilities()
+        if capabilities is not None and self.hidden_size_per_layer_input:
+            return replace(capabilities, wavefront=False)
+        return capabilities
+
+    def _validate_recirculation_model_config(
+        self,
+        hf_config: object,
+        config: RecirculationConfig,
+    ) -> None:
+        if self.fast_prefill_enabled:
+            raise ValueError("Recirculation does not support Gemma 4 YOCO fast prefill")
+        if self.hidden_size_per_layer_input and config.wavefront:
+            raise ValueError(
+                "Gemma 4 per-layer embeddings only support serial Recirculation"
+            )
+
+    def _forward_recirculation_layer(
+        self,
+        layer_idx: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **layer_kwargs: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        per_layer_inputs = layer_kwargs.pop("per_layer_inputs", None)
+        layer_per_input = (
+            per_layer_inputs[:, layer_idx, :]
+            if isinstance(per_layer_inputs, torch.Tensor)
+            else None
+        )
+        return self.layers[layer_idx](
+            positions,
+            hidden_states,
+            residual,
+            per_layer_input=layer_per_input,
+            **layer_kwargs,
+        )
 
     def get_per_layer_inputs(self, input_ids: torch.Tensor) -> torch.Tensor | None:
         """Get per-layer embeddings from embed_tokens_per_layer.
@@ -1273,6 +1326,9 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
         per_layer_inputs: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if self.fast_prefill_enabled:
@@ -1309,6 +1365,17 @@ class Gemma4Model(nn.Module, EagleModelMixin):
             if per_layer_inputs is not None:
                 per_layer_inputs = intermediate_tensors["per_layer_inputs"]
         residual = None
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+                per_layer_inputs=per_layer_inputs,
+                **kwargs,
+            )
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for layer_idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer)
@@ -1492,7 +1559,12 @@ class Gemma4Model(nn.Module, EagleModelMixin):
 
 
 class Gemma4ForCausalLM(
-    nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts, SupportsEagle3
+    nn.Module,
+    SupportsLoRA,
+    SupportsPP,
+    MixtureOfExperts,
+    SupportsEagle3,
+    SupportsRecirculation,
 ):
     hf_to_vllm_mapper = _GEMMA4_EXPERT_PARENT_MAPPER | WeightsMapper(
         orig_to_new_prefix={
@@ -1583,16 +1655,33 @@ class Gemma4ForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
+            **kwargs,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -63,7 +63,13 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import MixtureOfExperts, SupportsLoRA, SupportsPP
+from .interfaces import (
+    MixtureOfExperts,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsRecirculation,
+)
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -400,7 +406,8 @@ class Glm4MoeDecoderLayer(nn.Module):
         "inputs_embeds": 0,
     }
 )
-class Glm4MoeModel(nn.Module):
+class Glm4MoeModel(RecirculationDecoderMixin, nn.Module):
+    recirculation_capabilities = RecirculationCapabilities(adapter="glm4_moe")
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             ".q_proj": (".qkv_proj", "q"),
@@ -443,6 +450,7 @@ class Glm4MoeModel(nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
 
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
@@ -467,6 +475,9 @@ class Glm4MoeModel(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -478,6 +489,16 @@ class Glm4MoeModel(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual)
@@ -529,7 +550,13 @@ class Glm4MixtureOfExperts(MixtureOfExperts):
             moe.experts.update_expert_map()
 
 
-class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, Glm4MixtureOfExperts):
+class Glm4MoeForCausalLM(
+    nn.Module,
+    SupportsPP,
+    SupportsLoRA,
+    Glm4MixtureOfExperts,
+    SupportsRecirculation,
+):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -590,15 +617,31 @@ class Glm4MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA, Glm4MixtureOfExper
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/glm4_moe_lite.py
+++ b/vllm/model_executor/models/glm4_moe_lite.py
@@ -68,7 +68,8 @@ from vllm.model_executor.models.glm4_moe import (
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import SupportsLoRA, SupportsPP, SupportsRecirculation
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -213,7 +214,12 @@ class Glm4MoeLiteDecoderLayer(nn.Module):
         "inputs_embeds": 0,
     }
 )
-class Glm4MoeLiteModel(nn.Module):
+class Glm4MoeLiteModel(RecirculationDecoderMixin, nn.Module):
+    recirculation_capabilities = RecirculationCapabilities(
+        adapter="glm4_moe_lite",
+        wavefront=False,
+    )
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -255,6 +261,7 @@ class Glm4MoeLiteModel(nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
 
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
@@ -279,6 +286,9 @@ class Glm4MoeLiteModel(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -290,6 +300,16 @@ class Glm4MoeLiteModel(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual)
@@ -521,7 +541,11 @@ class Glm4MoeLiteModel(nn.Module):
 
 
 class Glm4MoeLiteForCausalLM(
-    nn.Module, SupportsPP, SupportsLoRA, Glm4LiteMixtureOfExperts
+    nn.Module,
+    SupportsPP,
+    SupportsLoRA,
+    Glm4LiteMixtureOfExperts,
+    SupportsRecirculation,
 ):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
@@ -600,15 +624,31 @@ class Glm4MoeLiteForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -57,7 +57,9 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsRecirculation,
 )
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
@@ -292,7 +294,11 @@ class TransformerBlock(torch.nn.Module):
 
 
 @support_torch_compile
-class GptOssModel(nn.Module, EagleModelMixin):
+class GptOssModel(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(
+        adapter="gpt_oss_moe",
+        wavefront=False,
+    )
     # Override to swap in an alternative TransformerBlock subclass.
     block_cls: type[nn.Module] = TransformerBlock
 
@@ -319,6 +325,7 @@ class GptOssModel(nn.Module, EagleModelMixin):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(self.config, self.start_layer, self.end_layer)
         self.norm = RMSNorm(self.config.hidden_size, eps=1e-5)
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], self.config.hidden_size
@@ -327,12 +334,30 @@ class GptOssModel(nn.Module, EagleModelMixin):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embedding(input_ids)
 
+    def _forward_recirculation_layer(
+        self,
+        layer_idx: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **layer_kwargs: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.layers[layer_idx](
+            hidden_states,
+            positions,
+            residual,
+            **layer_kwargs,
+        )
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -345,6 +370,16 @@ class GptOssModel(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             x = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                x,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         aux_hidden_states = self._maybe_add_hidden_state(
             [], self.start_layer, x, residual
@@ -1168,7 +1203,12 @@ class GptOssModel(nn.Module, EagleModelMixin):
 
 
 class GptOssForCausalLM(
-    nn.Module, SupportsPP, SupportsEagle, SupportsEagle3, SupportsLoRA
+    nn.Module,
+    SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsRecirculation,
 ):
     is_3d_moe_weight: bool = True
     packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
@@ -1228,14 +1268,32 @@ class GptOssForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+        return self.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
+        )
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         logits = self.logits_processor(self.lm_head, hidden_states)

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -820,7 +820,8 @@ def supports_pp(
 class SupportsRecirculation(Protocol):
     """Interface for causal models with Recirculation-aware forwards."""
 
-    supports_recirculation: bool
+    @property
+    def supports_recirculation(self) -> bool: ...
 
     def get_recirculation_capabilities(
         self,

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe import MoERunner
     from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
     from vllm.model_executor.models.interfaces_base import VllmModel
+    from vllm.model_executor.models.recirculation import RecirculationCapabilities
     from vllm.model_executor.models.utils import WeightsMapper
     from vllm.multimodal.inputs import MultiModalFeatureSpec, MultiModalKwargsItem
     from vllm.multimodal.registry import _ProcessorFactories
@@ -813,6 +814,66 @@ def supports_pp(
                 )
 
     return supports_attributes and supports_inspect
+
+
+@runtime_checkable
+class SupportsRecirculation(Protocol):
+    """Interface for causal models with Recirculation-aware forwards."""
+
+    supports_recirculation: bool
+
+    def get_recirculation_capabilities(
+        self,
+    ) -> "RecirculationCapabilities | None": ...
+
+    def forward(
+        self,
+        input_ids: Tensor | None,
+        positions: Tensor,
+        *,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: Tensor | None = None,
+        recirculation_wavefront_pending: Tensor | None = None,
+    ) -> "Tensor | IntermediateTensors": ...
+
+
+def supports_recirculation(model: object) -> TypeIs[SupportsRecirculation]:
+    return get_recirculation_capabilities(model) is not None
+
+
+def get_recirculation_capabilities(
+    model: object,
+) -> "RecirculationCapabilities | None":
+    if not getattr(model, "supports_recirculation", False):
+        return None
+
+    get_capabilities = getattr(model, "get_recirculation_capabilities", None)
+    if not callable(get_capabilities):
+        return None
+    capabilities = get_capabilities()
+    if capabilities is None:
+        return None
+
+    model_forward = getattr(model, "forward", None)
+    if not callable(model_forward):
+        return None
+    required_kwargs = (
+        "recirculation_wavefront_warmup",
+        "recirculation_wavefront_positions",
+        "recirculation_wavefront_pending",
+    )
+    missing_kwargs = tuple(
+        kwarg for kwarg in required_kwargs if not supports_kw(model_forward, kwarg)
+    )
+    if missing_kwargs:
+        logger.warning(
+            "The model (%s) advertises Recirculation support but its forward "
+            "method is missing arguments: %s",
+            model,
+            missing_kwargs,
+        )
+        return None
+    return capabilities
 
 
 def _supports_pp_attributes(model: type[object] | object) -> bool:

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -64,7 +64,9 @@ from .interfaces import (
     SupportsLoRA,
     SupportsPP,
     SupportsQuant,
+    SupportsRecirculation,
 )
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -341,7 +343,8 @@ class LlamaDecoderLayer(nn.Module):
         "inputs_embeds": {0: "b"},
     },
 )
-class LlamaModel(nn.Module, EagleModelMixin):
+class LlamaModel(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(adapter="llama")
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)
@@ -385,6 +388,7 @@ class LlamaModel(nn.Module, EagleModelMixin):
             lambda prefix: layer_type(vllm_config=vllm_config, prefix=prefix),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
         if get_pp_group().is_last_rank:
             self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         else:
@@ -403,6 +407,9 @@ class LlamaModel(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
         **extra_layer_kwargs,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
@@ -415,6 +422,17 @@ class LlamaModel(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+                **extra_layer_kwargs,
+            )
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
@@ -451,6 +469,7 @@ class LlamaForCausalLM(
     SupportsEagle,
     SupportsEagle3,
     SupportsQuant,
+    SupportsRecirculation,
 ):
     hf_to_vllm_mapper = LlamaModel.hf_to_vllm_mapper
     # LoRA specific attributes
@@ -513,15 +532,31 @@ class LlamaForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         model_output = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return model_output
 

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -59,6 +59,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from .llama import LlamaForCausalLM, LlamaMLP, LlamaModel
+from .recirculation import RecirculationCapabilities
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -384,6 +385,8 @@ class Llama4DecoderLayer(nn.Module):
 
 @support_torch_compile
 class Llama4Model(LlamaModel):
+    recirculation_capabilities = RecirculationCapabilities(adapter="llama4_moe")
+
     def __init__(
         self,
         *,

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -58,7 +58,9 @@ from .interfaces import (
     MixtureOfExperts,
     SupportsEagle3,
     SupportsPP,
+    SupportsRecirculation,
 )
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -538,7 +540,9 @@ def _shard_fp8_qkv_proj(
 
 
 @support_torch_compile
-class MiMoV2Model(nn.Module, EagleModelMixin):
+class MiMoV2Model(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(adapter="mimo_v2_moe")
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -571,6 +575,11 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(
+            vllm_config.model_config.hf_config,
+            self.start_layer,
+            self.end_layer,
+        )
 
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
@@ -589,6 +598,9 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -600,6 +612,16 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         aux_hidden_states = self._maybe_add_hidden_state(
             [], self.start_layer, hidden_states, residual
@@ -829,7 +851,13 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
         return True
 
 
-class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsEagle3):
+class MiMoV2FlashForCausalLM(
+    nn.Module,
+    SupportsPP,
+    MixtureOfExperts,
+    SupportsEagle3,
+    SupportsRecirculation,
+):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
@@ -866,15 +894,31 @@ class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsEa
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -56,7 +56,14 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import EagleModelMixin, SupportsEagle3, SupportsLoRA, SupportsPP
+from .interfaces import (
+    EagleModelMixin,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsRecirculation,
+)
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -318,7 +325,8 @@ class MiniMaxM2DecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class MiniMaxM2Model(nn.Module, EagleModelMixin):
+class MiniMaxM2Model(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(adapter="minimax_m2_moe")
     fall_back_to_pt_during_load = False
 
     hf_to_vllm_mapper = WeightsMapper(
@@ -362,6 +370,7 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
 
         if get_pp_group().is_last_rank:
             self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -388,6 +397,9 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -399,6 +411,16 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
@@ -425,7 +447,13 @@ class MiniMaxM2Model(nn.Module, EagleModelMixin):
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
-class MiniMaxM2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
+class MiniMaxM2ForCausalLM(
+    nn.Module,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsEagle3,
+    SupportsRecirculation,
+):
     hf_to_vllm_mapper = MiniMaxM2Model.hf_to_vllm_mapper
     packed_modules_mapping = {
         "qkv_proj": [
@@ -463,16 +491,31 @@ class MiniMaxM2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        **kwargs,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/mistral.py
+++ b/vllm/model_executor/models/mistral.py
@@ -23,6 +23,7 @@ from vllm.model_executor.models.llama import (
     LlamaForCausalLM,
     LlamaModel,
 )
+from vllm.model_executor.models.recirculation import RecirculationCapabilities
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
@@ -203,8 +204,18 @@ class MistralDecoderLayer(LlamaDecoderLayer):
         return hidden_states, residual
 
 
-@support_torch_compile
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": 0,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "t_cond": 0,
+    }
+)
 class MistralModel(LlamaModel):
+    recirculation_capabilities = RecirculationCapabilities(adapter="mistral")
+
     def __init__(
         self,
         *,
@@ -221,9 +232,19 @@ class MistralModel(LlamaModel):
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
         t_cond: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         return super().forward(
-            input_ids, positions, intermediate_tensors, inputs_embeds, t_cond=t_cond
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            t_cond=t_cond,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
 
 

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -55,7 +55,13 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import MixtureOfExperts, SupportsLoRA, SupportsPP
+from .interfaces import (
+    MixtureOfExperts,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsRecirculation,
+)
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -281,7 +287,8 @@ class MixtralDecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class MixtralModel(nn.Module):
+class MixtralModel(RecirculationDecoderMixin, nn.Module):
+    recirculation_capabilities = RecirculationCapabilities(adapter="mixtral")
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)
@@ -325,6 +332,7 @@ class MixtralModel(nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
 
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
@@ -340,6 +348,9 @@ class MixtralModel(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -351,6 +362,15 @@ class MixtralModel(nn.Module):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             hidden_states, residual = layer(positions, hidden_states, residual)
         if not get_pp_group().is_last_rank:
@@ -365,7 +385,13 @@ class MixtralModel(nn.Module):
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
-class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
+class MixtralForCausalLM(
+    nn.Module,
+    SupportsLoRA,
+    SupportsPP,
+    MixtureOfExperts,
+    SupportsRecirculation,
+):
     fall_back_to_pt_during_load = False
 
     hf_to_vllm_mapper = MixtralModel.hf_to_vllm_mapper
@@ -457,15 +483,31 @@ class MixtralForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -65,7 +65,9 @@ from .interfaces import (
     SupportsLoRA,
     SupportsPP,
     SupportsQuant,
+    SupportsRecirculation,
 )
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -319,7 +321,8 @@ class Qwen2DecoderLayer(nn.Module):
         "inputs_embeds": {0: "b"},
     }
 )
-class Qwen2Model(nn.Module, EagleModelMixin):
+class Qwen2Model(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(adapter="qwen2")
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)
@@ -382,6 +385,7 @@ class Qwen2Model(nn.Module, EagleModelMixin):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
 
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
@@ -400,6 +404,9 @@ class Qwen2Model(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -411,6 +418,16 @@ class Qwen2Model(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
@@ -439,7 +456,13 @@ class Qwen2Model(nn.Module, EagleModelMixin):
 
 
 class Qwen2ForCausalLM(
-    nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, SupportsEagle3, SupportsQuant
+    nn.Module,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsQuant,
+    SupportsRecirculation,
 ):
     hf_to_vllm_mapper = Qwen2Model.hf_to_vllm_mapper
     packed_modules_mapping = {
@@ -480,15 +503,31 @@ class Qwen2ForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -54,9 +54,11 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsRecirculation,
 )
 from .qwen2 import Qwen2MLP as Qwen3MLP
 from .qwen2 import Qwen2Model
+from .recirculation import RecirculationCapabilities
 from .utils import AutoWeightsLoader, PPMissingLayer, extract_layer_index, maybe_prefix
 
 logger = init_logger(__name__)
@@ -262,6 +264,8 @@ ALL_DECODER_LAYER_TYPES = {
     }
 )
 class Qwen3Model(Qwen2Model):
+    recirculation_capabilities = RecirculationCapabilities(adapter="qwen3")
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(
             vllm_config=vllm_config, prefix=prefix, decoder_layer_type=Qwen3DecoderLayer
@@ -269,7 +273,13 @@ class Qwen3Model(Qwen2Model):
 
 
 class Qwen3ForCausalLM(
-    LocalArgmaxMixin, nn.Module, SupportsLoRA, SupportsPP, SupportsEagle, SupportsEagle3
+    LocalArgmaxMixin,
+    nn.Module,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsRecirculation,
 ):
     hf_to_vllm_mapper = Qwen3Model.hf_to_vllm_mapper
     packed_modules_mapping = {
@@ -315,15 +325,31 @@ class Qwen3ForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -271,13 +271,6 @@ class Qwen3_5Model(Qwen3NextModel):
         )
         if self.recirculation_config is not None and self.use_sequence_parallel:
             raise ValueError("Recirculation does not support sequence-parallel Qwen3.5")
-        if (
-            self.recirculation_config is not None
-            and vllm_config.speculative_config is not None
-        ):
-            raise ValueError(
-                "Recirculation does not support speculative Qwen3.5 decoding"
-            )
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
             Qwen3NextSparseMoeBlock,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -71,6 +71,7 @@ from .interfaces import (
     SupportsLoRA,
     SupportsMRoPE,
     SupportsPP,
+    SupportsRecirculation,
     _require_is_multimodal,
 )
 from .qwen2_moe import Qwen2MoeMLP as Qwen3NextMLP
@@ -88,6 +89,7 @@ from .qwen3_vl import (
     Qwen3VLMultiModalProcessor,
     Qwen3VLProcessingInfo,
 )
+from .recirculation import RecirculationCapabilities
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -215,6 +217,11 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
     }
 )
 class Qwen3_5Model(Qwen3NextModel):
+    recirculation_capabilities = RecirculationCapabilities(
+        adapter="qwen3_5_hybrid",
+        wavefront=False,
+    )
+
     # Qwen3.5 ships the GDN in_proj checkpoints separately (qwen3-next
     # pre-fuses them); fuse them on top of the qwen3-next QKV/gate_up mapping.
     hf_to_vllm_mapper = Qwen3NextModel.hf_to_vllm_mapper | WeightsMapper(
@@ -257,6 +264,20 @@ class Qwen3_5Model(Qwen3NextModel):
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
         )
+        self._init_recirculation(
+            vllm_config.model_config.hf_config,
+            self.start_layer,
+            self.end_layer,
+        )
+        if self.recirculation_config is not None and self.use_sequence_parallel:
+            raise ValueError("Recirculation does not support sequence-parallel Qwen3.5")
+        if (
+            self.recirculation_config is not None
+            and vllm_config.speculative_config is not None
+        ):
+            raise ValueError(
+                "Recirculation does not support speculative Qwen3.5 decoding"
+            )
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
             Qwen3NextSparseMoeBlock,
@@ -297,6 +318,7 @@ class Qwen3_5ForCausalLMBase(
     SupportsLoRA,
     SupportsMRoPE,
     SupportsPP,
+    SupportsRecirculation,
 ):
     packed_modules_mapping = {
         "qkv_proj": [
@@ -363,6 +385,13 @@ class Qwen3_5ForCausalLMBase(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self.model.aux_hidden_state_layers = layers
 
@@ -376,10 +405,18 @@ class Qwen3_5ForCausalLMBase(
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        **kwargs: object,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ):
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
 
         return hidden_states

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -68,7 +68,9 @@ from .interfaces import (
     SupportsLoRA,
     SupportsPP,
     SupportsQuant,
+    SupportsRecirculation,
 )
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -423,7 +425,8 @@ class Qwen3MoeDecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class Qwen3MoeModel(nn.Module, EagleModelMixin):
+class Qwen3MoeModel(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(adapter="qwen3_moe")
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)
@@ -467,6 +470,7 @@ class Qwen3MoeModel(nn.Module, EagleModelMixin):
             lambda prefix: decoder_layer_type(vllm_config=vllm_config, prefix=prefix),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
@@ -481,6 +485,9 @@ class Qwen3MoeModel(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -492,6 +499,16 @@ class Qwen3MoeModel(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         aux_hidden_states = self._maybe_add_hidden_state(
             [], self.start_layer, hidden_states, residual
@@ -539,6 +556,7 @@ class Qwen3MoeForCausalLM(
     SupportsEagle3,
     MixtureOfExperts,
     SupportsQuant,
+    SupportsRecirculation,
 ):
     hf_to_vllm_mapper = Qwen3MoeModel.hf_to_vllm_mapper
     packed_modules_mapping = {
@@ -626,15 +644,31 @@ class Qwen3MoeForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
 

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -599,13 +599,6 @@ class Qwen3NextModel(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
             raise ValueError(
                 "Recirculation does not support sequence-parallel Qwen3-Next"
             )
-        if (
-            self.recirculation_config is not None
-            and vllm_config.speculative_config is not None
-        ):
-            raise ValueError(
-                "Recirculation does not support speculative Qwen3-Next decoding"
-            )
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
             Qwen3NextSparseMoeBlock,

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -17,6 +17,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
 from vllm.model_executor.layers.fused_moe.utils import (
@@ -63,7 +64,9 @@ from .interfaces import (
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
+    SupportsRecirculation,
 )
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -541,7 +544,11 @@ class Qwen3NextDecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class Qwen3NextModel(nn.Module, EagleModelMixin):
+class Qwen3NextModel(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(
+        adapter="qwen3_next_hybrid",
+        wavefront=False,
+    )
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             # weight_name: (param_name, shard_id)
@@ -583,6 +590,22 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
         )
+        self._init_recirculation(
+            vllm_config.model_config.hf_config,
+            self.start_layer,
+            self.end_layer,
+        )
+        if self.recirculation_config is not None and self.use_sequence_parallel:
+            raise ValueError(
+                "Recirculation does not support sequence-parallel Qwen3-Next"
+            )
+        if (
+            self.recirculation_config is not None
+            and vllm_config.speculative_config is not None
+        ):
+            raise ValueError(
+                "Recirculation does not support speculative Qwen3-Next decoding"
+            )
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
             Qwen3NextSparseMoeBlock,
@@ -602,6 +625,61 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
+    def _forward_recirculation_layer(
+        self,
+        layer_idx: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **layer_kwargs: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.layers[layer_idx](
+            hidden_states=hidden_states,
+            residual=residual,
+            positions=positions,
+            **layer_kwargs,
+        )
+
+    def _capture_recirculation_layer_state(
+        self, layer_idx: int
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, ...]] | None:
+        layer = self.layers[layer_idx]
+        if not isinstance(layer, Qwen3NextDecoderLayer) or not hasattr(
+            layer, "linear_attn"
+        ):
+            return None
+
+        forward_context = get_forward_context()
+        if forward_context.attn_metadata is None:
+            return None
+        assert isinstance(forward_context.attn_metadata, dict)
+        metadata = forward_context.attn_metadata[layer.linear_attn.prefix]
+        if metadata.spec_sequence_masks is not None:
+            raise RuntimeError(
+                "Recirculation does not support speculative Qwen GDN state"
+            )
+        assert metadata.non_spec_state_indices_tensor is not None
+        num_requests = metadata.num_prefills + metadata.num_decodes
+        state_indices = metadata.non_spec_state_indices_tensor[:num_requests].long()
+        snapshots = tuple(
+            state.index_select(0, state_indices) for state in layer.linear_attn.kv_cache
+        )
+        return state_indices, snapshots
+
+    def _restore_recirculation_layer_state(
+        self,
+        layer_idx: int,
+        state: tuple[torch.Tensor, tuple[torch.Tensor, ...]] | None,
+    ) -> None:
+        if state is None:
+            return
+        state_indices, snapshots = state
+        layer = self.layers[layer_idx]
+        assert isinstance(layer, Qwen3NextDecoderLayer)
+        assert hasattr(layer, "linear_attn")
+        for cache, snapshot in zip(layer.linear_attn.kv_cache, snapshots):
+            cache.index_copy_(0, state_indices, snapshot)
+
     @property
     def use_sequence_parallel(self) -> bool:
         return self.layers[self.start_layer].use_attn_reduce_scatter_for_moe
@@ -612,6 +690,9 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -628,6 +709,16 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
         if self.use_sequence_parallel:
             hidden_states = sequence_parallel_chunk(hidden_states)
             assert residual is None
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for layer_idx, layer in enumerate(
@@ -726,6 +817,7 @@ class Qwen3NextForCausalLM(
     QwenNextMixtureOfExperts,
     IsHybrid,
     SupportsEagle3,
+    SupportsRecirculation,
 ):
     # MTP weights are loaded by the draft model, not this one.
     hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix={"mtp.": None})
@@ -778,16 +870,31 @@ class Qwen3NextForCausalLM(
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        **kwargs: object,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ):
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
 
         return hidden_states

--- a/vllm/model_executor/models/recirculation.py
+++ b/vllm/model_executor/models/recirculation.py
@@ -17,6 +17,7 @@ class RecirculationConfig:
     alpha: float = 0.15
     beta: float | None = None
     ramp_tokens: int = 0
+    wavefront: bool = False
 
     @classmethod
     def from_hf_config(cls, hf_config: object) -> "RecirculationConfig | None":
@@ -32,6 +33,7 @@ class RecirculationConfig:
             "alpha",
             "beta",
             "ramp_tokens",
+            "wavefront",
         }
         unknown_keys = raw_config.keys() - valid_keys
         if unknown_keys:
@@ -49,6 +51,7 @@ class RecirculationConfig:
             alpha=raw_config.get("alpha", 0.15),
             beta=raw_config.get("beta"),
             ramp_tokens=raw_config.get("ramp_tokens", 0),
+            wavefront=raw_config.get("wavefront", False),
         )
         config.validate(hf_config.num_hidden_layers)
         if config.alpha == 0.0 and config.beta in (None, 1.0):
@@ -71,6 +74,8 @@ class RecirculationConfig:
             )
         if self.ramp_tokens < 0:
             raise ValueError("ramp_tokens must be non-negative")
+        if type(self.wavefront) is not bool:
+            raise ValueError("wavefront must be a boolean")
 
         self._validate_coefficient("alpha", self.alpha)
         if self.beta is not None:

--- a/vllm/model_executor/models/recirculation.py
+++ b/vllm/model_executor/models/recirculation.py
@@ -2,127 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from dataclasses import dataclass
-from numbers import Real
 from typing import Any, ClassVar
 
 import torch
 import torch.nn as nn
 
-
-@dataclass(frozen=True)
-class RecirculationConfig:
-    """Fixed-coefficient residual-stream recirculation configuration."""
-
-    source_layer: int
-    destination_layer: int
-    alpha: float = 0.15
-    beta: float | None = None
-    ramp_tokens: int = 0
-    wavefront: bool = False
-
-    @staticmethod
-    def _get_text_config(hf_config: object) -> object:
-        get_text_config = getattr(hf_config, "get_text_config", None)
-        if callable(get_text_config):
-            return get_text_config()
-        return hf_config
-
-    @classmethod
-    def from_hf_config(cls, hf_config: object) -> "RecirculationConfig | None":
-        text_config = cls._get_text_config(hf_config)
-        raw_config = getattr(hf_config, "recirculation_config", None)
-        if raw_config is None and text_config is not hf_config:
-            raw_config = getattr(text_config, "recirculation_config", None)
-        if raw_config is None:
-            return None
-        if not isinstance(raw_config, dict):
-            raise ValueError("recirculation_config must be a dictionary")
-
-        valid_keys = {
-            "source_layer",
-            "destination_layer",
-            "alpha",
-            "beta",
-            "ramp_tokens",
-            "wavefront",
-        }
-        unknown_keys = raw_config.keys() - valid_keys
-        if unknown_keys:
-            unknown = ", ".join(sorted(unknown_keys))
-            raise ValueError(f"Unknown recirculation_config fields: {unknown}")
-
-        missing_keys = {"source_layer", "destination_layer"} - raw_config.keys()
-        if missing_keys:
-            missing = ", ".join(sorted(missing_keys))
-            raise ValueError(f"Missing recirculation_config fields: {missing}")
-
-        config = cls(
-            source_layer=raw_config["source_layer"],
-            destination_layer=raw_config["destination_layer"],
-            alpha=raw_config.get("alpha", 0.15),
-            beta=raw_config.get("beta"),
-            ramp_tokens=raw_config.get("ramp_tokens", 0),
-            wavefront=raw_config.get("wavefront", False),
-        )
-        config.validate(text_config.num_hidden_layers)
-        if config.alpha == 0.0 and config.beta in (None, 1.0):
-            return None
-        return config
-
-    def validate(self, num_hidden_layers: int) -> None:
-        for name, value in (
-            ("source_layer", self.source_layer),
-            ("destination_layer", self.destination_layer),
-            ("ramp_tokens", self.ramp_tokens),
-        ):
-            if type(value) is not int:
-                raise ValueError(f"{name} must be an integer")
-
-        if not 0 <= self.destination_layer < self.source_layer < num_hidden_layers:
-            raise ValueError(
-                "recirculation layers must satisfy 0 <= destination_layer < "
-                "source_layer < num_hidden_layers"
-            )
-        if self.ramp_tokens < 0:
-            raise ValueError("ramp_tokens must be non-negative")
-        if type(self.wavefront) is not bool:
-            raise ValueError("wavefront must be a boolean")
-
-        self._validate_coefficient("alpha", self.alpha)
-        if self.beta is not None:
-            self._validate_coefficient("beta", self.beta)
-
-    @staticmethod
-    def _validate_coefficient(name: str, value: Any) -> None:
-        if isinstance(value, bool) or not isinstance(value, Real):
-            raise ValueError(f"{name} must be a real number")
-        if not 0.0 <= value <= 1.0:
-            raise ValueError(f"{name} must be between 0 and 1")
-
-    def mix(
-        self,
-        source: torch.Tensor,
-        destination: torch.Tensor,
-        positions: torch.Tensor,
-    ) -> torch.Tensor:
-        """Mix a norm-matched source residual into the destination residual."""
-        source_float = source.float()
-        destination_float = destination.float()
-        source_norm = torch.linalg.vector_norm(
-            source_float, dim=-1, keepdim=True
-        ).clamp_min(torch.finfo(torch.float32).tiny)
-        destination_norm = torch.linalg.vector_norm(
-            destination_float, dim=-1, keepdim=True
-        )
-        normalized_source = source_float * (destination_norm / source_norm)
-
-        alpha: float | torch.Tensor = self.alpha
-        if self.ramp_tokens:
-            ramp = positions.to(dtype=torch.float32).clamp(max=self.ramp_tokens)
-            alpha = (ramp / self.ramp_tokens).unsqueeze(-1) * self.alpha
-        beta = 1.0 - alpha if self.beta is None else self.beta
-        mixed = beta * destination_float + alpha * normalized_source
-        return mixed.to(dtype=destination.dtype)
+from vllm.config.recirculation import RecirculationConfig
 
 
 @dataclass(frozen=True)

--- a/vllm/model_executor/models/recirculation.py
+++ b/vllm/model_executor/models/recirculation.py
@@ -3,9 +3,10 @@
 
 from dataclasses import dataclass
 from numbers import Real
-from typing import Any
+from typing import Any, ClassVar
 
 import torch
+import torch.nn as nn
 
 
 @dataclass(frozen=True)
@@ -112,3 +113,203 @@ class RecirculationConfig:
         beta = 1.0 - alpha if self.beta is None else self.beta
         mixed = beta * destination_float + alpha * normalized_source
         return mixed.to(dtype=destination.dtype)
+
+
+@dataclass(frozen=True)
+class RecirculationCapabilities:
+    """Execution modes implemented by a concrete model-family adapter."""
+
+    adapter: str
+    serial: bool = True
+    wavefront: bool = True
+
+
+class RecirculationDecoderMixin:
+    """Shared Recirculation execution for residual-stream decoder stacks."""
+
+    recirculation_capabilities: ClassVar[RecirculationCapabilities | None] = None
+    recirculation_config: RecirculationConfig | None
+    start_layer: int
+    end_layer: int
+    layers: nn.ModuleList
+    norm: nn.Module
+
+    def _init_recirculation(
+        self,
+        hf_config: object,
+        start_layer: int,
+        end_layer: int,
+    ) -> None:
+        capabilities = type(self).__dict__.get("recirculation_capabilities")
+        if capabilities is None:
+            self.recirculation_config = None
+            return
+
+        config = RecirculationConfig.from_hf_config(hf_config)
+        if config is not None and not getattr(hf_config, "is_causal", True):
+            raise ValueError("Recirculation requires causal attention")
+        if config is not None and (
+            start_layer != 0 or end_layer != hf_config.num_hidden_layers
+        ):
+            raise ValueError("Recirculation does not support pipeline parallelism")
+        self.recirculation_config = config
+
+    def has_recirculation_adapter(self) -> bool:
+        return self.get_recirculation_capabilities() is not None
+
+    def get_recirculation_capabilities(
+        self,
+    ) -> RecirculationCapabilities | None:
+        return type(self).__dict__.get("recirculation_capabilities")
+
+    def _forward_recirculation(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        wavefront_warmup: bool | None,
+        wavefront_positions: torch.Tensor | None,
+        wavefront_pending: torch.Tensor | None,
+        **layer_kwargs: Any,
+    ) -> torch.Tensor:
+        config = self.recirculation_config
+        assert config is not None
+        if config.wavefront and wavefront_warmup is not None:
+            return self._forward_recirculation_wavefront(
+                positions,
+                hidden_states,
+                residual,
+                config,
+                wavefront_warmup,
+                wavefront_positions,
+                wavefront_pending,
+                **layer_kwargs,
+            )
+        return self._forward_recirculation_serial(
+            positions,
+            hidden_states,
+            residual,
+            config,
+            **layer_kwargs,
+        )
+
+    def _forward_recirculation_serial(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        config: RecirculationConfig,
+        **layer_kwargs: Any,
+    ) -> torch.Tensor:
+        hidden_states, residual, destination_states, source_states = (
+            self._forward_recirculation_normal_stack(
+                positions,
+                hidden_states,
+                residual,
+                config,
+                **layer_kwargs,
+            )
+        )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        recirculated_states = config.mix(source_states, destination_states, positions)
+        recirculated_residual = None
+        for layer_idx in range(config.destination_layer + 1, self.end_layer):
+            recirculated_states, recirculated_residual = self.layers[layer_idx](
+                positions,
+                recirculated_states,
+                recirculated_residual,
+                **layer_kwargs,
+            )
+        return hidden_states
+
+    def _forward_recirculation_normal_stack(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        config: RecirculationConfig,
+        **layer_kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
+        destination_states = None
+        source_states = None
+        for layer_idx in range(self.start_layer, self.end_layer):
+            hidden_states, residual = self.layers[layer_idx](
+                positions,
+                hidden_states,
+                residual,
+                **layer_kwargs,
+            )
+            if layer_idx == config.destination_layer:
+                destination_states = self._materialize_residual(hidden_states, residual)
+            if layer_idx == config.source_layer:
+                source_states = self._materialize_residual(hidden_states, residual)
+        assert destination_states is not None and source_states is not None
+        return hidden_states, residual, destination_states, source_states
+
+    def _forward_recirculation_wavefront(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        config: RecirculationConfig,
+        warmup: bool,
+        wavefront_positions: torch.Tensor | None,
+        wavefront_pending: torch.Tensor | None,
+        **layer_kwargs: Any,
+    ) -> torch.Tensor:
+        assert positions.shape[0] == 1
+        destination_states = None
+        source_states = None
+        if warmup:
+            hidden_states, residual, destination_states, source_states = (
+                self._forward_recirculation_normal_stack(
+                    positions,
+                    hidden_states,
+                    residual,
+                    config,
+                    **layer_kwargs,
+                )
+            )
+            hidden_states, _ = self.norm(hidden_states, residual)
+        else:
+            assert wavefront_positions is not None
+            assert wavefront_positions.shape[0] == 2
+            assert wavefront_pending is not None
+            assert wavefront_pending.shape == hidden_states.shape
+            for layer_idx in range(self.start_layer, config.destination_layer + 1):
+                hidden_states, residual = self.layers[layer_idx](
+                    positions,
+                    hidden_states,
+                    residual,
+                    **layer_kwargs,
+                )
+
+            destination_states = self._materialize_residual(hidden_states, residual)
+            hidden_states = torch.cat((wavefront_pending, destination_states), dim=0)
+            residual = None
+            for layer_idx in range(config.destination_layer + 1, self.end_layer):
+                hidden_states, residual = self.layers[layer_idx](
+                    wavefront_positions,
+                    hidden_states,
+                    residual,
+                    **layer_kwargs,
+                )
+                if layer_idx == config.source_layer:
+                    source_states = self._materialize_residual(hidden_states, residual)[
+                        1:
+                    ]
+            hidden_states, _ = self.norm(hidden_states, residual)
+            hidden_states = hidden_states[1:]
+
+        assert destination_states is not None and source_states is not None
+        next_pending = config.mix(source_states, destination_states, positions)
+        return torch.cat((hidden_states, next_pending), dim=0)
+
+    @staticmethod
+    def _materialize_residual(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if residual is None:
+            return hidden_states
+        return hidden_states + residual

--- a/vllm/model_executor/models/recirculation.py
+++ b/vllm/model_executor/models/recirculation.py
@@ -51,6 +51,8 @@ class RecirculationConfig:
             ramp_tokens=raw_config.get("ramp_tokens", 0),
         )
         config.validate(hf_config.num_hidden_layers)
+        if config.alpha == 0.0 and config.beta in (None, 1.0):
+            return None
         return config
 
     def validate(self, num_hidden_layers: int) -> None:

--- a/vllm/model_executor/models/recirculation.py
+++ b/vllm/model_executor/models/recirculation.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True)
+class RecirculationConfig:
+    """Fixed-coefficient residual-stream recirculation configuration."""
+
+    source_layer: int
+    destination_layer: int
+    alpha: float = 0.15
+    beta: float | None = None
+    ramp_tokens: int = 0
+
+    @classmethod
+    def from_hf_config(cls, hf_config: object) -> "RecirculationConfig | None":
+        raw_config = getattr(hf_config, "recirculation_config", None)
+        if raw_config is None:
+            return None
+        if not isinstance(raw_config, dict):
+            raise ValueError("recirculation_config must be a dictionary")
+
+        valid_keys = {
+            "source_layer",
+            "destination_layer",
+            "alpha",
+            "beta",
+            "ramp_tokens",
+        }
+        unknown_keys = raw_config.keys() - valid_keys
+        if unknown_keys:
+            unknown = ", ".join(sorted(unknown_keys))
+            raise ValueError(f"Unknown recirculation_config fields: {unknown}")
+
+        missing_keys = {"source_layer", "destination_layer"} - raw_config.keys()
+        if missing_keys:
+            missing = ", ".join(sorted(missing_keys))
+            raise ValueError(f"Missing recirculation_config fields: {missing}")
+
+        config = cls(
+            source_layer=raw_config["source_layer"],
+            destination_layer=raw_config["destination_layer"],
+            alpha=raw_config.get("alpha", 0.15),
+            beta=raw_config.get("beta"),
+            ramp_tokens=raw_config.get("ramp_tokens", 0),
+        )
+        config.validate(hf_config.num_hidden_layers)
+        return config
+
+    def validate(self, num_hidden_layers: int) -> None:
+        for name, value in (
+            ("source_layer", self.source_layer),
+            ("destination_layer", self.destination_layer),
+            ("ramp_tokens", self.ramp_tokens),
+        ):
+            if type(value) is not int:
+                raise ValueError(f"{name} must be an integer")
+
+        if not 0 <= self.destination_layer < self.source_layer < num_hidden_layers:
+            raise ValueError(
+                "recirculation layers must satisfy 0 <= destination_layer < "
+                "source_layer < num_hidden_layers"
+            )
+        if self.ramp_tokens < 0:
+            raise ValueError("ramp_tokens must be non-negative")
+
+        self._validate_coefficient("alpha", self.alpha)
+        if self.beta is not None:
+            self._validate_coefficient("beta", self.beta)
+
+    @staticmethod
+    def _validate_coefficient(name: str, value: Any) -> None:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ValueError(f"{name} must be a real number")
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(f"{name} must be between 0 and 1")
+
+    def mix(
+        self,
+        source: torch.Tensor,
+        destination: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Mix a norm-matched source residual into the destination residual."""
+        source_float = source.float()
+        destination_float = destination.float()
+        source_norm = torch.linalg.vector_norm(
+            source_float, dim=-1, keepdim=True
+        ).clamp_min(torch.finfo(torch.float32).tiny)
+        destination_norm = torch.linalg.vector_norm(
+            destination_float, dim=-1, keepdim=True
+        )
+        normalized_source = source_float * (destination_norm / source_norm)
+
+        alpha: float | torch.Tensor = self.alpha
+        if self.ramp_tokens:
+            ramp = positions.to(dtype=torch.float32).clamp(max=self.ramp_tokens)
+            alpha = (ramp / self.ramp_tokens).unsqueeze(-1) * self.alpha
+        beta = 1.0 - alpha if self.beta is None else self.beta
+        mixed = beta * destination_float + alpha * normalized_source
+        return mixed.to(dtype=destination.dtype)

--- a/vllm/model_executor/models/recirculation.py
+++ b/vllm/model_executor/models/recirculation.py
@@ -20,9 +20,19 @@ class RecirculationConfig:
     ramp_tokens: int = 0
     wavefront: bool = False
 
+    @staticmethod
+    def _get_text_config(hf_config: object) -> object:
+        get_text_config = getattr(hf_config, "get_text_config", None)
+        if callable(get_text_config):
+            return get_text_config()
+        return hf_config
+
     @classmethod
     def from_hf_config(cls, hf_config: object) -> "RecirculationConfig | None":
+        text_config = cls._get_text_config(hf_config)
         raw_config = getattr(hf_config, "recirculation_config", None)
+        if raw_config is None and text_config is not hf_config:
+            raw_config = getattr(text_config, "recirculation_config", None)
         if raw_config is None:
             return None
         if not isinstance(raw_config, dict):
@@ -54,7 +64,7 @@ class RecirculationConfig:
             ramp_tokens=raw_config.get("ramp_tokens", 0),
             wavefront=raw_config.get("wavefront", False),
         )
-        config.validate(hf_config.num_hidden_layers)
+        config.validate(text_config.num_hidden_layers)
         if config.alpha == 0.0 and config.beta in (None, 1.0):
             return None
         return config
@@ -149,10 +159,21 @@ class RecirculationDecoderMixin:
         if config is not None and not getattr(hf_config, "is_causal", True):
             raise ValueError("Recirculation requires causal attention")
         if config is not None and (
-            start_layer != 0 or end_layer != hf_config.num_hidden_layers
+            start_layer != 0
+            or end_layer
+            != RecirculationConfig._get_text_config(hf_config).num_hidden_layers
         ):
             raise ValueError("Recirculation does not support pipeline parallelism")
+        if config is not None:
+            self._validate_recirculation_model_config(hf_config, config)
         self.recirculation_config = config
+
+    def _validate_recirculation_model_config(
+        self,
+        hf_config: object,
+        config: RecirculationConfig,
+    ) -> None:
+        """Validate family-specific constraints before model execution."""
 
     def has_recirculation_adapter(self) -> bool:
         return self.get_recirculation_capabilities() is not None
@@ -201,7 +222,7 @@ class RecirculationDecoderMixin:
         config: RecirculationConfig,
         **layer_kwargs: Any,
     ) -> torch.Tensor:
-        hidden_states, residual, destination_states, source_states = (
+        hidden_states, residual, destination_states, source_states, layer_states = (
             self._forward_recirculation_normal_stack(
                 positions,
                 hidden_states,
@@ -210,15 +231,21 @@ class RecirculationDecoderMixin:
                 **layer_kwargs,
             )
         )
-        hidden_states, _ = self.norm(hidden_states, residual)
+        hidden_states = self._finalize_recirculation(hidden_states, residual)
         recirculated_states = config.mix(source_states, destination_states, positions)
         recirculated_residual = None
         for layer_idx in range(config.destination_layer + 1, self.end_layer):
-            recirculated_states, recirculated_residual = self.layers[layer_idx](
-                positions,
-                recirculated_states,
-                recirculated_residual,
-                **layer_kwargs,
+            self._restore_recirculation_layer_state(
+                layer_idx, layer_states.get(layer_idx)
+            )
+            recirculated_states, recirculated_residual = (
+                self._forward_recirculation_layer(
+                    layer_idx,
+                    positions,
+                    recirculated_states,
+                    recirculated_residual,
+                    **layer_kwargs,
+                )
             )
         return hidden_states
 
@@ -229,11 +256,23 @@ class RecirculationDecoderMixin:
         residual: torch.Tensor | None,
         config: RecirculationConfig,
         **layer_kwargs: Any,
-    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor,
+        torch.Tensor,
+        dict[int, Any],
+    ]:
         destination_states = None
         source_states = None
+        layer_states: dict[int, Any] = {}
         for layer_idx in range(self.start_layer, self.end_layer):
-            hidden_states, residual = self.layers[layer_idx](
+            if layer_idx > config.destination_layer:
+                layer_states[layer_idx] = self._capture_recirculation_layer_state(
+                    layer_idx
+                )
+            hidden_states, residual = self._forward_recirculation_layer(
+                layer_idx,
                 positions,
                 hidden_states,
                 residual,
@@ -244,7 +283,7 @@ class RecirculationDecoderMixin:
             if layer_idx == config.source_layer:
                 source_states = self._materialize_residual(hidden_states, residual)
         assert destination_states is not None and source_states is not None
-        return hidden_states, residual, destination_states, source_states
+        return hidden_states, residual, destination_states, source_states, layer_states
 
     def _forward_recirculation_wavefront(
         self,
@@ -261,7 +300,7 @@ class RecirculationDecoderMixin:
         destination_states = None
         source_states = None
         if warmup:
-            hidden_states, residual, destination_states, source_states = (
+            hidden_states, residual, destination_states, source_states, _ = (
                 self._forward_recirculation_normal_stack(
                     positions,
                     hidden_states,
@@ -270,14 +309,15 @@ class RecirculationDecoderMixin:
                     **layer_kwargs,
                 )
             )
-            hidden_states, _ = self.norm(hidden_states, residual)
+            hidden_states = self._finalize_recirculation(hidden_states, residual)
         else:
             assert wavefront_positions is not None
             assert wavefront_positions.shape[0] == 2
             assert wavefront_pending is not None
             assert wavefront_pending.shape == hidden_states.shape
             for layer_idx in range(self.start_layer, config.destination_layer + 1):
-                hidden_states, residual = self.layers[layer_idx](
+                hidden_states, residual = self._forward_recirculation_layer(
+                    layer_idx,
                     positions,
                     hidden_states,
                     residual,
@@ -288,7 +328,8 @@ class RecirculationDecoderMixin:
             hidden_states = torch.cat((wavefront_pending, destination_states), dim=0)
             residual = None
             for layer_idx in range(config.destination_layer + 1, self.end_layer):
-                hidden_states, residual = self.layers[layer_idx](
+                hidden_states, residual = self._forward_recirculation_layer(
+                    layer_idx,
                     wavefront_positions,
                     hidden_states,
                     residual,
@@ -298,12 +339,52 @@ class RecirculationDecoderMixin:
                     source_states = self._materialize_residual(hidden_states, residual)[
                         1:
                     ]
-            hidden_states, _ = self.norm(hidden_states, residual)
+            hidden_states = self._finalize_recirculation(hidden_states, residual)
             hidden_states = hidden_states[1:]
 
         assert destination_states is not None and source_states is not None
         next_pending = config.mix(source_states, destination_states, positions)
         return torch.cat((hidden_states, next_pending), dim=0)
+
+    def _forward_recirculation_layer(
+        self,
+        layer_idx: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **layer_kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        return self.layers[layer_idx](
+            positions,
+            hidden_states,
+            residual,
+            **layer_kwargs,
+        )
+
+    def _capture_recirculation_layer_state(self, layer_idx: int) -> Any:
+        """Capture non-overwritable state before an upper-layer first pass.
+
+        Attention KV entries are naturally overwritten by the rerun. Recurrent
+        families override this hook to retain the pre-block state that their
+        in-place update kernels would otherwise consume twice.
+        """
+
+    def _restore_recirculation_layer_state(self, layer_idx: int, state: Any) -> None:
+        """Restore family state captured by `_capture_recirculation_layer_state`."""
+
+    def _finalize_recirculation(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> torch.Tensor:
+        normalized = (
+            self.norm(hidden_states, residual)
+            if residual is not None
+            else self.norm(hidden_states)
+        )
+        if isinstance(normalized, tuple):
+            return normalized[0]
+        return normalized
 
     @staticmethod
     def _materialize_residual(

--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -47,7 +47,8 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
-from .interfaces import MixtureOfExperts, SupportsPP
+from .interfaces import MixtureOfExperts, SupportsPP, SupportsRecirculation
+from .recirculation import RecirculationCapabilities, RecirculationDecoderMixin
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -533,7 +534,9 @@ class Step3p5DecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class Step3p5Model(nn.Module):
+class Step3p5Model(RecirculationDecoderMixin, nn.Module):
+    recirculation_capabilities = RecirculationCapabilities(adapter="step3p5_moe")
+
     def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
 
@@ -562,6 +565,7 @@ class Step3p5Model(nn.Module):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
         if get_pp_group().is_last_rank:
             self.norm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
         else:
@@ -574,12 +578,35 @@ class Step3p5Model(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
+    def _forward_recirculation_layer(
+        self,
+        layer_idx: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        **layer_kwargs: object,
+    ) -> tuple[torch.Tensor, None]:
+        assert residual is None
+        return self.layers[layer_idx](positions, hidden_states), None
+
+    def _finalize_recirculation(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> torch.Tensor:
+        assert residual is None
+        # Step 3.5 applies the final norm in compute_logits, not model.forward.
+        return hidden_states
+
     def forward(
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -589,6 +616,15 @@ class Step3p5Model(nn.Module):
         else:
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                None,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
             hidden_states = layer(positions, hidden_states)
@@ -869,7 +905,9 @@ class Step3p5Model(nn.Module):
         return loaded_params
 
 
-class Step3p5ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
+class Step3p5ForCausalLM(
+    nn.Module, SupportsPP, MixtureOfExperts, SupportsRecirculation
+):
     # Required so quantization exclude lists match fused module prefixes.
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
@@ -933,11 +971,27 @@ class Step3p5ForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ):
         hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
         )
         return hidden_states
+
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         hidden_states = self.model.norm(hidden_states)

--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -75,6 +75,11 @@ from vllm.model_executor.models.interfaces import (
     SupportsEagle3,
     SupportsMultiModal,
     SupportsPP,
+    SupportsRecirculation,
+)
+from vllm.model_executor.models.recirculation import (
+    RecirculationCapabilities,
+    RecirculationDecoderMixin,
 )
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
@@ -1082,7 +1087,11 @@ class MiniMaxM3DecoderLayer(nn.Module):
         return hidden_states, residual
 
 
-class MiniMaxM3Model(nn.Module, EagleModelMixin):
+class MiniMaxM3Model(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(
+        adapter="minimax_m3_sparse_moe",
+        wavefront=False,
+    )
     fall_back_to_pt_during_load = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -1109,7 +1118,7 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         # layers (mirrors DeepseekV4); the indexer writes its per-head decode/
         # prefill block selection into it, the attend reads it back.
         sparse_cfg = getattr(config, "sparse_attention_config", None)
-        if sparse_cfg is not None:
+        if sparse_cfg:
             tp_size = get_tensor_model_parallel_world_size()
             num_index_heads = max(1, sparse_cfg["sparse_num_index_heads"] // tp_size)
             self.topk_indices_buffer = torch.empty(
@@ -1132,6 +1141,14 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
+        if (
+            self.recirculation_config is not None
+            and vllm_config.parallel_config.tensor_parallel_size != 1
+        ):
+            raise ValueError(
+                "Recirculation currently requires tensor-parallel size 1 for MiniMax M3"
+            )
         self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
             self.layers,
             MiniMaxM3MoE,
@@ -1155,6 +1172,9 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -1166,6 +1186,16 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         # EAGLE3 is not yet compatible with pipeline parallel
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
@@ -1310,7 +1340,9 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         return loaded_params
 
 
-class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
+class MiniMaxM3SparseForCausalLM(
+    nn.Module, SupportsPP, SupportsEagle3, SupportsRecirculation
+):
     """MiniMax M3 (sparse/dense backbone) for causal language modeling."""
 
     packed_modules_mapping = {
@@ -1344,15 +1376,33 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | IntermediateTensors:
-        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+        return self.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
+        )
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -58,6 +58,11 @@ from vllm.model_executor.models.interfaces import (
     SupportsEagle3,
     SupportsMultiModal,
     SupportsPP,
+    SupportsRecirculation,
+)
+from vllm.model_executor.models.recirculation import (
+    RecirculationCapabilities,
+    RecirculationDecoderMixin,
 )
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
@@ -788,7 +793,11 @@ class MiniMaxM3DecoderLayer(nn.Module):
         return not self.mlp.down_proj.reduce_results
 
 
-class MiniMaxM3Model(nn.Module, EagleModelMixin):
+class MiniMaxM3Model(RecirculationDecoderMixin, nn.Module, EagleModelMixin):
+    recirculation_capabilities = RecirculationCapabilities(
+        adapter="minimax_m3_sparse_moe",
+        wavefront=False,
+    )
     fall_back_to_pt_during_load = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -816,7 +825,7 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         # [total_q, num_index_heads, topk] so the indexer writes its native
         # [token, head, topk] top-k; the attend transposes to [H, tokens, topk].
         sparse_cfg = getattr(config, "sparse_attention_config", None)
-        if sparse_cfg is not None:
+        if sparse_cfg:
             tp_size = get_tensor_model_parallel_world_size()
             num_index_heads = max(1, sparse_cfg["sparse_num_index_heads"] // tp_size)
             # Pad tokens to a multiple of 4 so the buffer head stride stays
@@ -841,6 +850,14 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             ),
             prefix=f"{prefix}.layers",
         )
+        self._init_recirculation(config, self.start_layer, self.end_layer)
+        if (
+            self.recirculation_config is not None
+            and vllm_config.parallel_config.tensor_parallel_size != 1
+        ):
+            raise ValueError(
+                "Recirculation currently requires tensor-parallel size 1 for MiniMax M3"
+            )
 
         if get_pp_group().is_last_rank:
             self.norm = MiniMAXGemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -868,6 +885,9 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
@@ -879,6 +899,16 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
+
+        if self.recirculation_config is not None:
+            return self._forward_recirculation(
+                positions,
+                hidden_states,
+                residual,
+                recirculation_wavefront_warmup,
+                recirculation_wavefront_positions,
+                recirculation_wavefront_pending,
+            )
 
         # EAGLE3 is not yet compatible with pipeline parallel
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
@@ -1012,7 +1042,9 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         return loaded_params
 
 
-class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
+class MiniMaxM3SparseForCausalLM(
+    nn.Module, SupportsPP, SupportsEagle3, SupportsRecirculation
+):
     """MiniMax M3 (sparse/dense backbone) for causal language modeling."""
 
     packed_modules_mapping = {
@@ -1046,15 +1078,33 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsPP, SupportsEagle3):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    @property
+    def supports_recirculation(self) -> bool:
+        return self.model.has_recirculation_adapter()
+
+    def get_recirculation_capabilities(self) -> RecirculationCapabilities | None:
+        return self.model.get_recirculation_capabilities()
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
+        recirculation_wavefront_warmup: bool | None = None,
+        recirculation_wavefront_positions: torch.Tensor | None = None,
+        recirculation_wavefront_pending: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | IntermediateTensors:
-        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+        return self.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            recirculation_wavefront_warmup=recirculation_wavefront_warmup,
+            recirculation_wavefront_positions=recirculation_wavefront_positions,
+            recirculation_wavefront_pending=recirculation_wavefront_pending,
+        )
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -114,6 +114,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     mellum="MellumConfig",
     midashenglm="MiDashengLMConfig",
     minimax_m3_vl="MiniMaxM3Config",
+    minimax_m3_text="MiniMaxM3TextConfig",
     minimax_m3_mtp="MiniMaxM3MTPConfig",
     moondream3="Moondream3Config",
     moss_transcribe_diarize="MossTranscribeDiarizeConfig",

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -204,23 +204,46 @@ class BlockTable:
         query_start_loc: torch.Tensor,
         positions: torch.Tensor,
     ) -> None:
+        self.compute_slot_mapping_into(
+            num_reqs,
+            query_start_loc,
+            positions,
+            self.slot_mapping.gpu,
+            self.max_num_batched_tokens,
+        )
+
+    def compute_slot_mapping_into(
+        self,
+        num_reqs: int,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        max_num_tokens: int | None = None,
+    ) -> None:
+        """Compute slots into a caller-owned buffer."""
         num_tokens = positions.shape[0]
         if self.slot_mapping_mode == SlotMappingMode.NONE:
             # Mamba/GDN groups consume the block table as recurrent state
             # indices and do not use per-token slot mappings.
             return
         assert self.slot_mapping_mode == SlotMappingMode.TOKEN_TO_KV_SLOT
+        if max_num_tokens is None:
+            max_num_tokens = num_tokens
+        if max_num_tokens < num_tokens:
+            raise ValueError("max_num_tokens is smaller than the input")
+        if slot_mapping.numel() < max_num_tokens:
+            raise ValueError("slot_mapping is smaller than max_num_tokens")
 
         _COMPUTE_SLOT_MAPPING_KERNEL(
             num_reqs,
             num_tokens,
-            self.max_num_batched_tokens,
+            max_num_tokens,
             query_start_loc,
             positions,
             self.block_table.gpu,
             self.block_table.gpu.stride(0),
             self.block_size,
-            self.slot_mapping.gpu,
+            slot_mapping,
             self.kv_cache_block_size,
             self.blocks_per_kv_block,
             self.dcp_world_size,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -95,6 +95,7 @@ from vllm.model_executor.models.interfaces_base import (
     is_pooling_model,
     is_text_generation_model,
 )
+from vllm.model_executor.models.utils import extract_layer_index
 from vllm.model_executor.offloader import (
     create_offloader,
     get_offloader,
@@ -141,6 +142,7 @@ from vllm.v1.attention.backend import (
     AttentionType,
     CommonAttentionMetadata,
 )
+from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.linear_attn import (
     BailingLinearAttentionMetadataBuilder,
@@ -517,6 +519,32 @@ class GPUModelRunner(
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
+        raw_recirculation_config = getattr(
+            self.model_config.hf_config, "recirculation_config", None
+        )
+        self.recirculation_wavefront_enabled = bool(
+            isinstance(raw_recirculation_config, dict)
+            and raw_recirculation_config.get("wavefront") is True
+            and not (
+                raw_recirculation_config.get("alpha", 0.15) == 0.0
+                and raw_recirculation_config.get("beta") in (None, 1.0)
+            )
+        )
+        self.recirculation_wavefront_destination_layer: int | None = None
+        if self.recirculation_wavefront_enabled:
+            assert isinstance(raw_recirculation_config, dict)
+            self._validate_recirculation_wavefront_config(raw_recirculation_config)
+            self.recirculation_wavefront_destination_layer = raw_recirculation_config[
+                "destination_layer"
+            ]
+            # The external graph batch contains one token; the upper stack's
+            # second row is created inside the model. Preserve explicit eager
+            # execution, but specialize any enabled graph configuration for
+            # the fixed-shape wavefront decode path.
+            if self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+                self.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+                self.compilation_config.cudagraph_capture_sizes = [1]
+                self.compilation_config.max_cudagraph_capture_size = 1
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
 
         model_config = self.model_config
@@ -819,6 +847,24 @@ class GPUModelRunner(
         self.positions = torch.zeros(
             self.max_num_tokens, dtype=torch.int64, device=self.device
         )
+        if self.recirculation_wavefront_enabled:
+            self.recirculation_wavefront_positions = torch.tensor(
+                [0, 1], dtype=torch.int64, device=self.device
+            )
+            self.recirculation_wavefront_query_start_loc = torch.tensor(
+                [0, 2], dtype=torch.int32, device=self.device
+            )
+            self.recirculation_wavefront_seq_lens = torch.tensor(
+                [2], dtype=torch.int32, device=self.device
+            )
+            self.recirculation_wavefront_slot_mappings: dict[int, torch.Tensor] = {}
+            self.recirculation_wavefront_request_id: str | None = None
+            self.recirculation_wavefront_pending = torch.zeros(
+                1,
+                self.inputs_embeds_size,
+                dtype=self.dtype,
+                device=self.device,
+            )
         self.query_start_loc = self._make_buffer(
             self.max_num_reqs + 1, dtype=torch.int32
         )
@@ -4275,6 +4321,162 @@ class GPUModelRunner(
 
         return slot_mappings_by_gid, slot_mappings_by_layer
 
+    def _validate_recirculation_wavefront_config(
+        self, raw_config: dict[str, Any]
+    ) -> None:
+        architectures = getattr(self.model_config.hf_config, "architectures", None)
+        if architectures != ["Gemma3ForCausalLM"]:
+            raise ValueError(
+                "Recirculation wavefront execution only supports Gemma3ForCausalLM"
+            )
+        if self.scheduler_config.max_num_seqs != 1:
+            raise ValueError(
+                "Recirculation wavefront execution requires max_num_seqs=1"
+            )
+        if self.scheduler_config.long_prefill_token_threshold != 1:
+            raise ValueError(
+                "Recirculation wavefront execution requires "
+                "long_prefill_token_threshold=1"
+            )
+        if self.cache_config.enable_prefix_caching:
+            raise ValueError(
+                "Recirculation wavefront execution requires prefix caching "
+                "to be disabled"
+            )
+        if self.speculative_config is not None:
+            raise ValueError(
+                "Recirculation wavefront execution does not support "
+                "speculative decoding"
+            )
+        if self.parallel_config.use_ubatching:
+            raise ValueError(
+                "Recirculation wavefront execution does not support microbatching"
+            )
+        if self.parallel_config.decode_context_parallel_size != 1:
+            raise ValueError(
+                "Recirculation wavefront execution does not support decode "
+                "context parallelism"
+            )
+        if self.parallel_config.data_parallel_size != 1:
+            raise ValueError(
+                "Recirculation wavefront execution does not support data parallelism"
+            )
+        if self.compilation_config.pass_config.enable_sp:
+            raise ValueError(
+                "Recirculation wavefront execution does not support sequence "
+                "parallelism"
+            )
+        if type(raw_config.get("destination_layer")) is not int:
+            raise ValueError("destination_layer must be an integer")
+
+    def _apply_recirculation_wavefront_attention_metadata(
+        self,
+        attn_metadata: AttnMetadataDict,
+        slot_mappings: dict[str, torch.Tensor],
+        wavefront_slots_by_group: dict[int, torch.Tensor],
+    ) -> None:
+        assert self.recirculation_wavefront_destination_layer is not None
+        replacements: dict[tuple[int, int], FlashAttentionMetadata] = {}
+        for gid, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups):
+            wavefront_slots = wavefront_slots_by_group[gid]
+            for layer_name in kv_cache_group.layer_names:
+                if (
+                    extract_layer_index(layer_name)
+                    <= self.recirculation_wavefront_destination_layer
+                ):
+                    continue
+                metadata = attn_metadata[layer_name]
+                if not isinstance(metadata, FlashAttentionMetadata):
+                    raise RuntimeError(
+                        "Recirculation wavefront execution currently requires "
+                        "the FlashAttention backend"
+                    )
+                key = (id(metadata), gid)
+                wavefront_metadata = replacements.get(key)
+                if wavefront_metadata is None:
+                    wavefront_metadata = replace(
+                        metadata,
+                        num_actual_tokens=2,
+                        max_query_len=2,
+                        query_start_loc=self.recirculation_wavefront_query_start_loc,
+                        seq_lens=self.recirculation_wavefront_seq_lens,
+                        slot_mapping=wavefront_slots,
+                        use_cascade=False,
+                        common_prefix_len=0,
+                        cu_prefix_query_lens=None,
+                        prefix_kv_lens=None,
+                        suffix_kv_lens=None,
+                        scheduler_metadata=None,
+                        prefix_scheduler_metadata=None,
+                        max_num_splits=0,
+                    )
+                    replacements[key] = wavefront_metadata
+                attn_metadata[layer_name] = cast(AttentionMetadata, wavefront_metadata)
+                slot_mappings[layer_name] = wavefront_slots
+
+    def _prepare_recirculation_wavefront(
+        self,
+        attn_metadata: PerLayerAttnMetadata,
+        slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None,
+        positions: torch.Tensor,
+        num_reqs: int,
+        num_tokens_unpadded: int,
+        num_tokens_padded: int,
+        num_scheduled_tokens_np: np.ndarray,
+    ) -> bool:
+        """Prepare the two-token upper-stack view and return whether it is warmup."""
+        if (
+            num_reqs != 1
+            or num_tokens_unpadded != 1
+            or num_tokens_padded != 1
+            or num_scheduled_tokens_np.tolist() != [1]
+        ):
+            raise RuntimeError(
+                "Recirculation wavefront execution requires exactly one "
+                "scheduled token from one request per step"
+            )
+        if not isinstance(attn_metadata, dict) or not isinstance(slot_mappings, dict):
+            raise RuntimeError(
+                "Recirculation wavefront execution requires unsplit attention metadata"
+            )
+
+        request_id = self.input_batch.req_ids[0]
+        warmup = self.input_batch.num_computed_tokens_cpu[0] == 0
+        if warmup:
+            self.recirculation_wavefront_request_id = request_id
+            return True
+        if self.recirculation_wavefront_request_id != request_id:
+            raise RuntimeError(
+                "A Recirculation wavefront request resumed without its pending "
+                "recurrent state"
+            )
+
+        self.recirculation_wavefront_positions[0].copy_(positions[0])
+        self.recirculation_wavefront_positions[0].sub_(1)
+        self.recirculation_wavefront_positions[1].copy_(positions[0])
+        self.recirculation_wavefront_seq_lens.copy_(self.seq_lens[:1])
+
+        wavefront_slots_by_group: dict[int, torch.Tensor] = {}
+        for gid, _ in enumerate(self.kv_cache_config.kv_cache_groups):
+            block_table = self.input_batch.block_table[gid]
+            wavefront_slots = self.recirculation_wavefront_slot_mappings.get(gid)
+            if wavefront_slots is None:
+                wavefront_slots = torch.empty(2, dtype=torch.int64, device=self.device)
+                self.recirculation_wavefront_slot_mappings[gid] = wavefront_slots
+            block_table.compute_slot_mapping_into(
+                1,
+                self.recirculation_wavefront_query_start_loc,
+                self.recirculation_wavefront_positions,
+                wavefront_slots,
+            )
+            wavefront_slots_by_group[gid] = wavefront_slots
+
+        self._apply_recirculation_wavefront_attention_metadata(
+            attn_metadata, slot_mappings, wavefront_slots_by_group
+        )
+
+        return False
+
     def _is_all_reqs_chunked_prefill(self) -> bool:
         """Check if all scheduled requests are marked to discard sampled tokens.
 
@@ -4523,6 +4725,27 @@ class GPUModelRunner(
             ) = self._preprocess(
                 scheduler_output, num_tokens_padded, intermediate_tensors
             )
+            recirculation_wavefront_warmup = False
+            if self.recirculation_wavefront_enabled:
+                recirculation_wavefront_warmup = self._prepare_recirculation_wavefront(
+                    attn_metadata=attn_metadata,
+                    slot_mappings=slot_mappings,
+                    positions=positions,
+                    num_reqs=num_reqs,
+                    num_tokens_unpadded=num_tokens_unpadded,
+                    num_tokens_padded=num_tokens_padded,
+                    num_scheduled_tokens_np=num_scheduled_tokens_np,
+                )
+                model_kwargs["recirculation_wavefront_warmup"] = (
+                    recirculation_wavefront_warmup
+                )
+                if not recirculation_wavefront_warmup:
+                    model_kwargs["recirculation_wavefront_positions"] = (
+                        self.recirculation_wavefront_positions
+                    )
+                    model_kwargs["recirculation_wavefront_pending"] = (
+                        self.recirculation_wavefront_pending
+                    )
 
         # Encoder-decoder models can only compile the pure decode steps where no
         # encoder inputs are present. Use eager for the first pass.
@@ -4553,7 +4776,7 @@ class GPUModelRunner(
                 batch_descriptor=batch_desc,
                 ubatch_slices=ubatch_slices_padded,
                 slot_mapping=slot_mappings,
-                skip_compiled=has_encoder_input,
+                skip_compiled=(has_encoder_input or recirculation_wavefront_warmup),
             ),
             record_function_or_nullcontext("gpu_model_runner: forward"),
             self.maybe_get_kv_connector_output(
@@ -4568,6 +4791,11 @@ class GPUModelRunner(
                 inputs_embeds=inputs_embeds,
                 **model_kwargs,
             )
+            if self.recirculation_wavefront_enabled:
+                assert isinstance(model_output, torch.Tensor)
+                assert model_output.shape[0] == 2
+                self.recirculation_wavefront_pending.copy_(model_output[1:])
+                model_output = model_output[:1]
 
         with record_function_or_nullcontext("gpu_model_runner: postprocess"):
             if self.use_aux_hidden_state_outputs:
@@ -6219,6 +6447,28 @@ class GPUModelRunner(
             else:
                 positions = self.positions[:num_tokens_padded]
 
+            recirculation_wavefront_dummy = bool(
+                self.recirculation_wavefront_enabled
+                and num_tokens_unpadded == 1
+                and isinstance(attn_metadata, dict)
+                and isinstance(slot_mappings, dict)
+            )
+            if recirculation_wavefront_dummy:
+                assert isinstance(attn_metadata, dict)
+                assert isinstance(slot_mappings, dict)
+                self._apply_recirculation_wavefront_attention_metadata(
+                    attn_metadata,
+                    slot_mappings,
+                    self.recirculation_wavefront_slot_mappings,
+                )
+                model_kwargs["recirculation_wavefront_warmup"] = False
+                model_kwargs["recirculation_wavefront_positions"] = (
+                    self.recirculation_wavefront_positions
+                )
+                model_kwargs["recirculation_wavefront_pending"] = (
+                    self.recirculation_wavefront_pending
+                )
+
             if get_pp_group().is_first_rank:
                 intermediate_tensors = None
             else:
@@ -6256,6 +6506,10 @@ class GPUModelRunner(
                     batch_descriptor=batch_desc,
                     ubatch_slices=ubatch_slices_padded,
                     slot_mapping=slot_mappings,
+                    skip_compiled=(
+                        self.recirculation_wavefront_enabled
+                        and not recirculation_wavefront_dummy
+                    ),
                 ),
             ):
                 outputs = self.model(
@@ -7788,6 +8042,11 @@ class GPUModelRunner(
 
         # Reinitialize need to after initialize_attn_backend
         self.may_reinitialize_input_batch(kv_cache_config, kernel_block_sizes)
+        if self.recirculation_wavefront_enabled:
+            self.recirculation_wavefront_slot_mappings = {
+                gid: torch.full((2,), -1, dtype=torch.int64, device=self.device)
+                for gid, _ in enumerate(kv_cache_config.kv_cache_groups)
+            }
         kv_caches = self.initialize_kv_cache_tensors(
             kv_cache_config, kernel_block_sizes
         )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -31,6 +31,7 @@ from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import (
     CompilationMode,
     CUDAGraphMode,
+    RecirculationConfig,
     VllmConfig,
     get_layers_from_vllm_config,
     set_current_vllm_config,
@@ -96,7 +97,6 @@ from vllm.model_executor.models.interfaces_base import (
     is_pooling_model,
     is_text_generation_model,
 )
-from vllm.model_executor.models.recirculation import RecirculationConfig
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.model_executor.offloader import (
     create_offloader,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -83,6 +83,7 @@ from vllm.model_executor.models.interfaces import (
     SupportsMultiModal,
     SupportsXDRoPE,
     get_mixture_of_experts_model,
+    get_recirculation_capabilities,
     supports_eagle3,
     supports_mrope,
     supports_multimodal_pruning,
@@ -95,6 +96,7 @@ from vllm.model_executor.models.interfaces_base import (
     is_pooling_model,
     is_text_generation_model,
 )
+from vllm.model_executor.models.recirculation import RecirculationConfig
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.model_executor.offloader import (
     create_offloader,
@@ -519,24 +521,21 @@ class GPUModelRunner(
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
-        raw_recirculation_config = getattr(
-            self.model_config.hf_config, "recirculation_config", None
+        self.recirculation_config = RecirculationConfig.from_hf_config(
+            self.model_config.hf_config
         )
+        self.recirculation_enabled = self.recirculation_config is not None
         self.recirculation_wavefront_enabled = bool(
-            isinstance(raw_recirculation_config, dict)
-            and raw_recirculation_config.get("wavefront") is True
-            and not (
-                raw_recirculation_config.get("alpha", 0.15) == 0.0
-                and raw_recirculation_config.get("beta") in (None, 1.0)
-            )
+            self.recirculation_config is not None
+            and self.recirculation_config.wavefront
         )
         self.recirculation_wavefront_destination_layer: int | None = None
         if self.recirculation_wavefront_enabled:
-            assert isinstance(raw_recirculation_config, dict)
-            self._validate_recirculation_wavefront_config(raw_recirculation_config)
-            self.recirculation_wavefront_destination_layer = raw_recirculation_config[
-                "destination_layer"
-            ]
+            assert self.recirculation_config is not None
+            self._validate_recirculation_wavefront_config()
+            self.recirculation_wavefront_destination_layer = (
+                self.recirculation_config.destination_layer
+            )
             # The external graph batch contains one token; the upper stack's
             # second row is created inside the model. Preserve explicit eager
             # execution, but specialize any enabled graph configuration for
@@ -4321,13 +4320,10 @@ class GPUModelRunner(
 
         return slot_mappings_by_gid, slot_mappings_by_layer
 
-    def _validate_recirculation_wavefront_config(
-        self, raw_config: dict[str, Any]
-    ) -> None:
-        architectures = getattr(self.model_config.hf_config, "architectures", None)
-        if architectures != ["Gemma3ForCausalLM"]:
+    def _validate_recirculation_wavefront_config(self) -> None:
+        if self.model_config.runner_type != "generate":
             raise ValueError(
-                "Recirculation wavefront execution only supports Gemma3ForCausalLM"
+                "Recirculation wavefront execution requires a generation model"
             )
         if self.scheduler_config.max_num_seqs != 1:
             raise ValueError(
@@ -4366,8 +4362,6 @@ class GPUModelRunner(
                 "Recirculation wavefront execution does not support sequence "
                 "parallelism"
             )
-        if type(raw_config.get("destination_layer")) is not int:
-            raise ValueError("destination_layer must be an integer")
 
     def _apply_recirculation_wavefront_attention_metadata(
         self,
@@ -5662,6 +5656,29 @@ class GPUModelRunner(
                 self.model = model_loader.load_model(
                     vllm_config=self.vllm_config, model_config=self.model_config
                 )
+                if self.recirculation_enabled:
+                    capabilities = get_recirculation_capabilities(self.model)
+                    if capabilities is None:
+                        raise ValueError(
+                            f"{self.model.__class__.__name__} does not implement "
+                            "the Recirculation model interface"
+                        )
+                    if (
+                        self.recirculation_wavefront_enabled
+                        and not capabilities.wavefront
+                    ):
+                        raise ValueError(
+                            f"The {capabilities.adapter} Recirculation adapter "
+                            "does not support wavefront execution"
+                        )
+                    if (
+                        not self.recirculation_wavefront_enabled
+                        and not capabilities.serial
+                    ):
+                        raise ValueError(
+                            f"The {capabilities.adapter} Recirculation adapter "
+                            "does not support serial execution"
+                        )
                 if self.lora_config:
                     self.model = self.load_lora_model(
                         self.model, self.vllm_config, self.device


### PR DESCRIPTION
## Purpose

Add experimental [Recirculation](https://arxiv.org/abs/2608.17981) execution for causal residual-decoder models.

Recirculation feeds a norm-matched deep residual activation into a shallower boundary, returns logits from the normal pass, and reruns the upper stack so later tokens attend to recirculated KV state. The implementation provides:

- an engine-level, fully validated `recirculation_config` parser;
- explicit model capability negotiation and a shared residual-decoder execution mixin;
- correct serial execution plus an optimized two-token wavefront;
- scheduler state, KV-slot remapping, and dedicated CUDA-graph handling;
- recurrent-state snapshot/restore for Qwen3-Next and Qwen 3.5;
- adapters for 20 current dense, MoE, MLA, and recurrent model families;
- reproducible real-weight and no-download GPU validation harnesses.

Architecture discussion: [RFC #53178](https://github.com/vllm-project/vllm/issues/53178).

### Configuration

```bash
vllm serve google/gemma-3-1b-pt \
  --hf-overrides '{
    "recirculation_config": {
      "source_layer": 11,
      "destination_layer": 4,
      "alpha": 0.15,
      "ramp_tokens": 10,
      "wavefront": true
    }
  }' \
  --max-num-seqs 1 \
  --long-prefill-token-threshold 1 \
  --no-enable-prefix-caching
```

An identity configuration (`alpha=0`, with convex/default `beta`) is validated and then becomes a true no-op.

### Current restrictions

- Model Runner V1 only; Recirculation automatically selects it.
- Speculative decoding and auxiliary hidden-state extraction are rejected.
- No pipeline parallelism, multimodal wrappers, non-causal diffusion backbones, or DeepSeek-V4 hyperconnections.
- Wavefront currently requires one sequence/one scheduled token, FlashAttention, no prefix cache, and no DP/DCP/SP/PP.
- Qwen3-Next/Qwen 3.5 and other incompatible attention/recurrent backends use serial execution.
- MiniMax-M3 sparse attention was disabled in the tiny fixture, so its optional custom sparse-attention kernel is not covered by this PR's GPU matrix.

## Test Plan

Focused regression tests:

```bash
.venv/bin/python -m pytest -q \
  tests/model_executor/test_recirculation.py \
  tests/model_executor/test_gemma3_recirculation.py \
  tests/benchmarks/test_recirculation.py \
  tests/v1/worker/test_jit_warmup_migration.py \
  tests/v1/worker/test_gpu_model_runner.py::test_hybrid_block_table_initialization \
  tests/transformers_utils/test_minimax_m3_config.py

.venv/bin/python -m pytest -q tests/test_config.py -k recirculation
```

Repository checks:

```bash
.venv/bin/pre-commit run --files \
  benchmarks/benchmark_recirculation.py \
  benchmarks/validate_recirculation_adapters.py \
  docs/features/recirculation.md \
  tests/benchmarks/test_recirculation.py \
  tests/model_executor/test_gemma3_recirculation.py \
  tests/test_config.py \
  vllm/config/__init__.py \
  vllm/config/recirculation.py \
  vllm/config/vllm.py \
  vllm/model_executor/models/qwen3_5.py \
  vllm/model_executor/models/qwen3_next.py \
  vllm/model_executor/models/recirculation.py \
  vllm/v1/worker/gpu_model_runner.py
```

GPU validation uses `benchmarks/validate_recirculation_adapters.py` in separate processes for baseline/no-op/serial/wavefront and every documented family. It creates four-layer local configs with dummy weights and downloads no weights or tokenizer.

Real-weight quality uses `benchmarks/benchmark_recirculation.py` with the pinned Gemma 3 1B revision and the same pre-tokenized 16-window C4 file for both arms.

## Test Result

- Focused regressions: **73 passed**.
- Recirculation configuration tests: **3 passed**.
- Full pre-commit stack over all changed files: **passed** (Ruff, format, typos, Markdown, mypy 3.10, SPDX, import/config/CUDA API checks).
- `git diff --check`: **passed**.
- DCO: all seven commits signed off.
- No-download RTX 3080 matrix: **20/20 families passed** through real GPU engine paths.
- Qwen 3.5 dense and MoE MRoPE ramping: **passed** with `ramp_tokens=10`.
- Compiled Gemma 3 dummy:
  - baseline and no-op token IDs/log probabilities: **bit-identical**;
  - serial and wavefront token IDs: **identical**;
  - max selected-token log-probability difference: **1.235e-4**.
- Real compiled BF16 `google/gemma-3-1b-pt`, 16 fixed C4 windows / 16,368 scored tokens:
  - baseline: perplexity **19.1576**, mean prefill **7.9496 s**, decode **194.97 tok/s**;
  - wavefront: perplexity **16.9613**, mean prefill **8.4007 s**, decode **181.90 tok/s**;
  - wavefront: **11.46% lower perplexity**, **5.67% higher mean prefill latency**, and **6.70% lower decode throughput** on this small sample.

The documentation includes the full 20-family result table, methodology, revision behavior, benchmark beta support, memory-measurement fallback, and interpretation caveats.

## Duplicate-work check

Searched open issues and all PRs for `recirculation`, `residual stream recurrence`, `looped transformer`, `recurrent depth`, this branch name, and the proposed title. No duplicate implementation or RFC was found.

## AI assistance disclosure

OpenAI Codex assisted with implementation, code review fixes, test/harness development, and benchmark analysis. Results in this PR were produced by the committed harnesses on the stated hardware; the branch was also independently reviewed before these follow-up fixes.
