### PR TITLE
[Core][Spec Decode] Opt-in skip of the K=0 draft sync forward (MTP + DFlash, default off)

### DIFF
--- a/tests/config/test_skip_draft_when_k0.py
+++ b/tests/config/test_skip_draft_when_k0.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the opt-in ``skip_draft_when_k0`` speculative config option.
+
+The option skips the draft-model forward on engine steps whose
+dynamically resolved ``num_speculative_tokens`` is 0 (the ``DSD K=0``
+prefill normally kept to sync draft KV state for a possible K>0
+resume). It is refused for EAGLE-family methods: a full-attention
+drafter's acceptance collapses non-recovering after unsynced K=0 steps
+(issue #53420).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.config.model import ModelConfig
+from vllm.config.parallel import ParallelConfig
+from vllm.config.speculative import SpeculativeConfig
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
+    AutoRegressiveSpeculator,
+)
+
+MODEL = "facebook/opt-125m"
+DYNAMIC_SCHEDULE = [(1, 1, 0), (2, 16, 2)]
+
+
+def _spec_config(**kwargs) -> SpeculativeConfig:
+    target = ModelConfig(model=MODEL)
+    parallel = ParallelConfig(pipeline_parallel_size=1, tensor_parallel_size=1)
+    defaults = dict(
+        method="draft_model",
+        model=MODEL,
+        target_model_config=target,
+        target_parallel_config=parallel,
+        num_speculative_tokens=2,
+    )
+    defaults.update(kwargs)
+    return SpeculativeConfig(**defaults)
+
+
+def _validator_target(method: str, dynamic: bool = True):
+    config = SpeculativeConfig.__new__(SpeculativeConfig)
+    config.method = method
+    config.skip_draft_when_k0 = True
+    config.num_speculative_tokens_per_batch_size = DYNAMIC_SCHEDULE if dynamic else None
+    return config
+
+
+@pytest.mark.cpu_test
+def test_validator_accepts_mtp():
+    _validator_target("mtp")._validate_skip_draft_when_k0(
+        warn_without_dynamic_schedule=True
+    )  # must not raise
+
+
+@pytest.mark.cpu_test
+def test_rejected_for_unimplemented_speculators():
+    """Methods whose speculators do not implement the skip (or are
+    unmeasured) are rejected explicitly, not silently ignored."""
+    for method in ("dspark", "dflash"):
+        with pytest.raises(ValueError, match="not implemented"):
+            _validator_target(method)._validate_skip_draft_when_k0()
+
+
+@pytest.mark.cpu_test
+def test_refused_for_explicit_eagle_methods_without_model_access():
+    """The rejection must fire before any draft-config work: an
+    explicit eagle-family method is refused even with a bogus model
+    path (no download / filesystem access happens)."""
+    with pytest.raises(ValueError, match="skip_draft_when_k0"):
+        SpeculativeConfig(
+            method="eagle3",
+            model="/nonexistent/path",
+            num_speculative_tokens=2,
+            skip_draft_when_k0=True,
+        )
+    with pytest.raises(ValueError, match="skip_draft_when_k0"):
+        SpeculativeConfig(
+            method="eagle",
+            model="/nonexistent/path",
+            num_speculative_tokens=2,
+            skip_draft_when_k0=True,
+        )
+
+
+@pytest.mark.cpu_test
+def test_no_effect_warning_without_dynamic_schedule(caplog):
+    with caplog.at_level("WARNING", logger="vllm.config.speculative"):
+        _validator_target("mtp", dynamic=False)._validate_skip_draft_when_k0(
+            warn_without_dynamic_schedule=True
+        )
+    assert any(
+        "skip_draft_when_k0 has no effect" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.cpu_test
+def test_skip_does_not_fire_when_k_unresolved():
+    """num_speculative_tokens=None (no dynamic resolution information):
+    the skip must not fire — propose proceeds (sentinel)."""
+    spec = _bare_speculator(skip=True)
+    with pytest.raises(SentinelError):
+        _call_propose(spec, _k0_batch(num_reqs=2), num_speculative_tokens=None)
+
+
+class _ConcreteSpeculator(AutoRegressiveSpeculator):
+    """Stub making the abstract base instantiable via __new__."""
+
+    def load_draft_model(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _bare_speculator(skip: bool) -> AutoRegressiveSpeculator:
+    """Only the state propose() touches before the K=0 branch."""
+    spec = _ConcreteSpeculator.__new__(_ConcreteSpeculator)
+    spec.skip_draft_when_k0 = skip
+    spec.draft_tokens = torch.zeros(4, 2, dtype=torch.int64)
+    spec.num_speculative_steps = 2
+    spec.max_model_len = 128
+    spec.hidden_states = torch.zeros(8, 8)
+    spec.dtype = torch.float32
+    # sentinel on the first method call after the hidden-state copy:
+    # if propose() runs past the K=0 skip branch it reaches this and
+    # raises, proving the prefill path was entered.
+    spec._copy_request_inputs = _sentinel
+    return spec
+
+
+def _sentinel(*args, **kwargs):
+    raise SentinelError()
+
+
+def _k0_batch(num_reqs: int = 2):
+    return SimpleNamespace(
+        num_tokens=num_reqs,
+        num_tokens_after_padding=num_reqs,
+        num_reqs=num_reqs,
+        num_scheduled_tokens=torch.ones(num_reqs, dtype=torch.int64),
+        seq_lens_cpu_upper_bound=torch.full((num_reqs,), 8, dtype=torch.int64),
+        idx_mapping=torch.arange(num_reqs, dtype=torch.int64),
+    )
+
+
+def _call_propose(spec, batch, num_speculative_tokens=0):
+    return spec.propose(
+        batch,
+        {},
+        {},
+        torch.zeros(batch.num_tokens, 8),
+        None,
+        torch.zeros(batch.num_reqs, dtype=torch.int64),  # num_sampled
+        torch.zeros(batch.num_reqs, dtype=torch.int64),  # num_rejected
+        torch.zeros(4, dtype=torch.int64),  # last_sampled
+        torch.zeros(4, dtype=torch.int64),  # next_prefill_tokens
+        torch.zeros(4, dtype=torch.float32),  # temperature
+        torch.zeros(4, dtype=torch.int64),  # seeds
+        num_speculative_tokens=num_speculative_tokens,
+    )
+
+
+@pytest.mark.cpu_test
+def test_skip_returns_zero_width_without_running_prefill():
+    """K=0 + flag on: propose returns [num_reqs, 0] immediately; the
+    draft prefill path is never entered (proved by a sentinel raised
+    from the first prefill-path helper propose would otherwise reach)."""
+    spec = _bare_speculator(skip=True)
+    with patch(
+        "vllm.v1.worker.gpu.spec_decode.autoregressive.speculator."
+        "prepare_prefill_inputs",
+        side_effect=AssertionError("prefill path must not run"),
+    ):
+        out = _call_propose(spec, _k0_batch(num_reqs=2))  # must NOT raise
+    assert out.shape == (2, 0)
+    assert out.dtype == torch.int64
+
+
+@pytest.mark.cpu_test
+def test_flag_off_still_enters_prefill_path_at_k0():
+    """K=0 + flag off (default): behavior unchanged — propose continues
+    into the prefill path (sentinel fires), preserving the draft KV
+    sync forward."""
+    spec = _bare_speculator(skip=False)
+    with pytest.raises(SentinelError):
+        _call_propose(spec, _k0_batch(num_reqs=2))
+
+
+@pytest.mark.cpu_test
+def test_skip_does_not_fire_when_k_is_positive():
+    """K=2 + flag on: no early return — propose proceeds (sentinel)."""
+    spec = _bare_speculator(skip=True)
+    with pytest.raises(SentinelError):
+        _call_propose(spec, _k0_batch(num_reqs=2), num_speculative_tokens=2)
+
+
+class SentinelError(Exception):
+    pass
+
+
+@pytest.mark.cpu_test
+def test_support_matrix_validator_level():
+    """Every method boundary resolves to accept or a specific rejection
+    — none fall through to silently ignoring the option."""
+    # accepted (measured)
+    _validator_target("mtp")._validate_skip_draft_when_k0(
+        warn_without_dynamic_schedule=True
+    )  # must not raise
+    # measured-unsafe: EAGLE family (one EAGLE3 checkpoint collapsed;
+    # eagle excluded conservatively — shared full-attention risk)
+    for method in ("eagle", "eagle3"):
+        with pytest.raises(ValueError, match="not supported"):
+            _validator_target(method)._validate_skip_draft_when_k0()
+    # method strings whose speculators override propose() without the
+    # skip -> would be silently ignored -> rejected explicitly. (Real
+    # multi-module/gemma4 drafts route through method='mtp' + draft
+    # architecture — covered by the test_real_routing_* tests below.)
+    for method in ("dflash", "dspark"):
+        with pytest.raises(ValueError, match="silently ignored"):
+            _validator_target(method)._validate_skip_draft_when_k0()
+    # any other non-mtp method string (including impossible states)
+    # -> rejected as out of scope
+    for method in ("gemma4", "multi_module_mtp", "medusa", "ngram"):
+        with pytest.raises(ValueError, match="validated only for method"):
+            _validator_target(method)._validate_skip_draft_when_k0()
+
+
+@pytest.mark.cpu_test
+def test_early_validation_defers_method_inference_placeholder():
+    """method='draft_model' is the placeholder for method=None; the
+    early (pre-model-access) validation must NOT reject it — the real
+    method is inferred later in __post_init__ and checked at the final
+    call. Early rejection would block automatically detected MTP."""
+    cfg = _validator_target("draft_model")
+    cfg._validate_skip_draft_when_k0(early=True)  # deferred: no raise
+    cfg.method = "mtp"  # after successful inference: accepts
+    cfg._validate_skip_draft_when_k0(warn_without_dynamic_schedule=True)
+    cfg.method = "eagle"  # after inference to an unsafe method: rejects
+    with pytest.raises(ValueError, match="not supported"):
+        cfg._validate_skip_draft_when_k0()
+
+
+@pytest.mark.cpu_test
+def test_real_construction_unresolved_method_defers_then_rejects():
+    """End-to-end construction with the flag on and method left to
+    inference (placeholder 'draft_model', non-MTP draft): the early
+    call defers, construction proceeds, and the FINAL validation
+    rejects with a clear message — no silent ignore, no early block of
+    legitimate inference."""
+    with pytest.raises(ValueError, match="validated only for method 'mtp'"):
+        _spec_config(skip_draft_when_k0=True)
+
+
+@pytest.mark.cpu_test
+def test_cli_json_plumbing_via_engine_args():
+    """The real CLI path: --speculative-config JSON -> dict (hyphens
+    normalized) -> SpeculativeConfig(**kwargs). The flag must survive
+    with the correct type and reach validation."""
+    import json
+
+    from vllm.engine.arg_utils import EngineArgs
+
+    ea = EngineArgs(
+        model=MODEL,
+        speculative_config=json.loads(
+            '{"method": "draft_model", "model": "' + MODEL + '", '
+            '"num_speculative_tokens": 2, "skip-draft-when-k0": true}'
+        ),
+    )
+    # hyphenated CLI key normalized + flag typed bool + final validation
+    with pytest.raises(ValueError, match="validated only for method 'mtp'"):
+        ea.create_speculative_config(
+            ModelConfig(model=MODEL),
+            ParallelConfig(pipeline_parallel_size=1, tensor_parallel_size=1),
+        )
+
+    ea_false = EngineArgs(
+        model=MODEL,
+        speculative_config=json.loads(
+            '{"method": "draft_model", "model": "' + MODEL + '", '
+            '"num_speculative_tokens": 2, "skip_draft_when_k0": false}'
+        ),
+    )
+    spec = ea_false.create_speculative_config(
+        ModelConfig(model=MODEL),
+        ParallelConfig(pipeline_parallel_size=1, tensor_parallel_size=1),
+    )
+    assert spec.skip_draft_when_k0 is False
+
+
+def _mtp_target(model_type: str, num_nextn: int = 1):
+    """Target ModelConfig whose (callable) hf_overrides flow to the
+    draft config as well, routing method='mtp' to the requested draft
+    architecture — the same resolution init_speculator performs."""
+
+    def _override(cfg):
+        cfg.model_type = model_type
+        cfg.num_nextn_predict_layers = num_nextn
+        return cfg
+
+    return ModelConfig(model=MODEL, hf_overrides=_override)
+
+
+@pytest.mark.cpu_test
+def test_real_routing_accepts_single_module_mtp():
+    """Construction-level accept: method='mtp' resolving to the
+    standard single-module MTPSpeculator (the measured configuration)."""
+    spec = SpeculativeConfig(
+        method="mtp",
+        model=MODEL,
+        num_speculative_tokens=2,
+        num_speculative_tokens_per_batch_size=[[1, 1, 0], [2, 16, 2]],
+        skip_draft_when_k0=True,
+        target_model_config=_mtp_target("bailing_hybrid_mtp", num_nextn=1),
+        target_parallel_config=ParallelConfig(
+            pipeline_parallel_size=1, tensor_parallel_size=1
+        ),
+    )
+    assert spec.skip_draft_when_k0 is True
+    assert not spec.use_multi_module_mtp()
+    assert not spec.use_gemma4_mtp()
+
+
+@pytest.mark.cpu_test
+def test_real_routing_rejects_multi_module_mtp():
+    """method='mtp' + multi-module draft (num_nextn>1 with K>1):
+    MultiModuleMTPSpeculator overrides propose() without the skip —
+    the flag would be silently ignored, so construction rejects."""
+    with pytest.raises(ValueError, match="multi-module"):
+        SpeculativeConfig(
+            method="mtp",
+            model=MODEL,
+            num_speculative_tokens=2,
+            num_speculative_tokens_per_batch_size=[[1, 1, 0], [2, 16, 2]],
+            skip_draft_when_k0=True,
+            target_model_config=_mtp_target("bailing_hybrid_mtp", num_nextn=4),
+            target_parallel_config=ParallelConfig(
+                pipeline_parallel_size=1, tensor_parallel_size=1
+            ),
+        )
+
+
+@pytest.mark.cpu_test
+def test_real_routing_rejects_gemma4_mtp():
+    """method='mtp' + gemma4_mtp draft: Gemma4Speculator inherits the
+    skip but is unmeasured — rejected rather than applied."""
+    with pytest.raises(ValueError, match="gemma4"):
+        SpeculativeConfig(
+            method="mtp",
+            model=MODEL,
+            num_speculative_tokens=2,
+            num_speculative_tokens_per_batch_size=[[1, 1, 0], [2, 16, 2]],
+            skip_draft_when_k0=True,
+            target_model_config=_mtp_target("gemma4_mtp"),
+            target_parallel_config=ParallelConfig(
+                pipeline_parallel_size=1, tensor_parallel_size=1
+            ),
+        )

--- a/tests/config/test_skip_draft_when_k0.py
+++ b/tests/config/test_skip_draft_when_k0.py
@@ -22,6 +22,9 @@ from vllm.config.speculative import SpeculativeConfig
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
     AutoRegressiveSpeculator,
 )
+from vllm.v1.worker.gpu.spec_decode.dflash2.speculator import (
+    DFlash2Speculator,
+)
 
 MODEL = "facebook/opt-125m"
 DYNAMIC_SCHEDULE = [(1, 1, 0), (2, 16, 2)]
@@ -60,9 +63,47 @@ def test_validator_accepts_mtp():
 def test_rejected_for_unimplemented_speculators():
     """Methods whose speculators do not implement the skip (or are
     unmeasured) are rejected explicitly, not silently ignored."""
-    for method in ("dspark", "dflash"):
+    for method in ("dspark",):
         with pytest.raises(ValueError, match="not implemented"):
             _validator_target(method)._validate_skip_draft_when_k0()
+
+
+@pytest.mark.cpu_test
+def test_validator_accepts_dflash():
+    _validator_target("dflash")._validate_skip_draft_when_k0(
+        warn_without_dynamic_schedule=True
+    )  # must not raise
+
+
+@pytest.mark.cpu_test
+def test_dflash_tier_rungs_must_be_max_or_skipped_zero():
+    """DFlash proposes a fixed block width; tier rungs must resolve to
+    that width (the scheduler clamps rungs via min(k, max)) or skip
+    drafting entirely (the skip requires the flag)."""
+    _dflash_tiers(
+        [(1, 2, 7), (3, 16, 0)], skip=True
+    )._validate_dflash_dynamic_schedule()  # noqa: E501
+    # Over-max rungs clamp to the full width — scheduler-valid, accepted.
+    _dflash_tiers(
+        [(1, 2, 8), (3, 16, 0)], skip=True
+    )._validate_dflash_dynamic_schedule()  # noqa: E501
+    with pytest.raises(ValueError, match="rungs resolving to 7"):
+        _dflash_tiers(
+            [(1, 2, 7), (3, 16, 3)], skip=True
+        )._validate_dflash_dynamic_schedule()  # noqa: E501
+    with pytest.raises(ValueError, match="skip_draft_when_k0=true"):
+        _dflash_tiers(
+            [(1, 2, 7), (3, 16, 0)], skip=False
+        )._validate_dflash_dynamic_schedule()  # noqa: E501
+
+
+def _dflash_tiers(schedule, skip: bool):
+    config = SpeculativeConfig.__new__(SpeculativeConfig)
+    config.method = "dflash"
+    config.num_speculative_tokens = 7
+    config.skip_draft_when_k0 = skip
+    config.num_speculative_tokens_per_batch_size = schedule
+    return config
 
 
 @pytest.mark.cpu_test
@@ -199,6 +240,45 @@ class SentinelError(Exception):
     pass
 
 
+# --- DFlash speculator K=0 skip (mirrors the AutoRegressive tests above) ---
+
+
+def _bare_dflash(skip: bool) -> "DFlash2Speculator":
+    """Only the state propose() touches before the K=0 branch. The
+    hidden_states buffer is intentionally absent: propose() reaching the
+    forward path raises on it, proving the skip did (or did not) fire."""
+    spec = DFlash2Speculator.__new__(DFlash2Speculator)
+    spec.skip_draft_when_k0 = skip
+    spec.draft_tokens = torch.zeros(4, 7, dtype=torch.int64)
+    spec.num_query_per_req = 8
+    spec.max_model_len = 128
+    return spec
+
+
+@pytest.mark.cpu_test
+def test_dflash_skip_returns_zero_width_at_k0():
+    spec = _bare_dflash(skip=True)
+    out = _call_propose(spec, _k0_batch(num_reqs=2))  # must NOT raise
+    assert out.shape == (2, 0)
+    assert out.dtype == torch.int64
+
+
+@pytest.mark.cpu_test
+def test_dflash_flag_off_runs_forward_at_k0():
+    spec = _bare_dflash(skip=False)
+    with pytest.raises(AttributeError, match="hidden_states"):
+        _call_propose(spec, _k0_batch(num_reqs=2))
+
+
+@pytest.mark.cpu_test
+def test_dflash_skip_does_not_fire_when_k_unresolved_or_positive():
+    spec = _bare_dflash(skip=True)
+    with pytest.raises(AttributeError, match="hidden_states"):
+        _call_propose(spec, _k0_batch(num_reqs=2), num_speculative_tokens=None)
+    with pytest.raises(AttributeError, match="hidden_states"):
+        _call_propose(spec, _k0_batch(num_reqs=2), num_speculative_tokens=7)
+
+
 @pytest.mark.cpu_test
 def test_support_matrix_validator_level():
     """Every method boundary resolves to accept or a specific rejection
@@ -216,9 +296,13 @@ def test_support_matrix_validator_level():
     # skip -> would be silently ignored -> rejected explicitly. (Real
     # multi-module/gemma4 drafts route through method='mtp' + draft
     # architecture — covered by the test_real_routing_* tests below.)
-    for method in ("dflash", "dspark"):
+    for method in ("dspark",):
         with pytest.raises(ValueError, match="silently ignored"):
             _validator_target(method)._validate_skip_draft_when_k0()
+    # accepted since the DFlash propose() gained the K=0 skip
+    _validator_target("dflash")._validate_skip_draft_when_k0(
+        warn_without_dynamic_schedule=True
+    )  # must not raise
     # any other non-mtp method string (including impossible states)
     # -> rejected as out of scope
     for method in ("gemma4", "multi_module_mtp", "medusa", "ngram"):
@@ -248,7 +332,7 @@ def test_real_construction_unresolved_method_defers_then_rejects():
     call defers, construction proceeds, and the FINAL validation
     rejects with a clear message — no silent ignore, no early block of
     legitimate inference."""
-    with pytest.raises(ValueError, match="validated only for method 'mtp'"):
+    with pytest.raises(ValueError, match="validated only for methods"):
         _spec_config(skip_draft_when_k0=True)
 
 
@@ -269,7 +353,7 @@ def test_cli_json_plumbing_via_engine_args():
         ),
     )
     # hyphenated CLI key normalized + flag typed bool + final validation
