### PR TITLE
[NIXL] Simplify host-stager progress and shutdown

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -1752,7 +1752,7 @@ def test_host_stager_read_failure_reaches_terminal_state():
     stager.nixl_wrapper = MagicMock()
     stager.nixl_wrapper.check_xfer_state.return_value = "ERR"
 
-    assert stager.advance() == (set(), {"request"})
+    assert stager.get_finished() == (set(), {"request"})
     assert "request" not in stager.active_req_ids
     assert pool.free_slots == [slot]
 
@@ -1769,9 +1769,9 @@ def test_host_stager_abort_drains_read_before_reusing_slot():
     stager.nixl_wrapper.check_xfer_state.side_effect = ["PROC", "DONE"]
 
     stager.abort("request")
-    assert stager.advance() == (set(), set())
+    assert stager.get_finished() == (set(), set())
     assert pool.free_slots == []
-    assert stager.advance() == (set(), set())
+    assert stager.get_finished() == (set(), set())
     assert pool.free_slots == [slot]
     assert not stager.active_req_ids
 
@@ -1790,9 +1790,9 @@ def test_host_stager_copy_failure_waits_for_recorded_event():
     stager.nixl_wrapper.check_xfer_state.return_value = "DONE"
     stager._start_copy = MagicMock(side_effect=RuntimeError("copy failed"))
 
-    assert stager.advance() == (set(), set())
+    assert stager.get_finished() == (set(), set())
     assert pool.free_slots == []
-    assert stager.advance() == (set(), {"request"})
+    assert stager.get_finished() == (set(), {"request"})
     assert pool.free_slots == [slot]
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2072,7 +2072,7 @@ class NixlBaseConnectorWorker:
         assert self.transfer_topo is not None
         done_sending = self._get_new_notifs()
         done_recving = self._pop_done_transfers(self._recving_transfers)
-        done_recving.update(self._advance_host_staging())
+        done_recving.update(self._get_finished_host_staging())
 
         # Drain queue of requests where handshake or transfer setup failed.
         failed_recv_reqs = set[ReqId]()
@@ -2265,11 +2265,11 @@ class NixlBaseConnectorWorker:
             self._host_stager = None
         return self._host_stager
 
-    def _advance_host_staging(self) -> set[str]:
-        """Drive the staging pipeline; return req_ids whose KV is fully landed."""
+    def _get_finished_host_staging(self) -> set[str]:
+        """Return req_ids whose staged KV is fully landed in host memory."""
         if self._host_stager is None:
             return set()
-        done, failed = self._host_stager.advance()
+        done, failed = self._host_stager.get_finished()
         for req_id in done:
             self._send_pending_recv_notifs(req_id)
         for req_id in failed:
@@ -2673,9 +2673,20 @@ class NixlBaseConnectorWorker:
 
     def __del__(self):
         with contextlib.suppress(Exception):
-            self.shutdown(drain_timeout=0)
+            self.shutdown()
 
-    def _finish_shutdown(self) -> None:
+    def shutdown(self) -> None:
+        """Shutdown the connector worker."""
+        if not hasattr(self, "_handshake_initiation_executor"):
+            return
+        self._handshake_initiation_executor.shutdown(wait=False, cancel_futures=True)
+        for handles in self._recving_transfers.values():
+            for handle in handles:
+                self.nixl_wrapper.release_xfer_handle(handle)
+        self._recving_transfers.clear()
+        if self._host_stager is not None:
+            self._host_stager.shutdown()
+            self._host_stager = None
         for handle in self.src_xfer_handles_by_block_size.values():
             self.nixl_wrapper.release_dlist_handle(handle)
         self.src_xfer_handles_by_block_size.clear()
@@ -2688,19 +2699,3 @@ class NixlBaseConnectorWorker:
         for desc in self._registered_descs:
             self.nixl_wrapper.deregister_memory(desc)
         self._registered_descs.clear()
-
-    def shutdown(self, drain_timeout: float | None = None) -> None:
-        """Stop new work and bound the wait for host-staged reads."""
-        if not hasattr(self, "_handshake_initiation_executor"):
-            return
-        self._handshake_initiation_executor.shutdown(wait=False, cancel_futures=True)
-        for handles in self._recving_transfers.values():
-            for handle in handles:
-                self.nixl_wrapper.release_xfer_handle(handle)
-        self._recving_transfers.clear()
-        if self._host_stager is not None and not self._host_stager.shutdown(
-            drain_timeout=drain_timeout,
-            on_complete=self._finish_shutdown,
-        ):
-            return
-        self._finish_shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/host_staging.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/host_staging.py
@@ -10,9 +10,7 @@ destination. Requests complete only after every chunk reaches host memory.
 from __future__ import annotations
 
 import ctypes
-import threading
 import time
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,7 +22,6 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 _CUDA_MEMCPY_DEVICE_TO_HOST = 2
-_SHUTDOWN_TIMEOUT_S = 2.0
 _SHUTDOWN_POLL_INTERVAL_S = 0.001
 
 
@@ -168,7 +165,6 @@ class HostWriteStager:
         self._copy_stream = torch.cuda.Stream(device=device)
         self._reqs: dict[str, _ReqState] = {}
         self._closed = False
