### PR TITLE
[Bugfix] Make BatchedTritonExperts reduction deterministic

### DIFF
--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -164,8 +164,8 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
         first_expert = num_local_experts * self.rank
         last_expert = first_expert + num_local_experts
 
-        # Vectorized weighted scatter-add (single nonzero sync instead of a
-        # per-expert loop; mirrors the dispatch path).
+        # Vectorized weight application and reduction (single nonzero sync
+        # instead of a per-expert loop; mirrors the dispatch path).
         local_ids = torch.arange(
             first_expert, last_expert, device=topk_ids.device
         ).view(-1, 1, 1)
@@ -174,10 +174,18 @@ class TopKWeightAndReduceNaiveBatched(mk.TopKWeightAndReduce):
         slots = hits.to(torch.int32).cumsum(dim=1) - 1  # [E_local, T]
         e_idx, t_idx = hits.nonzero(as_tuple=True)
         gathered = fused_expert_output[e_idx, slots[e_idx, t_idx], :]
+        matched_routes = matching[e_idx, t_idx]
+        route_slots = matched_routes.to(torch.int32).argmax(dim=1)
         if not apply_router_weight_on_input:
-            # weight of token t at expert e: the topk weight on the matching slot
-            weights = (matching * topk_weights.unsqueeze(0)).sum(dim=2)  # [E_local, T]
-            gathered = gathered * weights[e_idx, t_idx].unsqueeze(1).to(gathered.dtype)
-        output.index_add_(0, t_idx, gathered.to(output.dtype))
+            weights = (matched_routes * topk_weights[t_idx]).sum(dim=1)
+            gathered = gathered * weights.unsqueeze(1).to(gathered.dtype)
+
+        reduction_input = torch.zeros(
+            (num_tokens, topk_ids.size(1), K),
+            device=output.device,
+            dtype=output.dtype,
+        )
+        reduction_input[t_idx, route_slots] = gathered.to(output.dtype)
+        ops.moe_sum(reduction_input, output)
 
         return output


### PR DESCRIPTION
## Summary

- make `TopKWeightAndReduceNaiveBatched` deterministic for identical inputs
- preserve the vectorized expert matching and gather path
- stage each gathered contribution at its unique `[token, topk_slot]` position
- use the existing fixed-order `moe_sum` kernel instead of CUDA `index_add_`

Fixes #53430.

## Root cause

The batched reducer gathered contributions in expert-major order and then used
`output.index_add_(0, t_idx, ...)`. A token routed to multiple experts appears
multiple times in `t_idx`, so CUDA may concurrently add several BF16 values to
the same output row. The additions are atomic but their order is not fixed.
Because floating-point addition is not associative, repeated calls can differ
in the low bits and those differences can propagate far enough to change a
greedy argmax.

## Implementation

The reducer now recovers the original top-k slot for every gathered
token/expert contribution. It writes those contributions to a zero-initialized
`[num_tokens, topk, hidden_size]` tensor at unique locations and calls the
existing `moe_sum` kernel. `moe_sum` accumulates each output element in fixed
top-k order with an FP32 accumulator, avoiding conflicting writes and
nondeterministic atomic reduction order.

This keeps the single vectorized `nonzero`/gather path and does not restore the
old per-expert Python loop. The tradeoff is one temporary
`[num_tokens, topk, hidden_size]` tensor.
