### PR TITLE
[Spec Decode] Add a static regression guard for DFlash2 decoder_layer_cls

### DIFF
--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -228,3 +228,20 @@ def test_dflash2_model_decoder_layer_cls(monkeypatch):
     # 4. Assert that the layers are DFlash2Qwen3DecoderLayer (the subclass)
     assert len(model.layers) == 2
     assert isinstance(model.layers[0], DFlash2Qwen3DecoderLayer)
+
+
+def test_dflash2_decoder_layer_cls_is_not_hardcoded():
+    """Static tripwire: the shared constructor must go through ``decoder_layer_cls``.
+
+    ``test_dflash2_model_decoder_layer_cls`` above checks the built model. This
+    checks the source, so the exact regression that caused #53428 -- someone
+    re-hardcoding ``DFlashQwen3DecoderLayer`` in the shared constructor, as #52560
+    did -- fails here without needing a model build.
+    """
+    import inspect
+
+    from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
+
+    src = inspect.getsource(DFlashQwen3Model.__init__)
+    assert "self.decoder_layer_cls(" in src
+    assert "DFlashQwen3DecoderLayer(" not in src

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -377,7 +377,9 @@ class DFlashQwen3DecoderLayer(nn.Module):
 
 @support_torch_compile
 class DFlashQwen3Model(nn.Module):
-    decoder_layer_cls = DFlashQwen3DecoderLayer
+    # Subclasses override this to have their own decoder layer built by the shared
+    # constructor below (e.g. DFlash2 adds a local convolution to every layer).
+    decoder_layer_cls: type[nn.Module] = DFlashQwen3DecoderLayer
 
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_substr={


### PR DESCRIPTION
## What changed after rebase

The source fix from this PR landed independently as #53435 (`a9a17e7`) while this was open,
so I rebased onto current `main` and dropped everything that is now redundant. What remains
is the part with no equivalent on `main`.

## The tripwire test

`test_dflash2_model_decoder_layer_cls` (from #53435) builds a model and asserts
`isinstance(model.layers[0], DFlash2Qwen3DecoderLayer)`. This adds a cheap static guard next
to it: it inspects the source of `DFlashQwen3Model.__init__` and asserts the layers are built
through `self.decoder_layer_cls(`, never by naming `DFlashQwen3DecoderLayer` directly.

```python
src = inspect.getsource(DFlashQwen3Model.__init__)
assert "self.decoder_layer_cls(" in src
assert "DFlashQwen3DecoderLayer(" not in src
```

That is the exact regression behind #53428: #52816 introduced the indirection, #52560
re-hardcoded the class, and DFlash2 drafts were silently built from plain DFlash layers until
weight loading failed on `layers.0.attention_conv`. The guard catches a third occurrence
without needing a model build or a GPU.

## Annotation + comment

`decoder_layer_cls` gets a `type[nn.Module]` annotation and a one-line comment saying why the
indirection exists, so the next person editing the constructor sees it.

## Verification

The assertions hold on current `main` and fail on `2f55ef2` (the commit that removed the
indirection).

Original DFlash2 load failure and end-to-end verification on an L40s
(`philbert440/Qwen3.8-27B-W4A16-AWQ` + `z-lab/Qwen3.8-27B-DFlash2`, acceptance length 7.98/8 at
`num_speculative_tokens=7`): #53428. Independent GB10 verification of the merged fix: #53122.

Thanks @jschmied for flagging the overlap.

Related: #53428, #53435
