### PR TITLE
[Spec Decode] Support single-file checkpoints for target and draft models

### DIFF
--- a/tests/config/test_speculative_hf_config_path.py
+++ b/tests/config/test_speculative_hf_config_path.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for ``SpeculativeConfig.hf_config_path``.
+
+``ModelConfig`` has long resolved its config and its weights from separate
+references, and ``EngineArgs`` forwards ``hf_config_path`` for the target. A
+draft had no way to say the same thing, so a draft whose weights reference
+carries no config of its own -- a single-file checkpoint, or one sitting in
+the directory of the model it drafts for -- could only be pointed at its
+config by rewriting ``model`` and restoring the weights path afterwards.
+"""
+
+import pytest
+
+from vllm.config.model import ModelConfig
+from vllm.config.parallel import ParallelConfig
+from vllm.config.speculative import SpeculativeConfig
+
+# Public repo; only config/tokenizer-config files are fetched.
+AR_MODEL = "JackFram/llama-68m"
+
+
+@pytest.fixture
+def weights_without_config(tmp_path):
+    """A weights reference that carries no config of its own."""
+    (tmp_path / "model.safetensors").touch()
+    return str(tmp_path)
+
+
+def _speculative_config(**kwargs) -> SpeculativeConfig:
+    return SpeculativeConfig(
+        target_model_config=ModelConfig(AR_MODEL),
+        target_parallel_config=ParallelConfig(),
+        method="draft_model",
+        num_speculative_tokens=3,
+        **kwargs,
+    )
+
+
+@pytest.mark.cpu_test
+def test_config_is_read_from_hf_config_path(weights_without_config):
+    draft = _speculative_config(
+        model=weights_without_config, hf_config_path=AR_MODEL
+    ).draft_model_config
+
+    assert draft.hf_config_path == AR_MODEL
+    assert draft.hf_config.model_type == "llama"
+    assert draft.hf_config.hidden_size == ModelConfig(AR_MODEL).hf_config.hidden_size
+
+
+@pytest.mark.cpu_test
+def test_weights_reference_is_left_alone(weights_without_config):
+    """The point of the field: the config moves, the weights stay put."""
+    draft = _speculative_config(
+        model=weights_without_config, hf_config_path=AR_MODEL
+    ).draft_model_config
+
+    assert draft.model == weights_without_config
+
+
+@pytest.mark.cpu_test
+def test_omitting_it_keeps_the_model_as_the_config_source():
+    draft = _speculative_config(model=AR_MODEL).draft_model_config
+
+    assert draft.hf_config_path is None
+    assert draft.model == AR_MODEL
+    assert draft.hf_config.model_type == "llama"

--- a/tests/transformers_utils/test_speculators_probe.py
+++ b/tests/transformers_utils/test_speculators_probe.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the speculators probe in ``maybe_override_with_speculators``.
+
+The probe reads a model reference only to look for a ``speculators_config``
+key. A reference this loader cannot read is not a speculators model, which is
+the same conclusion it draws for a config that reads fine without the key.
+Raising instead turned the probe into a gate, rejecting formats that an
+out-of-tree config parser resolves -- a single-file GGUF checkpoint, say --
+before that parser ever runs.
+"""
+
+import json
+import logging
+
+import pytest
+
+from vllm.transformers_utils.config import maybe_override_with_speculators
+
+_LOGGER = "vllm.transformers_utils.config"
+_SKIPPED_MSG = "Not probing"
+
+SPECULATORS_CONFIG = {
+    "speculators_model_type": "eagle",
+    "speculators_config": {
+        "proposal_methods": [{"speculative_tokens": 3}],
+        "verifier": {"name_or_path": "target/model"},
+    },
+    "transformer_layer_config": {},
+}
+
+
+@pytest.fixture
+def vllm_caplog(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch):
+    """Make caplog see vLLM logger records (vLLM sets propagate=False)."""
+    monkeypatch.setattr(logging.getLogger("vllm"), "propagate", True)
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER):
+        yield caplog
+
+
+def _probe_skipped(caplog: pytest.LogCaptureFixture) -> bool:
+    return any(_SKIPPED_MSG in record.getMessage() for record in caplog.records)
+
+
+def _probe(model: str, spec_config: dict | None = None):
+    return maybe_override_with_speculators(
+        model=model,
+        tokenizer=None,
+        trust_remote_code=False,
+        vllm_speculative_config=spec_config,
+    )
+
+
+@pytest.mark.cpu_test
+def test_unreadable_reference_is_not_a_speculators_model(tmp_path, vllm_caplog):
+    """A single file is what a GGUF checkpoint looks like to the probe."""
+    checkpoint = tmp_path / "draft.gguf"
+    checkpoint.touch()
+    spec_config = {"model": str(checkpoint)}
+
+    model, tokenizer, returned = _probe(str(checkpoint), spec_config)
+
+    assert (model, tokenizer) == (str(checkpoint), None)
+    assert returned is spec_config
+    assert _probe_skipped(vllm_caplog)
+
+
+@pytest.mark.cpu_test
+def test_readable_config_without_the_key_is_unchanged(tmp_path, vllm_caplog):
+    """The pre-existing conclusion, reached without going through the except."""
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    spec_config = {"num_speculative_tokens": 3}
+
+    model, tokenizer, returned = _probe(str(tmp_path), spec_config)
+
+    assert (model, tokenizer) == (str(tmp_path), None)
+    assert returned is spec_config
+    assert not _probe_skipped(vllm_caplog)
+
+
+@pytest.mark.cpu_test
+def test_readable_speculators_config_is_still_processed(tmp_path, vllm_caplog):
+    """Guards the success path the probe was wrapped in a try for."""
+    (tmp_path / "config.json").write_text(json.dumps(SPECULATORS_CONFIG))
+
+    model, tokenizer, returned = _probe(str(tmp_path))
+
+    verifier = SPECULATORS_CONFIG["speculators_config"]["verifier"]["name_or_path"]
+    assert (model, tokenizer) == (verifier, verifier)
+    assert returned["model"] == str(tmp_path)
+    assert returned["num_speculative_tokens"] == 3
+    assert not _probe_skipped(vllm_caplog)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -94,6 +94,12 @@ class SpeculativeConfig:
     model: str | None = None
     """The name of the draft model, eagle head, or additional weights, if
     provided."""
