### PR TITLE
fix(parser): stop leaking partially delivered DSML tags into streamed tool arguments

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -154,6 +154,28 @@ class TestArgConverter:
         assert result["city"] == "Tokyo"
         assert result["expr"] == "x<5"
 
+    def test_partial_closing_tag_not_leaked(self):
+        # Streaming can stop mid-closing-tag (missing final ">"); the
+        # fragment must not leak into the argument value.
+        raw = (
+            f"<{_PARAM_OPEN.format(name='location', is_str='true')}"
+            "Paris</｜DSML｜parameter"
+        )
+        result = json.loads(_dsml_arg_converter(raw, partial=True))
+        assert result == {"location": "Paris"}
+
+    def test_partial_closing_tag_truncated_midway(self):
+        # Truncation may land anywhere inside the closing tag.
+        raw = f"<{_PARAM_OPEN.format(name='b', is_str='true')}y</｜DSM"
+        result = json.loads(_dsml_arg_converter(raw, partial=True))
+        assert result == {"b": "y"}
+
+    def test_partial_json_param_with_close_remnant(self):
+        raw = f'<{_PARAM_OPEN.format(name="n", is_str="false")}{{"lo"}}x</｜DSM'
+        result = json.loads(_dsml_arg_converter(raw, partial=True))
+        # Invalid in-progress JSON stays omitted, remnant must not corrupt it.
+        assert result == {}
+
     def test_null_string_false(self):
         raw = self._raw(("val", "false", "null"))
         result = json.loads(_dsml_arg_converter(raw, partial=False))

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -49,6 +49,14 @@ DSML_INVOKE_NAME_END = '">'
 DSML_INVOKE_END = f"</{_DSML}invoke>"
 DSML_PARAM_CLOSE = f"</{_DSML}parameter>"
 
+# Any non-empty prefix of a DSML tag: while streaming, a partially
+# delivered ``</｜DSML｜parameter>`` (or the next ``<｜DSML｜...) tag can
+# follow an in-progress parameter value; capturing that fragment would
+# leak DSML markup into the streamed tool arguments.
+_TAG_PREFIXES = frozenset(
+    DSML_PARAM_CLOSE[:j] for j in range(1, len(DSML_PARAM_CLOSE) + 1)
+) | frozenset(f"<{_DSML}"[:j] for j in range(1, len(f"<{_DSML}") + 1))
+
 _ESCAPED_DSML = re.escape(_DSML)
 _PARAM_RE = re.compile(
     rf'<{_ESCAPED_DSML}parameter\s+name="([^"]+)"\s+string="(true|false)">'
@@ -60,6 +68,21 @@ _PARTIAL_PARAM_RE = re.compile(
     rf"(.*)$",
     re.DOTALL,
 )
+
+
+def _strip_partial_dsml_tag(value: str) -> str:
+    """Cut a trailing fragment that may be a partially delivered DSML tag.
+
+    During streaming a parameter value can be followed by the beginning of
+    ``</｜DSML｜parameter>`` (or of the next ``<｜DSML｜...) tag. Truncation
+    may happen at any point inside that tag, so instead of matching the
+    full marker we trim at the earliest offset where the remainder is a
+    prefix of one of those tags.
+    """
+    for i in range(len(value)):
+        if value[i:] in _TAG_PREFIXES:
+            return value[:i]
+    return value
 
 
 def _dsml_arg_converter(raw_args: str, partial: bool) -> str:
@@ -81,6 +104,7 @@ def _dsml_arg_converter(raw_args: str, partial: bool) -> str:
         pm = _PARTIAL_PARAM_RE.search(raw_args, last_end)
         if pm:
             name, is_str, value = pm.group(1), pm.group(2), pm.group(3)
+            value = _strip_partial_dsml_tag(value)
             if is_str == "true":
                 params[name] = value
             else:


### PR DESCRIPTION
## Purpose

While streaming DeepSeek V4 tool calls (`stream: true` + `tool_choice: required`), an in-progress parameter value can be followed by the *beginning* of its closing tag `</｜DSML｜parameter>`, because a chunk boundary may land anywhere inside that tag. The partial matcher in `_dsml_arg_converter` used a greedy `(.*)$`, so the truncated tag fragment was captured into the argument value:

```
{"location": "Paris</｜DSML｜parameter"}
```

This corrupts streamed tool arguments for every agent harness consuming them.

## Changes

- Add `_TAG_PREFIXES`, the set of all non-empty prefixes of `</｜DSML｜parameter>` and of `<｜DSML`.
- Add `_strip_partial_dsml_tag()`: trim the partial value at the earliest offset where the remainder is one of those prefixes. Applied only in the partial branch; the complete-parameter path is untouched.
- Three regression tests in `TestArgConverter`, including truncation in the middle of the closing tag.

### Why prefix trimming instead of a tempered regex

A tempered pattern such as `(?:(?!</?｜DSML｜).)*` only stops when it can see the full `｜DSML｜` sequence. Streaming truncation can land earlier than that — e.g. a value ending in `y</｜DSM` still leaks under that approach (verified experimentally). Checking whether any suffix of the value is a prefix of a DSML tag handles every truncation point exactly, and leaves ordinary angle brackets in values (`a<b`) untouched.

## Test Plan

- [x] New unit tests: partial closing tag missing final `>` (the issue's repro), closing tag truncated midway (`y</｜DSM`), invalid in-progress JSON plus close remnant stays omitted.
- [x] Full `TestArgConverter` class passes against the patched converter (20/20), and plain `<` values keep working via the existing angle-bracket tests.

Fixes #53227
