### PR TITLE
[ROCm][Perf] Reuse graph-stable attention metadata across Kimi-K3 cache groups

### DIFF
--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -14,6 +14,7 @@ from tests.v1.attention.utils import (
 )
 from vllm.config import SpeculativeConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.models.kimi_k3.amd.kda_metadata import KimiK3ROCmKDAMetadataBuilder
 from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
@@ -41,9 +42,6 @@ DEVICE = torch.device("cpu")
 PRUNED_METADATA_FIELDS = {
     "chunk_indices",
     "chunk_offsets",
-    "prefill_query_start_loc",
-    "prefill_state_indices",
-    "prefill_has_initial_state",
     "spec_sequence_masks",
 }
 
@@ -550,3 +548,59 @@ def test_aligned_block_table_matches_shared_gdn():
     )
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_mixed_regular_decode_and_prefill_preserves_prefill_views():
+    batch = BatchSpec(seq_lens=[65, 100], query_lens=[1, 50])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE
+    ).replace(is_prefilling=torch.tensor([False, True]))
+    actual = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+    ).build(0, common_attn_metadata)
+
+    assert actual.num_decodes == 1
+    assert actual.num_prefills == 1
+    assert actual.prefill_query_start_loc is not None
+    assert actual.prefill_state_indices is not None
+    assert actual.prefill_has_initial_state is not None
+    torch.testing.assert_close(
+        actual.prefill_query_start_loc,
+        torch.tensor([0, 50], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        actual.prefill_state_indices,
+        actual.non_spec_state_indices_tensor[1:],
+    )
+    torch.testing.assert_close(
+        actual.prefill_has_initial_state,
+        torch.tensor([True]),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_rocm_kimi_k3_prefill_builds_chunk_metadata_on_device():
+    device = torch.device("cuda")
+    batch = BatchSpec(seq_lens=[1024, 513], query_lens=[1024, 513])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, device
+    ).replace(is_prefilling=torch.tensor([True, True]))
+    reference = _make_builder(
+        GDNAttentionMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+        device=device,
+    ).build(0, common_attn_metadata)
+    actual = _make_builder(
+        KimiK3ROCmKDAMetadataBuilder,
+        num_speculative_tokens=0,
+        full_cuda_graph=False,
+        device=device,
+    ).build(0, common_attn_metadata)
+
+    assert actual.chunk_indices is not None
+    assert actual.chunk_offsets is not None
+    torch.testing.assert_close(actual.chunk_indices, reference.chunk_indices)
+    torch.testing.assert_close(actual.chunk_offsets, reference.chunk_offsets)

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -20,6 +20,7 @@ from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAMetadata,
     KimiK3KDAMetadataBuilder,
     _mamba_get_block_table_tensor,
+    stage_reused_spec_state_indices,
     stage_spec_decode_metadata,
 )
 from vllm.v1.attention.backend import AttentionMetadataBuilder
@@ -53,6 +54,9 @@ def _assert_matches_shared_gdn(
     assert actual.recoverssm_context is None
     for field in fields(GDNAttentionMetadata):
         actual_value = getattr(actual, field.name)
+        if field.name == "state_seq_lens":
+            assert actual_value is not None
+            continue
         expected_value = getattr(reference, field.name)
         if field.name in PRUNED_METADATA_FIELDS:
             assert actual_value is None
@@ -452,6 +456,8 @@ def test_kimi_k3_kda_backend_uses_private_metadata_builder():
     assert issubclass(KimiK3KDAAttentionBackend, GDNAttentionBackend)
     assert issubclass(KimiK3KDAMetadata, GDNAttentionMetadata)
     assert issubclass(KimiK3KDAMetadataBuilder, GDNAttentionMetadataBuilder)
+    assert not KimiK3KDAMetadataBuilder.supports_update_block_table
+    assert KimiK3KDAMetadataBuilder.supports_metadata_reuse
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
@@ -511,6 +517,168 @@ def test_stage_spec_decode_metadata_matches_pytorch():
     torch.testing.assert_close(staged_state_indices, expected_state_indices)
     torch.testing.assert_close(staged_query_start_loc, expected_query_start_loc)
     torch.testing.assert_close(staged_num_accepted_tokens, expected_num_accepted_tokens)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("mamba_cache_mode", ["none", "align"])
+def test_reused_kda_metadata_uses_shared_common_and_group_local_graph_buffers(
+    mamba_cache_mode: str,
+):
+    # "none" is the default. Only the aligned modes offset the state column by
+    # sequence position, so a reuse path that always applies the offset reads
+    # the wrong block-table column here (seq_lens 50/30 over BLOCK_SIZE 16 give
+    # offsets 3 and 1).
+    device = torch.device("cuda")
+    batch = BatchSpec(seq_lens=[50, 30], query_lens=[3, 3])
+    first_common = create_common_attn_metadata(batch, BLOCK_SIZE, device).replace(
+        is_prefilling=torch.tensor([False, False])
+    )
+    second_common = first_common.replace(
+        block_table_tensor=first_common.block_table_tensor.clone().add_(1000)
+    )
+    builders = [
+        _make_builder(
+            KimiK3KDAMetadataBuilder,
+            num_speculative_tokens=2,
+            full_cuda_graph=True,
+            device=device,
+            mamba_cache_mode=mamba_cache_mode,
+        )
+        for _ in range(3)
+    ]
+    source, reused, reference = builders
+    reused.share_reusable_metadata_buffers(source)
+    assert (
+        reused.spec_query_start_loc.data_ptr() == source.spec_query_start_loc.data_ptr()
+    )
+    assert (
+        reused.num_accepted_tokens.data_ptr() == source.num_accepted_tokens.data_ptr()
+    )
+    assert (
+        reused.spec_state_indices_tensor.data_ptr()
+        != source.spec_state_indices_tensor.data_ptr()
+    )
+
+    accepted = torch.tensor([3, 2], dtype=torch.int32, device=device)
+    drafts = torch.tensor([2, 2], dtype=torch.int32)
+    source_metadata = source.build(
+        0,
+        first_common,
+        num_accepted_tokens=accepted,
+        num_decode_draft_tokens_cpu=drafts,
+    )
+    reused_metadata = reused.update_block_table(
+        source_metadata,
+        second_common.block_table_tensor,
+        second_common.slot_mapping,
+    )
+    reference_metadata = reference.build(
+        0,
+        second_common,
+        num_accepted_tokens=accepted,
+        num_decode_draft_tokens_cpu=drafts,
+    )
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        reused_metadata.spec_state_indices_tensor,
+        reference_metadata.spec_state_indices_tensor,
+        rtol=0,
+        atol=0,
+    )
+
+    source_state = torch.empty_like(source_metadata.spec_state_indices_tensor)
+    reused_state = torch.empty_like(reused_metadata.spec_state_indices_tensor)
+    source_query = torch.empty_like(source_metadata.spec_query_start_loc)
+    reused_query = torch.empty_like(reused_metadata.spec_query_start_loc)
+    source_accepted = torch.empty_like(source_metadata.num_accepted_tokens)
+    reused_accepted = torch.empty_like(reused_metadata.num_accepted_tokens)
+    source_graph = torch.cuda.CUDAGraph()
+    reused_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(source_graph):
+        source_state.copy_(source_metadata.spec_state_indices_tensor)
+        source_query.copy_(source_metadata.spec_query_start_loc)
+        source_accepted.copy_(source_metadata.num_accepted_tokens)
+    with torch.cuda.graph(reused_graph):
+        reused_state.copy_(reused_metadata.spec_state_indices_tensor)
+        reused_query.copy_(reused_metadata.spec_query_start_loc)
+        reused_accepted.copy_(reused_metadata.num_accepted_tokens)
+
+    first_common.block_table_tensor.add_(7)
+    second_common.block_table_tensor.add_(11)
+    first_common.seq_lens.add_(16)
+    accepted.copy_(torch.tensor([1, 3], dtype=torch.int32, device=device))
+    source_metadata = source.build(
+        0,
+        first_common,
+        num_accepted_tokens=accepted,
+        num_decode_draft_tokens_cpu=drafts,
+    )
+    reused_metadata = reused.update_block_table(
+        source_metadata,
+        second_common.block_table_tensor,
+        second_common.slot_mapping,
+    )
+    reference_metadata = reference.build(
+        0,
+        second_common,
+        num_accepted_tokens=accepted,
+        num_decode_draft_tokens_cpu=drafts,
+    )
+    source_graph.replay()
+    reused_graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        source_state, source_metadata.spec_state_indices_tensor, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        reused_state, reference_metadata.spec_state_indices_tensor, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        source_query, source_metadata.spec_query_start_loc, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        reused_query, reference_metadata.spec_query_start_loc, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        source_accepted, source_metadata.num_accepted_tokens, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        reused_accepted, reference_metadata.num_accepted_tokens, rtol=0, atol=0
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_stage_reused_spec_state_indices_matches_aligned_reference():
+    device = torch.device("cuda")
+    num_spec_decodes = 33
+    batch_size = 65
+    block_table = torch.arange(
+        batch_size * 128, dtype=torch.int32, device=device
+    ).reshape(batch_size, 128)[:, ::2]
+    seq_lens = torch.arange(batch_size, dtype=torch.int32, device=device) * 17
+    staged = torch.empty((batch_size, 3), dtype=torch.int32, device=device)
+    stage_reused_spec_state_indices(
+        block_table,
+        seq_lens,
+        staged,
+        num_spec_decodes=num_spec_decodes,
+        cache_block_size=BLOCK_SIZE,
+        aligned=True,
+    )
+    expected = torch.full_like(staged, NULL_BLOCK_ID)
+    expected[:num_spec_decodes] = _mamba_get_block_table_tensor(
+        block_table[:num_spec_decodes],
+        seq_lens[:num_spec_decodes],
+        MambaSpec(
+            block_size=BLOCK_SIZE,
+            shapes=((16, 64),),
+            dtypes=(torch.float16,),
+            num_speculative_blocks=2,
+        ),
+        "align",
+    )
+    torch.testing.assert_close(staged, expected, rtol=0, atol=0)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
@@ -378,7 +378,10 @@ def test_decode_expands_kernel_block_page_indices(monkeypatch):
     assert expand_kernel.kernel_block_size == kernel_block_size
 
 
