### PR TITLE
fix(v1/core): ensure robust non-empty PYTHONHASHSEED handling in init_none_hash

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -109,7 +109,7 @@ def init_none_hash(hash_fn: Callable[[Any], bytes]):
             "fixed value for reproducibility."
         )
 
-    if hash_seed is None:
+    if not hash_seed:
         NONE_HASH = BlockHash(os.urandom(32))
     else:
         NONE_HASH = BlockHash(hash_fn(hash_seed))


### PR DESCRIPTION
### Summary
When `PYTHONHASHSEED` is set to an empty string (`""`) in containerized or orchestration environments, `init_none_hash` previously evaluated `hash_seed is None` as False, attempting to compute `hash_fn("")` rather than falling back to `os.urandom(32)`.

### Changes
* Changed check to `if not hash_seed:` to guarantee fallback to secure entropy whenever `PYTHONHASHSEED` is unset or empty.