### PR TITLE
[Bugfix] Keep grid dims for XD-RoPE models on a prefix-cache hit

### DIFF
--- a/tests/v1/core/test_output.py
+++ b/tests/v1/core/test_output.py
@@ -105,6 +105,24 @@ def _mm_feature_mixed(offset: int, length: int) -> MultiModalFeatureSpec:
     )
 
 
+def test_strip_covered_mm_data_xdrope() -> None:
+    """XD-RoPE models (e.g. HunyuanOCR) compute positions the same way, so a
+    covered item must keep its grid dims: stripping them made the worker index
+    an empty ``image_grid_thw`` and crash the engine on the second request with
+    an identical prompt."""
+    covered = _mm_feature_mixed(offset=0, length=100)
+    uncovered = _mm_feature_mixed(offset=300, length=100)
+
+    stripped = strip_covered_mm_data(
+        [covered, uncovered], num_computed_tokens=250, uses_xdrope=True
+    )
+
+    assert stripped[0].data is not None
+    assert list(stripped[0].data.keys()) == ["image_grid_thw"]
+    assert stripped[1].data is not None
+    assert set(stripped[1].data.keys()) == {"pixel_values", "image_grid_thw"}
+
+
 def test_strip_covered_mm_data_mrope() -> None:
     """For M-RoPE models, covered items keep their keep_on_cpu metadata fields
     (the worker needs them to compute positions); payload fields are dropped."""

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1844,6 +1844,10 @@ class ModelConfig:
         return uses_xdrope_dim(self.hf_config)
 
     @property
+    def uses_xdrope(self) -> bool:
+        return self.uses_xdrope_dim > 0
+
+    @property
     def is_multimodal_model(self) -> bool:
         return self.multimodal_config is not None
 

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -217,12 +217,13 @@ def strip_covered_mm_data(
     mm_features: list[MultiModalFeatureSpec],
     num_computed_tokens: int,
     uses_mrope: bool = False,
+    uses_xdrope: bool = False,
 ) -> list[MultiModalFeatureSpec]:
     """Drop the tensor data of mm items whose placeholder span is fully inside
     a prefix-cache-covered region: no encoder run can be scheduled for them,
-    so the workers never consume the payload fields. M-RoPE models are the
-    exception: the worker computes positions for the whole prompt from the
-    CPU-side metadata fields (e.g. grid dims), so those are kept. The
+    so the workers never consume the payload fields. M-RoPE and XD-RoPE models
+    are the exception: the worker computes positions for the whole prompt from
+    the CPU-side metadata fields (e.g. grid dims), so those are kept. The
     scheduler-side ``Request`` keeps the full features."""
     if not mm_features or num_computed_tokens == 0:
         return mm_features
@@ -234,7 +235,7 @@ def strip_covered_mm_data(
             return f
 
         data = None
-        if uses_mrope:
+        if uses_mrope or uses_xdrope:
             data = MultiModalKwargsItem(
                 {k: elem for k, elem in f.data.items() if elem.field.keep_on_cpu}
             )

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -55,6 +55,7 @@ class NewRequestData:
         block_ids: tuple[list[int], ...],
         prefill_token_ids: list[int] | None = None,
         uses_mrope: bool = False,
+        uses_xdrope: bool = False,
     ) -> "NewRequestData":
         return cls(
             req_id=request.request_id,
@@ -63,6 +64,7 @@ class NewRequestData:
                 request.mm_features,
                 request.num_computed_tokens,
                 uses_mrope=uses_mrope,
+                uses_xdrope=uses_xdrope,
             ),
             sampling_params=request.sampling_params,
             pooling_params=request.pooling_params,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -87,7 +87,7 @@ class Scheduler(SchedulerInterface):
         self.cache_config = vllm_config.cache_config
         self.lora_config = vllm_config.lora_config
         self.model_uses_mrope = vllm_config.model_config.uses_mrope
-        self.model_uses_xdrope = vllm_config.model_config.uses_xdrope_dim > 0
+        self.model_uses_xdrope = vllm_config.model_config.uses_xdrope
         self.kv_cache_config = kv_cache_config
         self.kv_events_config = vllm_config.kv_events_config
         self.parallel_config = vllm_config.parallel_config

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -87,6 +87,7 @@ class Scheduler(SchedulerInterface):
         self.cache_config = vllm_config.cache_config
         self.lora_config = vllm_config.lora_config
         self.model_uses_mrope = vllm_config.model_config.uses_mrope
+        self.model_uses_xdrope = vllm_config.model_config.uses_xdrope_dim > 0
         self.kv_cache_config = kv_cache_config
         self.kv_events_config = vllm_config.kv_events_config
         self.parallel_config = vllm_config.parallel_config
@@ -1223,6 +1224,7 @@ class Scheduler(SchedulerInterface):
                     req_to_new_blocks[req.request_id].get_block_ids(),
                     req._all_token_ids,
                     uses_mrope=self.model_uses_mrope,