-def test_update_block_table_reuses_schedule_and_rebuilds_page_indices(monkeypatch):
+@pytest.mark.parametrize("full_cudagraphs", [False, True])
+def test_update_block_table_reuses_schedule_and_rebuilds_page_indices(
+    monkeypatch, full_cudagraphs
+):
     expand_kernel = _ExpandPageIndicesKernel()
     monkeypatch.setattr(rocm_aiter_mla, "_expand_page_indices_kernel", expand_kernel)
 
@@ -407,6 +410,12 @@ def test_update_block_table_reuses_schedule_and_rebuilds_page_indices(monkeypatc
     builder = SimpleNamespace(
         paged_kv_indices=torch.empty(5, dtype=torch.int32),
         kernel_block_size=2,
+        # Exercise both the plain path and the full-graph path, where the
+        # group-local ones-buffer is resliced from the builder.
+        paged_kv_last_page_len=torch.ones(4, dtype=torch.int32),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=SimpleNamespace(has_full_cudagraphs=lambda: full_cudagraphs)
+        ),
     )
     new_block_table = torch.tensor([[10, 11, 12]], dtype=torch.int32)
     new_slot_mapping = torch.tensor([4, 5, 6], dtype=torch.int64)

--- a/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_mtp_split.py
@@ -15,7 +15,9 @@ if not current_platform.is_rocm():
 
 from vllm.v1.attention.backends.mla import rocm_aiter_mla  # noqa: E402
 from vllm.v1.attention.backends.mla.rocm_aiter_mla import (  # noqa: E402
+    AiterMLADecodeMetadata,
     AiterMLAHelper,
+    AiterMLAMetadata,
     AiterMLAMetadataBuilder,
 )
 
@@ -372,8 +374,62 @@ def test_decode_expands_kernel_block_page_indices(monkeypatch):
         metadata.paged_kv_indices[: expected_indices.numel()],
         expected_indices,
     )
-    assert expand_kernel.grid == (seq_lens.numel(),)
+    assert expand_kernel.grid == (seq_lens.numel(), 1)
     assert expand_kernel.kernel_block_size == kernel_block_size
+
+
+def test_update_block_table_reuses_schedule_and_rebuilds_page_indices(monkeypatch):
+    expand_kernel = _ExpandPageIndicesKernel()
+    monkeypatch.setattr(rocm_aiter_mla, "_expand_page_indices_kernel", expand_kernel)
+
+    old_block_table = torch.tensor([[1, 2, 3]], dtype=torch.int32)
+    old_slot_mapping = torch.tensor([1, 2, 3], dtype=torch.int64)
+    old_page_indices = torch.tensor([2, 3, 4, 5, 6], dtype=torch.int32)
+    decode = AiterMLADecodeMetadata(
+        block_table=old_block_table,
+        seq_lens=torch.tensor([5], dtype=torch.int32),
+        dcp_tot_seq_lens=None,
+        paged_kv_indptr=torch.tensor([0, 5], dtype=torch.int32),
+        paged_kv_indices=old_page_indices,
+    )
+    metadata = AiterMLAMetadata(
+        num_reqs=1,
+        max_query_len=3,
+        max_seq_len=5,
+        num_actual_tokens=3,
+        query_start_loc=torch.tensor([0, 3], dtype=torch.int32),
+        slot_mapping=old_slot_mapping,
+        num_decodes=1,
+        num_decode_tokens=3,
+        num_prefills=0,
+        decode=decode,
+    )
+    builder = SimpleNamespace(
+        paged_kv_indices=torch.empty(5, dtype=torch.int32),
+        kernel_block_size=2,
+    )
+    new_block_table = torch.tensor([[10, 11, 12]], dtype=torch.int32)
+    new_slot_mapping = torch.tensor([4, 5, 6], dtype=torch.int64)
+
+    updated = AiterMLAMetadataBuilder.update_block_table(
+        builder,
+        metadata,
+        new_block_table,
+        new_slot_mapping,
+    )
+
+    assert updated is not metadata
+    assert updated.decode is not metadata.decode
+    assert updated.slot_mapping is new_slot_mapping
+    assert updated.decode.block_table.data_ptr() == new_block_table.data_ptr()
+    assert torch.equal(
+        updated.decode.paged_kv_indices,
+        torch.tensor([20, 21, 22, 23, 24], dtype=torch.int32),
+    )
+    assert expand_kernel.grid == (1, 1)
+    assert metadata.slot_mapping is old_slot_mapping
+    assert metadata.decode.block_table is old_block_table
+    assert metadata.decode.paged_kv_indices is old_page_indices
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -7,6 +7,8 @@ while keeping per-block content compact, so padding bytes at the end of each pag
 never addressed by the logical view.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -21,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     compute_layout_strides,
 )
