### PR TITLE
[Performance][MRV2] Fuse vocab-parallel LM head projection for small-K prompt logprobs

### DIFF
--- a/tests/kernels/test_lm_head_logprobs.py
+++ b/tests/kernels/test_lm_head_logprobs.py
@@ -1,0 +1,902 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+@pytest.fixture(scope="module")
+def _require_supported_cutedsl_device() -> None:
+    pytest.importorskip("cutlass")
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("Requires SM80+")
+    props = torch.cuda.get_device_properties(torch.accelerator.current_device_index())
+    max_smem = getattr(
+        props, "shared_memory_per_block_optin", props.shared_memory_per_block
+    )
+    if max_smem < 144 * 1024:
+        pytest.skip("Requires at least 144 KiB of shared memory per block")
+
+
+@pytest.mark.usefixtures("_require_supported_cutedsl_device")
+@pytest.mark.parametrize("num_topk", [0, 1, 5, 20, 32])
+def test_lm_head_logprobs_matches_full_projection(num_topk: int) -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        lm_head_logprobs,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(34)
+    hidden_states = (
+        torch.randn((17, 72), device="cuda", dtype=torch.bfloat16, generator=generator)
+        * 0.01
+    )
+    lm_head_weight = (
+        torch.randn(
+            (1051, 72), device="cuda", dtype=torch.bfloat16, generator=generator
+        )
+        * 0.01
+    )
+    local_target_ids = torch.tensor(
+        [0, 511, 512, 1024, 1049] + [-1] * 12,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    target_logits = torch.linspace(-0.25, 0.25, 17, device="cuda", dtype=torch.float32)
+    valid_vocab_size = 1050
+    global_vocab_start = 2000
+
+    output = lm_head_logprobs(
+        hidden_states,
+        lm_head_weight,
+        local_target_ids,
+        target_logits,
+        num_topk,
+        valid_vocab_size=valid_vocab_size,
+        global_vocab_start=global_vocab_start,
+    )
+
+    logits = hidden_states.float() @ lm_head_weight[:valid_vocab_size].float().T
+    local_target_mask = local_target_ids >= 0
+    rows = torch.arange(hidden_states.shape[0], device="cuda")[local_target_mask]
+    logits[rows, local_target_ids[local_target_mask].long()] = target_logits[
+        local_target_mask
+    ]
+    expected_lse = torch.logsumexp(logits, dim=-1)
+    expected_rank = (logits >= target_logits[:, None]).sum(dim=-1).to(torch.int32)
+
+    assert torch.equal(output.rank_count, expected_rank)
+    assert torch.allclose(output.lse, expected_lse, rtol=2e-3, atol=2e-3)
+    if num_topk == 0:
+        assert output.topk_values.shape == (17, 0)
+        assert output.topk_ids.shape == (17, 0)
+        return
+
+    expected_values, expected_ids = torch.topk(logits, num_topk, dim=-1)
+    expected_ids = expected_ids.to(torch.int32) + global_vocab_start
+    assert torch.equal(output.topk_ids, expected_ids)
+    assert torch.allclose(output.topk_values, expected_values, rtol=2e-3, atol=2e-3)
+
+
+@pytest.mark.usefixtures("_require_supported_cutedsl_device")
+def test_lm_head_logprobs_preserves_empty_topk_width() -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        lm_head_logprobs,
+    )
+
+    output = lm_head_logprobs(
+        torch.empty((0, 64), device="cuda", dtype=torch.bfloat16),
+        torch.empty((128, 64), device="cuda", dtype=torch.bfloat16),
+        torch.empty(0, device="cuda", dtype=torch.int32),
+        torch.empty(0, device="cuda", dtype=torch.float32),
+        5,
+    )
+
+    assert output.topk_values.shape == (0, 5)
+    assert output.topk_ids.shape == (0, 5)
+    assert output.lse.shape == (0,)
+    assert output.rank_count.shape == (0,)
+
+
+@pytest.mark.usefixtures("_require_supported_cutedsl_device")
+def test_lm_head_logprobs_handles_ties_padding_and_rank_boundaries() -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        lm_head_logprobs,
+    )
+
+    hidden_states = torch.ones((2, 64), device="cuda", dtype=torch.bfloat16)
+    lm_head_weight = torch.zeros((260, 64), device="cuda", dtype=torch.bfloat16)
+    # Padding logits would dominate if valid_vocab_size were not respected.
+    lm_head_weight[257:] = 8
+    local_target_ids = torch.tensor([0, 256], device="cuda", dtype=torch.int32)
+    target_logits = torch.tensor([0.0, 1.0], device="cuda", dtype=torch.float32)
+
+    output = lm_head_logprobs(
+        hidden_states,
+        lm_head_weight,
+        local_target_ids,
+        target_logits,
+        5,
+        valid_vocab_size=257,
+        global_vocab_start=100,
+    )
+
+    expected_ids = torch.tensor(
+        [[100, 101, 102, 103, 104], [356, 100, 101, 102, 103]],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    expected_values = torch.tensor(
+        [[0.0] * 5, [1.0, 0.0, 0.0, 0.0, 0.0]],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    expected_lse = torch.tensor(
+        [math.log(257.0), math.log(math.e + 256.0)],
+        device="cuda",
+        dtype=torch.float32,
+    )
+
+    assert torch.equal(output.topk_ids, expected_ids)
+    assert torch.equal(output.topk_values, expected_values)
+    assert torch.equal(
+        output.rank_count,
+        torch.tensor([257, 1], device="cuda", dtype=torch.int32),
+    )
+    torch.testing.assert_close(output.lse, expected_lse, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "num_topk"),
+    [(1, 0), (2, 5), (4, 20)],
+)
+def test_merge_tp_prompt_logprobs_matches_full_logits(
+    tp_size: int, num_topk: int
+) -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        merge_tp_prompt_logprobs,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(61)
+    num_rows, local_vocab_size = 7, 37
+    logits = torch.randn(
+        (tp_size, num_rows, local_vocab_size),
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    global_logits = logits.permute(1, 0, 2).reshape(num_rows, -1)
+    target_token_ids = torch.linspace(
+        0,
+        global_logits.shape[1] - 1,
+        num_rows,
+        device="cuda",
+        dtype=torch.int64,
+    )
+    target_logits = global_logits.gather(1, target_token_ids[:, None]).squeeze(1)
+
+    local_values = []
+    local_ids = []
+    local_lse = []
+    local_rank_count = []
+    for tp_rank in range(tp_size):
+        values, ids = torch.topk(logits[tp_rank], num_topk, dim=1)
+        local_values.append(values)
+        local_ids.append((ids + tp_rank * local_vocab_size).to(torch.int32))
+        local_lse.append(torch.logsumexp(logits[tp_rank], dim=1))
+        local_rank_count.append(
+            (logits[tp_rank] >= target_logits[:, None]).sum(dim=1, dtype=torch.int32)
+        )
+
+    output_ids, output_logprobs, output_ranks = merge_tp_prompt_logprobs(
+        torch.stack(local_values),
+        torch.stack(local_ids),
+        torch.stack(local_lse),
+        torch.stack(local_rank_count),
+        target_token_ids,
+        target_logits,
+        num_topk,
+    )
+
+    global_lse = torch.logsumexp(global_logits, dim=1)
+    expected_ids = target_token_ids[:, None].to(torch.int32)
+    expected_logprobs = target_logits[:, None] - global_lse[:, None]
+    if num_topk > 0:
+        topk_values, topk_ids = torch.topk(global_logits, num_topk, dim=1)
+        expected_ids = torch.cat((expected_ids, topk_ids.to(torch.int32)), dim=1)
+        expected_logprobs = torch.cat(
+            (expected_logprobs, topk_values - global_lse[:, None]), dim=1
+        )
+    expected_ranks = (global_logits >= target_logits[:, None]).sum(
+        dim=1, dtype=torch.int32
+    )
+
+    assert torch.equal(output_ids, expected_ids)
+    assert torch.equal(output_ranks, expected_ranks)
+    assert torch.allclose(output_logprobs, expected_logprobs, atol=1e-5, rtol=1e-5)
+
+
+def test_merge_tp_prompt_logprobs_orders_cross_rank_ties() -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        merge_tp_prompt_logprobs,
+    )
+
+    local_logits = torch.tensor(
+        [[[2.0, 2.0, 1.0]], [[2.0, 1.5, 1.0]]],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    local_ids = torch.tensor(
+        [[[5, 7, 9]], [[2, 8, 10]]],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    local_lse = torch.logsumexp(local_logits, dim=-1)
+    output_ids, _, output_ranks = merge_tp_prompt_logprobs(
+        local_logits,
+        local_ids,
+        local_lse,
+        torch.tensor([[3], [3]], device="cuda", dtype=torch.int32),
+        torch.tensor([10], device="cuda", dtype=torch.int64),
+        torch.tensor([1.0], device="cuda", dtype=torch.float32),
+        3,
+    )
+
+    assert torch.equal(
+        output_ids,
+        torch.tensor([[10, 2, 5, 7]], device="cuda", dtype=torch.int32),
+    )
+    assert output_ranks.item() == 6
+
+
+def _prompt_target_logits_reference(
+    hidden_states: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    local_target_ids: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    output = torch.zeros(
+        hidden_states.shape[0],
+        dtype=torch.float32,
+        device=hidden_states.device,
+    )
+    is_local = (local_target_ids >= 0) & (local_target_ids < lm_head_weight.shape[0])
+    if not torch.any(is_local):
+        return output
+
+    target_ids = local_target_ids[is_local].to(torch.int64)
+    output[is_local] = (
+        hidden_states[is_local].float()
+        * lm_head_weight.index_select(0, target_ids).float()
+    ).sum(dim=-1)
+    if bias is not None:
+        output[is_local] += bias.index_select(0, target_ids).float()
+    return output
+
+
+def test_prompt_target_logits_non_local_targets_contribute_zero() -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        prompt_target_logits,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    hidden_states = torch.randn(
+        (7, 497),
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    lm_head_weight = torch.randn(
+        (19, 497),
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    bias = torch.randn(
+        19,
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    local_target_ids = torch.tensor(
+        [0, 18, -1, 19, 7, 3, 12],
+        device="cuda",
+        dtype=torch.int64,
+    )
+
+    actual = prompt_target_logits(
+        hidden_states,
+        lm_head_weight,
+        local_target_ids,
+        bias,
+    )
+    expected = _prompt_target_logits_reference(
+        hidden_states,
+        lm_head_weight,
+        local_target_ids,
+        bias,
+    )
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-4)
+    assert actual[2].item() == 0.0
+    assert actual[3].item() == 0.0
+
+
+@pytest.mark.parametrize(
+    ("dtype", "tolerance"),
+    [
+        pytest.param(torch.float16, 2e-3, id="fp16"),
+        pytest.param(torch.bfloat16, 2e-2, id="bf16"),
+    ],
+)
+def test_prompt_target_logits_fp32_accumulation(
+    dtype: torch.dtype,
+    tolerance: float,
+) -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        prompt_target_logits,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(1)
+    hidden_states = torch.randn(
+        (11, 4097),
+        device="cuda",
+        dtype=dtype,
+        generator=generator,
+    )
+    lm_head_weight = torch.randn(
+        (23, 4097),
+        device="cuda",
+        dtype=dtype,
+        generator=generator,
+    )
+    local_target_ids = torch.arange(11, device="cuda", dtype=torch.int32)
+
+    actual = prompt_target_logits(
+        hidden_states,
+        lm_head_weight,
+        local_target_ids,
+    )
+    expected = _prompt_target_logits_reference(
+        hidden_states,
+        lm_head_weight,
+        local_target_ids,
+    )
+
+    torch.testing.assert_close(
+        actual,
+        expected,
+        rtol=tolerance,
+        atol=tolerance,
+    )
+
+
+def test_prompt_target_logits_shard_sum_recovers_global_logits() -> None:
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        prompt_target_logits,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(2)
+    hidden_states = torch.randn(
+        (6, 513),
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    full_weight = torch.randn(
+        (20, 513),
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    full_bias = torch.randn(
+        20,
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    global_target_ids = torch.tensor(
+        [0, 9, 10, 11, 18, 19],
+        device="cuda",
+        dtype=torch.int64,
+    )
+    rank_0_ids = torch.where(global_target_ids < 10, global_target_ids, -1)
+    rank_1_ids = torch.where(
+        global_target_ids >= 10,
+        global_target_ids - 10,
+        -1,
+    )
+
+    rank_0_logits = prompt_target_logits(
+        hidden_states,
+        full_weight[:10],
+        rank_0_ids,
+        full_bias[:10],
+    )
+    rank_1_logits = prompt_target_logits(
+        hidden_states,
+        full_weight[10:],
+        rank_1_ids,
+        full_bias[10:],
+    )
+
+    expected = (
+        hidden_states.float() * full_weight.index_select(0, global_target_ids).float()
+    ).sum(dim=-1)
+    expected += full_bias.index_select(0, global_target_ids).float()
+    torch.testing.assert_close(
+        rank_0_logits + rank_1_logits,
+        expected,
+        rtol=1e-5,
+        atol=1e-4,
+    )
+
+
+def test_prompt_logprobs_warmup_compiles_cute_specializations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from tests.utils import ensure_current_vllm_config
+    from vllm.model_executor.kernels.linear.cute_dsl import lm_head_logprobs
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+    monkeypatch.setattr(
+        lm_head_logprobs,
+        "validate_lm_head_logprobs_environment",
+        lambda _weight: None,
+    )
+    compiled_k = []
+
+    with ensure_current_vllm_config():
+        processor = LogitsProcessor(128)
+
+    def record_k(*_args, num_logprobs: int | None = None):
+        # get_prompt_logprobs receives K as its fourth positional argument.
+        compiled_k.append(_args[-1] if num_logprobs is None else num_logprobs)
+
+    monkeypatch.setattr(processor, "get_prompt_logprobs", record_k)
+    processor.warmup_prompt_logprobs(
+        SimpleNamespace(
+            weight=torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+        )
+    )
+
+    assert compiled_k == [0, 32]
+
+
+def test_prompt_logprobs_warmup_reports_environment_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from tests.utils import ensure_current_vllm_config
+    from vllm.model_executor.kernels.linear.cute_dsl import lm_head_logprobs
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+    def reject_environment(_weight: torch.Tensor) -> None:
+        raise RuntimeError(
+            "the current GPU exposes only 128 KiB shared memory; "
+            "the compact prompt-logprobs path requires 144 KiB"
+        )
+
+    monkeypatch.setattr(
+        lm_head_logprobs,
+        "validate_lm_head_logprobs_environment",
+        reject_environment,
+    )
+    with ensure_current_vllm_config():
+        processor = LogitsProcessor(128)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS is enabled, but the current "
+            "GPU exposes only 128 KiB shared memory"
+        ),
+    ):
+        processor.warmup_prompt_logprobs(
+            SimpleNamespace(
+                weight=torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+            )
+        )
+
+
+def test_prompt_logprobs_warmup_reports_missing_cutedsl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+    from types import SimpleNamespace
+
+    from tests.utils import ensure_current_vllm_config
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+    module_name = "vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs"
+    monkeypatch.setitem(sys.modules, module_name, None)
+    with ensure_current_vllm_config():
+        processor = LogitsProcessor(128)
+
+    with pytest.raises(
+        RuntimeError, match="CuTe DSL dependencies could not be imported"
+    ):
+        processor.warmup_prompt_logprobs(
+            SimpleNamespace(
+                weight=torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("processor_updates", "lm_head_updates", "hidden_dtype", "error", "match"),
+    [
+        ({"logits_as_input": True}, {}, torch.bfloat16, ValueError, "projection"),
+        ({"scale": 2.0}, {}, torch.bfloat16, ValueError, "unmodified"),
+        ({"soft_cap": 10.0}, {}, torch.bfloat16, ValueError, "unmodified"),
+        ({"head_dtype": torch.float32}, {}, torch.bfloat16, ValueError, "FP32"),
+        ({}, {"quant_method": object()}, torch.bfloat16, TypeError, "unquantized"),
+        ({}, {}, torch.float16, TypeError, "BF16 hidden states"),
+        (
+            {},
+            {"weight": torch.empty((128, 64), dtype=torch.float16)},
+            torch.bfloat16,
+            TypeError,
+            "BF16 hidden states",
+        ),
+        (
+            {},
+            {"bias": torch.empty(128)},
+            torch.bfloat16,
+            ValueError,
+            "LM-head bias",
+        ),
+        (
+            {},
+            {"num_added_embeddings": 1},
+            torch.bfloat16,
+            ValueError,
+            "added vocabulary",
+        ),
+        (
+            {},
+            {"org_vocab_size": 129},
+            torch.bfloat16,
+            ValueError,
+            "vocabulary sizes must match",
+        ),
+    ],
+)
+def test_validate_prompt_logprobs_rejects_unsupported_config(
+    processor_updates: dict[str, object],
+    lm_head_updates: dict[str, object],
+    hidden_dtype: torch.dtype,
+    error: type[Exception],
+    match: str,
+) -> None:
+    from types import SimpleNamespace
+
+    from tests.utils import ensure_current_vllm_config
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        UnquantizedEmbeddingMethod,
+    )
+
+    with ensure_current_vllm_config():
+        processor = LogitsProcessor(128)
+    for name, value in processor_updates.items():
+        setattr(processor, name, value)
+
+    lm_head_attributes = {
+        "weight": torch.empty((128, 64), dtype=torch.bfloat16),
+        "bias": None,
+        "quant_method": UnquantizedEmbeddingMethod(),
+        "num_added_embeddings": 0,
+        "org_vocab_size": 128,
+    }
+    lm_head_attributes.update(lm_head_updates)
+    lm_head = SimpleNamespace(**lm_head_attributes)
+
+    with pytest.raises(error, match=match):
+        processor.validate_prompt_logprobs(lm_head, hidden_dtype)
+
+
+@pytest.mark.parametrize(
+    ("weight_layout", "match"),
+    [
+        ("noncontiguous", "contiguous"),
+        ("hidden_size", "hidden size must be divisible by 8"),
+        ("unaligned", "16-byte aligned"),
+    ],
+)
+def test_validate_lm_head_logprobs_environment_rejects_invalid_weight(
+    weight_layout: str,
+    match: str,
+) -> None:
+    pytest.importorskip("cutlass")
+    from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+        validate_lm_head_logprobs_environment,
+    )
+
+    if weight_layout == "noncontiguous":
+        weight = torch.empty((64, 128), device="cuda", dtype=torch.bfloat16).T
+    elif weight_layout == "hidden_size":
+        weight = torch.empty((128, 65), device="cuda", dtype=torch.bfloat16)
+    else:
+        storage = torch.empty(128 * 64 + 1, device="cuda", dtype=torch.bfloat16)
+        weight = storage[1:].view(128, 64)
+
+    with pytest.raises(ValueError, match=match):
+        validate_lm_head_logprobs_environment(weight)
+
+
+def test_validate_lm_head_logprobs_environment_rejects_pre_sm80(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    pytest.importorskip("cutlass")
+    from vllm.model_executor.kernels.linear.cute_dsl import lm_head_logprobs
+
+    capability = SimpleNamespace(major=7, to_int=lambda: 70)
+    monkeypatch.setattr(
+        lm_head_logprobs.current_platform,
+        "get_device_capability",
+        lambda _device_index: capability,
+    )
+    weight = torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+
+    with pytest.raises(RuntimeError, match="requires SM80 or newer"):
+        lm_head_logprobs.validate_lm_head_logprobs_environment(weight)
+
+
+def test_validate_lm_head_logprobs_environment_rejects_insufficient_smem(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    pytest.importorskip("cutlass")
+    from vllm.model_executor.kernels.linear.cute_dsl import lm_head_logprobs
+
+    capability = SimpleNamespace(major=8, to_int=lambda: 80)
+    monkeypatch.setattr(
+        lm_head_logprobs.current_platform,
+        "get_device_capability",
+        lambda _device_index: capability,
+    )
+    monkeypatch.setattr(
+        lm_head_logprobs,
+        "cuda_get_device_properties",
+        lambda *_args, **_kwargs: (128 * 1024,),
+    )
+    weight = torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+
+    with pytest.raises(RuntimeError, match="requires 144 KiB"):
+        lm_head_logprobs.validate_lm_head_logprobs_environment(weight)
+
+
+@pytest.mark.parametrize("num_logprobs", [0, 5, 20])
+@pytest.mark.usefixtures("_require_supported_cutedsl_device")
+def test_logits_processor_prompt_logprobs_tp1(num_logprobs: int) -> None:
+    """Validate the compact FP32-accumulator prompt-logprobs contract."""
+    from types import SimpleNamespace
+
+    from tests.utils import ensure_current_vllm_config
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        UnquantizedEmbeddingMethod,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(73)
+    num_rows, hidden_size, vocab_size = 17, 72, 1050
+    hidden_states = (
+        torch.randn(
+            (num_rows, hidden_size),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.01
+    )
+    lm_head_weight = (
+        torch.randn(
+            (vocab_size, hidden_size),
+            device="cuda",
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.01
+    )
+    target_token_ids = torch.linspace(
+        0,
+        vocab_size - 1,
+        num_rows,
+        device="cuda",
+        dtype=torch.int64,
+    )
+    shard_indices = SimpleNamespace(
+        org_vocab_start_index=0,
+        org_vocab_end_index=vocab_size,
+        num_org_elements=vocab_size,
+    )
+    lm_head = SimpleNamespace(
+        weight=lm_head_weight,
+        bias=None,
+        quant_method=UnquantizedEmbeddingMethod(),
+        num_added_embeddings=0,
+        org_vocab_size=vocab_size,
+        tp_size=1,
+        shard_indices=shard_indices,
+    )
+
+    with ensure_current_vllm_config():
+        output_ids, output_logprobs, output_ranks = LogitsProcessor(
+            vocab_size
+        ).get_prompt_logprobs(
+            lm_head,
+            hidden_states,
+            target_token_ids,
+            num_logprobs,
+        )
+
+    # Compact prompt logprobs intentionally keep FP32 accumulation through
+    # top-K, LSE, and rank computation; this is its numerical reference.
+    logits = hidden_states.float() @ lm_head_weight.float().T
+    target_logits = logits.gather(1, target_token_ids[:, None]).squeeze(1)
+    lse = torch.logsumexp(logits, dim=1)
+    expected_ids = target_token_ids[:, None].to(torch.int32)
+    expected_logprobs = target_logits[:, None] - lse[:, None]
+    if num_logprobs > 0:
+        topk_values, topk_ids = torch.topk(logits, num_logprobs, dim=1)
+        expected_ids = torch.cat((expected_ids, topk_ids.to(torch.int32)), dim=1)
+        expected_logprobs = torch.cat(
+            (expected_logprobs, topk_values - lse[:, None]), dim=1
+        )
+    expected_ranks = (logits >= target_logits[:, None]).sum(dim=1, dtype=torch.int32)
+
+    assert torch.equal(output_ids, expected_ids)
+    assert torch.equal(output_ranks, expected_ranks)
+    torch.testing.assert_close(
+        output_logprobs,
+        expected_logprobs,
+        rtol=2e-3,
+        atol=2e-3,
+    )
+
+
+def _run_logits_processor_prompt_logprobs_tp2(
+    local_rank: int,
+    world_size: int,
+    master_port: int,
+) -> None:
+    from types import SimpleNamespace
+
+    from tests.utils import ensure_current_vllm_config
+    from vllm.distributed import cleanup_dist_env_and_memory
+    from vllm.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from vllm.model_executor.layers.logits_processor import LogitsProcessor
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        UnquantizedEmbeddingMethod,
+    )
+    from vllm.utils.system_utils import update_environment_variables
+
+    device = torch.device("cuda", local_rank)
+    torch.accelerator.set_device_index(device)
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(master_port),
+        }
+    )
+
+    init_distributed_environment()
+    try:
+        with ensure_current_vllm_config():
+            initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+            generator = torch.Generator(device=device).manual_seed(79)
+            num_rows, hidden_size, vocab_size = 7, 64, 2048
+            local_vocab_size = vocab_size // world_size
+            hidden_states = (
+                torch.randn(
+                    (num_rows, hidden_size),
+                    device=device,
+                    dtype=torch.bfloat16,
+                    generator=generator,
+                )
+                * 0.01
+            )
+            full_weight = (
+                torch.randn(
+                    (vocab_size, hidden_size),
+                    device=device,
+                    dtype=torch.bfloat16,
+                    generator=generator,
+                )
+                * 0.01
+            )
+            vocab_start = local_rank * local_vocab_size
+            vocab_end = vocab_start + local_vocab_size
+            local_weight = full_weight[vocab_start:vocab_end]
+            target_token_ids = torch.tensor(
+                [0, 511, 1023, 1024, 1535, 1536, 2047],
+                device=device,
+                dtype=torch.int64,
+            )
+            shard_indices = SimpleNamespace(
+                org_vocab_start_index=vocab_start,
+                org_vocab_end_index=vocab_end,
+                num_org_elements=local_vocab_size,
+            )
+            lm_head = SimpleNamespace(
+                weight=local_weight,
+                bias=None,
+                quant_method=UnquantizedEmbeddingMethod(),
+                num_added_embeddings=0,
+                org_vocab_size=vocab_size,
+                tp_size=world_size,
+                shard_indices=shard_indices,
+            )
+            processor = LogitsProcessor(vocab_size)
+            logits = hidden_states.float() @ full_weight.float().T
+            target_logits = logits.gather(1, target_token_ids[:, None]).squeeze(1)
+            lse = torch.logsumexp(logits, dim=1)
+
+            for num_logprobs in (0, 20):
+                output_ids, output_logprobs, output_ranks = (
+                    processor.get_prompt_logprobs(
+                        lm_head,
+                        hidden_states,
+                        target_token_ids,
+                        num_logprobs,
+                    )
+                )
+                expected_ids = target_token_ids[:, None].to(torch.int32)
+                expected_logprobs = target_logits[:, None] - lse[:, None]
+                if num_logprobs > 0:
+                    topk_values, topk_ids = torch.topk(logits, num_logprobs, dim=1)
+                    expected_ids = torch.cat(
+                        (expected_ids, topk_ids.to(torch.int32)), dim=1
+                    )
+                    expected_logprobs = torch.cat(
+                        (expected_logprobs, topk_values - lse[:, None]), dim=1
+                    )
+                expected_ranks = (logits >= target_logits[:, None]).sum(
+                    dim=1, dtype=torch.int32
+                )
+
+                assert torch.equal(output_ids, expected_ids)
+                assert torch.equal(output_ranks, expected_ranks)
+                torch.testing.assert_close(
+                    output_logprobs,
+                    expected_logprobs,
+                    rtol=2e-3,
+                    atol=2e-3,
+                )
+    finally:
+        cleanup_dist_env_and_memory()
+
+
+@pytest.mark.distributed(num_gpus=2)
+@pytest.mark.usefixtures("_require_supported_cutedsl_device")
+def test_logits_processor_prompt_logprobs_tp2() -> None:
+    import torch.multiprocessing as mp
+
+    from vllm.utils.network_utils import get_open_port
+
+    world_size = 2
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip("Requires two GPUs")
+    mp.spawn(
+        _run_logits_processor_prompt_logprobs_tp2,
+        args=(world_size, get_open_port()),
+        nprocs=world_size,
+    )

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -55,6 +55,23 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, False), ("0", False), ("1", True)],
+)
+def test_v2_compact_prompt_logprobs_env(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str | None,
+    expected: bool,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS", raising=False)
+    else:
+        monkeypatch.setenv("VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS", value)
+
+    assert envs.VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS is expected
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/tests/v1/sample/test_prompt_logprob.py
+++ b/tests/v1/sample/test_prompt_logprob.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.warmup.kernel_warmup import (
+    _warmup_compact_prompt_logprobs,
+)
+from vllm.v1.outputs import LogprobsTensors
+from vllm.v1.worker.gpu.sample import prompt_logprob
+
+
+@pytest.mark.parametrize("num_prompt_logprobs", [0, 5])
+def test_compact_prompt_logprobs_callback_preserves_chunking(
+    num_prompt_logprobs: int,
+) -> None:
+    num_rows = 2050
+    hidden_states = torch.arange(num_rows * 2, dtype=torch.float32).view(num_rows, 2)
+    target_token_ids = torch.arange(num_rows, dtype=torch.int32)
+    chunk_sizes = []
+
+    def compact_fn(
+        chunk_hidden_states: torch.Tensor,
+        chunk_token_ids: torch.Tensor,
+        num_logprobs: int,
+    ) -> LogprobsTensors:
+        assert chunk_token_ids.dtype == torch.int64
+        assert num_logprobs == num_prompt_logprobs
+        chunk_sizes.append(chunk_hidden_states.shape[0])
+        columns = torch.arange(num_logprobs + 1)
+        return LogprobsTensors(
+            logprob_token_ids=chunk_token_ids[:, None] + columns,
+            logprobs=chunk_hidden_states[:, :1] + columns,
+            selected_token_ranks=chunk_token_ids.to(torch.int32) + 1,
+        )
+
+    def unexpected_logits_fn(hidden_states: torch.Tensor) -> torch.Tensor:
+        raise AssertionError("compact path must not materialize logits")
+
+    token_ids, logprobs, ranks = prompt_logprob.compute_prompt_logprobs_with_chunking(
+        target_token_ids,
+        hidden_states,
+        unexpected_logits_fn,
+        num_prompt_logprobs,
+        compact_prompt_logprobs_fn=compact_fn,
+    )
+
+    columns = torch.arange(num_prompt_logprobs + 1)
+    assert chunk_sizes == [1024, 1024, 2]
+    assert torch.equal(token_ids, target_token_ids.to(torch.int64)[:, None] + columns)
+    assert torch.equal(logprobs, hidden_states[:, :1] + columns)
+    assert torch.equal(ranks, target_token_ids + 1)
+
+
+def test_compact_prompt_logprobs_rejects_unsupported_mode() -> None:
+    def unused_fn(*args) -> LogprobsTensors:
+        raise AssertionError("invalid compact request must fail before execution")
+
+    with pytest.raises(ValueError, match="compact prompt logprobs"):
+        prompt_logprob.compute_prompt_logprobs_with_chunking(
+            torch.tensor([1]),
+            torch.zeros((1, 2)),
+            unused_fn,
+            5,
+            "raw_logits",
+            unused_fn,
+        )
+
+
+@pytest.mark.parametrize(
+    ("num_prompt_logprobs", "with_compact_callback"),
+    [(2, False), (-1, True), (33, True)],
+)
+def test_prompt_logprobs_uses_logits_fn_when_compact_is_unavailable(
+    num_prompt_logprobs: int,
+    with_compact_callback: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chunk_sizes = []
+
+    def logits_fn(hidden_states: torch.Tensor) -> torch.Tensor:
+        chunk_sizes.append(hidden_states.shape[0])
+        return torch.zeros((hidden_states.shape[0], 40))
+
+    def unexpected_compact_fn(*args) -> LogprobsTensors:
+        raise AssertionError("unsupported K must use the native logits path")
+
+    def fake_compute_topk_scores(
+        logits: torch.Tensor,
+        num_logprobs: int,
+        target_token_ids: torch.Tensor,
+        **kwargs,
+    ) -> LogprobsTensors:
+        expected_num_logprobs = 40 if num_prompt_logprobs == -1 else num_prompt_logprobs
+        assert num_logprobs == expected_num_logprobs
+        return LogprobsTensors(
+            logprob_token_ids=target_token_ids[:, None],
+            logprobs=torch.zeros((logits.shape[0], 1)),
+            selected_token_ranks=torch.ones(logits.shape[0], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(prompt_logprob, "compute_topk_scores", fake_compute_topk_scores)
+    prompt_logprob.compute_prompt_logprobs_with_chunking(
+        torch.arange(1025),
+        torch.zeros((1025, 2)),
+        logits_fn,
+        num_prompt_logprobs,
+        compact_prompt_logprobs_fn=(
+            unexpected_compact_fn if with_compact_callback else None
+        ),
+    )
+
+    assert chunk_sizes == [1024, 1]
+
+
+@pytest.mark.parametrize("wrapped_model", [False, True])
+def test_init_compact_prompt_logprobs_resolves_model_components(
+    wrapped_model: bool,
+) -> None:
+    token_ids = torch.tensor([[1, 2]], dtype=torch.int32)
+    logprobs = torch.tensor([[-0.1, -0.2]])
+    ranks = torch.tensor([1], dtype=torch.int32)
+    logits_processor = Mock()
+    logits_processor.get_prompt_logprobs.return_value = token_ids, logprobs, ranks
+    lm_head = Mock()
+    language_model = SimpleNamespace(
+        logits_processor=logits_processor,
+        lm_head=lm_head,
+    )
+    model = language_model
+    if wrapped_model:
+        model = SimpleNamespace(get_language_model=Mock(return_value=language_model))
+
+    compact_prompt_logprobs = prompt_logprob.init_compact_prompt_logprobs(
+        model=model,
+        hidden_dtype=torch.bfloat16,
+        logprobs_mode="raw_logprobs",
+    )
+
+    logits_processor.validate_prompt_logprobs.assert_called_once_with(
+        lm_head, torch.bfloat16
+    )
+    logits_processor.warmup_prompt_logprobs.assert_not_called()
+    hidden_states = torch.empty((2, 4), dtype=torch.bfloat16)
+    target_token_ids = torch.tensor([1, 2])
+    output = compact_prompt_logprobs.compute(hidden_states, target_token_ids, 5)
+    assert output.logprob_token_ids is token_ids
+    assert output.logprobs is logprobs
+    assert output.selected_token_ranks is ranks
+    logits_processor.get_prompt_logprobs.assert_called_once_with(
+        lm_head,
+        hidden_states,
+        target_token_ids,
+        5,
+    )
+    compact_prompt_logprobs.warmup()
+    logits_processor.warmup_prompt_logprobs.assert_called_once_with(lm_head)
+
+
+def test_kernel_warmup_delegates_to_compact_prompt_logprobs() -> None:
+    compact_prompt_logprobs = Mock()
+    worker = SimpleNamespace(
+        use_v2_model_runner=True,
+        model_runner=SimpleNamespace(
+            compact_prompt_logprobs=compact_prompt_logprobs,
+        ),
+    )
+
+    _warmup_compact_prompt_logprobs(worker)
+
+    compact_prompt_logprobs.warmup.assert_called_once_with()
+
+
+def test_kernel_warmup_skips_legacy_model_runner() -> None:
+    model_runner = Mock()
+    worker = SimpleNamespace(
+        use_v2_model_runner=False,
+        model_runner=model_runner,
+    )
+
+    _warmup_compact_prompt_logprobs(worker)
+
+    assert not model_runner.mock_calls
+
+
+def test_init_compact_prompt_logprobs_rejects_unsupported_model() -> None:
+    with pytest.raises(RuntimeError, match="standard LM head and LogitsProcessor"):
+        prompt_logprob.init_compact_prompt_logprobs(
+            model=SimpleNamespace(),
+            hidden_dtype=torch.bfloat16,
+            logprobs_mode="raw_logprobs",
+        )
+
+
+def test_kernel_warmup_skips_without_compact_prompt_logprobs() -> None:
+    model_runner = SimpleNamespace(compact_prompt_logprobs=None)
+    worker = SimpleNamespace(
+        use_v2_model_runner=True,
+        model_runner=model_runner,
+    )
+
+    _warmup_compact_prompt_logprobs(worker)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -294,6 +294,7 @@ if TYPE_CHECKING:
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
+    VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
@@ -2035,6 +2036,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Flag to control the v2 model runner. If unset, use config defaults.
     "VLLM_USE_V2_MODEL_RUNNER": lambda: maybe_convert_bool(
         os.getenv("VLLM_USE_V2_MODEL_RUNNER", None)
+    ),
+    # Experimental compact prompt-logprobs path for the v2 model runner.
+    "VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS": lambda: bool(
+        int(os.getenv("VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS", "0"))
     ),
     # Log model inspection after loading.
     # If enabled, logs a transformers-style hierarchical view of the model

--- a/vllm/model_executor/kernels/linear/cute_dsl/_lm_head_logprobs_mainloop.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/_lm_head_logprobs_mainloop.py
@@ -1,0 +1,1227 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""CuTe DSL LM-head projection for SM80+ GPUs with at least 144 KiB
+of opt-in shared memory.
+
+The GEMM mainloop is derived from CUTLASS's Ampere TensorOp GEMM example. It
+uses a multistage ``cp.async`` pipeline and BF16 tensor-core MMA with FP32
+accumulation. Logit tiles exist only in registers and CTA shared memory; the
+kernel never writes a global ``[M, V]`` logits tensor.
+"""
+
+# Modified from NVIDIA CUTLASS v4.4.2:
+# https://github.com/NVIDIA/cutlass/blob/da5e086dab31d63815acafdac9a9c5893b1c69e2/examples/python/CuTeDSL/ampere/tensorop_gemm.py  # noqa: E501
+
+from __future__ import annotations
+
+import math
+from functools import cache
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.utils as cutlass_utils
+from cutlass import cute
+from cutlass.cute.runtime import make_fake_stream, make_fake_tensor
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import triton
+from vllm.utils.platform_utils import cuda_get_device_properties
+
+_TILE_M = 128
+_TILE_N = 256
+_TILE_K = 64
+_NUM_STAGES = 3
+_ATOM_LAYOUT_M = 4
+_ATOM_LAYOUT_N = 2
+_K0_GROUP_N = 2
+_TOPK_GROUP_N = 4
+_TOPK_PARTIAL_WIDTH = 32
+_K0_REQUIRED_SMEM = 144 * 1024
+_TOPK_REQUIRED_SMEM = 144 * 1024
+
+
+def _validate_device_environment(device_index: int) -> None:
+    """Validate GPU requirements when a CuTe specialization compiles."""
+    capability = current_platform.get_device_capability(device_index)
+    if capability is None or capability.major < 8:
+        current_sm = "unknown" if capability is None else capability.to_int()
+        raise RuntimeError(
+            "the compact prompt-logprobs path requires SM80 or newer; "
+            f"the current GPU is SM{current_sm}"
+        )
+
+    try:
+        (max_smem,) = cuda_get_device_properties(
+            device_index, ("shared_memory_per_block_optin",), init_cuda=True
+        )
+    except AttributeError:
+        (max_smem,) = cuda_get_device_properties(
+            device_index, ("shared_memory_per_block",), init_cuda=True
+        )
+    required_smem = max(_K0_REQUIRED_SMEM, _TOPK_REQUIRED_SMEM)
+    if max_smem < required_smem:
+        raise RuntimeError(
+            f"the current GPU exposes only {max_smem // 1024} KiB shared memory; "
+            f"the compact prompt-logprobs path requires {required_smem // 1024} KiB"
+        )
+
+
+# Adapted from Dao-AILab/quack and modified for this SM80 accumulator layout:
+# https://github.com/Dao-AILab/quack/blob/60d88082272a256fa9b3b2ab631c82cfa78337c6/quack/layout_utils.py  # noqa: E501
+# Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+def _reshape_acc_to_mn(acc: cute.Tensor) -> cute.Tensor:
+    layout = acc.layout
+    column_major = cute.make_layout(layout.shape)
+    shape = (
+        (column_major.shape[0][1], column_major.shape[1]),
+        (
+            column_major.shape[0][0],
+            *column_major.shape[0][2:],
+            column_major.shape[2],
+        ),
+        *column_major.shape[3:],
+    )
+    stride = (
+        (column_major.stride[0][1], column_major.stride[1]),
+        (
+            column_major.stride[0][0],
+            *column_major.stride[0][2:],
+            column_major.stride[2],
+        ),
+        *column_major.stride[3:],
+    )
+    mn_layout = cute.composition(layout, cute.make_layout(shape, stride=stride))
+    return cute.make_tensor(acc.iterator, mn_layout)
+
+
+class _LMHeadLogprobsCpAsync:
+    """BF16 LM-head GEMM whose epilogue emits one compact state per tile."""
+
+    def __init__(
+        self,
+        tile_m: int,
+        tile_n: int,
+        tile_k: int,
+        num_stages: int,
+        atom_layout_m: int,
+        atom_layout_n: int,
+        num_topk: int,
+        group_n: int,
+    ) -> None:
+        self.tile_m = tile_m
+        self.tile_n = tile_n
+        self.tile_k = tile_k
+        self.num_stages = num_stages
+        self.atom_layout_mnk = (atom_layout_m, atom_layout_n, 1)
+        self.num_threads = math.prod(self.atom_layout_mnk) * 32
+        self.num_topk = num_topk
+        self.group_n = group_n
+
+    @cute.jit
+    def __call__(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mTargetIds: cute.Tensor,
+        mTargetLogits: cute.Tensor,
+        mPartialMax: cute.Tensor,
+        mPartialSumExp: cute.Tensor,
+        mPartialRankCount: cute.Tensor,
+        mPartialTopKValues: cute.Tensor,
+        mPartialTopKIds: cute.Tensor,
+        valid_vocab_size: cutlass.Int32,
+        global_vocab_start: cutlass.Int32,
+        vocab_block_start: cutlass.Int32,
+        num_vocab_blocks: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        """Build static copy/MMA layouts and launch the grouped-vocab grid."""
+        a_major = cutlass_utils.LayoutEnum.from_tensor(mA)
+        b_major = cutlass_utils.LayoutEnum.from_tensor(mB)
+        assert a_major == cutlass_utils.LayoutEnum.ROW_MAJOR
+        assert b_major == cutlass_utils.LayoutEnum.ROW_MAJOR
+
+        copy_bits = 128
+        sA_layout, sA_swizzle = self._make_smem_layout(
+            mA.element_type,
+            (self.tile_m, self.tile_k, self.num_stages),
+        )
+        sB_layout, sB_swizzle = self._make_smem_layout(
+            mB.element_type,
+            (self.tile_n, self.tile_k, self.num_stages),
+        )
+        # K=0 reduces per-N-warp statistics directly from the accumulator.
+        # Top-K needs the complete logits tile for row-wise warp selection.
+        if cutlass.const_expr(self.num_topk == 0):
+            stats_width = self.atom_layout_mnk[1] * 3
+            sC_layout = cute.make_layout(
+                (self.tile_m, stats_width),
+                stride=(stats_width, 1),
+            )
+        else:
+            sC_layout = cute.make_layout(
+                (self.tile_m, self.tile_n), stride=(self.tile_n, 1)
+            )
+
+        # Both operands use 128-bit cp.async copies into swizzled SMEM tiles.
+        copy_atom_A = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(cache_mode=cute.nvgpu.LoadCacheMode.GLOBAL),
+            mA.element_type,
+            num_bits_per_copy=copy_bits,
+        )
+        copy_atom_B = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(cache_mode=cute.nvgpu.LoadCacheMode.GLOBAL),
+            mB.element_type,
+            num_bits_per_copy=copy_bits,
+        )
+        tiled_copy_A = self._make_gmem_tiled_copy(copy_atom_A, mA.element_type)
+        tiled_copy_B = self._make_gmem_tiled_copy(copy_atom_B, mB.element_type)
+        mma_op = cute.nvgpu.warp.MmaF16BF16Op(
+            mA.element_type, cutlass.Float32, (16, 8, 16)
+        )
+        tiled_mma = cute.make_tiled_mma(
+            mma_op,
+            cute.make_layout(self.atom_layout_mnk),
+            permutation_mnk=(
+                self.atom_layout_mnk[0] * 16,
+                self.atom_layout_mnk[1] * 16,
+                16,
+            ),
+        )
+        # One CTA owns a row tile and group_n consecutive vocabulary tiles.
+        num_row_blocks = cute.ceil_div(mA.shape[0], self.tile_m)
+        num_output_groups = cute.ceil_div(num_vocab_blocks, self.group_n)
+        self.kernel(
+            mA,
+            mB,
+            mTargetIds,
+            mTargetLogits,
+            mPartialMax,
+            mPartialSumExp,
+            mPartialRankCount,
+            mPartialTopKValues,
+            mPartialTopKIds,
+            valid_vocab_size,
+            global_vocab_start,
+            vocab_block_start,
+            num_vocab_blocks,
+            sA_layout,
+            sA_swizzle,
+            sB_layout,
+            sB_swizzle,
+            sC_layout,
+            tiled_copy_A,
+            tiled_copy_B,
+            tiled_mma,
+        ).launch(
+            grid=(
+                num_row_blocks * num_output_groups,
+                1,
+                1,
+            ),
+            block=[self.num_threads, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mTargetIds: cute.Tensor,
+        mTargetLogits: cute.Tensor,
+        mPartialMax: cute.Tensor,
+        mPartialSumExp: cute.Tensor,
+        mPartialRankCount: cute.Tensor,
+        mPartialTopKValues: cute.Tensor,
+        mPartialTopKIds: cute.Tensor,
+        valid_vocab_size: cutlass.Int32,
+        global_vocab_start: cutlass.Int32,
+        vocab_block_start: cutlass.Int32,
+        num_vocab_blocks: cutlass.Int32,
+        sA_layout: cute.Layout,
+        sA_swizzle: cute.Swizzle,
+        sB_layout: cute.Layout,
+        sB_swizzle: cute.Swizzle,
+        sC_layout: cute.Layout,
+        tiled_copy_A: cute.TiledCopy,
+        tiled_copy_B: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+    ):
+        # Flatten the row/vocabulary-group grid to keep the launch one-dimensional.
+        block_linear, _, _ = cute.arch.block_idx()
+        num_output_groups = cute.ceil_div(num_vocab_blocks, self.group_n)
+        block_m = block_linear // num_output_groups
+        output_group = block_linear % num_output_groups
+        first_vocab_block = vocab_block_start + output_group * self.group_n
+
+        @cute.struct
+        class SharedStorageAB:
+            a: cute.struct.Align[
+                cute.struct.MemRange[mA.element_type, cute.cosize(sA_layout)],
+                16,
+            ]
+            b: cute.struct.Align[
+                cute.struct.MemRange[mB.element_type, cute.cosize(sB_layout)],
+                16,
+            ]
+
+        @cute.struct
+        class SharedStorageC:
+            c: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(sC_layout)],
+                16,
+            ]
+
+        # GEMM staging and epilogue scratch are phase-disjoint, so they alias
+        # one dynamic shared-memory allocation.
+        smem = cutlass_utils.SmemAllocator()
+        storage = smem.allocate(
+            max(
+                SharedStorageAB.size_in_bytes(),  # type: ignore[attr-defined]
+                SharedStorageC.size_in_bytes(),  # type: ignore[attr-defined]
+            ),
+            byte_alignment=16,
+        )
+        sA = SharedStorageAB(  # type: ignore[call-arg]
+            storage
+        ).a.get_tensor(sA_layout, swizzle=sA_swizzle)
+        sB = SharedStorageAB(  # type: ignore[call-arg]
+            storage
+        ).b.get_tensor(sB_layout, swizzle=sB_swizzle)
+        sC = SharedStorageC(  # type: ignore[call-arg]
+            storage
+        ).c.get_tensor(sC_layout)
+
+        tidx, _, _ = cute.arch.thread_idx()
+        # A warp owns rows_per_warp rows. Lane row_slot carries each row's
+        # LSE/rank state, while every lane carries one element of its top-32.
+        running_max = cute.make_rmem_tensor(1, cutlass.Float32)
+        running_sum_exp = cute.make_rmem_tensor(1, cutlass.Float32)
+        running_rank_count = cute.make_rmem_tensor(1, cutlass.Int32)
+        running_max[0] = -cutlass.Float32.inf
+        running_sum_exp[0] = cutlass.Float32(0.0)
+        running_rank_count[0] = cutlass.Int32(0)
+        topk_state_size = (
+            self.tile_m // (self.num_threads // 32) if self.num_topk > 0 else 1
+        )
+        running_topk_values = cute.make_rmem_tensor(topk_state_size, cutlass.Float32)
+        running_topk_ids = cute.make_rmem_tensor(topk_state_size, cutlass.Int32)
+        running_topk_values.fill(-cutlass.Float32.inf)
+        running_topk_ids.fill(cutlass.Int32(0x7FFFFFFF))
+
+        # Keep compact statistics in registers while this CTA traverses its
+        # vocabulary group; only the final per-group state reaches GMEM.
+        self._compute_vocab_block(
+            mA,
+            mB,
+            mTargetIds,
+            mTargetLogits,
+            valid_vocab_size,
+            global_vocab_start,
+            first_vocab_block,
+            block_m,
+            running_max,
+            running_sum_exp,
+            running_rank_count,
+            running_topk_values,
+            running_topk_ids,
+            sA,
+            sB,
+            sC,
+            sA_layout,
+            sA_swizzle,
+            sB_layout,
+            sB_swizzle,
+            sC_layout,
+            tiled_copy_A,
+            tiled_copy_B,
+            tiled_mma,
+        )
+        cute.arch.sync_threads()
+
+        for group_offset in cutlass.range(1, self.group_n, unroll=1):
+            local_vocab_block = output_group * self.group_n + group_offset
+            if local_vocab_block < num_vocab_blocks:
+                self._compute_vocab_block(
+                    mA,
+                    mB,
+                    mTargetIds,
+                    mTargetLogits,
+                    valid_vocab_size,
+                    global_vocab_start,
+                    vocab_block_start + local_vocab_block,
+                    block_m,
+                    running_max,
+                    running_sum_exp,
+                    running_rank_count,
+                    running_topk_values,
+                    running_topk_ids,
+                    sA,
+                    sB,
+                    sC,
+                    sA_layout,
+                    sA_swizzle,
+                    sB_layout,
+                    sB_swizzle,
+                    sC_layout,
+                    tiled_copy_A,
+                    tiled_copy_B,
+                    tiled_mma,
+                )
+                cute.arch.sync_threads()
+
+        # Emit one compact partial state per row and vocabulary group.
+        if cutlass.const_expr(self.num_topk == 0):
+            threads_per_row = self.num_threads // self.tile_m
+            if tidx < self.tile_m * threads_per_row:
+                row_in_tile = tidx // threads_per_row
+                lane_in_row = tidx % threads_per_row
+                row = block_m * self.tile_m + row_in_tile
+                if row < mA.shape[0] and lane_in_row == 0:
+                    mPartialMax[row, output_group] = running_max[0]
+                    mPartialSumExp[row, output_group] = running_sum_exp[0]
+                    mPartialRankCount[row, output_group] = running_rank_count[0]
+        else:
+            warp_id = tidx // 32
+            lane = tidx % 32
+            rows_per_warp = self.tile_m // (self.num_threads // 32)
+            for row_slot in cutlass.range(rows_per_warp, unroll=1):
+                row_in_tile = warp_id * rows_per_warp + row_slot
+                row = block_m * self.tile_m + row_in_tile
+                if row < mA.shape[0]:
+                    if lane == row_slot:
+                        mPartialMax[row, output_group] = running_max[0]
+                        mPartialSumExp[row, output_group] = running_sum_exp[0]
+                        mPartialRankCount[row, output_group] = running_rank_count[0]
+                    if lane < self.num_topk:
+                        mPartialTopKValues[row, output_group, lane] = (
+                            running_topk_values[row_slot]
+                        )
+                        mPartialTopKIds[row, output_group, lane] = running_topk_ids[
+                            row_slot
+                        ]
+
+    @cute.jit
+    def _compute_vocab_block(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mTargetIds: cute.Tensor,
+        mTargetLogits: cute.Tensor,
+        valid_vocab_size: cutlass.Int32,
+        global_vocab_start: cutlass.Int32,
+        vocab_block: cutlass.Int32,
+        block_m: cutlass.Int32,
+        running_max: cute.Tensor,
+        running_sum_exp: cute.Tensor,
+        running_rank_count: cute.Tensor,
+        running_topk_values: cute.Tensor,
+        running_topk_ids: cute.Tensor,
+        sA: cute.Tensor,
+        sB: cute.Tensor,
+        sC: cute.Tensor,
+        sA_layout: cute.Layout,
+        sA_swizzle: cute.Swizzle,
+        sB_layout: cute.Layout,
+        sB_swizzle: cute.Swizzle,
+        sC_layout: cute.Layout,
+        tiled_copy_A: cute.TiledCopy,
+        tiled_copy_B: cute.TiledCopy,
+        tiled_mma: cute.TiledMma,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        tiler_coord = (block_m, vocab_block, None)
+        cta_tiler = (self.tile_m, self.tile_n, self.tile_k)
+
+        # Shift K so the predicate-masked residual tile is consumed first;
+        # all following K tiles are full-width and use the same copy layout.
+        gA = cute.local_tile(
+            mA,
+            tiler=cta_tiler,
+            coord=tiler_coord,
+            proj=(1, None, 1),
+        )
+        gB = cute.local_tile(
+            mB,
+            tiler=cta_tiler,
+            coord=tiler_coord,
+            proj=(None, 1, 1),
+        )
+        residual_k = mA.shape[1] - cutlass.Int32(self.tile_k) * gA.shape[2]
+        gA = cute.domain_offset((0, residual_k, 0), gA)
+        gB = cute.domain_offset((0, residual_k, 0), gB)
+        gA = cute.make_tensor(gA.iterator.align(16), gA.layout)
+        gB = cute.make_tensor(gB.iterator.align(16), gB.layout)
+
+        # Coordinate tensors build boundary predicates without loading data.
+        cA = cute.local_tile(
+            cute.make_identity_tensor(mA.layout.shape),
+            tiler=cta_tiler,
+            coord=tiler_coord,
+            proj=(1, None, 1),
+        )
+        cB = cute.local_tile(
+            cute.make_identity_tensor(mB.layout.shape),
+            tiler=cta_tiler,
+            coord=tiler_coord,
+            proj=(None, 1, 1),
+        )
+        cA = cute.domain_offset((0, residual_k, 0), cA)
+        cB = cute.domain_offset((0, residual_k, 0), cB)
+
+        # Partition GMEM sources and SMEM destinations by copy-thread ownership.
+        thr_copy_A = tiled_copy_A.get_slice(tidx)
+        thr_copy_B = tiled_copy_B.get_slice(tidx)
+        tAgA = thr_copy_A.partition_S(gA)
+        tAsA = thr_copy_A.partition_D(sA)
+        tBgB = thr_copy_B.partition_S(gB)
+        tBsB = thr_copy_B.partition_D(sB)
+        tAcA = thr_copy_A.partition_S(cA)
+        tBcB = thr_copy_B.partition_S(cB)
+
+        tApA = cute.make_rmem_tensor(
+            cute.make_layout(
+                (
+                    tAgA.shape[0][1],
+                    cute.size(tAgA, mode=[1]),
+                    cute.size(tAgA, mode=[2]),
+                ),
+                stride=(cute.size(tAgA, mode=[1]), 1, 0),
+            ),
+            cutlass.Boolean,
+        )
+        tBpB = cute.make_rmem_tensor(
+            cute.make_layout(
+                (
+                    tBgB.shape[0][1],
+                    cute.size(tBgB, mode=[1]),
+                    cute.size(tBgB, mode=[2]),
+                ),
+                stride=(cute.size(tBgB, mode=[1]), 1, 0),
+            ),
+            cutlass.Boolean,
+        )
+        for rest_v in range(tApA.shape[0]):
+            for m in range(tApA.shape[1]):
+                tApA[rest_v, m, 0] = cute.elem_less(
+                    tAcA[(0, rest_v), m, 0, 0][0], mA.shape[0]
+                )
+        for rest_v in range(tBpB.shape[0]):
+            for n in range(tBpB.shape[1]):
+                tBpB[rest_v, n, 0] = cute.elem_less(
+                    tBcB[(0, rest_v), n, 0, 0][0], valid_vocab_size
+                )
+
+        # Masked elements must remain zero so they contribute nothing to MMA.
+        tAsA.fill(0)
+        tBsB.fill(0)
+        cute.arch.sync_threads()
+        num_smem_stages = cute.size(tAsA, mode=[3])
+        k_tile_count = cute.size(tAgA, mode=[3])
+        k_tile_index = cutlass.Int32(0)
+
+        # Prime num_stages - 1 cp.async groups before the steady-state loop.
+        for k in range(tApA.shape[2]):
+            if cute.elem_less(cutlass.Int32(-1), tAcA[0, 0, k, 0][1]):
+                cute.copy(
+                    tiled_copy_A,
+                    tAgA[None, None, k, k_tile_index],
+                    tAsA[None, None, k, 0],
+                    pred=tApA[None, None, k],
+                )
+        for k in range(tBpB.shape[2]):
+            if cute.elem_less(cutlass.Int32(-1), tBcB[0, 0, k, 0][1]):
+                cute.copy(
+                    tiled_copy_B,
+                    tBgB[None, None, k, k_tile_index],
+                    tBsB[None, None, k, 0],
+                    pred=tBpB[None, None, k],
+                )
+        k_tile_index = k_tile_index + 1
+        cute.arch.cp_async_commit_group()
+
+        for k_tile in range(1, num_smem_stages - 1):
+            if k_tile == k_tile_count:
+                tApA.fill(0)
+                tBpB.fill(0)
+            cute.copy(
+                tiled_copy_A,
+                tAgA[None, None, None, k_tile_index],
+                tAsA[None, None, None, k_tile],
+                pred=tApA,
+            )
+            cute.copy(
+                tiled_copy_B,
+                tBgB[None, None, None, k_tile_index],
+                tBsB[None, None, None, k_tile],
+                pred=tBpB,
+            )
+            k_tile_index = k_tile_index + 1
+            cute.arch.cp_async_commit_group()
+
+        thr_mma = tiled_mma.get_slice(tidx)
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+        tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
+        tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        # The full CTA output tile remains in FP32 registers across all K tiles.
+        tCrC = cute.make_rmem_tensor(
+            thr_mma.partition_shape_C((self.tile_m, self.tile_n)),
+            cutlass.Float32,
+        )
+        tCrC.fill(0.0)
+
+        # ldmatrix feeds register fragments consumed by BF16 mma.sync.
+        atom_s2r_A = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(False, 4),
+            mA.element_type,
+        )
+        atom_s2r_B = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(False, 4),
+            mB.element_type,
+        )
+        tiled_s2r_A = cute.make_tiled_copy_A(atom_s2r_A, tiled_mma)
+        tiled_s2r_B = cute.make_tiled_copy_B(atom_s2r_B, tiled_mma)
+        thr_s2r_A = tiled_s2r_A.get_slice(tidx)
+        thr_s2r_B = tiled_s2r_B.get_slice(tidx)
+        tCsA_copy = thr_s2r_A.partition_S(sA)
+        tCsB_copy = thr_s2r_B.partition_S(sB)
+        tCrA_copy = thr_s2r_A.retile(tCrA)
+        tCrB_copy = thr_s2r_B.retile(tCrB)
+
+        smem_pipe_read = 0
+        smem_pipe_write = num_smem_stages - 1
+        tCsA_pipe = tCsA_copy[None, None, None, smem_pipe_read]
+        tCsB_pipe = tCsB_copy[None, None, None, smem_pipe_read]
+        num_k_block = cute.size(tCrA, mode=[2])
+        if num_k_block > 1:
+            cute.arch.cp_async_wait_group(num_smem_stages - 2)
+            cute.arch.sync_threads()
+            cute.copy(
+                tiled_s2r_A,
+                tCsA_pipe[None, None, 0],
+                tCrA_copy[None, None, 0],
+            )
+            cute.copy(
+                tiled_s2r_B,
+                tCsB_pipe[None, None, 0],
+                tCrB_copy[None, None, 0],
+            )
+
+        # Overlap the future GMEM copy, next SMEM fragment load, and current MMA.
+        for k_tile in range(k_tile_count):
+            for k_block in cutlass.range(num_k_block, unroll_full=True):
+                if k_block == num_k_block - 1:
+                    tCsA_pipe = tCsA_copy[None, None, None, smem_pipe_read]
+                    tCsB_pipe = tCsB_copy[None, None, None, smem_pipe_read]
+                    cute.arch.cp_async_wait_group(num_smem_stages - 2)
+                    cute.arch.sync_threads()
+
+                k_block_next = (k_block + 1) % num_k_block
+                cute.copy(
+                    tiled_s2r_A,
+                    tCsA_pipe[None, None, k_block_next],
+                    tCrA_copy[None, None, k_block_next],
+                )
+                cute.copy(
+                    tiled_s2r_B,
+                    tCsB_pipe[None, None, k_block_next],
+                    tCrB_copy[None, None, k_block_next],
+                )
+
+                if k_block == 0:
+                    if k_tile + num_smem_stages - 1 < k_tile_count:
+                        cute.copy(
+                            tiled_copy_A,
+                            tAgA[None, None, None, k_tile_index],
+                            tAsA[None, None, None, smem_pipe_write],
+                            pred=tApA,
+                        )
+                        cute.copy(
+                            tiled_copy_B,
+                            tBgB[None, None, None, k_tile_index],
+                            tBsB[None, None, None, smem_pipe_write],
+                            pred=tBpB,
+                        )
+                    k_tile_index = k_tile_index + 1
+                    cute.arch.cp_async_commit_group()
+                    smem_pipe_write = smem_pipe_read
+                    smem_pipe_read = smem_pipe_read + 1
+                    if smem_pipe_read == num_smem_stages:
+                        smem_pipe_read = 0
+
+                cute.gemm(
+                    tiled_mma,
+                    tCrC,
+                    tCrA[None, None, k_block],
+                    tCrB[None, None, k_block],
+                    tCrC,
+                )
+
+        cute.arch.cp_async_wait_group(0)
+        cute.arch.sync_threads()
+        # K=0 reduces fragments directly. Top-K stages logits in sC so a warp
+        # can scan one complete row while preserving deterministic ordering.
+        if cutlass.const_expr(self.num_topk == 0):
+            self._update_stats_from_fragment(
+                tCrC,
+                thr_mma,
+                mA,
+                mTargetIds,
+                mTargetLogits,
+                valid_vocab_size,
+                vocab_block,
+                block_m,
+                running_max,
+                running_sum_exp,
+                running_rank_count,
+                sC,
+            )
+        else:
+            tCsC = thr_mma.partition_C(sC)
+            cute.autovec_copy(tCrC, tCsC)
+            cute.arch.sync_threads()
+            self._update_topk_warp_select_from_smem(
+                sC,
+                mA,
+                mTargetIds,
+                mTargetLogits,
+                valid_vocab_size,
+                global_vocab_start,
+                vocab_block,
+                block_m,
+                running_max,
+                running_sum_exp,
+                running_rank_count,
+                running_topk_values,
+                running_topk_ids,
+            )
+
+    @cute.jit
+    def _warp_bitonic_sort32_desc(
+        self,
+        value: cute.Tensor,
+        token_id: cute.Tensor,
+    ):
+        # Each lane contributes one (logit, token ID) pair. The secondary key
+        # keeps lower token IDs first when logits are equal.
+        tidx, _, _ = cute.arch.thread_idx()
+        lane = tidx % 32
+        for stage in cutlass.range_constexpr(5):
+            segment = 2 << stage
+            for step in cutlass.range_constexpr(stage + 1):
+                stride = (1 << stage) >> step
+                other_value = cute.arch.shuffle_sync_bfly(value[0], offset=stride)
+                other_id = cute.arch.shuffle_sync_bfly(token_id[0], offset=stride)
+                other_better = other_value > value[0] or (
+                    other_value == value[0] and other_id < token_id[0]
+                )
+                self_better = value[0] > other_value or (
+                    value[0] == other_value and token_id[0] < other_id
+                )
+                want_better = ((lane & stride) == 0) == ((lane & segment) == 0)
+                if (want_better and other_better) or (not want_better and self_better):
+                    value[0] = other_value
+                    token_id[0] = other_id
+
+    @cute.jit
+    def _warp_bitonic_merge32_desc(
+        self,
+        selected_value: cute.Tensor,
+        selected_id: cute.Tensor,
+        candidate_value: cute.Tensor,
+        candidate_id: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        lane = tidx % 32
+        # Reversing the sorted candidate sequence forms a bitonic sequence
+        # with the current selection, which needs only the merge half-network.
+        reversed_value = cute.arch.shuffle_sync(candidate_value[0], offset=31 - lane)
+        reversed_id = cute.arch.shuffle_sync(candidate_id[0], offset=31 - lane)
+        if reversed_value > selected_value[0] or (
+            reversed_value == selected_value[0] and reversed_id < selected_id[0]
+        ):
+            selected_value[0] = reversed_value
+            selected_id[0] = reversed_id
+
+        for step in cutlass.range_constexpr(5):
+            stride = 16 >> step
+            other_value = cute.arch.shuffle_sync_bfly(selected_value[0], offset=stride)
+            other_id = cute.arch.shuffle_sync_bfly(selected_id[0], offset=stride)
+            other_better = other_value > selected_value[0] or (
+                other_value == selected_value[0] and other_id < selected_id[0]
+            )
+            self_better = selected_value[0] > other_value or (
+                selected_value[0] == other_value and selected_id[0] < other_id
+            )
+            want_better = (lane & stride) == 0
+            if (want_better and other_better) or (not want_better and self_better):
+                selected_value[0] = other_value
+                selected_id[0] = other_id
+
+    @cute.jit
+    def _warp_select_add(
+        self,
+        candidate_value: cutlass.Float32,
+        candidate_id: cutlass.Int32,
+        selected_value: cute.Tensor,
+        selected_id: cute.Tensor,
+        buffer_length: cute.Tensor,
+        value_buffer: cute.Tensor,
+        id_buffer: cute.Tensor,
+        buffer_row: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        lane = tidx % 32
+        # selected lane K-1 is the admission threshold for every candidate.
+        threshold = cute.arch.shuffle_sync(selected_value[0], offset=self.num_topk - 1)
+        threshold_id = cute.arch.shuffle_sync(selected_id[0], offset=self.num_topk - 1)
+        do_add = candidate_value > threshold or (
+            candidate_value == threshold and candidate_id < threshold_id
+        )
+        mask = cutlass.Uint32(cute.arch.vote_ballot_sync(do_add))
+        if mask != 0:
+            # Compact accepted lanes into sC scratch. Merge every full batch of
+            # 32 so the persistent selection stays sorted in registers.
+            lower_lanes = (cutlass.Uint32(1) << lane) - cutlass.Uint32(1)
+            position = buffer_length[0] + cutlass.Int32(
+                cute.arch.popc(mask & lower_lanes)
+            )
+            if do_add and position < 32:
+                value_buffer[buffer_row, position] = candidate_value
+                id_buffer[buffer_row, 32 + position] = candidate_id
+                do_add = False
+
+            buffer_length[0] += cutlass.Int32(cute.arch.popc(mask))
+            if buffer_length[0] >= 32:
+                cute.arch.sync_warp()
+                batch_value = cute.make_rmem_tensor(1, cutlass.Float32)
+                batch_id = cute.make_rmem_tensor(1, cutlass.Int32)
+                batch_value[0] = value_buffer[buffer_row, lane]
+                batch_id[0] = id_buffer[buffer_row, 32 + lane]
+                self._warp_bitonic_sort32_desc(batch_value, batch_id)
+                self._warp_bitonic_merge32_desc(
+                    selected_value,
+                    selected_id,
+                    batch_value,
+                    batch_id,
+                )
+                buffer_length[0] -= 32
+                cute.arch.sync_warp()
+            if do_add:
+                position -= 32
+                value_buffer[buffer_row, position] = candidate_value
+                id_buffer[buffer_row, 32 + position] = candidate_id
+            cute.arch.sync_warp()
+
+    @cute.jit
+    def _warp_select_done(
+        self,
+        selected_value: cute.Tensor,
+        selected_id: cute.Tensor,
+        buffer_length: cute.Tensor,
+        value_buffer: cute.Tensor,
+        id_buffer: cute.Tensor,
+        buffer_row: cutlass.Int32,
+    ):
+        # Pad and merge the final incomplete candidate batch.
+        if buffer_length[0] > 0:
+            tidx, _, _ = cute.arch.thread_idx()
+            lane = tidx % 32
+            batch_value = cute.make_rmem_tensor(1, cutlass.Float32)
+            batch_id = cute.make_rmem_tensor(1, cutlass.Int32)
+            if lane < buffer_length[0]:
+                batch_value[0] = value_buffer[buffer_row, lane]
+                batch_id[0] = id_buffer[buffer_row, 32 + lane]
+            else:
+                batch_value[0] = -cutlass.Float32.inf
+                batch_id[0] = cutlass.Int32(0x7FFFFFFF)
+            self._warp_bitonic_sort32_desc(batch_value, batch_id)
+            self._warp_bitonic_merge32_desc(
+                selected_value,
+                selected_id,
+                batch_value,
+                batch_id,
+            )
+
+    @cute.jit
+    def _update_topk_warp_select_from_smem(
+        self,
+        sC: cute.Tensor,
+        mA: cute.Tensor,
+        mTargetIds: cute.Tensor,
+        mTargetLogits: cute.Tensor,
+        valid_vocab_size: cutlass.Int32,
+        global_vocab_start: cutlass.Int32,
+        vocab_block: cutlass.Int32,
+        block_m: cutlass.Int32,
+        running_max: cute.Tensor,
+        running_sum_exp: cute.Tensor,
+        running_rank_count: cute.Tensor,
+        running_topk_values: cute.Tensor,
+        running_topk_ids: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_id = tidx // 32
+        lane = tidx % 32
+        rows_per_warp = self.tile_m // (self.num_threads // 32)
+        # The first 64 sC columns are dead after loading logits and are reused
+        # as value/ID scratch for warp selection.
+        sC_ids = cute.recast_tensor(sC, cutlass.Int32)
+
+        for row_slot in cutlass.range(rows_per_warp, unroll=1):
+            row_in_tile = warp_id * rows_per_warp + row_slot
+            row = block_m * self.tile_m + row_in_tile
+            row_valid = row < mA.shape[0]
+            target_id = cutlass.Int32(-1)
+            target_logit = cutlass.Float32(0.0)
+            if row_valid:
+                target_id = mTargetIds[row]
+                target_logit = mTargetLogits[row]
+
+            # A warp covers 256 vocabulary entries with eight values per lane.
+            candidates = cute.make_rmem_tensor(8, cutlass.Float32)
+            row_max = -cutlass.Float32.inf
+            rank_count = cutlass.Int32(0)
+            vocab_start = vocab_block * self.tile_n
+            for candidate in cutlass.range(8, unroll=2):
+                n = lane + candidate * 32
+                local_vocab_id = vocab_start + n
+                logit = -cutlass.Float32.inf
+                if row_valid and local_vocab_id < valid_vocab_size:
+                    logit = sC[row_in_tile, n]
+                    # Use the separately computed global target value so rank
+                    # and returned target logprob share the same TP-reduced logit.
+                    if target_id == local_vocab_id:
+                        logit = target_logit
+                    row_max = cute.arch.fmax(row_max, logit)
+                    if logit >= target_logit:
+                        rank_count += 1
+                candidates[candidate] = logit
+
+            row_max = cute.arch.warp_reduction_max(row_max)
+            rank_count = cute.arch.warp_reduction_sum(rank_count)
+            row_sum_exp = cutlass.Float32(0.0)
+            if row_valid:
+                for candidate in cutlass.range(8, unroll=2):
+                    row_sum_exp += cute.math.exp(
+                        candidates[candidate] - row_max,
+                        fastmath=True,
+                    )
+            row_sum_exp = cute.arch.warp_reduction_sum(row_sum_exp)
+
+            # Lane row_slot owns this row's running LSE/rank state.
+            previous_max = cute.arch.shuffle_sync(running_max[0], offset=row_slot)
+            previous_sum_exp = cute.arch.shuffle_sync(
+                running_sum_exp[0], offset=row_slot
+            )
+            previous_rank_count = cute.arch.shuffle_sync(
+                running_rank_count[0], offset=row_slot
+            )
+            merged_max = cute.arch.fmax(previous_max, row_max)
+            merged_sum_exp = previous_sum_exp * cute.math.exp(
+                previous_max - merged_max, fastmath=True
+            ) + row_sum_exp * cute.math.exp(row_max - merged_max, fastmath=True)
+            if lane == row_slot:
+                running_max[0] = merged_max
+                running_sum_exp[0] = merged_sum_exp
+                running_rank_count[0] = previous_rank_count + rank_count
+
+            # Each lane holds one element of the row's sorted top-32 state.
+            selected_value = cute.make_rmem_tensor(1, cutlass.Float32)
+            selected_id = cute.make_rmem_tensor(1, cutlass.Int32)
+            selected_value[0] = running_topk_values[row_slot]
+            selected_id[0] = running_topk_ids[row_slot]
+            buffer_length = cute.make_rmem_tensor(1, cutlass.Int32)
+            buffer_length[0] = cutlass.Int32(0)
+            for candidate in cutlass.range(8, unroll=2):
+                local_vocab_id = vocab_start + lane + candidate * 32
+                self._warp_select_add(
+                    candidates[candidate],
+                    global_vocab_start + local_vocab_id,
+                    selected_value,
+                    selected_id,
+                    buffer_length,
+                    sC,
+                    sC_ids,
+                    row_in_tile,
+                )
+            self._warp_select_done(
+                selected_value,
+                selected_id,
+                buffer_length,
+                sC,
+                sC_ids,
+                row_in_tile,
+            )
+            running_topk_values[row_slot] = selected_value[0]
+            running_topk_ids[row_slot] = selected_id[0]
+
+    @cute.jit
+    def _update_stats_from_fragment(
+        self,
+        accumulator: cute.Tensor,
+        thr_mma: cute.ThrMma,
+        mA: cute.Tensor,
+        mTargetIds: cute.Tensor,
+        mTargetLogits: cute.Tensor,
+        valid_vocab_size: cutlass.Int32,
+        vocab_block: cutlass.Int32,
+        block_m: cutlass.Int32,
+        running_max: cute.Tensor,
+        running_sum_exp: cute.Tensor,
+        running_rank_count: cute.Tensor,
+        sC: cute.Tensor,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        lane = tidx % 32
+        warp_n = (tidx // 32) // self.atom_layout_mnk[0]
+        coordinates = thr_mma.partition_C(
+            cute.make_identity_tensor((self.tile_m, self.tile_n))
+        )
+        accumulator_mn = _reshape_acc_to_mn(accumulator)
+        coordinates_mn = _reshape_acc_to_mn(coordinates)
+
+        # Each four-lane MMA group first reduces the fragment columns it owns.
+        for local_row_slot in cutlass.range_constexpr(
+            cute.size(accumulator_mn, mode=[0])
+        ):
+            accumulator_row = accumulator_mn[local_row_slot, None]
+            coordinate_row = coordinates_mn[local_row_slot, None]
+            local_row = coordinate_row[0][0]
+            row = block_m * self.tile_m + local_row
+            target_id = cutlass.Int32(-1)
+            target_logit = cutlass.Float32(0.0)
+            if row < mA.shape[0]:
+                target_id = mTargetIds[row]
+                target_logit = mTargetLogits[row]
+
+            row_max = -cutlass.Float32.inf
+            rank_count = cutlass.Int32(0)
+            for element in cutlass.range_constexpr(cute.size(accumulator_row)):
+                local_vocab_id = vocab_block * self.tile_n + coordinate_row[element][1]
+                if row < mA.shape[0] and local_vocab_id < valid_vocab_size:
+                    logit = accumulator_row[element]
+                    if target_id == local_vocab_id:
+                        logit = target_logit
+                    row_max = cute.arch.fmax(row_max, logit)
+                    if logit >= target_logit:
+                        rank_count += 1
+
+            row_max = cute.arch.warp_reduction_max(
+                row_max,
+                threads_in_group=4,
+            )
+            rank_count = cute.arch.warp_reduction_sum(
+                rank_count,
+                threads_in_group=4,
+            )
+            row_sum_exp = cutlass.Float32(0.0)
+            for element in cutlass.range_constexpr(cute.size(accumulator_row)):
+                local_vocab_id = vocab_block * self.tile_n + coordinate_row[element][1]
+                if row < mA.shape[0] and local_vocab_id < valid_vocab_size:
+                    logit = accumulator_row[element]
+                    if target_id == local_vocab_id:
+                        logit = target_logit
+                    row_sum_exp += cute.math.exp(
+                        logit - row_max,
+                        fastmath=True,
+                    )
+            row_sum_exp = cute.arch.warp_reduction_sum(
+                row_sum_exp,
+                threads_in_group=4,
+            )
+            if lane % 4 == 0 and row < mA.shape[0]:
+                stats_column = warp_n * 3
+                sC[local_row, stats_column] = row_max
+                sC[local_row, stats_column + 1] = row_sum_exp
+                sC[local_row, stats_column + 2] = cutlass.Float32(rank_count)
+
+        cute.arch.sync_threads()
+        # Merge per-N-warp statistics into one state for each row in this tile.
+        threads_per_row = self.num_threads // self.tile_m
+        if tidx < self.tile_m * threads_per_row:
+            row_in_tile = tidx // threads_per_row
+            lane_in_row = tidx % threads_per_row
+            row = block_m * self.tile_m + row_in_tile
+            if lane_in_row == 0 and row < mA.shape[0]:
+                tile_max = -cutlass.Float32.inf
+                tile_sum_exp = cutlass.Float32(0.0)
+                tile_rank_count = cutlass.Int32(0)
+                for n_warp in cutlass.range_constexpr(self.atom_layout_mnk[1]):
+                    stats_column = n_warp * 3
+                    partial_max = sC[row_in_tile, stats_column]
+                    partial_sum_exp = sC[row_in_tile, stats_column + 1]
+                    if partial_max != -cutlass.Float32.inf:
+                        if tile_max == -cutlass.Float32.inf:
+                            tile_max = partial_max
+                            tile_sum_exp = partial_sum_exp
+                        else:
+                            merged_max = cute.arch.fmax(tile_max, partial_max)
+                            tile_sum_exp = tile_sum_exp * cute.math.exp(
+                                tile_max - merged_max,
+                                fastmath=True,
+                            ) + partial_sum_exp * cute.math.exp(
+                                partial_max - merged_max,
+                                fastmath=True,
+                            )
+                            tile_max = merged_max
+                    tile_rank_count += cutlass.Int32(sC[row_in_tile, stats_column + 2])
+
+                previous_max = running_max[0]
+                merged_max = cute.arch.fmax(previous_max, tile_max)
+                running_sum_exp[0] = running_sum_exp[0] * cute.math.exp(
+                    previous_max - merged_max,
+                    fastmath=True,
+                ) + tile_sum_exp * cute.math.exp(
+                    tile_max - merged_max,
+                    fastmath=True,
+                )
+                running_max[0] = merged_max
+                running_rank_count[0] += tile_rank_count
+
+    def _make_smem_layout(self, dtype, smem_tiler):
+        major_size = min(smem_tiler[1], 128 * 8 // dtype.width)
+        swizzle_bits = min(int(math.log2(major_size * dtype.width // 128)), 3)
+        base_bits = int(math.log2(128 // 8))
+        shift_bits = int(math.log2(128 // dtype.width))
+        swizzle = cute.make_swizzle(swizzle_bits, base_bits, shift_bits)
+        atom = cute.make_layout((8, major_size), stride=(major_size, 1))
+        return cute.tile_to_shape(atom, smem_tiler, (0, 1, 2)), swizzle
+
+    def _make_gmem_tiled_copy(self, copy_atom, dtype):
+        copy_elems = 128 // dtype.width
+        threads_k = self.tile_k // copy_elems
+        thread_layout = cute.make_layout(
+            (self.num_threads // threads_k, threads_k),
+            stride=(threads_k, 1),
+        )
+        value_layout = cute.make_layout((1, copy_elems))
+        return cute.make_tiled_copy_tv(copy_atom, thread_layout, value_layout)
+
+
+@cache
+def _compile_lm_head_logprobs(
+    hidden_size: int,
+    local_vocab_size: int,
+    num_vocab_blocks: int,
+    device_index: int,
+    num_topk: int,
+    group_n: int,
+):
+    _validate_device_environment(device_index)
+    # Keep M symbolic so one compiled specialization serves all prompt chunks.
+    num_rows = cute.sym_int()
+    num_partials = triton.cdiv(num_vocab_blocks, group_n)
+    hidden = make_fake_tensor(
+        cutlass.BFloat16,
+        (num_rows, hidden_size),
+        stride=(hidden_size, 1),
+        assumed_align=16,
+    )
+    weight = make_fake_tensor(
+        cutlass.BFloat16,
+        (local_vocab_size, hidden_size),
+        stride=(hidden_size, 1),
+        assumed_align=16,
+    )
+    target_ids = make_fake_tensor(
+        cutlass.Int32, (num_rows,), stride=(1,), assumed_align=4
+    )
+    target_logits = make_fake_tensor(
+        cutlass.Float32, (num_rows,), stride=(1,), assumed_align=4
+    )
+    partial_max = make_fake_tensor(
+        cutlass.Float32,
+        (num_rows, num_partials),
+        stride=(num_partials, 1),
+        assumed_align=4,
+    )
+    partial_sum_exp = make_fake_tensor(
+        cutlass.Float32,
+        (num_rows, num_partials),
+        stride=(num_partials, 1),
+        assumed_align=4,
+    )
+    partial_rank_count = make_fake_tensor(
+        cutlass.Int32,
+        (num_rows, num_partials),
+        stride=(num_partials, 1),
+        assumed_align=4,
+    )
+    # Preserve one compiled call signature without constructing zero-width
+    # fake top-K tensors for the statistics-only specialization.
+    if num_topk == 0:
+        partial_topk_values = partial_max
+        partial_topk_ids = partial_rank_count
+    else:
+        partial_topk_values = make_fake_tensor(
+            cutlass.Float32,
+            (num_rows, num_partials, num_topk),
+            stride=(num_partials * num_topk, num_topk, 1),
+            assumed_align=4,
+        )
+        partial_topk_ids = make_fake_tensor(
+            cutlass.Int32,
+            (num_rows, num_partials, num_topk),
+            stride=(num_partials * num_topk, num_topk, 1),
+            assumed_align=4,
+        )
+    op = _LMHeadLogprobsCpAsync(
+        _TILE_M,
+        _TILE_N,
+        _TILE_K,
+        _NUM_STAGES,
+        _ATOM_LAYOUT_M,
+        _ATOM_LAYOUT_N,
+        num_topk,
+        group_n,
+    )
+    return cute.compile(
+        op,
+        hidden,
+        weight,
+        target_ids,
+        target_logits,
+        partial_max,
+        partial_sum_exp,
+        partial_rank_count,
+        partial_topk_values,
+        partial_topk_ids,
+        cutlass.Int32(local_vocab_size),
+        cutlass.Int32(0),
+        cutlass.Int32(0),
+        cutlass.Int32(num_vocab_blocks),
+        make_fake_stream(),
+        options="--enable-tvm-ffi",
+    )

--- a/vllm/model_executor/kernels/linear/cute_dsl/lm_head_logprobs.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/lm_head_logprobs.py
@@ -1,0 +1,852 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compact prompt-logprob kernels for unquantized BF16 LM heads."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import cuda.bindings.driver as cuda
+import torch
+
+from vllm.model_executor.kernels.linear.cute_dsl._lm_head_logprobs_mainloop import (
+    _K0_GROUP_N,
+    _K0_REQUIRED_SMEM,
+    _TILE_N,
+    _TOPK_GROUP_N,
+    _TOPK_PARTIAL_WIDTH,
+    _TOPK_REQUIRED_SMEM,
+    _compile_lm_head_logprobs,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.platform_utils import cuda_get_device_properties
+from vllm.utils.torch_utils import current_stream
+
+
+class LMHeadLogprobsOutput(NamedTuple):
+    """Compact LM-head results for one tensor-parallel rank."""
+
+    topk_values: torch.Tensor
+    topk_ids: torch.Tensor
+    lse: torch.Tensor
+    rank_count: torch.Tensor
+
+
+@triton.jit
+def _pack_logit_token_keys(logits, token_ids, valid_mask):
+    float_bits = logits.to(tl.uint32, bitcast=True)
+    sign_bit = float_bits & 0x80000000
+    ordered_bits = tl.where(
+        sign_bit != 0,
+        float_bits ^ 0xFFFFFFFF,
+        float_bits ^ 0x80000000,
+    )
+    token_tie_break = token_ids.to(tl.uint32) ^ 0xFFFFFFFF
+    keys = (ordered_bits.to(tl.uint64) << 32) | token_tie_break.to(tl.uint64)
+    return tl.where(valid_mask, keys, 0)
+
+
+@triton.jit
+def _unpack_logit_token_keys(keys):
+    ordered_bits = (keys >> 32).to(tl.uint32)
+    was_nonnegative = (ordered_bits & 0x80000000) != 0
+    float_bits = tl.where(
+        was_nonnegative,
+        ordered_bits ^ 0x80000000,
+        ordered_bits ^ 0xFFFFFFFF,
+    )
+    values = float_bits.to(tl.float32, bitcast=True)
+    token_ids = ((keys & 0xFFFFFFFF).to(tl.uint32) ^ 0xFFFFFFFF).to(tl.int32)
+    valid = keys != 0
+    return (
+        tl.where(valid, values, -float("inf")),
+        tl.where(valid, token_ids, -1),
+    )
+
+
+@triton.jit
+def _prompt_target_logits_kernel(
+    hidden_states_ptr,  # [M, H]
+    lm_head_weight_ptr,  # [V_local, H]
+    local_target_ids_ptr,  # [M], shard-local; invalid means non-owner
+    bias_ptr,  # optional [V_local]
+    output_ptr,  # [M] FP32
+    hidden_size,
+    local_vocab_size,
+    hidden_stride_m,
+    hidden_stride_h,
+    weight_stride_v,
+    weight_stride_h,
+    target_stride_m,
+    bias_stride_v,
+    BLOCK_H: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    # One program owns a row to avoid partial-result atomics.
+    row_idx = tl.program_id(0).to(tl.int64)
+    local_target_id = tl.load(local_target_ids_ptr + row_idx * target_stride_m).to(
+        tl.int64
+    )
+    is_local = (local_target_id >= 0) & (local_target_id < local_vocab_size)
+
+    # Clamp non-local IDs before pointer arithmetic; their loads remain masked.
+    safe_target_id = tl.where(is_local, local_target_id, 0)
+
+    # Fixed-width H tiles bound register pressure and support unpadded H.
+    target_logit = 0.0
+    for hidden_start in range(0, hidden_size, BLOCK_H):
+        hidden_offsets = hidden_start + tl.arange(0, BLOCK_H)
+        mask = is_local & (hidden_offsets < hidden_size)
+        hidden_values = tl.load(
+            hidden_states_ptr
+            + row_idx * hidden_stride_m
+            + hidden_offsets * hidden_stride_h,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        weight_values = tl.load(
+            lm_head_weight_ptr
+            + safe_target_id * weight_stride_v
+            + hidden_offsets * weight_stride_h,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        # Accumulate in FP32 before the TP reduction.
+        target_logit += tl.sum(hidden_values * weight_values)
+
+    if HAS_BIAS:
+        # Only the owner adds bias so the TP SUM includes it once.
+        target_logit += tl.load(
+            bias_ptr + safe_target_id * bias_stride_v,
+            mask=is_local,
+            other=0.0,
+        ).to(tl.float32)
+
+    tl.store(output_ptr + row_idx, tl.where(is_local, target_logit, 0.0))
+
+
+@triton.jit
+def _merge_lse_rank_partials_kernel(
+    partial_max_ptr,
+    partial_sum_exp_ptr,
+    partial_rank_count_ptr,
+    local_lse_ptr,
+    local_rank_count_ptr,
+    num_rows,
+    num_partials,
+    BLOCK_S: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_S)
+    mask = offsets < num_partials
+    state_offsets = row * num_partials + offsets
+    partial_max = tl.load(
+        partial_max_ptr + state_offsets,
+        mask=mask,
+        other=-float("inf"),
+    )
+    partial_sum_exp = tl.load(
+        partial_sum_exp_ptr + state_offsets,
+        mask=mask,
+        other=0.0,
+    )
+    partial_rank_count = tl.load(
+        partial_rank_count_ptr + state_offsets,
+        mask=mask,
+        other=0,
+    )
+    local_max = tl.max(partial_max, axis=0)
+    local_sum_exp = tl.sum(partial_sum_exp * tl.exp(partial_max - local_max), axis=0)
+    tl.store(local_lse_ptr + row, local_max + tl.log(local_sum_exp))
+    tl.store(local_rank_count_ptr + row, tl.sum(partial_rank_count, axis=0))
+
+
+@triton.jit
+def _merge_topk_partials_kernel(
+    input_values_ptr,
+    input_ids_ptr,
+    output_values_ptr,
+    output_ids_ptr,
+    num_rows,
+    num_input_groups,
+    num_output_groups,
+    INPUTS_PER_OUTPUT: tl.constexpr,
+    INPUT_WIDTH: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    TOPK_BUCKET: tl.constexpr,
+    BLOCK_CANDIDATES: tl.constexpr,
+):
+    row = tl.program_id(0)
+    output_group = tl.program_id(1)
+    candidate_offsets = tl.arange(0, BLOCK_CANDIDATES)
+    group_in_output = candidate_offsets // INPUT_WIDTH
+    candidate_in_group = candidate_offsets % INPUT_WIDTH
+    input_group = output_group * INPUTS_PER_OUTPUT + group_in_output
+    mask = (group_in_output < INPUTS_PER_OUTPUT) & (input_group < num_input_groups)
+    input_offsets = (
+        row * num_input_groups + input_group
+    ) * INPUT_WIDTH + candidate_in_group
+    values = tl.load(input_values_ptr + input_offsets, mask=mask, other=-float("inf"))
+    ids = tl.load(input_ids_ptr + input_offsets, mask=mask, other=0)
+    keys = _pack_logit_token_keys(values, ids, mask)
+    topk_keys = tl.max(keys, axis=0) if TOPK_BUCKET == 1 else tl.topk(keys, TOPK_BUCKET)
+    topk_values, topk_ids = _unpack_logit_token_keys(topk_keys)
+    output_indices = tl.arange(0, TOPK_BUCKET)
+    output_offsets = (
+        row * num_output_groups + output_group
+    ) * OUTPUT_WIDTH + output_indices
+    output_mask = output_indices < OUTPUT_WIDTH
+    tl.store(output_values_ptr + output_offsets, topk_values, mask=output_mask)
+    tl.store(output_ids_ptr + output_offsets, topk_ids, mask=output_mask)
+
+
+@triton.jit
+def _merge_tp_prompt_logprobs_kernel(
+    tp_topk_values_ptr,  # [TP, M, K] FP32 logits
+    tp_topk_ids_ptr,  # [TP, M, K] INT32 global token IDs
+    tp_local_lse_ptr,  # [TP, M] FP32
+    tp_rank_count_ptr,  # [TP, M] INT32
+    target_token_ids_ptr,  # [M]
+    target_logits_ptr,  # [M] FP32
+    output_token_ids_ptr,  # [M, K + 1] INT32
+    output_logprobs_ptr,  # [M, K + 1] FP32
+    output_ranks_ptr,  # [M] INT32
+    num_rows,
+    topk_value_stride_tp,
+    topk_value_stride_m,
+    topk_value_stride_k,
+    topk_id_stride_tp,
+    topk_id_stride_m,
+    topk_id_stride_k,
+    lse_stride_tp,
+    lse_stride_m,
+    rank_stride_tp,
+    rank_stride_m,
+    target_id_stride_m,
+    target_logit_stride_m,
+    BLOCK_M: tl.constexpr,
+    TOPK_WIDTH: tl.constexpr,
+    TOPK_BUCKET: tl.constexpr,
+    NUM_TOPK: tl.constexpr,
+    TP_SIZE: tl.constexpr,
+):
+    # Each program independently merges a row block across all TP ranks.
+    row_offsets = (tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    row_mask = row_offsets < num_rows
+    running_max = tl.full((BLOCK_M,), -float("inf"), tl.float32)
+    running_sum_exp = tl.zeros((BLOCK_M,), tl.float32)
+    running_rank_count = tl.zeros((BLOCK_M,), tl.int32)
+    if TOPK_BUCKET > 0:
+        running_topk_keys = tl.full((BLOCK_M, TOPK_BUCKET), 0, tl.uint64)
+        topk_offsets = tl.arange(0, TOPK_BUCKET).to(tl.int64)
+
+    # Local LSE values merge with logaddexp; rank counts are additive because
+    # TP shards partition the vocabulary.
+    for tp_rank in range(TP_SIZE):
+        local_lse = tl.load(
+            tp_local_lse_ptr + tp_rank * lse_stride_tp + row_offsets * lse_stride_m,
+            mask=row_mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        local_rank_count = tl.load(
+            tp_rank_count_ptr + tp_rank * rank_stride_tp + row_offsets * rank_stride_m,
+            mask=row_mask,
+            other=0,
+        ).to(tl.int32)
+        merged_max = tl.maximum(running_max, local_lse)
+        running_sum_exp = running_sum_exp * tl.exp(running_max - merged_max) + tl.exp(
+            local_lse - merged_max
+        )
+        running_max = merged_max
+        running_rank_count += local_rank_count
+
+        if TOPK_BUCKET > 0:
+            # A shard's local top-K contains every candidate that can enter
+            # the global top-K, so the full vocabulary is never gathered.
+            value_ptrs = (
+                tp_topk_values_ptr
+                + tp_rank * topk_value_stride_tp
+                + row_offsets[:, None] * topk_value_stride_m
+                + topk_offsets[None, :] * topk_value_stride_k
+            )
+            id_ptrs = (
+                tp_topk_ids_ptr
+                + tp_rank * topk_id_stride_tp
+                + row_offsets[:, None] * topk_id_stride_m
+                + topk_offsets[None, :] * topk_id_stride_k
+            )
+            topk_mask = row_mask[:, None] & (topk_offsets[None, :] < TOPK_WIDTH)
+            local_values = tl.load(
+                value_ptrs,
+                mask=topk_mask,
+                other=-float("inf"),
+            ).to(tl.float32)
+            local_ids = tl.load(
+                id_ptrs,
+                mask=topk_mask,
+                other=-1,
+            ).to(tl.int32)
+            local_keys = _pack_logit_token_keys(
+                local_values,
+                local_ids,
+                topk_mask & (local_ids >= 0),
+            )
+            running_topk_keys = tl.topk(
+                tl.cat(running_topk_keys, local_keys, dim=1),
+                TOPK_BUCKET,
+                dim=1,
+            )
+
+    global_lse = running_max + tl.log(running_sum_exp)
+
+    # Column zero always contains the target, even when it is not in top-K.
+    target_token_ids = tl.load(
+        target_token_ids_ptr + row_offsets * target_id_stride_m,
+        mask=row_mask,
+        other=-1,
+    ).to(tl.int32)
+    target_logits = tl.load(
+        target_logits_ptr + row_offsets * target_logit_stride_m,
+        mask=row_mask,
+        other=-float("inf"),
+    ).to(tl.float32)
+    output_width = NUM_TOPK + 1
+    output_row_offsets = row_offsets * output_width
+    tl.store(
+        output_token_ids_ptr + output_row_offsets,
+        target_token_ids,
+        mask=row_mask,
+    )
+    tl.store(
+        output_logprobs_ptr + output_row_offsets,
+        target_logits - global_lse,
+        mask=row_mask,
+    )
+    tl.store(
+        output_ranks_ptr + row_offsets,
+        running_rank_count,
+        mask=row_mask,
+    )
+
+    if NUM_TOPK > 0:
+        # Remaining columns contain global top-K normalized by the same LSE.
+        topk_values, topk_ids = _unpack_logit_token_keys(running_topk_keys)
+        output_offsets = output_row_offsets[:, None] + 1 + topk_offsets[None, :]
+        output_mask = row_mask[:, None] & (topk_offsets[None, :] < NUM_TOPK)
+        tl.store(
+            output_token_ids_ptr + output_offsets,
+            topk_ids,
+            mask=output_mask,
+        )
+        tl.store(
+            output_logprobs_ptr + output_offsets,
+            topk_values - global_lse[:, None],
+            mask=output_mask,
+        )
+
+
+def prompt_target_logits(
+    hidden_states: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    local_target_ids: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute TP-local target logits without a full-vocabulary projection.
+
+    Args:
+        hidden_states: Prompt hidden states with shape [M, H].
+        lm_head_weight: Local unquantized LM-head weight with shape
+            [V_local, H].
+        local_target_ids: Shard-local target IDs with shape [M]. Values outside
+            [0, V_local) represent targets owned by another TP rank and produce
+            zero.
+        bias: Optional local LM-head bias with shape [V_local].
+
+    Returns:
+        FP32 local target logits with shape [M]. A TP SUM all-reduce turns these
+        local values into the global target logits.
+    """
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            f"hidden_states must have shape [M, H], got {tuple(hidden_states.shape)}"
+        )
+    if lm_head_weight.ndim != 2:
+        raise ValueError(
+            "lm_head_weight must have shape [V_local, H], got "
+            f"{tuple(lm_head_weight.shape)}"
+        )
+    if hidden_states.shape[1] != lm_head_weight.shape[1]:
+        raise ValueError(
+            "hidden_states and lm_head_weight hidden dimensions must match"
+        )
+    if (
+        local_target_ids.ndim != 1
+        or local_target_ids.shape[0] != hidden_states.shape[0]
+    ):
+        raise ValueError("local_target_ids must have shape [M]")
+    if local_target_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("local_target_ids must use torch.int32 or torch.int64")
+    if hidden_states.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError("hidden_states must use float16, bfloat16, or float32")
+    if lm_head_weight.dtype != hidden_states.dtype:
+        raise TypeError("lm_head_weight must have the same dtype as hidden_states")
+    if not hidden_states.is_cuda or not lm_head_weight.is_cuda:
+        raise ValueError("hidden_states and lm_head_weight must be CUDA tensors")
+    if local_target_ids.device != hidden_states.device:
+        raise ValueError("local_target_ids must be on the same device as hidden_states")
+    if lm_head_weight.device != hidden_states.device:
+        raise ValueError("lm_head_weight must be on the same device as hidden_states")
+    if bias is not None:
+        if bias.ndim != 1 or bias.shape[0] != lm_head_weight.shape[0]:
+            raise ValueError("bias must have shape [V_local]")
+        if bias.dtype != hidden_states.dtype or bias.device != hidden_states.device:
+            raise ValueError(
+                "bias must have the same dtype and device as hidden_states"
+            )
+
+    num_rows, hidden_size = hidden_states.shape
+    output = torch.empty(num_rows, dtype=torch.float32, device=hidden_states.device)
+    if num_rows == 0:
+        return output
+    if hidden_size == 0 or lm_head_weight.shape[0] == 0:
+        output.zero_()
+        return output
+
+    # Stream large H through fixed-width tiles instead of a large tl.arange.
+    block_h = min(triton.next_power_of_2(hidden_size), 1024)
+    num_warps = 4 if block_h <= 256 else 8
+    _prompt_target_logits_kernel[(num_rows,)](
+        hidden_states,
+        lm_head_weight,
+        local_target_ids,
+        bias,
+        output,
+        hidden_size,
+        lm_head_weight.shape[0],
+        hidden_states.stride(0),
+        hidden_states.stride(1),
+        lm_head_weight.stride(0),
+        lm_head_weight.stride(1),
+        local_target_ids.stride(0),
+        1 if bias is None else bias.stride(0),
+        BLOCK_H=block_h,
+        HAS_BIAS=bias is not None,
+        num_warps=num_warps,
+    )
+    return output
+
+
+def validate_lm_head_logprobs_environment(lm_head_weight: torch.Tensor) -> None:
+    """Validate requirements that are fixed after the LM head is loaded."""
+    if lm_head_weight.ndim != 2:
+        raise ValueError("the LM-head weight must have shape [V_local, H]")
+    if lm_head_weight.dtype != torch.bfloat16:
+        raise TypeError("the LM-head weight must use BF16")
+    if not lm_head_weight.is_cuda:
+        raise RuntimeError("the compact prompt-logprobs path requires CUDA")
+    if not lm_head_weight.is_contiguous():
+        raise ValueError("the LM-head weight must be contiguous")
+    if lm_head_weight.shape[0] == 0:
+        raise ValueError("the local vocabulary must not be empty")
+    if lm_head_weight.shape[1] % 8:
+        raise ValueError("the hidden size must be divisible by 8")
+    if lm_head_weight.data_ptr() % 16:
+        raise ValueError("the LM-head weight must be 16-byte aligned")
+
+    device = lm_head_weight.device
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    capability = current_platform.get_device_capability(device_index)
+    if capability is None or capability.major < 8:
+        current_sm = "unknown" if capability is None else capability.to_int()
+        raise RuntimeError(
+            "the compact prompt-logprobs path requires SM80 or newer; "
+            f"the current GPU is SM{current_sm}"
+        )
+
+    try:
+        (max_smem,) = cuda_get_device_properties(
+            device_index, ("shared_memory_per_block_optin",), init_cuda=True
+        )
+    except AttributeError:
+        (max_smem,) = cuda_get_device_properties(
+            device_index, ("shared_memory_per_block",), init_cuda=True
+        )
+    required_smem = max(_K0_REQUIRED_SMEM, _TOPK_REQUIRED_SMEM)
+    if max_smem < required_smem:
+        raise RuntimeError(
+            f"the current GPU exposes only {max_smem // 1024} KiB shared memory; "
+            f"the compact prompt-logprobs path requires {required_smem // 1024} KiB"
+        )
+
+
+def lm_head_logprobs(
+    hidden_states: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    local_target_ids: torch.Tensor,
+    global_target_logits: torch.Tensor,
+    num_topk: int,
+    *,
+    valid_vocab_size: int | None = None,
+    global_vocab_start: int = 0,
+) -> LMHeadLogprobsOutput:
+    """Compute TP-local logit statistics without materializing full logits.
+
+    Args:
+        hidden_states: Prompt hidden states with shape ``[M, H]`` in BF16.
+        lm_head_weight: Local LM-head shard with shape ``[V_local, H]`` in
+            BF16.
+        local_target_ids: Shard-local target IDs with shape ``[M]``. A negative
+            ID denotes a target owned by another TP rank.
+        global_target_logits: TP-reduced target logits with shape ``[M]`` in
+            FP32.
+        num_topk: Number of local top tokens to return, in ``[0, 32]``.
+        valid_vocab_size: Number of non-padding rows in the local LM-head shard.
+        global_vocab_start: Global token ID corresponding to local row zero.
+
+    Returns:
+        Compact local top-K values and IDs, LSE, and target-rank counts.
+
+    Notes:
+        For positive K, the CuTe kernel always emits 32 candidates per partial
+        and the local Triton merge immediately reduces them to the requested K.
+        With ``P = ceil(ceil(V_local / 256) / group_n)``, the principal
+        workspace buffers occupy approximately
+        ``M * (12P + 256P + 8K * ceil(P / 16) + 8K + 8)`` bytes before allocator
+        and communication temporaries. Large prompt chunks or vocabularies can
+        therefore still cause OOM even though this path does not materialize
+        the full ``[M, V]`` logits tensor.
+    """
+    if not 0 <= num_topk <= 32:
+        raise ValueError("num_topk must be in [0, 32]")
+    topk_bucket = 0 if num_topk == 0 else 1 << (num_topk - 1).bit_length()
+    # Keep only two CuTe specializations. Triton reduces the fixed top-32
+    # partials to the exact requested width before TP communication.
+    partial_topk_width = 0 if num_topk == 0 else _TOPK_PARTIAL_WIDTH
+    group_n = _K0_GROUP_N if num_topk == 0 else _TOPK_GROUP_N
+    if hidden_states.ndim != 2 or lm_head_weight.ndim != 2:
+        raise ValueError("hidden_states and lm_head_weight must be matrices")
+    if hidden_states.shape[1] != lm_head_weight.shape[1]:
+        raise ValueError("hidden dimensions must match")
+    if hidden_states.dtype != torch.bfloat16:
+        raise TypeError("hidden_states must use torch.bfloat16")
+    if lm_head_weight.dtype != torch.bfloat16:
+        raise TypeError("lm_head_weight must use torch.bfloat16")
+    if not hidden_states.is_cuda or not lm_head_weight.is_cuda:
+        raise ValueError("hidden_states and lm_head_weight must be CUDA tensors")
+    if hidden_states.device != lm_head_weight.device:
+        raise ValueError("hidden_states and lm_head_weight must share a device")
+    if not hidden_states.is_contiguous() or not lm_head_weight.is_contiguous():
+        raise ValueError("hidden_states and lm_head_weight must be contiguous")
+    if hidden_states.shape[1] % 8:
+        raise ValueError("hidden size must be divisible by 8 for 128-bit copies")
+    if local_target_ids.shape != (hidden_states.shape[0],):
+        raise ValueError("local_target_ids must have shape [M]")
+    if global_target_logits.shape != (hidden_states.shape[0],):
+        raise ValueError("global_target_logits must have shape [M]")
+    if global_target_logits.dtype != torch.float32:
+        raise TypeError("global_target_logits must use torch.float32")
+    if local_target_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("local_target_ids must use torch.int32 or torch.int64")
+    if local_target_ids.device != hidden_states.device:
+        raise ValueError("local_target_ids must share the input device")
+    if global_target_logits.device != hidden_states.device:
+        raise ValueError("global_target_logits must share the input device")
+    if hidden_states.data_ptr() % 16:
+        raise ValueError("hidden_states must be 16-byte aligned")
+    if global_vocab_start < 0:
+        raise ValueError("global_vocab_start must be non-negative")
+
+    local_vocab_size = lm_head_weight.shape[0]
+    if valid_vocab_size is None:
+        valid_vocab_size = local_vocab_size
+    if not 0 < valid_vocab_size <= local_vocab_size:
+        raise ValueError("valid_vocab_size must be in (0, V_local]")
+    num_rows = hidden_states.shape[0]
+    if num_rows == 0:
+        empty_values = torch.empty(
+            (0, num_topk), dtype=torch.float32, device=hidden_states.device
+        )
+        empty_ids = torch.empty(
+            (0, num_topk), dtype=torch.int32, device=hidden_states.device
+        )
+        return LMHeadLogprobsOutput(
+            empty_values,
+            empty_ids,
+            torch.empty(0, dtype=torch.float32, device=hidden_states.device),
+            torch.empty(0, dtype=torch.int32, device=hidden_states.device),
+        )
+
+    target_ids = local_target_ids.to(dtype=torch.int32).contiguous()
+    target_logits = global_target_logits.contiguous()
+    # A CTA emits one partial for group_n adjacent vocabulary blocks.
+    num_vocab_blocks = triton.cdiv(valid_vocab_size, _TILE_N)
+    num_partials = triton.cdiv(num_vocab_blocks, group_n)
+    partial_max = torch.empty(
+        (num_rows, num_partials), dtype=torch.float32, device=hidden_states.device
+    )
+    partial_sum_exp = torch.empty_like(partial_max)
+    partial_rank_count = torch.empty(
+        (num_rows, num_partials), dtype=torch.int32, device=hidden_states.device
+    )
+    partial_topk_values = torch.empty(
+        (num_rows, num_partials, partial_topk_width),
+        dtype=torch.float32,
+        device=hidden_states.device,
+    )
+    partial_topk_ids = torch.empty(
+        (num_rows, num_partials, partial_topk_width),
+        dtype=torch.int32,
+        device=hidden_states.device,
+    )
+    local_lse = torch.empty(num_rows, dtype=torch.float32, device=hidden_states.device)
+    local_rank_count = torch.empty(
+        num_rows, dtype=torch.int32, device=hidden_states.device
+    )
+
+    device_index = hidden_states.device.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    # Static H/V/K dimensions select a cached CuTe specialization; M remains
+    # symbolic so chunk lengths do not trigger recompilation.
+    with torch.accelerator.device_index(device_index):
+        compiled = _compile_lm_head_logprobs(
+            hidden_states.shape[1],
+            lm_head_weight.shape[0],
+            num_vocab_blocks,
+            device_index,
+            partial_topk_width,
+            group_n,
+        )
+        stream = cuda.CUstream(current_stream().cuda_stream)
+        compiled(
+            hidden_states,
+            lm_head_weight,
+            target_ids,
+            target_logits,
+            partial_max,
+            partial_sum_exp,
+            partial_rank_count,
+            partial_max if partial_topk_width == 0 else partial_topk_values,
+            partial_rank_count if partial_topk_width == 0 else partial_topk_ids,
+            valid_vocab_size,
+            global_vocab_start,
+            0,
+            num_vocab_blocks,
+            stream,
+        )
+
+    # The CuTe kernel leaves only compact per-group states in GMEM.
+    _merge_lse_rank_partials_kernel[(num_rows,)](
+        partial_max,
+        partial_sum_exp,
+        partial_rank_count,
+        local_lse,
+        local_rank_count,
+        num_rows,
+        num_partials,
+        BLOCK_S=triton.next_power_of_2(num_partials),
+        num_warps=4,
+    )
+    if partial_topk_width == 0:
+        local_topk_values = partial_topk_values.reshape(num_rows, 0)
+        local_topk_ids = partial_topk_ids.reshape(num_rows, 0)
+    else:
+        # Bound each Triton selection to 16 input groups, then merge the
+        # reduced groups once more to produce the final local top-K.
+        merge_width = 16
+        merged_groups = triton.cdiv(num_partials, merge_width)
+        merged_values = torch.empty(
+            (num_rows, merged_groups, num_topk),
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        merged_ids = torch.empty(
+            (num_rows, merged_groups, num_topk),
+            dtype=torch.int32,
+            device=hidden_states.device,
+        )
+        _merge_topk_partials_kernel[(num_rows, merged_groups)](
+            partial_topk_values,
+            partial_topk_ids,
+            merged_values,
+            merged_ids,
+            num_rows,
+            num_partials,
+            merged_groups,
+            INPUTS_PER_OUTPUT=merge_width,
+            INPUT_WIDTH=partial_topk_width,
+            OUTPUT_WIDTH=num_topk,
+            TOPK_BUCKET=topk_bucket,
+            BLOCK_CANDIDATES=triton.next_power_of_2(merge_width * partial_topk_width),
+            num_warps=8,
+        )
+        local_topk_values = torch.empty(
+            (num_rows, num_topk),
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        local_topk_ids = torch.empty(
+            (num_rows, num_topk),
+            dtype=torch.int32,
+            device=hidden_states.device,
+        )
+        final_width = triton.next_power_of_2(merged_groups)
+        _merge_topk_partials_kernel[(num_rows, 1)](
+            merged_values,
+            merged_ids,
+            local_topk_values[:, None, :],
+            local_topk_ids[:, None, :],
+            num_rows,
+            merged_groups,
+            1,
+            INPUTS_PER_OUTPUT=final_width,
+            INPUT_WIDTH=num_topk,
+            OUTPUT_WIDTH=num_topk,
+            TOPK_BUCKET=topk_bucket,
+            BLOCK_CANDIDATES=triton.next_power_of_2(final_width * num_topk),
+            num_warps=8,
+        )
+    return LMHeadLogprobsOutput(
+        local_topk_values,
+        local_topk_ids,
+        local_lse,
+        local_rank_count,
+    )
+
+
+def merge_tp_prompt_logprobs(
+    tp_topk_values: torch.Tensor,
+    tp_topk_ids: torch.Tensor,
+    tp_local_lse: torch.Tensor,
+    tp_rank_count: torch.Tensor,
+    target_token_ids: torch.Tensor,
+    target_logits: torch.Tensor,
+    num_topk: int,
+    *,
+    block_m: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Merge gathered TP-local statistics into prompt log probabilities.
+
+    Args:
+        tp_topk_values: Rank-major local top-K logits with shape
+            ``[TP, M, K]`` in FP32.
+        tp_topk_ids: Global token IDs corresponding to ``tp_topk_values`` with
+            shape ``[TP, M, K]`` in INT32.
+        tp_local_lse: Local log-sum-exp values with shape ``[TP, M]`` in FP32.
+        tp_rank_count: Local counts of logits greater than or equal to the
+            target logit with shape ``[TP, M]`` in INT32.
+        target_token_ids: Prompt target token IDs with shape ``[M]``.
+        target_logits: TP-reduced target logits with shape ``[M]`` in FP32.
+        num_topk: Number of global top tokens to place after the target column.
+        block_m: Optional number of rows processed by one Triton program.
+
+    Returns:
+        Prompt log probabilities with the target in column zero and global
+        top-K tokens in the remaining columns.
+    """
+    if tp_topk_values.ndim != 3:
+        raise ValueError("tp_topk_values must have shape [TP, M, K]")
+    if tp_topk_ids.shape != tp_topk_values.shape:
+        raise ValueError("tp_topk_ids must match tp_topk_values shape")
+    tp_size, num_rows, topk_width = tp_topk_values.shape
+    if tp_size == 0:
+        raise ValueError("TP size must be positive")
+    if tp_local_lse.shape != (tp_size, num_rows):
+        raise ValueError("tp_local_lse must have shape [TP, M]")
+    if tp_rank_count.shape != (tp_size, num_rows):
+        raise ValueError("tp_rank_count must have shape [TP, M]")
+    if target_token_ids.shape != (num_rows,):
+        raise ValueError("target_token_ids must have shape [M]")
+    if target_logits.shape != (num_rows,):
+        raise ValueError("target_logits must have shape [M]")
+    if not 0 <= num_topk <= topk_width:
+        raise ValueError("num_topk must be in [0, local top-K width]")
+    if topk_width > 32:
+        raise ValueError("local top-K width must not exceed 32")
+
+    if tp_topk_values.dtype != torch.float32:
+        raise TypeError("tp_topk_values must use torch.float32")
+    if tp_topk_ids.dtype != torch.int32:
+        raise TypeError("tp_topk_ids must use torch.int32")
+    if tp_local_lse.dtype != torch.float32:
+        raise TypeError("tp_local_lse must use torch.float32")
+    if tp_rank_count.dtype != torch.int32:
+        raise TypeError("tp_rank_count must use torch.int32")
+    if target_token_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("target_token_ids must use torch.int32 or torch.int64")
+    if target_logits.dtype != torch.float32:
+        raise TypeError("target_logits must use torch.float32")
+    if not tp_topk_values.is_cuda:
+        raise ValueError("inputs must be CUDA tensors")
+    device = tp_topk_values.device
+    for name, tensor in (
+        ("tp_topk_ids", tp_topk_ids),
+        ("tp_local_lse", tp_local_lse),
+        ("tp_rank_count", tp_rank_count),
+        ("target_token_ids", target_token_ids),
+        ("target_logits", target_logits),
+    ):
+        if tensor.device != device:
+            raise ValueError(f"{name} must be on the same device as tp_topk_values")
+
+    output_token_ids = torch.empty(
+        (num_rows, num_topk + 1), dtype=torch.int32, device=device
+    )
+    output_logprobs = torch.empty(
+        (num_rows, num_topk + 1), dtype=torch.float32, device=device
+    )
+    output_ranks = torch.empty(num_rows, dtype=torch.int32, device=device)
+    if num_rows == 0:
+        return output_token_ids, output_logprobs, output_ranks
+
+    # Bound the per-program TP x K candidate matrix as either dimension grows.
+    if block_m is None:
+        block_m = 16 if num_topk == 0 else 8 if tp_size == 1 else 2
+    if block_m <= 0 or block_m & (block_m - 1):
+        raise ValueError("block_m must be a positive power of two")
+    topk_bucket = 0 if topk_width == 0 else triton.next_power_of_2(topk_width)
+
+    # Compile-time TP/K dimensions let Triton unroll the rank merge and top-K.
+    _merge_tp_prompt_logprobs_kernel[(triton.cdiv(num_rows, block_m),)](
+        tp_topk_values,
+        tp_topk_ids,
+        tp_local_lse,
+        tp_rank_count,
+        target_token_ids,
+        target_logits,
+        output_token_ids,
+        output_logprobs,
+        output_ranks,
+        num_rows,
+        tp_topk_values.stride(0),
+        tp_topk_values.stride(1),
+        tp_topk_values.stride(2),
+        tp_topk_ids.stride(0),
+        tp_topk_ids.stride(1),
+        tp_topk_ids.stride(2),
+        tp_local_lse.stride(0),
+        tp_local_lse.stride(1),
+        tp_rank_count.stride(0),
+        tp_rank_count.stride(1),
+        target_token_ids.stride(0),
+        target_logits.stride(0),
+        BLOCK_M=block_m,
+        TOPK_WIDTH=topk_width,
+        TOPK_BUCKET=topk_bucket,
+        NUM_TOPK=num_topk,
+        TP_SIZE=tp_size,
+        num_warps=4,
+    )
+    return output_token_ids, output_logprobs, output_ranks
+
+
+__all__ = [
+    "LMHeadLogprobsOutput",
+    "lm_head_logprobs",
+    "merge_tp_prompt_logprobs",
+    "prompt_target_logits",
+    "validate_lm_head_logprobs_environment",
+]

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 from vllm.config import get_current_vllm_config
 from vllm.distributed import (
     tensor_model_parallel_all_gather,
+    tensor_model_parallel_all_reduce,
     tensor_model_parallel_gather,
 )
 from vllm.logger import init_logger
@@ -284,6 +285,202 @@ class LogitsProcessor(PluggableLayer):
         if self.soft_cap is not None:
             values = torch.tanh(values / self.soft_cap) * self.soft_cap
         return ids, values
+
+    def get_prompt_logprobs(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        target_token_ids: torch.Tensor,
+        num_logprobs: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Compute prompt log probabilities from TP-local LM-head shards.
+
+        Args:
+            lm_head: Unquantized vocabulary-parallel LM head.
+            hidden_states: Prompt hidden states with shape ``[M, H]`` in BF16.
+            target_token_ids: Global prompt target token IDs with shape ``[M]``.
+            num_logprobs: Number of global top tokens to return, in ``[0, 32]``.
+
+        Returns:
+            Target and global top-K prompt log probabilities.
+        """
+        # The current register selection network and compact local state are
+        # specialized for at most 32 candidates per row.
+        if not 0 <= num_logprobs <= 32:
+            raise ValueError("num_logprobs must be in [0, 32]")
+
+        from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+            lm_head_logprobs,
+            merge_tp_prompt_logprobs,
+            prompt_target_logits,
+        )
+
+        hidden_states = hidden_states.contiguous()
+        target_token_ids = target_token_ids.contiguous()
+        shard_indices = lm_head.shard_indices
+        vocab_start = shard_indices.org_vocab_start_index
+        vocab_end = shard_indices.org_vocab_end_index
+        target_is_local = (target_token_ids >= vocab_start) & (
+            target_token_ids < vocab_end
+        )
+        local_target_ids = torch.where(
+            target_is_local,
+            target_token_ids - vocab_start,
+            -1,
+        )
+
+        target_logits = prompt_target_logits(
+            hidden_states,
+            lm_head.weight,
+            local_target_ids,
+        )
+        if lm_head.tp_size > 1 and hidden_states.shape[0] > 0:
+            target_logits = tensor_model_parallel_all_reduce(target_logits)
+
+        local_output = lm_head_logprobs(
+            hidden_states,
+            lm_head.weight,
+            local_target_ids,
+            target_logits,
+            num_logprobs,
+            valid_vocab_size=shard_indices.num_org_elements,
+            global_vocab_start=vocab_start,
+        )
+        if hidden_states.shape[0] == 0:
+            return merge_tp_prompt_logprobs(
+                local_output.topk_values.unsqueeze(0),
+                local_output.topk_ids.unsqueeze(0),
+                local_output.lse.unsqueeze(0),
+                local_output.rank_count.unsqueeze(0),
+                target_token_ids,
+                target_logits,
+                num_logprobs,
+            )
+
+        # INT32 IDs and ranks are bit-cast into FP32 words so all compact state
+        # can use one homogeneous all-gather without losing integer precision.
+        compact = torch.cat(
+            (
+                local_output.topk_values,
+                local_output.topk_ids.view(torch.float32),
+                local_output.lse[:, None],
+                local_output.rank_count.view(torch.float32)[:, None],
+            ),
+            dim=-1,
+        )
+        if lm_head.tp_size > 1:
+            compact = tensor_model_parallel_all_gather(compact, dim=0)
+
+        compact_width = 2 * num_logprobs + 2
+        tp_compact = compact.view(
+            lm_head.tp_size, hidden_states.shape[0], compact_width
+        )
+        tp_topk_values = tp_compact[..., :num_logprobs]
+        tp_topk_ids = tp_compact[..., num_logprobs : 2 * num_logprobs].view(torch.int32)
+        tp_local_lse = tp_compact[..., -2]
+        tp_rank_count = tp_compact[..., -1:].view(torch.int32).squeeze(-1)
+        return merge_tp_prompt_logprobs(
+            tp_topk_values,
+            tp_topk_ids,
+            tp_local_lse,
+            tp_rank_count,
+            target_token_ids,
+            target_logits,
+            num_logprobs,
+        )
+
+    def validate_prompt_logprobs(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_dtype: torch.dtype,
+    ) -> None:
+        """Validate static requirements of the compact prompt-logprobs path."""
+        # This path performs the LM-head projection itself. Precomputed logits
+        # have no hidden states or local weight shard for the fused kernels.
+        if self.logits_as_input:
+            raise ValueError("prompt logprobs require an LM-head projection")
+
+        # The fused projection currently emits the raw BF16 dot product. Match
+        # forward() semantics by rejecting post-projection transforms and FP32
+        # head overrides until the kernels implement them directly.
+        if self.scale != 1.0 or self.soft_cap is not None:
+            raise ValueError("prompt logprobs require unmodified LM-head logits")
+        if self.head_dtype not in (None, torch.bfloat16):
+            raise ValueError("prompt logprobs do not support an FP32 LM head")
+
+        # The CuTe mainloop consumes a dense BF16 weight shard and uses BF16
+        # Tensor Cores with FP32 accumulation. Quantized weight layouts and
+        # other input dtypes require separate kernel implementations.
+        if not isinstance(lm_head.quant_method, UnquantizedEmbeddingMethod):
+            raise TypeError("prompt logprobs require an unquantized LM head")
+        if hidden_dtype != torch.bfloat16 or lm_head.weight.dtype != torch.bfloat16:
+            raise TypeError("prompt logprobs require BF16 hidden states and LM head")
+
+        # Although the target-only kernel can add bias, the tiled LM-head
+        # kernel does not yet add it to every vocabulary logit. Allowing bias
+        # would therefore produce inconsistent top-K, LSE, and rank results.
+        if getattr(lm_head, "bias", None) is not None:
+            raise ValueError("prompt logprobs do not support an LM-head bias")
+
+        # Added vocabulary rows use a separate padded layout inside each shard.
+        # The current global-ID mapping assumes one contiguous original-vocab
+        # range per rank, so added rows must use the existing logits path.
+        if lm_head.num_added_embeddings != 0:
+            raise ValueError("prompt logprobs do not support added vocabulary entries")
+
+        # Both components must describe the same global token-ID space; otherwise
+        # padding removal and shard-local ID conversion would disagree.
+        if self.org_vocab_size != lm_head.org_vocab_size:
+            raise ValueError("logits processor and LM-head vocabulary sizes must match")
+
+    def warmup_prompt_logprobs(self, lm_head: VocabParallelEmbedding) -> None:
+        """Compile the compact prompt-logprobs CuTe specializations."""
+        try:
+            from vllm.model_executor.kernels.linear.cute_dsl.lm_head_logprobs import (
+                validate_lm_head_logprobs_environment,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS is enabled, but CuTe DSL "
+                "dependencies could not be imported"
+            ) from exc
+
+        try:
+            validate_lm_head_logprobs_environment(lm_head.weight)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise RuntimeError(
+                f"VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS is enabled, but {exc}"
+            ) from exc
+
+        # M is symbolic in the CuTe kernel. A single row therefore compiles the
+        # same shape specialization used by every runtime prompt chunk.
+        hidden_states = torch.zeros(
+            (1, lm_head.weight.shape[1]),
+            dtype=torch.bfloat16,
+            device=lm_head.weight.device,
+        )
+        target_token_ids = torch.zeros(
+            1,
+            dtype=torch.int64,
+            device=lm_head.weight.device,
+        )
+        try:
+            with torch.inference_mode():
+                # Positive K values share the top-32 CuTe specialization.
+                # Triton merge kernels remain lazily compiled per requested K.
+                for num_logprobs in (0, 32):
+                    self.get_prompt_logprobs(
+                        lm_head,
+                        hidden_states,
+                        target_token_ids,
+                        num_logprobs,
+                    )
+                torch.accelerator.synchronize(lm_head.weight.device)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise RuntimeError(
+                "VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS failed during startup "
+                "kernel compilation"
+            ) from exc
 
     def extra_repr(self) -> str:
         s = f"vocab_size={self.vocab_size}"

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -108,6 +108,18 @@ def _warmup_kimi_k3_gemm_rs_ar() -> None:
         logger.info_once("Warmed up %d Kimi-K3 GEMM-RS/AR variants.", compiled)
 
 
+def _warmup_compact_prompt_logprobs(worker: "Worker") -> None:
+    """Compile the opt-in MRV2 prompt-logprobs kernels before serving."""
+    if not worker.use_v2_model_runner:
+        return
+
+    compact_prompt_logprobs = getattr(
+        worker.model_runner, "compact_prompt_logprobs", None
+    )
+    if compact_prompt_logprobs is not None:
+        compact_prompt_logprobs.warmup()
+
+
 def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
     from vllm.model_executor.warmup.minimax_m3_msa_warmup import (
         minimax_m3_msa_warmup,
@@ -136,6 +148,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
             time.perf_counter() - jit_warmup_start,
         )
 
+    _warmup_compact_prompt_logprobs(worker)
     qwen_triton_warmup(worker.model_runner, worker.vllm_config.model_config)
 
     compilation_config = worker.vllm_config.compilation_config

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -126,7 +126,11 @@ from vllm.v1.worker.gpu.model_states import init_model_state
 from vllm.v1.worker.gpu.pool.pooling_runner import PoolingRunner
 from vllm.v1.worker.gpu.pp_utils import PPHandler
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
-from vllm.v1.worker.gpu.sample.prompt_logprob import PromptLogprobsWorker
+from vllm.v1.worker.gpu.sample.prompt_logprob import (
+    CompactPromptLogprobs,
+    PromptLogprobsWorker,
+    init_compact_prompt_logprobs,
+)
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.shutdown import free_before_shutdown
 from vllm.v1.worker.gpu.spec_decode import init_speculator
@@ -172,6 +176,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
         self.observability_config = vllm_config.observability_config
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
+        self.compact_prompt_logprobs: CompactPromptLogprobs | None = None
 
         self.device = device
         self.dtype = self.model_config.dtype
@@ -427,9 +432,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     self.speculative_config,
                     self.device,
                 )
+            if envs.VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS:
+                self.compact_prompt_logprobs = init_compact_prompt_logprobs(
+                    model=self.model,
+                    hidden_dtype=self.dtype,
+                    logprobs_mode=self.model_config.logprobs_mode,
+                )
             self.prompt_logprobs_worker = PromptLogprobsWorker(
-                self.max_num_reqs,
+                max_num_reqs=self.max_num_reqs,
                 logprobs_mode=self.model_config.logprobs_mode,
+                compact_prompt_logprobs=self.compact_prompt_logprobs,
             )
             self.structured_outputs_worker = StructuredOutputsWorker(
                 max_num_logits=self.max_num_reqs * self.decode_query_len,

--- a/vllm/v1/worker/gpu/sample/prompt_logprob.py
+++ b/vllm/v1/worker/gpu/sample/prompt_logprob.py
@@ -6,6 +6,10 @@ import numpy as np
 import torch
 
 from vllm.config.model import LogprobsMode
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
 from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors
@@ -13,10 +17,90 @@ from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_scores
 
 
+class CompactPromptLogprobs:
+    """Model-owned components for the compact prompt-logprobs path."""
+
+    def __init__(
+        self,
+        logits_processor: LogitsProcessor,
+        lm_head: VocabParallelEmbedding,
+    ) -> None:
+        self._logits_processor = logits_processor
+        self._lm_head = lm_head
+
+    def compute(
+        self,
+        hidden_states: torch.Tensor,
+        target_token_ids: torch.Tensor,
+        num_logprobs: int,
+    ) -> LogprobsTensors:
+        """Compute one prompt chunk without materializing full logits."""
+        token_ids, logprobs, ranks = self._logits_processor.get_prompt_logprobs(
+            self._lm_head,
+            hidden_states,
+            target_token_ids,
+            num_logprobs,
+        )
+        return LogprobsTensors(
+            logprob_token_ids=token_ids,
+            logprobs=logprobs,
+            selected_token_ranks=ranks,
+        )
+
+    def warmup(self) -> None:
+        """Compile compact prompt-logprobs kernels."""
+        self._logits_processor.warmup_prompt_logprobs(self._lm_head)
+
+
+def init_compact_prompt_logprobs(
+    model: torch.nn.Module,
+    hidden_dtype: torch.dtype,
+    logprobs_mode: LogprobsMode,
+) -> CompactPromptLogprobs:
+    """Resolve and validate model components used by the compact path."""
+    if logprobs_mode != "raw_logprobs":
+        raise RuntimeError(
+            "VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS requires raw_logprobs mode"
+        )
+
+    # Multimodal wrappers expose their text decoder through this protocol.
+    language_model = (
+        model.get_language_model() if hasattr(model, "get_language_model") else model
+    )
+    logits_processor: LogitsProcessor | None = getattr(
+        language_model, "logits_processor", None
+    )
+    lm_head: VocabParallelEmbedding | None = getattr(language_model, "lm_head", None)
+    if (
+        logits_processor is None
+        or lm_head is None
+        or not hasattr(logits_processor, "validate_prompt_logprobs")
+    ):
+        raise RuntimeError(
+            "VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS requires a model with "
+            "a standard LM head and LogitsProcessor"
+        )
+
+    try:
+        logits_processor.validate_prompt_logprobs(lm_head, hidden_dtype)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise RuntimeError(
+            f"VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS is unsupported by this model: {exc}"
+        ) from exc
+
+    return CompactPromptLogprobs(logits_processor, lm_head)
+
+
 class PromptLogprobsWorker:
-    def __init__(self, max_num_reqs: int, logprobs_mode: LogprobsMode = "raw_logprobs"):
+    def __init__(
+        self,
+        max_num_reqs: int,
+        logprobs_mode: LogprobsMode = "raw_logprobs",
+        compact_prompt_logprobs: CompactPromptLogprobs | None = None,
+    ) -> None:
         self.max_num_reqs = max_num_reqs
         self.logprobs_mode = logprobs_mode
+        self._compact_prompt_logprobs = compact_prompt_logprobs
 
         self.uses_prompt_logprobs = np.zeros(self.max_num_reqs, dtype=bool)
         self.num_prompt_logprobs = np.zeros(self.max_num_reqs, dtype=np.int32)
@@ -85,6 +169,9 @@ class PromptLogprobsWorker:
                 logits_fn,
                 max_num_prompt_logprobs,
                 self.logprobs_mode,
+                self._compact_prompt_logprobs.compute
+                if self._compact_prompt_logprobs is not None
+                else None,
             )
         )
 
@@ -202,7 +289,20 @@ def compute_prompt_logprobs_with_chunking(
     logits_fn: Callable[[torch.Tensor], torch.Tensor],
     num_prompt_logprobs: int,
     logprobs_mode: LogprobsMode = "raw_logprobs",
+    compact_prompt_logprobs_fn: (
+        Callable[[torch.Tensor, torch.Tensor, int], LogprobsTensors] | None
+    ) = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if compact_prompt_logprobs_fn is not None:
+        if logprobs_mode != "raw_logprobs":
+            raise ValueError(
+                "compact prompt logprobs require logprobs_mode='raw_logprobs'"
+            )
+        if not 0 <= num_prompt_logprobs <= 32:
+            # All rows in a batch share one K. Fall back for the whole batch
+            # when any request needs semantics unsupported by the compact path.
+            compact_prompt_logprobs_fn = None
+
     # Since materializing the full prompt logits can take too much memory,
     # we compute it in chunks.
     CHUNK_SIZE = 1024
@@ -213,19 +313,28 @@ def compute_prompt_logprobs_with_chunking(
     prompt_token_ids = prompt_token_ids.to(torch.int64)
     for start_idx in range(0, prompt_token_ids.shape[0], CHUNK_SIZE):
         end_idx = start_idx + CHUNK_SIZE
-        # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
-        prompt_logits = logits_fn(prompt_hidden_states[start_idx:end_idx])
-        requested_num = (
-            prompt_logits.shape[-1]
-            if num_prompt_logprobs == -1
-            else num_prompt_logprobs
-        )
-        result = compute_topk_scores(
-            prompt_logits,
-            requested_num,
-            prompt_token_ids[start_idx:end_idx],
-            logits_mode=logits_mode,
-        )
+        chunk_hidden_states = prompt_hidden_states[start_idx:end_idx]
+        chunk_token_ids = prompt_token_ids[start_idx:end_idx]
+        if compact_prompt_logprobs_fn is not None:
+            result = compact_prompt_logprobs_fn(
+                chunk_hidden_states,
+                chunk_token_ids,
+                num_prompt_logprobs,
+            )
+        else:
+            # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
+            prompt_logits = logits_fn(chunk_hidden_states)
+            requested_num = (
+                prompt_logits.shape[-1]
+                if num_prompt_logprobs == -1
+                else num_prompt_logprobs
+            )
+            result = compute_topk_scores(
+                prompt_logits,
+                requested_num,
+                chunk_token_ids,
+                logits_mode=logits_mode,
+            )
         token_ids.append(result.logprob_token_ids)
         scores.append(result.logprobs)
         ranks.append(result.selected_token_ranks)


### PR DESCRIPTION
## What this does

This PR adds a Model Runner V2 prompt-logprobs path enabled by `VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS=1`. The path fuses the vocab-parallel LM-head projection with prompt-logprobs computation. Following the tiled online-reduction approach popularized by FlashAttention, it processes the vocabulary incrementally while retaining only compact Top-K and softmax statistics.

For small K, the compact path reduces TP communication from vocabulary-sized O(PV) data to compact O(PK) statistics, where P is the number of prompt tokens, K is the requested Top-K, and V is the vocabulary size. The local vocabulary scan is still required for exact computation.

## Why

Compared with Model Runner V1, Model Runner V2 already improves prompt-logprobs processing by operating on prompt-token row chunks and computing only the requested FP32 logprobs. This bounds peak memory with respect to the total prompt length and avoids materializing a full FP32 log-softmax tensor.

However, each chunk still materializes full-vocabulary logits of shape `[C, V]`. Under tensor parallelism, vocabulary-sized data must also be exchanged before computing `Top-K`, `LogSumExp`, and `target rank`.

This is inefficient when the requested Top-K is much smaller than the vocabulary. Exact computation must still scan each local vocabulary shard, but it does not need to write or communicate every logit. The final LogprobsTensors output requires only Top-K candidates and per-row normalization and rank statistics.



## Implementation

The compact path has three main stages:

1.  **Fused local projection.** Each TP rank scans its local LM-head vocabulary shard with a CuTe DSL kernel. The kernel uses BF16 inputs with FP32 accumulation and directly produces the target logit, local Top-K candidates, LogSumExp statistics, and target-rank statistics without materializing full vocabulary logits.

2. **Local reduction.** Triton kernels reduce the partial results to the requested local Top-K and statistics. The CuTe path uses two specializations: K=0 and a shared Top-32 specialization for K=1..32.

3. **TP merge.** Each rank exchanges only compact Top-K and normalization statistics. A final Triton kernel merges the TP-local results and returns the existing `LogprobsTensors` format.

> The path is enabled with `VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS=1`. Static model and device requirements
are checked during initialization, and the CuTe kernels are compiled during warmup. 


## Performance

The benchmark was run on `NVLink-connected NVIDIA A800-SXM4-80GB GPUs (SM80)` using `Qwen3.5-4B` with BF16 hidden states and LM-head weights. The scheduler chunk size was 8192 tokens, and the prompt-logprobs projection chunk size was 1024 rows.
We measured GPU-side hidden-to-logprobs latency, PyTorch allocator peak memory, and per-process NVML peak memory across TP1, TP2, and TP4 configurations. Memory savings are reported per GPU as the difference between the baseline and compact peak memory; values are not summed across tensor-parallel ranks.


### TP1

| Prompt tokens (P) | Top-K | Baseline hidden (ms) | Compact hidden (ms) | Hidden speedup | PyTorch saved/GPU (GiB) | NVML saved/GPU (GiB) |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 0 | 1.331 | 1.527 | 0.872x | -0.006 | -0.021 |
| 4 | 4 | 1.369 | 2.202 | 0.622x | -0.006 | -0.021 |
| 4 | 8 | 1.368 | 2.208 | 0.620x | -0.006 | -0.021 |
| 4 | 16 | 1.366 | 2.268 | 0.602x | -0.006 | -0.021 |
| 4 | 32 | 1.380 | 2.156 | 0.640x | -0.006 | -0.021 |
| 16 | 0 | 1.343 | 1.586 | 0.847x | -0.001 | -0.021 |
| 16 | 4 | 1.442 | 2.540 | 0.568x | -0.001 | -0.021 |
| 16 | 8 | 1.444 | 2.619 | 0.551x | -0.001 | -0.021 |
| 16 | 16 | 1.459 | 2.584 | 0.565x | -0.001 | -0.021 |
| 16 | 32 | 1.449 | 2.562 | 0.566x | -0.001 | -0.021 |
| 256 | 0 | 2.268 | 2.339 | 0.969x | 0.111 | 0.059 |
| 256 | 4 | 3.319 | 4.010 | 0.828x | 0.099 | 0.059 |
| 256 | 8 | 3.335 | 4.071 | 0.819x | 0.098 | 0.059 |
| 256 | 16 | 3.325 | 4.125 | 0.806x | 0.098 | 0.059 |
| 256 | 32 | 3.320 | 4.116 | 0.807x | 0.098 | 0.059 |
| 1K | 0 | 5.933 | 6.828 | 0.869x | 0.461 | 0.420 |
| 1K | 4 | 9.026 | 11.034 | 0.818x | 0.413 | 0.387 |
| 1K | 8 | 9.025 | 11.145 | 0.810x | 0.412 | 0.418 |
| 1K | 16 | 10.692 | 13.238 | 0.808x | 0.412 | 0.420 |
| 1K | 32 | 10.671 | 13.530 | 0.789x | 0.409 | 0.416 |
| 4K | 0 | 24.065 | 26.535 | 0.907x | 0.936 | 0.926 |
| 4K | 4 | 36.611 | 44.232 | 0.828x | 0.879 | 0.807 |
| 4K | 8 | 36.849 | 44.542 | 0.827x | 0.878 | 0.807 |
| 4K | 16 | 36.497 | 44.560 | 0.819x | 0.877 | 0.805 |
| 4K | 32 | 36.380 | 44.592 | 0.816x | 0.875 | 0.807 |
| 16K | 0 | 96.925 | 105.483 | 0.919x | 0.936 | 0.215 |
| 16K | 4 | 145.728 | 174.815 | 0.834x | 0.879 | 0.215 |
| 16K | 8 | 147.167 | 175.014 | 0.841x | 0.879 | 0.215 |
| 16K | 16 | 144.867 | 175.546 | 0.825x | 0.879 | 0.213 |
| 16K | 32 | 144.627 | 175.624 | 0.824x | 0.878 | 0.184 |
| 64K | 0 | 383.991 | 420.753 | 0.913x | 0.936 | 0.215 |
| 64K | 4 | 585.701 | 693.466 | 0.845x | 0.880 | 0.217 |
| 64K | 8 | 580.321 | 695.744 | 0.834x | 0.881 | 0.217 |
| 64K | 16 | 576.782 | 700.379 | 0.824x | 0.884 | 0.209 |
| 64K | 32 | 576.997 | 701.630 | 0.822x | 0.888 | 0.186 |
| 128K | 0 | 769.811 | 844.088 | 0.912x | 0.937 | 0.217 |
| 128K | 4 | 1169.305 | 1395.120 | 0.838x | 0.882 | 0.219 |
| 128K | 8 | 1162.574 | 1401.062 | 0.830x | 0.883 | 0.221 |
| 128K | 16 | 1160.743 | 1404.470 | 0.826x | 0.890 | 0.205 |
| 128K | 32 | 1158.470 | 1406.706 | 0.824x | 0.898 | 0.633 |


### TP2


| Prompt tokens (P) | Top-K | Baseline hidden (ms) | Compact hidden (ms) | Hidden speedup | PyTorch saved/GPU (GiB) | NVML saved/GPU (GiB) |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 0 | 1.209 | 1.527 | 0.792x | 0.005 | -0.002 |
| 4 | 4 | 1.313 | 1.952 | 0.673x | 0.005 | 0.000 |
| 4 | 8 | 1.285 | 2.042 | 0.629x | 0.005 | 0.000 |
| 4 | 16 | 1.276 | 2.091 | 0.610x | 0.005 | 0.000 |
| 4 | 32 | 1.366 | 2.094 | 0.652x | 0.005 | 0.000 |
| 16 | 0 | 1.307 | 1.575 | 0.830x | 0.018 | 0.020 |
| 16 | 4 | 1.362 | 2.224 | 0.612x | 0.018 | 0.020 |
| 16 | 8 | 1.340 | 2.178 | 0.615x | 0.018 | 0.020 |
| 16 | 16 | 1.471 | 2.260 | 0.651x | 0.018 | 0.020 |
| 16 | 32 | 1.410 | 2.261 | 0.624x | 0.018 | 0.020 |
| 256 | 0 | 2.716 | 1.923 | 1.413x | 0.297 | 0.318 |
| 256 | 4 | 3.619 | 2.799 | 1.293x | 0.290 | 0.299 |
| 256 | 8 | 3.860 | 3.117 | 1.238x | 0.290 | 0.299 |
| 256 | 16 | 3.889 | 3.124 | 1.245x | 0.289 | 0.299 |
| 256 | 32 | 3.845 | 3.153 | 1.220x | 0.289 | 0.299 |
| 1K | 0 | 7.170 | 4.149 | 1.728x | 1.183 | 1.436 |
| 1K | 4 | 10.261 | 6.432 | 1.595x | 1.153 | 1.197 |
| 1K | 8 | 11.670 | 7.319 | 1.594x | 1.153 | 1.197 |
| 1K | 16 | 11.758 | 7.385 | 1.592x | 1.152 | 1.184 |
| 1K | 32 | 11.769 | 7.329 | 1.606x | 1.151 | 1.182 |
| 4K | 0 | 27.851 | 13.943 | 1.998x | 1.658 | 1.898 |
| 4K | 4 | 40.361 | 22.755 | 1.774x | 1.628 | 1.604 |
| 4K | 8 | 40.552 | 22.826 | 1.777x | 1.628 | 1.607 |
| 4K | 16 | 40.019 | 22.897 | 1.748x | 1.628 | 1.611 |
| 4K | 32 | 40.116 | 22.979 | 1.746x | 1.627 | 1.609 |
| 16K | 0 | 111.388 | 55.002 | 2.025x | 1.658 | 1.299 |
| 16K | 4 | 161.014 | 90.408 | 1.781x | 1.630 | 1.236 |
| 16K | 8 | 163.328 | 90.775 | 1.799x | 1.629 | 1.238 |
| 16K | 16 | 160.674 | 91.400 | 1.758x | 1.630 | 1.234 |
| 16K | 32 | 160.678 | 96.886 | 1.658x | 1.628 | 1.234 |
| 64K | 0 | 444.935 | 220.638 | 2.017x | 1.658 | 1.236 |
| 64K | 4 | 656.621 | 365.405 | 1.797x | 1.631 | 1.238 |
| 64K | 8 | 651.845 | 365.040 | 1.786x | 1.631 | 1.238 |
| 64K | 16 | 646.962 | 368.677 | 1.755x | 1.639 | 1.232 |
| 64K | 32 | 647.037 | 372.753 | 1.736x | 1.632 | 1.230 |
| 128K | 0 | 891.154 | 443.496 | 2.009x | 1.659 | 1.236 |
| 128K | 4 | 1296.480 | 729.408 | 1.777x | 1.632 | 1.238 |
| 128K | 8 | 1288.738 | 727.928 | 1.770x | 1.634 | 1.240 |
| 128K | 16 | 1285.562 | 737.213 | 1.744x | 1.646 | 1.229 |
| 128K | 32 | 1287.032 | 739.430 | 1.741x | 1.644 | 1.701 |



### TP4

| Prompt tokens (P) | Top-K | Baseline hidden (ms) | Compact hidden (ms) | Hidden speedup | PyTorch saved/GPU (GiB) | NVML saved/GPU (GiB) |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 0 | 1.311 | 1.654 | 0.793x | 0.004 | -0.002 |
| 4 | 4 | 1.302 | 1.776 | 0.733x | 0.004 | -0.002 |
| 4 | 8 | 1.405 | 1.730 | 0.812x | 0.004 | -0.002 |
| 4 | 16 | 1.412 | 1.805 | 0.782x | 0.004 | -0.002 |
| 4 | 32 | 1.381 | 1.683 | 0.820x | 0.004 | -0.002 |
| 16 | 0 | 1.376 | 1.567 | 0.878x | 0.017 | 0.020 |
| 16 | 4 | 1.501 | 1.826 | 0.822x | 0.016 | 0.020 |
| 16 | 8 | 1.559 | 1.805 | 0.864x | 0.016 | 0.020 |
| 16 | 16 | 1.584 | 1.720 | 0.921x | 0.016 | 0.020 |
| 16 | 32 | 1.573 | 1.839 | 0.856x | 0.016 | 0.020 |
| 256 | 0 | 2.800 | 1.736 | 1.613x | 0.268 | 0.289 |
| 256 | 4 | 3.455 | 2.332 | 1.481x | 0.264 | 0.270 |
| 256 | 8 | 3.640 | 2.379 | 1.530x | 0.264 | 0.270 |
| 256 | 16 | 3.649 | 2.541 | 1.436x | 0.264 | 0.270 |
| 256 | 32 | 3.650 | 2.559 | 1.426x | 0.264 | 0.270 |
| 1K | 0 | 7.305 | 3.049 | 2.396x | 1.067 | 1.199 |
| 1K | 4 | 10.660 | 4.237 | 2.516x | 1.053 | 1.049 |
| 1K | 8 | 10.774 | 4.649 | 2.317x | 1.052 | 1.049 |
| 1K | 16 | 11.194 | 4.610 | 2.428x | 1.052 | 1.049 |
| 1K | 32 | 11.219 | 4.678 | 2.398x | 1.052 | 1.049 |
| 4K | 0 | 25.103 | 7.779 | 3.227x | 1.542 | 1.842 |
| 4K | 4 | 37.380 | 12.489 | 2.993x | 1.527 | 1.486 |
| 4K | 8 | 37.714 | 12.740 | 2.960x | 1.527 | 1.486 |
| 4K | 16 | 37.316 | 14.746 | 2.531x | 1.527 | 1.486 |
| 4K | 32 | 41.210 | 14.914 | 2.763x | 1.527 | 1.486 |
| 16K | 0 | 99.998 | 30.464 | 3.283x | 1.542 | 1.264 |
| 16K | 4 | 149.594 | 48.484 | 3.085x | 1.528 | 1.264 |
| 16K | 8 | 150.618 | 48.982 | 3.075x | 1.528 | 1.275 |
| 16K | 16 | 158.376 | 53.950 | 2.936x | 1.528 | 1.275 |
| 16K | 32 | 158.962 | 54.282 | 2.928x | 1.528 | 1.275 |
| 64K | 0 | 399.808 | 121.870 | 3.281x | 1.542 | 1.266 |
| 64K | 4 | 614.379 | 199.058 | 3.086x | 1.529 | 1.266 |
| 64K | 8 | 609.151 | 200.100 | 3.044x | 1.529 | 1.277 |
| 64K | 16 | 606.030 | 201.785 | 3.003x | 1.534 | 1.273 |
| 64K | 32 | 604.769 | 202.692 | 2.984x | 1.532 | 1.271 |
| 128K | 0 | 806.160 | 245.778 | 3.280x | 1.542 | 1.266 |
| 128K | 4 | 1217.174 | 393.786 | 3.091x | 1.530 | 1.266 |
| 128K | 8 | 1205.700 | 395.860 | 3.046x | 1.532 | 1.281 |
| 128K | 16 | 1204.134 | 397.657 | 3.028x | 1.539 | 1.270 |
| 128K | 32 | 1201.625 | 401.370 | 2.994x | 1.526 | 1.266 |



### CuTe DSL cold-start compilation

| TP | Compilation time |
|---:|---:|
| 1 | 7.294 s |
| 2 | 7.040 s |
| 4 | 7.142 s |


## Conclusion

For long prompts (`P >= 4K`), the geometric-mean hidden-to-logprobs speedups
are:

| TP | Hidden speedup | PyTorch peak memory saved/GPU |
|---:|---:|---:|
| 1 | 0.845x | 0.875–0.937 GiB |
| 2 | 1.807x | 1.627–1.659 GiB |
| 4 | 3.026x | 1.526–1.542 GiB |

The compact path trades some TP1 latency for lower peak memory, while TP2 and
TP4 provide substantial hidden-to-logprobs speedups together with significant
per-GPU memory savings.




## Test Plan

The compact path passed all focused kernel and integration tests:

- `tests/kernels/test_lm_head_logprobs.py`: 37 passed;
- `tests/test_envs.py -k v2_compact_prompt_logprobs_env`: 3 passed;
- `tests/v1/sample/test_prompt_logprob.py`: 12 passed.

The tests cover TP execution, Top-K boundaries, tie-breaking, vocabulary padding, target-rank calculation, unsupported configurations, warmup, and fallback behavior. Pre-commit and Python 3.12 mypy checks also passed.



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] **Purpose:** Add an opt-in Model Runner V2 compact prompt-logprobs path
      that fuses the vocab-parallel LM-head projection with Top-K and
      normalization statistics, reducing intermediate memory usage and TP
      communication for small Top-K values.
- [x] **Test plan:** Add focused kernel, environment, and prompt-logprobs
      integration coverage for the compact path.
- [x] **Test results:** Kernel and integration tests passed, including TP
      execution, Top-K boundaries, tie-breaking, vocabulary padding, target
      rank calculation, warmup, unsupported configurations, and fallback.
      The benchmark covers Qwen3.5-4B on TP1, TP2, and TP4 across the complete
      prompt-length and Top-K matrix.
- [ ] **Documentation update:** Not required. This is an opt-in experimental
      path controlled by `VLLM_USE_V2_COMPACT_PROMPT_LOGPROBS`.
</details>


