### PR TITLE
[SpecDecode] Fall back to text-only drafting on encoder cache miss (#38551)

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner_mm_gather.py
+++ b/tests/v1/worker/test_gpu_model_runner_mm_gather.py
@@ -98,3 +98,62 @@ def test_target_path_raises_on_encoder_cache_miss():
     f0 = _feature("h0", offset=0, length=8)
     with pytest.raises(RuntimeError, match="Encoder cache miss"):
         _gather([f0], [], num_scheduled=8, shift=0)
+
+
+def _draft_gather(features, cached, *, num_scheduled, num_computed=0):
+    """Drive _gather_draft_mm_embed_inputs end to end against the real
+    _gather_mm_embeddings, using the same lightweight stub as _gather."""
+    encoder_cache = {
+        f.identifier: torch.arange(
+            f.mm_position.length * HIDDEN, dtype=torch.float32
+        ).reshape(f.mm_position.length, HIDDEN)
+        for f in cached
+    }
+    req_state = SimpleNamespace(num_computed_tokens=num_computed, mm_features=features)
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(req_ids=["req0"]),
+        requests={"req0": req_state},
+        encoder_cache=encoder_cache,
+        _get_encoder_output_from_cache=lambda mm_hash: encoder_cache.get(mm_hash),
+        is_multimodal_pruning_enabled=False,
+        uses_mrope=False,
+    )
+    runner._gather_mm_embeddings = (
+        lambda so, shift_computed_tokens: GPUModelRunner._gather_mm_embeddings(
+            runner, so, shift_computed_tokens=shift_computed_tokens
+        )
+    )
+    scheduler_output = SimpleNamespace(
+        total_num_scheduled_tokens=num_scheduled,
+        num_scheduled_tokens={"req0": num_scheduled},
+    )
+    return GPUModelRunner._gather_draft_mm_embed_inputs(runner, scheduler_output)
+
+
+def test_draft_wrapper_degrades_on_interior_miss():
+    """An evicted entry within the processed range must not kill the engine
+    on the drafter path (vllm-project/vllm#38551): the wrapper degrades to
+    text-only drafting by returning None."""
+    f0 = _feature("h0", offset=0, length=8)  # interior, evicted
+    assert _draft_gather([f0], [], num_scheduled=8) is None
+
+
+def test_draft_wrapper_passes_through_when_cached():
+    f0 = _feature("h0", offset=0, length=8)
+    f1 = _feature("h1", offset=8, length=8)
+    result = _draft_gather([f0, f1], [f0, f1], num_scheduled=8)
+    assert result is not None
+    mm_embeds, is_mm_embed = result
+    assert len(mm_embeds) == 2
+    assert int(is_mm_embed.sum()) == 8
+
+
+def test_draft_wrapper_reraises_unrelated_runtime_errors():
+    def _boom(scheduler_output, shift_computed_tokens):
+        raise RuntimeError("boom")
+
+    runner = SimpleNamespace(_gather_mm_embeddings=_boom)
+    with pytest.raises(RuntimeError, match="boom"):
+        GPUModelRunner._gather_draft_mm_embed_inputs(
+            runner, SimpleNamespace(total_num_scheduled_tokens=0)
+        )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5366,10 +5366,23 @@ class GPUModelRunner(
                         target_hidden_states = hidden_states[:total_num_tokens]
 
             if self.supports_mm_inputs and self.drafter.supports_mm_inputs:
-                mm_embed_inputs = self._gather_mm_embeddings(
-                    scheduler_output,
-                    shift_computed_tokens=1,
-                )
+                try:
+                    mm_embed_inputs = self._gather_mm_embeddings(
+                        scheduler_output,
+                        shift_computed_tokens=1,
+                    )
+                except RuntimeError as e:
+                    if "Encoder cache miss" not in str(e):
+                        raise
+                    # The cache can evict an entry the drafter still needs
+                    # (vllm-project/vllm#38551); unlike the target forward
+                    # pass this is not an invariant violation, because every
+                    # draft is verified by the target model — draft without
+                    # the mm embeddings rather than kill the engine.
+                    logger.warning(
+                        "%s Drafting without mm embeddings for this step.", e
+                    )
+                    mm_embed_inputs = None
             else:
                 mm_embed_inputs = None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3411,6 +3411,29 @@ class GPUModelRunner(
 
         return mm_embeds, is_mm_embed
 
+    def _gather_draft_mm_embed_inputs(
+        self, scheduler_output: "SchedulerOutput"
+    ) -> tuple[list[torch.Tensor], torch.Tensor] | None:
+        """Gather mm embeddings for the drafter, tolerating cache eviction.
+
+        The encoder cache can evict an entry the drafter still needs
+        (vllm-project/vllm#38551); unlike the target forward pass this is not
+        an invariant violation, because every draft is verified by the target
+        model — a missing embedding can only lower acceptance for the step,
+        never correctness. Draft without the mm embeddings rather than kill
+        the engine. Target-pass misses still raise in _gather_mm_embeddings.
+        """
+        try:
+            return self._gather_mm_embeddings(
+                scheduler_output,
+                shift_computed_tokens=1,
+            )
+        except RuntimeError as e:
+            if "Encoder cache miss" not in str(e):
+                raise
+            logger.warning("%s Drafting without mm embeddings for this step.", e)
+            return None
+
     def get_model(self) -> nn.Module:
         if not hasattr(self, "model"):
             raise ValueError("Cannot get model before model has been initialized")
@@ -5366,23 +5389,7 @@ class GPUModelRunner(
                         target_hidden_states = hidden_states[:total_num_tokens]
 
             if self.supports_mm_inputs and self.drafter.supports_mm_inputs:
-                try:
-                    mm_embed_inputs = self._gather_mm_embeddings(
-                        scheduler_output,
-                        shift_computed_tokens=1,
-                    )
-                except RuntimeError as e:
-                    if "Encoder cache miss" not in str(e):
-                        raise
-                    # The cache can evict an entry the drafter still needs
-                    # (vllm-project/vllm#38551); unlike the target forward
-                    # pass this is not an invariant violation, because every
-                    # draft is verified by the target model — draft without
-                    # the mm embeddings rather than kill the engine.
-                    logger.warning(
-                        "%s Drafting without mm embeddings for this step.", e
-                    )
-                    mm_embed_inputs = None
+                mm_embed_inputs = self._gather_draft_mm_embed_inputs(scheduler_output)
             else:
                 mm_embed_inputs = None
 


### PR DESCRIPTION
With MTP + multimodal inputs under sustained load, the encoder cache can evict an entry the draft proposer still needs; `_gather_mm_embeddings` then raises `Encoder cache miss` inside `propose_draft_token_ids` and the whole engine dies, dropping every in-flight request (#38551). Unlike the target forward pass, a miss during *drafting* is not an invariant violation: every draft is verified by the target model, so drafting without the mm embeddings can only lower acceptance for that step, never corrupt output. Catch the miss at the draft call site (target-pass misses still raise), log a warning, and draft without mm embeddings.

Fixes #38551.