+from vllm.v1.worker.gpu import attn_utils
 from vllm.v1.worker.utils import (
     allocate_kv_cache,
     copy_kv_cache_blocks_inplace,
@@ -227,3 +230,94 @@ def test_copy_kv_cache_blocks_with_virtual_block_splitting(
             torch.testing.assert_close(
                 cache[dst_start + physical_idx], expected[layer_idx][physical_idx]
             )
+
+
+def test_build_attn_metadata_reuses_compatible_group_metadata():
+    class Builder:
+        supports_update_block_table = True
+
+        def __init__(self):
+            self.build_calls = []
+            self.capture_calls = []
+            self.update_calls = []
+            self.shared_from = []
+
+        def build(self, **kwargs):
+            self.build_calls.append(kwargs)
+            return SimpleNamespace(source="build")
+
+        def update_block_table(self, metadata, block_table, slot_mapping):
+            self.update_calls.append((metadata, block_table, slot_mapping))
+            return SimpleNamespace(source="update")
+
+        def build_for_cudagraph_capture(self, common_attn_metadata):
+            self.capture_calls.append(common_attn_metadata)
+            return SimpleNamespace(source="capture")
+
+        def share_reusable_metadata_buffers(self, source):
+            self.shared_from.append(source)
+
+    builders = [Builder(), Builder()]
+    attn_groups = [
+        [
+            SimpleNamespace(
+                layer_names=[f"layer.{group}"],
+                get_metadata_builder=lambda _, group=group: builders[group],
+            )
+        ]
+        for group in range(2)
+    ]
+    shared_spec = object()
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(kv_cache_spec=shared_spec),
+            SimpleNamespace(kv_cache_spec=shared_spec),
+        ]
+    )
+    block_tables = [
+        torch.tensor([[1]], dtype=torch.int32),
+        torch.tensor([[2]], dtype=torch.int32),
+    ]
+    slot_mappings = [
+        torch.tensor([1], dtype=torch.int64),
+        torch.tensor([2], dtype=torch.int64),
+    ]
+
+    common_args = dict(
+        attn_groups=attn_groups,
+        num_reqs=1,
+        num_tokens=1,
+        query_start_loc_gpu=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        max_query_len=1,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        max_seq_len=8,
+        block_tables=block_tables,
+        slot_mappings=slot_mappings,
+        kv_cache_config=kv_cache_config,
+    )
+    captured = attn_utils.build_attn_metadata(**common_args, for_cudagraph_capture=True)
+    assert captured["layer.0"].source == "capture"
+    assert captured["layer.1"].source == "capture"
+    assert len(builders[0].capture_calls) == 1
+    assert len(builders[1].capture_calls) == 1
+    assert builders[1].shared_from == [builders[0]]
+
+    for builder in builders:
+        builder.capture_calls.clear()
+        builder.shared_from.clear()
+
+    result = attn_utils.build_attn_metadata(**common_args)
+
+    assert result["layer.0"].source == "build"
+    assert result["layer.1"].source == "update"
+    assert len(builders[0].build_calls) == 1
+    assert builders[0].update_calls == []
+    assert builders[0].shared_from == []
+    assert builders[1].build_calls == []
+    assert builders[1].shared_from == [builders[0]]
+    assert len(builders[1].update_calls) == 1
+    cached, block_table, slot_mapping = builders[1].update_calls[0]
+    assert cached is result["layer.0"]
+    assert block_table is block_tables[1]
+    assert slot_mapping is slot_mappings[1]

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -236,11 +236,15 @@ def test_build_attn_metadata_reuses_compatible_group_metadata():
     class Builder:
         supports_update_block_table = True
 
+        def get_metadata_reuse_key(self):
+            return ()
+
         def __init__(self):
             self.build_calls = []
             self.capture_calls = []
             self.update_calls = []
             self.shared_from = []
+            self.allow_update = True
 
         def build(self, **kwargs):
             self.build_calls.append(kwargs)
@@ -256,6 +260,9 @@ def test_build_attn_metadata_reuses_compatible_group_metadata():
 
         def share_reusable_metadata_buffers(self, source):
             self.shared_from.append(source)
+
+        def can_reuse_metadata(self, metadata):
+            return self.allow_update
 
     builders = [Builder(), Builder()]
     attn_groups = [
@@ -321,3 +328,12 @@ def test_build_attn_metadata_reuses_compatible_group_metadata():
     assert cached is result["layer.0"]
     assert block_table is block_tables[1]
     assert slot_mapping is slot_mappings[1]
+
+    builders[1].allow_update = False
+    builders[1].build_calls.clear()
+    builders[1].update_calls.clear()
+    result = attn_utils.build_attn_metadata(**common_args)
+    assert result["layer.0"].source == "build"
+    assert result["layer.1"].source == "build"
+    assert len(builders[1].build_calls) == 1
+    assert builders[1].update_calls == []

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -319,13 +319,13 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         has_initial_state = m.has_initial_state
         non_spec_query_start_loc = m.non_spec_query_start_loc
         non_spec_state_indices_tensor = m.non_spec_state_indices_tensor
-        spec_sequence_masks = m.spec_sequence_masks
         spec_token_indx = m.spec_token_indx
         non_spec_token_indx = m.non_spec_token_indx
         spec_state_indices_tensor = m.spec_state_indices_tensor
         spec_query_start_loc = m.spec_query_start_loc
         num_accepted_tokens = m.num_accepted_tokens
         num_actual_tokens = m.num_actual_tokens
+        has_spec_decode = m.num_spec_decodes > 0
         mixed_qkv = mixed_qkv[:num_actual_tokens]
         g1 = g1[:, :num_actual_tokens]
         beta = beta[:, :num_actual_tokens]
@@ -341,7 +341,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         if (
             self.decode_conv1d_weight is not None
             and self.decode_norm_weight is not None
-            and spec_sequence_masks is None
+            and not has_spec_decode
             and m.num_prefills == 0
             and m.num_decodes > 0
         ):
@@ -377,7 +377,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
 
         # Split tokens into the multi-query spec-decode part and the remaining
         # (prefill / plain decode) part.
-        if spec_sequence_masks is not None:
+        if has_spec_decode:
             if m.num_prefills == 0 and m.num_decodes == 0:
                 mixed_qkv_spec = mixed_qkv
                 g1_spec, beta_spec = g1, beta
@@ -395,7 +395,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
 
         # ---------- spec-decode multi-query path ----------
         core_attn_out_spec = None
-        if spec_sequence_masks is not None:
+        if has_spec_decode:
             assert spec_state_indices_tensor is not None
             assert spec_query_start_loc is not None
             spec_conv_indices = spec_state_indices_tensor[:, 0][: m.num_spec_decodes]
@@ -495,7 +495,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                 # Send them to the recurrent kernel and give the chunk kernel the
                 # prefill tail only.
                 core_attn_out_decode = None
-                split_non_spec = spec_sequence_masks is None and m.num_decodes > 0
+                split_non_spec = not has_spec_decode and m.num_decodes > 0
                 if split_non_spec:
                     assert non_spec_query_start_loc is not None
                     nd_tok = m.num_decode_tokens

--- a/vllm/models/kimi_k3/amd/kda_metadata.py
+++ b/vllm/models/kimi_k3/amd/kda_metadata.py
@@ -2,20 +2,20 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """ROCm Kimi-K3 specialization of GDN attention metadata.
 
-The request classification and cudagraph staging intentionally mirror
-``GDNAttentionMetadataBuilder``. Only the FLA chunk metadata is built
-differently on device rather than on the host.
+The shared Kimi-K3 builder provides the low-overhead decode metadata path.
+ROCm overrides only the FLA chunk metadata hook so prefill metadata also stays
+on device.
 """
 
 import torch
 
 from vllm.logger import init_logger
+from vllm.models.kimi_k3.nvidia.kda_metadata import KimiK3KDAMetadataBuilder
 from vllm.third_party.flash_linear_attention.ops.utils import FLA_CHUNK_SIZE
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import next_power_of_2
 from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionBackend,
-    GDNAttentionMetadataBuilder,
 )
 
 logger = init_logger(__name__)
