### PR TITLE
[Bug]: finish_reason="tool_calls" is returned with an empty tool_calls array when tool_choice="re...

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat_error.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat_error.py
@@ -170,6 +170,59 @@ async def test_chat_error_non_stream():
 
 
 @pytest.mark.asyncio
+async def test_required_tool_choice_no_calls_non_stream_finish_reason():
+    """When tool_choice='required' but no tool calls are produced, the
+    non-streaming finish_reason must be 'stop' (not 'tool_calls')."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    # A completion output that finished with 'stop' but produced no tool calls
+    completion_output = CompletionOutput(
+        index=0,
+        text="Hello! I'm fine.",
+        token_ids=[],
+        cumulative_logprob=None,
+        logprobs=None,
+        finish_reason="stop",
+    )
+
+    request_output = RequestOutput(
+        request_id="test-id",
+        prompt="Test prompt",
+        prompt_token_ids=[1, 2, 3],
+        prompt_logprobs=None,
+        outputs=[completion_output],
+        finished=True,
+        metrics=None,
+        lora_request=None,
+        encoder_prompt=None,
+        encoder_prompt_token_ids=None,
+    )
+
+    async def mock_generate(*args, **kwargs):
+        yield request_output
+
+    mock_engine.generate = MagicMock(side_effect=mock_generate)
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=10,
+        stream=False,
+        tool_choice="required",
+    )
+
+    response = await serving_chat.create_chat_completion(request)
+    # Ensure non-streaming path reports 'stop' when no tool calls exist
+    assert response.choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_keeps_mm_cache_for_engine_execution():
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.errored = False

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1048,6 +1048,7 @@ class OpenAIServingChat(GenerateBaseServing):
                 request.tool_choice
                 and request.tool_choice == "required"
                 and output.finish_reason == "stop"
+                and bool(tool_calls)
             )
 
             routed_experts_b64 = (


### PR DESCRIPTION
Fixes #53255

_AI-assisted, auto-generated by the vLLM issue bot (Copilot Agent)._
_No existing open PR addresses this issue (checked before opening)._

Summary
- Root cause: non-streaming path set finish_reason="tool_calls" when tool_choice=="required" without verifying any tool_calls existed.
- Fix: require non-empty tool_calls before mapping stop->"tool_calls".
- Tests: added a minimal non-streaming unit test asserting finish_reason=="stop" when tool_choice="required" produces no calls.
What changed
- vllm/entrypoints/openai/chat_completion/serving.py
  - Guarded the non-streaming finish_reason decision with and bool(tool_calls).
- tests/entrypoints/openai/chat_completion/test_chat_error.py
  - Added test_required_tool_choice_no_calls_non_stream_finish_reason asserting the response finish_reason is "stop".
Commit & push
- Created branch fix/issue-53255 and committed the change with Co-authored-by trailer.
- Attempted to push to origin but push failed due to lack of GitHub credentials:
  fatal: could not read Username for 'https://github.com': terminal prompts disabled
Next steps for a human maintainer
1. Review the two-file diff (sm...