### PR TITLE
[Doc] Fix dead link in KV transfer README

### DIFF
--- a/vllm/distributed/kv_transfer/README.md
+++ b/vllm/distributed/kv_transfer/README.md
@@ -22,7 +22,7 @@ NOTE: If you want to not only transfer KV caches, but adjust the model execution
 
 ## Disaggregated prefilling
 
-The example usage is in [this file](../../../examples/disaggregated/disaggregated_prefill.sh).
+Example usage can be found in [this directory](../../../examples/disaggregated).
 
 Here is the diagram of how we run disaggregated prefilling.
 


### PR DESCRIPTION
## Purpose

The link to `examples/disaggregated/disaggregated_prefill.sh` in
`vllm/distributed/kv_transfer/README.md` is dead. That script was
removed in #44854 ("[Connector] Remove P2pNcclConnector"), since it
only demonstrated the now-removed `P2pNcclConnector` connector. Other
docs were updated in that PR, but this README was missed.

This PR points the link at the current `examples/disaggregated`
directory, which contains the up-to-date disaggregated-prefill
examples.

## Test Plan

- Confirmed `examples/disaggregated/disaggregated_prefill.sh` does not
  exist anywhere in the repo (`git grep` for the old path returns no
  hits after this change).
- Confirmed `examples/disaggregated` exists and resolves correctly
  from the README's location.

## Test Result

Link now resolves to a valid path, no other stale references to the
old path remain in the repo.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
