### PR TITLE
[Test] Fix _random_prompt length handling and exercise chunked prefill

### DIFF
--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -77,8 +77,8 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle(
     model = TEST_MODEL
     num_trials = int(os.getenv("VLLM_NEEDLE_TRIALS", "5"))
     max_batch_size = int(os.getenv("VLLM_NEEDLE_BATCH_SIZE", "128"))
-    min_random_prompt = int(os.getenv("VLLM_MIN_PROMPT", "1024"))
-    max_random_prompt = int(os.getenv("VLLM_MAX_PROMPT", "2048"))
+    min_random_prompt = int(os.getenv("VLLM_MIN_PROMPT", "256"))
+    max_random_prompt = int(os.getenv("VLLM_MAX_PROMPT", "512"))
     assert max_batch_size >= 2, "Batch size should be >= 2 to mix needle."
 
     # Keep GPU memory usage low to avoid startup allocation failures.
@@ -204,6 +204,8 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
         max_model_len=8192,
         dtype="auto",  # not everything is supported
         gpu_memory_utilization=0.9,
+        enable_chunked_prefill=True,
+        max_num_batched_tokens=2048,
         attention_config={
             "backend": backend,
             "flex_attn_block_m": block_m,
@@ -211,16 +213,14 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
         },
     )
 
-    # Use more realistic prompts for better token generation
-    prompts = [_random_prompt(10, 50) for _ in range(32)]
-
-    # TODO: Update prompts to have ragged lengths in order to test chunked prefill
-    #       The above tests are not currently long enough to exercise chunking.
-    # prompts = (
-    #     [_random_prompt(10, 50) for _ in range(28)]
-    #     + [_random_prompt(256, 512) for _ in range(50)]
-    #     + [_random_prompt(2048, 4096) for _ in range(50)]
-    # )
+    # Ragged lengths so the batched run exceeds max_num_batched_tokens (2048)
+    # and exercises chunked prefill, while each prompt alone stays below the
+    # chunk threshold and fits in a single step (~1.5 tokens/word).
+    prompts = (
+        [_random_prompt(10, 50) for _ in range(28)]
+        + [_random_prompt(256, 512) for _ in range(50)]
+        + [_random_prompt(1000, 1200) for _ in range(50)]
+    )
 
     sp = SamplingParams(
         temperature=0.6,

--- a/tests/v1/determinism/utils.py
+++ b/tests/v1/determinism/utils.py
@@ -103,14 +103,14 @@ def _random_prompt(min_words: int = 1024, max_words: int = 1024 * 2) -> str:
         max_words = min_words
     target_words = random.randint(min_words, max_words)
 
-    if target_words > 50:
-        # For longer prompts, repeat context
-        padding_text = (
-            " This is an interesting topic that deserves more explanation. "
-            # TODO: Update to * (target_words // 10) to better align with word ratio
-            * (target_words // 50)
-        )
-        base_prompt = padding_text + base_prompt
+    # Pad with repeated filler sentences until the prompt is roughly
+    # `target_words` words long, then prepend the chosen template.
+    filler = "This is an interesting topic that deserves more explanation."
+    filler_words = len(filler.split())
+    words_needed = target_words - len(base_prompt.split())
+    if words_needed > 0:
+        repeats = (words_needed + filler_words - 1) // filler_words
+        base_prompt = (filler + " ") * repeats + base_prompt
 
     return base_prompt
 


### PR DESCRIPTION
## Summary

`_random_prompt(min_words, max_words)` in `tests/v1/determinism/utils.py` silently produced prompts ~5× shorter than requested: it padded with `target_words // 50` repetitions of a 9-word filler instead of honoring the requested word count (a leftover `TODO` already flagged the discrepancy). Every prompt-length assumption in the determinism suite was therefore dishonest — e.g. "very long" `(1536, 3072)`-word prompts actually came out to only ~250–450 tokens.

This PR:

1. Fixes `_random_prompt` so it actually reaches `target_words` words.
2. Re-tunes the two callers that depended on the buggy lengths:
   - `test_v1_generation_is_deterministic_across_batch_sizes_with_needle`: `VLLM_MIN_PROMPT`/`VLLM_MAX_PROMPT` defaults 1024/2048 → 256/512, keeping the needle within a bounded KV-cache window for a 128-sequence batch (~1.5 tokens/word).
   - `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN`: enables `enable_chunked_prefill=True` + `max_num_batched_tokens=2048`, and replaces the uniform 32×`(10,50)` prompts with ragged lengths (28×`(10,50)`, 50×`(256,512)`, 50×`(1000,1200)`) so the batched run exceeds the chunk threshold and actually exercises chunked prefill, while each prompt alone stays below it.

## Why this is not duplicating an existing PR

- No open PR touches `_random_prompt`; the only PRs referencing it are closed (#27054, #32480, #27421) and none fix the length bug.
- #46592 ("Feat/invariant with prefix cache") targets prefix-caching invariance, a separate and currently-broken feature; this PR does not enable prefix caching.
- #43317 ("Use token-id prefix in batch-invariant decode/prefill consistency test") fixes `test_decode_logprobs_match_prefill_logprobs`; this PR does not modify that test.
- #27054 (closed) stabilized the inverse `should_fail` test; this PR changes the shared prompt helper and the needle/chunked-prefill tests instead.

## Test plan

Machine: NVIDIA H20, `VLLM_TEST_MODEL=/data/models/Qwen3-1.7B`.

```
.venv/bin/python -m pytest tests/v1/determinism/test_batch_invariance.py -v
```

Results (all run nodes pass):

- `test_v1_generation_is_deterministic_across_batch_sizes_with_needle` — 2 passed (FLASH_ATTN × rms_norm_impl default/vllm_c)
- `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN` — 6 passed (FLASH_ATTN/TRITON_ATTN/FLEX_ATTENTION × block_m 16/8)
- `test_simple_generation` — 3 passed
- `test_logprobs_without_batch_invariance_should_fail` — 3 passed
- `test_decode_logprobs_match_prefill_logprobs` — 1 passed

The full file is also exercised in CI (`.buildkite/test_areas/misc.yaml`) on A100/H100/B200.

## Model evaluation

Test-only change; no model, serving, or output behavior is affected.

## AI assistance

This PR was generated with AI assistance (Claude Code); the submitting human reviewed every changed line and ran the tests above.