### PR TITLE
[Model] Add Spark3 Model

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -464,6 +464,7 @@ th {
 | `SarvamMLAForCausalLM` | Sarvam 2 | `sarvamai/sarvam2-105b-a9b`, etc. | | ✅︎ |
 | `SeedOssForCausalLM` | SeedOss | `ByteDance-Seed/Seed-OSS-36B-Instruct`, etc. | ✅︎ | ✅︎ |
 | `SolarForCausalLM` | Solar Pro | `upstage/solar-pro-preview-instruct`, etc. | ✅︎ | ✅︎ |
+| `Spark3ForCausalLM` | Spark3 | `XHToken/Spark3-1.7B`, etc. | | |
 | `StableLmForCausalLM` | StableLM | `stabilityai/stablelm-3b-4e1t`, `stabilityai/stablelm-base-alpha-7b-v2`, etc. | | |
 | `StableLMEpochForCausalLM` | StableLM Epoch | `stabilityai/stablelm-zephyr-3b`, etc. | | ✅︎ |
 | `Step1ForCausalLM` | Step-Audio | `stepfun-ai/Step-Audio-EditX`, etc. | ✅︎ | ✅︎ |

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -211,6 +211,7 @@ _TEXT_GENERATION_MODELS = {
     "SarvamMoEForCausalLM": ("sarvam", "SarvamMoEForCausalLM"),
     "SarvamMLAForCausalLM": ("sarvam", "SarvamMLAForCausalLM"),
     "SeedOssForCausalLM": ("seed_oss", "SeedOssForCausalLM"),
+    "Spark3ForCausalLM": ("spark3", "Spark3ForCausalLM"),
     "Step1ForCausalLM": ("step1", "Step1ForCausalLM"),
     "Step3TextForCausalLM": ("step3_text", "Step3TextForCausalLM"),
     "Step3p5ForCausalLM": ("step3p5", "Step3p5ForCausalLM"),

--- a/vllm/model_executor/models/spark3.py
+++ b/vllm/model_executor/models/spark3.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Spark model."""
+
+from collections.abc import Iterable
+from itertools import islice
+
+import torch
+from torch import nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.activation import GeluAndMul
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.sequence import IntermediateTensors
+
+from .interfaces import SupportsPP
+from .utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    WeightsMapper,
+    extract_layer_index,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_prefix,
+)
+
+
+class Spark3MLP(nn.Module):
+    def __init__(
+        self,
+        config,
+        hidden_size: int,
+        intermediate_size: int,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.activation_fn = GeluAndMul()
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            reduce_results=True,
+            prefix=f"{prefix}.down_proj",
+        )
+
+    def forward(self, hidden_states):
+        intermediate_parallel, _ = self.gate_up_proj(hidden_states)
+        intermediate_parallel = self.activation_fn(intermediate_parallel)
+        output, _ = self.down_proj(intermediate_parallel)
+        return output
+    
+
+class Spark3Attention(nn.Module):
+    def __init__(
+        self,
+        config,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        max_position_embeddings: int,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.layer_idx = extract_layer_index(prefix)
+        self.hidden_size = hidden_size
+        self.total_num_heads = num_heads
+        self.total_num_kv_heads = num_kv_heads
+        self.head_dim = head_dim or self.hidden_size // self.total_num_heads
+        self.scaling = self.head_dim**-0.5
+
+        tp_size = get_tensor_model_parallel_world_size()
+        if self.total_num_kv_heads >= tp_size:
+            # Number of KV heads is greater than TP size, so we partition
+            # the KV heads across multiple tensor parallel GPUs.
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            # Number of KV heads is less than TP size, so we replicate
+            # the KV heads across multiple tensor parallel GPUs.
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+
+        layer_type = config.layer_types[self.layer_idx]
+        rope_parameters = dict(config.rope_parameters[layer_type])
+
+        self.headwise_attn_output_gate = config.headwise_attn_output_gate
+        if self.headwise_attn_output_gate:
+            self.g_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.total_num_heads,
+                bias=False,
+                quant_config=None,  # g_proj keeps bf16
+                prefix=f"{prefix}.g_proj",
+            )
+        self.q_k_v_proj = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_k_v_proj",
+        )
+
+        self.core_attention = Attention(
+            self.num_heads,
+            self.head_dim,
+            scale=self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            per_layer_sliding_window=config.sliding_window if layer_type == "sliding_attention" else None,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.core_attention",
+        )
+
+        self.out_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.out_proj",
+        )
+
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            max_position=max_position_embeddings,
+            is_neox_style=True,
+            rope_parameters=rope_parameters,
+        )
+
+    def forward(
+        self, positions: torch.Tensor, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        qkv, _ = self.q_k_v_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.core_attention(q, k, v)
+
+        if self.headwise_attn_output_gate:
+            g, _ = self.g_proj(hidden_states)
+            g = torch.sigmoid(g.float()).to(attn_output.dtype)
+            gate_output = (
+                attn_output.view(*attn_output.shape[:-1], self.num_heads, self.head_dim)
+                * g.unsqueeze(-1)
+            )
+            attn_output = gate_output.view(*attn_output.shape)
+
+        output, _ = self.out_proj(attn_output)
+        return output
+    
+
+class Spark3DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.hidden_size = config.hidden_size
+        self.input_layernorm = RMSNorm(hidden_size=self.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(hidden_size=self.hidden_size, eps=config.rms_norm_eps)
+
+        self.mlp = Spark3MLP(
+            config=config,
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+        self.self_attn = Spark3Attention(
+            config=config,
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            max_position_embeddings=config.max_position_embeddings,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+
+        return hidden_states, residual
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
+class Spark3Model(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+
+        if get_pp_group().is_first_rank:
+            self.embedding = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embedding",
+            )
+        else:
+            self.embedding = PPMissingLayer()
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            lambda prefix: Spark3DecoderLayer(
+                vllm_config=vllm_config,
+                config=config,
+                prefix=prefix,
+            ),
+            prefix=f"{prefix}.layers",
+        )
+
+        if get_pp_group().is_last_rank:
+            self.norm = RMSNorm(hidden_size=config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embedding(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        for layer in islice(self.layers, self.start_layer, self.end_layer):
+            hidden_states, residual = layer(positions, hidden_states, residual)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+
+class Spark3ForCausalLM(nn.Module, SupportsPP):
+    packed_modules_mapping = {
+        "q_k_v_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_stacked={
+            ".gate_proj": (".gate_up_proj", 0),
+            ".up_proj": (".gate_up_proj", 1),
+        }
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+
+        self.config = config
+        self.quant_config = quant_config
+
+        self.model = Spark3Model(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+
+        if get_pp_group().is_last_rank:
+            if self.config.tie_word_embeddings:
+                self.lm_head = self.model.embedding
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size, config.hidden_size, quant_config=quant_config, prefix=maybe_prefix(prefix, "lm_head")
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        model_output = self.model(
+            input_ids, positions, intermediate_tensors, inputs_embeds
+        )
+        return model_output
+    
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        return logits
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -178,6 +178,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "qwen3_engine_tool_parser",
         "Qwen3EngineToolParser",
     ),
+    "spark": (
+        "spark3_tool_parser",
+        "Spark3ToolParser",
+    ),
     "seed_oss": (
         "seed_oss_engine_tool_parser",
         "SeedOssEngineToolParser",

--- a/vllm/tool_parsers/spark3_tool_parser.py
+++ b/vllm/tool_parsers/spark3_tool_parser.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import regex as re
+from openai.types.responses import ToolChoiceFunction
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+from vllm.logger import init_logger
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
+from vllm.tool_parsers.utils import (
+    find_tool_name,
+    find_tool_properties,
+    partial_tag_overlap,
+)
+
+logger = init_logger(__name__)
+
+TOOL_CALL_BEGIN = "<tool_call>"
+TOOL_CALL_END = "</tool_call>"
+ARG_KEY_BEGIN = "<arg_key>"
+ARG_KEY_END = "</arg_key>"
+ARG_VALUE_BEGIN = "<arg_value>"
+ARG_VALUE_END = "</arg_value>"
+
+ARG_PAIR_PATTERN = re.compile(
+    rf"{re.escape(ARG_KEY_BEGIN)}(.*?){re.escape(ARG_KEY_END)}"
+    rf"{re.escape(ARG_VALUE_BEGIN)}(.*?){re.escape(ARG_VALUE_END)}",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class _Spark3ToolCall:
+    name: str
+    arguments: dict[str, Any]
+
+    def arguments_json(self) -> str:
+        return json.dumps(self.arguments, ensure_ascii=False, separators=(",", ":"))
+
+
+def _get_param_type(
+    tools: list[Tool] | None,
+    function_name: str,
+    param_name: str,
+) -> str:
+    """Return the declared JSON Schema type for one tool parameter."""
+    properties = find_tool_properties(tools, function_name)
+    definition = properties.get(param_name)
+    if isinstance(definition, dict):
+        param_type = definition.get("type")
+        if isinstance(param_type, str):
+            return param_type
+    return "string"
+
+
+def _convert_value(value: str, param_type: str) -> Any:
+    """Convert Spark3 XML text into a Python value."""
+    if value.lower() == "null":
+        return None
+
+    normalized_type = param_type.lower()
+    try:
+        if normalized_type in {"string", "str", "text"}:
+            return value
+        if normalized_type in {"integer", "int"}:
+            return int(value)
+        if normalized_type in {"number", "float"}:
+            number = float(value)
+            return int(number) if number.is_integer() else number
+        if normalized_type in {"boolean", "bool"}:
+            normalized_value = value.strip().lower()
+            if normalized_value not in {"true", "1", "false", "0"}:
+                raise ValueError(f"invalid boolean: {value}")
+            return normalized_value in {"true", "1"}
+        return json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        try:
+            return json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return value
+
+
+def _parse_tool_call_xml(
+    tool_xml: str,
+    tools: list[Tool] | None,
+) -> _Spark3ToolCall | None:
+    if not tool_xml.startswith(TOOL_CALL_BEGIN) or not tool_xml.endswith(
+        TOOL_CALL_END
+    ):
+        return None
+
+    body = tool_xml[len(TOOL_CALL_BEGIN) : -len(TOOL_CALL_END)]
+    first_arg = body.find(ARG_KEY_BEGIN)
+    function_name = (body if first_arg < 0 else body[:first_arg]).strip()
+    if not function_name:
+        return None
+    if tools and not find_tool_name(tools, function_name):
+        return None
+
+    arguments: dict[str, Any] = {}
+    for match in ARG_PAIR_PATTERN.finditer(body):
+        key, raw_value = match.group(1), match.group(2)
+        if not key:
+            continue
+        arguments[key] = _convert_value(
+            raw_value,
+            _get_param_type(tools, function_name, key),
+        )
+    return _Spark3ToolCall(name=function_name, arguments=arguments)
+
+
+def _has_unknown_tool_name(tool_xml: str, tools: list[Tool] | None) -> bool:
+    if not tools:
+        return False
+    if not tool_xml.startswith(TOOL_CALL_BEGIN) or not tool_xml.endswith(
+        TOOL_CALL_END
+    ):
+        return False
+    body = tool_xml[len(TOOL_CALL_BEGIN) : -len(TOOL_CALL_END)]
+    first_arg = body.find(ARG_KEY_BEGIN)
+    function_name = (body if first_arg < 0 else body[:first_arg]).strip()
+    return bool(function_name) and not find_tool_name(tools, function_name)
+
+
+class Spark3ToolParser(ToolParser):
+    """Tool parser for Spark3's XML-KV function-call format."""
+
+    supports_required_and_named = False
+    engine_based_streaming = True
+
+    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+        super().__init__(tokenizer, tools)
+        self.tool_call_start_token = TOOL_CALL_BEGIN
+        self.tool_call_end_token = TOOL_CALL_END
+        self._buffer = ""
+
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        if request.tools:
+            tool_choice = request.tool_choice
+            if tool_choice == "required" or isinstance(
+                tool_choice,
+                (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction),
+            ):
+                request.skip_special_tokens = False
+                return request
+
+        request = super().adjust_request(request)
+        if request.tools and request.tool_choice != "none":
+            request.skip_special_tokens = False
+        return request
+
+    def _append_tool_call(
+        self,
+        parsed: _Spark3ToolCall,
+        tool_index: int,
+        calls: list[DeltaToolCall] | list[ToolCall],
+        *,
+        is_streaming: bool,
+    ) -> None:
+        arguments_json = parsed.arguments_json()
+        if is_streaming:
+            self.prev_tool_call_arr.append(
+                {"name": parsed.name, "arguments": parsed.arguments}
+            )
+            self.streamed_args_for_tool.append(arguments_json)
+            calls.append(
+                DeltaToolCall(
+                    index=tool_index,
+                    id=make_tool_call_id(),
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name=parsed.name,
+                        arguments=arguments_json,
+                    ),
+                )
+            )
+            return
+
+        calls.append(
+            ToolCall(
+                id=make_tool_call_id(),
+                type="function",
+                function=FunctionCall(
+                    name=parsed.name,
+                    arguments=arguments_json,
+                ),
+            )
+        )
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> ExtractedToolCallInformation:
+        del request
+
+        calls: list[ToolCall] = []
+        normal_parts: list[str] = []
+        cursor = 0
+
+        while cursor < len(model_output):
+            start = model_output.find(TOOL_CALL_BEGIN, cursor)
+            if start < 0:
+                normal_parts.append(model_output[cursor:])
+                break
+
+            normal_parts.append(model_output[cursor:start])
+            end = model_output.find(TOOL_CALL_END, start + len(TOOL_CALL_BEGIN))
+            if end < 0:
+                normal_parts.append(model_output[start:])
+                break
+
+            end += len(TOOL_CALL_END)
+            raw_tool_call = model_output[start:end]
+            parsed = _parse_tool_call_xml(raw_tool_call, self.tools)
+            if parsed is None:
+                if not _has_unknown_tool_name(raw_tool_call, self.tools):
+                    normal_parts.append(raw_tool_call)
+            else:
+                self._append_tool_call(
+                    parsed,
+                    len(calls),
+                    calls,
+                    is_streaming=False,
+                )
+            cursor = end
+
+        return ExtractedToolCallInformation(
+            tools_called=bool(calls),
+            tool_calls=calls,
+            content="".join(normal_parts) if normal_parts else None,
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> DeltaMessage | None:
+        del (
+            previous_text,
+            current_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+            request,
+        )
+
+        self._buffer += delta_text
+        normal_parts: list[str] = []
+        tool_calls: list[DeltaToolCall] = []
+
+        while self._buffer:
+            start = self._buffer.find(TOOL_CALL_BEGIN)
+            if start < 0:
+                keep = partial_tag_overlap(self._buffer, TOOL_CALL_BEGIN)
+                if keep:
+                    normal_parts.append(self._buffer[:-keep])
+                    self._buffer = self._buffer[-keep:]
+                else:
+                    normal_parts.append(self._buffer)
+                    self._buffer = ""
+                break
+
+            if start > 0:
+                normal_parts.append(self._buffer[:start])
+                self._buffer = self._buffer[start:]
+
+            end = self._buffer.find(TOOL_CALL_END, len(TOOL_CALL_BEGIN))
+            if end < 0:
+                break
+
+            end += len(TOOL_CALL_END)
+            raw_tool_call = self._buffer[:end]
+            self._buffer = self._buffer[end:]
+            parsed = _parse_tool_call_xml(raw_tool_call, self.tools)
+            if parsed is None:
+                if not _has_unknown_tool_name(raw_tool_call, self.tools):
+                    normal_parts.append(raw_tool_call)
+                continue
+
+            self.current_tool_id += 1
+            self._append_tool_call(
+                parsed,
+                self.current_tool_id,
+                tool_calls,
+                is_streaming=True,
+            )
+
+        content = "".join(normal_parts)
+        if not content and not tool_calls:
+            return None
+        return DeltaMessage(content=content or None, tool_calls=tool_calls)
+
+    def finish_streaming(self) -> DeltaMessage | None:
+        pending = self._buffer
+        self._buffer = ""
+        if TOOL_CALL_BEGIN in pending:
+            pending = pending[: pending.find(TOOL_CALL_BEGIN)]
+        if not pending:
+            return None
+        return DeltaMessage(content=pending)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -124,6 +124,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     openvla="OpenVLAConfig",
     ovis="OvisConfig",
     ultravox="UltravoxConfig",
+    spark3="Spark3Config",
     step3_vl="Step3VLConfig",
     step3_text="Step3TextConfig",
     step3p5="Step3p5Config",

--- a/vllm/transformers_utils/configs/__init__.py
+++ b/vllm/transformers_utils/configs/__init__.py
@@ -50,6 +50,7 @@ _CLASS_TO_MODULE: dict[str, str] = {
     "HCXVisionConfig": "vllm.transformers_utils.configs.hyperclovax",
     "HYV3Config": "vllm.transformers_utils.configs.hy_v3",
     "HyperCLOVAXConfig": "vllm.transformers_utils.configs.hyperclovax",
+    "Spark3Config": "vllm.transformers_utils.configs.spark3",
     "IsaacConfig": "vllm.transformers_utils.configs.isaac",
     # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
     # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
@@ -186,6 +187,7 @@ __all__ = [
     "Step3VisionEncoderConfig",
     "Step3TextConfig",
     "Step3p5Config",
+    "Spark3Config",
     "QianfanOCRConfig",
     "QianfanOCRVisionConfig",
     "Qwen3ASRConfig",

--- a/vllm/transformers_utils/configs/spark3.py
+++ b/vllm/transformers_utils/configs/spark3.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any
+
+from transformers.configuration_utils import PretrainedConfig
+
+class Spark3Config(PretrainedConfig):
+    model_type = "spark3"
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        intermediate_size: int = 6656,
+        num_hidden_layers: int = 28,
+        num_attention_heads: int = 8,
+        num_key_value_heads: int = 2,
+        head_dim: int = 256,
+        headwise_attn_output_gate: bool = True,
+        sliding_window: int = 512,
+        vocab_size: int = 131072,
+        rms_norm_eps: float = 1e-6,
+        max_position_embeddings: int = 8192,
+        rope_parameters: dict[str, Any] | None = None,
+        layer_types: list[str] | None = None,
+        tie_word_embeddings: bool | None = False,
+        **kwargs,
+    ):
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.headwise_attn_output_gate = headwise_attn_output_gate
+        self.sliding_window = sliding_window
+        self.vocab_size = vocab_size
+        self.rms_norm_eps = rms_norm_eps
+        self.max_position_embeddings = max_position_embeddings
+        self.tie_word_embeddings = tie_word_embeddings
+
+        if layer_types is not None:
+            layer_types = layer_types[: self.num_hidden_layers]
+        else:
+            layer_types = [
+                "sliding_attention" if bool((i + 1) % 4) else "full_attention"
+                for i in range(self.num_hidden_layers)
+            ]
+        self.layer_types = layer_types
+
+        if rope_parameters is not None:
+            self.rope_parameters = rope_parameters
+        else:
+            self.rope_parameters = {
+                "full_attention": {
+                    "rope_theta": 5000000,
+                    "partial_rotary_factor": 0.25,
+                },
+                "sliding_attention": {
+                    "rope_theta": 10000,
+                    "partial_rotary_factor": 1.0,
+                },
+            }
+
+        super().__init__(**kwargs)


### PR DESCRIPTION
## Summary

This PR adds native support for the Spark 3 model architecture in SGLang.

The implementation introduces the Spark 3 configuration and causal language model, including sliding-window and full attention, head-wise attention output gating, tensor parallelism, pipeline parallelism, and checkpoint weight loading.

## Changes

|File|Description|
|---|---|
|`vllm/model_executor/models/spark3.py`|Implements `Spark3ForCausalLM`, including attention, MLP, decoder layers, TP/PP support, logits computation, and weight loading.|
|`vllm/transformers_utils/configs/spark3.py`|Adds the native `Spark3Config` implementation.|
|`vllm/model_executor/models/registry.py`|Registers `Spark3ForCausalLM` in the vLLM model registry.|
|`vllm/transformers_utils/config.py`|Registers the `spark3` model type and configuration.|
|`vllm/transformers_utils/configs/__init__.py`|Exposes `Spark3Config` through the vLLM config registry.|
|`docs/models/supported_models.md`|Documents Spark3 as a supported text-generation model.|
|`vllm/tool_parsers/spark3_tool_parser.py`|Implements Spark3 XML tool-call parsing, argument conversion, and streaming extraction.|
|`vllm/tool_parsers/__init__.py`|Registers `spark3` in the tool parser registry.|

## Key Technical Details

1. Efficient Architecture：The models adopt an efficiency-oriented architecture with Sliding Window Attention (SWA) and other structural optimizations, improving the balance between model quality, memory usage, and inference efficiency.
2. Native 1M Context：Both the 1.7B and 4B models natively support up to 1 million tokens of context, enabling long-document understanding, repository-level coding, and long-horizon agent tasks.
3. Strong Coding & Agent Capabilities：The models deliver leading coding and agent performance among models of comparable size, with strong capabilities in code generation, tool use, multi-step execution, and long-context reasoning.
4. Faster Inference：Through model architecture and inference-stack optimizations, the models achieve higher inference efficiency and throughput than many comparable-size models, especially in long-context scenarios.
5. Strong K–12 and Gaokao Performance：The models achieve leading K–12 question-answering performance at comparable parameter scales, with particularly strong results on challenging Chinese Gaokao-style tasks.
6. Advanced Post-Training：The release applies a comprehensive post-training recipe based on Scaled Reinforcement Learning and MOPD, improving reasoning, coding, instruction following, agentic capabilities, and alignment.
7. Controllable Thinking Budget：The models support configurable reasoning levels — none, low, medium, and high — allowing applications to dynamically trade off reasoning quality, latency, and inference cost.
8. 200+ Languages：Multilingual coverage has been expanded to more than 200 languages, supporting broad cross-lingual understanding, generation, translation, and localized applications.
    

## Performance

A serving benchmark was performed with **500 concurrent requests**, and all requests completed successfully.

|Metric|Result|
|---|--:|
|Successful requests|500|
|Failed requests|0|
|Benchmark duration|4.70 s|
|Total input tokens|762,489|
|Total generated tokens|63,478|
|Request throughput|106.42 req/s|
|Output token throughput|13,510.08 tok/s|
|Peak output token throughput|16,452.00 tok/s|
|Total token throughput|175,791.36 tok/s|
|Peak concurrent requests|500|

### Latency

|Metric|Mean|Median|P99|
|---|--:|--:|--:|
|TTFT|2122.04 ms|2111.73 ms|4169.35 ms|
|TPOT|11.58 ms|13.39 ms|14.13 ms|
|ITL|12.34 ms|11.13 ms|32.92 ms|

The benchmark completed with a **100% request success rate**. Under a peak concurrency of 500 requests, the server achieved **106.42 requests/s**, approximately **13.5K output tokens/s**, and **175.8K total tokens/s**.

Decode latency remained relatively stable, with a mean TPOT of **11.58 ms** and a P99 TPOT of **14.13 ms**. TTFT was approximately **2.12 s on average** and **4.17 s at P99** under this high-concurrency workload.

## Spark3 Tool Parser

### How to Start

Start the OpenAI server with:

```bash
python -m vllm.entrypoints.openai.api_server \
  --model /path/to/spark3-ckpt \
  --trust-remote-code \
  --enable-auto-tool-choice \
  --tool-call-parser spark
```

For Spark3 native tool prompting, `tool_choice` can be set to `required` or
`auto` in the request payload.

### Supported Functionality

- Parse Spark3 XML tool calls into OpenAI `tool_calls`.
- Support `required` and `auto` tool-choice flows for Spark3-native XML output.
- Emit tool-call deltas in streaming responses.
- Convert tool arguments to typed JSON values when schema metadata is present.


