### PR TITLE
[Bugfix][Frontend] Accept thinking as enable_thinking alias

### DIFF
--- a/tests/parser/engine/test_nemotron_v3.py
+++ b/tests/parser/engine/test_nemotron_v3.py
@@ -63,6 +63,24 @@ class TestNemotronSwap:
         assert content == "The answer is 42."
         assert reasoning is None
 
+    def test_thinking_alias_false_swaps(self, parser):
+        """``thinking=False`` is accepted as an alias for enable_thinking."""
+        text = "The answer is 42."
+        request = _make_request(thinking=False)
+        reasoning, content = parser.extract_reasoning(text, request)
+        assert content == "The answer is 42."
+        assert reasoning is None
+
+    def test_thinking_alias_sets_initial_content_state(self):
+        from vllm.parser.engine.parser_engine_config import ParserState
+
+        parser = NemotronV3Parser(
+            make_mock_tokenizer(_VOCAB),
+            chat_template_kwargs={"thinking": False},
+        )
+        assert parser.thinking_enabled is False
+        assert parser.parser_engine_config.initial_state == ParserState.CONTENT
+
     def test_force_nonempty_content_swaps(self, parser):
         """force_nonempty_content=True triggers swap when content empty."""
         text = "The answer is 42."

--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -701,3 +701,36 @@ class TestThinkingDisabled:
         reasoning, content = p.extract_reasoning("The answer is 42.", None)
         assert reasoning is None
         assert content == "The answer is 42."
+
+    def test_thinking_alias_disables_initial_state(self, mock_tokenizer):
+        """``thinking`` is accepted as an alias for ``enable_thinking``."""
+        p = Qwen3Parser(
+            mock_tokenizer,
+            chat_template_kwargs={"thinking": False},
+        )
+        assert p.parser_engine_config.initial_state == ParserState.CONTENT
+        assert p.thinking_enabled is False
+
+    def test_thinking_alias_enables_initial_state(self, mock_tokenizer):
+        p = Qwen3Parser(
+            mock_tokenizer,
+            chat_template_kwargs={"thinking": True},
+        )
+        assert p.parser_engine_config.initial_state == ParserState.REASONING
+        assert p.thinking_enabled is True
+
+    def test_thinking_alias_streaming_content_only(self, mock_tokenizer):
+        p = Qwen3Parser(
+            mock_tokenizer,
+            chat_template_kwargs={"thinking": False},
+        )
+        reasoning, content = simulate_reasoning_streaming(
+            p,
+            ["The answer", " is 42."],
+            [
+                (_TEXT_ID,),
+                (_TEXT_ID,),
+            ],
+        )
+        assert content == "The answer is 42."
+        assert reasoning == ""

