### PR TITLE
[Bugfix][Distributed] shm_broadcast: copy out-of-band buffers at enqueue to fix zero-copy send race

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -831,9 +831,13 @@ class MessageQueue:
             if len(raw_buf) < 1024 * 1024:
                 # In-line buffers smaller than 1MiB.
                 return True
-            all_buffers.append(raw_buf)
+            # raw_buf aliases the live tensor's memory, which could be
+            # mutated after enqueue() returns. Copy it so the async ZMQ
+            # send cannot race the mutation and deliver truncated data.
+            oob_buf = bytes(raw_buf)
+            all_buffers.append(oob_buf)
             nonlocal total_bytes
-            total_bytes += len(raw_buf) + 4
+            total_bytes += len(oob_buf) + 4
             return False
 
         # CPU tensors are routed through `_reduce_tensor` so that their


### PR DESCRIPTION
## Summary

`MessageQueue.enqueue` hands out-of-band (>=1MiB) buffers from the pickle stream to ZMQ via `send_multipart(copy=False)`. Those buffers are produced by `_reduce_tensor` as `PickleBuffer` views that **alias the live tensor's memory**. The scheduler can mutate or reuse that memory immediately after `enqueue()` returns, while ZMQ's async send is still reading it — so remote workers receive corrupted or truncated messages (`_pickle.UnpicklingError: pickle data was truncated`). The unlucky worker dies, and the remaining ranks spin in collectives waiting for the dead rank.

The fix copies each out-of-band buffer at enqueue time: `all_buffers.append(bytes(raw_buf))`. Cost is one memcpy per >=1MiB tensor, negligible compared with the transfer itself.

## Why this is not a duplicate

- #27858 (CLOSED) described the same failure family on aarch64. Its fix, #32022 (MERGED), added `memory_fence()` for the **local shm ring-buffer path** — it does not touch the ZMQ out-of-band path fixed here.
- No other open PR touches `shm_broadcast.py:oob_callback` / `send_multipart(copy=False)` (checked 52917, 40303, 52307, 50606, 50548 — all different MessageQueue concerns).

## Test commands and results

Deterministic race repro (two-process MessageQueue; writer enqueues a >=1MiB tensor then mutates its memory; reader compares):

```
# PRE-FIX code: FAIL - CORRUPTION REPRODUCED (reader received -999 sentinel values)
# POST-FIX code: PASS - data preserved
```

Existing suite (venv with `multiprocess` installed):

```
.venv/bin/python -m pytest tests/distributed/test_shm_broadcast.py -q -p no:cacheprovider
29 passed, 36 warnings in 24.36s
```

Field validation: the bug was observed in a live multi-node serving deployment; after deploying this change the deployment has served for extended periods with no recurrence.

## AI assistance disclosure

This change was developed and verified with the assistance of an AI coding agent; the human submitter reviewed every changed line and the reproduction/test results above.