### PR TITLE
fix(docker): build lmcache from source in KV-connectors images to match shipped torch ABI

### DIFF
--- a/.buildkite/scripts/install-kv-connectors.sh
+++ b/.buildkite/scripts/install-kv-connectors.sh
@@ -11,7 +11,14 @@ fi
 
 REQUIREMENTS_FILE="${KV_CONNECTORS_REQUIREMENTS:-/vllm-workspace/requirements/kv_connectors.txt}"
 
-uv pip install --system -r "${REQUIREMENTS_FILE}"
+# lmcache wheels on PyPI are compiled against a single pinned torch ABI. When
+# the CI image ships a different torch, the wheel install succeeds but
+# lmcache.c_ops fails to load at runtime (C++ ABI mismatch). Build lmcache
+# from source against the torch in this image instead; --no-build-isolation
+# makes the PEP 517 build reuse the installed torch.
+grep -v '^lmcache' "${REQUIREMENTS_FILE}" > /tmp/kv_connectors_rest.txt
+uv pip install --system -r /tmp/kv_connectors_rest.txt
+uv pip install --system 'lmcache >= 0.3.9' --no-binary lmcache --no-build-isolation-package lmcache
 
 KV_METADATA=$(python3 - <<'PY'
 import importlib.metadata as metadata

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1012,15 +1012,23 @@ RUN --mount=type=cache,target=/opt/uv/cache \
                 libcublas-dev-${CUDA_VERSION_DASH} \
                 libcusolver-dev-${CUDA_VERSION_DASH}"; \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
-        uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
-            # if the above fails, install from source
-            apt-get update -y && \
-            apt-get install -y --no-install-recommends --allow-change-held-packages ${BUILD_PKGS} && \
-            uv pip install --system -r /tmp/kv_connectors.txt --no-build-isolation && \
-            apt-get purge -y ${BUILD_PKGS} && \
-            # clean up -dev packages, keep runtime libraries
-            rm -rf /var/lib/apt/lists/* \
-        ); \
+        # lmcache ships wheels compiled against a single pinned torch ABI
+        # (torch==2.11 at time of writing). Installing that wheel into an image
+        # built with a different torch (e.g. 2.13) succeeds but its compiled
+        # lmcache.c_ops extension then fails to load at runtime due to the C++
+        # ABI mismatch, silently falling back to slow torch baseline ops. The
+        # wheel install succeeding also means the source-build fallback below
+        # never runs. So lmcache must ALWAYS be built from source against the
+        # torch version this image actually ships (--no-build-isolation makes
+        # the build reuse the installed torch instead of pulling a fresh one).
+        apt-get update -y && \
+        apt-get install -y --no-install-recommends --allow-change-held-packages ${BUILD_PKGS} && \
+        grep -v '^lmcache' /tmp/kv_connectors.txt > /tmp/kv_connectors_rest.txt; \
+        uv pip install --system -r /tmp/kv_connectors_rest.txt --no-build && \
+        uv pip install --system 'lmcache >= 0.3.9' --no-binary lmcache --no-build-isolation-package lmcache && \
+        apt-get purge -y ${BUILD_PKGS} && \
+        # clean up -dev packages, keep runtime libraries
+        rm -rf /var/lib/apt/lists/* && \
         # The default mooncake wheel links libcudart.so.12, so on CUDA 13 swap in the
         # cuda13 variant. Uninstall first; both ship the `mooncake` package.
         # Mirrors .buildkite/scripts/install-kv-connectors.sh.


### PR DESCRIPTION
## Purpose

Fixes #53424

`INSTALL_KV_CONNECTORS=true` images install LMCache from a PyPI wheel that is compiled against a single pinned torch ABI (torch 2.11 at the time of writing). When the vLLM image ships a newer torch (2.13 in v0.27.1), the wheel install **succeeds**, but its precompiled `lmcache/c_ops*.so` fails to load at runtime due to the C++ ABI mismatch, silently falling back to slow torch-baseline ops. Because the wheel install succeeds, the Dockerfile's source-build fallback never runs.

This PR makes the lmcache install path deterministic:

- `docker/Dockerfile` (KV-connectors stage): split `lmcache` out of the batched `--no-build` requirements install and install it separately with `--no-binary lmcache --no-build-isolation-package lmcache`, so uv builds the sdist against the torch version actually shipped in the image. The other connectors keep the existing wheel path.
- `.buildkite/scripts/install-kv-connectors.sh` (CI twin of that stage): same change, keeping image and CI installs consistent.

The apt build-deps block (`BUILD_PKGS`) now always runs for this stage since lmcache is always built from source; cleanup logic is unchanged.

## Why this is not duplicating an existing PR

- Issue #53424 has no linked or referenced PR (checked via issue timeline cross-references and open PR search for "lmcache"/"53424").
- No other open PR touches `requirements/kv_connectors.txt`, the KV-connectors stage of `docker/Dockerfile`, or `.buildkite/scripts/install-kv-connectors.sh`.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, via Hermes agent). The submitting author reviewed every changed line, verified the dependency-resolution behavior locally as described below, and understands the full diff end-to-end.

## Test Plan

- `bash -n .buildkite/scripts/install-kv-connectors.sh` passes.
- Flag semantics verified with uv in a clean container (torch installed, no GPU needed to observe artifact selection):
  - baseline `uv pip install 'lmcache==0.5.3'` selects the prebuilt wheel (`lmcache-0.5.3-cp312-cp312-manylinux_2_27_x86_64...whl`), which ships `lmcache/c_ops.cpython-312-x86_64-linux-gnu.so`;
  - adding `--no-binary lmcache --no-build-isolation-package lmcache` forces the sdist (`lmcache-0.5.3.tar.gz`) source build (observed entering the c_ops compile step; that compile requires CUDA headers, so full compilation is exercised by the KV-connectors image build CI).
- `typos` hook clean on both changed files.
- The CI job building the KV-connectors image exercises both changed paths end-to-end.

## Test Result

- Wheel-vs-source selection confirmed locally: default → `.whl`; with new flags → source build started.
- `typos docker/Dockerfile .buildkite/scripts/install-kv-connectors.sh` → clean.
- Runtime confirmation of `c_ops` loading under matching ABI will come from the KV-connectors image build + GPU CI on this PR.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR: fixes #53424 (LMCache wheel ABI mismatch in KV-connectors images).
- [x] The test plan: local flag-semantics proof + KV-connectors image build CI.
- [x] The test results: pasted above.
- [x] Documentation update not required (build/CI-only change).
</details>
