### PR TITLE
[ROCm][CI] Restore attention coverage after KV-cache layout refactor

### DIFF
--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -971,6 +971,21 @@ def test_aiter_sparse_pa_layout_contract(monkeypatch):
     assert value_cache.is_contiguous()
 
 
+def test_aiter_sparse_pa_rejects_multiple_kv_heads(monkeypatch):
+    """Do not pair AITER's separated cache layout with the Triton fallback."""
+    import vllm.models.minimax_m3.common.sparse_attention as sparse_attn_mod
+
+    monkeypatch.setattr(sparse_attn_mod.rocm_aiter_ops, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        sparse_attn_mod.rocm_aiter_ops,
+        "is_shuffle_kv_cache_enabled",
+        lambda: True,
+    )
+
+    with pytest.raises(ValueError, match="num_kv_heads == 1"):
+        sparse_attn_mod.minimax_m3_use_aiter_sparse_pa(2)
+
+
 def test_indexer_cache_squeezes_to_contiguous_3d():
     """The indexer side cache is standardized 4D with H=1: under both layouts
     the allocator's logical view stays contiguous and squeezes (as

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -42,9 +42,11 @@ BACKENDS_TO_TEST = [
 ]
 
 
-def _actual_backend(backend) -> AttentionBackendEnum:
+def _actual_backend(backend: AttentionBackendEnum | str) -> AttentionBackendEnum:
     """Resolve pseudo-backends (FLEX_ATTENTION_SLOW) to their real enum."""
-    if backend == "FLEX_ATTENTION_SLOW":
+    if isinstance(backend, str):
+        if backend != "FLEX_ATTENTION_SLOW":
+            raise ValueError(f"Unknown pseudo-backend: {backend}")
         return AttentionBackendEnum.FLEX_ATTENTION
     return backend
 
@@ -266,7 +268,7 @@ def _clone_kv_cache_in_layout(
 
 
 def run_attention_backend(
-    backend: AttentionBackendEnum,
+    backend: AttentionBackendEnum | str,
     kv_cache_spec: FullAttentionSpec,
     layer_names: list[str],
     vllm_config,
@@ -283,9 +285,7 @@ def run_attention_backend(
 ) -> torch.Tensor:
     """Run attention computation using the specified backend's AttentionImpl."""
 
-    use_direct_block_mask = not current_platform.is_rocm() and is_torch_equal_or_newer(
-        "2.9.0.dev0"
-    )
+    use_direct_block_mask = is_torch_equal_or_newer("2.9.0.dev0")
     if backend == "FLEX_ATTENTION_SLOW":
         use_direct_block_mask = False
     backend = _actual_backend(backend)
