### PR TITLE
[ROCm][CI] Halve Distributed Compile config matrix

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -689,7 +689,10 @@ steps:
   commands:
   - export VLLM_TEST_CLEAN_GPU_MEMORY=1
   - VLLM_TEST_CLEAN_GPU_MEMORY=1 pytest -v -s tests/compile/passes/distributed/test_async_tp.py
-  - pytest -v -s tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fusions
+  # Run all models, attn backends and custom op combos but only Inductor partition.
+  # Both custom op combos are kept because the ROCm AITER AR+RMS fusion path depends
+  # on them, unlike CUDA where the Quick jobs also drop +rms_norm.
+  - pytest -v -s tests/compile/fusions_e2e/test_tp2_ar_rms.py::test_tp2_ar_rms_fusions -k "inductor_partition"
 
 - label: ":amd: (MI300) Distributed Compile + RPC" # TBD
   timeout_in_minutes: 180


### PR DESCRIPTION
The MI300 Distributed Compile job runs for over an hour, almost entirely inside test_tp2_ar_rms_fusions. That test expands to 64 parametrizations (4 models x 4 attention backends x 2 custom_ops x 2 inductor_graph_partition) and every one builds a full 2-GPU engine and compiles it from scratch.

Restrict it to Inductor partition, the same trimming the CUDA Fusion E2E Quick jobs and the MI300 TP1 Fusion E2E jobs already apply. Collected tests drop from 64 to 32, and the tests that actually build an engine drop from 44 to 22, since FLASHINFER needs Blackwell and ROCM_ATTN skips gpt-oss-20b. Every model, attention backend and custom_ops combo is still covered.

Both custom_ops combos are kept deliberately: on ROCm the AITER AR+RMS fusion path depends on them, unlike CUDA where the Quick jobs also drop +rms_norm.

Sharding across parallel agents was considered instead, but it would be the only sharded step requiring 2 GPUs on a pool shared by 21 other steps, and the hash-based split is uneven (9/10/16/9 of the 44), giving 2.75x for 4x the GPU cost.