-        self._shutdown_thread: threading.Thread | None = None
 
         logger.info(
             "NIXL host write staging enabled: %.2f GiB device staging across "
@@ -264,8 +260,8 @@ class HostWriteStager:
             finally:
                 slot.event.record(stream)
 
-    def advance(self) -> tuple[set[str], set[str]]:
-        """Drive the pipeline. Returns (fully staged req_ids, failed req_ids)."""
+    def get_finished(self) -> tuple[set[str], set[str]]:
+        """Return successfully and unsuccessfully completed request IDs."""
         done: set[str] = set()
         failed: set[str] = set()
         for req_id, state in list(self._reqs.items()):
@@ -366,7 +362,7 @@ class HostWriteStager:
                     else:
                         slot.pool.free_slots.append(slot)
                 state.reading = still_reading
-        self.advance()
+        self.get_finished()
         if self._reqs:
             return False
         self._copy_stream.synchronize()
@@ -376,50 +372,8 @@ class HostWriteStager:
         self._closed = True
         return True
 
-    def _reap_shutdown(self, on_complete: Callable[[], None] | None) -> None:
-        try:
-            while not self._poll_shutdown(cancel=True):
-                time.sleep(_SHUTDOWN_POLL_INTERVAL_S)
-            if on_complete is not None:
-                on_complete()
-            logger.info("Deferred NIXL host-staging cleanup completed.")
-        finally:
-            self._shutdown_thread = None
-
-    def shutdown(
-        self,
-        drain_timeout: float | None = None,
-        on_complete: Callable[[], None] | None = None,
-    ) -> bool:
-        """Bound shutdown and defer cleanup while transfers remain active."""
-        if self._shutdown_thread is not None:
-            return False
-        if self._closed:
-            return True
-        if drain_timeout is None:
-            drain_timeout = _SHUTDOWN_TIMEOUT_S
-
+    def shutdown(self) -> None:
+        """Abort active requests and block until staging resources are safe."""
         self._begin_shutdown()
-        deadline = time.monotonic() + drain_timeout
-        drained = self._poll_shutdown()
-        while not drained and time.monotonic() < deadline:
+        while not self._poll_shutdown(cancel=True):
             time.sleep(_SHUTDOWN_POLL_INTERVAL_S)
-            drained = self._poll_shutdown()
-        if not drained:
-            drained = self._poll_shutdown(cancel=True)
-        if drained:
-            return True
-
-        logger.warning(
-            "NIXL host-staging shutdown timed out after %.1fs; retaining "
-            "registered memory until active operations become terminal.",
-            drain_timeout,
-        )
-        self._shutdown_thread = threading.Thread(
-            target=self._reap_shutdown,
-            args=(on_complete,),
-            name="vllm-nixl-host-staging-shutdown",
-            daemon=True,
-        )
-        self._shutdown_thread.start()
-        return False

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -325,7 +325,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 # Same-host destination is host memory: read into device staging
                 # and copy down, instead of letting UCX use TCP loopback.
                 # Notify the remote only once every chunk has landed, which the
-                # stager reports through _advance_host_staging.
+                # stager reports through _get_finished_host_staging.
                 self._pending_recv_notifs.setdefault(request_id, []).append(
                     (self._remote_agents[dst_engine_id][(0, remote_rank)], notif_id)
                 )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -141,7 +141,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             self._push_writer_thread.start()
             logger.info("nixl-push-writer thread started (rank=%d)", self.tp_rank)
 
-    def shutdown(self, drain_timeout: float | None = None) -> None:
+    def shutdown(self) -> None:
         self._push_writer_stop.set()
         # Unblock the writer if it's waiting in the no-active-state branch.
         self._push_writer_wake.set()
@@ -153,7 +153,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 for handle in handles:
                     self.nixl_wrapper.release_xfer_handle(handle)
             self._sending_transfers.clear()
-        super().shutdown(drain_timeout)
+        super().shutdown()
 
     # --- Engine-main-thread entry point -------------------------------- #
 


### PR DESCRIPTION
## Summary

- Rename `HostWriteStager.advance()` to `get_finished()` to match the existing connector lifecycle API while retaining result-based polling.
- Make host-stager shutdown block until active staging resources are safe to release.
- Remove the deferred shutdown thread, timeout, and `on_complete` hook so worker cleanup proceeds synchronously.
- Keep the push-worker shutdown override aligned with the base worker.

## Relationship to #53263

This PR targets the head branch of #53263 directly and contains only the requested review follow-ups. It addresses the blocking-shutdown discussion in https://github.com/vllm-project/vllm/pull/53263#discussion_r3833699803.

## Duplicate check

Open-PR searches for `53263 in:body`, `NIXL host staging shutdown`, and `HostWriteStager get_finished` found no separate PR implementing these follow-ups. The only matching work was #53263 itself; unrelated sparse-attention PRs appeared in the broader keyword search.

## Tests

- `.venv/bin/pre-commit run --files <changed files>`: passed, including ruff, formatting, typos, mypy, SPDX, and repository policy hooks.
- `.venv/bin/python -m compileall -q <changed Python files>`: passed.
- Focused `HostWriteStager.get_finished()` and blocking-shutdown smoke assertions: passed.
- `/home/LucasWilkinson/local/vllm/.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py -v -k host_stager`: collection blocked because the available environment lacks the `_vllm_fa2_C` or `_vllm_fa3_C` CUDA flash-attention extension.

## Evaluation

No model evaluation was run because this follow-up only changes lifecycle control flow and method naming; it does not affect model output or accuracy.

## AI assistance

AI assistance was used for implementation, tests, review, and PR preparation. The human submitter is responsible for reviewing every changed line and defending the change end-to-end.