### PR TITLE
[CI/Build] Use file rendezvous for direct DCP tests

### DIFF
--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -12,7 +12,7 @@ import torch.distributed as dist
 
 import vllm.v1.attention.ops.cp_common as cp_common
 import vllm.v1.attention.ops.dcp as dcp
-from vllm.utils.network_utils import get_open_port
+from vllm.utils.network_utils import get_file_store_init_method
 from vllm.utils.system_utils import update_environment_variables
 
 mp.set_start_method("spawn", force=True)
@@ -100,7 +100,7 @@ def _assert_q_gather_matches_reference(
 
 
 def _distributed_run(fn, world_size: int, extra_env: dict[str, str]) -> None:
-    port = str(get_open_port())
+    distributed_init_method = get_file_store_init_method()
     processes: list[mp.Process] = []
     for rank in range(world_size):
         env = {
@@ -108,8 +108,7 @@ def _distributed_run(fn, world_size: int, extra_env: dict[str, str]) -> None:
             "LOCAL_RANK": str(rank),
             "WORLD_SIZE": str(world_size),
             "LOCAL_WORLD_SIZE": str(world_size),
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": port,
+            "DISTRIBUTED_INIT_METHOD": distributed_init_method,
             **extra_env,
         }
         process = mp.Process(target=fn, args=(env,))
@@ -572,9 +571,15 @@ def test_sparse_mla_workspace_preserves_non_dcp_size():
 def _distributed_direct_q_gather_worker(env: dict[str, str]) -> None:
     update_environment_variables(env)
     local_rank = int(env["LOCAL_RANK"])
+    world_size = int(env["WORLD_SIZE"])
     device = torch.device(f"cuda:{local_rank}")
     torch.accelerator.set_device_index(local_rank)
-    dist.init_process_group(backend="nccl")
+    dist.init_process_group(
+        backend="nccl",
+        init_method=env["DISTRIBUTED_INIT_METHOD"],
+        rank=local_rank,
+        world_size=world_size,
+    )
     try:
         rank = dist.get_rank()
         world_size = dist.get_world_size()
@@ -739,9 +744,15 @@ def test_distributed_direct_q_gather_cuda_graph_replay(world_size: int):
 def _distributed_direct_kv_gather_worker(env: dict[str, str]) -> None:
     update_environment_variables(env)
     local_rank = int(env["LOCAL_RANK"])
+    world_size = int(env["WORLD_SIZE"])
     device = torch.device(f"cuda:{local_rank}")
     torch.accelerator.set_device_index(local_rank)
-    dist.init_process_group(backend="nccl")
+    dist.init_process_group(
+        backend="nccl",
+        init_method=env["DISTRIBUTED_INIT_METHOD"],
+        rank=local_rank,
+        world_size=world_size,
+    )
     try:
         rank = dist.get_rank()
         world_size = dist.get_world_size()
@@ -815,9 +826,15 @@ def test_distributed_direct_kv_gather_matches_reference(world_size: int):
 def _distributed_direct_a2a_worker(env: dict[str, str]) -> None:
     update_environment_variables(env)
     local_rank = int(env["LOCAL_RANK"])
+    world_size = int(env["WORLD_SIZE"])
     device = torch.device(f"cuda:{local_rank}")
     torch.accelerator.set_device_index(local_rank)
-    dist.init_process_group(backend="nccl")
+    dist.init_process_group(
+        backend="nccl",
+        init_method=env["DISTRIBUTED_INIT_METHOD"],
+        rank=local_rank,
+        world_size=world_size,
+    )
     try:
         from vllm.v1.attention.ops.dcp import _lse_weighted_combine
 


### PR DESCRIPTION
## Purpose

Continue the test-infrastructure cleanup tracked in #51275 by removing a probe-then-bind TCP rendezvous from the Direct DCP test harness added to `main` after the earlier FileStore cleanup in #51652.

`_distributed_run()` called `get_open_port()`, released the probe socket, and only then spawned two or four NCCL workers that performed the real bind. A competing local process could claim the port during that interval and fail an otherwise-correct GPU test with `EADDRINUSE`.

This PR:

- creates one unique `file://` rendezvous per Direct DCP test run;
- passes that init method to every spawned worker;
- initializes the q-gather, KV-gather, and A2A process groups with explicit rank and world size;
- removes the TCP port probe and `MASTER_ADDR` / `MASTER_PORT` handoff.

The change is test-only and does not affect production distributed initialization.

## Duplicate-work check

Immediately before submission, searches for open PRs mentioning `test_dcp_direct_a2a_lse_reduce.py` and Direct DCP FileStore rendezvous found no overlapping implementation.

## Test Plan

- `pre-commit run --files tests/distributed/test_dcp_direct_a2a_lse_reduce.py` — all applicable hooks passed, including ruff, Python 3.10 mypy, SPDX, and repository policy checks.
- Two-process CPU/Gloo spawn smoke using the same unique FileStore rendezvous contract — passed.
- Direct DCP NCCL tests — not run locally; they require two or four CUDA GPUs, and some cases require symmetric-memory multicast. These paths are left to upstream distributed CI.

## AI Assistance

OpenAI Codex was used for investigation, implementation, test execution, and drafting. The human submitter reviewed every changed line, confirmed the bounded test-only scope, and understands the change end-to-end before submission.