### PR TITLE
[CI][ARM64] Restore known-good CUDA 13 builder image

### DIFF
--- a/.buildkite/image_build/image_build_arm64.sh
+++ b/.buildkite/image_build/image_build_arm64.sh
@@ -26,7 +26,7 @@ else
     --platform linux/arm64 \
     --build-arg max_jobs=16 \
     --build-arg nvcc_threads=4 \
-    --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 \
+    --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-b8b5f17a7d9ccfc25bbc5cf17b3fcea12964a042 \
     --build-arg torch_cuda_arch_list="9.0 10.0 11.0 12.0" \
     --build-arg USE_SCCACHE=1 \
     --build-arg buildkite_commit="$BUILDKITE_COMMIT" \

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -33,7 +33,7 @@ steps:
         agents:
           queue: arm64_cpu_queue_release
         commands:
-          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=13.0.2 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_AARCH64}\" --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
+          - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=13.0.2 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_AARCH64}\" --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-b8b5f17a7d9ccfc25bbc5cf17b3fcea12964a042 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
           - "bash .buildkite/scripts/upload-nightly-wheels.sh"
@@ -260,7 +260,7 @@ steps:
               --build-arg CUDA_VERSION=13.0.2 \
               --build-arg torch_cuda_arch_list="${CUDA_ARCH_AARCH64}" \
               --build-arg INSTALL_KV_CONNECTORS=true \
-              --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 \
+              --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-b8b5f17a7d9ccfc25bbc5cf17b3fcea12964a042 \
               --target vllm-openai \
               --progress plain \
               -f docker/Dockerfile .
@@ -361,7 +361,7 @@ steps:
               --build-arg GDRCOPY_OS_VERSION=Ubuntu24_04 \
               --build-arg torch_cuda_arch_list="${CUDA_ARCH_AARCH64}" \
               --build-arg INSTALL_KV_CONNECTORS=true \
-              --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 \
+              --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-b8b5f17a7d9ccfc25bbc5cf17b3fcea12964a042 \
               --target vllm-openai \
               --progress plain \
               -f docker/Dockerfile .

--- a/.buildkite/scripts/hardware_ci/run-gh200-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-gh200-test.sh
@@ -15,7 +15,7 @@ DOCKER_BUILDKIT=1 docker build . \
   -t gh200-test \
   --build-arg max_jobs=66 \
   --build-arg nvcc_threads=2 \
-  --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-78e737ad29420ffc4800e677c51e2a852caf8359 \
+  --build-arg BUILD_BASE_IMAGE=pytorch/manylinuxaarch64-builder:cuda13.0-b8b5f17a7d9ccfc25bbc5cf17b3fcea12964a042 \
   --build-arg torch_cuda_arch_list="9.0+PTX"
 
 # Setup cleanup


### PR DESCRIPTION
## Purpose

Restore the last known-good immutable PyTorch CUDA 13.0 aarch64 builder after the current pinned image deterministically broke `Build arm64 image` during the `tilelang==0.1.12` sdist build.

Affected main jobs:

- [#85156 arm64 image](https://buildkite.com/vllm/ci/builds/85156#01a0280f-9b07-479f-bb9b-455dd63f4984)
- [#85165 arm64 image](https://buildkite.com/vllm/ci/builds/85165#01a028aa-987a-419d-9af8-61c2ed3e425e)

No test ran in either job; the image build failed first.

## Change

Replace every CUDA 13.0 `manylinuxaarch64-builder` reference with the immutable known-good tag:

```text
pytorch/manylinuxaarch64-builder:cuda13.0-b8b5f17a7d9ccfc25bbc5cf17b3fcea12964a042
```

The tag resolves to OCI index digest `sha256:4c06d37c1aa8542fba4233a8dfd12af2e2675e98db10fa6f340a3cde9f2754ae`. The last pre-pin cold arm64 build, [#84899](https://buildkite.com/vllm/ci/builds/84899#01a02143-e299-4a7b-ac5f-45ea90c05e0c), used this image and successfully built `tilelang==0.1.12` from sdist with CMake 4.4.2.

This updates the normal arm64 image build, release aarch64 CUDA 13 paths, and GH200 test path. CUDA 12.9 and x86 builders remain unchanged.

## Root-cause boundary

The failing `78e737ad...` image reports CMake 4.3 and hits missing `CUDA::cuda_driver` / `CUDA::cudart_static` imported-target errors, followed by a separate Cython 3.3 / `Py_LIMITED_API=3.8` rejection. The working and failing images are both manylinux_2_28, so this is not a glibc-policy change.

This PR restores the full known-good image rather than claiming CMake 4.3 alone is causal; multiple image components changed together.

## Duplicate-work check

Searched open PRs for `arm64 builder image`, `manylinuxaarch64 b8b5f17`, and `tilelang arm64`. Draft PR #53358 addresses the same failure by adding `cmake<4` and `cython<3.3` constraints while preserving `78e737ad...`. This PR is intentionally different: it rolls back the complete aarch64 CUDA 13 builder to the exact immutable image proven green before the regression, as requested by the CI owner, and avoids adding downstream tool constraints while the image delta has not been isolated.

## Validation

- Docker manifest inspection: tag exists, OCI index digest matches the historical #84899 image, and contains a Linux arm64 manifest.
- `pre-commit run --files` on all three changed files: passed (including shellcheck, dependency-graph validation, and config-default validation).
- `bash -n` on both changed shell scripts: passed.
- `.buildkite/release-pipeline.yaml` parsed with PyYAML: passed.
- `git diff --check`: passed.
- Exact `Build arm64 image` gate: pending.
- Model evaluation: not applicable; CI builder metadata only.

This is proposed-fix validation only. Final resolution requires merge plus a post-merge cold/main arm64 image pass.

## AI-assistance disclosure

This change was prepared with AI assistance and reviewed before submission.
