### PR TITLE
[Bugfix] Include num_speculative_tokens in SpeculativeConfig compute_hash

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -335,6 +335,11 @@ class SpeculativeConfig:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
 
+        # num_speculative_tokens changes the verification shape
+        factors.append(self.num_speculative_tokens)
+        if self.num_speculative_tokens_per_batch_size is not None:
+            factors.append(tuple(self.num_speculative_tokens_per_batch_size))
+
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 


### PR DESCRIPTION
num_speculative_tokens changes the target verification batch size and therefore the concrete tensor shapes seen by torch.compile Inductor. Including it (and num_speculative_tokens_per_batch_size when dynamic speculative decoding is enabled) in SpeculativeConfig.compute_hash() prevents compiled-graph collisions across different values of k.

Fixes #53366