### PR TITLE
perf: Optimize sliding window cache hit search time complexity to O(N/K) from O(N)

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -934,11 +934,6 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             kv_cache_spec.sliding_window, kv_cache_spec.block_size, drop_eagle_block
         )
 
-        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
-        # optimize the time complexity from O(max_num_blocks) to
-        # O(max_num_blocks / sliding_window_contiguous_blocks +
-        # sliding_window_contiguous_blocks),
-        # which is good for low cache hit rate scenarios.
         max_num_blocks = max_length // kv_cache_spec.block_size
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
             [block_pool.null_block] * max_num_blocks
@@ -947,8 +942,23 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         block_size = kv_cache_spec.block_size
         num_contiguous_blocks = 0
         match_found = False
+
         # Search from right to left and early stop when a match is found.
-        for i in range(max_num_blocks - 1, -1, -1):
+        i = max_num_blocks - 1
+        while i >= 0:
+            # Fast-path optimization: jump by sliding_window_contiguous_blocks
+            # if the start of the candidate sequence is a cache miss.
+            if num_contiguous_blocks == 0 and i >= sliding_window_contiguous_blocks - 1:
+                start_idx = i - sliding_window_contiguous_blocks + 1
+                if not block_pool.get_cached_block(
+                    block_hashes[start_idx], kv_cache_group_ids
+                ):
+                    # Cache miss at the boundary. No valid contiguous sequence can
+                    # exist that includes `start_idx`. Jump backwards.
+                    i = start_idx - 1
+                    continue
+
+            # Standard check if we are accumulating hits or didn't jump
             if cached_block := block_pool.get_cached_block(
                 block_hashes[i], kv_cache_group_ids
             ):
@@ -957,11 +967,14 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
                 if num_contiguous_blocks == 0 and block_size != alignment_tokens:
                     post_pop_blocks = i if drop_eagle_block else i + 1
                     if (post_pop_blocks * block_size) % alignment_tokens != 0:
+                        i -= 1
                         continue
+
                 # Add the cached block to the computed blocks.
                 for computed, cached in zip(computed_blocks, cached_block):
                     computed[i] = cached
                 num_contiguous_blocks += 1
+
                 if num_contiguous_blocks >= sliding_window_contiguous_blocks:
                     # Trim the trailing blocks.
                     # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
@@ -972,6 +985,9 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
                     break
             else:
                 num_contiguous_blocks = 0
+
+            i -= 1
+
         if not match_found:
             # The first `num_contiguous_blocks` is a cache hit even if
             # `num_contiguous_blocks < sliding_window_contiguous_blocks`.


### PR DESCRIPTION

## Purpose
This PR implements an outstanding TODO in find_longest_cache_hit for the sliding window manager, reducing the worst-case time complexity of cache miss searches from $O(N)$ to $O(N/K)$ (where $N$ is max_num_blocks and $K$ is sliding_window_contiguous_blocks).

Previously, searching for a contiguous cache sequence scanned backward block-by-block. In low cache-hit rate scenarios, this resulted in an **O(N)** linear scan overhead. By replacing the sequential for loop with a while loop, this PR introduces a Boyer-Moore-style lookahead: we now probe the beginning of the required contiguous window (i - K + 1) before evaluating the rest of the sequence. If the boundary block is a cache miss, we can conclusively skip the entire window, aggressively pruning the search space.
## Test Plan
1. Correctness: Ran the v1 core test suite to ensure the jump logic does not break block alignment or drop_eagle_block behavior.
 pytest tests/v1/core/test_single_type_kv_cache_manager.py -vv
 pytest tests/v1/core/ -vv

2. Performance: Created a localized micro-benchmark script using mock vLLM objects to simulate cache hit/miss scenarios without full engine initialization overhead. Tested on a local RTX 3070 Ti.

## Test Result
The optimization eliminates severe CPU blocking delays during large context misses, speeding up worst-case scenarios by ~15x to ~45x. As expected, the jump logic introduces a negligible constant-factor overhead (1-37µs) in highly fragmented cache scenarios due to occasional double-lookups, which is a highly favorable trade-off for flattening the O(N) scaling.

Main Branch Original (O(N))
Scenario                            | Avg Time       | Iterations
-----------------------------------------------------------------
100% Cache Miss (N=1024, K=64)      |    49.56 us/iter | 50000 iters
100% Cache Hit (N=1024, K=64)       |    23.08 us/iter | 50000 iters
Scattered Misses (N=1024, K=64)     |   411.15 us/iter | 50000 iters
Hit at end of sequence              |    23.73 us/iter | 50000 iters
Large Context Miss (N=8192, K=256)  |   414.51 us/iter | 50000 iters

The PR (Optimized O(N/K))
Scenario                            | Avg Time       | Iterations
-----------------------------------------------------------------
100% Cache Miss (N=1024, K=64)      |     3.31 us/iter | 50000 iters        ~15x speedup
100% Cache Hit (N=1024, K=64)       |    24.29 us/iter | 50000 iters        ~1x
Scattered Misses (N=1024, K=64)     |   448.64 us/iter | 50000 iters        ~0.9x expected because of double lookup of block 
Hit at end of sequence              |    24.28 us/iter | 50000 iters        ~1x
Large Context Miss (N=8192, K=256)  |     9.06 us/iter | 50000 iters        ~ 50x speedup


Please view attached benchmark script for how the benchmark was produced.
[bench_cache.py](https://github.com/user-attachments/files/31309313/bench_cache.py)

co author: Gemini 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

