### PR TITLE
[Bugfix][XPU] Add VLLM_INC_DISABLE_ARK opt-out for ARK WOQ backend

### DIFF
--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -1798,6 +1798,51 @@ def test_invalid_backend_value_raises(monkeypatch) -> None:
         _ = envs.VLLM_XPU_INC_WNA16_BACKEND
 
 
+_DISABLE_ARK_ENV = "VLLM_INC_DISABLE_ARK"
+
+
+def test_disable_ark_falls_back_to_onednn(monkeypatch) -> None:
+    """VLLM_INC_DISABLE_ARK=1 must bypass ARK even when it is importable."""
+    monkeypatch.delenv(_BACKEND_ENV, raising=False)
+    monkeypatch.setenv(_DISABLE_ARK_ENV, "1")
+    _fake_xpu(monkeypatch, ark_available=True)
+
+    method = _dispatch()
+
+    assert isinstance(method.scheme, INCXPULinearMethod)
+    assert not isinstance(method.scheme, INCARKLinearMethod)
+
+
+def test_disable_ark_rejects_int2(monkeypatch) -> None:
+    """Int2 has no non-ARK path; refuse loudly instead of serving garbage."""
+    monkeypatch.delenv(_BACKEND_ENV, raising=False)
+    monkeypatch.setenv(_DISABLE_ARK_ENV, "1")
+    _fake_xpu(monkeypatch, ark_available=True)
+
+    with pytest.raises(NotImplementedError, match="VLLM_INC_DISABLE_ARK"):
+        _dispatch(make_layer_config(bits=2))
+
+
+def test_disable_ark_conflicts_with_explicit_ark_request(monkeypatch) -> None:
+    monkeypatch.setenv(_BACKEND_ENV, "ark")
+    monkeypatch.setenv(_DISABLE_ARK_ENV, "1")
+    _fake_xpu(monkeypatch, ark_available=True)
+
+    with pytest.raises(NotImplementedError, match="VLLM_INC_DISABLE_ARK"):
+        _dispatch()
+
+
+def test_disable_ark_default_keeps_ark(monkeypatch) -> None:
+    """Unset/0 keeps current behaviour: ARK wins when importable."""
+    monkeypatch.delenv(_DISABLE_ARK_ENV, raising=False)
+    monkeypatch.delenv(_BACKEND_ENV, raising=False)
+    _fake_xpu(monkeypatch, ark_available=True)
+
+    method = _dispatch()
+
+    assert isinstance(method.scheme, INCARKLinearMethod)
+
+
 # ---------------------------------------------------------------------------
 # Partition shape
 # ---------------------------------------------------------------------------

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -316,6 +316,7 @@ if TYPE_CHECKING:
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
     VLLM_XPU_INC_WNA16_BACKEND: Literal["auto", "ark", "w4a16", "w4a8"] = "auto"
+    VLLM_INC_DISABLE_ARK: bool = False
     VLLM_LORA_ENABLE_DUAL_STREAM: bool = False
     VLLM_GPU_NIC_PCIE_MAPPING: str = ""
     VLLM_NIC_SELECTION_VARS: str = ""
@@ -2134,6 +2135,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_XPU_INC_WNA16_BACKEND": env_with_choices(
         "VLLM_XPU_INC_WNA16_BACKEND", "auto", ["auto", "ark", "w4a16", "w4a8"]
     ),
+    # Disable the ARK (auto_round_kernel) WOQ backend for INC quantized layers.
+    # Falls back to the oneDNN int4 path on XPU. Int2 checkpoints have no
+    # non-ARK path and will raise NotImplementedError, since silently serving
+    # them would be worse than refusing to start.
+    "VLLM_INC_DISABLE_ARK": lambda: bool(int(os.getenv("VLLM_INC_DISABLE_ARK", "0"))),
     # Enable simple KV offload.
     "VLLM_USE_SIMPLE_KV_OFFLOAD": lambda: bool(
         int(os.getenv("VLLM_USE_SIMPLE_KV_OFFLOAD", "0"))

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py
@@ -72,6 +72,7 @@ class INCWna16Scheme(INCScheme):
                 )
 
                 backend = envs.VLLM_XPU_INC_WNA16_BACKEND
