### PR TITLE
[Bugfix][Frontend] Start Muse Glimmer structured outputs at to=user

### DIFF
--- a/tests/tool_use/test_muse_glimmer.py
+++ b/tests/tool_use/test_muse_glimmer.py
@@ -384,3 +384,38 @@ def test_exact_match_kept():
         T, _call("get_weather"), _req("get_weather")
     )
     assert out.tool_calls[0].function.name == "get_weather"
+
+
+class _OrdTok:
+    """Character-level tokenizer so decode-based predicates can be unit-tested."""
+
+    def decode(self, ids, *args, **kwargs):
+        return "".join(chr(i) for i in ids)
+
+    def get_vocab(self):
+        return {}
+
+
+def _ord_ids(text: str) -> list[int]:
+    return [ord(c) for c in text]
+
+
+def test_grammar_starts_on_user_channel_without_tool_handoff():
+    """#52594: JSON schemas attach at ``to=user``, not only at a tool channel."""
+    parser = MuseGlimmerReasoningParser(_OrdTok())
+    reasoning_only = "<|start|>assistant to=self<|message|>think"
+    answer = (
+        "<|start|>assistant to=self<|message|>think<|eom|>"
+        "to=user<|message|>{\"scenario\":\"x\"}"
+    )
+    tool = _call("read.read")
+
+    assert parser.is_reasoning_end(_ord_ids(reasoning_only)) is False
+    assert parser.is_grammar_start_allowed(_ord_ids(reasoning_only), []) is False
+
+    assert parser.is_reasoning_end(_ord_ids(answer)) is False
+    assert parser.is_reasoning_end_streaming(_ord_ids(answer), []) is False
+    assert parser.is_grammar_start_allowed(_ord_ids(answer), []) is True
+
+    assert parser.is_reasoning_end(_ord_ids(tool)) is True
+    assert parser.is_grammar_start_allowed(_ord_ids(tool), []) is False

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -403,3 +403,27 @@ class TestReasoningStructuredOutput:
         assert manager_with_reasoner.trim_reasoning_for_advance(
             mock_request_with_structured_output, new_token_ids
         ) == [271, 5005]
