### PR TITLE
[ROCm] Ship rocprofiler-sdk 1.3.2 in Dockerfile.rocm_base to fix torch.profiler traces

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -13,6 +13,8 @@ ARG AITER_BRANCH="v0.1.19"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG MORI_BRANCH="v1.1.0"
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
+ARG ROCPROFILER_SDK_REPO="https://github.com/ROCm/rocm-systems.git"
+ARG ROCPROFILER_SDK_COMMIT="2b22ab0195cc1461cd9abf3b969e9dd7c10af350"
 
 # Sccache configuration (only used in release pipeline)
 ARG USE_SCCACHE
@@ -313,9 +315,44 @@ RUN --mount=type=bind,from=build_aiter,src=/app/install/,target=/install \
 RUN --mount=type=bind,from=build_mori,src=/app/install/,target=/install \
     cp /install/*.whl /app/debs
 
+# rocprofiler-sdk 1.3.2 fixes torch 2.12 profiler on ROCm 7.2.3
+FROM base AS build_rocprofiler_sdk
+ARG ROCPROFILER_SDK_REPO
+ARG ROCPROFILER_SDK_COMMIT
+ARG USE_SCCACHE
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libdw-dev libelf-dev libsqlite3-dev libzstd-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN git init -q /src && cd /src \
+    && git remote add origin ${ROCPROFILER_SDK_REPO} \
+    && git config core.sparseCheckout true \
+    && git config remote.origin.promisor true \
+    && git config remote.origin.partialclonefilter blob:none \
+    && git sparse-checkout init --cone \
+    && git sparse-checkout set projects/rocprofiler-sdk shared cmake \
+    && git fetch --filter=blob:none --depth 1 origin ${ROCPROFILER_SDK_COMMIT} \
+    && git checkout -q FETCH_HEAD
+RUN cd /src/projects/rocprofiler-sdk \
+    && if [ "$USE_SCCACHE" = "1" ]; then \
+           export CMAKE_C_COMPILER_LAUNCHER=sccache \
+           && export CMAKE_CXX_COMPILER_LAUNCHER=sccache; \
+       fi \
+    && cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH=/opt/rocm \
+        -DCMAKE_INSTALL_PREFIX=/opt/rocm \
+        -DROCPROFILER_BUILD_TESTS=OFF \
+        -DROCPROFILER_BUILD_SAMPLES=OFF \
+        -DROCPROFILER_BUILD_DOCS=OFF \
+    && cmake --build build --parallel "$(nproc)" \
+    && cmake --install build --prefix /staging --strip
+
 FROM base AS final
 RUN --mount=type=bind,from=debs,src=/app/debs,target=/install \
     pip install /install/*.whl
+
+COPY --from=build_rocprofiler_sdk /staging/ /opt/rocm/
+RUN ldconfig
 
 ARG BASE_IMAGE
 ARG TRITON_BRANCH
@@ -332,7 +369,11 @@ ARG AITER_BRANCH
 ARG AITER_REPO
 ARG MORI_BRANCH
 ARG MORI_REPO
+ARG ROCPROFILER_SDK_REPO
+ARG ROCPROFILER_SDK_COMMIT
 RUN echo "BASE_IMAGE: ${BASE_IMAGE}" > /app/versions.txt \
+    && echo "ROCPROFILER_SDK_REPO: ${ROCPROFILER_SDK_REPO}" >> /app/versions.txt \
+    && echo "ROCPROFILER_SDK_COMMIT: ${ROCPROFILER_SDK_COMMIT}" >> /app/versions.txt \
     && echo "TRITON_BRANCH: ${TRITON_BRANCH}" >> /app/versions.txt \
     && echo "TRITON_REPO: ${TRITON_REPO}" >> /app/versions.txt \
     && echo "PYTORCH_BRANCH: ${PYTORCH_BRANCH}" >> /app/versions.txt \


### PR DESCRIPTION
# [ROCm] Ship rocprofiler-sdk 1.3.2 in Dockerfile.rocm_base to fix torch.profiler HIP-graph traces

## Summary
The ROCm ≤ 7.2.3 base image (`rocm/dev-ubuntu-22.04:7.2.3-complete`) ships **rocprofiler-sdk 1.1.0**.
Since torch 2.12, PyTorch's Kineto GPU backend links `librocprofiler-sdk` (previously roctracer).
Under `torch.profiler`, rocprofiler-sdk **1.1.0** blows up `hipGraphLaunch` and disables the HIP
graph fast path, so profiled decode collapses GPU occupancy and profiled latency balloons —
making vLLM profiles unusable/misleading on gfx942/gfx950.

This is a **rocprofiler-sdk bug fixed in 1.3.2**. This PR builds rocprofiler-sdk 1.3.2
(`ROCm/rocm-systems @ 2b22ab0`) in a dedicated stage and overlays it onto `/opt/rocm` in the
final base image. torch/Kineto links `librocprofiler-sdk.so.1` by soname, so swapping the
runtime lib is sufficient — **no torch rebuild**, `build_pytorch` is untouched.

Self-removing: drop the stage + COPY once `BASE_IMAGE` ships rocprofiler-sdk ≥ 1.3.2 (ROCm 7.14,
tracked in #48826).

## Not a duplicate
Checked open PRs/issues (`rocprofiler`, `rocprofiler-sdk`, `kineto`, `roctracer`): no PR changes
the base image's rocprofiler-sdk. Related: #48826 (ROCm 7.14 migration — the eventual superseder)
and closed/stale #39162 (same `rocprofiler_configure in libtorch_cpu.so` observation, no fix).

## Evidence (gfx942 / MI300X, torch 2.12, llama-3.1-8B, `bench latency --profile`)
Measured on an image produced by this exact change (`docker build` of the new stage +
`COPY`/`ldconfig`, then the vLLM layer):
| rocprofiler-sdk | GPU occupancy | gaps >1ms | hipGraphLaunch avg |
|---|---|---|---|
| 1.1.0 (base) | 39.9% | 578 | 16.6 ms |
| **1.3.2 (this PR)** | **97.8%** | **2** | **893 µs** |

Microbench (HIP graph replay under profiler): `hipGraphLaunch` 380 µs → 56 µs (≈ roctracer's
50 µs). ROCm 7.14 (native rocprofiler-sdk 1.3.2) independently shows the healthy result (98.6%
occupancy at e2e), confirming the rocprofiler-sdk version is the fix.

## Test commands
```
# Base image build (surgical stage builds in-context; rest of the base is unchanged):
docker build -f docker/Dockerfile.rocm_base -t <base>:rocprofsdk-1.3.2 .
docker run --rm <base>:rocprofsdk-1.3.2 bash -c \
  'ldd $(python -c "import torch,pathlib;print(pathlib.Path(torch.__file__).parent/\"lib\")")/libtorch_cpu.so | grep rocprofiler-sdk; \
   cat /app/versions.txt | grep ROCPROFILER_SDK'
# expect: librocprofiler-sdk.so.1 -> ...1.3.2

# llama profile (on a vLLM image built from this base):
VLLM_TORCH_PROFILER_DIR=/tmp/prof vllm bench latency --model meta-llama/Llama-3.1-8B-Instruct \
  -tp 1 --batch-size 32 --input-len 512 --output-len 128 --num-iters 3 \
  --profile --profiler-config.profiler=torch --profiler-config.torch_profiler_dir=/tmp/prof
# expect: profiled GPU occupancy ~99%, hipGraphLaunch sub-ms (vs ~16ms on 1.1.0)
```

## Notes
- Adds a ~few-minute rocprofiler-sdk compile to base-image builds (uses `sccache` when
  `USE_SCCACHE=1`, matching the existing stages).
- Pinned commit is overridable via `--build-arg ROCPROFILER_SDK_COMMIT=...`.

## AI assistance
Developed with AI assistance (Claude): the investigation, the Dockerfile stage, and the
build + llama-profile validation above were AI-run on the submitter's MI300X box. Opened as
a **draft** pending the submitter's final line-by-line review before marking ready.
