### PR TITLE
fix(security): scope multimodal uuid cache keys to prevent cross-client disclosure

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -573,6 +573,17 @@ You can pass pre-computed audio embeddings similar to image embeddings:
 
 When using multi-modal inputs, vLLM normally hashes each media item by content to enable caching across requests. You can optionally pass `multi_modal_uuids` to provide your own stable IDs for each item so caching can reuse work across requests without rehashing the raw content.
 
+!!! warning "UUID uniqueness requirements"
+    Each UUID must be unique per distinct media content.  Generate UUIDs with
+    a high-entropy method such as UUIDv4 or a content hash of the media bytes.
+    Do **not** use predictable values (sequential counters, public URLs, or
+    short strings like `"K"`).
+
+    When media data **is** provided alongside a UUID, vLLM checks whether the
+    UUID was previously stored with different content and rejects the request
+    with HTTP 400 on mismatch.  When media is **omitted** (skip-send), the UUID
+    is trusted as-is, so its uniqueness is the caller's responsibility.
+
 ??? code
 
     ```python

--- a/tests/multimodal/test_cache.py
+++ b/tests/multimodal/test_cache.py
@@ -684,6 +684,95 @@ def test_processor_cache_shared_across_loras():
     assert feature_lora_b.data == item_data
 
 
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "cache_cls",
+    [
+        MultiModalProcessorOnlyCache,
+        MultiModalProcessorSenderCache,
+    ],
+)
+def test_content_hash_stored_on_insert(cache_cls):
+    """Inserting an item with a content fingerprint must make it retrievable."""
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = cache_cls(model_config)  # type: ignore[arg-type]
+
+    mm_hash = "uuid-derived-key"
+    item = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item, []), mm_hash)
+    cache.store_content_hash(mm_hash, "fp-abc123")
+
+    assert cache.get_content_hash(mm_hash) == "fp-abc123"
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "cache_cls",
+    [
+        MultiModalProcessorOnlyCache,
+        MultiModalProcessorSenderCache,
+    ],
+)
+def test_content_hash_none_when_not_stored(cache_cls):
+    """When no fingerprint was stored the getter must return None."""
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = cache_cls(model_config)  # type: ignore[arg-type]
+
+    mm_hash = "uuid-derived-key"
+    item = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item, []), mm_hash)
+
+    assert cache.get_content_hash(mm_hash) is None
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "cache_cls",
+    [
+        MultiModalProcessorOnlyCache,
+        MultiModalProcessorSenderCache,
+    ],
+)
+def test_content_hash_survives_touch(cache_cls):
+    """Touching a cached item must not drop its content fingerprint."""
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = cache_cls(model_config)  # type: ignore[arg-type]
+
+    mm_hash = "uuid-key"
+    item = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item, []), mm_hash)
+    cache.store_content_hash(mm_hash, "fp-xyz")
+    cache.touch_sender_cache_item(mm_hash)
+
+    assert cache.get_content_hash(mm_hash) == "fp-xyz"
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "cache_cls",
+    [
+        MultiModalProcessorOnlyCache,
+        MultiModalProcessorSenderCache,
+    ],
+)
+def test_content_hash_cleared_on_clear(cache_cls):
+    """clear_cache must drop content fingerprints along with items."""
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = cache_cls(model_config)  # type: ignore[arg-type]
+
+    mm_hash = "uuid-key"
+    item = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item, []), mm_hash)
+    cache.store_content_hash(mm_hash, "fp-xyz")
+    cache.clear_cache()
+
+    assert cache.get_content_hash(mm_hash) is None
+
+
 _SLEEP_VISION_PROMPT = (
     "<|im_start|>system\nYou are a helpful assistant.<|im_end|>"
     "\n<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"

--- a/tests/renderers/test_process_multi_modal_uuids.py
+++ b/tests/renderers/test_process_multi_modal_uuids.py
@@ -176,6 +176,366 @@ def test_multi_modal_uuids_accepts_empty(
     assert processed_mm_uuids == mm_uuids
 
 
+class _FakeDataItems:
+    """Minimal stub satisfying ModalityDataItems for hash testing."""
+
+    def __init__(self, items: list[object]):
+        self._items = items
+
+    def get_all_items_for_hash(self) -> list[object]:
+        return self._items
+
+    def get_count(self) -> int:
+        return len(self._items)
+
+
+class _FakeMultiModalDataItems(dict):
+    """Minimal stub satisfying MultiModalDataItems for hash testing."""
+
+    def items(self):
+        return super().items()
+
+
+def test_uuid_hash_scoped_by_model_id():
+    """Same uuid on different model_ids must produce different hashes."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    mm_data_items = _FakeMultiModalDataItems(
+        {"image": _FakeDataItems([b"placeholder"])}
+    )
+    mm_uuid_items = {"image": ["shared-uuid-value"]}
+
+    inputs = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=mm_data_items,
+        mm_uuid_items=mm_uuid_items,
+    )
+
+    hash_a = inputs.get_mm_hashes("model-A", "blake3")
+    hash_b = inputs.get_mm_hashes("model-B", "blake3")
+
+    assert hash_a["image"][0] != hash_b["image"][0]
+
+
+def test_uuid_hash_domain_separated_from_content_hash():
+    """A uuid-derived hash must differ from a content-derived hash,
+    even if the uuid string happens to match what content hashing
+    would produce."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    model_id = "test-model"
+    image_bytes = b"some image content"
+
+    # Request with uuid
+    inputs_with_uuid = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=_FakeMultiModalDataItems(
+            {"image": _FakeDataItems([image_bytes])}
+        ),
+        mm_uuid_items={"image": ["my-uuid"]},
+    )
+
+    # Request without uuid (content-hashed)
+    inputs_without_uuid = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=_FakeMultiModalDataItems(
+            {"image": _FakeDataItems([image_bytes])}
+        ),
+        mm_uuid_items=None,
+    )
+
+    hash_uuid = inputs_with_uuid.get_mm_hashes(model_id, "blake3")
+    hash_content = inputs_without_uuid.get_mm_hashes(model_id, "blake3")
+
+    assert hash_uuid["image"][0] != hash_content["image"][0]
+
+
+def test_uuid_hash_deterministic_for_same_inputs():
+    """Same uuid + same model_id must produce the same hash (caching works)."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    model_id = "test-model"
+    uuid_value = "stable-uuid"
+
+    inputs1 = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([b"img1"])}),
+        mm_uuid_items={"image": [uuid_value]},
+    )
+
+    inputs2 = ProcessorInputs(
+        prompt=[4, 5, 6],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([b"img2"])}),
+        mm_uuid_items={"image": [uuid_value]},
+    )
+
+    hash1 = inputs1.get_mm_hashes(model_id, "blake3")
+    hash2 = inputs2.get_mm_hashes(model_id, "blake3")
+
+    assert hash1["image"][0] == hash2["image"][0]
+
+
+def test_uuid_hash_not_raw_uuid_string():
+    """The cache key must not be the raw uuid string itself."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    uuid_value = "user-chosen-uuid"
+
+    inputs = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([b"img"])}),
+        mm_uuid_items={"image": [uuid_value]},
+    )
+
+    hashes = inputs.get_mm_hashes("test-model", "blake3")
+
+    assert hashes["image"][0] != uuid_value
+
+
+def test_content_fingerprint_present_when_uuid_and_data():
+    """When both uuid and media are provided, get_content_fingerprints
+    must return a non-None fingerprint for that item."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    inputs = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=_FakeMultiModalDataItems(
+            {"image": _FakeDataItems([b"some-image-bytes"])}
+        ),
+        mm_uuid_items={"image": ["my-uuid"]},
+    )
+
+    fps = inputs.get_content_fingerprints("test-model", "blake3")
+
+    assert fps["image"][0] is not None
+
+
+def test_content_fingerprint_none_for_skip_send():
+    """When media is None (skip-send), fingerprint must be None."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    inputs = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([None])}),
+        mm_uuid_items={"image": ["my-uuid"]},
+    )
+
+    fps = inputs.get_content_fingerprints("test-model", "blake3")
+
+    assert fps["image"][0] is None
+
+
+def test_content_fingerprint_none_without_uuid():
+    """When no uuid is set, fingerprint must be None (content-hashed path)."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    inputs = ProcessorInputs(
+        prompt=[1, 2, 3],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([b"img"])}),
+        mm_uuid_items=None,
+    )
+
+    fps = inputs.get_content_fingerprints("test-model", "blake3")
+
+    assert fps["image"][0] is None
+
+
+def test_content_fingerprint_differs_for_different_content():
+    """Same uuid with different media bytes must yield different fingerprints."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    model_id = "test-model"
+
+    inputs_a = ProcessorInputs(
+        prompt=[1],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([b"image-A"])}),
+        mm_uuid_items={"image": ["shared-uuid"]},
+    )
+    inputs_b = ProcessorInputs(
+        prompt=[1],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([b"image-B"])}),
+        mm_uuid_items={"image": ["shared-uuid"]},
+    )
+
+    fp_a = inputs_a.get_content_fingerprints(model_id, "blake3")
+    fp_b = inputs_b.get_content_fingerprints(model_id, "blake3")
+
+    assert fp_a["image"][0] != fp_b["image"][0]
+
+
+def test_content_fingerprint_same_for_same_content():
+    """Same content must always produce the same fingerprint."""
+    from vllm.multimodal.processing.inputs import ProcessorInputs
+
+    model_id = "test-model"
+    content = b"identical-image"
+
+    inputs1 = ProcessorInputs(
+        prompt=[1],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([content])}),
+        mm_uuid_items={"image": ["uuid-1"]},
+    )
+    inputs2 = ProcessorInputs(
+        prompt=[2],
+        mm_data_items=_FakeMultiModalDataItems({"image": _FakeDataItems([content])}),
+        mm_uuid_items={"image": ["uuid-2"]},
+    )
+
+    fp1 = inputs1.get_content_fingerprints(model_id, "blake3")
+    fp2 = inputs2.get_content_fingerprints(model_id, "blake3")
+
+    assert fp1["image"][0] == fp2["image"][0]
+
+
+def _run_collision_check(cache, mm_hashes, mm_data_items, mm_fingerprints):
+    """Run the collision-check portion of _get_cache_missing_items
+    without needing a full processor instance."""
+    mm_is_cached = {
+        modality: cache.is_cached(hashes) for modality, hashes in mm_hashes.items()
+    }
+
+    if mm_fingerprints is not None:
+        for modality, hashes in mm_hashes.items():
+            cached_flags = mm_is_cached[modality]
+            fps = mm_fingerprints.get(modality, [])
+            for idx, (is_cached, mm_hash) in enumerate(zip(cached_flags, hashes)):
+                if not is_cached:
+                    continue
+                fp = fps[idx] if idx < len(fps) else None
+                if fp is None:
+                    continue
+                stored = cache.get_content_hash(mm_hash)
+                if stored is not None and stored != fp:
+                    raise ValueError(
+                        f"Multimodal uuid collision for {modality} at "
+                        f"index {idx}: the same uuid was previously "
+                        f"used with different media content."
+                    )
+
+    return mm_is_cached
+
+
+def test_uuid_collision_rejected_by_cache():
+    """When a uuid hits the cache but the content fingerprint differs,
+    the collision check must raise ValueError."""
+    from vllm.multimodal.cache import MultiModalProcessorOnlyCache
+
+    from ..multimodal.test_cache import _StubModelConfig
+
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = MultiModalProcessorOnlyCache(model_config)  # type: ignore[arg-type]
+
+    from vllm.multimodal.inputs import MultiModalKwargsItem
+
+    mm_hash = "uuid-key"
+    item = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item, []), mm_hash)
+    cache.store_content_hash(mm_hash, "fp-original")
+
+    mm_hashes = {"image": [mm_hash]}
+    mm_fingerprints = {"image": ["fp-different"]}
+
+    mm_data_items = _FakeMultiModalDataItems(
+        {"image": _FakeDataItems([b"different-image"])}
+    )
+
+    with pytest.raises(ValueError, match="uuid collision"):
+        _run_collision_check(cache, mm_hashes, mm_data_items, mm_fingerprints)
+
+
+def test_uuid_cache_hit_with_matching_fingerprint():
+    """When the content fingerprint matches, a uuid cache hit must succeed."""
+    from vllm.multimodal.cache import MultiModalProcessorOnlyCache
+
+    from ..multimodal.test_cache import _StubModelConfig
+
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = MultiModalProcessorOnlyCache(model_config)  # type: ignore[arg-type]
+
+    from vllm.multimodal.inputs import MultiModalKwargsItem
+
+    mm_hash = "uuid-key"
+    item = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item, []), mm_hash)
+    cache.store_content_hash(mm_hash, "fp-same")
+
+    mm_hashes = {"image": [mm_hash]}
+    mm_fingerprints = {"image": ["fp-same"]}
+
+    mm_data_items = _FakeMultiModalDataItems({"image": _FakeDataItems([b"same-image"])})
+
+    mm_is_cached = _run_collision_check(
+        cache, mm_hashes, mm_data_items, mm_fingerprints
+    )
+
+    assert mm_is_cached["image"][0] is True
+
+
+def test_uuid_skip_send_no_collision_check():
+    """Skip-send (data=None, fingerprint=None) must not trigger collision
+    even when a content hash was stored previously."""
+    from vllm.multimodal.cache import MultiModalProcessorOnlyCache
+
+    from ..multimodal.test_cache import _StubModelConfig
+
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = MultiModalProcessorOnlyCache(model_config)  # type: ignore[arg-type]
+
+    from vllm.multimodal.inputs import MultiModalKwargsItem
+
+    mm_hash = "uuid-key"
+    item = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item, []), mm_hash)
+    cache.store_content_hash(mm_hash, "fp-original")
+
+    mm_hashes = {"image": [mm_hash]}
+    mm_fingerprints = {"image": [None]}
+
+    mm_data_items = _FakeMultiModalDataItems({"image": _FakeDataItems([None])})
+
+    mm_is_cached = _run_collision_check(
+        cache, mm_hashes, mm_data_items, mm_fingerprints
+    )
+
+    assert mm_is_cached["image"][0] is True
+
+
+def test_different_uuids_do_not_interact():
+    """Two different uuids with different content must not collide."""
+    from vllm.multimodal.cache import MultiModalProcessorOnlyCache
+
+    from ..multimodal.test_cache import _StubModelConfig
+
+    model_config = _StubModelConfig(mm_processor_cache_gb=1)
+    cache = MultiModalProcessorOnlyCache(model_config)  # type: ignore[arg-type]
+
+    from vllm.multimodal.inputs import MultiModalKwargsItem
+
+    item_a = MultiModalKwargsItem.dummy(nbytes=64)
+    item_b = MultiModalKwargsItem.dummy(nbytes=64)
+
+    cache.get_and_update_item((item_a, []), "uuid-A")
+    cache.store_content_hash("uuid-A", "fp-A")
+    cache.get_and_update_item((item_b, []), "uuid-B")
+    cache.store_content_hash("uuid-B", "fp-B")
+
+    mm_hashes = {"image": ["uuid-A", "uuid-B"]}
+    mm_fingerprints = {"image": ["fp-A", "fp-B"]}
+
+    mm_data_items = _FakeMultiModalDataItems(
+        {"image": _FakeDataItems([b"img-A", b"img-B"])}
+    )
+
+    mm_is_cached = _run_collision_check(
+        cache, mm_hashes, mm_data_items, mm_fingerprints
+    )
+
+    assert mm_is_cached["image"] == [True, True]
+
+
 def test_multi_modal_uuids_ignored_when_caching_disabled():
     # When both processor cache is 0 and prefix caching disabled, the
     # processor builds overrides from request id instead of using user UUIDs.

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -157,8 +157,10 @@ class ChatCompletionContentPartImageEmbedsParam(TypedDict, total=False):
     """The type of the content part."""
     uuid: str | None
     """
-    User-provided UUID of a media. User must guarantee that it is properly
-    generated and unique for different medias.
+    User-provided UUID of a media used as the cache identity.  Must be
+    generated with a high-entropy method (e.g. UUIDv4 or a content hash)
+    and unique per distinct media content.  Reusing a UUID with different
+    media when the original is still cached will be rejected.
     """
 
 
@@ -173,8 +175,10 @@ class ChatCompletionContentPartAudioEmbedsParam(TypedDict, total=False):
     """The type of the content part."""
     uuid: str | None
     """
-    User-provided UUID of a media. User must guarantee that it is properly
-    generated and unique for different medias.
+    User-provided UUID of a media used as the cache identity.  Must be
+    generated with a high-entropy method (e.g. UUIDv4 or a content hash)
+    and unique per distinct media content.  Reusing a UUID with different
+    media when the original is still cached will be rejected.
     """
 
 
@@ -224,8 +228,10 @@ class CustomChatCompletionContentPILImageParam(TypedDict, total=False):
     image_pil: PILImage | None
     uuid: str | None
     """
-    User-provided UUID of a media. User must guarantee that it is properly
-    generated and unique for different medias.
+    User-provided UUID of a media used as the cache identity.  Must be
+    generated with a high-entropy method (e.g. UUIDv4 or a content hash)
+    and unique per distinct media content.  Reusing a UUID with different
+    media when the original is still cached will be rejected.
     """
 
 
@@ -242,8 +248,10 @@ class CustomChatCompletionContentSimpleImageParam(TypedDict, total=False):
     image_url: str | None
     uuid: str | None
     """
-    User-provided UUID of a media. User must guarantee that it is properly
-    generated and unique for different medias.
+    User-provided UUID of a media used as the cache identity.  Must be
+    generated with a high-entropy method (e.g. UUIDv4 or a content hash)
+    and unique per distinct media content.  Reusing a UUID with different
+    media when the original is still cached will be rejected.
     """
 
 
@@ -271,8 +279,10 @@ class CustomChatCompletionContentSimpleVideoParam(TypedDict, total=False):
     video_url: str | None
     uuid: str | None
     """
-    User-provided UUID of a media. User must guarantee that it is properly
-    generated and unique for different medias.
+    User-provided UUID of a media used as the cache identity.  Must be
+    generated with a high-entropy method (e.g. UUIDv4 or a content hash)
+    and unique per distinct media content.  Reusing a UUID with different
+    media when the original is still cached will be rejected.
     """
 
 

--- a/vllm/multimodal/cache.py
+++ b/vllm/multimodal/cache.py
@@ -69,17 +69,22 @@ class MultiModalProcessorCacheItem:
     Args:
         item: The processed tensor data corresponding to a multi-modal item.
         prompt_updates: The prompt updates corresponding to `item`.
+        content_hash: Content-based fingerprint of the original media.
+            Used to reject uuid collisions when a subsequent request
+            presents different media under the same uuid.
     """
 
     def __init__(
         self,
         item: MultiModalKwargsItem,
         prompt_updates: Sequence["ResolvedPromptUpdate"],
+        content_hash: str | None = None,
     ) -> None:
         super().__init__()
 
         self.item = item
         self.prompt_updates = prompt_updates
+        self.content_hash = content_hash
 
 
 class MultiModalProcessorCacheItemMetadata:
@@ -94,17 +99,22 @@ class MultiModalProcessorCacheItemMetadata:
         prompt_updates: The prompt updates corresponding to `item`.
             This needs to stay on P0 because for some models, they are
             dependent on the processed tensor data (cached on P1).
+        content_hash: Content-based fingerprint of the original media.
+            Used to reject uuid collisions when a subsequent request
+            presents different media under the same uuid.
     """
 
     def __init__(
         self,
         item: MultiModalKwargsItem,
         prompt_updates: Sequence["ResolvedPromptUpdate"],
+        content_hash: str | None = None,
     ) -> None:
         super().__init__()
 
         self.item_size = MultiModalCache.get_item_size(item)
         self.prompt_updates = prompt_updates
+        self.content_hash = content_hash
 
 
 MultiModalCacheValue: TypeAlias = (
@@ -378,6 +388,14 @@ class BaseMultiModalProcessorCache(
         """
         raise NotImplementedError
 
+    def get_content_hash(self, mm_hash: str) -> str | None:
+        """Return the content fingerprint stored for *mm_hash*, or ``None``."""
+        return None
+
+    def store_content_hash(self, mm_hash: str, content_hash: str | None) -> None:
+        """Persist *content_hash* alongside the cached item keyed by
+        *mm_hash*.  Default implementation is a no-op; P0 caches override."""
+
     @abstractmethod
     def make_stats(self, *, delta: bool = False) -> CacheInfo:
         """
@@ -431,6 +449,17 @@ class MultiModalProcessorOnlyCache(BaseMultiModalProcessorCache):
     @override
     def touch_sender_cache_item(self, mm_hash: str) -> None:
         self._cache.touch(mm_hash)
+
+    @override
+    def get_content_hash(self, mm_hash: str) -> str | None:
+        cached = self._cache.get(mm_hash)
+        return cached.content_hash if cached is not None else None
+
+    @override
+    def store_content_hash(self, mm_hash: str, content_hash: str | None) -> None:
+        cached = self._cache.get(mm_hash)
+        if cached is not None:
+            cached.content_hash = content_hash
 
     @override
     def clear_cache(self) -> None:
@@ -492,6 +521,17 @@ class MultiModalProcessorSenderCache(BaseMultiModalProcessorCache):
         self._cache.touch(mm_hash)
 
     @override
+    def get_content_hash(self, mm_hash: str) -> str | None:
+        cached = self._cache.get(mm_hash)
+        return cached.content_hash if cached is not None else None
+
+    @override
+    def store_content_hash(self, mm_hash: str, content_hash: str | None) -> None:
+        cached = self._cache.get(mm_hash)
+        if cached is not None:
+            cached.content_hash = content_hash
+
+    @override
     def clear_cache(self) -> None:
         self._cache.clear()
 
@@ -537,6 +577,7 @@ class ShmObjectStoreSenderCache(BaseMultiModalProcessorCache):
         )
         # cache prompt_updates for P0 only
         self._p0_cache: dict[str, Sequence[ResolvedPromptUpdate]] = {}
+        self._content_hashes: dict[str, str] = {}
 
         self._hits = 0
         self._total = 0
@@ -613,9 +654,19 @@ class ShmObjectStoreSenderCache(BaseMultiModalProcessorCache):
         self._shm_cache.touch(mm_hash)
 
     @override
+    def get_content_hash(self, mm_hash: str) -> str | None:
+        return self._content_hashes.get(mm_hash)
+
+    @override
+    def store_content_hash(self, mm_hash: str, content_hash: str | None) -> None:
+        if content_hash is not None:
+            self._content_hashes[mm_hash] = content_hash
+
+    @override
     def clear_cache(self) -> None:
         self._shm_cache.clear()
         self._p0_cache.clear()
+        self._content_hashes.clear()
 
         self._hits = 0
         self._total = 0
@@ -635,6 +686,7 @@ class ShmObjectStoreSenderCache(BaseMultiModalProcessorCache):
         dangling_hashes = set(self._p0_cache.keys()) - cached_hashes
         for mm_hash in dangling_hashes:
             del self._p0_cache[mm_hash]
+            self._content_hashes.pop(mm_hash, None)
 
     def address_as_item(
         self,

--- a/vllm/multimodal/processing/inputs.py
+++ b/vllm/multimodal/processing/inputs.py
@@ -9,6 +9,8 @@ from vllm.inputs import MultiModalHashes
 from ..hasher import MultiModalHasher
 from ..parse import MultiModalDataItems, MultiModalUUIDItems
 
+MultiModalContentFingerprints = dict[str, list[str | None]]
+
 
 @dataclass
 class ProcessorInputs:
@@ -60,7 +62,13 @@ class ProcessorInputs:
                             )
                         )
                     else:
-                        hashes.append(uuid_item)
+                        hashes.append(
+                            hasher.hash_kwargs(
+                                hash_algorithm,
+                                model_id=model_id,
+                                mm_uuid=uuid_item,
+                            )
+                        )
 
                 mm_hashes[modality] = hashes
             else:
@@ -75,3 +83,46 @@ class ProcessorInputs:
                 ]
 
         return mm_hashes
+
+    def get_content_fingerprints(
+        self,
+        model_id: str,
+        hash_algorithm: MMHasherAlgorithm,
+    ) -> MultiModalContentFingerprints:
+        """Compute content-based fingerprints for uuid-bearing items.
+
+        Returns a dict mirroring the shape of ``get_mm_hashes``.  For each
+        modality/index the value is:
+
+        * A content hash when the item carries both a uuid **and** media data.
+        * ``None`` when the item has no uuid (content-hashed path) or has a
+          uuid but no media data (skip-send).
+        """
+        mm_data_items = self.mm_data_items
+        mm_uuid_items = self.mm_uuid_items or {}
+        hf_processor_mm_kwargs = self.hf_processor_mm_kwargs
+
+        hasher = MultiModalHasher
+        fingerprints = dict[str, list[str | None]]()
+
+        for modality, data_items in mm_data_items.items():
+            uuid_items = mm_uuid_items.get(modality)
+            fps: list[str | None] = []
+
+            for i, item in enumerate(data_items.get_all_items_for_hash()):
+                uuid_item = uuid_items[i] if uuid_items is not None else None
+                if uuid_item is not None and item is not None:
+                    fps.append(
+                        hasher.hash_kwargs(
+                            hash_algorithm,
+                            model_id=model_id,
+                            **{modality: item},
+                            **hf_processor_mm_kwargs,
+                        )
+                    )
+                else:
+                    fps.append(None)
+
+            fingerprints[modality] = fps
+
+        return fingerprints

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from transformers.feature_extraction_utils import BatchFeature
 
     from ..cache import BaseMultiModalProcessorCache
+    from .inputs import MultiModalContentFingerprints
 else:
     BatchFeature = object
 
@@ -1251,6 +1252,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         cache: BaseMultiModalProcessorCache,
         mm_data_items: MultiModalDataItems,
         mm_hashes: MultiModalHashes,
+        mm_fingerprints: "MultiModalContentFingerprints | None" = None,
     ) -> tuple[MultiModalIsCached, MultiModalDataItems]:
         mm_is_cached = {
             modality: cache.is_cached(hashes) for modality, hashes in mm_hashes.items()
@@ -1264,6 +1266,24 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             ]
             for modality, items_is_cached in mm_is_cached.items()
         }
+
+        if mm_fingerprints is not None:
+            for modality, hashes in mm_hashes.items():
+                cached_flags = mm_is_cached[modality]
+                fps = mm_fingerprints.get(modality, [])
+                for idx, (is_cached, mm_hash) in enumerate(zip(cached_flags, hashes)):
+                    if not is_cached:
+                        continue
+                    fp = fps[idx] if idx < len(fps) else None
+                    if fp is None:
+                        continue
+                    stored = cache.get_content_hash(mm_hash)
+                    if stored is not None and stored != fp:
+                        raise ValueError(
+                            f"Multimodal uuid collision for {modality} at "
+                            f"index {idx}: the same uuid was previously "
+                            f"used with different media content."
+                        )
 
         mm_missing_data = {}
         for modality, idxs in mm_missing_idxs.items():
@@ -1399,17 +1419,20 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         if cache is None or passthrough_data:
             return self._apply_hf_processor(inputs, timing_ctx)
 
+        algorithm = self.info.ctx.get_mm_config().mm_hasher_algorithm
+        model_id = self.info.model_id
+
         with timing_ctx.record("get_mm_hashes"):
-            mm_hashes = inputs.get_mm_hashes(
-                self.info.model_id,
-                self.info.ctx.get_mm_config().mm_hasher_algorithm,
-            )
+            mm_hashes = inputs.get_mm_hashes(model_id, algorithm)
+
+        mm_fingerprints = inputs.get_content_fingerprints(model_id, algorithm)
 
         with timing_ctx.record("get_cache_missing_items"):
             mm_is_cached, mm_missing_data_items = self._get_cache_missing_items(
                 cache=cache,
                 mm_data_items=inputs.mm_data_items,
                 mm_hashes=mm_hashes,
+                mm_fingerprints=mm_fingerprints,
             )
 
         # NOTE: The prompt does not correspond to `mm_missing_data_items`,
@@ -1442,6 +1465,13 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                 mm_missing_kwargs=mm_missing_kwargs,
                 mm_missing_prompt_updates=mm_missing_prompt_updates,
             )
+
+        for modality, hashes in mm_hashes.items():
+            fps = mm_fingerprints.get(modality, [])
+            for idx, mm_hash in enumerate(hashes):
+                fp = fps[idx] if idx < len(fps) else None
+                if fp is not None and cache.get_content_hash(mm_hash) is None:
+                    cache.store_content_hash(mm_hash, fp)
 
         mm_info = MultiModalProcessingInfo(
             kwargs=mm_kwargs,


### PR DESCRIPTION
The multimodal processor cache used client-supplied uuid strings verbatim as cache identities. A client that knew another client's uuid could retrieve that client's processed media from the shared cache.

Hash the uuid through MultiModalHasher.hash_kwargs with model_id and a dedicated mm_uuid domain tag so the cache key is never directly client-controlled and is isolated across models.
