### PR TITLE
fix(quant): bypass fc quantization for compressed-tensors MTP checkpo…

### DIFF
--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -86,13 +86,19 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             config.hidden_size,
         )
 
-        # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
-        # missing from hf_quant_config.json exclude_modules. Force unquantized.
+        # Workaround: mtp.fc is stored as BF16 in quantized checkpoints
+        # (NVFP4, compressed-tensors WNA16) but quantization configs may not
+        # exclude it, causing shape mismatches during weight loading.
+        # Force unquantized for affected formats.
         # Ref: https://github.com/vllm-project/vllm/pull/38650
         # Ref: https://github.com/NVIDIA/Model-Optimizer/pull/1124
+        # Ref: https://github.com/vllm-project/vllm/issues/53387
         fc_quant = (
             None
-            if (quant_config and quant_config.get_name() == "modelopt_fp4")
+            if (
+                quant_config
+                and quant_config.get_name() in ("modelopt_fp4", "compressed-tensors")
+            )
             else quant_config
         )
         self.fc = ColumnParallelLinear(

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -67,13 +67,17 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
             config.hidden_size,
         )
 
-        # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
-        # missing from the checkpoint quant exclude list (its `ignore` glob
-        # does not cover `mtp.fc`). Force unquantized to match the weights,
-        # mirroring the Qwen3.5 MTP handling (PR #38832).
+        # Workaround: mtp.fc is stored as BF16 in quantized checkpoints
+        # (NVFP4, compressed-tensors WNA16) but quantization configs may not
+        # exclude it, causing shape mismatches during weight loading.
+        # Force unquantized for affected formats.
+        # Ref: https://github.com/vllm-project/vllm/issues/53387
         fc_quant = (
             None
-            if (quant_config and quant_config.get_name() == "modelopt_fp4")
+            if (
+                quant_config
+                and quant_config.get_name() in ("modelopt_fp4", "compressed-tensors")
+            )
             else quant_config
         )
         self.fc = ColumnParallelLinear(


### PR DESCRIPTION
…ints

Qwen3.5 and Qwen3-next MTP models store mtp.fc as BF16 in compressed-tensors WNA16 checkpoints, but the existing fc_quant bypass only handled modelopt_fp4. Extend it to also cover compressed-tensors, preventing shape mismatches during weight loading.

Fixes #53387




## Purpose
Fix Qwen3.5 and Qwen3-next MTP crash when loading compressed-tensors WNA16 (W4A16) checkpoints.

`mtp.fc` is stored as BF16 in these checkpoints, but the `fc_quant` bypass only handled `modelopt_fp4`. The compressed-tensors config's broad targets (e.g. `"Linear"`) still match `mtp.fc`, so vLLM sets up quantized weight parameters that don't match the BF16 weights, causing a shape mismatch at load time.

Extends the bypass to also cover `"compressed-tensors"`, same pattern. Same fix applied to `qwen3_next_mtp.py`.

## Test Plan
- Load a Qwen3.5 MTP model from a compressed-tensors WNA16 checkpoint (e.g. AutoRound-quantized), confirm it loads without crashing
- Confirm non-MTP compressed-tensors models are unaffected (bypass only touches `fc`, not decoder layers)
- Confirm `modelopt_fp4` behavior is unchanged

## Test Result
- Ruff lint: all checks passed
- Ruff format: both files clean
- Unit tests: 7/7 passed covering `modelopt_fp4`, `compressed-tensors`, `gptq`, `awq`, `gptq_marlin`, and `None` quant configs

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

