### PR TITLE
[Perf][Spec Decode] Reuse DFlash context RoPE cache dtype

### DIFF
--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
 from vllm.model_executor.models.qwen3_dflash2 import _grouped_conv, _score_edges
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import DFlash2Speculator
@@ -116,3 +117,26 @@ def test_selector_asks_for_fp32_proposal_logits():
 
     assert dtype is torch.float32
     assert fill == float("-inf")
+
+
+def test_dflash_context_rope_cache_matches_k_dtype_and_reuses_storage():
+    """Context RoPE cache conversion is persistent for the fixed K dtype."""
+    model = DFlashQwen3Model.__new__(DFlashQwen3Model)
+    torch.nn.Module.__init__(model)
+    model._rope_cos_sin_cache = torch.randn(16, 8, dtype=torch.float32)
+    k = torch.randn(2, 8, dtype=torch.bfloat16)
+
+    cache = model._get_context_rope_cache(k)
+    assert cache.dtype is torch.bfloat16
+    first_data_ptr = cache.data_ptr()
+
+    assert model._get_context_rope_cache(k).data_ptr() == first_data_ptr
+
+    fp32_model = DFlashQwen3Model.__new__(DFlashQwen3Model)
+    torch.nn.Module.__init__(fp32_model)
+    fp32_model._rope_cos_sin_cache = torch.randn(16, 8, dtype=torch.float32)
+    fp32_k = torch.randn(2, 8, dtype=torch.float32)
+    original_data_ptr = fp32_model._rope_cos_sin_cache.data_ptr()
+    fp32_cache = fp32_model._get_context_rope_cache(fp32_k)
+    assert fp32_cache.dtype is torch.float32
+    assert fp32_cache.data_ptr() == original_data_ptr

--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -140,3 +140,31 @@ def test_dflash_context_rope_cache_matches_k_dtype_and_reuses_storage():
     fp32_cache = fp32_model._get_context_rope_cache(fp32_k)
     assert fp32_cache.dtype is torch.float32
     assert fp32_cache.data_ptr() == original_data_ptr
+
+
+def test_dflash_context_rope_cache_rejects_device_mismatch():
+    """DFlash cache placement errors are reported before the custom op call."""
+    model = DFlashQwen3Model.__new__(DFlashQwen3Model)
+    torch.nn.Module.__init__(model)
+    model._rope_cos_sin_cache = torch.randn(16, 8, dtype=torch.float32)
+
+    with pytest.raises(
+        RuntimeError,
+        match="RoPE cache and projected K must be on the same device",
+    ):
+        model._get_context_rope_cache(torch.empty(2, 8, device="meta"))
+
+
+def test_dflash_context_rope_cache_does_not_mutate_during_compile(monkeypatch):
+    """Compile tracing receives a converted cache without mutating the model."""
+    model = DFlashQwen3Model.__new__(DFlashQwen3Model)
+    torch.nn.Module.__init__(model)
+    original_cache = torch.randn(16, 8, dtype=torch.float32)
+    model._rope_cos_sin_cache = original_cache
+    k = torch.randn(2, 8, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    cache = model._get_context_rope_cache(k)
+
+    assert cache.dtype is torch.bfloat16
+    assert model._rope_cos_sin_cache is original_cache

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -590,13 +590,18 @@ class DFlashQwen3Model(nn.Module):
     def _get_context_rope_cache(self, k: torch.Tensor) -> torch.Tensor:
         """Return the context RoPE cache matched to the projected K tensor."""
         cos_sin_cache = self._rope_cos_sin_cache
-        if (
-            cos_sin_cache.device == k.device
-            and cos_sin_cache.dtype == k.dtype
-        ):
+        if cos_sin_cache.device != k.device:
+            raise RuntimeError(
+                "DFlash RoPE cache and projected K must be on the same device"
+            )
+
+        if cos_sin_cache.dtype == k.dtype:
             return cos_sin_cache
 
-        cos_sin_cache = cos_sin_cache.to(device=k.device, dtype=k.dtype)
+        cos_sin_cache = cos_sin_cache.to(dtype=k.dtype)
+        if torch.compiler.is_compiling():
+            return cos_sin_cache
+
         self._rope_cos_sin_cache = cos_sin_cache
         return cos_sin_cache
 

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -587,6 +587,19 @@ class DFlashQwen3Model(nn.Module):
         )
         return all_k_normed
 
+    def _get_context_rope_cache(self, k: torch.Tensor) -> torch.Tensor:
+        """Return the context RoPE cache matched to the projected K tensor."""
+        cos_sin_cache = self._rope_cos_sin_cache
+        if (
+            cos_sin_cache.device == k.device
+            and cos_sin_cache.dtype == k.dtype
+        ):
+            return cos_sin_cache
+
+        cos_sin_cache = cos_sin_cache.to(device=k.device, dtype=k.dtype)
+        self._rope_cos_sin_cache = cos_sin_cache
+        return cos_sin_cache
+
     def precompute_and_store_context_kv(
         self,
         context_states: torch.Tensor,
@@ -626,9 +639,7 @@ class DFlashQwen3Model(nn.Module):
         # In-place RoPE: pass K as the "query" arg with key=None.
         all_k_flat = all_k_normed.view(L * num_ctx, kv)
         positions_repeated = context_positions.repeat(L)
-        cos_sin_cache = self._rope_cos_sin_cache
-        if cos_sin_cache.dtype != all_k_flat.dtype:
-            cos_sin_cache = cos_sin_cache.to(dtype=all_k_flat.dtype)
+        cos_sin_cache = self._get_context_rope_cache(all_k_flat)
         ops.rotary_embedding(
             positions_repeated,
             all_k_flat,


### PR DESCRIPTION
## Summary

- Persist the dtype-matched RoPE cache in DFlash context-KV precompute.
- Avoid converting the full FP32→BF16 RoPE table on every speculative step.
- Keep device placement strict and avoid cache mutation during `torch.compile`.

## Benchmark

Environment: RTX 4080 SUPER 32 GiB, PyTorch 2.13.0+cu130, CUDA 13.0, vLLM 0.26.1rc1.dev252+g9a4fd57ca.

Model: `Qwen/Qwen3-0.6B` + `Eros483/Qwen3-0.6B-DFlash-shift-b8`, 8 speculative tokens.

- RoPE microbenchmark, 100 iterations × 3 rounds: conversion calls `100 → 1`; median total time `3.370 ms → 1.902 ms`; `aten::copy_` CUDA time `0.829 ms → 0.0087 ms`.
- Real context-KV precompute, 10 measured calls after warmup: median `0.889 ms → 0.608 ms`.
- End-to-end A/B: `313.2 → 309.0 tok/s`; this small-model result is within measurement noise and does not establish a stable E2E speedup.

The default BF16 configuration has matching RoPE/K dtypes, so the optimization is exercised with a controlled FP32 RoPE-cache mismatch condition.

## Tests

- DFlash/spec-decode tests: 27 passed.
- Pre-commit checks: passed.
- Target and draft models load and run successfully.

## Notes

- No overlapping open PR was found for DFlash RoPE cache dtype reuse. Existing DFlash cache-update PRs target KV-cache writes, not this RoPE-table conversion.
- AI assistance was used; all changed lines and test results should be reviewed by the submitting human.
