### PR TITLE
[Bugfix] Do not FULL-capture spec-decode batches in TurboQuant attention backend

### DIFF
--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -217,7 +217,17 @@ class TurboQuantMetadataBuilder(AttentionMetadataBuilder[TurboQuantMetadata]):
     """Builds TurboQuantMetadata from scheduler output."""
 
     kv_cache_spec: AttentionSpec
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    # UNIFORM_SINGLE_TOKEN_DECODE, not UNIFORM_BATCH: spec-decode verify
+    # batches (uniform query_len of 1 + num_speculative_tokens) route through
+    # the per-request Python prefill loop (supports_spec_as_decode=False),
+    # which reads CPU-resident metadata and is not graph-capturable. Under
+    # UNIFORM_BATCH the runner FULL-captures those batches with dummy
+    # metadata (seq_lens filled with 1), baking empty/garbage attention into
+    # the graph: silent repetition collapse for num_speculative_tokens > 1
+    # and illegal memory access for num_speculative_tokens == 1 (#52475).
+    _cudagraph_support: ClassVar[AttentionCGSupport] = (
+        AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+    )
 
     def __init__(self, kv_cache_spec, layer_names, vllm_config, device):
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)


### PR DESCRIPTION
## Purpose

Fixes #52475: MTP speculative decoding with any `turboquant_*` KV cache dtype silently collapses into repetition, and `num_speculative_tokens: 1` kills the engine with an illegal memory access.

Root cause: `TurboQuantMetadataBuilder` declares `_cudagraph_support = UNIFORM_BATCH` while also declaring `supports_spec_as_decode=False`. Those two declarations are contradictory under speculative decoding:

1. `UNIFORM_BATCH` tells the runner it may FULL-capture uniform batches, explicitly including spec-decode verify batches whose query_len is `1 + num_speculative_tokens` (see the `AttentionCGSupport.UNIFORM_BATCH` docstring). `GPUModelRunner._is_uniform_decode` classifies these batches by query length alone and does not consult `supports_spec_as_decode`.
2. But because `supports_spec_as_decode=False` sets `reorder_batch_threshold=1`, the TurboQuant forward routes every batch with `max_query_len > 1` through its per-request Python prefill loop (`_prefill_attention`). That loop iterates over CPU-resident metadata (`query_start_loc_cpu.tolist()`, `seq_lens_cpu.tolist()`), so it is not graph-capturable: capture bakes in the dummy metadata from `build_for_cudagraph_capture`, which fills `seq_lens` with 1. With query_len 4 and seq_len 1, `cached_len = seq_len - q_len` is negative and the synthetic seq_lens slice `_arange_cache[cached_len + 1 : seq_len + 1]` is empty, so the captured graph performs no attention at all. Every replayed verify step then returns zeros from all full-attention layers (the hybrid model's GDN layers keep the output superficially fluent, which is why the failure is silent and gradual). With `num_speculative_tokens=1` the same baked-in arithmetic indexes out of bounds instead, matching the illegal-memory-access crash in the issue.

This also explains the exact on/off pattern reported in #52475: fp8 KV is clean (FlashAttention masks from GPU-side tensors and supports spec-as-decode), turboquant without MTP is clean (pure decode batches are capture-safe), and turboquant with MTP under `--enforce-eager` is clean (same Python loop, real metadata).

The fix declares `UNIFORM_SINGLE_TOKEN_DECODE` so spec-shaped batches fall back to piecewise cudagraphs and the attention path runs eagerly with real metadata. Pure decode batches (query_len 1, no spec) keep FULL capture, so the non-speculative configuration is unchanged.

Not a duplicate: no open PR references #52475, and the open TurboQuant PRs (#53060, #52745, #53231, #51082, #50248, #49798, #49465, #40858) touch the decode kernels, cache-shape resolution, or platform enablement, not the cudagraph support declaration. #53059 is adjacent but different: it fixes prefills that alias the uniform-decode shape, while this bug is genuine spec-decode batches being FULL-captured by a backend whose spec path cannot be captured.

## Test Plan

Hardware: 2x RTX 5060 Ti (sm120), TP=2. Model: Qwen3.8-27B NVFP4 (`model_type: qwen3_5`, hybrid GDN, head_dim 256, GQA 6), the same model family as the issue.

Bisection matrix that isolated the bug, all with `--kv-cache-dtype turboquant_k8v4`, greedy sampling, identical prompts:

```bash
vllm serve <model> -tp 2 --max-model-len 32768 --max-num-seqs 1 \
  --kv-cache-dtype turboquant_k8v4 [--enforce-eager] \
  [--speculative-config '{"method":"mtp","num_speculative_tokens":3}']
```

| cudagraphs | MTP | output |
|---|---|---|
| on | on | repetition collapse ("The The The...") |
| off | on | coherent |
| on | off | coherent |
| off | off | coherent |
| on (with this fix) | on | coherent |

`--no-async-scheduling` with cudagraphs+MTP still collapses, ruling out async scheduling as the trigger.

The second failure mode from the issue is also resolved: `num_speculative_tokens: 1` with cudagraphs, which previously died with an illegal memory access on the first request, now serves and generates coherently with this fix (same command as above with `"num_speculative_tokens":1`).

After the fix, the full target configuration from the issue also works: `--max-model-len 262144 --kv-cache-dtype turboquant_4bit_nc` with MTP K3 and the vision tower loaded. 301,465-token KV pool (1.15x concurrency), needle retrieval passes at 12k and 60k token prompts, MTP draft acceptance 77.3% (per-position 0.864/0.727/0.727), prefill 10.6k tokens/s on this hardware.

## Test Result

Before (cudagraphs + MTP K3, turboquant_k8v4, greedy):

```
'\n\nRome\n\nR\n\nR\n\nR\n\nR\n\nR\n\nHere\n\nHere\n\nHere\n\nHere...'
```

After (same command, this fix applied):

```
"\n\n<think>\nThe user wants a detailed paragraph about the history of Rome...
</think>\n\nThe history of Rome stretches across roughly three millennia..."
```

Output quality matches the `--enforce-eager` control. Non-speculative serving before/after is unchanged (still FULL-captures single-token decode batches).

AI assistance was used to bisect this bug and draft this PR; I reviewed the change and ran the tests above.
