### PR TITLE
[Misc] Use VLLMValidationError in offline inference input validation

### DIFF
--- a/tests/entrypoints/llm/test_generate.py
+++ b/tests/entrypoints/llm/test_generate.py
@@ -6,6 +6,7 @@ import weakref
 import pytest
 
 from vllm import LLM, SamplingParams
+from vllm.exceptions import VLLMValidationError
 
 MODEL_NAME = "distilbert/distilgpt2"
 
@@ -52,7 +53,7 @@ def test_multiple_sampling_params(llm: LLM):
     assert len(PROMPTS) == len(outputs)
 
     # Exception raised, if the size of params does not match the size of prompts
-    with pytest.raises(ValueError):
+    with pytest.raises(VLLMValidationError):
         outputs = llm.generate(PROMPTS, sampling_params=sampling_params[:3])
 
     # Single SamplingParams should be applied to every prompt
@@ -75,13 +76,13 @@ def test_multiple_priority(llm: LLM):
     assert len(PROMPTS) == len(outputs)
 
     # Exception raised, if the length of priority does not match the length of prompts
-    with pytest.raises(ValueError):
+    with pytest.raises(VLLMValidationError):
         outputs = llm.generate(
             PROMPTS, sampling_params=None, priority=[0] * (len(PROMPTS) - 1)
         )
 
     # Exception raised, if the priority list is empty
-    with pytest.raises(ValueError):
+    with pytest.raises(VLLMValidationError):
         outputs = llm.generate(PROMPTS, sampling_params=None, priority=[])
 
 

--- a/tests/entrypoints/test_offline_utils.py
+++ b/tests/entrypoints/test_offline_utils.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm import SamplingParams
+from vllm.entrypoints.offline_utils import OfflineInferenceMixin
+from vllm.exceptions import VLLMValidationError
+from vllm.lora.request import LoRARequest
+
+
+@pytest.fixture
+def mixin() -> OfflineInferenceMixin:
+    return object.__new__(OfflineInferenceMixin)
+
+
+def test_rejects_mismatched_params(mixin: OfflineInferenceMixin):
+    with pytest.raises(VLLMValidationError) as exc_info:
+        mixin._params_to_seq([SamplingParams()], num_requests=2)
+
+    assert str(exc_info.value) == (
+        "The lengths of prompts (2) and params (1) must be the same."
+    )
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None
+
+
+def test_rejects_mismatched_lora_requests(mixin: OfflineInferenceMixin):
+    with pytest.raises(VLLMValidationError) as exc_info:
+        mixin._lora_request_to_seq([None], num_requests=2)
+
+    assert str(exc_info.value) == (
+        "The lengths of prompts (2) and lora_request (1) must be the same."
+    )
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None
+
+
+def test_rejects_mismatched_priority(mixin: OfflineInferenceMixin):
+    with pytest.raises(VLLMValidationError) as exc_info:
+        mixin._priority_to_seq([0], num_requests=2)
+
+    assert str(exc_info.value) == (
+        "The lengths of prompts (2) and priority (1) must be the same."
+    )
+    assert exc_info.value.parameter is None
+    assert exc_info.value.value is None
+
+
+def test_matching_lengths_pass_through(mixin: OfflineInferenceMixin):
+    lora = LoRARequest("l", 1, "/tmp/l")
+
+    assert mixin._params_to_seq([SamplingParams()], num_requests=1) == [
+        SamplingParams()
+    ]
+    assert mixin._lora_request_to_seq([lora], num_requests=1) == [lora]
+    assert mixin._priority_to_seq([3], num_requests=1) == [3]

--- a/tests/lora/test_qwen3_with_multi_loras.py
+++ b/tests/lora/test_qwen3_with_multi_loras.py
@@ -12,6 +12,7 @@ import pytest
 
 from tests.utils import multi_gpu_test
 from vllm import LLM, SamplingParams
+from vllm.exceptions import VLLMValidationError
 from vllm.lora.request import LoRARequest
 
 MODEL_PATH = "Qwen/Qwen3-0.6B"
@@ -192,7 +193,7 @@ def test_multiple_lora_requests():
     assert len(PROMPTS) == len(outputs)
 
     # Exception raised, if the size of params does not match the size of prompts
-    with pytest.raises(ValueError):
+    with pytest.raises(VLLMValidationError):
         outputs = llm.generate(PROMPTS, lora_request=lora_request[:1])
 
     # Single LoRARequest should be applied to every prompt

--- a/vllm/entrypoints/offline_utils.py
+++ b/vllm/entrypoints/offline_utils.py
@@ -19,6 +19,7 @@ from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -246,7 +247,7 @@ class OfflineInferenceMixin:
     ) -> Sequence[_P]:
         if isinstance(params, Sequence):
             if len(params) != num_requests:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The lengths of prompts ({num_requests}) "
                     f"and params ({len(params)}) must be the same."
                 )
