### PR TITLE
[Bugfix][Core] Include num_speculative_tokens in SpeculativeConfig.compute_hash for parallel drafting

### DIFF
--- a/tests/config/test_speculative_compute_hash.py
+++ b/tests/config/test_speculative_compute_hash.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that SpeculativeConfig.compute_hash covers num_speculative_tokens for
+parallel-drafting methods.
+
+Parallel drafting (DFlash, DSpark, P-EAGLE, PARD) emits the whole speculative
+block in one forward pass, so ``num_speculative_tokens`` fixes tensor shapes in
+the draft model's compiled graph -- DFlash2 derives
+``block_size = 1 + num_speculative_tokens``. If the hash ignores it, a cached
+compilation artifact built for one k is silently reused for another and the
+engine dies at cudagraph capture with a shape assertion such as
+``expected size 9==7, stride 5120==5120 at dim=1``.
+
+Sequential methods (MTP, EAGLE, n-gram) re-run a fixed q=1 draft graph k times,
+so their compiled graph does not depend on k; they must keep a stable hash so
+that changing k does not force a needless recompilation.
+"""
+
+from typing import Any
+
+import pytest
+
+from vllm.config.speculative import SpeculativeConfig
+
+
+def _config_with(
+    method: str, num_speculative_tokens: int, parallel_drafting: bool
+) -> Any:
+    """Build a bare SpeculativeConfig exposing only what compute_hash reads.
+
+    ``__post_init__`` resolves a real draft checkpoint, which a CPU-only unit
+    test must not do, so the attributes are set directly.
+    """
+    config = object.__new__(SpeculativeConfig)
+    config.__dict__.update(
+        method=method,
+        num_speculative_tokens=num_speculative_tokens,
+        draft_model_config=None,
+        parallel_drafting=parallel_drafting,
+    )
+    return config
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("method", ["dflash", "dspark"])
+def test_parallel_drafting_hash_depends_on_num_speculative_tokens(method: str):
+    """k changes the draft graph's shapes, so it must change the hash."""
+    a = _config_with(method, 7, parallel_drafting=True)
+    b = _config_with(method, 9, parallel_drafting=True)
+    assert a.compute_hash() != b.compute_hash()
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("method", ["mtp", "eagle", "eagle3"])
+def test_sequential_drafting_hash_ignores_num_speculative_tokens(method: str):
+    """k is only a loop count here, so the hash must stay stable."""
+    a = _config_with(method, 7, parallel_drafting=False)
+    b = _config_with(method, 9, parallel_drafting=False)
+    assert a.compute_hash() == b.compute_hash()
+
+
+@pytest.mark.cpu_test
+def test_same_num_speculative_tokens_hashes_equal():
+    """Identical configs must still hash identically (cache stays usable)."""
+    a = _config_with("dflash", 7, parallel_drafting=True)
+    b = _config_with("dflash", 7, parallel_drafting=True)
+    assert a.compute_hash() == b.compute_hash()

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -335,6 +335,19 @@ class SpeculativeConfig:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
 
+        # Parallel-drafting methods (e.g. DFlash, DSpark, P-EAGLE, PARD) build the
+        # whole speculative block in a single forward pass, so num_speculative_tokens
+        # determines tensor shapes inside the draft model's compiled graph -- DFlash2,
+        # for instance, derives block_size = 1 + num_speculative_tokens. Omitting it
+        # here lets a cached compilation artifact built for one k be silently reused
+        # for another, which fails at cudagraph capture with e.g.
+        #   AssertionError: expected size 9==7, stride 5120==5120 at dim=1
+        # Sequential methods (MTP, EAGLE, n-gram) re-run a fixed q=1 draft graph k
+        # times, so their graph does not depend on k and is deliberately left alone
+        # to avoid needless recompilation.
+        if self.parallel_drafting:
+            factors.append(self.num_speculative_tokens)
+
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 


### PR DESCRIPTION
## Purpose

