### PR TITLE
fix(security): enforce prompt-count bound on pooling and scoring routes

### DIFF
--- a/tests/entrypoints/pooling/test_pooling_prompt_limit.py
+++ b/tests/entrypoints/pooling/test_pooling_prompt_limit.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests that VLLM_MAX_COMPLETION_PROMPTS is enforced on pooling/scoring routes.
+
+The fan-out bound was originally only applied to /v1/completions
+(CVE-2026-73559). These tests verify it is now also enforced on
+/score, /rerank, /pooling, and /classify request models.
+"""
+
+import pytest
+
+from vllm.exceptions import VLLMValidationError
+
+
+def _clear_envs_cache():
+    from vllm import envs
+
+    if hasattr(envs.__getattr__, "cache_clear"):
+        envs.__getattr__.cache_clear()
+
+
+class TestScoringPromptLimit:
+    """Scoring and rerank request models reject oversized lists."""
+
+    def test_score_documents_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.scoring.protocol import (
+            ScoreQueriesDocumentsRequest,
+        )
+
+        with pytest.raises(VLLMValidationError, match="documents list length"):
+            ScoreQueriesDocumentsRequest(model="m", queries=["q"], documents=["d"] * 10)
+
+    def test_score_documents_within_limit(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.scoring.protocol import (
+            ScoreQueriesDocumentsRequest,
+        )
+
+        req = ScoreQueriesDocumentsRequest(
+            model="m", queries=["q"], documents=["d"] * 5
+        )
+        assert req.documents == ["d"] * 5
+
+    def test_score_items_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.scoring.protocol import (
+            ScoreQueriesItemsRequest,
+        )
+
+        with pytest.raises(VLLMValidationError, match="items list length"):
+            ScoreQueriesItemsRequest(model="m", queries=["q"], items=["d"] * 10)
+
+    def test_score_text_2_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.scoring.protocol import (
+            ScoreTextRequest,
+        )
+
+        with pytest.raises(VLLMValidationError, match="text_2 list length"):
+            ScoreTextRequest(model="m", text_1="q", text_2=["d"] * 10)
+
+    def test_rerank_documents_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
+
+        with pytest.raises(VLLMValidationError, match="documents list length"):
+            RerankRequest(model="m", query="q", documents=["d"] * 10)
+
+    def test_rerank_within_limit(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
+
+        req = RerankRequest(model="m", query="q", documents=["d"] * 5)
+        assert len(req.documents) == 5
+
+    def test_scalar_input_unaffected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
+
+        req = RerankRequest(model="m", query="q", documents="single doc")
+        assert req.documents == "single doc"
+
+
+class TestPoolingPromptLimit:
+    """PoolingCompletionRequest rejects oversized input lists."""
+
+    def test_string_list_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.pooling.protocol import (
+            PoolingCompletionRequest,
+        )
+
+        with pytest.raises(VLLMValidationError, match="input list length"):
+            PoolingCompletionRequest(model="m", input=["x"] * 10)
+
+    def test_token_id_lists_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.pooling.protocol import (
+            PoolingCompletionRequest,
+        )
+
+        with pytest.raises(VLLMValidationError, match="input list length"):
+            PoolingCompletionRequest(model="m", input=[[1]] * 10)
+
+    def test_single_token_id_list_unaffected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.pooling.protocol import (
+            PoolingCompletionRequest,
+        )
+
+        req = PoolingCompletionRequest(model="m", input=[1, 2, 3, 4, 5, 6])
+        assert req.input == [1, 2, 3, 4, 5, 6]
+
+    def test_within_limit_accepted(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.pooling.protocol import (
+            PoolingCompletionRequest,
+        )
+
+        req = PoolingCompletionRequest(model="m", input=["x"] * 5)
+        assert len(req.input) == 5
+
+    def test_scalar_string_unaffected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.pooling.protocol import (
+            PoolingCompletionRequest,
+        )
+
+        req = PoolingCompletionRequest(model="m", input="hello world")
+        assert req.input == "hello world"
+
+
+class TestIOProcessorPromptLimit:
+    """IOProcessorRequest rejects oversized data lists."""
+
+    def test_data_list_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.pooling.protocol import (
+            IOProcessorRequest,
+        )
+
+        with pytest.raises(VLLMValidationError, match="data list length"):
+            IOProcessorRequest(model="m", data=["x"] * 10)
+
+    def test_data_list_within_limit(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.pooling.protocol import (
+            IOProcessorRequest,
+        )
+
+        req = IOProcessorRequest(model="m", data=["x"] * 5)
+        assert len(req.data) == 5
+
+
+class TestClassifyPromptLimit:
+    """ClassificationCompletionRequest rejects oversized input lists."""
+
+    def test_input_list_rejected(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.classify.protocol import (
+            ClassificationCompletionRequest,
+        )
+
+        with pytest.raises(VLLMValidationError, match="input list length"):
+            ClassificationCompletionRequest(model="m", input=["x"] * 10)
+
+    def test_within_limit_accepted(self, monkeypatch):
+        monkeypatch.setenv("VLLM_MAX_COMPLETION_PROMPTS", "5")
+        _clear_envs_cache()
+
+        from vllm.entrypoints.pooling.classify.protocol import (
+            ClassificationCompletionRequest,
+        )
+
+        req = ClassificationCompletionRequest(model="m", input=["x"] * 5)
+        assert len(req.input) == 5

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import Field, model_validator
 
+from vllm import envs
 from vllm.config import ModelConfig
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -179,6 +180,26 @@ class CompletionRequestMixin(OpenAIBaseModel):
         ),
     )
     # --8<-- [end:completion-extra-params]
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_input_list_length(cls, data):
+        if not isinstance(data, dict):
+            return data
+        max_prompts = envs.VLLM_MAX_COMPLETION_PROMPTS
+        input_val = data.get("input")
+        if not isinstance(input_val, list) or len(input_val) == 0:
+            return data
+        if isinstance(input_val[0], int):
+            return data
+        if len(input_val) > max_prompts:
+            raise VLLMValidationError(
+                f"input list length {len(input_val)} exceeds the maximum "
+                f"allowed count of {max_prompts}. To increase this limit, "
+                "set the VLLM_MAX_COMPLETION_PROMPTS environment variable.",
+                parameter="input",
+            )
+        return data
 
 
 class ChatRequestOptionsMixin(OpenAIBaseModel):

--- a/vllm/entrypoints/pooling/pooling/protocol.py
+++ b/vllm/entrypoints/pooling/pooling/protocol.py
@@ -3,11 +3,12 @@
 import time
 from typing import Annotated, Generic, TypeAlias, TypeVar
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, model_validator
 
-from vllm import PoolingParams
+from vllm import PoolingParams, envs
 from vllm.config import ModelConfig
 from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel, UsageInfo
+from vllm.exceptions import VLLMValidationError
 from vllm.renderers import TokenizeParams
 from vllm.tasks import PoolingTask
 from vllm.utils import random_uuid
@@ -64,6 +65,22 @@ T = TypeVar("T")
 class IOProcessorRequest(PoolingBasicRequestMixin, EncodingRequestMixin, Generic[T]):
     data: T
     task: PoolingTask = "plugin"
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_data_list_length(cls, data):
+        if not isinstance(data, dict):
+            return data
+        max_prompts = envs.VLLM_MAX_COMPLETION_PROMPTS
+        data_val = data.get("data")
+        if isinstance(data_val, list) and len(data_val) > max_prompts:
+            raise VLLMValidationError(
+                f"data list length {len(data_val)} exceeds the maximum "
+                f"allowed count of {max_prompts}. To increase this limit, "
+                "set the VLLM_MAX_COMPLETION_PROMPTS environment variable.",
+                parameter="data",
+            )
+        return data
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:
         return self._build_pooling_tok_params(

--- a/vllm/entrypoints/pooling/scoring/protocol.py
+++ b/vllm/entrypoints/pooling/scoring/protocol.py
@@ -5,9 +5,10 @@ from typing import Any, TypeAlias
 
 from pydantic import BaseModel, Field, model_validator
 
-from vllm import PoolingParams
+from vllm import PoolingParams, envs
 from vllm.config import ModelConfig
 from vllm.entrypoints.openai.engine.protocol import OpenAIBaseModel, UsageInfo
+from vllm.exceptions import VLLMValidationError
 from vllm.renderers import TokenizeParams
 from vllm.tasks import PoolingTask
 from vllm.utils import random_uuid
@@ -51,6 +52,32 @@ class ScoringRequestMixin(PoolingBasicRequestMixin, ClassifyRequestMixin):
         ),
     )
     # --8<-- [end:scoring-common-params]
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_input_list_length(cls, data):
+        if not isinstance(data, dict):
+            return data
+        max_prompts = envs.VLLM_MAX_COMPLETION_PROMPTS
+        for field_name in (
+            "documents",
+            "items",
+            "text_2",
+            "data_2",
+            "queries",
+            "data_1",
+            "text_1",
+        ):
+            value = data.get(field_name)
+            if isinstance(value, list) and len(value) > max_prompts:
+                raise VLLMValidationError(
+                    f"{field_name} list length {len(value)} exceeds the "
+                    f"maximum allowed count of {max_prompts}. To increase "
+                    "this limit, set the VLLM_MAX_COMPLETION_PROMPTS "
+                    "environment variable.",
+                    parameter=field_name,
+                )
+        return data
 
     @model_validator(mode="after")
     def _merge_instruction_into_kwargs(self) -> "ScoringRequestMixin":


### PR DESCRIPTION
VLLM_MAX_COMPLETION_PROMPTS was only enforced on /v1/completions, leaving /score, /rerank, /pooling, and /classify endpoints vulnerable to unbounded fan-out of engine requests from a single API call. A client could turn one HTTP request into an attacker-chosen number of engine subrequests, starving other tenants of resources.

Add model_validator checks to ScoringRequestMixin (covers score and rerank), CompletionRequestMixin (covers pooling and classify), and IOProcessorRequest. Each rejects list-shaped inputs exceeding the configured limit at Pydantic validation time, before any engine allocation.
