### PR TITLE
Revert compile-cache device index regression on CPU

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1074,10 +1074,7 @@ class VllmBackend:
         self.compilation_config.cache_dir = cache_dir
         rank = vllm_config.parallel_config.rank
         dp_rank = vllm_config.parallel_config.data_parallel_index
-        dev = torch.accelerator.current_device_index()
-        local_cache_dir = os.path.join(
-            cache_dir, f"rank_{rank}_{dp_rank}_dev{dev}", self.prefix
-        )
+        local_cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}", self.prefix)
         os.makedirs(local_cache_dir, exist_ok=True)
         self.compilation_config.local_cache_dir = local_cache_dir
 

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -559,8 +559,7 @@ def _support_torch_compile(
 
             rank = self.vllm_config.parallel_config.rank
             dp_rank = self.vllm_config.parallel_config.data_parallel_index
-            dev = torch.accelerator.current_device_index()
-            cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}_dev{dev}")
+            cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}")
             aot_compilation_path = os.path.join(cache_dir, "model")
             if not envs.VLLM_DISABLE_COMPILE_CACHE:
                 loaded_fn = _try_load_aot_compiled_fn(self, aot_compilation_path)


### PR DESCRIPTION
## Why

This reverts #38962 because its unconditional `torch.accelerator.current_device_index()` calls break CPU-only execution before engine startup:

```
RuntimeError: Cannot access accelerator device when none is available.
```

The merged commit `6dcc5d7c` is the first affected main commit. Main Buildkite #85059 fails this way across multiple CPU suites and independent hosts. CPU Distributed PP+TP reproduced the identical startup failure on both retry hosts. Later main builds #85065 and #85078 independently reproduced the same CPU Language Generation signature.

The exact PR-head Buildkite #77551 selected CPU Language Generation and failed the same accelerator-device lookup signature. The other affected CPU jobs were blocked, so the exact CI was red rather than passing or merely unselected.

## Duplicate-work check

Searched open PRs for `38962`, `compile cache device index CPU accelerator`, and the exact `Cannot access accelerator device when none is available` signature. No existing revert or equivalent fix was found. Open #41688 concerns CPU-only shutdown cleanup and does not address these compile-cache paths.

## Validation

- `git diff --cached --check` before commit
- Verified the staged revert patch applies cleanly in reverse
- This commit is the exact inverse of merge commit `6dcc5d7caeffa7f69239153b171249e867ca6050`
- GitHub `pre-commit` passed at the exact signed head
- Exact CPU Language Generation passed in Buildkite #85071 on `cpu-aicf-jf-cicd-08` (40m, exit 0), directly converting the repeated main/culprit-head signature to green
- Exact CPU Distributed PP+TP passed in Buildkite #85086 on `cpu-aicf-jf-cicd-02` (8m38s, exit 0; 20/20 benchmark requests succeeded and `failed=0`)

`pre-commit` is not installed in this emergency worktree, so repository hooks were not run locally. Exact Buildkite jobs are the merge gate.

No model evaluation is applicable because this is an emergency rollback restoring CPU startup behavior present immediately before the breaking merge.

## Merge gate

Exact pre-merge CPU validation is complete. Keep this draft until human line-by-line review; after merge, require exact post-merge main CPU confirmation before closing the incident. The incident remains open after pre-merge validation and closes only after merge plus exact post-merge main CPU confirmation.

## AI assistance

AI assistance was used to investigate the CI failure, prepare the revert, and draft this PR. The human submitter must review every changed line and can explain and defend the change end-to-end.