### PR TITLE
[CI/Build] Pin Cython below 3.3 for arm64 tilelang sdist

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -209,6 +209,13 @@ RUN --mount=type=cache,target=/opt/uv/cache \
         sed -i 's/^nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' requirements/cuda.txt; \
         sed -i 's/^humming-kernels\[cu13\]/humming-kernels[cu12]/' requirements/cuda.txt; \
     fi \
+    && if [ "$(uname -m)" = "aarch64" ]; then \
+        # The manylinux 2_28 (glibc 2.28) aarch64 builder cannot use
+        # tilelang's manylinux_2_34 wheel, so tilelang builds from sdist.
+        # Cython 3.3 rejects tilelang's hardcoded Py_LIMITED_API=3.8.
+        printf 'cython<3.3\n' > /tmp/build-constraints.txt \
+        && export UV_BUILD_CONSTRAINT=/tmp/build-constraints.txt; \
+    fi \
     && if [ "${PYTORCH_NIGHTLY}" = "1" ]; then \
         echo "Installing torch nightly..." \
         && uv pip install --python /opt/venv/bin/python3 torch torchaudio torchvision --pre \


### PR DESCRIPTION
## Purpose

Fix the deterministic arm64 image-build failure caused by Cython 3.3 while building `tilelang==0.1.12` from source. No test runs: the image fails during dependency installation.

Exact reproductions on the restored immutable builder image:

- [PR-head arm64 image #85174](https://buildkite.com/vllm/ci/builds/85174#01a02917-5821-464a-a258-251e2db3a874)
- [post-merge main arm64 image #85175](https://buildkite.com/vllm/ci/builds/85175#01a02919-9021-4add-9b37-90cc0c58feb6)

## Root cause

The aarch64 build base is manylinux 2_28 / glibc 2.28, so it cannot install tilelang's `manylinux_2_34` aarch64 wheel and uv builds tilelang from sdist. Fresh isolated builds now resolve Cython 3.3, which rejects tilelang's hardcoded `Py_LIMITED_API=0x03080000` because Cython 3.3 requires Python Limited API 3.9 or newer. The previous successful build used the same immutable builder before Cython 3.3 was released, so it resolved an older compatible Cython.

## Change

On aarch64 only, set uv's isolated-build constraint to `cython<3.3` before installing CUDA requirements. x86_64 continues to install tilelang's wheel and is unaffected. CMake is no longer constrained; the restored builder remains on its existing CMake 4.4.2.

## Duplicate-work check

Searched open PRs for `cython arm64 tilelang`, `cython 3.3`, and `tilelang build`. This PR was already the only open match, so it was narrowed in place instead of opening a duplicate.

## Test status

- `uvx --from pre-commit pre-commit run --files docker/Dockerfile`: passed, including Dockerfile dependency-graph and `versions.json` validation.
- Exact updated-head [arm64 image #85232](https://buildkite.com/vllm/ci/builds/85232#01a02d89-31bf-4713-b188-ac28da85fb9f) at `66ad0efdceb4`: passed exit 0 in 39m34s, including the tilelang sdist build and complete vLLM image build/push under CMake 4.4.2.
- Merged as main `e25c586b9030`; [post-merge main arm64 #85235](https://buildkite.com/vllm/ci/builds/85235#01a02dac-36a1-413f-a4a1-dffd0b5d1e56) passed exit 0 in 39m21s, including the complete image build and registry push.
- [Post-merge GH200 #85236](https://buildkite.com/vllm/ci/builds/85236#01a02db0-c858-4867-8ff8-39e6a55d443d) at `7f17348fd67c` (exact merge commit plus only the selector scaffold `key: gh200-test` on a non-main validation branch) completed the full wheel build and reached Docker `build 17/17` with neither build-tool failure. It stopped only at the separately baseline-known wheel-size gate: 561.96 MB > 500 MB (baseline #84342: 552.17 MB > 500 MB). No retry.

Post-merge arm64 and GH200 both cleared the Cython/Limited-API and fatal CUDA imported-location signatures. This incident is resolved on main; the GH200 wheel-size gate remains separate baseline debt.

## AI-assistance disclosure

This change was prepared with AI assistance and reviewed before submission.
