### PR TITLE
[Bugfix] Restore WeightsMapper plugin compatibility

### DIFF
--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -217,3 +217,16 @@ def test_get_rename_mapper_keeps_only_renames():
     for name in ("drop_regex.w", "drop_substr.w", "drop_prefix.w", "w.drop_suffix"):
         assert mapper._map_name(name) is None
         assert renames._map_name(name) == name
+
+
+@pytest.mark.cpu_test
+def test_get_unstacked_mapper_compatibility():
+    mapper = WeightsMapper(
+        orig_to_new_substr={"drop_substr": None, "keep_substr": "kept"},
+        orig_to_new_stacked={".q_proj": (".qkv_proj", "q")},
+    )
+
+    unstacked = mapper.get_unstacked_mapper()
+
+    assert unstacked.orig_to_new_substr == mapper.orig_to_new_substr
+    assert unstacked.orig_to_new_stacked == {}

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -181,6 +181,13 @@ class WeightsMapper:
             orig_to_new_suffix=remove_none(self.orig_to_new_suffix),
         )
 
+    def get_unstacked_mapper(self) -> "WeightsMapper":
+        """Return a mapper without stacked parameter mappings.
+
+        Kept for compatibility with external weight-loader plugins.
+        """
+        return replace(self, orig_to_new_stacked={})
+
 
 def _get_tied_embedding_params(module: nn.Module) -> dict[str, str]:
     """Map each tied word embedding qualname to the first name it aliases."""


### PR DESCRIPTION
## Purpose

Restore the public `WeightsMapper.get_unstacked_mapper()` method removed by
#53106. The released `vllm-bnb-plugin==0.0.2` and its current `main` branch use
this method, so nightly main builds now fail during model startup with
`AttributeError` in 9 of 10 selected BitsAndBytes plugin tests.

This restores the previous behavior exactly: retain ordinary mappings,
including drop mappings, while removing only stacked parameter mappings.
`get_rename_mapper()` keeps its newer semantics for in-tree callers.

Duplicate check: no open issue or PR was found for `get_unstacked_mapper` or
BitsAndBytes plugin compatibility. This PR is a narrow compatibility fix rather
than an alternative to another open change.

AI assistance was used to investigate the CI failure, prepare the patch, and
run the tests. Human review of every changed line is required before moving the
PR out of draft.

## Test Plan

- Extend `tests/models/test_utils.py` to assert the compatibility method keeps
  non-stacked mappings and removes stacked mappings.
- Run the focused model-utils unit suite.
- Run all pre-commit hooks applicable to the changed files.
- Run the exact H200 BitsAndBytes Plugin Buildkite job at this PR head.
- Run the exact L4 BitsAndBytes Plugin Buildkite job after main reproduced the same compatibility failure on L4.

No model evaluation is needed because this restores an existing mapper API and
does not change model output or serving behavior.

## Test Result

```text
PYTHONPATH=. /home/ubuntu/vllm-fix-gemma-tied-head/.venv/bin/python -m pytest tests/models/test_utils.py -q
8 passed, 1 skipped

uvx pre-commit run --files vllm/model_executor/models/utils.py tests/models/test_utils.py
All applicable hooks passed.
```

Exact isolated-branch H200 BitsAndBytes Plugin validation: Buildkite #84976 passed at exact head 17c7c5114378dcf29d60b96056961391b934006e on h200-ci-5 with 10 passed, 1 skipped, 4 deselected, and 0 failed in 7m08s.

Main #84966 later reproduced the identical removed-API failure on the L4 `bitsandbytes-plugin-2-gpus` job: 4 failed / 11 deselected / 0 passing before engine startup completed. Exact isolated-branch L4 Buildkite #84993 then passed at the same PR head and exact PR metadata on `bk-gpu-4-queue-ci-i-0ba3c6228f88de036-1`. It exercised released `vllm-bnb-plugin==0.0.2` with `bitsandbytes==0.50.1` and finished 4 passed, 11 deselected, 0 failed in 207.78s (3m27s test time; 4m59s job time).

Both affected hardware gates are therefore green at the exact fix head. This is pre-merge validation only; resolution still requires merge plus a post-merge main/daily exact pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] Documentation update not needed for a compatibility restoration.
</details>