### PR TITLE
Exclude model field from ModelConfig.compute_hash()

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -422,6 +422,7 @@ class ModelConfig:
         the final hidden states.
         """
         ignored_factors = {
+            "model",
             "convert",
             "tokenizer",
             "tokenizer_mode",


### PR DESCRIPTION



## Purpose

ModelConfig.compute_hash() includes the model field (HF name or local path). This causes cache misses when the same model is loaded from different paths:

vllm serve /data1/Qwen3-8B --tensor-parallel-size 1

vllm serve /data2/Qwen3-8B --tensor-parallel-size 1
Both instances compute different config_hash solely because self.model differs, so Instance B cannot reuse Instance A's compiled cache.


Although both instances refer to the identical model, they compute different config_hash values solely because the model field differs. As a result, Instance B cannot reuse Instance A's compiled cache, leading to redundant compilation overhead.

hf_config already contains all the necessary information to uniquely identify a model's architecture and configuration.


We have tested this change on:

Qwen3-8B and Qwen3-32B

Tensor parallel sizes 1 and 2

In all cases, the computed hash remains consistent across different model paths (e.g., /data1/Qwen3-8B vs /data2/Qwen3-8B), while still correctly producing unique hashes for genuinely different models.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