+
+    def test_should_advance_uses_grammar_start_when_distinct_from_tool_end(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """Muse Glimmer: grammar may start at the answer channel (#52594)."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+
+        class SplitPredicateReasoner:
+            def is_reasoning_end_streaming(self, input_ids, delta_ids):
+                return False
+
+            def is_grammar_start_allowed(self, input_ids, delta_ids):
+                return True
+
+        structured_req.reasoner = SplitPredicateReasoner()
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output,
+            new_token_ids=[9],
+        )
+        assert result is True
+        assert structured_req.reasoning_ended is True

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -112,6 +112,19 @@ class ReasoningParser:
         """
         return self.is_reasoning_end(input_ids)
 
+    def is_grammar_start_allowed(
+        self, input_ids: Sequence[int], delta_ids: Iterable[int]
+    ) -> bool:
+        """When structured-output bitmasks may start filling.
+
+        Defaults to ``is_reasoning_end_streaming``. Parsers that keep a
+        user-facing answer channel separate from the tool-handoff channel
+        (Muse Glimmer's ``to=user`` vs tool XML) override this so JSON
+        schemas attach to the answer without flipping the serving parser
+        into the tool phase.
+        """
+        return self.is_reasoning_end_streaming(input_ids, delta_ids)
+
     @abstractmethod
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         """

--- a/vllm/reasoning/muse_glimmer_reasoning_parser.py
+++ b/vllm/reasoning/muse_glimmer_reasoning_parser.py
@@ -156,6 +156,26 @@ class MuseGlimmerReasoningParser(ReasoningParser):
     ) -> bool:
         return self.is_reasoning_end(list(input_ids))
 
+    def is_grammar_start_allowed(
+        self, input_ids: Sequence[int], delta_ids: Iterable[int]
+    ) -> bool:
+        """True once the current assistant turn has opened a ``to=user`` answer.
+
+        ``is_reasoning_end_streaming`` stays tool-only so ``DelegatingParser``
+        does not hand a prose answer to the ATEM tool parser. Structured
+        output is a second consumer of the same stream and must start the
+        grammar on the user-facing answer (#52594).
+        """
+        try:
+            text = self.model_tokenizer.decode(list(input_ids))
+        except Exception:
+            return False
+        turn = _current_assistant_turn(text)
+        return any(
+            match.group("recipient") == "user"
+            for match in _CHANNEL_HEADER_RE.finditer(turn)
+        )
+
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         # Content-id slicing is unreliable for multi-token markers; the serving
         # path uses extract_reasoning() for the final split.

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -33,6 +33,23 @@ else:
 logger = init_logger(__name__)
 
 
+def _grammar_start_allowed(
+    reasoner: "ReasoningParser",
+    input_ids: Sequence[int],
+    delta_ids: Iterable[int],
+) -> bool:
+    """When the structured-output bitmask may start filling.
+
+    Prefer ``is_grammar_start_allowed`` when the parser defines it; otherwise
+    fall back to ``is_reasoning_end_streaming`` so older / test stubs keep
+    working.
+    """
+    fn = getattr(reasoner, "is_grammar_start_allowed", None)
+    if callable(fn):
+        return bool(fn(input_ids, delta_ids))
+    return bool(reasoner.is_reasoning_end_streaming(input_ids, delta_ids))
+
+
 class StructuredOutputManager:
     """Engine-level manager for structured output requests."""
 
@@ -314,7 +331,7 @@ class StructuredOutputManager:
                             history_len = len(history)
                             simulated_buf = history + list(req_tokens)
                         simulated = simulated_buf[: history_len + i + 1]
-                        if reasoner.is_reasoning_end_streaming(simulated, [token]):
+                        if _grammar_start_allowed(reasoner, simulated, [token]):
                             # Reasoning ended mid-window. Constrain the rest
                             # of the window via bitmask. Skip grammar advance
                             # through the marker (it is reasoning content);
@@ -440,7 +457,7 @@ class StructuredOutputManager:
                 else max(len(all_token_ids) + delta_from, 0)
             )
             delta_ids = itertools.islice(all_token_ids, start, None)
-        if reasoner.is_reasoning_end_streaming(all_token_ids, delta_ids):
+        if _grammar_start_allowed(reasoner, all_token_ids, delta_ids):
             structured_req.reasoning_ended = True
 
             # Record the boundary so the scheduler can exclude reasoning tokens.
@@ -459,7 +476,7 @@ class StructuredOutputManager:
 
         Returns:
             The absolute index of the token at which
-            ``is_reasoning_end_streaming`` first fires. Falls back to the
+            ``is_grammar_start_allowed`` first fires. Falls back to the
             final index when no single token triggers the detection (e.g.
             a multi-token marker only recognized on the full delta), which
             conservatively treats the whole step as reasoning content.
@@ -468,7 +485,7 @@ class StructuredOutputManager:
         for idx in range(start, len(all_token_ids)):
             token = all_token_ids[idx]
             prefix.append(token)
-            if reasoner.is_reasoning_end_streaming(prefix, [token]):
+            if _grammar_start_allowed(reasoner, prefix, [token]):
                 return idx
         return len(all_token_ids) - 1
 


### PR DESCRIPTION
## Purpose

Fixes #52594.

With `--reasoning-parser muse_glimmer`, a JSON schema is silently skipped when `structured_outputs.enable_in_reasoning` is False. The structured-output bitmask gate reused `is_reasoning_end_streaming()`, which Muse Glimmer keeps **tool-only** so `DelegatingParser` does not hand a `to=user` prose answer to the ATEM tool parser. On a plain answer turn no tool channel opens, so the bitmask never fills.

This adds `ReasoningParser.is_grammar_start_allowed()`, defaulting to `is_reasoning_end_streaming()` so every other parser is unchanged. Muse Glimmer overrides it to become true at the `to=user` header. Tool-handoff and `extract_reasoning` are untouched.

Diagnosis and the separate-predicate design are from @jwLee527 in #52594.

## Test Plan

```bash
pytest tests/tool_use/test_muse_glimmer.py tests/v1/structured_output/test_reasoning_structured_output.py -q
```

## Test Result

Added:

- Muse Glimmer: `to=user` allows grammar and does **not** flip `is_reasoning_end`; a tool channel still does the reverse.
- Structured-output manager: a parser whose grammar predicate is true while `is_reasoning_end_streaming` is false still advances.

Existing `MockReasoner` / stub parsers without the new method keep using `is_reasoning_end_streaming`.

Local import of the full vLLM test stack was not run on this machine (torch + vLLM extras). CI should be the authority.

## AI assistance

Cursor was used to implement the predicate split and tests. I reviewed the call sites (`should_advance`, spec-decode bitmask fill, `_find_reasoning_end_index`) so only the structured-output gate uses the new method.

Made with [Cursor](https://cursor.com)