### PR TITLE
[Bugfix] Replace non-deterministic index_add_ with scatter-then-sum in TopKWeightAndReduceNaiveBatched

### DIFF
--- a/tests/kernels/moe/test_topk_weight_and_reduce.py
+++ b/tests/kernels/moe/test_topk_weight_and_reduce.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for TopKWeightAndReduceNaiveBatched.apply (PR #53440).
+
+PR #53440 replaced a non-deterministic ``output.index_add_`` (CUDA atomic
+floating-point adds, whose accumulation order varies run-to-run when several
+experts route to the same token) with a scatter-into-unique-slots followed by a
+``moe_sum`` reduction, giving bitwise-identical output across repeated calls.
+The PR shipped no tests. ``moe_sum`` is a compiled CUDA kernel, so these run on
+GPU.
+
+Covered:
+  * numerical equivalence against an independent float64 reference when
+    multiple experts contribute to the same token (the case index_add_'s
+    ordering affected), for topk in {1, 2, 3};
+  * bitwise determinism across repeated calls (fails on the old index_add_
+    path, passes on the scatter-then-sum path);
+  * the bf16 dtype path;
+  * apply_router_weight_on_input=True skips the topk re-weighting.
+"""
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNaiveBatched,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="moe_sum requires CUDA"
+)
+
+DEVICE = "cuda"
+
+
+def _build_batched_inputs(num_tokens, num_experts, K, topk, dtype, seed):
+    """Construct (fused_expert_output, topk_weights, topk_ids) in the layout
+    apply() expects, plus a float64 reference on CPU.
+
+    fused_expert_output has shape (num_experts, batch_size, K); for expert e,
+    row ``slot`` holds e's contribution for the slot-th token routed to e
+    (slot = running count of tokens routed to e, in token order).
+    """
+    g = torch.Generator().manual_seed(seed)
+
+    topk_ids = torch.empty((num_tokens, topk), dtype=torch.int64)
+    for t in range(num_tokens):
+        topk_ids[t] = torch.randperm(num_experts, generator=g)[:topk]
+    topk_weights = torch.rand((num_tokens, topk), generator=g).to(dtype)
+
+    batch_size = num_tokens  # upper bound on tokens routed to any one expert
+    fused = torch.zeros((num_experts, batch_size, K), dtype=dtype)
+    ref = torch.zeros((num_tokens, K), dtype=torch.float64)
+
+    slot_counter = [0] * num_experts
+    for t in range(num_tokens):
+        for j in range(topk):
+            e = int(topk_ids[t, j].item())
+            slot = slot_counter[e]
+            slot_counter[e] += 1
+            vals = torch.rand((K,), generator=g).to(dtype)
+            fused[e, slot, :] = vals
+            ref[t] += vals.to(torch.float64) * float(topk_weights[t, j].item())
+
+    return (
+        fused.to(DEVICE),
+        topk_weights.to(DEVICE),
+        topk_ids.to(DEVICE),
+        ref,
+    )
+
+
+@pytest.mark.parametrize("topk", [1, 2, 3])
+def test_matches_float64_reference_multi_expert_per_token(topk):
+    num_tokens, num_experts, K = 6, 4, 8
+    fused, topk_weights, topk_ids, ref = _build_batched_inputs(
+        num_tokens, num_experts, K, topk, torch.float32, seed=1234
+    )
+    red = TopKWeightAndReduceNaiveBatched(rank=0)
+    out = red.apply(
+        output=None,
+        fused_expert_output=fused,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        apply_router_weight_on_input=False,
+    )
+    assert out.shape == (num_tokens, K)
+    torch.testing.assert_close(
+        out.cpu().to(torch.float64), ref, rtol=1e-5, atol=1e-5
+    )
+
+
+def test_bitwise_deterministic_across_calls():
+    num_tokens, num_experts, K, topk = 8, 6, 16, 3
+    fused, topk_weights, topk_ids, _ = _build_batched_inputs(
+        num_tokens, num_experts, K, topk, torch.bfloat16, seed=99
+    )
+    red = TopKWeightAndReduceNaiveBatched(rank=0)
+
+    def run():
+        return red.apply(
+            output=None,
+            fused_expert_output=fused.clone(),
+            topk_weights=topk_weights.clone(),
+            topk_ids=topk_ids.clone(),
+            apply_router_weight_on_input=False,
+        )
+
+    a = run()
+    for _ in range(10):
+        assert torch.equal(a, run()), "reduction not bitwise-deterministic"
+
+
+def test_bf16_path_matches_reference():
+    num_tokens, num_experts, K, topk = 5, 4, 8, 2
+    fused, topk_weights, topk_ids, ref = _build_batched_inputs(
+        num_tokens, num_experts, K, topk, torch.bfloat16, seed=7
+    )
+    red = TopKWeightAndReduceNaiveBatched(rank=0)
+    out = red.apply(
+        output=None,
+        fused_expert_output=fused,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        apply_router_weight_on_input=False,
+    )
+    assert out.dtype == torch.bfloat16
+    torch.testing.assert_close(
+        out.cpu().to(torch.float64), ref, rtol=3e-2, atol=3e-2
+    )
+
+
+def test_apply_router_weight_on_input_skips_reweight():
+    num_tokens, num_experts, K, topk = 4, 3, 8, 2
+    fused, topk_weights, topk_ids, _ = _build_batched_inputs(
+        num_tokens, num_experts, K, topk, torch.float32, seed=42
+    )
+    # Independent unweighted reference (recompute slot map on CPU copy).
+    fused_cpu = fused.cpu()
+    ids_cpu = topk_ids.cpu()
+    ref = torch.zeros((num_tokens, K), dtype=torch.float64)
+    slot_counter = [0] * num_experts
+    for t in range(num_tokens):
+        for j in range(topk):
+            e = int(ids_cpu[t, j].item())
+            slot = slot_counter[e]
+            slot_counter[e] += 1
+            ref[t] += fused_cpu[e, slot, :].to(torch.float64)
+
+    red = TopKWeightAndReduceNaiveBatched(rank=0)
+    out = red.apply(
+        output=None,
+        fused_expert_output=fused,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        apply_router_weight_on_input=True,
+    )
+    torch.testing.assert_close(
+        out.cpu().to(torch.float64), ref, rtol=1e-5, atol=1e-5
+    )

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -164,8 +164,22 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
         first_expert = num_local_experts * self.rank
         last_expert = first_expert + num_local_experts
 
-        # Vectorized weighted scatter-add (single nonzero sync instead of a
-        # per-expert loop; mirrors the dispatch path).
+        # Vectorized weight application and deterministic reduction.
+        #
+        # Previously this used index_add_ to scatter-add gathered expert
+        # outputs directly to their source tokens.  When multiple experts
+        # route to the same token (the common case with top_k > 1), CUDA
+        # index_add_ performs atomic floating-point adds whose order of
+        # accumulation is non-deterministic across runs.  This makes the
+        # BF16 output differ run-to-run, which can change the greedy argmax
+        # token and break determinism for temperature=0 / fixed-seed
+        # inference.
+        #
+        # Instead, we scatter gathered contributions into a (T, topk, K)
+        # buffer where each (token, topk-slot) position is written at most
+        # once (no atomics), then reduce with moe_sum — the same kernel used
+        # by TopKWeightAndReduceContiguous, which accumulates in fixed
+        # top-k order with an FP32 accumulator.
         local_ids = torch.arange(
             first_expert, last_expert, device=topk_ids.device
         ).view(-1, 1, 1)
@@ -174,10 +188,19 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
         slots = hits.to(torch.int32).cumsum(dim=1) - 1  # [E_local, T]
         e_idx, t_idx = hits.nonzero(as_tuple=True)
         gathered = fused_expert_output[e_idx, slots[e_idx, t_idx], :]
+        # Recover the topk slot index for each (expert, token) pair so each
+        # contribution lands at a unique (token, slot) position in the buffer.
+        route_slots = matching[e_idx, t_idx].to(torch.int32).argmax(dim=1)
         if not apply_router_weight_on_input:
             # weight of token t at expert e: the topk weight on the matching slot
             weights = (matching * topk_weights.unsqueeze(0)).sum(dim=2)  # [E_local, T]
             gathered = gathered * weights[e_idx, t_idx].unsqueeze(1).to(gathered.dtype)
-        output.index_add_(0, t_idx, gathered.to(output.dtype))
+        reduction_input = torch.zeros(
+            (num_tokens, topk_ids.size(1), K),
+            device=output.device,
+            dtype=output.dtype,
+        )
+        reduction_input[t_idx, route_slots] = gathered.to(output.dtype)
+        ops.moe_sum(reduction_input, output)
 
         return output


### PR DESCRIPTION
## Purpose

Fixes #53430.

`TopKWeightAndReduceNaiveBatched.apply` used `output.index_add_(0, t_idx, gathered)` to scatter weighted expert outputs back to their source tokens. When multiple experts route to the same token (the common case with `top_k > 1`), `torch.index_add_` on CUDA performs **atomic floating-point adds** whose order of accumulation is non-deterministic across runs. Because floating-point addition is not associative, repeated calls can differ in the low bits, and those differences can propagate far enough to change a greedy argmax token and break determinism for `temperature=0` / fixed-seed inference.

## Root cause

`torch.index_add_` on CUDA uses atomic operations when multiple source indices map to the same destination. The order of atomic adds is non-deterministic, and since BF16 has limited precision, different accumulation orders produce slightly different results — enough to flip a greedy `argmax` at near-tie logits.

## Fix

Replace the atomic scatter-add with a deterministic two-step approach:

1. **Scatter** gathered expert outputs into a `(T, topk, K)` buffer where each `(token, topk-slot)` position is written at most once (no atomics, no races).
2. **Reduce** with `ops.moe_sum` — the same kernel already used by `TopKWeightAndReduceContiguous`, which accumulates in fixed top-k order with an FP32 accumulator.

This keeps the single vectorized `nonzero`/gather path and does not restore the old per-expert Python loop. The tradeoff is one temporary `(T, topk, K)` tensor.

## Related work

#53442 is an overlapping proposal for #53430. This existing PR includes regression coverage for the deterministic reduction; it is not an independent resolution of a different issue. The proposals need coordination before merge.

## Current-head validation (2026-09-17 UTC)

Head: `4cae08f0241e8eb00244a1b99c6c7f286e46a14b`. The follow-up commit only applies the repository formatter to the regression tests; production code is unchanged from `27e4e2259b5e8267f1653c07b0bf3ac290cdc14d`.

```bash
.venv/bin/python -m pytest tests/kernels/moe/test_topk_weight_and_reduce.py -q
.venv/bin/python -m pre_commit run --files \
  vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py \
  tests/kernels/moe/test_topk_weight_and_reduce.py
```

Results: **6 GPU tests passed**; all applicable pre-commit hooks passed across both changed files. Python 3.12.13, PyTorch 2.13.0+cu130, RTX PRO 5000 72GB (SM120). Editable PR source reused vLLM 0.27.1 native artifacts. Optional DeepEP could not import in this environment; these tests exercise the naive batched reducer, not DeepEP.

### Determinism and performance tradeoff

A separate old-versus-new reducer comparison used the actual pre-PR module and PR module, 60 experts, BF16 inputs, and five `(tokens, hidden size, topk)` shapes. The new reducer was bitwise identical in **19/19 repeats for every shape**. At `(8, 1408, 4)`, the old reducer matched its first output in **0/19 repeats**, while the new reducer matched in **19/19**. Some other baseline shapes happened to repeat identically; this is not a claim that every input reproduces the old race.

| Tokens | Hidden size | Top-k | Old median wall time (µs) | New median wall time (µs) | Increase | Reduction buffer (MiB) |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 1408 | 4 | 130.6 | 163.3 | 25.1% | 0.011 |
| 8 | 1408 | 4 | 133.1 | 165.5 | 24.4% | 0.086 |
| 64 | 1408 | 4 | 136.5 | 169.5 | 24.2% | 0.688 |
| 256 | 4096 | 4 | 177.1 | 191.1 | 7.9% | 8.000 |
| 1024 | 4096 | 8 | 741.3 | 781.6 | 5.4% | 64.000 |

Method: 25 warmups per implementation, then 60 synchronized wall-clock samples each with alternating execution order; input construction is outside timing, output is preallocated, and internal wrapper allocations are included. The benchmark ran on production-code head `27e4e2259b5e8267f1653c07b0bf3ac290cdc14d`. The source import path was checked explicitly. No CUDA graph was used because the dynamic `nonzero()` path synchronizes with the host.

**These are shared-GPU measurements:** an existing inference service remained running. The observed 5.4–25.1% reducer overhead is preliminary and is not an end-to-end throughput estimate. The buffer column is the size of the new `(T, topk, K)` tensor, not total peak-memory growth; its storage lifetime overlaps existing intermediates. Full-wrapper peak incremental allocations were also measured: at the largest shape, 129.372 MiB before versus 129.434 MiB after.

The independent reference sums BF16-rounded products in CPU FP64. The new result matched that BF16 reference exactly for four shapes; the largest shape had maximum absolute error 0.00048828125, consistent with FP32 versus FP64 accumulation rounding. Numerical closeness and strict bitwise repeatability were checked separately.

This fix has a measured performance cost. Maintainer review should assess whether this determinism/latency tradeoff is acceptable for the batched path. Model-generation accuracy and serving throughput were not evaluated in this rerun, so model-level validation remains outstanding.

## Earlier validation (not rerun in this workflow)

Tested on **NVIDIA RTX PRO 5000 (SM120, Blackwell)** with the minimal reproducer from the issue:

```python
import torch
from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
    TopKWeightAndReduceNaiveBatched,
)

torch.manual_seed(1)
num_experts, num_tokens, hidden_size, topk = 60, 64, 1408, 4
device = "cuda"

topk_ids = torch.stack(
    [(torch.arange(num_tokens, device=device) + slot * 13) % num_experts for slot in range(topk)],
    dim=1,
).to(torch.int32)
topk_weights = torch.rand(num_tokens, topk, device=device)
topk_weights /= topk_weights.sum(dim=1, keepdim=True)
counts = torch.bincount(topk_ids.flatten().long(), minlength=num_experts)
expert_output = torch.randn(num_experts, int(counts.max()), hidden_size, device=device, dtype=torch.bfloat16)

reducer = TopKWeightAndReduceNaiveBatched(rank=0)
outputs = [reducer.apply(None, expert_output, topk_weights, topk_ids, False).clone() for _ in range(20)]
torch.cuda.synchronize()

for repeat, output in enumerate(outputs[1:], start=1):
    difference = (output.float() - outputs[0].float()).abs()
    print(repeat, torch.equal(output, outputs[0]), difference.max().item(), int(torch.count_nonzero(difference).item()))
```

**Before fix:** 19/19 repeats non-deterministic (`equal=False`, `max_diff=0.015625`, ~1000-1700 changed elements per run).

**After fix:** 19/19 repeats bitwise-identical (`equal=True`, `max_diff=0.0`, `changed_elems=0`).

### Edge case tests

| Test | Result |
|------|--------|
| Basic determinism | ✅ PASS |
| Pre-allocated output tensor | ✅ PASS |
| None vs pre-allocated output match | ✅ PASS |
| `apply_router_weight_on_input=True` | ✅ PASS |
| EP rank > 0 | ✅ PASS |
| `topk=1` (no multi-expert) | ✅ PASS |
| All tokens same expert | ✅ PASS |
| `topk=8` (large) | ✅ PASS |
| FP16 dtype | ✅ PASS |
| Output size assertion | ✅ PASS |

### Modular kernel correctness (not model-generation evaluation)

Validated via `BatchedTritonExperts` + `BatchedPrepareAndFinalize` modular kernel path (the same path exercised by `test_batched_experts_end_to_end` in `tests/kernels/moe/test_batched_moe.py`) against a torch reference across 5 shapes:

| Shape (m, n, k, e, topk) | Correctness | Determinism |
|--------------------------|-------------|-------------|
| (4, 128, 256, 4, 2) | ✅ PASS | ✅ PASS |
| (8, 256, 512, 4, 2) | ✅ PASS | ✅ PASS |
| (16, 512, 512, 8, 4) | ✅ PASS | ✅ PASS |
| (32, 256, 128, 4, 2) | ✅ PASS | ✅ PASS |
| (1, 128, 64, 4, 2) | ✅ PASS | ✅ PASS |

## Tested hardware

- NVIDIA RTX PRO 5000 × 8 (Blackwell, SM120, 72GB each)
- vLLM 0.27.1, PyTorch 2.13.0+cu130, CUDA 13.0

AI assistance (OpenAI Codex) was used for analysis, test formatting, benchmarking, and server validation.
