### PR TITLE
[Bugfix][KV Offload] Guard P2P supply against consumer demand

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -38,10 +38,21 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
+    EncoderOnlyAttentionSpec,
     FullAttentionSpec,
+    HiddenStateCacheSpec,
     KVCacheGroupSpec,
+    KVCacheSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    RSWASpec,
+    SinkFullAttentionSpec,
+    SlidingWindowMLASpec,
     SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_offload.base import (
     GPULoadStoreSpec,
@@ -2451,6 +2462,189 @@ def test_request_level_supply_covers_consumer_demand(
         f"{len(missing)} of {len(demanded)} demanded keys are never offered to "
         f"prepare_store, so a peer fetching them would wait out the load timeout"
     )
+
+
+# Whether a policy keeps prefix-hit chunks in the store path. BLOCK_LEVEL skips
+# them, which is what left a warm PD producer with nothing to supply in #52808,
+# so a producer leg must never run a policy declared False here. A new policy
+# has to declare.
+_POLICY_KEEPS_PREFIX_HITS = {
+    OffloadPolicy.BLOCK_LEVEL: False,
+    OffloadPolicy.REQUEST_LEVEL: True,
+}
+
+
+@pytest.mark.parametrize("policy", list(OffloadPolicy))
+def test_prefix_hit_store_behavior_declared_for_every_policy(request_runner, policy):
+    """Whether prefix hits stay in the store path is what a warm producer has
+    left to supply, so every policy needs deliberate behavior."""
+    assert policy in _POLICY_KEEPS_PREFIX_HITS, f"{policy} has no declared behavior"
+    num_tokens = 32
+    runner = request_runner(block_size=16, num_gpu_blocks=200, async_scheduling=False)
+
+    def store_everything_offered():
+        runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(keys)
+        )
+
+    # Warm the prefix, so the next request computes no new block.
+    store_everything_offered()
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner._run(decoded_tokens=[0], complete_transfers=True)
+    runner._run(decoded_tokens=[EOS_TOKEN_ID], complete_transfers=True)
+
+    runner.manager.reset_mock()
+    store_everything_offered()
+    runner.manager.on_new_request.return_value = RequestOffloadingContext(policy=policy)
+    runner.manager.lookup.return_value = LookupResult.HIT
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner._run(decoded_tokens=[0], complete_transfers=True)
+    runner._run(decoded_tokens=[EOS_TOKEN_ID], complete_transfers=True)
+
+    offered = bool(runner.manager.prepare_store.call_args_list)
+    assert offered is _POLICY_KEEPS_PREFIX_HITS[policy]
+
+
+# The branch of get_sliding_window_size_in_chunks each KV cache spec resolves
+# to. The store path prunes exactly the groups reporting a window and the load
+# path scans those with _sliding_window_lookup, so the two only agree while
+# every spec lands where it is declared to. None means the spec is not handled
+# and trips the function's closing assert, which otherwise only surfaces at
+# runtime on a model that uses it. A new spec has to declare.
+#
+# UniformTypeKVCacheSpecs is declared None because it never reaches this
+# function: generate_scheduler_kv_cache_config replaces the wrapper with a
+# representative per-layer spec before the scheduler sees a group. Only the
+# worker side keeps the wrapper, which is why worker.py and canonical_mapping.py
+# branch on it and this file does not.
+_GROUP_STORE_PRUNING: dict[type[KVCacheSpec], type[KVCacheSpec] | None] = {
+    AttentionSpec: None,
+    ChunkedLocalAttentionSpec: ChunkedLocalAttentionSpec,
+    CrossAttentionSpec: None,
+    EncoderOnlyAttentionSpec: None,
+    FullAttentionSpec: FullAttentionSpec,
+    HiddenStateCacheSpec: FullAttentionSpec,
+    MambaSpec: MambaSpec,
+    MLAAttentionSpec: FullAttentionSpec,
+    RSWASpec: FullAttentionSpec,
+    SinkFullAttentionSpec: FullAttentionSpec,
+    SlidingWindowMLASpec: SlidingWindowSpec,
+    SlidingWindowSpec: SlidingWindowSpec,
+    UniformTypeKVCacheSpecs: None,
+}
+
+# What each declared branch reports for a spec built by _make_kv_cache_spec
+# below, at tokens_per_chunk=16.
+_BRANCH_WINDOW_IN_CHUNKS = {
+    FullAttentionSpec: None,
+    SlidingWindowSpec: 2,
+    ChunkedLocalAttentionSpec: 4,
+    MambaSpec: 1,
+}
+
+_SPEC_TOKENS_PER_CHUNK = 16
+
+
+def _concrete_kv_cache_specs() -> list[type[KVCacheSpec]]:
+    def walk(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from walk(sub)
+
+    return sorted(set(walk(KVCacheSpec)), key=lambda spec: spec.__name__)
+
+
+def _make_kv_cache_spec(spec_type: type[KVCacheSpec]) -> KVCacheSpec | None:
+    """Smallest instance of `spec_type`, or None if it needs real model shapes."""
+    if spec_type is MambaSpec:
+        return MambaSpec(block_size=16, shapes=((1,),), dtypes=(torch.float32,))
+    if spec_type is UniformTypeKVCacheSpecs:
+        return None
+    kwargs: dict = dict(block_size=16, num_kv_heads=1, head_size=1, dtype=torch.float32)
+    if issubclass(spec_type, SlidingWindowSpec):
+        kwargs["sliding_window"] = 32
+    if issubclass(spec_type, ChunkedLocalAttentionSpec):
+        kwargs["attention_chunk_size"] = 64
+    if issubclass(spec_type, RSWASpec):
+        kwargs["rswa_window"] = 32
+    return spec_type(**kwargs)
+
+
+@pytest.mark.parametrize("spec_type", _concrete_kv_cache_specs())
+def test_store_pruning_declared_for_every_kv_cache_spec(spec_type):
+    """A spec that starts pruning without the load path agreeing strands blocks
+    silently, and an unhandled one only fails on a model that uses it."""
+    assert spec_type in _GROUP_STORE_PRUNING, f"{spec_type.__name__} is not declared"
+    branch = _GROUP_STORE_PRUNING[spec_type]
+
+    spec = _make_kv_cache_spec(spec_type)
+    if spec is None:
+        return
+    if branch is None:
+        with pytest.raises(AssertionError):
+            get_sliding_window_size_in_chunks(spec, _SPEC_TOKENS_PER_CHUNK)
+        return
+    assert (
+        get_sliding_window_size_in_chunks(spec, _SPEC_TOKENS_PER_CHUNK)
+        == (_BRANCH_WINDOW_IN_CHUNKS[branch])
+    )
+
+
+@pytest.mark.parametrize("with_swa_group", [False, True])
+def test_demand_oracle_matches_a_real_lookup_scan(request_runner, with_swa_group: bool):
+    """`_demanded_keys` reimplements the scan it stands in for, so it can drift
+    along with production instead of pinning it. Pin it against the real one."""
+    full_attn_block_size = 16
+    swa_block_size = 4
+    num_tokens = 32
+
+    kv_cache_groups = (
+        _full_and_swa_groups(full_attn_block_size, swa_block_size, sliding_window=8)
+        if with_swa_group
+        else None
+    )
+    runner = request_runner(
+        block_size=swa_block_size if with_swa_group else full_attn_block_size,
+        num_gpu_blocks=200,
+        async_scheduling=False,
+        kv_cache_groups=kv_cache_groups,
+    )
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+    runner.manager.lookup.return_value = LookupResult.HIT_PENDING
+
+    scanned: list = []
+    offload_keys_per_group: list[list] = []
+
+    def capture_first_scan() -> None:
+        if scanned:
+            return
+        scanned.extend(c.args[0] for c in runner.manager.lookup.call_args_list)
+        for req_status in runner.connector_scheduler._req_status.values():
+            offload_keys_per_group.extend(
+                list(group_state.offload_keys)
+                for group_state in req_status.group_states
+            )
+        # HIT_PENDING defers admission forever; let the request through now
+        # that its scan is recorded.
+        runner.manager.lookup.return_value = LookupResult.MISS
+
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner._run(
+        decoded_tokens=[0, EOS_TOKEN_ID],
+        complete_transfers=True,
+        post_step_fn=capture_first_scan,
+    )
+
+    assert scanned, "the real scheduler scanned nothing"
+    assert set(scanned) == _demanded_keys(runner, offload_keys_per_group, num_tokens)
+
+    # The oracle must bound itself to num_tokens rather than lean on the
+    # captured key lists happening to end there, so padding them changes
+    # nothing.
+    padded = [keys + to_keys(range(9000, 9000 + 4)) for keys in offload_keys_per_group]
+    assert set(scanned) == _demanded_keys(runner, padded, num_tokens)
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -1207,12 +1207,21 @@ def test_two_groups_different_block_sizes(request_runner, async_scheduling: bool
 
 def _make_scheduler_with_lookup(
     lookup_results: dict[int, LookupResult],
+    default: LookupResult = LookupResult.MISS,
 ) -> OffloadingConnectorScheduler:
-    """Create an OffloadingConnectorScheduler with a mocked manager.lookup."""
+    """Create an OffloadingConnectorScheduler with a mocked manager.lookup.
+
+    Keys are addressed by their integer hash; `default` answers anything else.
+    """
     manager = MagicMock(spec=OffloadingManager)
-    manager.lookup.side_effect = lambda key, req_context: lookup_results.get(
-        int(get_offload_block_hash(key).decode()), LookupResult.MISS
-    )
+
+    def lookup(key, req_context):
+        block_hash = get_offload_block_hash(key)
+        if not block_hash.isdigit():
+            return default
+        return lookup_results.get(int(block_hash.decode()), default)
+
+    manager.lookup.side_effect = lookup
 
     scheduler = object.__new__(OffloadingConnectorScheduler)
     scheduler.manager = manager
@@ -1234,6 +1243,32 @@ def _maximal_lookup(sched, keys, start_chunk_idx: int = 0):
         _LOOKUP_GROUP_CONFIG,
         start_chunk_idx,
     )
+
+
+# Lookups issued, and end index returned, by a window-1 scan over 3 keys all
+# resolving to the same result. A result that keeps the streak alive ends the
+# scan at the first key; one that resets it makes the scan walk every key,
+# which is what widens the demanded set. A new member has to be added here.
+_SCAN_BEHAVIOR = {
+    LookupResult.HIT: (1, 3),
+    LookupResult.HIT_PENDING: (1, None),
+    LookupResult.RETRY: (3, None),
+    LookupResult.MISS: (3, 0),
+}
+
+
+@pytest.mark.parametrize("result", list(LookupResult))
+def test_scan_behavior_declared_for_every_lookup_result(result: LookupResult):
+    """Whether a result keeps a sliding-window streak alive decides how wide
+    the demanded chunk set gets, so every member needs deliberate behavior."""
+    assert result in _SCAN_BEHAVIOR, f"{result} has no declared scan behavior"
+    expected_lookups, expected_end = _SCAN_BEHAVIOR[result]
+
+    keys = to_keys([1, 2, 3])
+    sched = _make_scheduler_with_lookup(dict.fromkeys([1, 2, 3], result))
+
+    assert sched._sliding_window_lookup(keys, 1, _EMPTY_REQ_CTX) == expected_end
+    assert len(sched.manager.lookup.call_args_list) == expected_lookups
 
 
 class TestMaximalPrefixLookup:
@@ -1468,6 +1503,62 @@ class TestSlidingWindowLookup:
         assert (
             sched._sliding_window_lookup(to_keys([1, 2, 3]), 3, _EMPTY_REQ_CTX) is None
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for SWA store pruning vs. load demand
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alignment_chunk_count", [4, 8, 64])
+@pytest.mark.parametrize("sliding_window_chunks", [1, 2, 3])
+@pytest.mark.parametrize("is_eagle_group", [False, True])
+@pytest.mark.parametrize("tail_chunks", [0, 1, 5])
+def test_sliding_window_demand_is_store_reachable(
+    alignment_chunk_count: int,
+    sliding_window_chunks: int,
+    is_eagle_group: bool,
+    tail_chunks: int,
+):
+    """Every chunk the load path looks up must be one the store path keeps.
+
+    `is_store_reachable_swa_chunk` prunes chunks `_sliding_window_lookup` can
+    never query, but the two mirror each other by hand: this pins the relation,
+    where `test_is_store_reachable_swa_chunk` pins only the predicate's values.
+    A looked-up key is a demanded key, since a secondary-tier hit queues a
+    promotion immediately.
+    """
+    storable_chunk_count = alignment_chunk_count + tail_chunks
+    # Both sides widen by one for an unverified EAGLE group.
+    required_window = sliding_window_chunks + int(is_eagle_group)
+
+    sched = _make_scheduler_with_lookup(
+        {i: LookupResult.HIT_PENDING for i in range(storable_chunk_count)}
+    )
+    sched._sliding_window_lookup(
+        to_keys(range(storable_chunk_count)), required_window, _EMPTY_REQ_CTX
+    )
+
+    demanded = {
+        int(get_offload_block_hash(lookup_call.args[0]).decode())
+        for lookup_call in sched.manager.lookup.call_args_list
+    }
+    assert demanded, "the scan must query something"
+    unsuppliable = sorted(
+        chunk_idx
+        for chunk_idx in demanded
+        if not is_store_reachable_swa_chunk(
+            chunk_idx,
+            storable_chunk_count,
+            alignment_chunk_count,
+            sliding_window_chunks,
+            is_eagle_group,
+        )
+    )
+    assert not unsuppliable, (
+        f"chunks {unsuppliable} are demanded by the load path but pruned by the "
+        f"store path, so a warm producer can never supply them"
+    )
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])
@@ -2219,6 +2310,146 @@ def test_swa_alignment_skip(request_runner, async_scheduling: bool):
             (1, 6),
             (1, 7),
         ),