@@ -377,7 +377,7 @@ def run_attention_backend(
 def _test_backend_correctness(
     batch_spec: BatchSpec,
     model: str,
-    backend_to_test: list[AttentionBackendEnum],
+    backend_to_test: list[AttentionBackendEnum | str],
     mask_mod,
     *,
     causal: bool = True,
@@ -655,7 +655,7 @@ def _test_backend_correctness(
         )
 
         # Check numerical similarity
-        def error_msg(msg: str, backend_name: str):
+        def error_msg(msg: str, backend_name: AttentionBackendEnum | str):
             return f"[{backend_name}] output differs from SDPA baseline. {msg}"
 
         torch.testing.assert_close(
@@ -1046,13 +1046,23 @@ if current_platform.is_rocm():
     SLIDING_WINDOW_BACKENDS_TO_TEST = [
         AttentionBackendEnum.FLEX_ATTENTION,
         AttentionBackendEnum.TRITON_ATTN,
+        "FLEX_ATTENTION_SLOW",
     ]
 else:
     SLIDING_WINDOW_BACKENDS_TO_TEST = [
         AttentionBackendEnum.FLASH_ATTN,
         AttentionBackendEnum.FLEX_ATTENTION,
         AttentionBackendEnum.TRITON_ATTN,
+        "FLEX_ATTENTION_SLOW",
     ]
+
+# Encoder-only FlexAttention always uses the slow builder, so the pseudo-backend
+# would run an identical implementation twice.
+SLIDING_WINDOW_ENCODER_BACKENDS_TO_TEST = [
+    backend
+    for backend in SLIDING_WINDOW_BACKENDS_TO_TEST
+    if backend != "FLEX_ATTENTION_SLOW"
+]
 
 
 @pytest.mark.parametrize(
@@ -1162,7 +1172,7 @@ def test_sliding_window_encoder_backend_correctness(
     _test_backend_correctness(
         batch_spec,
         model,
-        SLIDING_WINDOW_BACKENDS_TO_TEST,
+        SLIDING_WINDOW_ENCODER_BACKENDS_TO_TEST,
         sliding_window_mask_mod_fn,
         causal=False,
         attn_type=AttentionType.ENCODER_ONLY,
@@ -1173,6 +1183,7 @@ def test_sliding_window_encoder_backend_correctness(
 NON_CAUSAL_BACKENDS_TO_TEST = [
     AttentionBackendEnum.FLASH_ATTN,
     AttentionBackendEnum.FLEX_ATTENTION,
+    "FLEX_ATTENTION_SLOW",
 ]
 
 if current_platform.is_rocm():

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -62,6 +62,9 @@ BACKENDS_TO_TEST = [
     AttentionBackendEnum.TOKENSPEED_MLA,
 ]
 
+if current_platform.is_rocm():
+    BACKENDS_TO_TEST.append(AttentionBackendEnum.ROCM_AITER_MLA)
+
 DEVICE_TYPE = current_platform.device_type
 
 
@@ -201,13 +204,18 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
 
 
 # Validate parameter combinations during collection, before GPU fixtures run.
-PREFILL_BACKENDS_TO_TEST = [
-    MLAPrefillBackendEnum.ROCM_AITER_FA,
-    MLAPrefillBackendEnum.FLASH_ATTN,
-    MLAPrefillBackendEnum.FLASHINFER,
-    MLAPrefillBackendEnum.TRTLLM_RAGGED,
-    MLAPrefillBackendEnum.TOKENSPEED_MLA,
-]
+PREFILL_BACKENDS_TO_TEST: list[MLAPrefillBackendEnum] = []
+if current_platform.is_cuda():
+    PREFILL_BACKENDS_TO_TEST.extend(
+        [
+            MLAPrefillBackendEnum.FLASH_ATTN,
+            MLAPrefillBackendEnum.FLASHINFER,
+            MLAPrefillBackendEnum.TRTLLM_RAGGED,
+            MLAPrefillBackendEnum.TOKENSPEED_MLA,
+        ]
+    )
+elif current_platform.is_rocm():
+    PREFILL_BACKENDS_TO_TEST.append(MLAPrefillBackendEnum.ROCM_AITER_FA)
 
 MLA_DIMENSIONS_TO_TEST = [
     ("deepseek", 128, 128),
@@ -249,15 +257,6 @@ def _prefill_backend_dimension_params():
                             f"{invalid_reasons}"
                         )
                     )
-                )
-            elif (
-                current_platform.is_rocm()
-                and prefill_backend == MLAPrefillBackendEnum.FLASH_ATTN
-            ):
-                # Pre-existing on main: flash-attn MLA prefill returns wrong
-                # outputs and faults on ROCm, so it fails on the base commit too.
-                marks.append(
-                    pytest.mark.skip(reason="FLASH_ATTN MLA prefill broken on ROCm")
                 )
             params.append(
                 pytest.param(


### PR DESCRIPTION
This is a follow-up to #51718, which standardized KV-cache layouts but also changed several ROCm test paths. It realigns FlexAttention tests with production and restores coverage for relevant AITER safety and MLA paths. It also avoids generating CUDA-only MLA prefill parameter matrices on ROCm, reducing collection from 2,911 to 591 cases. Together, these changes improve regression coverage while modestly reducing test resource usage.

- Build MLA prefill backend parameters positively by platform, using the CUDA backends on CUDA and `ROCM_AITER_FA` on ROCm.
- Exercise the production ROCm MLA combination by adding `ROCM_AITER_MLA` to the main backend matrix while retaining `ROCM_AITER_FA` for prefill.
- Restore FlexAttention direct-mask coverage on ROCm and retain slow-path coverage for sliding-window and non-causal attention without duplicating encoder-only execution.
- Restore the MiniMax M3 AITER multi-KV-head guard test and validate the follow-up on AITER-enabled MI355X GPUs.