### PR TITLE
[Bugfix] Guard missing end_token substring in streaming reasoning parsers

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -436,3 +436,26 @@ class TestBaseThinkingReasoningParserEdgeCases:
         # Should treat as regular content since tokens don't match exactly
         assert reasoning == ("<test:thinking>Not a real token</test:thinking>Content")
         assert content is None
+
+    def test_end_token_id_without_literal_substring(self, test_tokenizer):
+        """Test streaming when end_token_id is present in multi-token delta but end_token string is not in delta_text."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        start_id = parser.start_token_id
+        end_id = parser.end_token_id
+
+        # Scenario: start token in previous_token_ids, multi-token delta with end_token_id
+        # but delta_text does not contain '</test:think>' literally
+        delta_msg = parser.extract_reasoning_streaming(
+            previous_text="thinking text ",
+            current_text="thinking text step complete",
+            delta_text="step complete",
+            previous_token_ids=[start_id, 100],
+            current_token_ids=[start_id, 100, 101, end_id],
+            delta_token_ids=[101, end_id],
+        )
+        assert delta_msg is not None
+        # Ensures delta_text was not truncated with delta_text[:-1]
+        assert delta_msg.reasoning == "step complete"
+        assert delta_msg.content is None
+
+

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -122,10 +122,15 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 # start token in previous, end token in delta,
                 # extract reasoning content
                 end_index = delta_text.find(self.end_token)
-                reasoning = delta_text[:end_index]
-                content = delta_text[end_index + len(self.end_token) :]
+                if end_index != -1:
+                    reasoning = delta_text[:end_index]
+                    content = delta_text[end_index + len(self.end_token) :]
+                else:
+                    reasoning = delta_text
+                    content = None
                 return DeltaMessage(
-                    reasoning=reasoning, content=content if content else None
+                    reasoning=reasoning if reasoning else None,
+                    content=content if content else None,
                 )
             elif self.end_token_id in previous_token_ids:
                 # start token in previous, end token in previous,
@@ -141,10 +146,20 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 # extract reasoning content
                 start_index = delta_text.find(self.start_token)
                 end_index = delta_text.find(self.end_token)
-                reasoning = delta_text[start_index + len(self.start_token) : end_index]
-                content = delta_text[end_index + len(self.end_token) :]
+                if start_index != -1 and end_index != -1 and end_index >= start_index:
+                    reasoning = delta_text[
+                        start_index + len(self.start_token) : end_index
+                    ]
+                    content = delta_text[end_index + len(self.end_token) :]
+                elif start_index != -1:
+                    reasoning = delta_text[start_index + len(self.start_token) :]
+                    content = None
+                else:
+                    reasoning = delta_text
+                    content = None
                 return DeltaMessage(
-                    reasoning=reasoning, content=content if content else None
+                    reasoning=reasoning if reasoning else None,
+                    content=content if content else None,
                 )
             else:
                 # start token in delta, no end token in delta,

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -51,10 +51,14 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
                 # end token in delta with more tokens,
                 # extract reasoning content and content
                 end_index = delta_text.find(self.end_token)
-                reasoning = delta_text[:end_index]
-                content = delta_text[end_index + len(self.end_token) :]
+                if end_index != -1:
+                    reasoning = delta_text[:end_index]
+                    content = delta_text[end_index + len(self.end_token) :]
+                else:
+                    reasoning = delta_text
+                    content = None
                 return DeltaMessage(
-                    reasoning=reasoning,
+                    reasoning=reasoning if reasoning else None,
                     content=content if content else None,
                 )
             elif self.end_token_id in previous_token_ids:


### PR DESCRIPTION
## Motivation
In `BaseThinkingReasoningParser` and `DeepSeekR1ReasoningParser`, when `end_token_id` is present in `delta_token_ids`, `delta_text.find(self.end_token)` is called to split reasoning and content text.

If `self.end_token` literal string is not present in `delta_text` (e.g. during multi-token deltas where the special token is detokenized as empty or formatted separately), `find()` returns `-1`. Previously, slicing `delta_text[:end_index]` evaluated to `delta_text[:-1]`, silently clipping the last character off the reasoning buffer and slicing into `content`.

## Proposed Changes
- Added presence check `if end_index != -1:` before slicing `delta_text` in `BaseThinkingReasoningParser` and `DeepSeekR1ReasoningParser`.
- If `end_index == -1`, safely keeps `reasoning = delta_text` without character truncation.
- Added unit test `test_end_token_id_without_literal_substring` in `tests/reasoning/test_base_thinking_reasoning_parser.py` covering multi-token delta handling.