### PR TITLE
[Bugfix][NIXL] Fix PUSH heartbeat failing to renew KV leases

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -117,6 +117,22 @@ def _stub_sw_clipping(scheduler) -> None:
 
 
 class TestPushScheduler:
+    def test_heartbeat_uses_decode_internal_request_id(self):
+        sched = make_nixl_push_scheduler()
+        request = _make_request(
+            request_id="cmpl-shared-0-bbbbbbbb",
+            remote_request_id="shared",
+        )
+
+        sched.on_new_request(request)
+
+        info = sched._heartbeat_by_engine["prefill-engine"]
+        assert info.req_ids == {request.request_id}
+        assert sched._heartbeat_req_engine[request.request_id] == (
+            "prefill-engine",
+            request.request_id,
+        )
+
     def test_d_side_update_state_after_alloc_stages_registration(self):
         """D scheduler stashes registration data + arms watchdog deadline."""
         sched = make_nixl_push_scheduler()
@@ -984,6 +1000,19 @@ class TestPushWriterNegative:
             assert w._reqs_to_send[rid] >= now
         # Unknown request must not be inserted by the heartbeat path.
         assert "req-unknown" not in w._reqs_to_send
+
+    def test_heartbeat_matches_decode_id_by_base_request_id(self):
+        w = _StubWriterWorker.fresh()
+        w._lease_extension = 10
+        p_request_id = "cmpl-shared-0-aaaaaaaa"
+        d_request_id = "cmpl-shared-0-bbbbbbbb"
+        old_expiry = time.perf_counter() - 5.0
+        w._reqs_to_send[p_request_id] = old_expiry
+
+        w._handle_heartbeat(d_request_id)
+
+        assert w._reqs_to_send[p_request_id] > old_expiry
+        assert d_request_id not in w._reqs_to_send
 
 
 # ----------------------------------------------------------------- #

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -121,7 +121,8 @@ class NixlBaseConnectorScheduler:
         # Heartbeat tracking: requests needing periodic lease-renewal heartbeats to
         # remote P-side, stored as ready-to-send HeartbeatInfo grouped by remote engine
         self._heartbeat_by_engine: dict[EngineId, HeartbeatInfo] = {}
-        # Reverse lookup: local req_id -> (engine_id, remote_req_id) for O(1) removal
+        # Reverse lookup: local req_id -> (engine_id, req_id) for O(1) removal
+        # The req_id is remote in pull mode and local in push mode.
         self._heartbeat_req_engine: dict[ReqId, tuple[EngineId, ReqId]] = {}
         self._last_heartbeat_time: float = 0.0
 
@@ -221,10 +222,13 @@ class NixlBaseConnectorScheduler:
                 tp_size=tp_size,
                 pp_size=pp_size,
             )
-        self._heartbeat_by_engine[remote_engine_id].req_ids.add(remote_request_id)
+        heartbeat_request_id = (
+            request.request_id if self._TRANSFER_MODE == "push" else remote_request_id
+        )
+        self._heartbeat_by_engine[remote_engine_id].req_ids.add(heartbeat_request_id)
         self._heartbeat_req_engine[request.request_id] = (
             remote_engine_id,
-            remote_request_id,
+            heartbeat_request_id,
         )
 
     def _stop_heartbeat(self, req_id: ReqId) -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -53,6 +53,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.utils import (
     _NIXL_SUPPORTED_DEVICE,
+    get_base_request_id,
     get_representative_spec_type,
     zmq_ctx,
 )
@@ -2204,22 +2205,31 @@ class NixlBaseConnectorWorker:
         """Extend leases for requests referenced in a heartbeat.
 
         Args:
-            payload: comma-separated P-side request IDs, e.g.
-                     "req_abc,req_def".
+            payload: Comma-separated request IDs. Push mode sends D-side IDs
+                and matches their base IDs against P-side lease IDs.
         """
         new_expiry = time.perf_counter() + self._lease_extension
-        for req_id in payload.split(","):
-            if req_id in self._reqs_to_send:
-                old = self._reqs_to_send[req_id]
-                self._reqs_to_send[req_id] = max(old, new_expiry)
-                logger.debug(
-                    "Heartbeat extended lease for request %s "
-                    "by %ds (old_expiry=%.1f, new_expiry=%.1f)",
-                    req_id,
-                    self._lease_extension,
-                    old,
-                    new_expiry,
-                )
+        req_ids_by_base: dict[str, str] = {}
+        if self._TRANSFER_MODE == "push":
+            for req_id in self._reqs_to_send:
+                req_ids_by_base.setdefault(get_base_request_id(req_id), req_id)
+
+        for heartbeat_request_id in payload.split(","):
+            req_id = heartbeat_request_id
+            if req_id not in self._reqs_to_send:
+                req_id = req_ids_by_base.get(get_base_request_id(req_id), "")
+            if req_id not in self._reqs_to_send:
+                continue
+            old = self._reqs_to_send[req_id]
+            self._reqs_to_send[req_id] = max(old, new_expiry)
+            logger.debug(
+                "Heartbeat extended lease for request %s "
+                "by %ds (old_expiry=%.1f, new_expiry=%.1f)",
+                req_id,
+                self._lease_extension,
+                old,
+                new_expiry,
+            )
 
     def _pop_done_transfers(self, transfers: dict[str, list[int]]) -> set[str]:
         """


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm/issues/53095. This fixes PUSH mode Heartbeats failing to renew the P-side KV lease. No wire-format change. 

In PULL mode, remote_request_id is the P-side internal request ID, so Heartbeat can use it for exact matching.
In PUSH mode, the old Heartbeat also sent `remote_request_id`, but it is actually the Router UUID. 
Because requests are sent concurrently, D cannot know the P-side `internal request ID`. 

This change aligns `Heartbeat` with the existing `PUSH_REG` protocol:

  - PUSH_REG: D → P, carrying the D-side internal request ID.
  - Heartbeat: D → P, also carrying the D-side internal request ID.
  - P strips the random suffix and matches it against its own internal request ID by base ID.

## Test Plan
Added regression tests for the heartbeat request ID and base-ID matching.

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_push_connector.py -v
````

## Test Result
All passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