+                ark_disabled = envs.VLLM_INC_DISABLE_ARK
                 if backend in XPU_ONEDNN_BACKENDS:
                     if layer_config.bits != 4:
                         raise NotImplementedError(
@@ -84,19 +85,27 @@ class INCWna16Scheme(INCScheme):
                     return INCLinearMethod(INCXPULinearMethod(layer_config))
 
                 is_ark_available, ark_error, _, _ = get_ark_state()
-                if backend == "ark" and not is_ark_available:
-                    raise NotImplementedError(
-                        "VLLM_XPU_INC_WNA16_BACKEND=ark was requested but "
-                        f"auto_round_kernel is unavailable: "
-                        f"{ark_error or 'unknown error'}. Layer: {prefix}."
-                    )
-                if is_ark_available:
+                if backend == "ark":
+                    if ark_disabled:
+                        raise NotImplementedError(
+                            "VLLM_XPU_INC_WNA16_BACKEND=ark was requested but "
+                            "VLLM_INC_DISABLE_ARK is set. Layer: "
+                            f"{prefix}."
+                        )
+                    if not is_ark_available:
+                        raise NotImplementedError(
+                            "VLLM_XPU_INC_WNA16_BACKEND=ark was requested but "
+                            f"auto_round_kernel is unavailable: "
+                            f"{ark_error or 'unknown error'}. Layer: {prefix}."
+                        )
+                if is_ark_available and not ark_disabled:
                     return INCLinearMethod(INCARKLinearMethod(layer_config))
                 elif layer_config.bits == 2:
                     raise NotImplementedError(
                         "INC int2 on XPU requires the ARK backend. "
                         f"Layer: {prefix}. "
-                        f"auto_round_kernel unavailable: "
+                        + ("VLLM_INC_DISABLE_ARK is set. " if ark_disabled else "")
+                        + f"auto_round_kernel unavailable: "
                         f"{ark_error or 'unknown error'}"
                     )
 


### PR DESCRIPTION
AutoRound int4 models silently emit garbage under concurrent requests when the ARK WOQ backend is selected with graph capture enabled (vllm-project/vllm#53211). The kernel defect is tracked upstream (intel/auto-round#2206), but vLLM auto-selects ARK with no way to opt out short of uninstalling auto-round-lib.

Add `VLLM_INC_DISABLE_ARK=1` to fall back to the oneDNN int4 path. Int2 checkpoints have no non-ARK path, so the knob refuses loudly for int2 rather than silently breaking them. Explicitly requesting `VLLM_XPU_INC_WNA16_BACKEND=ark` while the flag is set raises a clear conflict error. Default behavior is unchanged.

AI assistance disclosure: this change was generated with AI assistance (GitHub Copilot) and reviewed by the submitter.



## Purpose

Fixes the vLLM-side request in #53211: there is no supported way to decline the ARK WOQ backend for INC/AutoRound checkpoints on XPU. This adds an opt-out env var with safe int2 handling:

- New env var `VLLM_INC_DISABLE_ARK=1`: falls back to the oneDNN int4 path (`INCXPULinearMethod`) instead of ARK.
- Int2 + flag set → raises `NotImplementedError` mentioning the env var, instead of silently breaking (int2 has no non-ARK path).
- `VLLM_XPU_INC_WNA16_BACKEND=ark` + flag set → clear conflict error.
- Default behavior unchanged.

## Test Plan

```
pytest tests/quantization/test_auto_round.py -k "disable_ark or default_backend_keeps_ark or w4a16_backend" -v
pre-commit run --files vllm/envs.py vllm/model_executor/layers/quantization/inc/schemes/inc_wna16_scheme.py tests/quantization/test_auto_round.py
```

## Test Result

6 passed, 0 failures. Teardown-only accelerator errors are pre-existing on CPU-only Windows machines and also occur on unmodified main.

pre-commit: ruff check / ruff format passed on all changed files. mypy failures in `vllm/v1/utils.py` pre-exist on main; that file is not part of this PR.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test result, such as pasting the results comparison before and after, or acc results.
- [ ] Optional) The necessary documentation update, such as updating `supported_models.md` and `examples/` for a new model.

</details>

