### PR TITLE
fix(linear): don't substitute module for missing parameter

### DIFF
--- a/tests/model_executor/test_linear_load_weights.py
+++ b/tests/model_executor/test_linear_load_weights.py
@@ -1,0 +1,12 @@
+import pytest
+import torch
+
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+
+
+def test_load_weights_missing_param_raises():
+    layer = ColumnParallelLinear(4, 4, bias=True, params_dtype=torch.float32)
+    weights = [("nonexistent", torch.tensor(1.0))]
+    with pytest.raises(ValueError) as excinfo:
+        list(layer.load_weights(weights))
+    assert "cannot load 'nonexistent'" in str(excinfo.value)

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -957,6 +957,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 param = getattr(self, name, self)
             if param is None and name == "bias":
                 continue
+            if not isinstance(param, Parameter):
+                raise ValueError(
+                    f"{self.prefix}: cannot load {name!r} — no such parameter, "
+                    f"got {type(param).__name__} instead. This usually means the "
+                    f"checkpoint carries a tensor the layer does not declare, e.g. a "
+                    f"quantization scale on a layer built without a quant_config."
+                )
             param.weight_loader(param, loaded_weight, shard_id)
             logger.debug(
                 "Loaded shard %s with shape %s into %s.%s",


### PR DESCRIPTION
Fixes #53107

- **Root cause**: for a dotted parameter name that does not exist, `getattr(..., self)` falls back to the module, violating the `Parameter` annotation and failing later inside `weight_loader` with a confusing `AttributeError`.
- **Fix**: raise a clear error when the parameter is missing instead of substituting the module.