-    with pytest.raises(ValueError, match="validated only for method 'mtp'"):
+    with pytest.raises(ValueError, match="validated only for methods"):
         ea.create_speculative_config(
             ModelConfig(model=MODEL),
             ParallelConfig(pipeline_parallel_size=1, tensor_parallel_size=1),

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -377,6 +377,86 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
     assert run_fullgraph.call_count == expected_graph_replays
 
 
+def test_propose_k0_runs_prefill_without_draft_decode(monkeypatch):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 2
+    speculator.max_model_len = 32
+    speculator.max_num_reqs = 2
+    speculator.dp_size = 1
+    speculator.dp_rank = 0
+    speculator.supports_mm_inputs = False
+    speculator.hidden_states = torch.zeros(2, 3)
+    speculator.draft_tokens = torch.tensor([[11, 12], [21, 22]])
+    speculator.last_token_indices = torch.zeros(2, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace()
+    speculator.prefill_cudagraph_manager = None
+    speculator.decode_cudagraph_manager = None
+    speculator.use_fused_multi_step_decode = False
+    speculator._copy_request_inputs = Mock()
+    speculator._prepare_eplb_forward = Mock()
+    speculator.on_prefill_begin = Mock()
+    speculator.on_prefill_end = Mock()
+    speculator.on_multi_step_decode_begin = Mock()
+    speculator.on_multi_step_decode_end = Mock()
+    speculator._prefill = Mock()
+    speculator._multi_step_decode = Mock()
+    speculator._fused_multi_step_decode = Mock()
+
+    prepare_prefill = Mock()
+    prepare_decode = Mock()
+    monkeypatch.setattr(spec_module, "prepare_prefill_inputs", prepare_prefill)
+    monkeypatch.setattr(spec_module, "prepare_decode_inputs", prepare_decode)
+    monkeypatch.setattr(spec_module, "get_uniform_decode_token_count", Mock())
+    monkeypatch.setattr(
+        spec_module,
+        "dispatch_cg_and_sync_dp",
+        Mock(
+            return_value=(
+                BatchExecutionDescriptor(
+                    cg_mode=CUDAGraphMode.NONE,
+                    num_tokens=2,
+                    num_reqs=2,
+                ),
+                None,
+            )
+        ),
+    )
+
+    input_batch = SimpleNamespace(
+        num_tokens=2,
+        num_tokens_after_padding=2,
+        num_reqs=2,
+        num_scheduled_tokens=torch.ones(2, dtype=torch.int32),
+        seq_lens=torch.ones(2, dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.ones(2, dtype=torch.int32),
+        idx_mapping=torch.arange(2),
+        has_prefill=False,
+    )
+    output = speculator.propose(
+        input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.ones(2, 3),
+        aux_hidden_states=None,
+        num_sampled=torch.ones(2, dtype=torch.int32),
+        num_rejected=torch.zeros(2, dtype=torch.int32),
+        last_sampled=torch.zeros(2, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int64),
+        temperature=torch.zeros(2),
+        seeds=torch.zeros(2, dtype=torch.int64),
+        num_speculative_tokens=0,
+    )
+
+    assert output.shape == (2, 0)
+    speculator._prefill.assert_called_once()
+    speculator.on_prefill_begin.assert_called_once_with(2)
+    speculator.on_prefill_end.assert_called_once_with(2)
+    prepare_decode.assert_not_called()
+    speculator._multi_step_decode.assert_not_called()
+    speculator._fused_multi_step_decode.assert_not_called()
+
+
 def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(
     monkeypatch,
 ):

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -148,7 +148,10 @@ def test_speculator_uses_draft_model_hidden_size(monkeypatch, hc_mult, expected)
 def test_mm_support_configured_after_model_load(monkeypatch):
     target_model_config = object()
     draft_model_config = object()
-    vllm_config = SimpleNamespace(model_config=target_model_config)
+    vllm_config = SimpleNamespace(
+        model_config=target_model_config,
+        speculative_config=SimpleNamespace(skip_draft_when_k0=False),
+    )
     draft_model = _MultimodalDraftModel()
 
     def init_base(speculator, vllm_config, device):
@@ -393,6 +396,7 @@ def test_propose_k0_runs_prefill_without_draft_decode(monkeypatch):
     speculator.prefill_cudagraph_manager = None
     speculator.decode_cudagraph_manager = None
     speculator.use_fused_multi_step_decode = False
+    speculator.skip_draft_when_k0 = False
     speculator._copy_request_inputs = Mock()
     speculator._prepare_eplb_forward = Mock()
     speculator.on_prefill_begin = Mock()

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -186,6 +186,8 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
         ec_connector_output=None,
         routed_experts=None,
         cudagraph_stats=None,
+        num_tokens_across_dp=None,
+        num_spec_tokens_to_schedule=None,
     )
     runner.req_states = SimpleNamespace()
 

--- a/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_eplb.py
@@ -4,6 +4,7 @@
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import torch
 
@@ -205,3 +206,74 @@ def test_v2_sample_tokens_runs_eplb_on_non_last_pp_rank(monkeypatch):
     output = mrv2.GPUModelRunner.sample_tokens(runner, None)
     assert output in (EMPTY_MODEL_RUNNER_OUTPUT, None)
     assert events == ["receive", "postprocess_num_computed_tokens", "eplb"]
+
+
+def test_v2_sample_tokens_propagates_k0_and_hides_stale_drafts(monkeypatch):
+    runner = _make_runner(num_speculative_steps=2, _draft_workspace_lane=0)
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        req_ids=["req-0", "req-1"],
+        idx_mapping=torch.arange(2),
+        query_start_loc=torch.arange(3),
+    )
+    runner.execute_model_state = SimpleNamespace(
+        input_batch=input_batch,
+        attn_metadata={},
+        slot_mappings_by_layer={},
+        hidden_states=torch.zeros(2, 3),
+        aux_hidden_states=None,
+        finished_req_ids=set(),
+        ec_connector_output=None,
+        routed_experts=None,
+        num_spec_tokens_to_schedule=0,
+    )
+    runner.pcp_manager = None
+    runner.pp_handler = None
+    runner.sample = Mock(
+        return_value=(
+            SimpleNamespace(sampled_token_ids=torch.zeros(2, dtype=torch.int64)),
+            torch.ones(2, dtype=torch.int32),
+            torch.zeros(2, dtype=torch.int32),
+        )
+    )
+    runner.prompt_logprobs_worker = SimpleNamespace(
+        compute_prompt_logprobs=Mock(return_value={})
+    )
+    runner.model = SimpleNamespace(compute_logits=Mock())
+    runner.req_states = SimpleNamespace(
+        all_token_ids=SimpleNamespace(gpu=torch.zeros(2, 1, dtype=torch.int64)),
+        num_computed_tokens=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int32)),
+        prompt_len=SimpleNamespace(np=None),
+        last_sampled_tokens=torch.zeros(2, dtype=torch.int64),
+        next_prefill_tokens=torch.zeros(2, dtype=torch.int64),
+        draft_tokens=torch.tensor([[91, 92], [93, 94]]),
+    )
+    runner.main_stream = None
+    runner.output_copy_stream = None
+    runner.check_ep_fault = False
+    runner.postprocess_sampled = Mock()
+    runner.sampler = SimpleNamespace(
+        sampling_states=SimpleNamespace(
+            temperature=SimpleNamespace(gpu=torch.zeros(2)),
+            seeds=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int64)),
+        )
+    )
+    runner.speculator = SimpleNamespace(
+        supports_mm_inputs=False,
+        propose=Mock(return_value=torch.empty((2, 0), dtype=torch.int64)),
+    )
+    runner.adaptive_verification = None
+    runner.draft_tokens_handler = SimpleNamespace(set_draft_tokens=Mock())
+
+    monkeypatch.setattr(
+        mrv2.pcp,
+        "maybe_restore_pcp_for_sampling",
+        lambda _, hidden_states, batch: (hidden_states, batch),
+    )
+    monkeypatch.setattr(mrv2, "AsyncOutput", lambda **kwargs: kwargs)
+
+    mrv2.GPUModelRunner.sample_tokens(runner, None)
+
+    assert runner.speculator.propose.call_args.kwargs["num_speculative_tokens"] == 0
+    handled_drafts = runner.draft_tokens_handler.set_draft_tokens.call_args.args[1]
+    assert handled_drafts.shape == (2, 0)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -497,7 +497,10 @@ class SpeculativeConfig:
     drafter's acceptance collapsed non-recovering after unsynced K=0
     steps, at every tested K. Safety is drafter-architecture dependent
     and validated only on the checkpoints named in issue #53420; EAGLE-family
