### PR TITLE
[Model] Enable sequence-parallel MoE with pipeline parallelism

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1267,9 +1267,7 @@ class DeepseekV2DecoderLayer(nn.Module):
         # TODO(wentao): enable SP MoE with PP after the PP boundary logic can safely
         # send/receive sequence-parallel hidden_states across stages.
         self.use_sequence_parallel_moe = (
-            parallel_config.use_sequence_parallel_moe
-            and parallel_config.pipeline_parallel_size == 1
-            and is_moe_layer
+            parallel_config.use_sequence_parallel_moe and is_moe_layer
         )
         self.self_attn = attn_cls(
             vllm_config=vllm_config,
@@ -1525,6 +1523,19 @@ class DeepseekV2Model(nn.Module):
             )
 
         if not get_pp_group().is_last_rank:
+            if any(
+                getattr(l, "use_sequence_parallel_moe", False)
+                for l in self.layers
+            ):
+                # SP keeps the residual stream sequence-sharded (padded to the
+                # TP size, so a shard can equal full_num_tokens on decode
+                # steps); the PP boundary protocol expects full-token tensors.
+                combined_states = torch.cat([hidden_states, residual], dim=-1)
+                combined_states = tensor_model_parallel_all_gather(combined_states, 0)
+                combined_states = combined_states[: positions.shape[0]]
+                hidden_states, residual = combined_states.split(
+                    [self.hidden_size, self.hidden_size], dim=-1
+                )
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -136,9 +136,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
         self.layer_idx = extract_layer_index(prefix)
         is_moe_layer = config.model_type == "qwen3_5_moe_text"
         self.use_attn_reduce_scatter_for_moe = (
-            parallel_config.use_sequence_parallel_moe
-            and parallel_config.pipeline_parallel_size == 1
-            and is_moe_layer
+            parallel_config.use_sequence_parallel_moe and is_moe_layer
         )
 
         if self.layer_type == "linear_attention":

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -15,6 +15,7 @@ from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
+    tensor_model_parallel_all_reduce,
     tensor_model_parallel_reduce_scatter,
 )
 from vllm.model_executor.layers.attention import Attention
@@ -83,7 +84,6 @@ def _should_use_sequence_parallel(vllm_config: VllmConfig) -> bool:
     parallel_config = vllm_config.parallel_config
     return (
         parallel_config.use_sequence_parallel_moe
-        and parallel_config.pipeline_parallel_size == 1
         and getattr(config, "num_experts", 0) > 0
         and not getattr(config, "mlp_only_layers", [])
         and getattr(config, "decoder_sparse_step", 1) == 1
@@ -505,17 +505,30 @@ class Qwen3NextDecoderLayer(nn.Module):
                     self.attn_layer_scale.to(hidden_states.dtype) + 1
                 )
 
-        if self.use_attn_reduce_scatter_for_moe:
+        # Runtime downgrade: with fewer tokens than TP ranks (decode
+        # steps), SP pads rows to the TP size; the pad rows go through
+        # norm/experts and can produce NaN. Fall back to the allreduce path.
+        sp_this_step = (
+            self.use_attn_reduce_scatter_for_moe
+            and hidden_states.shape[0] >= get_tensor_model_parallel_world_size()
+        )
+        if sp_this_step:
             tp_world_size = get_tensor_model_parallel_world_size()
             # small trick using minus, eg. -17 % 8 = 7
             sp_pad = (-hidden_states.shape[0]) % tp_world_size
             # pad if not divisible by world size
             hidden_states = torch.nn.functional.pad(hidden_states, (0, 0, 0, sp_pad))
             hidden_states = tensor_model_parallel_reduce_scatter(hidden_states, 0)
+            if not input_is_sequence_parallel:
+                residual = sequence_parallel_chunk(residual)
+        elif self.use_attn_reduce_scatter_for_moe:
+            # downgraded step: o_proj was built with reduce_results=False, so
+            # the partial sums must still be reduced explicitly.
+            hidden_states = tensor_model_parallel_all_reduce(hidden_states)
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        if self.use_attn_reduce_scatter_for_moe:
+        if sp_this_step:
             hidden_states = self.mlp(
                 hidden_states,
                 already_sequence_parallel=True,
@@ -644,6 +657,19 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             )
 
         if not get_pp_group().is_last_rank:
+            if any(
+                getattr(l, "use_attn_reduce_scatter_for_moe", False)
+                for l in self.layers
+            ):
+                # SP keeps the residual stream sequence-sharded (padded to the
+                # TP size, so a shard can equal full_num_tokens on decode
+                # steps); the PP boundary protocol expects full-token tensors.
+                hidden_states, residual = _all_gather_hidden_and_residual(
+                    hidden_states,
+                    residual,
+                    full_num_tokens,
+                    self.config.hidden_size,
+                )
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )


### PR DESCRIPTION
## Motivation

SP-MoE (`use_sequence_parallel_moe`) currently hard-disables itself when `pipeline_parallel_size > 1`, with a TODO in `deepseek_v2.py`: *"enable SP MoE with PP after the PP boundary logic can safely send/receive sequence-parallel hidden_states across stages."* This PR implements that boundary logic and removes the guards.

## Changes

1. **PP boundary gather** (`qwen3_next.py`, `deepseek_v2.py`): non-last stages packed the sequence-sharded `hidden_states`/`residual` into `IntermediateTensors` as-is. Now they are gathered first (same cat → all-gather → trim → split pattern already used at the last-rank exit). The gather is driven by an explicit SP flag, not a shape check: after SP padding, a shard can equal `full_num_tokens` on decode steps (T=1, tp=2), which silently skips the gather and leaks a pad row across the boundary.

2. **Runtime downgrade for small batches** (`qwen3_next.py`): with fewer tokens than TP ranks, SP pads rows up to the TP size; pad rows propagate through norm/experts and produce NaN that then spreads through every subsequent gather (observed: decode outputs collapse to a flat distribution; per-rank probes show NaN). Steps with `num_tokens < tp_size` now take the replicated path. Because `o_proj` is built with `reduce_results=False` under SP, the downgraded step reduces partial sums with an explicit all-reduce. SP gains are prefill-dominated; on decode-size batches the RS+AG pair is not faster than a single AR, so the downgrade costs nothing where it matters.

3. **Guard removal**: `pipeline_parallel_size == 1` dropped from `_should_use_sequence_parallel` (qwen3_next), `qwen3_5.py`, and `deepseek_v2.py`.

## Test plan

- [x] Ascend 910, Qwen3.5-35B-A3B (hybrid GatedDeltaNet MoE), **PP2 × DP2 × TP2** + EP + `allgather_reducescatter` a2a backend:
  - prefill runs SP: per-layer reduce-scatter kernels present in the profile; first-token logprobs exact-match the SP-off baseline (logprob −0.0)
  - decode runs the downgraded AR path; no NaN
  - outputs match both the PP=1 SP baseline and the PP>1 SP-off baseline across multiple prompts
- [ ] DeepSeek-V2 path: implemented symmetrically, **not yet hardware-verified**
- [ ] GPU validation + unit tests (feedback welcome on where to add them)

Draft until DeepSeek verification and maintainer feedback on the downgrade design.