### PR TITLE
[Bugfix] Avoid accelerator lookup for CPU compile-cache paths

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1074,7 +1074,10 @@ class VllmBackend:
         self.compilation_config.cache_dir = cache_dir
         rank = vllm_config.parallel_config.rank
         dp_rank = vllm_config.parallel_config.data_parallel_index
-        local_cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}", self.prefix)
+        dev = current_platform.current_device_index()
+        local_cache_dir = os.path.join(
+            cache_dir, f"rank_{rank}_{dp_rank}_dev{dev}", self.prefix
+        )
         os.makedirs(local_cache_dir, exist_ok=True)
         self.compilation_config.local_cache_dir = local_cache_dir
 

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -559,9 +559,12 @@ def _support_torch_compile(
             # /tmp default during import, making setdefault a no-op.
             os.environ["TORCHINDUCTOR_CACHE_DIR"] = inductor_cache
 
+            from vllm.platforms import current_platform
+
             rank = self.vllm_config.parallel_config.rank
             dp_rank = self.vllm_config.parallel_config.data_parallel_index
-            cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}")
+            dev = current_platform.current_device_index()
+            cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}_dev{dev}")
             aot_compilation_path = os.path.join(cache_dir, "model")
             if not envs.VLLM_DISABLE_COMPILE_CACHE:
                 loaded_fn = _try_load_aot_compiled_fn(self, aot_compilation_path)

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -125,6 +125,10 @@ class CpuPlatform(Platform):
         return meminfo.total_memory
 
     @classmethod
+    def current_device_index(cls) -> int:
+        return 0
+
+    @classmethod
     def set_device(cls, device: torch.device) -> None:
         """
         Set the device for the current platform.

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -531,6 +531,13 @@ class Platform:
         return torch.inference_mode(mode=True)
 
     @classmethod
+    def current_device_index(cls) -> int:
+        """Get the index of the current device for the platform."""
+        if not torch.accelerator.is_available():
+            return 0
+        return torch.accelerator.current_device_index()
+
+    @classmethod
     def set_device(cls, device: torch.device) -> None:
         """
         Set the device for the current platform.


### PR DESCRIPTION
## Summary

Restore the per-device compile-cache isolation introduced by #38962 without
reintroducing its CPU startup regression.

Both regular and AOT compile-cache paths now include the device index:

```text
  rank_0_0_dev0
  rank_0_0_dev1
```

Device-index selection is handled by the platform abstraction:

- Platform.current_device_index() returns the current accelerator index when
  available and otherwise falls back to 0.
- CpuPlatform.current_device_index() always returns 0 without querying
  torch.accelerator.

CPU cache paths therefore use rank_<rank>_<dp_rank>_dev0.

### Why

#38962 fixed compile-cache collisions when multiple engines in one process use
different accelerator devices but share the same rank and data-parallel index.
Inductor artifacts can contain device-specific stream references, so loading an
artifact compiled for another device can fail with errors such as:

```text
  CUDA driver error: invalid argument
```

Its unconditional use of torch.accelerator.current_device_index() also
caused CPU-only startup to fail:

```text
  RuntimeError: Cannot access accelerator device when none is available.
```

#53304 reverted the change to restore CPU execution, but that also removed the
per-device cache isolation.

This follow-up restores the device suffix while moving device-index lookup
behind current_platform. CPU avoids accelerator lookup entirely, while
accelerator platforms retain separate cache directories for each active
device.

### Implementation

- Add Platform.current_device_index() with a safe fallback when no
  accelerator is available.
- Override it in CpuPlatform to return 0 directly.
- Use the platform method in both:
    - vllm/compilation/backends.py
    - vllm/compilation/decorators.py

Using the current platform device rather than
vllm_config.device_config.device.index is necessary because accelerator
devices are commonly configured without an explicit index and selected later
by the worker.

### Duplicate-work check

Searched open PRs for 38962, compile cache device index CPU accelerator,
and current_device_index compile cache. No other open PR addresses this
follow-up. #53304 is the merged emergency revert; this PR restores the reverted
device isolation without restoring the CPU regression.

### Validation

Checked with ruff for lint rules and formatting.  Tested on Linux with CUDA and CPU platforms, confirming that cache path works.

The CPU Language Generation and CPU Distributed PP+TP Buildkite jobs should be
used as merge gates.

No model evaluation is applicable because this only changes compile-cache
directory selection and does not affect model execution or outputs.

### AI assistance

AI assistance was used to investigate the regression, prepare the patch, and
draft this PR description. The human submitter reviewed every changed line and
can explain and defend the change end-to-end.
