### PR TITLE
[ROCm] Add opt-in token chunking for the AITER fused-MoE experts call

### DIFF
--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -701,6 +701,70 @@ def test_aiter_fused_moe_mi350_mxfp4_w4a16_determinism():
     _assert_deterministic(run_mxfp4_moe, n_runs=4)
 
 
+def test_aiter_fused_moe_token_chunking_matches_unchunked():
+    """VLLM_ROCM_AITER_MOE_CHUNK_TOKENS slices the token dim across repeated
+    AITER calls to bound AITER's internal intermediate. MoE routing is
+    per-token, so the chunked result must match the unchunked one exactly."""
+    from tests.kernels.moe.utils import make_dummy_moe_config
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FUSED_MOE_UNQUANTIZED_CONFIG,
+    )
+    from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+        AiterExperts,
+    )
+
+    _assert_aiter_supported()
+    num_tokens, hidden_dim, intermediate_dim, num_experts, topk = 32, 512, 1024, 4, 2
+    case = _make_moe_case(
+        num_tokens=num_tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+        seed=23,
+    )
+    w1, w2 = _shuffle_moe_weights(case["w1"], case["w2"])
+    experts = AiterExperts(
+        make_dummy_moe_config(
+            num_experts=num_experts,
+            experts_per_token=topk,
+            hidden_dim=hidden_dim,
+            intermediate_size=intermediate_dim,
+        ),
+        FUSED_MOE_UNQUANTIZED_CONFIG,
+    )
+    empty = torch.empty(0, dtype=torch.bfloat16)
+
+    def run(chunk_tokens: int) -> torch.Tensor:
+        rocm_aiter_ops._MOE_CHUNK_TOKENS = chunk_tokens
+        out = torch.empty_like(case["hidden_states"])
+        experts.apply(
+            output=out,
+            hidden_states=case["hidden_states"],
+            w1=w1,
+            w2=w2,
+            topk_weights=case["topk_weights"],
+            topk_ids=case["topk_ids"],
+            activation=MoEActivation.SILU,
+            global_num_experts=num_experts,
+            expert_map=None,
+            a1q_scale=None,
+            a2_scale=None,
+            workspace13=empty,
+            workspace2=empty,
+            expert_tokens_meta=None,
+            apply_router_weight_on_input=False,
+        )
+        return out
+
+    unchunked = run(0)
+    # 32 tokens in chunks of 8 exercises the loop, including the final slice.
+    chunked = run(8)
+    torch.testing.assert_close(chunked, unchunked, atol=0.0, rtol=0.0)
+
+
 # FP8 group-quant tests ---------------------------------------------------
 
 

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1667,6 +1667,7 @@ class rocm_aiter_ops:
     """
 
     _MOE_DISPATCH_POLICY: int | None = None
+    _MOE_CHUNK_TOKENS: int | None = None
 
     @classmethod
     @if_aiter_supported
@@ -1677,6 +1678,16 @@ class rocm_aiter_ops:
 
             cls._MOE_DISPATCH_POLICY = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
         return cls._MOE_DISPATCH_POLICY
+
+    @classmethod
+    @if_aiter_supported
+    def get_moe_chunk_tokens(cls) -> int:
+        """Cached token-chunk size for the fused-MoE experts call."""
+        if cls._MOE_CHUNK_TOKENS is None:
+            import vllm.envs as envs
+
+            cls._MOE_CHUNK_TOKENS = envs.VLLM_ROCM_AITER_MOE_CHUNK_TOKENS
+        return cls._MOE_CHUNK_TOKENS
 
     # Check if the env variable is set
     _AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
@@ -1728,6 +1739,7 @@ class rocm_aiter_ops:
         cls._MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
         cls._MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
         cls._TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
+        cls._MOE_CHUNK_TOKENS = None
 
     @staticmethod
     def get_aiter_activation_type(activation_str: str):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -138,6 +138,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_LINEAR_HIPBMM: bool = False
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_AITER_MOE_DISPATCH_POLICY: int = 0
+    VLLM_ROCM_AITER_MOE_CHUNK_TOKENS: int = 0
     VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: bool = False
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
@@ -1276,6 +1277,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #       see PR #39177 for benchmarks)
     "VLLM_ROCM_AITER_MOE_DISPATCH_POLICY": lambda: int(
         os.getenv("VLLM_ROCM_AITER_MOE_DISPATCH_POLICY", "0")
+    ),
+    # Chunk size, in tokens, for the AITER fused-MoE experts call.
+    # AITER allocates its (num_tokens, topk, model_dim) intermediate
+    # internally, so it is invisible to vLLM's memory profiler and cannot be
+    # bounded by the modular-kernel chunking. Set >0 to cap that allocation.
+    #   0 = disabled (default): one call for the whole batch
+    "VLLM_ROCM_AITER_MOE_CHUNK_TOKENS": lambda: int(
+        os.getenv("VLLM_ROCM_AITER_MOE_CHUNK_TOKENS", "0")
     ),
     # use aiter rms norm op if aiter ops are enabled.
     "VLLM_ROCM_USE_AITER_RMSNORM": lambda: (

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -543,6 +543,42 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         else:
             num_local_tokens = None
 
+        # AITER sizes its intermediate off the token count, so slicing the
+        # token dim bounds it. Routing is per-token, so results are unchanged.
+        chunk = rocm_aiter_ops.get_moe_chunk_tokens()
+        num_tokens = hidden_states.shape[0]
+        if chunk > 0 and num_local_tokens is None and num_tokens > chunk:
+            for start in range(0, num_tokens, chunk):
+                end = min(start + chunk, num_tokens)
+                chunk_a1q_scale = a1q_scale
+                if (
+                    chunk_a1q_scale is not None
+                    and chunk_a1q_scale.dim() > 0
+                    and chunk_a1q_scale.shape[0] == num_tokens
+                ):
+                    chunk_a1q_scale = chunk_a1q_scale[start:end]
+                output[start:end].copy_(
+                    rocm_aiter_fused_experts(
+                        hidden_states=hidden_states[start:end],
+                        w1=w1,
+                        w2=w2,
+                        topk_weights=topk_weights[start:end],
+                        topk_ids=topk_ids[start:end],
+                        activation=activation,
+                        apply_router_weight_on_input=apply_router_weight_on_input,
+                        expert_mask=expert_map,
+                        quant_config=self.quant_config,
+                        moe_config=self.moe_config,
+                        a1q_scale=chunk_a1q_scale,
+                        num_local_tokens=None,
+                        output_dtype=output.dtype,
+                        moe_sorting_dispatch_policy=(
+                            rocm_aiter_ops.get_moe_dispatch_policy()
+                        ),
+                    )
+                )
+            return
+
         result = rocm_aiter_fused_experts(
             hidden_states=hidden_states,
             w1=w1,


### PR DESCRIPTION
## Summary

`AiterExperts.workspace_shapes()` returns `(0,)` because AITER allocates its
`(num_tokens, topk, model_dim)` intermediate internally. That allocation is invisible to
vLLM's memory profiler — which sizes the KV cache against the dummy-run peak — and it
cannot be bounded by the modular-kernel chunking either, since `_fused_experts` passes
`M_chunk = M_full` on this path.

On Kimi-K3 MXFP4 TP8 (gfx950) the profiled torch peak was **9.57 GiB** while the real
prefill peak was **26.75 GiB** — a 2.8x undercount. vLLM sizes the KV pool against the
smaller figure, so the first real batch overruns the budget.

This adds `VLLM_ROCM_AITER_MOE_CHUNK_TOKENS` to slice the token dimension across repeated
AITER calls, bounding that intermediate. MoE routing is per-token, so results are
unchanged. **Default `0` preserves current single-call behaviour**, so nothing changes
unless the flag is set.

The chunk size is read once through a cached `rocm_aiter_ops.get_moe_chunk_tokens()`
accessor, following the existing `get_moe_dispatch_policy()` pattern, to avoid an
env lookup in the MoE forward pass (ref #17067).

## Effect

Kimi-K3 MXFP4 TP8, 8x MI355X (288 GiB), chunk 2048 — same host, only the flag differs:

| per GPU | chunk off | chunk 2048 |
|---|---|---|
| weights | 194.08 GiB | 194.08 GiB |
| profiled torch peak | 9.57 GiB | **2.38 GiB** |
| available KV cache | 46.93 GiB | **54.72 GiB** |
| KV cache pool | 2,436,258 tok | **2,840,446 tok** |

Agentic trace replay, concurrency 4, 3600 s: 334 requests, 0 errors, TTFT p50 1327 ms,
ITL p50 11.68 ms, 1,836.8 tok/s/GPU total, prefix cache hit rate 90.1%.

## Tests

```
pytest tests/kernels/moe/test_rocm_aiter_moe.py -k chunking
1 passed, 31 deselected
```

Adds `test_aiter_fused_moe_token_chunking_matches_unchunked`, which drives
`AiterExperts.apply()` twice over the same inputs (chunked at 8 across 32 tokens vs
unchunked) and asserts equality with `atol=0.0, rtol=0.0`. The outputs are **bitwise
identical**, which is the direct check on the claim that slicing the token dim is a pure
reassociation rather than an approximation.

Run on 8x MI355X (gfx950), ROCm 7.2.3, aiter v0.1.20.

## Not a duplicate

No open PR or issue covers the `workspace_shapes()` undercount or AITER MoE token
chunking. The nearest related work (#51040, #51171, #52707) addresses different defects
in the same model path and is complementary.

## Follow-up not included here

`_fused_experts` passes `M_chunk = M_full`, which is why the existing modular-kernel
chunking cannot bound this allocation and a separate loop is needed in `apply()`. Making
`workspace_shapes()` report AITER's real allocation so the existing machinery can do the
bounding is the cleaner long-term fix; it needs AITER to expose the sizing and is left as
a follow-up.

---

AI assistance was used in preparing this change.
