### PR TITLE
[flex] expose max_scores for qk clipping

### DIFF
--- a/tests/kernels/test_flex_attention.py
+++ b/tests/kernels/test_flex_attention.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 from packaging import version
+from torch.nn.attention.flex_attention import AuxOutput, AuxRequest
 
 from tests.utils import set_random_seed
 from tests.v1.attention.utils import (
@@ -15,8 +16,10 @@ from tests.v1.attention.utils import (
 )
 from vllm.config import AttentionConfig
 from vllm.model_executor.layers.attention import Attention
+from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.flex_attention import (
     BlockSparsityHint,
+    FlexAttentionImpl,
     FlexAttentionMetadataBuilder,
     physical_to_logical_mapping,
 )
@@ -26,6 +29,35 @@ from ..models.utils import check_embeddings_close, check_logprobs_close
 TORCH_VERSION = version.parse(torch.__version__)
 MINIMUM_TORCH_VERSION = version.parse("2.7.0")
 DIRECT_BUILD_VERSION = version.parse("2.9.dev0")
+
+
+@pytest.mark.parametrize("use_out_transform", [False, True])
+def test_flex_attention_exposes_max_scores(use_out_transform):
+    impl = FlexAttentionImpl(
+        num_heads=2,
+        head_size=4,
+        scale=0.5,
+        num_kv_heads=2,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        attn_type=AttentionType.ENCODER_ONLY,
+    )
+    captured_max_scores: list[torch.Tensor] = []
+    impl.set_max_scores_capture_fn(captured_max_scores.append)
+
+    max_scores = torch.randn(1, 2, 3)
+    if use_out_transform:
+        impl.out_transform = lambda out, lse: out
+
+    assert impl._get_aux_request() == AuxRequest(
+        lse=use_out_transform,
+        max_scores=True,
+    )
+    impl._process_aux(AuxOutput(max_scores=max_scores))
+
+    assert len(captured_max_scores) == 1
+    assert captured_max_scores[0] is max_scores
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -12,6 +12,7 @@ import torch
 import torch._dynamo.decorators
 import torch.nn.functional as F
 from torch.nn.attention.flex_attention import (
+    AuxOutput,
     AuxRequest,
     BlockMask,
     _mask_mod_signature,
@@ -1241,6 +1242,29 @@ class FlexAttentionImpl(AttentionImpl):
 
         # Optional post-attention epilogue transform
         self.out_transform = kwargs.get("out_transform")
+        self.max_scores_capture_fn: Callable[[torch.Tensor], None] | None = kwargs.get(
+            "max_scores_capture_fn"
+        )
+
+    def set_max_scores_capture_fn(
+        self,
+        capture_fn: Callable[[torch.Tensor], None] | None,
+    ) -> None:
+        """Set a callback receiving per-query maximum scores with shape (B, H, Q)."""
+        self.max_scores_capture_fn = capture_fn
+
+    def _get_aux_request(self) -> AuxRequest | None:
+        return_aux = AuxRequest(
+            lse=self.out_transform is not None,
+            max_scores=self.max_scores_capture_fn is not None,
+        )
+        return return_aux if any(return_aux) else None
+
+    def _process_aux(self, aux: AuxOutput) -> None:
+        if self.max_scores_capture_fn is not None:
+            max_scores = aux.max_scores
+            assert max_scores is not None
+            self.max_scores_capture_fn(max_scores)
 
     @staticmethod
     def view_as_4d(tensor: torch.Tensor) -> torch.Tensor:
@@ -1397,6 +1421,7 @@ class FlexAttentionImpl(AttentionImpl):
             kernel_options["BLOCK_N"] = self.block_n
         if envs.VLLM_BATCH_INVARIANT:
             kernel_options["IS_DIVISIBLE"] = False
+        return_aux = self._get_aux_request()
         out = flex_attention_compiled(
             query,
             key_tensor,
@@ -1406,12 +1431,14 @@ class FlexAttentionImpl(AttentionImpl):
             self.scale,
             enable_gqa=enable_gqa,
             kernel_options=kernel_options,
-            return_aux=AuxRequest(lse=True) if self.out_transform is not None else None,
+            return_aux=return_aux,
         )
 
-        if self.out_transform is not None:
+        if return_aux is not None:
             out, aux = out
-            out = self.out_transform(out, aux.lse)
+            self._process_aux(aux)
+            if self.out_transform is not None:
+                out = self.out_transform(out, aux.lse)
 
         # Flex doesn't have an out variant today, rely on epilogue fusion
         out = out.permute(0, 2, 1, 3).squeeze(0)


### PR DESCRIPTION
expose `max_scores` through a callback function one example use case of this is to use for qk clipping in kimi k3