+    hf_config_path: str | None = None
+    """Name or path of the Hugging Face config to use for the draft model. If
+    unspecified, the draft model name or path is used. Mirrors
+    `ModelConfig.hf_config_path`, for drafts whose weights reference carries no
+    config of its own -- a single-file checkpoint, or one sitting in the
+    directory of the model it drafts for."""
     method: SpeculativeMethod | None = None
     """The name of the speculative method to use. If users provide and set the
     `model` param, the speculative method type will be detected automatically
@@ -901,6 +907,7 @@ class SpeculativeConfig:
                     )
                 self.draft_model_config = ModelConfig(
                     model=self.model,
+                    hf_config_path=self.hf_config_path,
                     runner="draft",
                     tokenizer=(
                         self.model

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -655,12 +655,22 @@ def maybe_override_with_speculators(
         Tuple of (resolved_model, resolved_tokenizer, speculative_config)
     """
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
-    config_dict, _ = PretrainedConfig.get_config_dict(
-        model,
-        revision=revision,
-        token=hf_token,
-        **without_trust_remote_code(kwargs),
-    )
+    try:
+        config_dict, _ = PretrainedConfig.get_config_dict(
+            model,
+            revision=revision,
+            token=hf_token,
+            **without_trust_remote_code(kwargs),
+        )
+    except OSError:
+        # This is a probe, and a reference this loader cannot read is not a
+        # speculators model -- the same conclusion drawn four lines down for a
+        # config that reads fine without the key. Formats resolved by an
+        # out-of-tree config parser (e.g. a single-file GGUF) only become
+        # readable after that parser runs, so raising here rejects them before
+        # it ever does.
+        logger.debug("Not probing %s for a speculators config", model)
+        return model, tokenizer, vllm_speculative_config
     speculators_config = config_dict.get("speculators_config")
 
     if speculators_config is None:


