### PR TITLE
[Kernel] Add NVFP4 support to the torch linear backend

### DIFF
--- a/tests/kernels/quantization/test_nvfp4_torch.py
+++ b/tests/kernels/quantization/test_nvfp4_torch.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+from vllm.model_executor.kernels.linear import init_nvfp4_linear_kernel
+from vllm.model_executor.kernels.linear.nvfp4.pytorch import (
+    TorchNvFp4LinearKernel,
+)
+
+
+def test_torch_backend_selects_nvfp4_kernel() -> None:
+    with (
+        patch(
+            "vllm.model_executor.kernels.linear._get_linear_backend",
+            return_value="torch",
+        ),
+        patch.object(
+            TorchNvFp4LinearKernel,
+            "is_supported",
+            return_value=(True, None),
+        ),
+    ):
+        kernel = init_nvfp4_linear_kernel()
+
+    assert isinstance(kernel, TorchNvFp4LinearKernel)

--- a/tests/models/quantization/test_nvfp4.py
+++ b/tests/models/quantization/test_nvfp4.py
@@ -94,6 +94,7 @@ SM_100_NVFP4_BACKENDS = [
     "flashinfer_cudnn",
     "flashinfer_trtllm",
     "flashinfer_cutlass",
+    "torch",
 ]
 
 
