### PR TITLE
[ROCm][Quantization] Match Quark exclude semantics in the shared-expert FSE check

### DIFF
--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -453,7 +453,7 @@ def test_is_model_fused_shared_expert_compatible() -> None:
     [
         (False, []),
         (True, []),
-        (True, ["*.shared_experts.*"]),
+        (True, [r"re:.*\.shared_experts?\..*"]),
     ],
 )
 def test_models_fse_init(
@@ -574,7 +574,7 @@ def test_models_fse_init(
 
 @pytest.mark.parametrize(
     ("exclude", "expected"),
-    [([], True), (["*.shared_expert.*"], False)],
+    [([], True), ([r"re:.*\.shared_expert\..*"], False)],
 )
 def test_quark_shared_expert_fse_compatibility(
     exclude: list[str], expected: bool
@@ -599,6 +599,42 @@ def test_quark_shared_expert_fse_compatibility(
             reason
             == "Quark excludes shared experts at model.layers.0.mlp.shared_expert"
         )
+
+
+def test_quark_shared_expert_fse_exclude_is_scoped_to_the_layer() -> None:
+    """Excluding one layer's shared experts must not disable FSE elsewhere.
+
+    amd/GLM-5.2-MXFP4 excludes its MTP layer (78) wholesale, including
+    ``model.layers.78.mlp.shared_experts.{gate,up,down}_proj``, while the 75
+    target MoE layers keep MXFP4 shared experts.
+    """
+    quant_config = QuarkConfig(
+        {
+            "exclude": [
+                f"model.layers.78.mlp.shared_experts.{projection_name}"
+                for projection_name in ("gate_proj", "up_proj", "down_proj")
+            ],
+            "global_quant_config": {},
+            "layer_quant_config": {},
+        }
+    )
+    quant_config.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+    assert is_shared_expert_quant_fse_compatible(
+        quant_config,
+        "model.layers.3.mlp.experts",
+        "model.layers.3.mlp.shared_experts",
+    ) == (True, None)
+
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        quant_config,
+        "model.layers.78.mlp.experts",
+        "model.layers.78.mlp.shared_experts",
+    )
+    assert compatible is False
+    assert (
+        reason == "Quark excludes shared experts at model.layers.78.mlp.shared_experts"
+    )
 
 
 def test_quark_shared_expert_fse_requires_matching_layer_quant_configs() -> None:

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -99,15 +99,29 @@ def is_shared_expert_quant_fse_compatible(
         )
 
     if isinstance(quant_config, QuarkConfig):
+        from vllm.model_executor.layers.quantization.quark.utils import (
+            should_ignore_layer,
+        )
+
         # TODO: layer_type_quant_config is not taken into account here.
         assert "exclude" in quant_config.quant_config
         assert "global_quant_config" in quant_config.quant_config
 
-        is_compatible = not any(
-            "shared_expert" in str(entry)
-            for entry in quant_config.quant_config["exclude"]
-        )
-        if not is_compatible:
+        exclude = quant_config.quant_config["exclude"]
+        try:
+            is_excluded = any(
+                should_ignore_layer(
+                    f"{shared_expert_prefix}.{projection_name}",
+                    ignore=exclude,
+                    fused_mapping=quant_config.packed_modules_mapping,
+                )
+                for projection_name in projection_names
+            )
+        except ValueError:
+            # Raised when the shards of a packed projection disagree, which
+            # rules out fusing the shared expert either way.
+            is_excluded = True
+        if is_excluded:
             return False, f"Quark excludes shared experts at {shared_expert_prefix}"
 
         global_quant_config = quant_config.quant_config["global_quant_config"]


### PR DESCRIPTION



## Purpose

**Affected model: `amd/GLM-5.2-MXFP4`**

`is_shared_expert_quant_fse_compatible()` decides, per MoE layer, whether the shared expert may be fused into the routed-expert grouped GEMM (`VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS`). 
Its `QuarkConfig` branch scanned the **whole-model** `exclude` list for the literal substring `"shared_expert"`
and never used the `shared_expert_prefix` argument it was handed — except to interpolate it into the rejection message:

So a single excluded shared expert anywhere in the checkpoint silently disables FSE for **every** MoE layer, and the warning names a prefix that has no exclude entry at all.

For `amd/GLM-5.2-MXFP4`, its `exclude` list has 1319 entries; exactly three of them mention shared experts, and all three belong to MTP layer 78, which the checkpoint leaves entirely unquantized:

```
model.layers.78.mlp.shared_experts.down_proj
model.layers.78.mlp.shared_experts.gate_proj
model.layers.78.mlp.shared_experts.up_proj
```

With `num_hidden_layers=78` and `first_k_dense_replace=3`, layers 3–77 are 75 MoE layers whose shared experts *are* MXFP4-quantized and appear nowhere in `exclude`. **Today all 75 lose the fusion because of layer 78.**

 In PR [#51695](https://github.com/vllm-project/vllm/pull/51695), @mgoin left an inline review comment https://github.com/vllm-project/vllm/pull/51695#discussion_r3797719032. 
That is what this PR does. Rather than hand-rolling a `startswith`, it reuses `should_ignore_layer()` from `quark/utils.py` — the same predicate `QuarkConfig.get_quant_method()` uses to decide whether a layer is excluded.

## Test Plan

### Unit tests
```bash
python -m pytest tests/model_executor/layers/test_fused_shared_expert.py -q
```

### Real-checkpoint probe against `amd/GLM-5.2-MXFP4`

```python
import json
from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
from vllm.model_executor.layers.quantization.utils.config_utils import (
    is_shared_expert_quant_fse_compatible)

qc = json.load(open("glm52_config.json"))["quantization_config"]
q = QuarkConfig(qc)
q.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
for n in (3, 5, 40, 77, 78):
    print(n, is_shared_expert_quant_fse_compatible(
        q, f"model.layers.{n}.mlp.experts", f"model.layers.{n}.mlp.shared_experts"))
```

## Test Result

### Real-checkpoint probe against `amd/GLM-5.2-MXFP4`

| shared-expert prefix | before | after |
|---|---|---|
| `model.layers.3.mlp.shared_experts` | `(False, 'Quark excludes shared experts at model.layers.3...')` | `(True, None)` |
| `model.layers.5.mlp.shared_experts` | `(False, ...)` | `(True, None)` |
| `model.layers.40.mlp.shared_experts` | `(False, ...)` | `(True, None)` |
| `model.layers.77.mlp.shared_experts` | `(False, ...)` | `(True, None)` |
| `model.layers.78.mlp.shared_experts` (MTP) | `(False, ...)` | `(False, 'Quark excludes shared experts at model.layers.78.mlp.shared_experts')` |

75 target MoE layers regain FSE eligibility; the genuinely-excluded MTP layer stays excluded.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

