### PR TITLE
[Bugfix] DeepSeekV4MTP: implement SupportsPP so the draft can start under PP

### DIFF
--- a/vllm/models/deepseek_v4/amd/mtp.py
+++ b/vllm/models/deepseek_v4/amd/mtp.py
@@ -38,7 +38,11 @@ from vllm.model_executor.model_loader.mtp_validation import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.deepseek_mtp import SharedHead
 from vllm.model_executor.models.deepseek_v2 import get_spec_layer_idx_from_weight_name
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.models.deepseek_v4.common.ops.fused_mtp_input_rmsnorm import (
     _FUSED_MTP_INPUT_RMSNORM_KERNEL,
     _MTP_SHARED_HEAD_RMSNORM_KERNEL,
@@ -269,7 +273,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         return logits
 
 
-class DeepSeekV4MTP(nn.Module):
+class DeepSeekV4MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
@@ -277,11 +281,22 @@ class DeepSeekV4MTP(nn.Module):
         self.model = DeepSeekV4MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The MTP draft only ever runs on the last PP stage
+        # (see gpu/model_runner.py: init_speculator is guarded on
+        # is_last_pp_rank), so this factory exists to satisfy the
+        # SupportsPP protocol and is never actually consumed at forward
+        # time. Same pattern as DeepSeekMTP / NemotronHMTP.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    # MTP drafts take an extra `hidden_states` from the target; the drafter
+    # is only ever built on the last PP stage so the SupportsPP-shaped
+    # forward is never called on it.
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -45,7 +45,11 @@ from vllm.model_executor.model_loader.mtp_validation import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.deepseek_mtp import SharedHead
 from vllm.model_executor.models.deepseek_v2 import get_spec_layer_idx_from_weight_name
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.models.common.ops.sequence_parallel import (
     sp_all_gather,
     sp_padding_mask,
@@ -283,7 +287,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         return logits
 
 
-class DeepSeekV4MTP(nn.Module):
+class DeepSeekV4MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
@@ -294,11 +298,22 @@ class DeepSeekV4MTP(nn.Module):
         self.model = DeepSeekV4MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The MTP draft only ever runs on the last PP stage
+        # (see gpu/model_runner.py: init_speculator is guarded on
+        # is_last_pp_rank), so this factory exists to satisfy the
+        # SupportsPP protocol and is never actually consumed at forward
+        # time. Same pattern as DeepSeekMTP / NemotronHMTP.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    # MTP drafts take an extra `hidden_states` from the target; the drafter
+    # is only ever built on the last PP stage so the SupportsPP-shaped
+    # forward is never called on it.
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,

--- a/vllm/models/deepseek_v4/xpu/mtp.py
+++ b/vllm/models/deepseek_v4/xpu/mtp.py
@@ -38,7 +38,11 @@ from vllm.model_executor.model_loader.mtp_validation import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.deepseek_mtp import SharedHead
 from vllm.model_executor.models.deepseek_v2 import get_spec_layer_idx_from_weight_name
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.utils import (
+    make_empty_intermediate_tensors_factory,
+    maybe_prefix,
+)
 from vllm.models.deepseek_v4.common.ops.fused_mtp_input_rmsnorm import (
     _FUSED_MTP_INPUT_RMSNORM_KERNEL,
     _MTP_SHARED_HEAD_RMSNORM_KERNEL,
@@ -266,7 +270,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         return logits
 
 
-class DeepSeekV4MTP(nn.Module):
+class DeepSeekV4MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
@@ -274,11 +278,22 @@ class DeepSeekV4MTP(nn.Module):
         self.model = DeepSeekV4MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
+        # The MTP draft only ever runs on the last PP stage
+        # (see gpu/model_runner.py: init_speculator is guarded on
+        # is_last_pp_rank), so this factory exists to satisfy the
+        # SupportsPP protocol and is never actually consumed at forward
+        # time. Same pattern as DeepSeekMTP / NemotronHMTP.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
-    def forward(
+    # MTP drafts take an extra `hidden_states` from the target; the drafter
+    # is only ever built on the last PP stage so the SupportsPP-shaped
+    # forward is never called on it.
+    def forward(  # type: ignore[override]
         self,
         input_ids: torch.Tensor | None,
         positions: torch.Tensor,


### PR DESCRIPTION
## Summary

`DeepSeekV4MTP` (all three of `nvidia/amd/xpu`) inherits from `nn.Module` only. The moment `--pipeline-parallel-size > 1` is combined with an MTP/DSpark speculative config, `SpeculativeConfig._verify_args` runs `draft_model_config.verify_with_parallel_config(draft_parallel_config)` — `draft_parallel_config.pipeline_parallel_size` is copied from the target — and the draft trips `is_pp_supported_model()`:

```
NotImplementedError: Pipeline parallelism is not supported for this model.
Supported models implement the `SupportsPP` interface.
```

Server never starts. Repro from #52761:

```
vllm serve /path/to/deepseek-v4-flash-0731 \
  --pipeline-parallel-size 3 \
  --speculative-config '{\"method\":\"dspark\",\"num_speculative_tokens\":7,\"draft_sample_method\":\"greedy\"}' \
  ...
```

## Fix

Add `SupportsPP` to `DeepSeekV4MTP` in each of the three platform variants and wire `self.make_empty_intermediate_tensors` from `utils.make_empty_intermediate_tensors_factory`.

The MTP draft only ever runs on the last PP stage — `gpu/model_runner.py` gates `init_speculator` on `is_last_pp_rank` — so the factory exists to satisfy the `SupportsPP` protocol and is never actually consumed at forward time. Same pattern as `NemotronHMTP` on `main` and `DeepSeekMTP` in the in-flight #46994.

`forward()` on the DSv4 MTP wrapper takes an extra positional `hidden_states` that the parent protocol doesn't have, so mypy needs a `# type: ignore[override]` — commented in place so it doesn't look like a stray silencer.

## Related

- #52761 — this specific error, DeepSeek-V4-Flash + PP + DSpark.
- #52069 — the systemic version (\"MTP draft models don't declare `SupportsPP`\").
- #46994 — the analogous fix for DeepSeek base MTP + Qwen3.5 (in review, doesn't touch DSv4).

## Test plan

- [x] `pre-commit run --files vllm/models/deepseek_v4/nvidia/mtp.py vllm/models/deepseek_v4/amd/mtp.py vllm/models/deepseek_v4/xpu/mtp.py` (ruff / mypy-3.10 / typos / DCO all pass locally)
- [ ] `vllm serve <DSv4-Flash-model> --pipeline-parallel-size 3 --speculative-config '{\"method\":\"dspark\", ...}'` — needs someone with the model + 3 GPUs; the failure this fixes is a pre-model-load config check, so \"server startup completes past speculative-config verification\" is sufficient signal.

AI assistance was used to locate the missing mixin and mirror the existing pattern; every changed line was reviewed and the mypy signature-override was verified against the pre-existing `NemotronHMTP` precedent.