### PR TITLE
[Docs] Add Qwen3-0.6B to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -123,7 +123,7 @@ for output in outputs:
 Batch invariance has been tested and verified on the following models:
 
 - **DeepSeek series**: `deepseek-ai/DeepSeek-V3`, `deepseek-ai/DeepSeek-V3-0324`, `deepseek-ai/DeepSeek-R1`, `deepseek-ai/DeepSeek-V3.1`
-- **Qwen3 (Dense)**: `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`, `Qwen/Qwen3-4B-AWQ`, `Qwen/Qwen3-8B-AWQ`
+- **Qwen3 (Dense)**: `Qwen/Qwen3-0.6B`, `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`, `Qwen/Qwen3-4B-AWQ`, `Qwen/Qwen3-8B-AWQ`
 - **Qwen3-VL (Vision-Language)**: `Qwen/Qwen3-VL-2B-Instruct`, `Qwen/Qwen3-VL-4B-Instruct` (single image and video inputs)
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`
 - **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`


### PR DESCRIPTION
## Summary

Adds `Qwen/Qwen3-0.6B` to the batch invariance tested models list in `docs/features/batch_invariance.md`.

## Why this is not a duplicate

- `Qwen/Qwen3-0.6B` does not appear in the existing tested-models list, which covers 1.7B, 8B, 4B-AWQ, and 8B-AWQ variants.
- Checked all open PRs — none cover Qwen3-0.6B.
- Related: `microsoft/Phi-4-mini-instruct` was tested in this session and also passed (16/16), but PR #46900 already covers that model so it is not added here.

## Test results (H100 NVL, Azure OCP)

Hardware: NVIDIA H100 NVL (94 GB VRAM), vLLM container `vllm/vllm-openai:latest` (v0.27.1)

**Command:**
```bash
VLLM_TEST_MODEL="Qwen/Qwen3-0.6B" VLLM_BATCH_INVARIANT=1 \
  VLLM_NEEDLE_TRIALS=3 VLLM_NEEDLE_BATCH_SIZE=16 \
  pytest tests/v1/determinism/test_batch_invariance.py \
  -k "not GDN_ATTN and not vllm_c" -v --timeout=600
```

**Result:** `16 passed, 3 deselected in 670.58s (0:11:10)` — all selected tests green.

All 16 tests passed:
- `test_v1_generation_is_deterministic_across_batch_sizes_with_needle` (FLASH_ATTN / FLEX_ATTENTION / TRITON_ATTN)
- `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN` (16-16 and 8-16, three backends each)
- `test_simple_generation` (three backends)
- `test_logprobs_without_batch_invariance_should_fail` (three backends)
- `test_decode_logprobs_match_prefill_logprobs` (FLASH_ATTN)

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code / Claude Sonnet 4.6). The human submitter ran and reviewed the test results, reviewed the diff, and validated there is no duplicate open PR covering this exact model.