### PR TITLE
Revert "[Bugfix][MoE] Tune FlashInfer experts to scheduler token limit" (#52989)

### DIFF
--- a/tests/kernels/moe/test_flashinfer_moe.py
+++ b/tests/kernels/moe/test_flashinfer_moe.py
@@ -72,7 +72,6 @@ def test_flashinfer_swigluoai_params_are_forwarded(activation, monkeypatch):
         moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
         in_dtype=torch.bfloat16,
         routing_method=RoutingMethodType.TopK,
-        max_num_tokens=16_384,
     )
     quant_config = FusedMoEQuantConfig.make(
         gemm1_alpha=1.702,
@@ -111,7 +110,6 @@ def test_flashinfer_swigluoai_params_are_forwarded(activation, monkeypatch):
 
     assert experts._supports_activation(activation)
     assert call_args["activation_type"] == ActivationType.Swiglu
-    assert call_args["tune_max_num_tokens"] == 16_384
     for name, value in (
         ("swiglu_alpha", 1.702),
         ("swiglu_beta", 1.0),

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -13,7 +13,6 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
-from vllm.model_executor.layers.fused_moe.utils import fi_moe_largest_bucket
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     activation_to_flashinfer_type,
 )
@@ -389,7 +388,6 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             use_deepseek_fp8_block_scale=self.use_deepseek_fp8_block_scale,
             use_mxfp8_act_scaling=use_mxfp8_act_scaling,
             use_w4_group_scaling=use_w4_group_scaling,
-            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
@@ -219,7 +219,6 @@ class TrtLlmBf16ExpertsModular(TrtLlmBf16ExpertsBase, mk.FusedMoEExpertsModular)
             weight_layout=WeightLayout.BlockMajorK,
             do_finalize=True,
             activation_type=activation_to_flashinfer_int(activation),
-            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
         # FlashInfer's BF16 routed wrapper does not expose an output= argument.
         output.copy_(result[0] if isinstance(result, list) else result)

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_lora_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_lora_moe.py
@@ -39,7 +39,6 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
 from vllm.model_executor.layers.fused_moe.utils import (
-    fi_moe_largest_bucket,
     trtllm_moe_pack_topk_ids_weights,
 )
 from vllm.platforms import current_platform
@@ -550,7 +549,6 @@ class TrtLlmBf16LoRAExperts(_TrtLlmLoRAExpertsBase):
             routing_method_type=self.routing_method_type,
             do_finalize=do_finalize,
             output=output if do_finalize else None,
-            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
         if not do_finalize:
             # [gemm2_output, expert_weights, expanded_idx, gemm1_activation]

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxint4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxint4_moe.py
@@ -11,7 +11,6 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
-from vllm.model_executor.layers.fused_moe.utils import fi_moe_largest_bucket
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kInt4Static32,
@@ -170,7 +169,6 @@ class TrtLlmMxint4ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
             e_score_correction_bias=e_score_correction_bias,
             routing_method_type=self.routing_method,
             routing_replay_out=routing_replay_out,
-            tune_max_num_tokens=fi_moe_largest_bucket(self.moe_config),
         )
         self._maybe_dispatch_routing_replay(
             routing_replay_out, num_tokens=hidden_states.shape[0]

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
@@ -191,7 +191,6 @@ def flashinfer_trtllm_mxint4_moe(
     e_score_correction_bias: torch.Tensor | None = None,
     routing_method_type: int | None = None,
     routing_replay_out: torch.Tensor | None = None,
-    tune_max_num_tokens: int = 8192,
 ) -> torch.Tensor:
     """
     Apply FlashInfer TensorRT-LLM MxInt4 MoE kernel.
@@ -212,7 +211,6 @@ def flashinfer_trtllm_mxint4_moe(
         topk_group: Top-k within groups (default: None -> 0)
         e_score_correction_bias: Optional routing bias. dtype: bfloat16
         routing_method_type: FlashInfer RoutingMethodType enum value
-        tune_max_num_tokens: Maximum token count covered by autotuning.
 
     Returns:
         Output tensor from MoE layer. dtype: same as x (bfloat16)
@@ -264,7 +262,7 @@ def flashinfer_trtllm_mxint4_moe(
         enable_pdl=None,
         do_finalize=True,
         output=None,
-        tune_max_num_tokens=tune_max_num_tokens,
+        tune_max_num_tokens=8192,
         routing_replay_out=routing_replay_out,
     )
     if isinstance(out, (tuple, list)):


### PR DESCRIPTION
Reverts #52989 ("[Bugfix][MoE] Tune FlashInfer experts to scheduler token limit", merged as `bfb6c1349`).

## Why

Nightly build [#84887](https://buildkite.com/vllm/ci/builds/84887) (`bfb6c1349`, the merge commit of #52989) turned `:nvidia: (B200) LM Eval PCP` red for the first time. That job was green in the previous four nightlies (84473, 84555, 84687, 84753).

`evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[GLM-5.2-NVFP4-TP2-PCP2-EP]` now dies with `Server exited unexpectedly.`; every one of the four workers raises:

```
MemoryError: CUDA out of memory. Tried to allocate 12.22 GiB.
GPU 0 has a total capacity of 178.35 GiB of which 9.68 GiB is free.
  File ".../fused_moe/experts/flashinfer_cutlass_moe.py", line 368, in apply
  File ".../flashinfer/fused_moe/core.py", line 636, in cutlass
  File "<unknown>", line 0, in FusedMoeRunner::getWorkspaceInfo(...)
```

Line 368 is the `flashinfer_cutlass_fused_moe(...)` call this PR modified. The job runs with `max_num_batched_tokens=32768`, so `fi_moe_largest_bucket()` returns `max(32768 * dp_size, 8192)` and the FlashInfer CUTLASS autotune bucket jumps **8192 -> 32768**, quadrupling the workspace `getWorkspaceInfo` reserves.

`fi_moe_largest_bucket`'s own docstring warns that "overestimation may be dangerous, increasing tuning-cost and memory use" and that PCP is not modelled by the estimate — which is exactly the configuration that broke. The sibling `GLM-5.2-NVFP4-TP1-PCP4-EP` config, which has a smaller per-rank footprint, still passes (0.9325).

Related: open issue #51071 tracks earlier OOMs in this job.

## Note for reviewers

This is a **draft**. The underlying autotune-coverage problem #52989 set out to fix is real; a narrower fix that caps the tuned bucket (or accounts for PCP/EP memory headroom) would be preferable to this revert. Reverting is proposed only to get the B200 PCP eval green while that fix is prepared. The revert applied cleanly with no conflicts and is an exact inverse of the original diff (6 files, 1 insertion, 12 deletions).

Auto-generated by CI failure analyzer.
