### PR TITLE
Fix hybrid mamba running state block size seeding

### DIFF
--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -109,8 +109,11 @@ class MambaHybridModelState(DefaultModelState):
         self.num_accepted_tokens_gpu[req_index].fill_(1)
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
+            mamba_bs = (self._mamba_spec.block_size
+                        if self._mamba_spec is not None
+                        else self.cache_config.block_size)
             self._mamba_state_idx_gpu[req_index].fill_(
-                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
+                (new_req_data.num_computed_tokens - 1) // mamba_bs
             )
 
     def _get_mamba_group_info(


### PR DESCRIPTION
Fixes out-of-bounds memory access crash during prefix-cache resumption for Hybrid Mamba models by dynamically seeding the Mamba KV-cache group's block size.