### PR TITLE
[Feature] Add PCP O-Proj tensor parallelism

### DIFF
--- a/docs/design/pcp_o_proj_tp.md
+++ b/docs/design/pcp_o_proj_tp.md
@@ -1,6 +1,6 @@
 # PCP O-Proj TP MVP Design
 
-Implementation baseline: `vllm-project/vllm upstream/main@f8e0602713`.
+Implementation baseline: `vllm-project/vllm upstream/main@b26039b09f`.
 
 ## Background
 
@@ -23,7 +23,11 @@ the name `pcp_o_proj_tp`.
 - Only DeepSeek V2/V3/V3.2 and GLM-4 MoE Lite MLA are supported. GLM-4 MoE Lite
   attention inherits the DeepSeekV2 MLA path, so it reuses the same explicit
   prefetch and dynamic O-Proj implementation.
-- Only unquantized FP16/BF16 weights with `bias=False` are supported.
+- O-Proj itself must use the unquantized linear method. Quantized checkpoints
+  remain usable when their quantization configuration excludes O-Proj, as the
+  PCP-validated GLM-5.2-NVFP4 checkpoint excludes all self-attention modules.
+  A quantized O-Proj fails during post-load processing.
+- `bias=False` is required.
 - Only eager execution is supported. CUDA Graph, `torch.compile`, and DBO are
   not supported yet.
 - LoRA is not supported yet.
@@ -54,6 +58,19 @@ The checkpoint loader uses flattened rank `t*P+p` and world size `T*P`, so no
 checkpoint format change is required. The resident O-Proj weight on each rank
 is reduced to `1/P` of the standard TP layout.
 
+## Weight-switch scope
+
+The implementation follows the vllm-ascend `TPWeightSwitchMixin` mechanism but
+opts in only `UnquantizedLinearMethod`. The method declares its `weight` tensor
+and post-load input-shard dimension; the mixin owns the reusable buffers,
+asynchronous collective handle, and local/full tensor aliases.
+
+This boundary matches the quantized model coverage already present for PCP.
+The upstream PCP GSM8K matrix contains GLM-5.2-NVFP4, whose ModelOpt
+configuration excludes every `self_attn` module from NVFP4 quantization. Its
+O-Proj therefore uses the same unquantized method as a BF16 checkpoint. The
+supported method set is intentionally limited to `UnquantizedLinearMethod`.
+
 ## Runtime paths
 
 ### Decode-only batches
@@ -75,10 +92,12 @@ responsible for the TP reduction.
 
 ### Prefill or mixed batches
 
-The attention module determines the batch type from the layer's
-`MLACommonMetadata.num_prefills`. If the batch contains any prefill requests,
-it asynchronously all-gathers the weight over PCP before the main attention
-computation:
+The model runner records whether the logical, pre-partition batch contains any
+prefill requests before PCP splits its tokens. Every PCP rank therefore makes
+the same collective decision, including when prefix caching leaves a rank with
+decode tokens while another rank receives a short prefill. If the logical batch
+contains prefill, the attention module asynchronously all-gathers the weight
+over PCP before the main attention computation:
 
 ```text
 W_local[t,p]^T --PCP AllGather--> W_tp[t]^T
@@ -89,31 +108,36 @@ reached, then applies `W_tp[t]` to the local tokens on the current PCP rank.
 This path does not perform a PCP output reduction because different PCP ranks
 process different tokens. The existing TP reduction remains unchanged.
 
-To concatenate along dimension 0 with `all_gather_into_tensor`, the collective
-input is a contiguous transposed weight with shape `[K/(T*P), N]`, and the
-output buffer has shape `[K/T, N]`. The full TP weight is retained only as a
-transposed view, avoiding an additional copy.
+Because the weight-sharded axis is not dimension 0, the mixin moves that axis
+to the front and makes a contiguous collective input for
+`all_gather_into_tensor`. If the target kernel accepts the resulting moved-dim
+view, the collective output is used directly. Kernels that require a contiguous
+post-load layout request a shared assembly buffer and copy the gathered view
+into it after the asynchronous handle completes.
 
 ## Buffer lifecycle
 
-The full TP weight buffer is shared by vLLM config scope, device, dtype, and
-shape. It is allocated during model construction, and all compatible layers
-hold the same shared buffer, so the cost is included in startup memory
-budgeting. With normal sequential layer execution, one layer waits for and
-consumes its gathered weight before the next layer reuses the buffer. The
-resident overhead is therefore one TP-sized O-Proj shard rather than one copy
-per layer.
+Full TP buffers are shared by vLLM config scope, method, tensor attribute,
+device, dtype, and shape and are allocated during model construction. All
+compatible layers hold the same shared full-weight buffer, so its cost is
+included before profiling and KV-cache sizing. Each layer also retains a local
+contiguous staging tensor for the dimension-1 collective input. With normal
+sequential layer execution, one layer waits for and consumes the shared gathered
+weight before the next layer reuses the full-weight buffer.
 
-The input to the asynchronous collective is a contiguous transpose of the
-current layer's local weight. It remains alive until the handle has completed
-and is then released. DBO is currently disabled to prevent two concurrent
-microbatches from using the shared buffer at the same time.
+The input to each asynchronous collective is either the local tensor itself or
+a persistent contiguous moved-dim staging tensor. Non-leading staging inputs
+are refreshed before every gather so in-place weight updates are visible. DBO
+is currently disabled to prevent two concurrent microbatches from using the
+shared buffers at the same time.
 
 ## Explicit triggering and correctness constraints
 
 Both the generic MLA wrapper and the modular DeepSeek-V3.2 attention path
 explicitly trigger the prefetch after their Q/KV normalization and before the
-remaining query projection and main attention computation.
+remaining query projection and main attention computation. The trigger uses
+the logical pre-partition batch type propagated through `ForwardContext`, so
+all PCP ranks preserve collective ordering.
 `PCPOProjRowParallelLinear.forward()` requires the trigger to have occurred
 before every invocation. A missing trigger raises an error instead of inferring
 the batch type. This guarantees that:
@@ -149,25 +173,27 @@ vllm serve <model> \
 
 ## MVP validation results
 
-Online accuracy was evaluated on August 21, 2026, using four H100 GPUs,
+The following end-to-end results cover the unquantized O-Proj path. The unit
+tests cover asynchronous gather, wait-before-use, full/local alias switching,
+restoration after a failed linear call, logical-versus-local prefill decisions,
+and rejection of a quantized O-Proj method.
+
+Online accuracy was evaluated on August 23, 2026, using four NVIDIA H20 GPUs,
 GLM-4.7-Flash BF16, and the 1,319-question GSM8K test set. TP4, PCP4TP1, and
-PCP2TP2 used eager execution, `max_model_len=8192`, 5-shot prompting,
-`temperature=0`, thinking disabled, and concurrency 32. The 32-question gate
-used `max_tokens=256`; the full evaluation used `max_tokens=4096`.
+PCP2TP2 used eager execution, DCP1, 5-shot prompting, `temperature=0`, seed 42,
+concurrency 32, and `max_tokens=4096`. Each topology first passed a 32-question
+output gate, then completed the full dataset.
 
 | Parallel strategy | 32-question gate | Full-set correct | Full-set accuracy | Failed requests | Invalid answers |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| TP4 baseline | 25/32 | 1134/1319 | 85.9742% | 0 | 0 |
-| PCP4TP1 | 25/32 | 1136/1319 | 86.1259% | 0 | 0 |
-| PCP2TP2 | 26/32 | 1135/1319 | 86.0500% | 0 | 0 |
+| TP4 baseline | 25/32 | 1129/1319 | 85.5951% | 0 | 0 |
+| PCP4TP1 | 25/32 | 1135/1319 | 86.0500% | 0 | 0 |
+| PCP2TP2 | 24/32 | 1131/1319 | 85.7468% | 0 | 0 |
 
-Relative to the TP4 baseline, PCP4TP1 changed 35 answers from incorrect to
-correct and 33 from correct to incorrect, for a net gain of two. PCP2TP2
-changed 32 answers from incorrect to correct and 31 from correct to incorrect,
-for a net gain of one. The three reduction topologies introduce numerical
-differences large enough to alter some autoregressive generation paths, so
-per-question text is not expected to match exactly. No accuracy regression was
-observed over the full dataset.
+PCP4TP1 and PCP2TP2 differ from TP4 by +0.4549 and +0.1516 percentage points,
+respectively. The three reduction topologies can follow different
+autoregressive generation paths because their floating-point reduction orders
+differ.
 
 Based on checkpoint safetensors metadata, the O-Proj weights across 48 layers
 total `1,006,632,960` bytes, or `3.2242%` of all model parameter bytes. With the
@@ -183,6 +209,70 @@ context, KV cache, communication buffers, the shared single-layer prefetch
 buffer, and allocator fragmentation, and therefore do not represent the total
 HBM reduction.
 
+The same four-H20 host was used to measure process-level memory with a fixed
+32 GiB KV cache. `Model loading took` is the model runner's allocated-memory
+measurement after loading and post-load processing. Ready HBM is the
+`nvidia-smi` value after engine initialization.
+
+| Parallel strategy | Feature | Model-load memory/rank | Ready HBM/rank |
+| --- | --- | ---: | ---: |
+| PCP4TP1 | disabled | 17.02 GiB | 59,461 MiB |
+| PCP4TP1 | enabled | 16.58 GiB | 60,021 MiB |
+| PCP2TP2 | disabled | 15.15 GiB | 56,541 MiB |
+| PCP2TP2 | enabled | 15.17 GiB | 57,140 MiB |
+
+PCP4TP1 reduces model-load allocation by 0.44 GiB per rank. For PCP2TP2, the
+smaller local parameter shard and the current persistent gather staging have
+similar sizes, yielding a 0.02 GiB measured increase. Ready HBM includes the
+communication and runtime workspaces initialized by the feature and is 560 MiB
+and 599 MiB higher for PCP4TP1 and PCP2TP2, respectively. These measurements
+distinguish the parameter-layout reduction from total serving-process HBM.
+
+Serving performance used random 32,768-token inputs and 1,024 generated tokens,
+`ignore_eos`, `temperature=0`, seed 12345, prefix caching disabled, and a fixed
+32 GiB KV cache. Each row is one completed controlled run; all requests
+succeeded. Throughput is generated-token throughput.
+
+| Topology | Feature | Concurrency | Mean TTFT | Mean TPOT | Throughput |
+| --- | --- | ---: | ---: | ---: | ---: |
+| PCP4TP1 | disabled | 1 | 2,027.49 ms | 82.33 ms | 11.87 tok/s |
+| PCP4TP1 | enabled | 1 | 2,030.59 ms | 86.39 ms | 11.33 tok/s |
+| PCP4TP1 | disabled | 8 | 9,368.98 ms | 89.98 ms | 80.51 tok/s |
+| PCP4TP1 | enabled | 8 | 9,402.45 ms | 94.69 ms | 76.84 tok/s |
+| PCP4TP1 | disabled | 16 | 17,376.00 ms | 97.19 ms | 139.50 tok/s |
+| PCP4TP1 | enabled | 16 | 17,438.39 ms | 104.49 ms | 131.04 tok/s |
+| PCP2TP2 | disabled | 1 | 2,091.03 ms | 89.73 ms | 10.91 tok/s |
+| PCP2TP2 | enabled | 1 | 2,151.26 ms | 95.16 ms | 10.29 tok/s |
+| PCP2TP2 | disabled | 8 | 9,008.10 ms | 95.98 ms | 76.17 tok/s |
+| PCP2TP2 | enabled | 8 | 8,968.01 ms | 103.23 ms | 71.27 tok/s |
+| PCP2TP2 | disabled | 16 | 16,404.51 ms | 103.03 ms | 133.75 tok/s |
+| PCP2TP2 | enabled | 16 | 16,417.18 ms | 108.64 ms | 127.70 tok/s |
+
+Across concurrency 1/8/16, enabling the feature changes mean TTFT by
+`+0.15%/+0.36%/+0.36%` for PCP4TP1 and `+2.88%/-0.45%/+0.08%` for PCP2TP2.
+Mean TPOT changes by `+4.93%/+5.23%/+7.51%` and
+`+6.05%/+7.55%/+5.45%`, respectively; generated-token throughput changes by
+`-4.55%/-4.56%/-6.06%` and `-5.68%/-6.43%/-4.52%`.
+
+## PCP8 parameter projections
+
+The following projections use Hugging Face checkpoint tensor metadata and
+assume TP1, PCP8, DCP1, and an implementation compatible with each model's
+O-Proj representation. They include the current single-layer full-weight
+prefetch buffer and exclude communication, staging, and allocator overhead.
+
+| Model/checkpoint | Total parameter bytes | Shardable O-Proj | Local O-Proj at PCP8 | Per-rank persistent saving | Resulting persistent weights |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| GLM-5.2 BF16 | 1,403.186 GiB | 14.812 GiB | 1.852 GiB | 12.773 GiB | 1,390.413 GiB |
+| GLM-5.2 FP8 | 703.723 GiB | 7.408 GiB | 0.926 GiB | 6.388 GiB | 697.335 GiB |
+| DeepSeek-V4 Flash-Base | 274.436 GiB | 1.375 GiB | 0.172 GiB | 1.172 GiB | 273.264 GiB |
+| DeepSeek-V4 Flash | 148.648 GiB | 1.375 GiB | 0.172 GiB | 1.172 GiB | 147.476 GiB |
+| DeepSeek-V4 Pro-Base | 1,495.734 GiB | 6.782 GiB | 0.848 GiB | 5.825 GiB | 1,489.910 GiB |
+| DeepSeek-V4 Pro | 805.319 GiB | 6.782 GiB | 0.848 GiB | 5.825 GiB | 799.495 GiB |
+
+For a combined TP size `T`, the local O-Proj, prefetch buffer, and per-rank
+saving in this table are divided by `T`.
+
 ## Future work
 
 1. Add per-layer tensor comparisons for TP-by-PCP prefill, mixed, and decode
@@ -191,7 +281,7 @@ HBM reduction.
 2. Integrate the shared-buffer lease with a concurrency-safe model-level
    workspace manager and remove the DBO restriction.
 3. Add CUDA Graph and `torch.compile`-capturable paths.
-4. Define joint gathering of weights, scales, and metadata for FP8, block
-   quantization, and other quantized formats.
+4. Extend the O-Proj method set together with representation-specific
+   reconstruction and an end-to-end PCP model validation.
 5. Evaluate a dedicated PCP communicator or stream to avoid serialization with
    attention PCP collectives.

--- a/docs/design/pcp_o_proj_tp.md
+++ b/docs/design/pcp_o_proj_tp.md
@@ -1,118 +1,138 @@
-# PCP O-Proj TP MVP 方案
+# PCP O-Proj TP MVP Design
 
-实现基线：`vllm-project/vllm upstream/main@f8e0602713`。
+Implementation baseline: `vllm-project/vllm upstream/main@f8e0602713`.
 
-## 背景
+## Background
 
-vllm-ascend 的细粒度 O-Proj TP 将 O-Proj 的输入维从 TP 继续切到更多
-rank，以减少每 rank 常驻权重。DSA-CP 场景在运行时按 batch 类型切换：decode
-使用更细的权重分片并归约部分和；包含 prefill 时，先聚合出原 TP 粒度的完整
-权重，再执行原有 O-Proj。
+The fine-grained O-Proj tensor parallelism in vllm-ascend further shards the
+O-Proj input dimension across additional ranks beyond TP, reducing the resident
+weight on each rank. In the DSA-CP implementation, the runtime path depends on
+the batch type: decode uses the finer-grained weight shards and reduces their
+partial sums, while a batch containing prefill first gathers the original
+TP-sized weight shard and then runs the standard O-Proj computation.
 
-vLLM 已有独立的 TP、PCP 和 DCP process group，但通用
-`RowParallelLinear` 只按 TP 切权重。本 MVP 使用 PCP 作为 O-Proj 的第二个
-权重切分轴，实现与上述动态切换等价的 `pcp_o_proj_tp`。
+vLLM already has independent TP, PCP, and DCP process groups, but the generic
+`RowParallelLinear` shards weights only across TP ranks. This MVP uses PCP as a
+second O-Proj weight-sharding axis and provides an equivalent dynamic path under
+the name `pcp_o_proj_tp`.
 
-## MVP 限制
+## MVP limitations
 
-- `prefill_context_parallel_size > 1`。
-- `decode_context_parallel_size = 1`。
-- 仅支持 DeepSeek V2/V3/V3.2 和 GLM-4 MoE Lite MLA。GLM-4 MoE Lite 的
-  attention 继承 DeepSeekV2 MLA 路径，因此复用相同的显式 prefetch 与 O-Proj
-  动态路径。
-- 仅支持 FP16/BF16 非量化权重、`bias=False`。
-- 仅支持 eager，暂不支持 CUDA Graph、torch.compile 和 DBO。
-- 暂不支持 LoRA。
-- 暂不支持 CPU weight offload。
-- attention module 必须在主 attention 计算前显式调用
-  `o_proj.prefetch_full_weight_if_needed(has_prefill)`。
+- `prefill_context_parallel_size > 1`.
+- `decode_context_parallel_size = 1`.
+- Only DeepSeek V2/V3/V3.2 and GLM-4 MoE Lite MLA are supported. GLM-4 MoE Lite
+  attention inherits the DeepSeekV2 MLA path, so it reuses the same explicit
+  prefetch and dynamic O-Proj implementation.
+- Only unquantized FP16/BF16 weights with `bias=False` are supported.
+- Only eager execution is supported. CUDA Graph, `torch.compile`, and DBO are
+  not supported yet.
+- LoRA is not supported yet.
+- CPU weight offloading is not supported yet.
+- The attention module must explicitly call
+  `o_proj.prefetch_full_weight_if_needed(has_prefill)` before the main attention
+  computation.
 
-这些限制全部通过配置或线性层构造检查 fail fast，避免功能开关静默失效。
+Configuration validation and linear-layer construction checks enforce all of
+these restrictions and fail fast instead of silently ignoring the feature.
 
-## 权重布局
+## Weight layout
 
-设 O-Proj 权重为 `W[N, K]`，TP 大小为 `T`，PCP 大小为 `P`。
-普通 row parallel 在 TP rank `t` 上常驻：
+Let the O-Proj weight be `W[N, K]`, the TP size be `T`, and the PCP size be `P`.
+Standard row parallelism keeps the following shard on TP rank `t`:
 
 ```text
 W_tp[t] = W[:, t*K/T : (t+1)*K/T]
 ```
 
-MVP 在同一个 TP shard 内继续按 PCP rank `p` 切分：
+The MVP further shards each TP shard across PCP rank `p`:
 
 ```text
 W_local[t,p] = W[:, (t*P+p)*K/(T*P) : (t*P+p+1)*K/(T*P)]
 ```
 
-checkpoint loader 使用展平 rank `t*P+p` 和 world size `T*P`，因此无需改变
-checkpoint 格式。每 rank 的 O-Proj 常驻权重降为原 TP 方案的 `1/P`。
+The checkpoint loader uses flattened rank `t*P+p` and world size `T*P`, so no
+checkpoint format change is required. The resident O-Proj weight on each rank
+is reduced to `1/P` of the standard TP layout.
 
-## 运行时路径
+## Runtime paths
 
-### Decode-only
+### Decode-only batches
 
-PCP rank `p` 从 TP-sharded attention output `X_t[..., K/T]` 中取对应 feature
-slice，与本地 `W_local[t,p]` 做 GEMM。各 PCP rank 的部分和先在 PCP group
-all-reduce，恢复普通 TP rank 的 O-Proj 部分结果；随后保持原有 TP reduction
-语义。
+PCP rank `p` takes the corresponding feature slice from the TP-sharded
+attention output `X_t[..., K/T]` and multiplies it by the local
+`W_local[t,p]`. The partial sums are first all-reduced over the PCP group to
+recover the standard O-Proj partial result for a TP rank. The existing TP
+reduction semantics are then preserved.
 
 ```text
 Y_t = PCP-AllReduce(X_t,p @ W_local[t,p]^T)
