### PR TITLE
[Bugfix][Parser] Fix DeepSeek V4 DSML markup leaking into streaming t…

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -27,6 +27,7 @@ from vllm.parser.deepseek_v4 import (
     DSML_INVOKE_NAME_END,
     DSML_INVOKE_PREFIX,
     DSML_THINK_END,
+    _ESCAPED_DSML,
     DSML_THINK_START,
     DSML_TOOL_END,
     DSML_TOOL_START,
@@ -153,6 +154,26 @@ class TestArgConverter:
         result = json.loads(_dsml_arg_converter(raw, partial=True))
         assert result["city"] == "Tokyo"
         assert result["expr"] == "x<5"
+
+    def test_partial_does_not_capture_closing_tag_prefix(self):
+        """When slot.args contains a partial closing tag (missing the
+        final >), _PARTIAL_PARAM_RE must not swallow it into the value."""
+        raw = (
+            f"<{_PARAM_OPEN.format(name='location', is_str='true')}"
+            f"Paris</{_ESCAPED_DSML}parameter"
+        )
+        result = json.loads(_dsml_arg_converter(raw, partial=True))
+        assert result == {"location": "Paris"}
+
+    def test_partial_with_complete_param_and_partial_closing_tag(self):
+        raw = self._raw(("city", "true", "Tokyo"))
+        raw += (
+            f"<{_PARAM_OPEN.format(name='date', is_str='true')}"
+            f"2025-01-01</{_ESCAPED_DSML}parameter"
+        )
+        result = json.loads(_dsml_arg_converter(raw, partial=True))
+        assert result["city"] == "Tokyo"
+        assert result["date"] == "2025-01-01"
 
     def test_null_string_false(self):
         raw = self._raw(("val", "false", "null"))

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -57,7 +57,7 @@ _PARAM_RE = re.compile(
 )
 _PARTIAL_PARAM_RE = re.compile(
     rf'<{_ESCAPED_DSML}parameter\s+name="([^"]+)"\s+string="(true|false)">'
-    rf"(.*)$",
+    rf"((?:(?!</?{_ESCAPED_DSML}).)*)",
     re.DOTALL,
 )
 


### PR DESCRIPTION
## Purpose

Fixes streaming tool call argument corruption in the DeepSeek V4 parser where DSML closing tag fragments leak into tool call arguments.

`_PARTIAL_PARAM_RE` used a greedy `(.*)$` capture that swallowed partial DSML closing tags (e.g. `Paris</｜DSML｜parameter` without the final `>`) into parameter values during streaming. Replaced with a tempered greedy token using a negative lookahead that stops at DSML tag prefixes:

```python
# Before
rf"(.*)$"
# After
rf"((?:(?!</?{_ESCAPED_DSML}).)*)"
```

This preserves literal `<` in values (the concern from #46047) while preventing partial closing tags from leaking into arguments.

## Root cause

Introduced in #45877 which ported DeepSeek V4 to the `StreamingParserEngine`. The old hand-written parser (`DeepSeekV32ToolParser`, #42879) used a buffer-and-split approach that never ran a regex on partial args.

## Verification

Tested on a live 8xH200 deployment (vLLM v0.27.1, dspark speculative decoding):
- `stream: true, tool_choice: required`: DSML markup no longer leaks into arguments (3/3 runs clean)
- `stream: true, tool_choice: auto`: tool calls now stream proper incremental argument deltas (previously emitted empty `{}`)
- `stream: false`: unchanged (always worked)

## Test plan

Added two regression tests in `tests/parser/engine/test_deepseek_v4.py`:
- `test_partial_does_not_capture_closing_tag_prefix` — partial closing tag in a single parameter
- `test_partial_with_complete_param_and_partial_closing_tag` — complete parameter followed by a partial closing tag

AI assistance was used. Every changed line was reviewed and tested.

Closes #53227