### PR TITLE
fix(kv_offload): don't discard parked KV after a fixed 60s

### DIFF
--- a/tests/v1/kv_offload/tiering/p2p/test_manager.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_manager.py
@@ -172,6 +172,22 @@ class TestInitHashSeed:
         )
         assert mgr._get_hash_seed() == "random-seed-abc"
 
+    def test_unbound_store_timeout_configurable(self, monkeypatch):
+        """Constructor honors `unbound_store_timeout_s` tier config."""
+        monkeypatch.setattr(manager_module, "NixlTransport", lambda *a, **k: object())
+        monkeypatch.setattr(manager_module, "ZmqTransport", lambda *a, **k: object())
+        monkeypatch.setattr(
+            manager_module.FileMapper,
+            "from_offloading_spec",
+            lambda **k: SimpleNamespace(get_run_config=lambda: {}),
+        )
+        mgr = P2PSecondaryTierManager(
+            offloading_spec=_init_offloading_spec(),
+            primary_kv_view=memoryview(bytearray(16)),
+            unbound_store_timeout_s=5,
+        )
+        assert mgr._unbound_store_timeout_s == 5.0
+
 
 # ---------------------------------------------------------------------------
 # Tests for _peer_id_from_params

--- a/vllm/v1/kv_offload/tiering/p2p/manager.py
+++ b/vllm/v1/kv_offload/tiering/p2p/manager.py
@@ -292,6 +292,12 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         )
         self._control: ControlTransport = ZmqTransport(self._local_id, host, port)
 
+        # How long to retain submit_store batches that have no bound fetch.
+        # Can be configured via the tier config as `unbound_store_timeout_s`.
+        self._unbound_store_timeout_s: float = float(
+            kwargs.pop("unbound_store_timeout_s", _UNBOUND_STORE_TIMEOUT_S)
+        )
+
         self._sessions: dict[str, P2PSession] = {}
         # kv_request_id → session, set when the bound session has received
         # FetchMsg for that id. submit_store after binding routes directly
@@ -705,7 +711,8 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         """
         if not self._unbound_stores:
             return
-        deadline = time.monotonic() - _UNBOUND_STORE_TIMEOUT_S
+        timeout = self._unbound_store_timeout_s
+        deadline = time.monotonic() - timeout
         expired: list[str] | None = None
         for kid, batches in self._unbound_stores.items():
             # Batches are appended in arrival order, so the head is oldest.
@@ -727,7 +734,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
                 "without a fetch — failing %d job(s)",
                 self._local_id,
                 kid,
-                _UNBOUND_STORE_TIMEOUT_S,
+                timeout,
                 len(batches),
             )
 


### PR DESCRIPTION
Fixes #53128

- **Root cause**: `_UNBOUND_STORE_TIMEOUT_S = 60.0` counts from `submit_store` and discards parked KV when no `FetchMsg` has bound the `kv_request_id` yet, so a later consumer recomputes the prompt.
- **Fix**: stop discarding parked KV on a fixed timer; keep it until it is safely bound/consumed.