-Y   = TP-AllReduce(Y_t)                    # reduce_results=True 时
+Y   = TP-AllReduce(Y_t)                    # when reduce_results=True
 ```
 
-DeepSeek-V3.2 的 O-Proj 使用 `reduce_results=False`，因此只做 PCP reduction，
-后续已有的 TP fused all-reduce/RMSNorm 仍负责 TP reduction。
+DeepSeek-V3.2 O-Proj uses `reduce_results=False`, so this path performs only the
+PCP reduction. The existing fused TP all-reduce/RMSNorm operation remains
+responsible for the TP reduction.
 
-### Prefill 或 mixed batch
+### Prefill or mixed batches
 
-attention module 根据该层 `MLACommonMetadata.num_prefills` 判断 batch。只要包含
-prefill，就在 attention 主计算前异步执行 PCP all-gather：
+The attention module determines the batch type from the layer's
+`MLACommonMetadata.num_prefills`. If the batch contains any prefill requests,
+it asynchronously all-gathers the weight over PCP before the main attention
+computation:
 
 ```text
 W_local[t,p]^T --PCP AllGather--> W_tp[t]^T
 ```
 
-O-Proj forward 到达时才等待异步 handle，然后直接用 `W_tp[t]` 处理当前 PCP
-rank 的本地 token。该路径不做 PCP output reduction，因为不同 PCP rank 处理的
-是不同 token。原 TP reduction 保持不变。
+O-Proj waits for the asynchronous handle only when its forward method is
+reached, then applies `W_tp[t]` to the local tokens on the current PCP rank.
+This path does not perform a PCP output reduction because different PCP ranks
+process different tokens. The existing TP reduction remains unchanged.
 
-为支持 `all_gather_into_tensor` 沿第 0 维拼接，通信输入使用连续的转置权重
-`[K/(T*P), N]`，输出 buffer 为 `[K/T, N]`。完整 TP 权重只保留转置 view，
-不再额外复制。
+To concatenate along dimension 0 with `all_gather_into_tensor`, the collective
+input is a contiguous transposed weight with shape `[K/(T*P), N]`, and the
+output buffer has shape `[K/T, N]`. The full TP weight is retained only as a
+transposed view, avoiding an additional copy.
 
-## Buffer 生命周期
+## Buffer lifecycle
 
-完整 TP 权重 buffer 按 vLLM config scope、device、dtype 和 shape 复用。模型
-构造时即分配并由各层持有同一个共享 buffer，使该开销进入启动显存预算；正常
-层序执行中，上一层 O-Proj 已等待并消费 gather 后，下一层才能复用它。因此
-常驻额外开销是一份 TP O-Proj 权重，而不是每层一份。
+The full TP weight buffer is shared by vLLM config scope, device, dtype, and
+shape. It is allocated during model construction, and all compatible layers
+hold the same shared buffer, so the cost is included in startup memory
+budgeting. With normal sequential layer execution, one layer waits for and
+consumes its gathered weight before the next layer reuses the buffer. The
+resident overhead is therefore one TP-sized O-Proj shard rather than one copy
+per layer.
 
-异步通信输入是当前层本地权重的连续转置临时 tensor，保持到 handle wait 完成
-后释放。DBO 暂时禁用，以排除两个 microbatch 并发占用共享 buffer。
+The input to the asynchronous collective is a contiguous transpose of the
+current layer's local weight. It remains alive until the handle has completed
+and is then released. DBO is currently disabled to prevent two concurrent
+microbatches from using the shared buffer at the same time.
 
-## 显式触发与正确性约束
+## Explicit triggering and correctness constraints
 
-通用 MLA wrapper 和模块化 DeepSeek-V3.2 attention 均显式触发 prefetch。
-`PCPOProjRowParallelLinear.forward()` 要求每次调用前必须完成触发；遗漏触发会
-直接报错，而不会猜测 batch 类型。这样可保证：
+Both the generic MLA wrapper and the modular DeepSeek-V3.2 attention path
+explicitly trigger the prefetch. `PCPOProjRowParallelLinear.forward()` requires
+the trigger to have occurred before every invocation. A missing trigger raises
+an error instead of inferring the batch type. This guarantees that:
 
-- prefill/mixed 的 gather 足够早，能够与 Q/K/V projection、RoPE、indexer 和
-  attention 主计算重叠；
-- decode-only 不误发 weight gather；
-- O-Proj 不会在异步权重未完成时读取共享 buffer；
-- metadata 为空的 profiling 路径按 decode-sharded 数学执行，零 attention
-  output 的正确性不受影响。
+- the prefill/mixed gather starts early enough to overlap with Q/K/V
+  projections, RoPE, the indexer, and the main attention computation;
+- decode-only batches do not issue an unnecessary weight gather;
+- O-Proj does not read the shared buffer before the asynchronous gather has
+  completed; and
+- profiling paths without metadata use the decode-sharded calculation, which
+  preserves correctness for zero attention outputs.
 
-## 配置
+## Configuration
 
-新增 CLI/config 开关：
+The MVP adds the following CLI/configuration option:
 
 ```text
 --enable-pcp-o-proj-tp
 ```
 
-示例：
+Example:
 
 ```bash
 vllm serve <model> \
