### PR TITLE
[Bugfix][Quantization] Floor UE8M0 scales at 1e-10 in per-token-group quant Triton paths

### DIFF
--- a/tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py
+++ b/tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py
@@ -137,3 +137,23 @@ def test_silu_mul_fp8_quant_deep_gemm_clamp(T: int, N: int, clamp_limit: float):
 
     torch.testing.assert_close(output.to(torch.float32), ref_output.to(torch.float32))
     torch.testing.assert_close(output_scales, ref_output_scales)
+
+
+@pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="ROCm does not support DeepGemm.",
+)
+def test_silu_mul_fp8_quant_deep_gemm_ue8m0_eps_floor():
+    """Regression companion to #53339: the fused kernel must floor
+    all-zero groups at 2**-33 like the decomposed reference."""
+    T, N = 128, 128 * 2
+    input = torch.zeros((T, N), dtype=torch.bfloat16, device=DEVICE)
+
+    output, output_scales = silu_mul_per_token_group_quant_fp8_colmajor(
+        input, use_ue8m0=True
+    )
+    ref_output, ref_output_scales = reference(input, True)
+
+    assert (output.to(torch.float32) == 0).all()
+    assert torch.equal(output_scales, ref_output_scales)
+    assert (output_scales == 2.0**-33).all()

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -56,6 +56,89 @@ def test_per_token_group_quant_fp8(
     assert torch.allclose(scale, ref_s, atol=0.01, rtol=0.01)
 
 
+@pytest.mark.parametrize("column_major", [False, True])
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Native op's UE8M0 scale floor is verified on CUDA/ROCm only.",
+)
+def test_per_token_group_quant_fp8_ue8m0_eps_floor_parity(column_major: bool):
+    """Regression test for #53339: native and Triton-fallback UE8M0
+    scales must match for tiny groups (native floors at 1e-10)."""
+    device = current_platform.device_type
+    group_size = 128
+
+    x = torch.zeros((8, 256), device=device, dtype=torch.bfloat16)
+    x[0, 0] = 1e-12  # tiny-but-nonzero, below the divergence crossover
+    x[1] = 1.0  # control row above the crossover
+
+    out_q, scale = fp8_utils.per_token_group_quant_fp8(
+        x,
+        group_size,
+        column_major_scales=column_major,
+        use_ue8m0=True,
+    )
+    with (
+        patch("vllm.platforms.current_platform.is_cuda_alike", return_value=False),
+        patch("vllm.platforms.current_platform.is_xpu", return_value=False),
+    ):
+        ref_q, ref_s = fp8_utils.per_token_group_quant_fp8(
+            x,
+            group_size,
+            column_major_scales=column_major,
+            use_ue8m0=True,
+        )
+
+    assert torch.equal(scale, ref_s)
+    assert torch.equal(out_q, ref_q)
+    # Both backends floor an all-zero / all-tiny group at 2**-33.
+    assert scale[0, 0] == 2.0**-33
+    assert scale[2, 0] == 2.0**-33
+
+    # The floor is hard-coded, not eps-derived: with eps=0 a zero group
+    # still floors at 2**-33.
+    _, scale0 = fp8_utils.per_token_group_quant_fp8(
+        torch.zeros_like(x),
+        group_size,
+        column_major_scales=column_major,
+        use_ue8m0=True,
+        eps=0.0,
+    )
+    with (
+        patch("vllm.platforms.current_platform.is_cuda_alike", return_value=False),
+        patch("vllm.platforms.current_platform.is_xpu", return_value=False),
+    ):
+        _, ref_s0 = fp8_utils.per_token_group_quant_fp8(
+            torch.zeros_like(x),
+            group_size,
+            column_major_scales=column_major,
+            use_ue8m0=True,
+            eps=0.0,
+        )
+    assert torch.equal(scale0, ref_s0)
+    assert (scale0 == 2.0**-33).all()
+
+    # The floor must not leak into the non-UE8M0 path: a zero group keeps
+    # the eps-derived scale (eps / fp8_max << 1e-10) on both backends.
+    _, scale2 = fp8_utils.per_token_group_quant_fp8(
+        x,
+        group_size,
+        column_major_scales=column_major,
+        use_ue8m0=False,
+    )
+    with (
+        patch("vllm.platforms.current_platform.is_cuda_alike", return_value=False),
+        patch("vllm.platforms.current_platform.is_xpu", return_value=False),
+    ):
+        _, ref_s2 = fp8_utils.per_token_group_quant_fp8(
+            x,
+            group_size,
+            column_major_scales=column_major,
+            use_ue8m0=False,
+        )
+    assert torch.allclose(scale2, ref_s2, rtol=1e-3, atol=0.0)
+    assert scale2[2, 0] < 1e-10
+
+
 @pytest.mark.parametrize(
     "num_tokens,hidden_dim,group_size",
     [

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -110,6 +110,10 @@ def _per_token_group_quant_fp8(
     # representable-value boundaries).
     _absmax = tl.maximum(tl.max(tl.abs(y)), eps)
     scale_raw = _absmax * (1.0 / fp8_max)
+    if use_ue8m0:
+        # Match the native kernel's hard-coded scale floor before the
+        # power-of-two rounding (per_token_group_quant.cu).
+        scale_raw = tl.maximum(scale_raw, 1e-10)
     y_s = tl.math.exp2(tl.ceil(tl.log2(scale_raw))) if use_ue8m0 else scale_raw
     y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
 
@@ -374,6 +378,10 @@ def _silu_mul_per_token_group_quant_fp8_colmajor(
     # quant
     _absmax = tl.maximum(tl.max(tl.abs(y), axis=1), eps)
     scale_raw = _absmax * (1.0 / fp8_max)
+    if use_ue8m0:
+        # Match the native kernel's hard-coded 1e-10 scale floor
+        # (per_token_group_quant.cu); keeps fused == decomposed path.
+        scale_raw = tl.maximum(scale_raw, 1e-10)
     y_s = tl.math.exp2(tl.ceil(tl.log2(scale_raw))) if use_ue8m0 else scale_raw
     y_s = tl.reshape(y_s, (BLOCK_M, 1))
     y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
@@ -524,6 +532,10 @@ def _per_token_group_quant_fp8_colmajor(
     # Quant
     _absmax = tl.maximum(tl.max(tl.abs(y)), eps)
     scale_raw = _absmax * (1.0 / fp8_max)
+    if use_ue8m0:
+        # Match the native kernel's hard-coded scale floor before the
+        # power-of-two rounding (per_token_group_quant.cu).
+        scale_raw = tl.maximum(scale_raw, 1e-10)
     y_s = tl.math.exp2(tl.ceil(tl.log2(scale_raw))) if use_ue8m0 else scale_raw
     y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
 


### PR DESCRIPTION
Fixes #53339

## Problem

Under `use_ue8m0=True`, `per_token_group_quant_fp8` returns different
scales depending on which backend the wrapper dispatches to. The C++ op
floors the scale at a hard-coded `1e-10` before rounding up to a power of
two (`per_token_group_quant.cu`:
`exp2f(ceilf(log2f(fmaxf(y_s, 1e-10f))))` — present since the native
kernel's introduction in #21083 and reproduced in the packed variant),
while the in-file Triton fallback kernels floor only the absmax. An
all-zero group therefore gets scale `2^-33` from the C++ op but `2^-42`
from the fallback, and the two backends emit different scales (and
different fp8 codes for tiny nonzero values) for any group with absmax
below `448 * 2^-34 ≈ 2.61e-8` (E4M3FN numbers; FNUZ shifts the exponents,
not the divergence).

The C++ backend serves contiguous CUDA/XPU inputs; the fallback runs for
non-contiguous inputs (and in unit tests), so the same op silently returns
different scales depending on input layout. The divergence is
runner-agnostic — it is in the shared quantization utility layer, so it
applies identically under the V1 and V2 model runners; the dispatch that
matters is native-vs-fallback, not the engine stack.

## Fix

Mirror the C++ floor in the two wrapper fallback kernels
(`_per_token_group_quant_fp8` and `_per_token_group_quant_fp8_colmajor`),
conditional on `use_ue8m0` (a `tl.constexpr`), leaving the non-UE8M0 path
bit-identical. The same clamp is applied to the fused
`_silu_mul_per_token_group_quant_fp8_colmajor` kernel: it computes the
identical scale expression, its packed sibling already floors, and the
fused and decomposed paths are interchangeable backends of the same
act+quant step — flooring only the wrapper fallbacks would leave the two
disagreeing at tiny groups.

Notes:

- **Alignment direction**: flooring the fallback (rather than removing the
  C++ floor) keeps primary-path numerics unchanged for every contiguous
  CUDA/XPU input; the C++ floor has been there since the op's
  introduction and is reproduced in the packed variant, so the reverse
  direction would require changing two primary kernels to fix a
  rarely-executed path.
- **Scope**: this restores parity between the implementations that
  actually serve this quantization today (the native op, the wrapper's
  Triton fallbacks, and the fused sibling). The optional Helion
  implementation of the same-named op
  (`vllm/kernels/helion/ops/per_token_group_fp8_quant.py`) also omits
  the floor, but it registers in its own `vllm_helion` library
  namespace rather than replacing the native op, has no production call
  site (only its own test file imports it), and its kernel and autotune
  baseline are both unfloored — internally self-consistent, so no
  current configuration can observe a divergence from it. Aligning it
  (kernel + baseline together) is a clean follow-up for whenever Helion
  is wired into the dispatch; it is deliberately out of scope here to
  keep this PR limited to the reachable parity fix reported in the
  issue.

## Tests

New `test_per_token_group_quant_fp8_ue8m0_eps_floor_parity` in
`tests/kernels/quantization/test_per_token_group_quant.py` (parametrized
`column_major ∈ {False, True}`, CUDA/ROCm): compares the native op and
the Triton fallback (forced via platform patching) **bitwise** on
all-zero, `1e-12`, and `1.0` rows under `use_ue8m0=True` — both backends
must emit `2^-33` for degenerate groups; verifies with `eps=0` that the
floor is hard-coded rather than eps-derived (the unfloored fallback
collapses the scale to 0 and produces NaN codes); and guards that the
non-UE8M0 path is unchanged (zero-group scale stays at `eps / fp8_max`).

New `test_silu_mul_fp8_quant_deep_gemm_ue8m0_eps_floor` in
`tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py`:
all-zero activation through the fused kernel and the decomposed reference
must agree bitwise and floor at `2^-33`.

Verified locally on an RTX 5090: on unpatched `main` the parity test
fails (native exponent −33 vs fallback −42 in both layouts; with `eps=0`
the fallback's zero-group scale collapses to 0; the fused kernel emits
2⁻⁴² for an all-zero group) while the non-UE8M0 guard passes on both
sides; with the fix, all checks pass bitwise.

## AI assistance

AI assistance was used for investigation, implementation, and test
orchestration. The submitter reviewed the changes and verified the
divergence bitwise on hardware during the campaign that found it.
