### PR TITLE
fix(spec_decode): thread spec_step_idx in llm_base_proposer for multi-layer MTP (#52688)

### DIFF
--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -652,6 +652,7 @@ class SpecDecodeBaseProposer:
                 "input_ids": input_ids,
                 "positions": self._get_positions(input_batch_size),
                 "inputs_embeds": inputs_embeds,
+                "spec_step_idx": token_index,
             }
             if self.pass_hidden_states_to_model:
                 model_kwargs["hidden_states"] = self.hidden_states[:input_batch_size]


### PR DESCRIPTION
### Description
Fixes #52688.

In multi-layer Multi-Token Prediction (MTP) models (such as `Qwen3_5MultiTokenPredictor` and `DeepseekMTP`), layer selection relies on `spec_step_idx` (`current_step_idx = spec_step_idx % self.num_mtp_layers`).

In `vllm/v1/spec_decode/llm_base_proposer.py`, `model_kwargs` previously omitted `spec_step_idx` during multi-step drafting. As a result, `spec_step_idx` defaulted to `0` across all $K$ draft steps, repeatedly executing physical `layers[0]` while leaving physical MTP layers `1..N-1` unexecuted.

This PR threads `"spec_step_idx": token_index` inside `model_kwargs` in `llm_base_proposer.py` so physical MTP layers execute sequentially as trained across draft positions.

### Test Plan
- Verified with `uvx pre-commit` (all hooks, ruff, mypy passing).
- Verified `model_kwargs` receives `spec_step_idx` matching `token_index` for multi-layer MTP drafting.