### PR TITLE
[Bugfix] Whisper prompt conditioning: use the real `<|startofprev|>` token

### DIFF
--- a/examples/speech_to_text/openai/openai_transcription_client.py
+++ b/examples/speech_to_text/openai/openai_transcription_client.py
@@ -40,7 +40,7 @@ def sync_openai(
 
     The optional ``prompt`` is the OpenAI-API ``prompt`` field (style /
     vocabulary hint). It is wired through model-by-model: Whisper uses it
-    as a ``<|prev|>`` continuation hint, Qwen3-ASR maps it into the
+    as a ``<|startofprev|>`` continuation hint, Qwen3-ASR maps it into the
     chat-template ``system`` turn. Models that do not consume it accept
     it without effect.
     """
@@ -214,7 +214,7 @@ if __name__ == "__main__":
         default=None,
         help=(
             "Optional `prompt` (OpenAI transcription API: style/vocabulary "
-            "hint). Wired model-by-model: Whisper uses it as a `<|prev|>` "
+            "hint). Wired model-by-model: Whisper uses it as a `<|startofprev|>` "
             "continuation hint, Qwen3-ASR maps it into the chat-template "
             "system turn."
         ),

--- a/tests/entrypoints/speech_to_text/transcription/test_whisper_prompt_special_token.py
+++ b/tests/entrypoints/speech_to_text/transcription/test_whisper_prompt_special_token.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test: the Whisper request prompt must be prefixed with the real
+``<|startofprev|>`` special token.
+
+``get_generation_prompt()`` used to build the prefix with ``<|prev|>``, which
+is not in the Whisper vocabulary. The tokenizer split it into ordinary text
+tokens (``< | pre v | >``) placed before ``<|startoftranscript|>``, corrupting
+the decoder conditioning: any request carrying the OpenAI ``prompt`` field
+degenerated into repetition loops, and on multi-chunk (>30 s) audio the
+transcription collapsed to the final chunk's output only.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from vllm.config.speech_to_text import SpeechToTextConfig, SpeechToTextParams
+from vllm.model_executor.models.whisper import WhisperForConditionalGeneration
+
+# Any Whisper checkpoint works: the special-token table is shared across the
+# family, so use the smallest one to keep the download negligible.
+TOKENIZER_MODEL = "openai/whisper-tiny"
+
+
+def _decoder_prompt(request_prompt: str) -> str:
+    params = SpeechToTextParams(
+        audio=np.zeros(16_000, dtype=np.float32),
+        stt_config=SpeechToTextConfig(),
+        model_config=MagicMock(),
+        language="en",
+        task_type="transcribe",
+        request_prompt=request_prompt,
+    )
+    prompt = WhisperForConditionalGeneration.get_generation_prompt(params)
+    return prompt["decoder_prompt"]["prompt"]
+
+
+@pytest.fixture(scope="module")
+def whisper_tokenizer():
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(TOKENIZER_MODEL)
+
+
+def test_prompt_prefix_is_a_single_special_token(whisper_tokenizer) -> None:
+    decoder_prompt = _decoder_prompt("style and vocabulary hint")
+
+    prev_id = whisper_tokenizer.convert_tokens_to_ids("<|startofprev|>")
+    assert prev_id is not None and prev_id != whisper_tokenizer.unk_token_id
+
+    ids = whisper_tokenizer.encode(decoder_prompt, add_special_tokens=False)
+    # The prefix must survive tokenization as one special token, not leak
+    # literal "<", "|", ... text tokens in front of <|startoftranscript|>.
+    assert ids[0] == prev_id
+
+
+def test_prompt_prefix_token_exists_in_vocab(whisper_tokenizer) -> None:
+    # Guards against regressing to a made-up token again: whatever prefix the
+    # prompt builder emits must round-trip as exactly one vocabulary entry.
+    decoder_prompt = _decoder_prompt("hint")
+    prefix = decoder_prompt.split("<|startoftranscript|>")[0]
+    prefix_token = prefix[: prefix.index(">") + 1]
+    ids = whisper_tokenizer.encode(prefix_token, add_special_tokens=False)
+    assert len(ids) == 1, (
+        f"{prefix_token!r} is not a single Whisper vocab token; "
+        f"it tokenizes to {len(ids)} tokens"
+    )
+
+
+def test_no_request_prompt_means_no_prefix() -> None:
+    decoder_prompt = _decoder_prompt("")
+    assert decoder_prompt.startswith("<|startoftranscript|>")

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -865,7 +865,7 @@ class WhisperForConditionalGeneration(
             )
 
         decoder_text = (
-            f"<|prev|>{request_prompt}" if request_prompt else ""
+            f"<|startofprev|>{request_prompt}" if request_prompt else ""
         ) + f"<|startoftranscript|><|{language}|><|{task_type}|><|notimestamps|>"
 
         return ExplicitEncoderDecoderPrompt(


### PR DESCRIPTION
## Purpose

FIX #53206

`WhisperForConditionalGeneration.get_generation_prompt()` builds the request-prompt prefix with `<|prev|>`, which is not in the Whisper vocabulary — the tokenizer splits it into six ordinary text tokens (`'<', '|', 'pre', 'v', '|', '>'`) placed before `<|startoftranscript|>`, corrupting decoder conditioning. Any request carrying the OpenAI `prompt` field degenerates into repetition loops; on multi-chunk (>30 s) audio the transcription collapses to the final chunk's output only, because the degenerate chunks fail `verbose_json` timestamp parsing and are silently dropped.

This PR replaces it with `<|startofprev|>`, the actual prompt-conditioning special token, updates the example docs that referenced the wrong token, and adds a tokenizer-backed regression test.

`<|startofprev|>` is defined in `added_tokens_decoder` of every official OpenAI checkpoint, while `<|prev|>` appears in none of them: [whisper-large-v3-turbo](https://huggingface.co/openai/whisper-large-v3-turbo/blob/main/tokenizer_config.json) (id 50362), [whisper-large-v3](https://huggingface.co/openai/whisper-large-v3/blob/main/tokenizer_config.json) (id 50362), [whisper-small](https://huggingface.co/openai/whisper-small/blob/main/tokenizer_config.json) (id 50361), [whisper-large-v2](https://huggingface.co/openai/whisper-large-v2/blob/main/tokenizer_config.json) (id 50361). The reference implementation likewise defines only `<|startofprev|>` ([openai/whisper `tokenizer.py`](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py), specials list + `sot_prev`).

Also explains #35276 (same symptom, closed as stale) and unblocks the standard-prompt half of #34518.

## Test Plan

- New unit test `tests/entrypoints/speech_to_text/transcription/test_whisper_prompt_special_token.py`: asserts the prompt prefix survives tokenization as a single vocabulary token (uses `openai/whisper-tiny`'s tokenizer; the special-token table is shared across the Whisper family).
- Manual before/after on a served `openai/whisper-large-v3-turbo` with a 30 s Mandarin clip and the OpenAI `prompt` field set.

## Test Result

Unit test — red on the old code, green on the fix:

```
# before (with <|prev|>)
FAILED test_whisper_prompt_special_token.py::test_prompt_prefix_is_a_single_special_token
FAILED test_whisper_prompt_special_token.py::test_prompt_prefix_token_exists_in_vocab
2 failed, 1 passed

# after (with <|startofprev|>)
3 passed
```

Serving before/after (same request: 30 s Mandarin clip, `response_format=verbose_json`, `prompt=這是繁體中文的語音轉錄。`):

| | segments | text |
|---|---|---|
| before | 1 | `。` (everything before the final chunk lost) |
| after | 2 | full correct transcript, prompt bias takes effect |

English 9 s clip with an English prompt: hallucinated `"The reason"` prefix before the fix; clean transcript after.