### PR TITLE
[Bugfix][MRV2] Dispatch uniform decode to a padded FULL cudagraph

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -109,3 +109,210 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
         manager.capture(create_forward_fn)
 
     mock_cuda_graph.assert_called_once()
+
+
+# Spec-decode query length used by the padding tests below. With qlen=3 the
+# uniform-decode graphs land on multiples of 3 (round_up(size, 3)), which leaves
+# gaps against the power-of-two capture ladder -- exactly the case the padding
+# dispatch has to cover.
+_DECODE_QUERY_LEN = 3
+
+
+def _create_decode_vllm_config(capture_sizes: list[int]) -> MagicMock:
+    """Config for the padding tests below.
+
+    With capture_sizes [1, 2, 4, 8, 16, 24] and qlen=3, the FULL decode graphs
+    land on round_up(size, 3) = 3, 6, 9, 18, 24 tokens while the PIECEWISE
+    graphs stay on the raw sizes. 12 tokens (4 requests x qlen 3) therefore has
+    no exact FULL decode graph; the only descriptor staged for it is the size-16
+    PIECEWISE one.
+    """
+    compilation_config = CompilationConfig(
+        cudagraph_mode="FULL_AND_PIECEWISE",
+        cudagraph_capture_sizes=capture_sizes,
+    )
+    compilation_config.max_cudagraph_capture_size = capture_sizes[-1]
+    compilation_config.post_init_cudagraph_sizes()
+
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.compilation_config = compilation_config
+    vllm_config.scheduler_config = SchedulerConfig.default_factory(max_num_seqs=8)
+    vllm_config.parallel_config = ParallelConfig()
+    vllm_config.speculative_config = None
+    vllm_config.num_speculative_tokens = 0
+    return vllm_config
+
+
+def _make_spec_decode_manager(
+    monkeypatch,
+    decode_query_len: int = _DECODE_QUERY_LEN,
+    capture_sizes: list[int] | None = None,
+    is_rocm: bool = True,
+) -> gpu_cudagraph_utils.CudaGraphManager:
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        gpu_cudagraph_utils.current_platform,
+        "get_global_graph_pool",
+        lambda: object(),
+    )
+    # Pad-up dispatch is ROCm-gated. Patching the platform keeps these tests
+    # running (and meaningful) on the CPU runner that executes this file in CI.
+    monkeypatch.setattr(
+        gpu_cudagraph_utils.current_platform,
+        "is_rocm",
+        lambda: is_rocm,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=_create_decode_vllm_config(
+            capture_sizes or [1, 2, 4, 8, 16, 24],
+        ),
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=decode_query_len,
+    )
+    # dispatch() only consults the candidate lists once capture has run; these
+    # tests exercise selection, not capture, so mark it done.
+    manager._graphs_captured = True
+    return manager
+
+
+def test_uniform_decode_pads_up_to_full_graph(monkeypatch):
+    """A uniform-decode batch with no exact FULL graph must pad, not go PIECEWISE.
+
+    ROCm only -- see test_pad_up_is_rocm_gated for the other platforms.
+
+    Without pad-up dispatch, 12 tokens finds only the size-16 PIECEWISE
+    descriptor -- which _is_compatible accepts, because a PIECEWISE descriptor
+    has uniform_token_count=None and matches anything -- so attention runs eager
+    (metadata build plus kernels on the host critical path) every decode step.
+    The size-18 FULL decode graph can serve the batch by padding 4 requests up
+    to 6, and must win.
+    """
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=4,
+        num_tokens=12,
+        uniform_token_count=_DECODE_QUERY_LEN,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert desc.uniform_token_count == _DECODE_QUERY_LEN
+    # Smallest FULL decode graph that fits, not merely any of them.
+    assert desc.num_tokens == 18
+    assert desc.num_reqs == 6
+
+
+def test_pad_up_is_rocm_gated(monkeypatch):
+    """Off ROCm, the same batch keeps the pre-change behaviour.
+
+    Identical to test_uniform_decode_pads_up_to_full_graph, except the platform
+    reports non-ROCm. The size-18 FULL decode graph is not offered, so dispatch
+    falls to the size-16 PIECEWISE descriptor exactly as it did before this
+    change. This is what pins the gate: delete it and this test fails.
+    """
+    manager = _make_spec_decode_manager(monkeypatch, is_rocm=False)
+
+    desc = manager.dispatch(
+        num_reqs=4,
+        num_tokens=12,
+        uniform_token_count=_DECODE_QUERY_LEN,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.PIECEWISE
+    assert desc.num_tokens == 16
+
+
+def test_uniform_decode_exact_match_is_not_over_padded(monkeypatch):
+    """An exact FULL decode graph still wins over larger pad-up candidates."""
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=3,
+        num_tokens=9,
+        uniform_token_count=_DECODE_QUERY_LEN,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert desc.num_tokens == 9
+    assert desc.num_reqs == 3
+
+
+def test_mixed_batch_never_selects_a_uniform_decode_graph(monkeypatch):
+    """The safety property: pad-up candidates must be inert for mixed batches.
+
+    Uniform-decode descriptors are offered ahead of the mixed fallback for every
+    token count, so this asserts _is_compatible really does reject them when the
+    batch is not uniform -- otherwise a prefill batch would replay a decode-only
+    graph and silently produce wrong results.
+    """
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=2,
+        num_tokens=12,
+        uniform_token_count=None,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.PIECEWISE
+    assert desc.uniform_token_count is None
+    assert desc.num_tokens == 16
+
+
+def test_uniform_decode_beyond_capture_ladder_falls_back(monkeypatch):
+    """Past the largest captured graph there is nothing to pad up to."""
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    desc = manager.dispatch(
+        num_reqs=9,
+        num_tokens=27,
+        uniform_token_count=_DECODE_QUERY_LEN,
+        num_active_loras=0,
+    )
+
+    assert desc.cg_mode == CUDAGraphMode.NONE
+
+
+@pytest.mark.parametrize(
+    "decode_query_len,capture_sizes",
+    [(1, [1, 2, 4, 8]), (2, [2, 4, 8, 16]), (8, [8, 16, 32, 64])],
+)
+def test_divisor_query_len_dispatch_is_unchanged(
+    monkeypatch, decode_query_len, capture_sizes
+):
+    """Pad-up dispatch is inert when the query length divides the ladder.
+
+    round_up(size, qlen) == size for every captured size, so a FULL decode
+    graph already exists at each one and there is no gap to pad across. The
+    smallest pad-up candidate that fits is then exactly the descriptor the
+    pre-change code took from the staged list. This covers decode_query_len=1
+    -- every deployment not running speculative decoding -- as well as
+    speculative query lengths that happen to divide the ladder.
+    """
+    manager = _make_spec_decode_manager(
+        monkeypatch,
+        decode_query_len=decode_query_len,
+        capture_sizes=capture_sizes,
+    )
+
+    max_reqs = capture_sizes[-1] // decode_query_len
+    for num_reqs in range(1, max_reqs + 1):
+        num_tokens = num_reqs * decode_query_len
+        desc = manager.dispatch(
+            num_reqs=num_reqs,
+            num_tokens=num_tokens,
+            uniform_token_count=decode_query_len,
+            num_active_loras=0,
+        )
+        expected = min(s for s in capture_sizes if s >= num_tokens)
+        assert desc.cg_mode == CUDAGraphMode.FULL, num_tokens
+        assert desc.num_tokens == expected, num_tokens
+        assert desc.num_reqs == expected // decode_query_len, num_tokens

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -111,22 +111,10 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
     mock_cuda_graph.assert_called_once()
 
 
-# Spec-decode query length used by the padding tests below. With qlen=3 the
-# uniform-decode graphs land on multiples of 3 (round_up(size, 3)), which leaves
-# gaps against the power-of-two capture ladder -- exactly the case the padding
-# dispatch has to cover.
 _DECODE_QUERY_LEN = 3
 
 
 def _create_decode_vllm_config(capture_sizes: list[int]) -> MagicMock:
-    """Config for the padding tests below.
-
-    With capture_sizes [1, 2, 4, 8, 16, 24] and qlen=3, the FULL decode graphs
-    land on round_up(size, 3) = 3, 6, 9, 18, 24 tokens while the PIECEWISE
-    graphs stay on the raw sizes. 12 tokens (4 requests x qlen 3) therefore has
-    no exact FULL decode graph; the only descriptor staged for it is the size-16
-    PIECEWISE one.
-    """
     compilation_config = CompilationConfig(
         cudagraph_mode="FULL_AND_PIECEWISE",
         cudagraph_capture_sizes=capture_sizes,
@@ -147,7 +135,6 @@ def _make_spec_decode_manager(
     monkeypatch,
     decode_query_len: int = _DECODE_QUERY_LEN,
     capture_sizes: list[int] | None = None,
-    is_rocm: bool = True,
 ) -> gpu_cudagraph_utils.CudaGraphManager:
     monkeypatch.setattr(
         gpu_cudagraph_utils,
@@ -159,13 +146,6 @@ def _make_spec_decode_manager(
         "get_global_graph_pool",
         lambda: object(),
     )
-    # Pad-up dispatch is ROCm-gated. Patching the platform keeps these tests
-    # running (and meaningful) on the CPU runner that executes this file in CI.
-    monkeypatch.setattr(
-        gpu_cudagraph_utils.current_platform,
-        "is_rocm",
-        lambda: is_rocm,
-    )
     manager = gpu_cudagraph_utils.CudaGraphManager(
         vllm_config=_create_decode_vllm_config(
             capture_sizes or [1, 2, 4, 8, 16, 24],
@@ -174,25 +154,18 @@ def _make_spec_decode_manager(
         cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
         decode_query_len=decode_query_len,
     )
-    # dispatch() only consults the candidate lists once capture has run; these
-    # tests exercise selection, not capture, so mark it done.
     manager._graphs_captured = True
     return manager
 
 
 def test_uniform_decode_pads_up_to_full_graph(monkeypatch):
-    """A uniform-decode batch with no exact FULL graph must pad, not go PIECEWISE.
-
-    ROCm only -- see test_pad_up_is_rocm_gated for the other platforms.
-
-    Without pad-up dispatch, 12 tokens finds only the size-16 PIECEWISE
-    descriptor -- which _is_compatible accepts, because a PIECEWISE descriptor
-    has uniform_token_count=None and matches anything -- so attention runs eager
-    (metadata build plus kernels on the host critical path) every decode step.
-    The size-18 FULL decode graph can serve the batch by padding 4 requests up
-    to 6, and must win.
-    """
     manager = _make_spec_decode_manager(monkeypatch)
+    assert [
+        (desc.cg_mode, desc.num_tokens) for desc in manager._candidates[(12, 0)]
+    ] == [
+        (CUDAGraphMode.FULL, 18),
+        (CUDAGraphMode.PIECEWISE, 16),
+    ]
 
     desc = manager.dispatch(
         num_reqs=4,
@@ -203,34 +176,11 @@ def test_uniform_decode_pads_up_to_full_graph(monkeypatch):
 
     assert desc.cg_mode == CUDAGraphMode.FULL
     assert desc.uniform_token_count == _DECODE_QUERY_LEN
-    # Smallest FULL decode graph that fits, not merely any of them.
     assert desc.num_tokens == 18
     assert desc.num_reqs == 6
 
 
-def test_pad_up_is_rocm_gated(monkeypatch):
-    """Off ROCm, the same batch keeps the pre-change behaviour.
-
-    Identical to test_uniform_decode_pads_up_to_full_graph, except the platform
-    reports non-ROCm. The size-18 FULL decode graph is not offered, so dispatch
-    falls to the size-16 PIECEWISE descriptor exactly as it did before this
-    change. This is what pins the gate: delete it and this test fails.
-    """
-    manager = _make_spec_decode_manager(monkeypatch, is_rocm=False)
-
-    desc = manager.dispatch(
-        num_reqs=4,
-        num_tokens=12,
-        uniform_token_count=_DECODE_QUERY_LEN,
-        num_active_loras=0,
-    )
-
-    assert desc.cg_mode == CUDAGraphMode.PIECEWISE
-    assert desc.num_tokens == 16
-
-
 def test_uniform_decode_exact_match_is_not_over_padded(monkeypatch):
-    """An exact FULL decode graph still wins over larger pad-up candidates."""
     manager = _make_spec_decode_manager(monkeypatch)
 
     desc = manager.dispatch(
@@ -246,13 +196,6 @@ def test_uniform_decode_exact_match_is_not_over_padded(monkeypatch):
 
 
 def test_mixed_batch_never_selects_a_uniform_decode_graph(monkeypatch):
-    """The safety property: pad-up candidates must be inert for mixed batches.
-
-    Uniform-decode descriptors are offered ahead of the mixed fallback for every
-    token count, so this asserts _is_compatible really does reject them when the
-    batch is not uniform -- otherwise a prefill batch would replay a decode-only
-    graph and silently produce wrong results.
-    """
     manager = _make_spec_decode_manager(monkeypatch)
 
     desc = manager.dispatch(
@@ -268,7 +211,6 @@ def test_mixed_batch_never_selects_a_uniform_decode_graph(monkeypatch):
 
 
 def test_uniform_decode_beyond_capture_ladder_falls_back(monkeypatch):
-    """Past the largest captured graph there is nothing to pad up to."""
     manager = _make_spec_decode_manager(monkeypatch)
 
     desc = manager.dispatch(
@@ -288,15 +230,6 @@ def test_uniform_decode_beyond_capture_ladder_falls_back(monkeypatch):
 def test_divisor_query_len_dispatch_is_unchanged(
     monkeypatch, decode_query_len, capture_sizes
 ):
-    """Pad-up dispatch is inert when the query length divides the ladder.
-
-    round_up(size, qlen) == size for every captured size, so a FULL decode
-    graph already exists at each one and there is no gap to pad across. The
-    smallest pad-up candidate that fits is then exactly the descriptor the
-    pre-change code took from the staged list. This covers decode_query_len=1
-    -- every deployment not running speculative decoding -- as well as
-    speculative query lengths that happen to divide the ladder.
-    """
     manager = _make_spec_decode_manager(
         monkeypatch,
         decode_query_len=decode_query_len,

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -229,6 +229,38 @@ def test_mixed_batch_never_selects_a_uniform_decode_graph(monkeypatch):
     assert desc.num_tokens == 16
 
 
+def test_mixed_batch_at_decode_only_token_count_still_gets_a_graph(monkeypatch):
+    """A mixed batch must not fall to eager where only decode graphs are staged.
+
+    ``round_up(size, decode_query_len)`` lands FULL decode graphs on token counts
+    the PIECEWISE ladder never uses -- with capture sizes [1, 2, 4, 8, 16, 24]
+    and query length 3, FULL covers 3, 6, 9 and 18 while PIECEWISE has only
+    1, 2, 4, 8, 16, 24. Building each mode's candidate ranges independently keeps
+    a PIECEWISE graph reachable there. Deriving the ranges from the staged sizes
+    instead offers a mixed batch nothing but decode descriptors, whose
+    ``uniform_token_count`` it can never match, so it runs fully eager.
+    """
+    manager = _make_spec_decode_manager(monkeypatch)
+
+    decode_only_token_counts = sorted(
+        {desc.num_tokens for desc in manager._capture_descs[CUDAGraphMode.FULL]}
+        - {desc.num_tokens for desc in manager._capture_descs[CUDAGraphMode.PIECEWISE]}
+    )
+    # Guard the premise: with no such token counts this test would cover nothing.
+    assert decode_only_token_counts
+
+    for num_tokens in decode_only_token_counts:
+        desc = manager.dispatch(
+            num_reqs=1,
+            num_tokens=num_tokens,
+            uniform_token_count=None,
+            num_active_loras=0,
+        )
+        assert desc.cg_mode == CUDAGraphMode.PIECEWISE, num_tokens
+        assert desc.uniform_token_count is None, num_tokens
+        assert desc.num_tokens >= num_tokens, num_tokens
+
+
 def test_uniform_decode_beyond_capture_ladder_falls_back(monkeypatch):
     manager = _make_spec_decode_manager(monkeypatch)
 

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections import defaultdict
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -114,7 +115,11 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
 _DECODE_QUERY_LEN = 3
 
 
-def _create_decode_vllm_config(capture_sizes: list[int]) -> MagicMock:
+def _create_decode_vllm_config(
+    capture_sizes: list[int],
+    num_speculative_tokens: int = 0,
+    dynamic_spec_num_tokens: list[int] | None = None,
+) -> MagicMock:
     compilation_config = CompilationConfig(
         cudagraph_mode="FULL_AND_PIECEWISE",
         cudagraph_capture_sizes=capture_sizes,
@@ -126,8 +131,18 @@ def _create_decode_vllm_config(capture_sizes: list[int]) -> MagicMock:
     vllm_config.compilation_config = compilation_config
     vllm_config.scheduler_config = SchedulerConfig.default_factory(max_num_seqs=8)
     vllm_config.parallel_config = ParallelConfig()
-    vllm_config.speculative_config = None
-    vllm_config.num_speculative_tokens = 0
+    vllm_config.num_speculative_tokens = num_speculative_tokens
+    if dynamic_spec_num_tokens is None:
+        vllm_config.speculative_config = None
+    else:
+        speculative_config = MagicMock()
+        speculative_config.uses_dynamic_speculative_decoding.return_value = True
+        # Each entry is (range_start, range_end, num_speculative_tokens); only
+        # the third element is read by the manager.
+        speculative_config.num_speculative_tokens_per_batch_size = [
+            (0, 0, n) for n in dynamic_spec_num_tokens
+        ]
+        vllm_config.speculative_config = speculative_config
     return vllm_config
 
 
@@ -135,6 +150,8 @@ def _make_spec_decode_manager(
     monkeypatch,
     decode_query_len: int = _DECODE_QUERY_LEN,
     capture_sizes: list[int] | None = None,
+    num_speculative_tokens: int = 0,
+    dynamic_spec_num_tokens: list[int] | None = None,
 ) -> gpu_cudagraph_utils.CudaGraphManager:
     monkeypatch.setattr(
         gpu_cudagraph_utils,
@@ -149,6 +166,8 @@ def _make_spec_decode_manager(
     manager = gpu_cudagraph_utils.CudaGraphManager(
         vllm_config=_create_decode_vllm_config(
             capture_sizes or [1, 2, 4, 8, 16, 24],
+            num_speculative_tokens=num_speculative_tokens,
+            dynamic_spec_num_tokens=dynamic_spec_num_tokens,
         ),
         device=torch.device("cpu"),
         cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
@@ -221,6 +240,45 @@ def test_uniform_decode_beyond_capture_ladder_falls_back(monkeypatch):
     )
 
     assert desc.cg_mode == CUDAGraphMode.NONE
+
+
+def test_dynamic_spec_decode_shared_token_count_stays_reachable(monkeypatch):
+    """Every captured decode graph must remain reachable from dispatch().
+
+    Under dynamic speculative decoding ``decode_query_lens`` is a list, and the
+    staging loop rounds each capture size up to *every* query length. Several
+    decode graphs therefore land on the same ``num_tokens`` -- e.g. capture size
+    2 stages both ``round_up(2, 1) == 2`` and ``round_up(2, 2) == 2``. Building
+    the candidate ranges one descriptor at a time would give all but the first
+    of those an empty range, so they would never enter a candidate list and
+    their batches would silently fall through to PIECEWISE.
+    """
+    manager = _make_spec_decode_manager(
+        monkeypatch,
+        decode_query_len=4,
+        capture_sizes=[2, 4, 6, 8],
+        num_speculative_tokens=3,
+        dynamic_spec_num_tokens=[0, 1, 2, 3],  # -> decode_query_lens [1, 2, 3, 4]
+    )
+
+    full_descs = manager._capture_descs[CUDAGraphMode.FULL]
+    by_num_tokens: dict[int, list] = defaultdict(list)
+    for desc in full_descs:
+        by_num_tokens[desc.num_tokens].append(desc)
+    # Guard the premise: without collisions this test would not cover the bug.
+    assert any(len(descs) > 1 for descs in by_num_tokens.values())
+
+    for desc in full_descs:
+        assert desc in manager._candidates[(desc.num_tokens, 0)], desc
+        assert (
+            manager.dispatch(
+                num_reqs=desc.num_reqs,
+                num_tokens=desc.num_tokens,
+                uniform_token_count=desc.uniform_token_count,
+                num_active_loras=0,
+            )
+            == desc
+        ), desc
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -194,9 +194,6 @@ class CudaGraphManager:
         separate_decode_routine = self.cudagraph_mode.separate_routine()
         max_cg_capture_size = self.compilation_config.max_cudagraph_capture_size
 
-        descs_by_token_lora: dict[tuple[int, int], list[BatchExecutionDescriptor]] = (
-            defaultdict(list)
-        )
         descs_by_mode: defaultdict[CUDAGraphMode, list[BatchExecutionDescriptor]] = (
             defaultdict(list)
         )
@@ -244,7 +241,6 @@ class CudaGraphManager:
                     num_active_loras=num_active_loras,
                 )
                 descs_by_mode[decode_mode].append(desc)
-                descs_by_token_lora[(num_tokens, num_active_loras)].append(desc)
             # Capture uniform decode specfifc graphs if required
             #  (i.e. separate decode routine)
             elif separate_decode_routine and decode_mode and not self.varlen_decode:
@@ -270,9 +266,6 @@ class CudaGraphManager:
                     # avoid duplicate graphs
                     if desc not in descs_by_mode[decode_mode]:
                         descs_by_mode[decode_mode].append(desc)
-                        descs_by_token_lora[
-                            (rounded_num_tokens, num_active_loras)
-                        ].append(desc)
 
             if mixed_mode:
                 # for PIECEWISE graphs there is no limit on requests when replaying
@@ -290,87 +283,21 @@ class CudaGraphManager:
                     num_active_loras=num_active_loras,
                 )
                 descs_by_mode[mixed_mode].append(desc)
-                descs_by_token_lora[(num_tokens, num_active_loras)].append(desc)
-
-        if not descs_by_token_lora:
-            return
-
-        # FULL decode graphs, ascending by token count, can serve any smaller
-        # uniform-decode batch via request/token padding. They are inert for
-        # non-uniform batches (rejected by _is_compatible on uniform_token_count),
-        # so it is safe to offer them ahead of the mixed/PIECEWISE fallback for
-        # every token count. Without this, a uniform-decode batch whose exact
-        # token count has no FULL decode graph (a gap in round_up(size, qlen))
-        # silently drops to an eager PIECEWISE graph -- e.g. with a spec-decode
-        # query length of 3 and the default capture ladder, 12 tokens (4 reqs)
-        # finds only the size-16 PIECEWISE desc and never the size-18 FULL decode
-        # desc that could pad 4->6 reqs, so attention runs eager (metadata build
-        # + kernels on the host critical path) every decode step.
-        #
-        # Gated to ROCm. The gap is not platform-specific -- it comes from
-        # round_up(capture_size, decode_query_len), which no backend influences --
-        # but the end-to-end measurements behind this change were taken on
-        # MI355X, so the behaviour change stays on the platform it was validated
-        # on until there are numbers from another one.
-        pad_up_uniform_decode = (
-            separate_decode_routine
-            and decode_mode == CUDAGraphMode.FULL
-            and current_platform.is_rocm()
-        )
-        decode_full_descs = (
-            sorted(
-                (
-                    d
-                    for d in descs_by_mode.get(decode_mode, [])
-                    if d.uniform_token_count is not None
-                ),
-                key=lambda d: d.num_tokens,
-            )
-            if pad_up_uniform_decode
-            else []
-        )
-
-        all_token_counts = sorted({k[0] for k in descs_by_token_lora})
-        current_range_start = 0
-        for token_cg_size in all_token_counts:
-            for i in range(current_range_start, token_cg_size + 1):
-                for num_active_loras in self.lora_capture_cases:
-                    staging_key = (token_cg_size, num_active_loras)
-                    if staging_key not in descs_by_token_lora:
-                        continue
-                    fallback = descs_by_token_lora[staging_key]
-                    # Prefer the smallest FULL decode graph that can pad up to
-                    # this token count over the mixed/PIECEWISE fallback.
-                    #
-                    # One candidate per query length is enough, given that a
-                    # uniform-decode batch always satisfies
-                    # num_tokens >= num_reqs * query_len -- equality in the
-                    # normal case, and greater when DP token-syncing hands us a
-                    # num_tokens from a larger peer. A decode graph staged at
-                    # num_tokens holds num_tokens // query_len requests, so the
-                    # smallest graph at or above this token count already has
-                    # enough request slots and _is_compatible's num_reqs check
-                    # cannot be what rejects it. Larger graphs of the same query
-                    # length are then never reachable, and offering them would
-                    # only add failed checks to dispatch()'s scan.
-                    pad_up: list[BatchExecutionDescriptor] = []
-                    padded_query_lens: set[int | None] = set()
-                    for d in decode_full_descs:  # ascending by num_tokens
-                        if (
-                            d.num_tokens >= i
-                            and d.num_active_loras == num_active_loras
-                            and d.uniform_token_count not in padded_query_lens
-                        ):
-                            padded_query_lens.add(d.uniform_token_count)
-                            pad_up.append(d)
-                    self._candidates[(i, num_active_loras)] = pad_up + [
-                        d for d in fallback if d not in pad_up
-                    ]
-            current_range_start = token_cg_size + 1
 
         for mode, descs in descs_by_mode.items():
             descs.sort(key=lambda d: d.num_tokens, reverse=True)
             self._capture_descs[mode] = descs
+
+        for mode in (CUDAGraphMode.FULL, CUDAGraphMode.PIECEWISE):
+            for num_active_loras in self.lora_capture_cases:
+                current_range_start = 0
+                for desc in reversed(descs_by_mode.get(mode, [])):
+                    if desc.num_active_loras != num_active_loras:
+                        continue
+                    for i in range(current_range_start, desc.num_tokens + 1):
+                        key = (i, num_active_loras)
+                        self._candidates.setdefault(key, []).append(desc)
+                    current_range_start = desc.num_tokens + 1
 
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -289,25 +289,20 @@ class CudaGraphManager:
             self._capture_descs[mode] = descs
 
         for mode in (CUDAGraphMode.FULL, CUDAGraphMode.PIECEWISE):
+            mode_descs = tuple(reversed(descs_by_mode.get(mode, [])))
             for num_active_loras in self.lora_capture_cases:
+                descs = filter(
+                    lambda d: d.num_active_loras == num_active_loras,
+                    mode_descs,
+                )
                 current_range_start = 0
-                # Descriptors are sorted by num_tokens. Under dynamic speculative
-                # decoding several decode graphs share a num_tokens (one per query
-                # length), so offer the whole group for the range: advancing the
-                # range once per descriptor would leave every descriptor after the
-                # first with an empty range and no candidate list at all.
-                for num_tokens, group in groupby(
-                    reversed(descs_by_mode.get(mode, [])),
-                    key=lambda d: d.num_tokens,
-                ):
-                    matching = [
-                        d for d in group if d.num_active_loras == num_active_loras
-                    ]
-                    if not matching:
-                        continue
+                # Dynamic speculative decoding can produce multiple graphs with the same
+                # num_tokens. Group them so each graph covers the same candidate range.
+                for num_tokens, group in groupby(descs, lambda d: d.num_tokens):
+                    group = list(group)
                     for i in range(current_range_start, num_tokens + 1):
                         key = (i, num_active_loras)
-                        self._candidates.setdefault(key, []).extend(matching)
+                        self._candidates.setdefault(key, []).extend(group)
                     current_range_start = num_tokens + 1
 
     def needs_capture(self) -> bool:

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -4,7 +4,7 @@ import gc
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
-from itertools import product
+from itertools import groupby, product
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
 import torch
@@ -291,13 +291,24 @@ class CudaGraphManager:
         for mode in (CUDAGraphMode.FULL, CUDAGraphMode.PIECEWISE):
             for num_active_loras in self.lora_capture_cases:
                 current_range_start = 0
-                for desc in reversed(descs_by_mode.get(mode, [])):
-                    if desc.num_active_loras != num_active_loras:
+                # Descriptors are sorted by num_tokens. Under dynamic speculative
+                # decoding several decode graphs share a num_tokens (one per query
+                # length), so offer the whole group for the range: advancing the
+                # range once per descriptor would leave every descriptor after the
+                # first with an empty range and no candidate list at all.
+                for num_tokens, group in groupby(
+                    reversed(descs_by_mode.get(mode, [])),
+                    key=lambda d: d.num_tokens,
+                ):
+                    matching = [
+                        d for d in group if d.num_active_loras == num_active_loras
+                    ]
+                    if not matching:
                         continue
-                    for i in range(current_range_start, desc.num_tokens + 1):
+                    for i in range(current_range_start, num_tokens + 1):
                         key = (i, num_active_loras)
-                        self._candidates.setdefault(key, []).append(desc)
-                    current_range_start = desc.num_tokens + 1
+                        self._candidates.setdefault(key, []).extend(matching)
+                    current_range_start = num_tokens + 1
 
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -291,18 +291,17 @@ class CudaGraphManager:
         for mode in (CUDAGraphMode.FULL, CUDAGraphMode.PIECEWISE):
             mode_descs = tuple(reversed(descs_by_mode.get(mode, [])))
             for num_active_loras in self.lora_capture_cases:
-                descs = filter(
-                    lambda d: d.num_active_loras == num_active_loras,
-                    mode_descs,
-                )
+                lora_descs = [
+                    d for d in mode_descs if d.num_active_loras == num_active_loras
+                ]
                 current_range_start = 0
                 # Dynamic speculative decoding can produce multiple graphs with the same
                 # num_tokens. Group them so each graph covers the same candidate range.
-                for num_tokens, group in groupby(descs, lambda d: d.num_tokens):
-                    group = list(group)
+                for num_tokens, group in groupby(lora_descs, lambda d: d.num_tokens):
+                    matching = list(group)
                     for i in range(current_range_start, num_tokens + 1):
                         key = (i, num_active_loras)
-                        self._candidates.setdefault(key, []).extend(group)
+                        self._candidates.setdefault(key, []).extend(matching)
                     current_range_start = num_tokens + 1
 
     def needs_capture(self) -> bool:

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -295,16 +295,77 @@ class CudaGraphManager:
         if not descs_by_token_lora:
             return
 
+        # FULL decode graphs, ascending by token count, can serve any smaller
+        # uniform-decode batch via request/token padding. They are inert for
+        # non-uniform batches (rejected by _is_compatible on uniform_token_count),
+        # so it is safe to offer them ahead of the mixed/PIECEWISE fallback for
+        # every token count. Without this, a uniform-decode batch whose exact
+        # token count has no FULL decode graph (a gap in round_up(size, qlen))
+        # silently drops to an eager PIECEWISE graph -- e.g. with a spec-decode
+        # query length of 3 and the default capture ladder, 12 tokens (4 reqs)
+        # finds only the size-16 PIECEWISE desc and never the size-18 FULL decode
+        # desc that could pad 4->6 reqs, so attention runs eager (metadata build
+        # + kernels on the host critical path) every decode step.
+        #
+        # Gated to ROCm. The gap is not platform-specific -- it comes from
+        # round_up(capture_size, decode_query_len), which no backend influences --
+        # but the end-to-end measurements behind this change were taken on
+        # MI355X, so the behaviour change stays on the platform it was validated
+        # on until there are numbers from another one.
+        pad_up_uniform_decode = (
+            separate_decode_routine
+            and decode_mode == CUDAGraphMode.FULL
+            and current_platform.is_rocm()
+        )
+        decode_full_descs = (
+            sorted(
+                (
+                    d
+                    for d in descs_by_mode.get(decode_mode, [])
+                    if d.uniform_token_count is not None
+                ),
+                key=lambda d: d.num_tokens,
+            )
+            if pad_up_uniform_decode
+            else []
+        )
+
         all_token_counts = sorted({k[0] for k in descs_by_token_lora})
         current_range_start = 0
         for token_cg_size in all_token_counts:
             for i in range(current_range_start, token_cg_size + 1):
                 for num_active_loras in self.lora_capture_cases:
                     staging_key = (token_cg_size, num_active_loras)
-                    if staging_key in descs_by_token_lora:
-                        self._candidates[(i, num_active_loras)] = descs_by_token_lora[
-                            staging_key
-                        ]
+                    if staging_key not in descs_by_token_lora:
+                        continue
+                    fallback = descs_by_token_lora[staging_key]
+                    # Prefer the smallest FULL decode graph that can pad up to
+                    # this token count over the mixed/PIECEWISE fallback.
+                    #
+                    # One candidate per query length is enough, given that a
+                    # uniform-decode batch always satisfies
+                    # num_tokens >= num_reqs * query_len -- equality in the
+                    # normal case, and greater when DP token-syncing hands us a
+                    # num_tokens from a larger peer. A decode graph staged at
+                    # num_tokens holds num_tokens // query_len requests, so the
+                    # smallest graph at or above this token count already has
+                    # enough request slots and _is_compatible's num_reqs check
+                    # cannot be what rejects it. Larger graphs of the same query
+                    # length are then never reachable, and offering them would
+                    # only add failed checks to dispatch()'s scan.
+                    pad_up: list[BatchExecutionDescriptor] = []
+                    padded_query_lens: set[int | None] = set()
+                    for d in decode_full_descs:  # ascending by num_tokens
+                        if (
+                            d.num_tokens >= i
+                            and d.num_active_loras == num_active_loras
+                            and d.uniform_token_count not in padded_query_lens
+                        ):
+                            padded_query_lens.add(d.uniform_token_count)
+                            pad_up.append(d)
+                    self._candidates[(i, num_active_loras)] = pad_up + [
+                        d for d in fallback if d not in pad_up
+                    ]
             current_range_start = token_cg_size + 1
 
         for mode, descs in descs_by_mode.items():


### PR DESCRIPTION
## Purpose

Under speculative decoding, **half of all decode batch sizes** silently fall back to running
attention eagerly every decode step instead of replaying a captured CUDA graph. This makes
them dispatch to a captured graph instead.

**Current state.** With a separate decode routine (`FULL_AND_PIECEWISE`) there are two kinds
of graph, staged at *different* sizes:

- **FULL decode** — the whole decode step, attention included, is captured. Staged only at
  `round_up(capture_size, decode_query_len)`.
- **PIECEWISE** — attention runs eagerly. Staged at the raw capture sizes.

**The problem.** When `decode_query_len` does not divide the capture ladder, those two sets
interleave and leave gaps. A batch landing in a gap finds that the smallest graph that fits
is a PIECEWISE one, even though a slightly larger FULL decode graph exists and could serve it
by padding a few dummy requests. PIECEWISE always matches, because its descriptor has
`uniform_token_count=None` and `_is_compatible` accepts anything against it. So the batch
takes it and pays the eager-attention cost — metadata build and kernels on the host critical
path — every single decode step.

Example (`decode_query_len=3`, capture sizes `[1, 2, 4, 8, 16, 24]`). FULL decode graphs land
on 3, 6, 9, 18, 24 tokens; PIECEWISE stays on the raw sizes:

| batch | tokens | smallest graph that fits | result |
|---|---|---|---|
| 4 requests | 12 | size-16 **PIECEWISE** | eager attention ❌ |
| 4 requests (this PR) | 12 | size-18 **FULL decode** (pad 4→6 reqs) | captured ✅ |

This is not a corner case. On the **stock default** config — default ladder,
`max_cudagraph_capture_size=512`, `max_num_seqs=128`, EAGLE/MTP with
`num_speculative_tokens=2` so `decode_query_len=3`:

| | on a FULL decode graph | falling back to eager PIECEWISE |
|---|---|---|
| before | 64 / 128 | **64 / 128** |
| after | 128 / 128 | 0 |

Affected request counts are 4, 5, 9, 10, 12, 13, 17, 18, 20, 21, 25, 26, … continuing in that
pattern. The issue was originally found in profiling traces on MI355X.

**Fix.** In `_init_candidates`, offer the FULL decode graphs ahead of the mixed/PIECEWISE
fallback. `dispatch()` then picks the smallest FULL decode graph that fits, and only falls
back to PIECEWISE when none does.

- No change to `dispatch()` or `_is_compatible()` — only the contents and order of the
  candidate lists built in `_init_candidates`.
- **Zero extra captured graphs**: no additional capture time or memory.
- **One candidate per query length**, not every larger graph. A uniform-decode batch always
  satisfies `num_tokens >= num_reqs * query_len`, and a decode graph staged at `T` tokens
  holds `T / query_len` requests — so the smallest graph at or above the batch's token count
  already has enough request slots, and larger graphs of the same query length are
  unreachable. On the default ladder this is 2 candidates per token count instead of 43.
- Inert for non-uniform batches: a mixed batch passes `uniform_token_count=None`, and
  `_is_compatible` rejects any descriptor that has one.
- Strict no-op when `varlen_decode=True`: those graphs are captured at every raw size, so
  they have no gaps, and they are excluded by the filter.

**Platform.** The change is gated behind `current_platform.is_rocm()`, so it is zero-diff on
CUDA by construction — the end-to-end numbers below were taken on MI355X.


## Test Plan

**1. Unit tests** — six new tests in `tests/v1/cudagraph/test_cudagraph_manager.py`: a decode
batch in a gap now runs on the next size up (regression test for the fix); the same batch off
ROCm keeps the old behaviour (pins the gate); an exact-size match is not over-padded; a mixed
batch never lands on a decode-only graph; a batch beyond the ladder still falls back to eager;
and, parametrized over query lengths 1, 2 and 8, dispatch is unchanged whenever the query
length divides the ladder.

This file runs on a non-ROCm CI runner (`.buildkite/test_areas/misc.yaml`, `device:
cpu-small`), so rather than skip there, the helper patches `current_platform.is_rocm` via
`monkeypatch` — the idiom used in `tests/test_config.py` and
`tests/kernels/test_gate_linear_rocm_dispatch.py` — and both sides of the gate stay covered.

**2. Exhaustive dispatch differential** — `dispatch()` replayed over every reachable
`(num_tokens, num_reqs, uniform_token_count)` triple for seven combinations of capture ladder,
`max_num_seqs` and `decode_query_len` (query lengths 1, 2, 3, 8), against both this change and
its parent commit, and the decision sets diffed. Reachability accounts for the data-parallel
path, where `sync_cudagraph_and_dp_padding` passes the synced (max-across-ranks) `num_tokens`
with the *local* `num_reqs`, so `num_tokens > num_reqs * query_len` is possible.

**3. Candidate-list narrowing differential** — the "one candidate per query length"
restriction diffed separately against the unrestricted version over the same harness.

**4. End-to-end** — Kimi-K3 TP8 on MI355X, `num_spec=2` (`decode_query_len=3`),
`FULL_AND_PIECEWISE`, long-context (68k ISL / 350 OSL).

## Test Result

**1. Unit tests.** All six pass, and both halves of the change are pinned: reverting the
dispatch change fails `test_uniform_decode_pads_up_to_full_graph`
(`assert <CUDAGraphMode.PIECEWISE: 1> == <CUDAGraphMode.FULL: 2>`), and replacing
`current_platform.is_rocm()` with `True` fails `test_pad_up_is_rocm_gated`. Full
`tests/v1/cudagraph/` suite: **98 passed, 5 skipped** (103 collected).

**2. Dispatch differential.** Of **4440** reachable batches, **52** dispatch differently. All
52 are `PIECEWISE -> FULL`; none move the other way. All 52 are at `decode_query_len=3`, the
only tested query length that does not divide its ladder — query lengths 1, 2 and 8 are
completely unchanged. `decode_query_len=1` covers every deployment not running speculative
decoding, so those configurations are provably unaffected.

Three safety properties hold across all 4440 batches with the fix applied: no mixed batch is
given a uniform-decode graph, no batch is given a graph smaller than its token count, and no
batch is given a graph smaller than its request count. The cost on the stock default config is
a mean of **1.27** extra padded requests, at most 5.

**3. Candidate-list narrowing.** Over **105576** reachable batches the narrowed and
unrestricted versions make **identical** decisions (0 differences), confirming the larger
same-query-length graphs are unreachable rather than merely unlikely. This was a readability
change, not a performance one: a uniform decode batch hits the first candidate in **0.11 µs,
unchanged either way**. Only mixed/prefill dispatch differed (0.14 → 1.70 µs unnarrowed),
negligible against a prefill step.

**4. End-to-end.** Kimi-K3 TP8 on MI355X, `num_spec=2` (so `uniform_decode_query_len=3`),
`FULL_AND_PIECEWISE`, 68k-ISL / 350-OSL long-context sweep. Both arms are the same container
and the same **stock** capture ladder; the only difference is this patch. With
`decode_query_len=3`, FULL decode graphs stage at `round_up(size, 3)`, so M = 3xconc lands on a
captured size at every concurrency except conc-4 (M=12) and conc-12 (M=36), which fall into a
gap and dispatch to PIECEWISE. Those two are the batches this PR pads onto the next FULL graph
(18 and 42); every other concurrency is a control.

Decode ITL p50 (ms):

| conc | M | before | after | delta |
|---:|---:|---:|---:|---:|
| 1 | 3 | 8.98 | 9.05 | +0.8% |
| 2 | 6 | 10.11 | 10.15 | +0.4% |
| **4** | **12 (gap)** | **62.14** | **12.15** | **-80.4%** |
| 8 | 24 | 13.94 | 13.77 | -1.2% |
| **12** | **36 (gap)** | **64.94** | **15.96** | **-75.4%** |

## AI assistance disclosure

Per `docs/contributing/README.md`: this change was developed with AI assistance (Claude Code).
I identified the bug from profiling traces on MI355X, reviewed and validated the change and
the tests myself, and ran the test suites and the end-to-end benchmark above. The commit
carries a `Co-authored-by: Claude` trailer.