### PR TITLE
[Model][Perf] Enable Inkling SplitKV on SM90

### DIFF
--- a/tests/models/inkling/test_fa4_rel_attention.py
+++ b/tests/models/inkling/test_fa4_rel_attention.py
@@ -62,22 +62,47 @@ def test_split_packed_kv_cache():
     torch.testing.assert_close(value_cache, attention.kv_cache[..., 8:].transpose(1, 2))
 
 
-def test_num_splits_hopper_is_unsplit(monkeypatch):
+@pytest.fixture
+def hopper_platform(monkeypatch):
     monkeypatch.setattr(
         current_platform,
         "get_device_capability",
         lambda: DeviceCapability(major=9, minor=0),
     )
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "expected"),
+    [
+        (1, 128),
+        (2, 64),
+        (4, 32),
+        (8, 16),
+        (16, 8),
+        (32, 4),
+        (48, 2),
+        (64, 2),
+        (80, 1),
+        (96, 1),
+        (128, 1),
+        (192, 1),
+        (256, 1),
+    ],
+)
+@pytest.mark.parametrize("max_query_len", [1, 2])
+def test_num_splits_hopper_uses_default_schedule(
+    hopper_platform, batch_size, max_query_len, expected
+):
     assert (
         inkling_fa4_num_splits(
             is_local=False,
-            batch_size=1,
-            max_query_len=1,
-            num_heads=16,
-            num_kv_heads=2,
+            batch_size=batch_size,
+            max_query_len=max_query_len,
+            num_heads=4,
+            num_kv_heads=1,
             max_kv_len=1_048_576,
         )
-        == 1
+        == expected
     )
 
 

--- a/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
+++ b/vllm/models/inkling/nvidia/ops/fa4_rel_attention.py
@@ -78,9 +78,6 @@ def inkling_fa4_num_splits(
     max_kv_len: int,
 ) -> int:
     """Return the split-KV cap for Inkling relative attention."""
-    capability = current_platform.get_device_capability()
-    if capability is not None and capability.major == 9:
-        return 1
     if is_local:
         return 1
 


### PR DESCRIPTION
## Purpose

Inkling's global FA4 relative-attention path currently forces `num_splits=1`
on SM90. For TP8 decode, that leaves too few CTAs to occupy an H200 when the
runtime batch is small.

This PR removes the SM90 unsplit override and lets Hopper use the existing
adaptive SplitKV heuristic. Local attention remains unsplit. The unit coverage
now checks the resulting SM90 schedule for the production TP8-local shape with
Q=1 and Q=2.

This does not duplicate #51416. That PR adds general SM90 FA4 Dense/MLA
integration and does not modify Inkling's specialized relative-attention op or
its split heuristic.

### H200 microbenchmark

The existing Inkling FA4 forward-plus-combine path was measured on one H200 with the TP8-local shape: 4 query heads, 1 KV head, head dimension 128,
BF16, batch 1, and Q in {1, 2}. Each arm used two opposite-order rounds, three
warmups per round, and ten timed samples per round. 

| Actual KV | Q | Split 64 | Split 128 | Split 256 | Result |
|---:|---:|---:|---:|---:|---|
| 8K | 1 | 86.672 us | 85.680 us | 94.416 us | 64 and 128 within 2% |
| 8K | 2 | 85.264 us | 84.352 us | 89.136 us | 64 and 128 within 2% |
| 64K | 1 | 117.424 us | 100.832 us | 114.640 us | 128 is 14.13% lower latency than 64 |
| 64K | 2 | 121.440 us | 106.288 us | 118.880 us | 128 is 12.48% lower latency than 64 |

This supports the existing `max_splits=128` cap and CTA targets on SM90.

All microbenchmark outputs passed the unsplit-reference correctness gate. The
worst absolute difference was 0.0002441 and the worst relative L2 was 0.003123.

### End-to-end serving

Configuration: `thinkingmachines/Inkling-Small-NVFP4`, H200x8 TP8, 64K ISL
(6.4K new + 57.6K reused), 400 OSL, MTP with synthetic acceptance length 1.80,
and concurrency 32.

| SM90 policy | Output tok/s | Output tok/s/GPU | p50 ITL | p50 tok/s/user | Errors |
|---|---:|---:|---:|---:|---:|
| Unsplit | 1095.339 | 136.917 | 23.218 ms | 43.070 | 0 |
| Existing adaptive heuristic | 1446.799 | 180.850 | 14.935 ms | 66.955 | 0 |

Two full concurrency sweeps also compared the existing adaptive heuristic
against a workload-specific tuned split table:

- 64K/400 with 90% prefix reuse: adaptive heuristic was -0.140% in throughput
  geometric mean.
- Static 8192/1024 with no shared prefix: adaptive heuristic was +0.085% in
  throughput geometric mean.

These comparisons support using the **existing general heuristic** instead of a
model/workload-specific split table.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/models/inkling/test_fa4_rel_attention.py -k 'num_splits' -v
```

The commit hooks also ran Ruff check/format, mypy, SPDX, forbidden-import, and
repository policy checks on the change.

## Test Result

```text
41 passed, 55 deselected
```

AI assistance was used to prepare the code, tests, benchmark analysis, and PR
description.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] The test command is provided.
- [x] Microbenchmark and end-to-end results are included.
- [x] No documentation update is required for this model-specific scheduling change.
</details>
