### PR TITLE
Feat/gemma4 for 1660

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -67,6 +67,9 @@ from vllm.transformers_utils.configs.gemma4 import gemma4_layer_config
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import KVSharingFastPrefillMetadata
 
+from vllm.utils.platform_utils import is_uva_available
+from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+
 from .interfaces import (
     EagleModelMixin,
     MixtureOfExperts,
@@ -976,12 +979,33 @@ class Gemma4Model(nn.Module, EagleModelMixin):
             and self.hidden_size_per_layer_input > 0
         ):
             total_ple_dim = self.hidden_size_per_layer_input * config.num_hidden_layers
-            self.embed_tokens_per_layer = VocabParallelEmbedding(
-                self.vocab_size_per_layer_input,
-                total_ple_dim,
-                quant_config=quant_config,
-                prefix=f"{prefix}.embed_tokens_per_layer",
-            )
+
+            # make_layers에 offloader 함수 존재 
+            # 이는 zero-copy uva(unified virtual mem)를 통해 ram의 메모리를 gpu가 참고할 수 있도록 하는것
+            # pin_memory 
+            # VocabParallelEmbedding (PLE) 는 해당 함수로 만들지 않아 임의로 패치
+            # VocabParallelEmbedding는 인덱싱을 통한 look up이라 해당 형태의 구현이 가능한 것
+
+            _ple_on_cpu = is_uva_available()
+            _ctx = torch.device("cpu") if _ple_on_cpu else torch.device("cuda")
+            with _ctx:
+                self.embed_tokens_per_layer = VocabParallelEmbedding(
+                    self.vocab_size_per_layer_input,
+                    total_ple_dim,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.embed_tokens_per_layer",
+                )
+            if _ple_on_cpu:
+                _w = self.embed_tokens_per_layer.weight
+                _cpu = _w.data.to("cpu").pin_memory()
+                _w.data = get_accelerator_view_from_cpu_tensor(_cpu)
+                _w._vllm_is_uva_offloaded = True
+                import vllm.logger as _vl
+                _vl.init_logger(__name__).info(
+                    "[PATCH-PLE-UVA-OFFLOAD] PLE created on CPU + UVA view, "
+                    "%.2f GB off-GPU",
+                    _cpu.numel() * _cpu.element_size() / 1e9,
+                )
             # Scaled embedding factor (from config, not hardcoded)
             # Register as buffer so it moves to GPU with the model
             # and interacts correctly with torch.compile AOT caching.

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -995,6 +995,18 @@ def unified_attention(
         TILE_SIZE_PREFILL = min(TILE_SIZE_PREFILL, block_size)
         TILE_SIZE_DECODE = min(TILE_SIZE_DECODE, block_size)
 
+    # [PATCH-TURING-TILE] pre-Ampere(Turing sm_75 등)는 블록당 공유메모리가 64KB 로,
+    # head_size=512(gemma4 full-attn) 의 KV 타일(TILE x 512 x fp16 x 2)이 이를 넘겨
+    # triton OutOfResources(shared memory) 로 죽는다. TILE 을 16 으로 줄여 64KB 안에
+    # 맞춘다(정확도 무관, 처리량만 손해). Ampere+ 는 100KB+ 라 조건에 안 걸린다.
+    if head_size >= 512:
+        if (
+            torch.cuda.is_available()
+            and torch.cuda.get_device_capability()[0] < 8
+        ):
+            TILE_SIZE_PREFILL = min(TILE_SIZE_PREFILL, 16)
+            TILE_SIZE_DECODE = min(TILE_SIZE_DECODE, 16)
+
     # Tensor descriptors for Q load / output store require every element
     # of ``block_shape`` to be a power of 2.  ``num_queries_per_kv`` is
     # not always pow2 (e.g. Qwen2-7B: 28 / 4 = 7), so gate the Q/O paths


### PR DESCRIPTION
## Purpose

gemma-4 E-시리즈(E2B/E4B)를 1660에 가능하게 구현 
PLE 크기가 커서 VRAM에 들어 가지 않음 
-> gemma4.py: PLE를 CPU 핀메모리에 생성 + zero-copy UVA 뷰로 처리해서 RAM에 올림

Turing 공유메모리 64KB 초과 
→ triton_unified_attention.py: KV Tile 크기를 줄여 처리

