### PR TITLE
[Kernel] Add tuned Mamba selective_state_update config for NVIDIA Thor (SM110)

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=NVIDIA_Thor,cache_dtype=float32.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=NVIDIA_Thor,cache_dtype=float32.json
@@ -1,0 +1,31 @@
+{
+    "triton_version": "3.7.1",
+    "128": {
+        "BLOCK_SIZE_M": 4,
+        "num_warps": 1
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 8
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 8
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 16,
+        "num_warps": 8
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 8
+    },
+    "16384": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 8
+    },
+    "32768": {
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 8
+    }
+}

--- a/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=NVIDIA_Thor,cache_dtype=float32.json
+++ b/vllm/model_executor/layers/mamba/ops/configs/selective_state_update/headdim=64,dstate=128,device_name=NVIDIA_Thor,cache_dtype=float32.json
@@ -1,31 +1,31 @@
 {
     "triton_version": "3.7.1",
+    "64": {
+        "BLOCK_SIZE_M": 4,
+        "num_warps": 1
+    },
     "128": {
         "BLOCK_SIZE_M": 4,
         "num_warps": 1
     },
+    "256": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
+    "512": {
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
+    },
     "1024": {
-        "BLOCK_SIZE_M": 32,
-        "num_warps": 8
+        "BLOCK_SIZE_M": 8,
+        "num_warps": 1
     },
     "2048": {
-        "BLOCK_SIZE_M": 16,
-        "num_warps": 8
+        "BLOCK_SIZE_M": 32,
+        "num_warps": 2
     },
     "4096": {
-        "BLOCK_SIZE_M": 16,
-        "num_warps": 8
-    },
-    "8192": {
         "BLOCK_SIZE_M": 32,
-        "num_warps": 8
-    },
-    "16384": {
-        "BLOCK_SIZE_M": 8,
-        "num_warps": 8
-    },
-    "32768": {
-        "BLOCK_SIZE_M": 32,
-        "num_warps": 8
+        "num_warps": 4
     }
 }


### PR DESCRIPTION
## Purpose

Adds a tuned `selective_state_update` config for **NVIDIA Thor (SM110)**. The tree ships 17 tuned Mamba SSU configs (B200, GB200, H100, MI300X/325X/350/355, RTX PRO 6000 Blackwell) and none for any Jetson, so every hybrid-Mamba model load on Thor logs:

```
[mamba_ssm.py] Using default Mamba SSU config. Performance might be sub-optimal!
Config file not found at .../selective_state_update/
  headdim=64,dstate=128,device_name=NVIDIA_Thor,cache_dtype=float32.json
```

and falls back to the heuristic (`BLOCK_SIZE_M=32, num_warps=8`) on the decode hot path.

## Test Plan

Generated with the repo's own tuner on the target device (Jetson AGX Thor, SM110, CUDA 13, triton 3.7.1), with the serving stack **stopped** so the GPU was quiet and the board pinned to **MAXN** so DVFS could not skew timings:

```bash
python -u benchmarks/kernels/benchmark_selective_state_update.py \
    --dstate 128 --headdim 64 --ngroups 8 --mamba-ssm-cache-dtype float32 \
    --nheads 64 --batch-sizes 1 2 4 8 16 32 64 --num-iters 100 \
    --save-configs --compare
```

`--nheads 64` is deliberate: real hybrid-Mamba checkpoints on this device report `mamba_num_heads=64`, and `effective_batch = batch * nheads`. An earlier pass at the tuner default (`--nheads 128`) never measured batch-1 decode at all, because batch 1 landed on `effective_batch=128` rather than 64.

Note for anyone reproducing: the tuner imports `tests.kernels.mamba.utils`, so it cannot run from an installed wheel or container alone — it needs the repo's `tests/` tree on `PYTHONPATH`.

## Test Result

```
Device : NVIDIA_Thor  (sm_110)   Blackwell: True   triton : 3.7.1
dtype  : bfloat16   ssm_cache_dtype: float32   headdim: 64   ngroups: 8
Heuristic: BLOCK_SIZE_M=32, num_warps=8

EffBatch |   Heur(us) |  Tuned(us) |  Speedup | Best config
      64 |       9.40 |       6.62 |    1.42x | M=4,w=1   <--
     128 |      15.57 |      11.69 |    1.33x | M=4,w=1   <--
     256 |      28.45 |      20.66 |    1.38x | M=8,w=1   <--
     512 |      66.51 |      64.73 |    1.03x | M=8,w=1
    1024 |     251.93 |     245.85 |    1.02x | M=8,w=1
    2048 |     574.74 |     566.56 |    1.01x | M=32,w=2
    4096 |    1142.47 |    1114.98 |    1.02x | M=32,w=4
```

The gains are concentrated at **eff_batch 64/256/512** — i.e. batch 1, 2 and 4 at `nheads=64`, the small-batch decode range. The heuristic's `BLOCK_SIZE_M=32` leaves a 20-SM part underfed there; tuning drops to `M=4..8, w=1`. At larger effective batch the heuristic is already within 1-3% and the tuned config essentially reproduces it.

Being precise about scope: these are **kernel-level** numbers on the SSU kernel, measured at concurrency 1. End-to-end effect on a hybrid model will be smaller, since Mamba layers share per-token time with attention and MLP/MoE.

The config is pure additive JSON, read only when a model requests exactly `headdim=64, dstate=128, cache_dtype=float32` on a device reporting `NVIDIA Thor`, so no existing device's behaviour changes.
