### PR TITLE
[Bugfix][MRV2] Keep fused draft graph metadata alive across sleep

### DIFF
--- a/tests/basic_correctness/test_mem.py
+++ b/tests/basic_correctness/test_mem.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from vllm import LLM, AsyncEngineArgs, AsyncLLMEngine, SamplingParams
+from vllm.config import CompilationConfig, CUDAGraphMode
 from vllm.device_allocator import get_mem_allocator_instance
 from vllm.platforms import current_platform
 from vllm.utils.mem_constants import GiB_bytes
@@ -242,6 +243,54 @@ def test_deep_sleep():
 
     # cmp output
     assert output[0].outputs[0].text == output2[0].outputs[0].text
+
+
+@create_new_process_for_each_test("spawn")
+def test_deep_sleep_with_fused_mtp_cudagraph(monkeypatch):
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    llm = LLM(
+        model="Qwen/Qwen3.5-0.8B-Base",
+        speculative_config={"method": "mtp", "num_speculative_tokens": 3},
+        compilation_config=CompilationConfig(cudagraph_mode=CUDAGraphMode.FULL),
+        enable_prefix_caching=False,
+        enable_sleep_mode=True,
+        limit_mm_per_prompt={"image": 0, "video": 0},
+        max_model_len=256,
+        max_num_seqs=1,
+        trust_remote_code=True,
+    )
+    assert llm.collective_rpc(_uses_fused_mtp_decode) == [True]
+    layout_ptrs = llm.collective_rpc(_block_table_layout_ptrs)
+    sampling_params = SamplingParams(temperature=0, max_tokens=4, ignore_eos=True)
+    output = llm.generate("The capital of France is", sampling_params)
+
+    llm.sleep(level=2)
+    llm.wake_up(tags=["weights"])
+    llm.collective_rpc("reload_weights")
+    llm.wake_up(tags=["kv_cache"])
+
+    assert llm.collective_rpc(_block_table_layout_ptrs) == layout_ptrs
+    output_after_wake = llm.generate("The capital of France is", sampling_params)
+    assert output[0].outputs[0].token_ids == output_after_wake[0].outputs[0].token_ids
+
+
+def _uses_fused_mtp_decode(worker) -> bool:
+    return worker.model_runner.speculator.use_fused_multi_step_decode
+
+
+def _block_table_layout_ptrs(worker) -> tuple[int, ...]:
+    block_tables = worker.model_runner.block_tables
+    return tuple(
+        tensor.data_ptr()
+        for tensor in (
+            block_tables.block_table_ptrs,
+            block_tables.block_table_strides,
+            block_tables.block_sizes_tensor,
+            block_tables.kernel_block_sizes_tensor,
+            block_tables.input_block_table_ptrs,
+        )
+    )
 
 
 @create_new_process_for_each_test()

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -86,11 +86,8 @@ class BlockTables:
         )
 
     def init_block_table_layout_tensors(self) -> None:
-        # Called at init and after a CuMem kv_cache wake-up. The ptr tensors
-        # cache raw data_ptr() values that go stale once the underlying tensors
-        # are reallocated on wake; the size tensors need re-populating because
-        # their storage lives under the kv_cache pool tag and comes back with
-        # undefined contents.
+        # These tensors are captured by CUDA graphs. Allocate them once; wake-up
+        # refreshes their undefined CuMem contents in place.
         self.block_table_ptrs = self._make_ptr_tensor(
             [b.gpu for b in self.block_tables]
         )
@@ -106,6 +103,28 @@ class BlockTables:
             self.kernel_block_sizes, dtype=torch.int32, device=self.device
         )
         self.input_block_table_ptrs = self._make_ptr_tensor(self.input_block_tables)