+    )
+
+
+def _full_and_swa_groups(
+    full_attn_block_size: int, swa_block_size: int, sliding_window: int
+) -> list[KVCacheGroupSpec]:
+    """Group 0 full attention (MLA-like), group 1 sliding window."""
+    return [
+        KVCacheGroupSpec(
+            ["layer0"],
+            FullAttentionSpec(
+                block_size=full_attn_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["layer1"],
+            SlidingWindowSpec(
+                block_size=swa_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=sliding_window,
+            ),
+        ),
+    ]
+
+
+def _demanded_keys(runner, offload_keys_per_group: list[list], num_tokens: int) -> set:
+    """Keys a cold consumer's lookup scan would demand for `num_tokens`.
+
+    Drives the real scan functions with every key resolving as a promoting
+    secondary tier resolves it.
+    """
+    scan = _make_scheduler_with_lookup({}, default=LookupResult.HIT_PENDING)
+    for group_config, offload_keys in zip(
+        runner.connector_scheduler.config.kv_group_configs, offload_keys_per_group
+    ):
+        num_chunks = num_tokens // group_config.tokens_per_chunk
+        keys = offload_keys[:num_chunks]
+        window = group_config.sliding_window_size_in_chunks
+        if window is None:
+            _maximal_lookup(scan, keys)
+        else:
+            scan._sliding_window_lookup(keys, window, _EMPTY_REQ_CTX)
+    return {lookup_call.args[0] for lookup_call in scan.manager.lookup.call_args_list}
+
+
+@pytest.mark.parametrize("warmth", ["cold", "gpu_warm", "primary_warm"])
+@pytest.mark.parametrize("with_swa_group", [False, True])
+def test_request_level_supply_covers_consumer_demand(
+    request_runner, warmth: str, with_swa_group: bool
+):
+    """A REQUEST_LEVEL producer must offer every key a consumer will demand.
+
+    Same relation as `test_sliding_window_demand_is_store_reachable`, but at
+    the level where the key set is really built: `_build_store_jobs` prunes
+    chunks with a null GPU block and unreachable SWA chunks, while the demand
+    comes from an independent scan.
+    """
+    full_attn_block_size = 16
+    swa_block_size = 4
+    num_tokens = 32
+
+    kv_cache_groups = (
+        _full_and_swa_groups(full_attn_block_size, swa_block_size, sliding_window=8)
+        if with_swa_group
+        else None
+    )
+    runner = request_runner(
+        block_size=swa_block_size if with_swa_group else full_attn_block_size,
+        num_gpu_blocks=200,
+        async_scheduling=False,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+    def store_everything_offered():
+        runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(keys)
+        )
+
+    # `_run` rather than `run`, which asserts on an expected GPU-block set this
+    # test deliberately does not hard-code.
+    if warmth != "cold":
+        runner.new_request(token_ids=[0] * num_tokens)
+        store_everything_offered()
+        runner._run(decoded_tokens=[0], complete_transfers=True)
+        runner._run(decoded_tokens=[EOS_TOKEN_ID], complete_transfers=True)
+        if warmth == "primary_warm":
+            # Warm only in the primary tier, so the producer must load first.
+            runner.scheduler.reset_prefix_cache()
+
+    # The producer leg: same prompt, REQUEST_LEVEL, so prefix hits stay in the
+    # store path instead of being skipped.
+    runner.manager.reset_mock()
+    store_everything_offered()
+    runner.manager.on_new_request.return_value = RequestOffloadingContext(
+        policy=OffloadPolicy.REQUEST_LEVEL
+    )
+    if warmth == "primary_warm":
+        # HIT is final; HIT_PENDING would defer the request on every step.
+        runner.manager.lookup.return_value = LookupResult.HIT
+    runner.new_request(token_ids=[0] * num_tokens)
+
+    offload_keys_per_group: list[list] = []
+
+    def capture_offload_keys() -> None:
+        for req_status in runner.connector_scheduler._req_status.values():
+            offload_keys_per_group.clear()
+            offload_keys_per_group.extend(
+                list(group_state.offload_keys)
+                for group_state in req_status.group_states
+            )
+
+    runner._run(
+        decoded_tokens=[0],
+        complete_transfers=True,
+        post_step_fn=capture_offload_keys,
+    )
+    runner._run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        complete_transfers=True,
+        post_step_fn=capture_offload_keys,
+    )
+
+    assert offload_keys_per_group, "no request state was captured"
+    supplied = {
+        key
+        for store_call in runner.manager.prepare_store.call_args_list
+        for key in store_call.args[0]
+    }
+    demanded = _demanded_keys(runner, offload_keys_per_group, num_tokens)
+
+    assert demanded, "the scan must demand something"
+    missing = demanded - supplied
+    assert not missing, (
+        f"{len(missing)} of {len(demanded)} demanded keys are never offered to "
+        f"prepare_store, so a peer fetching them would wait out the load timeout"
     )
 
 

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -65,7 +65,7 @@ def to_key(int_hash: int) -> OffloadKey:
     return make_offload_key(str(int_hash).encode(), 0)
 
 
