### PR TITLE
[ROCm][Perf] Use wvSplitK for single-output GEMMs

### DIFF
--- a/tests/model_executor/layers/test_rocm_unquantized_gemm.py
+++ b/tests/model_executor/layers/test_rocm_unquantized_gemm.py
@@ -17,9 +17,10 @@ if current_platform.is_cuda():
 from vllm.model_executor.layers import utils
 
 
-def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
+@pytest.mark.parametrize("m", [1, 128])
+def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch, m):
     x = torch.randn(1, 64, dtype=torch.float16)
-    weight = torch.randn(128, 64, dtype=torch.float16)
+    weight = torch.randn(m, 64, dtype=torch.float16)
 
     monkeypatch.setattr(utils, "use_aiter_triton_gemm", lambda *args: False)
     monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)
@@ -40,6 +41,20 @@ def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
     wvsplitk_mock.assert_called_once()
     llmm1_mock.assert_not_called()
     assert torch.allclose(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-only kernel test")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("n", range(1, 6))
+def test_rocm_unquantized_gemm_single_output_real_kernel(dtype, n):
+    torch.manual_seed(0)
+    x = torch.randn(n, 2048, device="cuda", dtype=dtype)
+    weight = torch.randn(1, 2048, device="cuda", dtype=dtype)
+
+    out = utils.rocm_unquantized_gemm_impl(x, weight, None)
+    ref = torch.nn.functional.linear(x, weight, None)
+
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
 
 
 def test_rocm_unquantized_gemm_makes_skinny_activation_contiguous(monkeypatch):
@@ -149,11 +164,12 @@ def test_rocm_unquantized_gemm_noncontiguous_activation_real_kernel(monkeypatch,
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
 
 
-def test_rocm_unquantized_gemm_gfx1x_n_gt_5_falls_back(monkeypatch):
+@pytest.mark.parametrize("m", [1, 128])
+def test_rocm_unquantized_gemm_gfx1x_n_gt_5_falls_back(monkeypatch, m):
     # wvSplitK skinny GEMM handles n in [1, 5] (see PR #40687); n > 5 must
     # fall back to torch.nn.functional.linear.
     x = torch.randn(6, 64, dtype=torch.float16)
-    weight = torch.randn(128, 64, dtype=torch.float16)
+    weight = torch.randn(m, 64, dtype=torch.float16)
 
     monkeypatch.setattr(utils, "use_aiter_triton_gemm", lambda *args: False)
     monkeypatch.setattr(utils.envs, "VLLM_ROCM_USE_SKINNY_GEMM", True)

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -186,7 +186,7 @@ def rocm_unquantized_gemm_impl(
         # The skinny kernels assume contiguous K elements. A shape-preserving
         # reshape can retain a transposed activation's non-contiguous strides.
         x_view = x.reshape(-1, x.size(-1)).contiguous()
-        if m > 8 and 0 < n <= 5:
+        if (m == 1 or m > 8) and 0 < n <= 5:
             cu_count = num_compute_units()
             out = ops.wvSplitK(weight, x_view, cu_count, bias)
             return out.reshape(*x.shape[:-1], weight.shape[0])


### PR DESCRIPTION
## Purpose

Fixes #52631. ROCm currently sends unquantized GEMMs with `weight.shape[0] == 1` to the generic `F.linear` fallback because the `wvSplitK` branch only accepts `m > 8`. This shape is used by the Qwen shared-expert gate during batch-1 decode. The existing `wvSplitK` kernel already supports `M_in=1`, so this PR extends the Python dispatch condition and adds focused coverage.

This does not duplicate an existing PR. The issue author confirmed that no PR was in progress. 

## Test Plan

```bash
.venv/bin/python -m pytest tests/model_executor/layers/test_rocm_unquantized_gemm.py -v
.venv/bin/pre-commit run ruff-check --files vllm/model_executor/layers/utils.py tests/model_executor/layers/test_rocm_unquantized_gemm.py
.venv/bin/pre-commit run ruff-format --files vllm/model_executor/layers/utils.py tests/model_executor/layers/test_rocm_unquantized_gemm.py
```

The end-to-end A/B test used `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` on an AMD Radeon 8060S (`gfx1151`)

## Test Result

The focused test suite passed: `21 passed`.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| BF16 `[1, 2048]` operator latency | 119.484 us | 3.161 us | 37.8x faster |
| Pure decode throughput | 23.74 tok/s | 26.77 tok/s | +12.79% |
| Decode latency per token | 42.125 ms | 37.350 ms | -11.34% |

The profiler confirmed the `wvSplitK` specialization with `YTILE=1`. All greedy output tokens were identical between the baseline and modified paths.

AI assistance was used during investigation, test development, and preparation of this PR. I reviewed every changed line and ran the tests and benchmarks above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
