### PR TITLE
[ROCm][Test] Use platform FP8 dtype in ModelOpt FP8_PB_WO test

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -508,10 +508,11 @@ def test_modelopt_fp8_pb_wo_checkpoint_setup(default_vllm_config, vllm_runner):
             assert isinstance(gate_up_proj.quant_method, ModelOptFp8PbWoLinearMethod)
             assert isinstance(down_proj.quant_method, ModelOptFp8PbWoLinearMethod)
 
-            assert qkv_proj.weight.dtype == torch.float8_e4m3fn
-            assert o_proj.weight.dtype == torch.float8_e4m3fn
-            assert gate_up_proj.weight.dtype == torch.float8_e4m3fn
-            assert down_proj.weight.dtype == torch.float8_e4m3fn
+            fp8_dtype = current_platform.fp8_dtype()
+            assert qkv_proj.weight.dtype == fp8_dtype
+            assert o_proj.weight.dtype == fp8_dtype
+            assert gate_up_proj.weight.dtype == fp8_dtype
+            assert down_proj.weight.dtype == fp8_dtype
 
             # Block scales; should be materialized as a 2D [out_blk, in_blk] tensor.
             assert hasattr(qkv_proj, "weight_scale")


### PR DESCRIPTION
## Purpose
`quantization/test_modelopt.py::test_modelopt_fp8_pb_wo_checkpoint_setup` failed on MI300. The test loads a ModelOpt FP8_PB_WO checkpoint and checks that the linear layer weights have the expected FP8 dtype, but it hardcoded `torch.float8_e4m3fn`.

On ROCm, FP8 weights are stored as `e4m3fnuz`. After #53132, the ModelOpt FP8_PB_WO weight post-processing path started running on load and converted the weights to the platform FP8 dtype. The test still expected the old hardcoded dtype, so it failed with: `assert torch.float8_e4m3fnuz == torch.float8_e4m3fn`

This change updates the test to resolve the expected dtype via `current_platform.fp8_dtype()`  and compare the loaded weight dtypes against the platform FP8 dtype instead of hardcoded torch.float8_e4m3fn
## Test Plan
`pytest tests/quantization/test_modelopt.py` on MI300X.
## Test Result
Before:
1 failed, 19 passed, 4 skipped
After:
20 passed, 4 skipped
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
