### PR TITLE
[Bugfix][Frontend] Match default MM LoRA for OpenAI input_audio parts

### DIFF
--- a/tests/entrypoints/serve/lora/test_serving_models.py
+++ b/tests/entrypoints/serve/lora/test_serving_models.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from http import HTTPStatus
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.pooling.base.serving import PoolingBaseServing
 from vllm.entrypoints.pooling.typing import PoolingServeContext
+from vllm.entrypoints.serve.engine.serving import BaseServing
 from vllm.entrypoints.serve.lora.protocol import (
     LoadLoRAAdapterRequest,
     UnloadLoRAAdapterRequest,
@@ -193,3 +195,21 @@ def test_pooling_maybe_get_adapters_unknown_model_raises():
 
     with pytest.raises(VLLMNotFoundError):
         _make_pooling_ctx("unknown-model", serving)
+
+
+@pytest.mark.parametrize(
+    ("content_type", "part"),
+    [
+        ("audio_url", {"audio_url": {"url": "http://example.com/a.wav"}}),
+        ("input_audio", {"input_audio": {"data": "abc", "format": "wav"}}),
+    ],
+)
+def test_get_message_types_maps_audio_parts_to_audio(content_type, part):
+    """Both "audio_url" and OpenAI-style "input_audio" parts must resolve to the
+    "audio" modality so a default multimodal LoRA keyed on "audio" can match."""
+    serving = object.__new__(BaseServing)
+    request = SimpleNamespace(
+        messages=[{"role": "user", "content": [{"type": content_type, **part}]}]
+    )
+
+    assert serving._get_message_types(request) == {"audio"}

--- a/vllm/entrypoints/serve/engine/serving.py
+++ b/vllm/entrypoints/serve/engine/serving.py
@@ -147,7 +147,11 @@ class BaseServing:
             ):
                 for content_dict in message["content"]:
                     if "type" in content_dict:
-                        message_types.add(content_dict["type"].split("_")[0])
+                        content_type = content_dict["type"]
+                        if content_type.startswith("input_"):
+                            message_types.add(content_type.removeprefix("input_"))
+                        else:
+                            message_types.add(content_type.split("_")[0])
         return message_types
 
     def _get_active_default_mm_loras(


### PR DESCRIPTION
## Purpose

Default per-modality LoRAs (`--default-mm-loras`, e.g. `{"audio": "<path>"}`)
are auto-selected by matching the LoRA name against the modalities present in a
chat request. `BaseServing._get_message_types` derives each content part's
modality with `type.split("_")[0]`:

- `audio_url` → `audio` ✅
- `image_url` → `image` ✅
- `input_audio` → `input` ❌ (should be `audio`)

`input_audio` is a fully supported OpenAI chat content type and maps to the
`audio` modality during parsing (`vllm/entrypoints/chat_utils.py`,
`part_type == "input_audio"` → `modality = "audio"`). Because the modality is
mis-derived as `input`, an `audio` default LoRA **never activates** for requests
that send audio via `input_audio`.

## Fix

Map OpenAI-style `input_<modality>` parts to `<modality>` (so `input_audio` →
`audio`), keeping the existing `<modality>_url` → `<modality>` behavior.

## Reproduction

Calling the real `_get_message_types` on a chat request:

Before:
```
audio_url   -> {'audio'}
input_audio -> {'input'}     # audio default LoRA never matches
```

After:
```
audio_url   -> {'audio'}
input_audio -> {'audio'}
```

## Verification

```
$ .venv/bin/python -m pytest \
    tests/entrypoints/serve/lora/test_serving_models.py -k message_types -v
...
tests/.../test_get_message_types_maps_audio_parts_to_audio[audio_url-part0] PASSED
tests/.../test_get_message_types_maps_audio_parts_to_audio[input_audio-part1] PASSED
2 passed
```

Lint/type checks (pre-commit): `ruff`, `ruff format`, `mypy-3.10`, SPDX — all
pass on the changed files.

## Not a duplicate

No open or merged PR on `vllm-project/vllm` targets default-MM-LoRA modality
detection / `_get_message_types` for `input_audio` (the feature was added in
#19126 and has not been touched since).

## Scope

One bug, one root cause: a 10-line change in `_get_message_types` plus a single
parametrized regression test. No behavior change for existing `*_url` / `text`
parts.

---

AI assistance was used to help identify, reproduce, and fix this bug; the change
has been reviewed and verified locally.
