### PR TITLE
[Bugfix][Parser] Restore engine-backed parser invocation metrics

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -25,6 +25,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaToolCall,
     FunctionDefinition,
 )
+from vllm.parser import abstract_parser as abstract_parser_module
 from vllm.parser import metrics as parser_metrics
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.engine import parser_engine as parser_engine_module
@@ -1163,6 +1164,66 @@ def test_parser_manager_preserves_tool_choice_capability(monkeypatch):
     assert parser_cls is not None
     assert issubclass(parser_cls, DelegatingParser)
     assert parser_cls.tool_parser_cls is _UnsupportedChoiceToolAdapter
+
+
+def _make_parser_manager_parser(monkeypatch, tool_parser_cls):
+    monkeypatch.setattr(
+        ParserManager,
+        "get_reasoning_parser",
+        classmethod(lambda cls, name: _CombinedReasoningAdapter),
+    )
+    monkeypatch.setattr(
+        ParserManager,
+        "get_tool_parser",
+        classmethod(lambda cls, name, enabled, model: tool_parser_cls),
+    )
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="combined",
+        reasoning_parser_name="combined",
+        enable_auto_tools=True,
+    )
+    assert parser_cls is not None
+    return parser_cls(make_mock_tokenizer(_VOCAB))
+
+
+@pytest.mark.parametrize(
+    ("tool_parser_cls", "expected_calls"),
+    [
+        pytest.param(_CombinedToolAdapter, 0, id="standard_choice_path"),
+        pytest.param(_UnsupportedChoiceToolAdapter, 1, id="tool_parser_path"),
+    ],
+)
+@pytest.mark.parametrize("tool_choice", ["required", "named"])
+@pytest.mark.parametrize(
+    "streaming",
+    [
+        pytest.param(False, id="non_streaming"),
+        pytest.param(True, id="streaming"),
+    ],
+)
+def test_parser_manager_metrics_respect_tool_choice_boundary(
+    monkeypatch, tool_parser_cls, expected_calls, tool_choice, streaming
+):
+    recorder = MagicMock()
+    monkeypatch.setattr(
+        abstract_parser_module,
+        "record_tool_parser_invocation",
+        recorder,
+    )
+    parser = _make_parser_manager_parser(monkeypatch, tool_parser_cls)
+    request = _make_tool_choice_request(tool_choice)
+
+    if streaming:
+        parser.parse_delta("</think>", [201], request, finished=False)
+        parser.parse_delta("Hello", [], request, finished=False)
+        expected_calls *= 2
+    else:
+        parser.parse("</think>Hello", request, enable_auto_tools=True)
+
+    assert recorder.call_count == expected_calls
+    for call in recorder.call_args_list:
+        assert call.kwargs["is_streaming"] is streaming
+        assert call.kwargs["request"] is request
 
 
 @pytest.mark.parametrize("tool_choice", ["required", "named"])

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -25,6 +25,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaToolCall,
     FunctionDefinition,
 )
+from vllm.parser import metrics as parser_metrics
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.engine import parser_engine as parser_engine_module
 from vllm.parser.engine.adapters import make_adapters
@@ -35,7 +36,6 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
-from vllm.parser.metrics import init_parser_metrics
 from vllm.parser.parser_manager import ParserManager
 
 # ── Shared test configs ──────────────────────────────────────────────
@@ -931,35 +931,49 @@ class TestEngineBasedPath:
             "outcome": "no_tool_call",
             "request_type": "chat_completions",
         }
-        init_parser_metrics(model_name=model_name)
-        request = ChatCompletionRequest(messages=[], model="test")
+        metric_name = "vllm:tool_call_parser_invocations"
+        previous_model_name = parser_metrics._model_name
+        previous_counter = parser_metrics._tool_call_parser_invocations
+        previous_collector = REGISTRY._names_to_collectors.get(metric_name)
+        test_counter = None
+        try:
+            parser_metrics.init_parser_metrics(model_name=model_name)
+            test_counter = parser_metrics._tool_call_parser_invocations
+            request = ChatCompletionRequest(messages=[], model="test")
 