`SpeculativeConfig.compute_hash()` omits `num_speculative_tokens`, but for **parallel-drafting** methods that value determines tensor shapes in the draft model's compiled graph. A cached compilation artifact built for one `k` is therefore silently reused for a different `k`, and the engine dies at cudagraph capture.

The method's own docstring already warns about exactly this case:

> WARNING: Whenever a new field is added to this config, ensure that it is included in the factors list if it affects the computation graph.

`num_speculative_tokens` does affect the computation graph under parallel drafting — DFlash2 derives `block_size = 1 + num_speculative_tokens` in `DFlash2Qwen3ForCausalLM` (`vllm/model_executor/models/qwen3_dflash2.py`) — but it is not in `factors`. This went unnoticed because it does *not* affect sequential methods (MTP/EAGLE), where `k` is only a loop count over a fixed `q=1` draft graph.

### Reproduction

Serve a DFlash2 draft, then change **only** `num_speculative_tokens` from 7 to 9:

```bash
vllm serve Qwen/Qwen3.8-27B \
  --speculative-config '{"method":"dflash","model":"incoai/Qwen3.8-27B-DFlash2","num_speculative_tokens":9}'
```

With a warm compile cache from a previous `k=7` run, the engine loads ~56 GB of weights and then dies at cudagraph capture:

```
AssertionError: expected size 32==32, stride 46080==35840 at dim=0;
                expected size 9==7, stride 5120==5120 at dim=1
Error in op: input
```

`46080 = 9*5120` and `35840 = 7*5120` — the `k=7` draft graph reused for `k=9`. The only workaround is a separate `VLLM_CACHE_ROOT` per value of `k`.

### Fix

Append `num_speculative_tokens` to `factors` **only when `parallel_drafting` is set**. That covers DFlash, DSpark, P-EAGLE and PARD — the methods whose draft graph shape depends on `k` — while leaving MTP/EAGLE/n-gram hashes stable, so changing `k` for those does not force a needless recompilation.

## Test Plan

New `tests/config/test_speculative_compute_hash.py`, all marked `@pytest.mark.cpu_test` (no GPU, no checkpoint download):

```bash
pytest tests/config/test_speculative_compute_hash.py -v
```

Covers both directions:

- hash **must differ** across `k` for `dflash` / `dspark` (parametrized)
- hash **must NOT differ** across `k` for `mtp` / `eagle` / `eagle3` — guards against regressing into needless recompiles
- identical configs still hash identically

## Test Result

The new tests fail before the fix and pass after:

```
# before (without the change to compute_hash)
FAILED test_parallel_drafting_hash_depends_on_num_speculative_tokens[dflash]
FAILED test_parallel_drafting_hash_depends_on_num_speculative_tokens[dspark]
2 failed, 4 passed

# after
6 passed
```

`ruff check` and `ruff format --check` are clean on both changed files.

End-to-end: with the fix applied, serving `incoai/Qwen3.8-27B-DFlash2` at `num_speculative_tokens=9` against a cache warmed at `k=7` now recompiles correctly and starts, instead of asserting at cudagraph capture. Verified on an RTX PRO 6000 Blackwell (sm120) serving `Qwen/Qwen3.8-27B` with the FlashInfer XQA decode backend, where this was hit while tuning `num_speculative_tokens`.

## Notes

One adjacent case is deliberately left alone because I have no reproduction for it: `num_speculative_tokens_per_batch_size` (dynamic speculative decoding) is also absent from `factors`, and its maximum could plausibly affect graph shapes too. Happy to fold that in if maintainers would like it covered.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. — N/A: internal bugfix to config hashing, no user-facing behaviour or docs affected.

</details>

---

*AI disclosure, per the contributing guide: this patch and its tests were written with Claude (Claude Code), which also produced the diagnosis and the before/after test runs. All results above were executed and verified on real hardware. The commit carries a `Co-authored-by:` trailer.*
