### PR TITLE
fix(entrypoints): add reasoning_content field and safe dict serializer to ChatMessage

### DIFF
--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -37,3 +37,19 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
+
+
+def test_chat_message_reasoning_content_serialization() -> None:
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatMessage
+
+    msg = ChatMessage(role="assistant", content="Answer", reasoning_content="Thinking process")
+    dumped = msg.model_dump()
+    assert dumped["role"] == "assistant"
+    assert dumped["content"] == "Answer"
+    assert dumped["reasoning_content"] == "Thinking process"
+    assert "tool_calls" not in dumped
+
+    msg_none = ChatMessage(role="assistant", content="Answer")
+    dumped_none = msg_none.model_dump()
+    assert "reasoning_content" not in dumped_none
+

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -70,12 +70,16 @@ class ChatMessage(OpenAIBaseModel):
 
     # vLLM-specific fields that are not in OpenAI spec
     reasoning: str | None = None
+    reasoning_content: str | None = None
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
-        if len(data.get("tool_calls", [])) == 0:
-            data.pop("tool_calls", None)
+        if isinstance(data, dict):
+            if len(data.get("tool_calls", [])) == 0:
+                data.pop("tool_calls", None)
+            if data.get("reasoning_content") is None:
+                data.pop("reasoning_content", None)
         return data
 
 


### PR DESCRIPTION
## Summary

Adds `reasoning_content` field and serializer safeguards to `ChatMessage` in `vllm.entrypoints.openai.chat_completion.protocol`:
- Adds `reasoning_content: str | None = None` to `ChatMessage`, supporting reasoning models (e.g. DeepSeek-R1, QwQ) and downstream OpenAI-compatible proxies that supply reasoning in `reasoning_content`.
- Protects `ChatMessage._serialize` with an `isinstance(data, dict)` check.
- Omit `reasoning_content` in serialized output when `None` to maintain strict backward compatibility.
- Added unit test `test_chat_message_reasoning_content_serialization` in `tests/entrypoints/openai/responses/test_protocol.py`.

## Motivation

Reasoning models and OpenAI-compatible endpoints increasingly use `reasoning_content` alongside `content` and `reasoning`. Providing `reasoning_content` on `ChatMessage` enables seamless deserialization and forwarding without extra-field validation errors or dropping reasoning tokens.

## Changes

- `vllm/entrypoints/openai/chat_completion/protocol.py`: Added `reasoning_content` to `ChatMessage` with conditional serialization.
- `tests/entrypoints/openai/responses/test_protocol.py`: Added serialization unit tests.

## Tests

- Added `test_chat_message_reasoning_content_serialization`.
