### PR TITLE
[Models] Fix MiMo V2 FP8 QKV scale sharding

### DIFF
--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -509,20 +509,17 @@ def _shard_fp8_qkv_proj(
     k_rows_per_group = head_dim
     v_rows_per_group = v_head_dim
     rows_per_group = q_rows_per_group + k_rows_per_group + v_rows_per_group
-    scale_rows_per_group = s_full.shape[0] // num_kv_heads
+    s_full_expanded = s_full.repeat_interleave(block, dim=0).repeat_interleave(
+        block, dim=1
+    )[: w_full.shape[0], : w_full.shape[1]]
     qs, ks, vs = [], [], []
     for g_idx in range(tp_rank * kv_heads_per_rank, (tp_rank + 1) * kv_heads_per_rank):
         row_start = g_idx * rows_per_group
-        scale_row_start = g_idx * scale_rows_per_group
         # Dequantize this group's weights.
         w_g = w_full[row_start : row_start + rows_per_group].to(torch.float32)
-        s_g = s_full[scale_row_start : scale_row_start + scale_rows_per_group].to(
-            torch.float32
-        )
-        s_g_expanded = s_g.repeat_interleave(block, dim=0).repeat_interleave(
-            block, dim=1
-        )[:rows_per_group]
-        w_g_dequant = w_g * s_g_expanded
+        w_g_dequant = w_g * s_full_expanded[
+            row_start : row_start + rows_per_group
+        ]
         # Track the dequantized q, k, and v weights separately.
         qs.append(w_g_dequant[:q_rows_per_group])
         ks.append(w_g_dequant[q_rows_per_group : q_rows_per_group + k_rows_per_group])


### PR DESCRIPTION


## Purpose

Fix FP8 block-scale mapping when sharding MiMo V2 fused QKV projections across tensor-parallel ranks.

MiMo V2 stores fused QKV weights as contiguous per-KV-head groups, while FP8 block scales are laid out continuously across the full fused tensor. The previous implementation split the scale tensor evenly by KV group before expansion, which breaks the weight-to-scale mapping when a KV group boundary is not aligned to the FP8 block size.

For the MiMo-V2.5 SWA layout:

- each KV group contains 1,856 weight rows;
- the full fused-QKV weight shape is `(14848, 4096)`;
- the FP8 scale shape is `(116, 32)`;
- integer division assigns 14 scale blocks to each of the 8 KV groups;
- 14 blocks expand to only 1,792 rows.

This causes the following weight-loading failure:

```text
The size of tensor a (1856) must match the size of tensor b (1792)
```

This change expands the block scales in the full fused-QKV row space first, then slices the expanded scale tensor using each KV group's actual global row offset.

This PR only changes MiMo V2 fused-QKV scale sharding. It does not include runtime layer pruning or backend-specific GEMM fallbacks.

## Test Plan

1. Verify Python syntax:

```bash
python3 -m py_compile vllm/model_executor/models/mimo_v2.py
```

2. Verify patch formatting:

```bash
git diff --check
```

3. Reproduce the original failure using the MiMo-V2.5 SWA dimensions (`num_heads=64`, `num_kv_heads=8`, `head_dim=192`, `v_head_dim=128`, and block size 128).

4. Compare the patched per-group dequantization result against a reference that expands scales over the full fused-QKV tensor.

5. Verify slices for all TP4 ranks.

## Test Result

- `python3 -m py_compile vllm/model_executor/models/mimo_v2.py`: passed with no output.
- `git diff --check`: passed with no output.
- Before the fix, the tensor-level reproducer fails with:

```text
The size of tensor a (1856) must match the size of tensor b (1792) at non-singleton dimension 0
```

- After the fix, the patched result matches the full-tensor reference exactly for all TP4 rank slices.
- Confirmed against the checkpoint metadata:

```text
model.layers.1.self_attn.qkv_proj.weight
    dtype: torch.float8_e4m3fn
    shape: (14848, 4096)

model.layers.1.self_attn.qkv_proj.weight_scale_inv
    dtype: torch.float32
    shape: (116, 32)
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is required because this is a loader correctness fix with no user-facing API or model-support change.
</details>

