### PR TITLE
[Bugfix][Hardware][XPU] Fix token-indexed GDN conv state copies

### DIFF
--- a/tests/kernels/mamba/test_precopy_mamba_align.py
+++ b/tests/kernels/mamba/test_precopy_mamba_align.py
@@ -215,6 +215,7 @@ def test_precopy_matches_v1_copy_specs(
         num_reqs,
         COPY_BLOCK_SIZE=1024,
         CONV_STATE_DIM_FIRST=conv_state_dim_first,
+        TOKEN_INDEXED_CONV=False,
         HAS_IDX_MAPPING=has_idx_mapping,
         TEMPORAL_TILES=temporal_tiles,
     )

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -12,6 +12,7 @@ import torch
 from vllm.model_executor.layers.mamba.mamba_utils import (
     get_conv_copy_spec,
     get_temporal_copy_spec,
+    get_token_indexed_conv_copy_spec,
 )
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec, MambaSpec
@@ -33,6 +34,21 @@ _COPY_FUNCS: tuple[MambaStateCopyFunc, ...] = (
     get_conv_copy_spec,
     get_temporal_copy_spec,
 )
+
+
+def test_token_indexed_conv_copy_spec_selects_full_accepted_snapshot():
+    state = torch.empty((8, 4, 16), dtype=torch.bfloat16)
+    block_ids = [7, 2, 5, 1]
+
+    copy_spec = get_token_indexed_conv_copy_spec(
+        state,
+        block_ids,
+        cur_block_idx=1,
+        num_accepted_tokens=3,
+    )
+
+    assert copy_spec.start_addr == state[block_ids[3]].data_ptr()
+    assert copy_spec.num_elements == state[0].numel()
 
 
 def postprocess_mamba(
@@ -689,6 +705,47 @@ class TestPostprocessMambaFusedKernel:
             batch_memcpy(src_ptrs, dst_ptrs, sizes)
             torch.accelerator.synchronize()
             torch.testing.assert_close(state, expected, rtol=0, atol=0)
+
+    def test_token_indexed_conv_copies_accepted_snapshot(self, device):
+        cfg = _TestConfig(num_layers=1)
+        layer_names = ["layer_0"]
+        kv_cache_config = _make_kv_cache_config(cfg, layer_names)
+
+        block_values = torch.arange(cfg.num_blocks, dtype=cfg.dtype, device=device)
+        conv_state = (
+            block_values[:, None, None]
+            .expand(-1, cfg.conv_width, cfg.conv_inner_dim)
+            .clone()
+        )
+        temporal_state = (
+            block_values[:, None].expand(-1, cfg.temporal_state_dim).clone()
+        )
+        forward_context = {"layer_0": _make_mock_attention(conv_state, temporal_state)}
+
+        # running=30, accepted=3 => aligned=32, token bias=2, dst col=1.
+        # Token-indexed state must copy the full snapshot from src col 0+2.
+        block_table = torch.tensor([[3, 7, 11, 15]], dtype=torch.int32, device=device)
+        gpu_ctx = _make_gpu_ctx(cfg, kv_cache_config, device)
+        _run_gpu_postprocess(
+            gpu_ctx,
+            kv_cache_config=kv_cache_config,
+            forward_context=forward_context,
+            copy_funcs=(get_token_indexed_conv_copy_spec, get_temporal_copy_spec),
+            block_table=block_table,
+            req_ids=["req_0"],
+            num_accepted_tokens=[3],
+            mamba_state_idx=[0],
+            num_scheduled_tokens={"req_0": 1},
+            num_computed_tokens=[29],
+            num_draft_tokens={},
+            device=device,
+        )
+
+        expected = torch.full_like(conv_state[7], 11)
+        torch.testing.assert_close(conv_state[7], expected, rtol=0, atol=0)
+        torch.testing.assert_close(
+            temporal_state[7], torch.full_like(temporal_state[7], 11), rtol=0, atol=0
+        )
 
     def test_matches_python_postprocess_mamba(self, device, test_config):
         """

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -381,6 +381,26 @@ def get_conv_copy_spec(
     )
 
 
+def get_token_indexed_conv_copy_spec(
+    state: torch.Tensor,
+    block_ids: list[int],
+    cur_block_idx: int,
+    num_accepted_tokens: int,
+) -> MambaCopySpec:
+    """Return the full conv snapshot for the selected speculative token.
+
+    Unlike the sliding-window convention used by :func:`get_conv_copy_spec`,
+    some kernels write a complete conv state snapshot to every block-table
+    entry in ``cache_indices``.  For those kernels, an accepted-token offset
+    selects a block-table column rather than a row within one conv state.
+    """
+    src_block_id = block_ids[cur_block_idx + num_accepted_tokens - 1]
+    src_state = state[src_block_id]
+    return MambaCopySpec(
+        start_addr=src_state.data_ptr(), num_elements=src_state.numel()
+    )
+
+
 def get_temporal_copy_spec(
     state: torch.Tensor,
     block_ids: list[int],
@@ -413,8 +433,13 @@ class MambaStateCopyFuncCalculator:
         return (get_conv_copy_spec,)
 
     @classmethod
-    def gated_delta_net_state_copy_func(cls):
-        return (get_conv_copy_spec, get_temporal_copy_spec)
+    def gated_delta_net_state_copy_func(cls, *, token_indexed_conv: bool = False):
+        conv_copy_func = (
+            get_token_indexed_conv_copy_spec
+            if token_indexed_conv
+            else get_conv_copy_spec
+        )
+        return (conv_copy_func, get_temporal_copy_spec)
 
     @classmethod
     def kda_state_copy_func(cls):

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -54,6 +54,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.tokenizers.registry import cached_tokenizer_from_config
 from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5Config, Qwen3_5TextConfig
@@ -421,7 +422,9 @@ class Qwen3_5ForCausalLMBase(
     def get_mamba_state_copy_func(
         cls,
     ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
-        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func(
+            token_indexed_conv=current_platform.is_xpu()
+        )
 
     def compute_logits(
         self,
@@ -630,7 +633,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
 
     @classmethod
     def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
-        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+        return Qwen3_5ForCausalLMBase.get_mamba_state_copy_func()
 
 
 ########################################################

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -827,7 +827,9 @@ class Qwen3NextForCausalLM(
 
     @classmethod
     def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
-        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func(
+            token_indexed_conv=current_platform.is_xpu()
+        )
 
     def compute_logits(
         self,

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFunc,
     get_conv_copy_spec,
     get_temporal_copy_spec,
+    get_token_indexed_conv_copy_spec,
     is_conv_state_dim_first,
 )
 from vllm.triton_utils import tl, triton
@@ -140,6 +141,7 @@ def _copy_mamba_state_block(
     tile_idx,
     COPY_BLOCK_SIZE: tl.constexpr,
     CONV_STATE_DIM_FIRST: tl.constexpr,
+    TOKEN_INDEXED_CONV: tl.constexpr,
     TEMPORAL_TILES: tl.constexpr,
 ):
     """Copy one (layer, state-type) mamba state block between block columns.
@@ -147,9 +149,10 @@ def _copy_mamba_state_block(
     Shared copy body of ``postprocess_mamba_fused_kernel`` and
     ``precopy_mamba_align_fused_kernel``, mirroring the V1 copy specs
     (``get_conv_copy_spec`` / ``get_temporal_copy_spec``):
-    - conv state (conv_width > 0): shift the window by ``token_bias`` tokens,
-      ``state[bt[src_col], token_bias:] ->
-      state[bt[dst_col], :conv_width - token_bias]``
+    - sliding-window conv state: shift the window by ``token_bias`` tokens,
+      ``state[bt[src_col], token_bias:] -> state[bt[dst_col], :width - bias]``
+    - token-indexed conv state: select and copy the complete accepted-token
+      snapshot, ``state[bt[src_col + token_bias]] -> state[bt[dst_col]]``
     - temporal state: ``token_bias`` selects the accepted speculative column,
       ``state[bt[src_col + token_bias]] -> state[bt[dst_col]]``
 
@@ -184,6 +187,25 @@ def _copy_mamba_state_block(
     dst_addr = state_base_addr + dest_block_id * state_block_stride
 
     is_conv_state = conv_width > 0
+
+    if TOKEN_INDEXED_CONV and is_conv_state:
+        if tile_idx > 0:
+            return
+        src_block_id = tl.load(block_table_base + src_col + token_bias).to(tl.int64)
+        src_addr = state_base_addr + src_block_id * state_block_stride
+        conv_inner_size = state_inner_size
+        if CONV_STATE_DIM_FIRST:
+            conv_inner_size = tl.load(state_dim_row_count_ptr + state_idx)
+        copy_size = conv_width.to(tl.int64) * conv_inner_size * state_elem_size
+        _memcpy_u64_tiled(
+            src_addr,
+            dst_addr,
+            copy_size,
+            tile_idx,
+            COPY_BLOCK_SIZE=COPY_BLOCK_SIZE,
+            NUM_TILES=1,
+        )
+        return
 
     if CONV_STATE_DIM_FIRST and is_conv_state:
         # Conv states are small; only tile 0 does the copy. Higher tiles
@@ -335,6 +357,7 @@ def postprocess_mamba_fused_kernel(
     # COPY_BLOCK_SIZE: fixed tuning parameter for memory copy loop
     COPY_BLOCK_SIZE: tl.constexpr,
     CONV_STATE_DIM_FIRST: tl.constexpr,
+    TOKEN_INDEXED_CONV: tl.constexpr,
     # HAS_IDX_MAPPING: when True, program_id(0) is a batch index resolved to a
     # req-state slot via idx_mapping_ptr (V2). When False, it is the req index.
     HAS_IDX_MAPPING: tl.constexpr = False,
@@ -430,6 +453,7 @@ def postprocess_mamba_fused_kernel(
         tile_idx,
         COPY_BLOCK_SIZE,
         CONV_STATE_DIM_FIRST,
+        TOKEN_INDEXED_CONV,
         TEMPORAL_TILES,
     )
 
@@ -502,6 +526,7 @@ def precopy_mamba_align_fused_kernel(
     num_reqs,
     COPY_BLOCK_SIZE: tl.constexpr,
     CONV_STATE_DIM_FIRST: tl.constexpr,
+    TOKEN_INDEXED_CONV: tl.constexpr,
     HAS_IDX_MAPPING: tl.constexpr = True,
     # TEMPORAL_TILES: see postprocess_mamba_fused_kernel. Default 1 preserves
     # the 2D-grid contract; > 1 requires a 3D grid.
@@ -561,6 +586,7 @@ def precopy_mamba_align_fused_kernel(
         tile_idx,
         COPY_BLOCK_SIZE,
         CONV_STATE_DIM_FIRST,
+        TOKEN_INDEXED_CONV,
         TEMPORAL_TILES,
     )
 
@@ -657,8 +683,8 @@ class MambaSpecDecodeGPUContext:
     Precomputes memory layout metadata (base addresses, strides, element sizes)
     so the GPU kernel can perform state copies without CPU-GPU sync.
 
-    State types are distinguished by conv_width: >0 for conv states (sliding
-    window with offset-based copies), 0 for temporal states (full block copies).
+    State types are distinguished by conv_width: >0 for conv states and 0 for
+    temporal states. Conv copy semantics are fixed for the lifetime of a context.
     """
 
     # Per-state metadata tensors (shape: [num_layers * num_state_types])
@@ -679,6 +705,7 @@ class MambaSpecDecodeGPUContext:
     num_state_types: int
     mamba_group_ids: list[int]
     num_groups: int
+    token_indexed_conv: bool  # full per-token conv snapshots
 
     # Output buffer for num_accepted_tokens updates
     num_accepted_tokens_out: torch.Tensor
@@ -752,6 +779,7 @@ class MambaSpecDecodeGPUContext:
             num_state_types=num_state_types,
             mamba_group_ids=mamba_group_ids,
             num_groups=len(mamba_group_ids),
+            token_indexed_conv=False,
             num_accepted_tokens_out=torch.zeros(
                 max_num_reqs, dtype=torch.int32, device=device
             ),
@@ -789,9 +817,8 @@ class MambaSpecDecodeGPUContext:
           used to compute offset when slicing state[block, offset:]. For temporal
           states, this field is unused (set to 1).
         - state_conv_widths: Conv dimension size for conv states, 0 for temporal states
-
-        The conv vs temporal state type is detected by inspecting the copy function
-        name: functions containing "conv" are treated as conv states.
+        Conv state kind and copy semantics are derived from the model-provided
+        state copy functions.
 
         This method is idempotent - it only executes once (guarded by is_initialized
         flag) since the metadata is static after model loading.
@@ -826,6 +853,10 @@ class MambaSpecDecodeGPUContext:
         mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
         block_tables: list[torch.Tensor],
     ) -> None:
+        self.token_indexed_conv = (
+            get_token_indexed_conv_copy_spec in mamba_state_copy_funcs
+        )
+
         idx = 0
         for group_local_idx, mamba_group_id in enumerate(self.mamba_group_ids):
             layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
@@ -858,11 +889,14 @@ class MambaSpecDecodeGPUContext:
                     # Element size
                     self.state_elem_sizes[idx] = state.element_size()
 
-                    assert (
-                        copy_func is get_conv_copy_spec
-                        or copy_func is get_temporal_copy_spec
-                    ), f"unexpected copy func: {copy_func}"
-                    if copy_func is get_conv_copy_spec:
+                    is_conv_copy = copy_func in (
+                        get_conv_copy_spec,
+                        get_token_indexed_conv_copy_spec,
+                    )
+                    assert is_conv_copy or copy_func is get_temporal_copy_spec, (
+                        f"unexpected copy func: {copy_func}"
+                    )
+                    if is_conv_copy:
                         if state.dim() != 3:
                             raise ValueError(
                                 "Expected 3D conv state cache, got "
@@ -990,6 +1024,7 @@ class MambaSpecDecodeGPUContext:
             block_size=self.block_size,
             COPY_BLOCK_SIZE=1024,
             CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
+            TOKEN_INDEXED_CONV=self.token_indexed_conv,
             TEMPORAL_TILES=_TEMPORAL_TILES,
         )
 
@@ -1034,6 +1069,7 @@ class MambaSpecDecodeGPUContext:
             num_reqs,
             COPY_BLOCK_SIZE=1024,
             CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
+            TOKEN_INDEXED_CONV=self.token_indexed_conv,
             HAS_IDX_MAPPING=idx_mapping is not None,
             TEMPORAL_TILES=_TEMPORAL_TILES,
         )
@@ -1088,6 +1124,7 @@ class MambaSpecDecodeGPUContext:
             block_size=self.block_size,
             COPY_BLOCK_SIZE=1024,
             CONV_STATE_DIM_FIRST=is_conv_state_dim_first(),
+            TOKEN_INDEXED_CONV=self.token_indexed_conv,
             HAS_IDX_MAPPING=True,
             PRECOMPUTED_NEW_COMPUTED=True,
             TEMPORAL_TILES=_TEMPORAL_TILES,


### PR DESCRIPTION
## Purpose

With MTP enabled on XPU, long-context generation can start coherently and then
abruptly collapse without a runtime error. The degraded tail often converges
to a narrow token and semantic neighborhood rather than uniformly random
tokens. One observed response, for example, repeatedly wandered around
translations and variants of "region":

```text
... Region区域區域 ... wilayah ... _REGION ... region ... area ... zone ...
```

The generation still completed normally, but did not recover once the
recurrent state had been corrupted.

The cause is a mismatch between two convolution-state copy conventions. The
existing vLLM Mamba copy path treats a conv state as a sliding window in one
block-table entry. An accepted-token offset therefore selects rows within that
state, conceptually:

```text
state[block_table[column], token_bias:]
```

The XPU GDN MTP kernel instead writes a complete rolling conv-state snapshot
for each speculative token to a separate block-table entry. The same offset
therefore selects a column and copies its complete snapshot:

```text
state[block_table[column + token_bias]]
```

The two conventions are byte-equivalent when `token_bias == 0`, but differ
when more than one token is accepted. At an aligned Mamba cache-block
transition, applying the sliding-window convention to the token-indexed XPU
state migrates the wrong conv state into the next block. The corrupted state
then feeds subsequent recurrent updates.

Increasing the attention block size is an effective temporary workaround
because it delays the state migration and can keep a shorter generation within
one block. It does not correct the copy: a sufficiently long generation
reproduces the failure at the new block boundary.

This PR adds an opt-in declaration for kernels that use token-indexed conv
snapshots and propagates that declaration through the V1 scalar, postprocess,
and precopy state-copy paths. Qwen3.5 and Qwen3-Next declare this convention
only when running on XPU. The existing sliding-window convention remains the
default and its copy behavior is unchanged on other platforms.

## Test Plan

Run the Mamba state-copy unit suites against the PR commit in the XPU serving
container:

```bash
python -m pytest -q -ra -p no:cacheprovider \
  tests/v1/worker/test_mamba_utils.py \
  tests/kernels/mamba/test_precopy_mamba_align.py
```

Run the repository's complete pre-commit suite:

```bash
pre-commit run --all-files
```

Run the standalone one-XPU reproducer from the
[reviewed Gist](https://gist.github.com/recutita/022e86ca28a614d896107b00f0bf4c72/b92813fb43c57ff981e73f8b75b467f9b7f369fa):

```bash
./run-repro.sh
```

The Gist is intended as a self-contained reproduction kit rather than an
archive of generated artifacts. The reproducer uses sequential
OpenAI-compatible HTTP requests and compares upstream, patched, and
no-boundary controls across the auto-selected block size and explicit block
sizes 3200 and 4000. Each run writes its JSON responses and server logs into a
local timestamped results directory.

## Test Result

The unit suites completed without failures on one Intel XPU:

```text
10 passed, 108 skipped, 17 warnings in 3.51s
```

The skips are existing accelerator guards: 36 cases require CUDA, and 72
`precopy_mamba_align_fused_kernel` cases require CUDA/Triton. The passing cases
include the new scalar copy-spec test. The new fused postprocess test belongs
to the CUDA-gated class and was therefore skipped in this XPU run; the
production XPU path is covered by the end-to-end reproducer below.

The complete non-manual pre-commit suite also passed:

```text
pre-commit run --all-files: all hooks passed
```

The end-to-end run produced the following token-ID comparisons:

| Boundary and request | Upstream vs no-boundary control | Patched vs no-boundary control |
|---|---|---|
| auto-selected 1152, 1800 tokens | DIFF at sequence position 1161 | MATCH, 1800 tokens |
| block 3200, variant 1, 3800 tokens | MATCH, output-insensitive case | MATCH, 3800 tokens |
| block 3200, variant 2, 3800 tokens | DIFF at sequence position 3199 | MATCH, 3800 tokens |
| block 3200, variant 3, 3800 tokens | DIFF at sequence position 3201 | MATCH, 3800 tokens |

Thus the larger block size hides the short-request failure, the failure moves
to the larger boundary for sufficiently long requests, and every patched
output matches its corresponding no-boundary control token-for-token. Full
commands, pinned revisions, and the recomputed comparison transcript are
documented in the Gist. The reproducer saves JSON responses and server logs
locally when it is run; those generated artifacts are not included in the
Gist.

Qwen3-Next is included because it uses the same XPU GDN path and appears usable
on XPU with sufficiently large hardware. It was not tested end-to-end because
it cannot be served on my 32 GB Intel Arc Pro B70 even with FP4 weights.

`openbmb/MiniCPM-V-4_6` also requests the generic GDN state-copy convention and
may be affected by the same mismatch. The model cannot currently run inference
on XPU in my environment, so there does not appear to be a current XPU user who
would benefit from opting it in. This PR therefore avoids expanding its scope
with a change that could not be validated end-to-end.

`OlmoHybridForCausalLM` also uses the generic GDN state-copy function, but its
GDN layer has no XPU-specific dispatch and writes conv state through the generic
sliding-window path. Leaving its copy convention unchanged is therefore
intentional.

## Related work

The token-indexed XPU convention predates this PR and was introduced
intentionally by [vllm-xpu-kernels PR #368](https://github.com/vllm-project/vllm-xpu-kernels/pull/368)
in [commit `80372569`](https://github.com/vllm-project/vllm-xpu-kernels/commit/80372569fd29030770c016eac367ad32f933cb57).
That change added Qwen MTP support by saving a complete conv-state snapshot for
each speculative token and selecting the accepted snapshot by column. The path
was subsequently connected to vLLM by
[PR #43565](https://github.com/vllm-project/vllm/pull/43565).

The existing vLLM convention originated with the generic Mamba align-mode
state copies in [PR #30877](https://github.com/vllm-project/vllm/pull/30877).
[PR #42406](https://github.com/vllm-project/vllm/pull/42406) moved that logic
into the shared fused copy body, and
[PR #50729](https://github.com/vllm-project/vllm/pull/50729) made overlapping
conv-state copies safe while retaining the same row-offset convention. This PR
does not replace that convention; it adds an explicit opt-in for the existing
XPU contract.

The closest output-degeneration and state-copy reports do not cover this
contract mismatch. [Issue #39273](https://github.com/vllm-project/vllm/issues/39273)
and [PR #40738](https://github.com/vllm-project/vllm/pull/40738) concern the
ngram and `mamba_cache_mode="none"` path. The newer open
[PR #52942](https://github.com/vllm-project/vllm/pull/52942) addresses another
failure in that mode by normalizing accepted state when an ngram proposer
returns no drafts; it does not address align-mode migration or the XPU
token-indexed copy contract. Separately,
[issue #40880](https://github.com/vllm-project/vllm/issues/40880) was traced to
a TurboQuant CUDA-graph problem, while
[issue #50837](https://github.com/vllm-project/vllm/issues/50837) reports DFlash
degeneration without identifying the XPU align-boundary mechanism. A
duplicate-work search found no existing issue or PR that connects the external
XPU GDN token-indexed layout to the vLLM align-mode copy paths.

## AI assistance

While reviewing Qwen3.8-27B generations with Claude Code (Opus 5), I
encountered an output-collapse issue. Opus 5 reported that the failure occurred
stochastically with MTP enabled and that the collapse rate correlated with the
draft length.

I then asked Claude Code (Fable 5) to investigate the cause. Fable 5 traced the
execution and state-copy paths and identified the copy-contract mismatch in
vLLM between the existing sliding-window convention and the token-indexed XPU
GDN convention.

I consolidated those findings and asked Codex CLI (gpt-5.6-sol xhigh) to
prepare the fix and the standalone reproduction kit. I ran the verification,
selected the final artifacts, moved the reviewer-facing files into the
[public Gist](https://gist.github.com/recutita/022e86ca28a614d896107b00f0bf4c72/b92813fb43c57ff981e73f8b75b467f9b7f369fa),
and audited the complete contents of the Gist.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

