### PR TITLE
[Bugfix] Raise a clear error when a linear weight parameter is missing

### DIFF
--- a/tests/model_executor/layers/test_linear.py
+++ b/tests/model_executor/layers/test_linear.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.linear import MergedColumnParallelLinear
+
+
+def test_load_weights_reports_missing_parameter() -> None:
+    layer = object.__new__(MergedColumnParallelLinear)
+    nn.Module.__init__(layer)
+    layer.add_module("projection", nn.Module())
+
+    weights = [("projection.weight_scale", torch.ones(1))]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Cannot load weight 'projection\.weight_scale': expected a "
+            r"torch\.nn\.Parameter, but found MergedColumnParallelLinear\."
+        ),
+    ):
+        list(layer.load_weights(weights))

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -957,6 +957,11 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 param = getattr(self, name, self)
             if param is None and name == "bias":
                 continue
+            if not isinstance(param, Parameter):
+                raise ValueError(
+                    f"Cannot load weight {name!r}: expected a torch.nn.Parameter, "
+                    f"but found {type(param).__name__}."
+                )
             param.weight_loader(param, loaded_weight, shard_id)
             logger.debug(
                 "Loaded shard %s with shape %s into %s.%s",


### PR DESCRIPTION
## Summary

Improve the error reported by `MergedColumnParallelLinear.load_weights` when a checkpoint weight does not correspond to a valid parameter.

Previously, a failed parameter lookup could fall back to the layer module itself. The subsequent weight-loading operation would then fail with a confusing `AttributeError`, making it difficult to identify the actual checkpoint or model-definition mismatch.

This change validates the resolved object before invoking its weight loader and raises a descriptive `ValueError` when it is not a `torch.nn.Parameter`.

## Changes

- Detect unresolved or invalid parameter lookups before calling `weight_loader`.
- Include the checkpoint weight name and resolved object type in the error message.
- Preserve the existing behavior for models with an optional, missing bias.
- Add a regression test for a missing nested parameter.

## Testing

- Verified the patch with `git diff --check`.
- Verified both modified Python files with `py_compile`.
- The pytest test suite could not be executed locally because `pytest` is not installed in the current environment.

Fixes #53107

## AI Assistance

OpenAI Codex assisted with the implementation and regression-test preparation. I reviewed the resulting changes and take responsibility for the contribution.
