### PR TITLE
[Bugfix][Model] Map HunyuanVL lm_head checkpoint weights

### DIFF
--- a/tests/models/multimodal/test_mapping.py
+++ b/tests/models/multimodal/test_mapping.py
@@ -16,6 +16,24 @@ from vllm.transformers_utils.config import try_get_safetensors_metadata
 from ..registry import _MULTIMODAL_EXAMPLE_MODELS, HF_EXAMPLE_MODELS
 
 
+def test_hunyuan_vl_checkpoint_weights_mapper():
+    from vllm.model_executor.models.hunyuan_vision import (
+        HunYuanVLForConditionalGeneration,
+    )
+
+    mapper = HunYuanVLForConditionalGeneration.hf_to_vllm_mapper
+
+    assert mapper.apply_list(
+        [
+            "model.embed_tokens.weight",
+            "lm_head.weight",
+        ]
+    ) == [
+        "language_model.model.embed_tokens.weight",
+        "language_model.lm_head.weight",
+    ]
+
+
 def test_cosmos3_new_checkpoint_weights_mapper():
     from vllm.model_executor.models.cosmos3 import Cosmos3ForConditionalGeneration
 

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -829,6 +829,7 @@ class HunYuanVLForConditionalGeneration(
             "vit.vit.": "visual.",
             "vit.": "visual.",
             "model.": "language_model.model.",
+            "lm_head.": "language_model.lm_head.",
         }
     )
 


### PR DESCRIPTION
## Summary

Fix HunyuanVL checkpoint loading after #51665 (`Fix weight tying`).

HunyuanVL checkpoints store the causal language-model head as the top-level
`lm_head.weight`, while the vLLM multimodal wrapper mounts that head at
`language_model.lm_head`. After #51665, `AutoWeightsLoader` intentionally
loads an explicit checkpoint `lm_head` so the generic tied-embedding logic can
compare it with the input embeddings and re-tie it when appropriate. The old
Hunyuan mapper did not translate this key, so loading failed with:

```text
ValueError: There is no module or parameter named 'lm_head'
```

This change adds the model-specific mapping and a focused regression test. It
keeps the post-#51665 load/tie semantics and does not restore the removed
`skip_prefixes` workaround.

## Why this is not a duplicate

The required searches found no open issue or PR for Hunyuan checkpoint
`lm_head` mapping or this loading regression.

- Open Hunyuan work such as #50429 (XD-RoPE image-start handling) and #51484
  (encoder CUDA graphs) covers different paths.
- #30412 is a GGUF tied-embedding loader issue, not Hunyuan checkpoint-name
  mapping.
- #49525 is a text-LoRA mapper fallback, not base-model weight loading.
- #52013 concerns a Qwen3.5 MTP draft head.
- #51665 is the merged generic tied-embedding change that exposed this
  model-specific name mismatch; this PR complements it rather than changing
  its implementation.

## Tests

```text
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/models/multimodal/test_mapping.py \
  -k hunyuan_vl_checkpoint_weights_mapper -q
1 passed, 4 deselected

VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/models/multimodal/test_mapping.py -q
4 passed, 1 skipped

.venv/bin/pre-commit run --files \
  vllm/model_executor/models/hunyuan_vision.py \
  tests/models/multimodal/test_mapping.py
passed

git diff --check
passed
```

The default CUDA-target test invocation was also attempted, but collection
was blocked by the existing environment missing `_vllm_fa2_C` and
`_vllm_fa3_C`; the same test suite passed with the repository's CPU target
selection.

## HunyuanOCR smoke validation

A local three-state smoke test using the HunyuanOCR checkpoint verified the
behavior around #51665:

| Revision | Weight loading | Minimal text generation |
| --- | --- | --- |
| Parent of #51665 (`6e85feb1b759`) | pass | pass |
| #51665 (`f0c14b4f776`) | fails with `There is no module or parameter named 'lm_head'` | not reached |
| This mapper fix | pass | pass |

## AI assistance

AI assistance was used for repository investigation, implementation, and
testing. The human submitter must review every changed line, rerun the
relevant tests, and be able to explain and defend this change before merge.
