### PR TITLE
[Perf] Prefer CUTLASS over FlashInfer for per-tensor FP8 linear on SM100

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -396,8 +396,9 @@ _POSSIBLE_INT8_KERNELS: dict[PlatformEnum, list[type[Int8ScaledMMLinearKernel]]]
 # in priority/performance order (when available)
 _POSSIBLE_FP8_KERNELS: dict[PlatformEnum, list[type[FP8ScaledMMLinearKernel]]] = {
     PlatformEnum.CUDA: [
-        FlashInferFP8ScaledMMLinearKernel,
+        # CUTLASS before FlashInfer: ~2x faster at prefill on SM100
         CutlassFP8ScaledMMLinearKernel,
+        FlashInferFP8ScaledMMLinearKernel,
         B12xTensorFP8ScaledMMLinearKernel,
         PerTensorTorchFP8ScaledMMLinearKernel,
         ChannelWiseTorchFP8ScaledMMLinearKernel,


### PR DESCRIPTION
## Purpose

On SM100, per-tensor FP8 checkpoints select the FlashInfer linear kernel by default. That kernel runs every linear layer through `bmm_fp8` with batch size 1. It is about 2x slower than the CUTLASS kernel at prefill sizes. Most of the FP8-vs-BF16 prefill gap reported in #49723 comes from this.

I moved CUTLASS above FlashInfer in `_POSSIBLE_FP8_KERNELS`. The FlashInfer kernel requires compute capability 100 or higher, so the default changes on Blackwell only. `--linear-backend flashinfer_cutlass` still selects it. The current ordering came from the #27814 refactor, and I could not find an SM100 performance comparison behind it.

Fixes #49723.

## Test Plan

I ran the same serving bench as the issue (`vllm bench serve`, random 300 in / 64 out, `--max-concurrency 64`, 1000 prompts) on `nvidia/Llama-3.1-8B-Instruct-FP8` with 1x B200, vLLM 0.27.1, FlashInfer 0.6.16.post3. I confirmed the selected kernel from the serve log for each run, and added the unquantized model as a BF16 reference. I also benchmarked the two kernels directly at the batch sizes prefill and decode produce (scripts below).

## Test Result

| linear kernel | req/s | TTFT P50 (ms) | TTFT P99 (ms) | TPOT P50 (ms) | TPOT P99 (ms) |
|---|---|---|---|---|---|
| FlashInfer (current default) | 63.9 | 583.2 | 879.6 | 5.37 | 12.66 |
| CUTLASS (this PR) | 103.7 | **240.5** | 380.9 | 5.71 | 7.86 |
| BF16 weights (reference) | 113.1 | 187.7 | 291.3 | 5.82 | 7.83 |

TTFT improved 59% and request throughput improved 62%. The remaining 1.28x gap to BF16 comes from per-layer activation quantization, not the GEMM (see the kernel table), and is a separate question from kernel selection.

Kernel-level, median of 100 iters (us):

| K=5120, N=5120 | FlashInfer | CUTLASS | BF16 matmul |
|---|---|---|---|
| M=256 | 91.3 | 24.4 | 20.4 |
| M=2048 | 145.2 | 50.6 | 68.4 |
| M=8192 | 368.5 | 169.6 | 294.5 |
| M=16384 | 739.8 | 310.9 | 559.5 |

FlashInfer was slower in all 72 cells of the full sweep (6 shapes, 12 batch sizes, 1.8-4.9x). CUDA-graph replay shows the same gap in device time, and the outputs of the two kernels match within fp8 rounding noise (max abs diff 0.016).

I measured on sm100 only.

<details>
<summary>kernel bench script (condensed)</summary>

```python
import torch
from vllm import _custom_ops as ops
from vllm.utils.flashinfer import flashinfer_scaled_fp8_mm

SHAPES = [(5120, 5120), (5120, 27648), (13824, 5120),
          (5120, 7168), (4096, 14336), (14336, 4096)]
MS = [1, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]

def t(fn, warmup=25, iters=100):
    for _ in range(warmup): fn()
    torch.cuda.synchronize()
    s, e = torch.cuda.Event(True), torch.cuda.Event(True)
    ts = []
    for _ in range(iters):
        s.record(); fn(); e.record(); torch.cuda.synchronize()
        ts.append(s.elapsed_time(e) * 1000)
    return sorted(ts)[iters // 2]

dev, dt = torch.device("cuda"), torch.bfloat16
for k, n in SHAPES:
    w = torch.randn(n, k, device=dev, dtype=dt) / k**0.5
    ws = (w.abs().amax() / torch.finfo(torch.float8_e4m3fn).max).float()
    b = (w / ws).to(torch.float8_e4m3fn).t()  # (K,N) col-major, as served
    for m in MS:
        a = torch.randn(m, k, device=dev, dtype=dt)
        as_ = (a.abs().amax() / torch.finfo(torch.float8_e4m3fn).max).float()
        af = (a / as_).to(torch.float8_e4m3fn)
        fi = t(lambda: flashinfer_scaled_fp8_mm(
            af, b, scale_a=as_.reshape(1), scale_b=ws.reshape(1), out_dtype=dt))
        cu = t(lambda: ops.cutlass_scaled_mm(
            af, b, scale_a=as_.reshape(1, 1), scale_b=ws.reshape(1, 1), out_dtype=dt))
        bf = t(lambda: torch.matmul(a, w.t()))
        print(k, n, m, fi, cu, bf)
```

For the CUDA-graph pass I captured 50 identical calls in one graph and timed
replays, per kernel, at M in {1, 16, 64, 256, 4096}.

</details>

---

**AI assistance disclosure** (per AGENTS.md): AI assistance (Claude Code) was used; I reviewed the change and the benchmarks. **Duplicate check**: no open PR reorders the FP8 scaled_mm priority or addresses #49723. #48210 pins bmm_fp8's backend on sm_12x, which is a different problem.