-def to_keys(int_hashes: list[int]) -> list[OffloadKey]:
+def to_keys(int_hashes: Iterable[int]) -> list[OffloadKey]:
     return [to_key(i) for i in int_hashes]
 
 

--- a/tests/v1/kv_offload/tiering/p2p/test_manager.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_manager.py
@@ -17,7 +17,12 @@ import pytest
 
 from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import DEFAULT_NONE_HASH_SEED, init_none_hash
-from vllm.v1.kv_offload.base import LookupResult, ReqContext, ScheduleEndContext
+from vllm.v1.kv_offload.base import (
+    LookupResult,
+    OffloadPolicy,
+    ReqContext,
+    ScheduleEndContext,
+)
 from vllm.v1.kv_offload.tiering.base import JobResult, TransferJob
 from vllm.v1.kv_offload.tiering.p2p import manager as manager_module
 from vllm.v1.kv_offload.tiering.p2p.manager import (
@@ -238,6 +243,46 @@ class TestLookup:
         mgr = _make_manager()
         ctx = _req_context(kv_params=_remote_decoder_kv_params())
         assert mgr.lookup(b"key", ctx) is LookupResult.MISS
+
+
+# ---------------------------------------------------------------------------
+# Tests for on_new_request offload policy
+# ---------------------------------------------------------------------------
+
+
+class TestOnNewRequestPolicy:
+    """The producer leg must offload every block the peer will fetch.
+
+    A producer serving a remote decoder has to supply the whole request, so it
+    asks for REQUEST_LEVEL: that is what makes the TieringManager cascade
+    blocks that are already resident in the primary tier. Under BLOCK_LEVEL a
+    warm producer cascades nothing and the peer's fetch demand parks until the
+    load timeout (see issue #52808).
+    """
+
+    def test_remote_decoder_request_is_request_level(self):
+        mgr = _make_manager()
+        ctx = _req_context(kv_params=_remote_decoder_kv_params())
+        assert mgr.on_new_request(ctx).policy is OffloadPolicy.REQUEST_LEVEL
+
+    def test_plain_request_stays_block_level(self):
+        mgr = _make_manager()
+        ctx = _req_context(kv_params=None)
+        assert mgr.on_new_request(ctx).policy is OffloadPolicy.BLOCK_LEVEL
+
+    def test_consumer_leg_stays_block_level(self, monkeypatch):
+        """The consumer fetches from the peer; it has nothing to supply."""
+        mgr = _make_manager()
+        monkeypatch.setattr(mgr, "_get_or_create_session", lambda peer_id: None)
+        ctx = _req_context(kv_params=_remote_prefiller_kv_params())
+        assert mgr.on_new_request(ctx).policy is OffloadPolicy.BLOCK_LEVEL
+
+    def test_malformed_remote_decoder_stays_block_level(self):
+        """No kv_request_id means submit_store will fail the request anyway,
+        so there is nothing to gain from widening the store set."""
+        mgr = _make_manager()
+        ctx = _req_context(kv_params={"remote_decoder": {}})
+        assert mgr.on_new_request(ctx).policy is OffloadPolicy.BLOCK_LEVEL
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/tiering/p2p/test_manager.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_manager.py
@@ -250,39 +250,20 @@ class TestLookup:
 # ---------------------------------------------------------------------------
 
 
-class TestOnNewRequestPolicy:
-    """The producer leg must offload every block the peer will fetch.
-
-    A producer serving a remote decoder has to supply the whole request, so it
-    asks for REQUEST_LEVEL: that is what makes the TieringManager cascade
-    blocks that are already resident in the primary tier. Under BLOCK_LEVEL a
-    warm producer cascades nothing and the peer's fetch demand parks until the
-    load timeout (see issue #52808).
-    """
-
-    def test_remote_decoder_request_is_request_level(self):
-        mgr = _make_manager()
-        ctx = _req_context(kv_params=_remote_decoder_kv_params())
-        assert mgr.on_new_request(ctx).policy is OffloadPolicy.REQUEST_LEVEL
-
-    def test_plain_request_stays_block_level(self):
-        mgr = _make_manager()
-        ctx = _req_context(kv_params=None)
-        assert mgr.on_new_request(ctx).policy is OffloadPolicy.BLOCK_LEVEL
-
-    def test_consumer_leg_stays_block_level(self, monkeypatch):
-        """The consumer fetches from the peer; it has nothing to supply."""
-        mgr = _make_manager()
-        monkeypatch.setattr(mgr, "_get_or_create_session", lambda peer_id: None)
-        ctx = _req_context(kv_params=_remote_prefiller_kv_params())
-        assert mgr.on_new_request(ctx).policy is OffloadPolicy.BLOCK_LEVEL
-
-    def test_malformed_remote_decoder_stays_block_level(self):
-        """No kv_request_id means submit_store will fail the request anyway,
-        so there is nothing to gain from widening the store set."""
-        mgr = _make_manager()
-        ctx = _req_context(kv_params={"remote_decoder": {}})
-        assert mgr.on_new_request(ctx).policy is OffloadPolicy.BLOCK_LEVEL
+@pytest.mark.parametrize(
+    "kv_params,expected",
+    [
+        (_remote_decoder_kv_params(), OffloadPolicy.REQUEST_LEVEL),
+        (_remote_prefiller_kv_params(), OffloadPolicy.BLOCK_LEVEL),
+        ({"remote_decoder": {}}, OffloadPolicy.BLOCK_LEVEL),
+    ],
+    ids=["producer", "plain", "consumer", "producer_no_id"],
+)
+def test_on_new_request_policy(monkeypatch, kv_params, expected):
+    """Only a producer leg carrying a kv_request_id widens to REQUEST_LEVEL."""
+    mgr = _make_manager()
+    monkeypatch.setattr(mgr, "_get_or_create_session", lambda peer_id: None)
+    assert mgr.on_new_request(_req_context(kv_params=kv_params)).policy is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/tiering/p2p/test_manager.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_manager.py
@@ -254,6 +254,7 @@ class TestLookup:
     "kv_params,expected",
     [
         (_remote_decoder_kv_params(), OffloadPolicy.REQUEST_LEVEL),
+        (None, OffloadPolicy.BLOCK_LEVEL),
         (_remote_prefiller_kv_params(), OffloadPolicy.BLOCK_LEVEL),
         ({"remote_decoder": {}}, OffloadPolicy.BLOCK_LEVEL),
     ],

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -1079,6 +1079,44 @@ class TestTieringOffloadingManager:
         # tier2 (block-level) does not get existing blocks here.
         self.secondary_tier2.submit_store.assert_not_called()
 
+    def test_fully_warm_request_still_cascades_to_request_level_tiers(
+        self, manager_setup
+    ):
+        """A request whose blocks are ALL already in primary still cascades.
+
+        This is the warm-producer shape from issue #52808: nothing is new, so
+        primary returns an empty keys_to_store and no GPU->primary transfer
+        runs. A request-level tier must still be handed the blocks, otherwise a
+        peer waiting on them has nothing to fetch.
+        """
+        existing_blocks = to_keys(range(3))
+        self._start_request()
+        assert self.manager.prepare_store(existing_blocks, _CTX) is not None
+        self.manager.complete_store(existing_blocks, _CTX, success=True)
+        self._simulate_on_schedule_end()
+
+        self.secondary_tier1.on_new_request = lambda req_context: (
+            RequestOffloadingContext(policy=OffloadPolicy.REQUEST_LEVEL)
+        )
+        ctx = ReqContext(req_id="req_fully_warm")
+        self.manager.on_new_request(ctx)
+
+        self.secondary_tier1.submit_store = MagicMock(
+            wraps=self.secondary_tier1.submit_store
+        )
+        self.secondary_tier2.submit_store = MagicMock(
+            wraps=self.secondary_tier2.submit_store
+        )
+
+        result = self.manager.prepare_store(existing_blocks, ctx)
+        assert result is not None
+        assert result.keys_to_store == []
+
+        self.secondary_tier1.submit_store.assert_called_once()
+        job_metadata = self.secondary_tier1.submit_store.call_args.args[0]
+        assert set(job_metadata.keys) == set(existing_blocks)
+        self.secondary_tier2.submit_store.assert_not_called()
+
     def test_reset_cache_clears_orchestrator_state(self, manager_setup):
         """reset_cache wipes every kind of orchestrator state and resets
         primary tier; pending submissions are dropped without being sent

--- a/tests/v1/kv_offload/tiering/test_tiering_offloading.py
+++ b/tests/v1/kv_offload/tiering/test_tiering_offloading.py
@@ -1034,10 +1034,17 @@ class TestTieringOffloadingManager:
         self.manager.on_request_finished(ctx)
         assert ctx.req_id not in self.manager._req_state
 
+    @pytest.mark.parametrize("new_ids", [(), (3, 4)], ids=["fully_warm", "mixed"])
     def test_prepare_store_cascades_existing_blocks_to_request_level_tiers(
-        self, manager_setup
+        self, manager_setup, new_ids
     ):
-        """prepare_store cascades hit blocks to request-level tiers only."""
+        """prepare_store cascades hit blocks to request-level tiers only.
+
+        The fully-warm case is the producer shape from issue #52808: nothing is
+        new, so primary returns an empty keys_to_store and no GPU->primary
+        transfer runs. A request-level tier must still be handed the blocks,
+        otherwise a peer waiting on them has nothing to fetch.
+        """
         # Store some blocks to primary first
         existing_blocks = to_keys(range(3))
         self._start_request()
@@ -1064,7 +1071,7 @@ class TestTieringOffloadingManager:
         )
 
         # Call prepare_store with existing + new blocks
-        new_blocks = to_keys(range(3, 5))
+        new_blocks = to_keys(new_ids)
         all_blocks = existing_blocks + new_blocks
         result = self.manager.prepare_store(all_blocks, ctx)
         assert result is not None
@@ -1077,44 +1084,6 @@ class TestTieringOffloadingManager:
         assert set(job_metadata.keys) == set(existing_blocks)
 
         # tier2 (block-level) does not get existing blocks here.
-        self.secondary_tier2.submit_store.assert_not_called()
-
-    def test_fully_warm_request_still_cascades_to_request_level_tiers(
-        self, manager_setup
-    ):
-        """A request whose blocks are ALL already in primary still cascades.
-
-        This is the warm-producer shape from issue #52808: nothing is new, so
-        primary returns an empty keys_to_store and no GPU->primary transfer
-        runs. A request-level tier must still be handed the blocks, otherwise a
-        peer waiting on them has nothing to fetch.
-        """
-        existing_blocks = to_keys(range(3))
-        self._start_request()
-        assert self.manager.prepare_store(existing_blocks, _CTX) is not None
-        self.manager.complete_store(existing_blocks, _CTX, success=True)
-        self._simulate_on_schedule_end()
-
-        self.secondary_tier1.on_new_request = lambda req_context: (
-            RequestOffloadingContext(policy=OffloadPolicy.REQUEST_LEVEL)
-        )
-        ctx = ReqContext(req_id="req_fully_warm")
-        self.manager.on_new_request(ctx)
-
-        self.secondary_tier1.submit_store = MagicMock(
-            wraps=self.secondary_tier1.submit_store
-        )
-        self.secondary_tier2.submit_store = MagicMock(
-            wraps=self.secondary_tier2.submit_store
-        )
-
-        result = self.manager.prepare_store(existing_blocks, ctx)
-        assert result is not None
-        assert result.keys_to_store == []
-
-        self.secondary_tier1.submit_store.assert_called_once()
-        job_metadata = self.secondary_tier1.submit_store.call_args.args[0]
-        assert set(job_metadata.keys) == set(existing_blocks)
         self.secondary_tier2.submit_store.assert_not_called()
 
     def test_reset_cache_clears_orchestrator_state(self, manager_setup):

--- a/vllm/v1/kv_offload/tiering/p2p/manager.py
+++ b/vllm/v1/kv_offload/tiering/p2p/manager.py
@@ -22,6 +22,7 @@ from vllm.v1.core.kv_cache_utils import get_none_hash_seed
 from vllm.v1.kv_offload.base import (
     LookupResult,
     OffloadKey,
+    OffloadPolicy,
     ReqContext,
     RequestOffloadingContext,
     ScheduleEndContext,
@@ -361,11 +362,18 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         prefiller side, sessions are created when the consumer's inbound
         connection arrives in _accept_new_peers — submit_store no longer
         pre-creates anything.
+
+        Producer-leg requests (``remote_decoder`` present) ask for
+        REQUEST_LEVEL: the peer needs every block of the request, not just
+        the ones this request computed.
         """
         _annotate_req_context(req_context)
         source = req_context.get_state(P2PSourceInfo)
         if source is not None:
             self._get_or_create_session(source.peer_id)
+        dest = req_context.get_state(P2PDestInfo)
+        if dest is not None and dest.kv_request_id:
+            return RequestOffloadingContext(policy=OffloadPolicy.REQUEST_LEVEL)
         return RequestOffloadingContext()
 
     @override

--- a/vllm/v1/kv_offload/tiering/p2p/session/server.py
+++ b/vllm/v1/kv_offload/tiering/p2p/session/server.py
@@ -18,12 +18,18 @@ coordinator's ``_dispatch_message`` can reuse its existing
 from __future__ import annotations
 
 import time
+from collections import Counter
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, NamedTuple
 
 from vllm.logger import init_logger
-from vllm.v1.kv_offload.base import LookupResult, OffloadKey, ReqContext
+from vllm.v1.kv_offload.base import (
+    LookupResult,
+    OffloadKey,
+    ReqContext,
+    get_offload_group_idx,
+)
 from vllm.v1.kv_offload.tiering.p2p.session.protocol import (
     TYPE_KEY,
     AbortAckMsg,
@@ -978,6 +984,23 @@ class ServerRole:
             len(req.available),
             send_done,
         )
+        if not success and req.demanded:
+            # The peer waits out its whole load timeout on this demand, so name
+            # it here: producer supply and consumer demand are computed
+            # independently, and a divergence is usually one KV cache group's
+            # store pruning rather than a transport failure.
+            per_group = Counter(get_offload_group_idx(key) for key in req.demanded)
+            logger.warning(
+                "P2PSession %s: kv_request_id=%s round=%s ended with %d "
+                "demanded blocks never supplied, per KV cache group %s, "
+                "and %d supplied blocks never demanded",
+                self._peer_id,
+                kv_request_id,
+                round_key,
+                len(req.demanded),
+                dict(sorted(per_group.items())),
+                len(req.available),
+            )
         if send_done and req.demand_received:
             self._send(
                 {


### PR DESCRIPTION
## Purpose

Addresses #53083.

In prefill/decode disaggregation over the P2P secondary tier, the prefill instance decides which KV blocks to store and the decode instance independently decides which blocks to ask for. Nothing checks that everything asked for was stored. When the two disagree, the decode instance waits for blocks that will never arrive, times out after `_LOAD_TIMEOUT_S` (30 seconds), and recomputes the prompt instead. #52808 and #53062 are two separate bugs of exactly this shape, found weeks apart.

They keep recurring because the two sides are computed in different files and neither one refers to the other. #51840 is the clearest example: it changed `lookup` to return `HIT_PENDING` instead of `RETRY` when it begins a promotion. `HIT_PENDING` keeps the consecutive-hit streak alive in `_sliding_window_lookup` while `RETRY` resets it, so a change to lookup semantics silently widened the set of blocks the decode instance asks for. Nothing in the test suite caught it.

This PR adds three tests that make a future change state its intent, plus one logging change.

## What it adds

**Which offload policies keep prefix-hit chunks in the store path.** Under `BLOCK_LEVEL` the scheduler skips chunks that were already in the prefix cache, which is why a prefill instance with a warm cache had nothing to send in #52808. Adding a new `OffloadPolicy` now fails the suite until its behavior is recorded.

**How each `KVCacheSpec` is classified by `get_sliding_window_size_in_chunks`.** That function decides whether a group's store path prunes chunks, and it ends in `assert isinstance(kv_cache_spec, FullAttentionSpec)`. So a new attention type does fail closed, but only at runtime and only on a model that uses it. The test walks every concrete `KVCacheSpec` subclass and requires each one to be listed.

**That the test helper standing in for the decode instance matches a real scheduler.** The helper re-implements the block scan, so it can drift along with production code rather than pinning it, which is the #51840 failure mode. It is now compared against a real request's lookups.

**Naming the unmatched blocks when a fetch round ends short.** This was a `debug` log with counts only. It is now a warning that groups the missing blocks by KV cache group index, since a mismatch is usually confined to one group's store pruning. In #52808 the timeout printed an unrelated `PYTHONHASHSEED` hint instead, and the reporter had to rebuild with added instrumentation to find the real cause.

## Depends on #52912

This is built on top of #52912 and includes its four commits, so the diff here is larger than the change itself. Only `[Bugfix][KV Offload] Guard P2P supply against consumer demand` belongs to this PR. Two of the helpers it tests are introduced by #52912, so this cannot target `main` until that merges. Happy to rebase once it does.

This does not duplicate an open PR. Searches for #53083, and for the offloading supply and demand paths, return only #52912 and #53062's fix in #53329.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector -q
```

A test that cannot fail is worth nothing, so each one was checked by breaking the thing it guards:

| what was broken | result |
|---|---|
| `BLOCK_LEVEL` no longer skips prefix hits | policy test fails |
| a new `AttentionSpec` subclass is added | spec test fails |
| the helper scans with the wrong window size | helper test fails |
| the helper stops bounding itself to the request length | helper test fails |

## Test Result

Run on one H100 in a `vllm/vllm-openai` container, with this branch's source.

`tests/v1/kv_connector/unit/offloading_connector` and `tests/v1/kv_offload/tiering` together: 684 passed without this commit and 701 with it. Two `test_fs_tier.py` tests fail on both sides because that container has no writable path for them, so no test changes state because of this PR.

`ruff check` and `ruff format --check` at v0.14.0, the version pinned in `.pre-commit-config.yaml`, pass on both changed files.

AI assistance was used for this change.
