### PR TITLE
[Bugfix][Distributed]  Gate MNNVL allreduce workspace creation on fabric support

### DIFF
--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -325,6 +325,160 @@ def test_cuda_communicator_checkpoints_flashinfer_workspaces(
         workspace.checkpoint_restore.assert_called_once_with(group)
 
 
+def _fabric_probe_must_not_run(device: int) -> bool:
+    raise AssertionError("fabric probe must not be consulted on this path")
+
+
+def _patch_fi_ar_module(
+    monkeypatch: pytest.MonkeyPatch,
+    node_count: int,
+    fabric_supported: Callable[[int], bool],
+    same_node: list[bool] | None = None,
+) -> tuple[Mock, Mock]:
+    # patch flashinfer_all_reduce for CPU-only _create_workspace tests; returns
+    # the fake flashinfer_comm and the all_ranks_support_mnnvl vote mock.
+    fake_comm = Mock()
+    fake_comm.create_allreduce_fusion_workspace.return_value.mc_ptr = 1
+    vote = Mock(
+        side_effect=lambda local_supported, world_size, comm_backend: local_supported
+    )
+    monkeypatch.setattr(
+        flashinfer_all_reduce, "flashinfer_comm", fake_comm, raising=False
+    )
+    monkeypatch.setattr(
+        flashinfer_all_reduce, "TorchDistBackend", lambda group: group, raising=False
+    )
+    monkeypatch.setattr(flashinfer_all_reduce, "_fi_ar_workspace_groups", {})
+    monkeypatch.setattr(
+        flashinfer_all_reduce, "_mnnvl_supported_groups", {}, raising=False
+    )
+    monkeypatch.setattr(flashinfer_all_reduce, "get_node_count", lambda: node_count)
+    monkeypatch.setattr(
+        flashinfer_all_reduce,
+        "in_the_same_node_as",
+        lambda group: same_node if same_node is not None else [True, False],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        flashinfer_all_reduce,
+        "is_mnnvl_fabric_supported",
+        fabric_supported,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        flashinfer_all_reduce, "all_ranks_support_mnnvl", vote, raising=False
+    )
+    monkeypatch.setattr(torch.accelerator, "current_device_index", lambda: 0)
+    return fake_comm, vote
+
+
+def _create_mnnvl_workspace(group: object | None = None):
+    return flashinfer_all_reduce._create_workspace(
+        backend="mnnvl",
+        world_size=4,
+        rank=0,
+        max_token_num=128,
+        hidden_dim=64,
+        dtype=torch.bfloat16,
+        group=group if group is not None else object(),
+    )
+
+
+def test_create_workspace_skips_mnnvl_when_multinode_fabric_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # on IB-only multi-node the creation attempt itself hangs and leaks
+    # (#51986), so the fabric must be probed before it is ever made.
+    group = object()
+    fake_comm, vote = _patch_fi_ar_module(
+        monkeypatch, node_count=2, fabric_supported=lambda device: False
+    )
+
+    assert _create_mnnvl_workspace(group) is None
+    fake_comm.create_allreduce_fusion_workspace.assert_not_called()
+    # TorchDistBackend is identity-patched: the vote must get this group's
+    # comm backend.
+    assert vote.call_args.args == (False, 4, group)
+
+
+def test_create_workspace_attempts_mnnvl_when_multinode_fabric_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_comm, _ = _patch_fi_ar_module(
+        monkeypatch, node_count=2, fabric_supported=lambda device: True
+    )
+
+    workspace = _create_mnnvl_workspace()
+
+    assert workspace is fake_comm.create_allreduce_fusion_workspace.return_value
+    fake_comm.create_allreduce_fusion_workspace.assert_called_once()
+
+
+def test_create_workspace_skips_fabric_probe_on_single_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # single-node mnnvl uses NVSwitch multicast, not the NVLink fabric.
+    fake_comm, _ = _patch_fi_ar_module(
+        monkeypatch, node_count=1, fabric_supported=_fabric_probe_must_not_run
+    )
+
+    workspace = _create_mnnvl_workspace()
+
+    assert workspace is fake_comm.create_allreduce_fusion_workspace.return_value
+    fake_comm.create_allreduce_fusion_workspace.assert_called_once()
+
+
+def test_create_workspace_skips_fabric_probe_for_intra_node_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a group confined to one node (e.g. TP=8 in a 2-node DP job) works via
+    # node-local handle exchange without an NVLink fabric.
+    fake_comm, _ = _patch_fi_ar_module(
+        monkeypatch,
+        node_count=2,
+        fabric_supported=_fabric_probe_must_not_run,
+        same_node=[True, True, True, True],
+    )
+
+    workspace = _create_mnnvl_workspace()
+
+    assert workspace is fake_comm.create_allreduce_fusion_workspace.return_value
+    fake_comm.create_allreduce_fusion_workspace.assert_called_once()
+
+
+def test_create_workspace_joins_collective_vote_when_local_probe_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a rank whose probe fails must still vote (as unsupported), otherwise
+    # the other ranks deadlock in the allgather.
+    def broken_probe(device: int) -> bool:
+        raise RuntimeError("NVML unavailable")
+
+    fake_comm, vote = _patch_fi_ar_module(
+        monkeypatch, node_count=2, fabric_supported=broken_probe
+    )
+
+    assert _create_mnnvl_workspace() is None
+    vote.assert_called_once()
+    assert vote.call_args.args[0] is False
+    fake_comm.create_allreduce_fusion_workspace.assert_not_called()
+
+
+def test_create_workspace_memoizes_negative_mnnvl_vote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # creation is retried on every call after a failure, so the negative vote
+    # must be latched to keep probes/allgathers out of the per-layer hot path.
+    group = object()
+    _, vote = _patch_fi_ar_module(
+        monkeypatch, node_count=2, fabric_supported=lambda device: False
+    )
+
+    assert _create_mnnvl_workspace(group) is None
+    assert _create_mnnvl_workspace(group) is None
+    vote.assert_called_once()
+
+
 @pytest.mark.parametrize(
     ("backend", "capability", "world_size", "nodes", "expected"),
     [

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -17,7 +17,11 @@ from vllm.config.compilation import PassConfig
 from vllm.distributed.device_communicators.all_reduce_utils import (
     FI_MNNVL_ALLREDUCE_MAX_SIZE_MB,
 )
-from vllm.distributed.parallel_state import _node_count, get_node_count
+from vllm.distributed.parallel_state import (
+    _node_count,
+    get_node_count,
+    in_the_same_node_as,
+)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
@@ -39,6 +43,15 @@ try:
 except ImportError:
     pass
 
+try:
+    from flashinfer.comm.mnnvl import (
+        all_ranks_support_mnnvl,  # type: ignore[import-not-found]
+        is_mnnvl_fabric_supported,
+    )
+except (ImportError, AttributeError):
+    all_ranks_support_mnnvl = None  # type: ignore[assignment]
+    is_mnnvl_fabric_supported = None  # type: ignore[assignment]
+
 # Workspace for standalone allreduce and non-quant ar+rms fusion
 _fi_ar_workspace = None
 # Extra workspace for quant fusion patterns. This may use either the primary
@@ -46,6 +59,60 @@ _fi_ar_workspace = None
 # available on the current topology.
 _fi_ar_quant_workspace = None
 _fi_ar_workspace_groups: dict[int, ProcessGroup] = {}
+
+
+# Agreed per-group MNNVL capability votes, keyed by id(group). Latched so the
+# per-layer workspace retry path does not repeat NVML probes and allgathers.
+_mnnvl_supported_groups: dict[int, bool] = {}
+
+
+# TODO: remove this guard once flashinfer gates explicit backend="mnnvl" with
+# a fabric-state probe itself (its auto-path vote only checks the local
+# multicast device attribute, which cannot detect IB-only multi-node).
+def _mnnvl_group_supported(
+    world_size: int, comm_backend: Any, group: ProcessGroup
+) -> bool:
+    """Collectively probe MNNVL fabric support before workspace creation.
+
+    On multi-node groups without an NVLink fabric (e.g. IB-only), mnnvl
+    workspace creation itself hangs for ~30s and leaks GPU memory, so probe
+    before attempting it. Groups confined to one node use node-local handle
+    exchange and need no fabric. Both the node-span check and the capability
+    vote are collectives and must run on every rank of the group.
+
+    Args:
+        world_size: Number of ranks in the workspace group.
+        comm_backend: Flashinfer comm backend scoped to the workspace group.
+        group: CPU (gloo) process group the workspace is created for.
+
+    Returns:
+        Whether mnnvl workspace creation should be attempted. True when the
+        probe APIs are unavailable (older flashinfer), falling back to the
+        pre-existing attempt-and-check behavior.
+    """
+    if get_node_count() == 1:
+        # Single-node mnnvl uses NVSwitch multicast, not the NVLink fabric;
+        # the mc_ptr check after creation covers that case.
+        return True
+    if is_mnnvl_fabric_supported is None or all_ranks_support_mnnvl is None:
+        return True
+    supported = _mnnvl_supported_groups.get(id(group))
+    if supported is not None:
+        return supported
+    if all(in_the_same_node_as(group)):
+        supported = True
+    else:
+        try:
+            local_supported = bool(
+                is_mnnvl_fabric_supported(torch.accelerator.current_device_index())
+            )
+        except Exception as e:
+            logger.debug_once("MNNVL fabric probe failed: %s", e)
+            # Still join the collective vote below or other ranks deadlock.
+            local_supported = False
+        supported = all_ranks_support_mnnvl(local_supported, world_size, comm_backend)
+    _mnnvl_supported_groups[id(group)] = supported
+    return supported
 
 
 def _get_tuned_standalone_max_size(
@@ -78,6 +145,16 @@ def _create_workspace(
     comm_backend = TorchDistBackend(group=group)
     rng_state = random.getstate()
     try:
+        if backend == "mnnvl" and not _mnnvl_group_supported(
+            world_size, comm_backend, group
+        ):
+            logger.warning_once(
+                "Skipping FlashInfer MNNVL allreduce workspace creation: the "
+                "group spans multiple nodes without NVLink fabric support "
+                "(check `nvidia-smi -q | grep -i fabric`). Fused allreduce "
+                "will fall back to unfused allreduce + rmsnorm."
+            )
+            return None
         random.seed(int.from_bytes(os.urandom(16), byteorder="big"))
         workspace = flashinfer_comm.create_allreduce_fusion_workspace(
             backend=backend,
@@ -315,6 +392,7 @@ def destroy_fi_ar_workspace():
 
         _fi_ar_workspace = _fi_ar_quant_workspace = None
         _fi_ar_workspace_groups.clear()
+        _mnnvl_supported_groups.clear()
 
 
 def _fi_ar_workspaces_for_group(group: ProcessGroup) -> list[Any]:


### PR DESCRIPTION


## Purpose

Fixes #51986.

On IB-only multi-node topologies, FlashInfer mnnvl workspace creation hangs ~30s and leaks GPU memory. vLLM resolves the `auto` backend to an explicit `"mnnvl"` before calling `create_allreduce_fusion_workspace()`, so FlashInfer's own capability vote (auto path only) never runs, and the existing `mc_ptr` check runs only after the doomed creation attempt. Full analysis in https://github.com/vllm-project/vllm/issues/51986#issuecomment-5380074578.

This PR gates mnnvl workspace creation on a collective capability probe:

- groups confined to one node keep working via node-local handle exchange (no fabric needed), checked with `in_the_same_node_as()`
- node-spanning groups vote `is_mnnvl_fabric_supported()` across ranks via `all_ranks_support_mnnvl()`; a rank whose local probe fails still joins the vote to keep the collective symmetric
- the result is latched per group so the per-layer workspace retry path doesn't repeat NVML probes and object allgathers
- older flashinfer without the probe APIs falls back to the pre-existing attempt-and-check behavior

When the vote is negative the workspace getter returns `None`, so `AllReduceFusionPass` disables itself and the unfused allreduce + rmsnorm path is kept, avoiding the hang and the leak.

Note: distinct from #48075 (single-node bridged NVLink where creation succeeds and the crash happens later) and from #53253, which gates the `CustomAllreduce` symmetric-memory rendezvous on pre-Blackwell cross-node groups. This PR is about the FlashInfer allreduce fusion workspace path.

## Test Plan

- Unit test for the new capability gate (mocked probe results)
- Manual: multi-node IB-only setup, verify no hang at pass init and fusion pass disabled cleanly

## Test Result

- Unit tests pass: gate returns `False` on mocked IB-only topology, workspace creation is skipped and `get_fi_ar_workspace()` returns `None`
- Verified on a 2-node IB-only setup (2x8 B300): no hang at pass init (previously ~30s x2), `AllReduceFusionPass` disables itself cleanly with a log message, no residual GPU memory from failed allocation

## AI assistance
This change was implemented with AI (Claude Code CLI) assistance; all changes were reviewed and tested by the human submitter.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>

