### PR TITLE
[Bugfix][ROCm] Pass AITER MoE the rank row count, not per-expert counts

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -539,7 +539,16 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         # with the interface once all quant integrations are complete.
 
         if expert_tokens_meta is not None:
-            num_local_tokens = expert_tokens_meta.expert_num_tokens
+            # AITER dereferences num_local_tokens[0] as the number of
+            # hidden_states rows this rank holds, while ExpertTokensMetadata
+            # carries one count per local expert. Forwarding the vector makes
+            # AITER stop at local expert 0's share and leave the remaining fp8
+            # activation and scale rows uninitialised, which the GEMM turns
+            # into NaNs. Reduce on device so the cudagraph path stays free of
+            # host synchronisation.
+            num_local_tokens = expert_tokens_meta.expert_num_tokens.sum(
+                dim=0, keepdim=True
+            ).to(torch.int32)
         else:
             num_local_tokens = None
 


### PR DESCRIPTION
## Summary

`AiterExperts.apply` forwards `ExpertTokensMetadata.expert_num_tokens` — one
count per *local expert* — into AITER's `num_local_tokens`. AITER defines that
argument as a single value, the number of `hidden_states` rows the rank holds,
and dereferences element `[0]`:

```c
// aiter csrc/include/moe_sorting_opus.h
const void* p_local_tokens;  // [1] if not nullptr, tokens read from here
...
return reinterpret_cast<const opus::index_t*>(kargs.p_local_tokens)[0];
```

It also passes the same value as `num_rows` to activation quantisation, so AITER
treats local expert 0's share as the whole rank's token count. With DeepSeek-R1's
256 experts over 8 expert-parallel ranks that entry is usually `0`: the rank
quantises nothing, the fp8 activation and scale buffers keep their uninitialised
`torch.empty` contents, and the GEMM turns them into NaNs.

Symptom: completions come back empty, and any request with `logprobs` fails with
`Out of range float values are not JSON compliant`.

## Fix

Reduce the vector to the value AITER asks for. The sum is exactly the number of
routed rows the rank received, and doing it on device keeps the cudagraph path
free of host synchronisation.

## Test

DeepSeek-R1 FP8, 8x MI350X (gfx950), `TP=1 / DP=8 / EP=8` over DeepEP,
`VLLM_ROCM_USE_AITER_MOE=1`. Same prompt, only this change:

| `num_local_tokens` | Completion | `logprobs` |
|---|---|---|
| after (`shape=(1,)`, `[4096]`) | `" Paris. 法国的首都是巴黎。"` | finite |
| before (`shape=(32,)`, `[0, 0, 0, 0, ...]`) | `""` | HTTP 400 `Out of range float values are not JSON compliant` |

In the failing case the expert output tensor comes back with the same numeric
range as its input, i.e. the experts never ran.

## Scope

Every `FusedMoEPrepareAndFinalize` that reports `ExpertTokensMetadata` builds
this argument the same way, so the DeepEP high-throughput path is affected too.