### PR TITLE
[XPU] follow cuda path for mrope on XPU

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -422,6 +422,15 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         return self.forward_native(positions, query, key, offsets)
 
+    def forward_xpu(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+        offsets: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        return self.forward_cuda(positions, query, key, offsets)
+
     @staticmethod
     def get_next_input_positions(
         mrope_position_delta: int,


### PR DESCRIPTION



## Purpose
PR #52005 rewrite interleaved_rope to fix torch.compile break but introduces additional overhead on eager mode on XPU. This PR switches mrope to `forward_cuda` to avoid this overhead and get better performance.
## Test Plan
```
IMAGE_SIZE=512 NUM_WARMUP=2  python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen3-VL-32B-Instruct --enforce-eager --port 8124 --host 0.0.0.0 --trust-remote-code --gpu-memory-util=0.92 --no-enable-prefix-caching --max-num-batched-tokens=8192  --max-model-len=6000  --limit-mm-per-prompt '{"image": 1}' --mm-processor-cache-gb 0 --max-num-seqs 12     -tp=4
python3 -m vllm.entrypoints.cli.main bench serve  --model Qwen/Qwen3-VL-32B-Instruct --ready-check-timeout-sec 1 --temperature=0  --num-warmups 2  --random-input-len=4096 --random-output-len=1024 --dataset-name random-mm --endpoint /v1/chat/completions  --ignore-eos --port=8124 --host 0.0.0.0 --num-prompts 10 --request-rate inf --backend openai-chat --save-result --metric-percentiles 95,99 --trust-remote-code --max-concurrency 2  --random-mm-base-items-per-request 1 --random-mm-limit-mm-per-prompt '{"image": 1, "video": 0}' --random-mm-bucket-config '{(512, 512, 1): 1.0}' --seed 42 
```
## Test Result
before:
<img width="341" height="335" alt="image" src="https://github.com/user-attachments/assets/90b905fe-33f4-4051-9163-e2e02da93865" />

after:
<img width="348" height="337" alt="image" src="https://github.com/user-attachments/assets/e2889af2-5d01-4b63-b085-3a5e7e71f639" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

