### PR TITLE
[Pooling] Improve BGE-M3 sync pooling throughput by up to 3.13%

### DIFF
--- a/tests/model_executor/layers/test_pooler_methods.py
+++ b/tests/model_executor/layers/test_pooler_methods.py
@@ -127,15 +127,12 @@ def test_build_pooling_cursor_caches_cpu_status() -> None:
 
 
 def test_pooling_params_update_combines_token_id_requirements() -> None:
-    update = PoolingParamsUpdate(requires_token_ids=True) | PoolingParamsUpdate(
-        requires_token_ids_gpu=True
-    )
+    update = PoolingParamsUpdate() | PoolingParamsUpdate(requires_token_ids=True)
     params = PoolingParams(task="embed")
 
     update.apply(params)
 
     assert params.requires_token_ids is True
-    assert params.requires_token_ids_gpu is True
 
 
 # ---------------------------------------------------------------------------
@@ -525,7 +522,6 @@ class TestStepPool:
         pooler = self._make_step_pool()
         update = pooler.get_pooling_updates("token_classify")
         assert update.requires_token_ids is True
-        assert update.requires_token_ids_gpu is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/model_executor/layers/test_pooler_methods.py
+++ b/tests/model_executor/layers/test_pooler_methods.py
@@ -5,9 +5,11 @@
 from dataclasses import dataclass
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 import torch
 
+from vllm.model_executor.layers.pooler import PoolingParamsUpdate
 from vllm.model_executor.layers.pooler.seqwise.methods import (
     CLSPool,
     LastPool,
@@ -99,6 +101,41 @@ def _make_metadata(
         pooling_states=pooling_states,
         pooling_cursor=cursor,
     )
+
+
+def test_build_pooling_cursor_caches_cpu_status() -> None:
+    metadata = PoolingMetadata(
+        prompt_lens=torch.tensor([3, 4, 2], dtype=torch.long),
+        prompt_token_ids=None,
+        prompt_token_ids_cpu=None,
+        pooling_params=[PoolingParams(task="embed") for _ in range(3)],
+        pooling_states=[PoolingStates() for _ in range(3)],
+    )
+    metadata.build_pooling_cursor(
+        np.array([3, 2, 2], dtype=np.int32),
+        seq_lens_cpu=torch.tensor([3, 2, 1], dtype=torch.long),
+        device=_CPU,
+    )
+
+    cursor = metadata.get_pooling_cursor()
+
+    assert cursor.is_partial_prefill() is True
+    assert cursor.get_finished_mask() == [True, False, False]
+    assert cursor[:1].is_partial_prefill() is False
+    assert cursor[1:2].is_partial_prefill() is True
+    assert cursor[1:].get_finished_mask() == [False, False]
+
+
+def test_pooling_params_update_combines_token_id_requirements() -> None:
+    update = PoolingParamsUpdate(requires_token_ids=True) | PoolingParamsUpdate(
+        requires_token_ids_gpu=True
+    )
+    params = PoolingParams(task="embed")
+
+    update.apply(params)
+
+    assert params.requires_token_ids is True
+    assert params.requires_token_ids_gpu is True
 
 
 # ---------------------------------------------------------------------------
@@ -488,6 +525,7 @@ class TestStepPool:
         pooler = self._make_step_pool()
         update = pooler.get_pooling_updates("token_classify")
         assert update.requires_token_ids is True
+        assert update.requires_token_ids_gpu is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/model_executor/layers/test_pooler_methods.py
+++ b/tests/model_executor/layers/test_pooler_methods.py
@@ -54,6 +54,8 @@ def _make_pooling_cursor(
         prompt_lens_cpu=prompt_lens_cpu,
         seq_lens_cpu=seq_lens_cpu,
         num_scheduled_tokens_cpu=num_scheduled_tokens_cpu,
+        partial_prefill=not torch.equal(prompt_lens_cpu, num_scheduled_tokens_cpu),
+        finished_mask=torch.eq(prompt_lens_cpu, seq_lens_cpu).tolist(),
     )
 
 

--- a/tests/models/language/pooling/test_splade_sparse_pooler.py
+++ b/tests/models/language/pooling/test_splade_sparse_pooler.py
@@ -12,9 +12,7 @@ from vllm.model_executor.models.bert import (
     BertMLMHead,
     SPLADESparsePooler,
 )
-from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
-from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.pool.late_interaction_runner import LateInteractionRunner
 from vllm.v1.pool.metadata import PoolingMetadata, PoolingStates
 from vllm.v1.worker.gpu.input_batch import InputBatch
@@ -119,18 +117,72 @@ def test_pooling_runner_gathers_required_token_ids() -> None:
     req_states = MagicMock(spec=RequestState)
     req_states.prompt_len = MagicMock(np=np.array([0, 2, 0, 3], dtype=np.int32))
     metadata = runner._get_pooling_metadata(
-        input_batch, req_states, torch.device(current_platform.device_type)
+        input_batch, req_states, torch.device("cpu")
     )
 
     expected = torch.tensor([[101, 11, 102], [101, 102, 0]])
     assert metadata.prompt_token_ids_cpu is not None
-    assert metadata.prompt_token_ids is not None
-    assert metadata.prompt_token_ids_cpu.is_pinned() == PIN_MEMORY
+    assert metadata.prompt_token_ids is None
+    assert metadata.prompt_token_ids_cpu.is_pinned() is False
     torch.testing.assert_close(
         metadata.prompt_lens, torch.tensor([3, 2], dtype=torch.int32)
     )
     torch.testing.assert_close(metadata.prompt_token_ids_cpu, expected)
+
+
+def test_pooling_runner_gathers_required_gpu_token_ids() -> None:
+    runner = PoolingRunner.__new__(PoolingRunner)
+    pooling_params = PoolingParams(task="embed", requires_token_ids_gpu=True)
+    runner.pooling_params = {1: pooling_params, 3: pooling_params}
+    runner.pooling_states = {1: PoolingStates(), 3: PoolingStates()}
+    runner.prompt_token_ids = {
+        1: torch.tensor([101, 102]),
+        3: torch.tensor([101, 11, 102]),
+    }
+
+    input_batch = MagicMock(spec=InputBatch)
+    input_batch.idx_mapping_np = np.array([3, 1], dtype=np.int32)
+    input_batch.num_reqs = 2
+    req_states = MagicMock(spec=RequestState)
+    req_states.prompt_len = MagicMock(np=np.array([0, 2, 0, 3], dtype=np.int32))
+    metadata = runner._get_pooling_metadata(
+        input_batch, req_states, torch.device("cpu")
+    )
+
+    expected = torch.tensor([[101, 11, 102], [101, 102, 0]])
+    assert metadata.prompt_token_ids_cpu is None
+    assert metadata.prompt_token_ids is not None
     torch.testing.assert_close(metadata.prompt_token_ids.cpu(), expected)
+
+
+def test_pooling_runner_gathers_mixed_required_token_ids() -> None:
+    runner = PoolingRunner.__new__(PoolingRunner)
+    cpu_pooling_params = PoolingParams(task="embed", requires_token_ids=True)
+    gpu_pooling_params = PoolingParams(task="embed", requires_token_ids_gpu=True)
+    runner.pooling_params = {1: cpu_pooling_params, 3: gpu_pooling_params}
+    runner.pooling_states = {1: PoolingStates(), 3: PoolingStates()}
+    runner.prompt_token_ids = {
+        1: torch.tensor([101, 102]),
+        3: torch.tensor([101, 11, 102]),
+    }
+
+    input_batch = MagicMock(spec=InputBatch)
+    input_batch.idx_mapping_np = np.array([1, 3], dtype=np.int32)
+    input_batch.num_reqs = 2
+    req_states = MagicMock(spec=RequestState)
+    req_states.prompt_len = MagicMock(np=np.array([0, 2, 0, 3], dtype=np.int32))
+    metadata = runner._get_pooling_metadata(
+        input_batch, req_states, torch.device("cpu")
+    )
+
+    assert metadata.prompt_token_ids_cpu is not None
+    assert metadata.prompt_token_ids is not None
+    torch.testing.assert_close(
+        metadata.prompt_token_ids_cpu[0], torch.tensor([101, 102, 0])
+    )
+    torch.testing.assert_close(
+        metadata.prompt_token_ids[1].cpu(), torch.tensor([101, 11, 102])
+    )
 
 
 def test_pooling_runner_stores_only_required_token_ids() -> None:
@@ -149,9 +201,16 @@ def test_pooling_runner_stores_only_required_token_ids() -> None:
         PoolingParams(task="embed", requires_token_ids=True),
         [101, 11, 102],
     )
