### PR TITLE
[Bugfix] Fix AOT caching for decorated forward methods

### DIFF
--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -1,17 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import functools
 import hashlib
+import json
 import os
 import pickle
+import subprocess
+import sys
 import tempfile
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
 
+import vllm.compilation.decorators as compilation_decorators
 import vllm.envs as envs
 from vllm.compilation.backends import VllmBackend
 from vllm.compilation.caching import (
@@ -75,6 +80,637 @@ class CompiledModTuple(torch.nn.Module):
 
     def forward(self, x: torch.Tensor):
         return reference_fn_tuple(x)
+
+
+def _capture_forward_state(enabled: bool):
+    def decorate(forward):
+        @functools.wraps(forward)
+        def wrapped(*args, **kwargs):
+            # Make the captured flag affect both the fingerprint and behavior.
+            output = forward(*args, **kwargs)
+            return output + 1 if enabled else output
+
+        return wrapped
+
+    return decorate
+
+
+def _capture_unsupported_forward_state():
+    # Capture a mutable value that the fingerprint protocol deliberately rejects.
+    mutable_state: list[object] = []
+
+    def decorate(forward):
+        @functools.wraps(forward)
+        def wrapped(*args, **kwargs):
+            if mutable_state:
+                return forward(*args, **kwargs)
+            return forward(*args, **kwargs)
+
+        return wrapped
+
+    return decorate
+
+
+class ExternalDataDecoratedMod(torch.nn.Module):
+    @_capture_forward_state(True)
+    @_capture_forward_state(False)
+    def forward(self, x: torch.Tensor):
+        return x + 1
+
+
+_EXTERNAL_DATA_AOT_FORWARD_FLAG = (
+    os.environ.get("VLLM_TEST_AOT_FORWARD_FLAG", "0") == "1"
+)
+
+
+@support_torch_compile
+class ExternalDataAOTMod(torch.nn.Module):
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    @_capture_forward_state(True)
+    @_capture_forward_state(_EXTERNAL_DATA_AOT_FORWARD_FLAG)
+    def forward(self, x: torch.Tensor):
+        return x + 1
+
+
+@support_torch_compile
+class UnsupportedExternalDataAOTMod(torch.nn.Module):
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    @_capture_unsupported_forward_state()
+    def forward(self, x: torch.Tensor):
+        return x + 1
+
+
+def _install_canonical_forward_model(
+    monkeypatch: pytest.MonkeyPatch, model_name: str, forward
+) -> torch.nn.Module:
+    """Install a dynamic model so module/qualname lookup resolves its forward."""
+    forward.__module__ = __name__
+    forward.__qualname__ = f"{model_name}.forward"
+    model_type = type(
+        model_name,
+        (torch.nn.Module,),
+        {"__module__": __name__, "forward": forward},
+    )
+    monkeypatch.setattr(sys.modules[__name__], model_name, model_type, raising=False)
+    return model_type()
+
+
+@pytest.mark.parametrize("inherited", [False, True])
+def test_forward_external_data_describes_direct_and_inherited_forward(inherited: bool):
+    if inherited:
+
+        class Model(ExternalDataDecoratedMod):
+            pass
+
+        model = Model()
+    else:
+        model = ExternalDataDecoratedMod()
+
+    outer = model.forward.__func__
+    inner = outer.__wrapped__
+    original = inner.__wrapped__
+
+    external_data = compilation_decorators._get_forward_external_data(model)
+
+    assert external_data is not None
+    assert set(external_data.values()) == {inner, original}
+    expected_prefix = (
+        f"aot:model-forward:{outer.__module__}:{outer.__qualname__}:wrapped:"
+    )
+    assert all(key.startswith(expected_prefix) for key in external_data)
+
+
+@pytest.mark.parametrize("case", ["instance_override", "noncanonical_outer"])
+def test_forward_external_data_rejects_unstable_outer_function(case: str):
+    if case == "instance_override":
+        model = ExternalDataDecoratedMod()
+        object.__setattr__(model, "forward", lambda x: x)
+    else:
+
+        class NonCanonicalOuterMod(torch.nn.Module):
+            @_capture_forward_state(False)
+            def forward(self, x):
+                return x
+
+        model = NonCanonicalOuterMod()
+
+    assert compilation_decorators._get_forward_external_data(model) is None
+
+
+@pytest.mark.parametrize("case", ["non_function", "cycle", "excessive_chain"])
+def test_forward_external_data_rejects_malformed_wrapped_chain(
+    case: str, monkeypatch: pytest.MonkeyPatch
+):
+    def original(self, x):
+        return x
+
+    if case == "excessive_chain":
+        outer = original
+        for _ in range(33):
+            outer = _capture_forward_state(False)(outer)
+    else:
+        outer = _capture_forward_state(False)(original)
+        monkeypatch.setattr(
+            outer,
+            "__wrapped__",
+            object() if case == "non_function" else outer,
+        )
+
+    model = _install_canonical_forward_model(
+        monkeypatch, "_MalformedWrappedChainMod", outer
+    )
+
+    assert compilation_decorators._get_forward_external_data(model) is None
+
+
+@pytest.mark.parametrize("case", ["empty_closure_cell", "missing_inner_metadata"])
+def test_forward_external_data_rejects_invalid_inner_state(
+    case: str, monkeypatch: pytest.MonkeyPatch
+):
+    def original(self, x):
+        return x
+
+    if case == "empty_closure_cell":
+        flag = True
+
+        @functools.wraps(original)
+        def outer(*args, **kwargs):
+            if flag:
+                return original(*args, **kwargs)
+            return original(*args, **kwargs)
+
+        del flag
+    else:
+        outer = _capture_forward_state(False)(original)
+        outer.__wrapped__.__module__ = None
+
+    model = _install_canonical_forward_model(
+        monkeypatch, "_InvalidInnerStateMod", outer
+    )
+
+    assert compilation_decorators._get_forward_external_data(model) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, ("none",)),
+        (False, ("bool", "0")),
+        (True, ("bool", "1")),
+        (10**100, ("int", str(10**100))),
+        (-12345678901234567890, ("int", "-12345678901234567890")),
+        (0.0, ("float", "0x0.0p+0")),
+        (-0.0, ("float", "-0x0.0p+0")),
+        ("forward-state", ("str", "forward-state")),
+        (b"\x00\xff", ("bytes", "00ff")),
+        (
+            (None, True, 7, "nested"),
+            (
+                "tuple",
+                (
+                    ("none",),
+                    ("bool", "1"),
+                    ("int", "7"),
+                    ("str", "nested"),
+                ),
+            ),
+        ),
+    ],
+)
+def test_normalize_aot_external_state_uses_tagged_values(value, expected):
+    assert compilation_decorators._normalize_aot_external_state(value) == expected
+
+
+def test_normalize_aot_external_state_only_accepts_next_wrapped_function():
+    def next_wrapped():
+        pass
+
+    assert compilation_decorators._normalize_aot_external_state(
+        next_wrapped,
+        next_wrapped=next_wrapped,
+        next_depth=2,
+    ) == ("wrapped", "2")
+
+    with pytest.raises(compilation_decorators._UnsupportedAOTExternalState):
+        compilation_decorators._normalize_aot_external_state(lambda: None)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [],
+        {},
+        set(),
+        frozenset(),
+        object(),
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+    ],
+)
+def test_normalize_aot_external_state_rejects_unsupported_values(value):
+    with pytest.raises(compilation_decorators._UnsupportedAOTExternalState):
+        compilation_decorators._normalize_aot_external_state(value)
+
+
+def test_normalize_aot_external_state_rejects_excessive_depth():
+    value: object = None
+    for _ in range(33):
+        value = (value,)
+
+    with pytest.raises(compilation_decorators._UnsupportedAOTExternalState):
+        compilation_decorators._normalize_aot_external_state(value)
+
+
+@pytest.mark.parametrize("flag_depth", [0, 1])
+def test_forward_external_data_key_covers_complete_decorator_chain(
+    monkeypatch: pytest.MonkeyPatch,
+    flag_depth: int,
+):
+    def build_model(flag: bool):
+        flags = [False, False]
+        flags[flag_depth] = flag
+
+        @_capture_forward_state(flags[0])
+        @_capture_forward_state(flags[1])
+        @_capture_forward_state(False)
+        def forward(self, x):
+            return x
+
+        return _install_canonical_forward_model(
+            monkeypatch, "_CanonicalChainHolder", forward
+        )
+
+    false_model = build_model(False)
+    false_keys = compilation_decorators._get_forward_external_data(false_model)
+
+    true_model = build_model(True)
+    true_keys = compilation_decorators._get_forward_external_data(true_model)
+
+    assert false_keys is not None
+    assert true_keys is not None
+    assert false_keys.keys().isdisjoint(true_keys.keys())
+
+
+@_capture_forward_state(False)
+def _canonical_middle_forward(self, x):
+    return x
+
+
+def test_forward_external_data_skips_canonical_inner_function(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    next_forward = _canonical_middle_forward
+
+    def outer(self, x):
+        return next_forward(self, x)
+
+    outer.__wrapped__ = next_forward
+    model = _install_canonical_forward_model(
+        monkeypatch, "_CanonicalInnerHolder", outer
+    )
+
+    external_data = compilation_decorators._get_forward_external_data(model)
+
+    assert external_data is not None
+    assert next_forward not in external_data.values()
+    assert next_forward.__wrapped__ in external_data.values()
+
+
+def test_forward_external_data_does_not_hide_internal_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        compilation_decorators,
+        "_normalize_aot_external_state",
+        Mock(side_effect=RuntimeError("fingerprint bug")),
+    )
+
+    with pytest.raises(RuntimeError, match="fingerprint bug"):
+        compilation_decorators._get_forward_external_data(ExternalDataDecoratedMod())
+
+
+def test_forward_external_data_rejects_unsupported_closure_state():
+    # This helper inspects class metadata only; avoid the compile-aware __init__.
+    model = UnsupportedExternalDataAOTMod.__new__(UnsupportedExternalDataAOTMod)
+
+    assert compilation_decorators._get_forward_external_data(model) is None
+
+
+@pytest.mark.parametrize(
+    ("supports_external_data", "external_data"),
+    [(False, None), (True, None), (True, {})],
+)
+def test_save_aot_compiled_function_uses_compatible_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    supports_external_data: bool,
+    external_data: dict | None,
+):
+    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "0")
+    monkeypatch.setattr(
+        compilation_decorators,
+        "_SUPPORTS_AOT_EXTERNAL_DATA",
+        supports_external_data,
+    )
+    disable_envs_cache()
+    model = ExternalDataDecoratedMod()
+    model.was_aot_compile_fn_loaded_from_disk = False
+    model._aot_cache_dir = str(tmp_path)
+    model._aot_compilation_path = str(tmp_path / "model")
+    saved_paths = []
+
+    class StandardCompiledFunction:
+        def save_compiled_function(self, path):
+            saved_paths.append(path)
+            Path(path).touch()
+
+    model.aot_compiled_fn = StandardCompiledFunction()
+    helper = Mock(return_value=external_data)
+    if not supports_external_data:
+        helper.side_effect = AssertionError("helper requires torch 2.11+")
+
+    with patch.object(
+        compilation_decorators,
+        "_get_forward_external_data",
+        helper,
+    ):
+        CompiledMod.save_aot_compiled_function(model)
+
+    assert helper.call_count == int(supports_external_data)
+    assert saved_paths == [f"{model._aot_compilation_path}.{os.getpid()}.tmp"]
+    assert Path(model._aot_compilation_path).exists()
+
+
+@pytest.mark.parametrize(
+    ("supports_external_data", "external_data"),
+    [(False, None), (True, None), (True, {})],
+)
+def test_load_aot_compiled_function_uses_compatible_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    supports_external_data: bool,
+    external_data: dict | None,
+):
+    monkeypatch.setenv("VLLM_FORCE_AOT_LOAD", "0")
+    monkeypatch.setattr(
+        compilation_decorators,
+        "_SUPPORTS_AOT_EXTERNAL_DATA",
+        supports_external_data,
+    )
+    disable_envs_cache()
+    artifact = tmp_path / "model"
+    artifact.write_bytes(b"invalid")
+    model = ExternalDataDecoratedMod()
+    model.vllm_config = Mock()
+    model._is_encoder = False
+    calls = []
+
+    def standard_load(file, *, f_globals=None):
+        calls.append((file, f_globals))
+        raise RuntimeError("stop after argument capture")
+
+    helper = Mock(return_value=external_data)
+    if not supports_external_data:
+        helper.side_effect = AssertionError("helper requires torch 2.11+")
+
+    with (
+        patch.object(
+            compilation_decorators,
+            "monitor_torch_compile",
+            return_value=nullcontext(),
+        ),
+        patch.object(
+            compilation_decorators,
+            "_get_forward_external_data",
+            helper,
+        ),
+        patch.object(torch.compiler, "load_compiled_function", standard_load),
+    ):
+        loaded = compilation_decorators._try_load_aot_compiled_fn(model, str(artifact))
+
+    assert helper.call_count == int(supports_external_data)
+    assert loaded is None
+    assert len(calls) == 1
+    assert calls[0][1] is model.forward.__globals__
+
+
+@pytest.mark.parametrize("force_load", [False, True])
+def test_forward_external_data_failure_obeys_load_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, force_load: bool
+):
+    monkeypatch.setenv("VLLM_FORCE_AOT_LOAD", "1" if force_load else "0")
+    disable_envs_cache()
+    artifact = tmp_path / "model"
+    artifact.write_bytes(b"unused")
+    model = ExternalDataDecoratedMod()
+    model.vllm_config = Mock()
+    model._is_encoder = False
+
+    with (
+        patch.object(
+            compilation_decorators,
+            "monitor_torch_compile",
+            return_value=nullcontext(),
+        ),
+        patch.object(
+            compilation_decorators,
+            "_get_forward_external_data",
+            side_effect=RuntimeError("unsafe decorator state"),
+        ),
+        patch.object(torch.compiler, "load_compiled_function") as load_mock,
+    ):
+        if force_load:
+            with pytest.raises(RuntimeError, match="unsafe decorator state"):
+                compilation_decorators._try_load_aot_compiled_fn(model, str(artifact))
+        else:
+            assert (
+                compilation_decorators._try_load_aot_compiled_fn(model, str(artifact))
+                is None
+            )
+
+    load_mock.assert_not_called()
+
+
+def _run_external_data_aot_process(result_path: str) -> None:
+    """Run one AOT phase in a fresh interpreter and persist its outcome."""
+    disable_envs_cache()
+    torch.manual_seed(0)
+    args = (torch.arange(100, device="cuda", dtype=torch.float32).reshape(10, 10),)
+    vllm_config = make_vllm_config()
+    model = None
+    try:
+        with use_vllm_config(vllm_config):
+            model_type = (
+                UnsupportedExternalDataAOTMod
+                if os.environ.get("VLLM_TEST_AOT_UNSUPPORTED_STATE") == "1"
+                else ExternalDataAOTMod
+            )
+            model = model_type(vllm_config=vllm_config)
+            output = model(*args)
+        result = {
+            "output": output.cpu().tolist(),
+            "loaded_from_disk": model.was_aot_compile_fn_loaded_from_disk,
+        }
+    except Exception as exc:
+        result = {
+            "error": f"{type(exc).__name__}: {exc}",
+            "loaded_from_disk": False,
+        }
+        raise
+    finally:
+        result.update(
+            {
+                "num_aot_compiles": compilation_counter.num_aot_compiles,
+                "num_aot_artifacts_saved": (
+                    compilation_counter.num_aot_artifacts_saved
+                ),
+                "num_aot_artifacts_loaded": (
+                    compilation_counter.num_aot_artifacts_loaded
+                ),
+                "artifact_exists": bool(
+                    model is not None
+                    and (artifact_path := getattr(model, "_aot_compilation_path", None))
+                    and Path(artifact_path).exists()
+                ),
+            }
+        )
+        Path(result_path).write_text(json.dumps(result))
+
+
+def _launch_external_data_aot_process(
+    cache_root: Path,
+    result_path: Path,
+    *,
+    force_load: bool,
+    forward_flag: bool = False,
+    unsupported_state: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], dict]:
+    """Launch an isolated process so no in-memory compile state is reused."""
+    env = os.environ.copy()
+    env.update(
+        {
+            "VLLM_CACHE_ROOT": str(cache_root),
+            "VLLM_USE_AOT_COMPILE": "1",
+            "VLLM_USE_MEGA_AOT_ARTIFACT": "1",
+            "VLLM_USE_STANDALONE_COMPILE": "1",
+            "VLLM_TEST_AOT_FORWARD_FLAG": "1" if forward_flag else "0",
+            "VLLM_TEST_AOT_UNSUPPORTED_STATE": ("1" if unsupported_state else "0"),
+        }
+    )
+    if force_load:
+        env["VLLM_FORCE_AOT_LOAD"] = "1"
+    else:
+        env.pop("VLLM_FORCE_AOT_LOAD", None)
+    code = (
+        "import sys; "
+        "from tests.compile.test_aot_compile import "
+        "_run_external_data_aot_process; "
+        "_run_external_data_aot_process(sys.argv[1])"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code, str(result_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=600,
+    )
+    result = json.loads(result_path.read_text()) if result_path.exists() else {}
+    return completed, result
+
+
+@pytest.mark.skipif(not is_torch_equal_or_newer("2.10.0"), reason="requires torch 2.10")
+def test_unsupported_closure_state_is_nonfatal_during_real_save(tmp_path: Path):
+    process, result = _launch_external_data_aot_process(
+        tmp_path / "cache",
+        tmp_path / "unsupported.json",
+        force_load=False,
+        unsupported_state=True,
+    )
+
+    assert process.returncode == 0, process.stderr
+    assert result["output"] == torch.arange(100).reshape(10, 10).add(1).tolist()
+    assert result["num_aot_artifacts_saved"] == 0
+    assert result["artifact_exists"] is False
+    logs = f"{process.stdout}\n{process.stderr}".lower()
+    assert "unable to save aot compiled function" in logs
+
+
+@pytest.mark.skipif(
+    not is_torch_equal_or_newer("2.11.0"),
+    reason="requires AOT external_data support in torch 2.11+",
+)
+def test_external_data_aot_cache_loads_across_fresh_processes(tmp_path: Path):
+    cache_root = tmp_path / "cache"
+    cold_process, cold = _launch_external_data_aot_process(
+        cache_root, tmp_path / "cold.json", force_load=False
+    )
+    assert cold_process.returncode == 0, cold_process.stderr
+    assert cold["num_aot_compiles"] == 1
+    assert cold["num_aot_artifacts_saved"] == 1
+    assert cold["num_aot_artifacts_loaded"] == 0
+    assert cold["loaded_from_disk"] is False
+
+    warm_process, warm = _launch_external_data_aot_process(
+        cache_root, tmp_path / "warm.json", force_load=True
+    )
+    assert warm_process.returncode == 0, warm_process.stderr
+    assert warm["num_aot_compiles"] == 0
+    assert warm["num_aot_artifacts_saved"] == 0
+    assert warm["num_aot_artifacts_loaded"] == 1
+    assert warm["loaded_from_disk"] is True
+    assert warm["output"] == cold["output"]
+
+
+@pytest.mark.skipif(
+    not is_torch_equal_or_newer("2.11.0"),
+    reason="requires AOT external_data support in torch 2.11+",
+)
+def test_external_data_fingerprint_mismatch_obeys_load_mode(tmp_path: Path):
+    cache_root = tmp_path / "cache"
+
+    # Save an artifact whose wrapper flag uses the old behavior.
+    cold_process, cold = _launch_external_data_aot_process(
+        cache_root,
+        tmp_path / "cold.json",
+        force_load=False,
+        forward_flag=False,
+    )
+    assert cold_process.returncode == 0, cold_process.stderr
+    assert cold["num_aot_artifacts_saved"] == 1
+
+    # Forced loading must reject the old fingerprint before compiling.
+    forced_process, forced = _launch_external_data_aot_process(
+        cache_root,
+        tmp_path / "forced.json",
+        force_load=True,
+        forward_flag=True,
+    )
+    assert forced_process.returncode != 0
+    assert "external reference" in forced["error"].lower()
+    assert forced["num_aot_compiles"] == 0
+    assert forced["num_aot_artifacts_loaded"] == 0
+
+    # Normal mode falls back to compilation and must run the new behavior.
+    warm_process, warm = _launch_external_data_aot_process(
+        cache_root,
+        tmp_path / "warm.json",
+        force_load=False,
+        forward_flag=True,
+    )
+    assert warm_process.returncode == 0, warm_process.stderr
+    assert warm["num_aot_compiles"] == 1
+    assert warm["num_aot_artifacts_loaded"] == 0
+    assert warm["loaded_from_disk"] is False
+    assert warm["output"] != cold["output"]
+    assert torch.equal(torch.tensor(warm["output"]), torch.tensor(cold["output"]) + 1)
+    logs = f"{warm_process.stdout}\n{warm_process.stderr}".lower()
+    assert "compiling model again due to a load failure" in logs
 
 
 def make_vllm_config() -> VllmConfig:

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -4,6 +4,8 @@
 import contextlib
 import hashlib
 import inspect
+import json
+import math
 import os
 import sys
 from collections.abc import Callable, Generator
@@ -34,6 +36,9 @@ from .monitor import monitor_profiling_run, monitor_torch_compile
 
 # shape_id parameter was added to mark_unbacked in PyTorch 2.11.0
 _SUPPORTS_SHAPE_ID = is_torch_equal_or_newer("2.11.0")
+# external_data was added to the AOT save/load APIs in PyTorch 2.11.0
+_SUPPORTS_AOT_EXTERNAL_DATA = is_torch_equal_or_newer("2.11.0")
+_MAX_AOT_EXTERNAL_STATE_DEPTH = 32
 
 if TYPE_CHECKING:
     # Only added on nightly/2.10 so wrap
@@ -262,6 +267,193 @@ def _model_hash_key(fn: Callable[..., Any]) -> str:
     return sha256_hash.hexdigest()
 
 
+class _UnsupportedAOTExternalState(Exception):
+    pass
+
+
+def _normalize_aot_external_state(
+    value: Any,
+    *,
+    next_wrapped: Callable[..., Any] | None = None,
+    next_depth: int | None = None,
+    _depth: int = 0,
+) -> tuple[Any, ...]:
+    """Normalize immutable decorator state deterministically."""
+    if _depth > _MAX_AOT_EXTERNAL_STATE_DEPTH:
+        raise _UnsupportedAOTExternalState("maximum depth exceeded")
+
+    value_type = type(value)
+    if value is None:
+        return ("none",)
+    if value_type is bool:
+        return ("bool", "1" if value else "0")
+    if value_type is int:
+        return ("int", str(value))
+    if value_type is float:
+        if not math.isfinite(value):
+            raise _UnsupportedAOTExternalState("non-finite float")
+        return ("float", value.hex())
+    if value_type is str:
+        return ("str", value)
+    if value_type is bytes:
+        return ("bytes", value.hex())
+
+    if inspect.isfunction(value):
+        # Function identities are not stable across processes. Only the
+        # validated edge to the next wrapper has a stable chain position.
+        if value is next_wrapped and next_depth is not None:
+            return ("wrapped", str(next_depth))
+        raise _UnsupportedAOTExternalState("function")
+
+    # Keep the state protocol narrow: exact tuples provide immutable, ordered
+    # nesting; other containers may be mutable, unordered, or carry custom state.
+    if value_type is not tuple:
+        raise _UnsupportedAOTExternalState(value_type.__qualname__)
+
+    return (
+        "tuple",
+        tuple(
+            _normalize_aot_external_state(
+                item,
+                next_wrapped=next_wrapped,
+                next_depth=next_depth,
+                _depth=_depth + 1,
+            )
+            for item in value
+        ),
+    )
+
+
+def _is_canonical_function(function: Callable[..., Any]) -> bool:
+    """Return whether standard pickle can resolve this function by name."""
+    module = getattr(function, "__module__", None)
+    qualname = getattr(function, "__qualname__", None)
+    if not isinstance(module, str) or not module:
+        return False
+    if not isinstance(qualname, str) or not qualname or "<locals>" in qualname:
+        return False
+
+    resolved: Any = sys.modules.get(module)
+    if resolved is None:
+        return False
+    try:
+        # Static lookup avoids binding descriptors while walking the qualname.
+        for name in qualname.split("."):
+            resolved = inspect.getattr_static(resolved, name)
+    except AttributeError:
+        return False
+    return resolved is function
+
+
+def _get_forward_external_data(model: Any) -> dict[str, Any] | None:
+    """Build stable external references for a decorated model ``forward``.
+
+    Return ``None`` when the complete wrapper chain cannot be described safely.
+    """
+    try:
+        # Instance-level overrides cannot be reconstructed from class metadata.
+        if "forward" in vars(model):
+            return None
+        bound_forward = model.forward
+        static_forward = inspect.getattr_static(type(model), "forward")
+        effective_forward = (
+            bound_forward.__func__ if inspect.ismethod(bound_forward) else bound_forward
+        )
+        if (
+            not inspect.isfunction(static_forward)
+            or effective_forward is not static_forward
+        ):
+            return None
+
+        # This mapping handles inner wrappers only; the outer function still
+        # needs to be picklable through its module and qualified name.
+        if not _is_canonical_function(effective_forward):
+            return None
+
+        # Validate the complete chain before creating any external references,
+        # rejecting cycles and pathologically deep decorator stacks.
+        chain: list[Callable[..., Any]] = []
+        seen: set[int] = set()
+        current = effective_forward
+        for depth in range(_MAX_AOT_EXTERNAL_STATE_DEPTH + 1):
+            if not inspect.isfunction(current) or id(current) in seen:
+                return None
+            module = getattr(current, "__module__", None)
+            qualname = getattr(current, "__qualname__", None)
+            if not isinstance(module, str) or not module:
+                return None
+            if not isinstance(qualname, str) or not qualname:
+                return None
+            seen.add(id(current))
+            chain.append(current)
+
+            wrapped = getattr(current, "__wrapped__", None)
+            if wrapped is None:
+                break
+            if depth == _MAX_AOT_EXTERNAL_STATE_DEPTH:
+                return None
+            current = wrapped
+
+        # Defaults and named closure values are compile-time wrapper state. Put
+        # every layer into the fingerprint so configuration changes invalidate
+        # all external keys for the chain.
+        chain_state: list[tuple[Any, ...]] = []
+        for depth, forward in enumerate(chain):
+            next_wrapped = chain[depth + 1] if depth + 1 < len(chain) else None
+            closure = forward.__closure__ or ()
+            if len(forward.__code__.co_freevars) != len(closure):
+                raise _UnsupportedAOTExternalState("invalid closure")
+            closure_values = []
+            for name, cell in zip(forward.__code__.co_freevars, closure):
+                try:
+                    closure_values.append((name, cell.cell_contents))
+                except ValueError as exc:
+                    raise _UnsupportedAOTExternalState("empty closure cell") from exc
+            state = (
+                ("module", forward.__module__),
+                ("qualname", forward.__qualname__),
+                ("defaults", forward.__defaults__),
+                (
+                    "kwdefaults",
+                    tuple(sorted(forward.__kwdefaults__.items()))
+                    if forward.__kwdefaults__ is not None
+                    else None,
+                ),
+                ("closure", tuple(closure_values)),
+            )
+            chain_state.append(
+                _normalize_aot_external_state(
+                    state,
+                    next_wrapped=next_wrapped,
+                    next_depth=depth + 1 if next_wrapped is not None else None,
+                )
+            )
+
+        chain_fingerprint = hashlib.sha256(
+            json.dumps(
+                ("chain", tuple(chain_state)),
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()
+        external_data: dict[str, Any] = {}
+        # Canonical functions remain on standard pickle. Only shadowed inner
+        # wrappers need identity-based external references.
+        for depth, forward in enumerate(chain):
+            if depth == 0 or _is_canonical_function(forward):
+                continue
+            key = (
+                f"aot:model-forward:{forward.__module__}:{forward.__qualname__}:"
+                f"wrapped:{depth}:{chain_fingerprint}"
+            )
+            external_data[key] = forward
+        return external_data
+    except _UnsupportedAOTExternalState:
+        # A partial map could leave unresolved functions in the artifact, so
+        # unsupported state falls back to the original path as a whole.
+        return None
+
+
 def _verify_source_unchanged(
     source_info: "SourceInfo", vllm_config: VllmConfig
 ) -> None:
@@ -296,9 +488,22 @@ def _try_load_aot_compiled_fn(
                 set_current_vllm_config(model.vllm_config),
                 open(aot_compilation_path, "rb") as f,
             ):
-                loaded_fn = torch.compiler.load_compiled_function(
-                    f, f_globals=model.forward.__globals__
+                external_data = (
+                    _get_forward_external_data(model)
+                    if _SUPPORTS_AOT_EXTERNAL_DATA
+                    else None
                 )
+                if external_data:
+                    loaded_fn = torch.compiler.load_compiled_function(
+                        f,
+                        f_globals=model.forward.__globals__,
+                        external_data=external_data,
+                    )
+                else:
+                    loaded_fn = torch.compiler.load_compiled_function(
+                        f,
+                        f_globals=model.forward.__globals__,
+                    )
             _verify_source_unchanged(loaded_fn.source_info(), model.vllm_config)
             ds_config = model.compilation_config.dynamic_shapes_config
             if not ds_config.evaluate_guards:
@@ -702,7 +907,17 @@ def _support_torch_compile(
             # File saving should be atomic, so we will save to a temporary location
             # first. Should be upstreamed to PyTorch 2.12 as well.
             tmp_file = f"{self._aot_compilation_path}.{os.getpid()}.tmp"
-            self.aot_compiled_fn.save_compiled_function(tmp_file)
+            external_data = (
+                _get_forward_external_data(self)
+                if _SUPPORTS_AOT_EXTERNAL_DATA
+                else None
+            )
+            if external_data:
+                self.aot_compiled_fn.save_compiled_function(
+                    tmp_file, external_data=external_data
+                )
+            else:
+                self.aot_compiled_fn.save_compiled_function(tmp_file)
             os.replace(tmp_file, self._aot_compilation_path)
             compilation_counter.num_aot_artifacts_saved += 1
             logger.info_once(


### PR DESCRIPTION
## Purpose

The Transformers backend can fail to save its AOT artifact when a model's
`forward` is wrapped by decorators. The artifact may reference a function from
the `__wrapped__` chain which is no longer importable by identity, so standard
pickle fails with errors such as:

```text
Can't pickle <function Qwen3Model.forward ...>: it's not the same object as
transformers.models.qwen3.modeling_qwen3.Qwen3Model.forward
```

This makes every warm start compile again even when the rest of the compile
cache is warm.

This PR uses PyTorch's `external_data` support to save and restore the
non-canonical functions in a decorated `forward` chain. The external keys
include a deterministic fingerprint of the whole chain, including defaults,
keyword defaults, and supported immutable closure state, so an artifact is not
reused when decorator configuration changes.

The mapping is all-or-nothing and unsupported state falls back to the existing
save/load behavior. The existing PyTorch 2.10 call path is unchanged;
`external_data` is only passed on PyTorch 2.11+.

This addresses the AOT warm-start cache failure identified in #50128. It does
not claim to eliminate or fully explain the remaining Transformers-backend
startup gap tracked by that issue.

## Test Plan

- Added unit coverage for decorated-forward resolution, deterministic chain
  fingerprints, unsupported state, canonical inner functions, inherited
  forwards, invalid/cyclic chains, and PyTorch 2.10 API compatibility.
- Added real AOT compile/save tests for the unsupported-state non-fatal path.
- Added cross-process tests for cold save + forced warm load and for fingerprint
  mismatch in normal and forced-load modes.
- Ran the complete AOT compile test file with the configuration that executes
  the functorch test instead of conditionally skipping it:

```bash
VLLM_USE_MEGA_AOT_ARTIFACT=0 pytest -q tests/compile/test_aot_compile.py
ruff check vllm/compilation/decorators.py tests/compile/test_aot_compile.py
ruff format --check vllm/compilation/decorators.py tests/compile/test_aot_compile.py
git diff --check
```

- Ran fresh-process cold + three warm-start checks on an NVIDIA L20 with
  PyTorch 2.13.0+cu129 and Transformers 5.15.0. Warm runs used
  `VLLM_FORCE_AOT_LOAD=1` so a failed load could not silently recompile.

## Test Result

```text
71 passed, 16 warnings in 178.91s
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

The warnings are existing dependency deprecations from PyTorch JIT (14) and
CUDA Python (2).

Fresh-process results:

| Model | Cold init | Warm init median | Warm compile median | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Qwen3-0.6B | 38.391 → 38.704 s | 25.737 → 17.632 s | 8.28 → 0.13 s | 31.5% |
| TinyLlama-1.1B | 29.360 → 29.056 s | 19.739 → 13.837 s | 5.80 → 0.12 s | 29.9% |
| Qwen3-14B | 50.103 → 50.033 s | 36.520 → 24.792 s | 11.36 → 0.13 s | 32.1% |

Values are `before → after`. All after-fix forced warm runs loaded the AOT
artifact with `compiles=0, loaded=1`.

<details>
<summary>Raw runs and AOT counters</summary>

| Model | Revision | Warm init runs | Warm compile runs | Cold counters | Warm counters |
| --- | --- | --- | --- | --- | --- |
| Qwen3-0.6B | Before | 25.755 / 25.737 / 25.571 s | 8.28 / 8.40 / 8.26 s | `1/0/0` | `1/0/0` |
| Qwen3-0.6B | After | 17.403 / 17.632 / 17.757 s | 0.13 / 0.12 / 0.13 s | `1/1/0` | `0/0/1` |
| TinyLlama-1.1B | Before | 19.807 / 19.739 / 19.723 s | 5.80 / 5.82 / 5.77 s | `1/0/0` | `1/0/0` |
| TinyLlama-1.1B | After | 13.962 / 13.800 / 13.837 s | 0.12 / 0.12 / 0.12 s | `1/1/0` | `0/0/1` |
| Qwen3-14B | Before | 36.307 / 36.520 / 36.533 s | 11.36 / 11.41 / 11.33 s | `1/0/0` | `1/0/0` |
| Qwen3-14B | After | 25.005 / 24.754 / 24.792 s | 0.13 / 0.14 / 0.13 s | `1/1/0` | `0/0/1` |

Counters are `compiled/saved/loaded`. Before the fix, every warm process
compiled again because artifact saving failed. After the fix, every forced
warm process loaded the artifact without compiling.

</details>

For every model, cold and warm runs produced identical token IDs.

## AI Assistance

Developed with assistance from OpenAI Codex. I reviewed all changes and
verified the reported tests and benchmarks.