@@ -107,6 +108,7 @@ SM_100_NVFP4_BACKENDS = [
         "flashinfer_cudnn",
         "flashinfer_trtllm",  # the small seq_len ensures trtllm_8x4_layout backend is used
         "flashinfer_cutlass",
+        "torch",
     ],
 )
 def test_nvfp4(vllm_runner, model, eager, backend):

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -158,6 +158,9 @@ from vllm.model_executor.kernels.linear.nvfp4.humming import (
 from vllm.model_executor.kernels.linear.nvfp4.marlin import (
     MarlinNvFp4LinearKernel,
 )
+from vllm.model_executor.kernels.linear.nvfp4.pytorch import (
+    TorchNvFp4LinearKernel,
+)
 from vllm.model_executor.kernels.linear.scaled_mm import (
     Fp8BlockScaledMMLinearKernel,
     FP8ScaledMMLinearKernel,
@@ -305,6 +308,7 @@ _LINEAR_BACKEND_KERNEL_MAP: dict[str, set[type]] = {
         ChannelWiseTorchFP8ScaledMMLinearKernel,
         RowWiseTorchFP8ScaledMMLinearKernel,
         BlockWiseTorchFP8ScaledMMLinearKernel,
+        TorchNvFp4LinearKernel,
     },
     "aiter": {
         AiterInt8ScaledMMLinearKernel,
@@ -534,6 +538,7 @@ _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
         FlashInferCudnnNvFp4LinearKernel,
         FbgemmNvFp4LinearKernel,
         B12xNvFp4LinearKernel,
+        TorchNvFp4LinearKernel,
         EmulationNvFp4LinearKernel,
         HummingNvFp4LinearKernel,
     ],
@@ -1232,6 +1237,7 @@ __all__ = [
     "FlashInferTrtllmNvFp4LinearKernel",
     "FlashInferCudnnNvFp4LinearKernel",
     "MarlinNvFp4LinearKernel",
+    "TorchNvFp4LinearKernel",
     "_KernelT",
     "DeepGemmFp8BlockScaledMMKernel",
     "FlashInferFp8DeepGEMMDynamicBlockScaledKernel",

--- a/vllm/model_executor/kernels/linear/nvfp4/pytorch.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/pytorch.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm._custom_ops import scaled_fp4_quant
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    pad_nvfp4_weight_for_cutlass,
+    slice_nvfp4_output,
+    swizzle_blockscale,
+)
+from vllm.platforms import current_platform
+
+from .base import NvFp4LinearKernel, NvFp4LinearLayerConfig
+
+
+class TorchNvFp4LinearKernel(NvFp4LinearKernel):
+    """NVFP4 GEMM implemented with PyTorch's native ``torch._scaled_mm``.
+
+    Eager execution uses PyTorch's native scaled-matmul implementation. Under
+    ``torch.compile``, TorchInductor may select any enabled scaled-GEMM backend,
+    including NVGEMM on supported Blackwell systems.
+    """
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_device_capability_family(100):
+            return False, "Torch NVFP4 requires sm_10x (Blackwell)"
+        if not hasattr(torch, "_scaled_mm"):
+            return False, "torch._scaled_mm not available"
+        if not hasattr(torch, "float4_e2m1fn_x2"):
+            return False, "torch.float4_e2m1fn_x2 not available"
+        return True, None
+
+    @classmethod
+    def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.weight_scale = torch.nn.Parameter(
+            swizzle_blockscale(layer.weight_scale.data), requires_grad=False
+        )
+        padded_weight, weights_padding_cols = pad_nvfp4_weight_for_cutlass(
+            layer.weight.data
+        )
+        layer.weight = torch.nn.Parameter(padded_weight, requires_grad=False)
+        layer.weights_padding_cols = weights_padding_cols
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        output_size = layer.output_size_per_partition
+        output_dtype = x.dtype
+        output_shape = [*x.shape[:-1], output_size]
+        weights_padding_bytes = getattr(layer, "weights_padding_cols", 0)
+
+        x_fp4, x_blockscale = scaled_fp4_quant(
+            x,
+            layer.input_global_scale_inv,
+            is_sf_swizzled_layout=True,
+            backend="cutlass",
+            padded_n=x.shape[-1] + weights_padding_bytes * 2,
+        )
+
+        # scaled_fp4_quant returns packed bytes, while torch._scaled_mm uses
+        # the corresponding shell dtype to describe the two FP4 values stored
+        # in each byte.
+        x_fp4 = x_fp4.view(torch.float4_e2m1fn_x2)
+        weight = layer.weight
+        if weight.dtype != torch.float4_e2m1fn_x2:
+            weight = weight.view(torch.float4_e2m1fn_x2)
+
+        out = torch._scaled_mm(
+            x_fp4,
+            weight.t(),
+            scale_a=x_blockscale,
+            scale_b=layer.weight_scale,
+            out_dtype=output_dtype,
+        )
+
+        # ModelOpt stores the product of the activation and weight global
+        # dequantization scales as alpha. TorchInductor can fold this multiply
+        # into an NVGEMM output-scale argument.
+        out = out * layer.alpha
+        out = slice_nvfp4_output(out, output_size)
+
+        if bias is not None:
+            out = out + bias
+        return out.view(*output_shape)


### PR DESCRIPTION
## Purpose

Extend the existing `torch` linear backend to ModelOpt W4A4 NVFP4 models on
SM10x (Blackwell).

The adapter reuses vLLM's NVFP4 quantization/layout utilities, calls native
`torch._scaled_mm`, applies the ModelOpt global dequantization scale and bias,
and lets `torch.compile`/TorchInductor select an enabled scaled-GEMM backend.
Existing optimized `auto` candidates retain priority; Torch is placed
immediately before emulation and can be selected explicitly with
`--linear-backend torch`.

This does not add or change a custom operator, schema, meta function, or C++
signature, so the custom-op `torch.library.opcheck()` requirements do not
apply.

## Relationship to #36721

This draft references and overlaps #36721, which first proposed an NVFP4
`torch._scaled_mm` backend. It is being kept as a draft successor/alternative
for review because #36721 is currently several months behind `main`, marked
`needs-rebase`, and its current diff includes unrelated dependency-file changes
from old merges.

The concrete delta here is:

- a clean three-file change on current `main`;
- integration with the current shared `--linear-backend torch` registry rather
  than the former NVFP4-specific environment-variable path;
- current weight/activation padding and swizzled-scale layout handling;
- coverage through the existing eager/compiled NVFP4 model test matrix; and
- paired B200 measurements against the current FlashInfer CuTeDSL backend.

If maintainers prefer updating #36721 in place, this branch and its results can
be folded into that PR rather than merged independently.

## Test Plan

- Run all pre-commit checks on the three changed files.
- Compare layer outputs against vLLM's CUTLASS NVFP4 implementation across
  small, aligned, and padded token counts.
- Run the existing real-weight Llama NVFP4 generation test in eager and
  compiled modes for both Torch and FlashInfer.
- Run vLLM's GSM8K evaluator for a model-level accuracy comparison.
- Run `vllm bench latency` on Qwen3-32B-FP4 at batch sizes 8, 32, and 128 for
  Torch/NVGEMM and FlashInfer CuTeDSL (input 32, output 128, 5 warmups, 30
  measured iterations).

## Test Result

- `pre-commit run --files ...`: passed (ruff, formatting, mypy, SPDX, config,
  and repository checks).
- Direct numerical comparison with vLLM CUTLASS for M in `{1, 10, 32, 128,
  150}`: all cases passed `torch.allclose(atol=0.1, rtol=0.1)`; maximum absolute
  difference was 0.5 BF16 units.
- The existing two-token Llama assertion currently fails for both Torch and
  FlashInfer in this local latest-main/source-versus-wheel environment. The
  compiled paths produce the same output, while neither matches the test's
  expected string. GSM8K comparison is in progress and will be the accuracy
  gate before this leaves draft.

Latest-main Qwen3-32B-FP4, batch 32, input 32, output 128, five warmups and 30
samples:

| NVFP4 linear backend | mean | median | stddev | min | max |
|---|---:|---:|---:|---:|---:|
| FlashInfer CuTeDSL | 1011.440 ms | 1009.460 ms | 7.364 ms | 1004.787 ms | 1045.525 ms |
| TorchInductor NVGEMM | **909.882 ms** | **907.764 ms** | **7.336 ms** | **902.888 ms** | **942.263 ms** |

TorchInductor was 101.696 ms / 10.07% faster at the median. The installed
FlashInfer wheel lacks a new startup-autotune API expected by latest `main`, so
that hook was disabled for both runs. Current `main` independently skips
`fp4_gemm` tactic autotuning for this CuTeDSL backend. A fully compatible run on
the immediately preceding checkout showed a more conservative 4.42% median
Qwen win (901.424 ms versus 943.091 ms).

The requested batch-size 8/32/128 matrix and GSM8K results are still in
progress. Dummy-weight latency validates dispatch and performance, not model
quality. The NVGEMM performance configuration also depends on a separate,
not-yet-upstream PyTorch stack; this vLLM adapter itself uses the native
`torch._scaled_mm` API.

## AI assistance disclosure

This PR includes code and text developed with OpenAI Codex assistance. The
human author is reviewing the full diff and validating behavior, accuracy, and
performance end to end before taking the PR out of draft.

---

- [x] Purpose and relationship to prior work are documented.
- [x] Test plan and current results are documented.
- [ ] Complete the accuracy evaluation and batch-size benchmark matrix.
- [x] No separate docs page is needed: this extends the documented `torch`
  value of `--linear-backend` without adding a CLI option.
