### PR TITLE
[ROCm] Warm the opus split-K GEMM workspace before cudagraph capture

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1670,6 +1670,22 @@ class rocm_aiter_ops:
 
     @classmethod
     @if_aiter_supported
+    def init_opus_gemm_workspace(cls) -> None:
+        """Register the opus split-K GEMM workspace for the current stream.
+
+        The gfx9 a16w16 split-K kernels keep their partial-sum buffer in a
+        per-stream registry that has to be populated eagerly. A graph capture
+        that is the first thing to touch it aborts with "splitk workspace not
+        initialized for the current CUDA stream".
+        """
+        try:
+            from aiter.ops.opus.gemm_op_a16w16 import opus_gemm_workspace_init
+        except ImportError:
+            return
+        opus_gemm_workspace_init()
+
+    @classmethod
+    @if_aiter_supported
     def get_moe_dispatch_policy(cls) -> int:
         """Cached MoE sorting dispatch policy."""
         if cls._MOE_DISPATCH_POLICY is None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 from tqdm import tqdm
 
 import vllm.envs as envs
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.breakable_cudagraph import (
     BreakableCUDAGraphWrapper,
     is_breakable_cudagraph_enabled,
@@ -6850,6 +6851,9 @@ class GPUModelRunner(
                 self._freeze_gc(),
                 graph_capture(device=self.device, graph_capture_context=cap_ctx),
             ):
+                # The gfx9 opus split-K workspace is per-stream and must be
+                # registered before anything captures on this stream.
+                rocm_aiter_ops.init_opus_gemm_workspace()
                 torch.accelerator.synchronize()
                 torch.accelerator.empty_cache()
 
@@ -6999,6 +7003,9 @@ class GPUModelRunner(
             )
 
         with self._freeze_gc(), graph_capture(device=self.device):
+            # The gfx9 opus split-K workspace is per-stream and must be
+            # registered before anything captures on this stream.
+            rocm_aiter_ops.init_opus_gemm_workspace()
             torch.accelerator.synchronize()
             torch.accelerator.empty_cache()
             start_free_gpu_memory = torch.accelerator.get_memory_info()[0]


### PR DESCRIPTION
## Summary

The gfx9 a16w16 split-K GEMM kernels keep their partial-sum buffer in a **per-stream**
registry that has to be populated eagerly. vLLM captures cudagraphs on a dedicated
stream, and nothing ever registers the workspace for it, so capture aborts as soon as a
tuned shape routes to opus:

```
[AITER] /app/aiter/aiter_meta/csrc/opus_gemm/opus_gemm.cu:487
        splitk workspace not initialized for the current CUDA stream.
        Call aiter.opus_gemm_workspace_init() ...
```

AITER documents this exact case in `aiter/tuned_gemm.py`: gfx1250 allocates the buffer
through `torch.empty`, which is HIP-graph-capture aware, while the **gfx942/gfx950**
a16w16 split-K path still uses the legacy per-stream `hipMalloc` registry and

> "still needs an eager warm before capture; if that path is ever exercised under
> cudagraphs, warm it via `aiter.opus_gemm_workspace_init()` on the capture stream."

vLLM contains no `opus_gemm` references at all, so that call is never made.

## Fix

Register the workspace on entry to both graph-capture contexts in `GPUModelRunner`
(the throwaway profiling capture and `capture_model`). The registry is per-stream and
each context runs on its own stream, so both need it.

The eager warmup vLLM already performs inside those contexts then grows the buffer
before any graph is recorded, which satisfies AITER's second requirement ("run the
largest expected gemm eagerly on the same stream to grow the buffer, then capture").

Gated by `if_aiter_supported`, so it is a no-op off gfx9 and on non-ROCm, and tolerant
of `ImportError` for AITER builds without the opus module.

## Reproduction

Kimi-K3 MXFP4 TP8 on 8x MI355X (gfx950), ROCm 7.2.3, AITER v0.1.20. Capture died at 58%
of the PIECEWISE ladder on shapes `M:20/19/18, N:6288` — 24 occurrences — taking the
engine down during startup:

```
Worker proc VllmWorker-6 died unexpectedly (exit code: None), shutting down executor
RuntimeError: Engine core initialization failed.
```

Note this is concurrency-dependent: at concurrency 1 the capture ladder is small enough
that no shape routes to opus and capture completes, so it only appears once the ladder
is wide enough to reach those shapes.

## Why this instead of the existing workaround

The workaround in use today is to delete all **527 opus rows** from the merged
tuned-GEMM table and point `AITER_CONFIG_GEMM_BF16` at the result, so those shapes fall
back to asm/skinny/torch. That avoids the crash by giving up the tuned kernels, and it
requires shipping a generated CSV alongside the image. This change keeps the tuned
kernels and needs no external file.

## Tests

Lint: `ruff check` and `ruff format --check` clean on both files.

Validation of the crash and the fix is on Kimi-K3 MXFP4 TP8 hardware (gfx950); results
will be posted as a comment.

## Not a duplicate

```
gh pr list --repo vllm-project/vllm --state open --search "opus_gemm workspace"
gh issue list --repo vllm-project/vllm --state open --search "splitk workspace not initialized"
```

Both return nothing. No open PR or issue covers the opus split-K workspace under
cudagraph capture.

---

AI assistance was used in preparing this change.
