### PR TITLE
[Bugfix][MoRIIO] Prevent remote KV reload after decoder preemption

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -139,6 +139,17 @@ def _write_consumer_scheduler_for_finished_request(tp_size: int = 2):
     return scheduler
 
 
+def test_write_mode_does_not_reload_remote_kv_after_preemption():
+    scheduler = _write_consumer_scheduler_for_finished_request()
+    request = create_request(request_id=1, num_tokens=32, do_remote_prefill=True)
+
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (32, True)
+
+    assert request.kv_transfer_params is not None
+    request.kv_transfer_params["do_remote_prefill"] = False
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+
+
 class FakeMoRIIOWrapper:
     # A fake MoRIIOWrapper for testing purposes
     def __init__(self, *args, **kwargs):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -501,8 +501,9 @@ class MoRIIOConnectorScheduler:
 
         token_ids = request.prompt_token_ids or []
         if self.mode == MoRIIOMode.WRITE:
-            # MoriiO in write mode, no remote prefill
-
+            params = request.kv_transfer_params or {}
+            if not params.get("do_remote_prefill"):
+                return 0, False
             return len(token_ids) - num_computed_tokens, True
 
         return len(token_ids) - 1 - num_computed_tokens, False


### PR DESCRIPTION
## Purpose

MoRIIO WRITE mode performs a one-shot KV transfer from the prefill worker to the decode worker. Under decoder KV-cache pressure, vLLM may preempt and reschedule a request.

After the initial transfer, do_remote_prefill is set to False. However, get_num_new_matched_tokens() ignored this flag and incorrectly requested another asynchronous remote-KV load.

The second transfer never occurs because the original transfer was already consumed. Depending on scheduler state, this caused either:
  - Requests to remain indefinitely deferred waiting for remote KV.
  - An EngineCore crash:

## Test Plan

Test with

server: `vllm-router` on 1P1D disaggregation
client: `vllm bench serve`

**vllm-router**
```bash
vllm-router --vllm-pd-disaggregation \
  --kv-connector moriio \
  --vllm-discovery-address 127.0.0.1:36431 \
  --port 10131
```

**Prefill engine**
```bash
HIP_VISIBLE_DEVICES=0 vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --port 20131 \
  --no-enable-prefix-caching \
  --enforce-eager \
  --max-model-len 1024 \
  --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_connector_extra_config":{"proxy_ip":"127.0.0.1","proxy_ping_port":"36431","http_port":"20131","handshake_port":"6311","notify_port":"6111","backend":"xgmi","host_ip":"127.0.0.1","read_mode":"false"}}'
```

**Decode engine with small kv-cache memory for reproduce**
```bash
HIP_VISIBLE_DEVICES=1 vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --port 40131 \
  --enforce-eager \
  --no-enable-prefix-caching \
  --max-model-len 1024 \
  --kv-cache-memory-bytes 134217728 \
  --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_connector_extra_config": {"proxy_ip":"127.0.0.1","proxy_ping_port":"36431","http_port":"40131","handshake_port":"7311","notify_port":"7511","backend":"xgmi","host_ip":"127.0.0.1","read_mode":"false"}}'
```

**Bench**
```bash
timeout 45s vllm bench serve \
  --base-url http://127.0.0.1:10131 \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --num-prompts 3 \
  --request-rate inf \
  --random-input-len 256 \
  --random-output-len 256 \
  --ignore-eos
```

## Test Result

**Before fix**: requested deferred and timeout
<img width="1107" height="77" alt="Screenshot 2026-08-21 at 5 46 45 PM" src="https://github.com/user-attachments/assets/71a924aa-4276-4248-8fc9-3f608e6dccb2" />

**After fix**: succeeded with
```
============ Serving Benchmark Result ============
Successful requests:                     3         
Failed requests:                         0         
Benchmark duration (s):                  4.48      
Total input tokens:                      768       
Total generated tokens:                  768       
Request throughput (req/s):              0.67      
Output token throughput (tok/s):         171.41    
Peak output token throughput (tok/s):    251.00    
Peak concurrent requests:                3.00      
Total token throughput (tok/s):          342.82    
---------------Time to First Token----------------
Mean TTFT (ms):                          151.95    
Median TTFT (ms):                        145.24    
P99 TTFT (ms):                           165.38    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.57     
Median TPOT (ms):                        10.73     
P99 TPOT (ms):                           16.79     
---------------Inter-token Latency----------------
Mean ITL (ms):                           12.57     
Median ITL (ms):                         9.97      
P99 ITL (ms):                            12.45     
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

