### PR TITLE
[Bug]: Kimi K3 tool calls returned empty tool calls when the model omits the think transition marker

### DIFF
--- a/rust/src/parser/src/unified/kimi_k3.rs
+++ b/rust/src/parser/src/unified/kimi_k3.rs
@@ -349,9 +349,14 @@ fn parse_idle_event(input: &mut KimiK3Input<'_>) -> ModalResult<KimiK3Event> {
 fn parse_reasoning_event(input: &mut KimiK3Input<'_>) -> ModalResult<KimiK3Event> {
     alt((
         literal(THINK_CLOSE).value(KimiK3Event::ThinkClose),
-        // `<|end_of_msg|>` can reach the parser under `ignore_eos` or
-        // `include_stop_str_in_output`; never leak it into reasoning.
-        literal(END_OF_MSG).value(KimiK3Event::MessageEnd),
+        // If the model omits the explicit think close, a later channel open
+        // (response / tools) or a message close should implicitly end
+        // reasoning. Accept those markers here so the parser resynchronizes.
+        literal(RESPONSE_OPEN).value(KimiK3Event::ResponseOpen),
+        literal(TOOLS_OPEN).value(KimiK3Event::ToolsOpen),
+        // `<|end_of_msg|>` or an explicit message close also terminates
+        // reasoning.
+        message_end_event,
         safe_reasoning_event,
     ))
     .parse_next(input)

--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
@@ -343,3 +343,20 @@ def test_reasoning_end_matches_reference_over_marker_dense_sequences(seed):
             assert parser.is_reasoning_end_streaming(
                 full, delta
             ) == _reference_is_reasoning_end(full), (head, delta)
+
+
+def test_inferred_think_close_preserves_tools_marker_simple():
+    parser = KimiK3ReasoningParser(DummyTokenizer())
+    request = ChatCompletionRequest(model="test-model", messages=[])
+
+    tools_block = (
+        f"{OPEN}tools{SEP}{OPEN}call tool=\"bash\" index=\"1\"{SEP}"
+        f"{OPEN}argument key=\"command\" type=\"string\"{SEP}ls{CLOSE}argument{SEP}"
+        f"{CLOSE}call{SEP}{CLOSE}tools{SEP}"
+    )
+
+    out = f"planning the edit. Applying it now:{CLOSE}response{SEP}{tools_block}{CLOSE}message{SEP}"
+
+    reasoning, rest = parser.extract_reasoning_content(out, request)
+    assert reasoning == "planning the edit. Applying it now:"
+    assert rest is not None and rest.startswith(f"{OPEN}tools{SEP}")

--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
@@ -274,10 +274,26 @@ class KimiK3ReasoningParser(ReasoningParser):
         if m_open is None and self._think_close_re.search(model_output) is None:
             return None, self._content_after_reasoning(model_output, request)
 
-        m_close = self._think_close_re.search(model_output, content_start)
-        if m_close is not None:
-            reasoning = model_output[content_start : m_close.start()]
-            rest = model_output[m_close.end() :]
+        # Look for an explicit think-close or an implicit end-of-reasoning
+        # marker (response open / message close). Prefer the earliest marker
+        # after the reasoning start. When the model omits the explicit
+        # think-close, treat later-channel markers as an inferred close but
+        # preserve that marker in `rest` so downstream tool parsing sees it.
+        m_think_close = self._think_close_re.search(model_output, content_start)
+        m_response_open = self._response_open_re.search(model_output, content_start)
+        m_message_close = self._message_close_re.search(model_output, content_start)
+
+        # Choose the earliest match (if any)
+        matches = [m for m in (m_think_close, m_response_open, m_message_close) if m]
+        if matches:
+            m_earliest = min(matches, key=lambda m: m.start())
+            if m_earliest is m_think_close:
+                reasoning = model_output[content_start : m_earliest.start()]
+                rest = model_output[m_earliest.end() :]
+                return (reasoning or None, self._content_after_reasoning(rest, request))
+            # Inferred close: do not consume the marker so downstream sees it
+            reasoning = model_output[content_start : m_earliest.start()]
+            rest = model_output[m_earliest.start() :]
             return (reasoning or None, self._content_after_reasoning(rest, request))
         # think not closed -> still reasoning, no content yet
         return (model_output[content_start:] or None, None)
@@ -387,21 +403,46 @@ class KimiK3ReasoningParser(ReasoningParser):
 
         # the close marker completes within this delta's accumulated text:
         # split the buffer at the close marker into reasoning vs trailing content.
-        m_close = self._think_close_re.search(current_text)
-        if m_close is not None:
-            self._last_streaming_delta_token_ids = tuple(delta_token_ids)
-            self._last_streaming_content_token_ids = self._extract_content_ids(
-                list(current_token_ids)
-            )
+        # Consider explicit think-close or implicit end-of-reasoning markers
+        # (response open / message close). Use the earliest marker in the
+        # accumulated text. When the model omits the explicit think-close treat
+        # those markers as an inferred close and preserve the marker in the
+        # returned content.
+        m_think_close = self._think_close_re.search(current_text)
+        m_response_open = self._response_open_re.search(current_text)
+        m_message_close = self._message_close_re.search(current_text)
+        matches = [m for m in (m_think_close, m_response_open, m_message_close) if m]
+        if matches:
+            m_earliest = min(matches, key=lambda m: m.start())
+            if m_earliest is m_think_close:
+                self._last_streaming_delta_token_ids = tuple(delta_token_ids)
+                self._last_streaming_content_token_ids = self._extract_content_ids(
+                    list(current_token_ids)
+                )
+                m_open = self._think_open_re.search(current_text)
+                r_start = m_open.end() if m_open is not None else 0
+                reasoning = current_text[r_start : m_earliest.start()]
+                already_sent = self._reasoning_text_ready_to_emit(previous_text)
+                if reasoning.startswith(already_sent):
+                    reasoning_delta = reasoning[len(already_sent) :]
+                else:
+                    reasoning_delta = reasoning
+                content = current_text[m_earliest.end() :]
+                return DeltaMessage(
+                    reasoning=reasoning_delta or None,
+                    content=content or None,
+                )
+            # Inferred close via a later-channel marker: preserve the marker
             m_open = self._think_open_re.search(current_text)
             r_start = m_open.end() if m_open is not None else 0
-            reasoning = current_text[r_start : m_close.start()]
+            reasoning = current_text[r_start : m_earliest.start()]
             already_sent = self._reasoning_text_ready_to_emit(previous_text)
             if reasoning.startswith(already_sent):
                 reasoning_delta = reasoning[len(already_sent) :]
             else:
                 reasoning_delta = reasoning
-            content = current_text[m_close.end() :]
+            # Preserve the marker so downstream tool parsing sees structured XTML
+            content = current_text[m_earliest.start() :]
             return DeltaMessage(
                 reasoning=reasoning_delta or None,
                 content=content or None,


### PR DESCRIPTION
Fixes #53246

_AI-assisted, auto-generated by the vLLM issue bot (Copilot Agent)._
_No existing open PR addresses this issue (checked before opening)._

Work done (summary)
- Root cause: parsers only ended think on exact think-close; when model omitted it and emitted a response/tools marker the reasoning stayed open and tool parser saw nothing.
- Fix: treat later-channel markers (response open / tools open / message close / end_of_msg) as inferred think-close so reasoning is flushed and the marker is preserved for downstream parsing.
- Files changed (minimal):
  - vllm/reasoning/kimi_k3_reasoning_parser.py — tolerate inferred close (non-streaming + streaming)
  - rust/src/parser/src/unified/kimi_k3.rs — accept response/tools/message markers inside reasoning
  - tests/reasoning/test_kimi_k3_reasoning_parser.py — added a focused regression test
What I ran
- Added/committed a branch fix/issue-53246 locally:
  - Commit: "kimi_k3: tolerate missing think-close by treating later-channel markers as inferred close\n\nFixes #53246\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
- Attempted to run the new pytest but pytes...