### PR TITLE
fix(scheduler): use realistic input budget for DSpark scheduling

### DIFF
--- a/tests/v1/core/test_scheduler_dspark_input_budget.py
+++ b/tests/v1/core/test_scheduler_dspark_input_budget.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Ensure DSpark scheduling does not charge drafting slots against the
+target/context input budget, allowing requests that fit the separate
+stages to be admitted.
+"""
+import pytest
+
+from tests.v1.core.utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_dspark_input_budget_separate():
+    # max_num_batched_tokens: target/context stage capacity
+    # num_speculative_tokens: K for DSpark
+    scheduler = create_scheduler(
+        max_num_batched_tokens=16,
+        num_speculative_tokens=4,
+        speculative_method="dspark",
+    )
+
+    # Two requests, each with 8 prefill tokens (fits target/context stage: 8+8=16)
+    requests = create_requests(num_requests=2, num_tokens=8)
+    for r in requests:
+        scheduler.add_request(r)
+
+    out = scheduler.schedule()
+
+    # Both requests should be admitted and scheduled for 8 tokens each.
+    assert len(out.num_scheduled_tokens) == 2
+    for v in out.num_scheduled_tokens.values():
+        assert v == 8

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -496,6 +496,9 @@ class Scheduler(SchedulerInterface):
         token_budget = self.max_num_scheduled_tokens
         spec = self.vllm_config.speculative_config
         draft_slots = spec.max_num_new_slots_for_drafting if spec is not None else 0
+        # For DSpark, drafting happens in a separate query stage; do not charge
+        # its additional drafting slots against the target/context input budget.
+        draft_slots_input_charge = 0 if spec is not None and spec.use_dspark() else draft_slots
         input_budget = self.scheduler_config.max_num_batched_tokens
         if self._pause_state == PauseState.PAUSED_ALL:
             # Do not schedule any requests when paused.
@@ -524,7 +527,7 @@ class Scheduler(SchedulerInterface):
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
-            if input_budget <= draft_slots:
+            if input_budget <= draft_slots_input_charge:
                 break
 
             if (
@@ -563,7 +566,7 @@ class Scheduler(SchedulerInterface):
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(
-                num_new_tokens, token_budget, input_budget - draft_slots
+                num_new_tokens, token_budget, input_budget - draft_slots_input_charge
             )
 
             # Make sure the input position does not exceed the max model len.
@@ -660,7 +663,7 @@ class Scheduler(SchedulerInterface):
                             scheduled_running_reqs.remove(preempted_req)
                             restored = num_scheduled_tokens.pop(preempted_req_id)
                             token_budget += restored
-                            input_budget += restored + draft_slots
+                            input_budget += restored + draft_slots_input_charge
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
@@ -698,7 +701,7 @@ class Scheduler(SchedulerInterface):
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
             token_budget -= num_new_tokens
-            input_budget -= num_new_tokens + draft_slots
+            input_budget -= num_new_tokens + draft_slots_input_charge
             req_index += 1
 
             # Speculative decode related.
@@ -749,7 +752,7 @@ class Scheduler(SchedulerInterface):
             step_skipped_waiting = create_request_queue(self.policy)
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
-                if input_budget <= draft_slots:
+                if input_budget <= draft_slots_input_charge:
                     break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
                 # in `running` but still hold a model-runner request slot.
@@ -924,7 +927,7 @@ class Scheduler(SchedulerInterface):
                     # compute to a cadence-aligned step.
                     break
                 else:
-                    request_token_budget = min(token_budget, input_budget - draft_slots)
+                    request_token_budget = min(token_budget, input_budget - draft_slots_input_charge)
                     # Number of tokens to be scheduled.
                     # We use `request.num_tokens` instead of
                     # `request.num_prompt_tokens` to consider the resumed
@@ -1131,7 +1134,7 @@ class Scheduler(SchedulerInterface):
                 )
                 num_scheduled_tokens[request_id] = num_new_tokens
                 token_budget -= num_new_tokens
-                input_budget -= num_new_tokens + draft_slots
+                input_budget -= num_new_tokens + draft_slots_input_charge
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
                 if pad_spec_decode:


### PR DESCRIPTION
Fixes #52922

- **Root cause**: the DSpark input-budget calculation was overly conservative (charging draft slots against the target budget).
- **Fix**: compute a realistic input budget in the scheduler so DSpark requests are not under-provisioned.