### PR TITLE
fix(parser): prevent DSML markup leak in DeepSeek V4 streaming tool calls

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -165,6 +165,12 @@ class TestArgConverter:
         assert result["n"] == "42"
         assert isinstance(result["n"], str)
 
+    def test_partial_closing_tag_not_leaked(self):
+        # Regression test for issue #53227: partial DSML tags leak into arguments
+        raw = '<｜DSML｜parameter name="location" string="true">Paris</｜DSML｜parameter'
+        result = json.loads(_dsml_arg_converter(raw, partial=True))
+        assert result == {"location": "Paris"}
+
 
 # ── Bare </think> absorption and duplicate <think> absorption ─────────
 

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -167,7 +167,9 @@ class TestArgConverter:
 
     def test_partial_closing_tag_not_leaked(self):
         # Regression test for issue #53227: partial DSML tags leak into arguments
-        raw = '<｜DSML｜parameter name="location" string="true">Paris</｜DSML｜parameter'
+        raw = (
+            '<｜DSML｜parameter name="location" string="true">Paris</｜DSML｜parameter'
+        )
         result = json.loads(_dsml_arg_converter(raw, partial=True))
         assert result == {"location": "Paris"}
 

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -57,7 +57,7 @@ _PARAM_RE = re.compile(
 )
 _PARTIAL_PARAM_RE = re.compile(
     rf'<{_ESCAPED_DSML}parameter\s+name="([^"]+)"\s+string="(true|false)">'
-    rf"(.*)$",
+    rf"((?:(?!</?{_ESCAPED_DSML}).)*)",
     re.DOTALL,
 )
 


### PR DESCRIPTION

### Description
Fixes #53227.

Streaming tool calls on DeepSeek-V4-Pro leak raw DSML markup into tool call arguments when using the `deepseek_v4` tool call parser. This happens because `_PARTIAL_PARAM_RE` uses a greedy `(.*)$` match that captures trailing DSML tags (like `</｜DSML｜parameter`) when they are only partially received or processed during streaming.

### Changes
- Updated `_PARTIAL_PARAM_RE` in `vllm/parser/deepseek_v4.py` to use a non-greedy match with a negative lookahead `((?:(?!</?{_ESCAPED_DSML}).)*)`. This ensures the parser stops capturing argument content as soon as it encounters the start of any DSML tag.

### Testing
Verified with a standalone reproduction script that simulates partial streaming chunks:
```python
raw = '<｜DSML｜parameter name="location" string="true">Paris</｜DSML｜parameter'
# Before: {"location": "Paris</｜DSML｜parameter"}
# After: {"location": "Paris"}
```
Confirmed that the fix correctly handles both complete and partial DSML tags without leaking markup into the argument JSON.
