### PR TITLE
[ROCm] DeepEP: configurable dispatch timeouts, deferred legacy annotations

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 import threading
 from dataclasses import dataclass
 from typing import Any
@@ -1026,6 +1027,14 @@ class DeepEPV2All2AllManager(All2AllManagerBase):
         num_topk: int,
         use_fp8_dispatch: bool,
     ) -> dict:
+        # A data-parallel rank that holds no request still joins every MoE
+        # collective through a dummy batch. When the rank that does hold the
+        # request spends minutes JIT-compiling attention/MoE kernels on its
+        # first real forward, those waiting ranks hit DeepEP's stock 100 s GPU
+        # and 300 s CPU dispatch timeouts and abort a healthy collective.
+        # Size both timeouts for that one-off compilation instead.
+        timeout_secs = int(os.getenv("VLLM_DEEPEP_TIMEOUT_SECS", "1800"))
+
         return dict(
             group=self._device_group
             if self._device_group is not None
@@ -1037,6 +1046,8 @@ class DeepEPV2All2AllManager(All2AllManagerBase):
             allow_hybrid_mode=envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE,
             prefer_overlap_with_compute=envs.VLLM_DEEPEP_V2_PREFER_OVERLAP,
             allow_multiple_reduction=(envs.VLLM_DEEPEP_V2_ALLOW_MULTIPLE_REDUCTION),
+            num_cpu_timeout_secs=timeout_secs,
+            num_gpu_timeout_secs=timeout_secs,
             explicitly_destroy=True,
         )
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ht.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ht.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 from collections.abc import Callable
 
 import deep_ep


### PR DESCRIPTION
## Summary

Two small changes needed to serve over a DeepEP build that does not include the
legacy backend.

**Dispatch timeouts.** A data-parallel rank that holds no request still joins
every MoE collective through a dummy batch. On the first real forward the rank
that does hold the request spends minutes JIT-compiling attention and MoE
kernels, and the waiting ranks abort a healthy collective on DeepEP's stock
100 s GPU and 300 s CPU limits. Both now come from `VLLM_DEEPEP_TIMEOUT_SECS`,
default 1800 s.

**Import under a `deep_ep` without the legacy backend.** Such a build has no
`Config` or `Buffer`, which `deepep_ht.py` evaluates in annotations at import
time, so `import vllm` fails before serving starts. `from __future__ import
annotations` defers that evaluation; the module still imports its own symbols
normally.

## Test

DeepSeek-R1 FP8 on 8x MI350X, `TP=1 / DP=8 / EP=8` over DeepEP. Without the
timeout change the first request aborts the collective partway through JIT
compilation; with it the request completes and later ones are unaffected.
Without the annotations change the server does not start at all against a
`deep_ep` built without the legacy backend.

Made with [Cursor](https://cursor.com)