--- a/tests/parser/test_resolve_enable_thinking.py
+++ b/tests/parser/test_resolve_enable_thinking.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for resolve_enable_thinking (#43728)."""
+
+from vllm.parser.utils import resolve_enable_thinking
+
+
+def test_default_when_kwargs_missing() -> None:
+    assert resolve_enable_thinking(None, default=True) is True
+    assert resolve_enable_thinking({}, default=True) is True
+    assert resolve_enable_thinking({}, default=False) is False
+
+
+def test_enable_thinking_canonical() -> None:
+    assert resolve_enable_thinking({"enable_thinking": True}) is True
+    assert resolve_enable_thinking({"enable_thinking": False}) is False
+
+
+def test_thinking_alias() -> None:
+    assert resolve_enable_thinking({"thinking": True}) is True
+    assert resolve_enable_thinking({"thinking": False}) is False
+
+
+def test_either_true_enables() -> None:
+    assert resolve_enable_thinking({"thinking": True, "enable_thinking": False}) is True
+    assert resolve_enable_thinking({"thinking": False, "enable_thinking": True}) is True
+
+
+def test_both_false_disables() -> None:
+    assert (
+        resolve_enable_thinking({"thinking": False, "enable_thinking": False}) is False
+    )

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -26,6 +26,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.parser.utils import resolve_enable_thinking
 
 if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -409,7 +410,7 @@ class Gemma4Parser(ParserEngine):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self._thinking_enabled = chat_kwargs.get("enable_thinking", False)
+        self._thinking_enabled = resolve_enable_thinking(chat_kwargs, default=False)
         super().__init__(
             tokenizer,
             tools,

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -27,6 +27,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.parser.utils import resolve_enable_thinking
 
 if TYPE_CHECKING:
     from vllm.tokenizers import TokenizerLike
@@ -182,13 +183,7 @@ class Glm47MoeParser(ParserEngine):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        thinking = chat_kwargs.get("thinking", None)
-        enable_thinking = chat_kwargs.get("enable_thinking", None)
-        self.thinking_enabled = (
-            True
-            if thinking is None and enable_thinking is None
-            else bool(thinking) or bool(enable_thinking)
-        )
+        self.thinking_enabled = resolve_enable_thinking(chat_kwargs, default=True)
         kwargs.setdefault(
             "parser_engine_config",
             glm47_moe_config(thinking=self.thinking_enabled),

--- a/vllm/parser/kimi_k2.py
+++ b/vllm/parser/kimi_k2.py
@@ -29,6 +29,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.parser.utils import resolve_enable_thinking
 
 if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -157,13 +158,7 @@ class KimiK2Parser(ParserEngine):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        thinking = chat_kwargs.get("thinking", None)
-        enable_thinking = chat_kwargs.get("enable_thinking", None)
-        self.thinking_enabled = (
-            True
-            if thinking is None and enable_thinking is None
-            else bool(thinking) or bool(enable_thinking)
-        )
+        self.thinking_enabled = resolve_enable_thinking(chat_kwargs, default=True)
         kwargs.setdefault(
             "parser_engine_config",
             kimi_k2_config(thinking=self.thinking_enabled),

--- a/vllm/parser/ling3.py
+++ b/vllm/parser/ling3.py
@@ -22,6 +22,7 @@ from vllm.parser.glm47_moe import (
     Glm47MoeParser,
     glm47_moe_config,
 )
+from vllm.parser.utils import resolve_enable_thinking
 
 if TYPE_CHECKING:
     from vllm.tokenizers import TokenizerLike
@@ -38,13 +39,7 @@ class Ling3Parser(Glm47MoeParser):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        thinking = chat_kwargs.get("thinking", None)
-        enable_thinking = chat_kwargs.get("enable_thinking", None)
-        self.thinking_enabled = (
-            True
-            if thinking is None and enable_thinking is None
-            else bool(thinking) or bool(enable_thinking)
-        )
+        self.thinking_enabled = resolve_enable_thinking(chat_kwargs, default=True)
         parser_config = replace(
             glm47_moe_config(thinking=self.thinking_enabled),
             name="ling3",

--- a/vllm/parser/nemotron_v3.py
+++ b/vllm/parser/nemotron_v3.py
@@ -17,6 +17,7 @@ import functools
 from typing import TYPE_CHECKING
 
 from vllm.parser.qwen3 import CHATML_TURN_BOUNDARIES, Qwen3Parser, qwen3_config
+from vllm.parser.utils import resolve_enable_thinking
 
 if TYPE_CHECKING:
     from vllm.entrypoints.generate.base.protocol import DeltaMessage
@@ -53,7 +54,7 @@ class NemotronV3Parser(Qwen3Parser):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        thinking = chat_kwargs.get("enable_thinking", True)
+        thinking = resolve_enable_thinking(chat_kwargs, default=True)
         super().__init__(
             tokenizer,
             tools,
@@ -84,7 +85,7 @@ class NemotronV3Parser(Qwen3Parser):
         return bool(
             chat_template_kwargs
             and (
-                chat_template_kwargs.get("enable_thinking") is False
+                not resolve_enable_thinking(chat_template_kwargs, default=True)
                 or chat_template_kwargs.get("force_nonempty_content") is True
             )
         )

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -29,6 +29,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
+from vllm.parser.utils import resolve_enable_thinking
 
 if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -227,7 +228,7 @@ class Qwen3Parser(ParserEngine):
         **kwargs,
     ) -> None:
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self.thinking_enabled = chat_kwargs.get("enable_thinking", True)
+        self.thinking_enabled = resolve_enable_thinking(chat_kwargs, default=True)
         kwargs.setdefault(
             "parser_engine_config",
             qwen3_config(

--- a/vllm/parser/utils.py
+++ b/vllm/parser/utils.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
 
 from openai.types.responses import ResponseFunctionToolCall
 
@@ -11,6 +12,25 @@ from vllm.entrypoints.openai.responses.protocol import (
     ResponseInputOutputItem,
     ResponsesRequest,
 )
+
+
+def resolve_enable_thinking(
+    chat_kwargs: Mapping[str, Any] | None,
+    *,
+    default: bool = True,
+) -> bool:
+    """Resolve whether thinking/reasoning mode is enabled.
+
+    ``enable_thinking`` is the canonical chat_template_kwargs name.
+    ``thinking`` is accepted as a backward-compatible alias so parsers and
+    chat templates stay in sync (see #43728).
+    """
+    chat_kwargs = chat_kwargs or {}
+    thinking = chat_kwargs.get("thinking")
+    enable_thinking = chat_kwargs.get("enable_thinking")
+    if thinking is None and enable_thinking is None:
+        return default
+    return bool(thinking) or bool(enable_thinking)
 
 
 def count_tool_calls(tool_calls: object) -> int:


### PR DESCRIPTION
## Purpose

Fixes #43728.

Some reasoning parsers only read `enable_thinking` from `chat_template_kwargs`, while clients / templates still pass `thinking`. When those disagree, you can get `content: null` or mismatched thinking mode.

This adds a shared `resolve_enable_thinking()` helper (`enable_thinking` canonical, `thinking` as alias) and wires it into the parsers that were still one-sided or duplicated the dual-read logic.

## Not a duplicate

- No open PR targets #43728.
- Follows the collaborator note on the issue: keep `enable_thinking` as the canonical name and accept `thinking` as a compatible alias.
- Does not rewrite chat templates; only parser-side resolution.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/parser/test_resolve_enable_thinking.py \
  tests/parser/engine/test_qwen3_reasoning.py::TestThinkingDisabled \
  tests/parser/engine/test_nemotron_v3.py::TestNemotronSwap \
  -v --noconftest
```

## Test Result

22 passed.

## AI assistance

Cursor helped draft the helper, parser wiring, tests, and this PR text. I reviewed every changed line and ran the tests above.

Made with [Cursor](https://cursor.com)