### PR TITLE
[Bugfix][Spec Decode] Isolate DFlash/DSpark compile cache by depth

### DIFF
--- a/tests/config/test_speculative_hash.py
+++ b/tests/config/test_speculative_hash.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any, cast
+
+import pytest
+
+from vllm.config import SpeculativeConfig
+
+
+def _config(
+    method: str, num_speculative_tokens: int, *, parallel_drafting: bool
+) -> SpeculativeConfig:
+    config = object.__new__(SpeculativeConfig)
+    config.method = cast(Any, method)
+    config.num_speculative_tokens = num_speculative_tokens
+    config.parallel_drafting = parallel_drafting
+    config.draft_model_config = cast(Any, None)
+    return config
+
+
+@pytest.mark.parametrize("method", ["dflash", "dspark", "eagle3", "draft_model"])
+@pytest.mark.parametrize("shallow, deep", [(3, 9), (1, 128)])
+def test_parallel_drafting_hash_includes_speculative_depth(
+    method: str, shallow: int, deep: int
+):
+    """Parallel drafting depth changes static query shapes."""
+    assert (
+        _config(method, shallow, parallel_drafting=True).compute_hash()
+        != _config(method, deep, parallel_drafting=True).compute_hash()
+    )
+
+
+@pytest.mark.parametrize("method", ["mtp", "eagle"])
+def test_sequential_drafting_hash_ignores_speculative_depth(method: str):
+    """Sequential drafting depth is a loop count, not a static query shape."""
+    assert (
+        _config(method, 3, parallel_drafting=False).compute_hash()
+        == _config(method, 9, parallel_drafting=False).compute_hash()
+    )

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -620,6 +620,11 @@ class SpeculativeConfig:
         )
         factors.append(uses_aux_hidden_states)
 
+        # Parallel drafting includes speculative depth in static query shapes.
+        # Keep it in the key so artifacts cannot be reused across depths.
+        if self.parallel_drafting:
+            factors.append(self.num_speculative_tokens)
+
         if self.draft_model_config is not None:
             factors.append(self.draft_model_config.compute_hash())
             # The specific layers used also affect the computation graph.


### PR DESCRIPTION
## Problem

Speculative depth for DFlash and DSpark was missing from
`SpeculativeConfig.compute_hash()`, even though it changes their CUDA
graph query shapes. Different depths could therefore share persisted
state keyed through `VllmConfig.compute_hash()`.

## Fix

Include `num_speculative_tokens` in the hash for DFlash and DSpark.

## Testing

On GB10 and H100 with a shared cache root and `VLLM_ENABLE_STARTUP_PLAN=1`,
depths 1 and 15 shared one startup plan before the fix—the depth-15 run
skipped memory profiling—and created separate plans afterward.

```text
.venv/bin/python -m pytest tests/config/test_speculative_hash.py -v
4 passed
```

No duplicate PR found. #40246 may require moving th
rebase.

AI assistance was used for analysis and drafting; a
reviewed and tests run by the submitter.