### PR TITLE
[KV Connector][NIXL] Support pipeline-parallel producers on the pull path (incl. hybrid-Mamba)

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -652,7 +652,7 @@ class TestNixlHandshake:
         worker = connector.connector_worker
         # simulate handshake
         worker.dst_xfer_side_handles = {
-            FakeNixlConnectorWorker.REMOTE_ENGINE_ID: {0: 1}
+            FakeNixlConnectorWorker.REMOTE_ENGINE_ID: {(0, 0): 1}
         }
         worker.kv_cache_layout = "LBHNC"
         num_xfers = 4
@@ -824,9 +824,9 @@ class TestNixlHandshake:
             assert split_key in worker.src_xfer_handles_by_tp_ratio
             assert len(worker.src_xfer_handles_by_tp_ratio[split_key]) == tp_ratio
             assert remote_engine_id in worker.dst_xfer_side_handles
-            assert set(worker.dst_xfer_side_handles[remote_engine_id].keys()) == set(
-                range(tp_ratio)
-            )
+            assert set(worker.dst_xfer_side_handles[remote_engine_id].keys()) == {
+                (0, r) for r in range(tp_ratio)
+            }
 
         remote_agents, _ = worker._nixl_handshake(
             host="localhost",
@@ -2032,7 +2032,7 @@ def test_register_kv_caches(
         # Region bases are exactly the block-0 window starts, one per region.
         base_addrs = connector.connector_worker.kv_caches_base_addr[
             connector.connector_worker.engine_id
-        ][0]
+        ][(0, 0)]
         if layout == "BLHNC":
             assert len(base_addrs) == 3
         assert set(base_addrs) == {
@@ -2106,7 +2106,7 @@ def test_register_packed_dsv4_mla_cache_as_single_region(
         packed_block_len = num_layers * spec.page_size_bytes
         assert connector.connector_worker.kv_caches_base_addr[
             connector.connector_worker.engine_id
-        ][0] == [raw.data_ptr()]
+        ][(0, 0)] == [raw.data_ptr()]
         assert blocks_data.tolist() == [
             [raw.data_ptr() + block_idx * packed_block_len, packed_block_len, 0]
             for block_idx in range(num_blocks)
@@ -2216,12 +2216,12 @@ def test_shutdown_cleans_up_resources(default_vllm_config, dist_init):
         worker.src_xfer_handles_by_block_size = {worker.block_size: 455}
         # P TP = 2 * D TP case, we should register 2 local handles
         worker.src_xfer_handles_by_tp_ratio = {(-2, 16): [456, 457]}
-        worker.dst_xfer_side_handles = {"engine1": {0: 789}}
+        worker.dst_xfer_side_handles = {"engine1": {(0, 0): 789}}
         worker._remote_agents = {"engine1": {(0, 0): "agent1"}}
         # _cleanup_remote_engine (called by shutdown) also clears these:
-        worker.kv_caches_base_addr["engine1"] = {0: [0xABC]}
+        worker.kv_caches_base_addr["engine1"] = {(0, 0): [0xABC]}
         worker.dst_num_blocks["engine1"] = 50
-        worker.tp_mappings["engine1"] = MagicMock()
+        worker.tp_mappings[("engine1", 0)] = MagicMock()
         worker._engine_last_active["engine1"] = time.perf_counter()
         worker._registered_descs = ["desc1", "desc2"]
 
@@ -2271,10 +2271,10 @@ def _setup_worker_with_remote_engine(
 
     engine_id = "remote-engine-1"
     worker._remote_agents[engine_id] = {(0, 0): "agent_0", (0, 1): "agent_1"}
-    worker.dst_xfer_side_handles[engine_id] = {0: 100, 1: 200}
-    worker.kv_caches_base_addr[engine_id] = {0: [0xABC]}
+    worker.dst_xfer_side_handles[engine_id] = {(0, 0): 100, (0, 1): 200}
+    worker.kv_caches_base_addr[engine_id] = {(0, 0): [0xABC]}
     worker.dst_num_blocks[engine_id] = 50
-    worker.tp_mappings[engine_id] = MagicMock()
+    worker.tp_mappings[(engine_id, 0)] = MagicMock()
     worker._engine_last_active[engine_id] = time.perf_counter()
 
     worker.transfer_topo = MagicMock()
@@ -2304,7 +2304,7 @@ def test_engine_ttl_eviction(default_vllm_config, dist_init):
         assert engine_id not in worker.dst_xfer_side_handles
         assert engine_id not in worker.kv_caches_base_addr
         assert engine_id not in worker.dst_num_blocks
-        assert engine_id not in worker.tp_mappings
+        assert (engine_id, 0) not in worker.tp_mappings
         assert engine_id not in worker._engine_last_active
         worker.transfer_topo.unregister_remote_engine.assert_called_with(engine_id)
 
@@ -3316,7 +3316,7 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
             (0, rank): f"agent_p{rank}" for rank in range(prefill_tp_size)
         }
         worker.dst_xfer_side_handles = {
-            remote_engine_id: {rank: 100 + rank for rank in range(prefill_tp_size)}
+            remote_engine_id: {(0, rank): 100 + rank for rank in range(prefill_tp_size)}
         }
         # Sanity: D TP=1, P TP=4 => tp_ratio = -4 (P > D).
         assert worker.transfer_topo.tp_ratio(prefill_tp_size) == -prefill_tp_size

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -413,7 +413,7 @@ def test_read_blocks_for_req_expands_remote_ids(
     mock_plan = MagicMock(spec=TPMapping)
     mock_plan.all_source_ranks = ()
     mock_plan.source_ranks_per_group = ()
-    worker.tp_mappings = {remote_engine_id: mock_plan}
+    worker.tp_mappings = {(remote_engine_id, 0): mock_plan}
 
     metadata = NixlConnectorMetadata()
     metadata.add_new_req_to_recv(
@@ -1762,6 +1762,7 @@ def test_register_kv_caches_hybrid_mla_dual_purpose_regions():
         patch.object(bw, "NixlWrapper"),
         patch.object(bw, "get_tensor_model_parallel_rank", return_value=0),
         patch.object(bw, "get_tensor_model_parallel_world_size", return_value=1),
+        patch.object(bw, "get_pp_group", return_value=MagicMock(rank_in_group=0)),
         patch.object(bw, "get_current_attn_backends", return_value=[fake_backend]),
         patch.object(bw, "current_platform", fake_platform),
         patch(
@@ -1840,14 +1841,14 @@ def test_push_write_hybrid_mla_replicates_attention():
     # Read-oriented mapping collapses the replicated attention group to one
     # source rank; the SSM state is sharded across both covered D ranks.
     worker.tp_mappings = {
-        engine_id: TPMapping(
+        (engine_id, 0): TPMapping(
             source_ranks_per_group=((0,), (0, 1)),
             all_source_ranks=(0, 1),
             rank_to_attention_slot={0: 0, 1: 0},
             rank_offset_factor=0,
         )
     }
-    worker.dst_xfer_side_handles = {engine_id: {0: 100, 1: 101}}
+    worker.dst_xfer_side_handles = {engine_id: {(0, 0): 100, (0, 1): 101}}
     worker.src_xfer_handles_by_tp_ratio = {(-2, 4): [200, 201]}
     worker.src_xfer_handles_by_block_size = {4: 300}
     worker._sending_transfers = defaultdict(list)

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -1,0 +1,776 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for pipeline-parallel producers in the NIXL pull connector."""
+
+import threading
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import msgspec
+import pytest
+import zmq
+
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler import (
+    NixlBaseConnectorScheduler,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+    ShardDescLayout,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
+    GET_META_MSG,
+    NIXL_CONNECTOR_VERSION,
+    NixlAgentMetadata,
+    NixlConnectorMetadata,
+    NixlHandshakePayload,
+    RemoteMeta,
+    ReqMeta,
+    compute_nixl_compatibility_hash,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.pull_worker import (
+    NixlPullConnectorWorker,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.nixl.tp_mapping import TPMapping
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+from .utils import make_kv_cache_config
+
+REMOTE_ENGINE_ID = "remote-engine"
+
+
+def _fake_vllm_config(pipeline_parallel_size: int) -> Any:
+    """Minimal stand-in carrying only what the compatibility hash reads."""
+    model_config = SimpleNamespace(
+        model="fake-model",
+        dtype="float16",
+        get_total_num_kv_heads=lambda: 8,
+        get_head_size=lambda: 16,
+        get_total_num_hidden_layers=lambda: 32,
+    )
+    return SimpleNamespace(
+        model_config=model_config,
+        cache_config=SimpleNamespace(cache_dtype="auto", block_size=16),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        speculative_config=None,
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=pipeline_parallel_size,
+            tensor_parallel_size=1,
+        ),
+    )
+
+
+@pytest.mark.cpu_test
+def test_compatibility_hash_ignores_pipeline_parallel_size():
+    """A PP-sharded producer must still handshake with a PP=1 consumer.
+
+    The hash gates whether two engines may transfer at all, so it must not
+    change with pipeline_parallel_size.
+    """
+    assert compute_nixl_compatibility_hash(
+        _fake_vllm_config(1), "FLASH_ATTN"
+    ) == compute_nixl_compatibility_hash(_fake_vllm_config(4), "FLASH_ATTN")
+
+
+@pytest.mark.cpu_test
+def test_req_meta_reads_pp_size_and_defaults_to_one():
+    metadata = NixlConnectorMetadata()
+    params = {
+        "remote_block_ids": ([0],),
+        "remote_engine_id": REMOTE_ENGINE_ID,
+        "remote_request_id": "remote-req",
+        "remote_host": "localhost",
+        "remote_port": 1234,
+        "tp_size": 2,
+        "pp_size": 4,
+    }
+
+    metadata.add_new_req_to_recv("req", ([0],), params)
+    assert metadata.reqs_to_recv["req"].pp_size == 4
+
+    params.pop("pp_size")
+    metadata.add_new_req_to_recv("req-default", ([0],), params)
+    assert metadata.reqs_to_recv["req-default"].pp_size == 1
+
+
+def _make_read_worker(pp_size: int) -> NixlPullConnectorWorker:
+    """Worker with only the state `_read_blocks_for_req` reaches."""
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker._engine_last_active = {}
+    worker._bidirectional_kv_xfer_enabled = False
+    worker.kv_cache_config = make_kv_cache_config(block_size=16)
+    worker.use_mla = False
+    worker.block_size = 16
+    worker._recving_metadata = {}
+    worker._recving_transfers = {}
+    worker.dcp_size = 1
+
+    worker.transfer_topo = MagicMock()
+    worker.transfer_topo.tp_ratio.return_value = 1
+    remote_info = MagicMock()
+    remote_info.remote_physical_blocks_per_logical = 1
+    remote_info.remote_block_size = 16
+    remote_info.remote_tp_size = 1
+    remote_info.remote_dcp_size = 1
+    worker.transfer_topo.get_engine_info.return_value = remote_info
+
+    plan = MagicMock(spec=TPMapping)
+    plan.all_source_ranks = (0,)
+    plan.source_ranks_per_group = ((0,),)
+    worker.tp_mappings = {
+        (REMOTE_ENGINE_ID, pp_rank): plan for pp_rank in range(pp_size)
+    }
+    worker.src_xfer_handles_by_block_size = {16: 1}
+    worker.src_xfer_handles_by_remote = {
+        (REMOTE_ENGINE_ID, pp_rank, 16): 100 + pp_rank for pp_rank in range(pp_size)
+    }
+    worker.dst_xfer_side_handles = {
+        REMOTE_ENGINE_ID: {(pp_rank, 0): 200 + pp_rank for pp_rank in range(pp_size)}
+    }
+    worker._remote_agents = {
+        REMOTE_ENGINE_ID: {
+            (pp_rank, 0): f"agent-{pp_rank}" for pp_rank in range(pp_size)
+        }
+    }
+    worker._read_blocks = MagicMock()
+    return worker
+
+
+def _req_meta(pp_size: int) -> ReqMeta:
+    return ReqMeta(
+        local_block_ids=([0, 1],),
+        local_physical_block_ids=([0, 1],),
+        tp_size=1,
+        pp_size=pp_size,
+        remote=RemoteMeta(
+            block_ids=([0, 1],),
+            host="localhost",
+            port=1234,
+            engine_id=REMOTE_ENGINE_ID,
+            request_id="prefill-req",
+        ),
+    )
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("pp_size", [1, 2, 4])
+def test_read_blocks_for_req_issues_one_read_per_producer_stage(pp_size):
+    """Each producer stage owns a distinct layer slice, so a consumer must
+    issue one read per stage to collect a request's whole KV."""
+    worker = _make_read_worker(pp_size)
+
+    worker._read_blocks_for_req("decode-req", _req_meta(pp_size))
+
+    assert worker._read_blocks.call_count == pp_size
+    seen_stages = [
+        call.kwargs["remote_pp_rank"] for call in worker._read_blocks.call_args_list
+    ]
+    assert seen_stages == list(range(pp_size))
+
+
+@pytest.mark.cpu_test
+def test_read_blocks_for_req_targets_the_handles_of_each_stage():
+    """Handles are per stage: reading stage N must use stage N's local and
+    remote dlist, otherwise descriptors land at another stage's offsets."""
+    worker = _make_read_worker(2)
+
+    worker._read_blocks_for_req("decode-req", _req_meta(2))
+
+    calls = worker._read_blocks.call_args_list
+    assert [c.kwargs["local_xfer_side_handle"] for c in calls] == [100, 101]
+    assert [c.kwargs["remote_xfer_side_handle"] for c in calls] == [200, 201]
+
+
+@pytest.mark.cpu_test
+def test_read_blocks_for_req_pp1_uses_whole_engine_handles():
+    """PP=1 must keep taking the stock whole-region handle, not a shard one."""
+    worker = _make_read_worker(1)
+    worker.src_xfer_handles_by_remote = {}
+
+    worker._read_blocks_for_req("decode-req", _req_meta(1))
+
+    call = worker._read_blocks.call_args_list[0]
+    assert call.kwargs["local_xfer_side_handle"] == 1
+    assert call.kwargs["remote_pp_size"] == 1
+
+
+@pytest.mark.cpu_test
+def test_read_blocks_for_req_keeps_remote_block_ids_logical_under_pp():
+    """Every stage expands the logical ids with its own geometry, so the
+    shared metadata must not be rewritten in place (PP=1 still is, since
+    callers downstream rely on the expansion)."""
+    worker = _make_read_worker(2)
+    meta = _req_meta(2)
+
+    worker._read_blocks_for_req("decode-req", meta)
+
+    assert meta.remote.block_ids == ([0, 1],)
+
+
+@pytest.mark.cpu_test
+def test_full_prefix_hit_under_pp_drops_pending_metadata():
+    """No read is posted on a full prefix hit, so nothing will ever report the
+    request complete; the PP path must clear it or the entry leaks."""
+    worker = _make_read_worker(2)
+    meta = _req_meta(2)
+    # A full prefix cache hit clears both the logical and physical block lists
+    # (the scheduler passes () for local_block_ids, which ReqMeta mirrors into
+    # local_physical_block_ids), so no read is posted for the request.
+    meta.local_block_ids = ()
+    meta.local_physical_block_ids = ()
+    worker._recving_metadata["decode-req"] = meta
+
+    worker._read_blocks_for_req("decode-req", meta)
+
+    assert "decode-req" not in worker._recving_metadata
+
+
+def _make_desc_shard_worker(
+    region_member_groups: tuple[tuple[int, ...], ...],
+    group_spec_types: tuple[type, ...],
+    ssm_regions_per_layer: int = 0,
+) -> NixlPullConnectorWorker:
+    """Worker with only the state `_get_block_descs_ids_for_shard` reaches."""
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker._group_spec_types = group_spec_types
+    worker._shard_desc_layouts = {
+        (REMOTE_ENGINE_ID, 1): ShardDescLayout(
+            region_member_groups=region_member_groups,
+            ssm_regions_per_layer=ssm_regions_per_layer,
+        )
+    }
+    return worker
+
+
+@pytest.mark.cpu_test
+def test_get_block_descs_ids_for_shard_is_relative_to_the_shard():
+    """A stage registers only its own layers, so descriptor ids run over that
+    shard's regions starting at 0 rather than over all local regions."""
+    worker = _make_desc_shard_worker(((0,), (0,)), (FullAttentionSpec,))
+
+    desc_ids = worker._get_block_descs_ids_for_shard(REMOTE_ENGINE_ID, 1, 4, ([0, 1],))
+
+    # 2 regions x blocks [0, 1] over num_blocks=4: region 0 -> 0,1; region 1 -> 4,5.
+    assert desc_ids.tolist() == [0, 1, 4, 5]
+
+
+@pytest.mark.cpu_test
+def test_get_block_descs_ids_for_shard_covers_every_pooled_member():
+    """HMA pools a layer per KV group into one region, and each group indexes
+    that region with its own block ids. Emitting only the representative
+    group's ids leaves the other members' state never transferred."""
+    worker = _make_desc_shard_worker(
+        ((0, 1), (0, 2)),
+        (FullAttentionSpec, FullAttentionSpec, FullAttentionSpec),
+    )
+
+    desc_ids = worker._get_block_descs_ids_for_shard(
+        REMOTE_ENGINE_ID, 1, 10, ([1, 2], [7], [4, 5])
+    )
+
+    # region 0 holds group 0 blocks [1, 2] and group 1 block [7];
+    # region 1 (offset 10) holds group 0 blocks [1, 2] and group 2 blocks [4, 5].
+    assert desc_ids.tolist() == [1, 2, 7, 11, 12, 14, 15]
+
+
+@pytest.mark.cpu_test
+def test_get_block_descs_ids_for_shard_emits_the_mamba_section():
+    """A hybrid shard's dlist is [fa | ssm], with the SSM half holding one
+    sub-region per conv projection plus the temporal state. Without the SSM
+    section a Mamba member's state is never read and decode goes stale."""
+    worker = _make_desc_shard_worker(
+        ((0, 1), (0, 1)),
+        (FullAttentionSpec, MambaSpec),
+        ssm_regions_per_layer=4,
+    )
+
+    desc_ids = worker._get_block_descs_ids_for_shard(
+        REMOTE_ENGINE_ID, 1, 10, ([1, 2], [3]), 2
+    )
+
+    # FA: 2 regions x num_blocks=10 -> ids 1,2 and 11,12 (num_fa_descs=20).
+    # SSM: logical_blocks = 10 // 2 = 5, 4 sub-regions per region, so region 0
+    # occupies 20,25,30,35 and region 1 40,45,50,55, each offset by block 3.
+    assert desc_ids.tolist() == [1, 2, 11, 12, 23, 28, 33, 38, 43, 48, 53, 58]
+
+
+@pytest.mark.cpu_test
+def test_get_block_descs_ids_for_shard_skips_empty_groups():
+    """A group with no blocks for this request contributes no descriptors."""
+    worker = _make_desc_shard_worker(((0, 1),), (FullAttentionSpec, FullAttentionSpec))
+
+    desc_ids = worker._get_block_descs_ids_for_shard(
+        REMOTE_ENGINE_ID, 1, 10, ([1, 2], [])
+    )
+
+    assert desc_ids.tolist() == [1, 2]
+
+
+@pytest.mark.cpu_test
+def test_handshake_complete_requires_every_stage_registered():
+    """`_remote_agents` alone cannot distinguish a partially-registered
+    pipelined peer from a fully-registered PP=1 one."""
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker._remote_agents = {REMOTE_ENGINE_ID: {(0, 0): "agent-0"}}
+    worker._remote_pp_size = {}
+
+    assert worker._handshake_complete(REMOTE_ENGINE_ID, 1)
+    assert not worker._handshake_complete(REMOTE_ENGINE_ID, 2)
+
+    worker._remote_pp_size[REMOTE_ENGINE_ID] = 2
+
+    assert worker._handshake_complete(REMOTE_ENGINE_ID, 2)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("pp_size", [1, 4])
+def test_background_handshake_forwards_the_remote_pp_size(pp_size):
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker._handshake_lock = threading.RLock()
+    worker._handshake_futures = {}
+    worker._remote_agents = {}
+    worker._remote_pp_size = {}
+    worker._engine_last_active = {}
+    worker._engine_ttl = 0
+    worker._ready_requests = MagicMock()
+    future = MagicMock()
+    worker._handshake_initiation_executor = MagicMock()
+    worker._handshake_initiation_executor.submit.return_value = future
+
+    worker._background_nixl_handshake("req", REMOTE_ENGINE_ID, _req_meta(pp_size))
+
+    # Drop the stub so __del__ takes shutdown()'s partially-initialized path.
+    executor = worker._handshake_initiation_executor
+    del worker._handshake_initiation_executor
+
+    executor.submit.assert_called_once_with(
+        worker._nixl_handshake,
+        "localhost",
+        1234,
+        1,
+        REMOTE_ENGINE_ID,
+        1,
+        pp_size,
+        False,
+    )
+
+
+class _InlineThread:
+    """Runs the listener on the calling thread so the test stays deterministic."""
+
+    def __init__(
+        self, *, target: Callable[..., Any], args: tuple[Any, ...], **_: Any
+    ) -> None:
+        self._target = target
+        self._args = args
+
+    def start(self) -> None:
+        self._target(*self._args)
+
+
+class _FakeHandshakeSocket:
+    def __init__(self, request_msg: bytes, stop_event: threading.Event) -> None:
+        self._request_msg = request_msg
+        self._stop_event = stop_event
+        self._served = False
+        self.sent_multipart: list[tuple[bytes, ...]] = []
+
+    def setsockopt(self, *_: Any) -> None:
+        return None
+
+    def recv_multipart(self) -> tuple[bytes, bytes, bytes]:
+        if not self._served:
+            self._served = True
+            return (b"identity", b"", self._request_msg)
+        self._stop_event.set()
+        raise zmq.Again()
+
+    def send_multipart(self, parts: tuple[bytes, ...]) -> None:
+        self.sent_multipart.append(parts)
+
+
+class _FakeZmqContext:
+    def __init__(self, sock: _FakeHandshakeSocket) -> None:
+        self._sock = sock
+
+    def __enter__(self) -> _FakeHandshakeSocket:
+        return self._sock
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+@pytest.mark.cpu_test
+def test_handshake_listener_serves_a_requested_pp_stage():
+    """A consumer asks for one (pp_rank, tp_rank) at a time, so a PP-sharded
+    producer must serve the payload keyed by the requested stage."""
+    stop_event = threading.Event()
+    payloads = {
+        (0, 0): NixlHandshakePayload(
+            compatibility_hash="h", agent_metadata_bytes=b"s0"
+        ),
+        (1, 0): NixlHandshakePayload(
+            compatibility_hash="h", agent_metadata_bytes=b"s1"
+        ),
+    }
+    request = msgspec.msgpack.encode((GET_META_MSG, 1, 0))
+    sock = _FakeHandshakeSocket(request, stop_event)
+
+    scheduler = object.__new__(NixlBaseConnectorScheduler)
+    scheduler._nixl_handshake_listener_t = None
+    scheduler._stop_event = stop_event
+    scheduler.side_channel_host = "localhost"
+    scheduler.side_channel_port = 1234
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler.zmq_ctx",
+            return_value=_FakeZmqContext(sock),
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler."
+            "threading.Thread",
+            _InlineThread,
+        ),
+    ):
+        scheduler.set_xfer_handshake_metadata(payloads)
+
+    assert len(sock.sent_multipart) == 1
+    identity, delimiter, encoded_payload, _ts = sock.sent_multipart[0]
+    assert identity == b"identity"
+    assert delimiter == b""
+    decoded = msgspec.msgpack.decode(encoded_payload, type=NixlHandshakePayload)
+    assert decoded == payloads[(1, 0)]
+
+
+def _agent_meta(**overrides: Any) -> NixlAgentMetadata:
+    """Handshake metadata of a single-region producer shard."""
+    kwargs: dict[str, Any] = dict(
+        engine_id=REMOTE_ENGINE_ID,
+        agent_metadata=b"",
+        kv_caches_base_addr=[0x1000],
+        device_id=0,
+        num_blocks=4,
+        block_lens=[128],
+        block_strides=[128],
+        kv_cache_layout="LBHNC",
+        block_size=16,
+        ssm_sizes=(0, 0),
+        attn_backend_name="FLASH_ATTN",
+        physical_blocks_per_logical_kv_block=1,
+        registered_layer_names=["layer0"],
+    )
+    kwargs.update(overrides)
+    return NixlAgentMetadata(**kwargs)
+
+
+@pytest.mark.cpu_test
+def test_nixl_agent_metadata_region_members_round_trip():
+    """A pooled region's non-representative members must survive the wire, or
+    the consumer cannot know they need transferring."""
+    meta = _agent_meta(
+        registered_layer_names=["layer0", "layer2"],
+        region_members=[["layer0", "mamba0"], ["layer2", "mamba1"]],
+    )
+
+    decoded = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(meta), type=NixlAgentMetadata
+    )
+
+    assert NIXL_CONNECTOR_VERSION == 10
+    assert decoded.region_members == [["layer0", "mamba0"], ["layer2", "mamba1"]]
+
+
+@pytest.mark.cpu_test
+def test_remote_region_members_defaults_to_one_layer_per_region():
+    """A peer that advertises no membership has no pooling, so each region
+    holds exactly its representative layer."""
+    meta = _agent_meta(registered_layer_names=["layer0", "layer2"])
+
+    members = NixlPullConnectorWorker._remote_region_members(meta)
+
+    assert members == [["layer0"], ["layer2"]]
+
+
+@pytest.mark.cpu_test
+def test_remote_region_members_rejects_a_partial_advertisement():
+    """Membership that does not cover every region would silently drop the
+    uncovered regions' non-representative members."""
+    meta = _agent_meta(
+        registered_layer_names=["layer0", "layer2"],
+        region_members=[["layer0", "mamba0"]],
+    )
+
+    with pytest.raises(RuntimeError, match="region_members"):
+        NixlPullConnectorWorker._remote_region_members(meta)
+
+
+@pytest.mark.cpu_test
+def test_shard_desc_layout_maps_members_to_their_kv_groups():
+    """The block ids addressing a pooled region are selected per member group,
+    so the layout must carry each member's group, not just the region's."""
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker._layer_name_to_kv_group_index = {"layer0": 0, "mamba0": 1}
+    worker._has_mamba = False
+
+    layout = worker._shard_desc_layout(
+        _agent_meta(region_members=[["layer0", "mamba0"]])
+    )
+
+    assert layout.region_member_groups == ((0, 1),)
+    assert layout.ssm_regions_per_layer == 0
+
+
+@pytest.mark.cpu_test
+def test_shard_desc_layout_rejects_an_unknown_member():
+    """A member with no local KV group cannot be routed; failing the handshake
+    beats emitting descriptors that address the wrong region."""
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker._layer_name_to_kv_group_index = {"layer0": 0}
+    worker._has_mamba = False
+
+    with pytest.raises(RuntimeError, match="no matching local KV cache group"):
+        worker._shard_desc_layout(_agent_meta(region_members=[["layer0", "ghost"]]))
+
+
+@pytest.mark.cpu_test
+def test_local_region_indices_resolve_a_pooled_member():
+    """A producer stage may advertise a layer that is a non-representative
+    member locally; it must still resolve to the region physically holding it."""
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker.local_seen_layer_names = ["layer0", "layer2"]
+    worker._member_to_local_region = {
+        "layer0": 0,
+        "mamba0": 0,
+        "layer2": 1,
+        "mamba1": 1,
+    }
+
+    assert worker._local_region_indices_for_layer_names(["mamba1", "layer0"]) == [1, 0]
+
+
+@pytest.mark.cpu_test
+def test_local_region_indices_still_reject_an_unknown_layer():
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker.local_seen_layer_names = ["layer0"]
+    worker._member_to_local_region = {"layer0": 0}
+
+    with pytest.raises(RuntimeError, match="no matching local region"):
+        worker._local_region_indices_for_layer_names(["ghost"])
+
+
+@pytest.mark.cpu_test
+def test_pull_declares_pp_hma_support_and_push_does_not():
+    """The constructor refuses pipeline parallelism with a hybrid KV cache
+    unless the transfer mode declares support. Pull resolves pooled regions by
+    layer membership; push slices regions per layer, which pooling breaks."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
+        NixlBaseConnectorWorker,
+    )
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.push_worker import (
+        NixlPushConnectorWorker,
+    )
+
+    assert NixlPullConnectorWorker._supports_pp_hma is True
+    assert NixlBaseConnectorWorker._supports_pp_hma is False
+    assert NixlPushConnectorWorker._supports_pp_hma is False
+
+
+def _make_overlap_worker(local_layers: list[str]) -> NixlPullConnectorWorker:
+    worker = object.__new__(NixlPullConnectorWorker)
+    worker.local_seen_layer_names = list(local_layers)
+    worker._member_to_local_region = {
+        name: idx for idx, name in enumerate(local_layers)
+    }
+    return worker
+
+
+@pytest.mark.cpu_test
+def test_overlap_indices_map_a_fully_local_shard():
+    worker = _make_overlap_worker(["layer0", "layer1"])
+
+    indices = worker._local_region_indices_if_overlapping(["layer0", "layer1"])
+
+    assert indices == [0, 1]
+
+
+@pytest.mark.cpu_test
+def test_overlap_indices_return_none_for_a_disjoint_shard():
+    """A producer stage owning another consumer stage's layers carries nothing
+    this rank needs; symmetric PP producer/consumer always hits this case."""
+    worker = _make_overlap_worker(["layer0", "layer1"])
+
+    assert worker._local_region_indices_if_overlapping(["layer2", "layer3"]) is None
+
+
+@pytest.mark.cpu_test
+def test_overlap_indices_reject_a_partially_local_shard():
+    """Producer and consumer stages splitting layers at incompatible
+    boundaries cannot be served by whole-shard registration; fail loudly
+    rather than transfer a subset."""
+    worker = _make_overlap_worker(["layer0", "layer1"])
+
+    with pytest.raises(RuntimeError, match="partially overlap"):
+        worker._local_region_indices_if_overlapping(["layer1", "layer2"])
+
+
+@pytest.mark.cpu_test
+def test_overlap_indices_count_a_pooled_member_as_local():
+    """A shard advertising only a non-representative member of a pooled local
+    region still overlaps: the region physically holds that layer."""
+    worker = _make_overlap_worker(["layer0"])
+    worker._member_to_local_region["mamba0"] = 0
+
+    assert worker._local_region_indices_if_overlapping(["mamba0"]) == [0]
+
+
+@pytest.mark.cpu_test
+def test_add_pp_remote_agent_skips_a_disjoint_shard():
+    """Registering a disjoint shard used to raise and kill the whole
+    handshake, making symmetric PP producer/consumer unusable."""
+    worker = _make_overlap_worker(["layer0"])
+    worker.transfer_topo = MagicMock()
+    meta = _agent_meta(registered_layer_names=["layer9"], pp_rank=1, pp_size=2)
+
+    result = worker._add_pp_remote_agent(meta, 0, 1, remote_pp_rank=1, remote_pp_size=2)
+
+    assert result is None
+
+
+@pytest.mark.cpu_test
+def test_read_blocks_for_req_skips_stages_without_local_layers():
+    """A stage skipped at handshake has no mapping or handles; reading it
+    would KeyError. Its KV is read by the consumer stage(s) owning it."""
+    worker = _make_read_worker(2)
+    del worker.tp_mappings[(REMOTE_ENGINE_ID, 0)]
+
+    worker._read_blocks_for_req("decode-req", _req_meta(2))
+
+    stages = [
+        call.kwargs["remote_pp_rank"] for call in worker._read_blocks.call_args_list
+    ]
+    assert stages == [1]
+
+
+@pytest.mark.cpu_test
+def test_representative_stage_is_a_registered_stage():
+    """Engine-wide lookups (e.g. block geometry in get_finished) must not
+    assume stage 0: a consumer stage that skipped producer stage 0 at
+    handshake never registers it."""
+    worker = _make_read_worker(2)
+    del worker.tp_mappings[(REMOTE_ENGINE_ID, 0)]
+
+    assert worker._representative_stage(REMOTE_ENGINE_ID) == 1
+
+    with pytest.raises(KeyError):
+        worker._representative_stage("never-registered-engine")
+
+
+class _FakeReqSocket:
+    """REQ socket answering each (pp, tp) metadata query with its payload."""
+
+    def __init__(self, payloads: dict[tuple[int, int], bytes]) -> None:
+        self._payloads = payloads
+        self._pending: tuple[int, int] | None = None
+
+    def setsockopt(self, *_: Any) -> None:
+        return None
+
+    def send(self, msg: bytes) -> None:
+        _, pp_rank, tp_rank = msgspec.msgpack.decode(msg)
+        self._pending = (pp_rank, tp_rank)
+
+    def recv_multipart(self) -> tuple[bytes, bytes]:
+        assert self._pending is not None
+        payload = self._payloads[self._pending]
+        self._pending = None
+        return (payload, msgspec.msgpack.encode(0.0))
+
+
+def _shard_payload(layer_names: list[str], pp_rank: int, pp_size: int) -> bytes:
+    meta = _agent_meta(
+        registered_layer_names=list(layer_names),
+        kv_caches_base_addr=[0x1000] * len(layer_names),
+        block_lens=[128] * len(layer_names),
+        block_strides=[128] * len(layer_names),
+        pp_rank=pp_rank,
+        pp_size=pp_size,
+    )
+    payload = NixlHandshakePayload(
+        compatibility_hash="hash",
+        agent_metadata_bytes=msgspec.msgpack.encode(meta),
+    )
+    return msgspec.msgpack.encode(payload)
+
+
+def _make_handshake_worker(local_layers: list[str]) -> NixlPullConnectorWorker:
+    worker = _make_overlap_worker(local_layers)
+    worker.use_host_buffer = True
+    worker.transfer_topo = MagicMock()
+    worker.transfer_topo.handshake_target_ranks.return_value = (0,)
+    worker.compat_hash = "hash"
+    worker.enforce_compat_hash = True
+    worker.pcp_size = 1
+    worker.dcp_size = 1
+    worker._is_csa_linear = False
+
+    def add_remote_agent(
+        meta: NixlAgentMetadata,
+        remote_rank: int = 0,
+        remote_tp_size: int = 1,
+        remote_dcp_size: int = 1,
+        *,
+        remote_pp_rank: int = 0,
+        remote_pp_size: int = 1,
+    ) -> str | None:
+        indices = worker._local_region_indices_if_overlapping(
+            meta.registered_layer_names
+        )
+        if indices is None:
+            return None
+        return f"agent-{remote_pp_rank}-{remote_rank}"
+
+    worker.add_remote_agent = add_remote_agent
+    return worker
+
+
+@pytest.mark.cpu_test
+def test_nixl_handshake_registers_only_the_overlapping_stages():
+    """Symmetric PP producer/consumer: each consumer stage meets exactly one
+    disjoint producer shard, which must be skipped, not fail the handshake."""
+    worker = _make_handshake_worker(["layer0", "layer1"])
+    payloads = {
+        (0, 0): _shard_payload(["layer0", "layer1"], 0, 2),
+        (1, 0): _shard_payload(["layer2", "layer3"], 1, 2),
+    }
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.zmq_ctx",
+        return_value=_FakeZmqContext(_FakeReqSocket(payloads)),
+    ):
+        agents, _ = worker._nixl_handshake(
+            "localhost", 1234, 1, REMOTE_ENGINE_ID, remote_pp_size=2
+        )
+
+    assert agents == {(0, 0): "agent-0-0"}
+
+
+@pytest.mark.cpu_test
+def test_nixl_handshake_rejects_uncovered_local_regions():
+    """Skipping disjoint shards must not silently drop a local region no
+    producer stage covers: that KV would never transfer."""
+    worker = _make_handshake_worker(["layer0", "layer1", "layer9"])
+    payloads = {
+        (0, 0): _shard_payload(["layer0", "layer1"], 0, 2),
+        (1, 0): _shard_payload(["layer2", "layer3"], 1, 2),
+    }
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.zmq_ctx",
+            return_value=_FakeZmqContext(_FakeReqSocket(payloads)),
+        ),
+        pytest.raises(RuntimeError, match="does not cover"),
+    ):
+        worker._nixl_handshake("localhost", 1234, 1, REMOTE_ENGINE_ID, remote_pp_size=2)

--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -674,6 +674,11 @@ def _eviction_worker(engine_ttl: float) -> NixlPushConnectorWorker:
     w.dst_num_blocks = {}
     w.tp_mappings = {}
     w.transfer_topo = None
+    w._remote_pp_size = {}
+    w.src_xfer_handles_by_remote = {}
+    w.src_blocks_data_by_remote = {}
+    w.src_xfer_handles_by_shard_tp_ratio = {}
+    w._shard_desc_layouts = {}
     w._logical_to_kernel_block_ids = lambda blocks, ratio: blocks
     w.writes = []
     w._xfer_blocks_for_req = lambda req_id, meta: w.writes.append(req_id)
@@ -1146,7 +1151,7 @@ class TestPushWriterMlaReplication:
         # The tp-mapping collapses MLA to a single source rank (correct for
         # the pull/read direction); the push path must fan it back out.
         w.tp_mappings = {
-            engine_id: TPMapping(
+            (engine_id, 0): TPMapping(
                 source_ranks_per_group=((0,),),
                 all_source_ranks=(0,),
                 rank_to_attention_slot={0: 0},
@@ -1154,7 +1159,7 @@ class TestPushWriterMlaReplication:
             )
         }
         w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
-        w.dst_xfer_side_handles = {engine_id: {r: 1000 + r for r in d_ranks}}
+        w.dst_xfer_side_handles = {engine_id: {(0, r): 1000 + r for r in d_ranks}}
         w.src_xfer_handles_by_block_size = {16: 2000}
         w._remote_agents = {engine_id: {(0, r): f"agent-{r}" for r in d_ranks}}
         return w, engine_id
@@ -1226,7 +1231,7 @@ class TestPushWriterMlaReplication:
         w.transfer_topo.tp_ratio.return_value = -2
         w.transfer_topo.handshake_target_ranks.return_value = (0, 1)
         w.tp_mappings = {
-            engine_id: TPMapping(
+            (engine_id, 0): TPMapping(
                 source_ranks_per_group=((0,), (0,), (0, 1), (0, 1)),
                 all_source_ranks=(0, 1),
                 rank_to_attention_slot={0: 0, 1: 0},
@@ -1234,7 +1239,7 @@ class TestPushWriterMlaReplication:
             )
         }
         w._logical_to_kernel_block_ids = lambda block_ids, ratio: block_ids
-        w.dst_xfer_side_handles = {engine_id: {0: 1000, 1: 1001}}
+        w.dst_xfer_side_handles = {engine_id: {(0, 0): 1000, (0, 1): 1001}}
         w.src_xfer_handles_by_tp_ratio = {(-2, 16): [2000, 2001]}
 
         writes = []
@@ -1306,7 +1311,7 @@ class TestPushPrefixCaching:
         w.transfer_topo.tp_ratio.return_value = 1
         w.transfer_topo.block_size_ratio.return_value = 1
         w.tp_mappings = {
-            engine_id: TPMapping(
+            (engine_id, 0): TPMapping(
                 source_ranks_per_group=((0,),),
                 all_source_ranks=(0,),
                 rank_to_attention_slot={0: 0},
@@ -1314,7 +1319,7 @@ class TestPushPrefixCaching:
             )
         }
         w.dst_num_blocks = {engine_id: 10_000, w.engine_id: 10_000}
-        w.dst_xfer_side_handles = {engine_id: {0: 5000}}
+        w.dst_xfer_side_handles = {engine_id: {(0, 0): 5000}}
         w.src_xfer_handles_by_block_size = {16: 2000}
 
         # Stub only the NIXL WRITE; kernel expansion, prefix-cache trim, desc

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import msgspec
 import numpy as np
@@ -63,8 +63,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import
 from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
 from vllm.distributed.parallel_state import (
     get_pcp_group,
+    get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    model_parallel_is_initialized,
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -99,6 +101,27 @@ def _share_storage_and_block_stride(caches: list[torch.Tensor]) -> bool:
     return len(block_strides) == len(storage_ptrs) == 1
 
 
+class ShardDescLayout(NamedTuple):
+    """Descriptor layout of one pipeline-parallel producer shard's dlist.
+
+    A stage registers only the layers it owns, so its descriptors run over that
+    shard's regions rather than over all local regions. With HMA a region is
+    pooled across KV groups: it holds one layer per group, and the group a
+    member belongs to selects which block ids address it. Descriptors are laid
+    out as ``[fa (all regions) | ssm (all regions x sub-regions)]``, mirroring
+    the whole-engine layout built by ``_compute_desc_ids``.
+
+    Attributes:
+        region_member_groups: KV group index of every layer pooled into each
+            region, in region order.
+        ssm_regions_per_layer: NIXL regions per SSM layer (conv sub-projections
+            plus the SSM temporal state); 0 when the shard has no Mamba layers.
+    """
+
+    region_member_groups: tuple[tuple[int, ...], ...]
+    ssm_regions_per_layer: int
+
+
 class NixlBaseConnectorWorker:
     """Base implementation of Worker side methods shared by pull and push."""
 
@@ -106,6 +129,18 @@ class NixlBaseConnectorWorker:
     # (WRITE) connector and a pull (READ) connector never handshake together.
     # Overridden by NixlPushConnectorWorker.
     _TRANSFER_MODE: str = "pull"
+
+    # Whether this transfer mode can read from a PP-sharded producer, i.e. it
+    # keys remote state per (pp_rank, tp_rank) and issues one transfer per
+    # producer stage. Push writes into a remote's regions by layer offset and
+    # cannot, so it keeps rejecting a PP consumer.
+    _supports_consumer_pp: bool = False
+
+    # Whether this transfer mode can describe a PP producer's *pooled* regions,
+    # where HMA shares one backing tensor across kv cache groups. Requires
+    # per-(region x member group) descriptor emission; push slices regions per
+    # layer assuming a uniform count, so it cannot.
+    _supports_pp_hma: bool = False
 
     def _compute_desc_ids(
         self,
@@ -297,6 +332,239 @@ class NixlBaseConnectorWorker:
         """
         return region_idx < len(self._region_is_mla) and self._region_is_mla[region_idx]
 
+    def _local_region_indices_for_layer_names(
+        self, registered_layer_names: list[str]
+    ) -> list[int]:
+        """Map a producer shard's registered layers onto local region indices.
+
+        Args:
+            registered_layer_names: Layer name backing each of the producer's
+                regions, in its registration order.
+
+        Returns:
+            Local region index for each producer region, same order.
+
+        Raises:
+            RuntimeError: A producer layer has no matching local region.
+        """
+        local_names = self.local_seen_layer_names
+        positions_by_name: dict[str, list[int]] = defaultdict(list)
+        for local_idx, layer_name in enumerate(local_names):
+            positions_by_name[layer_name].append(local_idx)
+
+        occurrences_by_name: dict[str, int] = defaultdict(int)
+        local_indices: list[int] = []
+        for layer_name in registered_layer_names:
+            occurrence = occurrences_by_name[layer_name]
+            occurrences_by_name[layer_name] += 1
+            matches = positions_by_name.get(layer_name, [])
+            if occurrence < len(matches):
+                local_indices.append(matches[occurrence])
+                continue
+            # HMA pools layers of different groups into one region, so a
+            # producer's representative may be a non-representative member here.
+            pooled_idx = self._member_to_local_region.get(layer_name)
+            if occurrence == 0 and pooled_idx is not None:
+                local_indices.append(pooled_idx)
+                continue
+            raise RuntimeError(
+                "NIXL handshake failed: producer registered layer "
+                f"{layer_name!r} occurrence {occurrence} has no matching "
+                f"local region. Local registered layers: {local_names}"
+            )
+        return local_indices
+
+    def _local_region_indices_if_overlapping(
+        self, registered_layer_names: list[str]
+    ) -> list[int] | None:
+        """Map a producer shard's layers onto local regions, if any overlap.
+
+        A pipeline-parallel consumer owns only its own layer slice, so a
+        producer stage may advertise layers with no local counterpart. Such a
+        shard carries nothing this rank needs: its KV is read by the consumer
+        stage(s) that do own those layers.
+
+        Args:
+            registered_layer_names: Layer name backing each of the producer's
+                regions, in its registration order.
+
+        Returns:
+            Local region index for each producer region (same order) when
+            every advertised layer is local, or ``None`` when none is.
+
+        Raises:
+            RuntimeError: The shard overlaps only part of the local slice:
+                producer and consumer pipeline stages split the layers at
+                incompatible boundaries.
+        """
+        local_names = set(self.local_seen_layer_names)
+        matched = [
+            name in local_names or name in self._member_to_local_region
+            for name in registered_layer_names
+        ]
+        if not any(matched):
+            return None
+        if not all(matched):
+            missing = [
+                name for name, hit in zip(registered_layer_names, matched) if not hit
+            ]
+            raise RuntimeError(
+                "NIXL handshake failed: producer shard layers partially "
+                "overlap the local layer slice; producer and consumer "
+                "pipeline stages must split layers at compatible boundaries. "
+                f"Non-local layers: {missing}"
+            )
+        return self._local_region_indices_for_layer_names(registered_layer_names)
+
+    def _shard_desc_layout(self, nixl_agent_meta: NixlAgentMetadata) -> ShardDescLayout:
+        """Descriptor layout of a pipeline-parallel producer shard's dlist.
+
+        Args:
+            nixl_agent_meta: Handshake metadata of the producer shard.
+
+        Returns:
+            Layout describing the shard's descriptor list.
+
+        Raises:
+            RuntimeError: A member layer is unknown locally.
+        """
+        region_member_groups: list[tuple[int, ...]] = []
+        for members in self._remote_region_members(nixl_agent_meta):
+            groups: list[int] = []
+            for member in members:
+                if member not in self._layer_name_to_kv_group_index:
+                    raise RuntimeError(
+                        "NIXL handshake failed: producer region member "
+                        f"{member!r} has no matching local KV cache group."
+                    )
+                groups.append(self._layer_name_to_kv_group_index[member])
+            region_member_groups.append(tuple(groups))
+
+        ssm_regions_per_layer = 0
+        if self._has_mamba:
+            assert self._conv_decomp is not None
+            ssm_regions_per_layer = len(self._conv_decomp.local_conv_offsets) + 1
+        return ShardDescLayout(
+            region_member_groups=tuple(region_member_groups),
+            ssm_regions_per_layer=ssm_regions_per_layer,
+        )
+
+    @staticmethod
+    def _remote_region_members(
+        nixl_agent_meta: NixlAgentMetadata,
+    ) -> list[list[str]]:
+        """Layers pooled into each of a producer shard's regions.
+
+        Falls back to the representative layer per region for a peer that does
+        not advertise membership (one layer per region, i.e. no pooling).
+
+        Raises:
+            RuntimeError: Advertised membership does not cover every region.
+        """
+        names = nixl_agent_meta.registered_layer_names
+        members = nixl_agent_meta.region_members
+        if not members:
+            return [[name] for name in names]
+        if len(members) != len(names):
+            raise RuntimeError(
+                "NIXL handshake failed: producer advertised "
+                f"{len(members)} region_members entries for "
+                f"{len(names)} registered regions."
+            )
+        return [list(region) for region in members]
+
+    def _get_block_descs_ids_for_shard(
+        self,
+        engine_id: EngineId,
+        remote_pp_rank: int,
+        num_blocks: int,
+        block_ids: BlockIds,
+        physical_blocks_per_logical: int = 1,
+    ) -> np.ndarray:
+        """Descriptor IDs relative to one producer stage's prepared dlist.
+
+        A PP producer stage registers only its own layer slice, so descriptor
+        ids run over that shard's regions rather than over all local regions.
+        With HMA a region is pooled across KV groups and holds one layer per
+        group, so every member's group contributes its own block ids to the
+        same region. Descriptors are laid out as
+        ``[fa (all regions) | ssm (all regions x sub-regions)]``, matching the
+        shard's dlist and the whole-engine layout of ``_compute_desc_ids``.
+
+        Args:
+            engine_id: Remote producer engine id.
+            remote_pp_rank: Producer pipeline-parallel rank of the shard.
+            num_blocks: Number of blocks per region in the shard's dlist.
+            block_ids: Physical block ids per local KV group.
+            physical_blocks_per_logical: Physical blocks per logical block on
+                the side being described, the stride divisor for SSM
+                descriptors. P and D may differ.
+
+        Returns:
+            Flat descriptor ids into the shard's prepared dlist.
+        """
+        layout = self._shard_desc_layouts[(engine_id, remote_pp_rank)]
+        region_member_groups = layout.region_member_groups
+        num_fa_descs = len(region_member_groups) * num_blocks
+        logical_blocks = num_blocks // physical_blocks_per_logical
+        ssm_per_layer = layout.ssm_regions_per_layer
+
+        fa_descs: list[np.ndarray] = []
+        ssm_descs: list[np.ndarray] = []
+        for region_id, member_groups in enumerate(region_member_groups):
+            for group_id in member_groups:
+                group_arr = np.asarray(block_ids[group_id], dtype=np.int64)
+                if group_arr.size == 0:
+                    continue
+                spec_type = self._group_spec_types[group_id]
+                if _is_attention_spec(spec_type):
+                    fa_descs.append(region_id * num_blocks + group_arr)
+                elif _is_ssm_spec(spec_type):
+                    # SSM state of a region is described by conv sub-projections
+                    # plus the temporal state, each with logical-block stride.
+                    for sub_region in range(ssm_per_layer):
+                        offset = (region_id * ssm_per_layer + sub_region) * (
+                            logical_blocks
+                        )
+                        ssm_descs.append(num_fa_descs + offset + group_arr)
+                else:
+                    raise ValueError(
+                        f"Unknown spec type {spec_type} for KV group {group_id}"
+                    )
+
+        desc_ids = fa_descs + ssm_descs
+        if not desc_ids:
+            return np.empty(0, dtype=np.int64)
+        return np.concatenate(desc_ids)
+
+    def _handshake_complete(self, engine_id: EngineId, pp_size: int) -> bool:
+        """Whether the handshake with ``engine_id`` finished.
+
+        ``_remote_agents[engine_id]`` is only assigned once the handshake
+        registered every producer shard that overlaps this consumer stage's
+        layer slice (all shards when the consumer is not pipelined), so its
+        presence alone covers PP=1. The recorded pp_size additionally forces
+        a re-handshake if a peer first seen as a single stage later announces
+        itself as pipelined.
+        """
+        return (
+            engine_id in self._remote_agents
+            and self._remote_pp_size.get(engine_id, 1) == pp_size
+        )
+
+    def _representative_stage(self, engine_id: EngineId) -> int:
+        """Any registered producer stage of ``engine_id``.
+
+        A pipeline-parallel consumer only registers the producer stages
+        overlapping its own layer slice, so stage 0 may be absent; block
+        geometry is uniform across a producer's stages, so any registered
+        one serves for engine-wide lookups.
+        """
+        for eid, pp_rank in self.tp_mappings:
+            if eid == engine_id:
+                return pp_rank
+        raise KeyError(f"No registered stage for engine {engine_id}")
+
     def __init__(
         self,
         vllm_config: "VllmConfig",
@@ -350,6 +618,13 @@ class NixlBaseConnectorWorker:
                 for spec in self._layer_specs.values()
             )
         )
+        # Map each layer to its KV-cache group index. Consumed by the pull-path
+        # PP producer logic to advertise all dedup'd members of a region.
+        self._layer_name_to_kv_group_index = {
+            layer: group_index
+            for group_index, group in enumerate(kv_cache_config.kv_cache_groups)
+            for layer in group.layer_names
+        }
 
         # ---- Model state (derived from model config) ----
         mamba_ssm_size = (0, 0)
@@ -508,9 +783,20 @@ class NixlBaseConnectorWorker:
 
         # Map of engine_id -> kv_caches_base_addr. For TP case, each local
         self.device_id: int = 0
-        # Current rank may pull from multiple remote TP workers.
-        # EngineId, dict[int, list[int]] -> engine_id, tp_rank, base_addr_for_layer
-        self.kv_caches_base_addr = defaultdict[EngineId, dict[int, list[int]]](dict)
+        # Current rank may pull from multiple remote workers. A PP producer is
+        # sharded over (pp_rank, tp_rank); a PP=1 remote uses (0, tp_rank).
+        # EngineId, dict[shard, list[int]] -> engine_id, shard, base_addr_for_layer
+        self.kv_caches_base_addr = defaultdict[
+            EngineId, dict[tuple[int, int], list[int]]
+        ](dict)
+        # Base address of each locally registered region, in registration order.
+        self.local_kv_caches_base_addr: list[int] = []
+        # Layer name backing each local region, 1:1 with the list above. Lets a
+        # PP producer's layer slice be mapped onto local regions by name.
+        self.local_seen_layer_names: list[str] = []
+        # Local region index of every layer, including the non-representative
+        # members that HMA pools into a shared region.
+        self._member_to_local_region: dict[str, int] = {}
 
         # Number of NIXL regions. Currently one region per cache
         # (so 1 per layer for MLA, otherwise 2 per layer)
@@ -520,17 +806,24 @@ class NixlBaseConnectorWorker:
         # transfers into the matching sub-range of a PP=1 remote's regions.
         self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
         self._remote_region_offset = 0
-        # PP push slices regions per layer (uniform count); HMA breaks that.
-        if self.pp_size > 1 and self._is_hma_required:
+        # HMA pools several kv cache groups into one backing tensor, so a
+        # region holds more than one layer. A mode that slices regions per
+        # layer assuming a uniform count cannot describe that under PP.
+        if self.pp_size > 1 and self._is_hma_required and not self._supports_pp_hma:
             raise NotImplementedError(
-                "NixlPushConnector does not support pipeline_parallel_size > 1 "
-                "with hybrid KV cache layouts (HMA) yet."
+                f"NIXL {self._TRANSFER_MODE} mode does not support "
+                "pipeline_parallel_size > 1 with hybrid KV cache layouts (HMA)."
             )
-        # Decode-side PP is unsupported (completions counted per consumer rank).
-        if vllm_config.kv_transfer_config.kv_role == "kv_consumer" and self.pp_size > 1:
+        # Reading from a PP-sharded producer needs remote state keyed per
+        # (pp_rank, tp_rank) and one transfer per stage.
+        if (
+            vllm_config.kv_transfer_config.kv_role == "kv_consumer"
+            and self.pp_size > 1
+            and not self._supports_consumer_pp
+        ):
             raise NotImplementedError(
-                "NixlPushConnector consumer (decode) does not support "
-                "pipeline_parallel_size > 1."
+                f"NIXL {self._TRANSFER_MODE} mode consumer (decode) does not "
+                "support pipeline_parallel_size > 1."
             )
         # Keep heartbeat handshakes to a PP-sharded producer notif-only.
         self._hb_handshake_notif_only = False
@@ -543,8 +836,25 @@ class NixlBaseConnectorWorker:
         # Populated dynamically during handshake based on remote configuration.
         # Per-source split handles, keyed by (tp_ratio, remote_block_size).
         self.src_xfer_handles_by_tp_ratio: dict[tuple[int, int], list[int]] = {}
-        # Map of engine_id -> {tp_rank: nixl_prepped_dlist_handle (int)}.
-        self.dst_xfer_side_handles = defaultdict[EngineId, dict[int, int]](dict)
+        # Local handles covering only a PP producer shard's layer slice, keyed
+        # by (engine_id, remote_pp_rank, remote_block_size). PP=1 remotes keep
+        # using the whole-region handles above.
+        self.src_xfer_handles_by_remote: dict[tuple[EngineId, int, int], int] = {}
+        self.src_blocks_data_by_remote: dict[tuple[EngineId, int, int], np.ndarray] = {}
+        # Per-shard split handles, keyed by (engine_id, remote_pp_rank, tp_ratio).
+        self.src_xfer_handles_by_shard_tp_ratio: dict[
+            tuple[EngineId, int, int], list[int]
+        ] = {}
+        # Descriptor layout of each PP producer shard's dlist, keyed by
+        # (engine_id, remote_pp_rank).
+        self._shard_desc_layouts: dict[tuple[EngineId, int], ShardDescLayout] = {}
+        # Map of engine_id -> {(pp_rank, tp_rank): nixl_prepped_dlist_handle}.
+        self.dst_xfer_side_handles = defaultdict[EngineId, dict[tuple[int, int], int]](
+            dict
+        )
+        # Map of engine_id -> remote pipeline-parallel size, set once the
+        # handshake with every producer shard has completed.
+        self._remote_pp_size: dict[EngineId, int] = {}
 
         # Map of engine_id -> num_blocks. All ranks in the same deployment will
         # have the same number of blocks.
@@ -646,8 +956,9 @@ class NixlBaseConnectorWorker:
         # within a block (BLHNC/BHLNC), where stride > block_len.
         self.block_stride_per_layer = list[int]()
 
-        # Per-engine TP mappings. Generated during handshake.
-        self.tp_mappings: dict[EngineId, TPMapping] = {}
+        # TP mappings per producer shard, keyed by (engine_id, remote_pp_rank).
+        # Generated during handshake; a PP=1 remote uses pp_rank 0.
+        self.tp_mappings: dict[tuple[EngineId, int], TPMapping] = {}
 
         self.enforce_compat_hash = self.kv_transfer_config.get_from_extra_config(
             "enforce_handshake_compat", True
@@ -743,6 +1054,9 @@ class NixlBaseConnectorWorker:
             remote_tp_size, remote_dcp_size
         )
         remote_rank_to_agent_name: dict[tuple[int, int], str] = {}
+        # Local regions covered by at least one producer shard, to verify a
+        # pipelined producer's stages jointly cover the local layer slice.
+        covered_local_regions: set[int] = set()
         path = make_zmq_path("tcp", host, port)
         # Clock offset to the peer, estimated from the handshake round-trip.
         # Keep the lowest-RTT sample: hop cost is ~uniform across ranks, so a
@@ -849,8 +1163,23 @@ class NixlBaseConnectorWorker:
                     )
                 else:
                     remote_agent_name = self.add_remote_agent(
-                        metadata, remote_rank, remote_tp_size, metadata.dcp_size
+                        metadata,
+                        remote_rank,
+                        remote_tp_size,
+                        metadata.dcp_size,
+                        remote_pp_rank=remote_pp_rank,
+                        remote_pp_size=remote_pp_size,
                     )
+                    if remote_agent_name is None:
+                        # Shard owns no layer of this consumer stage's slice;
+                        # the consumer stage(s) owning those layers read it.
+                        continue
+                    if remote_pp_size > 1:
+                        indices = self._local_region_indices_if_overlapping(
+                            metadata.registered_layer_names
+                        )
+                        assert indices is not None
+                        covered_local_regions.update(indices)
                 setup_agent_time = time.perf_counter()
                 logger.debug(
                     "NIXL handshake: add agent took: %s (notif_agents_only=%s)",
@@ -860,6 +1189,18 @@ class NixlBaseConnectorWorker:
                 remote_ranks = (remote_pp_rank, remote_rank)
                 remote_rank_to_agent_name[remote_ranks] = remote_agent_name
 
+        if not notif_agents_only and remote_pp_size > 1:
+            missing = [
+                name
+                for idx, name in enumerate(self.local_seen_layer_names)
+                if idx not in covered_local_regions
+            ]
+            if missing:
+                raise RuntimeError(
+                    "NIXL handshake failed: the union of the producer's "
+                    "pipeline stages does not cover this consumer stage's "
+                    f"layer slice; uncovered local regions: {missing}"
+                )
         assert best_offset is not None
         return remote_rank_to_agent_name, best_offset
 
@@ -1012,7 +1353,7 @@ class NixlBaseConnectorWorker:
         """
         self._evict_stale_engines()
         with self._handshake_lock:
-            if engine_id in self._remote_agents:
+            if self._handshake_complete(engine_id, pp_size):
                 return None
             fut = self._handshake_futures.get(engine_id)
             if fut is not None:
@@ -1032,6 +1373,7 @@ class NixlBaseConnectorWorker:
             def done_callback(
                 f: Future[tuple[dict[tuple[int, int], str], float]],
                 eid=engine_id,
+                pp=pp_size,
             ):
                 with self._handshake_lock:
                     del self._handshake_futures[eid]
@@ -1040,6 +1382,9 @@ class NixlBaseConnectorWorker:
                         self._remote_agents[eid] = remote_agents
                         self._engine_clock_offset[eid] = clock_offset
                         self._engine_last_active[eid] = time.perf_counter()
+                        # Mark complete only after every PP stage's TP shards
+                        # are registered, so reads never race a missing handle.
+                        self._remote_pp_size[eid] = pp
                     except Exception as e:
                         self._log_failure(
                             failure_type="handshake_setup_failed",
@@ -1110,6 +1455,7 @@ class NixlBaseConnectorWorker:
             self.backend_name,
             transfer_mode=self._TRANSFER_MODE,
         )
+        pp_rank = get_pp_group().rank_in_group if model_parallel_is_initialized() else 0
 
         if self._is_csa_linear and self.use_host_buffer:
             raise NotImplementedError(
@@ -1144,6 +1490,13 @@ class NixlBaseConnectorWorker:
         self._ssm_region_indices = []
         self._scratch_region_indices = []
         self._ple_region_index = None
+        # Layer backing each region, so a consumer can map a PP producer's
+        # layer slice onto its own regions by name.
+        seen_layer_names: list[str] = []
+        # Every layer pooled into each region. With HMA a region is shared
+        # across KV groups, so the region holds more than one layer's cache and
+        # a consumer must transfer all of them, not just the representative.
+        region_members: list[list[str]] = []
 
         packed_storage = _share_storage_and_block_stride(list(xfer_buffers.values()))
         # CSA-linear needs separate logical regions for attention and state
@@ -1260,10 +1613,20 @@ class NixlBaseConnectorWorker:
             for base_addr, block_len, block_stride in region_specs:
                 if base_addr in seen_base_addresses:
                     region_index = seen_base_addresses.index(base_addr)
+                    # Dual-purpose HMA tensor: an MLA layer may share a region
+                    # that a non-MLA layer registered first. MLA is not
+                    # head-sharded, so the region must stay flagged MLA.
                     self._region_is_mla[region_index] |= is_mla_region
+                    # This layer's cache is pooled into an already-registered
+                    # region; a consumer still has to transfer it.
+                    members = region_members[region_index]
+                    if layer_name not in members:
+                        members.append(layer_name)
                 else:
                     region_index = len(seen_base_addresses)
                     seen_base_addresses.append(base_addr)
+                    seen_layer_names.append(layer_name)
+                    region_members.append([layer_name])
                     self.block_len_per_layer.append(block_len)
                     self.block_stride_per_layer.append(block_stride)
                     self._region_is_mla.append(is_mla_region)
@@ -1308,11 +1671,21 @@ class NixlBaseConnectorWorker:
             == len(seen_base_addresses)
             == len(self._region_is_mla)
             == len(self.block_stride_per_layer)
+            == len(seen_layer_names)
         )
         # Descriptor ids must be region-ordered, matching the remote side.
         self._scratch_region_indices.sort()
 
-        self.kv_caches_base_addr[self.engine_id][self.tp_rank] = seen_base_addresses
+        self.kv_caches_base_addr[self.engine_id][(pp_rank, self.tp_rank)] = (
+            seen_base_addresses
+        )
+        self.local_kv_caches_base_addr = seen_base_addresses
+        self.local_seen_layer_names = seen_layer_names
+        self._member_to_local_region = {
+            member: region_idx
+            for region_idx, members in enumerate(region_members)
+            for member in members
+        }
         self.num_regions = len(seen_base_addresses)
 
         if self.pp_size > 1:
@@ -1320,9 +1693,20 @@ class NixlBaseConnectorWorker:
                 self.vllm_config.parallel_config
             )
             num_local_layers = end_layer - start_layer
-            assert num_local_layers > 0 and self.num_regions % num_local_layers == 0
-            regions_per_layer = self.num_regions // num_local_layers
-            self._remote_region_offset = regions_per_layer * start_layer
+            if not self._is_hma_required:
+                # A uniform region count per layer only holds without pooling;
+                # HMA resolves a producer's regions by layer membership instead.
+                assert num_local_layers > 0 and self.num_regions % num_local_layers == 0
+                regions_per_layer = self.num_regions // num_local_layers
+                self._remote_region_offset = regions_per_layer * start_layer
+            logger.info(
+                "Registering KV_Caches. pp_rank=%d/%d, layers=[%d, %d), num_regions=%d",
+                pp_rank,
+                self.pp_size,
+                start_layer,
+                end_layer,
+                self.num_regions,
+            )
 
         # Total local FA descriptors (boundary between FA and mamba descs).
         self.num_descs = self.num_regions * self.num_blocks
@@ -1360,7 +1744,7 @@ class NixlBaseConnectorWorker:
             engine_id=self.engine_id,
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
-            kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
+            kv_caches_base_addr=self.local_kv_caches_base_addr,
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_layer,
             block_strides=self.block_stride_per_layer,
@@ -1375,6 +1759,10 @@ class NixlBaseConnectorWorker:
             ),
             dcp_size=self.dcp_size,
             pcp_size=self.pcp_size,
+            pp_rank=pp_rank,
+            pp_size=self.pp_size,
+            registered_layer_names=seen_layer_names,
+            region_members=region_members,
         )
         # Wrap metadata in payload with hash for defensive decoding
         assert self.compat_hash is not None
@@ -1384,7 +1772,11 @@ class NixlBaseConnectorWorker:
             agent_metadata_bytes=encoder.encode(agent_metadata),
         )
 
-    def _build_mamba_local(self, base_addresses: list[int]) -> np.ndarray:
+    def _build_mamba_local(
+        self,
+        base_addresses: list[int],
+        local_region_indices: list[int] | None = None,
+    ) -> np.ndarray:
         """Build desc regions (conv sub-projections + ssm) per layer for
         local mamba blocks with DS conv layout, as an Nx3 uint64 array.
 
@@ -1416,9 +1808,21 @@ class NixlBaseConnectorWorker:
         descriptors always use the local page geometry regardless of any
         attention block-size ratio; their desc ids are likewise never
         ratio-expanded (see _compute_desc_ids).
+
+        Args:
+            base_addresses: Base address of each region to describe.
+            local_region_indices: Local region index of each entry in
+                ``base_addresses``, used to look up per-region block lengths
+                when describing a producer shard's layer slice. Defaults to
+                the identity mapping over all local regions.
+
+        Returns:
+            Nx3 uint64 array of (address, length, device_id) descriptors.
         """
         assert base_addresses, "Local KV cache base addresses must not be empty."
         assert self._conv_decomp is not None
+        if local_region_indices is None:
+            local_region_indices = list(range(len(base_addresses)))
         conv_offsets = self._conv_decomp.local_conv_offsets
         conv_size, ssm_size = self._mamba_ssm_size
         num_blocks = self._logical_num_blocks
@@ -1427,9 +1831,16 @@ class NixlBaseConnectorWorker:
         block_arange = np.arange(num_blocks, dtype=np.uint64)
         parts: list[np.ndarray] = []
 
-        region_indices = self._ssm_region_indices or range(len(base_addresses))
-        for i in region_indices:
-            base_addr = base_addresses[i]
+        # DCP restricts the walk to SSM regions via ``_ssm_region_indices``; a PP
+        # producer shard restricts ``base_addresses`` to the regions it owns and
+        # passes their global indices in ``local_region_indices``. Compose both:
+        # skip any region that is not an SSM region for this walk, and index the
+        # per-region arrays by the region's global index ``i`` while addressing
+        # from the shard-local ``base_addr``.
+        ssm_region_indices = set(self._ssm_region_indices)
+        for i, base_addr in zip(local_region_indices, base_addresses):
+            if ssm_region_indices and i not in ssm_region_indices:
+                continue
             block_stride = self.block_stride_per_layer[i] * physical_per_logical
             blk_addrs = base_addr + block_arange * block_stride
             for off, sz in conv_offsets:
@@ -1437,12 +1848,19 @@ class NixlBaseConnectorWorker:
             # SSM temporal state follows the conv state.
             parts.append(self._stack_descs(blk_addrs + conv_size, ssm_size, device_id))
 
-        if (region_index := self._ple_region_index) is not None:
+        # A PP producer shard describes only the regions it registered, so address
+        # the PLE region from its shard-local position; the per-region length/stride
+        # arrays stay globally indexed. A shard that does not own the PLE region
+        # skips it (the owning shard describes it).
+        if (
+            region_index := self._ple_region_index
+        ) is not None and region_index in local_region_indices:
+            base_addr = base_addresses[local_region_indices.index(region_index)]
             block_len = self.block_len_per_layer[region_index] * physical_per_logical
             block_stride = (
                 self.block_stride_per_layer[region_index] * physical_per_logical
             )
-            block_addrs = base_addresses[region_index] + block_arange * block_stride
+            block_addrs = base_addr + block_arange * block_stride
             parts.append(self._stack_descs(block_addrs, block_len, self.device_id))
 
         return np.concatenate(parts)
@@ -1532,15 +1950,30 @@ class NixlBaseConnectorWorker:
         self,
         base_addresses: list[int],
         block_size_ratio: int,
+        local_region_indices: list[int] | None = None,
     ) -> np.ndarray:
-        """Build local FA descriptors for all layers as an Nx3 uint64 array."""
+        """Build local FA descriptors for all layers as an Nx3 uint64 array.
+
+        Args:
+            base_addresses: Base address of each region to describe.
+            block_size_ratio: Local block size divided by remote block size.
+            local_region_indices: Local region index of each entry in
+                ``base_addresses``, used to look up per-region block lengths
+                when describing a producer shard's layer slice. Defaults to
+                the identity mapping over all local regions.
+
+        Returns:
+            Nx3 uint64 array of (address, length, device_id) descriptors.
+        """
         assert self.transfer_topo is not None
         assert base_addresses, "Local KV cache base addresses must not be empty."
+        if local_region_indices is None:
+            local_region_indices = list(range(len(base_addresses)))
         num_blocks = self.num_blocks * block_size_ratio
         device_id = self.device_id
         block_arange = np.arange(num_blocks, dtype=np.uint64)
         parts: list[np.ndarray] = []
-        for i, base_addr in enumerate(base_addresses):
+        for i, base_addr in zip(local_region_indices, base_addresses):
             block_len = self.block_len_per_layer[i] // block_size_ratio
             block_stride = self.block_stride_per_layer[i] // block_size_ratio
             addrs = base_addr + block_arange * block_stride
@@ -1552,12 +1985,28 @@ class NixlBaseConnectorWorker:
         plan: TPMapping,
         nixl_agent_meta: NixlAgentMetadata,
         block_size_ratio: int,
+        local_region_indices: list[int] | None = None,
     ) -> np.ndarray:
-        """Build remote FA descriptors for all layers as an Nx3 uint64 array."""
+        """Build remote FA descriptors for all layers as an Nx3 uint64 array.
+
+        Args:
+            plan: TP mapping against the producer shard being described.
+            nixl_agent_meta: Handshake metadata of that producer shard.
+            block_size_ratio: Local block size divided by remote block size.
+            local_region_indices: Local region index of each remote region,
+                used to look up per-region block lengths when the producer is
+                a PP stage holding only part of the layers. Defaults to the
+                identity mapping.
+
+        Returns:
+            Nx3 uint64 array of (address, length, device_id) descriptors.
+        """
         assert self.transfer_topo is not None
         assert nixl_agent_meta.kv_caches_base_addr, (
             "Remote KV cache base addresses must not be empty."
         )
+        if local_region_indices is None:
+            local_region_indices = list(range(len(nixl_agent_meta.kv_caches_base_addr)))
         fa_group_idx = next(
             i for i, t in enumerate(self._group_spec_types) if _is_attention_spec(t)
         )
@@ -1569,9 +2018,10 @@ class NixlBaseConnectorWorker:
         block_arange = np.arange(num_blocks, dtype=np.uint64)
         parts: list[np.ndarray] = []
         for i, base_addr in enumerate(nixl_agent_meta.kv_caches_base_addr):
-            replicated = self._is_region_replicated(i)
+            local_region_idx = local_region_indices[i]
+            replicated = self._is_region_replicated(local_region_idx)
             # Read our whole local region size from remote..
-            local_block_len = self.block_len_per_layer[i]
+            local_block_len = self.block_len_per_layer[local_region_idx]
             remote_kv_block_len = local_block_len // block_size_ratio
             if block_size_ratio > 1:
                 # ..using remote kv_block_len as transfer unit
@@ -1593,6 +2043,8 @@ class NixlBaseConnectorWorker:
     def register_local_xfer_handler(
         self,
         block_size: int,
+        *,
+        registered_layer_names: list[str] | None = None,
     ) -> tuple[int, np.ndarray]:
         """
         Function used for register local xfer handler with local block_size or
@@ -1604,12 +2056,34 @@ class NixlBaseConnectorWorker:
         When remote block size is less than local block size, we need to use
         register another local_xfer_handler using remote block len to ensure
         data copy correctness.
+
+        Args:
+            block_size: Block size the handler describes blocks with.
+            registered_layer_names: Layers a pipeline-parallel producer shard
+                registered, in its own registration order. When given, only the
+                matching local regions are described, so the handler lines up
+                1:1 with that shard's remote descriptors. ``None`` describes
+                every local region.
+
+        Returns:
+            The prepared local dlist handle and its descriptor array.
         """
         assert self.transfer_topo is not None
         block_size_ratio = self.block_size // block_size
-        local_base_addresses = self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        if registered_layer_names is None:
+            local_base_addresses = self.local_kv_caches_base_addr
+            local_region_indices = list(range(len(local_base_addresses)))
+        else:
+            local_region_indices = self._local_region_indices_for_layer_names(
+                registered_layer_names
+            )
+            local_base_addresses = [
+                self.local_kv_caches_base_addr[i] for i in local_region_indices
+            ]
 
-        blocks_data = self._build_fa_local(local_base_addresses, block_size_ratio)
+        blocks_data = self._build_fa_local(
+            local_base_addresses, block_size_ratio, local_region_indices
+        )
         logger.debug(
             "Created %s blocks for src engine %s and rank %s on device id %s",
             len(blocks_data),
@@ -1618,7 +2092,11 @@ class NixlBaseConnectorWorker:
             self.device_id,
         )
         if self._has_mamba:
-            assert self.num_descs * block_size_ratio == len(blocks_data)
+            # num_descs counts every local region; a PP producer shard's handler
+            # describes only the regions backing that stage's layers.
+            assert registered_layer_names is not None or (
+                self.num_descs * block_size_ratio == len(blocks_data)
+            )
             # TODO (ZhanqiuHu): For homogeneous TP (tp_ratio == 1), the 3-descs split
             # is unnecessary — a single conv desc per block suffices.  Consider
             # adding a fast path that falls back to the standard 2-region
@@ -1626,7 +2104,7 @@ class NixlBaseConnectorWorker:
             # remote has been seen.  Currently we always register 4 regions
             # because local descs are created before knowing the remote TP.
             logger.debug("Registering local Mamba descriptors (4 regions/layer)")
-            mamba = self._build_mamba_local(local_base_addresses)
+            mamba = self._build_mamba_local(local_base_addresses, local_region_indices)
             blocks_data = np.concatenate([blocks_data, mamba])
 
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
@@ -1639,10 +2117,14 @@ class NixlBaseConnectorWorker:
         remote_tp_rank: int = 0,
         remote_tp_size: int = 1,
         remote_dcp_size: int = 1,
-    ) -> str:
+        *,
+        remote_pp_rank: int = 0,
+        remote_pp_size: int = 1,
+    ) -> str | None:
         """
         Add the remote NIXL agent and prepare the descriptors for reading cache
-        blocks from remote.
+        blocks from remote. Returns ``None`` for a pipeline-parallel producer
+        shard that registers no layer of this consumer stage's slice.
 
         In particular, handle both homogeneous and heterogeneous TP. The former
         requires local rank_i to read from remote rank_i.
@@ -1682,17 +2164,32 @@ class NixlBaseConnectorWorker:
 
         For Mamba hetero-TP, both tp_ratio > 0 (D_TP > P_TP) and
         tp_ratio < 0 (P_TP > D_TP) are supported by the 3-read transfer.
+
+        A pipeline-parallel producer registers one shard per (pp_rank, tp_rank);
+        each shard holds only its own layer slice, so descriptors are built and
+        cached per shard.
         """  # noqa: E501
         engine_id = nixl_agent_meta.engine_id
+        shard_key = (remote_pp_rank, remote_tp_rank)
         # TODO re-evaluate refreshing for scaling/recovery
-        if (0, remote_tp_rank) in self._remote_agents.get(engine_id, {}):
+        if shard_key in self._remote_agents.get(engine_id, {}):
             logger.debug(
-                "Remote agent with engine_id %s and rank"
-                "%s already exchanged metadata, skip handshake.",
+                "Remote agent with engine_id %s, pp rank %s, tp rank %s "
+                "already exchanged metadata, skip handshake.",
                 engine_id,
+                remote_pp_rank,
                 remote_tp_rank,
             )
-            return self._remote_agents[engine_id][(0, remote_tp_rank)]
+            return self._remote_agents[engine_id][shard_key]
+
+        if remote_pp_size > 1:
+            return self._add_pp_remote_agent(
+                nixl_agent_meta,
+                remote_tp_rank,
+                remote_tp_size,
+                remote_pp_rank,
+                remote_pp_size,
+            )
 
         # Number of physical regions registered locally (one per layer/tensor).
         num_local_regions = len(self.block_len_per_layer)
@@ -1703,6 +2200,17 @@ class NixlBaseConnectorWorker:
             # This worker holds a PP layer-slice; the PP=1 remote registered
             # the full model. Slice its regions to our layer window so the
             # logic below sees congruent local/remote lists.
+            if self._supports_pp_hma and self._is_hma_required:
+                # Residual gate: the window offset assumes a uniform region
+                # count per layer, which pooling breaks. A PP consumer needs a
+                # PP producer to resolve pooled regions by layer membership.
+                # Modes without _supports_pp_hma reject HMA at construction, so
+                # they never reach this.
+                raise RuntimeError(
+                    "NIXL does not support a pipeline-parallel consumer with "
+                    "hybrid KV cache layouts (HMA) reading from a "
+                    "pipeline_parallel_size == 1 producer yet."
+                )
             start = self._remote_region_offset
             end = start + num_local_regions
             assert len(nixl_agent_meta.kv_caches_base_addr) >= end
@@ -1728,7 +2236,7 @@ class NixlBaseConnectorWorker:
         transfer_topo.register_remote_engine(engine_id, transfer_info)
         logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))
 
-        self.tp_mappings[engine_id] = compute_tp_mapping(
+        self.tp_mappings[(engine_id, 0)] = compute_tp_mapping(
             transfer_topology=transfer_topo,
             remote_tp_size=remote_tp_size,
             group_spec_types=self._group_spec_types,
@@ -1752,7 +2260,7 @@ class NixlBaseConnectorWorker:
             self.dst_num_blocks[engine_id] = nixl_agent_meta.num_blocks
 
         # Keep track of remote agent kv caches base addresses.
-        self.kv_caches_base_addr[engine_id][remote_tp_rank] = (
+        self.kv_caches_base_addr[engine_id][shard_key] = (
             nixl_agent_meta.kv_caches_base_addr
         )
         self._validate_remote_agent_handshake(
@@ -1770,7 +2278,7 @@ class NixlBaseConnectorWorker:
             tp_ratio,
         )
 
-        plan = self.tp_mappings[engine_id]
+        plan = self.tp_mappings[(engine_id, 0)]
 
         ### (Optional) Register a local handler at the remote engine's block
         ### granularity (remote/prefill blocks smaller than local).
@@ -1839,11 +2347,294 @@ class NixlBaseConnectorWorker:
 
         # Register with NIXL.
         descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
-        self.dst_xfer_side_handles[engine_id][remote_tp_rank] = (
+        self.dst_xfer_side_handles[engine_id][shard_key] = (
             self.nixl_wrapper.prep_xfer_dlist(remote_agent_name, descs)
         )
 
         return remote_agent_name
+
+    def _add_pp_remote_agent(
+        self,
+        nixl_agent_meta: NixlAgentMetadata,
+        remote_tp_rank: int,
+        remote_tp_size: int,
+        remote_pp_rank: int,
+        remote_pp_size: int,
+    ) -> str | None:
+        """Register one shard of a pipeline-parallel producer.
+
+        Each producer stage registers only the layers it owns, so descriptors,
+        TP mappings and local handles are all cached per (engine, pp_rank)
+        rather than per engine.
+
+        Args:
+            nixl_agent_meta: Handshake metadata of the producer shard.
+            remote_tp_rank: TP rank of the shard within its stage.
+            remote_tp_size: TP size of the producer.
+            remote_pp_rank: PP rank (stage index) of the shard.
+            remote_pp_size: PP size of the producer.
+
+        Returns:
+            The NIXL agent name of the registered shard, or ``None`` when the
+            shard registers no layer of this consumer stage's slice.
+        """
+        engine_id = nixl_agent_meta.engine_id
+        shard_key = (remote_pp_rank, remote_tp_rank)
+        assert self.transfer_topo is not None
+        transfer_topo = self.transfer_topo
+
+        if nixl_agent_meta.pp_size != remote_pp_size:
+            raise RuntimeError(
+                "NIXL handshake failed: producer advertised "
+                f"pp_size={nixl_agent_meta.pp_size} but was queried as a "
+                f"pp_size={remote_pp_size} engine."
+            )
+        if nixl_agent_meta.pp_rank != remote_pp_rank:
+            raise RuntimeError(
+                "NIXL handshake failed: producer advertised "
+                f"pp_rank={nixl_agent_meta.pp_rank} but was queried for "
+                f"pp_rank={remote_pp_rank}."
+            )
+        if not nixl_agent_meta.registered_layer_names:
+            raise RuntimeError(
+                "NIXL handshake failed: a pipeline-parallel producer must "
+                "advertise registered_layer_names so its layer slice can be "
+                "mapped onto local regions."
+            )
+        if (
+            self._local_region_indices_if_overlapping(
+                nixl_agent_meta.registered_layer_names
+            )
+            is None
+        ):
+            logger.info(
+                "NIXL handshake: skipping producer shard (%s, pp rank %s, tp "
+                "rank %s): it registers no layer of this consumer stage's "
+                "slice.",
+                engine_id,
+                remote_pp_rank,
+                remote_tp_rank,
+            )
+            return None
+
+        transfer_info = EngineTransferInfo(
+            remote_tp_size=remote_tp_size,
+            remote_block_size=nixl_agent_meta.block_size,
+            remote_block_len=nixl_agent_meta.block_lens[0],
+            remote_physical_blocks_per_logical=(
+                nixl_agent_meta.physical_blocks_per_logical_kv_block
+            ),
+            remote_pp_rank=remote_pp_rank,
+        )
+        transfer_topo.register_remote_engine(engine_id, transfer_info)
+        logger.info(
+            "Transfer plan: %s", transfer_topo.describe(engine_id, remote_pp_rank)
+        )
+
+        plan_key = (engine_id, remote_pp_rank)
+        self.tp_mappings[plan_key] = compute_tp_mapping(
+            transfer_topology=transfer_topo,
+            remote_tp_size=remote_tp_size,
+            group_spec_types=self._group_spec_types,
+        )
+
+        remote_agent_name = self.nixl_wrapper.add_remote_agent(
+            nixl_agent_meta.agent_metadata
+        )
+
+        block_size_ratio = transfer_topo.block_size_ratio(nixl_agent_meta.block_size)
+        if engine_id not in self.dst_num_blocks:
+            self.dst_num_blocks[engine_id] = nixl_agent_meta.num_blocks
+
+        self.kv_caches_base_addr[engine_id][shard_key] = (
+            nixl_agent_meta.kv_caches_base_addr
+        )
+        local_region_indices = self._validate_pp_remote_agent_handshake(
+            nixl_agent_meta,
+            remote_pp_rank,
+            remote_tp_size,
+            block_size_ratio,
+        )
+
+        tp_ratio = transfer_topo.tp_ratio(remote_tp_size)
+        if self._is_hma_required and tp_ratio != 1:
+            # Residual gate: pooled regions plus a per-rank read offset need a
+            # hetero-TP x HMA x PP descriptor test we do not have yet.
+            raise RuntimeError(
+                "NIXL does not support heterogeneous TP with hybrid KV cache "
+                "layouts (HMA) and pipeline_parallel_size > 1 yet. Got "
+                f"tp_ratio={tp_ratio}."
+            )
+        logger.debug(
+            "Registering remote agent (%s, pp rank %s, tp rank %s) memory "
+            "regions with tp_ratio %s",
+            engine_id,
+            remote_pp_rank,
+            remote_tp_rank,
+            tp_ratio,
+        )
+        plan = self.tp_mappings[plan_key]
+
+        # One local handler per (engine, stage, remote block size): sibling TP
+        # ranks of the same stage register the same layer slice.
+        local_handle_key = (engine_id, remote_pp_rank, nixl_agent_meta.block_size)
+        if local_handle_key not in self.src_xfer_handles_by_remote:
+            handle, local_blocks_data = self.register_local_xfer_handler(
+                nixl_agent_meta.block_size,
+                registered_layer_names=nixl_agent_meta.registered_layer_names,
+            )
+            self.src_xfer_handles_by_remote[local_handle_key] = handle
+            self.src_blocks_data_by_remote[local_handle_key] = local_blocks_data
+        self._shard_desc_layouts[plan_key] = self._shard_desc_layout(nixl_agent_meta)
+        src_blocks_data = self.src_blocks_data_by_remote[local_handle_key]
+        num_shard_regions = len(nixl_agent_meta.registered_layer_names)
+
+        ### (Optional) Register local agent memory regions. MLA is not split.
+        split_handle_key = (engine_id, remote_pp_rank, tp_ratio)
+        if (
+            tp_ratio < 0
+            and (not self.use_mla or len(plan.all_source_ranks) > 1)
+            and split_handle_key not in self.src_xfer_handles_by_shard_tp_ratio
+        ):
+            self.src_xfer_handles_by_shard_tp_ratio[split_handle_key] = []
+            num_shard_descs = num_shard_regions * self.num_blocks * block_size_ratio
+            for handle_data in self._build_local_splits_from_plan(
+                plan,
+                src_blocks_data,
+                num_shard_descs,
+                block_size_ratio,
+            ):
+                descs = self.nixl_wrapper.get_xfer_descs(
+                    handle_data, self.nixl_memory_type
+                )
+                handle = self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs)
+                self.src_xfer_handles_by_shard_tp_ratio[split_handle_key].append(handle)
+
+        blocks_data = self._build_fa_remote(
+            plan,
+            nixl_agent_meta,
+            block_size_ratio,
+            local_region_indices,
+        )
+        if self._has_mamba:
+            mamba = self._build_mamba_remote(nixl_agent_meta, tp_ratio, transfer_info)
+            blocks_data = np.concatenate([blocks_data, mamba])
+        logger.debug(
+            "Created %s blocks for dst engine %s with remote pp rank %s, "
+            "remote tp rank %s and local rank %s",
+            len(blocks_data),
+            engine_id,
+            remote_pp_rank,
+            remote_tp_rank,
+            self.tp_rank,
+        )
+
+        descs = self.nixl_wrapper.get_xfer_descs(blocks_data, self.nixl_memory_type)
+        self.dst_xfer_side_handles[engine_id][shard_key] = (
+            self.nixl_wrapper.prep_xfer_dlist(remote_agent_name, descs)
+        )
+        # _nixl_handshake only publishes _remote_agents once every shard is
+        # registered; record it now so a partially-registered engine can still
+        # resolve the agents it does have (e.g. for notifs).
+        self._remote_agents[engine_id][shard_key] = remote_agent_name
+
+        return remote_agent_name
+
+    def _validate_pp_remote_agent_handshake(
+        self,
+        nixl_agent_meta: NixlAgentMetadata,
+        remote_pp_rank: int,
+        remote_tp_size: int,
+        block_size_ratio: int,
+    ) -> list[int]:
+        """Validate one pipeline-parallel producer shard's handshake metadata.
+
+        Mirrors ``_validate_remote_agent_handshake`` but compares per-region
+        block lengths against the local regions the shard's layers map to,
+        instead of assuming the producer registered every layer.
+
+        Args:
+            nixl_agent_meta: Handshake metadata of the producer shard.
+            remote_pp_rank: PP rank (stage index) of the shard.
+            remote_tp_size: TP size of the producer.
+            block_size_ratio: Local block size divided by remote block size.
+
+        Returns:
+            Local region index for each of the shard's regions, in the shard's
+            registration order.
+
+        Raises:
+            RuntimeError: A producer layer has no matching local region, or the
+                producer's layout cannot serve a heterogeneous-TP read.
+        """
+        remote_engine_id = nixl_agent_meta.engine_id
+        assert self.transfer_topo is not None
+        assert (
+            len(nixl_agent_meta.kv_caches_base_addr)
+            == len(nixl_agent_meta.block_lens)
+            == len(nixl_agent_meta.registered_layer_names)
+        )
+        local_region_indices = self._local_region_indices_for_layer_names(
+            nixl_agent_meta.registered_layer_names
+        )
+
+        remote_info = self.transfer_topo.get_engine_info(
+            remote_engine_id, remote_pp_rank
+        )
+        assert remote_info.remote_tp_size == remote_tp_size
+
+        tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
+        assert tp_ratio != 0, "Local and remote TP size must be divisible."
+        if self.use_mla:
+            assert tp_ratio > 0, "MLA only supports remote TP size >= local TP size."
+        assert not (
+            tp_ratio < 0
+            and self.transfer_topo.is_kv_replicated(remote_engine_id, remote_pp_rank)
+        )
+
+        remote_physical_per_logical = remote_info.remote_physical_blocks_per_logical
+        assert remote_physical_per_logical >= 1
+
+        kv_cache_layout = nixl_agent_meta.kv_cache_layout
+        if (
+            abs(tp_ratio) != 1
+            and not self.use_mla
+            and not self.transfer_topo.is_kv_replicated(
+                remote_engine_id, remote_pp_rank
+            )
+            and not KVCacheLayout[kv_cache_layout].is_block_contiguous
+            and not self.enable_permute_local_kv
+        ):
+            raise RuntimeError(
+                "Heterogeneous TP head-dimension splitting requires contiguous "
+                f"heads, but remote kv_cache_layout is {kv_cache_layout}. Use a "
+                "block-contiguous layout (e.g. LBHNC) on the prefill side."
+            )
+
+        remote_replicates_kv = self.transfer_topo.is_kv_replicated(
+            remote_engine_id, remote_pp_rank
+        )
+        for j, remote_block_len in enumerate(nixl_agent_meta.block_lens):
+            local_block_len = self.block_len_per_layer[local_region_indices[j]]
+            if self.use_mla or remote_replicates_kv:
+                # With a replicated KV cache, only the number of blocks differs.
+                expected = local_block_len // block_size_ratio
+            elif tp_ratio > 0:
+                expected = (local_block_len * tp_ratio) // block_size_ratio
+            else:
+                assert block_size_ratio == 1, (
+                    "Different local/remote block sizes are not supported"
+                    " when P TP > D TP."
+                )
+                expected = local_block_len // (-tp_ratio)
+            assert remote_block_len == expected, (
+                "Remote P worker KV layer cache shape is incompatible with the "
+                "local decode worker."
+            )
+
+        # TP workers that handshake with same remote have same #blocks.
+        assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
+        return local_region_indices
 
     def _validate_remote_agent_handshake(
         self,
@@ -2263,8 +3054,13 @@ class NixlBaseConnectorWorker:
             # granularity (block_size_ratio > 1) or at kernel-block
             # granularity, when equal kernel pages meet differing logical
             # block sizes and _apply_prefix_caching front-trims to the
-            # minimum count (hybrid heterogeneous TP).
-            remote_info = self.transfer_topo.get_engine_info(meta.remote.engine_id)
+            # minimum count (hybrid heterogeneous TP). Block size is uniform
+            # across a producer's PP stages, so any registered stage is
+            # representative.
+            remote_info = self.transfer_topo.get_engine_info(
+                meta.remote.engine_id,
+                self._representative_stage(meta.remote.engine_id),
+            )
             block_size_ratio = self.transfer_topo.block_size_ratio(
                 remote_info.remote_block_size
             )
@@ -2777,9 +3573,25 @@ class NixlBaseConnectorWorker:
         for agent_name in self._remote_agents.pop(engine_id).values():
             self.nixl_wrapper.remove_remote_agent(agent_name)
 
+        # Per-producer-shard local handles (PP producers only).
+        for key in [k for k in self.src_xfer_handles_by_remote if k[0] == engine_id]:
+            self.nixl_wrapper.release_dlist_handle(
+                self.src_xfer_handles_by_remote.pop(key)
+            )
+            self.src_blocks_data_by_remote.pop(key, None)
+        for key in [
+            k for k in self.src_xfer_handles_by_shard_tp_ratio if k[0] == engine_id
+        ]:
+            for handle in self.src_xfer_handles_by_shard_tp_ratio.pop(key):
+                self.nixl_wrapper.release_dlist_handle(handle)
+        for key in [k for k in self._shard_desc_layouts if k[0] == engine_id]:
+            del self._shard_desc_layouts[key]
+
         self.kv_caches_base_addr.pop(engine_id, None)
         self.dst_num_blocks.pop(engine_id, None)
-        self.tp_mappings.pop(engine_id, None)
+        self._remote_pp_size.pop(engine_id, None)
+        for key in [k for k in self.tp_mappings if k[0] == engine_id]:
+            del self.tp_mappings[key]
         if self.transfer_topo is not None:
             self.transfer_topo.unregister_remote_engine(engine_id)
 
@@ -2817,6 +3629,16 @@ class NixlBaseConnectorWorker:
         self.src_xfer_handles_by_tp_ratio.clear()
         for engine_id in list(self._remote_agents):
             self._cleanup_remote_engine(engine_id, log_eviction=False)
+        # Shards of an engine whose handshake failed before it was published.
+        for handle in self.src_xfer_handles_by_remote.values():
+            self.nixl_wrapper.release_dlist_handle(handle)
+        self.src_xfer_handles_by_remote.clear()
+        self.src_blocks_data_by_remote.clear()
+        for handles in self.src_xfer_handles_by_shard_tp_ratio.values():
+            for handle in handles:
+                self.nixl_wrapper.release_dlist_handle(handle)
+        self.src_xfer_handles_by_shard_tp_ratio.clear()
+        self._shard_desc_layouts.clear()
         for desc in self._registered_descs:
             self.nixl_wrapper.deregister_memory(desc)
         self._registered_descs.clear()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Metadata dataclasses and helpers for the NIXL connector."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from vllm.config import VllmConfig
@@ -45,8 +45,10 @@ PUSH_REG_NOTIF_PREFIX = b"PUSH_REG:"
 #   7: Include NIXL transfer mode (push vs pull) in the compatibility hash
 #   8: Add dcp_size and pcp_size to NixlAgentMetadata
 #   9: Add block_strides
+#   10: Add pipeline-parallel producer metadata, per-request pp_size and the
+#       per-region layer membership of pooled (HMA) regions
 #
-NIXL_CONNECTOR_VERSION: int = 9
+NIXL_CONNECTOR_VERSION: int = 10
 
 
 @dataclass
@@ -65,6 +67,18 @@ class NixlAgentMetadata:
     physical_blocks_per_logical_kv_block: int
     dcp_size: int = 1
     pcp_size: int = 1
+    # Pipeline-parallel producer shard identity. Defaults keep a PP=1 peer
+    # that omits these fields decodable.
+    pp_rank: int = 0
+    pp_size: int = 1
+    # Layer names backing each registered region, in registration order. Lets
+    # a consumer map a PP producer's layer slice onto its own regions.
+    registered_layer_names: list[str] = field(default_factory=list)
+    # Every layer whose cache lives in each registered region, in registration
+    # order. With HMA a region is pooled across KV groups, so only the first
+    # layer of the pool appears in registered_layer_names while all of them
+    # must be transferred. Empty means one layer per region.
+    region_members: list[list[str]] = field(default_factory=list)
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -32,6 +32,13 @@ _KV_BLOCKS_EXPIRY_SAFETY_MARGIN = 5.0
 class NixlPullConnectorWorker(NixlBaseConnectorWorker):
     """Pull-specific (READ) worker logic."""
 
+    # Reads are issued per producer stage, so a PP-sharded decode is supported.
+    _supports_consumer_pp = True
+
+    # A shard's descriptors are emitted per (region x member group), so pooled
+    # (HMA) regions of a PP producer are fully covered.
+    _supports_pp_hma = True
+
     def __init__(
         self,
         vllm_config: "VllmConfig",
@@ -63,10 +70,10 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             )
             # always store metadata for failure recovery
             self._recving_metadata[req_id] = meta
-            if remote_engine_id not in self._remote_agents:
+            if not self._handshake_complete(remote_engine_id, meta.pp_size):
                 # Initiate handshake with remote engine to exchange metadata.
                 with self._handshake_lock:
-                    if remote_engine_id not in self._remote_agents:
+                    if not self._handshake_complete(remote_engine_id, meta.pp_size):
                         self._background_nixl_handshake(req_id, remote_engine_id, meta)
                         continue
 
@@ -144,6 +151,11 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             self._handle_failed_transfer(req_id, None)
             return
 
+        # The handshake gate in start_load_kv only lets a request through once
+        # the handshake for meta.pp_size stages completed, so every stage that
+        # overlaps this consumer's layer slice is present in the per-stage
+        # structures below.
+        remote_pp_size = meta.pp_size
         if any(len(group) > 0 for group in meta.local_block_ids):
             # The scheduler waits for finished_recving from *every* worker.
             # Under DCP a rank's slice can legitimately come out empty when its
@@ -152,120 +164,171 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
             # Seed the entry so this rank still reports completion.
             self._recving_transfers.setdefault(req_id, [])
 
-        plan = self.tp_mappings[engine_id]
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
-        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        # A request's KV is spread across the remote producer's PP stages; read
+        # each overlapping stage in turn (its own layer range, TP mapping and
+        # block geometry). A stage owning none of this consumer's layers was
+        # skipped at handshake and is read by the consumer(s) that own those
+        # layers. With PP=1 the loop runs once at remote_pp_rank 0.
+        for remote_pp_rank in range(remote_pp_size):
+            if (
+                remote_pp_size > 1
+                and (engine_id, remote_pp_rank) not in self.tp_mappings
+            ):
+                continue
+            plan = self.tp_mappings[(engine_id, remote_pp_rank)]
+            remote_info = self.transfer_topo.get_engine_info(engine_id, remote_pp_rank)
+            tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
-        remote_logical_block_ids = meta.remote.block_ids
-        meta.remote.block_ids = self._logical_to_kernel_block_ids(
-            remote_logical_block_ids,
-            remote_info.remote_physical_blocks_per_logical,
-        )
-        num_groups = len(meta.local_block_ids)
-        dcp_active = self.dcp_size > 1 or remote_info.remote_dcp_size > 1
-
-        def group_ids(block_ids: BlockIds, rank: int) -> list[list[int]]:
-            return [
-                list(block_ids[g]) if rank in plan.source_ranks_per_group[g] else []
-                for g in range(num_groups)
-            ]
-
-        read_specs = []
-        for rank in plan.all_source_ranks:
-            if dcp_active:
-                # DCP interleaves at block granularity, so slicing happens
-                # here on logical blocks, before kernel-block expansion.
-                local_ids = group_ids(meta.local_block_ids, rank)
-                remote_ids = group_ids(remote_logical_block_ids, rank)
-                for g in range(num_groups):
-                    if not local_ids[g]:
-                        continue
-                    # Prefix cache hit may lead to skip some of the remote reads
-                    # TODO (NickLucche) consider unifying prefix cache handling on
-                    # logical blocks here for both dcp and non-dcp
-                    local_ids[g], remote_ids[g] = self._apply_dcp_prefix_caching(
-                        local_ids[g],
-                        remote_ids[g],
-                        remote_rank=rank,
-                        local_dcp_size=self.dcp_size,
-                        local_dcp_rank=self.dcp_rank,
-                        remote_dcp_size=remote_info.remote_dcp_size,
-                        local_num_computed_blocks=meta.local_num_computed_blocks[g],
-                    )
-                local_physical_ids = self._logical_to_kernel_block_ids(
-                    local_ids, self._physical_blocks_per_logical_kv_block
-                )
-                remote_physical_ids = self._logical_to_kernel_block_ids(
-                    remote_ids, remote_info.remote_physical_blocks_per_logical
-                )
-            else:
-                # No DCP realignment needed: reuse the already-expanded full
-                # physical lists instead of re-deriving them from logical ids.
-                local_physical_ids = group_ids(meta.local_physical_block_ids, rank)
-                remote_physical_ids = group_ids(meta.remote.block_ids, rank)
-            read_specs.append(
-                ReadSpec(
-                    remote_rank=rank,
-                    local_block_ids=local_physical_ids,
-                    remote_block_ids=remote_physical_ids,
-                )
+            # Logical remote ids drive DCP realignment (interleaves at block
+            # granularity, before kernel-block expansion). With PP>1
+            # meta.remote.block_ids must stay logical so each stage can expand it
+            # with its own geometry; with PP=1 the single stage may expand it in
+            # place (pre-PP behavior).
+            remote_logical_block_ids = meta.remote.block_ids
+            remote_kernel_block_ids = self._logical_to_kernel_block_ids(
+                remote_logical_block_ids,
+                remote_info.remote_physical_blocks_per_logical,
             )
+            if remote_pp_size == 1:
+                meta.remote.block_ids = remote_kernel_block_ids
+            num_groups = len(meta.local_block_ids)
+            dcp_active = self.dcp_size > 1 or remote_info.remote_dcp_size > 1
 
-        # D may have to perform multiple reads from different remote ranks.
-        # Pure MLA reads once because its cache is replicated. Hybrid
-        # MLA+SSM still needs one read per SSM source rank. With DCP, pure
-        # MLA may also read from multiple ranks (disjoint token slices).
-        if self.use_mla and tp_ratio < 0 and not self._has_mamba and not dcp_active:
-            assert len(read_specs) == 1
-
-        for i, spec in enumerate(read_specs):
-            remote_block_size = remote_info.remote_block_size
-            logger.debug(
-                "Remote agent %s available, calling _read_blocks"
-                " on remote rank %s with remote block size %s for req %s",
-                meta.remote.engine_id,
-                spec.remote_rank,
-                remote_block_size,
-                req_id,
-            )
-            # Get side handles.
-            if tp_ratio < 0 and (not self.use_mla or len(read_specs) > 1):
-                # Remote tp_size > local tp_size: we must perform multiple
-                # reads. Get the memory chunk onto which we will write to.
-                split_key = (tp_ratio, remote_block_size)
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[split_key][i]
-            else:
-                # Single read from remote, we write to the whole memory region.
-                # Also handle remote block size different from local block size.
-                local_xfer_side_handle = self.src_xfer_handles_by_block_size[
-                    remote_block_size
+            def group_ids(
+                block_ids: BlockIds, rank: int, plan=plan, num_groups=num_groups
+            ) -> list[list[int]]:
+                return [
+                    list(block_ids[g]) if rank in plan.source_ranks_per_group[g] else []
+                    for g in range(num_groups)
                 ]
 
-            # Destination handle: remote_engine_id -> remote_rank -> handle.
-            remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
-            ]
+            read_specs = []
+            for rank in plan.all_source_ranks:
+                if dcp_active:
+                    # DCP interleaves at block granularity, so slicing happens
+                    # here on logical blocks, before kernel-block expansion.
+                    local_ids = group_ids(meta.local_block_ids, rank)
+                    remote_ids = group_ids(remote_logical_block_ids, rank)
+                    for g in range(num_groups):
+                        if not local_ids[g]:
+                            continue
+                        # Prefix cache hit may lead to skip some of the remote
+                        # reads
+                        # TODO (NickLucche) consider unifying prefix cache
+                        # handling on logical blocks here for both dcp and non-dcp
+                        local_ids[g], remote_ids[g] = self._apply_dcp_prefix_caching(
+                            local_ids[g],
+                            remote_ids[g],
+                            remote_rank=rank,
+                            local_dcp_size=self.dcp_size,
+                            local_dcp_rank=self.dcp_rank,
+                            remote_dcp_size=remote_info.remote_dcp_size,
+                            local_num_computed_blocks=meta.local_num_computed_blocks[g],
+                        )
+                    local_physical_ids = self._logical_to_kernel_block_ids(
+                        local_ids, self._physical_blocks_per_logical_kv_block
+                    )
+                    remote_physical_ids = self._logical_to_kernel_block_ids(
+                        remote_ids, remote_info.remote_physical_blocks_per_logical
+                    )
+                else:
+                    # No DCP realignment needed: reuse the already-expanded full
+                    # physical lists instead of re-deriving them from logical ids.
+                    local_physical_ids = group_ids(meta.local_physical_block_ids, rank)
+                    remote_physical_ids = group_ids(remote_kernel_block_ids, rank)
+                read_specs.append(
+                    ReadSpec(
+                        remote_rank=rank,
+                        local_block_ids=local_physical_ids,
+                        remote_block_ids=remote_physical_ids,
+                    )
+                )
 
-            self._read_blocks(
-                read_spec=spec,
-                request_id=req_id,
-                dst_engine_id=meta.remote.engine_id,
-                remote_request_id=meta.remote.request_id,
-                local_xfer_side_handle=local_xfer_side_handle,
-                remote_xfer_side_handle=remote_xfer_side_handle,
-                expected_consumers=plan.local_consumers,
-            )
+            # D may have to perform multiple reads from different remote ranks.
+            # Pure MLA reads once because its cache is replicated. Hybrid
+            # MLA+SSM still needs one read per SSM source rank. With DCP, pure
+            # MLA may also read from multiple ranks (disjoint token slices).
+            if self.use_mla and tp_ratio < 0 and not self._has_mamba and not dcp_active:
+                assert len(read_specs) == 1
 
-        if self.use_mla and tp_ratio < 0 and len(read_specs) == 1:
-            # ..but we still need to notify the other remote ranks that we
-            # have the blocks we need so they can update the request state.
-            # Same thing for DCP (tp_size == dcp_size), so the raw tp_ratio already
-            # reflects whether any remote replica is left unchosen.
-            notif_id = f"{meta.remote.request_id}:{plan.local_consumers}".encode()
-            remote_agents = self._remote_agents[meta.remote.engine_id]
-            for rank_to_notify, agent in remote_agents.items():
-                if rank_to_notify != (0, read_specs[0].remote_rank):
-                    self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+            for i, spec in enumerate(read_specs):
+                remote_block_size = remote_info.remote_block_size
+                logger.debug(
+                    "Remote agent %s available, calling _read_blocks on remote "
+                    "pp rank %s, tp rank %s with remote block size %s for req %s",
+                    meta.remote.engine_id,
+                    remote_pp_rank,
+                    spec.remote_rank,
+                    remote_block_size,
+                    req_id,
+                )
+                # Get side handles.
+                if tp_ratio < 0 and (not self.use_mla or len(read_specs) > 1):
+                    # Remote tp_size > local tp_size: we must perform multiple
+                    # reads. Get the memory chunk onto which we will write to.
+                    if remote_pp_size > 1:
+                        local_xfer_side_handle = (
+                            self.src_xfer_handles_by_shard_tp_ratio[
+                                (engine_id, remote_pp_rank, tp_ratio)
+                            ][i]
+                        )
+                    else:
+                        split_key = (tp_ratio, remote_block_size)
+                        local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[
+                            split_key
+                        ][i]
+                elif remote_pp_size > 1:
+                    # One handle per producer stage: it covers only the local
+                    # regions backing that stage's layer slice.
+                    local_xfer_side_handle = self.src_xfer_handles_by_remote[
+                        (engine_id, remote_pp_rank, remote_block_size)
+                    ]
+                else:
+                    # Single read from remote, we write to the whole memory region.
+                    # Also handle remote block size different from local block size.
+                    local_xfer_side_handle = self.src_xfer_handles_by_block_size[
+                        remote_block_size
+                    ]
+
+                # Destination handle:
+                # remote_engine_id -> (remote_pp_rank, remote_rank) -> handle.
+                remote_xfer_side_handle = self.dst_xfer_side_handles[
+                    meta.remote.engine_id
+                ][(remote_pp_rank, spec.remote_rank)]
+
+                self._read_blocks(
+                    read_spec=spec,
+                    request_id=req_id,
+                    dst_engine_id=meta.remote.engine_id,
+                    remote_request_id=meta.remote.request_id,
+                    remote_pp_rank=remote_pp_rank,
+                    remote_pp_size=remote_pp_size,
+                    local_xfer_side_handle=local_xfer_side_handle,
+                    remote_xfer_side_handle=remote_xfer_side_handle,
+                    expected_consumers=plan.local_consumers,
+                )
+
+            if self.use_mla and tp_ratio < 0 and len(read_specs) == 1:
+                # ..but we still need to notify the other remote ranks that we
+                # have the blocks we need so they can update the request state.
+                # Same thing for DCP (tp_size == dcp_size), so the raw tp_ratio
+                # already reflects whether any remote replica is left unchosen.
+                # Every reader reports the same aggregate count (plan.local_consumers)
+                # so the producer's free-accounting agrees across ranks.
+                notif_id = f"{meta.remote.request_id}:{plan.local_consumers}".encode()
+                remote_agents = self._remote_agents[meta.remote.engine_id]
+                for (pp_rank, rank_to_notify), agent in remote_agents.items():
+                    if (
+                        pp_rank == remote_pp_rank
+                        and rank_to_notify != read_specs[0].remote_rank
+                    ):
+                        self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+
+        if remote_pp_size > 1 and len(meta.local_physical_block_ids) == 0:
+            # Full prefix hit: no remote read happens, so no recv completion
+            # will report this request. Only the PP path needs this: with PP=1
+            # get_finished still pops the entry once the notification lands.
+            self._recving_metadata.pop(req_id, None)
 
     def _read_blocks(
         self,
@@ -273,6 +336,8 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         dst_engine_id: str,
         request_id: str,
         remote_request_id: str,
+        remote_pp_rank: int,
+        remote_pp_size: int,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
         expected_consumers: int,
@@ -280,13 +345,17 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         """
         Post a READ point-to-point xfer request from a single local worker to
         a single remote worker.
+
+        ``remote_pp_rank``/``remote_pp_size`` identify which pipeline stage of
+        the producer is being read: a pipelined producer registers only its own
+        layer slice, so descriptor ids are relative to that shard's dlist.
         """
         assert self.transfer_topo is not None
         remote_rank = read_spec.remote_rank
         local_block_ids = read_spec.local_block_ids
         remote_block_ids = read_spec.remote_block_ids
 
-        remote_info = self.transfer_topo.get_engine_info(dst_engine_id)
+        remote_info = self.transfer_topo.get_engine_info(dst_engine_id, remote_pp_rank)
         block_size_ratio = self.transfer_topo.block_size_ratio(
             remote_info.remote_block_size
         )
@@ -313,7 +382,9 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # just notify P worker that we have the blocks we need.
         if not any(len(group) > 0 for group in local_block_ids):
             # A full prefix cache hit is indicated with an empty list.
-            agent_name = self._remote_agents[dst_engine_id][(0, remote_rank)]
+            agent_name = self._remote_agents[dst_engine_id][
+                (remote_pp_rank, remote_rank)
+            ]
             try:
                 self.nixl_wrapper.send_notif(agent_name, notif_msg=notif_id)
             except Exception as e:
@@ -324,6 +395,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                     req_id=request_id,
                     error=e,
                     dst_engine_id=dst_engine_id,
+                    remote_pp_rank=remote_pp_rank,
                     remote_rank=remote_rank,
                     remote_agent_name=agent_name,
                 )
@@ -353,19 +425,40 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # corresponding rank. With heterogeneous TP, fixing D>P, the D tp
         # workers will issue xfers to parts of the P worker remote kv caches.
 
-        # Get descs ids.
-        remote_block_descs_ids = self._compute_desc_ids(
-            block_ids=remote_block_ids,
-            dst_num_blocks=self.dst_num_blocks[dst_engine_id],
-            block_size_ratio=None,
-            physical_blocks_per_logical=remote_info.remote_physical_blocks_per_logical,
-        )
-        local_block_descs_ids = self._compute_desc_ids(
-            block_ids=local_block_ids,
-            dst_num_blocks=self.dst_num_blocks[self.engine_id],
-            block_size_ratio=block_size_ratio,
-            physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
-        )
+        # Get descs ids. A single-stage (pp_size == 1) producer registers all of
+        # the engine's KV regions, so compute ids against the whole-engine layout
+        # (which also covers Mamba FA/SSM and hetero physical-per-logical). Per-PP
+        # -stage descriptor sharding is only needed when the producer is pipelined.
+        if remote_pp_size == 1:
+            remote_block_descs_ids = self._compute_desc_ids(
+                block_ids=remote_block_ids,
+                dst_num_blocks=self.dst_num_blocks[dst_engine_id],
+                block_size_ratio=None,
+                physical_blocks_per_logical=(
+                    remote_info.remote_physical_blocks_per_logical
+                ),
+            )
+            local_block_descs_ids = self._compute_desc_ids(
+                block_ids=local_block_ids,
+                dst_num_blocks=self.dst_num_blocks[self.engine_id],
+                block_size_ratio=block_size_ratio,
+                physical_blocks_per_logical=self._physical_blocks_per_logical_kv_block,
+            )
+        else:
+            remote_block_descs_ids = self._get_block_descs_ids_for_shard(
+                dst_engine_id,
+                remote_pp_rank,
+                self.dst_num_blocks[dst_engine_id],
+                remote_block_ids,
+                remote_info.remote_physical_blocks_per_logical,
+            )
+            local_block_descs_ids = self._get_block_descs_ids_for_shard(
+                dst_engine_id,
+                remote_pp_rank,
+                self.num_blocks * block_size_ratio,
+                local_block_ids,
+                self._physical_blocks_per_logical_kv_block,
+            )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
 
@@ -394,6 +487,7 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                 msg="Marking blocks as invalid",
                 error=e,
                 dst_engine_id=dst_engine_id,
+                remote_pp_rank=remote_pp_rank,
                 remote_rank=remote_rank,
             )
             self._handle_failed_transfer(request_id, handle)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -505,8 +505,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         """Issue WRITE transfers to one or more remote TP ranks."""
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
-        plan = self.tp_mappings[engine_id]
-        remote_info = self.transfer_topo.get_engine_info(engine_id)
+        # Push always targets a PP=1 consumer, hence the fixed stage index 0.
+        plan = self.tp_mappings[(engine_id, 0)]
+        remote_info = self.transfer_topo.get_engine_info(engine_id, 0)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
 
         # Expand D's logical IDs using the ratio learned during the
@@ -529,7 +530,9 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         replicate_attn = self.use_mla and tp_ratio < 0
         if replicate_attn and not self._has_mamba:
             assert len(plan.all_source_ranks) == 1
-            write_ranks = sorted(self.dst_xfer_side_handles[engine_id])
+            write_ranks = sorted(
+                rank for _, rank in self.dst_xfer_side_handles[engine_id]
+            )
         else:
             write_ranks = list(plan.all_source_ranks)
 
@@ -575,7 +578,7 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                 ]
 
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
-                spec.remote_rank
+                (0, spec.remote_rank)
             ]
 
             handle = self._xfer_blocks(


### PR DESCRIPTION
## Purpose

Lift the two `NotImplementedError` guards that block NIXL **pull-mode** disaggregation when the producer (prefill) runs with `pipeline_parallel_size > 1`:

1. the `kv_consumer` × `pp_size > 1` guard in the shared `NixlBaseConnectorWorker` constructor, and
2. the `pp_size > 1` × hybrid-KV (HMA) guard.

Successor of #48263 (draft, written against the pre-package single-file connector): the connector became a package and main absorbed that PR's foundation (per-`(pp_rank, tp_rank)` remote agents, multi-stage handshake, SSM-aware descriptor split), so this PR re-lands only the still-missing pull-path half, re-authored for the current architecture. I will close #48263 in favour of this PR.

**Not duplicating the open push-path PP work.** #50494 (`region_members` for attention-HMA PP push), #47981 (attention-HMA PP push prefill), #51053 (Kimi KDA+MLA members, stacked on #50494) and #50499 (packed MLA PP push) all extend `NixlPushConnectorWorker`. This PR touches the **pull** (READ) worker; the two modes are protocol-incompatible and separated in the compatibility hash by `transfer_mode`. Push semantics are unchanged here and the push guards keep raising.

One deliberate overlap to flag for reviewers: #50494 introduces a `NixlAgentMetadata.region_members` field with the same name and the same intent (per-region dedup'd member names) for the push path. This PR adds the field for the pull path. Whichever lands first should own the field; I am happy to rebase onto #50494's version and drop mine — the pull-side consumer logic here is orthogonal to how the producer advertises members.

**Commit 1 — pipeline-parallel producers on the pull path (no-HMA).**
The consumer completes one handshake per producer stage, keeps per-shard transfer handles and per-stage `TransferTopology` plans keyed by `(engine_id, pp_rank)`, and issues one read per producer stage against that stage's advertised regions (resolved via `registered_layer_names`). The constructor guard becomes a `_supports_consumer_pp` class flag: `True` on the pull worker, unchanged (raise) on push.

**Commit 2 — hybrid-Mamba (HMA) producers under PP.**
HMA pools several KV groups into one backing tensor; registration dedups by base address, so a pooled region is advertised under one representative layer name. A PP producer registers only its own layer slice, and a consumer that resolves that slice by representative names alone silently omits every non-representative member. With a hybrid model the Mamba members are exactly the ones dropped, so decode returns coherent-but-stale output instead of failing. The producer now records the dedup'd member names per region (`region_members`) and the consumer emits descriptors per (region × member-group) plus the Mamba conv/ssm section per stage, mirroring the whole-engine layout at shard scope.

**Commit 3 — pipeline-parallel consumers of pipeline-parallel producers (symmetric PP).**
Live 550B deployment of the first two commits surfaced this: a pipelined consumer queries every producer stage, and mapping a shard's layers onto local regions raised as soon as one advertised layer had no local counterpart — under symmetric PP each consumer stage always meets a non-overlapping producer shard, so the exception killed the whole handshake (including the matching shard) and no KV ever transferred. Registration now classifies each shard against the local slice: fully-local maps, disjoint is skipped (read by the consumer stage owning those layers), partial overlap still raises. A union-coverage check fails the handshake loudly if no shard covers a local region. Reads skip stages skipped at handshake, and `get_finished`'s engine-wide geometry lookup uses any registered stage instead of hardcoded stage 0 (which a pipelined consumer may never register).

Still raising by design: hetero-TP × HMA × PP; a PP consumer with HMA reading a PP=1 producer; a PP producer that advertises no `registered_layer_names`; producer/consumer stages splitting layers at incompatible boundaries (partial shard overlap); and push-mode PP consumers.

Interop: a stock PP=1 peer omits `registered_layer_names`/`region_members` (msgspec defaults) and takes the untouched whole-engine path. `NIXL_CONNECTOR_VERSION` bumps **9 → 10** (one bump for the series); `pp_size` stays out of the compatibility hash.

## Test Plan

Unit, no GPU, via `.venv/bin/python -m pytest`:

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_connector_pp.py -q
.venv/bin/python -m pytest tests/v1/kv_connector/unit/ -q
pre-commit run --all-files
```

`tests/v1/kv_connector/unit/test_nixl_connector_pp.py` is new (34 cases): per-stage handshake and read accounting, shard-relative descriptor ids, per-(region × member-group) emission, the Mamba section and its stride (Mamba1/Mamba2 parametrized), empty-group skipping, `region_members` round-trip plus rejection of a partial advertisement, pooled-member resolution, compat-hash `pp_size`-invariance, the guard narrowing (pull allows, push still raises), and — for commit 3 — the shard-overlap classifier (full/disjoint/partial/pooled-member), skip-at-registration and skip-at-read, socket-level handshake cases (symmetric PP registers only overlapping stages; an uncovered local region still fails), and the representative-stage lookup.

## Test Result

**Unit.** Rebased onto current `main` (`c21751c90b`) and re-run in full. `tests/v1/kv_connector/unit/` gives **87 failed / 1360 passed / 27 skipped** on this branch vs **87 failed / 1326 passed / 27 skipped** on stock `main`. The failing set is byte-identical — 87 ids, diffed both directions, zero tip-only failures — and is entirely pre-existing GPU/socket cases that fail the same way in a CPU-only environment (real-worker construction, socket handshakes, `No common block size`). Passes go 1326 → 1360, exactly the 34 new cases in `test_nixl_connector_pp.py`, which are absent from the failing set (all pass).

During the rebase, `register_kv_caches` was found to read `get_pp_group().rank_in_group` unconditionally; that read asserts ("pipeline model parallel group is not initialized") when a test drives registration without initializing the parallel groups, which regressed the pre-existing `test_nixl_desc_geometry.py` suite (202 pass on stock → 202 fail at the rebased tip before the fix). It is now guarded by `model_parallel_is_initialized()` and degenerates to `pp_rank=0` — the documented PP=1 `(0, tp_rank)` key — when the groups are uninitialized, a no-op in production where a worker always initializes the PP group. With the guard, `test_nixl_desc_geometry.py` is back to 202 passing and the full-directory failing set is identical to stock (above). `ruff check`, isort (`ruff check --select I`), and `ruff format --check` all clean.

**End-to-end**, 4× B200 (HyperPod EKS, EFA/libfabric NIXL backend), Nemotron-3-Ultra-550B (hybrid Mamba), Dynamo disagg pull mode, prefill **TP8/PP2** (2 nodes) → decode TP8/PP1, 2026-08-22:

- Stock: deterministic `NotImplementedError` in the shared worker constructor — the guard this PR lifts. Patched: all 4 pods Ready, 0 restarts over ~31 min, prefill `Worker_PP0`/`Worker_PP1` both serving.
- Decode NIXL telemetry reads **both** producer stages at byte parity: PP2 = 16 transfers × 30.41 MB, PP1 reference = 8 × 60.82 MB, **486.56 MB per request either way** (16 = 2 stages × 8 decode ranks). Per-stage transfer plans logged for `remote_pp=0` and `remote_pp=1`. So the stages tile the model exactly once, which is the discriminator for the dropped-member bug commit 2 fixes.
- Output vs the PP1/PP1 reference run at temperature 0: prompt A byte-identical across all 48 tokens; prompt B identical for ~40 tokens then a benign synonym variation inside the reasoning block, both coherent and correct. I read that as floating-point non-determinism across a different parallel decomposition rather than stale SSM state, which presents as incoherent or wrong content, not a one-word swap — but I want to be straight that it is **not** byte-identical on every prompt.
- **Symmetric PP2/PP2** (consumer-side PP with HMA), same fleet, 2026-08-23, after commit 3: prefill TP8/PP2 + decode TP8/PP2 (32 GPUs). The pre-commit-3 layer failed this shape on every request (`no matching local region` on both decode stages, empty-content responses). With commit 3: zero handshake errors; each decode stage logged the designed skip of its disjoint prefill shard (8× per stage, mirror-image); temperature-0 output **byte-identical to the PP1 reference** on both probe prompts; per-stage reads at byte parity (16 × 30.41 MB = 486.56 MB/request); streaming first content chunk at 0.36 s of a 5.39 s request. The B200 AMI exposes no EFA `hw_counters` sysfs, so NIXL telemetry is the byte evidence rather than device counters.

## AI assistance

AI assistance (Claude) was used to port these commits onto the current connector package and to draft the tests. I reviewed every changed line, ran the unit suites and negative controls listed above, and ran the end-to-end 550B validation on hardware myself.

---

<details>
<summary>Essential elements checklist</summary>

- [x] Purpose of the PR
- [x] Test plan
- [x] Test results
- [ ] (Optional) Documentation update

</details>