+
+    def refresh_block_table_layout_tensors(self) -> None:
+        """Restore graph-captured layout metadata without changing its addresses."""
+        self.block_table_ptrs.copy_(
+            self._make_ptr_tensor([b.gpu for b in self.block_tables])
+        )
+        self.block_table_strides.copy_(
+            torch.tensor(
+                [b.gpu.stride(0) for b in self.block_tables],
+                dtype=torch.int64,
+                device=self.device,
+            )
+        )
+        self.block_sizes_tensor.copy_(
+            torch.tensor(self.block_sizes, dtype=torch.int32, device=self.device)
+        )
+        self.kernel_block_sizes_tensor.copy_(
+            torch.tensor(self.kernel_block_sizes, dtype=torch.int32, device=self.device)
+        )
+        self.input_block_table_ptrs.copy_(
+            self._make_ptr_tensor(self.input_block_tables)
+        )
 
     def append_block_ids(
         self,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -850,7 +850,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         gc.collect()
 
     def post_kv_cache_wake_up(self) -> None:
-        self.block_tables.init_block_table_layout_tensors()
+        self.block_tables.refresh_block_table_layout_tensors()
 
     def reset_mm_cache(self) -> None:
         if self.encoder_cache is not None:


### PR DESCRIPTION
## Purpose

Fix a sleep/wake regression in MRV2 fused multi-step MTP decode introduced by the graph fusion in #46849.

The fused draft CUDA graph reads block-table layout metadata from captured tensor addresses. `post_kv_cache_wake_up()` previously rebuilt those tensors, so the CUDA graph kept the old addresses while Python used new tensors. Under memory pressure, the first request after wake could replay the graph against stale metadata and fail with `CUDA_ERROR_ILLEGAL_ADDRESS`.

## Design

CUDA Graph-visible storage has two requirements across wake-up:

1. its address must remain stable;
2. its values must describe the newly restored block tables.

This PR therefore allocates the five layout tensors once and refreshes their values with in-place `copy_()` after KV-cache wake-up. It does not recapture graphs, move allocator ownership, or add a new lifecycle abstraction.

Compared with the previous revision, the implementation is reduced from five changed files (including allocator refactoring) to three focused files: one refresh method, one wake-up call-site change, and one regression test.

Rebased onto `vllm-project/vllm@5e379a361e3ea8bb82b7efd768c36f39a0cf32fd`.

## A/B Test

Same node, image, model, cache, and command; only the two patched Python files differ.

- GPU: 4x NVIDIA H200
- Image: `vllm/vllm-openai:nightly`
- Image digest: `sha256:3578c1fa6a9676e1de068b9d75c777cc865d251fadfbe6175ae82278739c6674`
- Image vLLM commit: `a9a17e7095a66ef6c6685a1c7ddd657781a78d3c`
- Current-main files overlaid in both groups
- Model: `Qwen/Qwen3.5-35B-A3B`
- MRV2: enabled
- Parallelism: TP=4
- Spec decode: MTP, 3 speculative tokens
- CUDA Graph: full
- Sleep: level 2, then wake weights, reload weights, wake KV cache
- Limits: `max_model_len=256`, `max_num_seqs=1`

| Result | Baseline (`main`) | This PR |
|---|---:|---:|
| Layout tensor addresses stable | No | Yes |
| Post-wake decode | `CUDA_ERROR_ILLEGAL_ADDRESS` | Pass |
| Output tokens equal before/after wake | Not available (crash) | Yes |
| Sleep | 0.491 s | 0.481 s |
| Wake weights | 0.390 s | 0.430 s |
| Wake KV cache | 1.126 s | 1.118 s |
| Post-wake decode | Crash | 0.155 s |

The fix adds no measurable wake-up overhead; the stage deltas are within run-to-run noise, while the baseline deterministically crashes after wake.

## Test Plan / Results

```bash
uvx pre-commit run --files \
  tests/basic_correctness/test_mem.py \
  vllm/v1/worker/gpu/block_table.py \
  vllm/v1/worker/gpu/model_runner.py
```

Result: all hooks passed.

```bash
pytest -q \
  tests/basic_correctness/test_mem.py::test_deep_sleep_with_fused_mtp_cudagraph \
  -s
```

Result: `1 passed, 14 warnings in 53.85s` on H200.

The regression test requires at least three speculative tokens so the fused graph executes an intermediate in-graph slot-mapping step; two tokens do not cover that path.

## Duplicate Search

Searched open and closed vLLM issues/PRs for fused MTP + sleep/wake + block-table metadata. The only matching result is this PR.

## AI Assistance

OpenAI Codex assisted with the rebase, implementation refinement, test execution, and PR description. The author reviewed the design and will perform the required human review before merge.