-    methods are refused. Default off.
+    methods are refused. For dflash, skipped steps leave the drafter's
+    context-KV stale (its hidden-state buffer is per-step), so resume
+    acceptance after a K=0 phase is checkpoint-dependent and must be
+    validated. Default off.
     """
 
     # params generated in the post-init stage
@@ -1541,13 +1544,36 @@ class SpeculativeConfig:
         if self.method != "dspark" and self.enable_adaptive_verification:
             raise ValueError("Adaptive verification only supported with DSpark")
 
+        if self.method == "dflash":
+            self._validate_dflash_dynamic_schedule()
+
         self._validate_skip_draft_when_k0(warn_without_dynamic_schedule=True)
 
         return self
 
+    def _validate_dflash_dynamic_schedule(self) -> None:
+        """DFlash propose() drafts its fixed ``num_speculative_tokens``
+        block width regardless of the per-step schedule, so tier rungs
+        must resolve to that width or skip drafting entirely.
+        """
+        if not self.num_speculative_tokens_per_batch_size:
+            return
+        for start, end, k in self.num_speculative_tokens_per_batch_size:
+            if k == 0 and self.skip_draft_when_k0:
+                continue
+            # The scheduler clamps each rung: resolved_k = min(k, max_k).
+            if min(k, self.num_speculative_tokens) != self.num_speculative_tokens:
+                raise ValueError(
+                    "num_speculative_tokens_per_batch_size for dflash only "
+                    f"supports rungs resolving to {self.num_speculative_tokens} "
+                    "(values below it draft a block width the DFlash "
+                    "speculator cannot honor), or 0 with "
+                    f"skip_draft_when_k0=true (got ({start}, {end}, {k}))"
+                )
+
     # Methods whose speculators override propose() without the K=0
     # skip: the flag there would be silently ignored.
-    _SKIP_K0_UNSUPPORTED_SPECULATORS = frozenset({"dflash", "dspark"})
+    _SKIP_K0_UNSUPPORTED_SPECULATORS = frozenset({"dspark"})
 
     def _validate_skip_draft_when_k0(
         self,
@@ -1575,28 +1601,30 @@ class SpeculativeConfig:
                 "proposal path without the K=0 skip, so the option "
                 "would be silently ignored."
             )
-        if self.method != "mtp":
+        if self.method not in ("mtp", "dflash"):
             raise ValueError(
-                "skip_draft_when_k0 is validated only for method 'mtp' "
-                f"(got '{self.method}'); see issue #53420."
+                "skip_draft_when_k0 is validated only for methods "
+                f"'mtp' and 'dflash' (got '{self.method}'); see "
+                "issue #53420."
             )
-        # method == "mtp": the speculator is still selected by the
-        # DRAFT ARCHITECTURE, not the method string — resolve the same
-        # predicates init_speculator uses and reject the variants the
-        # skip does not cover (gemma4: unmeasured; multi-module: own
-        # propose() override — the flag would be silently ignored).
-        if self.use_gemma4_mtp():
-            raise ValueError(
-                "skip_draft_when_k0 is not validated for gemma4 MTP "
-                "drafters (unmeasured); see issue #53420."
-            )
-        if self.use_multi_module_mtp():
-            raise ValueError(
-                "skip_draft_when_k0 is not implemented for multi-module"
-                " MTP drafters: their speculator overrides the proposal"
-                " path without the K=0 skip, so the option would be "
-                "silently ignored; see issue #53420."
-            )
+        if self.method == "mtp":
+            # The speculator is still selected by the DRAFT ARCHITECTURE,
+            # not the method string — resolve the same predicates
+            # init_speculator uses and reject the variants the skip does
+            # not cover (gemma4: unmeasured; multi-module: own propose()
+            # override — the flag would be silently ignored).
+            if self.use_gemma4_mtp():
+                raise ValueError(
+                    "skip_draft_when_k0 is not validated for gemma4 MTP "
+                    "drafters (unmeasured); see issue #53420."
+                )
+            if self.use_multi_module_mtp():
+                raise ValueError(
+                    "skip_draft_when_k0 is not implemented for multi-module"
+                    " MTP drafters: their speculator overrides the proposal"
+                    " path without the K=0 skip, so the option would be "
+                    "silently ignored; see issue #53420."
+                )
         if warn_without_dynamic_schedule and (
             not self.uses_dynamic_speculative_decoding()
         ):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -483,6 +483,23 @@ class SpeculativeConfig:
     inclusive batch-size range.
     """
 
