### PR TITLE
[LoRA] Prepare Punica metadata on CPU

### DIFF
--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -24,6 +24,61 @@ def _to_ref_device(tensor: torch.Tensor) -> torch.Tensor:
     return tensor.cpu() if _REF_ON_CPU else tensor
 
 
+@pytest.mark.parametrize(
+    "mapping,expected_ids,expected_counts,expected_order",
+    [
+        ([2, -1, 0, 2, 0], [-1, 0, 2], [1, 2, 2], [1, 2, 4, 0, 3]),
+        ([1, 1, 1], [1], [3], [0, 1, 2]),
+    ],
+)
+def test_prepare_lora_metadata_on_cpu(
+    mapping, expected_ids, expected_counts, expected_order
+):
+    meta = LoRAKernelMeta.make(
+        max_loras=4,
+        max_num_tokens=len(mapping),
+        device=DEVICE_TYPE,
+        captured_lora_counts=[1, 2, 4],
+    )
+
+    meta.prepare_tensors_cpu(torch.tensor(mapping, dtype=torch.long))
+
+    num_active = len(expected_ids)
+    torch.testing.assert_close(
+        meta.token_lora_mapping.cpu(), torch.tensor(mapping, dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        meta.token_indices_sorted_by_lora_ids.cpu(),
+        torch.tensor(expected_order, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        meta.active_lora_ids[:num_active].cpu(),
+        torch.tensor(expected_ids, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        meta.num_tokens_per_lora[:num_active].cpu(),
+        torch.tensor(expected_counts, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        meta.lora_token_start_loc[: num_active + 1].cpu(),
+        torch.tensor([0, *expected_counts], dtype=torch.int32).cumsum(0),
+    )
+    expected_specialized_count = 4 if num_active == 3 else num_active
+    assert meta.num_active_loras_cpu.item() == expected_specialized_count
+
+
+def test_prepare_lora_metadata_on_cpu_no_lora():
+    meta = LoRAKernelMeta.make(
+        max_loras=4,
+        max_num_tokens=3,
+        device=DEVICE_TYPE,
+    )
+
+    meta.prepare_tensors_cpu(torch.full((3,), -1, dtype=torch.long))
+
+    assert meta.no_lora_flag_cpu.item()
+
+
 @pytest.fixture(autouse=True)
 def reset_device(reset_default_device):
     pass

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -41,7 +41,7 @@ def test_prepare_lora_metadata_on_cpu(
         captured_lora_counts=[1, 2, 4],
     )
 
-    meta.prepare_tensors_cpu(torch.tensor(mapping, dtype=torch.long))
+    meta.prepare_tensors_cpu(mapping)
 
     num_active = len(expected_ids)
     torch.testing.assert_close(
@@ -74,7 +74,7 @@ def test_prepare_lora_metadata_on_cpu_no_lora():
         device=DEVICE_TYPE,
     )
 
-    meta.prepare_tensors_cpu(torch.full((3,), -1, dtype=torch.long))
+    meta.prepare_tensors_cpu([-1, -1, -1])
 
     assert meta.no_lora_flag_cpu.item()
 

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -6,8 +6,10 @@ import pytest
 import torch
 
 import vllm.lora.ops.triton_ops as triton_ops
+from vllm.lora.layers import LoRAMapping
 from vllm.lora.ops.triton_ops import LoRAKernelMeta
 from vllm.lora.ops.triton_ops.utils import _LORA_A_PTR_DICT, _LORA_B_PTR_DICT
+from vllm.lora.punica_wrapper.utils import convert_mapping
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
@@ -77,6 +79,41 @@ def test_prepare_lora_metadata_on_cpu_no_lora():
     meta.prepare_tensors_cpu([-1, -1, -1])
 
     assert meta.no_lora_flag_cpu.item()
+
+
+def test_copy_prepared_lora_metadata():
+    mapping = [2, -1, 0, 2, 0]
+    source = LoRAKernelMeta.make(4, len(mapping), DEVICE_TYPE)
+    destination = LoRAKernelMeta.make(4, len(mapping), DEVICE_TYPE)
+
+    metadata = source.prepare_tensors_cpu(mapping)
+    destination.copy_tensors_cpu(metadata)
+
+    torch.testing.assert_close(
+        destination.token_lora_mapping, source.token_lora_mapping
+    )
+    torch.testing.assert_close(
+        destination.token_indices_sorted_by_lora_ids,
+        source.token_indices_sorted_by_lora_ids,
+    )
+    torch.testing.assert_close(destination.active_lora_ids, source.active_lora_ids)
+    torch.testing.assert_close(
+        destination.num_tokens_per_lora, source.num_tokens_per_lora
+    )
+    torch.testing.assert_close(
+        destination.lora_token_start_loc, source.lora_token_start_loc
+    )
+
+
+@pytest.mark.parametrize("reuse_mapping", [True, False])
+def test_convert_mapping_reuses_equal_cpu_mappings(reuse_mapping):
+    index_mapping = (1, 2)
+    prompt_mapping = index_mapping if reuse_mapping else (2, 1)
+    mapping = LoRAMapping(index_mapping, prompt_mapping)
+
+    result = convert_mapping(mapping, [1, 2], 2, 32000, 0, DEVICE_TYPE)
+
+    assert (result[-2] is result[-1]) is reuse_mapping
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lora/test_punica_ops.py
+++ b/tests/lora/test_punica_ops.py
@@ -81,13 +81,40 @@ def test_prepare_lora_metadata_on_cpu_no_lora():
     assert meta.no_lora_flag_cpu.item()
 
 
-def test_copy_prepared_lora_metadata():
+def test_prepare_lora_metadata_vectorized():
+    mapping = [2, -1, 0, 2, 0] * 103
+    meta = LoRAKernelMeta.make(4, len(mapping), DEVICE_TYPE)
+
+    meta.prepare_tensors_cpu(mapping)
+
+    mapping_tensor = torch.tensor(mapping, dtype=torch.int32, device=DEVICE_TYPE)
+    sorted_ids, sorted_indices = torch.sort(mapping_tensor, stable=True)
+    expected_ids, expected_counts = torch.unique_consecutive(
+        sorted_ids, return_counts=True
+    )
+    num_active = expected_ids.size(0)
+    torch.testing.assert_close(meta.token_lora_mapping, mapping_tensor)
+    torch.testing.assert_close(
+        meta.token_indices_sorted_by_lora_ids,
+        sorted_indices.to(dtype=torch.int32),
+    )
+    torch.testing.assert_close(meta.active_lora_ids[:num_active], expected_ids)
+    torch.testing.assert_close(
+        meta.num_tokens_per_lora[:num_active],
+        expected_counts.to(dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        meta.lora_token_start_loc[1 : num_active + 1],
+        torch.cumsum(expected_counts, dim=0, dtype=torch.int32),
+    )
+
+
+def test_prepare_lora_metadata_for_two_targets():
     mapping = [2, -1, 0, 2, 0]
     source = LoRAKernelMeta.make(4, len(mapping), DEVICE_TYPE)
     destination = LoRAKernelMeta.make(4, len(mapping), DEVICE_TYPE)
 
-    metadata = source.prepare_tensors_cpu(mapping)
-    destination.copy_tensors_cpu(metadata)
+    source.prepare_tensors_cpu(mapping, copy_to=destination)
 
     torch.testing.assert_close(
         destination.token_lora_mapping, source.token_lora_mapping

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 
 import torch
 
+from vllm.utils.torch_utils import PIN_MEMORY
+
 
 @dataclass
 class LoRAKernelMeta:
@@ -105,6 +107,49 @@ class LoRAKernelMeta:
         self.lora_token_start_loc.fill_(0)
         self.no_lora_flag_cpu.fill_(False)
         self.num_active_loras_cpu.fill_(0)
+
+    def prepare_tensors_cpu(self, token_lora_mapping: torch.Tensor) -> None:
+        """Prepare metadata on the CPU and asynchronously copy it to device."""
+        assert token_lora_mapping.is_cpu
+
+        self._reset()
+        num_tokens = token_lora_mapping.size(0)
+        mapping_cpu = token_lora_mapping.to(dtype=torch.int32)
+
+        no_lora = bool(torch.all(mapping_cpu == -1))
+        self.no_lora_flag_cpu[0] = no_lora
+        if no_lora:
+            return
+
+        _, sorted_indices = torch.sort(mapping_cpu, stable=True)
+        lora_ids, counts = torch.unique(
+            mapping_cpu, sorted=True, return_counts=True
+        )
+        num_active_loras = lora_ids.size(0)
+
+        start_locs = torch.cumsum(counts, dim=0)
+        if PIN_MEMORY:
+            mapping_cpu = mapping_cpu.pin_memory()
+            sorted_indices = sorted_indices.pin_memory()
+            lora_ids = lora_ids.pin_memory()
+            counts = counts.pin_memory()
+            start_locs = start_locs.pin_memory()
+
+        self.token_lora_mapping[:num_tokens].copy_(mapping_cpu, non_blocking=True)
+        self.token_indices_sorted_by_lora_ids[:num_tokens].copy_(
+            sorted_indices, non_blocking=True
+        )
+        self.active_lora_ids[:num_active_loras].copy_(lora_ids, non_blocking=True)
+        self.num_tokens_per_lora[:num_active_loras].copy_(counts, non_blocking=True)
+        self.lora_token_start_loc[1 : num_active_loras + 1].copy_(
+            start_locs, non_blocking=True
+        )
+
+        if self.captured_lora_counts:
+            idx = bisect.bisect_left(self.captured_lora_counts, num_active_loras)
+            if idx < len(self.captured_lora_counts):
+                num_active_loras = self.captured_lora_counts[idx]
+        self.num_active_loras_cpu[0] = num_active_loras
 
     def prepare_tensors(self, token_lora_mapping: torch.Tensor) -> None:
         """

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -108,13 +108,11 @@ class LoRAKernelMeta:
         self.no_lora_flag_cpu.fill_(False)
         self.num_active_loras_cpu.fill_(0)
 
-    def prepare_tensors_cpu(self, token_lora_mapping: torch.Tensor) -> None:
+    def prepare_tensors_cpu(self, token_lora_mapping: list[int]) -> None:
         """Prepare metadata on the CPU and asynchronously copy it to device."""
-        assert token_lora_mapping.is_cpu
-
         self._reset()
-        num_tokens = token_lora_mapping.size(0)
-        mapping_cpu = token_lora_mapping.to(dtype=torch.int32)
+        mapping_cpu = torch.tensor(token_lora_mapping, dtype=torch.int32)
+        num_tokens = mapping_cpu.size(0)
 
         no_lora = bool(torch.all(mapping_cpu == -1))
         self.no_lora_flag_cpu[0] = no_lora

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -120,7 +120,10 @@ class LoRAKernelMeta:
         num_tokens = len(token_lora_mapping)
         if not no_lora:
             mapping_cpu = torch.tensor(
-                token_lora_mapping, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
+                token_lora_mapping,
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=PIN_MEMORY,
             )
             if num_tokens >= _VECTORIZED_METADATA_MIN_TOKENS:
                 sorted_lora_ids = torch.empty_like(mapping_cpu)
@@ -141,9 +144,7 @@ class LoRAKernelMeta:
                 counts_cpu = torch.empty_like(
                     counts, dtype=torch.int32, pin_memory=PIN_MEMORY
                 ).copy_(counts)
-                start_locs_cpu = torch.empty_like(
-                    counts_cpu, pin_memory=PIN_MEMORY
-                )
+                start_locs_cpu = torch.empty_like(counts_cpu, pin_memory=PIN_MEMORY)
                 torch.cumsum(counts_cpu, dim=0, out=start_locs_cpu)
             else:
                 indices_by_lora_id = [[] for _ in range(self.active_lora_ids.numel())]

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -11,17 +11,7 @@ import torch
 
 from vllm.utils.torch_utils import PIN_MEMORY
 
-
-@dataclass(frozen=True)
-class LoRAKernelMetaCPU:
-    token_lora_mapping: torch.Tensor | None = None
-    token_indices_sorted_by_lora_ids: torch.Tensor | None = None
-    active_lora_ids: torch.Tensor | None = None
-    num_tokens_per_lora: torch.Tensor | None = None
-    lora_token_start_loc: torch.Tensor | None = None
-    num_tokens: int = 0
-    num_active_loras: int = 0
-    no_lora: bool = False
+_VECTORIZED_METADATA_MIN_TOKENS = 512
 
 
 @dataclass
@@ -120,108 +110,106 @@ class LoRAKernelMeta:
         self.no_lora_flag_cpu.fill_(False)
         self.num_active_loras_cpu.fill_(0)
 
-    def prepare_tensors_cpu(self, token_lora_mapping: list[int]) -> LoRAKernelMetaCPU:
+    def prepare_tensors_cpu(
+        self,
+        token_lora_mapping: list[int],
+        copy_to: "LoRAKernelMeta | None" = None,
+    ) -> None:
         """Prepare metadata on the CPU and asynchronously copy it to device."""
         no_lora = all(lora_id == -1 for lora_id in token_lora_mapping)
-        if no_lora:
-            metadata = LoRAKernelMetaCPU(no_lora=True)
-            self.copy_tensors_cpu(metadata)
-            return metadata
-
-        indices_by_lora_id = [[] for _ in range(self.active_lora_ids.numel())]
-        for token_index, lora_id in enumerate(token_lora_mapping):
-            indices_by_lora_id[lora_id + 1].append(token_index)
-
-        lora_ids: list[int] = []
-        counts: list[int] = []
-        sorted_indices: list[int] = []
-        start_locs: list[int] = []
-        next_start_loc = 0
-        for lora_id, token_indices in enumerate(indices_by_lora_id, start=-1):
-            if not token_indices:
-                continue
-            count = len(token_indices)
-            lora_ids.append(lora_id)
-            counts.append(count)
-            sorted_indices.extend(token_indices)
-            next_start_loc += count
-            start_locs.append(next_start_loc)
-
-        mapping_cpu = torch.tensor(
-            token_lora_mapping,
-            dtype=torch.int32,
-            pin_memory=PIN_MEMORY,
-        )
-        sorted_indices_cpu = torch.tensor(
-            sorted_indices,
-            dtype=torch.int32,
-            pin_memory=PIN_MEMORY,
-        )
-        lora_ids_cpu = torch.tensor(
-            lora_ids,
-            dtype=torch.int32,
-            pin_memory=PIN_MEMORY,
-        )
-        counts_cpu = torch.tensor(
-            counts,
-            dtype=torch.int32,
-            pin_memory=PIN_MEMORY,
-        )
-        start_locs_cpu = torch.tensor(
-            start_locs,
-            dtype=torch.int32,
-            pin_memory=PIN_MEMORY,
-        )
         num_tokens = len(token_lora_mapping)
-        num_active_loras = len(lora_ids)
+        if not no_lora:
+            mapping_cpu = torch.tensor(
+                token_lora_mapping,
+                dtype=torch.int32,
+                pin_memory=PIN_MEMORY,
+            )
+            if num_tokens >= _VECTORIZED_METADATA_MIN_TOKENS:
+                sorted_lora_ids, sorted_indices_cpu = torch.sort(
+                    mapping_cpu, stable=True
+                )
+                lora_ids_cpu, counts_cpu = torch.unique_consecutive(
+                    sorted_lora_ids, return_counts=True
+                )
+                sorted_indices_cpu = sorted_indices_cpu.to(dtype=torch.int32)
+                counts_cpu = counts_cpu.to(dtype=torch.int32)
+                start_locs_cpu = torch.cumsum(counts_cpu, dim=0, dtype=torch.int32)
+                if PIN_MEMORY:
+                    sorted_indices_cpu = sorted_indices_cpu.pin_memory()
+                    lora_ids_cpu = lora_ids_cpu.pin_memory()
+                    counts_cpu = counts_cpu.pin_memory()
+                    start_locs_cpu = start_locs_cpu.pin_memory()
+            else:
+                indices_by_lora_id = [[] for _ in range(self.active_lora_ids.numel())]
+                for token_index, lora_id in enumerate(token_lora_mapping):
+                    indices_by_lora_id[lora_id + 1].append(token_index)
 
-        metadata = LoRAKernelMetaCPU(
-            token_lora_mapping=mapping_cpu,
-            token_indices_sorted_by_lora_ids=sorted_indices_cpu,
-            active_lora_ids=lora_ids_cpu,
-            num_tokens_per_lora=counts_cpu,
-            lora_token_start_loc=start_locs_cpu,
-            num_tokens=num_tokens,
-            num_active_loras=num_active_loras,
-        )
-        self.copy_tensors_cpu(metadata)
-        return metadata
+                lora_ids: list[int] = []
+                counts: list[int] = []
+                sorted_indices: list[int] = []
+                start_locs: list[int] = []
+                next_start_loc = 0
+                for lora_id, token_indices in enumerate(indices_by_lora_id, start=-1):
+                    if not token_indices:
+                        continue
+                    count = len(token_indices)
+                    lora_ids.append(lora_id)
+                    counts.append(count)
+                    sorted_indices.extend(token_indices)
+                    next_start_loc += count
+                    start_locs.append(next_start_loc)
 
-    def copy_tensors_cpu(self, metadata: LoRAKernelMetaCPU) -> None:
-        """Asynchronously copy prepared CPU metadata to this device buffer."""
-        self._reset()
-        self.no_lora_flag_cpu[0] = metadata.no_lora
-        if metadata.no_lora:
-            return
+                sorted_indices_cpu = torch.tensor(
+                    sorted_indices,
+                    dtype=torch.int32,
+                    pin_memory=PIN_MEMORY,
+                )
+                lora_ids_cpu = torch.tensor(
+                    lora_ids,
+                    dtype=torch.int32,
+                    pin_memory=PIN_MEMORY,
+                )
+                counts_cpu = torch.tensor(
+                    counts,
+                    dtype=torch.int32,
+                    pin_memory=PIN_MEMORY,
+                )
+                start_locs_cpu = torch.tensor(
+                    start_locs,
+                    dtype=torch.int32,
+                    pin_memory=PIN_MEMORY,
+                )
 
-        assert metadata.token_lora_mapping is not None
-        assert metadata.token_indices_sorted_by_lora_ids is not None
-        assert metadata.active_lora_ids is not None
-        assert metadata.num_tokens_per_lora is not None
-        assert metadata.lora_token_start_loc is not None
+            num_active_loras = lora_ids_cpu.size(0)
 
-        self.token_lora_mapping[: metadata.num_tokens].copy_(
-            metadata.token_lora_mapping, non_blocking=True
-        )
-        self.token_indices_sorted_by_lora_ids[: metadata.num_tokens].copy_(
-            metadata.token_indices_sorted_by_lora_ids, non_blocking=True
-        )
-        self.active_lora_ids[: metadata.num_active_loras].copy_(
-            metadata.active_lora_ids, non_blocking=True
-        )
-        self.num_tokens_per_lora[: metadata.num_active_loras].copy_(
-            metadata.num_tokens_per_lora, non_blocking=True
-        )
-        self.lora_token_start_loc[1 : metadata.num_active_loras + 1].copy_(
-            metadata.lora_token_start_loc, non_blocking=True
-        )
+        for target in (self,) if copy_to is None else (self, copy_to):
+            target._reset()
+            target.no_lora_flag_cpu[0] = no_lora
+            if no_lora:
+                continue
 
-        num_active_loras = metadata.num_active_loras
-        if self.captured_lora_counts:
-            idx = bisect.bisect_left(self.captured_lora_counts, num_active_loras)
-            if idx < len(self.captured_lora_counts):
-                num_active_loras = self.captured_lora_counts[idx]
-        self.num_active_loras_cpu[0] = num_active_loras
+            target.token_lora_mapping[:num_tokens].copy_(mapping_cpu, non_blocking=True)
+            target.token_indices_sorted_by_lora_ids[:num_tokens].copy_(
+                sorted_indices_cpu, non_blocking=True
+            )
+            target.active_lora_ids[:num_active_loras].copy_(
+                lora_ids_cpu, non_blocking=True
+            )
+            target.num_tokens_per_lora[:num_active_loras].copy_(
+                counts_cpu, non_blocking=True
+            )
+            target.lora_token_start_loc[1 : num_active_loras + 1].copy_(
+                start_locs_cpu, non_blocking=True
+            )
+
+            specialized_num_active_loras = num_active_loras
+            if target.captured_lora_counts:
+                idx = bisect.bisect_left(
+                    target.captured_lora_counts, specialized_num_active_loras
+                )
+                if idx < len(target.captured_lora_counts):
+                    specialized_num_active_loras = target.captured_lora_counts[idx]
+            target.num_active_loras_cpu[0] = specialized_num_active_loras
 
     def prepare_tensors(self, token_lora_mapping: torch.Tensor) -> None:
         """

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -120,25 +120,30 @@ class LoRAKernelMeta:
         num_tokens = len(token_lora_mapping)
         if not no_lora:
             mapping_cpu = torch.tensor(
-                token_lora_mapping,
-                dtype=torch.int32,
-                pin_memory=PIN_MEMORY,
+                token_lora_mapping, dtype=torch.int32, pin_memory=PIN_MEMORY
             )
             if num_tokens >= _VECTORIZED_METADATA_MIN_TOKENS:
-                sorted_lora_ids, sorted_indices_cpu = torch.sort(
-                    mapping_cpu, stable=True
-                )
-                lora_ids_cpu, counts_cpu = torch.unique_consecutive(
+                sorted_lora_ids, sorted_indices = torch.sort(mapping_cpu, stable=True)
+                lora_ids, counts = torch.unique_consecutive(
                     sorted_lora_ids, return_counts=True
                 )
-                sorted_indices_cpu = sorted_indices_cpu.to(dtype=torch.int32)
-                counts_cpu = counts_cpu.to(dtype=torch.int32)
-                start_locs_cpu = torch.cumsum(counts_cpu, dim=0, dtype=torch.int32)
-                if PIN_MEMORY:
-                    sorted_indices_cpu = sorted_indices_cpu.pin_memory()
-                    lora_ids_cpu = lora_ids_cpu.pin_memory()
-                    counts_cpu = counts_cpu.pin_memory()
-                    start_locs_cpu = start_locs_cpu.pin_memory()
+
+                sorted_indices_cpu = torch.empty_like(
+                    sorted_indices, dtype=torch.int32, pin_memory=PIN_MEMORY
+                )
+                sorted_indices_cpu.copy_(sorted_indices)
+                lora_ids_cpu = torch.empty_like(
+                    lora_ids, dtype=torch.int32, pin_memory=PIN_MEMORY
+                )
+                lora_ids_cpu.copy_(lora_ids)
+                counts_cpu = torch.empty_like(
+                    counts, dtype=torch.int32, pin_memory=PIN_MEMORY
+                )
+                counts_cpu.copy_(counts)
+                start_locs_cpu = torch.empty_like(
+                    counts_cpu, pin_memory=PIN_MEMORY
+                )
+                torch.cumsum(counts_cpu, dim=0, out=start_locs_cpu)
             else:
                 indices_by_lora_id = [[] for _ in range(self.active_lora_ids.numel())]
                 for token_index, lora_id in enumerate(token_lora_mapping):
@@ -160,24 +165,16 @@ class LoRAKernelMeta:
                     start_locs.append(next_start_loc)
 
                 sorted_indices_cpu = torch.tensor(
-                    sorted_indices,
-                    dtype=torch.int32,
-                    pin_memory=PIN_MEMORY,
+                    sorted_indices, dtype=torch.int32, pin_memory=PIN_MEMORY
                 )
                 lora_ids_cpu = torch.tensor(
-                    lora_ids,
-                    dtype=torch.int32,
-                    pin_memory=PIN_MEMORY,
+                    lora_ids, dtype=torch.int32, pin_memory=PIN_MEMORY
                 )
                 counts_cpu = torch.tensor(
-                    counts,
-                    dtype=torch.int32,
-                    pin_memory=PIN_MEMORY,
+                    counts, dtype=torch.int32, pin_memory=PIN_MEMORY
                 )
                 start_locs_cpu = torch.tensor(
-                    start_locs,
-                    dtype=torch.int32,
-                    pin_memory=PIN_MEMORY,
+                    start_locs, dtype=torch.int32, pin_memory=PIN_MEMORY
                 )
 
             num_active_loras = lora_ids_cpu.size(0)

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -11,7 +11,7 @@ import torch
 
 from vllm.utils.torch_utils import PIN_MEMORY
 
-_VECTORIZED_METADATA_MIN_TOKENS = 512
+_VECTORIZED_METADATA_MIN_TOKENS = 1024
 
 
 @dataclass

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -12,6 +12,18 @@ import torch
 from vllm.utils.torch_utils import PIN_MEMORY
 
 
+@dataclass(frozen=True)
+class LoRAKernelMetaCPU:
+    token_lora_mapping: torch.Tensor | None = None
+    token_indices_sorted_by_lora_ids: torch.Tensor | None = None
+    active_lora_ids: torch.Tensor | None = None
+    num_tokens_per_lora: torch.Tensor | None = None
+    lora_token_start_loc: torch.Tensor | None = None
+    num_tokens: int = 0
+    num_active_loras: int = 0
+    no_lora: bool = False
+
+
 @dataclass
 class LoRAKernelMeta:
     token_lora_mapping: torch.Tensor
@@ -108,13 +120,13 @@ class LoRAKernelMeta:
         self.no_lora_flag_cpu.fill_(False)
         self.num_active_loras_cpu.fill_(0)
 
-    def prepare_tensors_cpu(self, token_lora_mapping: list[int]) -> None:
+    def prepare_tensors_cpu(self, token_lora_mapping: list[int]) -> LoRAKernelMetaCPU:
         """Prepare metadata on the CPU and asynchronously copy it to device."""
-        self._reset()
         no_lora = all(lora_id == -1 for lora_id in token_lora_mapping)
-        self.no_lora_flag_cpu[0] = no_lora
         if no_lora:
-            return
+            metadata = LoRAKernelMetaCPU(no_lora=True)
+            self.copy_tensors_cpu(metadata)
+            return metadata
 
         indices_by_lora_id = [[] for _ in range(self.active_lora_ids.numel())]
         for token_index, lora_id in enumerate(token_lora_mapping):
@@ -163,16 +175,48 @@ class LoRAKernelMeta:
         num_tokens = len(token_lora_mapping)
         num_active_loras = len(lora_ids)
 
-        self.token_lora_mapping[:num_tokens].copy_(mapping_cpu, non_blocking=True)
-        self.token_indices_sorted_by_lora_ids[:num_tokens].copy_(
-            sorted_indices_cpu, non_blocking=True
+        metadata = LoRAKernelMetaCPU(
+            token_lora_mapping=mapping_cpu,
+            token_indices_sorted_by_lora_ids=sorted_indices_cpu,
+            active_lora_ids=lora_ids_cpu,
+            num_tokens_per_lora=counts_cpu,
+            lora_token_start_loc=start_locs_cpu,
+            num_tokens=num_tokens,
+            num_active_loras=num_active_loras,
         )
-        self.active_lora_ids[:num_active_loras].copy_(lora_ids_cpu, non_blocking=True)
-        self.num_tokens_per_lora[:num_active_loras].copy_(counts_cpu, non_blocking=True)
-        self.lora_token_start_loc[1 : num_active_loras + 1].copy_(
-            start_locs_cpu, non_blocking=True
+        self.copy_tensors_cpu(metadata)
+        return metadata
+
+    def copy_tensors_cpu(self, metadata: LoRAKernelMetaCPU) -> None:
+        """Asynchronously copy prepared CPU metadata to this device buffer."""
+        self._reset()
+        self.no_lora_flag_cpu[0] = metadata.no_lora
+        if metadata.no_lora:
+            return
+
+        assert metadata.token_lora_mapping is not None
+        assert metadata.token_indices_sorted_by_lora_ids is not None
+        assert metadata.active_lora_ids is not None
+        assert metadata.num_tokens_per_lora is not None
+        assert metadata.lora_token_start_loc is not None
+
+        self.token_lora_mapping[: metadata.num_tokens].copy_(
+            metadata.token_lora_mapping, non_blocking=True
+        )
+        self.token_indices_sorted_by_lora_ids[: metadata.num_tokens].copy_(
+            metadata.token_indices_sorted_by_lora_ids, non_blocking=True
+        )
+        self.active_lora_ids[: metadata.num_active_loras].copy_(
+            metadata.active_lora_ids, non_blocking=True
+        )
+        self.num_tokens_per_lora[: metadata.num_active_loras].copy_(
+            metadata.num_tokens_per_lora, non_blocking=True
+        )
+        self.lora_token_start_loc[1 : metadata.num_active_loras + 1].copy_(
+            metadata.lora_token_start_loc, non_blocking=True
         )
 
+        num_active_loras = metadata.num_active_loras
         if self.captured_lora_counts:
             idx = bisect.bisect_left(self.captured_lora_counts, num_active_loras)
             if idx < len(self.captured_lora_counts):

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -123,15 +123,18 @@ class LoRAKernelMeta:
                 token_lora_mapping, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
             )
             if num_tokens >= _VECTORIZED_METADATA_MIN_TOKENS:
-                sorted_lora_ids, sorted_indices = torch.sort(mapping_cpu, stable=True)
+                sorted_lora_ids = torch.empty_like(mapping_cpu)
+                sorted_indices_cpu = torch.empty_like(
+                    mapping_cpu, dtype=torch.int64, pin_memory=PIN_MEMORY
+                )
+                torch.sort(
+                    mapping_cpu,
+                    stable=True,
+                    out=(sorted_lora_ids, sorted_indices_cpu),
+                )
                 lora_ids, counts = torch.unique_consecutive(
                     sorted_lora_ids, return_counts=True
                 )
-
-                sorted_indices_cpu = torch.empty_like(
-                    sorted_indices, dtype=torch.int32, pin_memory=PIN_MEMORY
-                )
-                sorted_indices_cpu.copy_(sorted_indices)
                 lora_ids_cpu = torch.empty_like(
                     lora_ids, dtype=torch.int32, pin_memory=PIN_MEMORY
                 ).copy_(lora_ids)

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -120,7 +120,7 @@ class LoRAKernelMeta:
         num_tokens = len(token_lora_mapping)
         if not no_lora:
             mapping_cpu = torch.tensor(
-                token_lora_mapping, dtype=torch.int32, pin_memory=PIN_MEMORY
+                token_lora_mapping, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
             )
             if num_tokens >= _VECTORIZED_METADATA_MIN_TOKENS:
                 sorted_lora_ids, sorted_indices = torch.sort(mapping_cpu, stable=True)
@@ -134,12 +134,10 @@ class LoRAKernelMeta:
                 sorted_indices_cpu.copy_(sorted_indices)
                 lora_ids_cpu = torch.empty_like(
                     lora_ids, dtype=torch.int32, pin_memory=PIN_MEMORY
-                )
-                lora_ids_cpu.copy_(lora_ids)
+                ).copy_(lora_ids)
                 counts_cpu = torch.empty_like(
                     counts, dtype=torch.int32, pin_memory=PIN_MEMORY
-                )
-                counts_cpu.copy_(counts)
+                ).copy_(counts)
                 start_locs_cpu = torch.empty_like(
                     counts_cpu, pin_memory=PIN_MEMORY
                 )

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -111,36 +111,66 @@ class LoRAKernelMeta:
     def prepare_tensors_cpu(self, token_lora_mapping: list[int]) -> None:
         """Prepare metadata on the CPU and asynchronously copy it to device."""
         self._reset()
-        mapping_cpu = torch.tensor(token_lora_mapping, dtype=torch.int32)
-        num_tokens = mapping_cpu.size(0)
-
-        no_lora = bool(torch.all(mapping_cpu == -1))
+        no_lora = all(lora_id == -1 for lora_id in token_lora_mapping)
         self.no_lora_flag_cpu[0] = no_lora
         if no_lora:
             return
 
-        _, sorted_indices = torch.sort(mapping_cpu, stable=True)
-        lora_ids, counts = torch.unique(
-            mapping_cpu, sorted=True, return_counts=True
-        )
-        num_active_loras = lora_ids.size(0)
+        indices_by_lora_id = [[] for _ in range(self.active_lora_ids.numel())]
+        for token_index, lora_id in enumerate(token_lora_mapping):
+            indices_by_lora_id[lora_id + 1].append(token_index)
 
-        start_locs = torch.cumsum(counts, dim=0)
-        if PIN_MEMORY:
-            mapping_cpu = mapping_cpu.pin_memory()
-            sorted_indices = sorted_indices.pin_memory()
-            lora_ids = lora_ids.pin_memory()
-            counts = counts.pin_memory()
-            start_locs = start_locs.pin_memory()
+        lora_ids: list[int] = []
+        counts: list[int] = []
+        sorted_indices: list[int] = []
+        start_locs: list[int] = []
+        next_start_loc = 0
+        for lora_id, token_indices in enumerate(indices_by_lora_id, start=-1):
+            if not token_indices:
+                continue
+            count = len(token_indices)
+            lora_ids.append(lora_id)
+            counts.append(count)
+            sorted_indices.extend(token_indices)
+            next_start_loc += count
+            start_locs.append(next_start_loc)
+
+        mapping_cpu = torch.tensor(
+            token_lora_mapping,
+            dtype=torch.int32,
+            pin_memory=PIN_MEMORY,
+        )
+        sorted_indices_cpu = torch.tensor(
+            sorted_indices,
+            dtype=torch.int32,
+            pin_memory=PIN_MEMORY,
+        )
+        lora_ids_cpu = torch.tensor(
+            lora_ids,
+            dtype=torch.int32,
+            pin_memory=PIN_MEMORY,
+        )
+        counts_cpu = torch.tensor(
+            counts,
+            dtype=torch.int32,
+            pin_memory=PIN_MEMORY,
+        )
+        start_locs_cpu = torch.tensor(
+            start_locs,
+            dtype=torch.int32,
+            pin_memory=PIN_MEMORY,
+        )
+        num_tokens = len(token_lora_mapping)
+        num_active_loras = len(lora_ids)
 
         self.token_lora_mapping[:num_tokens].copy_(mapping_cpu, non_blocking=True)
         self.token_indices_sorted_by_lora_ids[:num_tokens].copy_(
-            sorted_indices, non_blocking=True
+            sorted_indices_cpu, non_blocking=True
         )
-        self.active_lora_ids[:num_active_loras].copy_(lora_ids, non_blocking=True)
-        self.num_tokens_per_lora[:num_active_loras].copy_(counts, non_blocking=True)
+        self.active_lora_ids[:num_active_loras].copy_(lora_ids_cpu, non_blocking=True)
+        self.num_tokens_per_lora[:num_active_loras].copy_(counts_cpu, non_blocking=True)
         self.lora_token_start_loc[1 : num_active_loras + 1].copy_(
-            start_locs, non_blocking=True
+            start_locs_cpu, non_blocking=True
         )
 
         if self.captured_lora_counts:

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -135,19 +135,21 @@ class LoRAKernelMeta:
                     stable=True,
                     out=(sorted_lora_ids, sorted_indices_cpu),
                 )
-                lora_ids, counts = torch.unique_consecutive(
+                unique_lora_ids, unique_counts = torch.unique_consecutive(
                     sorted_lora_ids, return_counts=True
                 )
                 lora_ids_cpu = torch.empty_like(
-                    lora_ids, dtype=torch.int32, pin_memory=PIN_MEMORY
-                ).copy_(lora_ids)
+                    unique_lora_ids, dtype=torch.int32, pin_memory=PIN_MEMORY
+                ).copy_(unique_lora_ids)
                 counts_cpu = torch.empty_like(
-                    counts, dtype=torch.int32, pin_memory=PIN_MEMORY
-                ).copy_(counts)
+                    unique_counts, dtype=torch.int32, pin_memory=PIN_MEMORY
+                ).copy_(unique_counts)
                 start_locs_cpu = torch.empty_like(counts_cpu, pin_memory=PIN_MEMORY)
                 torch.cumsum(counts_cpu, dim=0, out=start_locs_cpu)
             else:
-                indices_by_lora_id = [[] for _ in range(self.active_lora_ids.numel())]
+                indices_by_lora_id: list[list[int]] = [
+                    [] for _ in range(self.active_lora_ids.numel())
+                ]
                 for token_index, lora_id in enumerate(token_lora_mapping):
                     indices_by_lora_id[lora_id + 1].append(token_index)
 

--- a/vllm/lora/punica_wrapper/punica_base.py
+++ b/vllm/lora/punica_wrapper/punica_base.py
@@ -182,6 +182,8 @@ class PunicaWrapperBase(PunicaWrapperABC):
             sampler_indices_padded,
             embeddings_indices,
             indices_len,
+            base_indices_cpu,
+            sampler_indices_cpu,
         ) = convert_mapping(
             mapping,
             lora_index_to_id,
@@ -200,6 +202,7 @@ class PunicaWrapperBase(PunicaWrapperABC):
         ].copy_(embeddings_indices)
 
         self.indices_len[:] = indices_len
+        return base_indices_cpu, sampler_indices_cpu
 
     def _update_prefill_metadata(self, token_lora_tensor: torch.Tensor) -> None:
         (

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -14,7 +14,6 @@ import torch
 from vllm.lora.layers import LoRAMapping
 from vllm.lora.utils import get_captured_lora_counts
 from vllm.triton_utils import HAS_TRITON, triton
-from vllm.utils.gpu_sync_debug import gpu_sync_allowed
 from vllm.utils.math_utils import round_up
 
 if HAS_TRITON:
@@ -82,13 +81,12 @@ class PunicaWrapperGPU(PunicaWrapperBase):
         **kwargs,
     ):
         self.is_prefill = mapping.is_prefill
-        self._update_base_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
+        token_lora_indices_cpu, sampler_indices_cpu = self._update_base_metadata(
+            mapping, lora_index_to_id, max_loras, vocab_size
+        )
 
-        # TODO avoid gpu<->cpu sync here
-        with gpu_sync_allowed():
-            # Prepare cuda kernel metadata tensors
-            self.token_mapping_meta.prepare_tensors(self.token_lora_indices)
-            self.prompt_mapping_meta.prepare_tensors(self.sampler_indices)
+        self.token_mapping_meta.prepare_tensors_cpu(token_lora_indices_cpu)
+        self.prompt_mapping_meta.prepare_tensors_cpu(sampler_indices_cpu)
 
     def add_shrink(
         self,

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -85,8 +85,13 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             mapping, lora_index_to_id, max_loras, vocab_size
         )
 
-        self.token_mapping_meta.prepare_tensors_cpu(token_lora_indices_cpu)
-        self.prompt_mapping_meta.prepare_tensors_cpu(sampler_indices_cpu)
+        token_metadata = self.token_mapping_meta.prepare_tensors_cpu(
+            token_lora_indices_cpu
+        )
+        if token_lora_indices_cpu is sampler_indices_cpu:
+            self.prompt_mapping_meta.copy_tensors_cpu(token_metadata)
+        else:
+            self.prompt_mapping_meta.prepare_tensors_cpu(sampler_indices_cpu)
 
     def add_shrink(
         self,

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -85,12 +85,13 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             mapping, lora_index_to_id, max_loras, vocab_size
         )
 
-        token_metadata = self.token_mapping_meta.prepare_tensors_cpu(
-            token_lora_indices_cpu
-        )
         if token_lora_indices_cpu is sampler_indices_cpu:
-            self.prompt_mapping_meta.copy_tensors_cpu(token_metadata)
+            self.token_mapping_meta.prepare_tensors_cpu(
+                token_lora_indices_cpu,
+                copy_to=self.prompt_mapping_meta,
+            )
         else:
+            self.token_mapping_meta.prepare_tensors_cpu(token_lora_indices_cpu)
             self.prompt_mapping_meta.prepare_tensors_cpu(sampler_indices_cpu)
 
     def add_shrink(

--- a/vllm/lora/punica_wrapper/utils.py
+++ b/vllm/lora/punica_wrapper/utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
+from vllm.utils.torch_utils import async_tensor_h2d
 
 if TYPE_CHECKING:
     # avoid circuit import
@@ -64,8 +64,8 @@ def convert_mapping(
     torch.Tensor,
     torch.Tensor,
     list[int],
-    torch.Tensor,
-    torch.Tensor,
+    list[int],
+    list[int],
 ]:
     """Converts LoRAMapping to index tensors.
 
@@ -95,8 +95,8 @@ def convert_mapping(
             indices_len: List of lengths of the above tensors. It contains
                 (base_indices, sampler_indices, sampler_indices_padded,
                 embeddings_indices).
-            base_indices_cpu: CPU copy of base_indices.
-            sampler_indices_cpu: CPU copy of sampler_indices.
+            lora_indices: CPU list containing the base LoRA indices.
+            prompt_mapping: CPU list containing the sampler LoRA indices.
     """
     index_mapping_indices: list[int] = list(mapping.index_mapping).copy()
     embedding_indices = index_mapping_indices.copy()
@@ -130,21 +130,9 @@ def convert_mapping(
         embedding_indices,
     ]
 
-    indices_cpu = torch.tensor(
-        indices_list,
-        dtype=torch.long,
-        device="cpu",
-        pin_memory=PIN_MEMORY,
-    )
-    prompt_mapping_cpu = torch.tensor(
-        prompt_mapping,
-        dtype=torch.long,
-        device="cpu",
-        pin_memory=PIN_MEMORY,
-    )
-    indices = async_tensor_h2d(indices_cpu, dtype=torch.long, device=device)
+    indices = async_tensor_h2d(indices_list, dtype=torch.long, device=device)
     prompt_mapping_tensor = async_tensor_h2d(
-        prompt_mapping_cpu, dtype=torch.long, device=device
+        prompt_mapping, dtype=torch.long, device=device
     )
     embeddings_indices = torch.stack(
         [
@@ -179,6 +167,6 @@ def convert_mapping(
         sampler_indices_padded,
         embeddings_indices,
         indices_len,
-        indices_cpu[1],
-        prompt_mapping_cpu,
+        lora_indices,
+        prompt_mapping,
     )

--- a/vllm/lora/punica_wrapper/utils.py
+++ b/vllm/lora/punica_wrapper/utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
 
 if TYPE_CHECKING:
     # avoid circuit import
@@ -58,7 +58,15 @@ def convert_mapping(
     vocab_size: int,
     extra_vocab_size: int,
     device: torch.device,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[int]]:
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    list[int],
+    torch.Tensor,
+    torch.Tensor,
+]:
     """Converts LoRAMapping to index tensors.
 
     Args:
@@ -87,6 +95,8 @@ def convert_mapping(
             indices_len: List of lengths of the above tensors. It contains
                 (base_indices, sampler_indices, sampler_indices_padded,
                 embeddings_indices).
+            base_indices_cpu: CPU copy of base_indices.
+            sampler_indices_cpu: CPU copy of sampler_indices.
     """
     index_mapping_indices: list[int] = list(mapping.index_mapping).copy()
     embedding_indices = index_mapping_indices.copy()
@@ -120,9 +130,21 @@ def convert_mapping(
         embedding_indices,
     ]
 
-    indices = async_tensor_h2d(indices_list, dtype=torch.long, device=device)
+    indices_cpu = torch.tensor(
+        indices_list,
+        dtype=torch.long,
+        device="cpu",
+        pin_memory=PIN_MEMORY,
+    )
+    prompt_mapping_cpu = torch.tensor(
+        prompt_mapping,
+        dtype=torch.long,
+        device="cpu",
+        pin_memory=PIN_MEMORY,
+    )
+    indices = async_tensor_h2d(indices_cpu, dtype=torch.long, device=device)
     prompt_mapping_tensor = async_tensor_h2d(
-        prompt_mapping, dtype=torch.long, device=device
+        prompt_mapping_cpu, dtype=torch.long, device=device
     )
     embeddings_indices = torch.stack(
         [
@@ -157,4 +179,6 @@ def convert_mapping(
         sampler_indices_padded,
         embeddings_indices,
         indices_len,
+        indices_cpu[1],
+        prompt_mapping_cpu,
     )

--- a/vllm/lora/punica_wrapper/utils.py
+++ b/vllm/lora/punica_wrapper/utils.py
@@ -111,9 +111,6 @@ def convert_mapping(
         if lora_id is not None
     }
 
-    prompt_mapping: list[int] = [
-        lora_id_to_index[x] if x > 0 else -1 for x in mapping.prompt_mapping
-    ]
     lora_idx = None
     for i in range(len(index_mapping_indices)):
         lora_idx = (
@@ -123,6 +120,13 @@ def convert_mapping(
         )
         embedding_indices[i] = lora_idx if index_mapping_indices[i] > 0 else 0
         lora_indices[i] = lora_idx
+
+    if mapping.index_mapping != mapping.prompt_mapping:
+        prompt_mapping = [
+            lora_id_to_index[x] if x > 0 else -1 for x in mapping.prompt_mapping
+        ]
+    else:
+        prompt_mapping = lora_indices
 
     indices_list: list[list[int] | torch.Tensor] = [
         index_mapping_indices,


### PR DESCRIPTION
## Summary

- prepare Punica LoRA kernel metadata from the CPU-side mapping
- use Python bucketing for small mappings and vectorized PyTorch operations for large mappings
- copy the prepared metadata to the existing device buffers with non-blocking H2D copies
- reuse prepared metadata for identical decode token and prompt mappings
- remove the `gpu_sync_allowed()` exception from `PunicaWrapperGPU.update_metadata()`
- cover mixed-LoRA, active-LoRA specialization, and no-LoRA metadata

## Why

This follows up on the TODO left by #43107. `PunicaWrapperGPU.update_metadata()` previously passed device mappings to `LoRAKernelMeta.prepare_tensors()`. Its no-LoRA check then consumed a CUDA scalar from Python and copied it into a CPU tensor, forcing a GPU-to-CPU synchronization on the main stream.

The mapping originates as Python/CPU data. This change retains the CPU LoRA indices during mapping conversion and prepares the sort, grouping, count, and start-location metadata on CPU. Small mappings use Python bucketing, while large mappings use vectorized PyTorch operations. The prepared metadata is copied asynchronously into the stable device buffers, and identical decode mappings share one preparation pass. This avoids reading metadata back from the GPU and preserves the buffer addresses used by CUDA graphs.

I searched open PRs for `43107`, `PunicaWrapperGPU update_metadata`, and `LoRA metadata GPU CPU sync`. I did not find another PR addressing this TODO. The related open LoRA slab PR optimizes adapter weight transfers rather than per-step Punica kernel metadata.

## Validation

- `.venv/bin/python -m compileall -q vllm/lora/punica_wrapper vllm/lora/ops/triton_ops/lora_kernel_metadata.py tests/lora/test_punica_ops.py`
- `git diff --check`
- `pytest tests/lora/test_punica_ops.py -k early_exit -q` could not start in the current environment because the existing virtual environment is missing `tblib` (and subsequently `numpy`); no pytest result is claimed.

Model evaluation is not applicable because this only changes how equivalent LoRA kernel metadata is prepared and transferred.

OpenAI Codex was used to inspect the synchronization path, implement the change, and draft tests and this description. I reviewed each line.