-        non_streaming_labels = {**labels, "mode": "non_streaming"}
-        assert (
-            REGISTRY.get_sample_value(
-                "vllm:tool_call_parser_invocations_total", non_streaming_labels
+            non_streaming_labels = {**labels, "mode": "non_streaming"}
+            assert (
+                REGISTRY.get_sample_value(
+                    "vllm:tool_call_parser_invocations_total",
+                    non_streaming_labels,
+                )
+                == 0
             )
-            == 0
-        )
-        engine = _make_engine(_hermes_config())
-        engine.parse("Hello", request)
-        assert (
-            REGISTRY.get_sample_value(
-                "vllm:tool_call_parser_invocations_total", non_streaming_labels
+            engine = _make_engine(_hermes_config())
+            engine.parse("Hello", request)
+            assert (
+                REGISTRY.get_sample_value(
+                    "vllm:tool_call_parser_invocations_total",
+                    non_streaming_labels,
+                )
+                == 1
             )
-            == 1
-        )
 
-        streaming_labels = {**labels, "mode": "streaming"}
-        engine.initialize_streaming()
-        engine.parse_delta("Hello", [], request, finished=False)
-        engine.parse_delta("", [], request, finished=True)
-        assert (
-            REGISTRY.get_sample_value(
-                "vllm:tool_call_parser_invocations_total", streaming_labels
+            streaming_labels = {**labels, "mode": "streaming"}
+            engine.initialize_streaming()
+            engine.parse_delta("Hello", [], request, finished=False)
+            engine.parse_delta("", [], request, finished=True)
+            assert (
+                REGISTRY.get_sample_value(
+                    "vllm:tool_call_parser_invocations_total", streaming_labels
+                )
+                == 2
             )
-            == 2
-        )
+        finally:
+            parser_metrics._model_name = previous_model_name
+            parser_metrics._tool_call_parser_invocations = previous_counter
+            if previous_collector is None and test_counter is not None:
+                REGISTRY.unregister(test_counter)
 
 
 # ── TestParseTokenIdPassthrough ────────────────────────────────────

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -814,6 +814,32 @@ class TestEngineBasedPath:
         assert result is not None
         assert len(result.tool_calls) > 0
 
+    def test_parse_delta_skips_reasoning_only_and_records_content(
+        self, mock_request, monkeypatch
+    ):
+        recorder = MagicMock()
+        monkeypatch.setattr(
+            parser_engine_module,
+            "record_tool_parser_invocation",
+            recorder,
+            raising=False,
+        )
+        engine = _make_engine(_combined_config())
+        engine.initialize_streaming()
+
+        engine.parse_delta("thinking", [], mock_request, finished=False)
+        recorder.assert_not_called()
+
+        engine.parse_delta("</think>", [], mock_request, finished=False)
+        recorder.assert_called_once_with(
+            is_tool_called=False,
+            is_streaming=True,
+            request=mock_request,
+        )
+
+        engine.parse_delta("Hello", [], mock_request, finished=False)
+        assert recorder.call_count == 2
+
     @pytest.mark.parametrize(
         ("text", "expected_tool_call"),
         [
@@ -834,7 +860,7 @@ class TestEngineBasedPath:
         )
         engine = _make_engine(_hermes_config())
 
-        _, _, tool_calls = engine.parse(text, mock_request)
+        _, _, tool_calls = engine.parse(text, mock_request, enable_auto_tools=True)
 
         assert bool(tool_calls) is expected_tool_call
         recorder.assert_called_once_with(
@@ -842,6 +868,21 @@ class TestEngineBasedPath:
             is_streaming=False,
             request=mock_request,
         )
+
+    def test_parse_skips_metrics_without_auto_tools(self, monkeypatch):
+        recorder = MagicMock()
+        monkeypatch.setattr(
+            parser_engine_module,
+            "record_tool_parser_invocation",
+            recorder,
+            raising=False,
+        )
+        request = ChatCompletionRequest(messages=[], model="test")
+        engine = _make_engine(_hermes_config())
+
+        engine.parse("Hello", request)
+
+        recorder.assert_not_called()
 
     @pytest.mark.parametrize(
         ("text", "expected_tool_call"),
@@ -890,7 +931,7 @@ class TestEngineBasedPath:
         monkeypatch.setattr(engine, "_single_pass_parse", fail)
 
         with pytest.raises(RuntimeError, match="parser failure"):
-            engine.parse("Hello", mock_request)
+            engine.parse("Hello", mock_request, enable_auto_tools=True)
 
         recorder.assert_called_once_with(
             is_tool_called=error,
@@ -939,7 +980,9 @@ class TestEngineBasedPath:
         try:
             parser_metrics.init_parser_metrics(model_name=model_name)
             test_counter = parser_metrics._tool_call_parser_invocations
-            request = ChatCompletionRequest(messages=[], model="test")
+            request = ChatCompletionRequest(
+                messages=[], model="test", tool_choice="auto"
+            )
 
             non_streaming_labels = {**labels, "mode": "non_streaming"}
             assert (
@@ -950,7 +993,7 @@ class TestEngineBasedPath:
                 == 0
             )
             engine = _make_engine(_hermes_config())
-            engine.parse("Hello", request)
+            engine.parse("Hello", request, enable_auto_tools=True)
             assert (
                 REGISTRY.get_sample_value(
                     "vllm:tool_call_parser_invocations_total",

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -840,6 +840,23 @@ class TestEngineBasedPath:
         engine.parse_delta("Hello", [], mock_request, finished=False)
         assert recorder.call_count == 2
 
+    def test_parse_delta_skips_unfinished_reasoning_at_stream_end(
+        self, mock_request, monkeypatch
+    ):
+        recorder = MagicMock()
+        monkeypatch.setattr(
+            parser_engine_module,
+            "record_tool_parser_invocation",
+            recorder,
+            raising=False,
+        )
+        engine = _make_engine(_combined_config())
+        engine.initialize_streaming()
+
+        engine.parse_delta("thinking", [], mock_request, finished=True)
+
+        recorder.assert_not_called()
+
     @pytest.mark.parametrize(
         ("text", "expected_tool_call"),
         [

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -17,6 +17,8 @@ from prometheus_client import REGISTRY
 
 from tests.parser.engine.conftest import make_mock_tokenizer
 from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedFunction,
+    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
     ChatCompletionToolsParam,
 )
@@ -28,7 +30,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.parser import metrics as parser_metrics
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.engine import parser_engine as parser_engine_module
-from vllm.parser.engine.adapters import make_adapters
+from vllm.parser.engine.adapters import ParserEngineToolAdapter, make_adapters
 from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine import ParserEngine
 from vllm.parser.engine.parser_engine_config import (
@@ -1112,9 +1114,122 @@ class _CombinedTestEngine(ParserEngine):
 _CombinedReasoningAdapter, _CombinedToolAdapter = make_adapters(_CombinedTestEngine)
 
 
+class _UnsupportedChoiceToolAdapter(ParserEngineToolAdapter):
+    _parser_engine_cls = _CombinedTestEngine
+    supports_required_and_named = False
+
+
 class _CombinedDelegating(DelegatingParser):
     reasoning_parser_cls = _CombinedReasoningAdapter
     tool_parser_cls = _CombinedToolAdapter
+
+
+def _make_tool_choice_request(tool_choice: str) -> ChatCompletionRequest:
+    if tool_choice == "named":
+        parsed_tool_choice = ChatCompletionNamedToolChoiceParam(
+            function=ChatCompletionNamedFunction(name="f")
+        )
+    else:
+        parsed_tool_choice = tool_choice
+    return ChatCompletionRequest(
+        messages=[],
+        model="test",
+        tools=[_make_tool("f", {})],
+        tool_choice=parsed_tool_choice,
+    )
+
+
+def test_parser_manager_preserves_tool_choice_capability(monkeypatch):
+    monkeypatch.setattr(
+        ParserManager,
+        "get_reasoning_parser",
+        classmethod(lambda cls, name: _CombinedReasoningAdapter),
+    )
+    monkeypatch.setattr(
+        ParserManager,
+        "get_tool_parser",
+        classmethod(lambda cls, name, enabled, model: _UnsupportedChoiceToolAdapter),
+    )
+
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="combined",
+        reasoning_parser_name="combined",
+        enable_auto_tools=True,
+    )
+
+    assert parser_cls is not None
+    assert issubclass(parser_cls, DelegatingParser)
+    assert parser_cls.tool_parser_cls is _UnsupportedChoiceToolAdapter
+
+
+@pytest.mark.parametrize("tool_choice", ["required", "named"])
+@pytest.mark.parametrize(
+    ("tool_parser_cls", "expected_calls"),
+    [
+        pytest.param(_CombinedToolAdapter, 0, id="standard_choice_path"),
+        pytest.param(_UnsupportedChoiceToolAdapter, 1, id="tool_parser_path"),
+    ],
+)
+def test_engine_metrics_respect_tool_choice_boundary(
+    monkeypatch, tool_choice, tool_parser_cls, expected_calls
+):
+    recorder = MagicMock()
+    monkeypatch.setattr(
+        parser_engine_module,
+        "record_tool_parser_invocation",
+        recorder,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        _CombinedTestEngine,
+        "tool_parser_cls",
+        tool_parser_cls,
+    )
+    engine = _CombinedTestEngine(make_mock_tokenizer(_VOCAB))
+    request = _make_tool_choice_request(tool_choice)
+
+    engine.parse("Hello", request, enable_auto_tools=True)
+
+    assert recorder.call_count == expected_calls
+    if expected_calls:
+        recorder.assert_called_once_with(
+            is_tool_called=False,
+            is_streaming=False,
+            request=request,
+        )
+
+
+@pytest.mark.parametrize("tool_choice", ["required", "named"])
+@pytest.mark.parametrize(
+    ("tool_parser_cls", "expected_calls"),
+    [
+        pytest.param(_CombinedToolAdapter, 0, id="standard_choice_path"),
+        pytest.param(_UnsupportedChoiceToolAdapter, 2, id="tool_parser_path"),
+    ],
+)
+def test_engine_streaming_metrics_respect_tool_choice_boundary(
+    monkeypatch, tool_choice, tool_parser_cls, expected_calls
+):
+    recorder = MagicMock()
+    monkeypatch.setattr(
+        parser_engine_module,
+        "record_tool_parser_invocation",
+        recorder,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        _CombinedTestEngine,
+        "tool_parser_cls",
+        tool_parser_cls,
+    )
+    engine = _CombinedTestEngine(make_mock_tokenizer(_VOCAB))
+    request = _make_tool_choice_request(tool_choice)
+    engine.initialize_streaming()
+
+    engine.parse_delta("</think>", [201], request, finished=False)
+    engine.parse_delta("Hello", [], request, finished=False)
+
+    assert recorder.call_count == expected_calls
 
 
 def test_parser_manager_preserves_shared_engine_adapters(monkeypatch):

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import regex as re
+from prometheus_client import REGISTRY
 
 from tests.parser.engine.conftest import make_mock_tokenizer
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -25,6 +26,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionDefinition,
 )
 from vllm.parser.abstract_parser import DelegatingParser
+from vllm.parser.engine import parser_engine as parser_engine_module
 from vllm.parser.engine.adapters import make_adapters
 from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine import ParserEngine
@@ -33,6 +35,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.parser.metrics import init_parser_metrics
 from vllm.parser.parser_manager import ParserManager
 
 # ── Shared test configs ──────────────────────────────────────────────
@@ -810,6 +813,153 @@ class TestEngineBasedPath:
         )
         assert result is not None
         assert len(result.tool_calls) > 0
+
+    @pytest.mark.parametrize(
+        ("text", "expected_tool_call"),
+        [
+            ("Hello", False),
+            ('<tool_call>{"name": "f", "arguments": {}}</tool_call>', True),
+        ],
+        ids=["no_tool_call", "tool_call"],
+    )
+    def test_parse_records_tool_parser_invocation(
+        self, mock_request, monkeypatch, text, expected_tool_call
+    ):
+        recorder = MagicMock()
+        monkeypatch.setattr(
+            parser_engine_module,
+            "record_tool_parser_invocation",
+            recorder,
+            raising=False,
+        )
+        engine = _make_engine(_hermes_config())
+
+        _, _, tool_calls = engine.parse(text, mock_request)
+
+        assert bool(tool_calls) is expected_tool_call
+        recorder.assert_called_once_with(
+            is_tool_called=expected_tool_call,
+            is_streaming=False,
+            request=mock_request,
+        )
+
+    @pytest.mark.parametrize(
+        ("text", "expected_tool_call"),
+        [
+            ("Hello", False),
+            ('<tool_call>{"name": "f", "arguments": {}}</tool_call>', True),
+        ],
+        ids=["no_tool_call", "tool_call"],
+    )
+    def test_parse_delta_records_tool_parser_invocation(
+        self, mock_request, monkeypatch, text, expected_tool_call
+    ):
+        recorder = MagicMock()
+        monkeypatch.setattr(
+            parser_engine_module,
+            "record_tool_parser_invocation",
+            recorder,
+            raising=False,
+        )
+        engine = _make_engine(_hermes_config())
+        engine._streaming_initialized = True
+
+        result = engine.parse_delta(text, [], mock_request, finished=True)
+
+        assert bool(result and result.tool_calls) is expected_tool_call
+        recorder.assert_called_once_with(
+            is_tool_called=expected_tool_call,
+            is_streaming=True,
+            request=mock_request,
+        )
+
+    def test_parse_records_parser_exception(self, mock_request, monkeypatch):
+        recorder = MagicMock()
+        monkeypatch.setattr(
+            parser_engine_module,
+            "record_tool_parser_invocation",
+            recorder,
+            raising=False,
+        )
+        engine = _make_engine(_hermes_config())
+        error = RuntimeError("parser failure")
+
+        def fail(*args, **kwargs):
+            raise error
+
+        monkeypatch.setattr(engine, "_single_pass_parse", fail)
+
+        with pytest.raises(RuntimeError, match="parser failure"):
+            engine.parse("Hello", mock_request)
+
+        recorder.assert_called_once_with(
+            is_tool_called=error,
+            is_streaming=False,
+            request=mock_request,
+        )
+
+    def test_parse_delta_records_parser_exception(self, mock_request, monkeypatch):
+        recorder = MagicMock()
+        monkeypatch.setattr(
+            parser_engine_module,
+            "record_tool_parser_invocation",
+            recorder,
+            raising=False,
+        )
+        engine = _make_engine(_hermes_config())
+        engine._streaming_initialized = True
+        error = RuntimeError("parser failure")
+
+        def fail(*args, **kwargs):
+            raise error
+
+        monkeypatch.setattr(engine, "_feed", fail)
+
+        with pytest.raises(RuntimeError, match="parser failure"):
+            engine.parse_delta("Hello", [], mock_request, finished=False)
+
+        recorder.assert_called_once_with(
+            is_tool_called=error,
+            is_streaming=True,
+            request=mock_request,
+        )
+
+    def test_parse_records_prometheus_metrics(self):
+        model_name = f"parser-engine-test-{id(self)}"
+        labels = {
+            "model_name": model_name,
+            "outcome": "no_tool_call",
+            "request_type": "chat_completions",
+        }
+        init_parser_metrics(model_name=model_name)
+        request = ChatCompletionRequest(messages=[], model="test")
+
+        non_streaming_labels = {**labels, "mode": "non_streaming"}
+        assert (
+            REGISTRY.get_sample_value(
+                "vllm:tool_call_parser_invocations_total", non_streaming_labels
+            )
+            == 0
+        )
+        engine = _make_engine(_hermes_config())
+        engine.parse("Hello", request)
+        assert (
+            REGISTRY.get_sample_value(
+                "vllm:tool_call_parser_invocations_total", non_streaming_labels
+            )
+            == 1
+        )
+
+        streaming_labels = {**labels, "mode": "streaming"}
+        engine.initialize_streaming()
+        engine.parse_delta("Hello", [], request, finished=False)
+        engine.parse_delta("", [], request, finished=True)
+        assert (
+            REGISTRY.get_sample_value(
+                "vllm:tool_call_parser_invocations_total", streaming_labels
+            )
+            == 2
+        )
 
 
 # ── TestParseTokenIdPassthrough ────────────────────────────────────

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -17,8 +17,6 @@ from prometheus_client import REGISTRY
 
 from tests.parser.engine.conftest import make_mock_tokenizer
 from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionNamedFunction,
-    ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
     ChatCompletionToolsParam,
 )
@@ -1000,7 +998,10 @@ class TestEngineBasedPath:
             parser_metrics.init_parser_metrics(model_name=model_name)
             test_counter = parser_metrics._tool_call_parser_invocations
             request = ChatCompletionRequest(
-                messages=[], model="test", tool_choice="auto"
+                messages=[],
+                model="test",
+                tools=[_make_tool("f", {})],
+                tool_choice="auto",
             )
 
             non_streaming_labels = {**labels, "mode": "non_streaming"}
@@ -1125,16 +1126,18 @@ class _CombinedDelegating(DelegatingParser):
 
 
 def _make_tool_choice_request(tool_choice: str) -> ChatCompletionRequest:
+    parsed_tool_choice: str | dict[str, object] = tool_choice
     if tool_choice == "named":
-        parsed_tool_choice = ChatCompletionNamedToolChoiceParam(
-            function=ChatCompletionNamedFunction(name="f")
-        )
+        parsed_tool_choice = {
+            "type": "function",
+            "function": {"name": "f"},
+        }
     else:
         parsed_tool_choice = tool_choice
     return ChatCompletionRequest(
         messages=[],
         model="test",
-        tools=[_make_tool("f", {})],
+        tools=[_make_tool("f", {}).model_dump()],
         tool_choice=parsed_tool_choice,
     )
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -45,6 +45,16 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+_TOOL_CALL_STATES = frozenset(
+    {
+        ParserState.TOOL_PREAMBLE,
+        ParserState.TOOL_NAME,
+        ParserState.TOOL_ARGS,
+        ParserState.TOOL_BETWEEN,
+    }
+)
+_TOOL_PARSER_PHASE_STATES = frozenset({ParserState.CONTENT, *_TOOL_CALL_STATES})
+
 
 class ToolCallSlot:
     __slots__ = (
@@ -107,6 +117,10 @@ class ParserEngine(Parser):
         self.parser_engine_config = parser_engine_config
         self._engine = StreamingParserEngine(
             parser_engine_config, tokenizer, vocab=self.vocab
+        )
+        self._has_tool_parser = any(
+            state in _TOOL_CALL_STATES or transition.next_state in _TOOL_CALL_STATES
+            for (state, _), transition in parser_engine_config.transitions.items()
         )
 
         self._has_reasoning = (
@@ -419,6 +433,9 @@ class ParserEngine(Parser):
             if tool_choice == "none" and tools:
                 self._suppress_tool_calls = True
 
+    def _in_tool_parser_phase(self) -> bool:
+        return self._has_tool_parser and self._engine.state in _TOOL_PARSER_PHASE_STATES
+
     def _strip_content_whitespace(
         self,
         content: str,
@@ -444,6 +461,7 @@ class ParserEngine(Parser):
     ) -> DeltaMessage | None:
         self._initialize_history_tool_call_cnt(request)
         is_tool_called: bool | Exception = False
+        record_invocation = self._in_tool_parser_phase()
         try:
             if not self._prompt_streaming_prepared and prompt_token_ids is not None:
                 # NOTE: call the hook BEFORE setting the flag, because the hook
@@ -451,6 +469,7 @@ class ParserEngine(Parser):
                 # clears ``_prompt_streaming_prepared``.
                 self.adjust_initial_state_from_prompt(prompt_token_ids)
                 self._prompt_streaming_prepared = True
+            record_invocation |= self._in_tool_parser_phase()
             self._check_skip_tool_parsing(request)
             events = self._feed(delta_text, delta_token_ids)
             if finished:
@@ -470,11 +489,12 @@ class ParserEngine(Parser):
             is_tool_called = e
             raise
         finally:
-            record_tool_parser_invocation(
-                is_tool_called=is_tool_called,
-                is_streaming=True,
-                request=request,
-            )
+            if record_invocation or self._in_tool_parser_phase():
+                record_tool_parser_invocation(
+                    is_tool_called=is_tool_called,
+                    is_streaming=True,
+                    request=request,
+                )
 
     def _strip_trailing_reasoning(
         self,
@@ -719,11 +739,12 @@ class ParserEngine(Parser):
             is_tool_called = e
             raise
         finally:
-            record_tool_parser_invocation(
-                is_tool_called=is_tool_called,
-                is_streaming=False,
-                request=request,
-            )
+            if enable_auto_tools and self._has_tool_parser:
+                record_tool_parser_invocation(
+                    is_tool_called=is_tool_called,
+                    is_streaming=False,
+                    request=request,
+                )
 
     # ── Event-to-delta conversion ─────────────────────────────────────
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -472,6 +472,7 @@ class ParserEngine(Parser):
             record_invocation |= self._in_tool_parser_phase()
             self._check_skip_tool_parsing(request)
             events = self._feed(delta_text, delta_token_ids)
+            record_invocation |= self._in_tool_parser_phase()
             if finished:
                 events.extend(self._engine.finish())
             result = self._events_to_delta(events, finished=finished)
@@ -489,7 +490,7 @@ class ParserEngine(Parser):
             is_tool_called = e
             raise
         finally:
-            if record_invocation or self._in_tool_parser_phase():
+            if record_invocation:
                 record_tool_parser_invocation(
                     is_tool_called=is_tool_called,
                     is_streaming=True,

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -27,6 +27,7 @@ from vllm.parser.abstract_parser import Parser, StreamState
 from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
 from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+from vllm.parser.metrics import record_tool_parser_invocation
 from vllm.tool_parsers.utils import (
     coerce_to_schema_type,
     extract_types_from_schema,
@@ -442,26 +443,38 @@ class ParserEngine(Parser):
         finished: bool,
     ) -> DeltaMessage | None:
         self._initialize_history_tool_call_cnt(request)
-        if not self._prompt_streaming_prepared and prompt_token_ids is not None:
-            # NOTE: call the hook BEFORE setting the flag, because the hook
-            # may invoke ``_reset`` (e.g. via ``initialize_streaming``) which
-            # clears ``_prompt_streaming_prepared``.
-            self.adjust_initial_state_from_prompt(prompt_token_ids)
-            self._prompt_streaming_prepared = True
-        self._check_skip_tool_parsing(request)
-        events = self._feed(delta_text, delta_token_ids)
-        if finished:
-            events.extend(self._engine.finish())
-        result = self._events_to_delta(events, finished=finished)
-        result = self._strip_trailing_reasoning(result)
+        is_tool_called: bool | Exception = False
+        try:
+            if not self._prompt_streaming_prepared and prompt_token_ids is not None:
+                # NOTE: call the hook BEFORE setting the flag, because the hook
+                # may invoke ``_reset`` (e.g. via ``initialize_streaming``) which
+                # clears ``_prompt_streaming_prepared``.
+                self.adjust_initial_state_from_prompt(prompt_token_ids)
+                self._prompt_streaming_prepared = True
+            self._check_skip_tool_parsing(request)
+            events = self._feed(delta_text, delta_token_ids)
+            if finished:
+                events.extend(self._engine.finish())
+            result = self._events_to_delta(events, finished=finished)
+            result = self._strip_trailing_reasoning(result)
 
-        # Suppress reasoning deltas if not requested
-        if result and not request.include_reasoning:
-            result.reasoning = None
-            if not result.content and not result.tool_calls:
-                result = None
+            # Suppress reasoning deltas if not requested
+            if result and not request.include_reasoning:
+                result.reasoning = None
+                if not result.content and not result.tool_calls:
+                    result = None
 
-        return result
+            is_tool_called = bool(result and result.tool_calls)
+            return result
+        except Exception as e:
+            is_tool_called = e
+            raise
+        finally:
+            record_tool_parser_invocation(
+                is_tool_called=is_tool_called,
+                is_streaming=True,
+                request=request,
+            )
 
     def _strip_trailing_reasoning(
         self,
@@ -681,24 +694,36 @@ class ParserEngine(Parser):
         model_output_token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         self._initialize_history_tool_call_cnt(request)
-        self._check_skip_tool_parsing(request)
-        reasoning, content, tool_call_info = self._single_pass_parse(
-            model_output,
-            model_output_token_ids,
-        )
+        is_tool_called: bool | Exception = False
+        try:
+            self._check_skip_tool_parsing(request)
+            reasoning, content, tool_call_info = self._single_pass_parse(
+                model_output,
+                model_output_token_ids,
+            )
 
-        tool_calls: list[FunctionCall] | None = None
-        if tool_call_info.tools_called:
-            tool_calls = [
-                FunctionCall(
-                    id=tc.id,
-                    name=tc.function.name,
-                    arguments=tc.function.arguments,
-                )
-                for tc in tool_call_info.tool_calls
-            ]
+            tool_calls: list[FunctionCall] | None = None
+            if tool_call_info.tools_called:
+                tool_calls = [
+                    FunctionCall(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=tc.function.arguments,
+                    )
+                    for tc in tool_call_info.tool_calls
+                ]
 
-        return reasoning, content, tool_calls
+            is_tool_called = bool(tool_calls)
+            return reasoning, content, tool_calls
+        except Exception as e:
+            is_tool_called = e
+            raise
+        finally:
+            record_tool_parser_invocation(
+                is_tool_called=is_tool_called,
+                is_streaming=False,
+                request=request,
+            )
 
     # ── Event-to-delta conversion ─────────────────────────────────────
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -122,6 +122,11 @@ class ParserEngine(Parser):
             state in _TOOL_CALL_STATES or transition.next_state in _TOOL_CALL_STATES
             for (state, _), transition in parser_engine_config.transitions.items()
         )
+        self._supports_required_and_named = getattr(
+            self.__class__.tool_parser_cls,
+            "supports_required_and_named",
+            True,
+        )
 
         self._has_reasoning = (
             "THINK_END" in parser_engine_config.token_id_terminals
@@ -436,6 +441,22 @@ class ParserEngine(Parser):
     def _in_tool_parser_phase(self) -> bool:
         return self._has_tool_parser and self._engine.state in _TOOL_PARSER_PHASE_STATES
 
+    def _should_record_tool_parser_invocation(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> bool:
+        """Return whether this request uses the ToolParser boundary."""
+        if not self._has_tool_parser:
+            return False
+        if not self._supports_required_and_named:
+            return True
+
+        tool_choice = getattr(request, "tool_choice", None)
+        return not (
+            tool_choice == "required"
+            or (tool_choice is not None and not isinstance(tool_choice, str))
+        )
+
     def _strip_content_whitespace(
         self,
         content: str,
@@ -461,7 +482,8 @@ class ParserEngine(Parser):
     ) -> DeltaMessage | None:
         self._initialize_history_tool_call_cnt(request)
         is_tool_called: bool | Exception = False
-        record_invocation = self._in_tool_parser_phase()
+        should_record_invocation = self._should_record_tool_parser_invocation(request)
+        record_invocation = should_record_invocation and self._in_tool_parser_phase()
         try:
             if not self._prompt_streaming_prepared and prompt_token_ids is not None:
                 # NOTE: call the hook BEFORE setting the flag, because the hook
@@ -469,10 +491,14 @@ class ParserEngine(Parser):
                 # clears ``_prompt_streaming_prepared``.
                 self.adjust_initial_state_from_prompt(prompt_token_ids)
                 self._prompt_streaming_prepared = True
-            record_invocation |= self._in_tool_parser_phase()
+            record_invocation |= (
+                should_record_invocation and self._in_tool_parser_phase()
+            )
             self._check_skip_tool_parsing(request)
             events = self._feed(delta_text, delta_token_ids)
-            record_invocation |= self._in_tool_parser_phase()
+            record_invocation |= (
+                should_record_invocation and self._in_tool_parser_phase()
+            )
             if finished:
                 events.extend(self._engine.finish())
             result = self._events_to_delta(events, finished=finished)
@@ -740,7 +766,9 @@ class ParserEngine(Parser):
             is_tool_called = e
             raise
         finally:
-            if enable_auto_tools and self._has_tool_parser:
+            if enable_auto_tools and self._should_record_tool_parser_invocation(
+                request
+            ):
                 record_tool_parser_invocation(
                     is_tool_called=is_tool_called,
                     is_streaming=False,


### PR DESCRIPTION
## Summary

- Restore `vllm:tool_call_parser_invocations_total` for collapsed engine-backed parsers.
- Keep the metric at the ToolParser boundary: non-streaming only records when automatic tool parsing is enabled, and streaming excludes reasoning-only deltas while counting each delta after the tool-parser phase begins.
- Add CPU-only regression coverage for disabled non-streaming parsing, reasoning-to-tool transition, outcomes, exceptions, and Prometheus increments.

## Why this is not duplicate work

Issue #53359 had no open PR addressing the engine-backed parser path when this PR was prepared. Open PR #51814 only adds tests for `vllm/parser/metrics.py`; it does not modify `ParserEngine` or restore the missing production calls. An earlier issue comment described an intended fix, but no implementation or PR was present.

Fixes #53359

## Test plan

- `.venv/bin/pre-commit run --files vllm/parser/engine/parser_engine.py tests/parser/engine/test_parser_engine.py` — **passed**.
- `.venv/bin/python -m compileall -q vllm/parser/engine/parser_engine.py tests/parser/engine/test_parser_engine.py` — **passed**.
- `.venv/bin/python -m pytest tests/parser/engine/test_parser_engine.py -k 'TestEngineBasedPath' -v --confcutdir=tests/parser/engine` — **blocked during import** by the local Transformers dependency scan; the run produced no test result before it was interrupted.
- Model evaluation: not applicable. This is a parser metrics instrumentation fix and does not change model output, accuracy, or serving behavior.

## AI assistance disclosure

AI assistance was used to investigate the issue, implement the production fix and tests, run verification, and prepare this PR. The human submitter must review every changed line and be able to explain and defend the change before merge.