### PR TITLE
[Docs] Document 7 undocumented kv_cache_dtype values

### DIFF
--- a/docs/features/quantization/quantized_kvcache.md
+++ b/docs/features/quantization/quantized_kvcache.md
@@ -39,6 +39,16 @@ You can configure how the quantization scales are computed in vLLM using three d
 - `kv_cache_dtype="auto"`: Use the model's default data type
 - `kv_cache_dtype="fp8_e4m3"`: Supported on CUDA 11.8+ and ROCm (AMD GPUs)
 - `kv_cache_dtype="fp8_e5m2"`: Supported on CUDA 11.8+
+- `kv_cache_dtype="fp8_inc"`: FP8 KV-cache dtype used on Intel Gaudi (HPU)
+- `kv_cache_dtype="fp8_ds_mla"`: Packed FP8 layout for DeepSeek's sparse MLA attention backends (FlashMLA / FlashInfer MLA sparse). For DeepSeek-V3.2 this is 512 NoPE + 16 scale + 128 RoPE bytes per token (656 bytes total); DeepSeek-V4 uses a different, 584-byte layout (448 NoPE + 128 RoPE + 8 scale bytes) — the exact byte structure is model-specific, not a fixed format. Some models (e.g. DeepSeek-V3.2) already default `kv_cache_dtype="fp8"` to this layout
+- `kv_cache_dtype="int4_per_token_head"`: Dynamic (no calibration) INT4 quantization with a separate scale per (token, KV head) pair, computed at runtime. Two 4-bit values are packed per storage byte, pre-rotated with a random Hadamard transform to smooth outliers (the head dimension must be a power of 2 for this transform), with an asymmetric zero-point hidden in the scale's low mantissa bits. Requires the Triton attention backend
+- `kv_cache_dtype="int8_per_token_head"`: Dynamic (no calibration) INT8 quantization with a separate scale per (token, KV head) pair, computed at runtime. Requires the Triton attention backend
+- `kv_cache_dtype="fp8_per_token_head"`: Dynamic (no calibration) FP8 quantization with a separate scale per (token, KV head) pair, computed at runtime. Requires the Triton attention backend and CUDA compute capability 8.9+ (like the other `fp8*` dtypes on this backend)
+- `kv_cache_dtype="nvfp4"`: NVIDIA's FP4 format — packed FP4 data with FP8 block scales, stored as separate per-head K/V slots. Requires FlashInfer's TensorRT-LLM-gen kernel path on SM100 (Blackwell datacenter-class GPUs), not just the FlashInfer backend generally
+- `kv_cache_dtype="nvfp4_4over6"`: An NVFP4 variant that, for each block of 16 values, picks between a max/6 and a max/4 scale by minimizing squared reconstruction error. Same SM100 TensorRT-LLM-gen requirement as `nvfp4`
+
+> **Note:**
+> The three `*_per_token_head` modes are a third, finer-grained alternative to the per-tensor and per-attention-head schemes described above: rather than one scale per tensor or per attention head, they compute a separate scale for every individual (token, KV head) pair dynamically at inference time, with no calibration step.
 
 ### Skipping Specific Layers from KV-Cache Quantization
 


### PR DESCRIPTION
## Summary

`docs/features/quantization/quantized_kvcache.md`'s `kv_cache_dtype` options list covers 3 of the 17 values `CacheDType` (`vllm/config/cache.py`) actually supports. This documents 7 of the remaining 11: `fp8_inc`, `fp8_ds_mla`, `int4_per_token_head`, `int8_per_token_head`, `fp8_per_token_head`, `nvfp4`, `nvfp4_4over6`.

Scoped to these 7 specifically because the other 4 undocumented values are the `turboquant_*` family, already the subject of the open (stalled, needs-rebase) #45422 — adding them here would collide with that PR.

## Why this doesn't duplicate an existing PR

Checked #49050 (open — despite how it's been described elsewhere, its actual diff only adds a performance section and swaps an example model, it doesn't touch this options list) and #45422 (open, TurboQuant-only, explicitly excluded from this PR's scope for that reason). Searched for any other open PR touching `quantized_kvcache.md`, `nvfp4 docs`, or `per_token_head docs` — no other open PR documents these 7 values in this file. (#48782 is an NVFP4 doc PR but touches a different file, `modelopt.md`, about ModelOpt's weight quantization, unrelated to KV-cache dtypes.)

## How each was verified

All 7 documented from source (no hardware available to verify beyond that) — grepped every implementation site for each dtype and cross-checked backend-support lists and existing docstrings against `vllm/config/cache.py`, `vllm/utils/torch_utils.py`, `vllm/v1/kv_cache_interface.py`, `vllm/v1/attention/backends/{triton_attn,flashinfer}.py`, `vllm/v1/attention/backends/mla/{flashmla_sparse,flashinfer_mla_sparse}.py`, `vllm/v1/attention/ops/int4_per_token_head.py`, and `vllm/model_executor/layers/quantization/inc/inc.py`.

Notable corrections from an early draft, caught during review before submission:
- `fp8_inc` is not "calibrated via Intel Neural Compressor" — INC's actual code path is model-weight quantization, not KV-cache calibration. Worded to state only what's confirmed.
- `fp8_ds_mla`'s byte layout is model-specific, not universal: DeepSeek-V3.2 uses 656 bytes (512 NoPE + 16 scale + 128 RoPE), DeepSeek-V4 uses a different 584-byte layout (448 NoPE + 128 RoPE + 8 scale, different scale format). Both are now called out explicitly.
- `nvfp4`/`nvfp4_4over6` require FlashInfer's TensorRT-LLM-gen kernel path on SM100 (Blackwell datacenter GPUs) specifically, not just "the FlashInfer backend" generally.
- Added the CUDA SM89+ requirement for `fp8_per_token_head` and the power-of-two head-dimension constraint for `int4_per_token_head`'s Hadamard transform, both enforced in source but missing from the first draft.
- "per-(token, head)" corrected to "per-(token, KV head)" throughout — this is per-KV-head granularity, not per-query-head.

## Test Plan

Docs-only change, no code touched. Ran `npx markdownlint-cli2@0.21.0` (the exact version pinned in this repo's `.pre-commit-config.yaml`) against the file with `--fix`: 0 errors, 0 changes beyond the content edit.

## AI assistance disclosure

AI assistance (Claude) was used to research the source locations for each dtype and draft this documentation, and a second AI review pass (Codex, run independently against the live source) was used specifically to adversarially check the draft's technical claims — it caught the five corrections listed above before this was submitted. I independently re-verified each of those corrections against the cited source lines myself, and reviewed every line of the diff.