### PR TITLE
[ROCm][Perf] Add `gelu_tanh` activation to AITER fp8 fmoe 

### DIFF
--- a/tests/kernels/moe/test_moe_kernel_oracle.py
+++ b/tests/kernels/moe/test_moe_kernel_oracle.py
@@ -49,3 +49,26 @@ class TestUnquantizedDelegation:
             None,  # routing_tables default
         )
         assert out is sentinel_kernel
+
+
+def test_fp8_round_up_intermediate_size_for_aiter() -> None:
+    """Ensure fp8 MoE GEMM is rounded up to factor 128 when on AITER."""
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+        Fp8MoeBackend,
+        fp8_round_up_hidden_size_and_intermediate_size,
+    )
+
+    # Should round
+    assert fp8_round_up_hidden_size_and_intermediate_size(
+        Fp8MoeBackend.AITER, 2048, 704
+    ) == (2048, 768)
+
+    # no-op
+    assert fp8_round_up_hidden_size_and_intermediate_size(
+        Fp8MoeBackend.AITER, 2048, 1024
+    ) == (2048, 1024)
+
+    # Non-AITER backends are untouched even when non-128-aligned.
+    assert fp8_round_up_hidden_size_and_intermediate_size(
+        Fp8MoeBackend.TRITON, 2048, 704
+    ) == (2048, 704)

--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -220,6 +220,8 @@ def ref_moe_forward(
             act = F.silu(gate) * up
         elif activation == "gelu":
             act = F.gelu(gate) * up
+        elif activation == "gelu_tanh":
+            act = F.gelu(gate, approximate="tanh") * up
         else:
             raise ValueError(f"Unknown activation: {activation}")
         output[expert_mask] = act @ w2_f[expert_idx].T
@@ -600,6 +602,7 @@ def test_activation_method_enum_values():
 
     assert ActivationMethod.SILU == 0
     assert ActivationMethod.GELU == 1
+    assert ActivationMethod.GELU_TANH == 4
 
 
 # MXFP4 kernel tests ------------------------------------------------------
@@ -845,6 +848,51 @@ def test_aiter_fused_moe_gelu_accuracy():
         out.float(),
         ref_out,
         label="gelu_accuracy",
+        atol=0.05,
+        rtol=0.0,
+    )
+
+
+def test_aiter_fused_moe_gelu_tanh_accuracy():
+    """The tanh-approx GELU variant (Gemma-family MoE) should stay aligned with
+    the float32 tanh-approx reference."""
+    from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+        ActivationMethod,
+        QuantMethod,
+    )
+
+    _assert_aiter_supported()
+    case = _make_moe_case(
+        num_tokens=32,
+        hidden_dim=512,
+        intermediate_dim=1024,
+        num_experts=4,
+        topk=2,
+        seed=42,
+    )
+    ref_out = ref_moe_forward(
+        case["hidden_states"],
+        case["w1"],
+        case["w2"],
+        case["topk_weights"],
+        case["topk_ids"],
+        activation="gelu_tanh",
+    )
+    out = _run_fused_moe(
+        case["hidden_states"],
+        case["w1"],
+        case["w2"],
+        case["topk_weights"],
+        case["topk_ids"],
+        activation_method=int(ActivationMethod.GELU_TANH),
+        quant_method=int(QuantMethod.NO),
+    )
+
+    assert out.shape == case["hidden_states"].shape
+    _assert_close_budget(
+        out.float(),
+        ref_out,
+        label="gelu_tanh_accuracy",
         atol=0.05,
         rtol=0.0,
     )

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -51,6 +51,7 @@ class ActivationMethod(IntEnum):
     # without importing the ActivationType enum from AITER globally.
     SILU = 0
     GELU = 1
+    GELU_TANH = 4
 
 
 aiter_topK_meta_data: tuple[torch.Tensor, torch.Tensor] | None = None
