### PR TITLE
[Rust Frontend] Add /derender endpoints: detokenization and state (phase 1/3)

### DIFF
--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -4,6 +4,7 @@
 mod abort_requests;
 mod cache;
 mod collective_rpc;
+mod derender;
 mod health;
 mod inference;
 mod load;
@@ -83,6 +84,14 @@ fn build_router_with_options(
         .route("/v1/models", get(openai::list_models))
         .route("/v1/completions", post(openai::completions))
         .route("/v1/chat/completions", post(openai::chat_completions))
+        .route(
+            "/v1/chat/completions/derender",
+            post(derender::derender_chat_completions),
+        )
+        .route(
+            "/v1/completions/derender",
+            post(derender::derender_completions),
+        )
         // vLLM specific endpoints
         .route("/tokenize", post(tokenize::tokenize))
         .route("/detokenize", post(tokenize::detokenize))

--- a/rust/src/server/src/routes/derender/detok.rs
+++ b/rust/src/server/src/routes/derender/detok.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Incremental detokenization for the streaming derender endpoints.
+//!
+//! Ports `vllm/tokenizers/detokenizer_utils.py::detokenize_incrementally`
+//! onto the caller-supplied, JSON-serializable [`DerenderStreamState`].
+//!
+//! Window reconstruction decodes from the token IDs carried alongside the
+//! wire pieces (`DerenderStreamState::prev_token_ids`), so byte-fallback
+//! pieces whose bytes are not valid UTF-8 on their own still decode exactly
+//! like one-shot `decode`. The Rust [`Tokenizer`] trait has no
+//! `convert_ids_to_tokens` / `convert_tokens_to_string` pair, and some
+//! backends' `id_to_token` is lossy UTF-8 (e.g. tiktoken stores base-token
+//! byte pieces with replacement characters), so round-tripping pieces back
+//! through `token_to_id` would drop or corrupt split multi-byte characters.
+//!
+//! States produced by the Python implementation carry only `prev_tokens`
+//! pieces; those are mapped back through `token_to_id` as a best-effort
+//! fallback.
+
+use thiserror_ext::AsReport as _;
+use vllm_text::tokenizer::DynTokenizer;
+
+use super::types::DerenderStreamState;
+use crate::error::{ApiError, server_error};
+
+/// Sentinel written into `DerenderStreamState::prev_token_ids` for window
+/// slots without a decodable token ID (only reachable via the foreign-state
+/// fallback). Always out of vocabulary, so window reconstruction filters it.
+const NO_TOKEN_ID: u32 = u32::MAX;
+
+/// One slot in the carried decode window: the wire piece plus its token ID.
+///
+/// `id` is `None` only for foreign (Python-produced) state whose piece did
+/// not map back through `token_to_id`.
+struct WindowToken {
+    piece: String,
+    id: Option<u32>,
+}
+
+/// Convert one token id into the raw token piece carried in the decode
+/// window.
+///
+/// Out-of-vocab ids and (when `skip_special_tokens`) special tokens map to
+/// `""`, matching Python's `convert_ids_to_tokens` + `_replace_none_with_empty`
+/// behavior.
+fn token_piece(tokenizer: &DynTokenizer, token_id: u32, skip_special_tokens: bool) -> String {
+    if token_id as usize >= tokenizer.vocab_size() {
+        return String::new();
+    }
+    if skip_special_tokens && tokenizer.is_special_id(token_id) {
+        return String::new();
+    }
+    tokenizer.id_to_token(token_id).unwrap_or_default()
+}
+
+/// Whether a window token ID participates in decoding: in vocabulary, and
+/// not a special token when `skip_special_tokens` is set (matching the `""`
+/// piece those tokens produce in [`token_piece`]).
+fn is_decodable(tokenizer: &DynTokenizer, token_id: u32, skip_special_tokens: bool) -> bool {
+    (token_id as usize) < tokenizer.vocab_size()
+        && !(skip_special_tokens && tokenizer.is_special_id(token_id))
+}
+
+fn decode_ids(tokenizer: &DynTokenizer, token_ids: &[u32]) -> Result<String, ApiError> {
+    tokenizer
+        .decode(token_ids, false)
+        .map_err(|error| server_error!("derender detokenization failed: {}", error.as_report()))
+}
+
+/// Decode the decodable IDs in `window[range]`, approximating Python's
+/// `convert_tokens_to_string(pieces)` without a lossy piece round-trip.
+fn decode_window(
+    tokenizer: &DynTokenizer,
+    window: &[WindowToken],
+    range: std::ops::Range<usize>,
+    skip_special_tokens: bool,
+) -> Result<String, ApiError> {
+    let ids: Vec<u32> = window[range]
+        .iter()
+        .filter_map(|token| token.id)
+        .filter(|&id| is_decodable(tokenizer, id, skip_special_tokens))
+        .collect();
+    decode_ids(tokenizer, &ids)
+}
+
+/// Slice `text` to the characters after the first `prefix_chars`, mirroring
+/// Python's `new_text[len(prefix_text):]` (which slices by code point).
+fn drop_prefix_chars(text: &str, prefix_chars: usize) -> String {
+    text.chars().skip(prefix_chars).collect()
+}
+
+/// Outcome of feeding one new token into the incremental decode window.
+struct IncrementalStep {
+    /// The window slot appended for this token.
+    new_token: WindowToken,
+    /// Newly visible text, or `""` when the tail is an unfinished multi-byte
+    /// sequence.
+    text: String,
+    prefix_offset: usize,
+    read_offset: usize,
+}
+
+/// Port of `detokenize_incrementally` for a single new token id.
+///
+/// The window is always a (possibly empty) list here, so this only implements
+/// the non-first-iteration path from Python.
+///
+/// The offsets are necessary to defeat cleanup algorithms in the decode which
+/// decide to add a space or not depending on the surrounding ids.
+fn detokenize_incrementally(
+    tokenizer: &DynTokenizer,
+    new_token_id: u32,
+    window: &[WindowToken],
+    prefix_offset: usize,
+    read_offset: usize,
+    skip_special_tokens: bool,
+) -> Result<IncrementalStep, ApiError> {
+    let new_piece = token_piece(tokenizer, new_token_id, skip_special_tokens);
+
+    // The prefix text is necessary only to defeat cleanup algorithms in
+    // the decode which decide to add a space or not depending on the
+    // surrounding ids.
+    let prefix_text = decode_window(
+        tokenizer,
+        window,
+        prefix_offset..read_offset,
+        skip_special_tokens,
+    )?;
+    let mut window_ids: Vec<u32> = window[prefix_offset..]
+        .iter()
+        .filter_map(|token| token.id)
+        .filter(|&id| is_decodable(tokenizer, id, skip_special_tokens))
+        .collect();
+    if is_decodable(tokenizer, new_token_id, skip_special_tokens) {
+        window_ids.push(new_token_id);
+    }
+    let new_text = decode_ids(tokenizer, &window_ids)?;
+
+    let prefix_chars = prefix_text.chars().count();
+    let new_token = WindowToken {
+        piece: new_piece,
+        id: Some(new_token_id),
+    };
+    // A trailing U+FFFD char means it's a potential unfinished byte sequence
+    // from byte fallback tokenization. If it's in the middle, it's probably a
+    // real invalid id generated by the model.
+    if new_text.chars().count() <= prefix_chars || new_text.ends_with('\u{FFFD}') {
+        return Ok(IncrementalStep {
+            new_token,
+            text: String::new(),
+            prefix_offset,
+            read_offset,
+        });
+    }
+
+    Ok(IncrementalStep {
+        new_token,
+        text: drop_prefix_chars(&new_text, prefix_chars),
+        prefix_offset: read_offset,
+        read_offset: window.len() + 1,
+    })
+}
+
+/// Incrementally detokenize `delta_token_ids` from prior stream state.
+///
+/// Resumes decoding from the offsets carried in `state` rather than
+/// replaying token history. `state.prev_tokens` holds the trailing decode
+/// window (from `prefix_offset` onward) that `detokenize_incrementally`
+/// still needs to reproduce any partially read multi-byte character
+/// (tracked by `read_offset`). The delta tokens are fed straight onto it.
+///
+/// The window is bounded. `detokenize_incrementally` never reads before
+/// `prefix_offset`, so after processing we trim `prev_tokens` to that
+/// tail and rebase the offsets to it. State transport therefore stays
+/// O(window) per chunk instead of re-sending the full token history.
+///
+/// Returns `(new_text, updated_state)` — the delta text for this chunk and
+/// the state to pass to the next call.
+// TODO: called by the phase-3 streaming endpoints.
+#[allow(dead_code)]
+pub(super) fn detokenize_delta(
+    tokenizer: &DynTokenizer,
+    delta_token_ids: &[u32],
+    state: &DerenderStreamState,
+    skip_special_tokens: bool,
+) -> Result<(String, DerenderStreamState), ApiError> {
+    // Prefer the carried token IDs. States produced by the Python
+    // implementation have only `prev_tokens` pieces; map those back through
+    // `token_to_id` as a best-effort fallback (lossy for backends whose
+    // `id_to_token` is lossy UTF-8, hence the ID side channel).
+    let mut window: Vec<WindowToken> = match &state.prev_token_ids {
+        Some(ids) => state
+            .prev_tokens
+            .iter()
+            .zip(ids)
+            .map(|(piece, &id)| WindowToken {
+                piece: piece.clone(),
+                id: (id != NO_TOKEN_ID).then_some(id),
+            })
+            .collect(),
+        None => state
+            .prev_tokens
+            .iter()
+            .map(|piece| WindowToken {
+                id: tokenizer.token_to_id(piece),
+                piece: piece.clone(),
+            })
+            .collect(),
+    };
+    let mut prefix_offset = state.prefix_offset;
+    let mut read_offset = state.read_offset;
+
+    let mut text = String::new();
+    for &token_id in delta_token_ids {
+        let step = detokenize_incrementally(
+            tokenizer,
+            token_id,
+            &window,
+            prefix_offset,
+            read_offset,
+            skip_special_tokens,
+        )?;
+        window.push(step.new_token);
+        text.push_str(&step.text);
+        prefix_offset = step.prefix_offset;
+        read_offset = step.read_offset;
+    }
+
+    // Trim to the tail still readable by detokenize_incrementally
+    // (everything before prefix_offset is dead) and rebase the offsets so
+    // the carried window stays bounded regardless of generation length.
+    let trimmed = window.split_off(prefix_offset);
+    let mut updated_state = state.clone();
+    updated_state.prev_tokens = trimmed.iter().map(|token| token.piece.clone()).collect();
+    updated_state.prev_token_ids =
+        Some(trimmed.iter().map(|token| token.id.unwrap_or(NO_TOKEN_ID)).collect());
+    updated_state.prefix_offset = 0;
+    updated_state.read_offset = read_offset - prefix_offset;
+    Ok((text, updated_state))
+}

--- a/rust/src/server/src/routes/derender/logprobs.rs
+++ b/rust/src/server/src/routes/derender/logprobs.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! `token_id:N` placeholder resolution and chat→completion logprobs
+//! conversion for the derender endpoints.
+//!
+//! Ports `_resolve_logprobs`, `_correct_decoded_token` and
+//! `_convert_chat_logprobs_to_completion_logprobs` from
+//! `vllm/renderers/online_derenderer.py`, plus `resolve_token_id_placeholder`
+//! from `vllm/entrypoints/generate/base/serving.py`.
+
+use std::collections::HashMap;
+
+use thiserror_ext::AsReport as _;
+use tracing::warn;
+use vllm_text::tokenizer::DynTokenizer;
+
+use crate::error::{ApiError, server_error};
+use crate::routes::inference::generate::GenerateLogprob;
+use crate::routes::openai::utils::logprobs::text_len;
+use crate::routes::openai::utils::types::{
+    ChatLogProbs, ChatLogProbsContent, LogProbs, TopLogProb,
+};
+
+/// Extract the token ID from a `token_id:N` placeholder string.
+fn parse_token_id_placeholder(token: &str) -> Option<u32> {
+    token.strip_prefix("token_id:")?.parse().ok()
+}
+
+/// Decode a `token_id:N` placeholder back to a token string and UTF-8 bytes.
+///
+/// Returns `(token, None)` unchanged if token is not a placeholder.
+/// This is the inverse of `format_token_id` on the /generate side
+/// when `return_tokens_as_token_ids` is active.
+///
+/// Decodes the ID directly rather than round-tripping through
+/// `id_to_token`/`token_to_id`, which is lossy for backends whose byte
+/// pieces are not valid UTF-8 on their own.
+fn resolve_token_id_placeholder(
+    token: &str,
+    tokenizer: &DynTokenizer,
+) -> Result<(String, Option<Vec<u8>>), ApiError> {
+    let Some(token_id) = parse_token_id_placeholder(token) else {
+        return Ok((token.to_string(), None));
+    };
+    if tokenizer.id_to_token(token_id).is_none() {
+        warn!(
+            token_id,
+            "resolve_token_id_placeholder: token_id has no vocab entry; substituting empty string"
+        );
+        return Ok((String::new(), None));
+    }
+    let token_str = tokenizer.decode(&[token_id], false).map_err(|error| {
+        server_error!("derender logprobs resolution failed: {}", error.as_report())
+    })?;
+    Ok((token_str.clone(), Some(token_str.into_bytes())))
+}
+
+/// Use preceding tokens as context to fix U+FFFD from byte-fallback.
+///
+/// Mirrors `LogprobsProcessor._correct_decoded_token` in
+/// v1/engine/logprobs.py.
+fn correct_decoded_token(
+    token_id: u32,
+    context_token_ids: &[u32],
+    tokenizer: &DynTokenizer,
+) -> Result<String, ApiError> {
+    let decode = |ids: &[u32]| {
+        tokenizer.decode(ids, true).map_err(|error| {
+            server_error!("derender logprobs correction failed: {}", error.as_report())
+        })
+    };
+    let max_ctx = context_token_ids.len().min(4);
+
+    for num_ctx in 1..=max_ctx {
+        let context = &context_token_ids[context_token_ids.len() - num_ctx..];
+        let mut full_ids = context.to_vec();
+        full_ids.push(token_id);
+        let full_decoded = decode(&full_ids)?;
+
+        if full_decoded.ends_with('\u{FFFD}') {
+            continue;
+        }
+
+        let mut clean_end = context.len();
+        for j in (0..context.len()).rev() {
+            if decode(&context[j..=j])?.ends_with('\u{FFFD}') {
+                clean_end = j;
+            } else {
+                break;
+            }
+        }
+
+        let clean_prefix = if clean_end > 0 {
+            decode(&context[..clean_end])?
+        } else {
+            String::new()
+        };
+
+        if let Some(suffix) = full_decoded.strip_prefix(&clean_prefix) {
+            return Ok(suffix.to_string());
+        }
+
+        let common_len = clean_prefix
+            .chars()
+            .zip(full_decoded.chars())
+            .take_while(|(a, b)| a == b)
+            .count();
+        return Ok(full_decoded.chars().skip(common_len).collect());
+    }
+
+    Ok(String::new())
+}
+
+/// Resolve `token_id:N` placeholders in a [`ChatLogProbs`] object.
+pub(super) fn resolve_logprobs(
+    logprobs: &ChatLogProbs,
+    tokenizer: &DynTokenizer,
+) -> Result<ChatLogProbs, ApiError> {
+    let Some(content) = &logprobs.content else {
+        return Ok(logprobs.clone());
+    };
+
+    let mut context_token_ids: Vec<u32> = Vec::new();
+    let mut resolved_content = Vec::with_capacity(content.len());
+
+    for entry in content {
+        let (mut token_str, mut token_bytes) =
+            resolve_token_id_placeholder(&entry.token, tokenizer)?;
+        let sampled_id = parse_token_id_placeholder(&entry.token);
+
+        if token_str.ends_with('\u{FFFD}')
+            && let Some(id) = sampled_id
+        {
+            token_str = correct_decoded_token(id, &context_token_ids, tokenizer)?;
+            token_bytes = Some(token_str.clone().into_bytes());
+        }
+
+        let mut resolved_top = Vec::with_capacity(entry.top_logprobs.len());
+        for top in &entry.top_logprobs {
+            let (mut top_str, mut top_bytes) = resolve_token_id_placeholder(&top.token, tokenizer)?;
+            let top_id = parse_token_id_placeholder(&top.token);
+            if top_str.ends_with('\u{FFFD}')
+                && let Some(id) = top_id
+            {
+                top_str = correct_decoded_token(id, &context_token_ids, tokenizer)?;
+                top_bytes = Some(top_str.clone().into_bytes());
+            }
+            resolved_top.push(TopLogProb {
+                token: top_str,
+                logprob: top.logprob,
+                bytes: top_bytes,
+            });
+        }
+
+        resolved_content.push(ChatLogProbsContent {
+            token: token_str,
+            logprob: entry.logprob,
+            bytes: token_bytes,
+            top_logprobs: resolved_top,
+        });
+
+        if let Some(id) = sampled_id {
+            context_token_ids.push(id);
+        }
+    }
+
+    Ok(ChatLogProbs {
+        content: Some(resolved_content),
+    })
+}
+
+/// Convert [`ChatLogProbs`] (per-token objects) to [`LogProbs`] (parallel
+/// flat lists) as required by the /v1/completions response schema.
+pub(super) fn chat_logprobs_to_completion(logprobs: &ChatLogProbs) -> LogProbs {
+    let mut tokens = Vec::new();
+    let mut token_logprobs = Vec::new();
+    let mut top_logprobs_list = Vec::new();
+    let mut text_offset = Vec::new();
+
+    let mut offset = 0;
+    if let Some(content) = &logprobs.content {
+        for entry in content {
+            text_offset.push(offset);
+            tokens.push(entry.token.clone());
+            token_logprobs.push(Some(entry.logprob));
+            top_logprobs_list.push(if entry.top_logprobs.is_empty() {
+                None
+            } else {
+                Some(
+                    entry
+                        .top_logprobs
+                        .iter()
+                        .map(|top| (top.token.clone(), top.logprob))
+                        .collect::<HashMap<String, f32>>(),
+                )
+            });
+            offset += text_len(&entry.token);
+        }
+    }
+
+    LogProbs {
+        tokens,
+        token_logprobs,
+        top_logprobs: top_logprobs_list,
+        text_offset,
+    }
+}
+
+/// Resolve one wire token string: `token_id:N` placeholders decode through
+/// the tokenizer, `decoded_token` strings pass through, and unknown IDs fall
+/// back to the placeholder form.
+fn wire_token_str(
+    token_id: u32,
+    decoded_token: Option<&str>,
+    tokenizer: &DynTokenizer,
+) -> Result<String, ApiError> {
+    match decoded_token {
+        Some(token) => Ok(resolve_token_id_placeholder(token, tokenizer)?.0),
+        None if tokenizer.id_to_token(token_id).is_some() => {
+            tokenizer.decode(&[token_id], false).map_err(|error| {
+                server_error!("derender logprobs resolution failed: {}", error.as_report())
+            })
+        }
+        None => Ok(format!("token_id:{token_id}")),
+    }
+}
+
+/// Convert engine-wire prompt logprobs (one candidate map per prompt
+/// position, as carried by `GenerateResponse.prompt_logprobs`) into the
+/// completions [`LogProbs`] shape, mirroring the normal path's echoed and
+/// prompt-only logprobs.
+///
+/// `prompt_token_ids` identifies the sampled token at each position; when it
+/// is shorter than the position list, the remaining positions fall back to
+/// their first candidate.
+pub(super) fn prompt_logprobs_to_completion(
+    prompt_logprobs: &[Option<HashMap<u32, GenerateLogprob>>],
+    prompt_token_ids: &[u32],
+    tokenizer: &DynTokenizer,
+) -> Result<LogProbs, ApiError> {
+    let mut tokens = Vec::with_capacity(prompt_logprobs.len());
+    let mut token_logprobs = Vec::with_capacity(prompt_logprobs.len());
+    let mut top_logprobs_list = Vec::with_capacity(prompt_logprobs.len());
+    let mut text_offset = Vec::with_capacity(prompt_logprobs.len());
+
+    let mut offset = 0;
+    for (position, position_logprobs) in prompt_logprobs.iter().enumerate() {
+        text_offset.push(offset);
+        let sampled_id = prompt_token_ids.get(position).copied();
+        match position_logprobs {
+            // The first prompt position carries no logprobs.
+            None => {
+                let token = match sampled_id {
+                    Some(id) => wire_token_str(id, None, tokenizer)?,
+                    None => String::new(),
+                };
+                offset += text_len(&token);
+                tokens.push(token);
+                token_logprobs.push(None);
+                top_logprobs_list.push(None);
+            }
+            Some(candidates) => {
+                let sampled = sampled_id
+                    .and_then(|id| candidates.get(&id).map(|entry| (id, entry)))
+                    .or_else(|| candidates.iter().next().map(|(&id, entry)| (id, entry)));
+                let (token, token_logprob) = match sampled {
+                    Some((id, entry)) => (
+                        wire_token_str(id, entry.decoded_token.as_deref(), tokenizer)?,
+                        Some(entry.logprob),
+                    ),
+                    None => (String::new(), None),
+                };
+                offset += text_len(&token);
+                tokens.push(token);
+                token_logprobs.push(token_logprob);
+                let mut top = HashMap::with_capacity(candidates.len());
+                for (&id, entry) in candidates {
+                    top.insert(
+                        wire_token_str(id, entry.decoded_token.as_deref(), tokenizer)?,
+                        entry.logprob,
+                    );
+                }
+                top_logprobs_list.push((!top.is_empty()).then_some(top));
+            }
+        }
+    }
+
+    Ok(LogProbs {
+        tokens,
+        token_logprobs,
+        top_logprobs: top_logprobs_list,
+        text_offset,
+    })
+}
+
+/// Shift every text offset by `prefix_len`, used when an echoed prompt is
+/// prepended to the choice text.
+pub(super) fn shift_text_offsets(logprobs: &mut LogProbs, prefix_len: u32) {
+    for offset in &mut logprobs.text_offset {
+        *offset = offset.saturating_add(prefix_len);
+    }
+}

--- a/rust/src/server/src/routes/derender/mod.rs
+++ b/rust/src/server/src/routes/derender/mod.rs
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Postprocessing counterpart to the /render endpoints: turn
+//! token-in/token-out `GenerateResponse`s back into OpenAI chat/completion
+//! responses without a GPU.
+//!
+//! Mirrors the Python vLLM implementation in
+//! `vllm/entrypoints/scale_out/derender/` (api_router.py, serving.py) and
+//! `vllm/renderers/online_derenderer.py`.
+//!
+//! This is phase 1 of the derender port: shared detokenization/state plus the
+//! plain non-streaming endpoints.
+//! TODO: phase 2 adds reasoning/tool-call parsing of the detokenized output;
+//! phase 3 adds the streaming endpoints (a `stream: true` body fails
+//! deserialization with 400 until then).
+//!
+//! Deliberate deviations from the Python implementation:
+//! - Non-streaming completion derender honours `completion_request.echo`
+//!   (including the `max_tokens=0` prompt-only case); Python ignores `echo`.
+
+mod detok;
+mod logprobs;
+mod types;
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use thiserror_ext::AsReport as _;
+use tracing::{debug, warn};
+use vllm_chat::ChatRequestProcessor;
+use vllm_text::tokenizer::DynTokenizer;
+use vllm_text::{Prompt, TextRequestProcessor};
+
+use self::types::{
+    DerenderChatCompletionResponse, DerenderChatRequest, DerenderChatRequestUnion,
+    DerenderCompletionRequest, DerenderCompletionRequestUnion,
+};
+use crate::error::{ApiError, bail_invalid_request, server_error};
+use crate::lora::LoraModelResolution;
+use crate::render::RenderState;
+use crate::routes::inference::generate::GenerateResponse;
+use crate::routes::openai::chat_completions::{
+    AssistantRole, ChatCompletionChoice, ChatCompletionMessage,
+};
+use crate::routes::openai::utils::logprobs::{append_openai_logprobs, text_len};
+use crate::routes::openai::utils::types::Usage;
+use crate::routes::openai::utils::validated_json::ValidatedJson;
+use crate::routes::openai::{CompletionChoice, CompletionResponse, completion_echo_text};
+use crate::state::AppState;
+use crate::utils::{ResolvedRequestContext, resolve_request_context, unix_timestamp};
+
+/// TODO: plumb `VLLM_MAX_N_SEQUENCES` through the server configuration;
+/// Python reads `envs.VLLM_MAX_N_SEQUENCES` (default 16384).
+const MAX_N_SEQUENCES: usize = 16384;
+
+/// Everything a derender handler needs, abstracted over the render-only and
+/// engine-backed servers.
+pub(crate) struct DerenderContext<'a> {
+    /// Public model names accepted by the frontend (including LoRA names).
+    lora_resolution: LoraModelResolution,
+    /// Primary public model name, echoed when the request omits `model`.
+    primary_model_name: &'a str,
+    /// Backend model id used for parser resolution.
+    // TODO: phase 2 (parsing) and phase 3 (streaming) read this again.
+    #[allow(dead_code)]
+    model_id: &'a str,
+    tokenizer: DynTokenizer,
+    max_model_len: u32,
+    max_logprobs: i32,
+    /// TODO: phase 2 (parser replay) reads this again.
+    #[allow(dead_code)]
+    text: &'a TextRequestProcessor,
+    /// TODO: phase 2 (parsing) and phase 3 (streaming) read this again.
+    #[allow(dead_code)]
+    chat: &'a ChatRequestProcessor,
+}
+
+fn render_context(state: &RenderState) -> DerenderContext<'_> {
+    DerenderContext {
+        lora_resolution: LoraModelResolution {
+            model_names: state.served_model_names.clone(),
+            lora_request: None,
+        },
+        primary_model_name: &state.served_model_names[0],
+        model_id: state.text.model_id(),
+        tokenizer: state.text.tokenizer(),
+        max_model_len: state.text.max_model_len(),
+        max_logprobs: state.text.max_logprobs(),
+        text: &state.text,
+        chat: &state.chat,
+    }
+}
+
+async fn app_context<'a>(state: &'a AppState, model: Option<&str>) -> DerenderContext<'a> {
+    let text = state.chat.text().request_processor();
+    DerenderContext {
+        lora_resolution: state.resolve_model_with_loras(model).await,
+        primary_model_name: state.primary_model_name(),
+        model_id: state.chat.model_id(),
+        tokenizer: text.tokenizer(),
+        max_model_len: text.max_model_len(),
+        max_logprobs: text.max_logprobs(),
+        text,
+        chat: state.chat.request_processor(),
+    }
+}
+
+/// Python `BaseServing._check_model`: an omitted model resolves the served
+/// name; an unknown one is a 404.
+fn check_model(ctx: &DerenderContext<'_>, model: Option<&str>) -> Result<(), ApiError> {
+    if let Some(model) = model
+        && !ctx.lora_resolution.model_names.iter().any(|name| name == model)
+    {
+        return Err(ApiError::model_not_found(model.to_string()));
+    }
+    Ok(())
+}
+
+fn response_model_name(ctx: &DerenderContext<'_>, model: Option<String>) -> String {
+    model.unwrap_or_else(|| ctx.primary_model_name.to_string())
+}
+
+/// Reject derender payloads that exceed resource bounds.
+///
+/// Runs before any tokenizer.decode() or parser invocation to prevent
+/// CPU/memory exhaustion from oversized caller-supplied token structures.
+fn validate_derender_bounds(
+    generate_responses: &[GenerateResponse],
+    max_model_len: u32,
+    max_logprobs: i32,
+) -> Result<(), ApiError> {
+    let max_model_len = max_model_len as usize;
+
+    if generate_responses.len() > MAX_N_SEQUENCES {
+        bail_invalid_request!(
+            "generate_responses count ({}) exceeds server maximum ({}). \
+             Set VLLM_MAX_N_SEQUENCES to increase this limit.",
+            generate_responses.len(),
+            MAX_N_SEQUENCES
+        );
+    }
+
+    for response in generate_responses {
+        if response.choices.len() > MAX_N_SEQUENCES {
+            bail_invalid_request!(
+                "choices count ({}) in response '{}' exceeds server maximum ({}).",
+                response.choices.len(),
+                response.request_id,
+                MAX_N_SEQUENCES
+            );
+        }
+
+        for choice in &response.choices {
+            if choice.token_ids.len() > max_model_len {
+                bail_invalid_request!(
+                    "token_ids length ({}) in choice {} exceeds max_model_len ({}).",
+                    choice.token_ids.len(),
+                    choice.index,
+                    max_model_len
+                );
+            }
+            if let Some(content) = choice.logprobs.as_ref().and_then(|l| l.content.as_ref()) {
+                if content.len() > max_model_len {
+                    bail_invalid_request!(
+                        "logprobs.content length ({}) in choice {} exceeds max_model_len ({}).",
+                        content.len(),
+                        choice.index,
+                        max_model_len
+                    );
+                }
+                for entry in content {
+                    if max_logprobs >= 0 && entry.top_logprobs.len() > max_logprobs as usize {
+                        bail_invalid_request!(
+                            "top_logprobs count ({}) in choice {} exceeds max_logprobs ({}).",
+                            entry.top_logprobs.len(),
+                            choice.index,
+                            max_logprobs
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Some(prompt_logprobs) = &response.prompt_logprobs
+            && prompt_logprobs.len() > max_model_len
+        {
+            bail_invalid_request!(
+                "prompt_logprobs length ({}) in response '{}' exceeds max_model_len ({}).",
+                prompt_logprobs.len(),
+                response.request_id,
+                max_model_len
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Postprocess a GenerateResponse into a chat completion response.
+///
+/// Non-streaming only: expects the complete GenerateResponse with all token
+/// IDs present. Phase 1 always plain-detokenizes, honouring the request's
+/// `skip_special_tokens` (default true when no request was given).
+/// TODO: phase 2 replays the output through the configured reasoning/tool
+/// parser (splitting reasoning, content and tool_calls) when `chat_request`
+/// is supplied, mirroring Python's `parser.parse()` one-shot extraction.
+async fn derender_chat(
+    ctx: &DerenderContext<'_>,
+    request: DerenderChatRequest,
+    // Used by the phase-2 parser replay.
+    _request_context: ResolvedRequestContext,
+) -> Result<DerenderChatCompletionResponse, ApiError> {
+    check_model(ctx, request.model.as_deref())?;
+    validate_derender_bounds(
+        std::slice::from_ref(&request.generate_response),
+        ctx.max_model_len,
+        ctx.max_logprobs,
+    )?;
+
+    let model_name = response_model_name(ctx, request.model.clone());
+    let response = &request.generate_response;
+    let mut choices = Vec::with_capacity(response.choices.len());
+
+    for choice in &response.choices {
+        if choice.token_ids.is_empty() {
+            bail_invalid_request!("choice {} has empty or null token_ids", choice.index);
+        }
+
+        let resolved_logprobs = choice
+            .logprobs
+            .as_ref()
+            .map(|logprobs| logprobs::resolve_logprobs(logprobs, &ctx.tokenizer))
+            .transpose()?;
+
+        let skip_special = request
+            .chat_request
+            .as_ref()
+            .map(|request| request.skip_special_tokens)
+            .unwrap_or(true);
+        let decoded_text = ctx
+            .tokenizer
+            .decode(&choice.token_ids, skip_special)
+            .map_err(|error| server_error!("derender decode failed: {}", error.as_report()))?;
+
+        choices.push(ChatCompletionChoice {
+            index: choice.index,
+            message: ChatCompletionMessage {
+                role: AssistantRole,
+                content: Some(decoded_text),
+                tool_calls: Vec::new(),
+                reasoning: None,
+            },
+            logprobs: resolved_logprobs,
+            finish_reason: choice.finish_reason.clone(),
+            stop_reason: None,
+            token_ids: None,
+        });
+    }
+
+    let prompt_tokens = request.prompt_tokens.unwrap_or(0);
+    let completion_tokens: usize =
+        response.choices.iter().map(|choice| choice.token_ids.len()).sum();
+    debug!(
+        request_id = %response.request_id,
+        model = %model_name,
+        choices = choices.len(),
+        completion_tokens,
+        "derender_chat"
+    );
+
+    Ok(DerenderChatCompletionResponse {
+        id: response.request_id.clone(),
+        object: "chat.completion".to_string(),
+        created: unix_timestamp(),
+        model: model_name,
+        choices,
+        usage: Usage {
+            prompt_tokens,
+            total_tokens: checked_total_tokens(prompt_tokens, completion_tokens)?,
+            completion_tokens: Some(completion_tokens),
+            prompt_tokens_details: None,
+        },
+        prompt_logprobs: response.prompt_logprobs.clone(),
+        kv_transfer_params: response.kv_transfer_params.clone(),
+        // The Python derender endpoint does not pass ec_transfer_params through.
+        ec_transfer_params: None,
+    })
+}
+
+/// Postprocess a list of GenerateResponses into a completion response.
+///
+/// Non-streaming only. Mirrors the multi-prompt completions case: one
+/// GenerateResponse per prompt, parallel to the list[GenerateRequest] from
+/// /v1/completions/render.
+fn derender_completion(
+    ctx: &DerenderContext<'_>,
+    request: DerenderCompletionRequest,
+) -> Result<CompletionResponse, ApiError> {
+    check_model(ctx, request.model.as_deref())?;
+
+    if request.generate_responses.is_empty() {
+        bail_invalid_request!("generate_responses must not be empty");
+    }
+    if let Some(prompt_tokens) = &request.prompt_tokens
+        && prompt_tokens.len() != request.generate_responses.len()
+    {
+        bail_invalid_request!(
+            "prompt_tokens length ({}) must equal generate_responses length ({})",
+            prompt_tokens.len(),
+            request.generate_responses.len()
+        );
+    }
+
+    validate_derender_bounds(
+        &request.generate_responses,
+        ctx.max_model_len,
+        ctx.max_logprobs,
+    )?;
+
+    let skip_special = request
+        .completion_request
+        .as_ref()
+        .map(|request| request.skip_special_tokens)
+        .unwrap_or(true);
+
+    // Honour `completion_request.echo` like the normal completions path
+    // (Python derender ignores `echo`): prepend the prompt to each choice's
+    // text, and for prompt-only requests (echo + max_tokens=0) expose just
+    // the prompt, hiding the one internally generated token.
+    let completion_request = request.completion_request.as_ref();
+    let echo = completion_request
+        .map(|request| completion_echo_text(request, ctx.tokenizer.as_ref()))
+        .transpose()?
+        .flatten();
+    let prompt_only =
+        echo.is_some() && completion_request.is_some_and(|request| request.max_tokens == Some(0));
+    let echo_prompt_token_ids = match completion_request.filter(|_| echo.is_some()) {
+        Some(request) => Some(match &request.prompt {
+            Prompt::Text(text) => {
+                ctx.tokenizer.encode(text, request.add_special_tokens).map_err(|error| {
+                    ApiError::invalid_request(
+                        format!("Failed to tokenize prompt for echo: {}", error.as_report()),
+                        Some("prompt"),
+                    )
+                })?
+            }
+            Prompt::TokenIds(token_ids) => token_ids.clone(),
+        }),
+        None => None,
+    };
+
+    let mut choices = Vec::new();
+    let mut total_prompt_tokens = 0;
+    let mut total_completion_tokens = 0;
+    let mut index = 0;
+
+    for (response_idx, response) in request.generate_responses.iter().enumerate() {
+        let prompt_tokens =
+            request.prompt_tokens.as_ref().map(|tokens| tokens[response_idx]).unwrap_or(0);
+        for choice in &response.choices {
+            if choice.token_ids.is_empty() {
+                bail_invalid_request!(
+                    "choice {} in response {} has empty or null token_ids",
+                    choice.index,
+                    response.request_id
+                );
+            }
+
+            let decoded_text = ctx
+                .tokenizer
+                .decode(&choice.token_ids, skip_special)
+                .map_err(|error| server_error!("derender decode failed: {}", error.as_report()))?;
+            let text = match &echo {
+                None => decoded_text,
+                Some(prompt) if prompt_only => prompt.clone(),
+                Some(prompt) => format!("{prompt}{decoded_text}"),
+            };
+            let mut logprobs = choice
+                .logprobs
+                .as_ref()
+                .map(|logprobs| {
+                    logprobs::resolve_logprobs(logprobs, &ctx.tokenizer)
+                        .map(|resolved| logprobs::chat_logprobs_to_completion(&resolved))
+                })
+                .transpose()?;
+            if let Some(prompt) = &echo {
+                if prompt_only {
+                    // Choice logprobs would describe the hidden internal
+                    // token; echo back prompt logprobs like the normal path.
+                    logprobs = match &response.prompt_logprobs {
+                        Some(prompt_logprobs) => Some(logprobs::prompt_logprobs_to_completion(
+                            prompt_logprobs,
+                            echo_prompt_token_ids.as_deref().unwrap_or(&[]),
+                            &ctx.tokenizer,
+                        )?),
+                        None => None,
+                    };
+                } else if let Some(completion_logprobs) = logprobs {
+                    logprobs = Some(match &response.prompt_logprobs {
+                        // The render step enables prompt logprobs for echo
+                        // requests, so prepend them exactly like the normal
+                        // echoed completions path.
+                        Some(prompt_logprobs) => {
+                            let prompt_logprobs = logprobs::prompt_logprobs_to_completion(
+                                prompt_logprobs,
+                                echo_prompt_token_ids.as_deref().unwrap_or(&[]),
+                                &ctx.tokenizer,
+                            )?;
+                            let completion_start = prompt_logprobs
+                                .text_offset
+                                .last()
+                                .zip(prompt_logprobs.tokens.last())
+                                .map(|(&offset, token)| offset.saturating_add(text_len(token)))
+                                .unwrap_or(0);
+                            let mut completion_logprobs = completion_logprobs;
+                            logprobs::shift_text_offsets(
+                                &mut completion_logprobs,
+                                completion_start,
+                            );
+                            append_openai_logprobs(prompt_logprobs, completion_logprobs)
+                        }
+                        None => {
+                            let mut completion_logprobs = completion_logprobs;
+                            logprobs::shift_text_offsets(
+                                &mut completion_logprobs,
+                                text_len(prompt),
+                            );
+                            completion_logprobs
+                        }
+                    });
+                }
+            }
+
+            choices.push(CompletionChoice {
+                index,
+                text,
+                logprobs,
+                finish_reason: choice.finish_reason.clone(),
+                stop_reason: None,
+                prompt_logprobs: None,
+                token_ids: None,
+                prompt_token_ids: None,
+            });
+            total_completion_tokens += choice.token_ids.len();
+            index += 1;
+        }
+        total_prompt_tokens = checked_total_tokens(total_prompt_tokens, prompt_tokens)?;
+    }
+
+    let first = &request.generate_responses[0];
+    let kv_params = first.kv_transfer_params.clone();
+    let kv_params = if request.generate_responses[1..]
+        .iter()
+        .any(|response| response.kv_transfer_params != kv_params)
+    {
+        warn!(
+            "derender_completion: kv_transfer_params differ across responses; \
+             setting to None on the aggregated response"
+        );
+        None
+    } else {
+        kv_params
+    };
+
+    let model_name = response_model_name(ctx, request.model.clone());
+    debug!(
+        request_id = %first.request_id,
+        model = %model_name,
+        choices = choices.len(),
+        total_completion_tokens,
+        "derender_completion"
+    );
+
+    Ok(CompletionResponse {
+        id: first.request_id.clone(),
+        object: "text_completion".to_string(),
+        created: unix_timestamp(),
+        model: model_name,
+        choices,
+        usage: Some(Usage {
+            prompt_tokens: total_prompt_tokens,
+            total_tokens: checked_total_tokens(total_prompt_tokens, total_completion_tokens)?,
+            completion_tokens: Some(total_completion_tokens),
+            prompt_tokens_details: None,
+        }),
+        system_fingerprint: None,
+        kv_transfer_params: kv_params,
+        ec_transfer_params: None,
+    })
+}
+
+/// `prompt_tokens` in derender requests is caller supplied, so adding the
+/// completion count with plain arithmetic could overflow.
+fn checked_total_tokens(prompt_tokens: usize, completion_tokens: usize) -> Result<usize, ApiError> {
+    prompt_tokens.checked_add(completion_tokens).ok_or_else(|| {
+        ApiError::invalid_request(
+            format!(
+                "prompt_tokens ({prompt_tokens}) + completion_tokens \
+                 ({completion_tokens}) overflows the token counter"
+            ),
+            None,
+        )
+    })
+}
+
+fn chat_request_model(request: &DerenderChatRequestUnion) -> Option<&str> {
+    match request {
+        DerenderChatRequestUnion::NonStreaming(request) => request.model.as_deref(),
+    }
+}
+
+fn completion_request_model(request: &DerenderCompletionRequestUnion) -> Option<&str> {
+    match request {
+        DerenderCompletionRequestUnion::NonStreaming(request) => request.model.as_deref(),
+    }
+}
+
+/// Derender a generate response into a chat completion response (render-only
+/// server variant).
+///
+/// TODO: phase 3 accepts streaming (`stream=true`) request bodies on the same
+/// path; until then they fail deserialization with a 400.
+pub async fn derender_chat_render(
+    State(state): State<Arc<RenderState>>,
+    headers: HeaderMap,
+    ValidatedJson(body): ValidatedJson<DerenderChatRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = render_context(&state);
+    let request_context = resolve_request_context(&headers, None);
+    match body {
+        DerenderChatRequestUnion::NonStreaming(request) => {
+            derender_chat(&ctx, request, request_context)
+                .await
+                .map(|response| Json(response).into_response())
+        }
+    }
+}
+
+/// Derender a generate response into a completion response (render-only
+/// server variant).
+pub async fn derender_completion_render(
+    State(state): State<Arc<RenderState>>,
+    ValidatedJson(body): ValidatedJson<DerenderCompletionRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = render_context(&state);
+    match body {
+        DerenderCompletionRequestUnion::NonStreaming(request) => {
+            derender_completion(&ctx, request).map(|response| Json(response).into_response())
+        }
+    }
+}
+
+/// Derender a generate response into a chat completion response
+/// (engine-backed server variant).
+pub async fn derender_chat_completions(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ValidatedJson(body): ValidatedJson<DerenderChatRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = app_context(&state, chat_request_model(&body)).await;
+    let request_context = resolve_request_context(&headers, None);
+    match body {
+        DerenderChatRequestUnion::NonStreaming(request) => {
+            derender_chat(&ctx, request, request_context)
+                .await
+                .map(|response| Json(response).into_response())
+        }
+    }
+}
+
+/// Derender a generate response into a completion response (engine-backed
+/// server variant).
+pub async fn derender_completions(
+    State(state): State<Arc<AppState>>,
+    ValidatedJson(body): ValidatedJson<DerenderCompletionRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = app_context(&state, completion_request_model(&body)).await;
+    match body {
+        DerenderCompletionRequestUnion::NonStreaming(request) => {
+            derender_completion(&ctx, request).map(|response| Json(response).into_response())
+        }
+    }
+}

--- a/rust/src/server/src/routes/derender/types.rs
+++ b/rust/src/server/src/routes/derender/types.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Wire types for the `/v1/chat/completions/derender` and
+//! `/v1/completions/derender` endpoints.
+//!
+//! Mirrors the Python vLLM `Derender*Request` / `Derender*Stream*` classes in
+//! `vllm/entrypoints/scale_out/token_in_token_out/protocol.py`.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use validator::{Validate, ValidationErrors};
+
+use crate::error::{ApiError, bail_invalid_request};
+use crate::routes::inference::generate::{GenerateResponse, PromptLogprobMaps};
+use crate::routes::openai::CompletionRequest;
+use crate::routes::openai::chat_completions::ChatCompletionRequest;
+use crate::routes::openai::utils::types::{Normalizable, Usage};
+
+/// Cap on the carried detok window in [`DerenderStreamState`].
+///
+/// INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET is small (5) and the trimmed
+/// window is O(offset). A generous limit rejects unusually large or malformed
+/// payloads without restricting legitimate multi-byte sequences.
+const MAX_PREV_TOKENS: usize = 1024;
+
+/// Per sequence state for stateless streaming derender.
+///
+/// The client carries this between successive per chunk HTTP calls to the
+/// streaming derender endpoint. All fields are plain JSON serializable data.
+/// No opaque tokenizer or parser internals are stored here.
+///
+/// The detokenization strategy carries the incremental decode offsets
+/// directly rather than re-sending the whole token history each chunk.
+/// `detokenize_incrementally` only ever reads the trailing token window
+/// `prev_tokens[prefix_offset..]`, so we carry just that tail plus the two
+/// offsets. Each chunk resumes exactly where the last one stopped, including
+/// any partially processed multi-byte character (tracked by `read_offset`),
+/// then trims and rebases the window so it never grows with generation
+/// length.
+///
+/// Do not skip serializing `None` fields here: Python's `model_dump()` emits
+/// them as explicit `null`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub(crate) struct DerenderStreamState {
+    /// Trailing decode window. Token strings from `prefix_offset` onward.
+    ///
+    /// Bounded, trimmed and rebased each chunk to the tail
+    /// `detokenize_incrementally` still reads, so it does not grow with the
+    /// number of chunks.
+    #[serde(default)]
+    pub prev_tokens: Vec<String>,
+    /// Token IDs parallel to `prev_tokens`, used to reconstruct the decode
+    /// window without a lossy `id_to_token` → `token_to_id` round-trip
+    /// (some backends store byte pieces as lossy UTF-8). Slots without a
+    /// decodable ID carry `u32::MAX`.
+    ///
+    /// Rust-specific extension: states produced by the Python implementation
+    /// lack this field (`null`/absent), in which case the pieces are mapped
+    /// back through `token_to_id` as a best-effort fallback. Python ignores
+    /// the unknown field when it parses our state.
+    #[serde(default)]
+    pub prev_token_ids: Option<Vec<u32>>,
+    /// Prefix offset into `prev_tokens` for incremental detokenization.
+    #[serde(default)]
+    pub prefix_offset: usize,
+    /// Read offset into `prev_tokens` for incremental detokenization.
+    #[serde(default)]
+    pub read_offset: usize,
+    /// True once the initial `role: "assistant"` delta has been emitted.
+    ///
+    /// Prevents re-emitting the role on subsequent chunks even when the detok
+    /// window is transiently empty (e.g. usage only final chunk).
+    #[serde(default)]
+    pub role_sent: bool,
+    // TODO: Properties used in follow on PR for tool call parsing
+    /// Last emitted cumulative assistant content text.
+    pub last_content: Option<String>,
+    /// Last emitted cumulative reasoning text.
+    pub last_reasoning: Option<String>,
+    /// Stable tool-call IDs, assigned once when each call first appears.
+    ///
+    /// Prevents ID regeneration across re-parsing.
+    #[serde(default)]
+    pub last_tool_call_ids: Vec<String>,
+}
+
+impl DerenderStreamState {
+    /// Reject malformed caller supplied offsets/lengths.
+    ///
+    /// Python enforces the `prev_tokens` cap through a Pydantic field
+    /// validator (surfaced as 400) and turns detok failures from out-of-range
+    /// offsets into a 400 "invalid stream_state" error; both checks live here.
+    // TODO: called by the phase-3 streaming endpoints.
+    #[allow(dead_code)]
+    pub(super) fn validate(&self) -> Result<(), ApiError> {
+        if self.prev_tokens.len() > MAX_PREV_TOKENS {
+            bail_invalid_request!(
+                "prev_tokens length ({}) exceeds maximum ({})",
+                self.prev_tokens.len(),
+                MAX_PREV_TOKENS
+            );
+        }
+        if self.prefix_offset > self.read_offset || self.read_offset > self.prev_tokens.len() {
+            bail_invalid_request!(
+                "invalid stream_state: detokenization failed (prefix_offset={}, \
+                 read_offset={}, prev_tokens length={})",
+                self.prefix_offset,
+                self.read_offset,
+                self.prev_tokens.len()
+            );
+        }
+        if let Some(ids) = &self.prev_token_ids
+            && ids.len() != self.prev_tokens.len()
+        {
+            bail_invalid_request!(
+                "invalid stream_state: prev_token_ids length ({}) does not match \
+                 prev_tokens length ({})",
+                ids.len(),
+                self.prev_tokens.len()
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Reject `stream: true` on the non-streaming request body.
+///
+/// TODO: phase 3 re-adds the streaming request variant, which this error
+/// steers the untagged union towards; until then a `stream: true` body fails
+/// deserialization outright and the endpoint responds 400.
+fn expect_stream_false<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = bool::deserialize(deserializer)?;
+    if value {
+        return Err(serde::de::Error::custom(
+            "`stream` must be false or omitted for the non-streaming derender request",
+        ));
+    }
+    Ok(false)
+}
+
+/// Request for the /v1/chat/completions/derender endpoint (non-streaming).
+///
+/// Wraps a complete GenerateResponse and caller supplied metadata needed to
+/// produce a fully formed ChatCompletionResponse without a GPU.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DerenderChatRequest {
+    #[serde(default, deserialize_with = "expect_stream_false")]
+    #[allow(dead_code)]
+    stream: bool,
+    /// Served model name. Defaults to the server's served model name.
+    pub model: Option<String>,
+    /// The complete token-in / token-out engine response to derender.
+    pub generate_response: GenerateResponse,
+    /// Prompt token count for usage; defaults to 0 if omitted.
+    ///
+    /// GenerateResponse carries only output tokens; the caller already has
+    /// `len(GenerateRequest.token_ids)` from the render step.
+    pub prompt_tokens: Option<usize>,
+    /// The original (post-adjust_request) ChatCompletionRequest from /render.
+    ///
+    /// Phase 1 honours its `skip_special_tokens` option; phase 2 additionally
+    /// feeds it to the reasoning/tool parsers so they receive the full
+    /// request context they expect.
+    pub chat_request: Option<ChatCompletionRequest>,
+}
+
+/// Request for the /v1/completions/derender endpoint (non-streaming).
+///
+/// Parallel to DerenderChatRequest but handles the multi-prompt completions
+/// case: one GenerateResponse per prompt, mirroring the list[GenerateRequest]
+/// returned by /v1/completions/render.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DerenderCompletionRequest {
+    #[serde(default, deserialize_with = "expect_stream_false")]
+    #[allow(dead_code)]
+    stream: bool,
+    /// Served model name. Defaults to the server's served model name.
+    pub model: Option<String>,
+    /// One response per prompt, parallel to the list[GenerateRequest]
+    /// returned by /v1/completions/render.
+    pub generate_responses: Vec<GenerateResponse>,
+    /// One prompt token count per response; each defaults to 0 if omitted.
+    ///
+    /// If provided, `len(prompt_tokens)` must equal `len(generate_responses)`.
+    pub prompt_tokens: Option<Vec<usize>>,
+    /// The original (post-adjust_request) CompletionRequest from /render.
+    ///
+    /// Mirrors chat_request on DerenderChatRequest.
+    pub completion_request: Option<CompletionRequest>,
+}
+
+/// Validation and normalization of embedded requests (e.g. `chat_request`)
+/// happen when the handler lowers them, not at extraction time.
+macro_rules! impl_union_validation {
+    ($union:ident) => {
+        impl Validate for $union {
+            fn validate(&self) -> Result<(), ValidationErrors> {
+                Ok(())
+            }
+        }
+
+        impl Normalizable for $union {}
+    };
+}
+
+/// Request body for the chat derender endpoint.
+///
+/// TODO: phase 3 re-adds the `Streaming` variant, discriminated by the
+/// `stream` field's literal value (a body without `stream` validates as the
+/// non-streaming member, whose `stream` defaults to false).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum DerenderChatRequestUnion {
+    NonStreaming(DerenderChatRequest),
+}
+
+impl_union_validation!(DerenderChatRequestUnion);
+
+/// See [`DerenderChatRequestUnion`].
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum DerenderCompletionRequestUnion {
+    NonStreaming(DerenderCompletionRequest),
+}
+
+impl_union_validation!(DerenderCompletionRequestUnion);
+
+/// Mirrors the Python vLLM `ChatCompletionResponse` as produced by the
+/// derender endpoint.
+///
+/// Unlike the normal chat path's response type, `prompt_logprobs` here
+/// carries the engine-side `HashMap<u32, GenerateLogprob>` shape passed
+/// through from `GenerateResponse`, and `usage` is always present.
+///
+/// Do not skip serializing `None` fields here: non-streaming response types
+/// should serialize `None` as explicit `null`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DerenderChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<crate::routes::openai::chat_completions::ChatCompletionChoice>,
+    pub usage: Usage,
+    pub prompt_logprobs: Option<PromptLogprobMaps>,
+    pub kv_transfer_params: Option<Value>,
+    pub ec_transfer_params: Option<Value>,
+}

--- a/rust/src/server/src/routes/inference/generate.rs
+++ b/rust/src/server/src/routes/inference/generate.rs
@@ -26,11 +26,11 @@ use vllm_llm::{
 };
 
 use self::convert::{ResponseOptions, prepare_generate_request};
-use self::types::{
-    GenerateLogprob, GenerateResponse, GenerateResponseChoice, GenerateResponseStreamChoice,
-    GenerateStreamResponse,
+pub(crate) use self::types::{
+    GenerateLogprob, GenerateRequest, GenerateResponse, GenerateResponseChoice,
+    GenerateResponseStreamChoice, GenerateSamplingParams, GenerateStreamResponse,
+    PromptLogprobMaps,
 };
-pub(crate) use self::types::{GenerateRequest, GenerateSamplingParams};
 pub(crate) use self::validate::validate_request_compat;
 use crate::config::ApiServerOptions;
 use crate::error::{ApiError, bail_server_error, server_error, text_submit_error};

--- a/rust/src/server/src/routes/inference/generate/types.rs
+++ b/rust/src/server/src/routes/inference/generate/types.rs
@@ -56,46 +56,98 @@ impl Normalizable for GenerateRequest {}
 ///
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateResponseChoice {
+///
+/// Also deserialized by the derender endpoints. A JSON `null` `token_ids`
+/// fails deserialization (400); the derender handler additionally rejects
+/// missing/empty `token_ids` with Python's "empty or null token_ids" error.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateResponseChoice {
     pub index: u32,
     pub logprobs: Option<ChatLogProbs>,
+    // Per OpenAI spec the Python default is "stop".
+    #[serde(default = "default_finish_reason")]
     pub finish_reason: Option<String>,
+    #[serde(default)]
     pub token_ids: Vec<u32>,
+}
+
+fn default_finish_reason() -> Option<String> {
+    Some("stop".to_string())
 }
 
 /// Mirrors the Python vLLM `GenerateResponseStreamChoice` class.
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateResponseStreamChoice {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateResponseStreamChoice {
     pub index: u32,
     pub logprobs: Option<ChatLogProbs>,
     pub finish_reason: Option<String>,
+    #[serde(default)]
     pub token_ids: Vec<u32>,
 }
 
 /// Mirrors the Python vLLM `GenerateStreamResponse` class.
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateStreamResponse {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateStreamResponse {
+    #[serde(default)]
     pub request_id: String,
     pub choices: Vec<GenerateResponseStreamChoice>,
     pub usage: Option<Usage>,
 }
 
+/// Engine-wire prompt logprobs: one candidate map per prompt position.
+pub(crate) type PromptLogprobMaps = Vec<Option<HashMap<u32, GenerateLogprob>>>;
+
 /// Mirrors the Python vLLM `GenerateResponse` class.
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateResponse {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateResponse {
+    #[serde(default)]
     pub request_id: String,
     pub choices: Vec<GenerateResponseChoice>,
-    pub prompt_logprobs: Option<Vec<Option<HashMap<u32, GenerateLogprob>>>>,
+    #[serde(default, deserialize_with = "deserialize_prompt_logprob_maps")]
+    pub prompt_logprobs: Option<PromptLogprobMaps>,
     pub kv_transfer_params: Option<Value>,
     pub ec_transfer_params: Option<Value>,
 }
 
+/// Deserialize prompt-logprob position maps with integer keys.
+///
+/// Serde's untagged-union buffering (used by the derender request unions)
+/// cannot drive `HashMap<u32, _>`'s key parsing, so accept string keys and
+/// parse them explicitly.
+fn deserialize_prompt_logprob_maps<'de, D>(
+    deserializer: D,
+) -> Result<Option<PromptLogprobMaps>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Option::<Vec<Option<HashMap<String, GenerateLogprob>>>>::deserialize(deserializer)?;
+    raw.map(|positions| {
+        positions
+            .into_iter()
+            .map(|position| {
+                position
+                    .map(|candidates| {
+                        candidates
+                            .into_iter()
+                            .map(|(key, value)| {
+                                key.parse::<u32>()
+                                    .map(|token_id| (token_id, value))
+                                    .map_err(serde::de::Error::custom)
+                            })
+                            .collect::<Result<HashMap<_, _>, _>>()
+                    })
+                    .transpose()
+            })
+            .collect::<Result<Vec<_>, _>>()
+    })
+    .transpose()
+}
+
 /// Mirrors the Python vLLM `Logprob` class used in prompt-logprobs payloads.
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateLogprob {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateLogprob {
     pub logprob: f32,
     pub rank: Option<u32>,
     pub decoded_token: Option<String>,

--- a/rust/src/server/src/routes/openai/chat_completions.rs
+++ b/rust/src/server/src/routes/openai/chat_completions.rs
@@ -28,13 +28,14 @@ use vllm_engine_core_client::protocol::output::StopReason;
 
 use self::convert::{ResponseOptions, prepare_chat_request};
 pub(crate) use self::types::ChatCompletionRequest;
+use self::types::ChatCompletionResponse;
+pub(crate) use self::types::{
+    AssistantRole, ChatCompletionChoice, ChatCompletionMessage, ChatCompletionStreamChoice,
+    ChatCompletionStreamResponse, ChatMessageDelta,
+};
 use crate::config::ApiServerOptions;
 use crate::error::{ApiError, bail_server_error, chat_submit_error, server_error};
 use crate::lora::LoraModelResolution;
-use crate::routes::openai::chat_completions::types::{
-    AssistantRole, ChatCompletionChoice, ChatCompletionMessage, ChatCompletionResponse,
-    ChatCompletionStreamChoice, ChatCompletionStreamResponse, ChatMessageDelta,
-};
 use crate::routes::openai::utils::logprobs::{
     decoded_logprobs_to_openai_chat, prompt_logprobs_to_maps,
 };

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -339,7 +339,7 @@ impl Normalizable for ChatCompletionRequest {
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionResponse {
+pub(crate) struct ChatCompletionResponse {
     pub id: String,
     pub object: String,
     pub created: u64,
@@ -355,7 +355,7 @@ pub(super) struct ChatCompletionResponse {
 
 /// Mirrors the Python vLLM `ChatCompletionResponseChoice` class.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionChoice {
+pub(crate) struct ChatCompletionChoice {
     pub index: u32,
     pub message: ChatCompletionMessage,
     pub logprobs: Option<ChatLogProbs>,
@@ -367,7 +367,7 @@ pub(super) struct ChatCompletionChoice {
 /// A literal type for the "assistant" role, since the API only allows that
 /// specific value in responses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, SerializeDisplay)]
-pub(super) struct AssistantRole;
+pub(crate) struct AssistantRole;
 
 impl fmt::Display for AssistantRole {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -377,7 +377,7 @@ impl fmt::Display for AssistantRole {
 
 /// Mirrors the Python vLLM response `ChatMessage` class.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionMessage {
+pub(crate) struct ChatCompletionMessage {
     pub role: AssistantRole,
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -388,7 +388,7 @@ pub(super) struct ChatCompletionMessage {
 /// Mirrors the Python vLLM `ChatCompletionStreamResponse` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionStreamResponse {
+pub(crate) struct ChatCompletionStreamResponse {
     #[serde(flatten)]
     pub envelope: Arc<StreamResponseEnvelope>,
     pub choices: Vec<ChatCompletionStreamChoice>,
@@ -411,7 +411,7 @@ impl ChatCompletionStreamResponse {
 /// Mirrors the Python vLLM `ChatCompletionResponseStreamChoice` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, Serialize)]
-pub(super) struct ChatCompletionStreamChoice {
+pub(crate) struct ChatCompletionStreamChoice {
     pub index: u32,
     pub delta: ChatMessageDelta,
     pub logprobs: Option<ChatLogProbs>,
@@ -423,7 +423,7 @@ pub(super) struct ChatCompletionStreamChoice {
 /// Mirrors the Python vLLM `DeltaMessage` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, Serialize)]
-pub(super) struct ChatMessageDelta {
+pub(crate) struct ChatMessageDelta {
     pub role: Option<AssistantRole>,
     pub content: Option<String>,
     pub tool_calls: Option<Vec<ToolCallDelta>>,

--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -27,8 +27,13 @@ use vllm_text::{
     TextOutputStreamExt as _, TextRequest,
 };
 
+pub(crate) use self::convert::completion_echo_text;
 use self::convert::{ResponseOptions, prepare_completion_request};
 pub(crate) use self::types::CompletionRequest;
+use self::types::CompletionSseChunk;
+pub(crate) use self::types::{
+    CompletionChoice, CompletionResponse, CompletionStreamChoice, CompletionStreamResponse,
+};
 use super::utils::logprobs::{
     collected_logprobs_to_openai, decoded_logprobs_to_openai, decoded_prompt_logprobs_to_openai,
     prompt_logprobs_to_maps, text_len,
@@ -37,10 +42,6 @@ use super::utils::types::{StreamResponseEnvelope, Usage};
 use crate::config::ApiServerOptions;
 use crate::error::{ApiError, bail_server_error, server_error, text_submit_error};
 use crate::lora::LoraModelResolution;
-use crate::routes::openai::completions::types::{
-    CompletionChoice, CompletionResponse, CompletionSseChunk, CompletionStreamChoice,
-    CompletionStreamResponse,
-};
 use crate::routes::openai::utils::types::LogProbs;
 use crate::routes::openai::utils::usage::ContinuousUsage;
 use crate::routes::openai::utils::validated_json::ValidatedJson;

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -176,7 +176,9 @@ pub(super) fn prepare_completion_request(
     })
 }
 
-fn completion_echo_text(
+/// Prompt text echoed back northbound when `echo=true`, mirroring the Python
+/// completions path. Shared with the derender endpoint.
+pub(crate) fn completion_echo_text(
     request: &CompletionRequest,
     tokenizer: &dyn Tokenizer,
 ) -> Result<Option<String>, ApiError> {

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -216,7 +216,7 @@ impl Normalizable for CompletionRequest {
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct CompletionResponse {
+pub(crate) struct CompletionResponse {
     pub id: String,
     pub object: String,
     pub created: u64,
@@ -230,7 +230,7 @@ pub(super) struct CompletionResponse {
 
 /// Mirrors the Python vLLM `CompletionResponseChoice` class.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct CompletionChoice {
+pub(crate) struct CompletionChoice {
     pub index: u32,
     pub text: String,
     pub logprobs: Option<LogProbs>,
@@ -244,7 +244,7 @@ pub(super) struct CompletionChoice {
 /// Mirrors the Python vLLM `CompletionStreamResponse` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct CompletionStreamResponse {
+pub(crate) struct CompletionStreamResponse {
     #[serde(flatten)]
     pub envelope: Arc<StreamResponseEnvelope>,
     pub choices: Vec<CompletionStreamChoice>,
@@ -265,7 +265,7 @@ impl CompletionStreamResponse {
 /// Mirrors the Python vLLM `CompletionResponseStreamChoice` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, Serialize)]
-pub(super) struct CompletionStreamChoice {
+pub(crate) struct CompletionStreamChoice {
     pub index: u32,
     pub text: String,
     pub logprobs: Option<LogProbs>,

--- a/rust/src/server/src/routes/openai/mod.rs
+++ b/rust/src/server/src/routes/openai/mod.rs
@@ -9,5 +9,10 @@ pub(crate) mod utils;
 pub use chat_completions::chat_completions;
 pub(crate) use chat_completions::{ChatCompletionRequest, lower_chat_request};
 pub use completions::completions;
-pub(crate) use completions::{CompletionRequest, lower_completion_request};
+// TODO: phase 3 of the derender endpoints re-exports CompletionStreamChoice
+// and CompletionStreamResponse here as well.
+pub(crate) use completions::{
+    CompletionChoice, CompletionRequest, CompletionResponse, completion_echo_text,
+    lower_completion_request,
+};
 pub use models::list_models;

--- a/rust/src/server/src/routes/openai/utils/types.rs
+++ b/rust/src/server/src/routes/openai/utils/types.rs
@@ -434,7 +434,10 @@ pub enum MessageContent {
 ///
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
-#[derive(Debug, Clone, Serialize)]
+///
+/// `Deserialize` is derived for the derender endpoints, which accept `Usage`
+/// embedded in `GenerateResponse` / `GenerateStreamResponse` request bodies.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub total_tokens: usize,
@@ -469,7 +472,7 @@ impl Usage {
 }
 
 /// Mirrors the Python vLLM `PromptTokenUsageInfo` class.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PromptTokenUsageInfo {
     pub cached_tokens: usize,
 }
@@ -534,13 +537,16 @@ pub struct PromptLogprob {
 pub type PromptLogprobs = Vec<Option<HashMap<u32, PromptLogprob>>>;
 
 /// Mirrors the Python vLLM `ChatCompletionLogProbs` class.
-#[derive(Debug, Clone, Serialize)]
+///
+/// `Deserialize` is derived for the derender endpoints, which accept
+/// chat-shaped logprobs embedded in `GenerateResponse` request bodies.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatLogProbs {
     pub content: Option<Vec<ChatLogProbsContent>>,
 }
 
 /// Mirrors the Python vLLM `ChatCompletionLogProbsContent` class.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatLogProbsContent {
     pub token: String,
     pub logprob: f32,
@@ -549,7 +555,7 @@ pub struct ChatLogProbsContent {
 }
 
 /// Mirrors the Python vLLM `ChatCompletionLogProb` class.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TopLogProb {
     pub token: String,
     pub logprob: f32,

--- a/rust/src/server/src/routes/render.rs
+++ b/rust/src/server/src/routes/render.rs
@@ -33,6 +33,14 @@ pub(crate) fn build_router(state: Arc<RenderState>) -> Router {
         .route("/v1/models", get(list_models))
         .route("/v1/chat/completions/render", post(render_chat))
         .route("/v1/completions/render", post(render_completion))
+        .route(
+            "/v1/chat/completions/derender",
+            post(crate::routes::derender::derender_chat_render),
+        )
+        .route(
+            "/v1/completions/derender",
+            post(crate::routes::derender::derender_completion_render),
+        )
         .with_state(state)
         .layer(DefaultBodyLimit::max(DEFAULT_REQUEST_BODY_LIMIT_BYTES))
 }

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -434,6 +434,7 @@ async fn recv_engine_message(dealer: &mut DealerSocket) -> Vec<Bytes> {
 struct FakeChatBackend {
     model_id: String,
     multimodal_model_info: Option<vllm_chat::multimodal::MultimodalModelInfo>,
+    tokenizer: TestTokenizer,
 }
 
 /// Synthetic BOS id used when `add_special_tokens` is true in tests.
@@ -458,13 +459,14 @@ impl FakeChatBackend {
         Self {
             model_id: "test-model".to_string(),
             multimodal_model_info: None,
+            tokenizer: fake_chat_tokenizer(),
         }
     }
 
     fn with_model_id(model_id: impl Into<String>) -> Self {
         Self {
             model_id: model_id.into(),
-            multimodal_model_info: None,
+            ..Self::new()
         }
     }
 
@@ -472,9 +474,14 @@ impl FakeChatBackend {
         multimodal_model_info: vllm_chat::multimodal::MultimodalModelInfo,
     ) -> Self {
         Self {
-            model_id: "test-model".to_string(),
             multimodal_model_info: Some(multimodal_model_info),
+            ..Self::new()
         }
+    }
+
+    fn with_tokenizer(mut self, tokenizer: TestTokenizer) -> Self {
+        self.tokenizer = tokenizer;
+        self
     }
 }
 
@@ -488,7 +495,7 @@ impl fmt::Debug for FakeChatBackend {
 
 impl TextBackend for FakeChatBackend {
     fn tokenizer(&self) -> DynTokenizer {
-        Arc::new(fake_chat_tokenizer())
+        Arc::new(self.tokenizer.clone())
     }
 
     fn model_id(&self) -> &str {
@@ -691,6 +698,30 @@ fn test_render_app_with_parser_selections(
     reasoning_parser: ParserSelection,
 ) -> axum::Router {
     let backend = Arc::new(FakeChatBackend::new());
+    build_render_router(Arc::new(RenderState {
+        model: "backend-model".to_string(),
+        served_model_names: vec!["render-model".to_string()],
+        text: TextRequestProcessor::new(backend.clone(), 128),
+        chat: ChatRequestProcessor::render_only(backend)
+            .with_parser_selections(tool_call_parser, reasoning_parser),
+    }))
+}
+
+/// Derender tests need byte-id token pieces that round-trip through
+/// `id_to_token`/`token_to_id`, so the fake tokenizer uses the byte-level
+/// piece mapping here (unlike the render fixtures above).
+fn test_derender_app() -> axum::Router {
+    test_derender_app_with_parser_selections(ParserSelection::Auto, ParserSelection::Auto)
+}
+
+fn test_derender_app_with_parser_selections(
+    tool_call_parser: ParserSelection,
+    reasoning_parser: ParserSelection,
+) -> axum::Router {
+    let backend = Arc::new(
+        FakeChatBackend::new()
+            .with_tokenizer(fake_chat_tokenizer().with_byte_level_piece_mapping()),
+    );
     build_render_router(Arc::new(RenderState {
         model: "backend-model".to_string(),
         served_model_names: vec!["render-model".to_string()],
@@ -6757,4 +6788,763 @@ async fn profile_routes_are_hidden_when_profiling_is_disabled() {
     }
 
     engine_task.abort_and_join().await;
+}
+
+// ---------------------------------------------------------------------------
+// /v1/{chat/completions,completions}/derender tests
+//
+// Port of tests/entrypoints/scale_out/derender/test_derender.py against the
+// render-only router fixture. Reasoning/tool parsing (phase 2) and streaming
+// (test_derender_stream.py, phase 3) tests land in later phases.
+// ---------------------------------------------------------------------------
+
+/// Build a chat `GenerateResponse` body mirroring `_make_generate_response`.
+fn derender_generate_response(token_ids: serde_json::Value) -> serde_json::Value {
+    json!({
+        "request_id": "chatcmpl-derender-test",
+        "choices": [{
+            "index": 0,
+            "token_ids": token_ids,
+            "finish_reason": "stop",
+            "logprobs": null,
+        }],
+        "prompt_logprobs": null,
+        "kv_transfer_params": null,
+    })
+}
+
+/// Byte-level token ids for ordinary text through the fake chat tokenizer.
+fn derender_token_ids(text: &str) -> Vec<u32> {
+    use vllm_text::tokenizer::Tokenizer as _;
+    fake_chat_tokenizer()
+        .with_byte_level_piece_mapping()
+        .encode(text, false)
+        .expect("encode text")
+}
+
+async fn derender_chat(
+    app: &mut axum::Router,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    post_json(app, "/v1/chat/completions/derender", body).await
+}
+
+async fn derender_completion(
+    app: &mut axum::Router,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    post_json(app, "/v1/completions/derender", body).await
+}
+
+#[tokio::test]
+async fn derender_chat_roundtrip() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("hello");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "stream": false,
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["object"], "chat.completion");
+    // The response id echoes the generate response request id verbatim.
+    assert_eq!(json["id"], "chatcmpl-derender-test");
+    assert_eq!(json["choices"][0]["index"], 0);
+    assert_eq!(json["choices"][0]["message"]["role"], "assistant");
+    assert_eq!(json["choices"][0]["message"]["content"], "hello");
+    // finish_reason passes through verbatim from the wire.
+    assert_eq!(json["choices"][0]["finish_reason"], "stop");
+    assert_eq!(json["prompt_logprobs"], serde_json::Value::Null);
+    assert_eq!(json["kv_transfer_params"], serde_json::Value::Null);
+    assert_eq!(json["ec_transfer_params"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_chat_usage() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+            "prompt_tokens": 10,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["usage"]["prompt_tokens"], 10);
+    assert_eq!(json["usage"]["completion_tokens"], 3);
+    assert_eq!(json["usage"]["total_tokens"], 13);
+}
+
+#[tokio::test]
+async fn derender_chat_usage_default() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["usage"]["prompt_tokens"], 0);
+}
+
+#[tokio::test]
+async fn derender_chat_prompt_logprobs_passthrough() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["prompt_logprobs"] = json!([null, null]);
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["prompt_logprobs"], json!([null, null]));
+}
+
+#[tokio::test]
+async fn derender_chat_kv_transfer_params_passthrough() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["kv_transfer_params"] = json!({"key": "value"});
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["kv_transfer_params"], json!({"key": "value"}));
+}
+
+#[tokio::test]
+async fn derender_chat_logprobs_placeholder_resolution() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("hi");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [{
+            "token": "token_id:104",
+            "logprob": -1.0,
+            "bytes": null,
+            "top_logprobs": [{"token": "token_id:105", "logprob": -2.0, "bytes": null}],
+        }],
+    });
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let content = &json["choices"][0]["logprobs"]["content"];
+    // token_id:N placeholders resolve to the decoded token and UTF-8 bytes.
+    assert_eq!(content[0]["token"], "h");
+    assert_eq!(content[0]["bytes"], json!([104]));
+    assert_eq!(content[0]["top_logprobs"][0]["token"], "i");
+    assert_eq!(content[0]["top_logprobs"][0]["bytes"], json!([105]));
+}
+
+#[tokio::test]
+async fn derender_chat_empty_token_ids_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!([])),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("empty or null token_ids"));
+}
+
+#[tokio::test]
+async fn derender_chat_null_token_ids_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, _) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(serde_json::Value::Null),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_chat_unknown_model_rejected() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "does-not-exist",
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND, "{json}");
+    assert_eq!(json["error"]["code"], "model_not_found");
+}
+
+#[tokio::test]
+async fn derender_chat_model_omitted_resolves_served_name() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "generate_response": derender_generate_response(json!(token_ids)) }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["model"], "render-model");
+}
+
+#[tokio::test]
+async fn derender_chat_oversized_token_ids_rejected() {
+    let mut app = test_derender_app();
+    // The fixture serves max_model_len=128.
+    let oversized_ids = vec![42_u32; 129];
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(oversized_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("max_model_len"));
+}
+
+#[tokio::test]
+async fn derender_chat_too_many_choices_rejected() {
+    let mut app = test_derender_app();
+    let choices: Vec<serde_json::Value> = (0..16_385)
+        .map(|index| json!({"index": index, "token_ids": [42], "finish_reason": "stop"}))
+        .collect();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": {
+                "request_id": "test-choices-bound",
+                "choices": choices,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("choices count"));
+}
+
+#[tokio::test]
+async fn derender_chat_negative_token_ids_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, _) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!([-1, 42, 100])),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_chat_oversized_logprobs_rejected() {
+    let mut app = test_derender_app();
+    let content: Vec<serde_json::Value> = (0..129)
+        .map(|_| json!({"token": "x", "logprob": -1.0, "bytes": null, "top_logprobs": []}))
+        .collect();
+    let mut response = derender_generate_response(json!([42]));
+    response["choices"][0]["logprobs"] = json!({ "content": content });
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("logprobs.content length"));
+}
+
+#[tokio::test]
+async fn derender_chat_oversized_top_logprobs_rejected() {
+    let mut app = test_derender_app();
+    // The fixture defaults to max_logprobs=20.
+    let top_logprobs: Vec<serde_json::Value> = (0..25)
+        .map(|i| json!({"token": format!("t{i}"), "logprob": -(i as f32), "bytes": null}))
+        .collect();
+    let mut response = derender_generate_response(json!([42]));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [{
+            "token": "x",
+            "logprob": -1.0,
+            "bytes": null,
+            "top_logprobs": top_logprobs,
+        }],
+    });
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    let message = json["error"]["message"].as_str().unwrap();
+    assert!(message.contains("top_logprobs count"), "{message}");
+    assert!(message.contains("max_logprobs"), "{message}");
+}
+
+#[tokio::test]
+async fn derender_chat_no_chat_request_falls_back_to_plain_detok() {
+    // Parser configured, but without chat_request the endpoint must plain
+    // detokenize; the fake think markers are regular tokens, so they survive
+    // skip_special_tokens=true decoding.
+    let mut app = test_derender_app_with_parser_selections(
+        ParserSelection::Auto,
+        ParserSelection::Explicit("deepseek_r1".to_string()),
+    );
+    let token_ids = derender_token_ids("<think>raw</think>text");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let message = &json["choices"][0]["message"];
+    assert_eq!(message["content"], "<think>raw</think>text");
+    assert_eq!(message["reasoning"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_completion_roundtrip() {
+    let mut app = test_derender_app();
+    let ids1 = derender_token_ids("ab");
+    let ids2 = derender_token_ids("cd");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [
+                derender_generate_response(json!(ids1)),
+                {
+                    "request_id": "cmpl-second",
+                    "choices": [{
+                        "index": 0,
+                        "token_ids": ids2,
+                        "finish_reason": "length",
+                    }],
+                },
+            ],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["object"], "text_completion");
+    // The response id comes from the first generate response.
+    assert_eq!(json["id"], "chatcmpl-derender-test");
+    // Choices are flattened across responses and re-indexed from 0.
+    assert_eq!(json["choices"][0]["index"], 0);
+    assert_eq!(json["choices"][0]["text"], "ab");
+    assert_eq!(json["choices"][0]["finish_reason"], "stop");
+    assert_eq!(json["choices"][1]["index"], 1);
+    assert_eq!(json["choices"][1]["text"], "cd");
+    assert_eq!(json["choices"][1]["finish_reason"], "length");
+}
+
+#[tokio::test]
+async fn derender_completion_usage_aggregation() {
+    let mut app = test_derender_app();
+    let ids1 = derender_token_ids("abc");
+    let ids2 = derender_token_ids("defg");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [
+                derender_generate_response(json!(ids1)),
+                derender_generate_response(json!(ids2)),
+            ],
+            "prompt_tokens": [5, 10],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["usage"]["prompt_tokens"], 15);
+    assert_eq!(json["usage"]["completion_tokens"], 7);
+    assert_eq!(json["usage"]["total_tokens"], 22);
+}
+
+#[tokio::test]
+async fn derender_completion_prompt_tokens_length_mismatch_rejected() {
+    let mut app = test_derender_app();
+    let ids = derender_token_ids("abc");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [derender_generate_response(json!(ids))],
+            "prompt_tokens": [5, 10],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("prompt_tokens length (2) must equal generate_responses length (1)")
+    );
+}
+
+#[tokio::test]
+async fn derender_completion_empty_generate_responses_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("generate_responses must not be empty")
+    );
+}
+
+#[tokio::test]
+async fn derender_completion_too_many_generate_responses_rejected() {
+    let mut app = test_derender_app();
+    let responses: Vec<serde_json::Value> = (0..16_385)
+        .map(|i| {
+            json!({
+                "request_id": format!("gen-{i}"),
+                "choices": [{"index": 0, "token_ids": [42], "finish_reason": "stop"}],
+            })
+        })
+        .collect();
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": responses }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("generate_responses count"));
+}
+
+#[tokio::test]
+async fn derender_completion_logprobs() {
+    let mut app = test_derender_app();
+    let mut response = derender_generate_response(json!(derender_token_ids("h")));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [{
+            "token": "token_id:104",
+            "logprob": -1.0,
+            "bytes": null,
+            "top_logprobs": [{"token": "token_id:105", "logprob": -2.0, "bytes": null}],
+        }],
+    });
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [response] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let logprobs = &json["choices"][0]["logprobs"];
+    // Chat-shaped logprobs flatten into the completions parallel lists.
+    assert_eq!(logprobs["tokens"], json!(["h"]));
+    assert_eq!(logprobs["token_logprobs"], json!([-1.0]));
+    assert_eq!(logprobs["top_logprobs"], json!([{"i": -2.0}]));
+    assert_eq!(logprobs["text_offset"], json!([0]));
+}
+
+#[tokio::test]
+async fn derender_completion_kv_transfer_params_passthrough() {
+    let mut app = test_derender_app();
+    let mut response = derender_generate_response(json!(derender_token_ids("abc")));
+    response["kv_transfer_params"] = json!({"node": "abc"});
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [response] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["kv_transfer_params"], json!({"node": "abc"}));
+}
+
+#[tokio::test]
+async fn derender_completion_kv_transfer_params_disagreement_nulled() {
+    let mut app = test_derender_app();
+    let mut first = derender_generate_response(json!(derender_token_ids("ab")));
+    first["kv_transfer_params"] = json!({"node": "a"});
+    let mut second = derender_generate_response(json!(derender_token_ids("cd")));
+    second["kv_transfer_params"] = json!({"node": "b"});
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [first, second] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["kv_transfer_params"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_completion_oversized_token_ids_rejected() {
+    let mut app = test_derender_app();
+    let oversized_ids = vec![42_u32; 129];
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [{
+                "request_id": "gen-0",
+                "choices": [{
+                    "index": 0,
+                    "token_ids": oversized_ids,
+                    "finish_reason": "stop",
+                }],
+            }],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("max_model_len"));
+}
+
+#[tokio::test]
+async fn derender_stream_invalid_body_rejected() {
+    let mut app = test_derender_app();
+
+    // stream=true is not supported until phase 3: the non-streaming request
+    // body's `stream` deserializer rejects it outright.
+    let (status, _) =
+        derender_completion(&mut app, json!({ "stream": true, "model": "render-model" })).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // A non-object JSON body.
+    let (status, _) = derender_completion(&mut app, json!([1, 2, 3])).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_chat_usage_overflow_rejected() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+            "prompt_tokens": u64::MAX,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("overflows the token counter"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn derender_completion_echo_prepends_prompt() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("there");
+
+    for prompt in [json!("hi "), json!(derender_token_ids("hi "))] {
+        let (status, json) = derender_completion(
+            &mut app,
+            json!({
+                "model": "render-model",
+                "generate_responses": [derender_generate_response(json!(token_ids))],
+                "completion_request": {
+                    "model": "render-model",
+                    "prompt": prompt,
+                    "echo": true,
+                    "max_tokens": 5,
+                },
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{json}");
+        assert_eq!(json["choices"][0]["text"], "hi there");
+    }
+}
+
+#[tokio::test]
+async fn derender_completion_prompt_only_echo_hides_internal_token() {
+    let mut app = test_derender_app();
+    // echo + max_tokens=0 generates one internal token to drive the engine to
+    // a finished event; the derendered choice must expose just the prompt.
+    let token_ids = derender_token_ids("x");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [derender_generate_response(json!(token_ids))],
+            "completion_request": {
+                "model": "render-model",
+                "prompt": "hi ",
+                "echo": true,
+                "max_tokens": 0,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["choices"][0]["text"], "hi ");
+}
+
+#[tokio::test]
+async fn derender_completion_prompt_only_echo_returns_prompt_logprobs() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("x");
+    let mut response = derender_generate_response(json!(token_ids));
+    // add_special_tokens defaults to true, so the prompt tokenizes to
+    // [BOS, 104, 105]; the first position carries no logprobs, matching the
+    // engine's prompt-logprobs convention.
+    response["prompt_logprobs"] = json!([
+        null,
+        {"104": {"logprob": -0.5, "rank": 1, "decoded_token": "token_id:104"}},
+        {"105": {"logprob": -0.25, "rank": 1, "decoded_token": "token_id:105"}},
+    ]);
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [response],
+            "completion_request": {
+                "model": "render-model",
+                "prompt": "hi",
+                "echo": true,
+                "max_tokens": 0,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let logprobs = &json["choices"][0]["logprobs"];
+    assert_eq!(logprobs["tokens"], json!(["<bos>", "h", "i"]), "{json}");
+    assert_eq!(
+        logprobs["token_logprobs"],
+        json!([null, -0.5, -0.25]),
+        "{json}"
+    );
+    // "<bos>" is 5 characters wide.
+    assert_eq!(logprobs["text_offset"], json!([0, 5, 6]), "{json}");
+}
+
+#[tokio::test]
+async fn derender_completion_echo_shifts_logprob_offsets() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("hi");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [
+            {"token": "token_id:104", "logprob": -1.0, "top_logprobs": []},
+            {"token": "token_id:105", "logprob": -2.0, "top_logprobs": []},
+        ],
+    });
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [response],
+            "completion_request": {
+                "model": "render-model",
+                "prompt": "say ",
+                "echo": true,
+                "max_tokens": 5,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["choices"][0]["text"], "say hi");
+    let logprobs = &json["choices"][0]["logprobs"];
+    // Without prompt logprobs in the response, the generated-token offsets are
+    // shifted past the echoed prompt ("say " is 4 characters).
+    assert_eq!(logprobs["text_offset"], json!([4, 5]), "{json}");
+    assert_eq!(logprobs["tokens"], json!(["h", "i"]), "{json}");
 }

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -82,6 +82,16 @@ impl TextRequestProcessor {
         self.max_model_len
     }
 
+    /// Return the maximum number of top log probabilities accepted.
+    pub fn max_logprobs(&self) -> i32 {
+        self.max_logprobs
+    }
+
+    /// Return the backend model id.
+    pub fn model_id(&self) -> &str {
+        self.backend.model_id()
+    }
+
     fn prepare_prompt_tokens(
         &self,
         prompt: Prompt,

--- a/rust/src/tokenizer/src/test_utils.rs
+++ b/rust/src/tokenizer/src/test_utils.rs
@@ -7,6 +7,45 @@ use crate::{Result, Tokenizer, TokenizerError};
 
 const FIRST_CONFIGURED_TOKEN_ID: u32 = 256;
 
+/// Whether the GPT-2 `bytes_to_unicode` table maps a byte to itself.
+fn is_nice_byte(byte: u8) -> bool {
+    matches!(byte, 0x21..=0x7E | 0xA1..=0xAC) || byte >= 0xAE
+}
+
+/// Map one byte to its GPT-2 `bytes_to_unicode` piece character.
+///
+/// "Nice" bytes map to themselves; the 68 others map to U+0100 + n where n is
+/// the byte's index among the non-nice bytes.
+fn byte_to_unicode_char(byte: u8) -> char {
+    if is_nice_byte(byte) {
+        return char::from(byte);
+    }
+    let n = match byte {
+        0x00..=0x20 => u32::from(byte),
+        0x7F..=0xA0 => 33 + u32::from(byte - 0x7F),
+        // 0xAD is the only remaining non-nice byte.
+        _ => 33 + 34,
+    };
+    char::from_u32(256 + n).expect("byte_to_unicode mapping stays below U+0144")
+}
+
+/// Inverse of [`byte_to_unicode_char`]; `None` for characters outside the
+/// GPT-2 byte-piece range.
+fn unicode_char_to_byte(ch: char) -> Option<u8> {
+    let code = ch as u32;
+    if code <= 0xFF {
+        let byte = u8::try_from(code).ok()?;
+        return is_nice_byte(byte).then_some(byte);
+    }
+    let n = code.checked_sub(256)?;
+    match n {
+        0..=32 => u8::try_from(n).ok(),
+        33..=66 => u8::try_from(n - 33 + 0x7F).ok(),
+        67 => Some(0xAD),
+        _ => None,
+    }
+}
+
 /// Whether a configured test token should be treated as special.
 ///
 /// Special tokens are skipped by [`Tokenizer::decode`] when
@@ -65,6 +104,12 @@ struct TestToken {
 /// Prefer this helper over ad-hoc fake tokenizers for tests that rely on
 /// tokenizer semantics. Keep dedicated tiny fakes for error injection or for
 /// tests that deliberately need a degenerate tokenizer.
+///
+/// By default `id_to_token` represents byte ids as their lossy UTF-8 decoding,
+/// which does not round-trip through `token_to_id` for bytes >= 0x80. Tests
+/// that exercise piece-based detokenization (e.g. the derender endpoints)
+/// should opt into [`TestTokenizer::with_byte_level_piece_mapping`], which
+/// uses the reversible GPT-2 `bytes_to_unicode` mapping instead.
 #[derive(Debug, Clone)]
 pub struct TestTokenizer {
     token_to_id: BTreeMap<String, u32>,
@@ -73,6 +118,7 @@ pub struct TestTokenizer {
     unknown_decode: UnknownDecode,
     vocab_size: Option<usize>,
     bos_token_id: Option<u32>,
+    byte_level_pieces: bool,
 }
 
 impl Default for TestTokenizer {
@@ -91,7 +137,20 @@ impl TestTokenizer {
             unknown_decode: UnknownDecode::Error,
             vocab_size: None,
             bos_token_id: None,
+            byte_level_pieces: false,
         }
+    }
+
+    /// Use the reversible GPT-2 `bytes_to_unicode` mapping for byte-id token
+    /// pieces, so `id_to_token` output round-trips through `token_to_id`.
+    ///
+    /// `decode` is unaffected (bytes still decode as raw UTF-8). Production
+    /// byte-level BPE tokenizers expose the same property, and detokenization
+    /// paths that rebuild text from token pieces (e.g. the streaming derender
+    /// endpoints) rely on it.
+    pub fn with_byte_level_piece_mapping(mut self) -> Self {
+        self.byte_level_pieces = true;
+        self
     }
 
     /// Add a configured token and return the updated tokenizer.
@@ -173,8 +232,14 @@ impl TestTokenizer {
         self.added_vocab.sort_unstable_by_key(|(_, id)| *id);
     }
 
-    fn byte_to_token(id: u32) -> Option<String> {
-        u8::try_from(id).ok().map(|byte| String::from_utf8_lossy(&[byte]).into_owned())
+    fn byte_to_token(&self, id: u32) -> Option<String> {
+        u8::try_from(id).ok().map(|byte| {
+            if self.byte_level_pieces {
+                byte_to_unicode_char(byte).to_string()
+            } else {
+                String::from_utf8_lossy(&[byte]).into_owned()
+            }
+        })
     }
 
     fn flush_bytes(bytes: &mut Vec<u8>, output: &mut String) {
@@ -257,7 +322,16 @@ impl Tokenizer for TestTokenizer {
     fn token_to_id(&self, token: &str) -> Option<u32> {
         self.token_to_id.get(token).copied().or_else(|| {
             let bytes = token.as_bytes();
-            (bytes.len() == 1).then(|| u32::from(bytes[0]))
+            if bytes.len() == 1 {
+                return Some(u32::from(bytes[0]));
+            }
+            if self.byte_level_pieces {
+                let mut chars = token.chars();
+                if let (Some(ch), None) = (chars.next(), chars.next()) {
+                    return unicode_char_to_byte(ch).map(u32::from);
+                }
+            }
+            None
         })
     }
 
@@ -265,7 +339,7 @@ impl Tokenizer for TestTokenizer {
         self.id_to_token
             .get(&id)
             .map(|token| token.text.clone())
-            .or_else(|| Self::byte_to_token(id))
+            .or_else(|| self.byte_to_token(id))
     }
 
     fn added_vocab(&self) -> &[(String, u32)] {
@@ -481,5 +555,22 @@ mod tests {
 
         assert_eq!(tokenizer.vocab_size(), 20_000);
         assert_eq!(tokenizer.id_to_token(10_000).as_deref(), Some("<high>"));
+    }
+
+    #[test]
+    fn byte_level_piece_mapping_roundtrips_all_bytes() {
+        let tokenizer = TestTokenizer::new().with_byte_level_piece_mapping();
+
+        for id in 0..=255_u32 {
+            let piece = tokenizer.id_to_token(id).expect("byte id has a piece");
+            assert_eq!(tokenizer.token_to_id(&piece), Some(id), "piece {piece:?}");
+        }
+        // Decode is unaffected: pieces still decode as raw UTF-8 bytes.
+        let text = "Hello ✅ 日本語";
+        let ids = tokenizer.encode(text, false).unwrap();
+        assert_eq!(tokenizer.decode(&ids, false).unwrap(), text);
+        // GPT-2 style: the space byte maps to U+0120 ("Ġ").
+        assert_eq!(tokenizer.id_to_token(0x20).as_deref(), Some("Ġ"));
+        assert_eq!(tokenizer.token_to_id("Ġ"), Some(0x20));
     }
 }


### PR DESCRIPTION
## Purpose

**Phase 1/3** — split per @sagearc's review, mirroring the Python derender phasing in #42729 (#43606 detok → #45919 parsing → #48617 streaming). Follow-ups: #53418 (parsing), #53419 (streaming + GPU e2e).

Add `POST /v1/chat/completions/derender` and `POST /v1/completions/derender` to the Rust frontend, wire-compatible with the Python implementation in `vllm/entrypoints/scale_out/derender/` + `vllm/renderers/online_derenderer.py`. The endpoints turn a `GenerateResponse` from `/inference/v1/generate` back into an OpenAI `ChatCompletionResponse` / `CompletionResponse` without a GPU, completing the render/derender pair used by disaggregated serving. The Rust frontend already has the render side (`/v1/*/render`); this adds the inverse.

Phase 1 ships the shared detokenization and state foundations plus the plain non-streaming endpoints — the equivalent of Python #43606:

- `derender/detok.rs`: the incremental detokenization window (`prev_tokens`/`prefix_offset`/`read_offset`, capped at 1024) porting `detokenize_incrementally`; shared with streaming in phase 3.
- `derender/types.rs`: non-streaming wire types plus `DerenderStreamState` (with validation) as the parsing-ready state; `stream: true` bodies are rejected with 400 until phase 3.
- `derender/logprobs.rs`: `token_id:N` logprob placeholders are resolved back to decoded tokens (with the U+FFFD byte-fallback repair), matching Python's `_resolve_logprobs`.
- Non-streaming chat derender always plain-detokenizes in this phase (reasoning/tool parsing lands in phase 2, exactly like Python #43606 → #45919); completion derender flattens `generate_responses` × choices with re-indexing from 0, converts chat logprobs to the flat completion shape, aggregates usage, and passes `kv_transfer_params` through (dropped with a warning when responses disagree).
- Caller payloads are bounds-checked (`max_model_len`, `max_logprobs`, sequence counts) before any tokenizer work, mirroring `_validate_derender_bounds`.
- Both endpoints are registered on the render-only server and the engine-backed server, as Python registers them on both the full API server and the render-only launcher.

Related: #42729 (derender endpoints RFC) and #47161 (streaming derender RFC) — this stack ports both the non-streaming and streaming derender contract to the Rust frontend; the broader RFC scope stays open.

**Duplicate-work check**: searched open PRs via `gh pr list --search` for `derender`, `derender path:rust`, `rust`, `frontend`, and related keywords. No open PR implements derender in `rust/`. The open derender PRs (#50550 stream reasoning/tool calls, #47931 tool_calls finish reason) modify only the Python implementation; they do not overlap with this Rust port, and this stack deliberately matches current Python semantics so those Python changes can be ported as follow-ups.

**AI assistance**: this PR was implemented with AI assistance (Kimi Code CLI). I have reviewed the full diff and run the tests below myself.

## Test Plan

31 route tests in `rust/src/server/src/routes/tests.rs` port the non-parsing, non-streaming behaviors asserted by `tests/entrypoints/scale_out/derender/test_derender.py`: text roundtrips, request_id echo, usage forwarding (supplied/omitted `prompt_tokens`), `prompt_logprobs`/`kv_transfer_params` passthrough, logprob placeholder resolution with `bytes`, all 400/404 error and bounds cases, and plain-detok fallback without `chat_request`.

```
cargo nextest run -p vllm-server -p vllm-chat -p vllm-text -p vllm-tokenizer
cargo clippy -p vllm-server -p vllm-chat -p vllm-text -p vllm-tokenizer --all-targets
cargo fmt --all --check
pre-commit run --files <changed files>
```

## Test Result

- `cargo nextest run` (4 touched crates): **825 passed, 1 skipped** — includes all 31 phase-1 derender tests.
- `cargo clippy --all-targets`: clean.
- `cargo fmt --check`: clean.
- `pre-commit run` on the changed files: all applicable hooks passed (SPDX headers, Rust fmt, etc.).

Model evals: N/A — this adds new endpoints to the Rust frontend without changing any existing serving behavior or model outputs; correctness is covered by the route-level tests above and wire compatibility with the existing Python derender contract. End-to-end GPU validation of the full stack (incl. Python↔Rust derender parity on real generations) lands with phase 3 (#53419).

### Known deviations from Python (intentional)

- Embedded `chat_request`/`completion_request` are validated on lowering (e.g. unknown `model` → 404); Python passes them to the parser unchecked.
- `null` `token_ids` → 400 at JSON parse; completion-side empty `token_ids` is a consistent 400 (Python leaks a 500 there).
- `MAX_N_SEQUENCES` is a constant (16384) with a TODO to plumb `VLLM_MAX_N_SEQUENCES` through server config.
- `convert_tokens_to_string` is approximated via piece→id roundtrip + one-shot decode (exact for byte-level BPE tokenizers).
