### PR TITLE
[Bugfix][MoE] Honor recv_x_scale_stride1 in ep_scatter_2 f32 scale load

### DIFF
--- a/tests/kernels/moe/test_deepgemm.py
+++ b/tests/kernels/moe/test_deepgemm.py
@@ -73,6 +73,60 @@ def test_deepgemm_moe_permute_initializes_padding_scales(workspace_init):
     )
 
 
+@pytest.mark.parametrize("num_tokens", [1, 2, 4])
+@pytest.mark.parametrize("use_ue8m0", [True, False])
+@pytest.mark.skipif(not is_deep_gemm_supported(), reason="Requires deep_gemm kernels")
+def test_deepgemm_moe_permute_column_major_scale_stride(
+    num_tokens, use_ue8m0, workspace_init
+):
+    """Regression test for #53338: the non-PACK_UE8M0 scale load must
+    honor recv_x_scale_stride1 (column-major f32 scales, M >= 2)."""
+    hidden_size, num_experts, topk, group_size = 2048, 256, 8, 128
+    num_groups = hidden_size // group_size
+    x = torch.zeros(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+    for t in range(num_tokens):
+        for g in range(num_groups):
+            x[t, g * group_size : (g + 1) * group_size] = 2.0 ** (g - 8 + 20 * t)
+
+    aq, aq_scale = per_token_group_quant_fp8(
+        x,
+        group_size,
+        column_major_scales=True,
+        use_ue8m0=use_ue8m0,
+    )
+    assert aq_scale.dtype == torch.float32
+    assert aq_scale.stride() == (1, num_tokens)
+    # Every (token, group) scale is unique, so wrong (t, g) addressing is
+    # bitwise-visible in the scattered rows.
+    assert torch.unique(aq_scale).numel() == num_tokens * num_groups
+
+    topk_ids = (
+        torch.arange(num_tokens * topk, device="cuda", dtype=torch.int64).reshape(
+            num_tokens, topk
+        )
+        % num_experts
+    )
+    _, aq_scale_out, _, inv_perm, _ = deepgemm_moe_permute(
+        aq=aq,
+        aq_scale=aq_scale,
+        topk_ids=topk_ids,
+        local_num_experts=num_experts,
+        expert_map=None,
+        expert_tokens_meta=None,
+        block_size=group_size,
+    )
+
+    for t in range(num_tokens):
+        for k in range(topk):
+            dest = int(inv_perm[t, k])
+            torch.testing.assert_close(
+                aq_scale_out[dest],
+                aq_scale[t],
+                rtol=0,
+                atol=0,
+            )
+
+
 def make_block_quant_fp8_weights(
     e: int,
     n: int,

--- a/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
+++ b/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py
@@ -234,7 +234,9 @@ def _fwd_kernel_ep_scatter_2(
             )
         else:
             to_copy_s = tl.load(
-                recv_x_scale + token_id * recv_x_scale_stride0 + offset_in_s,
+                recv_x_scale
+                + token_id * recv_x_scale_stride0
+                + offset_in_s * recv_x_scale_stride1,
                 mask=mask_s,
             )
 


### PR DESCRIPTION
Fixes #53338

## Problem

`_fwd_kernel_ep_scatter_2`'s non-`PACK_UE8M0` (f32-scales) branch loads the
scale row as `recv_x_scale + token_id * recv_x_scale_stride0 +
offset_in_s` — the group offset is added **without multiplying by
`recv_x_scale_stride1`**, although the packed branch applies the stride
correctly. The branch therefore assumes a row-major scale tensor
(`stride1 == 1`).

`per_token_group_quant_fp8(..., column_major_scales=True)` — the MoE input
quant used on this path — returns f32 scales with strides
`(1, num_tokens)`, so at `num_tokens >= 2` the kernel reads
`token_id + g` instead of `token_id + g * num_tokens` and each scattered
expert-workspace row receives scales from the wrong token/group
coordinates. At `num_tokens == 1` the layout coincides with row-major and
the read is accidentally correct.

In random fixtures the mis-association is numerically masked (~1e-9
end-output delta, because adjacent groups of a token frequently share a
power-of-two scale), which is why tolerance-based tests never caught it;
deterministic constructions with distinct per-token magnitudes expose it
immediately (details and a runnable repro are in the issue).

The bug is runner-agnostic: the kernel sits in the shared model-executor
MoE stack, so both the V1 and V2 model runners are affected wherever
this path is selected — the gating factors are quant layout and
`num_tokens`, not the engine stack.

## Fix

Multiply the group offset by the stride, mirroring the packed branch. No
signature change — the stride is already a kernel argument.

The non-packed *store* is deliberately not touched: in every in-tree
caller the non-packed output scale is allocated row-major contiguous
(`torch.zeros((M_sum, sf_k))` in `deepgemm_moe_permute`), so
`output_tensor_scale_stride1 == 1` there; the strided-output case is the
`PACK_UE8M0` branch, which already applies the stride.

## Tests

New `test_deepgemm_moe_permute_column_major_scale_stride` in
`tests/kernels/moe/test_deepgemm.py`, parametrized
`num_tokens ∈ {1, 2, 4}` × `use_ue8m0 ∈ {True, False}`: distinct
power-of-two magnitude bands per (token, group) make every scale unique,
and each scattered scale row is compared bitwise against its source
token's scales via `inv_perm`. `num_tokens == 1` guards the
coincidental-correct layout case. (With `use_ue8m0=True` the f32 scales
are power-of-two "ceil-UE8M0" values — the packed uint8 UE8M0 layout is a
different branch of the same kernel and is already stride-correct.)

Verified locally on an RTX 5090: on unpatched `main` the construction
fails at `num_tokens ∈ {2, 4}` — every routed row carries wrong scales,
under both `use_ue8m0` settings — and passes at `num_tokens == 1`; with
the fix, all parametrizations pass.

## AI assistance

AI assistance was used for investigation, implementation, and test
orchestration. The submitter reviewed the changes and verified the
diagnosis on hardware (bitwise fixtures during the campaign that found the
bug, plus the deterministic repro in the issue).
