### PR TITLE
[Bugfix] Honor a false boolean in a yaml config when the key uses underscores

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -82,6 +82,33 @@ def test_with_bool_flag(parser):
     assert args.enable_feature is True
 
 
+def test_config_bool_false_with_underscore_key(tmp_path):
+    """A false boolean must be honored whether the key uses dashes or underscores.
+
+    Registered option strings use dashes, so an underscore key used to miss the
+    --no- lookup and emit nothing, leaving the option at its opposite value.
+    """
+    parser = FlexibleArgumentParser()
+    parser.add_argument("--enable-prefix-caching", action=BooleanOptionalAction)
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("enable_prefix_caching: false\n")
+    assert parser.load_config_file(str(config_file)) == ["--no-enable-prefix-caching"]
+
+    config_file.write_text("enable-prefix-caching: false\n")
+    assert parser.load_config_file(str(config_file)) == ["--no-enable-prefix-caching"]
+
+
+def test_config_bool_false_without_no_variant_is_dropped(tmp_path):
+    """store_true options register no --no- counterpart, so false stays a no-op."""
+    parser = FlexibleArgumentParser()
+    parser.add_argument("--headless", action="store_true")
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("headless: false\n")
+    assert parser.load_config_file(str(config_file)) == []
+
+
 def test_invalid_choice(parser):
     with pytest.raises(SystemExit):
         parser.parse_args(["--image_input_type", "invalid_choice"])

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -573,7 +573,14 @@ class FlexibleArgumentParser(ArgumentParser):
             if isinstance(value, bool):
                 if value:
                     processed_args.append("--" + key)
-                elif (no_key := f"--no-{key}") in self._option_string_actions:
+                # Registered option strings use dashes, so normalize before the
+                # lookup. Without this a key written with underscores misses and
+                # the branch emits nothing, silently applying the opposite value.
+                # Keys with no --no- counterpart, such as store_true flags, are
+                # still dropped, which is the correct result for those.
+                elif (
+                    no_key := f"--no-{key.replace('_', '-')}"
+                ) in self._option_string_actions:
                     processed_args.append(no_key)
             elif isinstance(value, list):
                 if value:


### PR DESCRIPTION
## Purpose

A boolean set to `false` in a config file is silently discarded when the key is written with underscores, so the option keeps its previous value and the config applies the opposite of what it says.

`FlexibleArgumentParser.load_config_file` builds `--no-{key}` and looks it up in the registry. Registered option strings use dashes, so an underscore key misses and the branch emits nothing. The true branch does not have this problem, because argparse resolves `--enable_prefix_caching` to the registered action anyway. The same key therefore behaves differently depending on its value:

```
'enable_prefix_caching: false'   ->  []                              <- dropped
'enable-prefix-caching: false'   ->  ['--no-enable-prefix-caching']
'enable_prefix_caching: true'    ->  ['--enable_prefix_caching']
```

There is no error and no warning. Underscore keys are normal in these files; the docstring for this function uses them in its own nested examples.

This has bitten us twice on a serving deployment: a config that ran with prefix caching on for some time before anyone noticed, and later an A/B run where the arm meant to disable it silently measured the control condition instead.

## Fix

Normalize underscores to dashes before the registry lookup.

I considered raising when a false boolean resolves to no flag at all, since a silent drop is what made this hard to spot. That would be wrong here. `make_arg_parser` registers 157 `BooleanOptionalAction` options but also 6 `store_true` options (`--headless`, `--grpc`, `--disable-log-stats`, `--data-parallel-multi-port-external-lb`, `-dpm`, `--aggregate-engine-logging`), and those have no `--no-` counterpart, so dropping a `false` is the correct result for them. Normalization alone fixes the reported behavior without touching that case.

A separate gap remains, not addressed here: a misspelled key with a `false` value still resolves to nothing and is ignored without complaint, because nothing is emitted for argparse to reject. Happy to follow up if you want that caught.

## Test Plan

Two tests in `tests/utils_/test_argparse_utils.py`:

- `test_config_bool_false_with_underscore_key` asserts both the underscore and dashed spellings produce `--no-enable-prefix-caching`.
- `test_config_bool_false_without_no_variant_is_dropped` asserts a `store_true` option set to `false` still produces no flag, so a future change cannot turn that into an error.

## Test Result

Both pass. Behavior verified directly against the three cases above: underscore false now yields `['--no-enable-prefix-caching']`, dashed false is unchanged, and `store_true` false still yields `[]`.