+    runner.add_request(
+        "req-3",
+        3,
+        PoolingParams(task="embed", requires_token_ids_gpu=True),
+        [101, 12, 102],
+    )
 
     assert 1 not in runner.prompt_token_ids
     torch.testing.assert_close(runner.prompt_token_ids[2], torch.tensor([101, 11, 102]))
+    torch.testing.assert_close(runner.prompt_token_ids[3], torch.tensor([101, 12, 102]))
 
 
 def test_pooling_runner_releases_aborted_late_interaction_doc() -> None:

--- a/tests/models/language/pooling/test_splade_sparse_pooler.py
+++ b/tests/models/language/pooling/test_splade_sparse_pooler.py
@@ -130,61 +130,6 @@ def test_pooling_runner_gathers_required_token_ids() -> None:
     torch.testing.assert_close(metadata.prompt_token_ids_cpu, expected)
 
 
-def test_pooling_runner_gathers_required_gpu_token_ids() -> None:
-    runner = PoolingRunner.__new__(PoolingRunner)
-    pooling_params = PoolingParams(task="embed", requires_token_ids_gpu=True)
-    runner.pooling_params = {1: pooling_params, 3: pooling_params}
-    runner.pooling_states = {1: PoolingStates(), 3: PoolingStates()}
-    runner.prompt_token_ids = {
-        1: torch.tensor([101, 102]),
-        3: torch.tensor([101, 11, 102]),
-    }
-
-    input_batch = MagicMock(spec=InputBatch)
-    input_batch.idx_mapping_np = np.array([3, 1], dtype=np.int32)
-    input_batch.num_reqs = 2
-    req_states = MagicMock(spec=RequestState)
-    req_states.prompt_len = MagicMock(np=np.array([0, 2, 0, 3], dtype=np.int32))
-    metadata = runner._get_pooling_metadata(
-        input_batch, req_states, torch.device("cpu")
-    )
-
-    expected = torch.tensor([[101, 11, 102], [101, 102, 0]])
-    assert metadata.prompt_token_ids_cpu is None
-    assert metadata.prompt_token_ids is not None
-    torch.testing.assert_close(metadata.prompt_token_ids.cpu(), expected)
-
-
-def test_pooling_runner_gathers_mixed_required_token_ids() -> None:
-    runner = PoolingRunner.__new__(PoolingRunner)
-    cpu_pooling_params = PoolingParams(task="embed", requires_token_ids=True)
-    gpu_pooling_params = PoolingParams(task="embed", requires_token_ids_gpu=True)
-    runner.pooling_params = {1: cpu_pooling_params, 3: gpu_pooling_params}
-    runner.pooling_states = {1: PoolingStates(), 3: PoolingStates()}
-    runner.prompt_token_ids = {
-        1: torch.tensor([101, 102]),
-        3: torch.tensor([101, 11, 102]),
-    }
-
-    input_batch = MagicMock(spec=InputBatch)
-    input_batch.idx_mapping_np = np.array([1, 3], dtype=np.int32)
-    input_batch.num_reqs = 2
-    req_states = MagicMock(spec=RequestState)
-    req_states.prompt_len = MagicMock(np=np.array([0, 2, 0, 3], dtype=np.int32))
-    metadata = runner._get_pooling_metadata(
-        input_batch, req_states, torch.device("cpu")
-    )
-
-    assert metadata.prompt_token_ids_cpu is not None
-    assert metadata.prompt_token_ids is not None
-    torch.testing.assert_close(
-        metadata.prompt_token_ids_cpu[0], torch.tensor([101, 102, 0])
-    )
-    torch.testing.assert_close(
-        metadata.prompt_token_ids[1].cpu(), torch.tensor([101, 11, 102])
-    )
-
-
 def test_pooling_runner_stores_only_required_token_ids() -> None:
     runner = PoolingRunner.__new__(PoolingRunner)
     runner.model = MagicMock()
