### PR TITLE
[Rust Frontend] /derender: streaming derender + two-process e2e test (phase 3/3)

### DIFF
--- a/rust/src/chat/src/lib.rs
+++ b/rust/src/chat/src/lib.rs
@@ -213,11 +213,37 @@ impl ChatRequestProcessor {
         self.prepare_text_request(request).await
     }
 
-    /// Prepare one chat request without submitting it to an engine.
-    pub async fn prepare(
+    /// Effective tool-call parser name for the model, if parsing is enabled.
+    pub fn tool_call_parser_name(&self, model_id: &str) -> Option<&str> {
+        match &self.tool_call_parser {
+            ParserSelection::Auto => ToolParserFactory::global().resolve_name_for_model(model_id),
+            ParserSelection::None => None,
+            ParserSelection::Explicit(name) => Some(name),
+        }
+    }
+
+    /// Effective reasoning parser name for the model, if parsing is enabled.
+    pub fn reasoning_parser_name(&self, model_id: &str) -> Option<&str> {
+        match &self.reasoning_parser {
+            ParserSelection::Auto => {
+                ReasoningParserFactory::global().resolve_name_for_model(model_id)
+            }
+            ParserSelection::None => None,
+            ParserSelection::Explicit(name) => Some(name),
+        }
+    }
+
+    /// Validate one chat request and construct its output processor without
+    /// rendering or tokenizing.
+    ///
+    /// Returns the request as adjusted by the processor constructor (e.g.
+    /// `decode_options.skip_special_tokens` is forced off when a parser needs
+    /// special tokens preserved), so callers that decode outside the normal
+    /// pipeline (such as the derender endpoints) observe the same options.
+    pub fn new_output_processor(
         &self,
         mut request: ChatRequest,
-    ) -> Result<(TextRequest, DynChatOutputProcessor)> {
+    ) -> Result<(ChatRequest, DynChatOutputProcessor)> {
         request.validate()?;
         let output_processor = self.backend.new_chat_output_processor(
             &mut request,
@@ -226,6 +252,15 @@ impl ChatRequestProcessor {
                 reasoning_parser: &self.reasoning_parser,
             },
         )?;
+        Ok((request, output_processor))
+    }
+
+    /// Prepare one chat request without submitting it to an engine.
+    pub async fn prepare(
+        &self,
+        request: ChatRequest,
+    ) -> Result<(TextRequest, DynChatOutputProcessor)> {
+        let (request, output_processor) = self.new_output_processor(request)?;
         let text_request = self.prepare_text_request(request).await?;
         Ok((text_request, output_processor))
     }
@@ -326,24 +361,12 @@ impl ChatLlm {
 
     /// Effective tool-call parser name for this model, if parsing is enabled.
     pub fn tool_call_parser_name(&self) -> Option<&str> {
-        match &self.processor.tool_call_parser {
-            ParserSelection::Auto => {
-                ToolParserFactory::global().resolve_name_for_model(self.model_id())
-            }
-            ParserSelection::None => None,
-            ParserSelection::Explicit(name) => Some(name),
-        }
+        self.processor.tool_call_parser_name(self.model_id())
     }
 
     /// Effective reasoning parser name for this model, if parsing is enabled.
     pub fn reasoning_parser_name(&self) -> Option<&str> {
-        match &self.processor.reasoning_parser {
-            ParserSelection::Auto => {
-                ReasoningParserFactory::global().resolve_name_for_model(self.model_id())
-            }
-            ParserSelection::None => None,
-            ParserSelection::Explicit(name) => Some(name),
-        }
+        self.processor.reasoning_parser_name(self.model_id())
     }
 
     /// Render, tokenize, and submit one chat request.

--- a/rust/src/chat/src/stream.rs
+++ b/rust/src/chat/src/stream.rs
@@ -44,6 +44,18 @@ impl ChatEventStream {
         }
     }
 
+    /// Wrap an arbitrary stream of chat events.
+    ///
+    /// Used by callers that synthesize the structured event stream themselves
+    /// (e.g. the derender endpoints replaying already-generated tokens through
+    /// an output processor) rather than receiving it from the engine pipeline.
+    pub fn from_stream(request_id: String, inner: impl ChatEventStreamTrait) -> Self {
+        Self {
+            request_id,
+            inner: Box::pin(inner),
+        }
+    }
+
     /// Return the request ID associated with this stream.
     pub fn request_id(&self) -> &str {
         &self.request_id

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -4,6 +4,7 @@
 mod abort_requests;
 mod cache;
 mod collective_rpc;
+mod derender;
 mod health;
 mod inference;
 mod load;
@@ -83,6 +84,14 @@ fn build_router_with_options(
         .route("/v1/models", get(openai::list_models))
         .route("/v1/completions", post(openai::completions))
         .route("/v1/chat/completions", post(openai::chat_completions))
+        .route(
+            "/v1/chat/completions/derender",
+            post(derender::derender_chat_completions),
+        )
+        .route(
+            "/v1/completions/derender",
+            post(derender::derender_completions),
+        )
         // vLLM specific endpoints
         .route("/tokenize", post(tokenize::tokenize))
         .route("/detokenize", post(tokenize::detokenize))

--- a/rust/src/server/src/routes/derender/detok.rs
+++ b/rust/src/server/src/routes/derender/detok.rs
@@ -178,8 +178,6 @@ fn detokenize_incrementally(
 ///
 /// Returns `(new_text, updated_state)` — the delta text for this chunk and
 /// the state to pass to the next call.
-// TODO: called by the phase-3 streaming endpoints.
-#[allow(dead_code)]
 pub(super) fn detokenize_delta(
     tokenizer: &DynTokenizer,
     delta_token_ids: &[u32],

--- a/rust/src/server/src/routes/derender/detok.rs
+++ b/rust/src/server/src/routes/derender/detok.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Incremental detokenization for the streaming derender endpoints.
+//!
+//! Ports `vllm/tokenizers/detokenizer_utils.py::detokenize_incrementally`
+//! onto the caller-supplied, JSON-serializable [`DerenderStreamState`].
+//!
+//! Window reconstruction decodes from the token IDs carried alongside the
+//! wire pieces (`DerenderStreamState::prev_token_ids`), so byte-fallback
+//! pieces whose bytes are not valid UTF-8 on their own still decode exactly
+//! like one-shot `decode`. The Rust [`Tokenizer`] trait has no
+//! `convert_ids_to_tokens` / `convert_tokens_to_string` pair, and some
+//! backends' `id_to_token` is lossy UTF-8 (e.g. tiktoken stores base-token
+//! byte pieces with replacement characters), so round-tripping pieces back
+//! through `token_to_id` would drop or corrupt split multi-byte characters.
+//!
+//! States produced by the Python implementation carry only `prev_tokens`
+//! pieces; those are mapped back through `token_to_id` as a best-effort
+//! fallback.
+
+use thiserror_ext::AsReport as _;
+use vllm_text::tokenizer::DynTokenizer;
+
+use super::types::DerenderStreamState;
+use crate::error::{ApiError, server_error};
+
+/// Sentinel written into `DerenderStreamState::prev_token_ids` for window
+/// slots without a decodable token ID (only reachable via the foreign-state
+/// fallback). Always out of vocabulary, so window reconstruction filters it.
+const NO_TOKEN_ID: u32 = u32::MAX;
+
+/// One slot in the carried decode window: the wire piece plus its token ID.
+///
+/// `id` is `None` only for foreign (Python-produced) state whose piece did
+/// not map back through `token_to_id`.
+struct WindowToken {
+    piece: String,
+    id: Option<u32>,
+}
+
+/// Convert one token id into the raw token piece carried in the decode
+/// window.
+///
+/// Out-of-vocab ids and (when `skip_special_tokens`) special tokens map to
+/// `""`, matching Python's `convert_ids_to_tokens` + `_replace_none_with_empty`
+/// behavior.
+fn token_piece(tokenizer: &DynTokenizer, token_id: u32, skip_special_tokens: bool) -> String {
+    if token_id as usize >= tokenizer.vocab_size() {
+        return String::new();
+    }
+    if skip_special_tokens && tokenizer.is_special_id(token_id) {
+        return String::new();
+    }
+    tokenizer.id_to_token(token_id).unwrap_or_default()
+}
+
+/// Whether a window token ID participates in decoding: in vocabulary, and
+/// not a special token when `skip_special_tokens` is set (matching the `""`
+/// piece those tokens produce in [`token_piece`]).
+fn is_decodable(tokenizer: &DynTokenizer, token_id: u32, skip_special_tokens: bool) -> bool {
+    (token_id as usize) < tokenizer.vocab_size()
+        && !(skip_special_tokens && tokenizer.is_special_id(token_id))
+}
+
+fn decode_ids(tokenizer: &DynTokenizer, token_ids: &[u32]) -> Result<String, ApiError> {
+    tokenizer
+        .decode(token_ids, false)
+        .map_err(|error| server_error!("derender detokenization failed: {}", error.as_report()))
+}
+
+/// Decode the decodable IDs in `window[range]`, approximating Python's
+/// `convert_tokens_to_string(pieces)` without a lossy piece round-trip.
+fn decode_window(
+    tokenizer: &DynTokenizer,
+    window: &[WindowToken],
+    range: std::ops::Range<usize>,
+    skip_special_tokens: bool,
+) -> Result<String, ApiError> {
+    let ids: Vec<u32> = window[range]
+        .iter()
+        .filter_map(|token| token.id)
+        .filter(|&id| is_decodable(tokenizer, id, skip_special_tokens))
+        .collect();
+    decode_ids(tokenizer, &ids)
+}
+
+/// Slice `text` to the characters after the first `prefix_chars`, mirroring
+/// Python's `new_text[len(prefix_text):]` (which slices by code point).
+fn drop_prefix_chars(text: &str, prefix_chars: usize) -> String {
+    text.chars().skip(prefix_chars).collect()
+}
+
+/// Outcome of feeding one new token into the incremental decode window.
+struct IncrementalStep {
+    /// The window slot appended for this token.
+    new_token: WindowToken,
+    /// Newly visible text, or `""` when the tail is an unfinished multi-byte
+    /// sequence.
+    text: String,
+    prefix_offset: usize,
+    read_offset: usize,
+}
+
+/// Port of `detokenize_incrementally` for a single new token id.
+///
+/// The window is always a (possibly empty) list here, so this only implements
+/// the non-first-iteration path from Python.
+///
+/// The offsets are necessary to defeat cleanup algorithms in the decode which
+/// decide to add a space or not depending on the surrounding ids.
+fn detokenize_incrementally(
+    tokenizer: &DynTokenizer,
+    new_token_id: u32,
+    window: &[WindowToken],
+    prefix_offset: usize,
+    read_offset: usize,
+    skip_special_tokens: bool,
+) -> Result<IncrementalStep, ApiError> {
+    let new_piece = token_piece(tokenizer, new_token_id, skip_special_tokens);
+
+    // The prefix text is necessary only to defeat cleanup algorithms in
+    // the decode which decide to add a space or not depending on the
+    // surrounding ids.
+    let prefix_text = decode_window(
+        tokenizer,
+        window,
+        prefix_offset..read_offset,
+        skip_special_tokens,
+    )?;
+    let mut window_ids: Vec<u32> = window[prefix_offset..]
+        .iter()
+        .filter_map(|token| token.id)
+        .filter(|&id| is_decodable(tokenizer, id, skip_special_tokens))
+        .collect();
+    if is_decodable(tokenizer, new_token_id, skip_special_tokens) {
+        window_ids.push(new_token_id);
+    }
+    let new_text = decode_ids(tokenizer, &window_ids)?;
+
+    let prefix_chars = prefix_text.chars().count();
+    let new_token = WindowToken {
+        piece: new_piece,
+        id: Some(new_token_id),
+    };
+    // A trailing U+FFFD char means it's a potential unfinished byte sequence
+    // from byte fallback tokenization. If it's in the middle, it's probably a
+    // real invalid id generated by the model.
+    if new_text.chars().count() <= prefix_chars || new_text.ends_with('\u{FFFD}') {
+        return Ok(IncrementalStep {
+            new_token,
+            text: String::new(),
+            prefix_offset,
+            read_offset,
+        });
+    }
+
+    Ok(IncrementalStep {
+        new_token,
+        text: drop_prefix_chars(&new_text, prefix_chars),
+        prefix_offset: read_offset,
+        read_offset: window.len() + 1,
+    })
+}
+
+/// Incrementally detokenize `delta_token_ids` from prior stream state.
+///
+/// Resumes decoding from the offsets carried in `state` rather than
+/// replaying token history. `state.prev_tokens` holds the trailing decode
+/// window (from `prefix_offset` onward) that `detokenize_incrementally`
+/// still needs to reproduce any partially read multi-byte character
+/// (tracked by `read_offset`). The delta tokens are fed straight onto it.
+///
+/// The window is bounded. `detokenize_incrementally` never reads before
+/// `prefix_offset`, so after processing we trim `prev_tokens` to that
+/// tail and rebase the offsets to it. State transport therefore stays
+/// O(window) per chunk instead of re-sending the full token history.
+///
+/// Returns `(new_text, updated_state)` — the delta text for this chunk and
+/// the state to pass to the next call.
+// TODO: called by the phase-3 streaming endpoints.
+#[allow(dead_code)]
+pub(super) fn detokenize_delta(
+    tokenizer: &DynTokenizer,
+    delta_token_ids: &[u32],
+    state: &DerenderStreamState,
+    skip_special_tokens: bool,
+) -> Result<(String, DerenderStreamState), ApiError> {
+    // Prefer the carried token IDs. States produced by the Python
+    // implementation have only `prev_tokens` pieces; map those back through
+    // `token_to_id` as a best-effort fallback (lossy for backends whose
+    // `id_to_token` is lossy UTF-8, hence the ID side channel).
+    let mut window: Vec<WindowToken> = match &state.prev_token_ids {
+        Some(ids) => state
+            .prev_tokens
+            .iter()
+            .zip(ids)
+            .map(|(piece, &id)| WindowToken {
+                piece: piece.clone(),
+                id: (id != NO_TOKEN_ID).then_some(id),
+            })
+            .collect(),
+        None => state
+            .prev_tokens
+            .iter()
+            .map(|piece| WindowToken {
+                id: tokenizer.token_to_id(piece),
+                piece: piece.clone(),
+            })
+            .collect(),
+    };
+    let mut prefix_offset = state.prefix_offset;
+    let mut read_offset = state.read_offset;
+
+    let mut text = String::new();
+    for &token_id in delta_token_ids {
+        let step = detokenize_incrementally(
+            tokenizer,
+            token_id,
+            &window,
+            prefix_offset,
+            read_offset,
+            skip_special_tokens,
+        )?;
+        window.push(step.new_token);
+        text.push_str(&step.text);
+        prefix_offset = step.prefix_offset;
+        read_offset = step.read_offset;
+    }
+
+    // Trim to the tail still readable by detokenize_incrementally
+    // (everything before prefix_offset is dead) and rebase the offsets so
+    // the carried window stays bounded regardless of generation length.
+    let trimmed = window.split_off(prefix_offset);
+    let mut updated_state = state.clone();
+    updated_state.prev_tokens = trimmed.iter().map(|token| token.piece.clone()).collect();
+    updated_state.prev_token_ids =
+        Some(trimmed.iter().map(|token| token.id.unwrap_or(NO_TOKEN_ID)).collect());
+    updated_state.prefix_offset = 0;
+    updated_state.read_offset = read_offset - prefix_offset;
+    Ok((text, updated_state))
+}

--- a/rust/src/server/src/routes/derender/logprobs.rs
+++ b/rust/src/server/src/routes/derender/logprobs.rs
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! `token_id:N` placeholder resolution and chat→completion logprobs
+//! conversion for the derender endpoints.
+//!
+//! Ports `_resolve_logprobs`, `_correct_decoded_token` and
+//! `_convert_chat_logprobs_to_completion_logprobs` from
+//! `vllm/renderers/online_derenderer.py`, plus `resolve_token_id_placeholder`
+//! from `vllm/entrypoints/generate/base/serving.py`.
+
+use std::collections::HashMap;
+
+use thiserror_ext::AsReport as _;
+use tracing::warn;
+use vllm_text::tokenizer::DynTokenizer;
+
+use crate::error::{ApiError, server_error};
+use crate::routes::inference::generate::GenerateLogprob;
+use crate::routes::openai::utils::logprobs::text_len;
+use crate::routes::openai::utils::types::{
+    ChatLogProbs, ChatLogProbsContent, LogProbs, TopLogProb,
+};
+
+/// Extract the token ID from a `token_id:N` placeholder string.
+fn parse_token_id_placeholder(token: &str) -> Option<u32> {
+    token.strip_prefix("token_id:")?.parse().ok()
+}
+
+/// Decode a `token_id:N` placeholder back to a token string and UTF-8 bytes.
+///
+/// Returns `(token, None)` unchanged if token is not a placeholder.
+/// This is the inverse of `format_token_id` on the /generate side
+/// when `return_tokens_as_token_ids` is active.
+///
+/// Decodes the ID directly rather than round-tripping through
+/// `id_to_token`/`token_to_id`, which is lossy for backends whose byte
+/// pieces are not valid UTF-8 on their own.
+fn resolve_token_id_placeholder(
+    token: &str,
+    tokenizer: &DynTokenizer,
+) -> Result<(String, Option<Vec<u8>>), ApiError> {
+    let Some(token_id) = parse_token_id_placeholder(token) else {
+        return Ok((token.to_string(), None));
+    };
+    if tokenizer.id_to_token(token_id).is_none() {
+        warn!(
+            token_id,
+            "resolve_token_id_placeholder: token_id has no vocab entry; substituting empty string"
+        );
+        return Ok((String::new(), None));
+    }
+    let token_str = tokenizer.decode(&[token_id], false).map_err(|error| {
+        server_error!("derender logprobs resolution failed: {}", error.as_report())
+    })?;
+    Ok((token_str.clone(), Some(token_str.into_bytes())))
+}
+
+/// Use preceding tokens as context to fix U+FFFD from byte-fallback.
+///
+/// Mirrors `LogprobsProcessor._correct_decoded_token` in
+/// v1/engine/logprobs.py.
+fn correct_decoded_token(
+    token_id: u32,
+    context_token_ids: &[u32],
+    tokenizer: &DynTokenizer,
+) -> Result<String, ApiError> {
+    let decode = |ids: &[u32]| {
+        tokenizer.decode(ids, true).map_err(|error| {
+            server_error!("derender logprobs correction failed: {}", error.as_report())
+        })
+    };
+    let max_ctx = context_token_ids.len().min(4);
+
+    for num_ctx in 1..=max_ctx {
+        let context = &context_token_ids[context_token_ids.len() - num_ctx..];
+        let mut full_ids = context.to_vec();
+        full_ids.push(token_id);
+        let full_decoded = decode(&full_ids)?;
+
+        if full_decoded.ends_with('\u{FFFD}') {
+            continue;
+        }
+
+        let mut clean_end = context.len();
+        for j in (0..context.len()).rev() {
+            if decode(&context[j..=j])?.ends_with('\u{FFFD}') {
+                clean_end = j;
+            } else {
+                break;
+            }
+        }
+
+        let clean_prefix = if clean_end > 0 {
+            decode(&context[..clean_end])?
+        } else {
+            String::new()
+        };
+
+        if let Some(suffix) = full_decoded.strip_prefix(&clean_prefix) {
+            return Ok(suffix.to_string());
+        }
+
+        let common_len = clean_prefix
+            .chars()
+            .zip(full_decoded.chars())
+            .take_while(|(a, b)| a == b)
+            .count();
+        return Ok(full_decoded.chars().skip(common_len).collect());
+    }
+
+    Ok(String::new())
+}
+
+/// Resolve `token_id:N` placeholders in a [`ChatLogProbs`] object.
+pub(super) fn resolve_logprobs(
+    logprobs: &ChatLogProbs,
+    tokenizer: &DynTokenizer,
+) -> Result<ChatLogProbs, ApiError> {
+    let Some(content) = &logprobs.content else {
+        return Ok(logprobs.clone());
+    };
+
+    let mut context_token_ids: Vec<u32> = Vec::new();
+    let mut resolved_content = Vec::with_capacity(content.len());
+
+    for entry in content {
+        let (mut token_str, mut token_bytes) =
+            resolve_token_id_placeholder(&entry.token, tokenizer)?;
+        let sampled_id = parse_token_id_placeholder(&entry.token);
+
+        if token_str.ends_with('\u{FFFD}')
+            && let Some(id) = sampled_id
+        {
+            token_str = correct_decoded_token(id, &context_token_ids, tokenizer)?;
+            token_bytes = Some(token_str.clone().into_bytes());
+        }
+
+        let mut resolved_top = Vec::with_capacity(entry.top_logprobs.len());
+        for top in &entry.top_logprobs {
+            let (mut top_str, mut top_bytes) = resolve_token_id_placeholder(&top.token, tokenizer)?;
+            let top_id = parse_token_id_placeholder(&top.token);
+            if top_str.ends_with('\u{FFFD}')
+                && let Some(id) = top_id
+            {
+                top_str = correct_decoded_token(id, &context_token_ids, tokenizer)?;
+                top_bytes = Some(top_str.clone().into_bytes());
+            }
+            resolved_top.push(TopLogProb {
+                token: top_str,
+                logprob: top.logprob,
+                bytes: top_bytes,
+            });
+        }
+
+        resolved_content.push(ChatLogProbsContent {
+            token: token_str,
+            logprob: entry.logprob,
+            bytes: token_bytes,
+            top_logprobs: resolved_top,
+        });
+
+        if let Some(id) = sampled_id {
+            context_token_ids.push(id);
+        }
+    }
+
+    Ok(ChatLogProbs {
+        content: Some(resolved_content),
+    })
+}
+
+/// Convert [`ChatLogProbs`] (per-token objects) to [`LogProbs`] (parallel
+/// flat lists) as required by the /v1/completions response schema.
+pub(super) fn chat_logprobs_to_completion(logprobs: &ChatLogProbs) -> LogProbs {
+    let mut tokens = Vec::new();
+    let mut token_logprobs = Vec::new();
+    let mut top_logprobs_list = Vec::new();
+    let mut text_offset = Vec::new();
+
+    let mut offset = 0;
+    if let Some(content) = &logprobs.content {
+        for entry in content {
+            text_offset.push(offset);
+            tokens.push(entry.token.clone());
+            token_logprobs.push(Some(entry.logprob));
+            top_logprobs_list.push(if entry.top_logprobs.is_empty() {
+                None
+            } else {
+                Some(
+                    entry
+                        .top_logprobs
+                        .iter()
+                        .map(|top| (top.token.clone(), top.logprob))
+                        .collect::<HashMap<String, f32>>(),
+                )
+            });
+            offset += text_len(&entry.token);
+        }
+    }
+
+    LogProbs {
+        tokens,
+        token_logprobs,
+        top_logprobs: top_logprobs_list,
+        text_offset,
+    }
+}
+
+/// Resolve one wire token string: `token_id:N` placeholders decode through
+/// the tokenizer, `decoded_token` strings pass through, and unknown IDs fall
+/// back to the placeholder form.
+fn wire_token_str(
+    token_id: u32,
+    decoded_token: Option<&str>,
+    tokenizer: &DynTokenizer,
+) -> Result<String, ApiError> {
+    match decoded_token {
+        Some(token) => Ok(resolve_token_id_placeholder(token, tokenizer)?.0),
+        None if tokenizer.id_to_token(token_id).is_some() => {
+            tokenizer.decode(&[token_id], false).map_err(|error| {
+                server_error!("derender logprobs resolution failed: {}", error.as_report())
+            })
+        }
+        None => Ok(format!("token_id:{token_id}")),
+    }
+}
+
+/// Convert engine-wire prompt logprobs (one candidate map per prompt
+/// position, as carried by `GenerateResponse.prompt_logprobs`) into the
+/// completions [`LogProbs`] shape, mirroring the normal path's echoed and
+/// prompt-only logprobs.
+///
+/// `prompt_token_ids` identifies the sampled token at each position; when it
+/// is shorter than the position list, the remaining positions fall back to
+/// their first candidate.
+pub(super) fn prompt_logprobs_to_completion(
+    prompt_logprobs: &[Option<HashMap<u32, GenerateLogprob>>],
+    prompt_token_ids: &[u32],
+    tokenizer: &DynTokenizer,
+) -> Result<LogProbs, ApiError> {
+    let mut tokens = Vec::with_capacity(prompt_logprobs.len());
+    let mut token_logprobs = Vec::with_capacity(prompt_logprobs.len());
+    let mut top_logprobs_list = Vec::with_capacity(prompt_logprobs.len());
+    let mut text_offset = Vec::with_capacity(prompt_logprobs.len());
+
+    let mut offset = 0;
+    for (position, position_logprobs) in prompt_logprobs.iter().enumerate() {
+        text_offset.push(offset);
+        let sampled_id = prompt_token_ids.get(position).copied();
+        match position_logprobs {
+            // The first prompt position carries no logprobs.
+            None => {
+                let token = match sampled_id {
+                    Some(id) => wire_token_str(id, None, tokenizer)?,
+                    None => String::new(),
+                };
+                offset += text_len(&token);
+                tokens.push(token);
+                token_logprobs.push(None);
+                top_logprobs_list.push(None);
+            }
+            Some(candidates) => {
+                let sampled = sampled_id
+                    .and_then(|id| candidates.get(&id).map(|entry| (id, entry)))
+                    .or_else(|| candidates.iter().next().map(|(&id, entry)| (id, entry)));
+                let (token, token_logprob) = match sampled {
+                    Some((id, entry)) => (
+                        wire_token_str(id, entry.decoded_token.as_deref(), tokenizer)?,
+                        Some(entry.logprob),
+                    ),
+                    None => (String::new(), None),
+                };
+                offset += text_len(&token);
+                tokens.push(token);
+                token_logprobs.push(token_logprob);
+                let mut top = HashMap::with_capacity(candidates.len());
+                for (&id, entry) in candidates {
+                    top.insert(
+                        wire_token_str(id, entry.decoded_token.as_deref(), tokenizer)?,
+                        entry.logprob,
+                    );
+                }
+                top_logprobs_list.push((!top.is_empty()).then_some(top));
+            }
+        }
+    }
+
+    Ok(LogProbs {
+        tokens,
+        token_logprobs,
+        top_logprobs: top_logprobs_list,
+        text_offset,
+    })
+}
+
+/// Shift every text offset by `prefix_len`, used when an echoed prompt is
+/// prepended to the choice text.
+pub(super) fn shift_text_offsets(logprobs: &mut LogProbs, prefix_len: u32) {
+    for offset in &mut logprobs.text_offset {
+        *offset = offset.saturating_add(prefix_len);
+    }
+}

--- a/rust/src/server/src/routes/derender/mod.rs
+++ b/rust/src/server/src/routes/derender/mod.rs
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Postprocessing counterpart to the /render endpoints: turn
+//! token-in/token-out `GenerateResponse`s back into OpenAI chat/completion
+//! responses without a GPU.
+//!
+//! Mirrors the Python vLLM implementation in
+//! `vllm/entrypoints/scale_out/derender/` (api_router.py, serving.py) and
+//! `vllm/renderers/online_derenderer.py`.
+//!
+//! This is phase 1 of the derender port: shared detokenization/state plus the
+//! plain non-streaming endpoints.
+//! TODO: phase 2 adds reasoning/tool-call parsing of the detokenized output;
+//! phase 3 adds the streaming endpoints (a `stream: true` body fails
+//! deserialization with 400 until then).
+//!
+//! Deliberate deviations from the Python implementation:
+//! - Non-streaming completion derender honours `completion_request.echo`
+//!   (including the `max_tokens=0` prompt-only case); Python ignores `echo`.
+
+mod detok;
+mod logprobs;
+mod types;
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use thiserror_ext::AsReport as _;
+use tracing::{debug, warn};
+use vllm_chat::ChatRequestProcessor;
+use vllm_text::tokenizer::DynTokenizer;
+use vllm_text::{Prompt, TextRequestProcessor};
+
+use self::types::{
+    DerenderChatCompletionResponse, DerenderChatRequest, DerenderChatRequestUnion,
+    DerenderCompletionRequest, DerenderCompletionRequestUnion,
+};
+use crate::error::{ApiError, bail_invalid_request, server_error};
+use crate::lora::LoraModelResolution;
+use crate::render::RenderState;
+use crate::routes::inference::generate::GenerateResponse;
+use crate::routes::openai::chat_completions::{
+    AssistantRole, ChatCompletionChoice, ChatCompletionMessage,
+};
+use crate::routes::openai::utils::logprobs::{append_openai_logprobs, text_len};
+use crate::routes::openai::utils::types::Usage;
+use crate::routes::openai::utils::validated_json::ValidatedJson;
+use crate::routes::openai::{CompletionChoice, CompletionResponse, completion_echo_text};
+use crate::state::AppState;
+use crate::utils::{ResolvedRequestContext, resolve_request_context, unix_timestamp};
+
+/// TODO: plumb `VLLM_MAX_N_SEQUENCES` through the server configuration;
+/// Python reads `envs.VLLM_MAX_N_SEQUENCES` (default 16384).
+const MAX_N_SEQUENCES: usize = 16384;
+
+/// Everything a derender handler needs, abstracted over the render-only and
+/// engine-backed servers.
+pub(crate) struct DerenderContext<'a> {
+    /// Public model names accepted by the frontend (including LoRA names).
+    lora_resolution: LoraModelResolution,
+    /// Primary public model name, echoed when the request omits `model`.
+    primary_model_name: &'a str,
+    /// Backend model id used for parser resolution.
+    // TODO: phase 2 (parsing) and phase 3 (streaming) read this again.
+    #[allow(dead_code)]
+    model_id: &'a str,
+    tokenizer: DynTokenizer,
+    max_model_len: u32,
+    max_logprobs: i32,
+    /// TODO: phase 2 (parser replay) reads this again.
+    #[allow(dead_code)]
+    text: &'a TextRequestProcessor,
+    /// TODO: phase 2 (parsing) and phase 3 (streaming) read this again.
+    #[allow(dead_code)]
+    chat: &'a ChatRequestProcessor,
+}
+
+fn render_context(state: &RenderState) -> DerenderContext<'_> {
+    DerenderContext {
+        lora_resolution: LoraModelResolution {
+            model_names: state.served_model_names.clone(),
+            lora_request: None,
+        },
+        primary_model_name: &state.served_model_names[0],
+        model_id: state.text.model_id(),
+        tokenizer: state.text.tokenizer(),
+        max_model_len: state.text.max_model_len(),
+        max_logprobs: state.text.max_logprobs(),
+        text: &state.text,
+        chat: &state.chat,
+    }
+}
+
+async fn app_context<'a>(state: &'a AppState, model: Option<&str>) -> DerenderContext<'a> {
+    let text = state.chat.text().request_processor();
+    DerenderContext {
+        lora_resolution: state.resolve_model_with_loras(model).await,
+        primary_model_name: state.primary_model_name(),
+        model_id: state.chat.model_id(),
+        tokenizer: text.tokenizer(),
+        max_model_len: text.max_model_len(),
+        max_logprobs: text.max_logprobs(),
+        text,
+        chat: state.chat.request_processor(),
+    }
+}
+
+/// Python `BaseServing._check_model`: an omitted model resolves the served
+/// name; an unknown one is a 404.
+fn check_model(ctx: &DerenderContext<'_>, model: Option<&str>) -> Result<(), ApiError> {
+    if let Some(model) = model
+        && !ctx.lora_resolution.model_names.iter().any(|name| name == model)
+    {
+        return Err(ApiError::model_not_found(model.to_string()));
+    }
+    Ok(())
+}
+
+fn response_model_name(ctx: &DerenderContext<'_>, model: Option<String>) -> String {
+    model.unwrap_or_else(|| ctx.primary_model_name.to_string())
+}
+
+/// Reject derender payloads that exceed resource bounds.
+///
+/// Runs before any tokenizer.decode() or parser invocation to prevent
+/// CPU/memory exhaustion from oversized caller-supplied token structures.
+fn validate_derender_bounds(
+    generate_responses: &[GenerateResponse],
+    max_model_len: u32,
+    max_logprobs: i32,
+) -> Result<(), ApiError> {
+    let max_model_len = max_model_len as usize;
+
+    if generate_responses.len() > MAX_N_SEQUENCES {
+        bail_invalid_request!(
+            "generate_responses count ({}) exceeds server maximum ({}). \
+             Set VLLM_MAX_N_SEQUENCES to increase this limit.",
+            generate_responses.len(),
+            MAX_N_SEQUENCES
+        );
+    }
+
+    for response in generate_responses {
+        if response.choices.len() > MAX_N_SEQUENCES {
+            bail_invalid_request!(
+                "choices count ({}) in response '{}' exceeds server maximum ({}).",
+                response.choices.len(),
+                response.request_id,
+                MAX_N_SEQUENCES
+            );
+        }
+
+        for choice in &response.choices {
+            if choice.token_ids.len() > max_model_len {
+                bail_invalid_request!(
+                    "token_ids length ({}) in choice {} exceeds max_model_len ({}).",
+                    choice.token_ids.len(),
+                    choice.index,
+                    max_model_len
+                );
+            }
+            if let Some(content) = choice.logprobs.as_ref().and_then(|l| l.content.as_ref()) {
+                if content.len() > max_model_len {
+                    bail_invalid_request!(
+                        "logprobs.content length ({}) in choice {} exceeds max_model_len ({}).",
+                        content.len(),
+                        choice.index,
+                        max_model_len
+                    );
+                }
+                for entry in content {
+                    if max_logprobs >= 0 && entry.top_logprobs.len() > max_logprobs as usize {
+                        bail_invalid_request!(
+                            "top_logprobs count ({}) in choice {} exceeds max_logprobs ({}).",
+                            entry.top_logprobs.len(),
+                            choice.index,
+                            max_logprobs
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Some(prompt_logprobs) = &response.prompt_logprobs
+            && prompt_logprobs.len() > max_model_len
+        {
+            bail_invalid_request!(
+                "prompt_logprobs length ({}) in response '{}' exceeds max_model_len ({}).",
+                prompt_logprobs.len(),
+                response.request_id,
+                max_model_len
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Postprocess a GenerateResponse into a chat completion response.
+///
+/// Non-streaming only: expects the complete GenerateResponse with all token
+/// IDs present. Phase 1 always plain-detokenizes, honouring the request's
+/// `skip_special_tokens` (default true when no request was given).
+/// TODO: phase 2 replays the output through the configured reasoning/tool
+/// parser (splitting reasoning, content and tool_calls) when `chat_request`
+/// is supplied, mirroring Python's `parser.parse()` one-shot extraction.
+async fn derender_chat(
+    ctx: &DerenderContext<'_>,
+    request: DerenderChatRequest,
+    // Used by the phase-2 parser replay.
+    _request_context: ResolvedRequestContext,
+) -> Result<DerenderChatCompletionResponse, ApiError> {
+    check_model(ctx, request.model.as_deref())?;
+    validate_derender_bounds(
+        std::slice::from_ref(&request.generate_response),
+        ctx.max_model_len,
+        ctx.max_logprobs,
+    )?;
+
+    let model_name = response_model_name(ctx, request.model.clone());
+    let response = &request.generate_response;
+    let mut choices = Vec::with_capacity(response.choices.len());
+
+    for choice in &response.choices {
+        if choice.token_ids.is_empty() {
+            bail_invalid_request!("choice {} has empty or null token_ids", choice.index);
+        }
+
+        let resolved_logprobs = choice
+            .logprobs
+            .as_ref()
+            .map(|logprobs| logprobs::resolve_logprobs(logprobs, &ctx.tokenizer))
+            .transpose()?;
+
+        let skip_special = request
+            .chat_request
+            .as_ref()
+            .map(|request| request.skip_special_tokens)
+            .unwrap_or(true);
+        let decoded_text = ctx
+            .tokenizer
+            .decode(&choice.token_ids, skip_special)
+            .map_err(|error| server_error!("derender decode failed: {}", error.as_report()))?;
+
+        choices.push(ChatCompletionChoice {
+            index: choice.index,
+            message: ChatCompletionMessage {
+                role: AssistantRole,
+                content: Some(decoded_text),
+                tool_calls: Vec::new(),
+                reasoning: None,
+            },
+            logprobs: resolved_logprobs,
+            finish_reason: choice.finish_reason.clone(),
+            stop_reason: None,
+            token_ids: None,
+        });
+    }
+
+    let prompt_tokens = request.prompt_tokens.unwrap_or(0);
+    let completion_tokens: usize =
+        response.choices.iter().map(|choice| choice.token_ids.len()).sum();
+    debug!(
+        request_id = %response.request_id,
+        model = %model_name,
+        choices = choices.len(),
+        completion_tokens,
+        "derender_chat"
+    );
+
+    Ok(DerenderChatCompletionResponse {
+        id: response.request_id.clone(),
+        object: "chat.completion".to_string(),
+        created: unix_timestamp(),
+        model: model_name,
+        choices,
+        usage: Usage {
+            prompt_tokens,
+            total_tokens: checked_total_tokens(prompt_tokens, completion_tokens)?,
+            completion_tokens: Some(completion_tokens),
+            prompt_tokens_details: None,
+        },
+        prompt_logprobs: response.prompt_logprobs.clone(),
+        kv_transfer_params: response.kv_transfer_params.clone(),
+        // The Python derender endpoint does not pass ec_transfer_params through.
+        ec_transfer_params: None,
+    })
+}
+
+/// Postprocess a list of GenerateResponses into a completion response.
+///
+/// Non-streaming only. Mirrors the multi-prompt completions case: one
+/// GenerateResponse per prompt, parallel to the list[GenerateRequest] from
+/// /v1/completions/render.
+fn derender_completion(
+    ctx: &DerenderContext<'_>,
+    request: DerenderCompletionRequest,
+) -> Result<CompletionResponse, ApiError> {
+    check_model(ctx, request.model.as_deref())?;
+
+    if request.generate_responses.is_empty() {
+        bail_invalid_request!("generate_responses must not be empty");
+    }
+    if let Some(prompt_tokens) = &request.prompt_tokens
+        && prompt_tokens.len() != request.generate_responses.len()
+    {
+        bail_invalid_request!(
+            "prompt_tokens length ({}) must equal generate_responses length ({})",
+            prompt_tokens.len(),
+            request.generate_responses.len()
+        );
+    }
+
+    validate_derender_bounds(
+        &request.generate_responses,
+        ctx.max_model_len,
+        ctx.max_logprobs,
+    )?;
+
+    let skip_special = request
+        .completion_request
+        .as_ref()
+        .map(|request| request.skip_special_tokens)
+        .unwrap_or(true);
+
+    // Honour `completion_request.echo` like the normal completions path
+    // (Python derender ignores `echo`): prepend the prompt to each choice's
+    // text, and for prompt-only requests (echo + max_tokens=0) expose just
+    // the prompt, hiding the one internally generated token.
+    let completion_request = request.completion_request.as_ref();
+    let echo = completion_request
+        .map(|request| completion_echo_text(request, ctx.tokenizer.as_ref()))
+        .transpose()?
+        .flatten();
+    let prompt_only =
+        echo.is_some() && completion_request.is_some_and(|request| request.max_tokens == Some(0));
+    let echo_prompt_token_ids = match completion_request.filter(|_| echo.is_some()) {
+        Some(request) => Some(match &request.prompt {
+            Prompt::Text(text) => {
+                ctx.tokenizer.encode(text, request.add_special_tokens).map_err(|error| {
+                    ApiError::invalid_request(
+                        format!("Failed to tokenize prompt for echo: {}", error.as_report()),
+                        Some("prompt"),
+                    )
+                })?
+            }
+            Prompt::TokenIds(token_ids) => token_ids.clone(),
+        }),
+        None => None,
+    };
+
+    let mut choices = Vec::new();
+    let mut total_prompt_tokens = 0;
+    let mut total_completion_tokens = 0;
+    let mut index = 0;
+
+    for (response_idx, response) in request.generate_responses.iter().enumerate() {
+        let prompt_tokens =
+            request.prompt_tokens.as_ref().map(|tokens| tokens[response_idx]).unwrap_or(0);
+        for choice in &response.choices {
+            if choice.token_ids.is_empty() {
+                bail_invalid_request!(
+                    "choice {} in response {} has empty or null token_ids",
+                    choice.index,
+                    response.request_id
+                );
+            }
+
+            let decoded_text = ctx
+                .tokenizer
+                .decode(&choice.token_ids, skip_special)
+                .map_err(|error| server_error!("derender decode failed: {}", error.as_report()))?;
+            let text = match &echo {
+                None => decoded_text,
+                Some(prompt) if prompt_only => prompt.clone(),
+                Some(prompt) => format!("{prompt}{decoded_text}"),
+            };
+            let mut logprobs = choice
+                .logprobs
+                .as_ref()
+                .map(|logprobs| {
+                    logprobs::resolve_logprobs(logprobs, &ctx.tokenizer)
+                        .map(|resolved| logprobs::chat_logprobs_to_completion(&resolved))
+                })
+                .transpose()?;
+            if let Some(prompt) = &echo {
+                if prompt_only {
+                    // Choice logprobs would describe the hidden internal
+                    // token; echo back prompt logprobs like the normal path.
+                    logprobs = match &response.prompt_logprobs {
+                        Some(prompt_logprobs) => Some(logprobs::prompt_logprobs_to_completion(
+                            prompt_logprobs,
+                            echo_prompt_token_ids.as_deref().unwrap_or(&[]),
+                            &ctx.tokenizer,
+                        )?),
+                        None => None,
+                    };
+                } else if let Some(completion_logprobs) = logprobs {
+                    logprobs = Some(match &response.prompt_logprobs {
+                        // The render step enables prompt logprobs for echo
+                        // requests, so prepend them exactly like the normal
+                        // echoed completions path.
+                        Some(prompt_logprobs) => {
+                            let prompt_logprobs = logprobs::prompt_logprobs_to_completion(
+                                prompt_logprobs,
+                                echo_prompt_token_ids.as_deref().unwrap_or(&[]),
+                                &ctx.tokenizer,
+                            )?;
+                            let completion_start = prompt_logprobs
+                                .text_offset
+                                .last()
+                                .zip(prompt_logprobs.tokens.last())
+                                .map(|(&offset, token)| offset.saturating_add(text_len(token)))
+                                .unwrap_or(0);
+                            let mut completion_logprobs = completion_logprobs;
+                            logprobs::shift_text_offsets(
+                                &mut completion_logprobs,
+                                completion_start,
+                            );
+                            append_openai_logprobs(prompt_logprobs, completion_logprobs)
+                        }
+                        None => {
+                            let mut completion_logprobs = completion_logprobs;
+                            logprobs::shift_text_offsets(
+                                &mut completion_logprobs,
+                                text_len(prompt),
+                            );
+                            completion_logprobs
+                        }
+                    });
+                }
+            }
+
+            choices.push(CompletionChoice {
+                index,
+                text,
+                logprobs,
+                finish_reason: choice.finish_reason.clone(),
+                stop_reason: None,
+                prompt_logprobs: None,
+                token_ids: None,
+                prompt_token_ids: None,
+            });
+            total_completion_tokens += choice.token_ids.len();
+            index += 1;
+        }
+        total_prompt_tokens = checked_total_tokens(total_prompt_tokens, prompt_tokens)?;
+    }
+
+    let first = &request.generate_responses[0];
+    let kv_params = first.kv_transfer_params.clone();
+    let kv_params = if request.generate_responses[1..]
+        .iter()
+        .any(|response| response.kv_transfer_params != kv_params)
+    {
+        warn!(
+            "derender_completion: kv_transfer_params differ across responses; \
+             setting to None on the aggregated response"
+        );
+        None
+    } else {
+        kv_params
+    };
+
+    let model_name = response_model_name(ctx, request.model.clone());
+    debug!(
+        request_id = %first.request_id,
+        model = %model_name,
+        choices = choices.len(),
+        total_completion_tokens,
+        "derender_completion"
+    );
+
+    Ok(CompletionResponse {
+        id: first.request_id.clone(),
+        object: "text_completion".to_string(),
+        created: unix_timestamp(),
+        model: model_name,
+        choices,
+        usage: Some(Usage {
+            prompt_tokens: total_prompt_tokens,
+            total_tokens: checked_total_tokens(total_prompt_tokens, total_completion_tokens)?,
+            completion_tokens: Some(total_completion_tokens),
+            prompt_tokens_details: None,
+        }),
+        system_fingerprint: None,
+        kv_transfer_params: kv_params,
+        ec_transfer_params: None,
+    })
+}
+
+/// `prompt_tokens` in derender requests is caller supplied, so adding the
+/// completion count with plain arithmetic could overflow.
+fn checked_total_tokens(prompt_tokens: usize, completion_tokens: usize) -> Result<usize, ApiError> {
+    prompt_tokens.checked_add(completion_tokens).ok_or_else(|| {
+        ApiError::invalid_request(
+            format!(
+                "prompt_tokens ({prompt_tokens}) + completion_tokens \
+                 ({completion_tokens}) overflows the token counter"
+            ),
+            None,
+        )
+    })
+}
+
+fn chat_request_model(request: &DerenderChatRequestUnion) -> Option<&str> {
+    match request {
+        DerenderChatRequestUnion::NonStreaming(request) => request.model.as_deref(),
+    }
+}
+
+fn completion_request_model(request: &DerenderCompletionRequestUnion) -> Option<&str> {
+    match request {
+        DerenderCompletionRequestUnion::NonStreaming(request) => request.model.as_deref(),
+    }
+}
+
+/// Derender a generate response into a chat completion response (render-only
+/// server variant).
+///
+/// TODO: phase 3 accepts streaming (`stream=true`) request bodies on the same
+/// path; until then they fail deserialization with a 400.
+pub async fn derender_chat_render(
+    State(state): State<Arc<RenderState>>,
+    headers: HeaderMap,
+    ValidatedJson(body): ValidatedJson<DerenderChatRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = render_context(&state);
+    let request_context = resolve_request_context(&headers, None);
+    match body {
+        DerenderChatRequestUnion::NonStreaming(request) => {
+            derender_chat(&ctx, request, request_context)
+                .await
+                .map(|response| Json(response).into_response())
+        }
+    }
+}
+
+/// Derender a generate response into a completion response (render-only
+/// server variant).
+pub async fn derender_completion_render(
+    State(state): State<Arc<RenderState>>,
+    ValidatedJson(body): ValidatedJson<DerenderCompletionRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = render_context(&state);
+    match body {
+        DerenderCompletionRequestUnion::NonStreaming(request) => {
+            derender_completion(&ctx, request).map(|response| Json(response).into_response())
+        }
+    }
+}
+
+/// Derender a generate response into a chat completion response
+/// (engine-backed server variant).
+pub async fn derender_chat_completions(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ValidatedJson(body): ValidatedJson<DerenderChatRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = app_context(&state, chat_request_model(&body)).await;
+    let request_context = resolve_request_context(&headers, None);
+    match body {
+        DerenderChatRequestUnion::NonStreaming(request) => {
+            derender_chat(&ctx, request, request_context)
+                .await
+                .map(|response| Json(response).into_response())
+        }
+    }
+}
+
+/// Derender a generate response into a completion response (engine-backed
+/// server variant).
+pub async fn derender_completions(
+    State(state): State<Arc<AppState>>,
+    ValidatedJson(body): ValidatedJson<DerenderCompletionRequestUnion>,
+) -> Result<Response, ApiError> {
+    let ctx = app_context(&state, completion_request_model(&body)).await;
+    match body {
+        DerenderCompletionRequestUnion::NonStreaming(request) => {
+            derender_completion(&ctx, request).map(|response| Json(response).into_response())
+        }
+    }
+}

--- a/rust/src/server/src/routes/derender/mod.rs
+++ b/rust/src/server/src/routes/derender/mod.rs
@@ -9,10 +9,10 @@
 //! `vllm/entrypoints/scale_out/derender/` (api_router.py, serving.py) and
 //! `vllm/renderers/online_derenderer.py`.
 //!
-//! This is phase 1 of the derender port: shared detokenization/state plus the
-//! plain non-streaming endpoints.
-//! TODO: phase 2 adds reasoning/tool-call parsing of the detokenized output;
-//! phase 3 adds the streaming endpoints (a `stream: true` body fails
+//! This is phase 2 of the derender port: shared detokenization/state, the
+//! non-streaming endpoints, and reasoning/tool-call parsing of the
+//! detokenized output.
+//! TODO: phase 3 adds the streaming endpoints (a `stream: true` body fails
 //! deserialization with 400 until then).
 //!
 //! Deliberate deviations from the Python implementation:
@@ -29,25 +29,31 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
+use futures::StreamExt as _;
 use thiserror_ext::AsReport as _;
 use tracing::{debug, warn};
-use vllm_chat::ChatRequestProcessor;
+use vllm_chat::{AssistantContentBlock, AssistantMessageExt as _, ChatRequestProcessor};
+use vllm_chat::{ChatEventStream, FinishReason};
 use vllm_text::tokenizer::DynTokenizer;
-use vllm_text::{Prompt, TextRequestProcessor};
+use vllm_text::{DecodedTextEvent, Finished, Prompt, TextRequestProcessor};
 
 use self::types::{
     DerenderChatCompletionResponse, DerenderChatRequest, DerenderChatRequestUnion,
     DerenderCompletionRequest, DerenderCompletionRequestUnion,
 };
-use crate::error::{ApiError, bail_invalid_request, server_error};
+use crate::error::{
+    ApiError, bail_invalid_request, chat_submit_error, server_error, text_submit_error,
+};
 use crate::lora::LoraModelResolution;
 use crate::render::RenderState;
 use crate::routes::inference::generate::GenerateResponse;
 use crate::routes::openai::chat_completions::{
-    AssistantRole, ChatCompletionChoice, ChatCompletionMessage,
+    AssistantRole, ChatCompletionChoice, ChatCompletionMessage, lower_chat_request,
 };
 use crate::routes::openai::utils::logprobs::{append_openai_logprobs, text_len};
-use crate::routes::openai::utils::types::Usage;
+use crate::routes::openai::utils::types::{
+    FunctionCallResponse, ToolCall, ToolChoice, ToolChoiceValue, Usage,
+};
 use crate::routes::openai::utils::validated_json::ValidatedJson;
 use crate::routes::openai::{CompletionChoice, CompletionResponse, completion_echo_text};
 use crate::state::AppState;
@@ -65,18 +71,21 @@ pub(crate) struct DerenderContext<'a> {
     /// Primary public model name, echoed when the request omits `model`.
     primary_model_name: &'a str,
     /// Backend model id used for parser resolution.
-    // TODO: phase 2 (parsing) and phase 3 (streaming) read this again.
-    #[allow(dead_code)]
     model_id: &'a str,
     tokenizer: DynTokenizer,
     max_model_len: u32,
     max_logprobs: i32,
-    /// TODO: phase 2 (parser replay) reads this again.
-    #[allow(dead_code)]
     text: &'a TextRequestProcessor,
-    /// TODO: phase 2 (parsing) and phase 3 (streaming) read this again.
-    #[allow(dead_code)]
     chat: &'a ChatRequestProcessor,
+}
+
+impl DerenderContext<'_> {
+    /// Whether a reasoning or tool parser is effectively configured for this
+    /// model (Python: `self.parser is not None`).
+    fn has_parser(&self) -> bool {
+        self.chat.reasoning_parser_name(self.model_id).is_some()
+            || self.chat.tool_call_parser_name(self.model_id).is_some()
+    }
 }
 
 fn render_context(state: &RenderState) -> DerenderContext<'_> {
@@ -200,19 +209,149 @@ fn validate_derender_bounds(
     Ok(())
 }
 
+/// Map a wire `finish_reason` string to the internal enum for the replayed
+/// parse pipeline. The response echoes the wire string verbatim; this mapping
+/// only feeds the structured assembly.
+fn wire_finish_reason(finish_reason: Option<&str>) -> FinishReason {
+    match finish_reason {
+        Some("length") => FinishReason::Length,
+        Some("abort") => FinishReason::Abort,
+        Some("repetition") => FinishReason::Repetition(None),
+        _ => FinishReason::stop_eos(),
+    }
+}
+
+/// Replay already-generated tokens through the chat output pipeline so the
+/// configured reasoning/tool parser splits them into reasoning, content and
+/// tool calls, mirroring Python's `parser.parse()` one-shot extraction.
+///
+/// Returns the assembled message plus whether output metadata (logprobs, token
+/// IDs) may be attached: like the normal chat path, per-token data is
+/// suppressed when it would leak hidden reasoning tokens.
+async fn parse_chat_choice(
+    ctx: &DerenderContext<'_>,
+    chat_request: crate::routes::openai::chat_completions::ChatCompletionRequest,
+    token_ids: &[u32],
+    finish_reason: Option<&str>,
+    ctx_request: ResolvedRequestContext,
+) -> Result<(ChatCompletionMessage, bool), ApiError> {
+    let include_reasoning = chat_request.include_reasoning;
+    let is_named_tool_choice =
+        matches!(&chat_request.tool_choice, Some(ToolChoice::Function { .. }));
+    let is_required_tool_choice = matches!(
+        &chat_request.tool_choice,
+        Some(ToolChoice::Value(ToolChoiceValue::Required))
+    );
+
+    let lowered = lower_chat_request(chat_request, &ctx.lora_resolution, ctx_request)?;
+    // Render and tokenize the supplied chat request so the replayed stream
+    // starts from the real prompt: several parsers derive their starting mode
+    // from the prompt tail (e.g. a prefilled think/response channel opener).
+    let (text_request, processor) = ctx
+        .chat
+        .prepare(lowered)
+        .await
+        .map_err(|error| chat_submit_error("failed to prepare derender chat request", error))?;
+    let prepared = ctx
+        .text
+        .prepare(text_request)
+        .map_err(|error| text_submit_error("failed to prepare derender chat request", error))?;
+    let request_id = prepared.text_request.request_id.clone();
+    let prompt_token_ids = prepared.generate_request.prompt_token_ids;
+    let prompt_token_count = prompt_token_ids.len();
+
+    // Parser path: decode with special tokens preserved so the parser can see
+    // markers like </think>, <tool_call>, or Harmony channel tokens.
+    let decoded_text = ctx
+        .tokenizer
+        .decode(token_ids, false)
+        .map_err(|error| server_error!("derender decode failed: {}", error.as_report()))?;
+
+    let events = vec![
+        Ok(DecodedTextEvent::Start {
+            prompt_token_ids: Arc::from(prompt_token_ids),
+            prompt_logprobs: None,
+        }),
+        Ok(DecodedTextEvent::TextDelta {
+            delta: decoded_text,
+            token_ids: token_ids.to_vec(),
+            logprobs: None,
+            finished: Some(Finished {
+                usage: vllm_llm::TokenUsage {
+                    prompt_token_count,
+                    output_token_count: token_ids.len(),
+                    cached_token_count: 0,
+                },
+                finish_reason: wire_finish_reason(finish_reason),
+                kv_transfer_params: None,
+                ec_transfer_params: None,
+            }),
+        }),
+    ];
+    let decoded_stream = futures::stream::iter(events).boxed();
+    let chat_stream = processor
+        .process(decoded_stream)
+        .map_err(|error| chat_submit_error("failed to derender chat response", error))?;
+    let collected =
+        ChatEventStream::from_stream(request_id, chat_stream)
+            .collect_message()
+            .await
+            .map_err(|error| chat_submit_error("failed to derender chat response", error))?;
+
+    let has_content = collected
+        .message
+        .content
+        .iter()
+        .any(|block| matches!(block, AssistantContentBlock::Text { .. }));
+    // A named or required tool choice forces a (possibly empty) content
+    // string, matching Python's `content = content or ""`.
+    let content = if has_content {
+        Some(collected.message.text())
+    } else if is_named_tool_choice || is_required_tool_choice {
+        Some(String::new())
+    } else {
+        None
+    };
+    let tool_calls = collected
+        .message
+        .tool_calls()
+        .map(|call| ToolCall {
+            id: call.id.clone(),
+            tool_type: "function".to_string(),
+            function: FunctionCallResponse {
+                name: call.name.clone(),
+                arguments: Some(call.arguments.clone()),
+            },
+        })
+        .collect();
+
+    // Mirror collect_chat_completion: when reasoning is parsed out but the
+    // request hides it, per-token output metadata is suppressed as well so
+    // hidden reasoning tokens cannot leak through logprobs.
+    let reasoning = collected.message.reasoning();
+    let include_output_metadata = include_reasoning || reasoning.is_none();
+
+    Ok((
+        ChatCompletionMessage {
+            role: AssistantRole,
+            content,
+            tool_calls,
+            reasoning: if include_reasoning { reasoning } else { None },
+        },
+        include_output_metadata,
+    ))
+}
+
 /// Postprocess a GenerateResponse into a chat completion response.
 ///
 /// Non-streaming only: expects the complete GenerateResponse with all token
-/// IDs present. Phase 1 always plain-detokenizes, honouring the request's
-/// `skip_special_tokens` (default true when no request was given).
-/// TODO: phase 2 replays the output through the configured reasoning/tool
-/// parser (splitting reasoning, content and tool_calls) when `chat_request`
-/// is supplied, mirroring Python's `parser.parse()` one-shot extraction.
+/// IDs present. When `request.chat_request` is provided and a parser is
+/// configured, the parser splits the output into (reasoning, content,
+/// tool_calls). Otherwise falls back to plain detokenization.
 async fn derender_chat(
     ctx: &DerenderContext<'_>,
     request: DerenderChatRequest,
-    // Used by the phase-2 parser replay.
-    _request_context: ResolvedRequestContext,
+    request_context: ResolvedRequestContext,
 ) -> Result<DerenderChatCompletionResponse, ApiError> {
     check_model(ctx, request.model.as_deref())?;
     validate_derender_bounds(
@@ -236,25 +375,48 @@ async fn derender_chat(
             .map(|logprobs| logprobs::resolve_logprobs(logprobs, &ctx.tokenizer))
             .transpose()?;
 
-        let skip_special = request
-            .chat_request
-            .as_ref()
-            .map(|request| request.skip_special_tokens)
-            .unwrap_or(true);
-        let decoded_text = ctx
-            .tokenizer
-            .decode(&choice.token_ids, skip_special)
-            .map_err(|error| server_error!("derender decode failed: {}", error.as_report()))?;
+        let (message, include_output_metadata) = if ctx.has_parser()
+            && let Some(chat_request) = request.chat_request.clone()
+        {
+            parse_chat_choice(
+                ctx,
+                chat_request,
+                &choice.token_ids,
+                choice.finish_reason.as_deref(),
+                request_context.clone(),
+            )
+            .await?
+        } else {
+            // No parser: plain detokenization honouring the request's
+            // skip_special_tokens (default true when no request was given).
+            let skip_special = request
+                .chat_request
+                .as_ref()
+                .map(|request| request.skip_special_tokens)
+                .unwrap_or(true);
+            let decoded_text = ctx
+                .tokenizer
+                .decode(&choice.token_ids, skip_special)
+                .map_err(|error| server_error!("derender decode failed: {}", error.as_report()))?;
+            (
+                ChatCompletionMessage {
+                    role: AssistantRole,
+                    content: Some(decoded_text),
+                    tool_calls: Vec::new(),
+                    reasoning: None,
+                },
+                true,
+            )
+        };
 
         choices.push(ChatCompletionChoice {
             index: choice.index,
-            message: ChatCompletionMessage {
-                role: AssistantRole,
-                content: Some(decoded_text),
-                tool_calls: Vec::new(),
-                reasoning: None,
+            message,
+            logprobs: if include_output_metadata {
+                resolved_logprobs
+            } else {
+                None
             },
-            logprobs: resolved_logprobs,
             finish_reason: choice.finish_reason.clone(),
             stop_reason: None,
             token_ids: None,

--- a/rust/src/server/src/routes/derender/mod.rs
+++ b/rust/src/server/src/routes/derender/mod.rs
@@ -9,15 +9,17 @@
 //! `vllm/entrypoints/scale_out/derender/` (api_router.py, serving.py) and
 //! `vllm/renderers/online_derenderer.py`.
 //!
-//! This is phase 2 of the derender port: shared detokenization/state, the
-//! non-streaming endpoints, and reasoning/tool-call parsing of the
-//! detokenized output.
-//! TODO: phase 3 adds the streaming endpoints (a `stream: true` body fails
-//! deserialization with 400 until then).
-//!
 //! Deliberate deviations from the Python implementation:
+//! - Streaming chunks are bounds-checked like non-streaming payloads
+//!   (`validate_stream_bounds`); Python only bounds the non-streaming path.
+//! - Streaming chat derender is rejected for reasoning-parser models (Python
+//!   parity), but tool-parser models are rejected only when the request
+//!   actually engages tool parsing, matching the normal chat pipeline.
 //! - Non-streaming completion derender honours `completion_request.echo`
 //!   (including the `max_tokens=0` prompt-only case); Python ignores `echo`.
+//! - The streaming detok state additionally carries `prev_token_ids` so
+//!   window reconstruction decodes from token IDs instead of round-tripping
+//!   lossy `id_to_token` pieces through `token_to_id`.
 
 mod detok;
 mod logprobs;
@@ -39,7 +41,9 @@ use vllm_text::{DecodedTextEvent, Finished, Prompt, TextRequestProcessor};
 
 use self::types::{
     DerenderChatCompletionResponse, DerenderChatRequest, DerenderChatRequestUnion,
-    DerenderCompletionRequest, DerenderCompletionRequestUnion,
+    DerenderChatStreamRequest, DerenderChatStreamResponse, DerenderCompletionRequest,
+    DerenderCompletionRequestUnion, DerenderCompletionStreamRequest,
+    DerenderCompletionStreamResponse,
 };
 use crate::error::{
     ApiError, bail_invalid_request, chat_submit_error, server_error, text_submit_error,
@@ -48,14 +52,18 @@ use crate::lora::LoraModelResolution;
 use crate::render::RenderState;
 use crate::routes::inference::generate::GenerateResponse;
 use crate::routes::openai::chat_completions::{
-    AssistantRole, ChatCompletionChoice, ChatCompletionMessage, lower_chat_request,
+    AssistantRole, ChatCompletionChoice, ChatCompletionMessage, ChatCompletionStreamChoice,
+    ChatCompletionStreamResponse, ChatMessageDelta, lower_chat_request,
 };
 use crate::routes::openai::utils::logprobs::{append_openai_logprobs, text_len};
 use crate::routes::openai::utils::types::{
-    FunctionCallResponse, ToolCall, ToolChoice, ToolChoiceValue, Usage,
+    FunctionCallResponse, StreamResponseEnvelope, ToolCall, ToolChoice, ToolChoiceValue, Usage,
 };
 use crate::routes::openai::utils::validated_json::ValidatedJson;
-use crate::routes::openai::{CompletionChoice, CompletionResponse, completion_echo_text};
+use crate::routes::openai::{
+    CompletionChoice, CompletionResponse, CompletionStreamChoice, CompletionStreamResponse,
+    completion_echo_text,
+};
 use crate::state::AppState;
 use crate::utils::{ResolvedRequestContext, resolve_request_context, unix_timestamp};
 
@@ -206,6 +214,49 @@ fn validate_derender_bounds(
         }
     }
 
+    Ok(())
+}
+
+/// Bound one streaming chunk before decoding, matching the non-streaming
+/// `validate_derender_bounds` token/logprob limits. Python skips this check on
+/// the streaming path; we deliberately harden it so a single caller-supplied
+/// chunk cannot force token-by-token detokenization past `max_model_len`.
+fn validate_stream_bounds(
+    generate_chunk: &crate::routes::inference::generate::GenerateStreamResponse,
+    max_model_len: u32,
+    max_logprobs: i32,
+) -> Result<(), ApiError> {
+    let max_model_len = max_model_len as usize;
+    for choice in &generate_chunk.choices {
+        if choice.token_ids.len() > max_model_len {
+            bail_invalid_request!(
+                "token_ids length ({}) in choice {} exceeds max_model_len ({}).",
+                choice.token_ids.len(),
+                choice.index,
+                max_model_len
+            );
+        }
+        if let Some(content) = choice.logprobs.as_ref().and_then(|l| l.content.as_ref()) {
+            if content.len() > max_model_len {
+                bail_invalid_request!(
+                    "logprobs.content length ({}) in choice {} exceeds max_model_len ({}).",
+                    content.len(),
+                    choice.index,
+                    max_model_len
+                );
+            }
+            for entry in content {
+                if max_logprobs >= 0 && entry.top_logprobs.len() > max_logprobs as usize {
+                    bail_invalid_request!(
+                        "top_logprobs count ({}) in choice {} exceeds max_logprobs ({}).",
+                        entry.top_logprobs.len(),
+                        choice.index,
+                        max_logprobs
+                    );
+                }
+            }
+        }
+    }
     Ok(())
 }
 
@@ -669,14 +720,228 @@ fn checked_total_tokens(prompt_tokens: usize, completion_tokens: usize) -> Resul
     })
 }
 
+/// Aggregate chunk usage, forwarding the caller-supplied prompt token count.
+fn stream_usage(
+    prompt_tokens: Option<usize>,
+    usage: Option<&Usage>,
+) -> Result<Option<Usage>, ApiError> {
+    let Some(usage) = usage else {
+        return Ok(None);
+    };
+    let prompt_tokens = prompt_tokens.unwrap_or(usage.prompt_tokens);
+    let completion_tokens = usage.completion_tokens.unwrap_or(0);
+    Ok(Some(Usage {
+        prompt_tokens,
+        total_tokens: checked_total_tokens(prompt_tokens, completion_tokens)?,
+        completion_tokens: Some(completion_tokens),
+        prompt_tokens_details: None,
+    }))
+}
+
+/// Whether the supplied chat request would engage the tool parser in the
+/// normal chat pipeline (`ResolvedToolContext::parsing_enabled`): tools are
+/// declared and tool_choice is not explicitly "none". Function/Required/
+/// AllowedTools choices fail closed and count as engaged even without a
+/// tools list.
+fn tool_parsing_would_engage(
+    request: &crate::routes::openai::chat_completions::ChatCompletionRequest,
+) -> bool {
+    match &request.tool_choice {
+        Some(ToolChoice::Value(ToolChoiceValue::None)) => false,
+        Some(_) => true,
+        None => request.tools.as_ref().is_some_and(|tools| !tools.is_empty()),
+    }
+}
+
+/// Streaming counterpart to [`derender_chat`].
+///
+/// Processes one `GenerateStreamResponse` chunk and returns the derendered
+/// chunk together with the updated client carried state.
+///
+/// TODO: parse path for reasoning and tool calls is implemented in a future
+/// PR (Python raises NotImplementedError in the same situation).
+fn derender_chat_stream(
+    ctx: &DerenderContext<'_>,
+    request: DerenderChatStreamRequest,
+) -> Result<DerenderChatStreamResponse, ApiError> {
+    check_model(ctx, request.model.as_deref())?;
+    validate_stream_bounds(&request.generate_chunk, ctx.max_model_len, ctx.max_logprobs)?;
+
+    // Fail closed for reasoning parsers: the streaming parse path is not yet
+    // implemented (Python raises NotImplementedError in the same situation),
+    // so hidden reasoning markup must never leak through plain detok.
+    if ctx.chat.reasoning_parser_name(ctx.model_id).is_some() {
+        bail_invalid_request!(
+            "Streaming chat derender is not yet supported for models with a reasoning or \
+             tool parser configured. Use the non-streaming derender endpoint (stream=false) \
+             for parsed output."
+        );
+    }
+
+    // Deviation from Python (which rejects on any configured parser): the
+    // normal chat pipeline only engages the tool parser when the request
+    // itself enables tool parsing, so a tool-capable model serving a
+    // tool-free request streams plain text there. Mirror that here instead of
+    // rejecting on the mere presence of a tool parser.
+    if ctx.chat.tool_call_parser_name(ctx.model_id).is_some()
+        && let Some(chat_request) = &request.chat_request
+        && tool_parsing_would_engage(chat_request)
+    {
+        bail_invalid_request!(
+            "Streaming chat derender is not yet supported for models with a reasoning or \
+             tool parser configured. Use the non-streaming derender endpoint (stream=false) \
+             for parsed output."
+        );
+    }
+
+    // A single DerenderStreamState is threaded through every choice in this
+    // chunk. Correct only when there is at most one choice per SSE event
+    // (n=1, one call per index), as the streaming derender protocol assumes.
+    // Multiple choices sharing one chunk would corrupt each other's detok
+    // window.
+    if request.generate_chunk.choices.len() > 1 {
+        bail_invalid_request!("derender_chat_stream expects at most one choice per chunk");
+    }
+
+    let mut state = request.stream_state.map(|state| *state).unwrap_or_default();
+    state.validate()?;
+
+    let skip_special = request
+        .chat_request
+        .as_ref()
+        .map(|request| request.skip_special_tokens)
+        .unwrap_or(true);
+    let mut stream_choices = Vec::with_capacity(request.generate_chunk.choices.len());
+
+    for choice in &request.generate_chunk.choices {
+        let (new_text, updated_state) =
+            detok::detokenize_delta(&ctx.tokenizer, &choice.token_ids, &state, skip_special)?;
+        state = updated_state;
+
+        // Unlike OpenAI's API, which always emits `role: "assistant"` on the
+        // very first chunk, this emits it on the first chunk with a non empty
+        // `choices` list. A leading usage only chunk therefore defers the role
+        // to the following content chunk instead of sending an empty role only
+        // delta.
+        let include_role = !state.role_sent;
+        if include_role {
+            state.role_sent = true;
+        }
+
+        stream_choices.push(ChatCompletionStreamChoice {
+            index: choice.index,
+            delta: ChatMessageDelta {
+                role: include_role.then_some(AssistantRole),
+                content: (!new_text.is_empty()).then_some(new_text),
+                tool_calls: None,
+                reasoning: None,
+            },
+            logprobs: None,
+            finish_reason: choice.finish_reason.clone(),
+            stop_reason: None,
+            token_ids: None,
+        });
+    }
+
+    let model_name = response_model_name(ctx, request.model.clone());
+    debug!(
+        request_id = %request.generate_chunk.request_id,
+        model = %model_name,
+        "derender_chat_stream"
+    );
+    let envelope = Arc::new(StreamResponseEnvelope::new(
+        request.generate_chunk.request_id.clone(),
+        "chat.completion.chunk",
+        unix_timestamp(),
+        model_name,
+    ));
+    let mut chunk = ChatCompletionStreamResponse::new(&envelope);
+    chunk.choices = stream_choices;
+    chunk.usage = stream_usage(request.prompt_tokens, request.generate_chunk.usage.as_ref())?;
+
+    Ok(DerenderChatStreamResponse {
+        chunk,
+        stream_state: state,
+    })
+}
+
+/// Streaming counterpart to [`derender_completion`].
+///
+/// Processes one `GenerateStreamResponse` chunk (one output sequence's delta)
+/// and returns the derendered chunk and updated state.
+fn derender_completion_stream(
+    ctx: &DerenderContext<'_>,
+    request: DerenderCompletionStreamRequest,
+) -> Result<DerenderCompletionStreamResponse, ApiError> {
+    check_model(ctx, request.model.as_deref())?;
+    validate_stream_bounds(&request.generate_chunk, ctx.max_model_len, ctx.max_logprobs)?;
+
+    // See the equivalent check in derender_chat_stream: a single
+    // DerenderStreamState is threaded through every choice in this chunk, so
+    // more than one choice per chunk would corrupt the detok window across
+    // choices.
+    if request.generate_chunk.choices.len() > 1 {
+        bail_invalid_request!("derender_completion_stream expects at most one choice per chunk");
+    }
+
+    let mut state = request.stream_state.map(|state| *state).unwrap_or_default();
+    state.validate()?;
+
+    let skip_special = request
+        .completion_request
+        .as_ref()
+        .map(|request| request.skip_special_tokens)
+        .unwrap_or(true);
+    let mut stream_choices = Vec::with_capacity(request.generate_chunk.choices.len());
+
+    for choice in &request.generate_chunk.choices {
+        let (new_text, updated_state) =
+            detok::detokenize_delta(&ctx.tokenizer, &choice.token_ids, &state, skip_special)?;
+        state = updated_state;
+
+        stream_choices.push(CompletionStreamChoice {
+            index: choice.index,
+            text: new_text,
+            logprobs: None,
+            finish_reason: choice.finish_reason.clone(),
+            stop_reason: None,
+            token_ids: None,
+            prompt_token_ids: None,
+        });
+    }
+
+    let model_name = response_model_name(ctx, request.model.clone());
+    debug!(
+        request_id = %request.generate_chunk.request_id,
+        model = %model_name,
+        "derender_completion_stream"
+    );
+    let envelope = Arc::new(StreamResponseEnvelope::new(
+        request.generate_chunk.request_id.clone(),
+        "text_completion",
+        unix_timestamp(),
+        model_name,
+    ));
+    let mut chunk = CompletionStreamResponse::new(&envelope);
+    chunk.choices = stream_choices;
+    chunk.usage = stream_usage(request.prompt_tokens, request.generate_chunk.usage.as_ref())?;
+
+    Ok(DerenderCompletionStreamResponse {
+        chunk,
+        stream_state: state,
+    })
+}
+
 fn chat_request_model(request: &DerenderChatRequestUnion) -> Option<&str> {
     match request {
+        DerenderChatRequestUnion::Streaming(request) => request.model.as_deref(),
         DerenderChatRequestUnion::NonStreaming(request) => request.model.as_deref(),
     }
 }
 
 fn completion_request_model(request: &DerenderCompletionRequestUnion) -> Option<&str> {
     match request {
+        DerenderCompletionRequestUnion::Streaming(request) => request.model.as_deref(),
         DerenderCompletionRequestUnion::NonStreaming(request) => request.model.as_deref(),
     }
 }
@@ -684,8 +949,9 @@ fn completion_request_model(request: &DerenderCompletionRequestUnion) -> Option<
 /// Derender a generate response into a chat completion response (render-only
 /// server variant).
 ///
-/// TODO: phase 3 accepts streaming (`stream=true`) request bodies on the same
-/// path; until then they fail deserialization with a 400.
+/// Accepts both non-streaming (`stream=false`, default) and streaming
+/// (`stream=true`) request bodies on the same path; the `stream`
+/// discriminator selects the shape.
 pub async fn derender_chat_render(
     State(state): State<Arc<RenderState>>,
     headers: HeaderMap,
@@ -694,6 +960,9 @@ pub async fn derender_chat_render(
     let ctx = render_context(&state);
     let request_context = resolve_request_context(&headers, None);
     match body {
+        DerenderChatRequestUnion::Streaming(request) => {
+            derender_chat_stream(&ctx, request).map(|response| Json(response).into_response())
+        }
         DerenderChatRequestUnion::NonStreaming(request) => {
             derender_chat(&ctx, request, request_context)
                 .await
@@ -710,6 +979,9 @@ pub async fn derender_completion_render(
 ) -> Result<Response, ApiError> {
     let ctx = render_context(&state);
     match body {
+        DerenderCompletionRequestUnion::Streaming(request) => {
+            derender_completion_stream(&ctx, request).map(|response| Json(response).into_response())
+        }
         DerenderCompletionRequestUnion::NonStreaming(request) => {
             derender_completion(&ctx, request).map(|response| Json(response).into_response())
         }
@@ -726,6 +998,9 @@ pub async fn derender_chat_completions(
     let ctx = app_context(&state, chat_request_model(&body)).await;
     let request_context = resolve_request_context(&headers, None);
     match body {
+        DerenderChatRequestUnion::Streaming(request) => {
+            derender_chat_stream(&ctx, request).map(|response| Json(response).into_response())
+        }
         DerenderChatRequestUnion::NonStreaming(request) => {
             derender_chat(&ctx, request, request_context)
                 .await
@@ -742,6 +1017,9 @@ pub async fn derender_completions(
 ) -> Result<Response, ApiError> {
     let ctx = app_context(&state, completion_request_model(&body)).await;
     match body {
+        DerenderCompletionRequestUnion::Streaming(request) => {
+            derender_completion_stream(&ctx, request).map(|response| Json(response).into_response())
+        }
         DerenderCompletionRequestUnion::NonStreaming(request) => {
             derender_completion(&ctx, request).map(|response| Json(response).into_response())
         }

--- a/rust/src/server/src/routes/derender/types.rs
+++ b/rust/src/server/src/routes/derender/types.rs
@@ -12,10 +12,12 @@ use serde_json::Value;
 use validator::{Validate, ValidationErrors};
 
 use crate::error::{ApiError, bail_invalid_request};
-use crate::routes::inference::generate::{GenerateResponse, PromptLogprobMaps};
-use crate::routes::openai::CompletionRequest;
+use crate::routes::inference::generate::{
+    GenerateResponse, GenerateStreamResponse, PromptLogprobMaps,
+};
 use crate::routes::openai::chat_completions::ChatCompletionRequest;
 use crate::routes::openai::utils::types::{Normalizable, Usage};
+use crate::routes::openai::{CompletionRequest, CompletionStreamResponse};
 
 /// Cap on the carried detok window in [`DerenderStreamState`].
 ///
@@ -91,8 +93,6 @@ impl DerenderStreamState {
     /// Python enforces the `prev_tokens` cap through a Pydantic field
     /// validator (surfaced as 400) and turns detok failures from out-of-range
     /// offsets into a 400 "invalid stream_state" error; both checks live here.
-    // TODO: called by the phase-3 streaming endpoints.
-    #[allow(dead_code)]
     pub(super) fn validate(&self) -> Result<(), ApiError> {
         if self.prev_tokens.len() > MAX_PREV_TOKENS {
             bail_invalid_request!(
@@ -124,11 +124,8 @@ impl DerenderStreamState {
     }
 }
 
-/// Reject `stream: true` on the non-streaming request body.
-///
-/// TODO: phase 3 re-adds the streaming request variant, which this error
-/// steers the untagged union towards; until then a `stream: true` body fails
-/// deserialization outright and the endpoint responds 400.
+/// Reject `stream: true` on the non-streaming request body, steering the
+/// untagged union to the streaming variant (or to a 400 when malformed).
 fn expect_stream_false<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,
@@ -140,6 +137,20 @@ where
         ));
     }
     Ok(false)
+}
+
+/// Reject a missing or false `stream` on the streaming request body.
+fn expect_stream_true<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = bool::deserialize(deserializer)?;
+    if !value {
+        return Err(serde::de::Error::custom(
+            "`stream` must be true for the streaming derender request",
+        ));
+    }
+    Ok(true)
 }
 
 /// Request for the /v1/chat/completions/derender endpoint (non-streaming).
@@ -163,8 +174,32 @@ pub(crate) struct DerenderChatRequest {
     /// The original (post-adjust_request) ChatCompletionRequest from /render.
     ///
     /// Required by the parsing so that tool/reasoning parsers can receive the
-    /// full request context they expect. Without a configured parser, only
-    /// its `skip_special_tokens` option is honoured.
+    /// full request context they expect.
+    pub chat_request: Option<ChatCompletionRequest>,
+}
+
+/// One chunk streaming derender request for /v1/chat/completions/derender.
+///
+/// The client sends one request per SSE chunk received from
+/// `/inference/v1/generate`. Each request carries the generate chunk plus the
+/// `stream_state` returned by the previous call (`None` on the first call).
+/// The response contains the derendered chunk and the updated state to be
+/// passed to the next call.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DerenderChatStreamRequest {
+    #[serde(deserialize_with = "expect_stream_true")]
+    #[allow(dead_code)]
+    stream: bool,
+    pub model: Option<String>,
+    /// One SSE chunk from `/inference/v1/generate` (`stream=True`).
+    pub generate_chunk: GenerateStreamResponse,
+    /// Client carried detok state from the previous call. `None` on first.
+    ///
+    /// Boxed to keep the untagged request-union variants similarly sized.
+    pub stream_state: Option<Box<DerenderStreamState>>,
+    /// Prompt token count for usage. Forwarded from the render step.
+    pub prompt_tokens: Option<usize>,
+    /// The original (post adjust_request) ChatCompletionRequest from /render.
     pub chat_request: Option<ChatCompletionRequest>,
 }
 
@@ -193,6 +228,29 @@ pub(crate) struct DerenderCompletionRequest {
     pub completion_request: Option<CompletionRequest>,
 }
 
+/// One chunk streaming derender request for /v1/completions/derender.
+///
+/// Parallel to `DerenderChatStreamRequest` for the completions endpoint. Each
+/// call processes one SSE chunk (one output sequence's delta) and returns the
+/// derendered chunk plus updated state.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DerenderCompletionStreamRequest {
+    #[serde(deserialize_with = "expect_stream_true")]
+    #[allow(dead_code)]
+    stream: bool,
+    pub model: Option<String>,
+    /// One SSE chunk from `/inference/v1/generate`.
+    pub generate_chunk: GenerateStreamResponse,
+    /// Client-carried detok state. `None` on the first call.
+    ///
+    /// Boxed to keep the untagged request-union variants similarly sized.
+    pub stream_state: Option<Box<DerenderStreamState>>,
+    /// Prompt token count for usage.
+    pub prompt_tokens: Option<usize>,
+    /// The original (post adjust_request) CompletionRequest from /render.
+    pub completion_request: Option<CompletionRequest>,
+}
+
 /// Validation and normalization of embedded requests (e.g. `chat_request`)
 /// happen when the handler lowers them, not at extraction time.
 macro_rules! impl_union_validation {
@@ -207,14 +265,14 @@ macro_rules! impl_union_validation {
     };
 }
 
-/// Request body for the chat derender endpoint.
-///
-/// TODO: phase 3 re-adds the `Streaming` variant, discriminated by the
-/// `stream` field's literal value (a body without `stream` validates as the
-/// non-streaming member, whose `stream` defaults to false).
+/// Determines the type by checking the `stream` field's literal value. A body
+/// without `stream` validates as the non-streaming member (`stream` defaults
+/// to false there), so the server can validate and dispatch both shapes on a
+/// single path.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum DerenderChatRequestUnion {
+    Streaming(DerenderChatStreamRequest),
     NonStreaming(DerenderChatRequest),
 }
 
@@ -224,10 +282,30 @@ impl_union_validation!(DerenderChatRequestUnion);
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum DerenderCompletionRequestUnion {
+    Streaming(DerenderCompletionStreamRequest),
     NonStreaming(DerenderCompletionRequest),
 }
 
 impl_union_validation!(DerenderCompletionRequestUnion);
+
+/// Response for one streaming chat derender chunk.
+///
+/// Pairs the derendered SSE chunk with the updated client carried state to
+/// pass to the next call.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DerenderChatStreamResponse {
+    pub chunk: crate::routes::openai::chat_completions::ChatCompletionStreamResponse,
+    pub stream_state: DerenderStreamState,
+}
+
+/// Response for one streaming completions derender chunk.
+///
+/// Parallel to `DerenderChatStreamResponse` for the completions endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DerenderCompletionStreamResponse {
+    pub chunk: CompletionStreamResponse,
+    pub stream_state: DerenderStreamState,
+}
 
 /// Mirrors the Python vLLM `ChatCompletionResponse` as produced by the
 /// derender endpoint.

--- a/rust/src/server/src/routes/derender/types.rs
+++ b/rust/src/server/src/routes/derender/types.rs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Wire types for the `/v1/chat/completions/derender` and
+//! `/v1/completions/derender` endpoints.
+//!
+//! Mirrors the Python vLLM `Derender*Request` / `Derender*Stream*` classes in
+//! `vllm/entrypoints/scale_out/token_in_token_out/protocol.py`.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use validator::{Validate, ValidationErrors};
+
+use crate::error::{ApiError, bail_invalid_request};
+use crate::routes::inference::generate::{GenerateResponse, PromptLogprobMaps};
+use crate::routes::openai::CompletionRequest;
+use crate::routes::openai::chat_completions::ChatCompletionRequest;
+use crate::routes::openai::utils::types::{Normalizable, Usage};
+
+/// Cap on the carried detok window in [`DerenderStreamState`].
+///
+/// INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET is small (5) and the trimmed
+/// window is O(offset). A generous limit rejects unusually large or malformed
+/// payloads without restricting legitimate multi-byte sequences.
+const MAX_PREV_TOKENS: usize = 1024;
+
+/// Per sequence state for stateless streaming derender.
+///
+/// The client carries this between successive per chunk HTTP calls to the
+/// streaming derender endpoint. All fields are plain JSON serializable data.
+/// No opaque tokenizer or parser internals are stored here.
+///
+/// The detokenization strategy carries the incremental decode offsets
+/// directly rather than re-sending the whole token history each chunk.
+/// `detokenize_incrementally` only ever reads the trailing token window
+/// `prev_tokens[prefix_offset..]`, so we carry just that tail plus the two
+/// offsets. Each chunk resumes exactly where the last one stopped, including
+/// any partially processed multi-byte character (tracked by `read_offset`),
+/// then trims and rebases the window so it never grows with generation
+/// length.
+///
+/// Do not skip serializing `None` fields here: Python's `model_dump()` emits
+/// them as explicit `null`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub(crate) struct DerenderStreamState {
+    /// Trailing decode window. Token strings from `prefix_offset` onward.
+    ///
+    /// Bounded, trimmed and rebased each chunk to the tail
+    /// `detokenize_incrementally` still reads, so it does not grow with the
+    /// number of chunks.
+    #[serde(default)]
+    pub prev_tokens: Vec<String>,
+    /// Token IDs parallel to `prev_tokens`, used to reconstruct the decode
+    /// window without a lossy `id_to_token` → `token_to_id` round-trip
+    /// (some backends store byte pieces as lossy UTF-8). Slots without a
+    /// decodable ID carry `u32::MAX`.
+    ///
+    /// Rust-specific extension: states produced by the Python implementation
+    /// lack this field (`null`/absent), in which case the pieces are mapped
+    /// back through `token_to_id` as a best-effort fallback. Python ignores
+    /// the unknown field when it parses our state.
+    #[serde(default)]
+    pub prev_token_ids: Option<Vec<u32>>,
+    /// Prefix offset into `prev_tokens` for incremental detokenization.
+    #[serde(default)]
+    pub prefix_offset: usize,
+    /// Read offset into `prev_tokens` for incremental detokenization.
+    #[serde(default)]
+    pub read_offset: usize,
+    /// True once the initial `role: "assistant"` delta has been emitted.
+    ///
+    /// Prevents re-emitting the role on subsequent chunks even when the detok
+    /// window is transiently empty (e.g. usage only final chunk).
+    #[serde(default)]
+    pub role_sent: bool,
+    // TODO: Properties used in follow on PR for tool call parsing
+    /// Last emitted cumulative assistant content text.
+    pub last_content: Option<String>,
+    /// Last emitted cumulative reasoning text.
+    pub last_reasoning: Option<String>,
+    /// Stable tool-call IDs, assigned once when each call first appears.
+    ///
+    /// Prevents ID regeneration across re-parsing.
+    #[serde(default)]
+    pub last_tool_call_ids: Vec<String>,
+}
+
+impl DerenderStreamState {
+    /// Reject malformed caller supplied offsets/lengths.
+    ///
+    /// Python enforces the `prev_tokens` cap through a Pydantic field
+    /// validator (surfaced as 400) and turns detok failures from out-of-range
+    /// offsets into a 400 "invalid stream_state" error; both checks live here.
+    // TODO: called by the phase-3 streaming endpoints.
+    #[allow(dead_code)]
+    pub(super) fn validate(&self) -> Result<(), ApiError> {
+        if self.prev_tokens.len() > MAX_PREV_TOKENS {
+            bail_invalid_request!(
+                "prev_tokens length ({}) exceeds maximum ({})",
+                self.prev_tokens.len(),
+                MAX_PREV_TOKENS
+            );
+        }
+        if self.prefix_offset > self.read_offset || self.read_offset > self.prev_tokens.len() {
+            bail_invalid_request!(
+                "invalid stream_state: detokenization failed (prefix_offset={}, \
+                 read_offset={}, prev_tokens length={})",
+                self.prefix_offset,
+                self.read_offset,
+                self.prev_tokens.len()
+            );
+        }
+        if let Some(ids) = &self.prev_token_ids
+            && ids.len() != self.prev_tokens.len()
+        {
+            bail_invalid_request!(
+                "invalid stream_state: prev_token_ids length ({}) does not match \
+                 prev_tokens length ({})",
+                ids.len(),
+                self.prev_tokens.len()
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Reject `stream: true` on the non-streaming request body.
+///
+/// TODO: phase 3 re-adds the streaming request variant, which this error
+/// steers the untagged union towards; until then a `stream: true` body fails
+/// deserialization outright and the endpoint responds 400.
+fn expect_stream_false<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = bool::deserialize(deserializer)?;
+    if value {
+        return Err(serde::de::Error::custom(
+            "`stream` must be false or omitted for the non-streaming derender request",
+        ));
+    }
+    Ok(false)
+}
+
+/// Request for the /v1/chat/completions/derender endpoint (non-streaming).
+///
+/// Wraps a complete GenerateResponse and caller supplied metadata needed to
+/// produce a fully formed ChatCompletionResponse without a GPU.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DerenderChatRequest {
+    #[serde(default, deserialize_with = "expect_stream_false")]
+    #[allow(dead_code)]
+    stream: bool,
+    /// Served model name. Defaults to the server's served model name.
+    pub model: Option<String>,
+    /// The complete token-in / token-out engine response to derender.
+    pub generate_response: GenerateResponse,
+    /// Prompt token count for usage; defaults to 0 if omitted.
+    ///
+    /// GenerateResponse carries only output tokens; the caller already has
+    /// `len(GenerateRequest.token_ids)` from the render step.
+    pub prompt_tokens: Option<usize>,
+    /// The original (post-adjust_request) ChatCompletionRequest from /render.
+    ///
+    /// Phase 1 honours its `skip_special_tokens` option; phase 2 additionally
+    /// feeds it to the reasoning/tool parsers so they receive the full
+    /// request context they expect.
+    pub chat_request: Option<ChatCompletionRequest>,
+}
+
+/// Request for the /v1/completions/derender endpoint (non-streaming).
+///
+/// Parallel to DerenderChatRequest but handles the multi-prompt completions
+/// case: one GenerateResponse per prompt, mirroring the list[GenerateRequest]
+/// returned by /v1/completions/render.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DerenderCompletionRequest {
+    #[serde(default, deserialize_with = "expect_stream_false")]
+    #[allow(dead_code)]
+    stream: bool,
+    /// Served model name. Defaults to the server's served model name.
+    pub model: Option<String>,
+    /// One response per prompt, parallel to the list[GenerateRequest]
+    /// returned by /v1/completions/render.
+    pub generate_responses: Vec<GenerateResponse>,
+    /// One prompt token count per response; each defaults to 0 if omitted.
+    ///
+    /// If provided, `len(prompt_tokens)` must equal `len(generate_responses)`.
+    pub prompt_tokens: Option<Vec<usize>>,
+    /// The original (post-adjust_request) CompletionRequest from /render.
+    ///
+    /// Mirrors chat_request on DerenderChatRequest.
+    pub completion_request: Option<CompletionRequest>,
+}
+
+/// Validation and normalization of embedded requests (e.g. `chat_request`)
+/// happen when the handler lowers them, not at extraction time.
+macro_rules! impl_union_validation {
+    ($union:ident) => {
+        impl Validate for $union {
+            fn validate(&self) -> Result<(), ValidationErrors> {
+                Ok(())
+            }
+        }
+
+        impl Normalizable for $union {}
+    };
+}
+
+/// Request body for the chat derender endpoint.
+///
+/// TODO: phase 3 re-adds the `Streaming` variant, discriminated by the
+/// `stream` field's literal value (a body without `stream` validates as the
+/// non-streaming member, whose `stream` defaults to false).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum DerenderChatRequestUnion {
+    NonStreaming(DerenderChatRequest),
+}
+
+impl_union_validation!(DerenderChatRequestUnion);
+
+/// See [`DerenderChatRequestUnion`].
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum DerenderCompletionRequestUnion {
+    NonStreaming(DerenderCompletionRequest),
+}
+
+impl_union_validation!(DerenderCompletionRequestUnion);
+
+/// Mirrors the Python vLLM `ChatCompletionResponse` as produced by the
+/// derender endpoint.
+///
+/// Unlike the normal chat path's response type, `prompt_logprobs` here
+/// carries the engine-side `HashMap<u32, GenerateLogprob>` shape passed
+/// through from `GenerateResponse`, and `usage` is always present.
+///
+/// Do not skip serializing `None` fields here: non-streaming response types
+/// should serialize `None` as explicit `null`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DerenderChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<crate::routes::openai::chat_completions::ChatCompletionChoice>,
+    pub usage: Usage,
+    pub prompt_logprobs: Option<PromptLogprobMaps>,
+    pub kv_transfer_params: Option<Value>,
+    pub ec_transfer_params: Option<Value>,
+}

--- a/rust/src/server/src/routes/derender/types.rs
+++ b/rust/src/server/src/routes/derender/types.rs
@@ -162,9 +162,9 @@ pub(crate) struct DerenderChatRequest {
     pub prompt_tokens: Option<usize>,
     /// The original (post-adjust_request) ChatCompletionRequest from /render.
     ///
-    /// Phase 1 honours its `skip_special_tokens` option; phase 2 additionally
-    /// feeds it to the reasoning/tool parsers so they receive the full
-    /// request context they expect.
+    /// Required by the parsing so that tool/reasoning parsers can receive the
+    /// full request context they expect. Without a configured parser, only
+    /// its `skip_special_tokens` option is honoured.
     pub chat_request: Option<ChatCompletionRequest>,
 }
 

--- a/rust/src/server/src/routes/inference/generate.rs
+++ b/rust/src/server/src/routes/inference/generate.rs
@@ -26,11 +26,11 @@ use vllm_llm::{
 };
 
 use self::convert::{ResponseOptions, prepare_generate_request};
-use self::types::{
-    GenerateLogprob, GenerateResponse, GenerateResponseChoice, GenerateResponseStreamChoice,
-    GenerateStreamResponse,
+pub(crate) use self::types::{
+    GenerateLogprob, GenerateRequest, GenerateResponse, GenerateResponseChoice,
+    GenerateResponseStreamChoice, GenerateSamplingParams, GenerateStreamResponse,
+    PromptLogprobMaps,
 };
-pub(crate) use self::types::{GenerateRequest, GenerateSamplingParams};
 pub(crate) use self::validate::validate_request_compat;
 use crate::config::ApiServerOptions;
 use crate::error::{ApiError, bail_server_error, server_error, text_submit_error};

--- a/rust/src/server/src/routes/inference/generate/types.rs
+++ b/rust/src/server/src/routes/inference/generate/types.rs
@@ -56,46 +56,98 @@ impl Normalizable for GenerateRequest {}
 ///
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateResponseChoice {
+///
+/// Also deserialized by the derender endpoints. A JSON `null` `token_ids`
+/// fails deserialization (400); the derender handler additionally rejects
+/// missing/empty `token_ids` with Python's "empty or null token_ids" error.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateResponseChoice {
     pub index: u32,
     pub logprobs: Option<ChatLogProbs>,
+    // Per OpenAI spec the Python default is "stop".
+    #[serde(default = "default_finish_reason")]
     pub finish_reason: Option<String>,
+    #[serde(default)]
     pub token_ids: Vec<u32>,
+}
+
+fn default_finish_reason() -> Option<String> {
+    Some("stop".to_string())
 }
 
 /// Mirrors the Python vLLM `GenerateResponseStreamChoice` class.
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateResponseStreamChoice {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateResponseStreamChoice {
     pub index: u32,
     pub logprobs: Option<ChatLogProbs>,
     pub finish_reason: Option<String>,
+    #[serde(default)]
     pub token_ids: Vec<u32>,
 }
 
 /// Mirrors the Python vLLM `GenerateStreamResponse` class.
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateStreamResponse {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateStreamResponse {
+    #[serde(default)]
     pub request_id: String,
     pub choices: Vec<GenerateResponseStreamChoice>,
     pub usage: Option<Usage>,
 }
 
+/// Engine-wire prompt logprobs: one candidate map per prompt position.
+pub(crate) type PromptLogprobMaps = Vec<Option<HashMap<u32, GenerateLogprob>>>;
+
 /// Mirrors the Python vLLM `GenerateResponse` class.
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateResponse {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateResponse {
+    #[serde(default)]
     pub request_id: String,
     pub choices: Vec<GenerateResponseChoice>,
-    pub prompt_logprobs: Option<Vec<Option<HashMap<u32, GenerateLogprob>>>>,
+    #[serde(default, deserialize_with = "deserialize_prompt_logprob_maps")]
+    pub prompt_logprobs: Option<PromptLogprobMaps>,
     pub kv_transfer_params: Option<Value>,
     pub ec_transfer_params: Option<Value>,
 }
 
+/// Deserialize prompt-logprob position maps with integer keys.
+///
+/// Serde's untagged-union buffering (used by the derender request unions)
+/// cannot drive `HashMap<u32, _>`'s key parsing, so accept string keys and
+/// parse them explicitly.
+fn deserialize_prompt_logprob_maps<'de, D>(
+    deserializer: D,
+) -> Result<Option<PromptLogprobMaps>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Option::<Vec<Option<HashMap<String, GenerateLogprob>>>>::deserialize(deserializer)?;
+    raw.map(|positions| {
+        positions
+            .into_iter()
+            .map(|position| {
+                position
+                    .map(|candidates| {
+                        candidates
+                            .into_iter()
+                            .map(|(key, value)| {
+                                key.parse::<u32>()
+                                    .map(|token_id| (token_id, value))
+                                    .map_err(serde::de::Error::custom)
+                            })
+                            .collect::<Result<HashMap<_, _>, _>>()
+                    })
+                    .transpose()
+            })
+            .collect::<Result<Vec<_>, _>>()
+    })
+    .transpose()
+}
+
 /// Mirrors the Python vLLM `Logprob` class used in prompt-logprobs payloads.
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct GenerateLogprob {
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct GenerateLogprob {
     pub logprob: f32,
     pub rank: Option<u32>,
     pub decoded_token: Option<String>,

--- a/rust/src/server/src/routes/openai/chat_completions.rs
+++ b/rust/src/server/src/routes/openai/chat_completions.rs
@@ -28,13 +28,14 @@ use vllm_engine_core_client::protocol::output::StopReason;
 
 use self::convert::{ResponseOptions, prepare_chat_request};
 pub(crate) use self::types::ChatCompletionRequest;
+use self::types::ChatCompletionResponse;
+pub(crate) use self::types::{
+    AssistantRole, ChatCompletionChoice, ChatCompletionMessage, ChatCompletionStreamChoice,
+    ChatCompletionStreamResponse, ChatMessageDelta,
+};
 use crate::config::ApiServerOptions;
 use crate::error::{ApiError, bail_server_error, chat_submit_error, server_error};
 use crate::lora::LoraModelResolution;
-use crate::routes::openai::chat_completions::types::{
-    AssistantRole, ChatCompletionChoice, ChatCompletionMessage, ChatCompletionResponse,
-    ChatCompletionStreamChoice, ChatCompletionStreamResponse, ChatMessageDelta,
-};
 use crate::routes::openai::utils::logprobs::{
     decoded_logprobs_to_openai_chat, prompt_logprobs_to_maps,
 };

--- a/rust/src/server/src/routes/openai/chat_completions/types.rs
+++ b/rust/src/server/src/routes/openai/chat_completions/types.rs
@@ -339,7 +339,7 @@ impl Normalizable for ChatCompletionRequest {
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionResponse {
+pub(crate) struct ChatCompletionResponse {
     pub id: String,
     pub object: String,
     pub created: u64,
@@ -355,7 +355,7 @@ pub(super) struct ChatCompletionResponse {
 
 /// Mirrors the Python vLLM `ChatCompletionResponseChoice` class.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionChoice {
+pub(crate) struct ChatCompletionChoice {
     pub index: u32,
     pub message: ChatCompletionMessage,
     pub logprobs: Option<ChatLogProbs>,
@@ -367,7 +367,7 @@ pub(super) struct ChatCompletionChoice {
 /// A literal type for the "assistant" role, since the API only allows that
 /// specific value in responses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, SerializeDisplay)]
-pub(super) struct AssistantRole;
+pub(crate) struct AssistantRole;
 
 impl fmt::Display for AssistantRole {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -377,7 +377,7 @@ impl fmt::Display for AssistantRole {
 
 /// Mirrors the Python vLLM response `ChatMessage` class.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionMessage {
+pub(crate) struct ChatCompletionMessage {
     pub role: AssistantRole,
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -388,7 +388,7 @@ pub(super) struct ChatCompletionMessage {
 /// Mirrors the Python vLLM `ChatCompletionStreamResponse` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct ChatCompletionStreamResponse {
+pub(crate) struct ChatCompletionStreamResponse {
     #[serde(flatten)]
     pub envelope: Arc<StreamResponseEnvelope>,
     pub choices: Vec<ChatCompletionStreamChoice>,
@@ -411,7 +411,7 @@ impl ChatCompletionStreamResponse {
 /// Mirrors the Python vLLM `ChatCompletionResponseStreamChoice` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, Serialize)]
-pub(super) struct ChatCompletionStreamChoice {
+pub(crate) struct ChatCompletionStreamChoice {
     pub index: u32,
     pub delta: ChatMessageDelta,
     pub logprobs: Option<ChatLogProbs>,
@@ -423,7 +423,7 @@ pub(super) struct ChatCompletionStreamChoice {
 /// Mirrors the Python vLLM `DeltaMessage` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, Serialize)]
-pub(super) struct ChatMessageDelta {
+pub(crate) struct ChatMessageDelta {
     pub role: Option<AssistantRole>,
     pub content: Option<String>,
     pub tool_calls: Option<Vec<ToolCallDelta>>,

--- a/rust/src/server/src/routes/openai/completions.rs
+++ b/rust/src/server/src/routes/openai/completions.rs
@@ -27,8 +27,13 @@ use vllm_text::{
     TextOutputStreamExt as _, TextRequest,
 };
 
+pub(crate) use self::convert::completion_echo_text;
 use self::convert::{ResponseOptions, prepare_completion_request};
 pub(crate) use self::types::CompletionRequest;
+use self::types::CompletionSseChunk;
+pub(crate) use self::types::{
+    CompletionChoice, CompletionResponse, CompletionStreamChoice, CompletionStreamResponse,
+};
 use super::utils::logprobs::{
     collected_logprobs_to_openai, decoded_logprobs_to_openai, decoded_prompt_logprobs_to_openai,
     prompt_logprobs_to_maps, text_len,
@@ -37,10 +42,6 @@ use super::utils::types::{StreamResponseEnvelope, Usage};
 use crate::config::ApiServerOptions;
 use crate::error::{ApiError, bail_server_error, server_error, text_submit_error};
 use crate::lora::LoraModelResolution;
-use crate::routes::openai::completions::types::{
-    CompletionChoice, CompletionResponse, CompletionSseChunk, CompletionStreamChoice,
-    CompletionStreamResponse,
-};
 use crate::routes::openai::utils::types::LogProbs;
 use crate::routes::openai::utils::usage::ContinuousUsage;
 use crate::routes::openai::utils::validated_json::ValidatedJson;

--- a/rust/src/server/src/routes/openai/completions/convert.rs
+++ b/rust/src/server/src/routes/openai/completions/convert.rs
@@ -176,7 +176,9 @@ pub(super) fn prepare_completion_request(
     })
 }
 
-fn completion_echo_text(
+/// Prompt text echoed back northbound when `echo=true`, mirroring the Python
+/// completions path. Shared with the derender endpoint.
+pub(crate) fn completion_echo_text(
     request: &CompletionRequest,
     tokenizer: &dyn Tokenizer,
 ) -> Result<Option<String>, ApiError> {

--- a/rust/src/server/src/routes/openai/completions/types.rs
+++ b/rust/src/server/src/routes/openai/completions/types.rs
@@ -216,7 +216,7 @@ impl Normalizable for CompletionRequest {
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct CompletionResponse {
+pub(crate) struct CompletionResponse {
     pub id: String,
     pub object: String,
     pub created: u64,
@@ -230,7 +230,7 @@ pub(super) struct CompletionResponse {
 
 /// Mirrors the Python vLLM `CompletionResponseChoice` class.
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct CompletionChoice {
+pub(crate) struct CompletionChoice {
     pub index: u32,
     pub text: String,
     pub logprobs: Option<LogProbs>,
@@ -244,7 +244,7 @@ pub(super) struct CompletionChoice {
 /// Mirrors the Python vLLM `CompletionStreamResponse` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize)]
-pub(super) struct CompletionStreamResponse {
+pub(crate) struct CompletionStreamResponse {
     #[serde(flatten)]
     pub envelope: Arc<StreamResponseEnvelope>,
     pub choices: Vec<CompletionStreamChoice>,
@@ -265,7 +265,7 @@ impl CompletionStreamResponse {
 /// Mirrors the Python vLLM `CompletionResponseStreamChoice` class.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, Serialize)]
-pub(super) struct CompletionStreamChoice {
+pub(crate) struct CompletionStreamChoice {
     pub index: u32,
     pub text: String,
     pub logprobs: Option<LogProbs>,

--- a/rust/src/server/src/routes/openai/mod.rs
+++ b/rust/src/server/src/routes/openai/mod.rs
@@ -9,10 +9,8 @@ pub(crate) mod utils;
 pub use chat_completions::chat_completions;
 pub(crate) use chat_completions::{ChatCompletionRequest, lower_chat_request};
 pub use completions::completions;
-// TODO: phase 3 of the derender endpoints re-exports CompletionStreamChoice
-// and CompletionStreamResponse here as well.
 pub(crate) use completions::{
-    CompletionChoice, CompletionRequest, CompletionResponse, completion_echo_text,
-    lower_completion_request,
+    CompletionChoice, CompletionRequest, CompletionResponse, CompletionStreamChoice,
+    CompletionStreamResponse, completion_echo_text, lower_completion_request,
 };
 pub use models::list_models;

--- a/rust/src/server/src/routes/openai/mod.rs
+++ b/rust/src/server/src/routes/openai/mod.rs
@@ -9,5 +9,10 @@ pub(crate) mod utils;
 pub use chat_completions::chat_completions;
 pub(crate) use chat_completions::{ChatCompletionRequest, lower_chat_request};
 pub use completions::completions;
-pub(crate) use completions::{CompletionRequest, lower_completion_request};
+// TODO: phase 3 of the derender endpoints re-exports CompletionStreamChoice
+// and CompletionStreamResponse here as well.
+pub(crate) use completions::{
+    CompletionChoice, CompletionRequest, CompletionResponse, completion_echo_text,
+    lower_completion_request,
+};
 pub use models::list_models;

--- a/rust/src/server/src/routes/openai/utils/types.rs
+++ b/rust/src/server/src/routes/openai/utils/types.rs
@@ -434,7 +434,10 @@ pub enum MessageContent {
 ///
 /// Do not skip serializing `None` fields here: non-streaming response types
 /// should serialize `None` as explicit `null`.
-#[derive(Debug, Clone, Serialize)]
+///
+/// `Deserialize` is derived for the derender endpoints, which accept `Usage`
+/// embedded in `GenerateResponse` / `GenerateStreamResponse` request bodies.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub total_tokens: usize,
@@ -469,7 +472,7 @@ impl Usage {
 }
 
 /// Mirrors the Python vLLM `PromptTokenUsageInfo` class.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PromptTokenUsageInfo {
     pub cached_tokens: usize,
 }
@@ -534,13 +537,16 @@ pub struct PromptLogprob {
 pub type PromptLogprobs = Vec<Option<HashMap<u32, PromptLogprob>>>;
 
 /// Mirrors the Python vLLM `ChatCompletionLogProbs` class.
-#[derive(Debug, Clone, Serialize)]
+///
+/// `Deserialize` is derived for the derender endpoints, which accept
+/// chat-shaped logprobs embedded in `GenerateResponse` request bodies.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatLogProbs {
     pub content: Option<Vec<ChatLogProbsContent>>,
 }
 
 /// Mirrors the Python vLLM `ChatCompletionLogProbsContent` class.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatLogProbsContent {
     pub token: String,
     pub logprob: f32,
@@ -549,7 +555,7 @@ pub struct ChatLogProbsContent {
 }
 
 /// Mirrors the Python vLLM `ChatCompletionLogProb` class.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TopLogProb {
     pub token: String,
     pub logprob: f32,

--- a/rust/src/server/src/routes/render.rs
+++ b/rust/src/server/src/routes/render.rs
@@ -33,6 +33,14 @@ pub(crate) fn build_router(state: Arc<RenderState>) -> Router {
         .route("/v1/models", get(list_models))
         .route("/v1/chat/completions/render", post(render_chat))
         .route("/v1/completions/render", post(render_completion))
+        .route(
+            "/v1/chat/completions/derender",
+            post(crate::routes::derender::derender_chat_render),
+        )
+        .route(
+            "/v1/completions/derender",
+            post(crate::routes::derender::derender_completion_render),
+        )
         .with_state(state)
         .layer(DefaultBodyLimit::max(DEFAULT_REQUEST_BODY_LIMIT_BYTES))
 }

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -6793,9 +6793,8 @@ async fn profile_routes_are_hidden_when_profiling_is_disabled() {
 // ---------------------------------------------------------------------------
 // /v1/{chat/completions,completions}/derender tests
 //
-// Port of tests/entrypoints/scale_out/derender/test_derender.py against the
-// render-only router fixture. Streaming (test_derender_stream.py, phase 3)
-// tests land in a later phase.
+// Port of tests/entrypoints/scale_out/derender/test_derender.py and
+// test_derender_stream.py against the render-only router fixture.
 // ---------------------------------------------------------------------------
 
 /// Build a chat `GenerateResponse` body mirroring `_make_generate_response`.
@@ -7438,12 +7437,342 @@ async fn derender_completion_oversized_token_ids_rejected() {
     assert!(json["error"]["message"].as_str().unwrap().contains("max_model_len"));
 }
 
+// ---------------------------------------------------------------------------
+// Streaming derender tests
+// ---------------------------------------------------------------------------
+
+/// One streaming derender call, returning the response JSON.
+async fn derender_chat_stream_call(
+    app: &mut axum::Router,
+    token_ids: &[u32],
+    finish_reason: Option<&str>,
+    stream_state: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    derender_chat(
+        app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{
+                    "index": 0,
+                    "token_ids": token_ids,
+                    "finish_reason": finish_reason,
+                }],
+            },
+            "stream_state": stream_state,
+        }),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn derender_chat_stream_chunked_equals_one_shot() {
+    let mut app = test_derender_app();
+    // Multibyte characters straddling chunk boundaries must reproduce the
+    // one-shot decode (one token per chunk, the most granular streaming).
+    let text = "Hello ✅ 日本語";
+    let token_ids = derender_token_ids(text);
+
+    let mut stream_state = serde_json::Value::Null;
+    let mut streamed = String::new();
+    let mut last_state = serde_json::Value::Null;
+    for (position, &token_id) in token_ids.iter().enumerate() {
+        let finish_reason = (position == token_ids.len() - 1).then_some("stop");
+        let (status, json) =
+            derender_chat_stream_call(&mut app, &[token_id], finish_reason, stream_state).await;
+        assert_eq!(status, StatusCode::OK, "{json}");
+        let delta = &json["chunk"]["choices"][0]["delta"];
+        // role is emitted on the first processed chunk only.
+        if position == 0 {
+            assert_eq!(delta["role"], "assistant");
+        } else {
+            assert_eq!(delta["role"], serde_json::Value::Null);
+        }
+        streamed.push_str(delta["content"].as_str().unwrap_or_default());
+        stream_state = json["stream_state"].clone();
+        last_state = stream_state.clone();
+    }
+
+    assert_eq!(streamed, text);
+    // The carried window is trimmed and rebased each chunk.
+    assert_eq!(last_state["prefix_offset"], 0);
+    assert_eq!(last_state["role_sent"], true);
+    // Python model_dump emits the reserved fields as explicit nulls.
+    assert_eq!(last_state["last_content"], serde_json::Value::Null);
+    assert_eq!(last_state["last_reasoning"], serde_json::Value::Null);
+    assert_eq!(last_state["last_tool_call_ids"], json!([]));
+}
+
+#[tokio::test]
+async fn derender_chat_stream_finish_reason_and_id_forwarded() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("done");
+
+    let (status, json) = derender_chat_stream_call(
+        &mut app,
+        &token_ids,
+        Some("length"),
+        serde_json::Value::Null,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["chunk"]["id"], "test-stream");
+    assert_eq!(json["chunk"]["object"], "chat.completion.chunk");
+    assert_eq!(json["chunk"]["choices"][0]["finish_reason"], "length");
+    assert_eq!(json["chunk"]["usage"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_chat_stream_with_parser_rejected() {
+    let mut app = test_derender_app_with_parser_selections(
+        ParserSelection::Auto,
+        ParserSelection::Explicit("deepseek_r1".to_string()),
+    );
+    let token_ids = derender_token_ids("hello");
+
+    // Fail closed on the parser alone, even when chat_request is omitted.
+    for with_chat_request in [false, true] {
+        let mut body = json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{"index": 0, "token_ids": token_ids, "finish_reason": null}],
+            },
+        });
+        if with_chat_request {
+            body["chat_request"] = json!({
+                "model": "render-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            });
+        }
+        let (status, json) = derender_chat(&mut app, body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+        assert!(json["error"]["message"].as_str().unwrap().contains(
+            "Streaming chat derender is not yet supported for models with a reasoning or \
+                 tool parser configured"
+        ));
+    }
+}
+
+#[tokio::test]
+async fn derender_chat_stream_multiple_choices_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [
+                    {"index": 0, "token_ids": [104], "finish_reason": null},
+                    {"index": 1, "token_ids": [105], "finish_reason": null},
+                ],
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("at most one choice per chunk")
+    );
+}
+
+#[tokio::test]
+async fn derender_stream_prev_tokens_over_cap_rejected() {
+    let mut app = test_derender_app();
+    let prev_tokens: Vec<String> = std::iter::repeat_n("a".to_string(), 1025).collect();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{"index": 0, "token_ids": [104], "finish_reason": null}],
+            },
+            "stream_state": {"prev_tokens": prev_tokens},
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("prev_tokens length (1025) exceeds maximum (1024)")
+    );
+}
+
+#[tokio::test]
+async fn derender_stream_negative_offset_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, _) = derender_chat(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{"index": 0, "token_ids": [104], "finish_reason": null}],
+            },
+            "stream_state": {"prev_tokens": ["a"], "prefix_offset": -1},
+        }),
+    )
+    .await;
+
+    // Negative offsets fail JSON deserialization, mirroring Pydantic's ge=0.
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_stream_offset_out_of_range_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{"index": 0, "token_ids": [104], "finish_reason": null}],
+            },
+            "stream_state": {"prev_tokens": ["a"], "prefix_offset": 0, "read_offset": 5},
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("invalid stream_state"));
+}
+
+#[tokio::test]
+async fn derender_completion_stream_roundtrip() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("streaming completion");
+    let mid = token_ids.len() / 2;
+
+    // Non-streaming baseline.
+    let (status, baseline) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [{
+                "request_id": "test-ns",
+                "choices": [{
+                    "index": 0,
+                    "token_ids": token_ids,
+                    "finish_reason": "stop",
+                }],
+            }],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{baseline}");
+    let expected_text = baseline["choices"][0]["text"].as_str().unwrap().to_string();
+
+    let mut stream_state = serde_json::Value::Null;
+    let mut streamed = String::new();
+    for (chunk_ids, finish_reason) in [(&token_ids[..mid], None), (&token_ids[mid..], Some("stop"))]
+    {
+        let (status, json) = derender_completion(
+            &mut app,
+            json!({
+                "stream": true,
+                "model": "render-model",
+                "generate_chunk": {
+                    "request_id": "test-s",
+                    "choices": [{
+                        "index": 0,
+                        "token_ids": chunk_ids,
+                        "finish_reason": finish_reason,
+                    }],
+                },
+                "stream_state": stream_state,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{json}");
+        // Completion deltas always carry a string, even when empty.
+        streamed.push_str(json["chunk"]["choices"][0]["text"].as_str().unwrap());
+        stream_state = json["stream_state"].clone();
+    }
+
+    assert_eq!(streamed, expected_text);
+}
+
+#[tokio::test]
+async fn derender_completion_stream_usage_chunk() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("usage");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "usage-test",
+                "choices": [{
+                    "index": 0,
+                    "token_ids": token_ids,
+                    "finish_reason": "stop",
+                }],
+            },
+            "stream_state": null,
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let stream_state = json["stream_state"].clone();
+
+    // Usage-only final chunk: choices pass through empty and usage honors the
+    // caller-supplied prompt_tokens over the chunk's own value.
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "usage-test",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 5,
+                    "total_tokens": 8,
+                },
+            },
+            "stream_state": stream_state,
+            "prompt_tokens": 10,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["chunk"]["choices"], json!([]));
+    assert_eq!(json["chunk"]["usage"]["prompt_tokens"], 10);
+    assert_eq!(json["chunk"]["usage"]["completion_tokens"], 5);
+    assert_eq!(json["chunk"]["usage"]["total_tokens"], 15);
+}
+
 #[tokio::test]
 async fn derender_stream_invalid_body_rejected() {
     let mut app = test_derender_app();
 
-    // stream=true is not supported until phase 3: the non-streaming request
-    // body's `stream` deserializer rejects it outright.
+    // stream=true without the required generate_chunk.
     let (status, _) =
         derender_completion(&mut app, json!({ "stream": true, "model": "render-model" })).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -7548,6 +7877,269 @@ async fn derender_chat_usage_overflow_rejected() {
             .contains("overflows the token counter"),
         "{json}"
     );
+}
+
+#[tokio::test]
+async fn derender_chat_stream_usage_overflow_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "usage-overflow",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 5,
+                    "total_tokens": 8,
+                },
+            },
+            "prompt_tokens": u64::MAX,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("overflows the token counter"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn derender_chat_stream_oversized_chunk_rejected() {
+    let mut app = test_derender_app();
+    // One token past the fixture's max_model_len of 128.
+    let oversized_ids: Vec<u32> = (0..129u32).collect();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{"index": 0, "token_ids": oversized_ids, "finish_reason": null}],
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"].as_str().unwrap().contains("exceeds max_model_len"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn derender_completion_stream_oversized_chunk_rejected() {
+    let mut app = test_derender_app();
+    let oversized_ids: Vec<u32> = (0..129u32).collect();
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{"index": 0, "token_ids": oversized_ids, "finish_reason": null}],
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"].as_str().unwrap().contains("exceeds max_model_len"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn derender_stream_state_carries_token_ids() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("h");
+
+    let (status, json) =
+        derender_chat_stream_call(&mut app, &token_ids, None, serde_json::Value::Null).await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["stream_state"]["prev_tokens"], json!(["h"]));
+    assert_eq!(json["stream_state"]["prev_token_ids"], json!(token_ids));
+}
+
+#[tokio::test]
+async fn derender_stream_lossy_pieces_recover_via_token_ids() {
+    // The carried token IDs reconstruct the decode window even when the wire
+    // pieces no longer map back through token_to_id (e.g. a backend whose
+    // id_to_token is lossy UTF-8): corrupting prev_tokens must not change the
+    // output as long as prev_token_ids is intact.
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("日");
+    assert!(token_ids.len() > 1, "test needs a multi-byte character");
+
+    let (status, json) =
+        derender_chat_stream_call(&mut app, &token_ids[..1], None, serde_json::Value::Null).await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+    // The unfinished multi-byte sequence is held back.
+    assert_eq!(
+        json["chunk"]["choices"][0]["delta"]["content"],
+        serde_json::Value::Null
+    );
+
+    let mut state = json["stream_state"].clone();
+    state["prev_tokens"] = json!([""]); // lossy placeholder, unmappable
+    let (status, json) =
+        derender_chat_stream_call(&mut app, &token_ids[1..], Some("stop"), state).await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["chunk"]["choices"][0]["delta"]["content"], "日");
+}
+
+#[tokio::test]
+async fn derender_stream_foreign_state_without_token_ids() {
+    // States produced by the Python implementation carry only prev_tokens
+    // pieces; those map back through token_to_id as a fallback.
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("日本");
+
+    let (status, json) =
+        derender_chat_stream_call(&mut app, &token_ids[..1], None, serde_json::Value::Null).await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+
+    let mut state = json["stream_state"].clone();
+    state["prev_token_ids"] = serde_json::Value::Null;
+    let (status, json) =
+        derender_chat_stream_call(&mut app, &token_ids[1..], Some("stop"), state).await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["chunk"]["choices"][0]["delta"]["content"], "日本");
+}
+
+#[tokio::test]
+async fn derender_stream_mismatched_prev_token_ids_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "stream": true,
+            "model": "render-model",
+            "generate_chunk": {
+                "request_id": "test-stream",
+                "choices": [{"index": 0, "token_ids": [104], "finish_reason": null}],
+            },
+            "stream_state": {
+                "prev_tokens": ["a"],
+                "prev_token_ids": [97, 98],
+                "read_offset": 1,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"].as_str().unwrap().contains("prev_token_ids length"),
+        "{json}"
+    );
+}
+
+/// Tool-capable model (hermes tool parser, no reasoning parser) for the
+/// streaming tool-gating tests.
+fn test_derender_tool_parser_app() -> axum::Router {
+    test_derender_app_with_parser_selections(
+        ParserSelection::Explicit("hermes".to_string()),
+        ParserSelection::Auto,
+    )
+}
+
+fn derender_tool_stream_body(chat_request: serde_json::Value) -> serde_json::Value {
+    let mut body = json!({
+        "stream": true,
+        "model": "render-model",
+        "generate_chunk": {
+            "request_id": "test-stream",
+            "choices": [{"index": 0, "token_ids": derender_token_ids("hello"), "finish_reason": null}],
+        },
+    });
+    if !chat_request.is_null() {
+        body["chat_request"] = chat_request;
+    }
+    body
+}
+
+#[tokio::test]
+async fn derender_chat_stream_tool_parser_allows_plain_requests() {
+    let mut app = test_derender_tool_parser_app();
+
+    // No chat_request at all.
+    let (status, json) =
+        derender_chat(&mut app, derender_tool_stream_body(serde_json::Value::Null)).await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["chunk"]["choices"][0]["delta"]["content"], "hello");
+
+    // chat_request without tools: the normal pipeline would not engage the
+    // tool parser either.
+    let (status, json) = derender_chat(
+        &mut app,
+        derender_tool_stream_body(json!({
+            "model": "render-model",
+            "messages": [{"role": "user", "content": "hi"}],
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+
+    // Tools declared but tool_choice "none" disables tool parsing.
+    let (status, json) = derender_chat(
+        &mut app,
+        derender_tool_stream_body(json!({
+            "model": "render-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+            "tool_choice": "none",
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{json}");
+}
+
+#[tokio::test]
+async fn derender_chat_stream_tool_parser_rejects_tool_requests() {
+    let mut app = test_derender_tool_parser_app();
+
+    for chat_request in [
+        // Tools present with the default (auto) tool choice.
+        json!({
+            "model": "render-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        }),
+        // An explicit required tool choice.
+        json!({
+            "model": "render-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+            "tool_choice": "required",
+        }),
+    ] {
+        let (status, json) = derender_chat(&mut app, derender_tool_stream_body(chat_request)).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+        assert!(
+            json["error"]["message"].as_str().unwrap().contains(
+                "Streaming chat derender is not yet supported for models with a reasoning or \
+                 tool parser configured"
+            ),
+            "{json}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -6794,8 +6794,8 @@ async fn profile_routes_are_hidden_when_profiling_is_disabled() {
 // /v1/{chat/completions,completions}/derender tests
 //
 // Port of tests/entrypoints/scale_out/derender/test_derender.py against the
-// render-only router fixture. Reasoning/tool parsing (phase 2) and streaming
-// (test_derender_stream.py, phase 3) tests land in later phases.
+// render-only router fixture. Streaming (test_derender_stream.py, phase 3)
+// tests land in a later phase.
 // ---------------------------------------------------------------------------
 
 /// Build a chat `GenerateResponse` body mirroring `_make_generate_response`.
@@ -7140,6 +7140,64 @@ async fn derender_chat_oversized_top_logprobs_rejected() {
 }
 
 #[tokio::test]
+async fn derender_chat_parsed_reasoning() {
+    let mut app = test_derender_app_with_parser_selections(
+        ParserSelection::Auto,
+        ParserSelection::Explicit("deepseek_r1".to_string()),
+    );
+    // The deepseek_r1 parser starts inside a reasoning span (the model's chat
+    // template prefills `<think>` into the prompt), so the generated output
+    // carries only the closing delimiter.
+    let token_ids = derender_token_ids("the user says hi</think>hello there");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+            "chat_request": {
+                "model": "render-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let message = &json["choices"][0]["message"];
+    assert_eq!(message["reasoning"], "the user says hi");
+    assert_eq!(message["content"], "hello there");
+}
+
+#[tokio::test]
+async fn derender_chat_include_reasoning_false_hides_reasoning() {
+    let mut app = test_derender_app_with_parser_selections(
+        ParserSelection::Auto,
+        ParserSelection::Explicit("deepseek_r1".to_string()),
+    );
+    let token_ids = derender_token_ids("hidden</think>visible");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+            "chat_request": {
+                "model": "render-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "include_reasoning": false,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let message = &json["choices"][0]["message"];
+    assert_eq!(message["reasoning"], serde_json::Value::Null);
+    assert_eq!(message["content"], "visible");
+}
+
+#[tokio::test]
 async fn derender_chat_no_chat_request_falls_back_to_plain_detok() {
     // Parser configured, but without chat_request the endpoint must plain
     // detokenize; the fake think markers are regular tokens, so they survive
@@ -7393,6 +7451,78 @@ async fn derender_stream_invalid_body_rejected() {
     // A non-object JSON body.
     let (status, _) = derender_completion(&mut app, json!([1, 2, 3])).await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_chat_parser_sees_rendered_prompt() {
+    // The replayed parse starts from the real rendered prompt: a prompt whose
+    // last reasoning boundary is `</think>` leaves the parser in content
+    // mode, so the same tokens that parse as reasoning under an empty prompt
+    // here come out as plain content.
+    let mut app = test_derender_app_with_parser_selections(
+        ParserSelection::Auto,
+        ParserSelection::Explicit("deepseek_r1".to_string()),
+    );
+    let token_ids = derender_token_ids("plain answer");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+            "chat_request": {
+                "model": "render-model",
+                "messages": [{"role": "user", "content": "hi </think>"}],
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let message = &json["choices"][0]["message"];
+    assert_eq!(message["content"], "plain answer");
+    assert_eq!(message["reasoning"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_chat_hidden_reasoning_drops_logprobs() {
+    // Like the normal chat path, per-token output metadata is suppressed when
+    // reasoning is parsed out but hidden, so hidden reasoning tokens cannot
+    // leak through logprobs.
+    let mut app = test_derender_app_with_parser_selections(
+        ParserSelection::Auto,
+        ParserSelection::Explicit("deepseek_r1".to_string()),
+    );
+    let token_ids = derender_token_ids("hidden</think>visible");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [{"token": "token_id:104", "logprob": -1.0, "top_logprobs": []}],
+    });
+
+    for (include_reasoning, expect_logprobs) in [(false, false), (true, true)] {
+        let (status, json) = derender_chat(
+            &mut app,
+            json!({
+                "model": "render-model",
+                "generate_response": response,
+                "chat_request": {
+                    "model": "render-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "include_reasoning": include_reasoning,
+                },
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{json}");
+        let choice = &json["choices"][0];
+        assert_eq!(choice["message"]["content"], "visible");
+        if expect_logprobs {
+            assert!(choice["logprobs"].is_object(), "{json}");
+        } else {
+            assert_eq!(choice["logprobs"], serde_json::Value::Null, "{json}");
+        }
+    }
 }
 
 #[tokio::test]

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -434,6 +434,7 @@ async fn recv_engine_message(dealer: &mut DealerSocket) -> Vec<Bytes> {
 struct FakeChatBackend {
     model_id: String,
     multimodal_model_info: Option<vllm_chat::multimodal::MultimodalModelInfo>,
+    tokenizer: TestTokenizer,
 }
 
 /// Synthetic BOS id used when `add_special_tokens` is true in tests.
@@ -458,13 +459,14 @@ impl FakeChatBackend {
         Self {
             model_id: "test-model".to_string(),
             multimodal_model_info: None,
+            tokenizer: fake_chat_tokenizer(),
         }
     }
 
     fn with_model_id(model_id: impl Into<String>) -> Self {
         Self {
             model_id: model_id.into(),
-            multimodal_model_info: None,
+            ..Self::new()
         }
     }
 
@@ -472,9 +474,14 @@ impl FakeChatBackend {
         multimodal_model_info: vllm_chat::multimodal::MultimodalModelInfo,
     ) -> Self {
         Self {
-            model_id: "test-model".to_string(),
             multimodal_model_info: Some(multimodal_model_info),
+            ..Self::new()
         }
+    }
+
+    fn with_tokenizer(mut self, tokenizer: TestTokenizer) -> Self {
+        self.tokenizer = tokenizer;
+        self
     }
 }
 
@@ -488,7 +495,7 @@ impl fmt::Debug for FakeChatBackend {
 
 impl TextBackend for FakeChatBackend {
     fn tokenizer(&self) -> DynTokenizer {
-        Arc::new(fake_chat_tokenizer())
+        Arc::new(self.tokenizer.clone())
     }
 
     fn model_id(&self) -> &str {
@@ -691,6 +698,30 @@ fn test_render_app_with_parser_selections(
     reasoning_parser: ParserSelection,
 ) -> axum::Router {
     let backend = Arc::new(FakeChatBackend::new());
+    build_render_router(Arc::new(RenderState {
+        model: "backend-model".to_string(),
+        served_model_names: vec!["render-model".to_string()],
+        text: TextRequestProcessor::new(backend.clone(), 128),
+        chat: ChatRequestProcessor::render_only(backend)
+            .with_parser_selections(tool_call_parser, reasoning_parser),
+    }))
+}
+
+/// Derender tests need byte-id token pieces that round-trip through
+/// `id_to_token`/`token_to_id`, so the fake tokenizer uses the byte-level
+/// piece mapping here (unlike the render fixtures above).
+fn test_derender_app() -> axum::Router {
+    test_derender_app_with_parser_selections(ParserSelection::Auto, ParserSelection::Auto)
+}
+
+fn test_derender_app_with_parser_selections(
+    tool_call_parser: ParserSelection,
+    reasoning_parser: ParserSelection,
+) -> axum::Router {
+    let backend = Arc::new(
+        FakeChatBackend::new()
+            .with_tokenizer(fake_chat_tokenizer().with_byte_level_piece_mapping()),
+    );
     build_render_router(Arc::new(RenderState {
         model: "backend-model".to_string(),
         served_model_names: vec!["render-model".to_string()],
@@ -6757,4 +6788,763 @@ async fn profile_routes_are_hidden_when_profiling_is_disabled() {
     }
 
     engine_task.abort_and_join().await;
+}
+
+// ---------------------------------------------------------------------------
+// /v1/{chat/completions,completions}/derender tests
+//
+// Port of tests/entrypoints/scale_out/derender/test_derender.py against the
+// render-only router fixture. Reasoning/tool parsing (phase 2) and streaming
+// (test_derender_stream.py, phase 3) tests land in later phases.
+// ---------------------------------------------------------------------------
+
+/// Build a chat `GenerateResponse` body mirroring `_make_generate_response`.
+fn derender_generate_response(token_ids: serde_json::Value) -> serde_json::Value {
+    json!({
+        "request_id": "chatcmpl-derender-test",
+        "choices": [{
+            "index": 0,
+            "token_ids": token_ids,
+            "finish_reason": "stop",
+            "logprobs": null,
+        }],
+        "prompt_logprobs": null,
+        "kv_transfer_params": null,
+    })
+}
+
+/// Byte-level token ids for ordinary text through the fake chat tokenizer.
+fn derender_token_ids(text: &str) -> Vec<u32> {
+    use vllm_text::tokenizer::Tokenizer as _;
+    fake_chat_tokenizer()
+        .with_byte_level_piece_mapping()
+        .encode(text, false)
+        .expect("encode text")
+}
+
+async fn derender_chat(
+    app: &mut axum::Router,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    post_json(app, "/v1/chat/completions/derender", body).await
+}
+
+async fn derender_completion(
+    app: &mut axum::Router,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    post_json(app, "/v1/completions/derender", body).await
+}
+
+#[tokio::test]
+async fn derender_chat_roundtrip() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("hello");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "stream": false,
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["object"], "chat.completion");
+    // The response id echoes the generate response request id verbatim.
+    assert_eq!(json["id"], "chatcmpl-derender-test");
+    assert_eq!(json["choices"][0]["index"], 0);
+    assert_eq!(json["choices"][0]["message"]["role"], "assistant");
+    assert_eq!(json["choices"][0]["message"]["content"], "hello");
+    // finish_reason passes through verbatim from the wire.
+    assert_eq!(json["choices"][0]["finish_reason"], "stop");
+    assert_eq!(json["prompt_logprobs"], serde_json::Value::Null);
+    assert_eq!(json["kv_transfer_params"], serde_json::Value::Null);
+    assert_eq!(json["ec_transfer_params"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_chat_usage() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+            "prompt_tokens": 10,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["usage"]["prompt_tokens"], 10);
+    assert_eq!(json["usage"]["completion_tokens"], 3);
+    assert_eq!(json["usage"]["total_tokens"], 13);
+}
+
+#[tokio::test]
+async fn derender_chat_usage_default() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["usage"]["prompt_tokens"], 0);
+}
+
+#[tokio::test]
+async fn derender_chat_prompt_logprobs_passthrough() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["prompt_logprobs"] = json!([null, null]);
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["prompt_logprobs"], json!([null, null]));
+}
+
+#[tokio::test]
+async fn derender_chat_kv_transfer_params_passthrough() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["kv_transfer_params"] = json!({"key": "value"});
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["kv_transfer_params"], json!({"key": "value"}));
+}
+
+#[tokio::test]
+async fn derender_chat_logprobs_placeholder_resolution() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("hi");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [{
+            "token": "token_id:104",
+            "logprob": -1.0,
+            "bytes": null,
+            "top_logprobs": [{"token": "token_id:105", "logprob": -2.0, "bytes": null}],
+        }],
+    });
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let content = &json["choices"][0]["logprobs"]["content"];
+    // token_id:N placeholders resolve to the decoded token and UTF-8 bytes.
+    assert_eq!(content[0]["token"], "h");
+    assert_eq!(content[0]["bytes"], json!([104]));
+    assert_eq!(content[0]["top_logprobs"][0]["token"], "i");
+    assert_eq!(content[0]["top_logprobs"][0]["bytes"], json!([105]));
+}
+
+#[tokio::test]
+async fn derender_chat_empty_token_ids_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!([])),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("empty or null token_ids"));
+}
+
+#[tokio::test]
+async fn derender_chat_null_token_ids_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, _) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(serde_json::Value::Null),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_chat_unknown_model_rejected() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "does-not-exist",
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND, "{json}");
+    assert_eq!(json["error"]["code"], "model_not_found");
+}
+
+#[tokio::test]
+async fn derender_chat_model_omitted_resolves_served_name() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "generate_response": derender_generate_response(json!(token_ids)) }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["model"], "render-model");
+}
+
+#[tokio::test]
+async fn derender_chat_oversized_token_ids_rejected() {
+    let mut app = test_derender_app();
+    // The fixture serves max_model_len=128.
+    let oversized_ids = vec![42_u32; 129];
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(oversized_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("max_model_len"));
+}
+
+#[tokio::test]
+async fn derender_chat_too_many_choices_rejected() {
+    let mut app = test_derender_app();
+    let choices: Vec<serde_json::Value> = (0..16_385)
+        .map(|index| json!({"index": index, "token_ids": [42], "finish_reason": "stop"}))
+        .collect();
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": {
+                "request_id": "test-choices-bound",
+                "choices": choices,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("choices count"));
+}
+
+#[tokio::test]
+async fn derender_chat_negative_token_ids_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, _) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!([-1, 42, 100])),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_chat_oversized_logprobs_rejected() {
+    let mut app = test_derender_app();
+    let content: Vec<serde_json::Value> = (0..129)
+        .map(|_| json!({"token": "x", "logprob": -1.0, "bytes": null, "top_logprobs": []}))
+        .collect();
+    let mut response = derender_generate_response(json!([42]));
+    response["choices"][0]["logprobs"] = json!({ "content": content });
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("logprobs.content length"));
+}
+
+#[tokio::test]
+async fn derender_chat_oversized_top_logprobs_rejected() {
+    let mut app = test_derender_app();
+    // The fixture defaults to max_logprobs=20.
+    let top_logprobs: Vec<serde_json::Value> = (0..25)
+        .map(|i| json!({"token": format!("t{i}"), "logprob": -(i as f32), "bytes": null}))
+        .collect();
+    let mut response = derender_generate_response(json!([42]));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [{
+            "token": "x",
+            "logprob": -1.0,
+            "bytes": null,
+            "top_logprobs": top_logprobs,
+        }],
+    });
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({ "model": "render-model", "generate_response": response }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    let message = json["error"]["message"].as_str().unwrap();
+    assert!(message.contains("top_logprobs count"), "{message}");
+    assert!(message.contains("max_logprobs"), "{message}");
+}
+
+#[tokio::test]
+async fn derender_chat_no_chat_request_falls_back_to_plain_detok() {
+    // Parser configured, but without chat_request the endpoint must plain
+    // detokenize; the fake think markers are regular tokens, so they survive
+    // skip_special_tokens=true decoding.
+    let mut app = test_derender_app_with_parser_selections(
+        ParserSelection::Auto,
+        ParserSelection::Explicit("deepseek_r1".to_string()),
+    );
+    let token_ids = derender_token_ids("<think>raw</think>text");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let message = &json["choices"][0]["message"];
+    assert_eq!(message["content"], "<think>raw</think>text");
+    assert_eq!(message["reasoning"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_completion_roundtrip() {
+    let mut app = test_derender_app();
+    let ids1 = derender_token_ids("ab");
+    let ids2 = derender_token_ids("cd");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [
+                derender_generate_response(json!(ids1)),
+                {
+                    "request_id": "cmpl-second",
+                    "choices": [{
+                        "index": 0,
+                        "token_ids": ids2,
+                        "finish_reason": "length",
+                    }],
+                },
+            ],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["object"], "text_completion");
+    // The response id comes from the first generate response.
+    assert_eq!(json["id"], "chatcmpl-derender-test");
+    // Choices are flattened across responses and re-indexed from 0.
+    assert_eq!(json["choices"][0]["index"], 0);
+    assert_eq!(json["choices"][0]["text"], "ab");
+    assert_eq!(json["choices"][0]["finish_reason"], "stop");
+    assert_eq!(json["choices"][1]["index"], 1);
+    assert_eq!(json["choices"][1]["text"], "cd");
+    assert_eq!(json["choices"][1]["finish_reason"], "length");
+}
+
+#[tokio::test]
+async fn derender_completion_usage_aggregation() {
+    let mut app = test_derender_app();
+    let ids1 = derender_token_ids("abc");
+    let ids2 = derender_token_ids("defg");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [
+                derender_generate_response(json!(ids1)),
+                derender_generate_response(json!(ids2)),
+            ],
+            "prompt_tokens": [5, 10],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["usage"]["prompt_tokens"], 15);
+    assert_eq!(json["usage"]["completion_tokens"], 7);
+    assert_eq!(json["usage"]["total_tokens"], 22);
+}
+
+#[tokio::test]
+async fn derender_completion_prompt_tokens_length_mismatch_rejected() {
+    let mut app = test_derender_app();
+    let ids = derender_token_ids("abc");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [derender_generate_response(json!(ids))],
+            "prompt_tokens": [5, 10],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("prompt_tokens length (2) must equal generate_responses length (1)")
+    );
+}
+
+#[tokio::test]
+async fn derender_completion_empty_generate_responses_rejected() {
+    let mut app = test_derender_app();
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("generate_responses must not be empty")
+    );
+}
+
+#[tokio::test]
+async fn derender_completion_too_many_generate_responses_rejected() {
+    let mut app = test_derender_app();
+    let responses: Vec<serde_json::Value> = (0..16_385)
+        .map(|i| {
+            json!({
+                "request_id": format!("gen-{i}"),
+                "choices": [{"index": 0, "token_ids": [42], "finish_reason": "stop"}],
+            })
+        })
+        .collect();
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": responses }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("generate_responses count"));
+}
+
+#[tokio::test]
+async fn derender_completion_logprobs() {
+    let mut app = test_derender_app();
+    let mut response = derender_generate_response(json!(derender_token_ids("h")));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [{
+            "token": "token_id:104",
+            "logprob": -1.0,
+            "bytes": null,
+            "top_logprobs": [{"token": "token_id:105", "logprob": -2.0, "bytes": null}],
+        }],
+    });
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [response] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let logprobs = &json["choices"][0]["logprobs"];
+    // Chat-shaped logprobs flatten into the completions parallel lists.
+    assert_eq!(logprobs["tokens"], json!(["h"]));
+    assert_eq!(logprobs["token_logprobs"], json!([-1.0]));
+    assert_eq!(logprobs["top_logprobs"], json!([{"i": -2.0}]));
+    assert_eq!(logprobs["text_offset"], json!([0]));
+}
+
+#[tokio::test]
+async fn derender_completion_kv_transfer_params_passthrough() {
+    let mut app = test_derender_app();
+    let mut response = derender_generate_response(json!(derender_token_ids("abc")));
+    response["kv_transfer_params"] = json!({"node": "abc"});
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [response] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["kv_transfer_params"], json!({"node": "abc"}));
+}
+
+#[tokio::test]
+async fn derender_completion_kv_transfer_params_disagreement_nulled() {
+    let mut app = test_derender_app();
+    let mut first = derender_generate_response(json!(derender_token_ids("ab")));
+    first["kv_transfer_params"] = json!({"node": "a"});
+    let mut second = derender_generate_response(json!(derender_token_ids("cd")));
+    second["kv_transfer_params"] = json!({"node": "b"});
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({ "model": "render-model", "generate_responses": [first, second] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["kv_transfer_params"], serde_json::Value::Null);
+}
+
+#[tokio::test]
+async fn derender_completion_oversized_token_ids_rejected() {
+    let mut app = test_derender_app();
+    let oversized_ids = vec![42_u32; 129];
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [{
+                "request_id": "gen-0",
+                "choices": [{
+                    "index": 0,
+                    "token_ids": oversized_ids,
+                    "finish_reason": "stop",
+                }],
+            }],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(json["error"]["message"].as_str().unwrap().contains("max_model_len"));
+}
+
+#[tokio::test]
+async fn derender_stream_invalid_body_rejected() {
+    let mut app = test_derender_app();
+
+    // stream=true is not supported until phase 3: the non-streaming request
+    // body's `stream` deserializer rejects it outright.
+    let (status, _) =
+        derender_completion(&mut app, json!({ "stream": true, "model": "render-model" })).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // A non-object JSON body.
+    let (status, _) = derender_completion(&mut app, json!([1, 2, 3])).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn derender_chat_usage_overflow_rejected() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("abc");
+
+    let (status, json) = derender_chat(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_response": derender_generate_response(json!(token_ids)),
+            "prompt_tokens": u64::MAX,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{json}");
+    assert!(
+        json["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("overflows the token counter"),
+        "{json}"
+    );
+}
+
+#[tokio::test]
+async fn derender_completion_echo_prepends_prompt() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("there");
+
+    for prompt in [json!("hi "), json!(derender_token_ids("hi "))] {
+        let (status, json) = derender_completion(
+            &mut app,
+            json!({
+                "model": "render-model",
+                "generate_responses": [derender_generate_response(json!(token_ids))],
+                "completion_request": {
+                    "model": "render-model",
+                    "prompt": prompt,
+                    "echo": true,
+                    "max_tokens": 5,
+                },
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{json}");
+        assert_eq!(json["choices"][0]["text"], "hi there");
+    }
+}
+
+#[tokio::test]
+async fn derender_completion_prompt_only_echo_hides_internal_token() {
+    let mut app = test_derender_app();
+    // echo + max_tokens=0 generates one internal token to drive the engine to
+    // a finished event; the derendered choice must expose just the prompt.
+    let token_ids = derender_token_ids("x");
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [derender_generate_response(json!(token_ids))],
+            "completion_request": {
+                "model": "render-model",
+                "prompt": "hi ",
+                "echo": true,
+                "max_tokens": 0,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["choices"][0]["text"], "hi ");
+}
+
+#[tokio::test]
+async fn derender_completion_prompt_only_echo_returns_prompt_logprobs() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("x");
+    let mut response = derender_generate_response(json!(token_ids));
+    // add_special_tokens defaults to true, so the prompt tokenizes to
+    // [BOS, 104, 105]; the first position carries no logprobs, matching the
+    // engine's prompt-logprobs convention.
+    response["prompt_logprobs"] = json!([
+        null,
+        {"104": {"logprob": -0.5, "rank": 1, "decoded_token": "token_id:104"}},
+        {"105": {"logprob": -0.25, "rank": 1, "decoded_token": "token_id:105"}},
+    ]);
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [response],
+            "completion_request": {
+                "model": "render-model",
+                "prompt": "hi",
+                "echo": true,
+                "max_tokens": 0,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    let logprobs = &json["choices"][0]["logprobs"];
+    assert_eq!(logprobs["tokens"], json!(["<bos>", "h", "i"]), "{json}");
+    assert_eq!(
+        logprobs["token_logprobs"],
+        json!([null, -0.5, -0.25]),
+        "{json}"
+    );
+    // "<bos>" is 5 characters wide.
+    assert_eq!(logprobs["text_offset"], json!([0, 5, 6]), "{json}");
+}
+
+#[tokio::test]
+async fn derender_completion_echo_shifts_logprob_offsets() {
+    let mut app = test_derender_app();
+    let token_ids = derender_token_ids("hi");
+    let mut response = derender_generate_response(json!(token_ids));
+    response["choices"][0]["logprobs"] = json!({
+        "content": [
+            {"token": "token_id:104", "logprob": -1.0, "top_logprobs": []},
+            {"token": "token_id:105", "logprob": -2.0, "top_logprobs": []},
+        ],
+    });
+
+    let (status, json) = derender_completion(
+        &mut app,
+        json!({
+            "model": "render-model",
+            "generate_responses": [response],
+            "completion_request": {
+                "model": "render-model",
+                "prompt": "say ",
+                "echo": true,
+                "max_tokens": 5,
+            },
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{json}");
+    assert_eq!(json["choices"][0]["text"], "say hi");
+    let logprobs = &json["choices"][0]["logprobs"];
+    // Without prompt logprobs in the response, the generated-token offsets are
+    // shifted past the echoed prompt ("say " is 4 characters).
+    assert_eq!(logprobs["text_offset"], json!([4, 5]), "{json}");
+    assert_eq!(logprobs["tokens"], json!(["h", "i"]), "{json}");
 }

--- a/rust/src/text/src/lib.rs
+++ b/rust/src/text/src/lib.rs
@@ -82,6 +82,16 @@ impl TextRequestProcessor {
         self.max_model_len
     }
 
+    /// Return the maximum number of top log probabilities accepted.
+    pub fn max_logprobs(&self) -> i32 {
+        self.max_logprobs
+    }
+
+    /// Return the backend model id.
+    pub fn model_id(&self) -> &str {
+        self.backend.model_id()
+    }
+
     fn prepare_prompt_tokens(
         &self,
         prompt: Prompt,

--- a/rust/src/tokenizer/src/test_utils.rs
+++ b/rust/src/tokenizer/src/test_utils.rs
@@ -7,6 +7,45 @@ use crate::{Result, Tokenizer, TokenizerError};
 
 const FIRST_CONFIGURED_TOKEN_ID: u32 = 256;
 
+/// Whether the GPT-2 `bytes_to_unicode` table maps a byte to itself.
+fn is_nice_byte(byte: u8) -> bool {
+    matches!(byte, 0x21..=0x7E | 0xA1..=0xAC) || byte >= 0xAE
+}
+
+/// Map one byte to its GPT-2 `bytes_to_unicode` piece character.
+///
+/// "Nice" bytes map to themselves; the 68 others map to U+0100 + n where n is
+/// the byte's index among the non-nice bytes.
+fn byte_to_unicode_char(byte: u8) -> char {
+    if is_nice_byte(byte) {
+        return char::from(byte);
+    }
+    let n = match byte {
+        0x00..=0x20 => u32::from(byte),
+        0x7F..=0xA0 => 33 + u32::from(byte - 0x7F),
+        // 0xAD is the only remaining non-nice byte.
+        _ => 33 + 34,
+    };
+    char::from_u32(256 + n).expect("byte_to_unicode mapping stays below U+0144")
+}
+
+/// Inverse of [`byte_to_unicode_char`]; `None` for characters outside the
+/// GPT-2 byte-piece range.
+fn unicode_char_to_byte(ch: char) -> Option<u8> {
+    let code = ch as u32;
+    if code <= 0xFF {
+        let byte = u8::try_from(code).ok()?;
+        return is_nice_byte(byte).then_some(byte);
+    }
+    let n = code.checked_sub(256)?;
+    match n {
+        0..=32 => u8::try_from(n).ok(),
+        33..=66 => u8::try_from(n - 33 + 0x7F).ok(),
+        67 => Some(0xAD),
+        _ => None,
+    }
+}
+
 /// Whether a configured test token should be treated as special.
 ///
 /// Special tokens are skipped by [`Tokenizer::decode`] when
@@ -65,6 +104,12 @@ struct TestToken {
 /// Prefer this helper over ad-hoc fake tokenizers for tests that rely on
 /// tokenizer semantics. Keep dedicated tiny fakes for error injection or for
 /// tests that deliberately need a degenerate tokenizer.
+///
+/// By default `id_to_token` represents byte ids as their lossy UTF-8 decoding,
+/// which does not round-trip through `token_to_id` for bytes >= 0x80. Tests
+/// that exercise piece-based detokenization (e.g. the derender endpoints)
+/// should opt into [`TestTokenizer::with_byte_level_piece_mapping`], which
+/// uses the reversible GPT-2 `bytes_to_unicode` mapping instead.
 #[derive(Debug, Clone)]
 pub struct TestTokenizer {
     token_to_id: BTreeMap<String, u32>,
@@ -73,6 +118,7 @@ pub struct TestTokenizer {
     unknown_decode: UnknownDecode,
     vocab_size: Option<usize>,
     bos_token_id: Option<u32>,
+    byte_level_pieces: bool,
 }
 
 impl Default for TestTokenizer {
@@ -91,7 +137,20 @@ impl TestTokenizer {
             unknown_decode: UnknownDecode::Error,
             vocab_size: None,
             bos_token_id: None,
+            byte_level_pieces: false,
         }
+    }
+
+    /// Use the reversible GPT-2 `bytes_to_unicode` mapping for byte-id token
+    /// pieces, so `id_to_token` output round-trips through `token_to_id`.
+    ///
+    /// `decode` is unaffected (bytes still decode as raw UTF-8). Production
+    /// byte-level BPE tokenizers expose the same property, and detokenization
+    /// paths that rebuild text from token pieces (e.g. the streaming derender
+    /// endpoints) rely on it.
+    pub fn with_byte_level_piece_mapping(mut self) -> Self {
+        self.byte_level_pieces = true;
+        self
     }
 
     /// Add a configured token and return the updated tokenizer.
@@ -173,8 +232,14 @@ impl TestTokenizer {
         self.added_vocab.sort_unstable_by_key(|(_, id)| *id);
     }
 
-    fn byte_to_token(id: u32) -> Option<String> {
-        u8::try_from(id).ok().map(|byte| String::from_utf8_lossy(&[byte]).into_owned())
+    fn byte_to_token(&self, id: u32) -> Option<String> {
+        u8::try_from(id).ok().map(|byte| {
+            if self.byte_level_pieces {
+                byte_to_unicode_char(byte).to_string()
+            } else {
+                String::from_utf8_lossy(&[byte]).into_owned()
+            }
+        })
     }
 
     fn flush_bytes(bytes: &mut Vec<u8>, output: &mut String) {
@@ -257,7 +322,16 @@ impl Tokenizer for TestTokenizer {
     fn token_to_id(&self, token: &str) -> Option<u32> {
         self.token_to_id.get(token).copied().or_else(|| {
             let bytes = token.as_bytes();
-            (bytes.len() == 1).then(|| u32::from(bytes[0]))
+            if bytes.len() == 1 {
+                return Some(u32::from(bytes[0]));
+            }
+            if self.byte_level_pieces {
+                let mut chars = token.chars();
+                if let (Some(ch), None) = (chars.next(), chars.next()) {
+                    return unicode_char_to_byte(ch).map(u32::from);
+                }
+            }
+            None
         })
     }
 
@@ -265,7 +339,7 @@ impl Tokenizer for TestTokenizer {
         self.id_to_token
             .get(&id)
             .map(|token| token.text.clone())
-            .or_else(|| Self::byte_to_token(id))
+            .or_else(|| self.byte_to_token(id))
     }
 
     fn added_vocab(&self) -> &[(String, u32)] {
@@ -481,5 +555,22 @@ mod tests {
 
         assert_eq!(tokenizer.vocab_size(), 20_000);
         assert_eq!(tokenizer.id_to_token(10_000).as_deref(), Some("<high>"));
+    }
+
+    #[test]
+    fn byte_level_piece_mapping_roundtrips_all_bytes() {
+        let tokenizer = TestTokenizer::new().with_byte_level_piece_mapping();
+
+        for id in 0..=255_u32 {
+            let piece = tokenizer.id_to_token(id).expect("byte id has a piece");
+            assert_eq!(tokenizer.token_to_id(&piece), Some(id), "piece {piece:?}");
+        }
+        // Decode is unaffected: pieces still decode as raw UTF-8 bytes.
+        let text = "Hello ✅ 日本語";
+        let ids = tokenizer.encode(text, false).unwrap();
+        assert_eq!(tokenizer.decode(&ids, false).unwrap(), text);
+        // GPT-2 style: the space byte maps to U+0120 ("Ġ").
+        assert_eq!(tokenizer.id_to_token(0x20).as_deref(), Some("Ġ"));
+        assert_eq!(tokenizer.token_to_id("Ġ"), Some(0x20));
     }
 }

--- a/tests/entrypoints/scale_out/derender/test_derender_rust_e2e.py
+++ b/tests/entrypoints/scale_out/derender/test_derender_rust_e2e.py
@@ -120,7 +120,19 @@ async def _render_chat(rust_client: httpx.AsyncClient, chat_request: dict) -> di
 
 
 async def _generate(gpu_client: httpx.AsyncClient, generate_request: dict) -> dict:
-    resp = await gpu_client.post("/inference/v1/generate", json=generate_request)
+    # The Rust render server serializes unset sampling params as explicit
+    # nulls, which the Python /inference/v1/generate msgspec validation
+    # rejects (a pre-existing render-side wire incompatibility, unrelated to
+    # derender). Strip them before the generate hop.
+    stripped = {
+        key: (
+            {k: v for k, v in value.items() if v is not None}
+            if isinstance(value, dict)
+            else value
+        )
+        for key, value in generate_request.items()
+    }
+    resp = await gpu_client.post("/inference/v1/generate", json=stripped)
     assert resp.status_code == 200, resp.text
     return resp.json()
 
@@ -188,7 +200,9 @@ async def test_e2e_chat_roundtrip(gpu_client, rust_client):
     choice = derendered["choices"][0]
     output_ids = generate_response["choices"][0]["token_ids"]
     assert choice["message"]["role"] == "assistant"
-    assert choice["message"]["content"]
+    # A reasoning parser is configured, so output may land in `reasoning`.
+    message = choice["message"]
+    assert message["content"] or message.get("reasoning")
     assert derendered["usage"]["prompt_tokens"] == len(generate_request["token_ids"])
     assert derendered["usage"]["completion_tokens"] == len(output_ids)
 

--- a/tests/entrypoints/scale_out/derender/test_derender_rust_e2e.py
+++ b/tests/entrypoints/scale_out/derender/test_derender_rust_e2e.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""End-to-end test for the Rust frontend ``/derender`` endpoints.
+
+Boots the disaggregated stack as two separate processes — a real GPU engine
+(``vllm serve``, which also mounts the Python ``/derender`` endpoints) and the
+GPU-less Rust render server (``vllm-rs render``, mounting the Rust ``/render``
+and ``/derender`` endpoints) — and verifies:
+
+1. A full render -> generate -> derender roundtrip across the wire for both
+   chat and completions.
+2. Python vs Rust derender parity on identical greedy token IDs, mirroring
+   ``test_derender_parity.py`` (which pins the coupled path against the Python
+   derender). Feeding both derenders the same generated token IDs makes
+   generation nondeterminism irrelevant.
+3. The Rust streaming derender protocol (client-carried ``stream_state``)
+   against real generated tokens: chunked derendering must produce the same
+   text as the one-shot derender of the full token list.
+
+Requires the ``vllm-rs`` binary (``cargo build --release -p vllm-cmd``) and a
+GPU.
+"""
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from tests.utils import RemoteOpenAIServer, RemoteRustRenderServer
+
+MODEL = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+MAX_MODEL_LEN = 4096
+GPU_ARGS = [
+    "--enable-auto-tool-choice",
+    "--tool-call-parser",
+    "hermes",
+    "--reasoning-parser",
+    "deepseek_r1",
+    "--enforce-eager",
+    "--max-model-len",
+    str(MAX_MODEL_LEN),
+    # 8 GB cards share VRAM with the desktop; leave headroom.
+    "--gpu-memory-utilization",
+    "0.8",
+]
+RUST_RENDER_ARGS = [
+    "--max-model-len",
+    str(MAX_MODEL_LEN),
+    "--tool-call-parser",
+    "hermes",
+    "--reasoning-parser",
+    "deepseek_r1",
+]
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    }
+]
+FORCE_WEATHER_TOOL = {"type": "function", "function": {"name": "get_weather"}}
+
+
+@pytest.fixture(scope="module")
+def gpu_server():
+    with RemoteOpenAIServer(MODEL, GPU_ARGS) as server:
+        yield server
+
+
+@pytest.fixture(scope="module")
+def rust_render():
+    with RemoteRustRenderServer(MODEL, RUST_RENDER_ARGS, seed=None) as server:
+        yield server
+
+
+@pytest_asyncio.fixture
+async def gpu_client(gpu_server):
+    async with httpx.AsyncClient(
+        base_url=gpu_server.url_for(""), timeout=60.0
+    ) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def rust_client(rust_render):
+    async with httpx.AsyncClient(
+        base_url=rust_render.url_for(""), timeout=60.0
+    ) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chat_request(messages: list[dict], **extra) -> dict:
+    return {
+        "model": MODEL,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": 128,
+        **extra,
+    }
+
+
+async def _render_chat(rust_client: httpx.AsyncClient, chat_request: dict) -> dict:
+    resp = await rust_client.post("/v1/chat/completions/render", json=chat_request)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _generate(gpu_client: httpx.AsyncClient, generate_request: dict) -> dict:
+    resp = await gpu_client.post("/inference/v1/generate", json=generate_request)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _derender_chat(
+    client: httpx.AsyncClient,
+    generate_response: dict,
+    prompt_tokens: int,
+    chat_request: dict,
+) -> dict:
+    resp = await client.post(
+        "/v1/chat/completions/derender",
+        json={
+            "model": MODEL,
+            "generate_response": generate_response,
+            "prompt_tokens": prompt_tokens,
+            "chat_request": chat_request,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _tool_sig(choice: dict) -> list[tuple[str, dict]]:
+    """[(name, json normalized args)] so key ordering / whitespace don't
+    cause false negatives."""
+    return [
+        (tc["function"]["name"], json.loads(tc["function"]["arguments"]))
+        for tc in (choice["message"].get("tool_calls") or [])
+    ]
+
+
+def _assert_derender_parity(python: dict, rust: dict, output_ids: list[int]) -> None:
+    """Both derenders saw the same tokens, so they must agree unconditionally."""
+    p, r = python["choices"][0], rust["choices"][0]
+    assert r["message"]["content"] == p["message"]["content"]
+    assert r["message"].get("reasoning") == p["message"].get("reasoning")
+    assert _tool_sig(r) == _tool_sig(p)
+    assert r["finish_reason"] == p["finish_reason"]
+    assert rust["usage"]["prompt_tokens"] == python["usage"]["prompt_tokens"]
+    assert rust["usage"]["completion_tokens"] == len(output_ids)
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip tests: render (Rust) -> generate (GPU) -> derender (Rust)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_chat_roundtrip(gpu_client, rust_client):
+    """Full disaggregated chat flow across the two servers."""
+    chat_request = _chat_request(
+        [{"role": "user", "content": "What is 2+2? Answer in one short sentence."}]
+    )
+    generate_request = await _render_chat(rust_client, chat_request)
+    generate_response = await _generate(gpu_client, generate_request)
+
+    derendered = await _derender_chat(
+        rust_client,
+        generate_response,
+        prompt_tokens=len(generate_request["token_ids"]),
+        chat_request=chat_request,
+    )
+
+    choice = derendered["choices"][0]
+    output_ids = generate_response["choices"][0]["token_ids"]
+    assert choice["message"]["role"] == "assistant"
+    assert choice["message"]["content"]
+    assert derendered["usage"]["prompt_tokens"] == len(generate_request["token_ids"])
+    assert derendered["usage"]["completion_tokens"] == len(output_ids)
+
+
+@pytest.mark.asyncio
+async def test_e2e_completion_roundtrip(gpu_client, rust_client):
+    """Full disaggregated completions flow across the two servers."""
+    completion_request = {
+        "model": MODEL,
+        "prompt": "The capital of France is",
+        "temperature": 0,
+        "max_tokens": 32,
+    }
+    resp = await rust_client.post("/v1/completions/render", json=completion_request)
+    assert resp.status_code == 200, resp.text
+    generate_requests = resp.json()
+    assert len(generate_requests) == 1
+
+    generate_response = await _generate(gpu_client, generate_requests[0])
+    resp = await rust_client.post(
+        "/v1/completions/derender",
+        json={
+            "model": MODEL,
+            "generate_responses": [generate_response],
+            "prompt_tokens": [len(generate_requests[0]["token_ids"])],
+            "completion_request": completion_request,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    derendered = resp.json()
+
+    assert derendered["choices"][0]["text"]
+    assert derendered["usage"]["prompt_tokens"] == len(
+        generate_requests[0]["token_ids"]
+    )
+    assert derendered["usage"]["completion_tokens"] == len(
+        generate_response["choices"][0]["token_ids"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parity tests: Python /derender (GPU server) vs Rust /derender (render server)
+# ---------------------------------------------------------------------------
+
+
+async def _run_parity_case(
+    gpu_client: httpx.AsyncClient, rust_client: httpx.AsyncClient, chat_request: dict
+) -> tuple[dict, dict, list[int]]:
+    """One greedy generation, derendered by both implementations.
+
+    Returns (python_derender, rust_derender, output_ids)."""
+    resp = await gpu_client.post(
+        "/v1/chat/completions", json={**chat_request, "return_token_ids": True}
+    )
+    assert resp.status_code == 200, resp.text
+    coupled = resp.json()
+    choice = coupled["choices"][0]
+    output_ids = choice["token_ids"]
+
+    generate_response = {
+        "request_id": "parity",
+        "choices": [
+            {
+                "index": 0,
+                "token_ids": output_ids,
+                "finish_reason": choice["finish_reason"],
+            }
+        ],
+    }
+    prompt_tokens = coupled["usage"]["prompt_tokens"]
+    python = await _derender_chat(
+        gpu_client, generate_response, prompt_tokens, chat_request
+    )
+    rust = await _derender_chat(
+        rust_client, generate_response, prompt_tokens, chat_request
+    )
+    return python, rust, output_ids
+
+
+@pytest.mark.asyncio
+async def test_derender_parity_chat(gpu_client, rust_client):
+    """Plain + reasoning content parity between the Python and Rust derender."""
+    chat_request = _chat_request(
+        [{"role": "user", "content": "What is 17 times 23? Think it through."}],
+        include_reasoning=True,
+        max_tokens=256,
+    )
+    python, rust, output_ids = await _run_parity_case(
+        gpu_client, rust_client, chat_request
+    )
+    _assert_derender_parity(python, rust, output_ids)
+
+    if not python["choices"][0]["message"].get("reasoning"):
+        pytest.skip("Model did not emit a <think> block")
+    assert rust["choices"][0]["message"]["reasoning"]
+
+
+@pytest.mark.asyncio
+async def test_derender_parity_tool_call(gpu_client, rust_client):
+    """Tool call name+args parity between the Python and Rust derender."""
+    chat_request = _chat_request(
+        [{"role": "user", "content": "What's the weather in Paris?"}],
+        tools=TOOLS,
+        tool_choice=FORCE_WEATHER_TOOL,
+        max_tokens=1024,
+    )
+    python, rust, output_ids = await _run_parity_case(
+        gpu_client, rust_client, chat_request
+    )
+    _assert_derender_parity(python, rust, output_ids)
+
+    if not _tool_sig(python["choices"][0]):
+        pytest.skip("Model did not emit a tool call")
+    assert _tool_sig(rust["choices"][0])
+
+
+# ---------------------------------------------------------------------------
+# Streaming derender: chunked == one-shot over real generated tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_derender_streaming_roundtrip(gpu_client, rust_client):
+    """Rust streaming completions derender: chunked text == one-shot text.
+
+    Uses the completions endpoint because chat streaming derender fails closed
+    when a reasoning/tool parser is configured (same as Python's
+    ``NotImplementedError`` path).
+    """
+    completion_request = {
+        "model": MODEL,
+        "prompt": "The capital of France is",
+        "temperature": 0,
+        "max_tokens": 32,
+    }
+    resp = await rust_client.post("/v1/completions/render", json=completion_request)
+    assert resp.status_code == 200, resp.text
+    generate_response = await _generate(gpu_client, resp.json()[0])
+    output_ids: list[int] = generate_response["choices"][0]["token_ids"]
+    assert len(output_ids) >= 3, "need a few tokens to chunk the stream"
+
+    # One-shot baseline from the Rust derender.
+    resp = await rust_client.post(
+        "/v1/completions/derender",
+        json={"model": MODEL, "generate_responses": [generate_response]},
+    )
+    assert resp.status_code == 200, resp.text
+    expected_text = resp.json()["choices"][0]["text"]
+
+    # Chunked streaming derender, carrying stream_state between calls.
+    third = max(1, len(output_ids) // 3)
+    chunks = [
+        (output_ids[:third], None),
+        (output_ids[third : 2 * third], None),
+        (output_ids[2 * third :], "stop"),
+    ]
+    stream_state = None
+    streamed_text = ""
+    for chunk_ids, finish_reason in chunks:
+        resp = await rust_client.post(
+            "/v1/completions/derender",
+            json={
+                "stream": True,
+                "model": MODEL,
+                "generate_chunk": {
+                    "request_id": generate_response["request_id"],
+                    "choices": [
+                        {
+                            "index": 0,
+                            "token_ids": chunk_ids,
+                            "finish_reason": finish_reason,
+                        }
+                    ],
+                },
+                "stream_state": stream_state,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        streamed_text += payload["chunk"]["choices"][0]["text"]
+        stream_state = payload["stream_state"]
+
+    assert streamed_text == expected_text

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -848,10 +848,12 @@ def _resolve_vllm_rs_binary() -> str:
         candidates = [Path(env_path)]
     else:
         repo_root = Path(__file__).resolve().parent.parent
+        # Prefer local dev builds; the wheel-packaged binary may be older
+        # than the working tree (e.g. built from a main snapshot).
         candidates = [
-            Path(envs.__file__).resolve().parent / "vllm-rs",  # packaged wheel
             repo_root / "rust" / "target" / "release" / "vllm-rs",
             repo_root / "rust" / "target" / "debug" / "vllm-rs",
+            Path(envs.__file__).resolve().parent / "vllm-rs",  # packaged wheel
         ]
     for candidate in candidates:
         if candidate.is_file() and os.access(candidate, os.X_OK):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -247,7 +247,7 @@ class RemoteVLLMServer:
         vllm_serve_args: list[str],
         *,
         env_dict: dict[str, str] | None = None,
-        seed: int = 0,
+        seed: int | None = 0,
         auto_port: bool = True,
         max_wait_seconds: float | None = None,
         override_hf_configs: dict[str, Any] | None = None,
@@ -839,6 +839,56 @@ class RemoteLaunchRenderServer(RemoteVLLMServer):
         self, timeout: float = 30.0, log_interval: float = 10.0
     ):
         pass  # No GPU used
+
+
+def _resolve_vllm_rs_binary() -> str:
+    """Locate the ``vllm-rs`` binary for Rust frontend tests."""
+    env_path = os.environ.get("VLLM_RUST_FRONTEND_PATH")
+    if env_path and env_path.lower() not in ("auto", "1", "true"):
+        candidates = [Path(env_path)]
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+        candidates = [
+            Path(envs.__file__).resolve().parent / "vllm-rs",  # packaged wheel
+            repo_root / "rust" / "target" / "release" / "vllm-rs",
+            repo_root / "rust" / "target" / "debug" / "vllm-rs",
+        ]
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    pytest.skip(
+        "vllm-rs binary not found; build it with `cargo build --release "
+        "--manifest-path rust/Cargo.toml -p vllm-cmd` or set "
+        "VLLM_RUST_FRONTEND_PATH"
+    )
+    raise AssertionError("unreachable: pytest.skip raises")
+
+
+class RemoteRustRenderServer(RemoteLaunchRenderServer):
+    """Launches ``vllm-rs render`` (Rust GPU-less render/derender server).
+
+    Only pass args accepted by both the Rust ``render`` subcommand and the
+    ``vllm serve`` parser (e.g. ``--max-model-len``, ``--tool-call-parser``,
+    ``--reasoning-parser``), since the base class validates args against the
+    serve parser. Pass ``seed=None``: the Rust CLI has no ``--seed`` flag.
+    """
+
+    def _start_server(
+        self, model: str, vllm_serve_args: list[str], env_dict: dict[str, str] | None
+    ) -> None:
+        env = os.environ.copy()
+        if env_dict is not None:
+            env.update(env_dict)
+        _sanitize_pythonpath_env(env)
+        serve_cmd = [_resolve_vllm_rs_binary(), "render", model, *vllm_serve_args]
+        print(f"Launching RemoteRustRenderServer with: {' '.join(serve_cmd)}")
+        self.proc: subprocess.Popen = subprocess.Popen(
+            serve_cmd,
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            start_new_session=True,
+        )
 
 
 class RemoteOpenAIServerCustom(RemoteOpenAIServer):


### PR DESCRIPTION
## Purpose

**Stacked on #53418 (phase 2/3)** — review only the top commit(s). Split per @sagearc's review on #53223, mirroring the Python derender phasing in #42729 (#43606 detok → #45919 parsing → #48617 streaming).

Phase 3: **streaming derender** for both `/v1/chat/completions/derender` and `/v1/completions/derender`, mirroring Python #48617 — plus a two-process GPU end-to-end test.

- Implements the client-carried `DerenderStreamState` protocol: bounded incremental detok window (`prev_tokens`/`prefix_offset`/`read_offset`, capped at 1024) porting `detokenize_incrementally`, role emitted once, usage forwarding. Chunked derendering produces byte-identical text to one-shot decode, including multibyte characters split across chunk boundaries.
- Chat streaming fails closed when a reasoning/tool parser is configured — same as Python's `NotImplementedError` path.
- Adds `tests/entrypoints/scale_out/derender/test_derender_rust_e2e.py`: boots a real GPU engine (`vllm serve`) and the Rust render server (`vllm-rs render`) as two processes and verifies render → `/inference/v1/generate` → derender roundtrips, Python↔Rust derender parity on identical greedy token IDs, and streaming chunked == one-shot over real tokens. Adds `RemoteRustRenderServer` to `tests/utils.py` (skips cleanly when no `vllm-rs` binary is built).

**Duplicate-work check**: no open PR implements streaming derender in `rust/`; #50550 extends the Python streaming derender only. Related: #42729, #47161.

**AI assistance**: implemented with AI assistance (Kimi Code CLI). I have reviewed the full diff and run the tests below myself.

## Test Plan

```
cargo nextest run -p vllm-server -p vllm-chat -p vllm-text -p vllm-tokenizer
cargo clippy -p vllm-server -p vllm-chat -p vllm-text -p vllm-tokenizer --all-targets
cargo fmt --all --check
pytest -v -s tests/entrypoints/scale_out/derender/test_derender_rust_e2e.py  # requires GPU + vllm-rs binary
```

## Test Result

- `cargo nextest run`: **847 passed, 1 skipped** (includes all 21 streaming derender tests).
- `cargo clippy --all-targets`: clean. `cargo fmt --check`: clean. `pre-commit run` on the Python files: all hooks pass.
- GPU e2e on a single RTX 3070 (8 GB, WSL2, `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` with hermes/deepseek_r1 parsers): **4 passed, 1 skipped** in ~95 s — the skip is `test_derender_parity_tool_call` gated on the model emitting a tool call (same gating as `test_derender_parity.py`).

Model evals: N/A — adds endpoints to the Rust frontend without changing existing serving behavior or model outputs.

### Notes for reviewers

- The e2e surfaced a pre-existing (main-branch) wire incompatibility: the Rust render server serializes unset sampling params as explicit `null`s, which the Python `/inference/v1/generate` msgspec validation rejects. The test strips them before the generate hop with a comment; a render-side fix can be a separate PR.
- Local WSL2 bring-up needed `VLLM_WSL2_ENABLE_PIN_MEMORY=1` and `VLLM_USE_FLASHINFER_SAMPLER=0` (no CUDA toolkit); not test-code concerns.
