### PR TITLE
[ROCm][Perf][MiniMax-M3] Speed up the lightning indexer and add an opt-in fp8 index cache

### DIFF
--- a/tests/kernels/attention/test_minimax_m3_amd_indexer.py
+++ b/tests/kernels/attention/test_minimax_m3_amd_indexer.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the ROCm MiniMax-M3 lightning-indexer kernels.
+
+``test_minimax_m3.py`` covers the platform-common kernels; these cover
+``vllm/models/minimax_m3/amd/ops/index_topk.py``, which ``common/indexer.py``
+dispatches to on ROCm.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import triton
+
+if not current_platform.is_rocm():
+    pytest.skip("ROCm-only indexer kernels", allow_module_level=True)
+
+from vllm.models.minimax_m3.amd.ops.index_topk import (
+    SPARSE_BLOCK_SIZE,
+    TOPK_QUERY_TILE,
+    TOPK_QUERY_TILE_SMALL,
+    _topk_query_tile,
+    minimax_m3_index_decode,
+    minimax_m3_index_score,
+    minimax_m3_index_topk,
+)
+
+HEAD_DIM = 128
+DEV = "cuda"
+
+
+def _build(q_lens, prefix_lens, num_idx_heads, cache_dtype, seed=0):
+    q_lens = torch.tensor(q_lens, device=DEV, dtype=torch.int32)
+    prefix_lens = torch.tensor(prefix_lens, device=DEV, dtype=torch.int32)
+    seq_lens = prefix_lens + q_lens
+    batch = q_lens.numel()
+    max_seq_len = int(seq_lens.max())
+    max_blocks = (max_seq_len + SPARSE_BLOCK_SIZE - 1) // SPARSE_BLOCK_SIZE
+    num_pages = batch * max_blocks
+    cu = torch.zeros(batch + 1, device=DEV, dtype=torch.int32)
+    cu[1:] = q_lens.cumsum(0)
+    g = torch.Generator(device=DEV).manual_seed(seed)
+    block_table = torch.randperm(
+        num_pages, generator=g, device=DEV, dtype=torch.int32
+    ).reshape(batch, max_blocks)
+    idx_q = torch.randn(
+        int(q_lens.sum()), num_idx_heads, HEAD_DIM, generator=g, device=DEV
+    ).to(cache_dtype)
+    cache = torch.randn(
+        num_pages, SPARSE_BLOCK_SIZE, HEAD_DIM, generator=g, device=DEV
+    ).to(cache_dtype)
+    return dict(
+        q_lens=q_lens,
+        prefix_lens=prefix_lens,
+        seq_lens=seq_lens,
+        cu=cu,
+        block_table=block_table,
+        idx_q=idx_q,
+        cache=cache,
+        max_seq_len=max_seq_len,
+        num_idx_heads=num_idx_heads,
+    )
+
+
+def _reference_scores(t):
+    """Per-(head, token, block) max score, computed densely in fp32."""
+    q_lens = t["q_lens"].tolist()
+    prefix = t["prefix_lens"].tolist()
+    out = []
+    for req, q_len in enumerate(q_lens):
+        n_blocks = (
+            int(t["seq_lens"][req]) + SPARSE_BLOCK_SIZE - 1
+        ) // SPARSE_BLOCK_SIZE
+        pages = t["block_table"][req, :n_blocks]
+        k = t["cache"][pages].reshape(-1, HEAD_DIM).float()
+        start = int(t["cu"][req])
+        q = t["idx_q"][start : start + q_len].float()
+        s = torch.einsum("qhd,kd->hqk", q, k)
+        q_pos = prefix[req] + torch.arange(q_len, device=DEV)
+        k_pos = torch.arange(k.shape[0], device=DEV)
+        s.masked_fill_(k_pos[None, None, :] > q_pos[None, :, None], -float("inf"))
+        out.append(s.reshape(s.shape[0], q_len, n_blocks, SPARSE_BLOCK_SIZE).max(-1)[0])
+    return out
+
+
+def _assert_valid_topk(actual, t, topk, local_blocks):
+    """Every stored block must be within the causal window and be a true top-k.
+
+    Validity rather than exact index match: scores tie at the k-th place.
+    """
+    ref = _reference_scores(t)
+    prefix = t["prefix_lens"].tolist()
+    for req, per_req in enumerate(ref):
+        start = int(t["cu"][req])
+        for h in range(per_req.shape[0]):
+            for tok in range(per_req.shape[1]):
+                valid = (prefix[req] + tok + SPARSE_BLOCK_SIZE) // SPARSE_BLOCK_SIZE
+                row = per_req[h, tok, :valid].clone()
+                row[max(0, valid - local_blocks) : valid] = 1e29
+                sel = [i for i in actual[h, start + tok].tolist() if i >= 0]
+                assert len(set(sel)) == len(sel), "duplicate block id"
+                assert not sel or max(sel) < valid, "selected a non-causal block"
+                assert len(sel) == min(topk, valid), (
+                    f"expected {min(topk, valid)} blocks, got {len(sel)}"
+                )
+                kth = row.sort(descending=True).values[min(topk, valid) - 1]
+                assert row[sel].min() >= kth, "dropped a strictly larger score"
+
+
+@pytest.mark.parametrize("topk", [1, 6, 16, 64])
+@pytest.mark.parametrize("num_idx_heads", [1, 2])
+@pytest.mark.parametrize("cache_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_prefill_topk_matches_reference(topk, num_idx_heads, cache_dtype):
+    t = _build([300, 1, 133], [0, 1024, 4096], num_idx_heads, cache_dtype)
+    score = minimax_m3_index_score(
+        t["idx_q"],
+        t["cache"],
+        t["block_table"],
+        t["cu"],
+        t["seq_lens"],
+        t["prefix_lens"],
+        max_query_len=int(t["q_lens"].max()),
+        max_seq_len=t["max_seq_len"],
+        num_kv_heads=num_idx_heads,
+    )
+    actual = minimax_m3_index_topk(
+        score,
+        t["cu"],
+        t["prefix_lens"],
+        max_query_len=int(t["q_lens"].max()),
+        topk=topk,
+        init_blocks=0,
+        local_blocks=1,
+    )
+    _assert_valid_topk(actual.cpu(), t, topk, local_blocks=1)
+
+
+@pytest.mark.parametrize("q_len", [1, 7, 33, 40, 257])
+def test_prefill_topk_tail_rows_untouched(q_len):
+    """Query lengths that do not divide the tile must not write past the request."""
+    topk = 16
+    t = _build([q_len, q_len + 1], [0, 512], 1, torch.bfloat16)
+    total_q = int(t["q_lens"].sum())
+    score = minimax_m3_index_score(
+        t["idx_q"],
+        t["cache"],
+        t["block_table"],
+        t["cu"],
+        t["seq_lens"],
+        t["prefix_lens"],
+        max_query_len=int(t["q_lens"].max()),
+        max_seq_len=t["max_seq_len"],
+        num_kv_heads=1,
+    )
+    poison = -12345
+    out = torch.full((1, total_q + 64, topk), poison, dtype=torch.int32, device=DEV)
+    minimax_m3_index_topk(
+        score,
+        t["cu"],
+        t["prefix_lens"],
+        max_query_len=int(t["q_lens"].max()),
+        topk=topk,
+        init_blocks=0,
+        local_blocks=1,
+        out=out,
+    )
+    assert (out[:, total_q:, :] == poison).all(), "wrote past total_q"
+    assert (out[:, :total_q, :] != poison).any()
+    _assert_valid_topk(out[:, :total_q].cpu(), t, topk, local_blocks=1)
+
+
+def test_query_tile_always_leaves_a_usable_config():
+    """The tile `_topk_query_tile` picks must survive `_topk_prune_configs`.
+
+    These are two halves of one invariant: pick a tile no config can serve and
+    the launch dies inside Triton instead of raising an actionable error.
+    """
+    from vllm.models.minimax_m3.amd.ops.index_topk import (
+        _topk_index_kernel,
+        _topk_prune_configs,
+    )
+
+    configs = _topk_index_kernel.fn.configs
+    for topk in (1, 6, 16, 64, 128, 256, 512, 1024):
+        for max_query_len in (1, 33, 1024, 8160, 8192, 32768, 73728):
+            for batch in (1, 4, 32, 128):
+                tile = _topk_query_tile(max_query_len, batch, 1, topk)
+                assert tile <= TOPK_QUERY_TILE and tile & (tile - 1) == 0
+                kept = _topk_prune_configs(
+                    configs,
+                    {"topk": topk},
+                    BLOCK_SIZE_T=triton.next_power_of_2(topk),
+                    BLOCK_SIZE_Q=tile,
+                )
+                assert kept, f"no config for topk={topk} tile={tile}"
+    # Both named widths stay reachable at M3's topk.
+    assert _topk_query_tile(32768, 8, 1, 16) == TOPK_QUERY_TILE
+    assert _topk_query_tile(1024, 1, 1, 16) == TOPK_QUERY_TILE_SMALL
+
+
+@pytest.mark.parametrize("q_len", [8192, 8225])
+def test_prefill_topk_wide_query_tile(q_len):
+    """Exercise the 32-row tile, which needs a launch big enough to fill the device.
+
+    Every other prefill test here is small enough to fall through to the 8-row
+    tile, so without this the shipping configuration is never compiled.
+    """
+    topk = 16
+    t = _build([q_len], [0], 1, torch.bfloat16, seed=3)
+    assert _topk_query_tile(q_len, 1, 1, topk) == TOPK_QUERY_TILE
+    score = minimax_m3_index_score(
+        t["idx_q"],
+        t["cache"],
+        t["block_table"],
+        t["cu"],
+        t["seq_lens"],
+        t["prefix_lens"],
+        max_query_len=q_len,
+        max_seq_len=t["max_seq_len"],
+        num_kv_heads=1,
+    )
+    poison = -12345
+    out = torch.full((1, q_len + 64, topk), poison, dtype=torch.int32, device=DEV)
+    minimax_m3_index_topk(
+        score,
+        t["cu"],
+        t["prefix_lens"],
+        max_query_len=q_len,
+        topk=topk,
+        init_blocks=0,
+        local_blocks=1,
+        out=out,
+    )
+    assert (out[:, q_len:, :] == poison).all(), "wrote past total_q"
+    _assert_valid_topk(out[:, :q_len].cpu(), t, topk, local_blocks=1)
+
+
+@pytest.mark.parametrize("topk", [16, 64, 128, 256, 512, 1024])
+def test_prefill_topk_supports_wide_topk(topk):
+    """topk wide enough to force a wide BLOCK_SIZE_K must still launch."""
+    t = _build([64, 64], [0, 2048], 1, torch.bfloat16)
+    score = minimax_m3_index_score(
+        t["idx_q"],
+        t["cache"],
+        t["block_table"],
+        t["cu"],
+        t["seq_lens"],
+        t["prefix_lens"],
+        max_query_len=64,
+        max_seq_len=t["max_seq_len"],
+        num_kv_heads=1,
+    )
+    actual = minimax_m3_index_topk(
+        score,
+        t["cu"],
+        t["prefix_lens"],
+        max_query_len=64,
+        topk=topk,
+        init_blocks=0,
+        local_blocks=1,
+    )
+    assert actual.shape[-1] == topk
+    _assert_valid_topk(actual.cpu(), t, topk, local_blocks=1)
+
+
+def test_prefill_topk_rejects_unservable_topk():
+    """No legal config must raise an actionable error, not a compile assert."""
+    t = _build([64], [0], 1, torch.bfloat16)
+    score = minimax_m3_index_score(
+        t["idx_q"],
+        t["cache"],
+        t["block_table"],
+        t["cu"],
+        t["seq_lens"],
+        t["prefix_lens"],
+        max_query_len=64,
+        max_seq_len=t["max_seq_len"],
+        num_kv_heads=1,
+    )
+    with pytest.raises(ValueError, match="no usable config"):
+        minimax_m3_index_topk(
+            score,
+            t["cu"],
+            t["prefix_lens"],
+            max_query_len=64,
+            topk=4096,
+            init_blocks=0,
+            local_blocks=1,
+        )
+
+
+@pytest.mark.parametrize("cache_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("batch", [1, 8, 40])
+def test_decode_topk_matches_reference(cache_dtype, batch):
+    topk, local_blocks = 16, 1
+    ctx = 3000
+    t = _build([1] * batch, [ctx - 1] * batch, 1, cache_dtype)
+    actual = minimax_m3_index_decode(
+        t["idx_q"],
+        t["cache"],
+        t["block_table"],
+        t["seq_lens"],
+        max_seq_len=t["max_seq_len"],
+        topk=topk,
+        init_blocks=0,
+        local_blocks=local_blocks,
+        num_kv_heads=1,
+        decode_query_len=1,
+        max_decode_query_len=1,
+    )
+    _assert_valid_topk(actual.cpu(), t, topk, local_blocks=local_blocks)
+
+
+def test_fp8_index_cache_insert_clamps_out_of_range():
+    """bf16 index keys above the e4m3 max must saturate, not become NaN/inf."""
+    from vllm.models.minimax_m3.amd.ops.sparse_pa import minimax_m3_insert_index_cache
+
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    index_k = torch.tensor(
+        [[1e4] * HEAD_DIM, [-1e4] * HEAD_DIM, [1.5] * HEAD_DIM],
+        device=DEV,
+        dtype=torch.bfloat16,
+    )
+    cache = torch.zeros(
+        4, SPARSE_BLOCK_SIZE, HEAD_DIM, device=DEV, dtype=torch.float8_e4m3fn
+    )
+    slots = torch.tensor([0, 1, 2], device=DEV, dtype=torch.int32)
+    minimax_m3_insert_index_cache(index_k, cache, slots)
+    got = cache[0, :3].float()
+    assert torch.isfinite(got).all(), "e4m3 convert produced NaN/inf"
+    assert torch.allclose(got[0], torch.full_like(got[0], fp8_max))
+    assert torch.allclose(got[1], torch.full_like(got[1], -fp8_max))
+    assert torch.allclose(got[2], torch.full_like(got[2], 1.5))

--- a/tests/kernels/attention/test_minimax_m3_amd_indexer.py
+++ b/tests/kernels/attention/test_minimax_m3_amd_indexer.py
@@ -20,6 +20,7 @@ from vllm.models.minimax_m3.amd.ops.index_topk import (
     SPARSE_BLOCK_SIZE,
     TOPK_QUERY_TILE,
     TOPK_QUERY_TILE_SMALL,
+    _min_topk_programs,
     _topk_query_tile,
     minimax_m3_index_decode,
     minimax_m3_index_score,
@@ -199,14 +200,49 @@ def test_query_tile_always_leaves_a_usable_config():
     assert _topk_query_tile(1024, 1, 1, 16) == TOPK_QUERY_TILE_SMALL
 
 
-@pytest.mark.parametrize("q_len", [8192, 8225])
-def test_prefill_topk_wide_query_tile(q_len):
+def test_score_kv_chunks_invariants(monkeypatch):
+    """The split the scorer picks must be launchable for any shape and device.
+
+    The kernel divides its causal scan by this count and shifts by its bit
+    length, so a zero or a non-power-of-two is a launch failure rather than a
+    slow kernel. The CU count is patched so the sweep covers parts this test is
+    not running on.
+    """
+    from vllm.models.minimax_m3.amd.ops import index_topk as ops
+
+    for cus in (64, 80, 128, 256, 304, 1024):
+        monkeypatch.setattr(ops, "num_compute_units", lambda _c=cus: _c)
+        for num_q_blocks in (1, 2, 7, 64, 512, 1024):
+            for batch in (1, 2, 8, 64, 512):
+                for heads in (1, 2):
+                    for max_block in (0, 1, 2, 7, 8, 63, 64, 1024, 100000):
+                        n = ops._score_kv_chunks(num_q_blocks, batch, heads, max_block)
+                        assert n >= 1
+                        assert n & (n - 1) == 0, f"{n} is not a power of two"
+                        assert n <= max(1, max_block)
+                        assert n <= ops.PREFILL_SCORE_MAX_KV_CHUNKS
+
+
+def _wide_tile_query_len() -> int:
+    """Shortest single-request prefill that still selects the wide top-k tile.
+
+    The tile widens once the grid can fill the device, so the threshold is a
+    property of the GPU rather than a constant: hard-coding a length picks the
+    narrow tile on any part with more CUs than the one it was written on.
+    """
+    return _min_topk_programs() * TOPK_QUERY_TILE
+
+
+@pytest.mark.parametrize("tail", [0, 33])
+def test_prefill_topk_wide_query_tile(tail):
     """Exercise the 32-row tile, which needs a launch big enough to fill the device.
 
     Every other prefill test here is small enough to fall through to the 8-row
-    tile, so without this the shipping configuration is never compiled.
+    tile, so without this the shipping configuration is never compiled. ``tail``
+    adds rows that do not divide the tile.
     """
     topk = 16
+    q_len = _wide_tile_query_len() + tail
     t = _build([q_len], [0], 1, torch.bfloat16, seed=3)
     assert _topk_query_tile(q_len, 1, 1, topk) == TOPK_QUERY_TILE
     score = minimax_m3_index_score(

--- a/tests/kernels/attention/test_minimax_m3_amd_indexer.py
+++ b/tests/kernels/attention/test_minimax_m3_amd_indexer.py
@@ -316,7 +316,8 @@ def test_fp8_index_cache_insert_clamps_out_of_range():
     """bf16 index keys above the e4m3 max must saturate, not become NaN/inf."""
     from vllm.models.minimax_m3.amd.ops.sparse_pa import minimax_m3_insert_index_cache
 
-    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    fp8_min, fp8_max = finfo.min, finfo.max
     index_k = torch.tensor(
         [[1e4] * HEAD_DIM, [-1e4] * HEAD_DIM, [1.5] * HEAD_DIM],
         device=DEV,
@@ -330,5 +331,5 @@ def test_fp8_index_cache_insert_clamps_out_of_range():
     got = cache[0, :3].float()
     assert torch.isfinite(got).all(), "e4m3 convert produced NaN/inf"
     assert torch.allclose(got[0], torch.full_like(got[0], fp8_max))
-    assert torch.allclose(got[1], torch.full_like(got[1], -fp8_max))
+    assert torch.allclose(got[1], torch.full_like(got[1], fp8_min))
     assert torch.allclose(got[2], torch.full_like(got[2], 1.5))

--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -679,8 +679,12 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         # the attend impl reads them back (no Python value crosses the break).
         self.topk_indices_buffer = topk_indices_buffer
         self.attn_backend = MiniMaxM3SparseBackend
+        # Side-cache dtype (--attention-config '{"indexer_kv_dtype": "fp8"}').
+        self.indexer_kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype(
+            "bf16"
+        )
         # Indexer and main attention are separate impls. On ROCm the SM100 gate
-        # is always False, so both pick Triton and the index cache stays bf16.
+        # is always False, so both pick Triton.
         # impl is AttentionImplBase (broader than AttentionLayerBase's annotation).
         self.impl: MiniMaxM3SparseImpl = select_main_impl_cls(  # type: ignore[assignment]
             topk_blocks=sparse_cfg["sparse_topk_blocks"],
@@ -713,6 +717,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             local_blocks=sparse_cfg.get("sparse_local_block", 0),
             score_type=sparse_cfg.get("sparse_score_type", "max"),
             cache_config=cache_config,
+            indexer_kv_dtype=self.indexer_kv_dtype,
             topk_indices_buffer=topk_indices_buffer,
         )
 
@@ -914,7 +919,12 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
                 )
         else:
             index_slot_mapping = fwd_slot_mapping[self.indexer.index_cache.prefix]
-            index_q = qkv.new_empty((num_tokens, self.index_q_size))
+            # The fused writer requires index_q_out and index_cache to share a
+            # dtype, so index_q follows the side cache.
+            index_q = qkv.new_empty(
+                (num_tokens, self.index_q_size),
+                dtype=self.indexer.index_cache.dtype,
+            )
             if self.use_aiter_sparse_pa:
                 ops.fused_minimax_m3_qknorm_rope_kv_insert(
                     qkv,

--- a/vllm/models/minimax_m3/amd/ops/index_topk.py
+++ b/vllm/models/minimax_m3/amd/ops/index_topk.py
@@ -19,9 +19,10 @@ import functools
 import torch
 
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx950
+from vllm.platforms.rocm import on_gfx950, on_mi3xx
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import round_up
+from vllm.utils.platform_utils import num_compute_units
 
 # One sparse block == one KV page.
 SPARSE_BLOCK_SIZE = 128
@@ -29,10 +30,46 @@ SPARSE_BLOCK_SIZE = 128
 # The fp8 index cache is implemented and measured on gfx950 only.
 TRITON_INDEXER_KV_DTYPES = ("bf16", "fp8", "fp8_e4m3") if on_gfx950() else ("bf16",)
 
-# Query rows per program in the prefill scorer. 128 is swept on gfx950; other
+# Query rows per program in the prefill scorer. 128 is swept on MI3xx; other
 # archs keep the original 64 until they are (cf. _SPARSE_ATTN_SUB_K in
 # sparse_attn.py). Sets grid dim 0, so it cannot be an autotune key.
-PREFILL_BLOCK_SIZE_Q = 128 if on_gfx950() else 64
+PREFILL_BLOCK_SIZE_Q = 128 if on_mi3xx() else 64
+
+# Prefill scorer split-K. Named apart from the decode scorer, which targets a
+# much smaller grid of its own (see minimax_m3_index_decode).
+PREFILL_SCORE_TARGET_GRID = 4096
+PREFILL_SCORE_MAX_KV_CHUNKS = 32
+# Each chunk re-reads the query tile, so a chunk covering fewer blocks than this
+# spends more on setup than the parallelism it buys back. Divided into
+# max_block, roughly twice the mean causal depth, so the mean chunk is half this.
+PREFILL_SCORE_MIN_BLOCKS_PER_CHUNK = 8
+
+
+def _score_kv_chunks(
+    num_q_blocks: int, batch: int, num_idx_heads: int, max_block: int
+) -> int:
+    """Number of KV chunks the prefill scorer splits each causal scan into.
+
+    The target grid and the per-chunk block floor cap the split. The occupancy
+    floor then overrides both when the unsplit grid cannot fill the device even
+    once, since there is no query-tile reuse to protect there; rounding down to
+    a power of two can still leave it up to half a wave short.
+    """
+    ctas_per_chunk = max(1, num_q_blocks * batch * num_idx_heads)
+    target = min(
+        PREFILL_SCORE_MAX_KV_CHUNKS,
+        max(1, max_block // PREFILL_SCORE_MIN_BLOCKS_PER_CHUNK),
+        max(1, PREFILL_SCORE_TARGET_GRID // ctas_per_chunk),
+    )
+    target = max(
+        target,
+        min(
+            PREFILL_SCORE_MAX_KV_CHUNKS,
+            max_block,
+            triton.cdiv(num_compute_units(), ctas_per_chunk),
+        ),
+    )
+    return 1 << (target.bit_length() - 1)
 
 
 # ---------------------------------------------------------------------------
@@ -863,20 +900,7 @@ def minimax_m3_index_score(
         device=idx_q.device,
     )
     num_q_blocks = triton.cdiv(max_query_len, PREFILL_BLOCK_SIZE_Q)
-    # split-K over seq blocks, capped by the deepest possible scan so short
-    # prefills do not launch chunks that can only early-return.
-    TARGET_GRID = 4096
-    MAX_NUM_KV_CHUNKS = 32
-    score_ctas_per_chunk = num_q_blocks * batch * num_idx_heads
-    target = max(
-        1,
-        min(
-            MAX_NUM_KV_CHUNKS,
-            max_block,
-            TARGET_GRID // max(1, score_ctas_per_chunk),
-        ),
-    )
-    num_kv_chunks = 1 << (target.bit_length() - 1)
+    num_kv_chunks = _score_kv_chunks(num_q_blocks, batch, num_idx_heads, max_block)
     grid_score = (num_q_blocks, batch * num_idx_heads, num_kv_chunks)
     _index_block_score_kernel[grid_score](
         idx_q,

--- a/vllm/models/minimax_m3/amd/ops/index_topk.py
+++ b/vllm/models/minimax_m3/amd/ops/index_topk.py
@@ -14,14 +14,25 @@ disabled (score-only indexer), single shared index head. The selected block ids
 feed the block-sparse attention kernels in ``sparse_attn``.
 """
 
+import functools
+
 import torch
 
 from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx950
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import round_up
 
 # One sparse block == one KV page.
 SPARSE_BLOCK_SIZE = 128
+
+# The fp8 index cache is implemented and measured on gfx950 only.
+SUPPORTED_INDEXER_KV_DTYPES = ("bf16", "fp8", "fp8_e4m3") if on_gfx950() else ("bf16",)
+
+# Query rows per program in the prefill scorer. 128 is swept on gfx950; other
+# archs keep the original 64 until they are (cf. _SPARSE_ATTN_SUB_K in
+# sparse_attn.py). Sets grid dim 0, so it cannot be an autotune key.
+PREFILL_BLOCK_SIZE_Q = 128 if on_gfx950() else 64
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +81,88 @@ def _bitonic_merge(
     return x, ids
 
 
+@triton.jit
+def _topk_pair_max(
+    x, ids, t_dims: tl.constexpr, n_outer: tl.constexpr, n_dims: tl.constexpr
+):
+    """Halve the sort axis, keeping the top 2**t_dims of each pair of runs.
+
+    ``x`` is ``[n_outer, 2**n_dims]``; runs of 2**t_dims must alternate direction
+    (2r ascending, 2r+1 descending) or the pairwise max is not a half-cleaner.
+    ``x`` must also be finite: the halves are gathered by masked sum, so an inf
+    would contaminate its pair through ``inf * 0``.
+    """
+    tl.static_assert(n_outer > 1)
+    shape: tl.constexpr = [n_outer * 2 ** (n_dims - t_dims - 1), 2, 2**t_dims]
+    y = tl.reshape(x, shape)
+    y_idx = tl.reshape(ids, shape)
+    mask = tl.arange(0, 2)[None, :, None]
+    a = tl.sum(y * (1 - mask), 1)
+    b = tl.sum(y * mask, 1)
+    a_idx = tl.sum(y_idx * (1 - mask), 1)
+    b_idx = tl.sum(y_idx * mask, 1)
+    keep_a = a >= b
+    out_x = tl.where(keep_a, a, b)
+    out_idx = tl.where(keep_a, a_idx, b_idx)
+    out_shape: tl.constexpr = [n_outer, 2 ** (n_dims - 1)]
+    return tl.reshape(out_x, out_shape), tl.reshape(out_idx, out_shape)
+
+
+@triton.jit
+def _bitonic_topk(
+    x,
+    ids,
+    t_dims: tl.constexpr,
+    n_outer: tl.constexpr,
+    n_dims: tl.constexpr,
+    desc: tl.constexpr,
+):
+    """Exact top-2**t_dims along the sort axis of an ``[n_outer, 2**n_dims]`` tile.
+
+    ``desc`` orders the survivors; ``_topk_stream_merge`` requires ascending.
+    """
+    tl.static_assert(n_dims >= t_dims)
+    if n_dims == t_dims:
+        # Plain bitonic sort: runs stop one stage short because an order=2 merge
+        # at stage == n_dims would ask for a 2**-1 tile dimension.
+        for j in tl.static_range(1, n_dims):
+            x, ids = _bitonic_merge(x, ids.to(tl.int32), j, 2, n_dims)
+        x, ids = _bitonic_merge(x, ids.to(tl.int32), n_dims, desc, n_dims)
+    else:
+        for j in tl.static_range(1, t_dims + 1):
+            x, ids = _bitonic_merge(x, ids.to(tl.int32), j, 2, n_dims)
+        for lvl in tl.static_range(n_dims - t_dims):
+            x, ids = _topk_pair_max(x, ids, t_dims, n_outer, n_dims - lvl)
+            if n_dims - lvl - 1 > t_dims:
+                x, ids = _bitonic_merge(
+                    x, ids.to(tl.int32), t_dims, 2, n_dims - lvl - 1
+                )
+            else:
+                x, ids = _bitonic_merge(
+                    x, ids.to(tl.int32), t_dims, desc, n_dims - lvl - 1
+                )
+    return x, ids
+
+
+@triton.jit
+def _topk_stream_merge(run_score, run_idx, new_score, new_idx, t_dims: tl.constexpr):
+    """Fold an ascending tile top-k into a descending running top-k.
+
+    ``run_*`` must be descending and ``new_*`` ascending, or the merge is wrong.
+    Carrying 2**t_dims between iterations instead of the whole BLOCK_SIZE_K tile
+    is what this buys: the pass count is unchanged at M3's widths, but halving the
+    live state is worth 4-13% of this kernel at long context.
+    """
+    keep = run_score >= new_score
+    return _bitonic_merge(
+        tl.where(keep, run_score, new_score),
+        tl.where(keep, run_idx, new_idx).to(tl.int32),
+        t_dims,
+        True,
+        t_dims,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Index block-score kernel (paged). score[h, token, block] = max over the
 # 128-token block of (idx_q . index_k), causal-masked. BLOCK_SIZE_K == 128 so
@@ -78,7 +171,10 @@ def _bitonic_merge(
 # since prefill metadata is sliced from mixed batch metadata, seq_lens and prefix_lens
 # might lose pointer alignment, which trigger Triton recompiles. we don't actually
 # need pointer alignment for those tensors anyway because we do scalar load.
-@triton.jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+@triton.jit(
+    do_not_specialize=["num_kv_chunks"],
+    do_not_specialize_on_alignment=["seq_lens", "prefix_lens"],
+)
 def _index_block_score_kernel(
     q_ptr,  # idx_q: [total_q, num_idx_heads, head_dim]
     ik_cache_ptr,  # index-K cache: [num_blocks, 128, head_dim]
@@ -101,9 +197,11 @@ def _index_block_score_kernel(
     stride_bt_b,
     BLOCK_SIZE_Q: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+    num_kv_chunks,
 ):
     pid_q = tl.program_id(0)
     pid_bh = tl.program_id(1)
+    pid_c = tl.program_id(2)
     pid_b = pid_bh // num_idx_heads
     pid_h = pid_bh % num_idx_heads
 
@@ -112,6 +210,17 @@ def _index_block_score_kernel(
     seq_len = tl.load(seq_lens + pid_b)
     prefix_len = tl.load(prefix_lens + pid_b)
     if BLOCK_SIZE_Q * pid_q >= q_len:
+        return
+
+    # Causal window: only blocks up to the last query token's position.
+    hi = min(seq_len, prefix_len + (pid_q + 1) * BLOCK_SIZE_Q)
+    num_blocks = tl.cdiv(hi, BLOCK_SIZE_K)
+    # Block-aligned fixed-count split of this query block's causal scan. Chunks
+    # cover disjoint block ranges, hence disjoint `score` columns.
+    chunk_size_blocks = tl.cdiv(num_blocks, num_kv_chunks)
+    chunk_start_block = pid_c * chunk_size_blocks
+    chunk_end_block = min(chunk_start_block + chunk_size_blocks, num_blocks)
+    if chunk_start_block >= chunk_end_block:
         return
 
     q_ptrs = tl.make_block_ptr(
@@ -130,10 +239,8 @@ def _index_block_score_kernel(
     off_d = tl.arange(0, head_dim)
     # Block table row for this request.
     bt_row = block_table_ptr + pid_b * stride_bt_b
-    # Causal window: only blocks up to the last query token's position.
-    hi = min(seq_len, prefix_len + (pid_q + 1) * BLOCK_SIZE_Q)
-    for i in tl.range(0, hi, BLOCK_SIZE_K):
-        blk = i // BLOCK_SIZE_K
+    for blk in tl.range(chunk_start_block, chunk_end_block):
+        i = blk * BLOCK_SIZE_K
         page = tl.load(bt_row + blk).to(tl.int64)
         pos = i + off_k
         # index-K for this page: [BLOCK_SIZE_D, BLOCK_SIZE_K] (transposed)
@@ -146,7 +253,8 @@ def _index_block_score_kernel(
             + off_k[None, :] * stride_ik_pos
             + off_d[:, None] * stride_ik_d,
         )
-        qk = tl.dot(q, k)
+        # fp32 accumulator: q/k may be e4m3 and the score is a max over 128 products.
+        qk = tl.dot(q, k, out_dtype=tl.float32)
         # apply causal mask as needed
         if q_start < i + BLOCK_SIZE_K:
             qk = tl.where(off_q[:, None] >= pos[None, :], qk, float("-inf"))
@@ -167,20 +275,87 @@ def _index_block_score_kernel(
 # Top-k selection over per-token block scores (layout-agnostic). block_size_q
 # is 1 for M3, so top-k is computed per query token.
 # ---------------------------------------------------------------------------
+# Query tokens per top-k program: wider amortises the selection network but divides
+# the grid. Clamped by TOPK_TILE_AREA, so intermediate widths are also reachable.
+TOPK_QUERY_TILE = 32
+TOPK_QUERY_TILE_SMALL = 8
+
+
+@functools.cache
+def _min_topk_programs() -> int:
+    """Occupancy floor for the wide tile: one program per CU. Queried lazily so
+    importing this module does not initialise the device."""
+    return current_platform.num_compute_units()
+
+
+# Empirical cap on BLOCK_SIZE_Q * BLOCK_SIZE_K: both tiles stay live in registers
+# across the selection network, so the two cannot be chosen independently.
+TOPK_TILE_AREA = 8192
+
+
+def _min_block_size_k(topk: int) -> int:
+    """Narrowest BLOCK_SIZE_K the kernel's ``> BLOCK_SIZE_T`` assert permits."""
+    return 2 * triton.next_power_of_2(topk)
+
+
+def _topk_query_tile(
+    max_query_len: int, batch: int, num_idx_heads: int, topk: int
+) -> int:
+    """Widest tile that fills the device and stays inside ``TOPK_TILE_AREA``."""
+    programs = triton.cdiv(max_query_len, TOPK_QUERY_TILE) * batch * num_idx_heads
+    tile = (
+        TOPK_QUERY_TILE if programs >= _min_topk_programs() else TOPK_QUERY_TILE_SMALL
+    )
+    # Floor of 2: `_topk_pair_max` needs n_outer > 1.
+    return min(tile, max(2, TOPK_TILE_AREA // _min_block_size_k(topk)))
+
+
+def _topk_prune_configs(configs, named_args, **kwargs):
+    """Drop configs the kernel cannot legally or affordably run.
+
+    An illegal config is otherwise scored as infinitely slow and then re-run for
+    real, surfacing a Triton compile assert instead of the ValueError below.
+    """
+    # Triton splits the call across named_args (positional) and kwargs.
+    args = {**named_args, **kwargs}
+    block_t = args["BLOCK_SIZE_T"]
+    block_q = args["BLOCK_SIZE_Q"]
+    legal = [
+        c
+        for c in configs
+        if c.kwargs["BLOCK_SIZE_K"] > block_t
+        and c.kwargs["BLOCK_SIZE_K"] * block_q <= TOPK_TILE_AREA
+    ]
+    if not legal:
+        raise ValueError(
+            f"MiniMax M3 index top-k has no usable config for topk={args['topk']} "
+            f"(BLOCK_SIZE_T={block_t}, BLOCK_SIZE_Q={block_q}): needs "
+            f"{block_t} < BLOCK_SIZE_K <= {TOPK_TILE_AREA // block_q}."
+        )
+    return legal
+
+
 # since prefill metadata is sliced from mixed batch metadata, prefix_lens
 # might lose pointer alignment, which trigger Triton recompiles. we don't actually
 # need pointer alignment for those tensors anyway because we do scalar load.
 @triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_SIZE_K": 2048}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_K": 1024}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_K": 512}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 32}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 32}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_SIZE_K": 64}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=8, num_stages=2),
+        # Not competitive at M3's topk (pruned by TOPK_TILE_AREA) but the only
+        # legal configs once BLOCK_SIZE_T grows; do not delete.
+        triton.Config({"BLOCK_SIZE_K": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 2048}, num_warps=8, num_stages=2),
     ],
-    key=["BLOCK_SIZE_T"],
+    # BLOCK_SIZE_Q is in the key: the tiles want different BLOCK_SIZE_K.
+    key=["BLOCK_SIZE_T", "BLOCK_SIZE_Q"],
+    prune_configs_by={"early_config_prune": _topk_prune_configs},
 )
 @triton.jit(do_not_specialize_on_alignment=["prefix_lens"])
 def _topk_index_kernel(
@@ -202,9 +377,15 @@ def _topk_index_kernel(
     stride_ti_t,
     BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_T: tl.constexpr,
+    BLOCK_SIZE_Q: tl.constexpr,
     MASK_INIT: tl.constexpr,
     MASK_LOCAL: tl.constexpr,
 ):
+    """Top-k blocks for BLOCK_SIZE_Q consecutive query tokens per program.
+
+    The bitonic helpers infer their outer count from ``numel >> n_dims``, so the
+    score tile must stay exactly ``[BLOCK_SIZE_Q, BLOCK_SIZE_K]``.
+    """
     tl.static_assert(BLOCK_SIZE_K > BLOCK_SIZE_T)
     pid_q = tl.program_id(0)
     pid_b = tl.program_id(1)
@@ -213,24 +394,35 @@ def _topk_index_kernel(
     block_start = tl.load(cu_seqblocks_q + pid_b)
     block_num = tl.load(cu_seqblocks_q + pid_b + 1) - block_start
     prefix_len = tl.load(prefix_lens + pid_b)
-    if pid_q >= block_num:
+    if pid_q * BLOCK_SIZE_Q >= block_num:
         return
+    q_ids = pid_q * BLOCK_SIZE_Q + tl.arange(0, BLOCK_SIZE_Q)
+    q_ok = q_ids < block_num
+    # Rows past the end of this request read row 0 and are masked on store.
+    q_pos = tl.where(q_ok, q_ids, 0) * sample_interval
+
     off_k = tl.arange(0, BLOCK_SIZE_K)
     off_t = tl.arange(0, BLOCK_SIZE_T)
+    n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
+    t_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_T)
+
+    valid_blocks = (prefix_len + q_pos + block_size) // block_size
+    vb_max = tl.max(tl.where(q_ok, valid_blocks, 0), axis=0)
+
     s_ptrs = (
         s_ptr
-        + (seq_start + pid_q * sample_interval) * stride_s_n
         + pid_h * stride_s_h
-        + off_k * stride_s_k
+        + (seq_start + q_pos)[:, None] * stride_s_n
+        + off_k[None, :] * stride_s_k
     )
-    topk_score = tl.full((BLOCK_SIZE_K,), -1e30, dtype=tl.float32)
-    topk_idx = tl.full((BLOCK_SIZE_K,), 0, dtype=tl.int32)
-    left_half_mask = tl.arange(0, BLOCK_SIZE_K) < BLOCK_SIZE_K // 2
-    valid_blocks = (prefix_len + pid_q * sample_interval + block_size) // block_size
-    for i in tl.range(0, valid_blocks, BLOCK_SIZE_K):
-        causal_mask = i + off_k < valid_blocks
-        local_mask = i + off_k >= max(0, valid_blocks - local_blocks)
-        init_mask = i + off_k < init_blocks
+    run_score = tl.full((BLOCK_SIZE_Q, BLOCK_SIZE_T), -1e30, dtype=tl.float32)
+    run_idx = tl.full((BLOCK_SIZE_Q, BLOCK_SIZE_T), 0, dtype=tl.int32)
+
+    for i in tl.range(0, vb_max, BLOCK_SIZE_K):
+        blk = i + off_k[None, :]
+        causal_mask = (blk < valid_blocks[:, None]) & q_ok[:, None]
+        local_mask = blk >= tl.maximum(valid_blocks[:, None] - local_blocks, 0)
+        init_mask = blk < init_blocks
         score = tl.load(s_ptrs, mask=causal_mask, other=-1e30).to(tl.float32)
         score = tl.where(score != score, -1e30, score)
         s_ptrs = s_ptrs + stride_s_k * BLOCK_SIZE_K
@@ -242,44 +434,27 @@ def _topk_index_kernel(
             score = tl.where(causal_mask & local_mask, score - 1e28, score)
         else:
             score = tl.where(causal_mask & local_mask, 1e29, score)
-        topk_score, last_topk_score = score, topk_score
-        topk_idx, last_topk_idx = (tl.where(causal_mask, i + off_k + 1, 0), topk_idx)
-        n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
-        for j in tl.static_range(1, n_dims):
-            topk_score, topk_idx = _bitonic_merge(
-                topk_score, topk_idx.to(tl.int32), j, 2, n_dims
-            )
-        if i != 0:
-            topk_score, topk_idx = _bitonic_merge(
-                topk_score, topk_idx.to(tl.int32), n_dims, False, n_dims
-            )
-            topk_score_new = last_topk_score * left_half_mask + topk_score * (
-                1 - left_half_mask
-            )
-            topk_idx_new = last_topk_idx * left_half_mask + topk_idx * (
-                1 - left_half_mask
-            )
-            topk_score, topk_idx = _bitonic_merge(
-                topk_score_new, topk_idx_new.to(tl.int32), n_dims, True, n_dims
-            )
-        else:
-            topk_score, topk_idx = _bitonic_merge(
-                topk_score, topk_idx.to(tl.int32), n_dims, True, n_dims
-            )
-    topk_mask = tl.arange(0, BLOCK_SIZE_K // BLOCK_SIZE_T) == 0
-    topk_idx = tl.sum(
-        topk_mask[:, None]
-        * tl.reshape(topk_idx - 1, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
-        axis=0,
-    )
+        new_score, new_idx = _bitonic_topk(
+            score,
+            tl.where(causal_mask, blk + 1, 0),
+            t_dims,
+            BLOCK_SIZE_Q,
+            n_dims,
+            False,
+        )
+        run_score, run_idx = _topk_stream_merge(
+            run_score, run_idx, new_score, new_idx, t_dims
+        )
+
+    topk_idx = run_idx - 1
     ti_ptrs = (
         ti_ptr
-        + (block_start + pid_q) * stride_ti_n
+        + (block_start + q_ids)[:, None] * stride_ti_n
         + pid_h * stride_ti_h
-        + off_t * stride_ti_t
+        + off_t[None, :] * stride_ti_t
     )
-    store_mask = off_t < topk
-    valid_mask = off_t < valid_blocks
+    store_mask = (off_t[None, :] < topk) & q_ok[:, None]
+    valid_mask = off_t[None, :] < valid_blocks[:, None]
     topk_idx = tl.where(store_mask & valid_mask, topk_idx, -1)
     tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty), mask=store_mask)
 
@@ -291,6 +466,10 @@ def _topk_index_kernel(
 # constants so the grid is fixed within a cuda graph. The score scale is omitted
 # because decode only consumes block ordering.
 # ---------------------------------------------------------------------------
+# Block-loop pipeline depth used only for a 1-byte index cache.
+SCORE_PIPELINE_DEPTH = 3
+
+
 @triton.jit(do_not_specialize=["num_kv_chunks", "decode_query_len"])
 def _decode_index_score_kernel(
     q_ptr,  # idx_q: [total_q, num_idx_heads, head_dim]
@@ -317,6 +496,7 @@ def _decode_index_score_kernel(
     BLOCK_SIZE_Q: tl.constexpr,
     num_kv_chunks,
     USE_PDL: tl.constexpr,
+    SCORE_PIPELINE: tl.constexpr = 1,
 ):
     BLOCK_SIZE_HQ: tl.constexpr = num_idx_heads * BLOCK_SIZE_Q
     pid_r = tl.program_id(0)
@@ -360,7 +540,7 @@ def _decode_index_score_kernel(
         mask=q_mask[None, :],
         other=0.0,
     )  # [D,HQ]
-    for blk in tl.range(chunk_start_block, chunk_end_block):
+    for blk in tl.range(chunk_start_block, chunk_end_block, num_stages=SCORE_PIPELINE):
         page = tl.load(bt_row + blk).to(tl.int64)
         pos = blk * BLOCK_SIZE_K + off_k
         pos_mask = pos[:, None] < kv_len[None, :]
@@ -682,8 +862,22 @@ def minimax_m3_index_score(
         dtype=torch.float32,
         device=idx_q.device,
     )
-    BLOCK_SIZE_Q = 64
-    grid_score = (triton.cdiv(max_query_len, BLOCK_SIZE_Q), batch * num_idx_heads)
+    num_q_blocks = triton.cdiv(max_query_len, PREFILL_BLOCK_SIZE_Q)
+    # split-K over seq blocks, capped by the deepest possible scan so short
+    # prefills do not launch chunks that can only early-return.
+    TARGET_GRID = 4096
+    MAX_NUM_KV_CHUNKS = 32
+    score_ctas_per_chunk = num_q_blocks * batch * num_idx_heads
+    target = max(
+        1,
+        min(
+            MAX_NUM_KV_CHUNKS,
+            max_block,
+            TARGET_GRID // max(1, score_ctas_per_chunk),
+        ),
+    )
+    num_kv_chunks = 1 << (target.bit_length() - 1)
+    grid_score = (num_q_blocks, batch * num_idx_heads, num_kv_chunks)
     _index_block_score_kernel[grid_score](
         idx_q,
         index_kv_cache,
@@ -704,8 +898,9 @@ def minimax_m3_index_score(
         score.stride(1),
         score.stride(2),
         block_table.stride(0),
-        BLOCK_SIZE_Q=BLOCK_SIZE_Q,
+        BLOCK_SIZE_Q=PREFILL_BLOCK_SIZE_Q,
         BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        num_kv_chunks=num_kv_chunks,
     )
     return score
 
@@ -738,8 +933,14 @@ def minimax_m3_index_topk(
             dtype=torch.int32,
             device=score.device,
         )
-    # block_size_q == 1 -> query blocks coincide with query tokens.
-    grid_topk = (max_query_len, batch, num_idx_heads)
+    # The grid divisor and the kernel's BLOCK_SIZE_Q must be the same value, or
+    # tail query rows go unwritten and `sparse_attn` reads stale block ids.
+    query_tile = _topk_query_tile(max_query_len, batch, num_idx_heads, topk)
+    grid_topk = (
+        triton.cdiv(max_query_len, query_tile),
+        batch,
+        num_idx_heads,
+    )
     _topk_index_kernel[grid_topk](
         score,
         topk_idx,
@@ -757,6 +958,7 @@ def minimax_m3_index_topk(
         topk_idx.stride(0),
         topk_idx.stride(1),
         topk_idx.stride(2),
+        BLOCK_SIZE_Q=query_tile,
         MASK_INIT=False,
         MASK_LOCAL=False,
     )
@@ -828,6 +1030,17 @@ def minimax_m3_index_decode(
     )
     num_kv_chunks = 1 << (target.bit_length() - 1)
     grid_score = (seq_lens.shape[0], num_kv_chunks)
+
+    # Deeper pipelining only pays for a 1-byte cache on the single-head,
+    # single-position path. All inputs are shape constants, so the grid is fixed.
+    chunk_blocks = triton.cdiv(max_block, num_kv_chunks)
+    gemv_path = num_idx_heads == 1 and BLOCK_SIZE_Q == 1
+    pipeline_pays = (
+        index_kv_cache.element_size() == 1
+        and gemv_path
+        and chunk_blocks > SCORE_PIPELINE_DEPTH
+    )
+    score_kwargs["SCORE_PIPELINE"] = SCORE_PIPELINE_DEPTH if pipeline_pays else 1
     _decode_index_score_kernel[grid_score](
         idx_q,
         index_kv_cache,

--- a/vllm/models/minimax_m3/amd/ops/index_topk.py
+++ b/vllm/models/minimax_m3/amd/ops/index_topk.py
@@ -27,7 +27,7 @@ from vllm.utils.math_utils import round_up
 SPARSE_BLOCK_SIZE = 128
 
 # The fp8 index cache is implemented and measured on gfx950 only.
-SUPPORTED_INDEXER_KV_DTYPES = ("bf16", "fp8", "fp8_e4m3") if on_gfx950() else ("bf16",)
+TRITON_INDEXER_KV_DTYPES = ("bf16", "fp8", "fp8_e4m3") if on_gfx950() else ("bf16",)
 
 # Query rows per program in the prefill scorer. 128 is swept on gfx950; other
 # archs keep the original 64 until they are (cf. _SPARSE_ATTN_SUB_K in

--- a/vllm/models/minimax_m3/amd/ops/sparse_pa.py
+++ b/vllm/models/minimax_m3/amd/ops/sparse_pa.py
@@ -258,6 +258,8 @@ def _insert_index_cache_kernel(
     CACHE_BLOCK_SIZE: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    FP8_OUT: tl.constexpr,
+    FP8_MAX: tl.constexpr,
 ):
     pid_t = tl.program_id(0)
     offs_d = tl.arange(0, BLOCK_D)
@@ -274,7 +276,11 @@ def _insert_index_cache_kernel(
     )
     mask = (slot >= 0) & (offs_d < HEAD_DIM)
     value = tl.load(src, mask=offs_d < HEAD_DIM, other=0.0)
-    tl.store(dst, value, mask=mask)
+    if FP8_OUT:
+        # e4m3 has no infinity, so an out-of-range convert is undefined; clamp
+        # explicitly, matching the fused CUDA writer.
+        value = tl.clamp(value.to(tl.float32), -FP8_MAX, FP8_MAX)
+    tl.store(dst, value.to(dst.dtype.element_ty), mask=mask)
 
 
 @torch.no_grad()
@@ -296,6 +302,8 @@ def minimax_m3_insert_index_cache(
         raise ValueError("MiniMax-M3 index cache requires contiguous head dimension")
 
     head_dim = index_k.shape[1]
+    fp8_out = index_cache.element_size() == 1
+    fp8_max = torch.finfo(index_cache.dtype).max if fp8_out else 0.0
     _insert_index_cache_kernel[(index_k.shape[0],)](
         index_k,
         index_cache,
@@ -309,6 +317,8 @@ def minimax_m3_insert_index_cache(
         CACHE_BLOCK_SIZE=index_cache.shape[1],
         HEAD_DIM=head_dim,
         BLOCK_D=triton.next_power_of_2(head_dim),
+        FP8_OUT=fp8_out,
+        FP8_MAX=fp8_max,
         num_warps=4,
     )
 

--- a/vllm/models/minimax_m3/amd/ops/sparse_pa.py
+++ b/vllm/models/minimax_m3/amd/ops/sparse_pa.py
@@ -259,6 +259,7 @@ def _insert_index_cache_kernel(
     HEAD_DIM: tl.constexpr,
     BLOCK_D: tl.constexpr,
     FP8_OUT: tl.constexpr,
+    FP8_MIN: tl.constexpr,
     FP8_MAX: tl.constexpr,
 ):
     pid_t = tl.program_id(0)
@@ -279,7 +280,7 @@ def _insert_index_cache_kernel(
     if FP8_OUT:
         # e4m3 has no infinity, so an out-of-range convert is undefined; clamp
         # explicitly, matching the fused CUDA writer.
-        value = tl.clamp(value.to(tl.float32), -FP8_MAX, FP8_MAX)
+        value = tl.clamp(value.to(tl.float32), FP8_MIN, FP8_MAX)
     tl.store(dst, value.to(dst.dtype.element_ty), mask=mask)
 
 
@@ -303,7 +304,10 @@ def minimax_m3_insert_index_cache(
 
     head_dim = index_k.shape[1]
     fp8_out = index_cache.element_size() == 1
-    fp8_max = torch.finfo(index_cache.dtype).max if fp8_out else 0.0
+    # Bounds from the buffer, not the platform: the cache dtype is pinned to
+    # e4m3fn, so a platform-derived range would disagree on fnuz parts.
+    finfo = torch.finfo(index_cache.dtype)
+    fp8_min, fp8_max = (finfo.min, finfo.max) if fp8_out else (0.0, 0.0)
     _insert_index_cache_kernel[(index_k.shape[0],)](
         index_k,
         index_cache,
@@ -318,6 +322,7 @@ def minimax_m3_insert_index_cache(
         HEAD_DIM=head_dim,
         BLOCK_D=triton.next_power_of_2(head_dim),
         FP8_OUT=fp8_out,
+        FP8_MIN=fp8_min,
         FP8_MAX=fp8_max,
         num_warps=4,
     )

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -31,12 +31,14 @@ from vllm.platforms import current_platform
 
 if current_platform.is_rocm():
     from vllm.models.minimax_m3.amd.ops.index_topk import (
+        SUPPORTED_INDEXER_KV_DTYPES,
         minimax_m3_index_decode,
         minimax_m3_index_score,
         minimax_m3_index_topk,
     )
 else:
     from vllm.models.minimax_m3.common.ops.index_topk import (
+        SUPPORTED_INDEXER_KV_DTYPES,
         minimax_m3_index_decode,
         minimax_m3_index_score,
         minimax_m3_index_topk,
@@ -115,6 +117,8 @@ class MiniMaxM3IndexerCache(nn.Module, AttentionLayerBase):
     ) -> None:
         super().__init__()
         if indexer_kv_dtype in ("fp8", "fp8_e4m3"):
+            # e4m3fn specifically: the fused writer checks for Float8_e4m3fn and
+            # saturates at its 448, so an fnuz cache would disagree on range.
             cache_dtype = torch.float8_e4m3fn
         elif indexer_kv_dtype == "bf16":
             cache_dtype = torch.bfloat16
@@ -468,7 +472,7 @@ def select_indexer_impl_cls(
     On Blackwell (SM100) with ``topk_blocks == 16`` (the only width fmha_sm100's
     ``sparse_topk_select`` kernel supports), the fmha_sm100 score + top-k path is
     used for both bf16 and fp8 index caches. Everything else falls back to the
-    Triton indexer (bf16 only).
+    Triton indexer: bf16 anywhere, plus fp8 e4m3 on gfx950.
     """
     if indexer_kv_dtype in ("mxfp4", "nvfp4"):
         raise NotImplementedError(
@@ -496,10 +500,10 @@ def select_indexer_impl_cls(
             indexer_kv_dtype,
         )
         return MiniMaxM3IndexerMSAImpl
-    if indexer_kv_dtype != "bf16":
+    if indexer_kv_dtype not in SUPPORTED_INDEXER_KV_DTYPES:
         raise NotImplementedError(
             f"indexer_kv_dtype={indexer_kv_dtype!r} is not supported by the "
-            "Triton indexer impl."
+            f"Triton indexer impl (supported: {SUPPORTED_INDEXER_KV_DTYPES})."
         )
     logger.info_once(
         "MiniMax M3 indexer: selected Triton (no fmha_sm100) "

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -31,14 +31,14 @@ from vllm.platforms import current_platform
 
 if current_platform.is_rocm():
     from vllm.models.minimax_m3.amd.ops.index_topk import (
-        SUPPORTED_INDEXER_KV_DTYPES,
+        TRITON_INDEXER_KV_DTYPES,
         minimax_m3_index_decode,
         minimax_m3_index_score,
         minimax_m3_index_topk,
     )
 else:
     from vllm.models.minimax_m3.common.ops.index_topk import (
-        SUPPORTED_INDEXER_KV_DTYPES,
+        TRITON_INDEXER_KV_DTYPES,
         minimax_m3_index_decode,
         minimax_m3_index_score,
         minimax_m3_index_topk,
@@ -500,10 +500,10 @@ def select_indexer_impl_cls(
             indexer_kv_dtype,
         )
         return MiniMaxM3IndexerMSAImpl
-    if indexer_kv_dtype not in SUPPORTED_INDEXER_KV_DTYPES:
+    if indexer_kv_dtype not in TRITON_INDEXER_KV_DTYPES:
         raise NotImplementedError(
             f"indexer_kv_dtype={indexer_kv_dtype!r} is not supported by the "
-            f"Triton indexer impl (supported: {SUPPORTED_INDEXER_KV_DTYPES})."
+            f"Triton indexer impl (supported: {TRITON_INDEXER_KV_DTYPES})."
         )
     logger.info_once(
         "MiniMax M3 indexer: selected Triton (no fmha_sm100) "

--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -23,6 +23,9 @@ from vllm.utils.math_utils import round_up
 # One sparse block == one KV page.
 SPARSE_BLOCK_SIZE = 128
 
+# The common Triton kernels read a bf16 index cache only.
+SUPPORTED_INDEXER_KV_DTYPES = ("bf16",)
+
 
 # ---------------------------------------------------------------------------
 # Bitonic top-k helpers (layout-agnostic).

--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -24,7 +24,7 @@ from vllm.utils.math_utils import round_up
 SPARSE_BLOCK_SIZE = 128
 
 # The common Triton kernels read a bf16 index cache only.
-SUPPORTED_INDEXER_KV_DTYPES = ("bf16",)
+TRITON_INDEXER_KV_DTYPES = ("bf16",)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

MiniMax-M3 uses sparse attention. Before attention runs, a small indexer scores every 128 token block against the current query and keeps the best 16, and attention only looks at those. Each call is cheap, but the indexer runs for every token on almost every layer.

Two of its prefill kernels do more work than they need to.

The scorer gives one workgroup the entire causal scan for a query block, so the longest sequence in the batch decides when the launch finishes and the rest sit idle.

The top-k sorts one query token per program. The sorting network costs the same number of passes whether it carries one row or thirty two, so nearly all of that work goes unused.

The decode scorer is different: it is memory bound, re-reading the whole index cache on every launch. That is what the optional fp8 cache addresses.

## Proposed Fix

**Split the prefill scorer over the KV axis.** Each query block's causal scan is cut into fixed, block aligned chunks, so no single program owns the whole scan. The scorer also takes 128 query rows per program instead of 64, sharing the same scan across twice as many rows.

**Carry several query rows per top-k program.** The sorting passes are then shared across a tile instead of one row. A wide tile divides the grid though, so it would starve short prefills: the width is picked on the host from the launch shape, and capped so the score tile and the sort stay small enough to keep registers free. Configs that cannot serve the requested top-k are rejected before launch with a clear error rather than a compile assertion.

The tile also carries only the running best 16 between iterations rather than the full sorted width. Keeping the full sort is bit identical to the baseline but costs 4 to 13 percent at long context, which is why the narrower selection network is here.

**Optionally store the index cache as fp8 e4m3.** This halves the bytes the decode scorer re-reads on every token. The score only decides which blocks attention looks at and the dot product still accumulates in fp32, so narrower keys are tolerable. It is the same configuration NVIDIA's M3 recipe already uses on B200.

The fp8 cache is opt-in behind `--attention-config '{"indexer_kv_dtype": "fp8"}'`, on gfx950 only. The default stays bf16 and both prefill changes apply either way.

## Kernel Benchmarking and E2E Results

Environment: `vllm/vllm-openai-rocm:nightly-6f7df92a8e6cdc74a725b8f10b4d0b48ba2b37ef` on 4x MI350X (gfx950), `amd/MiniMax-M3-MXFP4` at TP=4. Baseline is that same image with only the four touched files reverted.

| context / batch | prefill score | prefill top-k |
|---|---|---|
| 1k / 1 | 1.19x | 0.91x |
| 4k / 1 | 1.79x | 0.98x |
| 8k / 8 | 1.18x | 2.14x |
| 32k / 1 | 1.71x | 2.42x |
| 32k / 4 | 1.30x | 3.35x |
| 60k / 1 | 1.54x | 3.10x |
| 72k / 1 | 1.43x | 3.37x |


End to end benchmarking results comparing the baseline against this PR

| input / conc | tput bf16 | TPOT bf16 | TTFT bf16 | tput fp8 | TPOT fp8 | TTFT fp8 |
|---|---|---|---|---|---|---|
| 8k / 8 | +1.1% | -1.1% | -0.6% | +1.4% | -1.5% | -1.0% |
| 8k / 16 | +0.4% | -0.4% | -0.1% | +2.1% | -2.3% | -0.6% |
| 8k / 32 | +0.7% | -1.2% | +2.3% | +2.1% | -2.9% | +3.8% |
| 32k / 8 | +0.2% | +0.2% | -1.7% | +1.8% | -1.5% | -2.7% |
| 32k / 16 | +0.5% | -0.3% | -1.3% | +3.8% | -4.5% | -1.1% |
| 32k / 32 | +1.1% | -1.4% | +0.2% | +4.8% | -5.6% | -0.2% |
| 72k / 8 | +1.5% | -0.8% | -2.8% | +4.8% | -4.7% | -4.4% |
| 72k / 16 | +2.0% | -2.2% | -1.2% | +6.4% | -7.8% | -1.5% |
| 72k / 32 | +2.1% | -2.2% | -1.8% | +7.4% | -8.3% | -0.9% |

The bf16 gain tracks input length only, where the prefill kernels live. The fp8 gain tracks concurrency too, which is the decode scorer reading half as many bytes per token. 

GSM8K, full 1319 at 8 shot with chat template,

| arm | exact match |
|---|---|
| baseline | 0.9363 |
| this PR, bf16 | 0.9439 |
| this PR, fp8 | 0.9454 |

## Reproduction

<details>
<summary>Serve</summary>

```bash
export HIP_VISIBLE_DEVICES=0,1,2,3
export VLLM_USE_BREAKABLE_CUDAGRAPH=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export SAFETENSORS_FAST_GPU=1

vllm serve amd/MiniMax-M3-MXFP4 \
  --served-model-name minimax-m3 \
  --tensor-parallel-size 4 \
  --distributed-executor-backend mp \
  --trust-remote-code \
  --block-size 128 \
  --no-enable-prefix-caching \
  --language-model-only \
  --max-model-len 133120 \
  --gpu-memory-utilization 0.95 \
  --max-num-batched-tokens 32768 \
  --max-num-seqs 128 \
  --enable-chunked-prefill \
  --async-scheduling \
  --attention-backend ROCM_AITER_UNIFIED_ATTN \
  --moe-backend aiter \
  --kv-cache-dtype fp8 \
  --tool-call-parser minimax_m3 \
  --enable-auto-tool-choice \
  --reasoning-parser minimax_m3 \
  --no-enable-log-requests \
  --port 8000
```

For the fp8 index cache, add `--attention-config '{"indexer_kv_dtype": "fp8"}'`.


</details>

<details>
<summary>GSM8K</summary>

```bash
pip install "lm_eval[api]"

lm_eval --model local-chat-completions \
  --model_args model=minimax-m3,base_url=http://localhost:8000/v1/chat/completions,num_concurrent=32,tokenized_requests=False,max_gen_toks=16384,timeout=3600 \
  --tasks gsm8k --num_fewshot 8 \
  --apply_chat_template --fewshot_as_multiturn \
  --batch_size 32
```

</details>