### PR TITLE
[Bugfix][Frontend] Recover Kimi K3 tools after omitted think close

### DIFF
--- a/rust/src/parser/src/unified/kimi_k3.rs
+++ b/rust/src/parser/src/unified/kimi_k3.rs
@@ -80,7 +80,13 @@ const IDLE_MARKERS: &[&str] = &[
     MESSAGE_CLOSE,
     END_OF_MSG,
 ];
-const REASONING_MARKERS: &[&str] = &[THINK_CLOSE, END_OF_MSG];
+const REASONING_MARKERS: &[&str] = &[
+    THINK_CLOSE,
+    RESPONSE_OPEN,
+    RESPONSE_CLOSE,
+    TOOLS_OPEN,
+    END_OF_MSG,
+];
 const RESPONSE_MARKERS: &[&str] = &[RESPONSE_CLOSE, TOOLS_OPEN, MESSAGE_CLOSE, END_OF_MSG];
 const EPILOGUE_MARKERS: &[&str] = &[TOOLS_OPEN, MESSAGE_CLOSE, END_OF_MSG];
 const TOOLS_MARKERS: &[&str] = &[CALL_OPEN, TOOLS_CLOSE, MESSAGE_CLOSE, END_OF_MSG];
@@ -349,6 +355,11 @@ fn parse_idle_event(input: &mut KimiK3Input<'_>) -> ModalResult<KimiK3Event> {
 fn parse_reasoning_event(input: &mut KimiK3Input<'_>) -> ModalResult<KimiK3Event> {
     alt((
         literal(THINK_CLOSE).value(KimiK3Event::ThinkClose),
+        // A later channel unambiguously ends reasoning even if the model
+        // omitted the explicit think-close marker.
+        literal(RESPONSE_OPEN).value(KimiK3Event::ResponseOpen),
+        literal(RESPONSE_CLOSE).value(KimiK3Event::ResponseClose),
+        literal(TOOLS_OPEN).value(KimiK3Event::ToolsOpen),
         // `<|end_of_msg|>` can reach the parser under `ignore_eos` or
         // `include_stop_str_in_output`; never leak it into reasoning.
         literal(END_OF_MSG).value(KimiK3Event::MessageEnd),
@@ -780,6 +791,22 @@ mod tests {
             assert_eq!(output.normal_text(), "the answer", "chunk size {size}");
             assert_eq!(first_call(&output).name.as_deref(), Some("calc"));
             assert_eq!(first_call(&output).arguments, r#"{"x":42}"#);
+        }
+    }
+
+    #[test]
+    fn kimi_k3_recovers_tool_call_when_think_close_is_missing() {
+        let tool = call("tool=\"bash\" index=\"1\"", &arg("command", "string", "ls"));
+        let text = format!("{THINK_OPEN}planning{RESPONSE_CLOSE}{TOOLS_OPEN}{tool}{TOOLS_CLOSE}");
+
+        for size in [1, 3, 7] {
+            let chunks = char_chunks(&text, size);
+            let chunk_refs: Vec<&str> = chunks.iter().map(String::as_str).collect();
+            let output = collect_stream(&mut test_parser(), &chunk_refs);
+
+            assert_eq!(output.reasoning_text(), "planning", "chunk size {size}");
+            assert_eq!(first_call(&output).name.as_deref(), Some("bash"));
+            assert_eq!(first_call(&output).arguments, r#"{"command":"ls"}"#);
         }
     }
 

--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -19,6 +19,8 @@ SEP = "<|sep|>"
 THINK_OPEN = f"{OPEN}think{SEP}"
 THINK_CLOSE = f"{CLOSE}think{SEP}"
 RESPONSE_OPEN = f"{OPEN}response{SEP}"
+RESPONSE_CLOSE = f"{CLOSE}response{SEP}"
+TOOLS_OPEN = f"{OPEN}tools{SEP}"
 
 
 class DummyTokenizer:
@@ -78,6 +80,30 @@ def test_extract_reasoning_with_generation_prefix_consumed():
 
     assert reasoning == "step"
     assert content == "answer"
+
+
+def test_extract_reasoning_recovers_at_later_channel_without_think_close():
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "bash", "parameters": {"type": "object"}},
+            }
+        ],
+        tool_choice="auto",
+    )
+    tools = f'{TOOLS_OPEN}{OPEN}call tool="bash" index="1"{SEP}'
+
+    reasoning, content = parser.extract_reasoning_content(
+        f"planning{RESPONSE_CLOSE}{tools}",
+        request,
+    )
+
+    assert reasoning == "planning"
+    assert content == f"{RESPONSE_CLOSE}{tools}"
 
 
 def test_delegating_parser_strips_response_wrapper_without_tool_parser():
@@ -179,6 +205,25 @@ def test_streaming_split_close_marker_hands_content_downstream():
     assert closed.reasoning is None
     assert closed.content == f"{RESPONSE_OPEN}answer"
     assert parser.extract_content_ids([2, 3, 10]) == [10]
+
+
+def test_streaming_split_later_channel_recovers_without_think_close():
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    previous_text = f"{THINK_OPEN}planning{CLOSE}respon"
+    current_text = f"{THINK_OPEN}planning{RESPONSE_CLOSE}{TOOLS_OPEN}"
+
+    delta = parser.extract_reasoning_content_streaming(
+        previous_text=previous_text,
+        current_text=current_text,
+        delta_text=f"se{SEP}{TOOLS_OPEN}",
+        previous_token_ids=[1, 2, 3, 9],
+        current_token_ids=[1, 2, 3, 9, 10],
+        delta_token_ids=[10],
+    )
+
+    assert isinstance(delta, DeltaMessage)
+    assert delta.reasoning is None
+    assert delta.content == f"{RESPONSE_CLOSE}{TOOLS_OPEN}"
 
 
 def test_thinking_disabled_streams_content():

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -106,6 +106,7 @@ class KimiK3ReasoningParser(ReasoningParser):
         # bypassed and the reasoning parser must strip them itself.
         self._response_open = "<|open|>response<|sep|>"
         self._response_close = "<|close|>response<|sep|>"
+        self._tools_open = "<|open|>tools<|sep|>"
         self._message_close = "<|close|>message<|sep|>"
 
         # Tolerant matchers: defense-in-depth against vLLM's added-token spacing
@@ -123,6 +124,7 @@ class KimiK3ReasoningParser(ReasoningParser):
         self._response_close_re = re.compile(
             close_marker + r"\s*response\s*" + sep_marker
         )
+        self._tools_open_re = re.compile(open_marker + r"\s*tools\s*" + sep_marker)
         self._message_close_re = re.compile(
             close_marker + r"\s*message\s*" + sep_marker
         )
@@ -251,6 +253,22 @@ class KimiK3ReasoningParser(ReasoningParser):
             return text or None
         return self._strip_content_wrapper(text) or None
 
+    def _inferred_reasoning_end(self, text: str, start: int = 0):
+        """Find the first later-channel marker after an omitted think close."""
+        matches = (
+            matcher.search(text, start)
+            for matcher in (
+                self._response_open_re,
+                self._response_close_re,
+                self._tools_open_re,
+            )
+        )
+        return min(
+            (match for match in matches if match is not None),
+            key=lambda match: match.start(),
+            default=None,
+        )
+
     def extract_reasoning(
         self, model_output: str, request: "ChatCompletionRequest | ResponsesRequest"
     ) -> tuple[str | None, str | None]:
@@ -269,18 +287,33 @@ class KimiK3ReasoningParser(ReasoningParser):
         m_open = self._think_open_re.search(model_output)
         # reasoning content begins right after think-open (or at start if the
         # open marker was already consumed as a generation prefix)
-        content_start = m_open.end() if m_open is not None else 0
-        # if there is no think channel at all, everything is content
-        if m_open is None and self._think_close_re.search(model_output) is None:
+        reasoning_start = m_open.end() if m_open is not None else 0
+        m_close = self._think_close_re.search(model_output, reasoning_start)
+        m_inferred_close = self._inferred_reasoning_end(model_output, reasoning_start)
+        # if there is no think channel or later-channel boundary at all,
+        # everything is content
+        if m_open is None and m_close is None and m_inferred_close is None:
             return None, self._content_after_reasoning(model_output, request)
 
-        m_close = self._think_close_re.search(model_output, content_start)
-        if m_close is not None:
-            reasoning = model_output[content_start : m_close.start()]
-            rest = model_output[m_close.end() :]
+        if m_close is not None and (
+            m_inferred_close is None or m_close.start() < m_inferred_close.start()
+        ):
+            reasoning_end = m_close.start()
+            downstream_start = m_close.end()
+        elif m_inferred_close is not None:
+            reasoning_end = m_inferred_close.start()
+            # Preserve the inferred marker for the downstream parser.
+            downstream_start = m_inferred_close.start()
+        else:
+            reasoning_end = None
+            downstream_start = len(model_output)
+
+        if reasoning_end is not None:
+            reasoning = model_output[reasoning_start:reasoning_end]
+            rest = model_output[downstream_start:]
             return (reasoning or None, self._content_after_reasoning(rest, request))
         # think not closed -> still reasoning, no content yet
-        return (model_output[content_start:] or None, None)
+        return (model_output[reasoning_start:] or None, None)
 
     def _reasoning_text_ready_to_emit(self, text: str) -> str:
         """Return the reasoning prefix that is safe to stream now.
@@ -306,7 +339,13 @@ class KimiK3ReasoningParser(ReasoningParser):
         if m_open is not None:
             text = text[m_open.end() :]
         overlap = 0
-        for marker in (self._think_open, self._think_close):
+        for marker in (
+            self._think_open,
+            self._think_close,
+            self._response_open,
+            self._response_close,
+            self._tools_open,
+        ):
             max_check = min(len(marker) - 1, len(text))
             for n in range(max_check, 0, -1):
                 if text.endswith(marker[:n]):
@@ -382,26 +421,42 @@ class KimiK3ReasoningParser(ReasoningParser):
             return DeltaMessage(content=delta_text)
 
         # reasoning already ended -> downstream content
-        if self._think_close_re.search(previous_text):
+        if self._think_close_re.search(previous_text) or self._inferred_reasoning_end(
+            previous_text
+        ):
             return DeltaMessage(content=delta_text)
 
         # the close marker completes within this delta's accumulated text:
         # split the buffer at the close marker into reasoning vs trailing content.
         m_close = self._think_close_re.search(current_text)
-        if m_close is not None:
+        m_inferred_close = self._inferred_reasoning_end(current_text)
+        if m_close is not None and (
+            m_inferred_close is None or m_close.start() < m_inferred_close.start()
+        ):
+            reasoning_end = m_close.start()
+            content_start = m_close.end()
+        elif m_inferred_close is not None:
+            reasoning_end = m_inferred_close.start()
+            content_start = m_inferred_close.start()
+        else:
+            reasoning_end = None
+
+        if reasoning_end is not None:
             self._last_streaming_delta_token_ids = tuple(delta_token_ids)
-            self._last_streaming_content_token_ids = self._extract_content_ids(
-                list(current_token_ids)
+            self._last_streaming_content_token_ids = (
+                self._extract_content_ids(list(current_token_ids))
+                if m_close is not None and reasoning_end == m_close.start()
+                else list(delta_token_ids)
             )
             m_open = self._think_open_re.search(current_text)
             r_start = m_open.end() if m_open is not None else 0
-            reasoning = current_text[r_start : m_close.start()]
+            reasoning = current_text[r_start:reasoning_end]
             already_sent = self._reasoning_text_ready_to_emit(previous_text)
             if reasoning.startswith(already_sent):
                 reasoning_delta = reasoning[len(already_sent) :]
             else:
                 reasoning_delta = reasoning
-            content = current_text[m_close.end() :]
+            content = current_text[content_start:]
             return DeltaMessage(
                 reasoning=reasoning_delta or None,
                 content=content or None,


### PR DESCRIPTION
Fixes #53246.

When Kimi K3 omits the explicit think-close marker, treat a subsequent response or tools channel marker as an inferred reasoning boundary. Preserve the marker for downstream Python parsing and apply the equivalent state transition in the Rust frontend.

Tests cover non-streaming recovery, markers split across streaming chunks, and the equivalent Rust parser behavior.

Verification:
- Python parser harness: 3 checks passed
- `cargo test -p vllm-parser unified::kimi_k3::tests`: 27 passed
- Ruff check and format check
- `cargo fmt --check`