### PR TITLE
Explore topK overflow/non-determinism

### DIFF
--- a/csrc/libtorch_stable/cooperative_topk.cu
+++ b/csrc/libtorch_stable/cooperative_topk.cu
@@ -84,8 +84,7 @@ void launch_cooperative_topk_impl(const torch::stable::Tensor& logits,
   params.tie_ws =
       reinterpret_cast<hist4096::Tie*>(workspace.mutable_data_ptr<uint8_t>());
 
-  constexpr uint32_t kTieWsPerRow =
-      TopK <= hist4096::kBlockSize ? hist4096::kMaxTies : TopK;
+  constexpr uint32_t kTieWsPerRow = ct::kCoarseTieCapacity;
   STD_TORCH_CHECK(
       workspace.size(0) >=
           static_cast<int64_t>(num_rows * kTieWsPerRow * sizeof(hist4096::Tie)),

--- a/csrc/libtorch_stable/cooperative_topk.cuh
+++ b/csrc/libtorch_stable/cooperative_topk.cuh
@@ -467,7 +467,7 @@ __device__ __forceinline__ ClusterCandidateOffsets candidate_offsets(
 // The probe either resolves an exact FP16-grid pivot or leaves enough state
 // for recovery to resume at the second radix digit.
 template <uint32_t TopK, uint32_t CS, bool UseResident, typename SmemType>
-__device__ __noinline__ OverflowProbeStatus probe_coarse_overflow(
+__device__ __noinline__ OverflowProbeStatus probe_reduced_precision_overflow(
     const float* __restrict__ row_input, uint32_t my_start, uint32_t my_len,
     uint32_t coarse_bin, uint32_t coarse_above, SmemType* smem,
     int32_t* scratch) {
@@ -655,6 +655,93 @@ __device__ __noinline__ OverflowProbeStatus probe_coarse_overflow(
   }
   __syncthreads();
   return static_cast<OverflowProbeStatus>(smem->match.equal_count);
+}
+
+// Arbitrary-FP32 overflow path: build the first exact radix digit directly.
+template <uint32_t TopK, uint32_t CS, bool UseResident, typename SmemType>
+__device__ __noinline__ OverflowProbeStatus probe_arbitrary_fp32_overflow(
+    const float* __restrict__ row_input, uint32_t my_start, uint32_t my_len,
+    uint32_t coarse_bin, uint32_t coarse_above, SmemType* smem,
+    int32_t* scratch) {
+  constexpr uint32_t kDigitBits = 11;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t needed = TopK - coarse_above;
+  auto* exact_histogram = reinterpret_cast<uint32_t*>(scratch);
+
+  const auto range = coarse_bin_range(coarse_bin);
+  if (!range.finite) {
+    return OverflowProbeStatus::kFullRescan;
+  }
+
+  for (uint32_t bin = tx; bin < kExactHistBins;
+       bin += hist4096::kBlockSize) {
+    exact_histogram[bin] = 0;
+  }
+  __syncthreads();
+
+  // A finite coarse bin is fully covered by the two 11-bit radix digits.
+  for_each_partition_score<UseResident>(
+      row_input + my_start, my_len, smem, [&](uint32_t, float score) {
+        if (extract_coarse_bin(score) != coarse_bin) return;
+        const uint32_t ordered = hist4096::convert_to_uint32_v2(score);
+        const uint32_t delta = ordered - range.base_key;
+        atomicAdd(&exact_histogram[delta >> kDigitBits], 1);
+      });
+  __syncthreads();
+
+  dsmem_hist_reduce<CS, kExactHistBins>(exact_histogram);
+  find_threshold_exact(exact_histogram, smem->warp_sum, needed, &smem->match);
+
+  if (tx == 0) {
+    const uint32_t first_prefix = smem->match.bin << kDigitBits;
+    const uint32_t remaining = needed - smem->match.above_count;
+    smem->match = {
+        .bin = first_prefix,
+        .above_count = remaining,
+        .equal_count =
+            static_cast<uint32_t>(OverflowProbeStatus::kFirstDigitReady)};
+  }
+  __syncthreads();
+  return OverflowProbeStatus::kFirstDigitReady;
+}
+
+// Every CTA reads the same sample, making the choice cluster-uniform without a
+// cluster synchronization. A missed arbitrary-FP32 input only takes the slower
+// general probe; both paths remain exact.
+__device__ __forceinline__ bool prefer_direct_fp32_probe(
+    const float* __restrict__ row_input) {
+  const uint32_t tx = threadIdx.x;
+  __shared__ uint32_t use_direct;
+  if (tx < hist4096::kWarpSize) {
+    const float score = row_input[tx];
+    const uint32_t raw = __float_as_uint(score);
+    const bool is_bf16 = (raw & 0xFFFFu) == 0;
+    const bool is_fp16 =
+        raw == __float_as_uint(__half2float(__float2half_rn(score)));
+    const uint32_t arbitrary_mask =
+        __ballot_sync(0xFFFFFFFFu, !is_bf16 && !is_fp16);
+    const uint32_t unequal_mask =
+        __ballot_sync(0xFFFFFFFFu,
+                      raw != __float_as_uint(row_input[0]));
+    if (tx == 0) {
+      use_direct = arbitrary_mask != 0 && unequal_mask != 0;
+    }
+  }
+  __syncthreads();
+  return use_direct != 0;
+}
+
+template <uint32_t TopK, uint32_t CS, bool UseResident, typename SmemType>
+__device__ __noinline__ OverflowProbeStatus probe_coarse_overflow(
+    const float* __restrict__ row_input, uint32_t my_start, uint32_t my_len,
+    uint32_t coarse_bin, uint32_t coarse_above, SmemType* smem,
+    int32_t* scratch) {
+  if (prefer_direct_fp32_probe(row_input)) {
+    return probe_arbitrary_fp32_overflow<TopK, CS, UseResident>(
+        row_input, my_start, my_len, coarse_bin, coarse_above, smem, scratch);
+  }
+  return probe_reduced_precision_overflow<TopK, CS, UseResident>(
+      row_input, my_start, my_len, coarse_bin, coarse_above, smem, scratch);
 }
 
 template <uint32_t TopK, uint32_t CS, typename SmemType>

--- a/csrc/libtorch_stable/cooperative_topk.cuh
+++ b/csrc/libtorch_stable/cooperative_topk.cuh
@@ -22,7 +22,11 @@ namespace hist4096 = topk_histogram_4096;
 
 constexpr uint32_t kHistBits = 10;
 constexpr uint32_t kHistBins = 1 << kHistBits;
+using ExactRadix = hist4096::ExactRadixTraits<true>;
+constexpr uint32_t kExactHistBins = ExactRadix::kBins;
 constexpr uint32_t kMaxTopK = 2048;
+// Retain this many threshold-bin candidates before exact recovery.
+constexpr uint32_t kCoarseTieCapacity = kMaxTopK;
 
 constexpr uint32_t kElemPerStage = 16;
 constexpr uint32_t kSizePerStage =
@@ -71,6 +75,53 @@ __device__ __forceinline__ uint32_t extract_coarse_bin(float x) {
   return hist4096::extract_coarse_bin_N<kHistBits>(x);
 }
 
+// Records how far the cheap overflow probe advanced exact selection.
+enum class OverflowProbeStatus : uint32_t {
+  kFullRescan = 0,
+  kKnownPivot = 1,
+  kFirstDigitReady = 2,
+};
+
+// Bounds one coarse FP16 bin in the monotonic ordered-FP32 key space.
+struct CoarseBinRange {
+  uint32_t base_key;
+  bool finite;
+};
+
+struct OverflowProbeSummary {
+  uint32_t min_key;
+  uint32_t max_key;
+  uint32_t flags;
+};
+
+// Reconstruct exact ordered-FP32 boundaries from reduced-precision keys.
+__device__ __forceinline__ uint32_t ordered_fp32_from_fp16_key(
+    uint16_t key) {
+  const uint16_t bits = (key & 0x8000u)
+                            ? static_cast<uint16_t>(key & 0x7FFFu)
+                            : static_cast<uint16_t>(~key);
+  return hist4096::convert_to_uint32_v2(
+      __half2float(__ushort_as_half(bits)));
+}
+
+__device__ __forceinline__ uint32_t ordered_fp32_from_bf16_key(
+    uint32_t key) {
+  return (key << 16) | ((key & 0x8000u) ? 0u : 0xFFFFu);
+}
+
+__device__ __forceinline__ CoarseBinRange coarse_bin_range(
+    uint32_t coarse_bin) {
+  const uint16_t lower_key =
+      static_cast<uint16_t>(coarse_bin << (16 - kHistBits));
+  const uint16_t lower_bits =
+      (lower_key & 0x8000u)
+          ? static_cast<uint16_t>(lower_key & 0x7FFFu)
+          : static_cast<uint16_t>(~lower_key);
+  const uint32_t ordered_lower = ordered_fp32_from_fp16_key(lower_key);
+  return {.base_key = ordered_lower > 8192 ? ordered_lower - 8192 : 0,
+          .finite = (lower_bits & 0x7C00u) != 0x7C00u};
+}
+
 __device__ __forceinline__ void mbarrier_init(uint64_t* a, uint32_t n) {
   cuda::ptx::mbarrier_init(a, n);
 }
@@ -94,18 +145,21 @@ __device__ __forceinline__ void tma_load(void* d, const void* s, uint32_t n,
 // DSMEM histogram reduce
 // ============================================================================
 
-template <uint32_t CS>
+template <uint32_t CS, uint32_t NumBins>
 __device__ __forceinline__ void dsmem_hist_reduce(uint32_t* histogram) {
-  static_assert(kHistBins <= hist4096::kBlockSize);
+  static_assert(NumBins % CS == 0);
+  // Fold the distributed per-rank bins into cluster-visible totals.
   auto cluster = cooperative_groups::this_cluster();
   cluster.sync();
-  const auto tx = threadIdx.x;
-  const auto rank = blockIdx.y;
-  constexpr auto kLocal = kHistBins / CS;
-  const auto off = kLocal * rank;
-  if (tx < kHistBins) {
-    const auto addr = &histogram[off + tx / CS];
-    const auto src = cluster.map_shared_rank(addr, tx % CS);
+  const uint32_t tx = threadIdx.x;
+  const uint32_t rank = blockIdx.y;
+  constexpr uint32_t kLocal = NumBins / CS;
+  const uint32_t off = kLocal * rank;
+#pragma unroll
+  for (uint32_t bin = tx; bin < NumBins;
+       bin += hist4096::kBlockSize) {
+    auto* addr = &histogram[off + bin / CS];
+    auto* src = cluster.map_shared_rank(addr, bin % CS);
     *src = warp_reduce_sum_subN<CS>(*src);
   }
   cluster.sync();
@@ -137,6 +191,45 @@ __device__ __forceinline__ void find_threshold(uint32_t* histogram,
   if (tx < kHistBins && above < TopK && above + value >= TopK) {
     *counter_gt = *counter_eq = 0;
     *match = {.bin = tx, .above_count = above, .equal_count = value};
+  }
+  __syncthreads();
+}
+
+// Locate the target digit in a 2,048-bin exact-radix histogram.
+__device__ __forceinline__ void find_threshold_exact(
+    uint32_t* histogram, uint32_t* warp_sum, uint32_t target,
+    hist4096::MatchBin* match) {
+  const uint32_t tx = threadIdx.x;
+  const uint32_t lane = tx % hist4096::kWarpSize;
+  const uint32_t warp = tx / hist4096::kWarpSize;
+  const uint32_t bin0 = 2 * tx;
+  const uint32_t bin1 = bin0 + 1;
+  const uint32_t count0 = histogram[bin0];
+  const uint32_t count1 = histogram[bin1];
+  const uint32_t local = count0 + count1;
+  const uint32_t warp_inclusive =
+      hist4096::warp_inclusive_sum(lane, local);
+  if (lane == hist4096::kWarpSize - 1) {
+    warp_sum[warp] = warp_inclusive;
+  }
+  __syncthreads();
+  if (warp == 0) {
+    warp_sum[lane] =
+        hist4096::warp_inclusive_sum(lane, warp_sum[lane]);
+  }
+  __syncthreads();
+
+  const uint32_t total = warp_sum[hist4096::kNumWarps - 1];
+  const uint32_t before_warp = warp == 0 ? 0 : warp_sum[warp - 1];
+  const uint32_t before_thread = before_warp + warp_inclusive - local;
+  uint32_t above = total - before_thread - local;
+  if (above < target && above + count1 >= target) {
+    *match = {.bin = bin1, .above_count = above, .equal_count = count1};
+  } else {
+    above += count1;
+    if (above < target && above + count0 >= target) {
+      *match = {.bin = bin0, .above_count = above, .equal_count = count0};
+    }
   }
   __syncthreads();
 }
@@ -201,7 +294,7 @@ __device__ void tma_stream_pass(const float* scores, uint32_t length,
           indices[atomicAdd(&smem->counter_gt, 1)] = gi;
         } else if (bn == thr_bin) {
           const auto p = atomicAdd(&smem->counter_eq, 1);
-          if (p < hist4096::kMaxTies) {
+          if (p < kCoarseTieCapacity) {
             smem->tie_buffer[p] = {gi, sc};
           }
         }
@@ -239,16 +332,579 @@ struct SmemFused {
   alignas(128) hist4096::MatchBin match;
   uint32_t warp_sum[hist4096::kNumWarps];
   union {
-    uint32_t histogram[kHistBins];
+    uint32_t histogram[kExactHistBins];
     hist4096::Tie tie_buffer[kMaxTopK];
   };
   alignas(128) float score_buffer[kStages][kSizePerStage];
 };
 
-using Smem8 = SmemFused<kFusedStagesCS8>;
-using Smem16 = SmemFused<kFusedStagesCS16>;
 using Smem4 = SmemFused<kStreamingStagesCS4, 2>;
 using SmemSinglePass = SmemFused<kMaxSinglePassStages>;
+
+// Build one radix digit when the coarse bin cannot bound the FP32 keys.
+__device__ void build_exact_histogram(const float* __restrict__ scores,
+                                      uint32_t length, uint32_t prefix,
+                                      uint32_t round, uint32_t* histogram) {
+  const uint32_t shift = ExactRadix::shift(round);
+  const uint32_t digit_mask = ExactRadix::digit_mask(round);
+  const uint32_t prefix_mask = ExactRadix::prefix_mask(round);
+  hist4096::scan_scores<hist4096::kBlockSize, 4>(
+      scores, length, [&](uint32_t, float score) {
+        const uint32_t ordered = hist4096::convert_to_uint32_v2(score);
+        if ((ordered & prefix_mask) == prefix) {
+          atomicAdd(&histogram[(ordered >> shift) & digit_mask], 1);
+        }
+      });
+}
+
+// Reuse resident TMA data when possible; otherwise rescan global memory.
+template <bool UseResident, typename SmemType, typename Visit>
+__device__ __forceinline__ void for_each_partition_score(
+    const float* __restrict__ scores, uint32_t length, SmemType* smem,
+    Visit visit) {
+  if constexpr (UseResident) {
+    const uint32_t tx = threadIdx.x;
+    const uint32_t stages = (length + kSizePerStage - 1) / kSizePerStage;
+    for (uint32_t stage = 0; stage < stages; ++stage) {
+      const uint32_t offset = stage * kSizePerStage;
+      const uint32_t size = min(kSizePerStage, length - offset);
+#pragma unroll
+      for (uint32_t i = 0; i < kElemPerStage; ++i) {
+        const uint32_t local = tx + i * hist4096::kBlockSize;
+        if (local >= size) break;
+        visit(offset + local, smem->score_buffer[stage][local]);
+      }
+    }
+  } else {
+    hist4096::scan_scores<hist4096::kBlockSize, 4>(scores, length, visit);
+  }
+}
+
+// A finite 10-bit FP16 bin spans fewer than 22 ordered-FP32 bits, so two
+// radix-2048 passes are sufficient to select its exact pivot.
+template <bool UseResident, typename SmemType>
+__device__ void build_coarse_refine_histogram(
+    const float* __restrict__ scores, uint32_t length, uint32_t coarse_bin,
+    uint32_t base_key, uint32_t prefix, uint32_t round, SmemType* smem,
+    uint32_t* histogram) {
+  const uint32_t shift = round == 0 ? 11 : 0;
+  const uint32_t prefix_mask = round == 0 ? 0u : 0xFFFFF800u;
+  for_each_partition_score<UseResident>(
+      scores, length, smem, [&](uint32_t, float score) {
+        if (extract_coarse_bin(score) != coarse_bin) return;
+        const uint32_t delta =
+            hist4096::convert_to_uint32_v2(score) - base_key;
+        if (round == 0 || (delta & prefix_mask) == prefix) {
+          atomicAdd(&histogram[(delta >> shift) & 0x7FFu], 1);
+        }
+      });
+}
+
+template <bool UseResident, typename SmemType>
+__device__ void collect_exact_candidates(
+    const float* __restrict__ scores, uint32_t length, uint32_t pivot,
+    uint32_t equal_limit, SmemType* smem, uint32_t* above_count,
+    uint32_t* equal_count, int32_t* above_indices, int32_t* equal_indices) {
+  for_each_partition_score<UseResident>(
+      scores, length, smem, [&](uint32_t idx, float score) {
+        const uint32_t ordered = hist4096::convert_to_uint32_v2(score);
+        if (ordered > pivot) {
+          above_indices[atomicAdd(above_count, 1)] =
+              static_cast<int32_t>(idx);
+        } else if (ordered == pivot) {
+          const uint32_t pos = atomicAdd(equal_count, 1);
+          if (pos < equal_limit) {
+            equal_indices[pos] = static_cast<int32_t>(idx);
+          }
+        }
+      });
+}
+
+struct ClusterCandidateOffsets {
+  uint32_t above;
+  uint32_t equal;
+  uint32_t total_above;
+};
+
+template <uint32_t CS>
+__device__ __forceinline__ ClusterCandidateOffsets candidate_offsets(
+    uint32_t local_above, uint32_t local_equal) {
+  constexpr uint32_t kCountBits = 16;
+  constexpr uint32_t kCountMask = (1u << kCountBits) - 1;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t rank = blockIdx.y;
+  auto cluster = cooperative_groups::this_cluster();
+  __shared__ uint32_t counts[CS];
+  __shared__ uint32_t packed_offset;
+  __shared__ uint32_t total_above;
+
+  if (tx < CS) {
+    auto* dst = cluster.map_shared_rank(counts, tx);
+    dst[rank] = (local_equal << kCountBits) | local_above;
+  }
+  cluster.sync();
+
+  if (tx == 0) {
+    uint32_t above = 0;
+    uint32_t equal = 0;
+    for (uint32_t i = 0; i < CS; ++i) {
+      if (i == rank) packed_offset = (equal << kCountBits) | above;
+      above += counts[i] & kCountMask;
+      equal += counts[i] >> kCountBits;
+    }
+    total_above = above;
+  }
+  __syncthreads();
+
+  return {
+      .above = packed_offset & kCountMask,
+      .equal = packed_offset >> kCountBits,
+      .total_above = total_above,
+  };
+}
+
+// Build the first exact radix digit while probing an overflowing coarse bin.
+// The probe either resolves an exact FP16-grid pivot or leaves enough state
+// for recovery to resume at the second radix digit.
+template <uint32_t TopK, uint32_t CS, bool UseResident, typename SmemType>
+__device__ __noinline__ OverflowProbeStatus probe_coarse_overflow(
+    const float* __restrict__ row_input, uint32_t my_start, uint32_t my_len,
+    uint32_t coarse_bin, uint32_t coarse_above, SmemType* smem,
+    int32_t* scratch) {
+  constexpr uint32_t kBf16Bins = 256;
+  constexpr uint32_t kDigitBits = 11;
+  constexpr uint32_t kDeltaLimit = 1u << (2 * kDigitBits);
+  constexpr uint32_t kValid = 1;
+  constexpr uint32_t kHasNonBf16 = 2;
+  constexpr uint32_t kHasNonFp16 = 4;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t rank = blockIdx.y;
+  const uint32_t needed = TopK - coarse_above;
+  auto cluster = cooperative_groups::this_cluster();
+  __shared__ uint32_t rank_min[CS];
+  __shared__ uint32_t rank_max[CS];
+  __shared__ uint32_t rank_flags[CS];
+  __shared__ OverflowProbeSummary summary;
+  auto* exact_histogram = reinterpret_cast<uint32_t*>(scratch);
+
+  const auto range = coarse_bin_range(coarse_bin);
+
+  for (uint32_t bin = tx; bin < kBf16Bins;
+       bin += hist4096::kBlockSize) {
+    smem->histogram[bin] = 0;
+  }
+  for (uint32_t bin = tx; bin < kExactHistBins;
+       bin += hist4096::kBlockSize) {
+    exact_histogram[bin] = 0;
+  }
+  if (tx == 0) {
+    smem->warp_sum[0] = 0xFFFFFFFFu;
+    smem->warp_sum[1] = 0;
+    smem->warp_sum[2] = range.finite;
+    smem->warp_sum[3] = 0;
+  }
+  __syncthreads();
+
+  uint32_t thread_min = 0xFFFFFFFFu;
+  uint32_t thread_max = 0;
+  uint32_t thread_invalid = 0;
+  uint32_t thread_non_bf16 = 0;
+  uint32_t thread_non_fp16 = 0;
+  const auto visit = [&](uint32_t, float score) {
+    const uint32_t bin = extract_coarse_bin(score);
+    if (bin != coarse_bin) return;
+
+    const uint32_t raw = __float_as_uint(score);
+    const uint32_t ordered = hist4096::convert_to_uint32_v2(score);
+    thread_min = min(thread_min, ordered);
+    thread_max = max(thread_max, ordered);
+    const bool is_bf16 = (raw & 0xFFFFu) == 0;
+    if (is_bf16) {
+      atomicAdd(&smem->histogram[(ordered >> 16) & 0xFFu], 1);
+    } else {
+      thread_non_bf16 = 1;
+    }
+    const __half half_score = __float2half_rn(score);
+    thread_non_fp16 |=
+        raw ^ __float_as_uint(__half2float(half_score));
+    const uint32_t delta = ordered - range.base_key;
+    const bool valid = ordered >= range.base_key && delta < kDeltaLimit;
+    thread_invalid |= !valid;
+    if (valid && !is_bf16) {
+      atomicAdd(&exact_histogram[delta >> kDigitBits], 1);
+    }
+  };
+
+  for_each_partition_score<UseResident>(
+      row_input + my_start, my_len, smem, visit);
+  atomicMin(&smem->warp_sum[0], thread_min);
+  atomicMax(&smem->warp_sum[1], thread_max);
+  atomicAnd(&smem->warp_sum[2], thread_invalid == 0);
+  atomicOr(&smem->warp_sum[3],
+           (thread_non_bf16 ? kHasNonBf16 : 0) |
+               (thread_non_fp16 ? kHasNonFp16 : 0));
+  __syncthreads();
+
+  if (tx < CS) {
+    auto* min_dst = cluster.map_shared_rank(rank_min, tx);
+    auto* max_dst = cluster.map_shared_rank(rank_max, tx);
+    auto* flags_dst = cluster.map_shared_rank(rank_flags, tx);
+    min_dst[rank] = smem->warp_sum[0];
+    max_dst[rank] = smem->warp_sum[1];
+    flags_dst[rank] = smem->warp_sum[2] |
+                      smem->warp_sum[3];
+  }
+  cluster.sync();
+
+  if (tx == 0) {
+    summary = {.min_key = 0xFFFFFFFFu, .max_key = 0, .flags = 0};
+    uint32_t valid = kValid;
+    uint32_t features = 0;
+    for (uint32_t i = 0; i < CS; ++i) {
+      summary.min_key = min(summary.min_key, rank_min[i]);
+      summary.max_key = max(summary.max_key, rank_max[i]);
+      valid &= rank_flags[i] & kValid;
+      features |= rank_flags[i] & ~kValid;
+    }
+    summary.flags = valid | features;
+  }
+  __syncthreads();
+
+  if (summary.min_key == summary.max_key) {
+    if (tx == 0) {
+      smem->match = {.bin = summary.min_key,
+                     .above_count = needed,
+                     .equal_count = static_cast<uint32_t>(
+                         OverflowProbeStatus::kKnownPivot)};
+    }
+    __syncthreads();
+    return OverflowProbeStatus::kKnownPivot;
+  }
+
+  const uint32_t min_bf16 = summary.min_key >> 16;
+  const uint32_t max_bf16 = summary.max_key >> 16;
+  if ((summary.flags & kHasNonBf16) == 0 &&
+      max_bf16 - min_bf16 < kBf16Bins) {
+    dsmem_hist_reduce<CS, kBf16Bins>(smem->histogram);
+    if (tx == 0) {
+      uint32_t above = 0;
+      for (uint32_t key = max_bf16;; --key) {
+        const uint32_t count = smem->histogram[key & 0xFFu];
+        if (above < needed && above + count >= needed) {
+          const uint32_t pivot = ordered_fp32_from_bf16_key(key);
+          smem->match = {.bin = pivot,
+                         .above_count = needed - above,
+                         .equal_count = static_cast<uint32_t>(
+                             OverflowProbeStatus::kKnownPivot)};
+          break;
+        }
+        above += count;
+        if (key == min_bf16) break;
+      }
+    }
+    __syncthreads();
+    return OverflowProbeStatus::kKnownPivot;
+  }
+
+  const bool bf16_keys_unambiguous = max_bf16 - min_bf16 < kBf16Bins;
+  if ((summary.flags & kValid) != 0 && bf16_keys_unambiguous) {
+    for (uint32_t key = min_bf16 + tx; key <= max_bf16;
+         key += hist4096::kBlockSize) {
+      const uint32_t count = smem->histogram[key & 0xFFu];
+      if (count == 0) continue;
+      const uint32_t ordered = ordered_fp32_from_bf16_key(key);
+      const uint32_t delta = ordered - range.base_key;
+      atomicAdd(&exact_histogram[delta >> kDigitBits], count);
+    }
+    __syncthreads();
+    dsmem_hist_reduce<CS, kExactHistBins>(exact_histogram);
+    find_threshold_exact(exact_histogram, smem->warp_sum, needed,
+                         &smem->match);
+  }
+
+  if (tx == 0) {
+    uint32_t status = 0;
+    uint32_t pivot = 0;
+    uint32_t remaining = 0;
+    if ((summary.flags & kValid) != 0 && bf16_keys_unambiguous) {
+      const uint32_t first_prefix = smem->match.bin << kDigitBits;
+      remaining = needed - smem->match.above_count;
+      if ((summary.flags & kHasNonFp16) == 0) {
+        const uint32_t first_lower = range.base_key + first_prefix;
+        const uint32_t first_upper = first_lower + (1u << kDigitBits) - 1;
+        for (uint32_t low = 0; low < (1u << (16 - kHistBits)); ++low) {
+          const uint16_t half_key =
+              static_cast<uint16_t>((coarse_bin << (16 - kHistBits)) | low);
+          const uint32_t candidate = ordered_fp32_from_fp16_key(half_key);
+          if (candidate >= first_lower && candidate <= first_upper) {
+            status = static_cast<uint32_t>(
+                OverflowProbeStatus::kKnownPivot);
+            pivot = candidate;
+            break;
+          }
+        }
+      }
+      if (status == 0) {
+        status = static_cast<uint32_t>(
+            OverflowProbeStatus::kFirstDigitReady);
+        pivot = first_prefix;
+      }
+    }
+    smem->match = {
+        .bin = pivot, .above_count = remaining, .equal_count = status};
+  }
+  __syncthreads();
+  return static_cast<OverflowProbeStatus>(smem->match.equal_count);
+}
+
+template <uint32_t TopK, uint32_t CS, typename SmemType>
+__device__ bool emit_staged_candidates(
+    const float* __restrict__ row_input, int32_t* __restrict__ row_output,
+    uint32_t my_start, uint32_t pivot, uint32_t remaining,
+    uint32_t staged_above, uint32_t staged_candidates, SmemType* smem,
+    int32_t* scratch) {
+  const uint32_t tx = threadIdx.x;
+  __shared__ uint32_t rank_staging_ok[CS];
+  __shared__ uint32_t staging_ok;
+  auto cluster = cooperative_groups::this_cluster();
+
+  if (tx < CS) {
+    auto* dst = cluster.map_shared_rank(rank_staging_ok, tx);
+    dst[blockIdx.y] = staged_above + staged_candidates <= kMaxTopK;
+  }
+  cluster.sync();
+  if (tx == 0) {
+    staging_ok = 1;
+    for (uint32_t i = 0; i < CS; ++i) {
+      staging_ok &= rank_staging_ok[i];
+    }
+  }
+  __syncthreads();
+  if (staging_ok == 0) return false;
+
+  if (tx == 0) {
+    smem->counter_gt = 0;
+    smem->counter_eq = 0;
+  }
+  __syncthreads();
+  for (uint32_t i = tx; i < staged_candidates;
+       i += hist4096::kBlockSize) {
+    const int32_t idx = scratch[kMaxTopK - 1 - i];
+    const uint32_t ordered = hist4096::convert_to_uint32_v2(
+        row_input[my_start + idx]);
+    if (ordered > pivot) {
+      atomicAdd(&smem->counter_gt, 1);
+    } else if (ordered == pivot) {
+      atomicAdd(&smem->counter_eq, 1);
+    }
+  }
+  __syncthreads();
+
+  const auto offsets = candidate_offsets<CS>(
+      staged_above + smem->counter_gt, smem->counter_eq);
+  for (uint32_t i = tx; i < staged_above; i += hist4096::kBlockSize) {
+    row_output[offsets.above + i] = scratch[i] + my_start;
+  }
+
+  if (tx == 0) {
+    smem->counter_gt = 0;
+    smem->counter_eq = 0;
+  }
+  __syncthreads();
+  for (uint32_t i = tx; i < staged_candidates;
+       i += hist4096::kBlockSize) {
+    const int32_t idx = scratch[kMaxTopK - 1 - i];
+    const uint32_t ordered = hist4096::convert_to_uint32_v2(
+        row_input[my_start + idx]);
+    if (ordered > pivot) {
+      const uint32_t pos = atomicAdd(&smem->counter_gt, 1);
+      row_output[offsets.above + staged_above + pos] = idx + my_start;
+    } else if (ordered == pivot) {
+      const uint32_t pos = atomicAdd(&smem->counter_eq, 1);
+      if (offsets.equal + pos < remaining) {
+        row_output[offsets.total_above + offsets.equal + pos] =
+            idx + my_start;
+      }
+    }
+  }
+  return true;
+}
+
+template <uint32_t TopK, uint32_t CS, bool UseResident, typename SmemType>
+__device__ __noinline__ void exact_topk_rescan_cluster(
+    const float* __restrict__ row_input, int32_t* __restrict__ row_output,
+    uint32_t my_start, uint32_t my_len, uint32_t coarse_bin,
+    uint32_t coarse_above, uint32_t start_round, uint32_t initial_prefix,
+    uint32_t initial_remaining, bool has_known_pivot, uint32_t known_pivot,
+    SmemType* smem, int32_t* s_topk) {
+  const uint32_t tx = threadIdx.x;
+  const auto range = coarse_bin_range(coarse_bin);
+
+  uint32_t prefix = initial_prefix;
+  uint32_t remaining = has_known_pivot
+                           ? initial_remaining
+                           : (start_round != 0
+                                  ? initial_remaining
+                                  : (range.finite ? TopK - coarse_above
+                                                  : TopK));
+  const uint32_t rounds = range.finite ? 2 : ExactRadix::kRounds;
+  const bool stage_final_candidates =
+      range.finite && start_round == 1 && my_len >= 16384;
+  uint32_t staged_above = 0;
+  uint32_t staged_candidates = 0;
+  for (uint32_t round = start_round;
+       round < (has_known_pivot ? start_round : rounds); ++round) {
+    for (uint32_t bin = tx; bin < kExactHistBins;
+         bin += hist4096::kBlockSize) {
+      smem->histogram[bin] = 0;
+    }
+    __syncthreads();
+
+    if (range.finite) {
+      if (stage_final_candidates && round == 1) {
+        if (tx == 0) {
+          smem->counter_gt = 0;
+          smem->counter_eq = 0;
+        }
+        __syncthreads();
+        const uint32_t interval_lower = range.base_key + prefix;
+        const uint32_t interval_upper = interval_lower + 0x7FFu;
+        for_each_partition_score<UseResident>(
+            row_input + my_start, my_len, smem,
+            [&](uint32_t idx, float score) {
+              const uint32_t ordered =
+                  hist4096::convert_to_uint32_v2(score);
+              if (ordered > interval_upper) {
+                const uint32_t pos = atomicAdd(&smem->counter_gt, 1);
+                if (pos < kMaxTopK) {
+                  s_topk[pos] = static_cast<int32_t>(idx);
+                }
+              } else if (ordered >= interval_lower) {
+                const uint32_t pos = atomicAdd(&smem->counter_eq, 1);
+                if (pos < kMaxTopK) {
+                  s_topk[kMaxTopK - 1 - pos] = static_cast<int32_t>(idx);
+                }
+                atomicAdd(&smem->histogram[ordered - interval_lower], 1);
+              }
+            });
+        __syncthreads();
+        staged_above = smem->counter_gt;
+        staged_candidates = smem->counter_eq;
+      } else {
+        build_coarse_refine_histogram<UseResident>(
+            row_input + my_start, my_len, coarse_bin, range.base_key, prefix,
+            round, smem, smem->histogram);
+      }
+    } else {
+      build_exact_histogram(row_input + my_start, my_len, prefix, round,
+                            smem->histogram);
+    }
+    __syncthreads();
+
+    dsmem_hist_reduce<CS, kExactHistBins>(smem->histogram);
+    find_threshold_exact(smem->histogram, smem->warp_sum, remaining,
+                         &smem->match);
+    const uint32_t shift = range.finite ? (round == 0 ? 11 : 0)
+                                        : ExactRadix::shift(round);
+    prefix |= smem->match.bin << shift;
+    remaining -= smem->match.above_count;
+  }
+
+  const uint32_t pivot = has_known_pivot
+                             ? known_pivot
+                             : (range.finite ? range.base_key + prefix
+                                             : prefix);
+
+  if (stage_final_candidates && !has_known_pivot &&
+      emit_staged_candidates<TopK, CS>(
+          row_input, row_output, my_start, pivot, remaining, staged_above,
+          staged_candidates, smem, s_topk)) {
+    return;
+  }
+
+  if (tx == 0) {
+    smem->counter_gt = 0;
+    smem->counter_eq = 0;
+  }
+  __syncthreads();
+
+  int32_t* equal_indices = reinterpret_cast<int32_t*>(smem->tie_buffer);
+  collect_exact_candidates<UseResident>(
+      row_input + my_start, my_len, pivot, remaining, smem,
+      &smem->counter_gt, &smem->counter_eq, s_topk, equal_indices);
+  __syncthreads();
+
+  const uint32_t local_above = smem->counter_gt;
+  const uint32_t local_equal = min(smem->counter_eq, remaining);
+  const auto offsets = candidate_offsets<CS>(local_above, local_equal);
+  for (uint32_t i = tx; i < local_above; i += hist4096::kBlockSize) {
+    row_output[offsets.above + i] = s_topk[i] + my_start;
+  }
+  const uint32_t equal_to_write = offsets.equal < remaining
+                                      ? min(local_equal,
+                                            remaining - offsets.equal)
+                                      : 0;
+  for (uint32_t i = tx; i < equal_to_write; i += hist4096::kBlockSize) {
+    row_output[offsets.total_above + offsets.equal + i] =
+        equal_indices[i] + my_start;
+  }
+}
+
+// Keep all exceptional-path state behind one call boundary so the healthy
+// large kernel retains the same live ranges as the original implementation.
+template <uint32_t TopK, uint32_t CS, bool UseResident, typename SmemType>
+__device__ __noinline__ void recover_coarse_overflow(
+    const float* __restrict__ row_input, int32_t* __restrict__ row_output,
+    uint32_t my_start, uint32_t my_len, SmemType* smem, int32_t* s_topk) {
+  const uint32_t coarse_bin = smem->match.bin;
+  const uint32_t coarse_above = smem->match.above_count;
+  const auto probe_status = probe_coarse_overflow<TopK, CS, UseResident>(
+      row_input, my_start, my_len, coarse_bin, coarse_above, smem, s_topk);
+  const bool has_known_pivot =
+      probe_status == OverflowProbeStatus::kKnownPivot;
+  const uint32_t start_round =
+      probe_status == OverflowProbeStatus::kFirstDigitReady ? 1 : 0;
+
+  exact_topk_rescan_cluster<TopK, CS, UseResident>(
+      row_input, row_output, my_start, my_len, coarse_bin, coarse_above,
+      start_round, start_round == 0 ? 0 : smem->match.bin,
+      smem->match.above_count, has_known_pivot,
+      has_known_pivot ? smem->match.bin : 0, smem, s_topk);
+}
+
+// Keep the two-candidate-per-thread refinement out of the common kernel body.
+// Inlining it increases register pressure even when the coarse bin contains at
+// most 1,024 candidates and this branch is never executed.
+template <uint32_t TopK>
+__device__ __noinline__ void refine_large_coarse_ties(
+    const hist4096::Tie* ties, uint32_t num_ties, uint32_t num_above,
+    int32_t* output, void* smem) {
+  static_assert(TopK <= hist4096::kBlockSize);
+  hist4096::tie_handle_large<TopK, kCoarseTieCapacity>(
+      ties, num_ties, num_above, output, smem);
+}
+
+// Keep the second candidate copy out of the one-candidate-per-thread path.
+template <uint32_t TopK>
+__device__ __noinline__ void copy_extra_coarse_ties(
+    const hist4096::Tie* tie_buffer, uint32_t num_ties,
+    uint32_t prefix_equal, uint32_t total_above, uint32_t row_start,
+    hist4096::Tie* tie_ws, int32_t* row_output) {
+  const uint32_t i = hist4096::kBlockSize + threadIdx.x;
+  if (i >= num_ties) {
+    return;
+  }
+
+  const auto tie = tie_buffer[i];
+  const uint32_t output_pos = total_above + prefix_equal + i;
+  if (output_pos < TopK) {
+    row_output[output_pos] = tie.idx + row_start;
+  }
+  const uint32_t tie_pos = prefix_equal + i;
+  if (tie_pos < kCoarseTieCapacity) {
+    tie_ws[tie_pos] = {tie.idx + row_start, tie.score};
+  }
+}
 
 // Cluster-cooperative large path.
 // kFused=true: all TMA stages resident, single-pass histogram + scatter (rescan
@@ -283,9 +939,7 @@ __device__ void large_topk(const float* __restrict__ row_input,
 
   if constexpr (kFused) {
     // Fused init + TMA prologue
-    if (tx < kHistBins) {
-      smem->histogram[tx] = 0;  // all threads zero histogram
-    }
+    if (tx < kHistBins) smem->histogram[tx] = 0;
     if (tx == 0) {  // thread 0 issues TMA - then all threads continue working
                     // until mbarrier sync
       smem->counter_gt = 0;
@@ -330,9 +984,7 @@ __device__ void large_topk(const float* __restrict__ row_input,
     }
   } else {
     // Twopass: init then stream histogram pass
-    if (tx < kHistBins) {
-      smem->histogram[tx] = 0;
-    }
+    if (tx < kHistBins) smem->histogram[tx] = 0;
     if (tx == 0) {
       smem->counter_gt = 0;
       smem->counter_eq = 0;
@@ -343,12 +995,19 @@ __device__ void large_topk(const float* __restrict__ row_input,
   }
 
   // DSMEM all-reduce + find threshold
-  dsmem_hist_reduce<CS>(
+  dsmem_hist_reduce<CS, kHistBins>(
       smem->histogram);  // each block histogram is summed across all CS blocks
   find_threshold<TopK>(smem->histogram, smem->warp_sum, &smem->counter_gt,
                        &smem->counter_eq, &smem->match);
 
   const auto thr = smem->match.bin;
+  // A larger threshold bin needs the exact overflow path.
+  if (__builtin_expect(
+          smem->match.equal_count > kCoarseTieCapacity, 0)) {
+    recover_coarse_overflow<TopK, CS, kFused>(
+        row_input, row_output, my_start, my_len, smem, s_topk);
+    return;
+  }
 
   if constexpr (kFused) {
     // Fused scatter: rescan score_buffer (still in smem)
@@ -369,7 +1028,7 @@ __device__ void large_topk(const float* __restrict__ row_input,
         } else if (bin == thr) {
           const auto p = atomicAdd(&smem->counter_eq,
                                    1);  // equal -> ties (later refinement)
-          if (p < hist4096::kMaxTies) {
+          if (p < kCoarseTieCapacity) {
             smem->tie_buffer[p] = {gidx, score};
           }
         }
@@ -378,7 +1037,7 @@ __device__ void large_topk(const float* __restrict__ row_input,
     __syncthreads();
   } else {
     // Twopass scatter: re-stream data via TMA
-    uint32_t scatter_phases[kStreamingStagesCS4] = {0, 0};
+    uint32_t scatter_phases[kStreamingStagesCS4] = {};
     tma_stream_pass<SmemType, kStreamingStagesCS4, kHistBits, true>(
         row_input + my_start, my_len, thr, s_topk, scatter_phases, smem);
   }
@@ -393,7 +1052,7 @@ __device__ void large_topk(const float* __restrict__ row_input,
   const uint32_t la = smem->counter_gt;
   const uint32_t le_full = smem->counter_eq;
   const uint32_t le =
-      min(le_full, hist4096::kMaxTies);  // written smem tie_buffer entries
+      min(le_full, kCoarseTieCapacity);  // written smem tie_buffer entries
 
   __shared__ uint32_t s_local_counts[CS];
   __shared__ uint32_t s_prefix_packed;
@@ -435,16 +1094,22 @@ __device__ void large_topk(const float* __restrict__ row_input,
     row_output[prefix_above + i] =
         s_topk[i] + my_start;  // my_start: block-local -> row-global index
   }
-  for (uint32_t i = tx; i < le; i += hist4096::kBlockSize) {
+  const uint32_t common_le = min(le, hist4096::kBlockSize);
+  if (tx < common_le) {
+    const uint32_t i = tx;
     const auto t = smem->tie_buffer[i];
-    uint32_t p = s_total_above + prefix_equal + i;
+    const uint32_t p = s_total_above + prefix_equal + i;
     if (p < TopK) {
       row_output[p] = t.idx + my_start;
     }
-    uint32_t tp = prefix_equal + i;
-    if (tp < (TopK <= hist4096::kBlockSize ? hist4096::kMaxTies : TopK)) {
+    const uint32_t tp = prefix_equal + i;
+    if (tp < kCoarseTieCapacity) {
       tie_ws[tp] = hist4096::Tie{t.idx + my_start, t.score};
     }
+  }
+  if (__builtin_expect(le > hist4096::kBlockSize, 0)) {
+    copy_extra_coarse_ties<TopK>(smem->tie_buffer, le, prefix_equal,
+                                 s_total_above, my_start, tie_ws, row_output);
   }
 
   // Tie refinement
@@ -458,19 +1123,22 @@ __device__ void large_topk(const float* __restrict__ row_input,
 
   // Tie-breaking uses FP32 (4-round radix sort)
   if constexpr (TopK <= hist4096::kBlockSize) {
-    // copy ties from tie_ws back to smem, then refine
-    const uint32_t num_ties = min(s_total_equal, hist4096::kMaxTies);
-    // TODO (roberto): could vectorize with uint2 (8 bytes = exactly one Tie)
-    for (uint32_t i = tx; i < num_ties; i += hist4096::kBlockSize) {
-      smem->tie_buffer[i] = hist4096::Tie{tie_ws[i].idx, tie_ws[i].score};
+    if (s_total_equal <= hist4096::kMaxTies) {
+      // Common case: copy one tie per thread back to smem, then refine.
+      const uint32_t num_ties = s_total_equal;
+      for (uint32_t i = tx; i < num_ties; i += hist4096::kBlockSize) {
+        smem->tie_buffer[i] = hist4096::Tie{tie_ws[i].idx, tie_ws[i].score};
+      }
+      __syncthreads();
+      hist4096::tie_handle<TopK>(smem->tie_buffer, num_ties, s_total_above,
+                                 row_output, smem);
+    } else {
+      // Rare case: retain and rank two threshold-bin candidates per thread.
+      refine_large_coarse_ties<TopK>(tie_ws, s_total_equal, s_total_above,
+                                     row_output, smem);
     }
-    __syncthreads();
-    hist4096::tie_handle<TopK>(smem->tie_buffer, num_ties, s_total_above,
-                               row_output, smem);
   } else {
-    // TopK=2048: process directly from tie_ws (GMEM)
-    const uint32_t num_ties = min(s_total_equal, static_cast<uint32_t>(TopK));
-    hist4096::tie_handle_large<TopK>(tie_ws, num_ties, s_total_above,
+    hist4096::tie_handle_large<TopK>(tie_ws, s_total_equal, s_total_above,
                                      row_output, smem);
   }
 }
@@ -505,7 +1173,9 @@ __device__ void cooperative_topk_body(CooperativeTopKParams<TopK> params) {
   if (sl <= static_cast<int32_t>(hist4096::kHist4096MaxLen)) {
     if (rank == 0) {
       extern __shared__ uint8_t sr[];
-      hist4096::histogram_4096_topk<TopK, 12>(
+      hist4096::histogram_4096_topk<
+          TopK, 12, hist4096::kHist4096VecsPerThread, false,
+          hist4096::OverflowRecovery::kRescan>(
           in, out, sl, sr);  // 4096-bin (12-bit) histogram
     }
     return;
@@ -530,8 +1200,7 @@ __device__ void cooperative_topk_body(CooperativeTopKParams<TopK> params) {
 
   extern __shared__ uint8_t sr[];
 
-  constexpr uint32_t kTieWsPerRow =
-      TopK <= hist4096::kBlockSize ? hist4096::kMaxTies : TopK;
+  constexpr uint32_t kTieWsPerRow = kCoarseTieCapacity;
   hist4096::Tie* row_tie_ws = params.tie_ws + row * kTieWsPerRow;
 
   if (use_singlepass) {
@@ -547,15 +1216,12 @@ __device__ void cooperative_topk_body(CooperativeTopKParams<TopK> params) {
         {};  // tracks the parity for mbarrier wait/arrive protocol
     large_topk<TopK, CS, FusedSmem, true>(in, out, sl, phases, row_tie_ws);
   } else {
-    // Two-pass: only CS=4 in practice (CS=8 always fits in singlepass)
     auto* smem = reinterpret_cast<Smem4*>(sr);
     if (tx < 2 * kStreamingStagesCS4) {
-      mbarrier_init(&smem->barrier[0][tx],
-                    1);  // init 2×2=4 barriers (2 passes × 2 stages)
+      mbarrier_init(&smem->barrier[0][tx], 1);
     }
     __syncthreads();
-    uint32_t hp[kStreamingStagesCS4] = {0,
-                                        0};  // histogram+scatter pass counters
+    uint32_t hp[kStreamingStagesCS4] = {};
     large_topk<TopK, CS, Smem4, false>(in, out, sl, hp, row_tie_ws);
   }
 }

--- a/csrc/libtorch_stable/persistent_topk.cuh
+++ b/csrc/libtorch_stable/persistent_topk.cuh
@@ -16,6 +16,8 @@
 namespace vllm {
 namespace persistent {
 
+using topk_histogram_4096::convert_to_uint32_v2;
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -25,7 +27,7 @@ constexpr int RADIX = 256;
 
 // Medium path: all shared state in dynamic smem (no static __shared__,
 // which would inflate the kernel's smem footprint and kill occupancy
-// for the decode/trivial paths).
+// for the short and trivial paths).
 constexpr size_t kMediumHistBytes = 2 * (RADIX + 128) * sizeof(int);  // 3072
 constexpr size_t kMediumScalarsBytes = 5 * sizeof(int);               // 20
 constexpr size_t kMediumHeaderSize =
@@ -33,83 +35,18 @@ constexpr size_t kMediumHeaderSize =
 constexpr int MAX_BUFFERED_ITEMS = 4096;
 constexpr size_t kSmemMedium =
     kMediumHeaderSize + 2 * MAX_BUFFERED_ITEMS * sizeof(int);  // 35968
+static_assert(topk_histogram_4096::kExactCandidateOffset +
+                      MAX_BUFFERED_ITEMS * sizeof(int) <=
+                  kSmemMedium);
 constexpr uint32_t RADIX_THRESHOLD = 32768;
 
-// Decode path constants
-constexpr int kDecodeBins = 2048;
-constexpr uint32_t HIST2048_THRESHOLD = 8192;
+// Short and medium path constants
+constexpr int kCoarseBins = 2048;
+constexpr uint32_t SHORT_EXACT_THRESHOLD = 8192;
 
 // Large path: fixed shared memory for histograms + scalars
 constexpr size_t kFixedSmemLarge =
     ((RADIX + RADIX + 5) * sizeof(uint32_t) + 15) & ~size_t(15);
-
-// ============================================================================
-// Common helpers
-// ============================================================================
-
-__device__ __forceinline__ auto convert_to_uint32_v2(float x) -> uint32_t {
-  uint32_t bits = __float_as_uint(x);
-  return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
-}
-
-__device__ __forceinline__ auto convert_to_uint8(float x) -> uint8_t {
-  __half h = __float2half_rn(x);
-  uint16_t bits = __half_as_ushort(h);
-  uint16_t key = (bits & 0x8000) ? static_cast<uint16_t>(~bits)
-                                 : static_cast<uint16_t>(bits | 0x8000);
-  return static_cast<uint8_t>(key >> 8);
-}
-
-// ============================================================================
-// Vectorized load helpers
-// ============================================================================
-
-// Unconditional float4 load with cache hint (.cg = cache at global level only).
-__device__ __forceinline__ void load_float4(const float* ptr, float& v0,
-                                            float& v1, float& v2, float& v3) {
-  uint32_t r0, r1, r2, r3;
-  asm volatile("ld.global.cg.v4.u32 {%0,%1,%2,%3}, [%4];\n"
-               : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3)
-               : "l"(ptr));
-  v0 = __uint_as_float(r0);
-  v1 = __uint_as_float(r1);
-  v2 = __uint_as_float(r2);
-  v3 = __uint_as_float(r3);
-}
-
-// Per-element predicated scalar loads with -inf default.
-__device__ __forceinline__ void load_float4_predicated(const float* ptr,
-                                                       int base, int seq_len,
-                                                       float& v0, float& v1,
-                                                       float& v2, float& v3) {
-  uint32_t r0, r1, r2, r3;
-  int p0 = (base < seq_len);
-  int p1 = (base + 1 < seq_len);
-  int p2 = (base + 2 < seq_len);
-  int p3 = (base + 3 < seq_len);
-  asm volatile(
-      "{\n"
-      "  .reg .pred pr0, pr1, pr2, pr3;\n"
-      "  setp.ne.u32 pr0, %4, 0;\n"
-      "  setp.ne.u32 pr1, %5, 0;\n"
-      "  setp.ne.u32 pr2, %6, 0;\n"
-      "  setp.ne.u32 pr3, %7, 0;\n"
-      "  mov.u32 %0, 0xFF800000;\n"
-      "  mov.u32 %1, 0xFF800000;\n"
-      "  mov.u32 %2, 0xFF800000;\n"
-      "  mov.u32 %3, 0xFF800000;\n"
-      "  @pr0 ld.global.cg.u32 %0, [%8];\n"
-      "  @pr1 ld.global.cg.u32 %1, [%8+4];\n"
-      "  @pr2 ld.global.cg.u32 %2, [%8+8];\n"
-      "  @pr3 ld.global.cg.u32 %3, [%8+12];\n"
-      "}\n"
-      : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3)
-      : "r"(p0), "r"(p1), "r"(p2), "r"(p3), "l"(ptr));
-  v0 = __uint_as_float(r0);
-  v1 = __uint_as_float(r1);
-  v2 = __uint_as_float(r2);
-  v3 = __uint_as_float(r3);
-}
 
 // ============================================================================
 // Large path: inter-CTA coordination state (one per group)
@@ -141,279 +78,8 @@ struct PersistentTopKParams {
 };
 
 // ============================================================================
-// Decode path: 2048-bin histogram for short sequences (seq_len <= 8192)
-// Uses 11-bit half-precision bins for fine granularity.
-// One histogram pass typically suffices since 8192/2048 = 4 elements/bin avg.
-// ============================================================================
-
-// 11-bit bin from half-precision representation (ascending: high values -> high
-// bins)
-__device__ __forceinline__ uint32_t decode_bin(float x) {
-  __half hx = __float2half(x);
-  uint16_t bits = __half_as_ushort(hx);
-  uint16_t key = (bits & 0x8000) ? static_cast<uint16_t>(~bits)
-                                 : static_cast<uint16_t>(bits | 0x8000);
-  return key >> 5;
-}
-
-template <int TopK>
-__device__ __noinline__ void histogram_2048_topk(
-    const float* __restrict__ logits, int32_t* __restrict__ output_indices,
-    int32_t seq_len) {
-  extern __shared__ int decode_smem[];
-  const int tx = threadIdx.x;
-  const int lane = tx & 31;
-
-  // ---- Layout constants ----
-  constexpr int SBASE = 8192 - 8;           // 8184
-  constexpr int RHIST = RADIX + 128;        // 384
-  constexpr int BOFF = 2 * RHIST;           // 768
-  constexpr int DBUF = (SBASE - BOFF) / 2;  // 3708
-  constexpr int MAX_ITEMS_PER_THREAD =
-      (HIST2048_THRESHOLD + kThreadsPerBlock - 1) / kThreadsPerBlock;
-
-  enum : int { sTHR = 0, sOUT = 1, sREF = 2, sFIN = 3, sBUF0 = 4, sBUF1 = 5 };
-
-  // ---- Initialize scalars (prevents stale data from prior rows) ----
-  if (tx < 8) {
-    decode_smem[SBASE + tx] = 0;
-  }
-
-  // ---- Phase 1: Build 2048-bin histogram with float4 vectorized loads ----
-  int* histo = decode_smem;
-  uint16_t reg_bins[MAX_ITEMS_PER_THREAD];
-  int nitems = 0;
-
-  for (int i = tx; i < kDecodeBins; i += kThreadsPerBlock) {
-    histo[i] = 0;
-  }
-  __syncthreads();
-
-  const int n_vec = (seq_len + 3) >> 2;
-  const bool row_aligned = ((reinterpret_cast<uintptr_t>(logits) & 15) == 0);
-
-  for (int i = tx; i < n_vec; i += kThreadsPerBlock) {
-    const int base = i << 2;
-    float v0, v1, v2, v3;
-
-    if (row_aligned && base + 3 < seq_len) {
-      load_float4(logits + base, v0, v1, v2, v3);
-    } else {
-      load_float4_predicated(logits + base, base, seq_len, v0, v1, v2, v3);
-    }
-
-    const uint16_t b0 = static_cast<uint16_t>(decode_bin(v0));
-    const uint16_t b1 = static_cast<uint16_t>(decode_bin(v1));
-    const uint16_t b2 = static_cast<uint16_t>(decode_bin(v2));
-    const uint16_t b3 = static_cast<uint16_t>(decode_bin(v3));
-    reg_bins[nitems++] = b0;
-    reg_bins[nitems++] = b1;
-    reg_bins[nitems++] = b2;
-    reg_bins[nitems++] = b3;
-    atomicAdd(&histo[b0], 1);
-    atomicAdd(&histo[b1], 1);
-    atomicAdd(&histo[b2], 1);
-    atomicAdd(&histo[b3], 1);
-  }
-  __syncthreads();
-
-  // ---- CUB suffix sum ----
-  using BlockScanT = cub::BlockScan<int, kThreadsPerBlock>;
-  const int h0 = histo[2 * tx];
-  const int pair_sum = h0 + histo[2 * tx + 1];
-
-  auto& scan_storage = *reinterpret_cast<typename BlockScanT::TempStorage*>(
-      decode_smem + kDecodeBins);
-
-  int pair_prefix, total;
-  BlockScanT(scan_storage).ExclusiveSum(pair_sum, pair_prefix, total);
-
-  // Find threshold bin purely from registers
-  const int pair_suffix = total - pair_prefix;
-
-  if (pair_suffix >= TopK && (pair_suffix - h0) < TopK) {
-    decode_smem[SBASE + sTHR] = 2 * tx;
-  }
-  {
-    const int right_suf = pair_suffix - h0;
-    const int next_suf = pair_suffix - pair_sum;
-    if (right_suf >= TopK && next_suf < TopK) {
-      decode_smem[SBASE + sTHR] = 2 * tx + 1;
-    }
-  }
-  __syncthreads();
-
-  const int threshold = decode_smem[SBASE + sTHR];
-
-  // ---- Phase 2: Collection with warp-aggregated atomicAdds ----
-  int* bufs[2] = {decode_smem + BOFF, decode_smem + BOFF + DBUF};
-  const int sOUT_abs = SBASE + sOUT;
-  const int sBUF0_abs = SBASE + sBUF0;
-
-  {
-    const uint32_t uthr = static_cast<uint32_t>(threshold);
-    int item = 0;
-    const int n_vec_iters = (n_vec + kThreadsPerBlock - 1) / kThreadsPerBlock;
-
-    for (int iter = 0; iter < n_vec_iters; iter++) {
-      const int i = tx + iter * kThreadsPerBlock;
-      const bool vec_valid = (i < n_vec);
-      const int base_idx = i << 2;
-
-#pragma unroll 4
-      for (int sub = 0; sub < 4; sub++) {
-        const int elem_idx = base_idx + sub;
-        uint32_t bin = 0;
-        if (vec_valid) bin = reg_bins[item++];
-        const bool is_above = vec_valid && (bin > uthr);
-        const bool is_equal = vec_valid && (bin == uthr);
-
-        const uint32_t above_mask = __ballot_sync(0xffffffff, is_above);
-        if (above_mask) {
-          const int above_count = __popc(above_mask);
-          const int above_rank = __popc(above_mask & ((1u << lane) - 1));
-          int above_base;
-          if (lane == 0) {
-            above_base = atomicAdd(&decode_smem[sOUT_abs], above_count);
-          }
-          above_base = __shfl_sync(0xffffffff, above_base, 0);
-          if (is_above) {
-            output_indices[above_base + above_rank] = elem_idx;
-          }
-        }
-
-        const uint32_t equal_mask = __ballot_sync(0xffffffff, is_equal);
-        if (equal_mask) {
-          const int equal_count = __popc(equal_mask);
-          const int equal_rank = __popc(equal_mask & ((1u << lane) - 1));
-          int equal_base;
-          if (lane == 0) {
-            equal_base = atomicAdd(&decode_smem[sBUF0_abs], equal_count);
-          }
-          equal_base = __shfl_sync(0xffffffff, equal_base, 0);
-          if (is_equal && __builtin_expect(equal_base + equal_rank < DBUF, 1)) {
-            bufs[0][equal_base + equal_rank] = elem_idx;
-          }
-        }
-      }
-    }
-  }
-  __syncthreads();
-
-  int remaining_k = TopK - decode_smem[SBASE + sOUT];
-  if (remaining_k <= 0) return;
-
-  // If all buffered elements fit, output them all (common for short seqs)
-  const int raw_buf0 = decode_smem[SBASE + sBUF0];
-  if (raw_buf0 <= remaining_k) {
-    const int nb = (raw_buf0 < DBUF) ? raw_buf0 : DBUF;
-    const int base = decode_smem[SBASE + sOUT];
-    for (int i = tx; i < nb; i += kThreadsPerBlock) {
-      output_indices[base + i] = bufs[0][i];
-    }
-    __syncthreads();
-    return;
-  }
-
-  // ---- Phase 3: Deferred refinement (rare path) ----
-  int* refine[2] = {decode_smem, decode_smem + RHIST};
-  const int num_buf0 = (raw_buf0 < DBUF) ? raw_buf0 : DBUF;
-
-  for (int i = tx; i < RHIST; i += kThreadsPerBlock) {
-    refine[0][i] = 0;
-  }
-  __syncthreads();
-
-  for (int i = tx; i < num_buf0; i += kThreadsPerBlock) {
-    const uint32_t fp32 = convert_to_uint32_v2(logits[bufs[0][i]]);
-    atomicAdd(&refine[0][(fp32 >> 24) & 0xFF], 1);
-  }
-  __syncthreads();
-
-  auto compute_suffix_sum = [&]() {
-#pragma unroll 8
-    for (int i = 0; i < 8; ++i) {
-      if (tx < RADIX) {
-        const int stride = 1 << i;
-        const int s = i & 1;
-        const int d = s ^ 1;
-        int value = refine[s][tx];
-        if (tx < RADIX - stride) value += refine[s][tx + stride];
-        refine[d][tx] = value;
-      }
-      __syncthreads();
-    }
-  };
-
-#pragma unroll 4
-  for (int pass = 0; pass < 4; ++pass) {
-    const int src = pass & 1;
-    const int dst = src ^ 1;
-
-    const int raw_buf = decode_smem[SBASE + sBUF0 + src];
-    const int num_buffered = (raw_buf < DBUF) ? raw_buf : DBUF;
-
-    compute_suffix_sum();
-
-    if (tx < RADIX && refine[0][tx] > remaining_k &&
-        refine[0][tx + 1] <= remaining_k) {
-      decode_smem[SBASE + sREF] = tx;
-      decode_smem[SBASE + sBUF0 + dst] = 0;
-      decode_smem[SBASE + sFIN] = remaining_k - refine[0][tx + 1];
-    }
-    __syncthreads();
-
-    const int ref_thr = decode_smem[SBASE + sREF];
-    remaining_k -= refine[0][ref_thr + 1];
-    const int bit_offset = 24 - pass * 8;
-
-    if (remaining_k == 0) {
-      for (int i = tx; i < num_buffered; i += kThreadsPerBlock) {
-        const int idx = bufs[src][i];
-        const uint32_t fp32 = convert_to_uint32_v2(logits[idx]);
-        if (((fp32 >> bit_offset) & 0xFF) > static_cast<uint32_t>(ref_thr)) {
-          const int pos = atomicAdd(&decode_smem[SBASE + sOUT], 1);
-          output_indices[pos] = idx;
-        }
-      }
-      __syncthreads();
-      break;
-    }
-
-    __syncthreads();
-    if (tx < RADIX + 1) refine[0][tx] = 0;
-    __syncthreads();
-
-    for (int i = tx; i < num_buffered; i += kThreadsPerBlock) {
-      const int idx = bufs[src][i];
-      const float logit_val = logits[idx];
-      const uint32_t fp32 = convert_to_uint32_v2(logit_val);
-      const int bin = (fp32 >> bit_offset) & 0xFF;
-
-      if (bin > ref_thr) {
-        const int pos = atomicAdd(&decode_smem[SBASE + sOUT], 1);
-        output_indices[pos] = idx;
-      } else if (bin == ref_thr) {
-        if (pass == 3) {
-          const int slot = atomicAdd(&decode_smem[SBASE + sFIN], -1);
-          if (slot > 0) output_indices[TopK - slot] = idx;
-        } else {
-          const int bp = atomicAdd(&decode_smem[SBASE + sBUF0 + dst], 1);
-          if (__builtin_expect(bp < DBUF, 1)) {
-            bufs[dst][bp] = idx;
-            const int nbo = bit_offset - 8;
-            atomicAdd(&refine[0][(fp32 >> nbo) & 0xFF], 1);
-          }
-        }
-      }
-    }
-    __syncthreads();
-  }
-}
-
-// ============================================================================
-// Medium path: coarse FP16 histogram + 4-pass FP32 radix refinement
-// For sequences 8K < seq_len <= 64K.
+// Medium path: exact 11-bit FP32 histogram + 3-pass FP32 refinement
+// For sequences 8K < seq_len <= 32K.
 // ============================================================================
 
 // Adapted from:
@@ -422,7 +88,7 @@ __device__ __noinline__ void histogram_2048_topk(
 // which at the same time is an optimized topk kernel copied from tilelang
 // kernel
 template <int TopK>
-__device__ __noinline__ void histogram_256_topk(
+__device__ __noinline__ bool histogram_medium_topk(
     const float* __restrict__ logits, int* __restrict__ output_indices,
     int logits_offset, int seq_len) {
   // All shared state lives in dynamic shared memory to avoid static
@@ -442,16 +108,67 @@ __device__ __noinline__ void histogram_256_topk(
   const int thread_id = threadIdx.x;
   int remaining_k = TopK;
 
-  if (thread_id < RADIX + 1) {
-    shared_histogram[0][thread_id] = 0;
+  using CoarseScan = cub::BlockScan<int, kThreadsPerBlock>;
+  struct CoarseSmem {
+    int histogram[kCoarseBins + 1];
+    typename CoarseScan::TempStorage scan;
+    int threshold;
+  };
+  static_assert(sizeof(CoarseSmem) <= kSmemMedium);
+  auto* coarse = reinterpret_cast<CoarseSmem*>(medium_smem);
+
+  for (int bin = thread_id; bin < kCoarseBins + 1;
+       bin += kThreadsPerBlock) {
+    coarse->histogram[bin] = 0;
   }
   __syncthreads();
 
   for (int idx = thread_id; idx < seq_len; idx += kThreadsPerBlock) {
-    const auto bin = convert_to_uint8(logits[idx + logits_offset]);
-    atomicAdd(&shared_histogram[0][bin], 1);
+    const uint32_t ordered =
+        convert_to_uint32_v2(logits[idx + logits_offset]);
+    atomicAdd(&coarse->histogram[ordered >> 21], 1);
   }
   __syncthreads();
+
+  const int coarse_bin0 = 2 * thread_id;
+  const int coarse_count0 = coarse->histogram[coarse_bin0];
+  const int coarse_count1 = coarse->histogram[coarse_bin0 + 1];
+  const int coarse_local_sum = coarse_count0 + coarse_count1;
+  int coarse_lower_prefix;
+  int coarse_total;
+  CoarseScan(coarse->scan)
+      .ExclusiveSum(coarse_local_sum, coarse_lower_prefix, coarse_total);
+  __syncthreads();
+  coarse->histogram[coarse_bin0] = coarse_total - coarse_lower_prefix;
+  coarse->histogram[coarse_bin0 + 1] =
+      coarse_total - coarse_lower_prefix - coarse_count0;
+  if (thread_id == 0) coarse->histogram[kCoarseBins] = 0;
+  __syncthreads();
+
+  for (int i = 0; i < 2; ++i) {
+    const int bin = coarse_bin0 + i;
+    if (coarse->histogram[bin] > TopK &&
+        coarse->histogram[bin + 1] <= TopK) {
+      coarse->threshold = bin;
+    }
+  }
+  __syncthreads();
+
+  const int threshold_bin = coarse->threshold;
+  const int count_above = coarse->histogram[threshold_bin + 1];
+  const int threshold_bin_count =
+      coarse->histogram[threshold_bin] - count_above;
+  __syncthreads();
+
+  if (thread_id == 0) {
+    shared_threshold_bin = threshold_bin;
+    shared_buffered_count[0] = threshold_bin_count > MAX_BUFFERED_ITEMS
+                                   ? MAX_BUFFERED_ITEMS + 1
+                                   : 0;
+    shared_output_count = 0;
+  }
+  __syncthreads();
+  remaining_k -= count_above;
 
   auto compute_cumulative_sum = [&]() {
 #pragma unroll 8
@@ -470,29 +187,27 @@ __device__ __noinline__ void histogram_256_topk(
     }
   };
 
-  compute_cumulative_sum();
-
-  if (thread_id < RADIX && shared_histogram[0][thread_id] > remaining_k &&
-      shared_histogram[0][thread_id + 1] <= remaining_k) {
-    shared_threshold_bin = thread_id;
-    shared_buffered_count[0] = 0;
-    shared_output_count = 0;
-  }
-  __syncthreads();
-
-  const int threshold_bin = shared_threshold_bin;
-  remaining_k -= shared_histogram[0][threshold_bin + 1];
-
   if (remaining_k == 0) {
     for (int idx = thread_id; idx < seq_len; idx += kThreadsPerBlock) {
-      const int bin = convert_to_uint8(logits[idx + logits_offset]);
+      const uint32_t bin =
+          convert_to_uint32_v2(logits[idx + logits_offset]) >> 21;
       if (bin > threshold_bin) {
         const int output_pos = atomicAdd(&shared_output_count, 1);
         output_indices[output_pos] = idx;
       }
     }
     __syncthreads();
-    return;
+    return false;
+  }
+
+  if (__builtin_expect(shared_buffered_count[0] > MAX_BUFFERED_ITEMS, 0)) {
+    if (thread_id == 0) {
+      auto* fallback_state = reinterpret_cast<uint32_t*>(medium_smem);
+      fallback_state[0] = static_cast<uint32_t>(threshold_bin) << 21;
+      fallback_state[1] = static_cast<uint32_t>(remaining_k);
+    }
+    __syncthreads();
+    return true;
   }
 
   __syncthreads();
@@ -501,26 +216,28 @@ __device__ __noinline__ void histogram_256_topk(
   }
   __syncthreads();
 
-  for (int idx = thread_id; idx < seq_len; idx += kThreadsPerBlock) {
-    const float logit_value = logits[idx + logits_offset];
-    const int bin = convert_to_uint8(logit_value);
-    if (bin > threshold_bin) {
-      const int output_pos = atomicAdd(&shared_output_count, 1);
-      output_indices[output_pos] = idx;
-    } else if (bin == threshold_bin) {
-      const int buffer_pos = atomicAdd(&shared_buffered_count[0], 1);
-      if (__builtin_expect(buffer_pos < MAX_BUFFERED_ITEMS, 1)) {
-        buffered_indices[0][buffer_pos] = idx;
-        const uint32_t fp32_bits = convert_to_uint32_v2(logit_value);
-        const int next_bin = (fp32_bits >> 24) & 0xFF;
-        atomicAdd(&shared_histogram[0][next_bin], 1);
+  if (__builtin_expect(shared_buffered_count[0] <= MAX_BUFFERED_ITEMS, 1)) {
+    for (int idx = thread_id; idx < seq_len; idx += kThreadsPerBlock) {
+      const float logit_value = logits[idx + logits_offset];
+      const uint32_t bin = convert_to_uint32_v2(logit_value) >> 21;
+      if (bin > threshold_bin) {
+        const int output_pos = atomicAdd(&shared_output_count, 1);
+        output_indices[output_pos] = idx;
+      } else if (bin == threshold_bin) {
+        const int buffer_pos = atomicAdd(&shared_buffered_count[0], 1);
+        if (__builtin_expect(buffer_pos < MAX_BUFFERED_ITEMS, 1)) {
+          buffered_indices[0][buffer_pos] = idx;
+          const uint32_t fp32_bits = convert_to_uint32_v2(logit_value);
+          const int next_bin = (fp32_bits >> 16) & 0xFF;
+          atomicAdd(&shared_histogram[0][next_bin], 1);
+        }
       }
     }
   }
   __syncthreads();
 
-#pragma unroll 4
-  for (int pass = 0; pass < 4; ++pass) {
+#pragma unroll 3
+  for (int pass = 0; pass < 3; ++pass) {
     const int src_buffer = pass % 2;
     const int dst_buffer = src_buffer ^ 1;
     const int raw_buffered = shared_buffered_count[src_buffer];
@@ -539,7 +256,7 @@ __device__ __noinline__ void histogram_256_topk(
 
     const int threshold_bin = shared_threshold_bin;
     remaining_k -= shared_histogram[0][threshold_bin + 1];
-    const int bit_offset = 24 - pass * 8;
+    const int bit_offset = 16 - pass * 8;
 
     if (remaining_k == 0) {
       for (int i = thread_id; i < num_buffered; i += kThreadsPerBlock) {
@@ -571,7 +288,7 @@ __device__ __noinline__ void histogram_256_topk(
         const int output_pos = atomicAdd(&shared_output_count, 1);
         output_indices[output_pos] = idx;
       } else if (bin == threshold_bin) {
-        if (pass == 3) {
+        if (pass == 2) {
           const int slot = atomicAdd(&shared_final_k, -1);
           if (slot > 0) {
             output_indices[TopK - slot] = idx;
@@ -590,6 +307,7 @@ __device__ __noinline__ void histogram_256_topk(
     }
     __syncthreads();
   }
+  return false;
 }
 
 // ============================================================================
@@ -856,7 +574,7 @@ __device__ void radix_topk(const float* __restrict__ row_input,
 }
 
 // ============================================================================
-// Persistent kernel — BS≤32, decode/medium/large paths with RadixTopK
+// Persistent kernel — BS≤32, short/medium/large paths with RadixTopK
 // BS>32 uses standalone histogram_256_buffered_topk (separate kernel,
 // see filtered_topk.cuh)
 // ============================================================================
@@ -869,7 +587,7 @@ __global__ void __launch_bounds__(kThreadsPerBlock, 2)
 
   // ========================================================================
   // Group mode: multi-CTA groups with static round-robin row assignment.
-  // Non-large rows: CTA-0 handles trivial/decode/medium.
+  // Non-large rows: CTA-0 handles the trivial, short, and medium paths.
   // Large rows: all CTAs in the group cooperate via RadixTopK.
   // ========================================================================
   const uint32_t ctas_per_group = params.ctas_per_group;
@@ -937,10 +655,26 @@ __global__ void __launch_bounds__(kThreadsPerBlock, 2)
                i += kThreadsPerBlock) {
             row_output[i] = (i < seq_len) ? static_cast<int32_t>(i) : -1;
           }
-        } else if (seq_len <= static_cast<uint32_t>(HIST2048_THRESHOLD)) {
-          histogram_2048_topk<TopK>(row_input, row_output, seq_len);
         } else {
-          histogram_256_topk<TopK>(row_input, row_output, 0, seq_len);
+          auto* fallback_state = reinterpret_cast<uint32_t*>(smem_raw);
+          if (seq_len <= static_cast<uint32_t>(SHORT_EXACT_THRESHOLD)) {
+            topk_histogram_4096::exact_topk_rescan<
+                TopK, kThreadsPerBlock, true, VEC_SIZE, true>(
+                row_input, row_output, seq_len, smem_raw);
+          } else {
+            if (__builtin_expect(
+                    histogram_medium_topk<TopK>(row_input, row_output, 0,
+                                                seq_len),
+                    0)) {
+              const uint32_t initial_prefix = fallback_state[0];
+              const uint32_t initial_remaining = fallback_state[1];
+              __syncthreads();
+              topk_histogram_4096::exact_topk_rescan<
+                  TopK, kThreadsPerBlock, true, VEC_SIZE, true, 1, 4096>(
+                  row_input, row_output, seq_len, smem_raw, initial_prefix,
+                  initial_remaining);
+            }
+          }
         }
       }
       continue;
@@ -998,24 +732,23 @@ struct vec_t {
 #undef FLASHINFER_INLINE
 
 // FilteredTopK traits for different data types
-template <typename DType>
+template <typename DType, bool UseWideCoarse = false>
 struct FilteredTopKTraits;
 
-// Specialization for float (32-bit): coarse histogram uses FP16 high 8 bits, 4
-// refinement rounds
+// Specialization for float (32-bit): use the high 11 bits of the exact ordered
+// FP32 key. Besides reducing candidate-buffer pressure, this prefix can be
+// reused directly by the exact overflow fallback.
 template <>
-struct FilteredTopKTraits<float> {
+struct FilteredTopKTraits<float, false> {
   using OrderedType = uint32_t;
-  static constexpr int NUM_REFINE_ROUNDS = 4;
-  static constexpr int FIRST_REFINE_SHIFT = 24;
+  static constexpr int COARSE_BITS = 11;
+  static constexpr int COARSE_RADIX = 1 << COARSE_BITS;
+  static constexpr int NUM_REFINE_ROUNDS = 3;
+  static constexpr int FIRST_REFINE_SHIFT = 16;
+  static constexpr int REFINE_BITS = 8;
 
-  __device__ __forceinline__ static uint8_t ToCoarseKey(float x) {
-    // Convert to FP16 representation and extract high 8 bits
-    __half h = __float2half_rn(x);
-    uint16_t bits = __half_as_ushort(h);
-    uint16_t key = (bits & 0x8000) ? static_cast<uint16_t>(~bits)
-                                   : static_cast<uint16_t>(bits | 0x8000);
-    return static_cast<uint8_t>(key >> 8);
+  __device__ __forceinline__ static uint16_t ToCoarseKey(float x) {
+    return static_cast<uint16_t>(ToOrdered(x) >> (32 - COARSE_BITS));
   }
 
   __device__ __forceinline__ static OrderedType ToOrdered(float x) {
@@ -1024,11 +757,181 @@ struct FilteredTopKTraits<float> {
   }
 };
 
+template <>
+struct FilteredTopKTraits<float, true> {
+  using OrderedType = uint32_t;
+  static constexpr int COARSE_BITS = 12;
+  static constexpr int COARSE_RADIX = 1 << COARSE_BITS;
+  static constexpr int NUM_REFINE_ROUNDS = 2;
+  static constexpr int FIRST_REFINE_SHIFT = 10;
+  static constexpr int REFINE_BITS = 10;
+
+  __device__ __forceinline__ static uint16_t ToCoarseKey(float x) {
+    return static_cast<uint16_t>(ToOrdered(x) >> (32 - COARSE_BITS));
+  }
+
+  __device__ __forceinline__ static OrderedType ToOrdered(float x) {
+    uint32_t bits = __float_as_uint(x);
+    return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+  }
+};
+
+// Sample a pivot, bound the candidate set, then select it exactly by radix.
+template <typename DType, typename IdType, int VecSize, uint32_t BlockSize,
+          uint32_t CandidateCapacity>
+__device__ bool try_sampled_exact_topk(
+    const DType* __restrict__ scores, IdType* __restrict__ output,
+    uint32_t length, uint32_t top_k, void* dynamic_smem, int* histogram,
+    int* candidate_count, int* output_counter, int* radix_prefix,
+    int* radix_remaining) {
+  using Traits = FilteredTopKTraits<DType>;
+  constexpr uint32_t kItemsPerThread = 2;
+  constexpr uint32_t kSampleSize = BlockSize * kItemsPerThread;
+  using SampleSort =
+      cub::BlockRadixSort<uint32_t, BlockSize, kItemsPerThread>;
+  static_assert(sizeof(typename SampleSort::TempStorage) <=
+                2 * CandidateCapacity * sizeof(int));
+
+  const uint32_t tx = threadIdx.x;
+  uint32_t sample_keys[kItemsPerThread];
+#pragma unroll
+  for (uint32_t i = 0; i < kItemsPerThread; ++i) {
+    const uint32_t sample_idx = tx * kItemsPerThread + i;
+    const uint32_t score_idx = static_cast<uint32_t>(
+        (static_cast<uint64_t>(2 * sample_idx + 1) * length) /
+        (2 * kSampleSize));
+    sample_keys[i] = Traits::ToOrdered(scores[score_idx]);
+  }
+
+  auto* sort_smem =
+      static_cast<typename SampleSort::TempStorage*>(dynamic_smem);
+  SampleSort(*sort_smem).SortDescending(sample_keys);
+  __syncthreads();
+
+  const uint32_t target_candidates =
+      min(CandidateCapacity / 2, (top_k < 2048) ? 4 * top_k : 2 * top_k);
+  uint32_t sample_rank = static_cast<uint32_t>(
+      (static_cast<uint64_t>(target_candidates) * kSampleSize + length - 1) /
+      length);
+  sample_rank = max(1u, min(sample_rank, kSampleSize));
+  const uint32_t rank_index = sample_rank - 1;
+  if (tx == rank_index / kItemsPerThread) {
+    *radix_prefix = static_cast<int>(sample_keys[rank_index % kItemsPerThread]);
+  }
+  if (tx == 0) *candidate_count = 0;
+  __syncthreads();
+
+  auto* candidates = static_cast<int*>(dynamic_smem);
+  const uint32_t proposed_pivot = static_cast<uint32_t>(*radix_prefix);
+  const auto collect_candidate = [&](uint32_t idx, DType score) {
+    if (Traits::ToOrdered(score) >= proposed_pivot) {
+      const int pos = atomicAdd(candidate_count, 1);
+      if (pos < static_cast<int>(CandidateCapacity)) candidates[pos] = idx;
+    }
+  };
+
+  vec_t<DType, VecSize> score_vec;
+  const uint32_t aligned_length = length / VecSize * VecSize;
+  for (uint32_t base = tx * VecSize; base < aligned_length;
+       base += BlockSize * VecSize) {
+    score_vec.cast_load(scores + base);
+#pragma unroll
+    for (uint32_t i = 0; i < VecSize; ++i) {
+      collect_candidate(base + i, score_vec[i]);
+    }
+  }
+  for (uint32_t idx = aligned_length + tx; idx < length; idx += BlockSize) {
+    collect_candidate(idx, scores[idx]);
+  }
+  __syncthreads();
+
+  const int num_candidates = *candidate_count;
+  if (num_candidates < static_cast<int>(top_k) ||
+      num_candidates > static_cast<int>(CandidateCapacity)) {
+    return false;
+  }
+
+  auto* candidate_keys = candidates + CandidateCapacity;
+  for (int i = tx; i < num_candidates; i += BlockSize) {
+    candidate_keys[i] =
+        static_cast<int>(Traits::ToOrdered(scores[candidates[i]]));
+  }
+
+  if (tx == 0) {
+    *radix_prefix = 0;
+    *radix_remaining = static_cast<int>(top_k);
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (uint32_t round = 0; round < 4; ++round) {
+    if (tx < 256) histogram[tx] = 0;
+    __syncthreads();
+
+    const uint32_t prefix = static_cast<uint32_t>(*radix_prefix);
+    const uint32_t prefix_mask =
+        (round == 0) ? 0u : (~0u << (32 - 8 * round));
+    const uint32_t shift = 24 - 8 * round;
+    for (int i = tx; i < num_candidates; i += BlockSize) {
+      const uint32_t ordered = static_cast<uint32_t>(candidate_keys[i]);
+      if ((ordered & prefix_mask) == prefix) {
+        atomicAdd(&histogram[(ordered >> shift) & 0xFF], 1);
+      }
+    }
+    __syncthreads();
+
+    if (tx == 0) {
+      int count_above = 0;
+      const int remaining = *radix_remaining;
+      for (int bin = 255; bin >= 0; --bin) {
+        const int count = histogram[bin];
+        if (count_above + count >= remaining) {
+          *radix_remaining = remaining - count_above;
+          *radix_prefix =
+              static_cast<int>(prefix | (static_cast<uint32_t>(bin) << shift));
+          break;
+        }
+        count_above += count;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (tx == 0) {
+    *output_counter = 0;
+    histogram[0] = 0;
+  }
+  __syncthreads();
+
+  const uint32_t pivot = static_cast<uint32_t>(*radix_prefix);
+  const int equal_count = *radix_remaining;
+  const int equal_base = static_cast<int>(top_k) - equal_count;
+  for (int i = tx; i < num_candidates; i += BlockSize) {
+    const int idx = candidates[i];
+    const uint32_t ordered = static_cast<uint32_t>(candidate_keys[i]);
+    if (ordered > pivot) {
+      output[atomicAdd(output_counter, 1)] = static_cast<IdType>(idx);
+    } else if (ordered == pivot) {
+      const int pos = atomicAdd(&histogram[0], 1);
+      if (pos < equal_count) output[equal_base + pos] = static_cast<IdType>(idx);
+    }
+  }
+  __syncthreads();
+  return true;
+}
+
 constexpr uint32_t FILTERED_TOPK_BLOCK_THREADS = 1024;
 constexpr uint32_t FILTERED_TOPK_SMEM_INPUT_SIZE =
     16 * 1024;  // 16K indices per buffer
 constexpr size_t FILTERED_TOPK_SMEM_DYNAMIC =
     sizeof(int) * 2 * FILTERED_TOPK_SMEM_INPUT_SIZE;  // 128KB
+constexpr uint32_t FILTERED_TOPK_SAMPLING_MIN_ROWS = 96;
+constexpr uint32_t FILTERED_TOPK_SAMPLING_MIN_LENGTH = 192 * 1024;
+constexpr uint32_t FILTERED_TOPK_WIDE_COARSE_MIN_LENGTH = 64 * 1024;
+constexpr uint32_t FILTERED_TOPK_WIDE_COARSE_MAX_LENGTH = 192 * 1024;
+static_assert(hist4096::kExactCandidateOffset +
+                      FILTERED_TOPK_SMEM_INPUT_SIZE * sizeof(int) <=
+                  FILTERED_TOPK_SMEM_DYNAMIC);
 
 /*!
  * \brief Filtered Top-K kernel for ragged sequences.
@@ -1038,7 +941,7 @@ constexpr size_t FILTERED_TOPK_SMEM_DYNAMIC =
  * \tparam VEC_SIZE Vector size for input loads (1, 2, 4, or 8)
  */
 template <typename DType, typename IdType, int VEC_SIZE, uint32_t MAX_K = 2048,
-          bool UsePredicatedShortLoads = false>
+          bool UsePredicatedShortLoads = false, bool UseWideCoarse = false>
 __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
     FilteredTopKUnifiedKernel(const DType* __restrict__ input,
                               IdType* __restrict__ output,
@@ -1046,8 +949,23 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
                               uint32_t num_rows, uint32_t top_k,
                               uint32_t max_len) {
   constexpr uint32_t BLOCK_SIZE = FILTERED_TOPK_BLOCK_THREADS;
-  constexpr int RADIX = 256;
   constexpr int SMEM_INPUT_SIZE = FILTERED_TOPK_SMEM_INPUT_SIZE;
+  using Traits = FilteredTopKTraits<DType, UseWideCoarse>;
+  constexpr int RADIX = 1 << Traits::REFINE_BITS;
+  constexpr int COARSE_RADIX = Traits::COARSE_RADIX;
+  constexpr int COARSE_BINS_PER_THREAD = COARSE_RADIX / BLOCK_SIZE;
+  static_assert(COARSE_RADIX % BLOCK_SIZE == 0);
+  using CoarseScan = cub::BlockScan<int, BLOCK_SIZE>;
+  struct CoarseSmem {
+    int histogram[COARSE_RADIX + 1];
+    typename CoarseScan::TempStorage scan;
+  };
+  static_assert(sizeof(CoarseSmem) <= FILTERED_TOPK_SMEM_DYNAMIC);
+
+  // The long path's coarse histogram and candidate double-buffer are never
+  // live at the same time. Overlay them in the existing 128 KiB dynamic
+  // allocation so widening the histogram does not increase per-CTA SMEM.
+  extern __shared__ __align__(16) uint8_t dynamic_smem[];
 
   const uint32_t bid = blockIdx.x;
   const int tx = threadIdx.x;
@@ -1069,13 +987,12 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
 
   // Short path
   if (length <= 32768) {
-    extern __shared__ uint8_t _smem_reg[];
     if constexpr (UsePredicatedShortLoads) {
       hist4096::histogram_4096_topk_predicated<MAX_K, 12, 8>(score, dst, length,
-                                                             _smem_reg);
+                                                             dynamic_smem);
     } else {
       hist4096::histogram_4096_topk<MAX_K, 12, 8>(score, dst, length,
-                                                  _smem_reg);
+                                                  dynamic_smem);
     }
     return;
   }
@@ -1089,14 +1006,17 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
 
   auto& s_histogram = s_histogram_buf[0];
 
-  // Dynamic shared memory for input double buffer
-  extern __shared__ int s_input_idx[][SMEM_INPUT_SIZE];
+  auto* coarse_smem = reinterpret_cast<CoarseSmem*>(dynamic_smem);
+  auto* s_coarse_histogram = coarse_smem->histogram;
+  auto* s_input_idx =
+      reinterpret_cast<int (*)[SMEM_INPUT_SIZE]>(dynamic_smem);
 
-  using Traits = FilteredTopKTraits<DType>;
   int topk = top_k;
 
-  // Stage 1: 8-bit coarse histogram with vectorized loads
-  if (tx < RADIX + 1) s_histogram[tx] = 0;
+  // Stage 1: high 11 bits of the exact ordered-FP32 key.
+  for (int bin = tx; bin < COARSE_RADIX + 1; bin += BLOCK_SIZE) {
+    s_coarse_histogram[bin] = 0;
+  }
   __syncthreads();
 
   vec_t<DType, VEC_SIZE> score_vec;
@@ -1109,20 +1029,43 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
 #pragma unroll
     for (int j = 0; j < VEC_SIZE; ++j) {
       const auto bin = Traits::ToCoarseKey(score_vec[j]);
-      atomicAdd(&s_histogram[bin], 1);
+      atomicAdd(&s_coarse_histogram[bin], 1);
     }
   }
   // Handle tail
   for (int i = aligned_length + tx; i < length; i += BLOCK_SIZE) {
     const auto bin = Traits::ToCoarseKey(score[i]);
-    atomicAdd(&s_histogram[bin], 1);
+    atomicAdd(&s_coarse_histogram[bin], 1);
   }
   __syncthreads();
 
-  // Suffix sum
-  const auto run_cumsum = [&]() {
-#pragma unroll 8
-    for (int i = 0; i < 8; ++i) {
+  // One block scan covers a contiguous group of bins per thread.
+  const int coarse_bin0 = COARSE_BINS_PER_THREAD * tx;
+  int coarse_counts[COARSE_BINS_PER_THREAD];
+  int coarse_local_sum = 0;
+#pragma unroll
+  for (int i = 0; i < COARSE_BINS_PER_THREAD; ++i) {
+    coarse_counts[i] = s_coarse_histogram[coarse_bin0 + i];
+    coarse_local_sum += coarse_counts[i];
+  }
+  int coarse_lower_prefix;
+  int coarse_total;
+  CoarseScan(coarse_smem->scan)
+      .ExclusiveSum(coarse_local_sum, coarse_lower_prefix, coarse_total);
+  __syncthreads();
+  int coarse_suffix = coarse_total - coarse_lower_prefix;
+#pragma unroll
+  for (int i = 0; i < COARSE_BINS_PER_THREAD; ++i) {
+    s_coarse_histogram[coarse_bin0 + i] = coarse_suffix;
+    coarse_suffix -= coarse_counts[i];
+  }
+  if (tx == 0) s_coarse_histogram[COARSE_RADIX] = 0;
+  __syncthreads();
+
+  // Suffix sum for the exact-refinement histograms.
+  const auto run_refine_cumsum = [&]() {
+#pragma unroll
+    for (int i = 0; i < Traits::REFINE_BITS; ++i) {
       if (tx < RADIX) {
         const auto j = 1 << i;
         const auto k = i & 1;
@@ -1136,16 +1079,19 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
     }
   };
 
-  run_cumsum();
-  if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
-    s_threshold_bin_id = tx;
-    s_num_input[0] = 0;
-    s_counter = 0;
+  for (int i = 0; i < COARSE_BINS_PER_THREAD; ++i) {
+    const int bin = coarse_bin0 + i;
+    if (s_coarse_histogram[bin] > topk &&
+        s_coarse_histogram[bin + 1] <= topk) {
+      s_threshold_bin_id = bin;
+      s_num_input[0] = 0;
+      s_counter = 0;
+    }
   }
   __syncthreads();
 
   const auto threshold_bin = s_threshold_bin_id;
-  topk -= s_histogram[threshold_bin + 1];
+  topk -= s_coarse_histogram[threshold_bin + 1];
 
   constexpr int NUM_ROUNDS = Traits::NUM_REFINE_ROUNDS;
   constexpr int FIRST_SHIFT = Traits::FIRST_REFINE_SHIFT;
@@ -1175,8 +1121,45 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
     }
     __syncthreads();
   } else {
+    // The fixed candidate buffer cannot safely truncate the threshold bin.
+    const bool coarse_overflow =
+        s_coarse_histogram[threshold_bin] -
+            s_coarse_histogram[threshold_bin + 1] >
+        SMEM_INPUT_SIZE;
     __syncthreads();
-    if (tx < RADIX + 1) s_histogram[tx] = 0;
+    if (__builtin_expect(coarse_overflow, 0)) {
+      // Sampling amortizes its fixed block-sort cost only for long rows at
+      // enough concurrency to saturate memory bandwidth.
+      if (num_rows >= FILTERED_TOPK_SAMPLING_MIN_ROWS &&
+          length >= FILTERED_TOPK_SAMPLING_MIN_LENGTH &&
+          try_sampled_exact_topk<DType, IdType, VEC_SIZE, BLOCK_SIZE,
+                                 SMEM_INPUT_SIZE>(
+              score, dst, length, top_k, dynamic_smem, s_histogram,
+              &s_num_input[0], &s_counter, &s_threshold_bin_id,
+              &s_num_input[1])) {
+        return;
+      }
+      if constexpr (Traits::COARSE_BITS == 12) {
+        const uint32_t high11_bin =
+            static_cast<uint32_t>(threshold_bin) >> 1;
+        const uint32_t count_above_high11 =
+            s_coarse_histogram[(high11_bin + 1) << 1];
+        hist4096::exact_topk_rescan<MAX_K, BLOCK_SIZE, true, VEC_SIZE, true, 1,
+                                    SMEM_INPUT_SIZE>(
+            score, dst, length, dynamic_smem, high11_bin << 21,
+            static_cast<uint32_t>(top_k) - count_above_high11);
+      } else {
+        hist4096::exact_topk_rescan<MAX_K, BLOCK_SIZE, true, VEC_SIZE, true, 1,
+                                    SMEM_INPUT_SIZE>(
+            score, dst, length, dynamic_smem,
+            static_cast<uint32_t>(threshold_bin) << 21,
+            static_cast<uint32_t>(topk));
+      }
+      return;
+    }
+    for (int bin = tx; bin < RADIX + 1; bin += BLOCK_SIZE) {
+      s_histogram[bin] = 0;
+    }
     __syncthreads();
 
     // Filter + histogram for refinement
@@ -1190,7 +1173,7 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
         if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
           s_input_idx[0][pos] = index;
           const auto ordered = Traits::ToOrdered(raw_input);
-          const auto sub_bin = (ordered >> FIRST_SHIFT) & 0xFF;
+          const auto sub_bin = (ordered >> FIRST_SHIFT) & (RADIX - 1);
           atomicAdd(&s_histogram[sub_bin], 1);
         }
       }
@@ -1217,10 +1200,16 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
       const auto r_idx = round % 2;
 
       const auto _raw_num_input = s_num_input[r_idx];
+      // Refinement overflow falls back to an exact full-row selection.
+      if (_raw_num_input > SMEM_INPUT_SIZE) {
+        hist4096::exact_topk_rescan<MAX_K, BLOCK_SIZE, true, VEC_SIZE, true>(
+            score, dst, length, s_input_idx);
+        return;
+      }
       const auto num_input =
           (_raw_num_input < SMEM_INPUT_SIZE) ? _raw_num_input : SMEM_INPUT_SIZE;
 
-      run_cumsum();
+      run_refine_cumsum();
       if (tx < RADIX && s_histogram[tx] > topk && s_histogram[tx + 1] <= topk) {
         s_threshold_bin_id = tx;
         s_num_input[r_idx ^ 1] = 0;
@@ -1231,13 +1220,14 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
       const auto threshold = s_threshold_bin_id;
       topk -= s_histogram[threshold + 1];
 
-      const int offset = FIRST_SHIFT - round * 8;
+      const int offset = FIRST_SHIFT - round * Traits::REFINE_BITS;
       const bool is_last_round = (round == NUM_ROUNDS - 1);
 
       if (topk == 0) {
         for (int i = tx; i < num_input; i += BLOCK_SIZE) {
           const auto idx = s_input_idx[r_idx][i];
-          const auto bin = (Traits::ToOrdered(score[idx]) >> offset) & 0xFF;
+          const auto bin =
+              (Traits::ToOrdered(score[idx]) >> offset) & (RADIX - 1);
           if (static_cast<int>(bin) > threshold) {
             const auto pos = atomicAdd(&s_counter, 1);
             s_indices[pos] = idx;
@@ -1247,12 +1237,15 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
         break;
       } else {
         __syncthreads();
-        if (tx < RADIX + 1) s_histogram[tx] = 0;
+        for (int bin = tx; bin < RADIX + 1; bin += BLOCK_SIZE) {
+          s_histogram[bin] = 0;
+        }
         __syncthreads();
         for (int i = tx; i < num_input; i += BLOCK_SIZE) {
           const auto idx = s_input_idx[r_idx][i];
           const auto raw_input = score[idx];
-          const auto bin = (Traits::ToOrdered(raw_input) >> offset) & 0xFF;
+          const auto bin =
+              (Traits::ToOrdered(raw_input) >> offset) & (RADIX - 1);
           if (static_cast<int>(bin) > threshold) {
             const auto pos = atomicAdd(&s_counter, 1);
             s_indices[pos] = idx;
@@ -1267,7 +1260,8 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
               if (__builtin_expect(pos < SMEM_INPUT_SIZE, 1)) {
                 s_input_idx[r_idx ^ 1][pos] = idx;
                 const auto bin32 = Traits::ToOrdered(raw_input);
-                const auto sub_bin = (bin32 >> (offset - 8)) & 0xFF;
+                const auto sub_bin =
+                    (bin32 >> (offset - Traits::REFINE_BITS)) & (RADIX - 1);
                 atomicAdd(&s_histogram[sub_bin], 1);
               }
             }
@@ -1322,16 +1316,30 @@ cudaError_t FilteredTopKRaggedTransform(const DType* input,
                   &num_rows, &top_k_val,      &max_len};
 
   const int vec_size = ComputeFilteredTopKVecSize<DType>(max_len);
+  const bool use_wide_coarse =
+      MAX_K == 1024 && max_len >= FILTERED_TOPK_WIDE_COARSE_MIN_LENGTH &&
+      max_len < FILTERED_TOPK_WIDE_COARSE_MAX_LENGTH;
 
-#define DISPATCH_VEC_SIZE(VS)                                                 \
-  if (vec_size == VS) {                                                       \
-    auto kernel =                                                             \
-        FilteredTopKUnifiedKernel<DType, IdType, VS, MAX_K, (VS != MAX_VEC)>; \
-    FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(                                \
-        kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));     \
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, grid, block, args,   \
-                                          smem_size, stream));                \
-    return cudaSuccess;                                                       \
+#define DISPATCH_VEC_SIZE(VS)                                                   \
+  if (vec_size == VS) {                                                         \
+    if constexpr (MAX_K == 1024) {                                              \
+      if (use_wide_coarse) {                                                    \
+        auto kernel = FilteredTopKUnifiedKernel<                                \
+            DType, IdType, VS, MAX_K, (VS != MAX_VEC), true>;                   \
+        FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(                              \
+            kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));   \
+        FLASHINFER_CUDA_CALL(cudaLaunchKernel(                                  \
+            (void*)kernel, grid, block, args, smem_size, stream));              \
+        return cudaSuccess;                                                     \
+      }                                                                         \
+    }                                                                           \
+    auto kernel = FilteredTopKUnifiedKernel<                                    \
+        DType, IdType, VS, MAX_K, (VS != MAX_VEC), false>;                      \
+    FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(                                  \
+        kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));       \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel(                                      \
+        (void*)kernel, grid, block, args, smem_size, stream));                  \
+    return cudaSuccess;                                                         \
   }
 
   DISPATCH_VEC_SIZE(1)

--- a/csrc/libtorch_stable/topk_histogram_4096.cuh
+++ b/csrc/libtorch_stable/topk_histogram_4096.cuh
@@ -7,6 +7,7 @@
 
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <cub/block/block_scan.cuh>
 #include <cstdint>
 
 namespace vllm {
@@ -19,6 +20,7 @@ static_assert(kMaxTies <= kBlockSize,
               "tie_handle requires kMaxTies <= kBlockSize");
 constexpr uint32_t kWarpSize = 32;
 constexpr uint32_t kNumWarps = kBlockSize / kWarpSize;
+constexpr uint32_t kExactCandidateOffset = 16 * 1024;
 
 // Register path
 constexpr uint32_t kHist4096VecsPerThread = 4;
@@ -73,6 +75,301 @@ __device__ __forceinline__ auto convert_to_uint32_v2(float x) -> uint32_t {
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
+// Visit a row with vectorized loads and a scalar tail.
+template <uint32_t BlockSize, uint32_t VecSize, typename Visit>
+__device__ __forceinline__ void scan_scores(
+    const float* __restrict__ scores, uint32_t length, Visit visit) {
+  static_assert(VecSize == 1 || VecSize == 2 || VecSize == 4);
+  const uint32_t tx = threadIdx.x;
+
+  if constexpr (VecSize == 1) {
+    for (uint32_t idx = tx; idx < length; idx += BlockSize) {
+      visit(idx, scores[idx]);
+    }
+    return;
+  }
+
+  const uint32_t aligned_length = length - length % VecSize;
+
+  for (uint32_t base = tx * VecSize; base < aligned_length;
+       base += BlockSize * VecSize) {
+    if constexpr (VecSize == 4) {
+      const float4 values =
+          *reinterpret_cast<const float4*>(scores + base);
+      visit(base, values.x);
+      visit(base + 1, values.y);
+      visit(base + 2, values.z);
+      visit(base + 3, values.w);
+    } else {
+      const float2 values =
+          *reinterpret_cast<const float2*>(scores + base);
+      visit(base, values.x);
+      visit(base + 1, values.y);
+    }
+  }
+
+  for (uint32_t idx = aligned_length + tx; idx < length; idx += BlockSize) {
+    visit(idx, scores[idx]);
+  }
+}
+
+template <bool Wide>
+struct ExactRadixTraits;
+
+template <>
+struct ExactRadixTraits<false> {
+  static constexpr uint32_t kBins = 256;
+  static constexpr uint32_t kRounds = 4;
+
+  __device__ static constexpr uint32_t shift(uint32_t round) {
+    return 24 - round * 8;
+  }
+
+  __device__ static constexpr uint32_t digit_mask(uint32_t) { return 0xFFu; }
+
+  __device__ static constexpr uint32_t prefix_mask(uint32_t round) {
+    return round == 0 ? 0u : (~0u << (32 - round * 8));
+  }
+};
+
+template <>
+struct ExactRadixTraits<true> {
+  static constexpr uint32_t kBins = 2048;
+  static constexpr uint32_t kRounds = 3;
+
+  __device__ static constexpr uint32_t shift(uint32_t round) {
+    return round == 0 ? 21 : (round == 1 ? 10 : 0);
+  }
+
+  __device__ static constexpr uint32_t digit_mask(uint32_t round) {
+    return round < 2 ? 0x7FFu : 0x3FFu;
+  }
+
+  __device__ static constexpr uint32_t prefix_mask(uint32_t round) {
+    return round == 0 ? 0u
+                      : (round == 1 ? 0xFFE00000u : 0xFFFFFC00u);
+  }
+};
+
+// Exact bounded-memory radix selection. Each round rescans the row, so memory
+// use and correctness are independent of coarse-bin occupancy.
+template <uint32_t TopK, uint32_t BlockSize, bool FuseOutputScan = false,
+          uint32_t VecSize = 1, bool UseWideRadix = false,
+          uint32_t StartRound = 0, uint32_t FinalCandidateCapacity = 0>
+__device__ void exact_topk_rescan(
+    const float* __restrict__ scores, int32_t* __restrict__ output,
+    uint32_t length, void* _smem, uint32_t initial_prefix = 0,
+    uint32_t initial_remaining = TopK) {
+  static_assert(BlockSize >= RADIX);
+  static_assert(VecSize == 1 || VecSize == 2 || VecSize == 4);
+  using Radix = ExactRadixTraits<UseWideRadix>;
+  constexpr uint32_t kHistogramBins = Radix::kBins;
+  constexpr uint32_t kRadixRounds = Radix::kRounds;
+  static_assert(StartRound < kRadixRounds);
+  static_assert(!UseWideRadix || kHistogramBins % BlockSize == 0);
+  static_assert(FinalCandidateCapacity == 0 ||
+                (FuseOutputScan && UseWideRadix));
+  using BlockScan = cub::BlockScan<uint32_t, BlockSize>;
+  struct ExactSmem {
+    uint32_t histogram[kHistogramBins];
+    typename BlockScan::TempStorage scan;
+    uint32_t prefix;
+    uint32_t remaining;
+    uint32_t output_counter;
+    uint32_t candidate_count;
+  };
+  static_assert(FinalCandidateCapacity == 0 ||
+                sizeof(ExactSmem) <= kExactCandidateOffset);
+
+  auto* smem = static_cast<ExactSmem*>(_smem);
+  auto* final_candidates = reinterpret_cast<int32_t*>(
+      static_cast<uint8_t*>(_smem) + kExactCandidateOffset);
+  const uint32_t tx = threadIdx.x;
+
+  if (tx == 0) {
+    smem->prefix = initial_prefix;
+    smem->remaining = initial_remaining;
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (uint32_t round = StartRound; round < kRadixRounds; ++round) {
+    for (uint32_t bin = tx; bin < kHistogramBins; bin += BlockSize) {
+      smem->histogram[bin] = 0;
+    }
+    __syncthreads();
+
+    const uint32_t shift = Radix::shift(round);
+    const uint32_t digit_mask = Radix::digit_mask(round);
+    const uint32_t prefix_mask = Radix::prefix_mask(round);
+    const uint32_t prefix = smem->prefix;
+
+    if constexpr (FinalCandidateCapacity > 0) {
+      if (round == kRadixRounds - 1) {
+        if (tx == 0) {
+          smem->output_counter = 0;
+          smem->candidate_count = 0;
+        }
+        __syncthreads();
+      }
+    }
+
+    const auto add_to_histogram = [&](uint32_t idx, float score) {
+      const uint32_t ordered = convert_to_uint32_v2(score);
+      const uint32_t ordered_prefix = ordered & prefix_mask;
+      if (ordered_prefix == prefix) {
+        atomicAdd(&smem->histogram[(ordered >> shift) & digit_mask], 1);
+        if constexpr (FinalCandidateCapacity > 0) {
+          if (round == kRadixRounds - 1) {
+            const uint32_t pos = atomicAdd(&smem->candidate_count, 1);
+            if (pos < FinalCandidateCapacity) {
+              final_candidates[pos] = static_cast<int32_t>(idx);
+            }
+          }
+        }
+      } else if constexpr (FinalCandidateCapacity > 0) {
+        if (round == kRadixRounds - 1 && ordered_prefix > prefix) {
+          const uint32_t pos = atomicAdd(&smem->output_counter, 1);
+          output[pos] = static_cast<int32_t>(idx);
+        }
+      }
+    };
+
+    scan_scores<BlockSize, VecSize>(scores, length, add_to_histogram);
+    __syncthreads();
+
+    if constexpr (UseWideRadix) {
+      constexpr uint32_t kBinsPerThread = kHistogramBins / BlockSize;
+      uint32_t counts[kBinsPerThread];
+      uint32_t local_sum = 0;
+#pragma unroll
+      for (uint32_t i = 0; i < kBinsPerThread; ++i) {
+        counts[i] = smem->histogram[tx * kBinsPerThread + i];
+        local_sum += counts[i];
+      }
+
+      uint32_t lower_prefix;
+      uint32_t total;
+      // Snapshot before the block scan; its barrier precedes any update.
+      const uint32_t remaining = smem->remaining;
+      BlockScan(smem->scan).ExclusiveSum(local_sum, lower_prefix, total);
+      uint32_t count_above = total - lower_prefix - local_sum;
+#pragma unroll
+      for (int i = static_cast<int>(kBinsPerThread) - 1; i >= 0; --i) {
+        const uint32_t count = counts[i];
+        if (count_above < remaining && count_above + count >= remaining) {
+          const uint32_t bin = tx * kBinsPerThread + i;
+          smem->remaining = remaining - count_above;
+          smem->prefix = prefix | (bin << shift);
+        }
+        count_above += count;
+      }
+    } else if (tx == 0) {
+      uint32_t count_above = 0;
+      for (int bin = RADIX - 1; bin >= 0; --bin) {
+        const uint32_t count = smem->histogram[bin];
+        if (count_above + count >= smem->remaining) {
+          smem->remaining -= count_above;
+          smem->prefix |= static_cast<uint32_t>(bin) << shift;
+          break;
+        }
+        count_above += count;
+      }
+    }
+    __syncthreads();
+  }
+
+  const uint32_t pivot = smem->prefix;
+  if constexpr (FinalCandidateCapacity > 0) {
+    if (tx == 0) smem->histogram[0] = 0;
+    __syncthreads();
+
+    const uint32_t candidate_count = smem->candidate_count;
+    const uint32_t equal_count = smem->remaining;
+    const uint32_t equal_base = TopK - equal_count;
+    const auto collect = [&](uint32_t idx, float score) {
+      const uint32_t ordered = convert_to_uint32_v2(score);
+      if (ordered > pivot) {
+        const uint32_t pos = atomicAdd(&smem->output_counter, 1);
+        output[pos] = static_cast<int32_t>(idx);
+      } else if (ordered == pivot) {
+        const uint32_t pos = atomicAdd(&smem->histogram[0], 1);
+        if (pos < equal_count) {
+          output[equal_base + pos] = static_cast<int32_t>(idx);
+        }
+      }
+    };
+
+    if (candidate_count <= FinalCandidateCapacity) {
+      for (uint32_t i = tx; i < candidate_count; i += BlockSize) {
+        const uint32_t idx = final_candidates[i];
+        collect(idx, scores[idx]);
+      }
+    } else {
+      scan_scores<BlockSize, VecSize>(
+          scores, length, [&](uint32_t idx, float score) {
+            if ((convert_to_uint32_v2(score) & 0xFFFFFC00u) ==
+                (pivot & 0xFFFFFC00u)) {
+              collect(idx, score);
+            }
+          });
+    }
+    __syncthreads();
+  } else if constexpr (FuseOutputScan) {
+    if (tx == 0) {
+      smem->output_counter = 0;
+      smem->histogram[0] = 0;
+    }
+    __syncthreads();
+
+    const uint32_t equal_count = smem->remaining;
+    const uint32_t equal_base = TopK - equal_count;
+    const auto collect = [&](uint32_t idx, float score) {
+      const uint32_t ordered = convert_to_uint32_v2(score);
+      if (ordered > pivot) {
+        const uint32_t pos = atomicAdd(&smem->output_counter, 1);
+        output[pos] = static_cast<int32_t>(idx);
+      } else if (ordered == pivot) {
+        const uint32_t pos = atomicAdd(&smem->histogram[0], 1);
+        if (pos < equal_count) {
+          output[equal_base + pos] = static_cast<int32_t>(idx);
+        }
+      }
+    };
+    scan_scores<BlockSize, VecSize>(scores, length, collect);
+    __syncthreads();
+  } else {
+    if (tx == 0) smem->output_counter = 0;
+    __syncthreads();
+
+    scan_scores<BlockSize, VecSize>(
+        scores, length, [&](uint32_t idx, float score) {
+          if (convert_to_uint32_v2(score) > pivot) {
+            const uint32_t pos = atomicAdd(&smem->output_counter, 1);
+            if (pos < TopK) output[pos] = static_cast<int32_t>(idx);
+          }
+        });
+    __syncthreads();
+
+    scan_scores<BlockSize, VecSize>(
+        scores, length, [&](uint32_t idx, float score) {
+          if (convert_to_uint32_v2(score) == pivot) {
+            const uint32_t pos = atomicAdd(&smem->output_counter, 1);
+            if (pos < TopK) output[pos] = static_cast<int32_t>(idx);
+          }
+        });
+    __syncthreads();
+  }
+}
+
+template <uint32_t TopK, uint32_t BlockSize, uint32_t VecSize>
+__device__ __noinline__ void exact_topk_rescan_cold(
+    const float* __restrict__ scores, int32_t* __restrict__ output,
+    uint32_t length, void* smem) {
+  exact_topk_rescan<TopK, BlockSize, true, VecSize, true>(scores, output,
+                                                          length, smem);
+}
+
 // Converts each score to a 12-bit bin (FP16 sign-magnitude -> top 12 bits ->
 // bin 0-4095)
 template <uint32_t kBits>
@@ -82,6 +379,262 @@ __device__ __forceinline__ uint32_t extract_coarse_bin_N(float x) {
   uint16_t key = (bits & 0x8000) ? static_cast<uint16_t>(~bits)
                                  : static_cast<uint16_t>(bits | 0x8000);
   return key >> (16 - kBits);
+}
+
+// Refine an overflowing FP16 histogram bin from values already resident in
+// registers. A 12-bit FP16 bin spans at most 22 ordered-FP32 bits for finite
+// values, so two radix-2048 passes select the exact pivot.
+template <uint32_t TopK, uint32_t HistBits, uint32_t VecsPerThread>
+__device__ __forceinline__ bool exact_topk_refine_registers(
+    const float4 (&vecs)[VecsPerThread], int32_t* __restrict__ output,
+    uint32_t length, uint32_t coarse_bin, uint32_t num_above, void* _smem) {
+  constexpr uint32_t kBins = 2048;
+  constexpr uint32_t kDigitBits = 11;
+  constexpr uint32_t kDigitMask = kBins - 1;
+  constexpr uint32_t kDeltaLimit = 1u << (2 * kDigitBits);
+  static_assert(HistBits == 12);
+  static_assert(kBins == 2 * kBlockSize);
+  using RefineScan = cub::BlockScan<uint32_t, kBlockSize>;
+  struct RefineSmem {
+    uint32_t histogram[kBins];
+    typename RefineScan::TempStorage scan;
+    uint32_t prefix;
+    uint32_t remaining;
+    uint32_t output_counter;
+    uint32_t equal_counter;
+    uint32_t valid;
+  };
+
+  auto* smem = static_cast<RefineSmem*>(_smem);
+  const uint32_t tx = threadIdx.x;
+  const uint16_t lower_half_key = static_cast<uint16_t>(coarse_bin << 4);
+  const uint16_t lower_half_bits =
+      (lower_half_key & 0x8000u)
+          ? static_cast<uint16_t>(lower_half_key & 0x7FFFu)
+          : static_cast<uint16_t>(~lower_half_key);
+  const uint32_t lower_key =
+      convert_to_uint32_v2(__half2float(__ushort_as_half(lower_half_bits)));
+  const uint32_t base_key = lower_key > 8192 ? lower_key - 8192 : 0;
+
+  if (tx == 0) {
+    smem->prefix = 0;
+    smem->remaining = TopK - num_above;
+    smem->valid = (lower_half_bits & 0x7C00u) != 0x7C00u;
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (uint32_t round = 0; round < 2; ++round) {
+    for (uint32_t bin = tx; bin < kBins; bin += kBlockSize) {
+      smem->histogram[bin] = 0;
+    }
+    __syncthreads();
+
+    const uint32_t prefix = smem->prefix;
+    const uint32_t shift = round == 0 ? kDigitBits : 0;
+    bool done = false;
+#pragma unroll
+    for (uint32_t v = 0; v < VecsPerThread && !done; ++v) {
+      const float* values = reinterpret_cast<const float*>(&vecs[v]);
+#pragma unroll
+      for (uint32_t e = 0; e < 4 && !done; ++e) {
+        const uint32_t idx = (tx + v * kBlockSize) * 4 + e;
+        if (idx >= length) {
+          done = true;
+        } else if (extract_coarse_bin_N<HistBits>(values[e]) == coarse_bin) {
+          const uint32_t key = convert_to_uint32_v2(values[e]);
+          const uint32_t delta = key - base_key;
+          if (key < base_key || delta >= kDeltaLimit) {
+            atomicExch(&smem->valid, 0);
+          } else if (round == 0 || (delta & ~kDigitMask) == prefix) {
+            atomicAdd(&smem->histogram[(delta >> shift) & kDigitMask], 1);
+          }
+        }
+      }
+    }
+    __syncthreads();
+
+    if (smem->valid == 0) return false;
+
+    const uint32_t bin0 = 2 * tx;
+    const uint32_t count0 = smem->histogram[bin0];
+    const uint32_t count1 = smem->histogram[bin0 + 1];
+    const uint32_t local_sum = count0 + count1;
+    const uint32_t remaining = smem->remaining;
+    uint32_t lower_prefix;
+    uint32_t total;
+    RefineScan(smem->scan).ExclusiveSum(local_sum, lower_prefix, total);
+    uint32_t count_above = total - lower_prefix - local_sum;
+    if (count_above < remaining && count_above + count1 >= remaining) {
+      smem->remaining = remaining - count_above;
+      smem->prefix = prefix | ((bin0 + 1) << shift);
+    }
+    count_above += count1;
+    if (count_above < remaining && count_above + count0 >= remaining) {
+      smem->remaining = remaining - count_above;
+      smem->prefix = prefix | (bin0 << shift);
+    }
+    __syncthreads();
+  }
+
+  if (tx == 0) {
+    smem->output_counter = 0;
+    smem->equal_counter = 0;
+  }
+  __syncthreads();
+
+  const uint32_t pivot = base_key + smem->prefix;
+  const uint32_t equal_base = TopK - smem->remaining;
+  bool done = false;
+#pragma unroll
+  for (uint32_t v = 0; v < VecsPerThread && !done; ++v) {
+    const float* values = reinterpret_cast<const float*>(&vecs[v]);
+#pragma unroll
+    for (uint32_t e = 0; e < 4 && !done; ++e) {
+      const uint32_t idx = (tx + v * kBlockSize) * 4 + e;
+      if (idx >= length) {
+        done = true;
+      } else {
+        const uint32_t key = convert_to_uint32_v2(values[e]);
+        if (key > pivot) {
+          const uint32_t pos = atomicAdd(&smem->output_counter, 1);
+          output[pos] = static_cast<int32_t>(idx);
+        } else if (key == pivot) {
+          const uint32_t pos = atomicAdd(&smem->equal_counter, 1);
+          if (equal_base + pos < TopK) {
+            output[equal_base + pos] = static_cast<int32_t>(idx);
+          }
+        }
+      }
+    }
+  }
+  __syncthreads();
+  return true;
+}
+
+// Refine an overflowing finite FP16 histogram bin with two radix-2048
+// rescans. Keeping this cold path independent of the caller's register array
+// preserves the regular path's register allocation.
+template <uint32_t TopK, uint32_t HistBits, uint32_t VecSize>
+__device__ __noinline__ bool exact_topk_refine_rescan(
+    const float* __restrict__ scores, int32_t* __restrict__ output,
+    uint32_t length, uint32_t coarse_bin, uint32_t num_above, void* _smem) {
+  constexpr uint32_t kBins = 2048;
+  constexpr uint32_t kDigitBits = 11;
+  constexpr uint32_t kDigitMask = kBins - 1;
+  constexpr uint32_t kDeltaLimit = 1u << (2 * kDigitBits);
+  static_assert(HistBits == 12);
+  static_assert(kBins == 2 * kBlockSize);
+  using RefineScan = cub::BlockScan<uint32_t, kBlockSize>;
+  struct RefineSmem {
+    uint32_t histogram[kBins];
+    typename RefineScan::TempStorage scan;
+    uint32_t prefix;
+    uint32_t remaining;
+    uint32_t output_counter;
+    uint32_t equal_counter;
+    uint32_t valid;
+  };
+
+  auto* smem = static_cast<RefineSmem*>(_smem);
+  const uint32_t tx = threadIdx.x;
+  const uint16_t lower_half_key = static_cast<uint16_t>(coarse_bin << 4);
+  const uint16_t lower_half_bits =
+      (lower_half_key & 0x8000u)
+          ? static_cast<uint16_t>(lower_half_key & 0x7FFFu)
+          : static_cast<uint16_t>(~lower_half_key);
+  const uint32_t lower_key =
+      convert_to_uint32_v2(__half2float(__ushort_as_half(lower_half_bits)));
+  const uint32_t base_key = lower_key > 8192 ? lower_key - 8192 : 0;
+
+  if (tx == 0) {
+    smem->prefix = 0;
+    smem->remaining = TopK - num_above;
+    smem->valid = (lower_half_bits & 0x7C00u) != 0x7C00u;
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (uint32_t round = 0; round < 2; ++round) {
+    for (uint32_t bin = tx; bin < kBins; bin += kBlockSize) {
+      smem->histogram[bin] = 0;
+    }
+    __syncthreads();
+
+    const uint32_t prefix = smem->prefix;
+    const uint32_t shift = round == 0 ? kDigitBits : 0;
+    scan_scores<kBlockSize, VecSize>(
+        scores, length, [&](uint32_t, float score) {
+          if (extract_coarse_bin_N<HistBits>(score) != coarse_bin) return;
+          const uint32_t key = convert_to_uint32_v2(score);
+          const uint32_t delta = key - base_key;
+          if (key < base_key || delta >= kDeltaLimit) {
+            atomicExch(&smem->valid, 0);
+          } else if (round == 0 || (delta & ~kDigitMask) == prefix) {
+            atomicAdd(&smem->histogram[(delta >> shift) & kDigitMask], 1);
+          }
+        });
+    __syncthreads();
+
+    if (smem->valid == 0) return false;
+
+    const uint32_t bin0 = 2 * tx;
+    const uint32_t count0 = smem->histogram[bin0];
+    const uint32_t count1 = smem->histogram[bin0 + 1];
+    const uint32_t local_sum = count0 + count1;
+    const uint32_t remaining = smem->remaining;
+    uint32_t lower_prefix;
+    uint32_t total;
+    RefineScan(smem->scan).ExclusiveSum(local_sum, lower_prefix, total);
+    uint32_t count_above = total - lower_prefix - local_sum;
+    if (count_above < remaining && count_above + count1 >= remaining) {
+      smem->remaining = remaining - count_above;
+      smem->prefix = prefix | ((bin0 + 1) << shift);
+    }
+    count_above += count1;
+    if (count_above < remaining && count_above + count0 >= remaining) {
+      smem->remaining = remaining - count_above;
+      smem->prefix = prefix | (bin0 << shift);
+    }
+    __syncthreads();
+  }
+
+  if (tx == 0) {
+    smem->output_counter = 0;
+    smem->equal_counter = 0;
+  }
+  __syncthreads();
+
+  const uint32_t pivot = base_key + smem->prefix;
+  const uint32_t equal_base = TopK - smem->remaining;
+  scan_scores<kBlockSize, VecSize>(
+      scores, length, [&](uint32_t idx, float score) {
+        const uint32_t key = convert_to_uint32_v2(score);
+        if (key > pivot) {
+          const uint32_t pos = atomicAdd(&smem->output_counter, 1);
+          output[pos] = static_cast<int32_t>(idx);
+        } else if (key == pivot) {
+          const uint32_t pos = atomicAdd(&smem->equal_counter, 1);
+          if (equal_base + pos < TopK) {
+            output[equal_base + pos] = static_cast<int32_t>(idx);
+          }
+        }
+      });
+  __syncthreads();
+  return true;
+}
+
+// Keep overflow recovery behind one cold call so the regular histogram path
+// does not inherit the register pressure of either exact implementation.
+template <uint32_t TopK, uint32_t HistBits, uint32_t VecSize>
+__device__ __noinline__ void exact_topk_recover_rescan(
+    const float* __restrict__ scores, int32_t* __restrict__ output,
+    uint32_t length, uint32_t coarse_bin, uint32_t num_above, void* _smem) {
+  if (!exact_topk_refine_rescan<TopK, HistBits, VecSize>(
+          scores, output, length, coarse_bin, num_above, _smem)) {
+    exact_topk_rescan_cold<TopK, kBlockSize, VecSize>(scores, output, length,
+                                                      _smem);
+  }
 }
 
 // running sum within each warp — thread 0 gets its own value, thread 1 gets
@@ -201,11 +754,11 @@ __device__ void tie_handle(const Tie* ties, uint32_t num_ties,
 // Extended tie_handle for TopK > kBlockSize (e.g. TopK=2048).
 // tie_handle assumes 1 tie per thread (max 1024).
 // This version handles 2 ties per thread via kPerThread=2
-template <uint32_t TopK>
+template <uint32_t TopK, uint32_t MaxTies = TopK>
 __device__ void tie_handle_large(const Tie* ties, uint32_t num_ties,
                                  uint32_t num_above, int32_t* output,
                                  void* _smem) {
-  static_assert(TopK > kBlockSize);
+  static_assert(MaxTies > kBlockSize);
   struct TS {
     alignas(128) uint32_t counter;
     alignas(128) MatchBin match;
@@ -217,7 +770,8 @@ __device__ void tie_handle_large(const Tie* ties, uint32_t num_ties,
   const auto li = tx % kWarpSize;
   const auto wi = tx / kWarpSize;
 
-  constexpr uint32_t kPerThread = (TopK + kBlockSize - 1) / kBlockSize;
+  constexpr uint32_t kPerThread =
+      (MaxTies + kBlockSize - 1) / kBlockSize;
   Tie my_ties[kPerThread];
   uint32_t keys[kPerThread];
   bool active[kPerThread];
@@ -327,9 +881,12 @@ struct Histogram4096Smem {
   };
 };
 
+enum class OverflowRecovery { kRegisterValues, kRescan };
+
 template <uint32_t TopK, uint32_t HIST_BITS,
           uint32_t VECS_PER_THREAD = kHist4096VecsPerThread,
-          bool UsePredicatedLoads = false>
+          bool UsePredicatedLoads = false,
+          OverflowRecovery Recovery = OverflowRecovery::kRegisterValues>
 __device__ void histogram_4096_topk(const float* __restrict__ scores,
                                     int32_t* __restrict__ output,
                                     uint32_t length, void* _smem) {
@@ -446,6 +1003,23 @@ __device__ void histogram_4096_topk(const float* __restrict__ scores,
   const auto [thr_bin, num_above, num_equal] = smem->match;
   const bool need_tie = (num_equal + num_above > TopK);
 
+  // Coarse-bin overflow must be refined before emitting any candidates.
+  if (need_tie && num_equal > TopK) {
+    if constexpr (Recovery == OverflowRecovery::kRescan) {
+      exact_topk_recover_rescan<TopK, HIST_BITS,
+                                UsePredicatedLoads ? 1 : 4>(
+          scores, output, length, thr_bin, num_above, _smem);
+    } else {
+      if (!exact_topk_refine_registers<TopK, HIST_BITS, VECS_PER_THREAD>(
+              vecs, output, length, thr_bin, num_above, _smem)) {
+        exact_topk_rescan<TopK, kBlockSize, true,
+                          UsePredicatedLoads ? 1 : 4, true>(
+            scores, output, length, _smem);
+      }
+    }
+    return;
+  }
+
   done = false;
 #pragma unroll
   for (uint32_t v = 0; v < VECS_PER_THREAD && !done; v++) {
@@ -468,7 +1042,7 @@ __device__ void histogram_4096_topk(const float* __restrict__ scores,
             }
           } else {
             if (pos < TopK) {
-              smem->tie_buffer[pos] = {idx, elems[e]};  // store for refirement
+              smem->tie_buffer[pos] = {idx, elems[e]};
             }
           }
         }
@@ -508,10 +1082,8 @@ __device__ void histogram_4096_topk(const float* __restrict__ scores,
     if (lane_id == 0 && rank < topk_remain) {
       output[num_above + rank] = target.idx;  // place at correct position
     }
-  } else if (num_ties <=
-             kWarpSize *
-                 2) {  // TODO (roberto): try to refactor this with <=32 case
-    //  Same idea but each thread handles 2 tie elements
+  } else if (num_ties <= kWarpSize * 2) {
+    // Same idea, with each thread handling two tie elements.
     const auto lane_id = tx % kWarpSize;
     const auto warp_id = tx / kWarpSize;
     const auto lane1 = lane_id + kWarpSize;

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -836,16 +836,98 @@ def test_cooperative_topk_512_tie_workspace_is_per_row() -> None:
     )
 
 
+def _make_candidate_overflow_row(
+    seq_len: int,
+    top_k: int,
+    score_kind: str,
+    candidate_count: int | None,
+) -> torch.Tensor:
+    if score_kind == "fp32_narrow":
+        return 1.0 + torch.arange(seq_len, dtype=torch.float32) * (
+            0.01 / seq_len
+        )
+    if score_kind == "negative_fp32_narrow":
+        return -1.01 + torch.arange(seq_len, dtype=torch.float32) * (
+            0.01 / seq_len
+        )
+    if score_kind == "16bit_grid":
+        return (
+            1.0
+            + torch.arange(seq_len, dtype=torch.float32) * (0.01 / seq_len)
+        ).to(torch.bfloat16).float()
+    if score_kind == "all_equal":
+        return torch.ones(seq_len, dtype=torch.float32)
+    if score_kind == "positive_inf":
+        return torch.full((seq_len,), float("inf"), dtype=torch.float32)
+
+    row = torch.full((seq_len,), -2.0, dtype=torch.float32)
+    if score_kind == "mixed_threshold":
+        num_above = top_k // 4
+        row[:num_above] = 2.0 + torch.arange(
+            num_above, dtype=torch.float32
+        ) * (0.01 / num_above)
+        start = num_above
+    elif score_kind == "capacity_boundary":
+        start = 0
+    else:
+        raise ValueError(f"Unknown overflow score kind: {score_kind}")
+
+    assert candidate_count is not None
+    values = 1.0 + torch.arange(candidate_count, dtype=torch.float32) * (
+        0.01 / candidate_count
+    )
+    row[start : start + candidate_count] = values
+    return row
+
+
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
 @pytest.mark.parametrize("top_k", [512, 1024, 2048])
 @pytest.mark.parametrize(
-    "seq_len",
+    ("seq_len", "stride", "score_kind", "candidate_count"),
     [
-        pytest.param(8 * 1024, id="8k"),
-        pytest.param(32 * 1024, id="32k"),
-        pytest.param(128 * 1024, id="128k"),
-        pytest.param(256 * 1024, id="256k"),
-        pytest.param(512 * 1024, id="512k"),
+        pytest.param(8 * 1024, None, "fp32_narrow", None, id="fp32-8k"),
+        pytest.param(32 * 1024, None, "fp32_narrow", None, id="fp32-32k"),
+        pytest.param(128 * 1024, None, "fp32_narrow", None, id="fp32-128k"),
+        pytest.param(256 * 1024, None, "fp32_narrow", None, id="fp32-256k"),
+        pytest.param(512 * 1024, None, "fp32_narrow", None, id="fp32-512k"),
+        pytest.param(
+            32769,
+            64 * 1024,
+            "fp32_narrow",
+            None,
+            id="padded-invalid-tail",
+        ),
+        pytest.param(32 * 1024, None, "16bit_grid", None, id="16bit-grid"),
+        pytest.param(
+            32 * 1024,
+            None,
+            "negative_fp32_narrow",
+            None,
+            id="negative-fp32",
+        ),
+        pytest.param(
+            32 * 1024,
+            None,
+            "mixed_threshold",
+            4096,
+            id="candidates-above-threshold",
+        ),
+        pytest.param(8 * 1024, None, "all_equal", None, id="all-equal"),
+        pytest.param(8 * 1024, None, "positive_inf", None, id="positive-inf"),
+        pytest.param(
+            8 * 1024,
+            None,
+            "capacity_boundary",
+            0,
+            id="candidate-capacity",
+        ),
+        pytest.param(
+            8 * 1024,
+            None,
+            "capacity_boundary",
+            1,
+            id="candidate-capacity-plus-one",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -869,14 +951,26 @@ def test_workspace_topk_candidate_overflow(
     backend: str,
     num_rows: int,
     seq_len: int,
+    stride: int | None,
+    score_kind: str,
+    candidate_count: int | None,
     top_k: int,
 ) -> None:
     """TopK remains exact when one coarse bin exceeds candidate capacity."""
     torch.set_default_device("cuda:0")
 
-    # These are unequal FP32 values but all map to the same 12-bit FP16
-    # coarse bin, exceeding the candidate capacity at every tested top-k.
-    row = 1.0 + torch.arange(seq_len, dtype=torch.float32) * (0.01 / seq_len)
+    if score_kind == "capacity_boundary":
+        assert candidate_count in (0, 1)
+        capacity = 2048 if backend == "cooperative_topk" else max(top_k, 1024)
+        candidate_count = capacity + candidate_count
+
+    row = _make_candidate_overflow_row(
+        seq_len, top_k, score_kind, candidate_count
+    )
+    if stride is not None:
+        padded = torch.full((stride,), float("inf"), dtype=torch.float32)
+        padded[:seq_len] = row
+        row = padded
     logits = row.expand(num_rows, -1).contiguous()
     lengths = torch.full((num_rows,), seq_len, dtype=torch.int32)
     indices = torch.empty((num_rows, top_k), dtype=torch.int32)
@@ -891,8 +985,11 @@ def test_workspace_topk_candidate_overflow(
     )
     torch.accelerator.synchronize()
 
+    assert torch.all((indices >= 0) & (indices < seq_len))
+    sorted_indices = indices.sort(dim=1).values
+    assert torch.all(sorted_indices[:, 1:] != sorted_indices[:, :-1])
     actual = logits.gather(1, indices.to(torch.int64)).sort(dim=1).values
-    expected = logits.topk(top_k, dim=1).values.sort(dim=1).values
+    expected = logits[:, :seq_len].topk(top_k, dim=1).values.sort(dim=1).values
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -837,6 +837,66 @@ def test_cooperative_topk_512_tie_workspace_is_per_row() -> None:
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@pytest.mark.parametrize("top_k", [512, 1024, 2048])
+@pytest.mark.parametrize(
+    "seq_len",
+    [
+        pytest.param(8 * 1024, id="8k"),
+        pytest.param(32 * 1024, id="32k"),
+        pytest.param(128 * 1024, id="128k"),
+        pytest.param(256 * 1024, id="256k"),
+        pytest.param(512 * 1024, id="512k"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("backend", "num_rows"),
+    [
+        pytest.param("persistent_topk", 1, id="persistent"),
+        pytest.param("persistent_topk", 64, id="filtered"),
+        pytest.param(
+            "cooperative_topk",
+            1,
+            id="cooperative",
+            marks=pytest.mark.skipif(
+                not _has_device_capability(90),
+                reason="cooperative_topk requires SM90+",
+            ),
+        ),
+    ],
+)
+@torch.inference_mode()
+def test_workspace_topk_candidate_overflow(
+    backend: str,
+    num_rows: int,
+    seq_len: int,
+    top_k: int,
+) -> None:
+    """TopK remains exact when one coarse bin exceeds candidate capacity."""
+    torch.set_default_device("cuda:0")
+
+    # These are unequal FP32 values but all map to the same 12-bit FP16
+    # coarse bin, exceeding the candidate capacity at every tested top-k.
+    row = 1.0 + torch.arange(seq_len, dtype=torch.float32) * (0.01 / seq_len)
+    logits = row.expand(num_rows, -1).contiguous()
+    lengths = torch.full((num_rows,), seq_len, dtype=torch.int32)
+    indices = torch.empty((num_rows, top_k), dtype=torch.int32)
+
+    _run_topk_backend(
+        backend,
+        logits,
+        lengths,
+        indices,
+        top_k,
+        seq_len,
+    )
+    torch.accelerator.synchronize()
+
+    actual = logits.gather(1, indices.to(torch.int64)).sort(dim=1).values
+    expected = logits.topk(top_k, dim=1).values.sort(dim=1).values
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
 @pytest.mark.parametrize(
     "test_config",
     [


### PR DESCRIPTION
Context: https://github.com/vllm-project/vllm/issues/51782, https://github.com/vllm-project/vllm/pull/52149

The evaluation shows no measurable accuracy regression in MAIN, meaning that either overflow is never hit in real use-cases/data-distributions, or that non-determinism in top-K doesn't affect model accuracy. Note that, even when overflow occurs (which is a rare event) the discarded candidates will have the same high bits as the retained ones. Retained and discarded candidates belong to the same current radix-threshold bin. Therefore, they share the radix prefix, meaning their values are close.

<img width="1474" height="595" alt="dsv4_mrcr" src="https://github.com/user-attachments/assets/b844553c-1255-4fca-80d2-858a6a8c9ef3" />

</br></br>

A double-check of this is that no performance regressions were observed in our e2e evals with the current PR, reinforcing the idea that overflow doesn't happen, or it is very rare. Even with this PR, where overflow situations were optimized, there is a non-trivial overhead vs non-overflow cases kernel-wise.

<img width="813" height="695" alt="handle_overf" src="https://github.com/user-attachments/assets/586390e5-3a46-4fb3-b5b7-d84a51c6badc" />

This PR pretends to be a go-to if this becomes a real issue in the future.