@@ -262,7 +263,7 @@ class OfflineInferenceMixin:
     ) -> Sequence[LoRARequest | None]:
         if isinstance(lora_request, Sequence):
             if len(lora_request) != num_requests:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The lengths of prompts ({num_requests}) "
                     f"and lora_request ({len(lora_request)}) must be the same."
                 )
@@ -278,7 +279,7 @@ class OfflineInferenceMixin:
     ) -> Sequence[int]:
         if priority is not None:
             if len(priority) != num_requests:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"The lengths of prompts ({num_requests}) "
                     f"and priority ({len(priority)}) must be the same."
                 )


### PR DESCRIPTION
## Purpose

Part of #48227 Step 5.

Migrate the three caller-caused length-mismatch errors in `OfflineInferenceMixin`
(`vllm/entrypoints/offline_utils.py`) from raw `ValueError` to `VLLMValidationError`:

- `_params_to_seq` — prompt/params count mismatch
- `_lora_request_to_seq` — prompt/lora_request count mismatch
- `_priority_to_seq` — prompt/priority count mismatch

This file is the generate-side counterpart of `vllm/entrypoints/pooling/base/io_processor.py`,
migrated in #51931 — `OfflineInferenceMixin` and `PoolingIOProcessor` each carry their own
copies of these three helpers with identical messages. The pooling side was migrated; the
generate side still raised raw `ValueError`, so the same failure surfaced as a different
exception type depending on which entrypoint the caller used:

```
generate side _params_to_seq  -> ValueError
pooling  side _params_to_seq  -> VLLMValidationError
                                 (identical message in both cases)
```

All three are reachable from the public offline API: they are called from
`_add_completion_requests` and `_add_chat_requests`, `OfflineInferenceMixin` is a base of
`LLM`, and `params`, `lora_request` and `priority` are public parameters of
`LLM.generate()`, `LLM.enqueue()` and `LLM.enqueue_chat()`, documented as having to match
the length of `prompts`.

Existing messages and validation behavior are unchanged. These paths are offline-only
(`LLM`, not `AsyncLLM`), so there is no HTTP status-code change; the benefit is that
offline callers can catch a semantic type instead of a bare `ValueError`.

### Difference from #51931

That PR deliberately left `_priority_to_seq` as a raw `ValueError` because it was not
reachable through the public pooling paths. On the generate side it *is* reachable, via
`LLM.generate(..., priority=[...])`, so it is migrated here. Happy to drop it if you would
rather keep the two sides symmetric.

### Updated existing assertions

`VLLMValidationError` no longer inherits from `ValueError`, so four existing assertions that
expected `ValueError` from these paths are updated to expect the semantic type:

- `tests/entrypoints/llm/test_generate.py` — params mismatch, priority mismatch, empty priority list
- `tests/lora/test_qwen3_with_multi_loras.py` — lora_request mismatch

`BeamSearchOfflineMixin` also inherits `_params_to_seq` and `_lora_request_to_seq`, so beam
search callers see the same type change. No existing test asserts `ValueError` on those paths.
`PoolingOfflineMixin` is unaffected: it goes through `PoolingIOProcessor`'s own copies.

`parameter`/`value` are left unset, consistent with #51753 and #51931 — these helpers serve
`generate`, `chat` and `enqueue`, whose public argument names differ (`params` is exposed as
`sampling_params` on `generate()`).

## Duplicate-work check

I searched open PRs for #48227, `offline_utils`, `OfflineInferenceMixin`, `_params_to_seq`
and `_priority_to_seq`, and inspected the current `main` implementation. I found no open PR
migrating these errors. #48544 touches the same file for an unrelated tokenization speedup
and is a stale draft; it mocks these helpers in tests but does not modify the raise sites.

AI assistance disclosure: Claude Code assisted with the audit, implementation, test
generation and review. I reviewed and understand all changed lines and validated the
behavior locally.

## Test Plan

```bash
.venv/bin/python -m pytest tests/entrypoints/test_offline_utils.py -q
.venv/bin/python -m pytest tests/entrypoints/llm/test_generate.py \
    tests/lora/test_qwen3_with_multi_loras.py --collect-only -q
pre-commit run --files vllm/entrypoints/offline_utils.py \
    tests/entrypoints/test_offline_utils.py \
    tests/entrypoints/llm/test_generate.py \
    tests/lora/test_qwen3_with_multi_loras.py
```

## Test Result

```text
4 passed in 0.37s
9 tests collected
All applicable pre-commit hooks passed.
```

I also verified the new tests fail against unmodified `main` (3 failed, 1 passed), confirming
they exercise the change rather than passing vacuously.

The model-backed suites (`test_generate.py`, `test_qwen3_with_multi_loras.py`) were not
executed locally — they require a real model and this was developed on an Apple Silicon CPU
build. They are verified to collect, and their updated assertions are covered by CI.

Environment note: `requirements/test/cpu.txt` is compiled for `x86_64-manylinux` and does not
install on arm64 macOS, so only `tblib` was installed to satisfy `tests/conftest.py`.