### PR TITLE
docs: add OrcaRouter deployment framework guide

### DIFF
--- a/docs/deployment/frameworks/orcarouter.md
+++ b/docs/deployment/frameworks/orcarouter.md
@@ -1,0 +1,53 @@
+# OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway. Point your application at OrcaRouter and it forwards requests to the best upstream — including a self-hosted vLLM server registered as a custom endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Routing requests through OrcaRouter keeps a single OpenAI-compatible base URL for all of your applications: instead of configuring each one with the address of your vLLM server, they all talk to OrcaRouter, which sends traffic to your vLLM deployment (and can fall back to other upstreams when it is unavailable).
+
+## Prerequisites
+
+Set up the vLLM and OrcaRouter environment:
+
+```bash
+pip install vllm openai
+```
+
+You also need an [OrcaRouter API key](https://www.orcarouter.ai).
+
+## Deploy
+
+### 1. Start the vLLM server
+
+Serve the model that will be the upstream, e.g.
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct
+```
+
+### 2. Register your vLLM server as a custom endpoint
+
+In the OrcaRouter console, register your vLLM endpoint (`http://{your-vllm-server-host}:{your-vllm-server-port}/v1`) as a custom endpoint and assign it a model id, e.g. `my-org/vllm-llama-3-1-8b`. Requests to that model id are routed to your vLLM server.
+
+### 3. Call it through OrcaRouter
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.orcarouter.ai/v1", # OrcaRouter's OpenAI-compatible endpoint
+    api_key="sk-orca-...", # your OrcaRouter API key
+)
+
+response = client.chat.completions.create(
+    model="my-org/vllm-llama-3-1-8b", # the id you assigned to your vLLM endpoint
+    messages=[{"role": "user", "content": "Hello, how are you?"}],
+    temperature=0.2,
+    max_tokens=80,
+)
+
+print(response.choices[0].message.content)
+```
+
+You can also use the router model `orcarouter/auto`, which picks an upstream automatically for the request.
+
+For details, see the [OrcaRouter documentation](https://docs.orcarouter.ai).


### PR DESCRIPTION
## Purpose

Add an [OrcaRouter](https://www.orcarouter.ai) page to the deployment framework guides, mirroring the existing [LiteLLM](docs/deployment/frameworks/litellm.md) entry.

vLLM is a fast and easy-to-use library for LLM inference and serving, and its OpenAI-compatible server is a common upstream for gateway routers. OrcaRouter is an OpenAI-compatible model routing gateway: you register your vLLM server as a custom endpoint, and OrcaRouter forwards requests to it — giving every application that already speaks OpenAI-compatible a single base URL, plus fallback across other upstreams. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The new page follows the same shape as the existing framework docs: start the vLLM server, register it as a custom endpoint, then call it through OrcaRouter's OpenAI-compatible endpoint.

## Test Plan

- `npx markdownlint-cli2 docs/deployment/frameworks/orcarouter.md` — 0 errors (repo `.markdownlint.yaml` config).
- `mkdocs build` with the repo's `requirements/docs.in` — exit 0; the page renders at `deployment/frameworks/orcarouter/`.
- Live check: `POST https://api.orcarouter.ai/v1/chat/completions` with `model: orcarouter/auto` and an OrcaRouter API key returned HTTP 200 with a normal completion.

## Test Result

- markdownlint-cli2: `0 error(s)`.
- `mkdocs build`: `Documentation built in ... seconds`, exit 0, no warnings for the new file.
- Live chat completion against the OrcaRouter endpoint documented in the page returned `HTTP 200`.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

