### PR TITLE
[Bugfix] Disable Qwen3-VL dummy prompt truncation

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl.py
@@ -6,6 +6,7 @@ Covers the fix for num_frames-based timestamp calculation
 (issue vllm-project/vllm#35909).
 """
 
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
@@ -184,3 +185,39 @@ def test_processor_multi_video_list_kwargs(
     assert len(video_phs) == 2, (
         f"Expected exactly 2 video placeholders, got {len(video_phs)}"
     )
+
+
+@pytest.mark.parametrize("model_id", [MODEL_ID])
+def test_profiling_dummy_image_is_not_truncated(model_id, monkeypatch):
+    """The profiling-time dummy prompt expands the image placeholder to more
+    tokens than the HF tokenizer's ``model_max_length``. HF-side truncation of
+    that expansion makes ``Qwen3VLProcessor`` fail its image-token consistency
+    check, aborting engine startup during memory profiling. Multi-modal
+    processor calls must therefore explicitly disable HF truncation."""
+    ctx = build_model_context(
+        model_id,
+        model_config_kwargs={"max_model_len": 4096},
+        limit_mm_per_prompt={"image": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    original_call = processor.info.ctx.call_hf_processor
+    hf_calls: list[tuple[Mapping[str, Any], dict[str, Any]]] = []
+
+    def spying_call(self, hf_processor, data, kwargs=None, **kw):
+        kwargs = kwargs or {}
+        hf_calls.append((data, dict(kwargs)))
+        return original_call(hf_processor, data, kwargs, **kw)
+
+    monkeypatch.setattr(type(processor.info.ctx), "call_hf_processor", spying_call)
+
+    mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
+        ctx.model_config, {"image": 1}, processor=processor
+    )
+
+    mm_call_kwargs = [
+        kwargs for data, kwargs in hf_calls if data.get("images") is not None
+    ]
+    assert mm_call_kwargs, "expected at least one HF processor call with images"
+    assert all(kwargs.get("truncation") is False for kwargs in mm_call_kwargs)
+    assert len(mm_inputs["prompt_token_ids"]) > 4096

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -2,14 +2,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import time
+from collections.abc import Mapping
 from contextlib import nullcontext
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
 
 from vllm.config import ModelConfig
+from vllm.config.multimodal import BaseDummyOptions
 from vllm.exceptions import VLLMValidationError
+from vllm.inputs import MultiModalDataDict
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.processing import BaseDummyInputsBuilder
 from vllm.multimodal.processing.context import InputProcessingContext
 from vllm.multimodal.processing.processor import (
     PlaceholderFeaturesInfo,
@@ -28,6 +33,38 @@ from vllm.multimodal.processing.processor import (
 from .utils import random_image
 
 pytestmark = pytest.mark.cpu_test
+
+
+class _DummyInputsBuilder(BaseDummyInputsBuilder):
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        return "dummy prompt"
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions],
+    ) -> MultiModalDataDict:
+        return {}
+
+
+def test_dummy_processor_inputs_disable_truncation() -> None:
+    info = Mock()
+    info.parse_mm_data.return_value = {}
+    info.default_tok_params.get_encode_kwargs.return_value = {
+        "add_special_tokens": False,
+        "truncation": True,
+    }
+    info.ctx.tokenizer.encode.return_value = [1, 2, 3]
+
+    inputs = _DummyInputsBuilder(info).get_dummy_processor_inputs(16, {}, {})
+
+    assert inputs.prompt == [1, 2, 3]
+    info.ctx.tokenizer.encode.assert_called_once_with(
+        "dummy prompt",
+        add_special_tokens=False,
+        truncation=False,
+    )
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1288,6 +1288,30 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
     ) -> BatchFeature:
         mm_data = dict(mm_data)
 
+        def call_hf_processor(
+            prompt: str,
+            mm_data: Mapping[str, object],
+            mm_kwargs: Mapping[str, object],
+        ) -> BatchFeature:
+            # vLLM enforces max_model_len itself, and HF-side truncation of a
+            # prompt whose placeholders were expanded to per-item feature
+            # tokens (e.g. the profiling-time dummy prompt for a max-size
+            # image) breaks Qwen3VLProcessor's token-count consistency check.
+            # Keep truncation semantics for text-only calls; disable it only
+            # when the call carries multi-modal data, matching
+            # ColPaliMultiModalProcessor.
+            if not mm_data:
+                return self.info.ctx.call_hf_processor(
+                    self.info.get_hf_processor(**mm_kwargs),
+                    dict(text=prompt),
+                    mm_kwargs,
+                )
+            return self.info.ctx.call_hf_processor(
+                self.info.get_hf_processor(**mm_kwargs),
+                dict(text=prompt, **mm_data),
+                dict(mm_kwargs, truncation=False),
+            )
+
         # Separate video processing from image processing. Because the videos
         # are processed into several image patches
         video_input_ids_lst: list[list[int]] = []
@@ -1365,7 +1389,7 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
                 if "num_frames" in video_mm_kwargs and "fps" not in video_mm_kwargs:
                     video_mm_kwargs["fps"] = None
 
-                video_outputs = super()._call_hf_processor(
+                video_outputs = call_hf_processor(
                     prompt="<|vision_start|><|video_pad|><|vision_end|>",
                     mm_data=video_mm_data,
                     mm_kwargs=video_mm_kwargs,
@@ -1426,7 +1450,7 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
         non_video_mm_kwargs = {
             k: v for k, v in mm_kwargs.items() if k not in ("fps", "num_frames")
         }
-        processed_outputs = super()._call_hf_processor(
+        processed_outputs = call_hf_processor(
             prompt=prompt,
             mm_data=mm_data,
             mm_kwargs=non_video_mm_kwargs,

--- a/vllm/multimodal/processing/dummy_inputs.py
+++ b/vllm/multimodal/processing/dummy_inputs.py
@@ -91,9 +91,10 @@ class BaseDummyInputsBuilder(ABC, Generic[_I]):
             # prompt tokens.
             dummy_prompt = []
         else:
+            encode_kwargs = self.info.default_tok_params.get_encode_kwargs()
             dummy_prompt = tokenizer.encode(
                 dummy_text,
-                **self.info.default_tok_params.get_encode_kwargs(),
+                **dict(encode_kwargs, truncation=False),
             )
 
         return ProcessorInputs(


### PR DESCRIPTION
## Purpose

Fix the deterministic engine-startup failure for Qwen3-VL-family models introduced by #53093, first seen in scheduled main #84966 and reproduced in daily #84887's A100/H100 `LM Eval Humming FP16` shard 2 and B200 Humming: during memory profiling, `Qwen3VLProcessor` fails with mismatched image tokens (e.g. `ids=[4095]` vs text `[16384]`) and the server aborts with `Failed to apply Qwen3VLProcessor on data={'text': '<|vision_start|><|image_pad|><|vision_end|>', 'images': [4096x4096 image]}`.

## Root cause

The profiling-time dummy prompt expands the image placeholder to more tokens than the HF tokenizer's `model_max_length` (16384 image-pad tokens for a max-size image, while e.g. `RedHatAI/Qwen3.6-35B-A3B-NVFP4` ships `model_max_length=4096`). Pre-#53093, the dummy path carried `tokenization_kwargs={"truncation": False}` into the HF processor call via `_apply_hf_processor_mm_only`'s kwargs merge, which suppressed HF-side truncation. #53093 removed the `tokenization_kwargs` channel (`ProcessorInputs` no longer carries it and `_call_hf_processor` lost `tok_kwargs`), so the HF tokenizer's own truncation default surfaced and cuts the expanded placeholder tokens, breaking `Qwen3VLProcessor`'s token-count consistency check.

## Fix

Two narrow pieces, no framework changes:

1. `BaseDummyInputsBuilder.get_dummy_processor_inputs` encodes the dummy text with `truncation=False` so the dummy prompt token ids themselves are never truncated (per review feedback).
2. `Qwen3VLMultiModalProcessor._call_hf_processor` disables HF truncation **only for processor calls that carry multi-modal data**, keeping HF truncation semantics for text-only calls. This matches the existing in-tree precedent in `ColPaliMultiModalProcessor._call_hf_processor` (small tokenizer `max_length` truncating expanded image tokens; vLLM enforces `max_model_len` itself). Note the first attempt at review scope — modifying only `get_dummy_processor_inputs` — was validated insufficient by exact Buildkite #85127: the failing HF call happens later, in `processor.apply` → `_apply_hf_processor_mm_only`, whose dummy-text tokenization output is discarded, so truncating it is never meaningful.

## Duplicate-work check

Searched open PRs/issues for `Qwen3VLProcessor truncation`, `get_dummy_processor_inputs`, and the failure signature; no other open PR addresses this regression.

## Test plan

- New regression test `tests/models/multimodal/processing/test_qwen3_vl.py::test_profiling_dummy_image_is_not_truncated`: spies on `call_hf_processor` during `get_dummy_mm_inputs` and asserts every mm-bearing HF call carries `truncation=False` and the dummy prompt exceeds `max_model_len` untruncated. Verified it fails without the `qwen3_vl.py` change and passes with it.
- `tests/models/multimodal/processing/test_qwen3_vl.py` full file: 8 passed.
- `tests/multimodal/test_processing.py::test_dummy_processor_inputs_disable_truncation` (generic dummy-encode coverage): passed.
- All applicable pre-commit hooks (ruff check/format, typos, mypy) pass.
- Exact CI validation at current head `54318114d3`: isolated build [#85131](https://buildkite.com/vllm/ci/builds/85131) (exact PR metadata, all LM Eval Humming families) is terminal green — A100 shards 1/2/3, H100 shards 1/2/3, and B200 all passed, every family exercising the formerly failing `Qwen3.6-35B-A3B-NVFP4` profiling path. (H100 shard 3's first attempt was an unrelated borderline GSM8K miss on text-only `Qwen3.5-35B-A3B-FP8`; its precise retry passed.) Details in comment 5377173774.

### Prior validation history

- Old head `41189437` (unconditional truncation=False): exact B200 #84979 passed 14/14; exact A100/H100 #84987 passed all six shards including decisive shard 2 on each.
- Review head `1bffbc80` (dummy-encode only): exact #85127 **failed** A100 shard 2 and H100 shard 2 with the original signature, proving that scope insufficient.

## AI-assistance disclosure

This change was prepared with AI assistance and reviewed before submission.