@@ -257,6 +258,8 @@ def rocm_aiter_fused_experts(
         activation_method = ActivationMethod.SILU
     elif activation == MoEActivation.GELU:
         activation_method = ActivationMethod.GELU
+    elif activation == MoEActivation.GELU_TANH:
+        activation_method = ActivationMethod.GELU_TANH
     elif activation == MoEActivation.SWIGLUOAI:
         activation_method = rocm_aiter_ops.get_aiter_activation_type("swiglu")
     elif activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
@@ -484,6 +487,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         return activation in [
             MoEActivation.SILU,
             MoEActivation.GELU,
+            MoEActivation.GELU_TANH,
             MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -35,6 +35,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
 )
 from vllm.platforms import current_platform
+from vllm.utils.math_utils import round_up
 
 logger = init_logger(__name__)
 
@@ -64,6 +65,21 @@ class Fp8MoeBackend(Enum):
     TRITON_MXFP8 = "TRITON_MXFP8"
     # MXFP8 MoE via AITER (FlyDSL two-stage grouped GEMM) on gfx950.
     AITER_MXFP8 = "AITER_MXFP8"
+
+
+def fp8_round_up_hidden_size_and_intermediate_size(
+    backend: Fp8MoeBackend,
+    hidden_size: int,
+    intermediate_size: int,
+) -> tuple[int, int]:
+    """Round up hidden_size and intermediate_size based on backend requirements."""
+    if backend == Fp8MoeBackend.AITER:
+        # AITER's 2-stage CK fp8 MoE GEMM is numerically broken for intermediate
+        # sizes that aren't 128-aligned (e.g. Gemma4-26B-A4B's 704;
+        # activation-independent). Align to 128; the padded tail is zeroed by the
+        # standard weight-loading narrow-and-copy path.
+        intermediate_size = round_up(intermediate_size, 128)
+    return hidden_size, intermediate_size
 
 
 def _get_priority_backends(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -11,6 +11,7 @@ from compressed_tensors.quantization import (
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
+    FusedMoEParallelConfig,
     FusedMoeWeightScaleSupported,
     RoutedExperts,
     SharedExperts,
@@ -21,6 +22,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     convert_to_fp8_moe_kernel_format,
+    fp8_round_up_hidden_size_and_intermediate_size,
     make_fp8_moe_kernel,
     make_fp8_moe_quant_config,
     select_fp8_moe_backend,
@@ -108,6 +110,23 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
             weight_key=weight_key,
             activation_key=activation_key,
             allow_vllm_cutlass=True,
+        )
+
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            act_dtype=act_dtype,
+            moe_parallel_config=moe_parallel_config,
+        )
+        return fp8_round_up_hidden_size_and_intermediate_size(
+            self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
 
     def create_weights(

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -19,6 +19,7 @@ from vllm.model_executor.kernels.linear.scaled_mm import (
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEMethodBase,
+    FusedMoEParallelConfig,
     FusedMoeWeightScaleSupported,
     RoutedExperts,
     SharedExperts,
@@ -29,6 +30,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     convert_to_fp8_moe_kernel_format,
+    fp8_round_up_hidden_size_and_intermediate_size,
     make_fp8_moe_kernel,
     make_fp8_moe_quant_config,
     select_fp8_moe_backend,
@@ -501,6 +503,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             weight_key=weight_key,
             activation_key=activation_key,
             allow_vllm_cutlass=False,
+        )
+
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> tuple[int, int]:
+        hidden_size, intermediate_size_per_partition = super().maybe_roundup_sizes(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size_per_partition,
+            act_dtype=act_dtype,
+            moe_parallel_config=moe_parallel_config,
+        )
+        return fp8_round_up_hidden_size_and_intermediate_size(
+            self.fp8_backend, hidden_size, intermediate_size_per_partition
         )
 
     def create_weights(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

**Depends on AITER v0.1.21 bump (for https://github.com/ROCm/aiter/pull/4620)**

Useful for Gemma4-style models. We get rid of these logs:

```
(EngineCore pid=20921) WARNING 08-21 12:08:05 [activation.py:444] [ROCm] PyTorch's native GELU with tanh approximation is unstable with torch.compile. For native implementation, fallback to 'none' approximation. The custom kernel implementation is unaffected.
```

Co-authored with: @elliotz-ai

## Test Plan

Unit tests run:
```
python -m pytest \
  tests/kernels/moe/test_moe_kernel_oracle.py::test_fp8_round_up_intermediate_size_for_aiter \
  tests/kernels/moe/test_rocm_aiter_moe.py::test_activation_method_enum_values \
  tests/kernels/moe/test_rocm_aiter_moe.py::test_aiter_fused_moe_gelu_tanh_accuracy -v
```

## Test Result

```
TODO
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)


