### PR TITLE
[Core][Frontend] Bind weight versions to generation requests

### DIFF
--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -130,6 +130,9 @@ pub struct EngineCoreOutput {
     /// the Rust frontend does not yet surface it in responses.
     #[serde(default)]
     pub spec_decode_metrics: Option<OpaqueValue>,
+    /// Weight version bound when EngineCore admitted this request.
+    #[serde(default)]
+    pub weight_version: Option<String>,
 }
 
 impl EngineCoreOutput {
@@ -449,6 +452,7 @@ mod tests {
                             mm_cache_miss_hashes: None,
                             new_sampling_mask: None,
                             spec_decode_metrics: None,
+                            weight_version: None,
                         },
                     ],
                     scheduler_stats: None,

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2744,6 +2744,9 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                         mm_cache_miss_hashes: None,
                         new_sampling_mask: None,
                         spec_decode_metrics: None,
+                        weight_version: Some(
+                            "step-7",
+                        ),
                     },
                 ],
                 scheduler_stats: None,

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -100,6 +100,8 @@ class EngineCoreOutput(
     num_nans_in_logits: int = 0
     mm_cache_miss_hashes: list[str] | None = None
     new_sampling_mask: object | None = None
+    spec_decode_metrics: object | None = None
+    weight_version: str | None = None
 
 
 class EngineCoreOutputs(
@@ -200,6 +202,7 @@ outputs = EngineCoreOutputs(
             request_id="req-1",
             new_token_ids=[7, 8],
             finish_reason=FinishReason.LENGTH,
+            weight_version="step-7",
         )
     ],
     finished_requests={"req-1"},

--- a/tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py
@@ -125,6 +125,7 @@ def _make_request_output(
     logprobs: list[dict[int, Any] | None] | None = None,
     num_cached_tokens: int | None = None,
     index: int = 0,
+    weight_version: str = "step-7",
 ) -> RequestOutput:
     return RequestOutput(
         request_id=request_id,
@@ -147,6 +148,7 @@ def _make_request_output(
         encoder_prompt=None,
         encoder_prompt_token_ids=None,
         num_cached_tokens=num_cached_tokens,
+        weight_version=weight_version,
     )
 
 
@@ -197,6 +199,7 @@ async def test_serve_tokens_skips_mm_cache_for_remote_engine_execution():
     response = await serving.serve_tokens(request)
 
     assert isinstance(response, GenerateResponse)
+    assert response.weight_version == "step-7"
     assert (
         serving.online_renderer.preprocess_completion.call_args.kwargs["skip_mm_cache"]
         is True
@@ -264,6 +267,7 @@ async def test_stream_basic():
     assert len(data_chunks) == 3
 
     assert data_chunks[0]["choices"][0]["token_ids"] == [10]
+    assert data_chunks[0]["weight_version"] == "step-7"
     assert data_chunks[1]["choices"][0]["token_ids"] == [20, 30]
     assert data_chunks[2]["choices"][0]["token_ids"] == [40]
     assert data_chunks[2]["choices"][0]["finish_reason"] == "stop"

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import msgspec
 import pytest
 
 from vllm.outputs import RequestOutput
+from vllm.v1.engine import EngineCoreOutput
 
 pytestmark = pytest.mark.cpu_test
 
@@ -19,3 +21,27 @@ def test_request_output_forward_compatible():
         example_arg_added_in_new_version="some_value",
     )
     assert output is not None
+
+
+def test_weight_version_output_propagation():
+    core_output = EngineCoreOutput(
+        request_id="request-1",
+        new_token_ids=[1],
+        weight_version="step-7",
+    )
+    decoded = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(core_output),
+        type=EngineCoreOutput,
+    )
+    assert decoded.weight_version == "step-7"
+
+    request_output = RequestOutput(
+        request_id="request-1",
+        prompt=None,
+        prompt_token_ids=[1],
+        prompt_logprobs=None,
+        outputs=[],
+        finished=True,
+        weight_version=decoded.weight_version,
+    )
+    assert request_output.weight_version == "step-7"

--- a/tests/v1/engine/test_engine_core.py
+++ b/tests/v1/engine/test_engine_core.py
@@ -76,7 +76,9 @@ def test_engine_core():
     """Test basic request lifecycle."""
 
     # First request.
-    engine_core.add_request(*engine_core.preprocess_add_request(make_request()))
+    request, wave = engine_core.preprocess_add_request(make_request())
+    engine_core.add_request(request, wave)
+    assert request.weight_version == "default"
     assert len(engine_core.scheduler.waiting) == 1
     assert len(engine_core.scheduler.running) == 0
 
@@ -85,7 +87,10 @@ def test_engine_core():
     assert len(engine_core.scheduler.running) == 1
 
     # Second request.
-    engine_core.add_request(*engine_core.preprocess_add_request(make_request()))
+    engine_core.set_weight_version("step-7")
+    request, wave = engine_core.preprocess_add_request(make_request())
+    engine_core.add_request(request, wave)
+    assert request.weight_version == "step-7"
     assert len(engine_core.scheduler.waiting) == 1
     assert len(engine_core.scheduler.running) == 1
 

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -240,6 +240,7 @@ class GenerateStreamResponse(BaseModel):
     )
     choices: list[GenerateResponseStreamChoice]
     usage: UsageInfo | None = Field(default=None)
