### PR TITLE
[KVConnector][P2P] Configurable unbound-store timeout and one-RTT rejection of a late fetch

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -199,8 +199,30 @@ Block content hashes must match across instances for peers to exchange blocks (s
 | `port` | no | `$VLLM_P2P_SIDE_CHANNEL_PORT` (`5710`) | Base port for the control socket. Must be reachable from peers. The bound port is `base + data_parallel_index` (one socket per DP replica). When omitted, the base resolves from the env var below. |
 | `backends` | no | `["UCX"]` | NIXL transport backends. See [NixlConnector Usage Guide](nixl_connector_usage.md#selecting-a-nixl-transport-backend-plugin) for available backends and selection guidance. |
 | `num_threads` | no | `4` | NIXL agent worker threads. Only used when `backends` is UCX-only; ignored when any non-UCX backend is requested. |
+| `unbound_store_timeout_s` | no | `60` | Seconds a producer holds stored blocks for a consumer that has not fetched them yet. Raise it for deployments whose prefills outlast the default; the blocks keep primary-tier CPU slots pinned for the whole window. Once it expires a late fetch is rejected in a single round trip, so the consumer falls back to local prefill immediately. |
 
 The `backends` and `num_threads` options mirror the conditional logic used by [`NixlConnector`](nixl_connector_usage.md#selecting-a-nixl-transport-backend-plugin): when any non-UCX backend is configured, NIXL is initialised with `backends=...`; otherwise it falls back to a UCX-only agent with the configured `num_threads`. This lets the P2P tier use a different transport (e.g. `MOONCAKE`, `GDS_MT`, `LIBFABRIC`) than the main `NixlConnector` running in the same process.
+
+A producer parks a request's blocks until the consumer's `FetchMsg` arrives; if none arrives
+within `unbound_store_timeout_s` the blocks are released so they stop pinning primary-tier
+slots. Raise it when prefills legitimately take longer than the default:
+
+```bash
+vllm serve <model> \
+  --kv-transfer-config '{
+    "kv_connector": "OffloadingConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "spec_name": "TieringOffloadingSpec",
+      "secondary_tiers": [
+        {
+          "type": "p2p",
+          "unbound_store_timeout_s": 180
+        }
+      ]
+    }
+  }'
+```
 
 #### Environment Variables
 

--- a/tests/v1/kv_offload/tiering/p2p/test_manager.py
+++ b/tests/v1/kv_offload/tiering/p2p/test_manager.py
@@ -112,6 +112,8 @@ def _make_manager() -> P2PSecondaryTierManager:
     mgr._sessions = {}
     mgr._kv_to_session = {}
     mgr._unbound_stores = {}
+    mgr._reaped_stores = {}
+    mgr._unbound_store_timeout_s = _UNBOUND_STORE_TIMEOUT_S
     mgr._failed_serve_ctxs = []
     return mgr
 
@@ -732,9 +734,9 @@ class TestGetFinished:
         assert "req-fresh" in mgr._unbound_stores
 
     def test_unbound_store_reaped_after_timeout(self):
-        """Unbound stores past _UNBOUND_STORE_TIMEOUT_S surface as failed
-        and their kv_request_id lands in _failed_req_ids so a late
-        FetchMsg/lookup doesn't try to satisfy them."""
+        """Unbound stores past the reap deadline surface as failed and their
+        kv_request_id lands in _reaped_stores so a late FetchMsg is rejected
+        instead of parking demand nothing can satisfy."""
         from vllm.v1.kv_offload.tiering.p2p.manager import _UnboundStoreBatch
 
         mgr = self._make()
@@ -752,7 +754,7 @@ class TestGetFinished:
         # 2 baseline + 2 buffered stores
         assert JobResult(job_id=10, success=False) in results
         assert JobResult(job_id=11, success=False) in results
-        assert "req-stale" in mgr._failed_req_ids
+        assert "req-stale" in mgr._reaped_stores
 
     def test_submit_store_parks_unbound_batch(self):
         """submit_store on an unbound id appends a batch with a fresh
@@ -1176,6 +1178,75 @@ class TestBidirectionalManager:
         # B: load job 201 + store job 200
         assert 201 in b_ok, f"B loads succeeded: {b_ok}"
         assert 200 in b_ok, f"B stores succeeded: {b_ok}"
+
+    def test_late_fetch_after_reap_fails_immediately(self):
+        """A fetch for a reaped kv_request_id fails in one round trip.
+
+        The producer drops parked blocks once unbound_store_timeout_s
+        expires. A consumer whose fetch arrives after that must learn on the
+        next tick via TransferDoneMsg(success=False) — not stall for
+        _LOAD_TIMEOUT_S and then take the abort path.
+        """
+        from vllm.v1.kv_offload.tiering.p2p.session.client import _LOAD_TIMEOUT_S
+
+        mgr_a, mgr_b = _build_paired_managers()
+        kv_id = "req-late"
+
+        # Record every message type leaving the consumer, so the assertion
+        # below can prove no abort was ever needed.
+        sent_from_a: list[str] = []
+        drain = mgr_a._control._drain_outbound_to
+
+        def recording_drain(peer_local_id: str):
+            out = drain(peer_local_id)
+            sent_from_a.extend(msg.get("type") for _, msg in out)
+            return out
+
+        mgr_a._control._drain_outbound_to = recording_drain  # type: ignore[method-assign]
+
+        # Producer parks the blocks, then reaps them before any fetch lands.
+        mgr_b.submit_store(
+            _job_metadata(
+                job_id=200,
+                keys=[b"b-block"],
+                block_ids=[0],
+                kv_params={"remote_decoder": {"kv_request_id": kv_id}},
+            )
+        )
+        mgr_b._unbound_store_timeout_s = 0.0
+        reap_results = list(mgr_b.get_finished_jobs())
+        assert JobResult(job_id=200, success=False) in reap_results
+        assert kv_id in mgr_b._reaped_stores
+
+        # Consumer now asks for the blocks that no longer exist.
+        consumer_params = {
+            "remote_prefiller": {
+                "kv_request_id": kv_id,
+                "remote_host": "B",
+                "remote_port": 2,
+            },
+        }
+        mgr_a.on_new_request(_req_context(consumer_params))
+        mgr_a.submit_load(
+            _job_metadata(
+                job_id=101,
+                keys=[b"b-block"],
+                block_ids=[0],
+                kv_params=consumer_params,
+            )
+        )
+
+        started = time.monotonic()
+        all_a: list[JobResult] = []
+        for _ in range(8):
+            all_a.extend(list(mgr_a.get_finished_jobs()))
+            list(mgr_b.get_finished_jobs())
+        elapsed = time.monotonic() - started
+
+        assert JobResult(job_id=101, success=False) in all_a, all_a
+        assert kv_id in mgr_a._failed_req_ids
+        assert "abort_fetch" not in sent_from_a, sent_from_a
+        assert elapsed < _LOAD_TIMEOUT_S
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/v1/kv_offload/tiering/p2p/manager.py
+++ b/vllm/v1/kv_offload/tiering/p2p/manager.py
@@ -48,7 +48,14 @@ logger = init_logger(__name__)
 # prefiller buffering blocks for a decoder that never asks (decoder died,
 # network partition, lost kv_request_id). Must be longer than the per-store
 # deadline so the store-timeout path fires first for individual jobs.
+# Overridable per tier via the ``unbound_store_timeout_s`` config key.
 _UNBOUND_STORE_TIMEOUT_S = 60.0
+
+# How long a reaped kv_request_id is remembered so a fetch that arrives
+# after the reap can be rejected immediately. Must exceed the consumer's
+# load timeout (session.client._LOAD_TIMEOUT_S): past that the consumer has
+# already given up on its own, so there is nobody left to reject.
+_REAPED_ID_RETENTION_S = 60.0
 
 # Time we wait during shutdown for inflight transfers to drain via
 # cancel(mode="wait") before falling back to mode="immediate". Bounded
@@ -207,6 +214,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         port: int | None = None,
         backends: list[str] | None = None,
         num_threads: int = 4,
+        unbound_store_timeout_s: float = _UNBOUND_STORE_TIMEOUT_S,
         **kwargs: Any,
     ) -> None:
         """Initialize the P2P secondary tier manager.
@@ -244,9 +252,24 @@ class P2PSecondaryTierManager(SecondaryTierManager):
             num_threads: NIXL agent worker threads for the UCX-only
                 branch. Ignored when ``backends`` contains a non-UCX
                 entry.
+            unbound_store_timeout_s: Seconds a producer holds stored blocks
+                for a consumer that has not fetched them yet, before
+                ``_reap_unbound_stores`` drops them. Raise it for
+                deployments whose prefills outlast the default; the blocks
+                keep primary-tier slots pinned for the whole window.
             **kwargs: Reserved for future tier-specific options.
+
+        Raises:
+            ValueError: If ``unbound_store_timeout_s`` is not positive.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
+        if unbound_store_timeout_s <= 0:
+            raise ValueError(
+                f"unbound_store_timeout_s must be positive, "
+                f"got {unbound_store_timeout_s}"
+            )
+        self._unbound_store_timeout_s = float(unbound_store_timeout_s)
+
         # Block hashes chain from NONE_HASH (see v1/core/kv_cache_utils.py).
         # Peers whose seeds differ compute different hashes for identical
         # content, so lookups silently miss and no KV crosses the wire. The
@@ -302,8 +325,13 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         # kv_request_id → list of batches submit_store'd before any peer
         # asked for that id. Drained into a session by _on_session_fetch
         # when the corresponding FetchMsg arrives, or surfaced as failures
-        # by _reap_unbound_stores after _UNBOUND_STORE_TIMEOUT_S.
+        # by _reap_unbound_stores after _unbound_store_timeout_s.
         self._unbound_stores: dict[str, list[_UnboundStoreBatch]] = {}
+        # kv_request_id → time its parked batches were reaped. A FetchMsg for
+        # one of these ids can never be served, so _poll_once rejects it on
+        # the spot instead of parking demand until the consumer's own load
+        # timeout. Entries are pruned after _REAPED_ID_RETENTION_S.
+        self._reaped_stores: dict[str, float] = {}
 
         self._finished_jobs: list[JobResult] = []
         # kv_request_ids that hit a transport/session failure; On load lookup()
@@ -382,7 +410,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         kv_transfer_params; if a session has bound the id, finish it. If
         no session has bound the id yet, this is a no-op: parked batches
         in `_unbound_stores` are left in place and cleaned up only by
-        `_reap_unbound_stores` after `_UNBOUND_STORE_TIMEOUT_S`.
+        `_reap_unbound_stores` after `_unbound_store_timeout_s`.
         """
         source = req_context.get_state(P2PSourceInfo)
         dest = req_context.get_state(P2PDestInfo)
@@ -699,13 +727,26 @@ class P2PSecondaryTierManager(SecondaryTierManager):
         """Time out submit_store batches that no peer has ever fetched.
 
         Walks `_unbound_stores` for entries whose oldest batch is older
-        than `_UNBOUND_STORE_TIMEOUT_S`. Drops the kv_request_id, surfaces
-        every batched job as failed, and adds the id to `_failed_req_ids`
-        so a late inbound FetchMsg short-circuits to a clean rejection.
+        than `_unbound_store_timeout_s`. Drops the kv_request_id, surfaces
+        every batched job as failed, and records the id in `_reaped_stores`
+        so a late inbound FetchMsg is rejected in one round trip.
+
+        Also expires `_reaped_stores` entries whose consumer can no longer
+        be waiting, which is why this runs before the empty check below.
         """
+        now = time.monotonic()
+        if self._reaped_stores:
+            retention_deadline = now - _REAPED_ID_RETENTION_S
+            for kid in [
+                kid
+                for kid, reaped_at in self._reaped_stores.items()
+                if reaped_at <= retention_deadline
+            ]:
+                del self._reaped_stores[kid]
+
         if not self._unbound_stores:
             return
-        deadline = time.monotonic() - _UNBOUND_STORE_TIMEOUT_S
+        deadline = now - self._unbound_store_timeout_s
         expired: list[str] | None = None
         for kid, batches in self._unbound_stores.items():
             # Batches are appended in arrival order, so the head is oldest.
@@ -717,7 +758,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
             return
         for kid in expired:
             batches = self._unbound_stores.pop(kid)
-            self._failed_req_ids.add(kid)
+            self._reaped_stores[kid] = now
             for batch in batches:
                 self._finished_jobs.append(
                     JobResult(job_id=batch.job_id, success=False)
@@ -727,7 +768,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
                 "without a fetch — failing %d job(s)",
                 self._local_id,
                 kid,
-                _UNBOUND_STORE_TIMEOUT_S,
+                self._unbound_store_timeout_s,
                 len(batches),
             )
 
@@ -771,6 +812,17 @@ class P2PSecondaryTierManager(SecondaryTierManager):
             # inline in dispatch, so the replayed add_stored_blocks calls
             # match that demand and submit transfers immediately.
             for kv_request_id in result.new_fetch_ids:
+                if kv_request_id in self._reaped_stores:
+                    # This id's blocks were already reaped, so no
+                    # submit_store will ever satisfy the demand on_fetch
+                    # just recorded. Finalize the round now: the peer gets
+                    # TransferDoneMsg(success=False) on this tick and falls
+                    # back to local prefill, instead of parking until its
+                    # own load timeout expires. The id is deliberately left
+                    # unbound so any later submit_store keeps taking the
+                    # unbound path.
+                    session.finish_request(kv_request_id)
+                    continue
                 self._kv_to_session[kv_request_id] = session
                 for batch in self._unbound_stores.pop(kv_request_id, ()):
                     session.add_stored_blocks(
@@ -802,6 +854,7 @@ class P2PSecondaryTierManager(SecondaryTierManager):
                     JobResult(job_id=batch.job_id, success=False)
                 )
         self._unbound_stores.clear()
+        self._reaped_stores.clear()
         self._control.close()
         self._data.close()
 


### PR DESCRIPTION
## Purpose

Fixes the two problems reported in #53128 for the `p2p` secondary offloading tier.

A producer parks a request's stored KV blocks until the consumer's `FetchMsg` binds them to a
session, and reaps them after 60 s so they stop pinning primary-tier CPU slots.

1. **The 60 s ceiling was not configurable.** Deployments whose prefills legitimately run
   longer than that had no recourse. This adds an `unbound_store_timeout_s` tier config key,
   defaulting to the existing 60 s, shaped like the tier's other keys (`host`, `port`,
   `backends`, `num_threads`) — i.e. per-tier, documented, and validated:

   ```bash
   --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_role":"kv_both",
     "kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec",
       "secondary_tiers":[{"type":"p2p","unbound_store_timeout_s":180}]}}'
   ```

2. **A fetch arriving after the reap was never rejected** — this is the user-visible damage.
   `_poll_once` bound the id to the session and `ServerRole` parked demand that no
   `submit_store` could ever satisfy, so the consumer burned its full
   `_LOAD_TIMEOUT_S` (30 s) plus an abort round trip before falling back to local prefill.
   Reaped ids now go into a time-pruned `_reaped_stores` map and `_poll_once` finalizes the
   round on the spot, so the peer receives `TransferDoneMsg(success=False)` on the same tick
   and recomputes immediately. No protocol change and no new session API — this reuses the
   existing `finish_request` → `_finalize_outbound` terminal path.

Where the reap clock starts (first vs. last stored chunk) is deliberately left alone: the
reporter measured only ~6 s of spread when idle and ~13 s under load, which is not what makes
the failure painful.

As a side effect this removes a real leak. The reap path's `self._failed_req_ids.add(kid)` was
documented as making "a late inbound `FetchMsg` short-circuit to a clean rejection", but no
code on the fetch path ever read that set, so the claim never held; and because the producer
request had already run `on_request_finished` (the only `discard` site), the id was never
removed and the set grew for the lifetime of the process.

## Not a duplicate

- **#53235** adds an `unbound_store_timeout_s` knob via an undocumented `kwargs.pop` and
  nothing else. The knob alone leaves the 30 s consumer stall in place, which is the actual
  regression; its PR body also misdescribes the change ("keep it until it is safely
  bound/consumed" — it parameterises the reap, it does not remove it). This PR carries both
  halves of the fix and shapes the knob as documented, validated tier config.
- **#52912** is referenced by the issue but addresses a different area.

## Test plan

```
venv/bin/pytest tests/v1/kv_offload/tiering/p2p/test_manager.py -v   # 69 passed
venv/bin/pytest tests/v1/kv_offload/tiering/p2p/ -v                 # 207 passed
pre-commit run --files vllm/v1/kv_offload/tiering/p2p/manager.py \
  tests/v1/kv_offload/tiering/p2p/test_manager.py \
  docs/features/kv_offloading_usage.md                              # all hooks pass
```

New test `test_late_fetch_after_reap_fails_immediately` asserts the *path*, not just the
outcome: the consumer's load job completes with `success=False`, **no `AbortFetchMsg` ever
crosses the wire** (proving it came from `TransferDoneMsg`, not the timeout-then-abort path),
and elapsed wall clock is far below `_LOAD_TIMEOUT_S`. Verified that the test fails on the
unpatched manager — the consumer gets no result at all within the bounded poll count.

The existing `test_unbound_store_reaped_after_timeout` was updated for the `_failed_req_ids`
→ `_reaped_stores` move.

No model eval: the change affects only failure-path timing and a config default, never
generated output.

## AI assistance

AI assistance (Claude Code) was used to write this change. I reviewed every changed line and
ran the test commands above myself.

Closes #53128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
