### PR TITLE
[Docs] Explain how to measure prefix cache effectiveness

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -25,8 +25,8 @@ In v1, an extensive set of metrics are exposed via a Prometheus-compatible `/met
 
 - `vllm:num_requests_running` (Gauge) - Number of requests currently running.
 - `vllm:kv_cache_usage_perc` (Gauge) - Fraction of used KV cache blocks (0–1).
-- `vllm:prefix_cache_queries` (Counter) - Number of prefix cache queries.
-- `vllm:prefix_cache_hits` (Counter) - Number of prefix cache hits.
+- `vllm:prefix_cache_queries` (Counter) - Number of tokens queried in the prefix cache.
+- `vllm:prefix_cache_hits` (Counter) - Number of tokens found in the prefix cache.
 - `vllm:prompt_tokens_total` (Counter) - Total number of prompt tokens processed.
 - `vllm:generation_tokens_total` (Counter) - Total number of generated tokens.
 - `vllm:request_success_total` (Counter) - Number of finished requests (by finish reason).

--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -20,6 +20,38 @@ We describe two example workloads, where APC can provide huge performance benefi
 - Long document query, where the user repeatedly queries the same long document (e.g. software manual or annual report) with different queries. In this case, instead of processing the long document again and again, APC allows vLLM to process this long document *only once*, and all future requests can avoid recomputing this long document by reusing its KV cache. This allows vLLM to serve future requests with much higher throughput and much lower latency.
 - Multi-round conversation, where the user may chat with the application multiple times in the same chatting session. In this case, instead of processing the whole chatting history again and again, APC allows vLLM to reuse the processing results of the chat history across all future rounds of conversation, allowing vLLM to serve future requests with much higher throughput and much lower latency.
 
+## Measuring cache effectiveness
+
+The Prometheus-compatible `/metrics` endpoint exposes two cumulative token
+counters:
+
+- `vllm:prefix_cache_queries`: prompt tokens queried in the prefix cache.
+- `vllm:prefix_cache_hits`: prompt tokens found in the prefix cache.
+
+Their ratio measures token reuse, rather than the fraction of requests that had
+at least one hit. For example, this PromQL query calculates the aggregate hit
+ratio over a five-minute window:
+
+```promql
+sum(rate(vllm:prefix_cache_hits[5m]))
+/
+clamp_min(sum(rate(vllm:prefix_cache_queries[5m])), 1)
+```
+
+Use counter deltas over an isolated interval when comparing two fixed
+workloads. Keep request ordering, prompt and output lengths, concurrency, and
+the initial cache state constant. A fresh engine provides the cleanest empty
+cache. In a development-only environment, the cache-management API can reset
+the prefix cache when no requests are active; do not enable development
+endpoints in production.
+
+Report the token hit ratio together with time to first token (TTFT), request
+latency, and token throughput. A high hit ratio does not imply the same
+percentage improvement in end-to-end performance: APC removes shared prefill
+work, while queueing, scheduling, and decoding still take time. Cache capacity,
+eviction, request routing across replicas, and full-block alignment can also
+change the observed ratio.
+
 ## Limits
 
 APC in general does not reduce the performance of vLLM. With that being said, APC only reduces the time of processing the queries (the prefilling phase) and does not reduce the time of generating new tokens (the decoding phase). So APC does not bring performance gain when vLLM spends most of the time generating answers to the queries (e.g. when the length of the answer is long), or new queries do not share the same prefix with any of existing queries (so that the computation cannot be reused).


### PR DESCRIPTION
## Purpose

The Automatic Prefix Caching guide explains where APC helps, but does not currently tell operators how to measure cache effectiveness or distinguish token reuse from end-to-end performance gains.

This change:

- documents the token units of `vllm:prefix_cache_queries` and `vllm:prefix_cache_hits`;
- adds a PromQL example for aggregate token hit ratio;
- describes how to control request order, concurrency, and initial cache state for comparisons;
- recommends reporting TTFT, latency, and throughput alongside hit ratio;
- clarifies that decode, scheduling, eviction, routing, and block alignment can make a high hit ratio differ from the observed speedup; and
- corrects the metric overview so both counter descriptions explicitly say tokens.

This guidance is informed by an isolated prefix-cache experiment in which a 94.59% full-block token hit ratio produced only a 5.7%–6.2% throughput improvement for a short agentic workload at concurrency 64. Related offline-analysis discussion: #47993.

## Test Plan

Run the repository's Markdown and spelling hooks on both changed files:

```bash
pre-commit run markdownlint-cli2 --files \
  docs/features/automatic_prefix_caching.md docs/design/metrics.md
pre-commit run typos --files \
  docs/features/automatic_prefix_caching.md docs/design/metrics.md
```

## Test Result

Both focused hooks pass locally:

```text
markdownlint-cli2........................................................Passed
typos....................................................................Passed
```
