### PR TITLE
[CI] Allow empty final audio streaming chunk

### DIFF
--- a/tests/entrypoints/multimodal/openai/chat_completion/test_audio.py
+++ b/tests/entrypoints/multimodal/openai/chat_completion/test_audio.py
@@ -295,7 +295,7 @@ async def test_chat_streaming_audio(
     # finish reason should only return in last block
     assert finish_reason_count == 1
     assert chunk.choices[0].finish_reason == stop_reason
-    assert delta.content
+    assert chunks
     assert "".join(chunks) == output
 
 
@@ -355,7 +355,7 @@ async def test_chat_streaming_input_audio(
     # finish reason should only return in last block
     assert finish_reason_count == 1
     assert chunk.choices[0].finish_reason == stop_reason
-    assert delta.content
+    assert chunks
     assert "".join(chunks) == output
 
 


### PR DESCRIPTION
## Purpose

Fix the multimodal audio streaming test failures seen in main
[#85221 MI355](https://buildkite.com/vllm/ci/builds/85221#01a02cb3-7ce7-48f5-9480-0feb102409b8), its
[automatic retry](https://buildkite.com/vllm/ci/builds/85221#01a02ccb-a498-41e5-b658-e3900afeb786), and
[#85223 H200](https://buildkite.com/vllm/ci/builds/85223#01a02ce7-9eb1-4f78-811e-994933061fc6).

The OpenAI-compatible streaming response may put `finish_reason` in a final
chunk whose `delta.content` is empty. Both tests already collect content across
all chunks and compare it with the non-streaming response, so requiring the
last chunk itself to contain text is incorrect. Assert that content was emitted
somewhere in the stream instead.

This does not duplicate an open issue or PR. Searches for `audio streaming
assertion`, `test_chat_streaming_audio`, and `audio streaming test content`
found no overlapping open work.

AI assistance was used to investigate the CI failure and prepare this draft.
The human submitter must review every changed line before marking it ready.

## Test Plan

- Run repository pre-commit hooks on the changed test file.
- Run the exact MI355 and H200 Entrypoints Integration (Multimodal) Buildkite jobs.
- No model evaluation is needed because this only corrects a test assertion;
  serving behavior and output are unchanged.

## Test Result

- `uvx pre-commit run --files tests/entrypoints/multimodal/openai/chat_completion/test_audio.py`: passed all applicable hooks.
- Exact feature-branch/PR-metadata [Buildkite #85222 MI355 gate](https://buildkite.com/vllm/ci/builds/85222#01a02ce5-1740-4193-985c-9d367012bc6b): passed on `crsuse2-m2m-296` with 121 passed / 1 skipped / 1 xfailed in 17m47s; all four audio-streaming parametrizations passed, including both formerly red `winning_call.ogg` cases.
- Exact feature-branch/PR-metadata [Buildkite #85222 H200 gate](https://buildkite.com/vllm/ci/builds/85222#01a02ce5-16ca-4261-accd-34eed314ffef): passed on `h200-ci-2-16` with 121 passed / 1 skipped / 1 xfailed in 20m12s; all four audio-streaming parametrizations passed.
- Subsequent unpatched main [#85223 H200](https://buildkite.com/vllm/ci/builds/85223#01a02ce7-9eb1-4f78-811e-994933061fc6) reproduced both `winning_call.ogg` assertion failures (2 failed / 119 passed / 1 skipped / 1 xfailed), providing independent cross-backend confirmation of the test defect.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (Not applicable.)
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