+                    uses_xdrope=self.model_uses_xdrope,
                 )
                 for req in scheduled_new_reqs
             ]
@@ -1232,6 +1234,7 @@ class Scheduler(SchedulerInterface):
                     req,
                     req_to_new_blocks[req.request_id].get_block_ids(),
                     uses_mrope=self.model_uses_mrope,
+                    uses_xdrope=self.model_uses_xdrope,
                 )
                 for req in scheduled_new_reqs
             ]


### PR DESCRIPTION
## Purpose

HunyuanOCR (any XD-RoPE model) takes the whole server down on the second request whose prompt hits the prefix cache:

```
File "vllm/v1/worker/gpu_model_runner.py", line 1755, in _init_xdrope_positions
  req_state.xdrope_positions = xdrope_model.get_xdrope_input_positions(...)
File "vllm/model_executor/models/hunyuan_vision.py", line 865, in get_xdrope_input_positions
  t, h, w = image_grid_thw[image_index]
IndexError: list index out of range
```

`EngineCore encountered a fatal error` follows and the API server shuts down, so one bad request ends the process.

### Root cause

`strip_covered_mm_data()` drops the tensor data of multimodal items whose placeholder span is fully inside the prefix-cache-covered region. Its own docstring names the exception:

> M-RoPE models are the exception: the worker computes positions for the whole prompt from the CPU-side metadata fields (e.g. grid dims), so those are kept.

XD-RoPE models compute positions the same way (`get_xdrope_input_positions()` reads `image_grid_thw`), but the scheduler only ever passes `uses_mrope`. So for HunyuanVL the grid dims are stripped, `MultiModalFeatureSpec.gather_kwargs()` skips the feature because its data is `None`, and `image_grid_thw` arrives empty while `prompt_token_ids` still contains the `image_start` token. The loop runs over `image_start_indices` and indexes past the end.

Instrumented `get_xdrope_input_positions()` on two identical requests, printing what actually arrives:

```
XDROPE-DBG starts=1 grids=1 features=1 data_none=0   <- first request, ok
XDROPE-DBG starts=1 grids=0 features=1 data_none=1   <- prefix-cache hit, IndexError
```

`image_grid_thw` is already marked `keep_on_cpu=True` in `hunyuan_vision.py`, so nothing else is needed: the metadata just has to survive the strip.

### Fix

Extend the existing exception to XD-RoPE: `strip_covered_mm_data()` takes `uses_xdrope`, `NewRequestData.from_request()` passes it through, and the scheduler derives it from `model_config.uses_xdrope_dim > 0`.

## Test Plan

**Minimal reproducer** (a blank image is enough, the trigger is the repeated prompt):

```bash
vllm serve tencent/HunyuanOCR --trust-remote-code --max-model-len 16384
python repro.py    # sends the same image+prompt three times
```

```python
import base64, io, json, urllib.request
from PIL import Image
buf = io.BytesIO(); Image.new("RGB", (320, 120), "white").save(buf, "PNG")
b = base64.b64encode(buf.getvalue()).decode()
for i in range(3):
    body = {"model": "tencent/HunyuanOCR", "temperature": 0, "max_tokens": 16,
            "messages": [{"role": "user", "content": [
                {"type": "image_url", "image_url": {"url": "data:image/png;base64," + b}},
                {"type": "text", "text": "What is in the image?"}]}]}
    req = urllib.request.Request("http://127.0.0.1:8000/v1/chat/completions",
                                 json.dumps(body).encode(), {"Content-Type": "application/json"})
    try:
        json.load(urllib.request.urlopen(req, timeout=120)); print(i, "ok")
    except Exception as ex: print(i, type(ex).__name__, str(ex)[:70])
```

Unit test: `tests/v1/core/test_output.py::test_strip_covered_mm_data_xdrope`, mirroring the existing M-RoPE case.

## Test Result

Same image, same commit, `--gpu-memory-utilization 0.10 --max-model-len 16384`, H200:

| | request 0 | request 1 | request 2 |
|---|---|---|---|
| before | ok | HTTP 500, EngineCore dead | connection refused |
| after | ok | ok | ok |

Real workload: reading a document page as 52 separate crops through one server (many crops share a size, so their prompts are token-identical) went from dying on crop 10 to all 52 completing.

`--no-enable-prefix-caching` also avoids the crash, which is what pinned the cause.

## Note on #50429

#50429 fixes a different `IndexError` at the same line (duplicate `image_start` tokens) and is not a fix for this one. Its loop change from `range(len(image_start_indices))` to `range(num_images)` would make this path silently skip the XD-RoPE computation when `num_images == 0` and leave plain `arange` positions for the image tokens, turning a crash into wrong output. Worth landing both: that PR guards the token-count side, this one keeps the grid dims from being stripped in the first place.
