### PR TITLE
[CI][Release] Extend DSv4 engine readiness timeout

### DIFF
--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -237,6 +237,7 @@ steps:
     PREFILL_BLOCK_SIZE: "256"
     DECODE_BLOCK_SIZE: "256"
     MODEL_NAMES: "deepseek-ai/DeepSeek-V4-Flash"
+    VLLM_ENGINE_READY_TIMEOUT_S: "900"
     VLLM_SERVE_EXTRA_ARGS: "--trust-remote-code,--kv-cache-dtype,fp8"
   commands:
     - bash /vllm-workspace/.buildkite/scripts/install-kv-connectors.sh


### PR DESCRIPTION
## Purpose

Set `VLLM_ENGINE_READY_TIMEOUT_S=900` for the release-branch DSv4-Flash disaggregated CI step. The rc1 original/retry and rc2 build #84971 all exceeded the current internal 600-second readiness deadline on `h200-ci-1`; the rc2 engine became reachable only after the job had already failed. The outer 1200-second wait and 60-minute Buildkite timeout already accommodate a 900-second engine-start budget.

Duplicate check: no open PR or issue was found for the DSv4 engine-readiness timeout on `releases/v0.28.0`.

AI assistance was used to investigate the CI timing and prepare this one-line configuration change. Human review of the changed line is required.

## Test plan

- `git diff --check`
- `uvx pre-commit run --files .buildkite/test_areas/disaggregated.yaml`
- After merge, run the exact `dsv4-flash-disaggregated` Buildkite step at the merged `releases/v0.28.0` commit.

## Test results

- `git diff --check`: passed.
- All applicable pre-commit hooks: passed.
- Model evaluation is not applicable because this only changes the CI engine-readiness budget; the exact DSv4 accuracy job is the validation gate.