@@ -201,16 +146,9 @@ def test_pooling_runner_stores_only_required_token_ids() -> None:
         PoolingParams(task="embed", requires_token_ids=True),
         [101, 11, 102],
     )
-    runner.add_request(
-        "req-3",
-        3,
-        PoolingParams(task="embed", requires_token_ids_gpu=True),
-        [101, 12, 102],
-    )
 
     assert 1 not in runner.prompt_token_ids
     torch.testing.assert_close(runner.prompt_token_ids[2], torch.tensor([101, 11, 102]))
-    torch.testing.assert_close(runner.prompt_token_ids[3], torch.tensor([101, 12, 102]))
 
 
 def test_pooling_runner_releases_aborted_late_interaction_doc() -> None:

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -475,25 +475,14 @@ def test_placeholder_spec_token_ids_written_verbatim():
 
 
 @pytest.mark.parametrize(
-    ("pooling_params", "expect_device_prompt_token_ids", "expect_cpu_prompt_token_ids"),
+    ("pooling_params", "expect_cpu_prompt_token_ids"),
     [
-        ({"task": "classify"}, False, False),
-        ({"task": "classify", "requires_token_ids": True}, False, True),
-        ({"task": "classify", "requires_token_ids_gpu": True}, True, False),
-        (
-            {
-                "task": "classify",
-                "requires_token_ids": True,
-                "requires_token_ids_gpu": True,
-            },
-            True,
-            True,
-        ),
+        ({"task": "classify"}, False),
+        ({"task": "classify", "requires_token_ids": True}, True),
     ],
 )
 def test_pooling_metadata_token_id_buffers(
     pooling_params: dict[str, object],
-    expect_device_prompt_token_ids: bool,
     expect_cpu_prompt_token_ids: bool,
 ):
     from vllm.pooling_params import PoolingParams
