### PR TITLE
[Bugfix][Frontend] Keep the real finish_reason when a streamed tool call is truncated

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -32,7 +32,9 @@ from vllm.entrypoints.openai.chat_completion.serving import (
     _make_prompt_tokens_details,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
     DeltaMessage,
+    DeltaToolCall,
     ErrorResponse,
     RequestResponseMetadata,
 )
@@ -839,6 +841,93 @@ async def test_streaming_reasoning_usage_counts_across_deltas():
     assert usage_chunks[-1]["usage"]["completion_tokens_details"] == {
         "reasoning_tokens": 1
     }
+
+
+_TRAVEL_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "book_travel",
+        "description": "Book a travel itinerary",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "origin": {"type": "string"},
+                "destination": {"type": "string"},
+            },
+            "required": ["origin", "destination"],
+        },
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_streaming_truncation_is_not_reported_as_a_completed_tool_call():
+    """A tool call cut short by ``max_tokens`` must still report "length".
+
+    Once any tool-call delta has been streamed the terminal reason was
+    rewritten to "tool_calls" unconditionally, which threw away the engine's
+    actual reason. A generation truncated mid-arguments was then handed to the
+    caller as a finished tool call, with arguments that do not parse as JSON.
+
+    The full generator never had this problem because it only translates when
+    ``output.finish_reason == "stop"``, so the same request answered
+    differently depending on ``stream``.
+    """
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    serving.model_config = None
+
+    parser = MagicMock()
+    parser.parse_delta.side_effect = [
+        DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    id="call_abc",
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name="book_travel", arguments='{"origin": "San Fra'
+                    ),
+                )
+            ]
+        ),
+        DeltaMessage(),
+    ]
+    parser.count_reasoning_tokens.return_value = 0
+    serving.parser_cls = MagicMock(return_value=parser)
+
+    first = _make_metrics_request_output(metrics=None, token_ids=(10, 11))
+    first.outputs[0].finish_reason = None
+    # the engine ran out of budget part way through the arguments
+    second = _make_metrics_request_output(metrics=None, token_ids=(12, 13))
+    second.outputs[0].finish_reason = "length"
+
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Book me a trip"}],
+        tools=[_TRAVEL_TOOL],
+        tool_choice="required",
+        max_tokens=16,
+        stream=True,
+    )
+
+    finish_reasons = []
+    async for line in serving.chat_completion_stream_generator(
+        request,
+        _stream_request_outputs(first, second),
+        "chatcmpl-test-id",
+        "test-model",
+        conversation=[{"role": "user", "content": "Book me a trip"}],
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+    ):
+        payload = line.removeprefix("data: ").strip()
+        if payload == "[DONE]":
+            continue
+        for choice in json.loads(payload).get("choices", []):
+            if choice.get("finish_reason"):
+                finish_reasons.append(choice["finish_reason"])
+
+    assert finish_reasons == ["length"]
 
 
 @dataclass

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -738,7 +738,20 @@ class OpenAIServingChat(GenerateBaseServing):
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if tools_streamed[i] and not tool_choice_function_name:
+                        #
+                        # Only translate a clean end of generation. If the engine
+                        # stopped for any other reason -- "length", "abort",
+                        # "repetition" -- that reason has to survive, because the
+                        # tool call it was in the middle of emitting is truncated.
+                        # Overwriting it with "tool_calls" tells the caller the
+                        # call is complete while the arguments it streamed do not
+                        # even parse as JSON. The full generator already gates on
+                        # ``output.finish_reason == "stop"`` for this reason.
+                        if (
+                            tools_streamed[i]
+                            and not tool_choice_function_name
+                            and output.finish_reason == "stop"
+                        ):
                             finish_reason_ = "tool_calls"
                         else:
                             finish_reason_ = (


### PR DESCRIPTION
## Purpose

Fixes #53269.

In the streaming chat handler, once any tool-call delta has been emitted the
terminal reason is rewritten to `"tool_calls"` unconditionally, discarding the
engine's actual reason. A generation cut short by `max_tokens` part way through
the arguments is therefore reported to the caller as a completed tool call —
with arguments that do not parse as JSON.

The non-streaming path already gates the same translation on
`output.finish_reason == "stop"`, so today the identical request answers
differently depending only on `stream`, and the streaming answer is the wrong
one (OpenAI reports `"length"` on truncation).

```python
-if tools_streamed[i] and not tool_choice_function_name:
+if (
+    tools_streamed[i]
+    and not tool_choice_function_name
+    and output.finish_reason == "stop"
+):
     finish_reason_ = "tool_calls"
 else:
     finish_reason_ = output.finish_reason if output.finish_reason else "stop"
```

This also stops `abort` and `repetition` being swallowed the same way. Named
`tool_choice` is unaffected — it was already excluded and still reports
`"stop"`.

Related but separate: #53255 / #53256 fix the mirror-image problem on the
non-streaming path (reporting `"tool_calls"` when no call was produced at all).
The two changes are independent and can land in either order.

## Test Plan

Unit test added: `test_streaming_truncation_is_not_reported_as_a_completed_tool_call`
in `tests/entrypoints/openai/chat_completion/test_serving_chat.py`. It drives
the streaming generator with a tool-call delta followed by an engine finish
reason of `"length"` and asserts the terminal chunk reports `"length"`.

```
pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py \
  -k streaming_truncation_is_not_reported
```

End-to-end, two servers were run side by side from the same image on the same
host — one patched, one not — and swept over `max_tokens` across the point where
truncation lands inside the tool call. Greedy decoding (`temperature=0`, fixed
`seed`) so the streaming and non-streaming requests produce the same token
sequence; without that, a request sitting exactly at the boundary can finish
cleanly in one sample and be cut in the next, which is sampling noise rather
than a code path.

## Test Result

`tool_choice="required"`, greedy, patch as the only difference between columns:

| `max_tokens` | unpatched non-stream | unpatched stream | patched non-stream | patched stream |
|---|---|---|---|---|
| 64 | `length` | **`tool_calls`** (args do not parse) | `length` | `length` |
| 80 | `length` | **`tool_calls`** (args do not parse) | `length` | `length` |
| 96 | `length` | **`tool_calls`** (args do not parse) | `length` | `length` |
| 112 | `length` | **`tool_calls`** (args do not parse) | `length` | `length` |
| 128 | `tool_calls` | `tool_calls` | `tool_calls` | `tool_calls` |
| 144–256 | `tool_calls` | `tool_calls` | `tool_calls` | `tool_calls` |

```
diverging max_tokens BEFORE : [64, 80, 96, 112]
diverging max_tokens AFTER  : []
```

Completed tool calls (128 and above) still report `"tool_calls"` on both paths,
so the working case is not regressed.

I was not able to run the full suite locally (no CUDA/torch on the development
machine), so the unit test is offered for CI to exercise; the table above comes
from the end-to-end runs.