### PR TITLE
[Doc] Fix local input path in run-batch examples across docs

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -196,7 +196,7 @@ Running with a local file:
 
 ```bash
 vllm run-batch \
-    -i features/openai_batch/openai_example_batch.jsonl \
+    -i examples/features/openai_batch/openai_example_batch.jsonl \
     -o results.jsonl \
     --model meta-llama/Meta-Llama-3-8B-Instruct
 ```

--- a/examples/features/openai_batch/README.md
+++ b/examples/features/openai_batch/README.md
@@ -36,7 +36,7 @@ wget https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/
 Once you've created your batch file it should look like this
 
 ```bash
-cat features/openai_batch/openai_example_batch.jsonl
+cat examples/features/openai_batch/openai_example_batch.jsonl
 {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "meta-llama/Meta-Llama-3-8B-Instruct", "messages": [{"role": "system", "content": "You are a helpful assistant."},{"role": "user", "content": "Hello world!"}],"max_completion_tokens": 1000}}
 {"custom_id": "request-2", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "meta-llama/Meta-Llama-3-8B-Instruct", "messages": [{"role": "system", "content": "You are an unhelpful assistant."},{"role": "user", "content": "Hello world!"}],"max_completion_tokens": 1000}}
 ```
@@ -49,7 +49,7 @@ You can run the batch with the following command, which will write its results t
 
 ```bash
 python -m vllm.entrypoints.launchers.run_batch \
-    -i features/openai_batch/openai_example_batch.jsonl \
+    -i examples/features/openai_batch/openai_example_batch.jsonl \
     -o results.jsonl \
     --model meta-llama/Meta-Llama-3-8B-Instruct
 ```
@@ -58,7 +58,7 @@ or use command-line:
 
 ```bash
 vllm run-batch \
-    -i features/openai_batch/openai_example_batch.jsonl \
+    -i examples/features/openai_batch/openai_example_batch.jsonl \
     -o results.jsonl \
     --model meta-llama/Meta-Llama-3-8B-Instruct
 ```
@@ -119,7 +119,7 @@ wget https://raw.githubusercontent.com/vllm-project/vllm/main/examples/features/
 Once you've created your batch file it should look like this
 
 ```bash
-cat features/openai_batch/openai_example_batch.jsonl
+cat examples/features/openai_batch/openai_example_batch.jsonl
 {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "meta-llama/Meta-Llama-3-8B-Instruct", "messages": [{"role": "system", "content": "You are a helpful assistant."},{"role": "user", "content": "Hello world!"}],"max_completion_tokens": 1000}}
 {"custom_id": "request-2", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "meta-llama/Meta-Llama-3-8B-Instruct", "messages": [{"role": "system", "content": "You are an unhelpful assistant."},{"role": "user", "content": "Hello world!"}],"max_completion_tokens": 1000}}
 ```
@@ -127,7 +127,7 @@ cat features/openai_batch/openai_example_batch.jsonl
 Now upload your batch file to your S3 bucket.
 
 ```bash
-aws s3 cp features/openai_batch/openai_example_batch.jsonl s3://MY_BUCKET/MY_INPUT_FILE.jsonl
+aws s3 cp examples/features/openai_batch/openai_example_batch.jsonl s3://MY_BUCKET/MY_INPUT_FILE.jsonl
 ```
 
 ### Step 2: Generate your presigned urls


### PR DESCRIPTION
## Purpose

Fix the local input path in `vllm run-batch` examples across multiple docs.

Affected files:
- `docs/cli/README.md`
- `examples/features/openai_batch/README.md`

The examples use `-i features/openai_batch/openai_example_batch.jsonl` (or `cat`, `aws s3 cp` with the same path), but the actual file is at `examples/features/openai_batch/openai_example_batch.jsonl`. There is no `features/` directory at the repo root, so running the commands from the root directory fails with `FileNotFoundError`. The remote-file example in the same docs already uses the `examples/` prefix, making the inconsistency obvious.

## Why not duplicating an existing PR

Searched `gh issue list` / `gh pr list` for "run-batch" / "openai_batch" path issues: no open issue or PR addresses this. Related PRs are code changes (#47697, #12430) not documentation.

## Test Plan

Run the old command from the repo root:

    vllm run-batch -i features/openai_batch/openai_example_batch.jsonl ...

This fails with:

    FileNotFoundError: [Errno 2] No such file or directory: 'features/openai_batch/openai_example_batch.jsonl'

After correcting the path to `examples/features/openai_batch/openai_example_batch.jsonl`, the file is read successfully.

## Test Result

Verified on Ubuntu 24.04 with vLLM 0.27.1 — the path issue is resolved after the fix.

## AI Assistance

This PR was drafted with AI assistance; the human submitter reviewed every changed line.
Co-authored-by: deepseek-v4-flash