### PR TITLE
[CI] Disable FlashInfer autotune for B200 PCP eval

### DIFF
--- a/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP2-PCP2-EP.yaml
+++ b/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP2-PCP2-EP.yaml
@@ -7,6 +7,7 @@ server_args: >-
   --enforce-eager
   --max-model-len 4096
   --max-num-batched-tokens 32768
+  --kernel-config.enable_flashinfer_autotune=False
   --safetensors-load-strategy prefetch
   --moe-backend flashinfer_cutlass
   --tensor-parallel-size 2


### PR DESCRIPTION
## Summary

Disable FlashInfer autotuning only for the `GLM-5.2-NVFP4-TP2-PCP2-EP` B200 accuracy eval. The eval keeps its 32,768-token scheduler limit and production FlashInfer CUTLASS behavior remains unchanged.

## Root cause

PR #52989 began forwarding vLLM’s scheduler-aware token ceiling to FlashInfer CUTLASS MoE. For this eval, `--max-num-batched-tokens 32768` changed the effective FlashInfer CUTLASS autotune ceiling from the previous/default **8,192 tokens to 32,768 tokens**.

That 4x increase also quadrupled the CUTLASS tuning workspace. During the nightly eval, each worker attempted to allocate 12.22 GiB with only 9.68 GiB free and failed during the explicit FlashInfer autotune dummy run.

The added `--kernel-config.enable_flashinfer_autotune=False` skips that tuning-only dummy run for this accuracy test. Runtime continues to use FlashInfer heuristics, while the scheduler can still exercise batches up to 32,768 tokens.

## Why test-local

This is an accuracy eval, not a performance benchmark, so autotuned tactic quality is not part of what it validates. Keeping the workaround in this configuration avoids reverting the scheduler-aware tuning coverage added by #52989 for production users and other expert paths.

## Duplicate-work check

Open PR #53186 fully reverts #52989 across six files. This PR is materially narrower: it changes one eval argument and leaves production code untouched.

I also checked issue #51071 and searched open PRs for `52989 in:body` and `FlashInfer CUTLASS MoE autotune`. No other open PR provides this test-local alternative.

## Tests

- parsed the YAML and shell-split `server_args`; confirmed `--kernel-config.enable_flashinfer_autotune=False` is present
- commit-time pre-commit suite: passed, including Ruff, formatting, mypy, SPDX, import, and configuration checks
- full GLM-5.2-NVFP4 TP2/PCP2/EP LM eval: not run locally; requires the four-GPU model evaluation environment

## AI assistance

Codex was used to investigate the nightly failure, implement and validate this test configuration change, and draft the PR description. I reviewed the changed line and understand the change end-to-end.

Related: #52989, #53186, #51071