+    skip_draft_when_k0: bool = False
+    """Opt-in: on engine steps whose dynamically resolved
+    ``num_speculative_tokens`` is 0, skip the draft-model forward entirely
+    (the ``DSD K=0`` prefill normally kept to sync draft KV state for a
+    possible later K>0 resume).
+
+    Measured (see the linked issue): the sync forward costs 4-11% decode
+    time on K=0-resolving batch sizes. Skipping it is safe only for
+    drafters whose proposals do not depend on their own full-attention KV
+    history: on the tested 1-layer target-anchored MTP drafter the resume
+    cost was ~1.5% acceptance at K=2 (12-16% at K=8), while an EAGLE3
+    drafter's acceptance collapsed non-recovering after unsynced K=0
+    steps, at every tested K. Safety is drafter-architecture dependent
+    and validated only on the checkpoints named in issue #53420; EAGLE-family
+    methods are refused. Default off.
+    """
+
     # params generated in the post-init stage
     draft_model_config: SkipValidation[ModelConfig] = None  # type: ignore
     """The configuration of the draft model initialized internal."""
@@ -1105,6 +1122,11 @@ class SpeculativeConfig:
             )
             self.method = "mtp"
 
+        # Reject before any draft-config work; re-checked post-inference.
+        # `draft_model` is the placeholder for method=None and may be
+        # inferred as mtp (or eagle) later in __post_init__ — defer it.
+        self._validate_skip_draft_when_k0(early=True)
+
         if self.model is None and self.num_speculative_tokens is not None:
             if self.method == "mtp":
                 if self.target_model_config is None:
@@ -1519,7 +1541,70 @@ class SpeculativeConfig:
         if self.method != "dspark" and self.enable_adaptive_verification:
             raise ValueError("Adaptive verification only supported with DSpark")
 
+        self._validate_skip_draft_when_k0(warn_without_dynamic_schedule=True)
+
         return self
+
+    # Methods whose speculators override propose() without the K=0
+    # skip: the flag there would be silently ignored.
+    _SKIP_K0_UNSUPPORTED_SPECULATORS = frozenset({"dflash", "dspark"})
+
+    def _validate_skip_draft_when_k0(
+        self,
+        warn_without_dynamic_schedule: bool = False,
+        early: bool = False,
+    ) -> None:
+        if not self.skip_draft_when_k0:
+            return
+        if early and self.method == "draft_model":
+            # Placeholder for method=None; the real method is inferred
+            # later in __post_init__ — validate at the final call.
+            return
+        if self.method in ("eagle", "eagle3"):
+            raise ValueError(
+                "skip_draft_when_k0 is not supported for method "
+                f"'{self.method}': full-attention drafters lose "
+                "non-recovering speculative acceptance after unsynced "
+                "K=0 steps (measured on an EAGLE3 checkpoint; see "
+                "issue #53420)."
+            )
+        if self.method in self._SKIP_K0_UNSUPPORTED_SPECULATORS:
+            raise ValueError(
+                "skip_draft_when_k0 is not implemented for method "
+                f"'{self.method}': its speculator overrides the "
+                "proposal path without the K=0 skip, so the option "
+                "would be silently ignored."
+            )
+        if self.method != "mtp":
+            raise ValueError(
+                "skip_draft_when_k0 is validated only for method 'mtp' "
+                f"(got '{self.method}'); see issue #53420."
+            )
+        # method == "mtp": the speculator is still selected by the
+        # DRAFT ARCHITECTURE, not the method string — resolve the same
+        # predicates init_speculator uses and reject the variants the
+        # skip does not cover (gemma4: unmeasured; multi-module: own
+        # propose() override — the flag would be silently ignored).
+        if self.use_gemma4_mtp():
+            raise ValueError(
+                "skip_draft_when_k0 is not validated for gemma4 MTP "
+                "drafters (unmeasured); see issue #53420."
+            )
+        if self.use_multi_module_mtp():
+            raise ValueError(
+                "skip_draft_when_k0 is not implemented for multi-module"
+                " MTP drafters: their speculator overrides the proposal"
+                " path without the K=0 skip, so the option would be "
+                "silently ignored; see issue #53420."
+            )
+        if warn_without_dynamic_schedule and (
+            not self.uses_dynamic_speculative_decoding()
+        ):
+            logger.warning(
+                "skip_draft_when_k0 has no effect without "
+                "num_speculative_tokens_per_batch_size: static-K "
+                "configurations never resolve K=0 mid-run."
+            )
 
     def _validate_suffix_decoding(self):
         if not has_arctic_inference():

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1880,6 +1880,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             ec_connector_output=ec_connector_output,
             routed_experts=routed_experts,
             cudagraph_stats=cudagraph_stats,