@@ -514,13 +503,8 @@ def test_pooling_metadata_token_id_buffers(
     input_batch.refresh_metadata()
 
     metadata = input_batch.get_pooling_metadata()
-    if expect_device_prompt_token_ids:
-        assert input_batch.sampling_metadata.prompt_token_ids is not None
-        assert metadata.prompt_token_ids is not None
-        assert metadata.get_prompt_token_ids()[0].tolist() == req.prompt_token_ids
-    else:
-        assert input_batch.sampling_metadata.prompt_token_ids is None
-        assert metadata.prompt_token_ids is None
+    assert input_batch.sampling_metadata.prompt_token_ids is None
+    assert metadata.prompt_token_ids is None
 
     if expect_cpu_prompt_token_ids:
         assert metadata.prompt_token_ids_cpu is not None

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -478,7 +478,17 @@ def test_placeholder_spec_token_ids_written_verbatim():
     ("pooling_params", "expect_device_prompt_token_ids", "expect_cpu_prompt_token_ids"),
     [
         ({"task": "classify"}, False, False),
-        ({"task": "classify", "requires_token_ids": True}, True, True),
+        ({"task": "classify", "requires_token_ids": True}, False, True),
+        ({"task": "classify", "requires_token_ids_gpu": True}, True, False),
+        (
+            {
+                "task": "classify",
+                "requires_token_ids": True,
+                "requires_token_ids_gpu": True,
+            },
+            True,
+            True,
+        ),
     ],
 )
 def test_pooling_metadata_token_id_buffers(

--- a/vllm/model_executor/layers/pooler/common.py
+++ b/vllm/model_executor/layers/pooler/common.py
@@ -18,15 +18,21 @@ ActivationFn = Callable[[_T], _T]
 @dataclass(frozen=True)
 class PoolingParamsUpdate:
     requires_token_ids: bool = False
-    """Set this flag to enable prompt token IDs for your pooler."""
+    """Set this flag to enable CPU prompt token IDs for your pooler."""
+    requires_token_ids_gpu: bool = False
+    """Set this flag to also enable model-device prompt token IDs."""
 
     def __or__(self, other: "PoolingParamsUpdate") -> "PoolingParamsUpdate":
         return PoolingParamsUpdate(
             requires_token_ids=self.requires_token_ids or other.requires_token_ids,
+            requires_token_ids_gpu=(
+                self.requires_token_ids_gpu or other.requires_token_ids_gpu
+            ),
         )
 
     def apply(self, params: PoolingParams) -> None:
         params.requires_token_ids = self.requires_token_ids
+        params.requires_token_ids_gpu = self.requires_token_ids_gpu
 
 
 __all__ = ["ActivationFn", "ClassifierFn", "ProjectorFn", "PoolingParamsUpdate"]

--- a/vllm/model_executor/layers/pooler/common.py
+++ b/vllm/model_executor/layers/pooler/common.py
@@ -19,20 +19,14 @@ ActivationFn = Callable[[_T], _T]
 class PoolingParamsUpdate:
     requires_token_ids: bool = False
     """Set this flag to enable CPU prompt token IDs for your pooler."""
-    requires_token_ids_gpu: bool = False
-    """Set this flag to also enable model-device prompt token IDs."""
 
     def __or__(self, other: "PoolingParamsUpdate") -> "PoolingParamsUpdate":
         return PoolingParamsUpdate(
             requires_token_ids=self.requires_token_ids or other.requires_token_ids,
-            requires_token_ids_gpu=(
-                self.requires_token_ids_gpu or other.requires_token_ids_gpu
-            ),
         )
 
     def apply(self, params: PoolingParams) -> None:
         params.requires_token_ids = self.requires_token_ids
-        params.requires_token_ids_gpu = self.requires_token_ids_gpu
 
 
 __all__ = ["ActivationFn", "ClassifierFn", "ProjectorFn", "PoolingParamsUpdate"]

--- a/vllm/model_executor/layers/pooler/tokwise/methods.py
+++ b/vllm/model_executor/layers/pooler/tokwise/methods.py
@@ -69,7 +69,7 @@ class AllPool(TokenPoolingMethod):
             return hidden_states_lst
 
         pooling_states = pooling_metadata.pooling_states
-        finished_mask = pooling_cursor.is_finished().tolist()
+        finished_mask = pooling_cursor.get_finished_mask()
 
         # If chunked_prefill is enabled
         # 1. first store the chunked hidden_states in pooling_states.hidden_states_cache

--- a/vllm/model_executor/models/jina.py
+++ b/vllm/model_executor/models/jina.py
@@ -17,7 +17,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import PoolingTask
 from vllm.transformers_utils.repo_utils import get_hf_file_bytes
-from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.pool.metadata import PoolingMetadata
 
 from ..layers.pooler import DispatchPooler
@@ -106,7 +106,7 @@ class JinaForRankingPool(StepPool):
         return {"token_embed"}
 
     def get_pooling_updates(self, task: PoolingTask) -> PoolingParamsUpdate:
-        return PoolingParamsUpdate(requires_token_ids=True, requires_token_ids_gpu=True)
+        return PoolingParamsUpdate(requires_token_ids=True)
 
     def forward(
         self,
@@ -114,27 +114,28 @@ class JinaForRankingPool(StepPool):
         pooling_metadata: PoolingMetadata,
     ) -> list[TokenPoolingMethodOutputItem]:
         pooled_data_lst = super().forward(hidden_states, pooling_metadata)
-        prompt_token_ids = pooling_metadata.get_prompt_token_ids()
+        prompt_token_ids_cpu = pooling_metadata.get_prompt_token_ids_cpu()
 
         embeds_list = list[torch.Tensor | None]()
-        # `torch.where` resolves the match count on the host.
-        with gpu_sync_allowed():
-            for data, token_ids in zip(pooled_data_lst, prompt_token_ids):
-                # for unfinished chunked prefill
-                if data is None:
-                    embeds_list.append(None)
-                else:
-                    doc_match = torch.eq(token_ids, self.doc_token_id)
-                    docs_indexes = torch.where(doc_match)[0]
-                    query_indexes = torch.where(
-                        torch.eq(token_ids, self.query_token_id)
-                    )[0]
+        for data, token_ids_cpu in zip(pooled_data_lst, prompt_token_ids_cpu):
+            # for unfinished chunked prefill
+            if data is None:
+                embeds_list.append(None)
+            else:
+                doc_match = torch.eq(token_ids_cpu, self.doc_token_id)
+                docs_indexes_cpu = torch.where(doc_match)[0]
+                query_indexes_cpu = torch.where(
+                    torch.eq(token_ids_cpu, self.query_token_id)
+                )[0]
 
-                    # The JinaForRanking model concatenates docs first, then query.
-                    # Let's stay consistent with this novel design.
-                    indexes = torch.cat([docs_indexes, query_indexes])
-                    embeds = self.projector(data[indexes])
-                    embeds_list.append(embeds)
+                # The JinaForRanking model concatenates docs first, then query.
+                # Let's stay consistent with this novel design.
+                indexes_cpu = torch.cat([docs_indexes_cpu, query_indexes_cpu])
+                indexes = async_tensor_h2d(
+                    indexes_cpu, device=data.device, dtype=torch.long
+                )
+                embeds = self.projector(data[indexes])
+                embeds_list.append(embeds)
 
         return embeds_list
 

--- a/vllm/model_executor/models/jina.py
+++ b/vllm/model_executor/models/jina.py
@@ -12,6 +12,7 @@ from torch import nn
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.pooler import PoolingParamsUpdate
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import PoolingTask
@@ -103,6 +104,9 @@ class JinaForRankingPool(StepPool):
 
     def get_supported_tasks(self) -> set[PoolingTask]:
         return {"token_embed"}
+
+    def get_pooling_updates(self, task: PoolingTask) -> PoolingParamsUpdate:
+        return PoolingParamsUpdate(requires_token_ids=True, requires_token_ids_gpu=True)
 
     def forward(
         self,

--- a/vllm/pooling_params.py
+++ b/vllm/pooling_params.py
@@ -65,6 +65,7 @@ class PoolingParams(
     ## Internal use only
     task: PoolingTask | None = None
     requires_token_ids: bool = False
+    requires_token_ids_gpu: bool = False
     skip_reading_prefix_cache: bool | None = None
     late_interaction_params: LateInteractionParams | None = None
     extra_kwargs: dict[str, Any] | None = None
@@ -224,6 +225,7 @@ class PoolingParams(
             f"step_tag_id={self.step_tag_id}, "
             f"returned_token_ids={self.returned_token_ids}, "
             f"requires_token_ids={self.requires_token_ids}, "
+            f"requires_token_ids_gpu={self.requires_token_ids_gpu}, "
             f"skip_reading_prefix_cache={self.skip_reading_prefix_cache}, "
             f"late_interaction_params={self.late_interaction_params}, "
             f"extra_kwargs={self.extra_kwargs})"

--- a/vllm/pooling_params.py
+++ b/vllm/pooling_params.py
@@ -65,7 +65,6 @@ class PoolingParams(
     ## Internal use only
     task: PoolingTask | None = None
     requires_token_ids: bool = False
-    requires_token_ids_gpu: bool = False
     skip_reading_prefix_cache: bool | None = None
     late_interaction_params: LateInteractionParams | None = None
     extra_kwargs: dict[str, Any] | None = None
@@ -225,7 +224,6 @@ class PoolingParams(
             f"step_tag_id={self.step_tag_id}, "
             f"returned_token_ids={self.returned_token_ids}, "
             f"requires_token_ids={self.requires_token_ids}, "
-            f"requires_token_ids_gpu={self.requires_token_ids_gpu}, "
             f"skip_reading_prefix_cache={self.skip_reading_prefix_cache}, "
             f"late_interaction_params={self.late_interaction_params}, "
             f"extra_kwargs={self.extra_kwargs})"

--- a/vllm/v1/pool/metadata.py
+++ b/vllm/v1/pool/metadata.py
@@ -17,34 +17,32 @@ class PoolingCursor:
     prompt_lens_cpu: torch.Tensor
     seq_lens_cpu: torch.Tensor
     num_scheduled_tokens_cpu: torch.Tensor
-    partial_prefill: bool | None = None
-    finished_mask: list[bool] | None = None
+    partial_prefill: bool
+    finished_mask: list[bool]
 
     def __getitem__(self, indices: slice) -> "PoolingCursor":
+        prompt_lens_cpu = self.prompt_lens_cpu[indices]
+        seq_lens_cpu = self.seq_lens_cpu[indices]
+        num_scheduled_tokens_cpu = self.num_scheduled_tokens_cpu[indices]
+
         return PoolingCursor(
             first_token_indices_gpu=self.first_token_indices_gpu[indices],
             last_token_indices_gpu=self.last_token_indices_gpu[indices],
-            prompt_lens_cpu=self.prompt_lens_cpu[indices],
-            seq_lens_cpu=self.seq_lens_cpu[indices],
-            num_scheduled_tokens_cpu=self.num_scheduled_tokens_cpu[indices],
-            partial_prefill=False if self.partial_prefill is False else None,
-            finished_mask=None
-            if self.finished_mask is None
-            else self.finished_mask[indices],
+            prompt_lens_cpu=prompt_lens_cpu,
+            seq_lens_cpu=seq_lens_cpu,
+            num_scheduled_tokens_cpu=num_scheduled_tokens_cpu,
+            partial_prefill=not torch.equal(prompt_lens_cpu, num_scheduled_tokens_cpu),
+            finished_mask=torch.eq(prompt_lens_cpu, seq_lens_cpu).tolist(),
         )
 
     def is_partial_prefill(self) -> bool:
-        if self.partial_prefill is not None:
-            return self.partial_prefill
-        return not torch.equal(self.prompt_lens_cpu, self.num_scheduled_tokens_cpu)
+        return self.partial_prefill
 
     def is_finished(self) -> torch.Tensor:
         return self.prompt_lens_cpu == self.seq_lens_cpu
 
     def get_finished_mask(self) -> list[bool]:
-        if self.finished_mask is not None:
-            return self.finished_mask
-        return self.is_finished().tolist()
+        return self.finished_mask
 
 
 class PoolingStates:

--- a/vllm/v1/pool/metadata.py
+++ b/vllm/v1/pool/metadata.py
@@ -17,6 +17,8 @@ class PoolingCursor:
     prompt_lens_cpu: torch.Tensor
     seq_lens_cpu: torch.Tensor
     num_scheduled_tokens_cpu: torch.Tensor
+    partial_prefill: bool | None = None
+    finished_mask: list[bool] | None = None
 
     def __getitem__(self, indices: slice) -> "PoolingCursor":
         return PoolingCursor(
@@ -25,13 +27,24 @@ class PoolingCursor:
             prompt_lens_cpu=self.prompt_lens_cpu[indices],
             seq_lens_cpu=self.seq_lens_cpu[indices],
             num_scheduled_tokens_cpu=self.num_scheduled_tokens_cpu[indices],
+            partial_prefill=False if self.partial_prefill is False else None,
+            finished_mask=None
+            if self.finished_mask is None
+            else self.finished_mask[indices],
         )
 
     def is_partial_prefill(self) -> bool:
-        return not torch.all(self.prompt_lens_cpu == self.num_scheduled_tokens_cpu)
+        if self.partial_prefill is not None:
+            return self.partial_prefill
+        return not torch.equal(self.prompt_lens_cpu, self.num_scheduled_tokens_cpu)
 
     def is_finished(self) -> torch.Tensor:
         return self.prompt_lens_cpu == self.seq_lens_cpu
+
+    def get_finished_mask(self) -> list[bool]:
+        if self.finished_mask is not None:
+            return self.finished_mask
+        return self.is_finished().tolist()
 
 
 class PoolingStates:
@@ -93,7 +106,9 @@ class PoolingMetadata:
         if prompt_token_ids is None:
             raise ValueError(
                 "prompt_token_ids is required but was not set. "
-                "Please set `requires_token_ids=True` in `get_pooling_updates`"
+                "Please set `requires_token_ids=True` for CPU token IDs or "
+                "`requires_token_ids_gpu=True` for model-device token IDs in "
+                "`get_pooling_updates`"
             )
         return [prompt_token_ids[i, :num] for i, num in enumerate(self.prompt_lens)]
 
@@ -130,9 +145,14 @@ class PoolingMetadata:
             )
 
         num_scheduled_tokens_cpu = torch.from_numpy(num_scheduled_tokens_np)
+        prompt_lens_np = prompt_lens.numpy()
+        seq_lens_np = seq_lens_cpu.numpy()
         if query_start_loc_gpu is None:
             cumsum = torch.zeros(
-                n_seq + 1, dtype=torch.int64, pin_memory=PIN_MEMORY, device="cpu"
+                n_seq + 1,
+                dtype=torch.int64,
+                pin_memory=PIN_MEMORY and device.type != "cpu",
+                device="cpu",
             )
             torch.cumsum(num_scheduled_tokens_cpu, dim=0, out=cumsum[1:])
             cumsum = cumsum.to(device, non_blocking=True)
@@ -155,4 +175,6 @@ class PoolingMetadata:
             prompt_lens_cpu=prompt_lens,
             seq_lens_cpu=seq_lens_cpu,
             num_scheduled_tokens_cpu=num_scheduled_tokens_cpu,
+            partial_prefill=not np.array_equal(prompt_lens_np, num_scheduled_tokens_np),
+            finished_mask=np.equal(prompt_lens_np, seq_lens_np).tolist(),
         )

--- a/vllm/v1/pool/metadata.py
+++ b/vllm/v1/pool/metadata.py
@@ -106,9 +106,7 @@ class PoolingMetadata:
         if prompt_token_ids is None:
             raise ValueError(
                 "prompt_token_ids is required but was not set. "
-                "Please set `requires_token_ids=True` for CPU token IDs or "
-                "`requires_token_ids_gpu=True` for model-device token IDs in "
-                "`get_pooling_updates`"
+                "Please set `requires_token_ids=True` in `get_pooling_updates`"
             )
         return [prompt_token_ids[i, :num] for i, num in enumerate(self.prompt_lens)]
 

--- a/vllm/v1/pool/metadata.py
+++ b/vllm/v1/pool/metadata.py
@@ -147,7 +147,7 @@ class PoolingMetadata:
             cumsum = torch.zeros(
                 n_seq + 1,
                 dtype=torch.int64,
-                pin_memory=PIN_MEMORY and device.type != "cpu",
+                pin_memory=PIN_MEMORY,
                 device="cpu",
             )
             torch.cumsum(num_scheduled_tokens_cpu, dim=0, out=cumsum[1:])

--- a/vllm/v1/worker/gpu/pool/pooling_runner.py
+++ b/vllm/v1/worker/gpu/pool/pooling_runner.py
@@ -76,7 +76,7 @@ class PoolingRunner:
         self.late_interaction_runner.register_request(req_id, pooling_params)
         self.pooling_params[req_index] = pooling_params
         self.pooling_states[req_index] = PoolingStates()
-        if pooling_params.requires_token_ids or pooling_params.requires_token_ids_gpu:
+        if pooling_params.requires_token_ids:
             self.prompt_token_ids[req_index] = torch.tensor(
                 prompt_token_ids, dtype=torch.int64
             )
@@ -106,38 +106,23 @@ class PoolingRunner:
             req_states.prompt_len.np[input_batch.idx_mapping_np]
         )
 
-        prompt_token_ids_cpu_staging = None
         prompt_token_ids_cpu = None
-        prompt_token_ids = None
-        needs_token_ids_cpu = any(
-            params.requires_token_ids for params in pooling_params
-        )
-        needs_token_ids_gpu = any(
-            params.requires_token_ids_gpu for params in pooling_params
-        )
-        if needs_token_ids_cpu or needs_token_ids_gpu:
+        if any(params.requires_token_ids for params in pooling_params):
             max_prompt_len = int(prompt_lens.max())
-            prompt_token_ids_cpu_staging = torch.zeros(
+            prompt_token_ids_cpu = torch.zeros(
                 (input_batch.num_reqs, max_prompt_len),
                 dtype=torch.int64,
                 pin_memory=PIN_MEMORY and device.type != "cpu",
             )
             for i, (req_index, params) in enumerate(zip(req_indices, pooling_params)):
-                if not (params.requires_token_ids or params.requires_token_ids_gpu):
+                if not params.requires_token_ids:
                     continue
                 token_ids = self.prompt_token_ids[req_index]
-                prompt_token_ids_cpu_staging[i, : token_ids.numel()] = token_ids
-            if needs_token_ids_cpu:
-                prompt_token_ids_cpu = prompt_token_ids_cpu_staging
-        if needs_token_ids_gpu:
-            assert prompt_token_ids_cpu_staging is not None
-            prompt_token_ids = prompt_token_ids_cpu_staging.to(
-                device, non_blocking=True
-            )
+                prompt_token_ids_cpu[i, : token_ids.numel()] = token_ids
 
         return PoolingMetadata(
             prompt_lens=prompt_lens,
-            prompt_token_ids=prompt_token_ids,
+            prompt_token_ids=None,
             prompt_token_ids_cpu=prompt_token_ids_cpu,
             pooling_params=pooling_params,
             pooling_states=pooling_states,
@@ -187,23 +172,15 @@ class PoolingRunner:
         pooling_params = PoolingParams(task=task)
         pooling_params.verify(self.model_config)
         self.model.pooler.get_pooling_updates(task).apply(pooling_params)
-        prompt_token_ids_cpu_staging = None
         prompt_token_ids_cpu = None
-        prompt_token_ids = None
-        if pooling_params.requires_token_ids or pooling_params.requires_token_ids_gpu:
-            prompt_token_ids_cpu_staging = torch.zeros(
+        if pooling_params.requires_token_ids:
+            prompt_token_ids_cpu = torch.zeros(
                 (num_reqs, int(prompt_lens.max())),
                 dtype=torch.int64,
             )
-            if pooling_params.requires_token_ids:
-                prompt_token_ids_cpu = prompt_token_ids_cpu_staging
-            if pooling_params.requires_token_ids_gpu:
-                prompt_token_ids = prompt_token_ids_cpu_staging.to(
-                    hidden_states.device, non_blocking=True
-                )
         pooling_metadata = PoolingMetadata(
             prompt_lens=prompt_lens,
-            prompt_token_ids=prompt_token_ids,
+            prompt_token_ids=None,
             prompt_token_ids_cpu=prompt_token_ids_cpu,
             pooling_params=[pooling_params] * num_reqs,
             pooling_states=[PoolingStates() for _ in range(num_reqs)],

--- a/vllm/v1/worker/gpu/pool/pooling_runner.py
+++ b/vllm/v1/worker/gpu/pool/pooling_runner.py
@@ -76,7 +76,7 @@ class PoolingRunner:
         self.late_interaction_runner.register_request(req_id, pooling_params)
         self.pooling_params[req_index] = pooling_params
         self.pooling_states[req_index] = PoolingStates()
-        if pooling_params.requires_token_ids:
+        if pooling_params.requires_token_ids or pooling_params.requires_token_ids_gpu:
             self.prompt_token_ids[req_index] = torch.tensor(
                 prompt_token_ids, dtype=torch.int64
             )
@@ -103,24 +103,37 @@ class PoolingRunner:
         pooling_params = [self.pooling_params[i] for i in req_indices]
         pooling_states = [self.pooling_states[i] for i in req_indices]
         prompt_lens = torch.from_numpy(
-            req_states.prompt_len.np[input_batch.idx_mapping_np].copy()
+            req_states.prompt_len.np[input_batch.idx_mapping_np]
         )
 
+        prompt_token_ids_cpu_staging = None
         prompt_token_ids_cpu = None
         prompt_token_ids = None
-        if any(params.requires_token_ids for params in pooling_params):
+        needs_token_ids_cpu = any(
+            params.requires_token_ids for params in pooling_params
+        )
+        needs_token_ids_gpu = any(
+            params.requires_token_ids_gpu for params in pooling_params
+        )
+        if needs_token_ids_cpu or needs_token_ids_gpu:
             max_prompt_len = int(prompt_lens.max())
-            prompt_token_ids_cpu = torch.zeros(
+            prompt_token_ids_cpu_staging = torch.zeros(
                 (input_batch.num_reqs, max_prompt_len),
                 dtype=torch.int64,
-                pin_memory=PIN_MEMORY,
+                pin_memory=PIN_MEMORY and device.type != "cpu",
             )
             for i, (req_index, params) in enumerate(zip(req_indices, pooling_params)):
-                if not params.requires_token_ids:
+                if not (params.requires_token_ids or params.requires_token_ids_gpu):
                     continue
                 token_ids = self.prompt_token_ids[req_index]
-                prompt_token_ids_cpu[i, : token_ids.numel()] = token_ids
-            prompt_token_ids = prompt_token_ids_cpu.to(device, non_blocking=True)
+                prompt_token_ids_cpu_staging[i, : token_ids.numel()] = token_ids
+            if needs_token_ids_cpu:
+                prompt_token_ids_cpu = prompt_token_ids_cpu_staging
+        if needs_token_ids_gpu:
+            assert prompt_token_ids_cpu_staging is not None
+            prompt_token_ids = prompt_token_ids_cpu_staging.to(
+                device, non_blocking=True
+            )
 
         return PoolingMetadata(
             prompt_lens=prompt_lens,
@@ -150,7 +163,7 @@ class PoolingRunner:
             query_start_loc_gpu=input_batch.query_start_loc[: num_reqs + 1],
         )
         pooler_output = self.model.pooler(hidden_states, pooling_metadata)
-        finished_mask = pooling_metadata.get_pooling_cursor().is_finished().tolist()
+        finished_mask = pooling_metadata.get_pooling_cursor().get_finished_mask()
         pooler_output = self.late_interaction_runner.postprocess_pooler_output(
             raw_pooler_output=pooler_output,
             pooling_params=pooling_metadata.pooling_params,
@@ -174,19 +187,24 @@ class PoolingRunner:
         pooling_params = PoolingParams(task=task)
         pooling_params.verify(self.model_config)
         self.model.pooler.get_pooling_updates(task).apply(pooling_params)
+        prompt_token_ids_cpu_staging = None
+        prompt_token_ids_cpu = None
         prompt_token_ids = None
-        if pooling_params.requires_token_ids:
-            prompt_token_ids = torch.zeros(
+        if pooling_params.requires_token_ids or pooling_params.requires_token_ids_gpu:
+            prompt_token_ids_cpu_staging = torch.zeros(
                 (num_reqs, int(prompt_lens.max())),
                 dtype=torch.int64,
-                device=hidden_states.device,
             )
+            if pooling_params.requires_token_ids:
+                prompt_token_ids_cpu = prompt_token_ids_cpu_staging
+            if pooling_params.requires_token_ids_gpu:
+                prompt_token_ids = prompt_token_ids_cpu_staging.to(
+                    hidden_states.device, non_blocking=True
+                )
         pooling_metadata = PoolingMetadata(
             prompt_lens=prompt_lens,
             prompt_token_ids=prompt_token_ids,
-            prompt_token_ids_cpu=None
-            if prompt_token_ids is None
-            else prompt_token_ids.cpu(),
+            prompt_token_ids_cpu=prompt_token_ids_cpu,
             pooling_params=[pooling_params] * num_reqs,
             pooling_states=[PoolingStates() for _ in range(num_reqs)],
         )

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -476,9 +476,7 @@ class InputBatch:
 
             self.pooling_params[req_id] = pooling_params
             self.pooling_states[req_id] = pooling_states
-            self.logits_processing_needs_token_ids[req_index] = (
-                pooling_params.requires_token_ids_gpu
-            )
+            self.logits_processing_needs_token_ids[req_index] = False
         else:
             raise NotImplementedError("Unrecognized request type")
 
@@ -976,15 +974,10 @@ class InputBatch:
         prompt_token_ids_cpu = None
         if any(p.requires_token_ids for p in pooling_params):
             prompt_token_ids_cpu = self._make_prompt_token_ids_cpu_tensor()
-        prompt_token_ids = (
-            self.sampling_metadata.prompt_token_ids
-            if any(p.requires_token_ids_gpu for p in pooling_params)
-            else None
-        )
 
         return PoolingMetadata(
             prompt_lens=self.num_prompt_tokens_cpu_tensor[: self.num_reqs].clone(),
-            prompt_token_ids=prompt_token_ids,
+            prompt_token_ids=None,
             prompt_token_ids_cpu=prompt_token_ids_cpu,
             pooling_params=pooling_params,
             pooling_states=pooling_states,

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -477,7 +477,7 @@ class InputBatch:
             self.pooling_params[req_id] = pooling_params
             self.pooling_states[req_id] = pooling_states
             self.logits_processing_needs_token_ids[req_index] = (
-                pooling_params.requires_token_ids
+                pooling_params.requires_token_ids_gpu
             )
         else:
             raise NotImplementedError("Unrecognized request type")
@@ -890,8 +890,8 @@ class InputBatch:
             not self.no_penalties
             or self.logits_processing_needs_token_ids[:num_reqs].any()
         )
-        # The prompt tokens are used only for applying penalties or
-        # step pooling during the sampling/pooling process.
+        # The device prompt tokens are used only for applying penalties or
+        # pooling methods that explicitly request GPU token IDs.
         # Hence copy these tensors only when there are requests which
         # need penalties/step_pooler to be applied.
         prompt_token_ids_cpu = (
@@ -976,10 +976,15 @@ class InputBatch:
         prompt_token_ids_cpu = None
         if any(p.requires_token_ids for p in pooling_params):
             prompt_token_ids_cpu = self._make_prompt_token_ids_cpu_tensor()
+        prompt_token_ids = (
+            self.sampling_metadata.prompt_token_ids
+            if any(p.requires_token_ids_gpu for p in pooling_params)
+            else None
+        )
 
         return PoolingMetadata(
             prompt_lens=self.num_prompt_tokens_cpu_tensor[: self.num_reqs].clone(),
-            prompt_token_ids=self.sampling_metadata.prompt_token_ids,
+            prompt_token_ids=prompt_token_ids,
             prompt_token_ids_cpu=prompt_token_ids_cpu,
             pooling_params=pooling_params,
             pooling_states=pooling_states,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3550,10 +3550,7 @@ class GPUModelRunner(
             hidden_states=hidden_states, pooling_metadata=pooling_metadata
         )
 
-        finished_mask = [
-            seq_len == prompt_len
-            for seq_len, prompt_len in zip(seq_lens_cpu, pooling_metadata.prompt_lens)
-        ]
+        finished_mask = pooling_metadata.get_pooling_cursor().get_finished_mask()
         raw_pooler_output = self.late_interaction_runner.postprocess_pooler_output(
             raw_pooler_output=raw_pooler_output,
             pooling_params=pooling_metadata.pooling_params,


### PR DESCRIPTION
## Purpose


Improve BGE-M3 and other CPU-token-ID pooling workloads on pooling Model Runner V2 by avoiding unnecessary model-device prompt-token-ID metadata.

Today `requires_token_ids=True` makes MRV2 preserve prompt token IDs for poolers that need token-level postprocessing. BGE-M3's sparse embedding path uses SPLADE, which only needs prompt token IDs on CPU, so copying the full prompt-token-ID batch to GPU adds unnecessary serving overhead.

For Jina/BGE-M3 ranking, doc/query marker indexes are computed from CPU prompt token IDs, and only the final concatenated index tensor is copied to GPU before indexing hidden states. This keeps the implementation aligned with MRV2's no-consistent-batch design while preserving the existing pooling behavior.


## Test

### Accuracy

```bash
CUDA_VISIBLE_DEVICES=1 VLLM_USE_V2_MODEL_RUNNER=1 \
  .venv/bin/python -m pytest \
  tests/models/transformers/test_backend.py::test_pooling -v
```

```text
================== 4 passed, 15 warnings in 139.13s (0:02:19) ==================
```

Ran a dedicated numerical `main` vs branch BGE-M3 accuracy diff with MRV2 enabled.

- Prompt count: `8`
- Prompt SHA256: `fd8c88bf564e8d7261d16beecbebf91233ce02c45ad3734eaaadebbf7d570f01`
- Dense/sparse max-abs tolerance: `5e-4`
- Result: `PASS`

| Output | Compared | Max abs diff | Max relative diff | Result |
|---|---:|---:|---:|---|
| Standard dense embeddings | 8 vectors / 8192 values | 0.000149 | 1.42 | PASS |
| BGE-M3 plugin dense embeddings | 8 vectors / 8192 values | 0.000244 | 1.42 | PASS |
| BGE-M3 plugin sparse embeddings | 8 rows / 110 weights | 0.000488 | 0.0329 | PASS |

Sparse output details:

| Field | Result |
|---|---|
| Sparse token sets | Matched |
| Sparse token text | Matched |
| Nonzero range per row | `[3, 28]` |

The accuracy results are numerically stable within `5e-4` max-abs tolerance

### Perf: Performance Comparisons Results

Each benchmark request contains 32 RuBQ documents. Documents/second is `request_throughput * 32`. Each row below is the median of 3 repetitions, and each repetition completed all 128 requests with 0 failures.

Benchmark client:

```bash
bench_bge() {
  local label="$1"
  local concurrency="$2"

  for repetition in 1 2 3; do
    .venv/bin/vllm bench serve \
      --backend openai-embeddings \
      --base-url "http://127.0.0.1:${PORT}" \
      --endpoint /v1/embeddings \
      --model bge \
      --tokenizer BAAI/bge-m3 \
      --dataset-name custom \
      --dataset-path /tmp/bge-bench/rubq_batches32.jsonl \
      --disable-shuffle \
      --skip-chat-template \
      --num-prompts 128 \
      --num-warmups 4 \
      --request-rate inf \
      --max-concurrency "$concurrency" \
      --percentile-metrics e2el \
      --metric-percentiles 50,99 \
      --disable-tqdm \
      --save-result \
      --result-dir /tmp/bge-bench/results \
      --result-filename "${label}_rep${repetition}.json"
  done
}
```

MRV2 sync server, run once on `origin/main` and once on this branch:

```bash
CUDA_VISIBLE_DEVICES="$GPU" \
VLLM_USE_V2_MODEL_RUNNER=1 \
.venv/bin/vllm serve BAAI/bge-m3 \
  --served-model-name bge \
  --runner pooling \
  --host 127.0.0.1 \
  --port "$PORT" \
  --api-server-count 8 \
  --no-async-scheduling
```
Benchmarked current `main` against this branch on the same NVIDIA H200 GPU, same RuBQ dataset, same server/client commands, and 3 repetitions per configuration.

- Dataset: `mteb/RuBQRetrieval`, first 4096 corpus documents
- Request shape: 128 requests, 32 documents/request
- Metric: documents/second = `request_throughput * 32`
- Main commit: `39eba6ac368133ab4e69a0589fcd53c481dddc44`
- Branch commit: `71b2ce24429a0b821cef7ae55aacb64e0429630d`

| Mode | Concurrency | Main median docs/s | Branch median docs/s | Delta | Main median p50 | Branch median p50 | Main median p99 | Branch median p99 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| MRV2 sync | 16 | 3229.0 | 3330.1 | +3.13% | 144.2 ms | 129.0 ms | 231.2 ms | 264.1 ms |
| MRV2 sync | 32 | 3222.0 | 3249.7 | +0.86% | 264.2 ms | 263.8 ms | 568.8 ms | 633.8 ms |

The primary pooling comparison is the sync server configuration, where this branch improves median throughput by +3.13% at concurrency 16 and ~1% at concurrency 32. 

Per-repetition docs/s:

| Configuration | Main docs/s | Branch docs/s |
|---|---:|---:|
| MRV2 sync c16 | `[2992.6, 3229.0, 3350.4]` | `[3033.5, 3330.1, 3355.0]` |
| MRV2 sync c32 | `[3222.0, 3169.0, 3283.7]` | `[3375.2, 3213.6, 3249.7]` |

Deltas:
sync c16: +3.13%
sync c32: ~1%

## AI assistance disclosure

OpenAI Codex (GPT-5) assisted with finding optimization exploration pathways and drafting the code,. I reviewed every changed line and ran all tests and benchmarks listed above.