@@ -124,41 +144,51 @@ vllm serve <model> \
   --dtype bfloat16
 ```
 
-## MVP 验证结果
+## MVP validation results
 
-2026-08-21 在 4 张 H100 上使用 GLM-4.7-Flash BF16 和 GSM8K test
-（1319 题）完成了 TP4、PCP4TP1、PCP2TP2 的在线精度验证。三组统一使用
-eager、`max_model_len=8192`、5-shot、`temperature=0`、关闭 thinking、32
-并发；32 题门禁使用 `max_tokens=256`，完整集使用
-`max_tokens=4096`。
+Online accuracy was evaluated on August 21, 2026, using four H100 GPUs,
+GLM-4.7-Flash BF16, and the 1,319-question GSM8K test set. TP4, PCP4TP1, and
+PCP2TP2 used eager execution, `max_model_len=8192`, 5-shot prompting,
+`temperature=0`, thinking disabled, and concurrency 32. The 32-question gate
+used `max_tokens=256`; the full evaluation used `max_tokens=4096`.
 
-| 并行策略 | 32 题门禁 | 完整集正确数 | 完整集准确率 | 请求失败 | 无效答案 |
+| Parallel strategy | 32-question gate | Full-set correct | Full-set accuracy | Failed requests | Invalid answers |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | TP4 baseline | 25/32 | 1134/1319 | 85.9742% | 0 | 0 |
 | PCP4TP1 | 25/32 | 1136/1319 | 86.1259% | 0 | 0 |
 | PCP2TP2 | 26/32 | 1135/1319 | 86.0500% | 0 | 0 |
 
-相对 TP4 baseline，PCP4TP1 有 35 题由错变对、33 题由对变错，净增 2
-题；PCP2TP2 有 32 题由错变对、31 题由对变错，净增 1 题。三种归约
-拓扑会产生足以改变部分自回归生成路径的数值扰动，因此逐题文本并不要求完全
-一致；完整集结果未观察到精度回退。
+Relative to the TP4 baseline, PCP4TP1 changed 35 answers from incorrect to
+correct and 33 from correct to incorrect, for a net gain of two. PCP2TP2
+changed 32 answers from incorrect to correct and 31 from correct to incorrect,
+for a net gain of one. The three reduction topologies introduce numerical
+differences large enough to alter some autoregressive generation paths, so
+per-question text is not expected to match exactly. No accuracy regression was
+observed over the full dataset.
 
-按 checkpoint safetensors 元数据核算，48 层 O-Proj 共
-`1,006,632,960` bytes，占模型参数字节的 `3.2242%`。特性开启后：
+Based on checkpoint safetensors metadata, the O-Proj weights across 48 layers
+total `1,006,632,960` bytes, or `3.2242%` of all model parameter bytes. With the
+feature enabled:
 
-- PCP4TP1 每 rank 的 O-Proj 常驻权重从完整 O-Proj 的 100% 降到 25%，即减少
-  75%；
-- PCP2TP2 每 rank 的 O-Proj 常驻权重从原 TP2 shard 的 100% 降到 50%，即
-  减少 50%。
+- PCP4TP1 reduces the resident O-Proj weight on each rank from 100% of the full
+  O-Proj weight to 25%, a 75% reduction; and
+- PCP2TP2 reduces the resident O-Proj weight on each rank from 100% of the
+  original TP2 shard to 50%, a 50% reduction.
 
-该比例只描述参数权重，不包含 CUDA context、KV cache、通信 buffer、共享的
-单层 prefetch buffer 和 allocator 碎片，不能等同于整机 HBM 降幅。
+These percentages describe parameter weights only. They exclude the CUDA
+context, KV cache, communication buffers, the shared single-layer prefetch
+buffer, and allocator fragmentation, and therefore do not represent the total
+HBM reduction.
 
-## 后续工作
+## Future work
 
-1. 补充 TP×PCP 的逐层 prefill、mixed、decode tensor 数值对齐、多轮稳定性
-   验证，并采集 weight gather/attention overlap trace。
-2. 将共享 buffer lease 纳入可并发的模型级 workspace manager，解除 DBO 限制。
-3. 增加 CUDA Graph/torch.compile 可捕获路径。
-4. 为 FP8、block quant 等量化格式定义 weight、scale 和 metadata 的联合聚合。
-5. 评估独立 PCP communicator/stream，避免与 attention PCP collective 互相串行。
+1. Add per-layer tensor comparisons for TP-by-PCP prefill, mixed, and decode
+   paths, multi-run stability tests, and traces of weight-gather/attention
+   overlap.
+2. Integrate the shared-buffer lease with a concurrency-safe model-level
+   workspace manager and remove the DBO restriction.
+3. Add CUDA Graph and `torch.compile`-capturable paths.
+4. Define joint gathering of weights, scales, and metadata for FP8, block
+   quantization, and other quantized formats.
+5. Evaluate a dedicated PCP communicator or stream to avoid serialization with
+   attention PCP collectives.

--- a/docs/design/pcp_o_proj_tp.md
+++ b/docs/design/pcp_o_proj_tp.md
@@ -112,12 +112,15 @@ microbatches from using the shared buffer at the same time.
 ## Explicit triggering and correctness constraints
 
 Both the generic MLA wrapper and the modular DeepSeek-V3.2 attention path
-explicitly trigger the prefetch. `PCPOProjRowParallelLinear.forward()` requires
-the trigger to have occurred before every invocation. A missing trigger raises
-an error instead of inferring the batch type. This guarantees that:
+explicitly trigger the prefetch after their Q/KV normalization and before the
+remaining query projection and main attention computation.
+`PCPOProjRowParallelLinear.forward()` requires the trigger to have occurred
+before every invocation. A missing trigger raises an error instead of inferring
+the batch type. This guarantees that:
 
-- the prefill/mixed gather starts early enough to overlap with Q/K/V
-  projections, RoPE, the indexer, and the main attention computation;
+- the prefill/mixed gather avoids contending with Q/KV RMSNorm while retaining
+  the remaining query projection, RoPE, the indexer, and the main attention
+  computation as overlap candidates;
 - decode-only batches do not issue an unnecessary weight gather;
 - O-Proj does not read the shared buffer before the asynchronous gather has
   completed; and

--- a/docs/design/pcp_o_proj_tp.md
+++ b/docs/design/pcp_o_proj_tp.md
@@ -23,10 +23,11 @@ the name `pcp_o_proj_tp`.
 - Only DeepSeek V2/V3/V3.2 and GLM-4 MoE Lite MLA are supported. GLM-4 MoE Lite
   attention inherits the DeepSeekV2 MLA path, so it reuses the same explicit
   prefetch and dynamic O-Proj implementation.
-- O-Proj itself must use the unquantized linear method. Quantized checkpoints
-  remain usable when their quantization configuration excludes O-Proj, as the
-  PCP-validated GLM-5.2-NVFP4 checkpoint excludes all self-attention modules.
-  A quantized O-Proj fails during post-load processing.
+- O-Proj may use the unquantized linear method or ModelOpt W4A4 NVFP4 with a
+  CUTLASS-compatible post-load layout. The NVFP4 adapter covers native CUTLASS
+  and FlashInfer backends that use the same packed-weight and swizzled-scale
+  representation. Other quantized O-Proj methods and NVFP4 backend layouts fail
+  during post-load processing.
 - `bias=False` is required.
 - Only eager execution is supported. CUDA Graph, `torch.compile`, and DBO are
   not supported yet.
@@ -60,16 +61,33 @@ is reduced to `1/P` of the standard TP layout.
 
 ## Weight-switch scope
 
-The implementation follows the vllm-ascend `TPWeightSwitchMixin` mechanism but
-opts in only `UnquantizedLinearMethod`. The method declares its `weight` tensor
-and post-load input-shard dimension; the mixin owns the reusable buffers,
-asynchronous collective handle, and local/full tensor aliases.
+The implementation follows the vllm-ascend `TPWeightSwitchMixin` mechanism.
+Each compatible linear method declares every post-load tensor consumed by its
+kernel and the corresponding input-shard dimension. The mixin owns the reusable
+buffers, asynchronous collective handles, and local/full tensor aliases.
+
+`UnquantizedLinearMethod` declares only `weight`. The ModelOpt W4A4 NVFP4
+adapter is the quantized example: it declares the packed `weight` and per-block
+`weight_scale`. Packed weights concatenate directly on dimension 1. CUTLASS
+block scales do not: every local scale is already stored in a 128x4 swizzled
+layout. The adapter exposes a logical unswizzled view to the collective and,
+after the asynchronous gather completes, assembles the full swizzled scale in a
+shared buffer before switching both layer attributes. Scale payloads use
+`uint8` views so the collective preserves FP8 bits without requiring an FP8
+reduction datatype. Replicated global scales
+(`input_global_scale_inv`, `weight_global_scale`, and `alpha`) remain unchanged.
+
+The adapter validates the concrete kernel layout before allocating state.
+Marlin repacking, TensorRT-LLM shuffling, Humming renaming, FBGEMM flattening,
+and local input-axis padding are not treated as concatenative and fail closed.
+This keeps the mixin extension representation-specific rather than claiming
+support for every backend selected by the `modelopt_fp4` configuration name.
 
 This boundary matches the quantized model coverage already present for PCP.
 The upstream PCP GSM8K matrix contains GLM-5.2-NVFP4, whose ModelOpt
 configuration excludes every `self_attn` module from NVFP4 quantization. Its
-O-Proj therefore uses the same unquantized method as a BF16 checkpoint. The
-supported method set is intentionally limited to `UnquantizedLinearMethod`.
+O-Proj therefore uses the same unquantized method as a BF16 checkpoint; it does
+not exercise the quantized O-Proj adapter.
 
 ## Runtime paths
 
@@ -174,9 +192,11 @@ vllm serve <model> \
 ## MVP validation results
 
 The following end-to-end results cover the unquantized O-Proj path. The unit
-tests cover asynchronous gather, wait-before-use, full/local alias switching,
-restoration after a failed linear call, logical-versus-local prefill decisions,
-and rejection of a quantized O-Proj method.
+tests additionally cover ModelOpt NVFP4 packed-weight gathering, logical scale
+gathering and full CUTLASS-layout reassembly, preservation of replicated global
+scales, and rejection of non-CUTLASS NVFP4 post-load layouts. A quantized
+end-to-end model result is still required before promoting the NVFP4 adapter
+beyond example status.
 
 Online accuracy was evaluated on August 23, 2026, using four NVIDIA H20 GPUs,
 GLM-4.7-Flash BF16, and the 1,319-question GSM8K test set. TP4, PCP4TP1, and

--- a/docs/design/pcp_o_proj_tp.md
+++ b/docs/design/pcp_o_proj_tp.md
@@ -1,0 +1,164 @@
+# PCP O-Proj TP MVP 方案
+
+实现基线：`vllm-project/vllm upstream/main@f8e0602713`。
+
+## 背景
+
+vllm-ascend 的细粒度 O-Proj TP 将 O-Proj 的输入维从 TP 继续切到更多
+rank，以减少每 rank 常驻权重。DSA-CP 场景在运行时按 batch 类型切换：decode
+使用更细的权重分片并归约部分和；包含 prefill 时，先聚合出原 TP 粒度的完整
+权重，再执行原有 O-Proj。
+
+vLLM 已有独立的 TP、PCP 和 DCP process group，但通用
+`RowParallelLinear` 只按 TP 切权重。本 MVP 使用 PCP 作为 O-Proj 的第二个
+权重切分轴，实现与上述动态切换等价的 `pcp_o_proj_tp`。
+
+## MVP 限制
+
+- `prefill_context_parallel_size > 1`。
+- `decode_context_parallel_size = 1`。
+- 仅支持 DeepSeek V2/V3/V3.2 和 GLM-4 MoE Lite MLA。GLM-4 MoE Lite 的
+  attention 继承 DeepSeekV2 MLA 路径，因此复用相同的显式 prefetch 与 O-Proj
+  动态路径。
+- 仅支持 FP16/BF16 非量化权重、`bias=False`。
+- 仅支持 eager，暂不支持 CUDA Graph、torch.compile 和 DBO。
+- 暂不支持 LoRA。
+- 暂不支持 CPU weight offload。
+- attention module 必须在主 attention 计算前显式调用
+  `o_proj.prefetch_full_weight_if_needed(has_prefill)`。
+
+这些限制全部通过配置或线性层构造检查 fail fast，避免功能开关静默失效。
+
+## 权重布局
+
+设 O-Proj 权重为 `W[N, K]`，TP 大小为 `T`，PCP 大小为 `P`。
+普通 row parallel 在 TP rank `t` 上常驻：
+
+```text
+W_tp[t] = W[:, t*K/T : (t+1)*K/T]
+```
+
+MVP 在同一个 TP shard 内继续按 PCP rank `p` 切分：
+
+```text
+W_local[t,p] = W[:, (t*P+p)*K/(T*P) : (t*P+p+1)*K/(T*P)]
+```
+
+checkpoint loader 使用展平 rank `t*P+p` 和 world size `T*P`，因此无需改变
+checkpoint 格式。每 rank 的 O-Proj 常驻权重降为原 TP 方案的 `1/P`。
+
+## 运行时路径
+
+### Decode-only
+
+PCP rank `p` 从 TP-sharded attention output `X_t[..., K/T]` 中取对应 feature
+slice，与本地 `W_local[t,p]` 做 GEMM。各 PCP rank 的部分和先在 PCP group
+all-reduce，恢复普通 TP rank 的 O-Proj 部分结果；随后保持原有 TP reduction
+语义。
+
+```text
+Y_t = PCP-AllReduce(X_t,p @ W_local[t,p]^T)
+Y   = TP-AllReduce(Y_t)                    # reduce_results=True 时
+```
+
+DeepSeek-V3.2 的 O-Proj 使用 `reduce_results=False`，因此只做 PCP reduction，
+后续已有的 TP fused all-reduce/RMSNorm 仍负责 TP reduction。
+
+### Prefill 或 mixed batch
+
+attention module 根据该层 `MLACommonMetadata.num_prefills` 判断 batch。只要包含
+prefill，就在 attention 主计算前异步执行 PCP all-gather：
+
+```text
+W_local[t,p]^T --PCP AllGather--> W_tp[t]^T
+```
+
+O-Proj forward 到达时才等待异步 handle，然后直接用 `W_tp[t]` 处理当前 PCP
+rank 的本地 token。该路径不做 PCP output reduction，因为不同 PCP rank 处理的
+是不同 token。原 TP reduction 保持不变。
+
+为支持 `all_gather_into_tensor` 沿第 0 维拼接，通信输入使用连续的转置权重
+`[K/(T*P), N]`，输出 buffer 为 `[K/T, N]`。完整 TP 权重只保留转置 view，
+不再额外复制。
+
+## Buffer 生命周期
+
+完整 TP 权重 buffer 按 vLLM config scope、device、dtype 和 shape 复用。模型
+构造时即分配并由各层持有同一个共享 buffer，使该开销进入启动显存预算；正常
+层序执行中，上一层 O-Proj 已等待并消费 gather 后，下一层才能复用它。因此
+常驻额外开销是一份 TP O-Proj 权重，而不是每层一份。
+
+异步通信输入是当前层本地权重的连续转置临时 tensor，保持到 handle wait 完成
+后释放。DBO 暂时禁用，以排除两个 microbatch 并发占用共享 buffer。
+
+## 显式触发与正确性约束
+
+通用 MLA wrapper 和模块化 DeepSeek-V3.2 attention 均显式触发 prefetch。
+`PCPOProjRowParallelLinear.forward()` 要求每次调用前必须完成触发；遗漏触发会
+直接报错，而不会猜测 batch 类型。这样可保证：
+
+- prefill/mixed 的 gather 足够早，能够与 Q/K/V projection、RoPE、indexer 和
+  attention 主计算重叠；
+- decode-only 不误发 weight gather；
+- O-Proj 不会在异步权重未完成时读取共享 buffer；
+- metadata 为空的 profiling 路径按 decode-sharded 数学执行，零 attention
+  output 的正确性不受影响。
+
+## 配置
+
+新增 CLI/config 开关：
+
+```text
+--enable-pcp-o-proj-tp
+```
+
+示例：
+
+```bash
+vllm serve <model> \
+  --tensor-parallel-size 2 \
+  --prefill-context-parallel-size 2 \
+  --decode-context-parallel-size 1 \
+  --enable-pcp-o-proj-tp \
+  --enforce-eager \
+  --dtype bfloat16
+```
+
+## MVP 验证结果
+
+2026-08-21 在 4 张 H100 上使用 GLM-4.7-Flash BF16 和 GSM8K test
+（1319 题）完成了 TP4、PCP4TP1、PCP2TP2 的在线精度验证。三组统一使用
+eager、`max_model_len=8192`、5-shot、`temperature=0`、关闭 thinking、32
+并发；32 题门禁使用 `max_tokens=256`，完整集使用
+`max_tokens=4096`。
+
+| 并行策略 | 32 题门禁 | 完整集正确数 | 完整集准确率 | 请求失败 | 无效答案 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| TP4 baseline | 25/32 | 1134/1319 | 85.9742% | 0 | 0 |
+| PCP4TP1 | 25/32 | 1136/1319 | 86.1259% | 0 | 0 |
+| PCP2TP2 | 26/32 | 1135/1319 | 86.0500% | 0 | 0 |
+
+相对 TP4 baseline，PCP4TP1 有 35 题由错变对、33 题由对变错，净增 2
+题；PCP2TP2 有 32 题由错变对、31 题由对变错，净增 1 题。三种归约
+拓扑会产生足以改变部分自回归生成路径的数值扰动，因此逐题文本并不要求完全
+一致；完整集结果未观察到精度回退。
+
+按 checkpoint safetensors 元数据核算，48 层 O-Proj 共
+`1,006,632,960` bytes，占模型参数字节的 `3.2242%`。特性开启后：
+
+- PCP4TP1 每 rank 的 O-Proj 常驻权重从完整 O-Proj 的 100% 降到 25%，即减少
+  75%；
+- PCP2TP2 每 rank 的 O-Proj 常驻权重从原 TP2 shard 的 100% 降到 50%，即
+  减少 50%。
+
+该比例只描述参数权重，不包含 CUDA context、KV cache、通信 buffer、共享的
+单层 prefetch buffer 和 allocator 碎片，不能等同于整机 HBM 降幅。
+
+## 后续工作
+
+1. 补充 TP×PCP 的逐层 prefill、mixed、decode tensor 数值对齐、多轮稳定性
+   验证，并采集 weight gather/attention overlap trace。
+2. 将共享 buffer lease 纳入可并发的模型级 workspace manager，解除 DBO 限制。
+3. 增加 CUDA Graph/torch.compile 可捕获路径。
+4. 为 FP8、block quant 等量化格式定义 weight、scale 和 metadata 的联合聚合。
+5. 评估独立 PCP communicator/stream，避免与 attention PCP collective 互相串行。

--- a/tests/model_executor/layers/test_pcp_o_proj_tp.py
+++ b/tests/model_executor/layers/test_pcp_o_proj_tp.py
@@ -2,13 +2,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn.functional as F
 
 import vllm.model_executor.layers.linear as linear_module
 import vllm.model_executor.parameter as parameter_module
-from vllm.model_executor.layers.linear import PCPOProjRowParallelLinear
+from vllm.model_executor.layers.linear import (
+    LinearMethodBase,
+    PCPOProjLinearMethod,
+    PCPOProjRowParallelLinear,
+)
 
 
 class _FakeWork:
@@ -29,6 +35,17 @@ class _FakePCPGroup:
     def all_reduce(self, tensor: torch.Tensor) -> torch.Tensor:
         assert self.other_output is not None
         return tensor + self.other_output
+
+
+class _UnsupportedLinearMethod(LinearMethodBase):
+    def create_weights(self, *args, **kwargs) -> None:
+        raise AssertionError("weights are installed by the test")
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        del layer
+
+    def apply(self, layer, x, bias=None):
+        raise AssertionError("unsupported method must fail during post-load")
 
 
 def _make_layer(
@@ -96,6 +113,23 @@ def test_forward_requires_explicit_attention_prefetch(monkeypatch):
         layer(torch.zeros(1, 4))
 
 
+@pytest.mark.parametrize(
+    ("global_has_prefill", "local_num_prefills", "expected"),
+    [(True, 0, True), (False, 1, False), (None, 1, True), (None, 0, False)],
+)
+def test_prefetch_decision_uses_global_pcp_batch_type(
+    monkeypatch, global_has_prefill, local_num_prefills, expected
+):
+    monkeypatch.setattr(
+        linear_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(global_has_prefill=global_has_prefill),
+    )
+    metadata = SimpleNamespace(num_prefills=local_num_prefills)
+
+    assert linear_module.get_pcp_o_proj_batch_has_prefill(metadata) is expected
+
+
 def test_decode_slices_features_and_reduces_over_pcp(monkeypatch):
     layer, pcp_group = _make_layer(monkeypatch, pcp_rank=1)
     full_weight = torch.arange(12, dtype=torch.float32).view(3, 4)
@@ -109,3 +143,37 @@ def test_decode_slices_features_and_reduces_over_pcp(monkeypatch):
 
     assert output_bias is None
     torch.testing.assert_close(output, F.linear(input_, full_weight))
+
+
+def test_quantized_o_proj_method_is_rejected(monkeypatch):
+    layer, _ = _make_layer(monkeypatch, pcp_rank=0)
+    layer.quant_method = PCPOProjLinearMethod(_UnsupportedLinearMethod())
+
+    with pytest.raises(RuntimeError, match="only an unquantized O-Proj"):
+        layer.quant_method.process_weights_after_loading(layer)
+
+
+def test_unquantized_method_restores_local_weight_after_kernel_failure(monkeypatch):
+    layer, _ = _make_layer(monkeypatch, pcp_rank=0)
+    full_weight = torch.arange(12, dtype=torch.float32).view(3, 4)
+    layer.weight_loader_v2(layer.weight, full_weight)
+
+    def _raise_on_apply(_self, layer, x, bias=None):
+        raise RuntimeError("fake linear kernel failure")
+
+    monkeypatch.setattr(linear_module.UnquantizedLinearMethod, "apply", _raise_on_apply)
+
+    def _all_gather_into_tensor(output, input_, group, async_op):
+        output.copy_(full_weight.transpose(0, 1))
+        return _FakeWork()
+
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", _all_gather_into_tensor
+    )
+
+    layer.prefetch_full_weight_if_needed(has_prefill=True)
+    with pytest.raises(RuntimeError, match="fake linear kernel failure"):
+        layer(torch.zeros(1, 4))
+
+    assert layer.weight.shape == (3, 2)
+    assert layer._use_full_weight is None

--- a/tests/model_executor/layers/test_pcp_o_proj_tp.py
+++ b/tests/model_executor/layers/test_pcp_o_proj_tp.py
@@ -10,10 +10,17 @@ import torch.nn.functional as F
 
 import vllm.model_executor.layers.linear as linear_module
 import vllm.model_executor.parameter as parameter_module
+from vllm.model_executor.kernels.linear import (
+    CutlassNvFp4LinearKernel,
+    MarlinNvFp4LinearKernel,
+)
 from vllm.model_executor.layers.linear import (
     LinearMethodBase,
     PCPOProjLinearMethod,
     PCPOProjRowParallelLinear,
+)
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptNvFp4LinearMethod,
 )
 
 
@@ -149,8 +156,124 @@ def test_quantized_o_proj_method_is_rejected(monkeypatch):
     layer, _ = _make_layer(monkeypatch, pcp_rank=0)
     layer.quant_method = PCPOProjLinearMethod(_UnsupportedLinearMethod())
 
-    with pytest.raises(RuntimeError, match="only an unquantized O-Proj"):
+    with pytest.raises(RuntimeError, match="does not support the selected O-Proj"):
         layer.quant_method.process_weights_after_loading(layer)
+
+
+def _swizzle_nvfp4_scale(scale: torch.Tensor) -> torch.Tensor:
+    output_size, scale_cols = scale.shape
+    padded_output_size = (output_size + 127) // 128 * 128
+    padded_scale_cols = (scale_cols + 3) // 4 * 4
+    padded = torch.zeros((1, padded_output_size, padded_scale_cols), dtype=scale.dtype)
+    padded[0, :output_size, :scale_cols] = scale
+    return (
+        padded.view(
+            1,
+            padded_output_size // 128,
+            4,
+            32,
+            padded_scale_cols // 4,
+            4,
+        )
+        .permute(0, 1, 4, 3, 2, 5)
+        .contiguous()
+        .view(padded_output_size, padded_scale_cols)
+    )
+
+
+def test_modelopt_nvfp4_switches_packed_weight_and_swizzled_scale(monkeypatch):
+    output_size = 256
+    local_input_size = 64
+    pcp_size = 2
+    full_weight = (
+        torch.arange(
+            output_size * local_input_size,
+            dtype=torch.int64,
+        )
+        .to(torch.uint8)
+        .view(output_size, local_input_size)
+    )
+    full_scale = (
+        (
+            torch.arange(
+                output_size * local_input_size // 8,
+                dtype=torch.int64,
+            )
+            % 64
+        )
+        .to(torch.uint8)
+        .view(torch.float8_e4m3fn)
+        .view(output_size, 8)
+    )
+
+    layer = torch.nn.Module()
+    layer.output_size_per_partition = output_size
+    layer.input_size_per_partition = local_input_size
+    layer.weights_padding_cols = 0
+    layer.register_parameter(
+        "weight",
+        torch.nn.Parameter(full_weight[:, :32], requires_grad=False),
+    )
+    local_swizzled_scale = _swizzle_nvfp4_scale(full_scale[:, :4])
+    layer.register_parameter(
+        "weight_scale",
+        torch.nn.Parameter(local_swizzled_scale, requires_grad=False),
+    )
+    layer.register_parameter(
+        "input_global_scale_inv",
+        torch.nn.Parameter(torch.tensor(2.0), requires_grad=False),
+    )
+    layer.register_parameter(
+        "alpha",
+        torch.nn.Parameter(torch.tensor(3.0), requires_grad=False),
+    )
+
+    method = ModelOptNvFp4LinearMethod.__new__(ModelOptNvFp4LinearMethod)
+    method.quant_config = SimpleNamespace(group_size=16)
+    method.kernel = CutlassNvFp4LinearKernel.__new__(CutlassNvFp4LinearKernel)
+    state = method.enable_tp_weight_switch(layer, pcp_size)
+
+    works: list[_FakeWork] = []
+
+    def _all_gather_into_tensor(output, input_, group, async_op):
+        del group
+        assert async_op
+        if input_.shape[0] == full_weight.shape[1] // pcp_size:
+            output.copy_(full_weight.T)
+        else:
+            torch.testing.assert_close(input_, full_scale[:, :4].view(torch.uint8).T)
+            output.copy_(full_scale.view(torch.uint8).T)
+        work = _FakeWork()
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", _all_gather_into_tensor
+    )
+
+    input_global_scale_inv = layer.input_global_scale_inv
+    alpha = layer.alpha
+    method.all_gather_tp_weight(state, group=object())
+    method.wait_tp_weight_all_gather(state)
+    assert all(work.waited for work in works)
+
+    method.switch_tp_weight(layer, state, use_full_weight=True)
+    torch.testing.assert_close(layer.weight, full_weight)
+    torch.testing.assert_close(layer.weight_scale, _swizzle_nvfp4_scale(full_scale))
+    assert layer.input_global_scale_inv is input_global_scale_inv
+    assert layer.alpha is alpha
+
+    method.switch_tp_weight(layer, state, use_full_weight=False)
+    torch.testing.assert_close(layer.weight, full_weight[:, :32])
+    torch.testing.assert_close(layer.weight_scale, local_swizzled_scale)
+
+
+def test_modelopt_nvfp4_rejects_non_cutlass_post_load_layout():
+    method = ModelOptNvFp4LinearMethod.__new__(ModelOptNvFp4LinearMethod)
+    method.kernel = MarlinNvFp4LinearKernel.__new__(MarlinNvFp4LinearKernel)
+
+    with pytest.raises(RuntimeError, match="CUTLASS-compatible"):
+        method.get_tp_weight_switch_specs(torch.nn.Module())
 
 
 def test_unquantized_method_restores_local_weight_after_kernel_failure(monkeypatch):

--- a/tests/model_executor/layers/test_pcp_o_proj_tp.py
+++ b/tests/model_executor/layers/test_pcp_o_proj_tp.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import vllm.model_executor.layers.linear as linear_module
+import vllm.model_executor.parameter as parameter_module
+from vllm.model_executor.layers.linear import PCPOProjRowParallelLinear
+
+
+class _FakeWork:
+    def __init__(self) -> None:
+        self.waited = False
+
+    def wait(self) -> None:
+        self.waited = True
+
+
+class _FakePCPGroup:
+    def __init__(self, rank: int) -> None:
+        self.rank_in_group = rank
+        self.world_size = 2
+        self.device_group = object()
+        self.other_output: torch.Tensor | None = None
+
+    def all_reduce(self, tensor: torch.Tensor) -> torch.Tensor:
+        assert self.other_output is not None
+        return tensor + self.other_output
+
+
+def _make_layer(
+    monkeypatch, pcp_rank: int
+) -> tuple[PCPOProjRowParallelLinear, _FakePCPGroup]:
+    pcp_group = _FakePCPGroup(pcp_rank)
+    config_scope = object()
+    monkeypatch.setattr(linear_module, "get_pcp_group", lambda: pcp_group)
+    monkeypatch.setattr(linear_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        linear_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(linear_module, "get_current_vllm_config", lambda: config_scope)
+    monkeypatch.setattr(
+        linear_module.UnquantizedLinearMethod,
+        "apply",
+        lambda _self, layer, x, bias=None: F.linear(x, layer.weight, bias),
+    )
+    layer = PCPOProjRowParallelLinear(
+        input_size=4,
+        output_size=3,
+        params_dtype=torch.float32,
+        reduce_results=False,
+    )
+    return layer, pcp_group
+
+
+def test_prefill_waits_for_async_full_weight_gather(monkeypatch):
+    layer, _ = _make_layer(monkeypatch, pcp_rank=1)
+    full_weight = torch.arange(12, dtype=torch.float32).view(3, 4)
+    layer.weight_loader_v2(layer.weight, full_weight)
+    torch.testing.assert_close(layer.weight, full_weight[:, 2:])
+
+    work = _FakeWork()
+
+    def _all_gather_into_tensor(output, input_, group, async_op):
+        torch.testing.assert_close(input_, full_weight[:, 2:].transpose(0, 1))
+        output.copy_(full_weight.transpose(0, 1))
+        assert group is layer.pcp_group.device_group
+        assert async_op
+        return work
+
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", _all_gather_into_tensor
+    )
+
+    input_ = torch.arange(8, dtype=torch.float32).view(2, 4)
+    layer.prefetch_full_weight_if_needed(has_prefill=True)
+    assert not work.waited
+
+    output, output_bias = layer(input_)
+    assert work.waited
+    assert output_bias is None
+    torch.testing.assert_close(output, F.linear(input_, full_weight))
+
+
+def test_forward_requires_explicit_attention_prefetch(monkeypatch):
+    layer, _ = _make_layer(monkeypatch, pcp_rank=0)
+
+    with pytest.raises(RuntimeError, match="Attention must call"):
+        layer(torch.zeros(1, 4))
+
+
+def test_decode_slices_features_and_reduces_over_pcp(monkeypatch):
+    layer, pcp_group = _make_layer(monkeypatch, pcp_rank=1)
+    full_weight = torch.arange(12, dtype=torch.float32).view(3, 4)
+    layer.weight_loader_v2(layer.weight, full_weight)
+
+    input_ = torch.arange(8, dtype=torch.float32).view(2, 4)
+    pcp_group.other_output = F.linear(input_[:, :2], full_weight[:, :2])
+
+    layer.prefetch_full_weight_if_needed(has_prefill=False)
+    output, output_bias = layer(input_)
+
+    assert output_bias is None
+    torch.testing.assert_close(output, F.linear(input_, full_weight))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -717,6 +717,25 @@ def test_data_parallel_rpc_port_has_fixed_default():
     assert ParallelConfig().data_parallel_rpc_port == 29550
 
 
+def test_pcp_o_proj_tp_requires_pcp_and_dcp_one():
+    with pytest.raises(ValidationError, match="requires PCP > 1"):
+        ParallelConfig(enable_pcp_o_proj_tp=True)
+
+    with pytest.raises(ValidationError, match="requires DCP = 1"):
+        ParallelConfig(
+            prefill_context_parallel_size=2,
+            decode_context_parallel_size=2,
+            enable_pcp_o_proj_tp=True,
+        )
+
+    config = ParallelConfig(
+        prefill_context_parallel_size=2,
+        decode_context_parallel_size=1,
+        enable_pcp_o_proj_tp=True,
+    )
+    assert config.enable_pcp_o_proj_tp
+
+
 @pytest.mark.parametrize("port", [1, 29550, 65535])
 def test_data_parallel_rpc_port_accepts_valid_ports(port: int):
     assert ParallelConfig(data_parallel_rpc_port=port).data_parallel_rpc_port == port

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -126,6 +126,9 @@ class ParallelConfig:
     prefill_context_parallel_size: int = Field(default=1, ge=1)
     """Number of ranks that split prefill sequence computation. PCP expands
     the process world size but does not increase the KV-cache shard count."""
+    enable_pcp_o_proj_tp: bool = False
+    """Shard MLA O-Proj weights over TP x PCP. This experimental MVP supports
+    unquantized eager execution with DCP disabled."""
     data_parallel_size: int = Field(default=1, ge=1)
     """Number of data parallel groups. MoE layers will be sharded according to
     the product of the tensor, prefill-context, and data parallel sizes."""
@@ -538,6 +541,11 @@ class ParallelConfig:
         tp = self.tensor_parallel_size
         pcp = self.prefill_context_parallel_size
         dcp = self.decode_context_parallel_size
+        if self.enable_pcp_o_proj_tp:
+            if pcp <= 1:
+                raise ValueError("PCP O-Proj TP requires PCP > 1.")
+            if dcp != 1:
+                raise ValueError("PCP O-Proj TP MVP requires DCP = 1.")
         if pcp > 1 and self.data_parallel_size > 1:
             raise ValueError("PCP does not support data parallelism yet.")
         if pcp == 1:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1124,8 +1124,6 @@ class VllmConfig:
             raise ValueError("PCP O-Proj TP requires a model config.")
         if not model_config.enforce_eager:
             raise ValueError("PCP O-Proj TP MVP requires enforce_eager=True.")
-        if self.quant_config is not None:
-            raise ValueError("PCP O-Proj TP MVP does not support quantization.")
         if model_config.dtype not in (torch.float16, torch.bfloat16):
             raise ValueError("PCP O-Proj TP MVP supports only float16 and bfloat16.")
         if not model_config.use_mla:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1115,6 +1115,43 @@ class VllmConfig:
         if not self.use_v2_model_runner:
             raise ValueError("trace replay requires Model Runner V2")
 
+    def _verify_pcp_o_proj_tp_config(self) -> None:
+        if not self.parallel_config.enable_pcp_o_proj_tp:
+            return
+
+        model_config = self.model_config
+        if model_config is None:
+            raise ValueError("PCP O-Proj TP requires a model config.")
+        if not model_config.enforce_eager:
+            raise ValueError("PCP O-Proj TP MVP requires enforce_eager=True.")
+        if self.quant_config is not None:
+            raise ValueError("PCP O-Proj TP MVP does not support quantization.")
+        if model_config.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("PCP O-Proj TP MVP supports only float16 and bfloat16.")
+        if not model_config.use_mla:
+            raise ValueError("PCP O-Proj TP requires an MLA model.")
+
+        supported_architectures = {
+            "DeepseekV2ForCausalLM",
+            "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
+            "Glm4MoeLiteForCausalLM",
+        }
+        if supported_architectures.isdisjoint(model_config.architectures):
+            raise ValueError(
+                "PCP O-Proj TP MVP supports only DeepSeek V2/V3/V3.2 and "
+                "GLM-4 MoE Lite MLA architectures."
+            )
+        if self.parallel_config.enable_dbo:
+            raise ValueError("PCP O-Proj TP MVP does not support DBO.")
+        if self.lora_config is not None:
+            raise ValueError("PCP O-Proj TP MVP does not support LoRA.")
+        if (
+            self.offload_config.uva.cpu_offload_gb > 0
+            or self.offload_config.prefetch.offload_group_size > 0
+        ):
+            raise ValueError("PCP O-Proj TP MVP does not support weight offloading.")
+
     def __post_init__(self):
         """Verify configs are valid & consistent with each other."""
 
@@ -1203,6 +1240,8 @@ class VllmConfig:
             self.quant_config = VllmConfig._get_quantization_config(
                 self.model_config, self.load_config
             )
+
+        self._verify_pcp_o_proj_tp_config()
 
         # "dummy" reads no weights at all, and the sharded formats read a vLLM
         # state dict, which stores tied word embeddings under the lm_head only.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -480,6 +480,7 @@ class EngineArgs:
     device_ids: list[int | str] | None = None
     tensor_parallel_size: int = ParallelConfig.tensor_parallel_size
     prefill_context_parallel_size: int = ParallelConfig.prefill_context_parallel_size
+    enable_pcp_o_proj_tp: bool = ParallelConfig.enable_pcp_o_proj_tp
     decode_context_parallel_size: int = ParallelConfig.decode_context_parallel_size
     dcp_comm_backend: DCPCommBackend | None = ParallelConfig.dcp_comm_backend
     dcp_q_replicate: bool | None = ParallelConfig.dcp_q_replicate
@@ -1087,6 +1088,10 @@ class EngineArgs:
             "--prefill-context-parallel-size",
             "-pcp",
             **parallel_kwargs["prefill_context_parallel_size"],
+        )
+        parallel_group.add_argument(
+            "--enable-pcp-o-proj-tp",
+            **parallel_kwargs["enable_pcp_o_proj_tp"],
         )
         parallel_group.add_argument(
             "--data-parallel-size", "-dp", **parallel_kwargs["data_parallel_size"]
@@ -2263,6 +2268,7 @@ class EngineArgs:
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
             prefill_context_parallel_size=self.prefill_context_parallel_size,
+            enable_pcp_o_proj_tp=self.enable_pcp_o_proj_tp,
             data_parallel_size=self.data_parallel_size,
             data_parallel_rank=self.data_parallel_rank or 0,
             data_parallel_external_lb=data_parallel_external_lb,

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -148,6 +148,12 @@ class ForwardContext:
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE
     batch_descriptor: BatchDescriptor | None = None
 
+    # Whether the logical batch contains prefill work before any local
+    # context-parallel partitioning. Collective consumers must use this value
+    # instead of rank-local attention metadata so every rank makes the same
+    # launch decision.
+    global_has_prefill: bool | None = None
+
     ubatch_slices: UBatchSlices | None = None
 
     # Boolean mask over the token axis: True for padding rows that are not real
@@ -220,6 +226,7 @@ def create_forward_context(
     additional_kwargs: dict[str, Any] | None = None,
     skip_compiled: bool = False,
     is_padding: torch.Tensor | None = None,
+    global_has_prefill: bool | None = None,
 ):
     if vllm_config.compilation_config.fast_moe_cold_start:
         all_moe_layers = vllm_config.compilation_config.static_all_moe_layers
@@ -234,6 +241,7 @@ def create_forward_context(
         dp_metadata=dp_metadata,
         cudagraph_runtime_mode=cudagraph_runtime_mode,
         batch_descriptor=batch_descriptor,
+        global_has_prefill=global_has_prefill,
         ubatch_slices=ubatch_slices,
         skip_compiled=skip_compiled,
         additional_kwargs=additional_kwargs or {},
@@ -268,6 +276,7 @@ def set_forward_context(
     slot_mapping: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None,
     skip_compiled: bool = False,
     is_padding: torch.Tensor | None = None,
+    global_has_prefill: bool | None = None,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -337,6 +346,7 @@ def set_forward_context(
         additional_kwargs,
         skip_compiled,
         is_padding=is_padding,
+        global_has_prefill=global_has_prefill,
     )
 
     try:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -4,6 +4,7 @@
 from abc import abstractmethod
 from collections.abc import Iterable
 from typing import Any
+from weakref import WeakValueDictionary
 
 import torch
 from torch.nn.parameter import Parameter
@@ -13,6 +14,7 @@ import vllm.envs as envs
 from vllm.config import get_current_vllm_config
 from vllm.distributed import (
     divide,
+    get_pcp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     split_tensor_along_last_dim,
@@ -1556,10 +1558,21 @@ class RowParallelLinear(LinearBase):
         *,
         return_bias: bool = True,
         disable_tp: bool = False,
+        tp_rank: int | None = None,
+        tp_size: int | None = None,
     ):
         # Divide the weight matrix along the first dimension.
-        self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
-        self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
+        if disable_tp:
+            self.tp_rank, self.tp_size = 0, 1
+        else:
+            self.tp_rank = (
+                tp_rank if tp_rank is not None else get_tensor_model_parallel_rank()
+            )
+            self.tp_size = (
+                tp_size
+                if tp_size is not None
+                else get_tensor_model_parallel_world_size()
+            )
         self.input_size_per_partition = divide(input_size, self.tp_size)
         self.output_size_per_partition = output_size
         self.output_partition_sizes = [output_size]
@@ -1574,6 +1587,8 @@ class RowParallelLinear(LinearBase):
             prefix,
             return_bias=return_bias,
             disable_tp=disable_tp,
+            tp_rank=self.tp_rank,
+            tp_size=self.tp_size,
         )
 
         self.input_is_parallel = input_is_parallel
@@ -1673,3 +1688,168 @@ class RowParallelLinear(LinearBase):
         s += f", tp_size={self.tp_size}"
         s += f", reduce_results={self.reduce_results}"
         return s
+
+
+class PCPOProjRowParallelLinear(RowParallelLinear):
+    """MVP row-parallel O-Proj with a second weight shard over PCP."""
+
+    _full_weight_buffers: WeakValueDictionary[tuple[Any, ...], torch.Tensor] = (
+        WeakValueDictionary()
+    )
+
+    def __init__(
+        self,
+        input_size: int,
+        output_size: int,
+        bias: bool = False,
+        input_is_parallel: bool = True,
+        skip_bias_add: bool = False,
+        params_dtype: torch.dtype | None = None,
+        reduce_results: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        *,
+        return_bias: bool = True,
+    ) -> None:
+        if quant_config is not None:
+            raise ValueError("PCP O-Proj TP MVP does not support quantization.")
+        if bias:
+            raise ValueError("PCP O-Proj TP MVP requires bias=False.")
+        if not input_is_parallel:
+            raise ValueError("PCP O-Proj TP MVP requires input_is_parallel=True.")
+
+        self.pcp_group = get_pcp_group()
+        self.pcp_rank = self.pcp_group.rank_in_group
+        self.pcp_size = self.pcp_group.world_size
+        if self.pcp_size <= 1:
+            raise ValueError("PCP O-Proj TP requires prefill context parallelism.")
+
+        self.o_proj_tp_rank = get_tensor_model_parallel_rank()
+        self.o_proj_tp_size = get_tensor_model_parallel_world_size()
+        weight_tp_rank = self.o_proj_tp_rank * self.pcp_size + self.pcp_rank
+        weight_tp_size = self.o_proj_tp_size * self.pcp_size
+
+        super().__init__(
+            input_size=input_size,
+            output_size=output_size,
+            bias=bias,
+            input_is_parallel=input_is_parallel,
+            skip_bias_add=skip_bias_add,
+            params_dtype=params_dtype,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=prefix,
+            return_bias=return_bias,
+            tp_rank=weight_tp_rank,
+            tp_size=weight_tp_size,
+        )
+
+        self._tp_input_size = divide(input_size, self.o_proj_tp_size)
+        self._buffer_scope = id(get_current_vllm_config())
+        self._full_weight_buffer: torch.Tensor | None = None
+        self._prefetch_input: torch.Tensor | None = None
+        self._prefetch_handle: Any | None = None
+        self._use_full_weight: bool | None = None
+        self._get_full_weight_buffer()
+
+    def _get_full_weight_buffer(self) -> torch.Tensor:
+        if self._full_weight_buffer is not None:
+            return self._full_weight_buffer
+
+        key = (
+            self._buffer_scope,
+            self.weight.device,
+            self.weight.dtype,
+            self._tp_input_size,
+            self.output_size,
+        )
+        buffer = self._full_weight_buffers.get(key)
+        if buffer is None:
+            buffer = self.weight.new_empty(self._tp_input_size, self.output_size)
+            self._full_weight_buffers[key] = buffer
+        self._full_weight_buffer = buffer
+        return buffer
+
+    def prefetch_full_weight_if_needed(self, has_prefill: bool) -> None:
+        """Start the PCP weight gather before attention compute when needed."""
+        if self._use_full_weight is not None:
+            raise RuntimeError(
+                "PCP O-Proj prefetch was called before the previous forward "
+                "consumed it."
+            )
+
+        self._use_full_weight = has_prefill
+        if not has_prefill:
+            return
+
+        full_weight_buffer = self._get_full_weight_buffer()
+        self._prefetch_input = self.weight.transpose(0, 1).contiguous()
+        try:
+            self._prefetch_handle = torch.distributed.all_gather_into_tensor(
+                full_weight_buffer,
+                self._prefetch_input,
+                group=self.pcp_group.device_group,
+                async_op=True,
+            )
+        except Exception:
+            self._prefetch_input = None
+            self._use_full_weight = None
+            raise
+
+    def _apply_full_tp_weight(self, input_: torch.Tensor) -> torch.Tensor:
+        if self._prefetch_handle is None or self._full_weight_buffer is None:
+            raise RuntimeError("PCP O-Proj full weight was not prefetched.")
+        self._prefetch_handle.wait()
+        self._prefetch_handle = None
+        self._prefetch_input = None
+        return torch.nn.functional.linear(
+            input_, self._full_weight_buffer.transpose(0, 1)
+        )
+
+    def _apply_pcp_weight_shard(self, input_: torch.Tensor) -> torch.Tensor:
+        shard_start = self.pcp_rank * self.input_size_per_partition
+        input_parallel = input_.narrow(
+            -1, shard_start, self.input_size_per_partition
+        ).contiguous()
+        output_parallel = self.quant_method.apply(self, input_parallel, None)
+        return self.pcp_group.all_reduce(output_parallel)
+
+    def forward(
+        self, input_: torch.Tensor
+    ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        if self._use_full_weight is None:
+            raise RuntimeError(
+                "Attention must call o_proj.prefetch_full_weight_if_needed() "
+                "before PCP O-Proj forward."
+            )
+        if input_.shape[-1] != self._tp_input_size:
+            if self._prefetch_handle is not None:
+                self._prefetch_handle.wait()
+                self._prefetch_handle = None
+                self._prefetch_input = None
+            self._use_full_weight = None
+            raise ValueError(
+                "PCP O-Proj expected a TP-sharded input with last dimension "
+                f"{self._tp_input_size}, but got {input_.shape[-1]}."
+            )
+
+        try:
+            if self._use_full_weight:
+                output_parallel = self._apply_full_tp_weight(input_)
+            else:
+                output_parallel = self._apply_pcp_weight_shard(input_)
+
+            if self.reduce_results and self.o_proj_tp_size > 1:
+                output = tensor_model_parallel_all_reduce(output_parallel)
+            else:
+                output = output_parallel
+        finally:
+            self._use_full_weight = None
+
+        if not self.return_bias:
+            return output
+        return output, None
+
+    def extra_repr(self) -> str:
+        s = super().extra_repr()
+        return f"{s}, pcp_size={self.pcp_size}, o_proj_tp_size={self.o_proj_tp_size}"

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1823,9 +1823,9 @@ class PCPOProjRowParallelLinear(RowParallelLinear):
         ):
             return quant_method
         raise RuntimeError(
-            "PCP O-Proj TP currently supports only an unquantized O-Proj; "
-            f"got {type(quant_method).__name__}. Quantized checkpoints must "
-            "exclude O-Proj from weight quantization."
+            "PCP O-Proj TP does not support the selected O-Proj linear method "
+            f"or post-load layout: {type(quant_method).__name__}. Quantized "
+            "checkpoints may exclude O-Proj from weight quantization."
         )
 
     def _enable_pcp_weight_switch(self) -> None:
@@ -1902,7 +1902,8 @@ class PCPOProjRowParallelLinear(RowParallelLinear):
             )
         if input_.shape[-1] != self._tp_input_size:
             if self._use_full_weight and self._tp_weight_state is not None:
-                TPWeightSwitchMixin.wait_tp_weight_all_gather(self._tp_weight_state)
+                assert self._tp_weight_method is not None
+                self._tp_weight_method.wait_tp_weight_all_gather(self._tp_weight_state)
             self._use_full_weight = None
             raise ValueError(
                 "PCP O-Proj expected a TP-sharded input with last dimension "

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -21,6 +21,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
+from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.batch_invariant import (
@@ -29,6 +30,11 @@ from vllm.model_executor.layers.batch_invariant import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.tp_weight_switch import (
+    TPWeightGatherSpec,
+    TPWeightSwitchMixin,
+    TPWeightSwitchState,
 )
 from vllm.model_executor.layers.utils import (
     dispatch_unquantized_gemm,
@@ -46,6 +52,15 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
+
+
+def get_pcp_o_proj_batch_has_prefill(attn_metadata: Any) -> bool:
+    """Resolve a PCP-group-consistent O-Proj weight gather decision."""
+    global_has_prefill = get_forward_context().global_has_prefill
+    if global_has_prefill is not None:
+        return global_has_prefill
+    return attn_metadata is not None and getattr(attn_metadata, "num_prefills", 0) > 0
+
 
 WEIGHT_LOADER_V2_SUPPORTED = [
     "UnquantizedLinearMethod",
@@ -165,8 +180,11 @@ class LinearMethodBase(QuantizeMethodBase):
         raise NotImplementedError
 
 
-class UnquantizedLinearMethod(LinearMethodBase):
+class UnquantizedLinearMethod(TPWeightSwitchMixin, LinearMethodBase):
     """Linear method without quantization."""
+
+    supports_tp_weight_switch = True
+    tp_weight_gather_specs = (TPWeightGatherSpec("weight", gather_dim=1),)
 
     def create_weights(
         self,
@@ -1690,8 +1708,54 @@ class RowParallelLinear(LinearBase):
         return s
 
 
+class PCPOProjLinearMethod(LinearMethodBase):
+    """Delegate linear execution while adding a post-load PCP switch hook."""
+
+    def __init__(self, quant_method: LinearMethodBase) -> None:
+        self.quant_method = quant_method
+
+    def __getattr__(self, name: str) -> Any:
+        """Preserve access to backend-specific method configuration."""
+        quant_method = self.__dict__.get("quant_method")
+        if quant_method is None:
+            raise AttributeError(name)
+        return getattr(quant_method, name)
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        self.quant_method.create_weights(
+            layer=layer,
+            input_size_per_partition=input_size_per_partition,
+            output_partition_sizes=output_partition_sizes,
+            input_size=input_size,
+            output_size=output_size,
+            params_dtype=params_dtype,
+            **extra_weight_attrs,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.quant_method.process_weights_after_loading(layer)
+        layer._enable_pcp_weight_switch()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.quant_method.apply(layer, x, bias)
+
+
 class PCPOProjRowParallelLinear(RowParallelLinear):
-    """MVP row-parallel O-Proj with a second weight shard over PCP."""
+    """Row-parallel O-Proj with a second weight shard over PCP."""
 
     _full_weight_buffers: WeakValueDictionary[tuple[Any, ...], torch.Tensor] = (
         WeakValueDictionary()
@@ -1711,8 +1775,6 @@ class PCPOProjRowParallelLinear(RowParallelLinear):
         *,
         return_bias: bool = True,
     ) -> None:
-        if quant_config is not None:
-            raise ValueError("PCP O-Proj TP MVP does not support quantization.")
         if bias:
             raise ValueError("PCP O-Proj TP MVP requires bias=False.")
         if not input_is_parallel:
@@ -1746,29 +1808,53 @@ class PCPOProjRowParallelLinear(RowParallelLinear):
 
         self._tp_input_size = divide(input_size, self.o_proj_tp_size)
         self._buffer_scope = id(get_current_vllm_config())
-        self._full_weight_buffer: torch.Tensor | None = None
-        self._prefetch_input: torch.Tensor | None = None
-        self._prefetch_handle: Any | None = None
+        self.quant_method = PCPOProjLinearMethod(self.quant_method)
+        self._tp_weight_method: TPWeightSwitchMixin | None = None
+        self._tp_weight_state: TPWeightSwitchState | None = None
         self._use_full_weight: bool | None = None
-        self._get_full_weight_buffer()
+        if quant_config is None:
+            self._enable_pcp_weight_switch()
 
-    def _get_full_weight_buffer(self) -> torch.Tensor:
-        if self._full_weight_buffer is not None:
-            return self._full_weight_buffer
-
-        key = (
-            self._buffer_scope,
-            self.weight.device,
-            self.weight.dtype,
-            self._tp_input_size,
-            self.output_size,
+    def _get_tp_weight_switch_method(self) -> TPWeightSwitchMixin:
+        quant_method = self.quant_method.quant_method
+        if (
+            isinstance(quant_method, TPWeightSwitchMixin)
+            and quant_method.supports_tp_weight_switch
+        ):
+            return quant_method
+        raise RuntimeError(
+            "PCP O-Proj TP currently supports only an unquantized O-Proj; "
+            f"got {type(quant_method).__name__}. Quantized checkpoints must "
+            "exclude O-Proj from weight quantization."
         )
-        buffer = self._full_weight_buffers.get(key)
-        if buffer is None:
-            buffer = self.weight.new_empty(self._tp_input_size, self.output_size)
-            self._full_weight_buffers[key] = buffer
-        self._full_weight_buffer = buffer
-        return buffer
+
+    def _enable_pcp_weight_switch(self) -> None:
+        if self._tp_weight_state is not None:
+            if self._tp_weight_state.handles:
+                raise RuntimeError(
+                    "Cannot rebuild PCP O-Proj weight state while a gather is pending."
+                )
+            self._tp_weight_state = None
+        method = self._get_tp_weight_switch_method()
+        state = method.enable_tp_weight_switch(
+            self,
+            self.pcp_size,
+            pool=self._full_weight_buffers,
+            pool_key_prefix=(
+                self._buffer_scope,
+                type(method).__qualname__,
+                "pcp_o_proj",
+            ),
+        )
+        self._tp_weight_method = method
+        self._tp_weight_state = state
+
+    def _weight_switch(self) -> tuple[TPWeightSwitchMixin, TPWeightSwitchState]:
+        if self._tp_weight_method is None or self._tp_weight_state is None:
+            self._enable_pcp_weight_switch()
+        assert self._tp_weight_method is not None
+        assert self._tp_weight_state is not None
+        return self._tp_weight_method, self._tp_weight_state
 
     def prefetch_full_weight_if_needed(self, has_prefill: bool) -> None:
         """Start the PCP weight gather before attention compute when needed."""
@@ -1782,29 +1868,21 @@ class PCPOProjRowParallelLinear(RowParallelLinear):
         if not has_prefill:
             return
 
-        full_weight_buffer = self._get_full_weight_buffer()
-        self._prefetch_input = self.weight.transpose(0, 1).contiguous()
+        method, state = self._weight_switch()
         try:
-            self._prefetch_handle = torch.distributed.all_gather_into_tensor(
-                full_weight_buffer,
-                self._prefetch_input,
-                group=self.pcp_group.device_group,
-                async_op=True,
-            )
+            method.all_gather_tp_weight(state, self.pcp_group)
         except Exception:
-            self._prefetch_input = None
             self._use_full_weight = None
             raise
 
     def _apply_full_tp_weight(self, input_: torch.Tensor) -> torch.Tensor:
-        if self._prefetch_handle is None or self._full_weight_buffer is None:
-            raise RuntimeError("PCP O-Proj full weight was not prefetched.")
-        self._prefetch_handle.wait()
-        self._prefetch_handle = None
-        self._prefetch_input = None
-        return torch.nn.functional.linear(
-            input_, self._full_weight_buffer.transpose(0, 1)
-        )
+        method, state = self._weight_switch()
+        method.wait_tp_weight_all_gather(state)
+        method.switch_tp_weight(self, state, use_full_weight=True)
+        try:
+            return self.quant_method.apply(self, input_, None)
+        finally:
+            method.switch_tp_weight(self, state, use_full_weight=False)
 
     def _apply_pcp_weight_shard(self, input_: torch.Tensor) -> torch.Tensor:
         shard_start = self.pcp_rank * self.input_size_per_partition
@@ -1823,10 +1901,8 @@ class PCPOProjRowParallelLinear(RowParallelLinear):
                 "before PCP O-Proj forward."
             )
         if input_.shape[-1] != self._tp_input_size:
-            if self._prefetch_handle is not None:
-                self._prefetch_handle.wait()
-                self._prefetch_handle = None
-                self._prefetch_input = None
+            if self._use_full_weight and self._tp_weight_state is not None:
+                TPWeightSwitchMixin.wait_tp_weight_all_gather(self._tp_weight_state)
             self._use_full_weight = None
             raise ValueError(
                 "PCP O-Proj expected a TP-sharded input with last dimension "

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -154,19 +154,6 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         hidden_states: torch.Tensor,
         llama_4_scaling: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if hasattr(self.o_proj, "prefetch_full_weight_if_needed"):
-            attn_metadata_raw = get_forward_context().attn_metadata
-            if isinstance(attn_metadata_raw, dict):
-                attn_metadata = attn_metadata_raw.get(self.mla_attn.layer_name)
-            elif isinstance(attn_metadata_raw, list):
-                attn_metadata = attn_metadata_raw[0].get(self.mla_attn.layer_name)
-            else:
-                attn_metadata = attn_metadata_raw
-            self.o_proj.prefetch_full_weight_if_needed(
-                attn_metadata is not None
-                and getattr(attn_metadata, "num_prefills", 0) > 0
-            )
-
         q_c = None
         kv_lora = None
 
@@ -202,6 +189,22 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
 
         kv_c, k_pe = kv_lora.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
         kv_c_normed = self.kv_a_layernorm(kv_c)
+
+        # Keep the weight gather off the Q/KV RMSNorm kernels while retaining
+        # Q projection, RoPE, indexer, and attention as overlap candidates.
+        if hasattr(self.o_proj, "prefetch_full_weight_if_needed"):
+            attn_metadata_raw = get_forward_context().attn_metadata
+            if isinstance(attn_metadata_raw, dict):
+                attn_metadata = attn_metadata_raw.get(self.mla_attn.layer_name)
+            elif isinstance(attn_metadata_raw, list):
+                attn_metadata = attn_metadata_raw[0].get(self.mla_attn.layer_name)
+            else:
+                attn_metadata = attn_metadata_raw
+            self.o_proj.prefetch_full_weight_if_needed(
+                attn_metadata is not None
+                and getattr(attn_metadata, "num_prefills", 0) > 0
+            )
+
         # Add head dim of 1 to k_pe
         k_pe = k_pe.unsqueeze(1)
 

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import torch
 
 from vllm.config import CacheConfig
+from vllm.forward_context import get_forward_context
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -153,6 +154,19 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         hidden_states: torch.Tensor,
         llama_4_scaling: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if hasattr(self.o_proj, "prefetch_full_weight_if_needed"):
+            attn_metadata_raw = get_forward_context().attn_metadata
+            if isinstance(attn_metadata_raw, dict):
+                attn_metadata = attn_metadata_raw.get(self.mla_attn.layer_name)
+            elif isinstance(attn_metadata_raw, list):
+                attn_metadata = attn_metadata_raw[0].get(self.mla_attn.layer_name)
+            else:
+                attn_metadata = attn_metadata_raw
+            self.o_proj.prefetch_full_weight_if_needed(
+                attn_metadata is not None
+                and getattr(attn_metadata, "num_prefills", 0) > 0
+            )
+
         q_c = None
         kv_lora = None
 

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -8,6 +8,7 @@ from vllm.config import CacheConfig
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
+from vllm.model_executor.layers.linear import get_pcp_o_proj_batch_has_prefill
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.platforms import current_platform
 
@@ -201,8 +202,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             else:
                 attn_metadata = attn_metadata_raw
             self.o_proj.prefetch_full_weight_if_needed(
-                attn_metadata is not None
-                and getattr(attn_metadata, "num_prefills", 0) > 0
+                get_pcp_o_proj_batch_has_prefill(attn_metadata)
             )
 
         # Add head dim of 1 to k_pe

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -11,6 +11,11 @@ import vllm.envs as envs
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
+    CutlassNvFp4LinearKernel,
+    FlashInferB12xNvFp4LinearKernel,
+    FlashInferCudnnNvFp4LinearKernel,
+    FlashInferCuteDslNvFp4LinearKernel,
+    FlashInferCutlassNvFp4LinearKernel,
     init_fp8_linear_kernel,
     init_mxfp8_linear_kernel,
     init_nvfp4_linear_kernel,
@@ -55,6 +60,11 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
+from vllm.model_executor.layers.quantization.tp_weight_switch import (
+    TPWeightGatherPart,
+    TPWeightGatherSpec,
+    TPWeightSwitchMixin,
+)
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     process_fp8_input_tensor_strategy_moe,
     process_fp8_weight_channel_strategy,
@@ -90,6 +100,7 @@ from vllm.model_executor.parameter import (
     PerTensorScaleParameter,
 )
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.utils.math_utils import round_up
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -1106,7 +1117,16 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
         )
 
 
-class ModelOptNvFp4LinearMethod(LinearMethodBase):
+_PCP_TP_NVFP4_CUTLASS_LAYOUT_KERNELS = (
+    CutlassNvFp4LinearKernel,
+    FlashInferB12xNvFp4LinearKernel,
+    FlashInferCudnnNvFp4LinearKernel,
+    FlashInferCuteDslNvFp4LinearKernel,
+    FlashInferCutlassNvFp4LinearKernel,
+)
+
+
+class ModelOptNvFp4LinearMethod(TPWeightSwitchMixin, LinearMethodBase):
     """Linear method for Model Optimizer NVFP4.
     Supports loading NVFP4 checkpoints with the following structure:
 
@@ -1117,10 +1137,161 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
     Args: quant_config: The ModelOpt quantization config.
     """
 
+    supports_tp_weight_switch = True
+    tp_weight_gather_specs = (
+        TPWeightGatherSpec("weight", gather_dim=1, make_full_contiguous=True),
+        TPWeightGatherSpec("weight_scale", gather_dim=1),
+    )
+
     def __init__(self, quant_config: ModelOptNvFp4Config) -> None:
         self.quant_config = quant_config
         self.marlin_input_dtype = None
         self.kernel = init_nvfp4_linear_kernel()
+
+    def get_tp_weight_switch_specs(
+        self, layer: torch.nn.Module
+    ) -> tuple[TPWeightGatherSpec, ...]:
+        """Validate the NVFP4 post-load layout used by PCP O-Proj TP.
+
+        CUTLASS-compatible kernels keep packed weights concatenative on the
+        input axis, but store per-block scales in a 128x4 swizzled layout. The
+        custom gather part below gathers logical scales and reassembles the
+        full swizzled layout. Global input/weight scales are replicated and do
+        not participate in the collective.
+        """
+        if not isinstance(self.kernel, _PCP_TP_NVFP4_CUTLASS_LAYOUT_KERNELS):
+            raise RuntimeError(
+                "ModelOpt NVFP4 PCP O-Proj TP currently supports only "
+                "CUTLASS-compatible post-load layouts; got "
+                f"{type(self.kernel).__name__}."
+            )
+        if getattr(layer, "weights_padding_cols", 0) != 0:
+            raise RuntimeError(
+                "ModelOpt NVFP4 PCP O-Proj TP requires each local packed "
+                "weight shard to need no input-axis padding."
+            )
+        return self.tp_weight_gather_specs
+
+    def _create_tp_weight_gather_part(
+        self,
+        layer: torch.nn.Module,
+        spec: TPWeightGatherSpec,
+        tp_size: int,
+        *,
+        pool: Any | None,
+        pool_key_prefix: Any | None,
+    ) -> TPWeightGatherPart:
+        if spec.attr_name != "weight_scale":
+            return super()._create_tp_weight_gather_part(
+                layer,
+                spec,
+                tp_size,
+                pool=pool,
+                pool_key_prefix=pool_key_prefix,
+            )
+
+        scale = layer.weight_scale.detach()
+        output_size = layer.output_size_per_partition
+        local_scale_cols = (
+            layer.input_size_per_partition // self.quant_config.group_size
+        )
+        padded_output_size = round_up(output_size, 128)
+        padded_local_scale_cols = round_up(local_scale_cols, 4)
+        expected_shape = (padded_output_size, padded_local_scale_cols)
+        if scale.dtype != torch.float8_e4m3fn or tuple(scale.shape) != expected_shape:
+            raise RuntimeError(
+                "Unexpected CUTLASS-compatible ModelOpt NVFP4 block-scale "
+                f"layout: expected dtype=torch.float8_e4m3fn and shape "
+                f"{expected_shape}, got dtype={scale.dtype} and "
+                f"shape={tuple(scale.shape)}."
+            )
+
+        full_scale_cols = local_scale_cols * tp_size
+        padded_full_scale_cols = round_up(full_scale_cols, 4)
+        pool_key = (
+            pool_key_prefix,
+            spec.attr_name,
+            scale.device.type,
+            scale.device.index,
+            scale.dtype,
+            output_size,
+            local_scale_cols,
+            full_scale_cols,
+            "nvfp4_cutlass_layout",
+        )
+        gather_input = self._get_or_create_tp_weight_buffer(
+            pool,
+            (*pool_key, "gather_input"),
+            (local_scale_cols, output_size),
+            dtype=torch.uint8,
+            device=scale.device,
+        )
+        gather_output = self._get_or_create_tp_weight_buffer(
+            pool,
+            (*pool_key, "gather_output"),
+            (full_scale_cols, output_size),
+            dtype=torch.uint8,
+            device=scale.device,
+        )
+        local_padded = self._get_or_create_tp_weight_buffer(
+            pool,
+            (*pool_key, "local_padded"),
+            (1, padded_output_size, padded_local_scale_cols),
+            dtype=scale.dtype,
+            device=scale.device,
+        )
+        full_padded = self._get_or_create_tp_weight_buffer(
+            pool,
+            (*pool_key, "full_padded"),
+            (1, padded_output_size, padded_full_scale_cols),
+            dtype=scale.dtype,
+            device=scale.device,
+        )
+        full_tensor = self._get_or_create_tp_weight_buffer(
+            pool,
+            (*pool_key, "full"),
+            (padded_output_size, padded_full_scale_cols),
+            dtype=scale.dtype,
+            device=scale.device,
+        )
+
+        local_m_tiles = padded_output_size // 128
+        local_k_tiles = padded_local_scale_cols // 4
+        full_k_tiles = padded_full_scale_cols // 4
+
+        def prepare() -> None:
+            local_padded_view = local_padded.view(
+                1, local_m_tiles, 4, 32, local_k_tiles, 4
+            )
+            local_swizzled_view = scale.view(1, local_m_tiles, local_k_tiles, 32, 4, 4)
+            local_padded_view.copy_(local_swizzled_view.permute(0, 1, 4, 3, 2, 5))
+            gather_input.copy_(
+                local_padded[0, :output_size, :local_scale_cols].view(torch.uint8).T
+            )
+
+        def finalize() -> None:
+            full_padded.zero_()
+            full_padded[0, :output_size, :full_scale_cols].view(torch.uint8).copy_(
+                gather_output.T
+            )
+            full_swizzled_view = full_tensor.view(
+                1, local_m_tiles, full_k_tiles, 32, 4, 4
+            )
+            full_padded_view = full_padded.view(
+                1, local_m_tiles, 4, 32, full_k_tiles, 4
+            )
+            full_swizzled_view.copy_(full_padded_view.permute(0, 1, 4, 3, 2, 5))
+
+        return TPWeightGatherPart(
+            spec=spec,
+            tp_tensor=scale,
+            gather_source=scale,
+            gather_input=gather_input,
+            gather_output=gather_output,
+            full_tensor=full_tensor,
+            prepare=prepare,
+            finalize=finalize,
+        )
 
     def create_weights(
         self,

--- a/vllm/model_executor/layers/quantization/tp_weight_switch.py
+++ b/vllm/model_executor/layers/quantization/tp_weight_switch.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""TP full-weight switching for compatible linear quantization methods."""
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+import torch
+
+
+@dataclass(frozen=True)
+class TPWeightGatherSpec:
+    """A direct layer tensor attribute to all-gather across TP-like ranks."""
+
+    attr_name: str
+    gather_dim: int = 0
+    make_full_contiguous: bool = False
+
+
+@dataclass
+class TPWeightGatherPart:
+    """Runtime tensors for one gathered attribute."""
+
+    spec: TPWeightGatherSpec
+    tp_tensor: torch.Tensor
+    gather_input: torch.Tensor
+    gather_output: torch.Tensor
+    full_tensor: torch.Tensor
+
+
+@dataclass
+class TPWeightSwitchState:
+    """Reusable buffers and outstanding collectives for one linear layer."""
+
+    gather_parts: dict[str, TPWeightGatherPart] = field(default_factory=dict)
+    handles: list[Any] = field(default_factory=list)
+
+
+class TPWeightSwitchMixin:
+    """Opt-in TP/full-weight switching for a linear method or scheme.
+
+    The current PCP O-Proj TP implementation opts in only the unquantized linear
+    method. Keeping the switching mechanics on the method makes unsupported
+    quantized O-Proj layouts fail closed without quantization-specific branches
+    in the PCP layer.
+    """
+
+    tp_weight_gather_specs: ClassVar[tuple[TPWeightGatherSpec, ...]] = ()
+    supports_tp_weight_switch: ClassVar[bool] = False
+
+    def get_tp_weight_switch_specs(
+        self, layer: torch.nn.Module
+    ) -> tuple[TPWeightGatherSpec, ...]:
+        """Return specs for the method's post-load layout on ``layer``."""
+        del layer
+        return self.tp_weight_gather_specs
+
+    def enable_tp_weight_switch(
+        self,
+        layer: torch.nn.Module,
+        tp_size: int,
+        *,
+        pool: Any | None = None,
+        pool_key_prefix: Any | None = None,
+    ) -> TPWeightSwitchState:
+        """Allocate local/full tensor aliases and reusable gather buffers."""
+        if not self.supports_tp_weight_switch:
+            raise RuntimeError(
+                f"{type(self).__name__} does not support TP weight switching."
+            )
+
+        gather_specs = self.get_tp_weight_switch_specs(layer)
+        if not gather_specs:
+            raise RuntimeError(
+                f"{type(self).__name__} did not declare TP weight switch specs."
+            )
+
+        state = TPWeightSwitchState()
+        for spec in gather_specs:
+            tensor = getattr(layer, spec.attr_name, None)
+            if not isinstance(tensor, torch.Tensor):
+                raise RuntimeError(
+                    f"{type(self).__name__} declares TP gather attribute "
+                    f"{spec.attr_name!r}, but layer "
+                    f"{getattr(layer, 'prefix', layer)} does not have it."
+                )
+            dim = (
+                spec.gather_dim
+                if spec.gather_dim >= 0
+                else tensor.dim() + spec.gather_dim
+            )
+            if dim < 0 or dim >= tensor.dim():
+                raise RuntimeError(
+                    f"Invalid TP gather dim {spec.gather_dim} for attribute "
+                    f"{spec.attr_name!r} with shape {tuple(tensor.shape)}."
+                )
+
+            tp_tensor = tensor.detach()
+            full_shape = list(tp_tensor.shape)
+            full_shape[dim] *= tp_size
+            gather_shape = (
+                full_shape[dim],
+                *full_shape[:dim],
+                *full_shape[dim + 1 :],
+            )
+            gather_input = (
+                tp_tensor
+                if dim == 0 and tp_tensor.is_contiguous()
+                else torch.movedim(tp_tensor, dim, 0).contiguous()
+            )
+            pool_key = (
+                pool_key_prefix,
+                spec.attr_name,
+                tp_tensor.device.type,
+                tp_tensor.device.index,
+                tp_tensor.dtype,
+                dim,
+                spec.make_full_contiguous,
+                tuple(full_shape),
+            )
+            gather_key = (*pool_key, "gather")
+            gather_output = None if pool is None else pool.get(gather_key)
+            if gather_output is None:
+                gather_output = torch.empty(
+                    gather_shape,
+                    dtype=tp_tensor.dtype,
+                    device=tp_tensor.device,
+                )
+                if pool is not None:
+                    pool[gather_key] = gather_output
+            if dim == 0:
+                full_tensor = gather_output
+            elif not spec.make_full_contiguous:
+                full_tensor = torch.movedim(gather_output, 0, dim)
+            else:
+                full_key = (*pool_key, "full")
+                full_tensor = None if pool is None else pool.get(full_key)
+                if full_tensor is None:
+                    full_tensor = torch.empty(
+                        full_shape,
+                        dtype=tp_tensor.dtype,
+                        device=tp_tensor.device,
+                    )
+                    if pool is not None:
+                        pool[full_key] = full_tensor
+            state.gather_parts[spec.attr_name] = TPWeightGatherPart(
+                spec=spec,
+                tp_tensor=tp_tensor,
+                gather_input=gather_input,
+                gather_output=gather_output,
+                full_tensor=full_tensor,
+            )
+
+        return state
+
+    @staticmethod
+    def _device_group(group: Any) -> Any:
+        return getattr(group, "device_group", group)
+
+    def all_gather_tp_weight(
+        self,
+        state: TPWeightSwitchState,
+        group: Any,
+        *,
+        async_op: bool = True,
+    ) -> None:
+        """All-gather every input-sharded tensor in ``state``."""
+        if state.handles:
+            raise RuntimeError(
+                "TP weight all-gather is still pending; wait before launching "
+                "another one."
+            )
+        try:
+            for part in state.gather_parts.values():
+                dim = part.spec.gather_dim
+                dim = dim if dim >= 0 else part.tp_tensor.dim() + dim
+                if dim != 0:
+                    part.gather_input.copy_(torch.movedim(part.tp_tensor, dim, 0))
+                handle = torch.distributed.all_gather_into_tensor(
+                    part.gather_output,
+                    part.gather_input,
+                    group=self._device_group(group),
+                    async_op=async_op,
+                )
+                if handle is not None:
+                    state.handles.append(handle)
+        except Exception:
+            self.wait_tp_weight_all_gather(state)
+            raise
+
+    @staticmethod
+    def wait_tp_weight_all_gather(state: TPWeightSwitchState) -> None:
+        try:
+            for handle in state.handles:
+                handle.wait()
+            for part in state.gather_parts.values():
+                dim = part.spec.gather_dim
+                dim = dim if dim >= 0 else part.tp_tensor.dim() + dim
+                if dim != 0 and part.spec.make_full_contiguous:
+                    part.full_tensor.copy_(torch.movedim(part.gather_output, 0, dim))
+        finally:
+            state.handles.clear()
+
+    @staticmethod
+    def switch_tp_weight(
+        layer: torch.nn.Module,
+        state: TPWeightSwitchState,
+        *,
+        use_full_weight: bool,
+    ) -> None:
+        """Switch direct tensor attributes between local and full storage."""
+        for attr_name, part in state.gather_parts.items():
+            target = part.full_tensor if use_full_weight else part.tp_tensor
+            with torch.no_grad():
+                getattr(layer, attr_name).set_(target)

--- a/vllm/model_executor/layers/quantization/tp_weight_switch.py
+++ b/vllm/model_executor/layers/quantization/tp_weight_switch.py
@@ -3,6 +3,7 @@
 
 """TP full-weight switching for compatible linear quantization methods."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
@@ -24,9 +25,12 @@ class TPWeightGatherPart:
 
     spec: TPWeightGatherSpec
     tp_tensor: torch.Tensor
+    gather_source: torch.Tensor
     gather_input: torch.Tensor
     gather_output: torch.Tensor
     full_tensor: torch.Tensor
+    prepare: Callable[[], None] | None = None
+    finalize: Callable[[], None] | None = None
 
 
 @dataclass
@@ -40,10 +44,9 @@ class TPWeightSwitchState:
 class TPWeightSwitchMixin:
     """Opt-in TP/full-weight switching for a linear method or scheme.
 
-    The current PCP O-Proj TP implementation opts in only the unquantized linear
-    method. Keeping the switching mechanics on the method makes unsupported
-    quantized O-Proj layouts fail closed without quantization-specific branches
-    in the PCP layer.
+    Each method declares the tensors consumed by its post-load kernel layout.
+    Keeping the switching mechanics on the method makes unsupported layouts
+    fail closed without quantization-specific branches in the PCP layer.
     """
 
     tp_weight_gather_specs: ClassVar[tuple[TPWeightGatherSpec, ...]] = ()
@@ -55,6 +58,106 @@ class TPWeightSwitchMixin:
         """Return specs for the method's post-load layout on ``layer``."""
         del layer
         return self.tp_weight_gather_specs
+
+    @staticmethod
+    def _get_or_create_tp_weight_buffer(
+        pool: Any | None,
+        key: Any,
+        shape: tuple[int, ...] | list[int],
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        buffer = None if pool is None else pool.get(key)
+        if buffer is None:
+            buffer = torch.empty(shape, dtype=dtype, device=device)
+            if pool is not None:
+                pool[key] = buffer
+        return buffer
+
+    def _create_tp_weight_gather_part(
+        self,
+        layer: torch.nn.Module,
+        spec: TPWeightGatherSpec,
+        tp_size: int,
+        *,
+        pool: Any | None,
+        pool_key_prefix: Any | None,
+    ) -> TPWeightGatherPart:
+        """Build runtime state for one direct, concatenative tensor layout.
+
+        Quantization methods with a post-load layout that is not directly
+        concatenative may override this method for the affected attribute. The
+        returned ``gather_source`` is refreshed into ``gather_input`` before
+        every collective, and ``finalize`` may assemble the kernel's full
+        layout after the collective completes.
+        """
+        tensor = getattr(layer, spec.attr_name, None)
+        if not isinstance(tensor, torch.Tensor):
+            raise RuntimeError(
+                f"{type(self).__name__} declares TP gather attribute "
+                f"{spec.attr_name!r}, but layer "
+                f"{getattr(layer, 'prefix', layer)} does not have it."
+            )
+        dim = (
+            spec.gather_dim if spec.gather_dim >= 0 else tensor.dim() + spec.gather_dim
+        )
+        if dim < 0 or dim >= tensor.dim():
+            raise RuntimeError(
+                f"Invalid TP gather dim {spec.gather_dim} for attribute "
+                f"{spec.attr_name!r} with shape {tuple(tensor.shape)}."
+            )
+
+        tp_tensor = tensor.detach()
+        full_shape = list(tp_tensor.shape)
+        full_shape[dim] *= tp_size
+        gather_shape = (
+            full_shape[dim],
+            *full_shape[:dim],
+            *full_shape[dim + 1 :],
+        )
+        gather_input = (
+            tp_tensor
+            if dim == 0 and tp_tensor.is_contiguous()
+            else torch.movedim(tp_tensor, dim, 0).contiguous()
+        )
+        pool_key = (
+            pool_key_prefix,
+            spec.attr_name,
+            tp_tensor.device.type,
+            tp_tensor.device.index,
+            tp_tensor.dtype,
+            dim,
+            spec.make_full_contiguous,
+            tuple(full_shape),
+        )
+        gather_output = self._get_or_create_tp_weight_buffer(
+            pool,
+            (*pool_key, "gather"),
+            gather_shape,
+            dtype=tp_tensor.dtype,
+            device=tp_tensor.device,
+        )
+        if dim == 0:
+            full_tensor = gather_output
+        elif not spec.make_full_contiguous:
+            full_tensor = torch.movedim(gather_output, 0, dim)
+        else:
+            full_tensor = self._get_or_create_tp_weight_buffer(
+                pool,
+                (*pool_key, "full"),
+                full_shape,
+                dtype=tp_tensor.dtype,
+                device=tp_tensor.device,
+            )
+        return TPWeightGatherPart(
+            spec=spec,
+            tp_tensor=tp_tensor,
+            gather_source=tp_tensor,
+            gather_input=gather_input,
+            gather_output=gather_output,
+            full_tensor=full_tensor,
+        )
 
     def enable_tp_weight_switch(
         self,
@@ -78,78 +181,12 @@ class TPWeightSwitchMixin:
 
         state = TPWeightSwitchState()
         for spec in gather_specs:
-            tensor = getattr(layer, spec.attr_name, None)
-            if not isinstance(tensor, torch.Tensor):
-                raise RuntimeError(
-                    f"{type(self).__name__} declares TP gather attribute "
-                    f"{spec.attr_name!r}, but layer "
-                    f"{getattr(layer, 'prefix', layer)} does not have it."
-                )
-            dim = (
-                spec.gather_dim
-                if spec.gather_dim >= 0
-                else tensor.dim() + spec.gather_dim
-            )
-            if dim < 0 or dim >= tensor.dim():
-                raise RuntimeError(
-                    f"Invalid TP gather dim {spec.gather_dim} for attribute "
-                    f"{spec.attr_name!r} with shape {tuple(tensor.shape)}."
-                )
-
-            tp_tensor = tensor.detach()
-            full_shape = list(tp_tensor.shape)
-            full_shape[dim] *= tp_size
-            gather_shape = (
-                full_shape[dim],
-                *full_shape[:dim],
-                *full_shape[dim + 1 :],
-            )
-            gather_input = (
-                tp_tensor
-                if dim == 0 and tp_tensor.is_contiguous()
-                else torch.movedim(tp_tensor, dim, 0).contiguous()
-            )
-            pool_key = (
-                pool_key_prefix,
-                spec.attr_name,
-                tp_tensor.device.type,
-                tp_tensor.device.index,
-                tp_tensor.dtype,
-                dim,
-                spec.make_full_contiguous,
-                tuple(full_shape),
-            )
-            gather_key = (*pool_key, "gather")
-            gather_output = None if pool is None else pool.get(gather_key)
-            if gather_output is None:
-                gather_output = torch.empty(
-                    gather_shape,
-                    dtype=tp_tensor.dtype,
-                    device=tp_tensor.device,
-                )
-                if pool is not None:
-                    pool[gather_key] = gather_output
-            if dim == 0:
-                full_tensor = gather_output
-            elif not spec.make_full_contiguous:
-                full_tensor = torch.movedim(gather_output, 0, dim)
-            else:
-                full_key = (*pool_key, "full")
-                full_tensor = None if pool is None else pool.get(full_key)
-                if full_tensor is None:
-                    full_tensor = torch.empty(
-                        full_shape,
-                        dtype=tp_tensor.dtype,
-                        device=tp_tensor.device,
-                    )
-                    if pool is not None:
-                        pool[full_key] = full_tensor
-            state.gather_parts[spec.attr_name] = TPWeightGatherPart(
-                spec=spec,
-                tp_tensor=tp_tensor,
-                gather_input=gather_input,
-                gather_output=gather_output,
-                full_tensor=full_tensor,
+            state.gather_parts[spec.attr_name] = self._create_tp_weight_gather_part(
+                layer,
+                spec,
+                tp_size,
+                pool=pool,
+                pool_key_prefix=pool_key_prefix,
             )
 
         return state
@@ -173,10 +210,15 @@ class TPWeightSwitchMixin:
             )
         try:
             for part in state.gather_parts.values():
-                dim = part.spec.gather_dim
-                dim = dim if dim >= 0 else part.tp_tensor.dim() + dim
-                if dim != 0:
-                    part.gather_input.copy_(torch.movedim(part.tp_tensor, dim, 0))
+                if part.prepare is not None:
+                    part.prepare()
+                else:
+                    dim = part.spec.gather_dim
+                    dim = dim if dim >= 0 else part.gather_source.dim() + dim
+                    if part.gather_input.data_ptr() != part.gather_source.data_ptr():
+                        part.gather_input.copy_(
+                            torch.movedim(part.gather_source, dim, 0)
+                        )
                 handle = torch.distributed.all_gather_into_tensor(
                     part.gather_output,
                     part.gather_input,
@@ -189,14 +231,16 @@ class TPWeightSwitchMixin:
             self.wait_tp_weight_all_gather(state)
             raise
 
-    @staticmethod
-    def wait_tp_weight_all_gather(state: TPWeightSwitchState) -> None:
+    def wait_tp_weight_all_gather(self, state: TPWeightSwitchState) -> None:
         try:
             for handle in state.handles:
                 handle.wait()
             for part in state.gather_parts.values():
+                if part.finalize is not None:
+                    part.finalize()
+                    continue
                 dim = part.spec.gather_dim
-                dim = dim if dim >= 0 else part.tp_tensor.dim() + dim
+                dim = dim if dim >= 0 else part.gather_source.dim() + dim
                 if dim != 0 and part.spec.make_full_contiguous:
                     part.full_tensor.copy_(torch.movedim(part.gather_output, 0, dim))
         finally:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -67,6 +67,7 @@ from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     DCPGroupColumnParallelLinear,
     MergedColumnParallelLinear,
+    PCPOProjRowParallelLinear,
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
@@ -1085,7 +1086,12 @@ class DeepseekV2MLAAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.kv_b_proj",
         )
-        self.o_proj = RowParallelLinear(
+        o_proj_cls = (
+            PCPOProjRowParallelLinear
+            if vllm_config.parallel_config.enable_pcp_o_proj_tp
+            else RowParallelLinear
+        )
+        self.o_proj = o_proj_cls(
             self.num_heads * self.v_head_dim,
             self.hidden_size,
             bias=False,

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -288,19 +288,6 @@ class DeepseekV32Attention(MLAAttention):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        if isinstance(self.o_proj, PCPOProjRowParallelLinear):
-            attn_metadata_raw = get_forward_context().attn_metadata
-            if isinstance(attn_metadata_raw, dict):
-                o_proj_attn_metadata = attn_metadata_raw.get(self.layer_name)
-            elif isinstance(attn_metadata_raw, list):
-                o_proj_attn_metadata = attn_metadata_raw[0].get(self.layer_name)
-            else:
-                o_proj_attn_metadata = attn_metadata_raw
-            self.o_proj.prefetch_full_weight_if_needed(
-                o_proj_attn_metadata is not None
-                and getattr(o_proj_attn_metadata, "num_prefills", 0) > 0
-            )
-
         # Captured: A-projections (+ indexer A-GEMM on indexer layers).
         qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
         q_c, kv_c, k_pe = qkv_lora.split(
@@ -394,6 +381,14 @@ class DeepseekV32Attention(MLAAttention):
             k_pe_out=k_pe_out,
             index_k_out=index_k_out,
         )
+
+        # Keep the weight gather off fused_norm_rope while retaining the Q
+        # projection, indexer, and main attention as overlap candidates.
+        if isinstance(self.o_proj, PCPOProjRowParallelLinear):
+            self.o_proj.prefetch_full_weight_if_needed(
+                attn_metadata is not None
+                and getattr(attn_metadata, "num_prefills", 0) > 0
+            )
 
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.linear import (
     PCPOProjRowParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    get_pcp_o_proj_batch_has_prefill,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.rotary_embedding import get_rope
@@ -386,8 +387,7 @@ class DeepseekV32Attention(MLAAttention):
         # projection, indexer, and main attention as overlap candidates.
         if isinstance(self.o_proj, PCPOProjRowParallelLinear):
             self.o_proj.prefetch_full_weight_if_needed(
-                attn_metadata is not None
-                and getattr(attn_metadata, "num_prefills", 0) > 0
+                get_pcp_o_proj_batch_has_prefill(attn_metadata)
             )
 
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
+    PCPOProjRowParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -254,7 +255,12 @@ class DeepseekV32Attention(MLAAttention):
         )
         self.kv_a_layernorm = RMSNorm(kv_lora_rank, eps=config.rms_norm_eps)
 
-        self.o_proj = RowParallelLinear(
+        o_proj_cls = (
+            PCPOProjRowParallelLinear
+            if vllm_config.parallel_config.enable_pcp_o_proj_tp
+            else RowParallelLinear
+        )
+        self.o_proj = o_proj_cls(
             num_heads * v_head_dim,
             hidden_size,
             bias=False,
@@ -282,6 +288,19 @@ class DeepseekV32Attention(MLAAttention):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        if isinstance(self.o_proj, PCPOProjRowParallelLinear):
+            attn_metadata_raw = get_forward_context().attn_metadata
+            if isinstance(attn_metadata_raw, dict):
+                o_proj_attn_metadata = attn_metadata_raw.get(self.layer_name)
+            elif isinstance(attn_metadata_raw, list):
+                o_proj_attn_metadata = attn_metadata_raw[0].get(self.layer_name)
+            else:
+                o_proj_attn_metadata = attn_metadata_raw
+            self.o_proj.prefetch_full_weight_if_needed(
+                o_proj_attn_metadata is not None
+                and getattr(o_proj_attn_metadata, "num_prefills", 0) > 0
+            )
+
         # Captured: A-projections (+ indexer A-GEMM on indexer layers).
         qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
         q_c, kv_c, k_pe = qkv_lora.split(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1615,6 +1615,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 has_lora=self.lora_config is not None,
                 num_active_loras=batch_desc.num_active_loras,
             )
+            global_has_prefill = (
+                self.pcp_manager.global_has_prefill
+                if self.pcp_manager is not None
+                else input_batch.has_prefill
+            )
 
             with set_forward_context(
                 attn_metadata,
@@ -1626,6 +1631,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 slot_mapping=slot_mappings_by_layer,
                 skip_compiled=skip_compiled,
                 is_padding=input_batch.is_padding,
+                global_has_prefill=global_has_prefill,
             ):
                 self.kv_connector.pre_forward(scheduler_output)
                 if batch_desc.cg_mode == CUDAGraphMode.PIECEWISE:

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -618,6 +618,12 @@ class PCPManager:
         assert self._global_batch is not None
         return self.restore_hidden_states(hidden_states), self._global_batch
 
+    @property
+    def global_has_prefill(self) -> bool:
+        """Return the pre-partition batch type shared by every PCP rank."""
+        assert self._global_batch is not None
+        return self._global_batch.has_prefill
+
 
 def maybe_partition_pcp_batch(
     manager: PCPManager | None,


### PR DESCRIPTION
This PR adds an opt-in `--enable-pcp-o-proj-tp` path that shards the resident MLA O-Proj parameter across the combined PCP-by-TP rank grid while preserving the existing TP reduction semantics.

## Summary

The feature further partitions each TP-local O-Proj input shard across the PCP group, reducing the resident O-Proj parameter on each rank to `1 / PCP` of its standard TP layout. The MVP is intentionally limited to `decode_context_parallel_size=1` and eager execution.

Supported architectures are DeepSeek V2, V3, and V3.2, plus GLM-4 MoE Lite MLA. Supported O-Proj representations are `UnquantizedLinearMethod` and ModelOpt W4A4 NVFP4 with a CUTLASS-compatible post-load layout. The NVFP4 adapter is an implementation example for quantized methods; its packed weight and swizzled block scale are handled explicitly. Other post-load layouts fail during post-load processing.

## Runtime behavior

The model runner records the logical, pre-partition batch type and propagates it consistently to every PCP rank. This keeps the collective decision identical even when PCP token partitioning gives different local batch shapes to different ranks.

- For prefill or mixed batches, generic MLA starts an asynchronous O-Proj weight all-gather after Q/KV normalization and before the remaining Q projection, RoPE, indexer, and main attention work. O-Proj waits for the gather only when the full TP shard is needed, then runs the normal TP-local O-Proj computation.
- For decode-only batches, each rank slices the TP attention output to its local PCP feature shard, computes a partial O-Proj result with the resident weight, and all-reduces that result over PCP.
- The existing TP reduction behavior remains unchanged, including paths where TP reduction is handled outside O-Proj.

## Implementation

- Adds a reusable `TPWeightSwitchMixin` with opt-in tensor/method specifications, asynchronous gather and wait handling, local/full tensor alias switching, and representation-specific prepare/finalize hooks.
- Reuses shared full-weight and assembly buffers across compatible layers.
- Adds a ModelOpt W4A4 NVFP4 adapter for native CUTLASS and FlashInfer kernels that use the CUTLASS packed-weight and 128x4 swizzled block-scale layout. Block-scale payloads are gathered through `uint8` views, then assembled into the complete kernel layout after the asynchronous handle completes. Replicated global scales remain unchanged.
- Validates the concrete NVFP4 kernel representation and local input padding. Marlin, TensorRT-LLM shuffle, Humming, FBGEMM, and other post-load layouts remain fail-closed until they receive layout-specific adapters.
- Adds an explicit attention hook so the gather can overlap with the remaining attention work and O-Proj cannot consume an incomplete shared buffer.
- Adds configuration and post-load checks that fail fast outside the MVP scope or for an unsupported O-Proj representation.

## Accuracy validation

Online accuracy used four NVIDIA H20 GPUs with GLM-4.7-Flash BF16, eager execution, DCP1, the full 1,319-question GSM8K test set, 5-shot prompting, concurrency 32, `temperature=0`, seed 42, and `max_tokens=4096`. These results cover the unquantized O-Proj path.

| Topology | 32-question output gate | Correct | Accuracy | Failed requests | Invalid answers |
| --- | ---: | ---: | ---: | ---: | ---: |
| TP4 baseline | 25/32 | 1129/1319 | 85.5951% | 0 | 0 |
| PCP4TP1 | 25/32 | 1135/1319 | 86.0500% | 0 | 0 |
| PCP2TP2 | 24/32 | 1131/1319 | 85.7468% | 0 | 0 |

## Process memory

The following measurements used the same four-H20 setup and a fixed 32 GiB KV cache. `Model-load allocation` is the model runner allocation reported after loading and post-load processing; `Ready HBM` is per-rank process HBM after engine initialization.

| Topology | Metric | Disabled | Enabled |
| --- | --- | ---: | ---: |
| PCP4TP1 | Model-load allocation | 17.02 GiB/rank | 16.58 GiB/rank |
| PCP4TP1 | Ready HBM | 59,461 MiB/rank | 60,021 MiB/rank |
| PCP2TP2 | Model-load allocation | 15.15 GiB/rank | 15.17 GiB/rank |
| PCP2TP2 | Ready HBM | 56,541 MiB/rank | 57,140 MiB/rank |

The resident parameter layout is smaller, but that saving is not equivalent to a total process-HBM reduction. Ready HBM also includes the fixed KV cache, CUDA context, communication buffers, the shared one-layer full-weight buffer, persistent staging, runtime workspaces, and allocator effects. In these measurements, PCP4TP1 reduced model-load allocation while ready HBM increased; PCP2TP2's local parameter saving was offset at model load and ready HBM also increased.

## Serving performance

Serving used four H20 GPUs, GLM-4.7-Flash BF16, random 32,768-token inputs and 1,024-token outputs, `ignore_eos`, `temperature=0`, seed 12345, prefix caching disabled, and a fixed 32 GiB KV cache. Each row is one controlled completed run; all runs had zero failed requests. Throughput is output-token throughput. These results cover the unquantized O-Proj path.

| Topology | Feature | Concurrency | TTFT (ms) | TPOT (ms) | Output throughput (tok/s) |
| --- | --- | ---: | ---: | ---: | ---: |
| PCP4TP1 | disabled | 1 | 2027.49 | 82.33 | 11.87 |
| PCP4TP1 | enabled | 1 | 2030.59 | 86.39 | 11.33 |
| PCP4TP1 | disabled | 8 | 9368.98 | 89.98 | 80.51 |
| PCP4TP1 | enabled | 8 | 9402.45 | 94.69 | 76.84 |
| PCP4TP1 | disabled | 16 | 17376.00 | 97.19 | 139.50 |
| PCP4TP1 | enabled | 16 | 17438.39 | 104.49 | 131.04 |
| PCP2TP2 | disabled | 1 | 2091.03 | 89.73 | 10.91 |
| PCP2TP2 | enabled | 1 | 2151.26 | 95.16 | 10.29 |
| PCP2TP2 | disabled | 8 | 9008.10 | 95.98 | 76.17 |
| PCP2TP2 | enabled | 8 | 8968.01 | 103.23 | 71.27 |
| PCP2TP2 | disabled | 16 | 16404.51 | 103.03 | 133.75 |
| PCP2TP2 | enabled | 16 | 16417.18 | 108.64 | 127.70 |

## Validation

- Ruff check and format
- `compileall`
- `git diff --check`
- Focused PCP O-Proj tests: 11 passed, including NVFP4 packed-weight gather, block-scale layout reconstruction, replicated-scale preservation, and unsupported-backend rejection
- Three configuration checks
- Full online GSM8K accuracy matrix and serving-performance matrix for the unquantized O-Proj path

## Documentation

`docs/design/pcp_o_proj_tp.md` documents the design and constraints, the validation evidence, the NVFP4 mixin example, and PCP8 parameter-layout projections for GLM-5.2 and DeepSeek-V4 checkpoints.