+    weight_version: str | None = None
 
 
 class GenerateResponse(BaseModel):
@@ -255,6 +256,7 @@ class GenerateResponse(BaseModel):
     created: int | None = None
     choices: list[GenerateResponseChoice]
     usage: UsageInfo | None = Field(default=None)
+    weight_version: str | None = None
     prompt_logprobs: list[dict[int, Logprob] | None] | None = None
 
     kv_transfer_params: dict[str, Any] | None = Field(

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -351,6 +351,7 @@ class ServingTokens(GenerateBaseServing):
             model=model_name,
             choices=choices,
             usage=usage,
+            weight_version=final_res.weight_version,
             prompt_logprobs=clamp_prompt_logprobs(final_res.prompt_logprobs),
             kv_transfer_params=final_res.kv_transfer_params,
             ec_transfer_params=final_res.ec_transfer_params,
@@ -436,6 +437,7 @@ class ServingTokens(GenerateBaseServing):
 
                     chunk = GenerateStreamResponse(
                         request_id=request_id,
+                        weight_version=res.weight_version,
                         choices=[
                             GenerateResponseStreamChoice(
                                 index=i,
@@ -470,6 +472,7 @@ class ServingTokens(GenerateBaseServing):
             if include_usage:
                 final_chunk = GenerateStreamResponse(
                     request_id=request_id,
+                    weight_version=res.weight_version,
                     choices=[],
                     usage=final_usage_info,
                 )

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -128,6 +128,7 @@ class RequestOutput:
             prefix-cache writes for this request.
         kv_transfer_params: The params for remote K/V transfer.
         ec_transfer_params: The params for remote encoder-cache transfer.
+        weight_version: The model weight version bound to this request.
     """
 
     def __init__(
@@ -147,6 +148,7 @@ class RequestOutput:
         *,
         kv_transfer_params: dict[str, Any] | None = None,
         ec_transfer_params: dict[str, Any] | None = None,
+        weight_version: str | None = None,
         # Forward compatibility, code that uses args added in new release can
         # still run with older versions of vLLM without breaking.
         **kwargs: Any,
@@ -169,6 +171,7 @@ class RequestOutput:
         self.num_cache_creation_tokens = num_cache_creation_tokens
         self.kv_transfer_params = kv_transfer_params
         self.ec_transfer_params = ec_transfer_params
+        self.weight_version = weight_version
 
     def add(self, next_output: "RequestOutput", aggregate: bool) -> None:
         """Merge subsequent RequestOutput into this one"""
@@ -176,6 +179,7 @@ class RequestOutput:
         self.finished |= next_output.finished
         self.kv_transfer_params = next_output.kv_transfer_params
         self.ec_transfer_params = next_output.ec_transfer_params
+        self.weight_version = next_output.weight_version
 
         for next_completion in next_output.outputs:
             for i, completion in enumerate(self.outputs):
@@ -214,7 +218,8 @@ class RequestOutput:
             f"metrics={self.metrics}, "
             f"lora_request={self.lora_request}, "
             f"num_cached_tokens={self.num_cached_tokens}, "
-            f"num_cache_creation_tokens={self.num_cache_creation_tokens})"
+            f"num_cache_creation_tokens={self.num_cache_creation_tokens}, "
+            f"weight_version={self.weight_version!r})"
         )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2046,6 +2046,7 @@ class Scheduler(SchedulerInterface):
                             if finish_reason is not None
                             else None
                         ),
+                        weight_version=request.weight_version,
                         kv_transfer_params=kv_transfer_params,
                         ec_transfer_params=ec_transfer_params,
                         trace_headers=request.trace_headers,
@@ -2082,6 +2083,7 @@ class Scheduler(SchedulerInterface):
                         finish_reason=request.get_finished_reason(),
                         events=request.take_events(),
                         trace_headers=request.trace_headers,
+                        weight_version=request.weight_version,
                     )
                 )
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -233,6 +233,9 @@ class EngineCoreOutput(
     # Appended last so `array_like` positional serialization stays compatible.
     spec_decode_metrics: RequestSpecDecodeMetrics | None = None
 
+    # Weight version bound when EngineCore admits this request.
+    weight_version: str | None = None
+
     @property
     def finished(self) -> bool:
         return self.finish_reason is not None

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -475,6 +475,7 @@ class EngineCore:
                 "Disabling ECTransfer for this request."
             )
 
+        request.weight_version = self._weight_version
         self.scheduler.add_request(request)
         if request.abort_immediately:
             # Immediately abort so the connector's request_finished hook runs

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -288,6 +288,7 @@ class RequestState:
         stop_reason: int | str | None,
         kv_transfer_params: dict[str, Any] | None = None,
         ec_transfer_params: dict[str, Any] | None = None,
+        weight_version: str | None = None,
     ) -> RequestOutput | PoolingRequestOutput | None:
         finished = finish_reason is not None
         final_only = self.output_kind == RequestOutputKind.FINAL_ONLY
@@ -344,6 +345,7 @@ class RequestState:
             finished,
             kv_transfer_params,
             ec_transfer_params,
+            weight_version,
         )
 
     def _new_request_output(
@@ -353,6 +355,7 @@ class RequestState:
         finished: bool,
         kv_transfer_params: dict[str, Any] | None = None,
         ec_transfer_params: dict[str, Any] | None = None,
+        weight_version: str | None = None,
     ) -> RequestOutput | PoolingRequestOutput:
         # If prompt embeds were used, put placeholder prompt token ids
         prompt_token_ids = self.prompt_token_ids
@@ -387,6 +390,7 @@ class RequestState:
             finished=finished,
             kv_transfer_params=kv_transfer_params,
             ec_transfer_params=ec_transfer_params,
+            weight_version=weight_version,
             num_cached_tokens=self.num_cached_tokens,
             num_cache_creation_tokens=self.num_cache_creation_tokens,
             metrics=self.stats,
@@ -693,6 +697,7 @@ class OutputProcessor:
                 stop_reason,
                 kv_transfer_params,
                 ec_transfer_params,
+                engine_core_output.weight_version,
             ):
                 if req_state.streaming_input:
                     request_output.finished = False

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -98,6 +98,7 @@ class Request:
         self.status = RequestStatus.WAITING
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: int | str | None = None
+        self.weight_version: str | None = None
 
         # P/D: Connector-specific KV transfer parameters.
         self.kv_transfer_params: dict[str, Any] | None = None


### PR DESCRIPTION
Snapshot the committed EngineCore weight version when a request is admitted and propagate it through EngineCoreOutput, RequestOutput, Rust protocol compatibility, and token-in/token-out responses.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