+            num_spec_tokens_to_schedule=scheduler_output.num_spec_tokens_to_schedule,
         )
 
         if not self.is_last_pp_rank:
@@ -1910,6 +1911,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         ec_connector_output = self.execute_model_state.ec_connector_output
         routed_experts = self.execute_model_state.routed_experts
         cudagraph_stats = self.execute_model_state.cudagraph_stats
+        num_spec_tokens_to_schedule = (
+            self.execute_model_state.num_spec_tokens_to_schedule
+        )
         self.execute_model_state = None
 
         if not self.is_last_pp_rank:
@@ -2031,8 +2035,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     self.sampler.sampling_states.seeds.gpu,
                     dp_sync=dp_sync,
                     mm_inputs=mm_inputs,
+                    num_speculative_tokens=num_spec_tokens_to_schedule,
                 )
-            self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+            self.req_states.draft_tokens[
+                input_batch.idx_mapping, : draft_tokens.shape[1]
+            ] = draft_tokens
             if self.adaptive_verification is not None:
                 self.adaptive_verification.record_confidences(
                     self.speculator.draft_token_confidence_probs, input_batch
@@ -2041,9 +2048,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
             # not have a speculator (i.e. self.speculator is None)
+            # When the speculator produced a narrow width (e.g. DSD K=0),
+            # only pass the active-width slice to the handler — stale columns
+            # in the persistent buffer would create phantom draft slots.
+            active_width = (
+                draft_tokens.shape[1]
+                if self.speculator is not None
+                else self.num_speculative_steps
+            )
             self.draft_tokens_handler.set_draft_tokens(
                 input_batch,
-                self.req_states.draft_tokens[input_batch.idx_mapping],
+                self.req_states.draft_tokens[input_batch.idx_mapping, :active_width],
             )
             if self.pp_handler is not None:
                 self.pp_handler.broadcast_drafts(
@@ -2189,6 +2204,7 @@ class ExecuteModelState(NamedTuple):
     ec_connector_output: ECConnectorOutput | None
     routed_experts: RoutedExpertsTensors | None
     cudagraph_stats: CUDAGraphStat | None
+    num_spec_tokens_to_schedule: int | None = None
 
 
 class BatchReqState(NamedTuple):

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -227,6 +227,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_tokens = input_batch.num_tokens
         num_tokens_padded = input_batch.num_tokens_after_padding
@@ -320,6 +321,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
         self.on_prefill_end(num_reqs)
 
+        # DSD K=0: prefill has been run to keep draft KV cache in sync with
+        # the target, but no speculative decode steps are needed.
+        if num_speculative_tokens is not None and num_speculative_tokens == 0:
+            return self.draft_tokens[:num_reqs, :0]
         if self.num_speculative_steps == 1:
             # Early exit.
             return self.draft_tokens[:num_reqs, :1]

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -29,6 +29,10 @@ logger = init_logger(__name__)
 class AutoRegressiveSpeculator(DraftModelSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
+        # Opt-in skip of resolved-K=0 steps; see SpeculativeConfig.
+        self.skip_draft_when_k0 = bool(
+            vllm_config.speculative_config.skip_draft_when_k0
+        )
 
         self.hidden_states = torch.zeros(
             self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
@@ -232,6 +236,12 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens = input_batch.num_tokens
         num_tokens_padded = input_batch.num_tokens_after_padding
         num_reqs = input_batch.num_reqs
+
+        # The prefill below syncs draft KV state for a possible K>0
+        # resume; operators can opt out (drafter-dependent, issue #53420).
+        if self.skip_draft_when_k0 and num_speculative_tokens == 0:
+            return self.draft_tokens[:num_reqs, :0]
+
         max_query_len = input_batch.num_scheduled_tokens.max()
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
         self.draft_max_seq_len = min(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -346,6 +346,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -44,6 +44,12 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
         )
 
+        # K=0 skip mirrors AutoRegressiveSpeculator; see
+        # SpeculativeConfig.skip_draft_when_k0 for the resume caveat.
+        self.skip_draft_when_k0 = bool(
+            vllm_config.speculative_config.skip_draft_when_k0
+        )
+
         # Multimodal inputs not currently supported.
         self.supports_mm_inputs = False
 
@@ -355,6 +361,11 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.draft_max_seq_len = min(
             max_seq_len + self.num_query_per_req, self.max_model_len
         )
+
+        # The forward below also syncs draft context-KV for a later K>0
+        # resume; operators can opt out (drafter-dependent, issue #53420).
+        if self.skip_draft_when_k0 and num_speculative_tokens == 0:
+            return self.draft_tokens[:num_reqs, :0]
 
         # NOTE: To avoid CPU-GPU synchronization without CPU knowing the
         # number of rejected tokens, we maintain the size of input_ids and

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -155,6 +155,7 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
         seq_lens_cpu_upper_bound = input_batch.seq_lens_cpu_upper_bound

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -81,6 +81,7 @@ class BaseSpeculator(ABC):
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
+        num_speculative_tokens: int | None = None,
     ) -> torch.Tensor:
         pass
 


### PR DESCRIPTION

**Stacked on #51575** — this branch contains rebased equivalents of its
two commits until that PR merges; please merge #51575 first.
Implements the opt-in option discussed in #53420.

## Purpose

When Dynamic Speculative Decoding resolves K=0 for a step, vLLM still
runs one draft-model forward per step — the prefill inside
`AutoRegressiveSpeculator.propose()` (and equivalently in
`DFlashSpeculator.propose()`), deliberately kept as per-step draft
KV-state sync (#51510/#51575 lineage). On K=0-resolving batch sizes
this is measurable overhead (+4–11% decode in our MTP measurements),
but skipping it is only safe for some drafter architectures: drafters
whose proposals depend on their own full-attention KV history (the
EAGLE family) lose nearly all speculative acceptance after unsynced
K=0 steps, at every K tested.

Because safety is a property of the drafter's internal architecture —
which cannot be reliably predicted for unmeasured models — this PR
exposes the skip as an **explicit opt-in, default off**. The operator
decides. The option is accepted when the method resolves to `mtp` or
`dflash`: EAGLE-family methods are refused as measured-unsafe (one
EAGLE3 checkpoint collapsed; `eagle` shares the full-attention risk);
methods whose speculators override `propose()` without the skip
(`dspark`, multi-module-MTP) are refused rather than silently ignoring
the option; other variants (e.g. `gemma4`) are refused as unmeasured.
Default off.

**Where the overhead lands: the high-concurrency serving regime.**
Dynamic spec tables deliberately resolve K=0 at exactly the batch
sizes where speculation stops paying — high concurrency, vLLM's core
serving workload. Every step of that regime still pays the draft sync
forward, for every concurrent request, for as long as traffic stays
high. This option removes that per-step tax precisely where DSD
deployments spend most of their time. Two scoping notes: (a)
measurements below cover c=1 through c=16; (b) K=1 steps are
unaffected — at K≥1 the drafter is genuinely proposing, and the skip
fires only on resolved-K=0 steps.

## Measurements behind the flag — MTP

RTX 5090 ×2, nightly `0.26.1rc1.dev926+gb05ae5dc0`, greedy, TP=2.
Full methodology and limitations in the companion issue #53420.

Benefit (sync forward skipped via the same early return this PR adds):

| model / drafter | workload | stock | skipped | time reduction |
|---|---|---|---|---|
| Qwen3.6-35B-A3B (1-layer hybrid-GDN MTP) | dynamic `[[1,2,2],[3,16,0]]`, c=1 — K=2 region, skip must not fire (control) | 5210 µs/step | 5303 µs/step | −1.8% (noise) |
| Qwen3.6-35B-A3B | **dynamic `[[1,2,2],[3,16,0]]`, c=8 — K=0 (serving regime)** | 11121 µs/step | 10075 µs/step | **9.4%** |
| Qwen3.6-35B-A3B | **dynamic `[[1,2,2],[3,16,0]]`, c=16 — K=0 (serving regime)** | 13606 µs/step | 12495 µs/step | **8.2%** |
| Qwen3.6-35B-A3B | K≡0 table `[[1,16,0]]`, c=1 | 6585 µs/step | 6317 µs/step | **4.1%** |
| Qwen3.6-35B-A3B | K≡0 table `[[1,16,0]]`, c=2 | 6778 µs/step | 6015 µs/step | **11.3%** |
| Llama-3.1-8B-Instruct + EAGLE3 drafter | 950-token solo K=0 phase | 6.78 s | 6.33 s | **6.6% (7.1% throughput)** |

The c=1–16 rows ran the real flag through `speculative_config` parsing
(end-to-end for this implementation; single boot per arm; walls
include identical prefill per cell; artifacts available). The c=1
control confirms no effect where K>0.

Risk when enabled on a drafter that needs the sync (same request
resuming K>0 after K=0 steps; per-request streamed-output proxy):

| drafter | resume K | acceptance-like ratio vs control |
|---|---|---|
| MTP (tested checkpoint) | 2 | 0.985× (batch-aggregate proxy, joiner-diluted; worst round 0.97×) |
| MTP (tested checkpoint) | 8 | 0.84–0.88× (streamed proxy, two boots) |
| EAGLE3 | 2 and 8 | **collapse to ~zero, non-recovering** (streamed proxy) |

Context on the K=8 row: stress configuration, not a realistic
production setting — in the healthy control arms of the K=8
experiments the drafter accepted only ~2 of 8 proposals per step
(streamed-output proxy), so deep-K MTP is already past its
efficiency point at this checkpoint; the dynamic tables in our
measurements use K=2. The row bounds the skip cost at depths where
the rollout leans hardest on the drafter's own state.

Output token identity as recorded: full-stream identity in the K=8
experiments, first-40 identity in the K=2 MTP experiment, and as
persisted in the K≡0 comparisons (greedy; target verification is
lossless — the risk is spec-efficiency only, which is why the flag is
opt-in rather than forbidden outright where untested).

## Measurements behind the flag — DFlash (this update)

Same hardware/wheel, Qwen3.8-27B-FP8 target (hybrid GDN) + DFlash2
drafter (`z-lab/Qwen3.8-27B-DFlash2`, 2B conv + candidate selector),
TP=2, dynamic `[[1,2,7],[3,16,0]]` (K=7 is the drafter's trained
block width: `block_size = 1 + K`).

- **Skip fires where it must**: at c=8, the tiered boot ran 25–51
  draft steps per full workload leg vs 3,119 for a static-K=7 boot on
  identical traffic — the residual is the brief c≤2 completion tails
  where the K=7 rung correctly re-engages (same signature as the MTP
  option).
- **Resume behavior on the tested checkpoint**, two distinct cases:
  same-request recovery (requests that lived through a K=0 phase and
  resumed K=7 mid-request) accepted ~3.0 tokens/step on the resumed
  steps; a new-request c=1 workload run immediately after two K=0
  phases measured acceptance 2.87 vs 3.36 on a static-K reference
  boot — 14.6% lower, but with no EAGLE-style collapse (new requests
  rebuild drafter state via their own prefill+decode). The docstring
  records the caveat: DFlash's context-KV is per-step, so resume
  acceptance after unsynced K=0 phases is checkpoint-dependent and
  must be validated per deployment.
- **End-to-end (aggregate t/s, exact-32k chat, 4 rounds, temp 0.7)**,
  DFlash tiers with the skip vs MTP `[[1,2,2],[3,16,0]]` with the
  skip: c=1 (decode-only) 135.6 vs 133.7; c=4 168.9 vs 140.9; c=8
  232.2 vs 193.2. Scoping note, kept honest: a no-spec engine at
  c≥4 is still faster than either spec arm (202.6 / 331.2 t/s) —
  resolved-K=0 steps route through the spec-decode step machinery
  even with drafting skipped. That machinery overhead is pre-existing
  (we measured MTP-K0 at 30–42% below no-spec at batch, DFlash-K0 at
  17–30%) and out of scope for this option, which removes the draft
  forward only.

## Changes

- `vllm/config/speculative.py`: new `skip_draft_when_k0: bool = False`
  field on `SpeculativeConfig` with a docstring carrying the measured
  trade-offs and the #53420 reference; `_validate_skip_draft_when_k0()`
  called twice — early in construction (before any draft-config/model
  access, deferring the `draft_model` inference placeholder) and at
  the end of `__post_init__` (after method inference, where the
  resolved draft config is available) — resolving the ACTUAL
  speculator via the same predicates `init_speculator` uses
  (`use_gemma4_mtp()`, `use_multi_module_mtp()`), not just the method
  string: refusing `eagle`/`eagle3` (measured collapse), `dspark` and
  multi-module-MTP drafts (own `propose()` overrides — the option
  would be silently ignored) and gemma4-MTP drafts (unmeasured), and
  warning when no dynamic schedule is configured (static-K never
  resolves K=0). Accepted for `mtp` and `dflash`.
- `vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py`:
  `AutoRegressiveSpeculator.__init__` reads the flag; `propose()`
  returns `draft_tokens[:num_reqs, :0]` before any hidden-state copy,
  input preparation, CUDA-graph dispatch, or draft forward when the
  resolved `num_speculative_tokens == 0` and the flag is on. The
  buffer is allocated in `__init__`, so the pre-prefill return is
  safe; downstream `active_width == 0` handling already exists from
  the K=0 fix.
- `vllm/v1/worker/gpu/spec_decode/dflash/speculator.py` (this update):
  the same mechanism in `DFlashSpeculator` — flag read in `__init__`,
  early return after the count locals in `propose()`, before the
  hidden-state copy / context-KV preparation / CUDA-graph dispatch /
  draft generation. Capture and profiling paths cannot fire it (dummy
  and capture calls resolve `num_speculative_tokens=None`, and the
  DFlash drafter's graph capture path bypasses `propose()`).
- **Fixed-width tier validation for dflash (this update)**:
  `_validate_dflash_dynamic_schedule()` — DFlash proposes a fixed
  `1 + num_speculative_tokens` block width regardless of the per-step
  schedule, so `num_speculative_tokens_per_batch_size` rungs must
  resolve (via the scheduler's `min(k, num_speculative_tokens)`
  clamp) to the full width, or be `0` with this flag. Without this, a
  K=0-resolving step would draft the full block against a 0-draft
  step — a shape mismatch, not just a wrong value; and below-max rungs
  would be silently ignored. Fail at config time instead.
- Method resolution: the flag requires the method to resolve to `mtp`
  or `dflash` — explicit method, or a draft model whose config infers
  it. The `draft_model` placeholder (method=None) defers the check to
  final validation (nothing is silently ignored, and inference is
  never blocked early).

```python
# propose(), first statements after the count locals (both speculators):
if self.skip_draft_when_k0 and num_speculative_tokens == 0:
    return self.draft_tokens[:num_reqs, :0]
```

## Tests

New `tests/config/test_skip_draft_when_k0.py` (20 tests) + a 6-line
update to `tests/v1/worker/test_gpu_autoregressive_speculator.py`
(existing K=0 prefill test now pins `skip_draft_when_k0 = False` and
the multimodal stub provides the config attribute).

- Default off; flag accepted for `mtp` and `dflash`.
- `eagle`/`eagle3` refused at construction with a bogus draft path —
  proving the rejection fires before any model/download access.
- Support matrix at validator level: `mtp` and `dflash` accepted;
  `eagle`/`eagle3` refused (unsafe); `dspark` refused (would be
  silently ignored); other method strings refused (out of scope).
- REAL-ROUTING construction tests (no mocks): method=`mtp` with a
  callable target override routing the draft to (a) a single-module
  MTP draft — accepted, flag on; (b) a multi-module draft
  (`num_nextn_predict_layers=4`) — rejected, own-propose override;
  (c) a `gemma4_mtp` draft — rejected, unmeasured. These resolve the
  same predicates `init_speculator` uses, closing the silent-ignore
  gap a method-string check misses.
- Inference deferral: the `draft_model` placeholder (method=None) is
  NOT rejected by the early validation; at validator level the final
  call accepts a resolved `mtp` and rejects a resolved `eagle`
  (simulated method assignment; construction-time inference coverage
  is provided by the REAL-ROUTING tests below).
- Real construction (no mocks) with the flag on and an unresolved
  method: defers early, rejects at final validation with the clear
  message.
- Real CLI path via `EngineArgs.create_speculative_config`: JSON to
  hyphen-normalized dict to constructor; flag typed bool; `false`
  constructs cleanly.
- Warning when enabled without a dynamic schedule.
- K=0 + flag on: `propose` returns `[num_reqs, 0]` and the prefill
  path is never entered — proven by a sentinel on the first
  prefill-path helper (`_copy_request_inputs`), which sits before both
  the eager prefill and the FULL-graph dispatch, so neither path can
  be reached without tripping it.
- K=0 + flag off: sentinel fires (existing sync behavior preserved).
- K=2 + flag on, and K unresolved (`None`) + flag on: no early return
  (sentinel fires) — the skip is K=0-specific.
- CLI JSON round-trip preserves the flag type.
- DFlash tier-rung validation (this update): a `0` rung accepted with
  the flag, rejected without it; an over-max rung (8 with max 7)
  accepted — it clamps to the full width in the scheduler; a
  below-max rung rejected with the fixed-width rationale.
- DFlash speculator (this update, bare-instance sentinel style
  mirroring the AutoRegressive set): K=0 + flag on returns
  `[num_reqs, 0]` without entering the forward path; flag off, K>0,
  and K unresolved each proceed (sentinel on the first stateful
  access after the branch).

Local run (source tree, CPU, rebased on current main): **20/20 new +
23/23 speculator+EPLB tests passed; ruff clean on all touched files.**

## Non-duplication / relation to neighbors

- #51575 (stacked here): propagates dynamic K=0 from the scheduler to
  `AutoRegressiveSpeculator` — the bugfix that makes K=0-resolving
  steps correct at all; it contains no skip option, no config flag,
  and nothing for DFlash.
- #52816 (merged): added the DFlash/DFlash2 drafter — without a K=0
  skip (its `propose()` runs the sync forward on K=0 steps) and
  without fixed-width tier validation.
- No other open or recent PR adds a `skip_draft_when_k0` option or
  DFlash dynamic-schedule validation (checked before opening).

## Test commands (source tree, CPU)

```
pytest tests/config/test_skip_draft_when_k0.py                          # 20 passed
pytest tests/v1/worker/test_gpu_autoregressive_speculator.py \
       tests/v1/worker/test_gpu_model_runner_v2_eplb.py                 # 23 passed
```
Ruff clean on all touched files.

## Why a knob instead of auto-enabling at provable K≡0

The structurally safe auto case (spec table resolves K=0 for every
reachable batch size) is worth having, but it cannot serve dynamic
tables — which are the real DSD deployment pattern (K>0 rows at low
concurrency, K=0 rows at high concurrency, requests crossing between
them). For those, the trade-off is genuinely model-dependent and the
operator is the right decision-maker; the flag carries the measured
evidence in its docs. Auto-enable-at-provable-K≡0 composes with this
flag and is a natural follow-up if maintainers want it. (Dynamic K is
disabled under DP today, so the early return cannot diverge DP ranks.)

## Notes

- Extends the #51510/#51575 K=0-respect lineage (same reporter/author;
  the sync remnant was deliberate insurance — this makes it optional
  where measurements justify it).
- The DFlash addition is the same mechanism applied to the second
  speculator that runs the K=0 sync forward, plus the config-time
  fixed-width tier guard its proposer needs. DSpark still refuses the
  option (its proposer override has no skip; identical reasoning to
  multi-module MTP).
- Long-term generalization path (catch-up state reconstruction on
  K=0→K>0 resume) tracked in #53420; would let the flag's
  restriction be lifted family-wide.
- AI assistance: **this PR includes AI-generated code**, authored
  with Claude (ZCode) under human direction; every line reviewed,
  tests run, and measurements human-verified from saved artifacts
  (per the vLLM AI contribution policy; commit carries the
  Co-authored-by trailer).

*(v1 quarantine banner and misattribution audit trail retained in git
history / `codex-review-pr-draft.md`.)*