### PR TITLE
[CI][BugFix] Harden DeepEP NVSHMEM re-initialization in MoE layer tests

### DIFF
--- a/tests/kernels/moe/modular_kernel_tools/make_feature_matrix.py
+++ b/tests/kernels/moe/modular_kernel_tools/make_feature_matrix.py
@@ -142,6 +142,7 @@ def make_feature_matrix(csv_file_path: str):
                     rank_worker,
                     vllm_config,
                     env_dict,
+                    None,
                     config,
                     weights,
                 )

--- a/tests/kernels/moe/modular_kernel_tools/parallel_utils.py
+++ b/tests/kernels/moe/modular_kernel_tools/parallel_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 import os
+import time
 import traceback
 from collections.abc import Callable
 from typing import Any, Concatenate
@@ -145,22 +146,45 @@ def parallel_launch_with_config(
     worker: Callable[Concatenate[ProcessGroupInfo, VllmConfig, Any, P], None],
     vllm_config: VllmConfig,
     env_dict: dict[Any, Any] | None,
+    join_timeout_s: float | None,
     *args: P.args,
     **kwargs: P.kwargs,
 ) -> None:
-    spawn(
-        _worker_parallel_launch,
-        args=(
-            world_size,
-            world_size,
-            0,
-            f"tcp://{os.getenv('LOCALHOST', 'localhost')}:{get_open_port()}",
-            worker,
-            vllm_config,
-            env_dict,
-            kwargs,
+    spawn_args = (
+        world_size,
+        world_size,
+        0,
+        f"tcp://{os.getenv('LOCALHOST', 'localhost')}:{get_open_port()}",
+        worker,
+        vllm_config,
+        env_dict,
+        kwargs,
+    ) + args
+
+    if join_timeout_s is None:
+        spawn(
+            _worker_parallel_launch,
+            args=spawn_args,
+            nprocs=world_size,
+            join=True,
         )
-        + args,
+        return
+
+    ctx = spawn(
+        _worker_parallel_launch,
+        args=spawn_args,
         nprocs=world_size,
-        join=True,
+        join=False,
     )
+    assert ctx is not None
+    deadline = time.monotonic() + join_timeout_s
+    while not ctx.join(timeout=min(10.0, join_timeout_s)):
+        if time.monotonic() >= deadline:
+            for process in ctx.processes:
+                if process.is_alive():
+                    process.kill()
+            for process in ctx.processes:
+                process.join()
+            raise TimeoutError(
+                f"parallel worker group did not finish within {join_timeout_s}s"
+            )

--- a/tests/kernels/moe/modular_kernel_tools/profile_modular_kernel.py
+++ b/tests/kernels/moe/modular_kernel_tools/profile_modular_kernel.py
@@ -159,7 +159,7 @@ def run(config: Config):
     weights: WeightTensors = WeightTensors.make(config)
     vllm_config, env_dict = config.make_env_data()
     parallel_launch_with_config(
-        config.world_size, rank_worker, vllm_config, env_dict, config, weights
+        config.world_size, rank_worker, vllm_config, env_dict, None, config, weights
     )
 
 

--- a/tests/kernels/moe/test_modular_kernel_combinations.py
+++ b/tests/kernels/moe/test_modular_kernel_combinations.py
@@ -202,7 +202,14 @@ def run(config: Config, verbose: bool):
 
     vllm_config, env_dict = config.make_env_data()
     parallel_launch_with_config(
-        config.world_size, rank_worker, vllm_config, env_dict, config, weights, verbose
+        config.world_size,
+        rank_worker,
+        vllm_config,
+        env_dict,
+        None,
+        config,
+        weights,
+        verbose,
     )
 
 

--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -2097,27 +2097,58 @@ def test_moe_layer(
         test_config_batches = _group_deepep_ll_configs(test_configs)
 
     rocm_deepep = current_platform.is_rocm() and backend in DEEPEP_BACKENDS
+    cuda_deepep = current_platform.is_cuda() and backend in DEEPEP_BACKENDS
     parallel_worker = _parallel_worker_rocm_deepep if rocm_deepep else _parallel_worker
     launch_failures: list[str] = []
+
+    # On CUDA every DeepEP subtest destroys and recreates the DeepEP buffer,
+    # so NVSHMEM is fully re-initialized dozens of times per worker process.
+    # One of those re-inits can intermittently kill or hang the whole worker
+    # group before any subtest failure is recorded (observed as an NCCL
+    # 'unhandled cuda error' in nvshmem team init followed by SIGSEGV, and as
+    # 'nvshmem setup connections failed' followed by a hang). Bound the hang
+    # with a join timeout and retry such init crashes once with NVSHMEM/NCCL
+    # debug logging so a recurrence captures per-rank diagnostics. Genuine
+    # subtest failures are recorded in the shared report and never retried.
+    deepep_join_timeout_s = 900.0 if cuda_deepep else None
+    deepep_init_retry_env = {
+        "NVSHMEM_DEBUG": "INFO",
+        "NVSHMEM_DEBUG_SUBSYS": "INIT,TRANSPORT",
+        "NCCL_DEBUG": "WARN",
+    }
 
     try:
         for test_config_batch in test_config_batches:
             report_size_before = os.path.getsize(failure_report_path)
-            try:
-                parallel_launch_with_config(
-                    world_size,
-                    parallel_worker,
-                    vllm_config,
-                    None,
-                    test_config_batch,
-                    verbosity,
-                    failure_report_path=failure_report_path,
-                    deep_ep_handle_keepalive=[] if rocm_deepep else None,
-                )
-            except Exception as ex:
-                # Normal subtest failures are already in the shared report.
-                # Preserve launcher/setup errors that occur before that write.
-                if os.path.getsize(failure_report_path) == report_size_before:
+            max_attempts = 2 if cuda_deepep else 1
+            for attempt in range(max_attempts):
+                try:
+                    parallel_launch_with_config(
+                        world_size,
+                        parallel_worker,
+                        vllm_config,
+                        deepep_init_retry_env if attempt > 0 else None,
+                        deepep_join_timeout_s,
+                        test_config_batch,
+                        verbosity,
+                        failure_report_path=failure_report_path,
+                        deep_ep_handle_keepalive=[] if rocm_deepep else None,
+                    )
+                    break
+                except Exception as ex:
+                    # Normal subtest failures are already in the shared report.
+                    # Preserve launcher/setup errors that occur before that
+                    # write.
+                    if os.path.getsize(failure_report_path) != report_size_before:
+                        break
+                    if attempt + 1 < max_attempts:
+                        print(
+                            "DEEPEP-INIT-CRASH-RETRY: worker group died without"
+                            f" a recorded subtest failure ({ex!r}); retrying"
+                            " once with NVSHMEM/NCCL debug logging.",
+                            flush=True,
+                        )
+                        continue
                     launch_failures.append(str(ex))
 
         if os.path.getsize(failure_report_path) > 0:


### PR DESCRIPTION
## Purpose

Harden the DeepEP paths in `tests/kernels/moe/test_moe_layer.py` against an intermittent NVSHMEM re-initialization failure that is currently failing or hanging main-branch CI jobs with no product defect involved.

On CUDA, the test tears down the DeepEP buffer after every DeepEP subtest (the managers are not reliably reusable across subtests), so NVSHMEM goes through a full init→finalize cycle dozens of times inside one spawned worker group. One of those re-inits can intermittently take down the whole worker group **before any subtest failure is recorded**:

- **H100** (main builds #84887, #85047, job `kernels-fusedmoe-layer-test-2-h100s`): NVSHMEM team init fails with `Failed, NCCL error ... team_internal.cpp:679 'unhandled cuda error'`, then a rank dies with SIGSEGV → `torch.multiprocessing.spawn.ProcessExitedException`. The unchanged exact retry passed on the same physical node, and every executed subtest in the failing run had passed.
- **B200** (main builds #85034, #85048): the same parametrization `test_moe_layer[False-deepep_low_latency-2-1-True]` dies differently — `ibv_modify_qp failed` → `nvshmem setup connections failed` — and then hangs to the 90-minute Buildkite job timeout on two independent physical nodes.

The per-re-init `nvshmemi_transport_init:282: init failed for transport: IBGDA` warnings appear identically in failing and passing runs on the same hosts, so they are environmental fallback noise, not the defect signal.

## Changes

Test-side only; no production code touched.

- `parallel_launch_with_config` gains an explicit `join_timeout_s` parameter. When set, a worker group that does not finish in time is killed and surfaced as a `TimeoutError` instead of hanging to the job timeout. Passing `None` preserves today's behavior exactly; the three other call sites pass `None`.
- `test_moe_layer` applies a 900s per-batch timeout for CUDA DeepEP batches and retries a batch **exactly once**, only when the worker group died without recording any subtest failure in the shared failure-report file (the init-crash/hang signature). Genuine subtest failures are recorded in the report before the group exits and are never retried.
- The single retry attempt runs with `NVSHMEM_DEBUG=INFO`, `NVSHMEM_DEBUG_SUBSYS=INIT,TRANSPORT` and `NCCL_DEBUG=WARN` injected through the existing `env_dict` hook, and prints a grep-able `DEEPEP-INIT-CRASH-RETRY` marker line — so any recurrence captures per-rank initialization diagnostics for an upstream NVSHMEM/DeepEP report while staying visible to flaky-test tracking.

## Duplicate-work check

Searched open PRs and issues for `deepep nvshmem`, `test_moe_layer`, `team_internal`, `ibv_modify_qp`, and the retry/timeout keywords; no existing PR addresses this initialization failure family.

## Test plan

- `pre-commit` (ruff check/format, typos, mypy 3.10 on `tests/kernels/moe`) passes on all changed files.
- The join-timeout mechanics (normal join, hung-group kill + `TimeoutError`, crashed-rank `ProcessExitedException` propagation) were exercised standalone against torch 2.13 spawn semantics.
- Exact-job validation to be attached: isolated-branch Buildkite runs of the H100 FusedMoE Layer Kernels job and the B200 FusedMoE Layer job at this head.

## AI-assistance disclosure

This change was prepared with AI assistance and reviewed before submission.
