### PR TITLE
[Bugfix] Surface SamplingParams.verify errors as client errors (HTTP 400)

### DIFF
--- a/tests/v1/engine/test_input_processor_trace_replay.py
+++ b/tests/v1/engine/test_input_processor_trace_replay.py
@@ -108,3 +108,27 @@ def test_trace_replay_requires_v2_model_runner():
 
     with pytest.raises(ValueError, match="trace replay requires Model Runner V2"):
         VllmConfig._verify_trace_replay_config(config)
+
+
+def test_verify_value_error_is_surfaced_as_client_error():
+    """A plain `ValueError` from `SamplingParams.verify` (e.g. the fuzzable
+    `trace_decode_token_ids=[]`) must be converted to `VLLMValidationError`.
+
+    Otherwise `AsyncLLM.generate` wraps it in `EngineGenerateError` and the
+    API server returns an empty HTTP 500 instead of a 400 (as found by the
+    schemathesis fuzz of `POST /inference/v1/generate`)."""
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(
+            return_sampling_mask=False,
+            enable_trace_replay=True,
+            max_logprobs=20,
+        ),
+        vllm_config=SimpleNamespace(reasoning_config=None),
+        speculative_config=None,
+        structured_outputs_config=None,
+        tokenizer=None,
+    )
+    params = SamplingParams(trace_decode_token_ids=[])
+
+    with pytest.raises(VLLMValidationError, match="non-empty list"):
+        InputProcessor._validate_params(processor, params, ("generate",))

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -94,23 +94,34 @@ class InputProcessor:
             if not supported_generation_tasks:
                 raise VLLMValidationError("This model does not support generation")
 
-            params.verify(
-                self.model_config,
-                self.speculative_config,
-                self.structured_outputs_config,
-                self.tokenizer,
-            )
+            try:
+                params.verify(
+                    self.model_config,
+                    self.speculative_config,
+                    self.structured_outputs_config,
+                    self.tokenizer,
+                )
+            except ValueError as e:
+                # `SamplingParams.verify` still raises plain `ValueError` for
+                # some request-caused failures. Those must surface as client
+                # errors (HTTP 400); otherwise `AsyncLLM.generate` wraps them
+                # in `EngineGenerateError` and the API returns an empty 500.
+                raise VLLMValidationError(str(e)) from e
 
             if self.model_config.return_sampling_mask:
                 if params.temperature <= 0:
-                    raise ValueError(
-                        "sampling distribution replay requires temperature > 0"
+                    raise VLLMValidationError(
+                        "sampling distribution replay requires temperature > 0",
+                        parameter="temperature",
+                        value=params.temperature,
                     )
                 if params.top_k <= 0:
-                    raise ValueError(
+                    raise VLLMValidationError(
                         "sampling distribution replay requires top_k > 0 to "
                         "bound sampling mask size, reduce transfer overhead, "
-                        "and avoid potential OOMs"
+                        "and avoid potential OOMs",
+                        parameter="top_k",
+                        value=params.top_k,
                     )
             if params.thinking_token_budget is not None and (
                 self.vllm_config.reasoning_config is None
@@ -151,7 +162,10 @@ class InputProcessor:
                     f"Supported tasks: {supported_pooling_tasks}"
                 )
 
-            params.verify(self.model_config)
+            try:
+                params.verify(self.model_config)
+            except ValueError as e:
+                raise VLLMValidationError(str(e)) from e
         else:
             raise TypeError(
                 f"params must be either SamplingParams or PoolingParams, "


### PR DESCRIPTION
## Purpose

Fix the recurring randomized-Schemathesis failures in the H200 `Entrypoints Integration (API Server OpenAI - Part 1)` CI job: fuzzed `POST /inference/v1/generate` requests intermittently produced `{"error":{"message":"","type":"InternalServerError","param":null,"code":500}}` (main builds #84796, #85124, #85154 — the job now fails most runs).

## Root cause

`SamplingParams.verify()` still raises plain `ValueError` for some request-caused validation failures (e.g. `trace_decode_token_ids=[]`, which passes pydantic and the endpoint's msgspec pre-check). `InputProcessor._validate_params` runs lazily inside `AsyncLLM.generate()`, whose exception handling deliberately passes `VLLMClientError` through — but a plain `ValueError` falls into the generic branch and is wrapped in a **bare `EngineGenerateError`** (`async_llm.py`), which the entrypoints error mapper classifies as a server error. Result: HTTP 500 with an **empty message** instead of a 400, and the fuzz check correctly flags every 5xx.

Reproduced deterministically with the exact schemathesis-shrunk payload against the CI image (SmolVLM-256M, the schema-test server config): unpatched → empty 500 with the full `EngineGenerateError` chain in `--log-error-stack`; patched → `400 {"message":"trace_decode_token_ids must be a non-empty list.","type":"BadRequestError"}`.

## Changes

- `InputProcessor._validate_params`: convert `ValueError` from **both** `params.verify()` call sites (sampling and pooling) into `VLLMValidationError` at the validation boundary, so current and future plain-`ValueError` validations surface as 400s with their real message via the existing `except VLLMClientError: raise` pass-through.
- Migrate the two remaining plain `ValueError` raises in the sampling branch (`return_sampling_mask` temperature/top_k gates) to `VLLMValidationError` with `parameter`/`value`, matching the rest of the function.
- Regression test in `tests/v1/engine/test_input_processor_trace_replay.py` running the real `verify()` with `trace_decode_token_ids=[]` and asserting `VLLMValidationError`; verified it fails without the fix.

## Duplicate-work check

Searched open PRs for `trace_decode_token_ids`, `EngineGenerateError 500`, and `schemathesis inference generate`; no open PR addresses this classification bug.

## Test plan

- `tests/v1/engine/test_input_processor_trace_replay.py`: 6/6 passed (new test fails without the fix).
- Live reproduction on the CI image (`vllm serve HuggingFaceTB/SmolVLM-256M-Instruct` with the schema-test args): exact fuzzed payload returns 400 with message after the fix, empty 500 before.
- All applicable pre-commit hooks pass.
- Exact CI validation: isolated-branch run of `entrypoints-integration-api-server-openai-part-1` (the schemathesis job) to be linked in comments.

## AI-assistance disclosure

This change was prepared with AI assistance and reviewed before submission.