@@ -85,7 +85,7 @@ def prepare_chunk_metadata_device(
     return chunk_indices, chunk_offsets
 
 
-class KimiK3ROCmKDAMetadataBuilder(GDNAttentionMetadataBuilder):
+class KimiK3ROCmKDAMetadataBuilder(KimiK3KDAMetadataBuilder):
     def _build_chunk_metadata(
         self,
         prefill_query_start_loc: torch.Tensor,

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Kimi-K3 specialization of GDN attention metadata.
 
+Shared by the NVIDIA and ROCm paths; the ROCm builder subclasses it and
+overrides the prefill chunk-metadata hook.
+
 The request classification and cudagraph staging intentionally mirror
 ``GDNAttentionMetadataBuilder``. Kimi-K3 builds the metadata required by its
 prefill KDA kernel internally, so this builder omits the shared FLA chunk
@@ -340,6 +343,16 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
         self.recoverssm_context = context
         return context
 
+    def _build_chunk_metadata(
+        self,
+        prefill_query_start_loc: torch.Tensor,
+        prefill_query_start_loc_cpu: torch.Tensor,
+        device: torch.device,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        # NVIDIA KDA builds this metadata inside its prefill kernel. ROCm
+        # overrides this hook to build it on device for the chunk KDA kernel.
+        return None, None
+
     def build(  # type: ignore[override]
         self,
         common_prefix_len: int,
@@ -543,16 +556,49 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
         # Unlike the shared GDN layer, Kimi-K3's prefill KDA wrapper prepares
         # its own chunk indices. Only causal-convolution metadata is needed here.
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
+        chunk_indices, chunk_offsets = None, None
+        prefill_query_start_loc = None
+        prefill_state_indices = None
+        prefill_has_initial_state = None
         if num_prefills > 0:
+            assert non_spec_query_start_loc is not None
+            assert non_spec_query_start_loc_cpu is not None
+            assert non_spec_state_indices_tensor is not None
+
+            # AMD peels ordinary decodes off a mixed non-spec batch before its
+            # chunk KDA call. Preserve the prefill-only views at no extra device
+            # cost; NVIDIA ignores them.
+            if num_spec_decodes == 0 and num_decodes > 0:
+                prefill_query_start_loc = (
+                    non_spec_query_start_loc[num_decodes:] - num_decode_tokens
+                )
+                prefill_query_start_loc_cpu = (
+                    non_spec_query_start_loc_cpu[num_decodes:] - num_decode_tokens
+                )
+                prefill_state_indices = non_spec_state_indices_tensor[num_decodes:]
+            else:
+                prefill_query_start_loc = non_spec_query_start_loc
+                prefill_query_start_loc_cpu = non_spec_query_start_loc_cpu
+                prefill_state_indices = non_spec_state_indices_tensor
+
             has_initial_state = m.compute_num_computed_tokens() > 0
             if num_spec_decodes > 0:
                 has_initial_state = has_initial_state[active_non_spec_mask_cpu]
-                assert non_spec_query_start_loc_cpu is not None
             nums_dict, batch_ptr, token_chunk_offset_ptr = (
                 compute_causal_conv1d_metadata(
                     non_spec_query_start_loc_cpu,
                     device=query_start_loc.device,
                 )
+            )
+            chunk_indices, chunk_offsets = self._build_chunk_metadata(
+                prefill_query_start_loc,
+                prefill_query_start_loc_cpu,
+                query_start_loc.device,
+            )
+            prefill_has_initial_state = (
+                has_initial_state[num_decodes:]
+                if num_spec_decodes == 0 and num_decodes > 0
+                else has_initial_state
             )
         else:
             has_initial_state = None
@@ -647,6 +693,11 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
+            chunk_indices=chunk_indices,
+            chunk_offsets=chunk_offsets,
+            prefill_query_start_loc=prefill_query_start_loc,
+            prefill_state_indices=prefill_state_indices,
+            prefill_has_initial_state=prefill_has_initial_state,
         )
 
 

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -14,9 +14,10 @@ For Kimi-K3 speculative decoding, ``--use-replayssm`` selects the simplified
 RecoverSSM path implemented here instead of the Mamba2 ReplaySSM kernel.
 """
 
+import copy
 from dataclasses import dataclass, field
 from functools import cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 
@@ -245,6 +246,103 @@ def stage_spec_decode_metadata(
     )
 
 
+@triton.jit(do_not_specialize=["num_spec_decodes", "batch_size"])
+def _stage_reused_spec_state_indices_kernel(
+    block_table_ptr,
+    seq_lens_ptr,
+    staged_state_indices_ptr,
+    block_table_stride_0: tl.constexpr,
+    block_table_stride_1: tl.constexpr,
+    seq_lens_stride: tl.constexpr,
+    staged_state_indices_stride_0: tl.constexpr,
+    staged_state_indices_stride_1: tl.constexpr,
+    num_spec_decodes,
+    batch_size,
+    CACHE_BLOCK_SIZE: tl.constexpr,
+    NUM_STATE_SLOTS: tl.constexpr,
+    BLOCK_STATE_SLOTS: tl.constexpr,
+    NULL_STATE_ID: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+):
+    """Stage one cache group's state indices into its graph-local buffer."""
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    rows = tl.program_id(0) * BLOCK_ROWS + tl.arange(0, BLOCK_ROWS)
+    real_request = rows < num_spec_decodes
+    seq_lens = tl.load(
+        seq_lens_ptr + rows * seq_lens_stride,
+        mask=real_request,
+        other=1,
+    )
+    first_state_slot = tl.maximum((seq_lens - 1) // CACHE_BLOCK_SIZE, 0)
+
+    state_slots = tl.arange(0, BLOCK_STATE_SLOTS)
+    valid_state_slot = state_slots < NUM_STATE_SLOTS
+    state_indices = tl.load(
+        block_table_ptr
+        + rows[:, None] * block_table_stride_0
+        + (first_state_slot[:, None] + state_slots[None, :]) * block_table_stride_1,
+        mask=real_request[:, None] & valid_state_slot[None, :],
+        other=NULL_STATE_ID,
+    )
+    tl.store(
+        staged_state_indices_ptr
+        + rows[:, None] * staged_state_indices_stride_0
+        + state_slots[None, :] * staged_state_indices_stride_1,
+        state_indices,
+        mask=(rows < batch_size)[:, None] & valid_state_slot[None, :],
+    )
+
+
+def stage_reused_spec_state_indices(
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    staged_state_indices: torch.Tensor,
+    *,
+    num_spec_decodes: int,
+    cache_block_size: int,
+    aligned: bool,
+) -> None:
+    """Update only the group-local state indices for metadata reuse."""
+    assert block_table.is_cuda and seq_lens.is_cuda
+    assert staged_state_indices.is_cuda
+    if not aligned:
+        # Unaligned cache modes keep the raw block table, so the state columns
+        # are a contiguous prefix. A slice copy beats a Triton launch here: the
+        # kernel is tiny and its dispatch, not its work, dominates.
+        batch_size, num_state_slots = staged_state_indices.shape
+        staged_state_indices[:num_spec_decodes].copy_(
+            block_table[:num_spec_decodes, :num_state_slots]
+        )
+        if num_spec_decodes < batch_size:
+            staged_state_indices[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+        return
+    batch_size, num_state_slots = staged_state_indices.shape
+    block_rows = 32
+    _stage_reused_spec_state_indices_kernel[(triton.cdiv(batch_size, block_rows),)](
+        block_table,
+        seq_lens,
+        staged_state_indices,
+        block_table.stride(0),
+        block_table.stride(1),
+        seq_lens.stride(0),
+        staged_state_indices.stride(0),
+        staged_state_indices.stride(1),
+        num_spec_decodes,
+        batch_size,
+        CACHE_BLOCK_SIZE=cache_block_size,
+        NUM_STATE_SLOTS=num_state_slots,
+        BLOCK_STATE_SLOTS=triton.next_power_of_2(num_state_slots),
+        NULL_STATE_ID=NULL_BLOCK_ID,
+        BLOCK_ROWS=block_rows,
+        num_warps=1,
+        launch_pdl=_metadata_launch_pdl(),
+    )
+
+
 @dataclass
 class KDARecoverSSMAlignMetadata:
     block_table: torch.Tensor
@@ -266,6 +364,11 @@ class KimiK3KDAMetadata(GDNAttentionMetadata, RecoverSSMMetadata):
     recoverssm_context: "KDARecoverSSMCommitContext | None" = field(
         default=None, repr=False, compare=False
     )
+
+    # The aligned state-table column is common across cache groups. Retaining
+    # the graph-stable sequence-length view lets another group update only its
+    # own state-index buffer without rebuilding common speculative metadata.
+    state_seq_lens: torch.Tensor | None = None
 
     def commit_recoverssm_state(
         self, num_accepted_tokens: torch.Tensor
@@ -299,6 +402,10 @@ class KimiK3KDAMetadata(GDNAttentionMetadata, RecoverSSMMetadata):
 
 
 class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
+    # Narrower than supports_update_block_table: can_reuse_metadata() rejects
+    # mixed and prefill batches, which fall back to a normal build.
+    supports_metadata_reuse = True
+
     def __init__(
         self,
         kv_cache_spec: MambaSpec,
@@ -342,6 +449,85 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
         )
         self.recoverssm_context = context
         return context
+
+    def get_metadata_reuse_key(self) -> tuple[object, ...]:
+        return (
+            self.num_spec,
+            self.decode_cudagraph_max_bs,
+            self.vllm_config.cache_config.mamba_cache_mode,
+        )
+
+    reusable_metadata_buffers: ClassVar[tuple[str, ...]] = (
+        "spec_query_start_loc",
+        "num_accepted_tokens",
+    )
+
+    def share_reusable_metadata_buffers(
+        self, source: "KimiK3KDAMetadataBuilder"
+    ) -> None:
+        """Share only common, read-only-at-execution graph inputs.
+
+        State indices remain local because each KDA cache group owns a
+        different block table. Query offsets and accepted counts describe the
+        request batch and are identical for every compatible group.
+        """
+        if not (self.use_full_cuda_graph and self.use_spec_decode):
+            return
+        # recoverssm keeps both groups on the normal build, where each one
+        # stages into its own buffer; sharing would make them collide.
+        if self.use_recoverssm:
+            return
+        super().share_reusable_metadata_buffers(source)
+
+    def can_reuse_metadata(self, metadata: KimiK3KDAMetadata) -> bool:
+        """Limit the fast path to uniform speculative FULL-graph decode."""
+        return (
+            self.use_full_cuda_graph
+            # recoverssm collapses spec_state_slots to 1 and owns its own
+            # commit path; leave that regime on the normal build.
+            and not self.use_recoverssm
+            and metadata.num_spec_decodes > 0
+            and metadata.num_prefills == 0
+            and metadata.num_decodes == 0
+            and metadata.state_seq_lens is not None
+            and metadata.spec_state_indices_tensor is not None
+            and metadata.spec_query_start_loc is not None
+            and metadata.num_accepted_tokens is not None
+            # build() only stages into the persistent graph buffers when the
+            # batch fits them. If it bailed out, these views point at the
+            # request tensors instead and must not be reused.
+            and metadata.spec_query_start_loc.data_ptr()
+            == self.spec_query_start_loc.data_ptr()
+        )
+
+    def update_block_table(
+        self,
+        metadata: KimiK3KDAMetadata,
+        blk_table: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> KimiK3KDAMetadata:
+        """Reuse batch-common decode metadata for another KDA cache group."""
+        assert self.can_reuse_metadata(metadata)
+        assert metadata.state_seq_lens is not None
+        assert metadata.spec_state_indices_tensor is not None
+        batch_size = metadata.spec_state_indices_tensor.shape[0]
+        state_indices = self.spec_state_indices_tensor[:batch_size]
+        stage_reused_spec_state_indices(
+            blk_table,
+            metadata.state_seq_lens,
+            state_indices,
+            num_spec_decodes=metadata.num_spec_decodes,
+            cache_block_size=self.kv_cache_spec.block_size,
+            aligned=self.vllm_config.cache_config.mamba_cache_mode
+            not in ("all", "none"),
+        )
+        # copy.copy rather than dataclasses.replace: replace() re-runs __init__
+        # over every field, and this is a per-group hot path.
+        updated = copy.copy(metadata)
+        updated.spec_state_indices_tensor = state_indices
+        updated.spec_query_start_loc = self.spec_query_start_loc[: batch_size + 1]
+        updated.num_accepted_tokens = self.num_accepted_tokens[:batch_size]
+        return updated
 
     def _build_chunk_metadata(
         self,
@@ -565,9 +751,8 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             assert non_spec_query_start_loc_cpu is not None
             assert non_spec_state_indices_tensor is not None
 
-            # AMD peels ordinary decodes off a mixed non-spec batch before its
-            # chunk KDA call. Preserve the prefill-only views at no extra device
-            # cost; NVIDIA ignores them.
+            # A mixed non-spec batch needs prefill-only views of the query
+            # offsets; the chunk KDA path consumes them.
             if num_spec_decodes == 0 and num_decodes > 0:
                 prefill_query_start_loc = (
                     non_spec_query_start_loc[num_decodes:] - num_decode_tokens
@@ -698,6 +883,7 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             prefill_query_start_loc=prefill_query_start_loc,
             prefill_state_indices=prefill_state_indices,
             prefill_has_initial_state=prefill_has_initial_state,
+            state_seq_lens=m.seq_lens,
         )
 
 

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -597,6 +597,13 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     # Whether all step-dependent draft decode metadata can be updated in place,
     # allowing one metadata build to be reused across autoregressive draft steps.
     supports_draft_decode_metadata_update: bool = False
+    # Narrower than supports_update_block_table: the reuse site falls back to
+    # a full build whenever can_reuse_metadata() rejects the cached metadata.
+    supports_metadata_reuse: bool = False
+    # Graph-stable buffer attributes this builder may adopt from a compatible
+    # builder for another KV-cache group. Consumed by the default
+    # share_reusable_metadata_buffers().
+    reusable_metadata_buffers: ClassVar[tuple[str, ...]] = ()
 
     @abstractmethod
     def __init__(
@@ -686,6 +693,33 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
         Only needs to be implemented if supports_update_block_table is True.
         """
         raise NotImplementedError
+
+    def get_metadata_reuse_key(self) -> tuple[object, ...]:
+        """Extra identity of this builder for cross-group metadata reuse.
+
+        Two builders may share a metadata build only when their keys compare
+        equal, on top of matching type and KV-cache spec.
+        """
+        return ()
+
+    def share_reusable_metadata_buffers(
+        self, source: "AttentionMetadataBuilder"
+    ) -> None:
+        """Adopt `source`'s graph-stable buffers before reusing its metadata.
+
+        Runs before the build, so a captured graph sees the shared storage.
+        """
+        for name in self.reusable_metadata_buffers:
+            destination = getattr(self, name)
+            shared = getattr(source, name)
+            assert destination.shape == shared.shape
+            assert destination.dtype == shared.dtype
+            assert destination.device == shared.device
+            setattr(self, name, shared)
+
+    def can_reuse_metadata(self, metadata: M) -> bool:
+        """Whether `metadata` from a compatible builder may be block-table swapped."""
+        return self.supports_update_block_table or self.supports_metadata_reuse
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -32,6 +32,9 @@ from vllm.v1.kv_cache_interface import AttentionSpec, is_quantized_kv_cache
 
 logger = init_logger(__name__)
 
+# Token tile for the page-index expansion grid.
+_EXPAND_PAGE_BLOCK = 1024
+
 
 @functools.lru_cache(maxsize=1)
 def _get_mla_gluon():
@@ -441,6 +444,16 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             )
         self._shared_schedule_needs_build = False
 
+    reusable_metadata_buffers: ClassVar[tuple[str, ...]] = (
+        "_mla_work_indptr",
+        "_mla_work_info_set",
+        "_mla_reduce_indptr",
+        "_mla_reduce_final_map",
+        "_mla_reduce_partial_map",
+        "paged_kv_indptr",
+        "qo_indptr",
+    )
+
     def share_reusable_metadata_buffers(
         self, source: "AiterMLAMetadataBuilder"
     ) -> None:
@@ -453,25 +466,29 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         """
         if not self.compilation_config.cudagraph_mode.has_full_cudagraphs():
             return
-        schedule_names = (
-            "_mla_work_indptr",
-            "_mla_work_info_set",
-            "_mla_reduce_indptr",
-            "_mla_reduce_final_map",
-            "_mla_reduce_partial_map",
-            "paged_kv_indptr",
-            "qo_indptr",
-        )
         if self._mla_work_indptr.data_ptr() == source._mla_work_indptr.data_ptr():
             return
-        for name in schedule_names:
-            destination = getattr(self, name)
-            shared = getattr(source, name)
-            assert destination.shape == shared.shape
-            assert destination.dtype == shared.dtype
-            assert destination.device == shared.device
-            setattr(self, name, shared)
+        super().share_reusable_metadata_buffers(source)
         self._shared_schedule_needs_build = True
+
+    def can_reuse_metadata(self, metadata: AiterMLAMetadata) -> bool:
+        """Reuse only once this builder has rebuilt against the shared schedule.
+
+        ``share_reusable_metadata_buffers`` rebinds the schedule storage but
+        leaves ``work_meta_data`` holding addresses into the old allocation.
+        One full build after rebinding re-derives it; until then, and whenever
+        the schedule was never shared (the MRV1 runner does not share), a
+        normal build is required.
+        """
+        if not self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+            return True
+        if self._shared_schedule_needs_build:
+            return False
+        return metadata.decode is None or (
+            metadata.decode.paged_kv_indptr is not None
+            and self.paged_kv_indptr.data_ptr()
+            == metadata.decode.paged_kv_indptr.data_ptr()
+        )
 
     def get_metadata_reuse_key(self) -> tuple[object, ...]:
         return (
@@ -720,14 +737,16 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # to the original _copy_page_indices_kernel).
         # When kernel_block_size=K>1, block_table entry b covering K tokens
         # gets expanded to flat indices b*K, b*K+1, ..., b*K+(K-1).
-        _expand_page_indices_kernel[(num_reqs, triton.cdiv(max_seq_len, 1024))](
+        _expand_page_indices_kernel[
+            (num_reqs, triton.cdiv(max_seq_len, _EXPAND_PAGE_BLOCK))
+        ](
             self.paged_kv_indices,
             block_table_tensor,
             block_table_tensor.stride(0),
             paged_kv_indptr,
             seq_lens_for_kernel,
             KERNEL_BLOCK_SIZE=self.kernel_block_size,
-            BLOCK_SIZE=1024,
+            BLOCK_SIZE=_EXPAND_PAGE_BLOCK,
         )
         paged_kv_indices = self.paged_kv_indices
 
@@ -877,35 +896,13 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             decode.block_table = blk_table[: metadata.num_decodes]
             assert decode.paged_kv_indptr is not None
             assert decode.seq_lens is not None
-            numeric_schedule = (
-                ("work_indptr", "_mla_work_indptr"),
-                ("work_info_set", "_mla_work_info_set"),
-                ("reduce_indptr", "_mla_reduce_indptr"),
-                ("reduce_final_map", "_mla_reduce_final_map"),
-                ("reduce_partial_map", "_mla_reduce_partial_map"),
-            )
-            shared_graph_schedule = (
-                hasattr(self, "_shared_schedule_needs_build")
-                and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
-            )
-            if shared_graph_schedule:
-                assert not self._shared_schedule_needs_build, (
-                    "shared MLA schedule must be initialized before reuse"
-                )
-                assert decode.qo_indptr is not None
-                assert self.paged_kv_indptr.data_ptr() == (
-                    decode.paged_kv_indptr.data_ptr()
-                )
-                assert self.qo_indptr.data_ptr() == decode.qo_indptr.data_ptr()
-                num_indptr = decode.paged_kv_indptr.numel()
-                num_qo_indptr = decode.qo_indptr.numel()
-                decode.paged_kv_indptr = self.paged_kv_indptr[:num_indptr]
-                decode.qo_indptr = self.qo_indptr[:num_qo_indptr]
-
+            # can_reuse_metadata already proved the schedule was shared and
+            # rebuilt, so the shallow copy carries the shared views; only the
+            # group-local buffers below need rebinding.
             _expand_page_indices_kernel[
                 (
                     metadata.num_decodes,
-                    triton.cdiv(metadata.max_seq_len, 1024),
+                    triton.cdiv(metadata.max_seq_len, _EXPAND_PAGE_BLOCK),
                 )
             ](
                 self.paged_kv_indices,
@@ -914,29 +911,22 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
                 decode.paged_kv_indptr,
                 decode.seq_lens,
                 KERNEL_BLOCK_SIZE=self.kernel_block_size,
-                BLOCK_SIZE=1024,
+                BLOCK_SIZE=_EXPAND_PAGE_BLOCK,
             )
-
-            if shared_graph_schedule:
+            if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
                 decode.paged_kv_last_page_len = self.paged_kv_last_page_len[
                     : metadata.num_decodes
                 ]
             decode.paged_kv_indices = self.paged_kv_indices
             updated.decode = decode
 
-            if shared_graph_schedule:
-                # work_meta_data contains addresses into this builder's
-                # persistent schedule buffers. Keep the pointer table created
-                # for this group at capture time; it cannot be copied.
-                if metadata.work_meta_data is not None:
-                    updated.work_meta_data = self._mla_work_meta_data
-
-                for field, destination_name in numeric_schedule:
-                    source = getattr(metadata, field)
-                    if source is not None:
-                        destination = getattr(self, destination_name)
-                        assert destination.data_ptr() == source.data_ptr()
-                        setattr(updated, field, destination)
+            # work_meta_data holds addresses into the shared schedule and is
+            # rebuilt per group at capture; it cannot be copied over.
+            if (
+                self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+                and metadata.work_meta_data is not None
+            ):
+                updated.work_meta_data = self._mla_work_meta_data
 
         return updated
 

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 import functools
 from dataclasses import dataclass
 from pathlib import Path
@@ -257,6 +258,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
     #  https://github.com/vllm-project/vllm/issues/22945
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+    supports_update_block_table: bool = True
 
     @staticmethod
     def _uniform_padded_mtp_qo_len(
@@ -434,10 +436,52 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             self.paged_kv_indptr = torch.zeros(
                 max_num_reqs + 1, dtype=torch.int32, device=device
             )
-
             self.qo_indptr = torch.zeros(
                 max_num_reqs + 1, dtype=torch.int32, device=device
             )
+        self._shared_schedule_needs_build = False
+
+    def share_reusable_metadata_buffers(
+        self, source: "AiterMLAMetadataBuilder"
+    ) -> None:
+        """Share graph-stable numeric schedule storage across compatible groups.
+
+        The schedule is read-only during MLA execution and depends on request
+        geometry, not a group's block table. ``work_meta_data`` remains local:
+        it contains addresses into the shared views and is rebuilt once after
+        rebinding, before graph capture.
+        """
+        if not self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+            return
+        schedule_names = (
+            "_mla_work_indptr",
+            "_mla_work_info_set",
+            "_mla_reduce_indptr",
+            "_mla_reduce_final_map",
+            "_mla_reduce_partial_map",
+            "paged_kv_indptr",
+            "qo_indptr",
+        )
+        if self._mla_work_indptr.data_ptr() == source._mla_work_indptr.data_ptr():
+            return
+        for name in schedule_names:
+            destination = getattr(self, name)
+            shared = getattr(source, name)
+            assert destination.shape == shared.shape
+            assert destination.dtype == shared.dtype
+            assert destination.device == shared.device
+            setattr(self, name, shared)
+        self._shared_schedule_needs_build = True
+
+    def get_metadata_reuse_key(self) -> tuple[object, ...]:
+        return (
+            self.num_heads,
+            self._num_attention_heads,
+            self._mtp_decode_qlen,
+            self.kernel_block_size,
+            self._kv_cache_dtype_str,
+            self.decode_attn_out_dtype,
+        )
 
     def _init_fp8_prefill_ps_buffers(
         self,
@@ -676,7 +720,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         # to the original _copy_page_indices_kernel).
         # When kernel_block_size=K>1, block_table entry b covering K tokens
         # gets expanded to flat indices b*K, b*K+1, ..., b*K+(K-1).
-        _expand_page_indices_kernel[(num_reqs,)](
+        _expand_page_indices_kernel[(num_reqs, triton.cdiv(max_seq_len, 1024))](
             self.paged_kv_indices,
             block_table_tensor,
             block_table_tensor.stride(0),
@@ -802,6 +846,100 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         return attn_metadata
 
+    def update_block_table(
+        self,
+        metadata: AiterMLAMetadata,
+        blk_table: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> AiterMLAMetadata:
+        """Reuse request-shape metadata for another MLA KV-cache group.
+
+        Kimi-K3 has several MLA groups with identical request/query geometry
+        but distinct block tables. The persistent decode schedule depends on
+        the geometry, while only the expanded page indices depend on the table.
+
+        Full CUDA graphs capture stable metadata addresses. Compatible groups
+        share their read-only numeric schedule allocation before capture, while
+        retaining group-local page indices and pointer-bearing work metadata.
+        """
+        updated = copy.copy(metadata)
+        updated.slot_mapping = slot_mapping
+
+        if metadata.prefill is not None:
+            prefill = copy.copy(metadata.prefill)
+            prefill.block_table = blk_table[metadata.num_decodes :]
+            prefill.prefill_backend = self._prefill_backend
+            self._prefill_backend.prepare_metadata(prefill)
+            updated.prefill = prefill
+
+        if metadata.decode is not None:
+            decode = copy.copy(metadata.decode)
+            decode.block_table = blk_table[: metadata.num_decodes]
+            assert decode.paged_kv_indptr is not None
+            assert decode.seq_lens is not None
+            numeric_schedule = (
+                ("work_indptr", "_mla_work_indptr"),
+                ("work_info_set", "_mla_work_info_set"),
+                ("reduce_indptr", "_mla_reduce_indptr"),
+                ("reduce_final_map", "_mla_reduce_final_map"),
+                ("reduce_partial_map", "_mla_reduce_partial_map"),
+            )
+            shared_graph_schedule = (
+                hasattr(self, "_shared_schedule_needs_build")
+                and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+            )
+            if shared_graph_schedule:
+                assert not self._shared_schedule_needs_build, (
+                    "shared MLA schedule must be initialized before reuse"
+                )
+                assert decode.qo_indptr is not None
+                assert self.paged_kv_indptr.data_ptr() == (
+                    decode.paged_kv_indptr.data_ptr()
+                )
+                assert self.qo_indptr.data_ptr() == decode.qo_indptr.data_ptr()
+                num_indptr = decode.paged_kv_indptr.numel()
+                num_qo_indptr = decode.qo_indptr.numel()
+                decode.paged_kv_indptr = self.paged_kv_indptr[:num_indptr]
+                decode.qo_indptr = self.qo_indptr[:num_qo_indptr]
+
+            _expand_page_indices_kernel[
+                (
+                    metadata.num_decodes,
+                    triton.cdiv(metadata.max_seq_len, 1024),
+                )
+            ](
+                self.paged_kv_indices,
+                decode.block_table,
+                decode.block_table.stride(0),
+                decode.paged_kv_indptr,
+                decode.seq_lens,
+                KERNEL_BLOCK_SIZE=self.kernel_block_size,
+                BLOCK_SIZE=1024,
+            )
+
+            if shared_graph_schedule:
+                decode.paged_kv_last_page_len = self.paged_kv_last_page_len[
+                    : metadata.num_decodes
+                ]
+            decode.paged_kv_indices = self.paged_kv_indices
+            updated.decode = decode
+
+            if shared_graph_schedule:
+                # work_meta_data contains addresses into this builder's
+                # persistent schedule buffers. Keep the pointer table created
+                # for this group at capture time; it cannot be copied.
+                if metadata.work_meta_data is not None:
+                    updated.work_meta_data = self._mla_work_meta_data
+
+                for field, destination_name in numeric_schedule:
+                    source = getattr(metadata, field)
+                    if source is not None:
+                        destination = getattr(self, destination_name)
+                        assert destination.data_ptr() == source.data_ptr()
+                        setattr(updated, field, destination)
+
+        return updated
+
     def build(
         self,
         common_prefix_len: int,
@@ -811,6 +949,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         attn_metadata = super().build(
             common_prefix_len, common_attn_metadata, fast_build
         )
+        self._shared_schedule_needs_build = False
         if (
             attn_metadata.decode is not None
             and attn_metadata.decode.has_persistent_metadata
@@ -854,31 +993,28 @@ def _expand_page_indices_kernel(
     is expanded to flat indices b*K, b*K+1, ..., b*K+(K-1).
     """
     req_idx = tl.program_id(0)
+    token_offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     row_ptr = block_table + req_idx * block_table_stride
     start_idx = tl.load(cu_num_tokens + req_idx)
     num_tokens = tl.load(seq_lens + req_idx)
+    mask = token_offsets < num_tokens
 
-    offset = tl.arange(0, BLOCK_SIZE)
-    for i in tl.range(0, num_tokens, BLOCK_SIZE):
-        token_offsets = i + offset
-        mask = token_offsets < num_tokens
+    # Which block in the block table does this token belong to?
+    block_idx = token_offsets // KERNEL_BLOCK_SIZE
+    # Offset within that block
+    offset_in_block = token_offsets % KERNEL_BLOCK_SIZE
 
-        # Which block in the block table does this token belong to?
-        block_idx = token_offsets // KERNEL_BLOCK_SIZE
-        # Offset within that block
-        offset_in_block = token_offsets % KERNEL_BLOCK_SIZE
+    # Load the block ID from the block table
+    block_ids = tl.load(row_ptr + block_idx, mask=mask)
 
-        # Load the block ID from the block table
-        block_ids = tl.load(row_ptr + block_idx, mask=mask)
+    # Compute flat index in the flattened kv_buffer
+    flat_indices = block_ids * KERNEL_BLOCK_SIZE + offset_in_block
 
-        # Compute flat index in the flattened kv_buffer
-        flat_indices = block_ids * KERNEL_BLOCK_SIZE + offset_in_block
-
-        tl.store(
-            page_indices + start_idx + token_offsets,
-            flat_indices,
-            mask=mask,
-        )
+    tl.store(
+        page_indices + start_idx + token_offsets,
+        flat_indices,
+        mask=mask,
+    )
 
 
 class AiterMLAHelper:

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -251,9 +251,9 @@ def build_attn_metadata(
         seq_lens_cpu_upper_bound = seq_lens_cpu_upper_bound[:num_reqs]
 
     attn_metadata: dict[str, Any] = {}
-    cached_attn_metadata: dict[tuple[object, ...], AttentionMetadata] = {}
-    cached_attn_metadata_builders: dict[
-        tuple[object, ...], AttentionMetadataBuilder
+    # cache key -> (builder that produced the metadata, the metadata)
+    reuse_cache: dict[
+        tuple[object, ...], tuple[AttentionMetadataBuilder, AttentionMetadata]
     ] = {}
 
     def value_identity(value: object) -> object:
@@ -310,38 +310,31 @@ def build_attn_metadata(
             kv_cache_spec = kv_cache_config.kv_cache_groups[i].kv_cache_spec
             if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
                 kv_cache_spec = kv_cache_spec.kv_cache_specs[attn_group.layer_names[0]]
-            builder_reuse_key_fn = getattr(
-                attn_metadata_builder, "get_metadata_reuse_key", None
-            )
-            builder_reuse_key = (
-                builder_reuse_key_fn() if builder_reuse_key_fn is not None else None
-            )
-
             cache_key = (
                 kv_cache_spec,
                 type(attn_metadata_builder),
-                builder_reuse_key,
+                attn_metadata_builder.get_metadata_reuse_key(),
                 value_identity(group_causal),
                 value_identity(group_is_prefilling),
             )
-            cached_builder = cached_attn_metadata_builders.get(cache_key)
-            share_buffers = getattr(
-                attn_metadata_builder, "share_reusable_metadata_buffers", None
+            cached_builder, cached_metadata = reuse_cache.get(cache_key, (None, None))
+            if cached_builder is not None:
+                attn_metadata_builder.share_reusable_metadata_buffers(cached_builder)
+            can_reuse = (
+                not for_cudagraph_capture
+                and cached_metadata is not None
+                and attn_metadata_builder.can_reuse_metadata(cached_metadata)
             )
-            if cached_builder is not None and share_buffers is not None:
-                share_buffers(cached_builder)
-            if for_cudagraph_capture:
-                metadata = attn_metadata_builder.build_for_cudagraph_capture(
-                    common_attn_metadata
-                )
-            elif (
-                cache_key in cached_attn_metadata
-                and attn_metadata_builder.supports_update_block_table
-            ):
+            if can_reuse:
+                assert cached_metadata is not None
                 metadata = attn_metadata_builder.update_block_table(
-                    cached_attn_metadata[cache_key],
+                    cached_metadata,
                     common_attn_metadata.block_table_tensor,
                     common_attn_metadata.slot_mapping,
+                )
+            elif for_cudagraph_capture:
+                metadata = attn_metadata_builder.build_for_cudagraph_capture(
+                    common_attn_metadata
                 )
             else:
                 attn_metadata_extra_kwargs = (
@@ -357,12 +350,10 @@ def build_attn_metadata(
                     common_attn_metadata=common_attn_metadata,
                     **attn_metadata_extra_kwargs,
                 )
-                if attn_metadata_builder.supports_update_block_table:
-                    cached_attn_metadata[cache_key] = metadata
-            if attn_metadata_builder.supports_update_block_table:
-                cached_attn_metadata_builders[cache_key] = attn_metadata_builder
-                if for_cudagraph_capture:
-                    cached_attn_metadata[cache_key] = metadata
+            reuse_cache[cache_key] = (
+                attn_metadata_builder,
+                cached_metadata if can_reuse else metadata,
+            )
             for layer_name in attn_group.layer_names:
                 attn_metadata[layer_name] = metadata
     return attn_metadata

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -12,6 +12,8 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
     CommonAttentionMetadata,
 )
 from vllm.v1.kv_cache_interface import (
@@ -249,6 +251,21 @@ def build_attn_metadata(
         seq_lens_cpu_upper_bound = seq_lens_cpu_upper_bound[:num_reqs]
 
     attn_metadata: dict[str, Any] = {}
+    cached_attn_metadata: dict[tuple[object, ...], AttentionMetadata] = {}
+    cached_attn_metadata_builders: dict[
+        tuple[object, ...], AttentionMetadataBuilder
+    ] = {}
+
+    def value_identity(value: object) -> object:
+        if isinstance(value, torch.Tensor):
+            return (
+                value.data_ptr(),
+                tuple(value.shape),
+                value.dtype,
+                value.device,
+            )
+        return value
+
     num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
     for i in range(num_kv_cache_groups):
         block_table = block_tables[i]
@@ -290,9 +307,41 @@ def build_attn_metadata(
 
         for attn_group in attn_groups[i]:
             attn_metadata_builder = attn_group.get_metadata_builder(0)
+            kv_cache_spec = kv_cache_config.kv_cache_groups[i].kv_cache_spec
+            if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
+                kv_cache_spec = kv_cache_spec.kv_cache_specs[attn_group.layer_names[0]]
+            builder_reuse_key_fn = getattr(
+                attn_metadata_builder, "get_metadata_reuse_key", None
+            )
+            builder_reuse_key = (
+                builder_reuse_key_fn() if builder_reuse_key_fn is not None else None
+            )
+
+            cache_key = (
+                kv_cache_spec,
+                type(attn_metadata_builder),
+                builder_reuse_key,
+                value_identity(group_causal),
+                value_identity(group_is_prefilling),
+            )
+            cached_builder = cached_attn_metadata_builders.get(cache_key)
+            share_buffers = getattr(
+                attn_metadata_builder, "share_reusable_metadata_buffers", None
+            )
+            if cached_builder is not None and share_buffers is not None:
+                share_buffers(cached_builder)
             if for_cudagraph_capture:
                 metadata = attn_metadata_builder.build_for_cudagraph_capture(
                     common_attn_metadata
+                )
+            elif (
+                cache_key in cached_attn_metadata
+                and attn_metadata_builder.supports_update_block_table
+            ):
+                metadata = attn_metadata_builder.update_block_table(
+                    cached_attn_metadata[cache_key],
+                    common_attn_metadata.block_table_tensor,
+                    common_attn_metadata.slot_mapping,
                 )
             else:
                 attn_metadata_extra_kwargs = (
@@ -308,6 +357,12 @@ def build_attn_metadata(
                     common_attn_metadata=common_attn_metadata,
                     **attn_metadata_extra_kwargs,
                 )
+                if attn_metadata_builder.supports_update_block_table:
+                    cached_attn_metadata[cache_key] = metadata
+            if attn_metadata_builder.supports_update_block_table:
+                cached_attn_metadata_builders[cache_key] = attn_metadata_builder
+                if for_cudagraph_capture:
+                    cached_attn_metadata[cache_key] = metadata
             for layer_name in attn_group.layer_names:
                 attn_metadata[layer_name] = metadata
     return attn_metadata


### PR DESCRIPTION
## Purpose

Kimi-K3 on ROCm runs many KV-cache groups over one batch: at TP8, six MLA groups and
fourteen KDA groups. Every group currently builds its own attention metadata, but most
of it describes the batch — query offsets, sequence lengths, speculative offsets, the
split-K schedule — and is identical across groups. Only the page indices and state
indices differ, because only the block table differs.

This builds once per step and, for the remaining groups, redoes only the
block-table-dependent part.

Full CUDA graphs bake tensor addresses at capture, so metadata cannot simply be handed
to another group, and buffers two groups will share must be rebound before capture.
Four hooks, declared on `AttentionMetadataBuilder` with no-op defaults so backends that
don't opt in are unaffected:

- `share_reusable_metadata_buffers()` — before capture, point compatible groups at one
  allocation for the buffers that are read-only during execution.
- `can_reuse_metadata()` — per step; anything it rejects falls back to a normal build.
- `update_block_table()` — redo only page/state indices.
- `get_metadata_reuse_key()` — extra identity beyond (builder type, kv-cache spec).

AITER MLA and Kimi-K3 KDA implement them.

## Test Plan

Unit tests, in the upstream image matching this branch's base:

```bash
docker run --rm --entrypoint bash --device /dev/kfd --device /dev/dri \
  --group-add video --ipc=host -v $PWD:/work \
  vllm/vllm-openai-rocm:nightly-d626108b1841888ec90aced33367149a6bbc7e4b -c '
  pip install -q tblib
  SP=$(python3 -c "import vllm,os;print(os.path.dirname(vllm.__file__))")
  for f in models/kimi_k3/amd/kda.py models/kimi_k3/amd/kda_metadata.py \
           models/kimi_k3/nvidia/kda_metadata.py v1/attention/backend.py \
           v1/attention/backends/mla/rocm_aiter_mla.py v1/worker/gpu/attn_utils.py; do
    cp /work/vllm/$f $SP/$f; done
  cd /work && python3 -m pytest -q tests/v1/worker/test_attn_utils.py \
    tests/v1/attention/test_rocm_aiter_mla_mtp_split.py \
    tests/models/kimi_k3/test_kda_metadata.py'
```

`ruff check` and `ruff format --check` (pinned 0.14.0) on the six changed files.

Accuracy on 8x MI355X, Kimi-K3 TP8 with a DSpark draft and fp8 KV. Control and candidate
are the same image with only these files swapped in (same approach as #52356); serve
flags follow #51253 / #50619:

```bash
vllm serve /model --served-model-name k3 --tensor-parallel-size 8 --trust-remote-code \
  --kv-cache-dtype fp8 --max-model-len 16384 --max-num-seqs 128 \
  --max-num-batched-tokens 16384 --gpu-memory-utilization 0.93 --block-size 128 \
  --no-enable-prefix-caching --mm-encoder-tp-mode data \
  --compilation-config '{"custom_ops":["+fused_rms_norm_gated"]}' \
  --speculative-config '{"method":"dspark","model":"/draft","num_speculative_tokens":2,"attention_backend":"TRITON_MLA"}'

lm_eval --model local-chat-completions \
  --model_args model=k3,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=32,tokenized_requests=False \
  --tasks gsm8k --num_fewshot 5 --batch_size 32 --limit 200 \
  --apply_chat_template --gen_kwargs temperature=0
```

## Test Result

**Unit tests: 72 passed.** Two of them are regression tests that fail without this
change: one covers `mamba_cache_mode="none"` (the default), where the state column is a
contiguous prefix rather than the `align` offset; the other covers the full-cudagraph
branch of `update_block_table`.

**Lint:** clean on all six files.

**gsm8k, 200 questions, 5-shot greedy:** 0.995 control, 0.995 candidate, both filters.

**Metadata build cost** (14 KDA groups, 8 requests, `num_speculative_tokens=2`),
fourteen builds versus one build plus thirteen reuses:

| context | 14x build | 1 build + 13 reuse | saved | |
|---|---|---|---|---|
| 1,024 | 663.4 us | 191.1 us | 472.3 us | 3.47x |
| 16,384 | 674.8 us | 199.4 us | 475.4 us | 3.38x |
| 262,144 | 668.3 us | 197.2 us | 471.1 us | 3.39x |

Scope of the claim:

- The saving does not vary with context length. Both halves are launch-bound: MLA's
  page-index expansion is also flat at ~10.3 us per group from 1K to 262K tokens. It
  scales with group count and batch size instead.
- It is a fixed ~0.5 ms per decode step, so its relative value depends on step time. At
  `num_speculative_tokens=2` a step is ~10 ms. Under a `num_speculative_tokens=7`
  draft-verify loop a step is ~163 ms and the same saving is ~0.3%.

No serving throughput number is claimed: a single control/candidate pair on this
hardware is within run-to-run drift, and separating them needs alternating arms with a
paired bootstrap.