### PR DESCRIPTION
## Summary

Two small fixes that together let a draft model whose weights are a single file resolve through the speculative decoding config path. Both are places where a condition that is not an error is treated as one, and both sit on that same path, so fixing either on its own changes nothing observable.

The case that motivated them is a GGUF draft head shipped as one file next to the target it drafts for, loaded by an out-of-tree quantization plugin. Neither fix is specific to GGUF: any draft that is not an HF directory hits the same two places.

## Relationship to the GGUF plugin PRs

This is the upstream half of GGUF support for this model pair in the out-of-tree plugin, so it is worth reading alongside those PRs. vllm-project/vllm-gguf-plugin#113 (Muse Glimmer multimodal GGUF) carries a monkeypatch that replaces `maybe_override_with_speculators` so that a `.gguf` target survives the probe, and vllm-project/vllm-gguf-plugin#115 (the dflash draft head), stacked on it, works around the missing draft `hf_config_path` by rewriting `speculative_config["model"]` to the config directory and restoring the weights reference afterwards. Both plugin PRs work today without this one; what they cannot do is stop reaching into vLLM internals to get there. With the two fixes below in, the follow-up plugin PR (vllm-project/vllm-gguf-plugin#117) deletes both workarounds and passes `hf_config_path` straight through; it stays a draft until this PR lands, since it needs both to exist. The launch command is the same before and after, so removing the workarounds changes nothing user-visible.

## The two

1. **`SpeculativeConfig` accepts `hf_config_path` and forwards it to the draft `ModelConfig`.** `ModelConfig` has resolved its config and its weights from separate references for a long time, and `EngineArgs` forwards `hf_config_path` for the target; the draft had no way to say the same thing. Without it, the only way to point a draft at its config is to rewrite `speculative_config["model"]` and restore the weights path afterwards, which silently loads the wrong checkpoint if it happens twice.
2. **The speculators probe tolerates a reference it cannot read.** `maybe_override_with_speculators` calls `get_config_dict` purely to check for a `speculators_config` key; a reference it cannot read is not a speculators model, which is the conclusion it already draws four lines later when the key is absent. Raising instead rejects formats an out-of-tree config parser would have resolved, before that parser runs.

## Testing

- Unit tests for each: `hf_config_path` reaching `draft_model_config` while the weights reference stays put; the probe returning its inputs unchanged for an unreadable reference.
- End to end with a 2.56B GGUF draft against a 30B GGUF target, via the out-of-tree GGUF plugin, with that plugin's workarounds for both fixes removed so these paths are the only ones in play: 60.8% . Sampling the loading process confirms every weight came from a GGUF file and neither the target's nor the draft's unquantized safetensors was touched.
- The same pair through `vllm serve` using the command below: the server starts, the draft resolves to its own architecture from `hf_config_path` while `speculative_config["model"]` stays pointed at the `.gguf` file, and speculative decoding is live on the served request (42 of 66 draft tokens accepted).

## Usage

Once the plugin PRs are merged, a GGUF target with a GGUF draft head launches as below, with config and tokenizer resolved from the HF directories and every weight read from the `.gguf` files:

```bash
vllm serve /models/Muse-Glimmer-30B-GGUF/Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf \
  --tokenizer /models/Muse-Glimmer-30B \
  --hf-config-path /models/Muse-Glimmer-30B \
  --speculative-config '{"model": "/models/Muse-Glimmer-30B-GGUF/dflash-Muse-Glimmer-30B-Q4_K_M.gguf", "hf_config_path": "/models/Muse-Glimmer-30B-assistant", "num_speculative_tokens": 3}'
```
