### PR TITLE
[Bugfix][V1] Mamba align: materialize a state at every boundary and drop the speculative one-block back-off

### DIFF
--- a/tests/v1/core/prefix_cache/test_eagle_mamba_drop_cost.py
+++ b/tests/v1/core/prefix_cache/test_eagle_mamba_drop_cost.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""What the EAGLE/MTP block drop actually costs a hybrid mamba model.
+
+`prefix_match_unit` exists so the drop is one hash unit instead of one cache
+block. It does that for full attention. It does not do it for the reconciled
+hit, because the mamba group only materializes state at block boundaries: capped
+at the attention candidate, its lookup floors to the previous boundary and the
+joint hit gives up a whole block.
+
+Config below: block 16, hash unit 4, owner caches three blocks (48 tokens).
+
+    full attention alone   48 -> 44   one hash unit, as intended
+    mamba alone            48         (it ignores drop_eagle_block)
+    reconciled                  32    a whole block
+
+Neither group loses a block by itself. The block is lost in the reconciliation.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+BLOCK = 16
+HASH = 4  # prefix_match_unit: partial matching is ON
+OWNER = 48  # three whole blocks
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _manager(use_eagle: bool):
+    kv_cache_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=BLOCK,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=BLOCK,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=4096,
+        enable_caching=True,
+        hash_block_size=HASH,
+        use_eagle=use_eagle,
+    )
+    assert manager.coordinator.enable_partial_hash_hits, "partial matching must be on"
+    return manager
+
+
+def _seed_owner(manager):
+    """Prefill 48 tokens the way the scheduler splits them.
+
+    Stops on each block boundary, and also one hash unit below each -- the
+    position EAGLE resumes from. A chunk has to END there for the state to be
+    materializable, so the stop is what gives the fix something to register.
+    Today nothing is registered at those positions; the assertion below is what
+    changes when something is.
+    """
+    owner = make_request("owner", [7] * OWNER, HASH, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    done, first = 0, True
+    stops = sorted(
+        {b - HASH for b in range(BLOCK, OWNER + 1, BLOCK)}
+        | set(range(BLOCK, OWNER + 1, BLOCK))
+    )
+    for stop in stops:
+        step = stop - done
+        if step <= 0:
+            continue
+        ok = (
+            manager.allocate_slots(owner, step, num_computed, computed)
+            if first
+            else manager.allocate_slots(owner, step)
+        )
+        assert ok is not None
+        first, done = False, stop
+        owner.num_computed_tokens = done
+        manager.new_step_starts()
+    return owner
+
+
+def _follower(manager):
+    f = make_request("follower", [7] * OWNER + [9] * 8, HASH, sha256)
+    blocks, joint, _ = manager.get_computed_blocks(f)
+    _pg_blocks, per_group = manager.coordinator.find_longest_cache_hit_per_group(
+        f.block_hashes, OWNER + 7
+    )
+    return joint, tuple(per_group), blocks
+
+
+def test_full_attention_gives_up_only_one_hash_unit():
+    """The property `prefix_match_unit` is supposed to deliver. It holds."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group, _ = _follower(manager)
+    assert per_group[0] == OWNER - HASH == 44
+
+
+def test_mamba_alone_reaches_the_full_prefix():
+    """Evaluated on its own, mamba ignores drop_eagle_block and reaches 48."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group, _ = _follower(manager)
+    assert per_group[1] == OWNER == 48
+
+
+def test_without_eagle_nothing_is_given_up():
+    """Isolates the drop as the cause: no eagle, no loss."""
+    manager = _manager(use_eagle=False)
+    _seed_owner(manager)
+    joint, _per_group, _ = _follower(manager)
+    assert joint == OWNER == 48
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mamba has no checkpoint at the position EAGLE resumes from, so the "
+    "reconciled hit floors to the previous block boundary",
+)
+def test_reconciled_hit_should_not_give_up_a_whole_block():
+    """The defect. Both groups individually reach at least 44, but the
+    reconciled hit is 32: mamba is capped at the attention candidate (44) and
+    its state exists only at 16/32/48, so it floors to 32.
+
+    Fails on main (32). Passes once a mamba checkpoint exists at the position
+    EAGLE resumes from, i.e. one hash unit below a block boundary.
+    """
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    joint, per_group, blocks = _follower(manager)
+    assert min(per_group) >= OWNER - HASH, per_group
+    assert joint == OWNER - HASH, (
+        f"joint hit {joint} gave up a whole {BLOCK}-token block; full attention "
+        f"only gave up {OWNER - per_group[0]} (per-group hits {per_group})"
+    )
+    assert all(len(g) * BLOCK >= joint for g in blocks.blocks)

--- a/tests/v1/core/prefix_cache/test_eagle_mamba_shared_system_prompt.py
+++ b/tests/v1/core/prefix_cache/test_eagle_mamba_shared_system_prompt.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The EAGLE/MTP drop when the shared prefix ends before the owner's prompt.
+
+The sibling file pins the case where the shared prefix runs to the END of the
+owner's prompt. This one pins the other shape, which is what a served system
+prompt looks like: every request begins with the same preamble and then diverges
+into its own question. The owner's prompt tail therefore sits over tokens no
+sibling shares, so nothing cached there can serve them.
+
+Config below: block 16, hash unit 4. Owner prompt is 40 tokens -- a 24-token
+shared prefix followed by a 16-token private suffix. The follower shares the
+first 24 and then diverges.
+
+    full attention alone   16 -> 12   one hash unit below the shared boundary
+    mamba alone            16         (it ignores drop_eagle_block)
+    reconciled                   0    everything
+
+The shared prefix ends mid-block (24 % 16 = 8), so full attention's own match
+stops at the last whole shared block, 16, and the drop takes it to 12. Mamba has
+state only at 0 and 16; capped at 12 it can only fall back to 0, and the joint
+hit is nothing at all. Without EAGLE the same follower keeps 16.
+
+This is the shape where a check-point at the *prompt tail* cannot help: 40, and
+36 one hash unit below it, are both over the owner's private suffix.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+BLOCK = 16
+HASH = 4  # prefix_match_unit: partial matching is ON
+SHARED = 24  # the system prompt; ends mid-block on purpose
+SUFFIX = 16  # the owner's own question
+PROMPT = SHARED + SUFFIX
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _manager(use_eagle: bool):
+    kv_cache_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=BLOCK,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=BLOCK,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=4096,
+        enable_caching=True,
+        hash_block_size=HASH,
+        use_eagle=use_eagle,
+    )
+    assert manager.coordinator.enable_partial_hash_hits, "partial matching must be on"
+    return manager
+
+
+def _seed_owner(manager):
+    """Prefill the owner's 40 tokens, stopping everywhere state could be kept.
+
+    Block boundaries, one hash unit below each -- the position EAGLE resumes
+    from -- and the prompt tail. Stopping is what makes a position registrable;
+    which of them actually get an entry is what these tests report.
+    """
+    owner = make_request("owner", [7] * SHARED + [8] * SUFFIX, HASH, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    done, first = 0, True
+    stops = sorted(
+        {b - HASH for b in range(BLOCK, PROMPT + 1, BLOCK)}
+        | set(range(BLOCK, PROMPT + 1, BLOCK))
+        | {PROMPT}
+    )
+    for stop in stops:
+        step = stop - done
+        if step <= 0:
+            continue
+        ok = (
+            manager.allocate_slots(owner, step, num_computed, computed)
+            if first
+            else manager.allocate_slots(owner, step)
+        )
+        assert ok is not None
+        first, done = False, stop
+        owner.num_computed_tokens = done
+        manager.new_step_starts()
+    return owner
+
+
+def _follower(manager):
+    """A sibling that shares the system prompt and then asks something else."""
+    f = make_request("follower", [7] * SHARED + [9] * 8, HASH, sha256)
+    _blocks, joint, _ = manager.get_computed_blocks(f)
+    _pg_blocks, per_group = manager.coordinator.find_longest_cache_hit_per_group(
+        f.block_hashes, SHARED + 7
+    )
+    return joint, tuple(per_group)
+
+
+def test_full_attention_gives_up_only_one_hash_unit():
+    """Full attention matches the last whole shared block and drops one unit."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group = _follower(manager)
+    assert per_group[0] == BLOCK - HASH  # 12
+
+
+def test_mamba_alone_reaches_the_shared_block_boundary():
+    """Mamba never applies the drop, so on its own it keeps the whole block."""
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    _joint, per_group = _follower(manager)
+    assert per_group[1] == BLOCK  # 16
+
+
+def test_without_eagle_the_hit_survives():
+    """No drop, so the two groups agree and the follower keeps the block."""
+    manager = _manager(use_eagle=False)
+    _seed_owner(manager)
+    joint, per_group = _follower(manager)
+    assert per_group == (BLOCK, BLOCK)
+    assert joint == BLOCK
+
+
+def test_reconciled_hit_is_currently_nothing():
+    """Today the two groups reconcile to zero: the follower recomputes it all.
+
+    Capped at full attention's 12, mamba's only lower position is 0.
+    """
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    joint, _per_group = _follower(manager)
+    assert joint == 0
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="mamba materializes no state one hash unit below a block boundary, "
+    "so the reconciled hit falls to 0 even though both groups reached >= 12",
+)
+def test_reconciled_hit_should_reach_the_resume_point():
+    """What the follower should keep: the position EAGLE actually resumes from.
+
+    Both groups reach at least 12 on their own. A check-point at the owner's
+    prompt tail cannot supply this -- 40 and 36 are over the private suffix --
+    so the state has to exist one hash unit below the shared block boundary.
+    """
+    manager = _manager(use_eagle=True)
+    _seed_owner(manager)
+    joint, _per_group = _follower(manager)
+    assert joint == BLOCK - HASH  # 12

--- a/tests/v1/core/prefix_cache/test_mamba_align_sparse_keys.py
+++ b/tests/v1/core/prefix_cache/test_mamba_align_sparse_keys.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mamba "align" stores keys only at sparse boundaries; the KV-cache event
+stream indexes the hit list as a dense grid.
+
+Interior mamba blocks are null and carry no block hash -- that part is by design
+(``reachable_block_mask``). ``emit_cached_block_events`` then walks the hit list
+positionally, so for the mamba group it publishes a key per hit block. The keys
+it publishes are the wrong ones: the interior block that was never stored, and
+one past the end of the hit, while the group's only real key is omitted. When
+the consumer's prompt is not mamba-block-aligned the same walk indexes past the
+block-hash view and raises IndexError inside ``get_computed_blocks``.
+
+Requires ``kv_cache_report_mode = "full"`` (KV-cache events). CPU only.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import (
+    get_block_hash,
+    get_group_id,
+    init_none_hash,
+    maybe_convert_block_hash,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+# (hash_block_size, full_attn_block_size, mamba_block_size)
+SIZES = [
+    pytest.param(2, 2, 4, id="toy"),
+    pytest.param(16, 64, 64, id="large-block"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _manager(hash_bs, fa_bs, mamba_bs, events=True, num_blocks=64):
+    cfg = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=fa_bs, num_kv_heads=1, head_size=1, dtype=torch.float32
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_bs,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    return make_kv_cache_manager(
+        kv_cache_config=cfg,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_bs,
+        enable_kv_cache_events=events,
+    )
+
+
+def _produce(manager, tokens, hash_bs):
+    req = make_request("producer", tokens, hash_bs, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(req)
+    assert num_computed == 0
+    assert manager.allocate_slots(req, len(tokens), num_computed, computed) is not None
+    manager.free(req)
+    manager.new_step_starts()
+    manager.take_events()
+    return req
+
+
+# ---------------------------------------------------------------- PART 1 ----
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+def test_mamba_group_grid_is_sparse(hash_bs, fa_bs, mamba_bs):
+    """The mamba group stores ONE key (the prompt tail). Every interior mamba
+    block index of the same request carries no key at all."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs, events=False)
+    n = mamba_bs + hash_bs  # 6 / 80: just over one mamba block
+    req = _produce(manager, list(range(n)), hash_bs)
+
+    key_at = {
+        t: req.block_hashes[t // hash_bs - 1] for t in range(hash_bs, n + 1, hash_bs)
+    }
+
+    # mamba: only the prompt-tail key exists.
+    have = [t for t, h in key_at.items() if manager.block_pool.get_cached_block(h, [1])]
+    assert have == [n], have
+    hit = manager.block_pool.get_cached_block(key_at[n], [1])[0]
+    assert get_group_id(hit.block_hash) == 1
+    assert get_block_hash(hit.block_hash) == key_at[n]
+    assert hit.block_hash_num_tokens == n
+
+    # mamba block index 0 covers tokens [0, mamba_bs) and would be keyed by the
+    # hash at mamba_bs tokens: never written (intermediate state snapshot).
+    assert manager.block_pool.get_cached_block(key_at[mamba_bs], [1]) is None
+
+
+# ---------------------------------------------------------------- PART 2 ----
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+@pytest.mark.xfail(
+    strict=True,
+    reason="emit_cached_block_events walks the hit list positionally: it publishes "
+    "mamba keys that were never stored and omits the one that was",
+)
+def test_emit_cached_block_events_invents_mamba_keys(hash_bs, fa_bs, mamba_bs):
+    """kv_cache_report_mode='full' publishes mamba keys that were never stored,
+    over a token range that was never hit."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs)
+    n = mamba_bs + hash_bs
+    _produce(manager, list(range(n)), hash_bs)
+
+    req1 = make_request("consumer", list(range(2 * mamba_bs)), hash_bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == n, num_computed
+    assert len(blocks.blocks[1]) == 2  # [null, hit] -- 2 blocks for an n-token hit
+
+    stored = [e for e in manager.take_events() if type(e).__name__ == "BlockStored"]
+    mamba_event = {e.group_idx: e for e in stored}[1]
+    emitted = list(mamba_event.block_hashes)
+
+    real_key = maybe_convert_block_hash(req1.block_hashes[n // hash_bs - 1])
+    beyond_the_hit = maybe_convert_block_hash(
+        req1.block_hashes[2 * mamba_bs // hash_bs - 1]
+    )
+    assert manager.block_pool.get_cached_block(req1.block_hashes[n // hash_bs - 1], [1])
+    assert (
+        manager.block_pool.get_cached_block(
+            req1.block_hashes[mamba_bs // hash_bs - 1], [1]
+        )
+        is None
+    )
+    assert (
+        manager.block_pool.get_cached_block(
+            req1.block_hashes[2 * mamba_bs // hash_bs - 1], [1]
+        )
+        is None
+    )
+
+    assert real_key in emitted, (
+        f"mamba group's only stored key (at {n} tokens) was not published"
+    )
+    assert beyond_the_hit not in emitted, (
+        f"published a key at {2 * mamba_bs} tokens; hit was only {n}"
+    )
+
+
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+def test_emit_cached_block_events_current_shape(hash_bs, fa_bs, mamba_bs):
+    """What main emits today. Unmarked, so it goes red when the shape changes."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs)
+    n = mamba_bs + hash_bs
+    _produce(manager, list(range(n)), hash_bs)
+
+    req1 = make_request("consumer", list(range(2 * mamba_bs)), hash_bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    manager.get_computed_blocks(req1)
+    stored = [e for e in manager.take_events() if type(e).__name__ == "BlockStored"]
+    mamba_event = {e.group_idx: e for e in stored}[1]
+
+    never_stored_interior = maybe_convert_block_hash(
+        req1.block_hashes[mamba_bs // hash_bs - 1]
+    )
+    beyond_the_hit = maybe_convert_block_hash(
+        req1.block_hashes[2 * mamba_bs // hash_bs - 1]
+    )
+    assert list(mamba_event.block_hashes) == [never_stored_interior, beyond_the_hit]
+    assert len(mamba_event.token_ids) == 2 * mamba_bs
+
+
+@pytest.mark.parametrize("hash_bs,fa_bs,mamba_bs", SIZES)
+@pytest.mark.xfail(
+    strict=True,
+    raises=IndexError,
+    reason="the same positional walk indexes past the block-hash view and raises "
+    "IndexError inside get_computed_blocks",
+)
+def test_emit_cached_block_events_indexerror_on_unaligned_prompt(
+    hash_bs, fa_bs, mamba_bs
+):
+    """The dense-grid index walks off the end of the block-hash view -> crash
+    inside Scheduler.schedule()."""
+    manager = _manager(hash_bs, fa_bs, mamba_bs)
+    n = mamba_bs + hash_bs
+    _produce(manager, list(range(n)), hash_bs)
+
+    # Consumer prompt = n + 1 tokens: floor(len/mamba_bs) == 1 mamba-granular
+    # hash, but the mamba hit list is 2 long.
+    req1 = make_request("consumer", list(range(n + 1)), hash_bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == n, num_computed
+
+
+# ---------------------------------------------------------------- PART 3 ----
+@pytest.mark.xfail(
+    strict=True,
+    reason="invented keys are not specific to partial matching; reproduces with "
+    "no prefix_match_unit set",
+)
+def test_plain_mamba_align_no_partial_hash_also_invents_keys():
+    """No prefix_match_unit at all (hash_block_size == every block_size):
+    align mode still leaves interior mamba blocks null/unkeyed, and the event
+    stream still publishes a key for each of them."""
+    bs = 4
+    manager = _manager(bs, bs, bs, events=True)
+    _produce(manager, list(range(2 * bs)), bs)  # 8 tokens
+
+    assert not manager.coordinator.enable_partial_hash_hits
+
+    req1 = make_request("consumer", list(range(3 * bs)), bs, sha256)
+    req1.kv_cache_report_mode = "full"
+    blocks, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 2 * bs
+    assert len(blocks.blocks[1]) == 2
+    assert blocks.blocks[1][0].is_null  # interior mamba block: null, no key
+
+    h4, h8 = req1.block_hashes[0], req1.block_hashes[1]
+    assert manager.block_pool.get_cached_block(h8, [1]) is not None
+    assert manager.block_pool.get_cached_block(h4, [1]) is None  # never stored
+
+    stored = [e for e in manager.take_events() if type(e).__name__ == "BlockStored"]
+    emitted = list({e.group_idx: e for e in stored}[1].block_hashes)
+    assert maybe_convert_block_hash(h4) not in emitted, (
+        "published a mamba key for a null (never-written) block"
+    )

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -121,10 +121,11 @@ def make_full_mamba_manager(
 
 @pytest.mark.parametrize("dcp_world_size", [1, 4])
 def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
-    """Chunk ends with partial hits on: block-aligned chunks, one extra stop
-    at the prompt's last hash boundary (registering the partial tail), then
-    the remaining tokens. block=512, hash=32, prompt=10000, budget=8192:
-    0 -> 8192 -> 9728 -> 9984 -> 10000."""
+    """Chunk ends with partial hits on: one block per step (a reusable state
+    materializes at every crossed boundary), one extra stop at the prompt's
+    last hash boundary (registering the partial tail), then the remaining
+    tokens. block=512, hash=32, prompt=10000, budget=8192:
+    0 -> 512 -> 1024 -> ... -> 9728 -> 9984 -> 10000."""
     block_size = 512
     scheduler_block_size = block_size * dcp_world_size
     hash_block_size = 32
@@ -143,11 +144,13 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
 
     req = make_request("0", [0] * 10000, hash_block_size, sha256)
     req.num_computed_tokens = 0
-    assert split(self=mock, request=req, num_new_tokens=8192) == 8192
-    req.num_computed_tokens = 8192
-    # Stop at the last block boundary (9728).
-    assert split(self=mock, request=req, num_new_tokens=1808) == 1536
-    req.num_computed_tokens = 9728
+    # One block per step up to the last block boundary (9728).
+    for boundary in range(block_size, 9728 + 1, block_size):
+        remaining = 10000 - req.num_computed_tokens
+        assert split(self=mock, request=req, num_new_tokens=min(8192, remaining)) == (
+            block_size
+        )
+        req.num_computed_tokens = boundary
     # Extra stop at the prompt's last hash boundary (9984).
     assert split(self=mock, request=req, num_new_tokens=272) == 256
     req.num_computed_tokens = 9984

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -139,6 +139,8 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
         scheduler_block_size=scheduler_block_size,
         mamba_partial_cache_hit=True,
         mamba_has_prefill_checkpoint_blocks=False,
+        mamba_retention_interval=None,
+        mamba_eagle_reach_margin=0,
     )
     split = Scheduler._mamba_block_aligned_split
 
@@ -187,6 +189,8 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
         hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
+        mamba_retention_interval=None,
+        mamba_eagle_reach_margin=0,
     )
     req = make_request("0", [0] * prompt_length, 32, sha256)
     split = Scheduler._mamba_block_aligned_split
@@ -226,6 +230,8 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
         hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
+        mamba_retention_interval=None,
+        mamba_eagle_reach_margin=0,
     )
     req = make_request("0", [0] * prompt_length, 32, sha256)
     split = Scheduler._mamba_block_aligned_split

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -294,3 +294,62 @@ def test_unaligned_resume_never_runs_past_its_block(
             f"intermediate chunk end {end} is neither block-aligned nor the "
             f"partial-tail boundary"
         )
+
+
+def test_split_stops_at_every_boundary_without_checkpoints() -> None:
+    """Without internal checkpoints a reusable state exists only at chunk
+    ends, so each chunk stops at its next block boundary; otherwise a sibling
+    sharing fewer tokens than the deepest chunk end can never hit (#52897)."""
+    prompt_len = 3 * MAMBA_BLOCK_SIZE + 500
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
+    ends = []
+    while request.num_computed_tokens < prompt_len:
+        num_new = _split(
+            request, prompt_len - request.num_computed_tokens, use_eagle=False
+        )
+        request.num_computed_tokens += num_new
+        ends.append(request.num_computed_tokens)
+    assert ends == [
+        MAMBA_BLOCK_SIZE,
+        2 * MAMBA_BLOCK_SIZE,
+        3 * MAMBA_BLOCK_SIZE,
+        prompt_len,
+    ]
+
+
+def test_split_keeps_last_boundary_reachable_under_eagle() -> None:
+    """The speculative one-block back-off forfeited a full mamba block of
+    reusable prefix (measured as half the cache on aligned prompts, #52897).
+    With a state at every crossed boundary, a lookup whose last block is
+    pruned falls back one block instead of missing, so the back-off is gone:
+    the deepest boundary below the prompt stays a chunk end."""
+    prompt_len = 3 * MAMBA_BLOCK_SIZE + 500
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
+    ends = []
+    while request.num_computed_tokens < prompt_len:
+        num_new = _split(
+            request, prompt_len - request.num_computed_tokens, use_eagle=True
+        )
+        request.num_computed_tokens += num_new
+        ends.append(request.num_computed_tokens)
+    assert 3 * MAMBA_BLOCK_SIZE in ends
+
+
+def test_quiet_prefill_caches_state_at_every_boundary() -> None:
+    """End to end through the manager: a single-budget ("quiet") prefill must
+    leave a hash-consistent cached state at every crossed boundary, not only
+    at the chunk ends the budget happens to produce (#52897)."""
+    prompt_len = 3 * MAMBA_BLOCK_SIZE + 500
+    manager = _make_hybrid_kv_cache_manager()
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
+    state_at = _run_chunked_prefill(manager, request, budgets=[prompt_len])
+    assert set(state_at.values()) == {
+        MAMBA_BLOCK_SIZE,
+        2 * MAMBA_BLOCK_SIZE,
+        3 * MAMBA_BLOCK_SIZE,
+        prompt_len,
+    }
+    # How many of these the manager hashes during an in-flight prefill is
+    # lookup-side policy (eagle lookahead defers hashing); every hashed slot
+    # must still be consistent with the state it holds.
+    assert _count_cached_boundary_states(manager, request, state_at) >= 1

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -15,6 +15,7 @@ import torch
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import get_group_id
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -39,15 +40,18 @@ MAMBA_GROUP_ID = 1
 
 def _make_hybrid_kv_cache_manager(
     num_prefill_checkpoint_blocks: int = 0,
+    retention_interval: int | None = None,
+    attn_block_size: int = ATTN_BLOCK_SIZE,
 ) -> KVCacheManager:
     config = KVCacheConfig(
         num_blocks=10000,
         kv_cache_tensors=[],
+        prefix_cache_retention_interval=retention_interval,
         kv_cache_groups=[
             KVCacheGroupSpec(
                 ["full_layer"],
                 FullAttentionSpec(
-                    block_size=ATTN_BLOCK_SIZE,
+                    block_size=attn_block_size,
                     num_kv_heads=1,
                     head_size=1,
                     dtype=torch.float32,
@@ -70,7 +74,7 @@ def _make_hybrid_kv_cache_manager(
         config,
         max_model_len=262144,
         scheduler_block_size=MAMBA_BLOCK_SIZE,
-        hash_block_size=ATTN_BLOCK_SIZE,
+        hash_block_size=attn_block_size,
         enable_caching=True,
         use_eagle=True,
     )
@@ -82,11 +86,15 @@ def _split(
     use_eagle: bool = True,
     partial_hit: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
+    retention_interval: int | None = None,
+    eagle_reach_margin: int = 0,
 ) -> int:
     """Call the real `Scheduler._mamba_block_aligned_split` on a stub self."""
     stub = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=MAMBA_BLOCK_SIZE),
         use_eagle=use_eagle,
+        mamba_retention_interval=retention_interval,
+        mamba_eagle_reach_margin=eagle_reach_margin,
         max_num_scheduled_tokens=16384,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         # `prefix_match_unit` finer than the block size (#46384).
@@ -353,3 +361,134 @@ def test_quiet_prefill_caches_state_at_every_boundary() -> None:
     # lookup-side policy (eagle lookahead defers hashing); every hashed slot
     # must still be consistent with the state it holds.
     assert _count_cached_boundary_states(manager, request, state_at) >= 1
+
+
+def _chunk_ends(prompt_len: int, **split_kwargs) -> list[int]:
+    """Chunk ends of an unbudgeted prefill through the real split."""
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
+    ends = []
+    while request.num_computed_tokens < prompt_len:
+        num_new = _split(
+            request, prompt_len - request.num_computed_tokens, **split_kwargs
+        )
+        assert num_new > 0
+        request.num_computed_tokens += num_new
+        ends.append(request.num_computed_tokens)
+    return ends
+
+
+@pytest.mark.parametrize(
+    ("prompt_len", "expected"),
+    [
+        # Unaligned: the eagle-reachable boundary, the replay boundary, the tail.
+        (
+            4 * MAMBA_BLOCK_SIZE + 892,
+            [3 * MAMBA_BLOCK_SIZE, 4 * MAMBA_BLOCK_SIZE, 4 * MAMBA_BLOCK_SIZE + 892],
+        ),
+        # Aligned: the replay boundary is one block below the prompt end.
+        (
+            4 * MAMBA_BLOCK_SIZE,
+            [2 * MAMBA_BLOCK_SIZE, 3 * MAMBA_BLOCK_SIZE, 4 * MAMBA_BLOCK_SIZE],
+        ),
+    ],
+)
+def test_split_default_retention_stops_only_where_states_are_kept(
+    prompt_len: int, expected: list[int]
+) -> None:
+    """`prefix_cache_retention_interval=0` (the default) hashes only the
+    replay boundary and shared-prefix junctions, so a boundary stop anywhere
+    else splits the prefill for a state that is discarded. Under EAGLE/MTP the
+    attention lookup drops one block, so the state a replay can reach is one
+    block below the replay boundary: the split materializes both, and nothing
+    else (#53479)."""
+    ends = _chunk_ends(
+        prompt_len,
+        use_eagle=True,
+        retention_interval=0,
+        eagle_reach_margin=MAMBA_BLOCK_SIZE,
+    )
+    assert ends == expected
+
+
+def test_split_segment_retention_stops_at_segment_boundaries() -> None:
+    """A positive interval keeps one state per interval-sized segment plus
+    the replay boundary, so those are the only mandatory chunk ends."""
+    prompt_len = 5 * MAMBA_BLOCK_SIZE + 100
+    ends = _chunk_ends(
+        prompt_len, use_eagle=False, retention_interval=2 * MAMBA_BLOCK_SIZE
+    )
+    assert ends == [
+        2 * MAMBA_BLOCK_SIZE,
+        4 * MAMBA_BLOCK_SIZE,
+        5 * MAMBA_BLOCK_SIZE,
+        prompt_len,
+    ]
+
+
+def test_split_dense_retention_keeps_every_boundary_stop() -> None:
+    """`None`, or an interval at/below the block size, hashes every boundary
+    state, so every boundary stays a chunk end."""
+    prompt_len = 3 * MAMBA_BLOCK_SIZE + 500
+    dense = [MAMBA_BLOCK_SIZE, 2 * MAMBA_BLOCK_SIZE, 3 * MAMBA_BLOCK_SIZE, prompt_len]
+    assert (
+        _chunk_ends(
+            prompt_len,
+            use_eagle=True,
+            retention_interval=None,
+            eagle_reach_margin=MAMBA_BLOCK_SIZE,
+        )
+        == dense
+    )
+    assert (
+        _chunk_ends(prompt_len, use_eagle=False, retention_interval=MAMBA_BLOCK_SIZE)
+        == dense
+    )
+
+
+def _cached_mamba_states(manager: KVCacheManager) -> set[int]:
+    """Token offsets of every hash-cached mamba state in the pool (align mode
+    relocates the running state and frees earlier slots into the pool, where a
+    hashed one stays findable)."""
+    cache = manager.block_pool.cached_block_hash_to_block._cache
+    return {
+        block.block_hash_num_tokens
+        for key, value in cache.items()
+        if get_group_id(key) == MAMBA_GROUP_ID
+        for block in (value.values() if isinstance(value, dict) else [value])
+    }
+
+
+@pytest.mark.parametrize("keep_eagle_reach", [True, False])
+def test_default_retention_keeps_the_eagle_reachable_state(
+    keep_eagle_reach: bool,
+) -> None:
+    """End to end through the manager, in "align" geometry (attention and
+    mamba blocks equal, as the engine forces): with the default interval and
+    EAGLE/MTP, sparse retention kept only the replay boundary's state (block 3
+    for a 4-block-plus-tail prompt) while the pruned lookup reaches one block
+    less, so an identical prompt only hit once a junction formed — on its
+    third send. The state one block below must be kept too, so the second
+    send hits (#53479). `keep_eagle_reach=False` reproduces the old behaviour
+    by zeroing the margin, proving the test discriminates."""
+    block = MAMBA_BLOCK_SIZE
+    manager = _make_hybrid_kv_cache_manager(retention_interval=0, attn_block_size=block)
+    assert manager.coordinator.eagle_reach_margin == block
+    if not keep_eagle_reach:
+        for single_type_manager in manager.coordinator.single_type_managers:
+            single_type_manager.eagle_reach_margin = 0
+    prompt_len = 4 * block + 892
+    (request,) = create_requests(
+        1, num_tokens=prompt_len, block_size=block, same_prompt=True, req_ids=["p0"]
+    )
+    _run_chunked_prefill(manager, request, budgets=[prompt_len])
+    (repeat,) = create_requests(
+        1, num_tokens=prompt_len, block_size=block, same_prompt=True, req_ids=["p1"]
+    )
+    # The lookup drops the last matched attention block (4 -> 3 blocks) and
+    # needs the mamba state exactly there. Sparse retention keeps nothing else.
+    if keep_eagle_reach:
+        assert _cached_mamba_states(manager) == {3 * block, 4 * block}
+        assert manager.get_computed_blocks(repeat)[1] == 3 * block
+    else:
+        assert _cached_mamba_states(manager) == {4 * block}
+        assert manager.get_computed_blocks(repeat)[1] == 0

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1097,7 +1097,9 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
         request=req_2,
         num_new_tokens=3 * block_size,
     )
-    assert num_new_tokens_adjusted == 2 * block_size  # adjust to the common prefix
+    # Dense boundary stops subsume the junction stop: every boundary becomes
+    # a chunk end, so the junction's state is still cached one step later.
+    assert num_new_tokens_adjusted == block_size
 
     manager.allocate_slots(req_2, 3 * block_size, 0, computed_blocks)
     # Cleanup

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1090,6 +1090,8 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
         hash_block_size=block_size,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
+        mamba_retention_interval=None,
+        mamba_eagle_reach_margin=0,
     )
     req_2.shared_prefix_boundary = shared_prefix_boundary
     num_new_tokens_adjusted = Scheduler._mamba_block_aligned_split(

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -40,7 +40,9 @@ from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
+    KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.base import (
@@ -2698,8 +2700,9 @@ class TestEagle:
 
         Groups: 0=non-eagle full-attn, 1=eagle full-attn.
         Group 0 has only 1 hit (out of 3 keys) → max_hit tightens to 4.
-        This clears eagle_verified. Group 1 runs with max_hit=4 → only 1
-        key queried, 1 hit, pop to 0 → returns 0.
+        This clears eagle_verified. Group 1 runs with max_hit=4 → widened
+        query of 2 keys, 2 hits, pop to 1 → the confirmed boundary holds
+        at 4 tokens.
         """
         block_size = 4
         groups = [
@@ -2744,9 +2747,12 @@ class TestEagle:
             offload_keys_per_group=[[10, 11, 12], [1, 2, 3]],
         )
         # Group 0 (non-eagle FA): prefix finds 1 hit → max_hit=4, num_hit=4
-        # Group 1 (eagle FA): max_hit=4 → num_blocks=1, keys=[1].
-        #   Finds 1 hit, pop to 0 → new_num_hit = 0 < block_size → return 0
-        assert sched._lookup(req_status) == 0
+        # Group 1 (eagle FA): max_hit=4, widened query → keys=[1, 2].
+        #   Finds 2 hits, pop to 1 → boundary stays at 4 tokens. Before the
+        #   #52735 fix the query was not widened for full-attention groups,
+        #   so the pop landed on the only queried chunk and zeroed the
+        #   whole request.
+        assert sched._lookup(req_status) == 4
 
     def test_eagle_verified_survives_eagle_tighten(self, request_runner):
         """Eagle group tightening does NOT clear eagle_verified.
@@ -2862,10 +2868,12 @@ class TestEagle:
         runner.manager.prepare_store.side_effect = lambda keys, req_context: (
             generate_store_output(keys)
         )
-        # 4 decoded tokens fill block 3 entirely with decode tokens (one
-        # extra token so the block is stored under async scheduling too).
+        # 4 decoded tokens fill block 3; the extra decode steps let its store
+        # job complete within this run under both scheduling modes. The
+        # eagle group holds back its volatile trailing block (1, 3) while the
+        # request is still decoding, while the normal group stores (0, 3).
         runner.run(
-            decoded_tokens=[1, 1, 1, 1, 1, EOS_TOKEN_ID],
+            decoded_tokens=[1, 1, 1, 1, 1, 1, 1],
             expected_stored=(
                 (0, 0),
                 (0, 1),
@@ -2875,6 +2883,13 @@ class TestEagle:
                 (1, 1),
                 (1, 2),
             ),
+        )
+        # Once the request finishes, no spec rejection can rewrite the tail,
+        # so the exclusion is lifted (issue #52735): the held-back (1, 3) and
+        # the just-completed block 4 are stored for both groups.
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            expected_stored=((0, 4), (1, 3), (1, 4)),
         )
 
     @pytest.mark.parametrize("async_scheduling", [True, False])
@@ -2917,10 +2932,16 @@ class TestEagle:
         runner.manager.prepare_store.side_effect = lambda keys, req_context: (
             generate_store_output(keys)
         )
-        # 4 decoded tokens fill block 3 entirely with decode tokens.
+        # 4 decoded tokens fill block 3 entirely with decode tokens. The
+        # eagle group holds back its volatile trailing block while decoding.
         runner.run(
-            decoded_tokens=[1, 1, 1, 1, EOS_TOKEN_ID],
+            decoded_tokens=[1, 1, 1, 1],
             expected_stored=((0, 0), (0, 1), (0, 2)),
+        )
+        # Finish lifts the exclusion; the tail block is stored (issue #52735).
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            expected_stored=((0, 3),),
         )
 
     @pytest.mark.parametrize("async_scheduling", [True, False])
@@ -3363,3 +3384,226 @@ def test_chunked_local_attention_reports_its_chunk_window():
     assert get_sliding_window_size_in_chunks(spec, tokens_per_chunk=1024) == 8
     # Partial chunks round up, so the reachable tail is never understated.
     assert get_sliding_window_size_in_chunks(spec, tokens_per_chunk=3000) == 3
+
+
+def _shared_kv_mtp_config():
+    """Speculative config for a shared-group MTP model: eagle-family method
+    whose drafter layer merges into a target KV-cache group, so no group
+    self-identifies as a drafter group (issue #52735)."""
+    spec = MagicMock(name="shared_kv_mtp_spec")
+    spec.use_eagle.return_value = True
+    spec.use_multi_module_mtp.return_value = False
+    spec.num_speculative_tokens_per_batch_size = None
+    spec.max_num_new_slots_for_drafting = 0
+    spec.num_speculative_tokens = 1
+    return spec
+
+
+class TestSharedGroupMTPOffload:
+    """Regression tests for issue #52735: OffloadingConnector must keep
+    serving when speculative decoding is enabled but no KV-cache group is
+    annotated as a drafter group (shared-group MTP models)."""
+
+    def test_no_annotation_marks_no_groups(self, request_runner):
+        """Spec decode on + zero annotated groups must NOT mark every group
+        as a drafter group; the full store->load roundtrip must match the
+        non-speculative behavior of test_two_groups_full_and_sliding_window."""
+        block_size = 4
+        kv_cache_groups = [
+            KVCacheGroupSpec(
+                ["layer0"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer1"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=8,
+                ),
+            ),
+        ]
+        runner = request_runner(
+            block_size=block_size,
+            num_gpu_blocks=100,
+            async_scheduling=True,
+            kv_cache_groups=kv_cache_groups,
+            speculative_config=_shared_kv_mtp_config(),
+        )
+        kv_group_configs = runner.connector_scheduler.config.kv_group_configs
+        assert [c.is_eagle_group for c in kv_group_configs] == [False, False]
+
+        runner.new_request(token_ids=[0] * block_size * 3)
+        runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(keys)
+        )
+        runner.run(decoded_tokens=[0])
+        runner.run(
+            decoded_tokens=[0] * (block_size * 3 + 2),
+            expected_stored=(0, 1, 2, 3, 4, 5),
+        )
+        runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(6,))
+
+        runner.scheduler.reset_prefix_cache()
+
+        runner.new_request(token_ids=[0] * (block_size * 3 + 1))
+        runner.manager.lookup.return_value = LookupResult.HIT
+        runner.run(
+            decoded_tokens=[EOS_TOKEN_ID],
+            expected_loaded=((0, 0), (0, 1), (0, 2), (1, 1), (1, 2)),
+        )
+
+
+class TestMambaHybridOffloadServing:
+    """Store->finish->lookup flows on a full-attention + mamba-align hybrid,
+    with a manager that only HITs keys that were actually stored. Guards the
+    two collapse routes of issue #52735."""
+
+    BLOCK = 4
+    MAMBA_BLOCK = 16
+    PROMPT_TOKENS = 28  # 7 hash blocks; 1 full mamba chunk
+
+    def _make_scheduler(self, speculative_config, mamba_eagle=False):
+        vllm_config = _make_vllm_config(
+            extra_config={"self_describing_kv_events": True}
+        )
+        vllm_config.cache_config.block_size = self.BLOCK
+        vllm_config.cache_config.prefix_match_unit = self.BLOCK
+        vllm_config.speculative_config = speculative_config
+        vllm_config.kv_events_config = KVEventsConfig(
+            enable_kv_cache_events=True, publisher="null"
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=64,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full_layer"],
+                    FullAttentionSpec(
+                        block_size=self.BLOCK,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                    is_eagle_group=mamba_eagle,
+                ),
+                KVCacheGroupSpec(
+                    ["mamba_layer"],
+                    MambaSpec(
+                        block_size=self.MAMBA_BLOCK,
+                        shapes=((1, 1),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                ),
+            ],
+        )
+        spec = MockOffloadingSpec(build_offloading_config(vllm_config, kv_cache_config))
+        return OffloadingConnectorScheduler(spec, vllm_config, kv_cache_config)
+
+    def _roundtrip_served_tokens(self, scheduler) -> int:
+        """Request A: prompt-only store, finish; request A2: served tokens."""
+        stored: set = set()
+        scheduler.manager.lookup.side_effect = lambda key, ctx: (
+            LookupResult.HIT if key in stored else LookupResult.MISS
+        )
+        scheduler.manager.prepare_store.side_effect = lambda keys, ctx: (
+            generate_store_output(list(keys))
+        )
+
+        def complete_all_jobs():
+            job_ids = list(scheduler._jobs.keys())
+            for jid in job_ids:
+                stored.update(scheduler._jobs[jid].keys)
+            if job_ids:
+                scheduler.update_connector_output(
+                    KVConnectorOutput(
+                        kv_connector_worker_meta=OffloadingWorkerMetadata(
+                            completed_jobs={jid: 1 for jid in job_ids}
+                        )
+                    )
+                )
+
+        def make_request(req_id):
+            request = MagicMock()
+            request.request_id = req_id
+            request.kv_transfer_params = None
+            request.num_prompt_tokens = self.PROMPT_TOKENS
+            request.num_tokens = self.PROMPT_TOKENS
+            request.num_computed_tokens = 0
+            request.block_hashes = [
+                BlockHash(f"h{i}".encode())
+                for i in range(self.PROMPT_TOKENS // self.BLOCK)
+            ]
+            request.all_token_ids = list(range(self.PROMPT_TOKENS))
+            request.lora_request = None
+            request.is_finished.return_value = False
+            request.status = None
+            scheduler.on_new_request(request)
+            return request
+
+        req = make_request("A")
+        req_status = scheduler._req_status["A"]
+        req_status.num_locally_computed_tokens = 0
+        req_status.update_offload_keys()
+        assert scheduler._lookup(req_status) == 0  # cold
+
+        n_full = self.PROMPT_TOKENS // self.BLOCK
+        n_mamba = self.PROMPT_TOKENS // self.MAMBA_BLOCK
+        req_status.group_states[0].block_ids[:] = list(range(1, n_full + 1))
+        req_status.group_states[1].block_ids[:] = list(range(101, 101 + n_mamba + 1))
+
+        out = SimpleNamespace(
+            num_scheduled_tokens={"A": self.PROMPT_TOKENS},
+            finished_req_ids=set(),
+        )
+        scheduler._build_store_jobs(out)
+        complete_all_jobs()
+
+        req.num_computed_tokens = self.PROMPT_TOKENS
+        req.num_tokens = self.PROMPT_TOKENS + 1
+        req.is_finished.return_value = True
+        req_status.update_offload_keys()
+        scheduler.request_finished(req)
+        out2 = SimpleNamespace(num_scheduled_tokens={}, finished_req_ids={"A"})
+        scheduler._build_store_jobs(out2)
+        complete_all_jobs()
+
+        make_request("A2")
+        rs2 = scheduler._req_status["A2"]
+        rs2.num_locally_computed_tokens = 0
+        rs2.update_offload_keys()
+        served = scheduler._lookup(rs2)
+        return served if served is not None else 0
+
+    def test_shared_group_mtp_serves_like_non_speculative(self):
+        """Route 1 of #52735: with spec decode on and no drafter annotation,
+        serving must equal the non-speculative baseline (was 0 before the
+        fix: the all-groups fallback marked the mamba group as a drafter and
+        the volatile-tail pop consumed its only servable chunk)."""
+        baseline = self._roundtrip_served_tokens(self._make_scheduler(None))
+        assert baseline == 16
+        served = self._roundtrip_served_tokens(
+            self._make_scheduler(_shared_kv_mtp_config())
+        )
+        assert served == baseline
+
+    def test_annotated_eagle_group_does_not_starve_coarse_sibling(self):
+        """Route 2 of #52735 (F1): a genuinely annotated eagle full-attention
+        group must not drag the confirmed boundary below a coarser sibling's
+        chunk granularity. The widened query makes the volatile-tail pop
+        land on an extra queried chunk, holding the boundary at 16 tokens
+        (was 0 before the fix: 4 hits -> pop -> 12 tokens < mamba chunk)."""
+        scheduler = self._make_scheduler(None, mamba_eagle=True)
+        assert [c.is_eagle_group for c in scheduler.config.kv_group_configs] == [
+            True,
+            False,
+        ]
+        assert self._roundtrip_served_tokens(scheduler) == 16

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -180,6 +180,7 @@ class RequestRunner:
         kv_cache_groups: list[KVCacheGroupSpec] | None = None,
         extra_config_overrides: dict[str, Any] | None = None,
         worker_count: int = 1,
+        speculative_config: Any | None = None,
     ):
         assert blocks_per_chunk == 1 or kv_cache_groups is None, (
             "blocks_per_chunk > 1 requires all groups to have the same "
@@ -200,6 +201,8 @@ class RequestRunner:
         )
         vllm_config.scheduler_config.async_scheduling = async_scheduling
         vllm_config.parallel_config.world_size = worker_count
+        if speculative_config is not None:
+            vllm_config.speculative_config = speculative_config
 
         extra_config: dict[str, Any] = {
             "spec_name": "MockOffloadingSpec",
@@ -241,19 +244,13 @@ class RequestRunner:
                 )
             ]
 
-        # Groups overlay one allocation, sized by the largest group.
-        block_stride = max(
-            group.kv_cache_spec.page_size_bytes * len(group.layer_names)
-            for group in kv_cache_groups
-        )
         kv_cache_tensors = [
             KVCacheTensor(
-                size=block_stride * num_gpu_blocks,
-                layers=list(group.layer_names),
-                layer_stride=group.kv_cache_spec.page_size_bytes * num_gpu_blocks,
-                block_stride=group.kv_cache_spec.page_size_bytes,
+                size=group.kv_cache_spec.page_size_bytes * num_gpu_blocks,
+                shared_by=[layer_name],
             )
             for group in kv_cache_groups
+            for layer_name in group.layer_names
         ]
 
         kv_cache_config = KVCacheConfig(
@@ -283,6 +280,7 @@ class RequestRunner:
         )
 
         # register worker kv_caches to enable OffloadingWorker creations
+        # set_current_vllm_config is needed for get_kv_cache_layout() to work
         kv_caches: dict[str, torch.Tensor] = {}
         for group in kv_cache_groups:
             spec = group.kv_cache_spec
@@ -676,6 +674,7 @@ def request_runner():
         kv_cache_groups=None,
         extra_config_overrides=None,
         worker_count=1,
+        speculative_config=None,
     ):
         runner = RequestRunner(
             block_size=block_size,
@@ -685,6 +684,7 @@ def request_runner():
             kv_cache_groups=kv_cache_groups,
             extra_config_overrides=extra_config_overrides,
             worker_count=worker_count,
+            speculative_config=speculative_config,
         )
         runners.append(runner)
         return runner

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -157,6 +157,13 @@ class KVCacheCoordinator(ABC):
             self.retention_interval, self.scheduler_block_size, kv_cache_config
         )
 
+    @property
+    def eagle_reach_margin(self) -> int:
+        """Tokens an EAGLE/MTP lookup drops below the deepest cached
+        position (the attention groups' pruned block). 0 without speculative
+        decoding or without a pruned attention group."""
+        return 0
+
     def get_num_blocks_to_allocate(
         self,
         request_id: str,
@@ -650,6 +657,33 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     ", ".join(sorted(unsupported_partial_hit_managers)),
                 )
         self.verify_and_split_kv_cache_groups()
+        # Sparse retention (`MambaManager._reachable_boundaries`) must keep a
+        # state where a pruned speculative lookup can reach, not only at the
+        # replay boundary.
+        for manager in self.single_type_managers:
+            manager.eagle_reach_margin = self.eagle_reach_margin
+
+    def _eagle_margin(
+        self, manager_cls: type[SingleTypeKVCacheManager], group_block_size: int
+    ) -> int:
+        """Tokens the EAGLE/MTP lookup drops from a group's hit: one hash
+        block under fine-grained partial hits, otherwise one group block."""
+        return (
+            self.hash_block_size
+            if self.enable_partial_hash_hits
+            and manager_cls.supports_fine_grained_hash_lookup
+            and group_block_size > self.hash_block_size
+            else group_block_size
+        )
+
+    @property
+    def eagle_reach_margin(self) -> int:
+        for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
+            if use_eagle and not isinstance(spec, MambaSpec):
+                return self._eagle_margin(
+                    manager_cls, self.single_type_managers[group_ids[0]].block_size
+                )
+        return 0
 
     @property
     def _cache_hit_alignment_tokens(self) -> int:
@@ -825,13 +859,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 # mamba: its finder never drops (draft models have no mamba
                 # layers), so the hit would grow past the candidate.
                 if drop_eagle_block and not isinstance(spec, MambaSpec):
-                    eagle_margin = (
-                        self.hash_block_size
-                        if self.enable_partial_hash_hits
-                        and manager_cls.supports_fine_grained_hash_lookup
-                        and group_block_size > self.hash_block_size
-                        else group_block_size
-                    )
+                    eagle_margin = self._eagle_margin(manager_cls, group_block_size)
                     _max_length = min(
                         curr_hit_length + eagle_margin, max_cache_hit_length
                     )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -408,12 +408,11 @@ class Scheduler(SchedulerInterface):
             return num_new_tokens
 
         block_size = self.cache_config.block_size
-        # The last block-aligned position whose state can be cached. With
-        # Eagle, FullAttn prunes the last matching block, so back off one
-        # block to avoid a Mamba cache miss.
+        # The last block-aligned position whose state can be cached. No
+        # speculative back-off: with a state at every crossed boundary (the
+        # unconditional stop below), a lookup whose last block is pruned
+        # falls back to the previous boundary's state instead of missing.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle:
-            last_cache_position = max(last_cache_position - block_size, 0)
 
         end = start + num_new_tokens
         use_internal_checkpoint = (
@@ -442,9 +441,13 @@ class Scheduler(SchedulerInterface):
             else 0
         )
         stops = (
-            # Same invariant: a chunk starting mid-block stops at the boundary
-            # rather than running past it.
-            next_block_boundary if start % block_size != 0 else 0,
+            # Without internal checkpoints, states exist only at chunk
+            # ends, so every chunk stops at its next block boundary to
+            # materialize a reusable state at every crossed boundary; the
+            # prompt's final sub-block tail may still end unaligned. With
+            # checkpoints, mid-block states are recoverable and deep chunks
+            # need no boundary stops.
+            next_block_boundary if not use_internal_checkpoint else 0,
             # Never run past the last cacheable block boundary mid-chunk.
             last_cache_position,
             # Fine-grained hits: the prompt's partial-tail entry can only be

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -342,6 +342,16 @@ class Scheduler(SchedulerInterface):
             and self.hash_block_size < self.block_size
             and self.kv_cache_manager.coordinator.enable_partial_hash_hits
         )
+        # Sparse Mamba retention (`prefix_cache_retention_interval`) hashes only
+        # some boundary states, so the split only stops where one will be
+        # kept. `eagle_reach_margin`: how far below the replay boundary an
+        # EAGLE/MTP lookup can reach (`MambaManager._reachable_boundaries`).
+        self.mamba_retention_interval = kv_cache_config.prefix_cache_retention_interval
+        self.mamba_eagle_reach_margin = (
+            self.kv_cache_manager.coordinator.eagle_reach_margin
+            if self.need_mamba_block_aligned_split
+            else 0
+        )
 
         # Counts of non-empty steps scheduled / processed. update_from_output
         # is called once per scheduled step in FIFO order, so these stay in sync.
@@ -440,14 +450,38 @@ class Scheduler(SchedulerInterface):
             if self.mamba_partial_cache_hit
             else 0
         )
+        # Without internal checkpoints, states exist only at chunk ends, so a
+        # chunk stops at every boundary whose state retention will hash: every
+        # boundary under dense retention (`None`, or an interval at/below the
+        # block size), the next segment boundary under a positive interval,
+        # none under 0. Stopping elsewhere splits the prefill for a state that
+        # is discarded. With checkpoints, mid-block states are recoverable and
+        # deep chunks need no boundary stops.
+        retention = self.mamba_retention_interval
+        if use_internal_checkpoint or retention == 0:
+            boundary_stop = 0
+        elif retention is None or retention <= block_size:
+            boundary_stop = next_block_boundary
+        else:
+            boundary_stop = (start // retention + 1) * retention
+        # Sparse retention keeps the replay boundary's state and, under
+        # EAGLE/MTP, the deepest one a pruned lookup can reach; a chunk must
+        # end there for that state to exist at all.
+        replay_boundary = eagle_reach = 0
+        if retention is not None and not use_internal_checkpoint:
+            replay_end = request.num_prompt_tokens - 1
+            replay_boundary = replay_end // block_size * block_size
+            if self.mamba_eagle_reach_margin > 0:
+                eagle_reach = max(
+                    (replay_end - self.mamba_eagle_reach_margin)
+                    // block_size
+                    * block_size,
+                    0,
+                )
         stops = (
-            # Without internal checkpoints, states exist only at chunk
-            # ends, so every chunk stops at its next block boundary to
-            # materialize a reusable state at every crossed boundary; the
-            # prompt's final sub-block tail may still end unaligned. With
-            # checkpoints, mid-block states are recoverable and deep chunks
-            # need no boundary stops.
-            next_block_boundary if not use_internal_checkpoint else 0,
+            boundary_stop,
+            replay_boundary,
+            eagle_reach,
             # Never run past the last cacheable block boundary mid-chunk.
             last_cache_position,
             # Fine-grained hits: the prompt's partial-tail entry can only be

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -41,6 +41,10 @@ class SingleTypeKVCacheManager(ABC):
 
     supports_fine_grained_hash_lookup: ClassVar[bool] = False
 
+    # Tokens an EAGLE/MTP lookup drops below the deepest cached position;
+    # set by the hybrid coordinator, used by sparse Mamba retention.
+    eagle_reach_margin: int = 0
+
     def __init__(
         self,
         kv_cache_spec: KVCacheSpec,
@@ -421,6 +425,15 @@ class SingleTypeKVCacheManager(ABC):
         self._pending_cow_copies.append((source_block, cow_block))
         cow_block.ref_cnt += 1
 
+    def _reachable_boundaries(self, request: Request) -> list[int]:
+        """Token boundaries whose reachable tail must be retained under
+        sparse retention: the replay boundary (``num_prompt - 1``, capped by
+        ``get_computed_blocks``) and any detected shared-prefix junction."""
+        reachable_boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            reachable_boundaries.append(request.shared_prefix_boundary)
+        return reachable_boundaries
+
     def cache_blocks(
         self,
         request: Request,
@@ -445,12 +458,7 @@ class SingleTypeKVCacheManager(ABC):
         if num_cached_blocks >= num_full_blocks:
             return
 
-        # Token boundaries whose reachable tail must be retained under sparse
-        # retention: the replay boundary (``num_prompt - 1``, capped by
-        # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
-        if request.shared_prefix_boundary:
-            reachable_boundaries.append(request.shared_prefix_boundary)
+        reachable_boundaries = self._reachable_boundaries(request)
 
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
@@ -1267,6 +1275,20 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
 
 class MambaManager(SingleTypeKVCacheManager):
     supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
+    def _reachable_boundaries(self, request: Request) -> list[int]:
+        boundaries = super()._reachable_boundaries(request)
+        # Under EAGLE/MTP the attention lookup drops its last matched block
+        # (`eagle_reach_margin` tokens), so the deepest state a replay can
+        # actually use lies that far below the replay boundary. Without it
+        # sparse retention keeps a state one block beyond any speculative
+        # lookup's reach and an identical prompt only hits once a junction
+        # forms (#53479).
+        if self.eagle_reach_margin > 0:
+            eagle_reach = request.num_prompt_tokens - 1 - self.eagle_reach_margin
+            if eagle_reach >= 0:
+                boundaries.append(eagle_reach)
+        return boundaries
 
     def __init__(
         self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs


### PR DESCRIPTION
**Important — superseded draft and attribution correction**

This PR is back in draft. Its current branch is superseded and should not be
reviewed as the intended final change.

Three standalone test files currently in this branch are byte-identical to
files first published by @akshaver in #52371, but this branch does not
preserve that commit attribution. They have been removed from my local
rewrite, and the final revision will explicitly credit #52371 as prior test
coverage. I have also removed unrelated offloading changes from the rewrite;
that work remains scoped to my #52771.

I am rebuilding this as a narrow scheduler follow-up to #54076 and #54713. I
will update this body and branch only after #54076 and #54713 merge; if
either closes unmerged, I will reassess. The focused change will then be
reverified against current `main`.

AI assistance from Claude Code and OpenAI Codex was used in the
investigation and rewrite; I reviewed and verified this correction.

## Purpose

Two coupled defects in `_mamba_block_aligned_split` (#52897) leave hybrid-model prefix caching mostly inert outside of exact-repeat traffic:

1. **States are sparse.** Align-mode states materialize only at chunk ends, and a quiet prefill produces one deep mid-prompt chunk end — so a sibling sharing anything less than that single position gets **zero** reuse even on an idle server (measured: shared 2,000 of 4,278 → 0). An exactly block-aligned prompt gets zero on *identical repeats* too: its only state sits at `num_tokens`, above the `num_tokens - 1` lookup cap.
2. **The speculative one-block back-off forfeits a full mamba block.** `last_cache_position -= block_size` under `use_eagle` was sized for 16-token attention blocks; align blocks are 544–2,128 tokens, so the whole speculative family (`eagle/eagle3/mtp/dflash/dspark`) gives up one entire block of reusable prefix. Measured on GB10 production hardware by @jschmied (#52897): half the reusable prefix on aligned prompts, one extra cold pass, ~9× warm prefill (combined speculative/checkpoint path).

**Fix:** a chunk stops at every block boundary whose state retention will hash, so a reusable state materializes wherever a lookup can find one; with states at those boundaries, a lookup whose last block is pruned falls back one block instead of missing, which is what made the back-off necessary — so it is removed. When `mamba_has_prefill_checkpoint_blocks` applies (#52789), mid-block states are recoverable and deep chunks are kept (no extra steps on that path).

**Retention coupling (found in review by @jschmied).** `prefix_cache_retention_interval` defaults to **0** since #52216 (Aug 17): `MambaManager.reachable_block_mask` then hashes only the replay boundary and shared-prefix junctions, so on a default install (a) unconditional boundary stops would split the prefill for states that are discarded, and (b) the one state that *is* kept — the replay boundary, `num_prompt_tokens - 1` — sits one attention block beyond what an EAGLE/MTP lookup can reach (the lookup drops its last matched block), so an identical prompt only hit once a junction formed, on its third send. This PR therefore:
- makes the boundary stops **retention-aware**: every boundary under dense retention (`None`, or an interval at/below the block size), the next segment boundary under a positive interval, only the kept boundaries under 0 — a default install pays no extra chunk splits;
- keeps the state at the **EAGLE-reachable boundary** as well: the hybrid coordinator exposes `eagle_reach_margin` (the same rule its lookup already applies — one hash block under fine-grained partial hits, otherwise one group block), `MambaManager` adds that boundary to the retained set, and the split ends a chunk there so the state exists.

Measured on the CPU scheduler+manager harness at retention 0 (`main` @ `8d6b1832`, @jschmied's 3-send identical-prompt protocol, 1,600-token align blocks; first hit on send N, amount in parentheses):

| default retention (0) | base | this PR |
|---|---|---|
| 7,292-token prompt (4 blocks + tail) | send 3 (4,800), carve [4800, 7292] | **send 2** (4,800), carve [4800, 6400, 7292] |
| 6,400-token prompt (aligned) | send 3 (3,200), carve [4800, 6400] | **send 2** (3,200), carve [3200, 4800, 6400] |

Every dense-retention cell is unchanged by the retention work. Dense-retention results (harness `main` @ `185cada36`-era, every cell n=2; full matrix and per-group attribution in [#52897](https://github.com/vllm-project/vllm/issues/52897#issuecomment-5387493050)): sibling geometries go from {0, 0, 1600-capped} to {1600, 1600, 3200}; the aligned-prompt zero becomes 3,200 (spec on) / 4,800 (off). GPU end-to-end on an A100 against the **`vllm==0.27.1` release wheel** (hybrid GDN, engine-forced 544-token align blocks; the wheel predates #52216, so these are dense-retention measurements): a sibling sharing 700 tokens goes from **+0 to +544** cached tokens, deep siblings unchanged; worst-case latency cost measured at +33 ms per extra boundary step on a 0.8B `--enforce-eager` setup (per-step overhead dominated; low single-digit % on production-scale prefills).

## Relationship to prior art (and why this is not a duplicate)

- **#48815** identified the back-off waste first (July 16). It is an opt-in env flag, `method == "mtp"` only, and intentionally keeps the back-off for exactly-aligned prompts. This PR removes the back-off unconditionally and makes that safe via states at the reachable boundaries; no flag.
- **#52244** identified the aligned-prompt zero and the `num_tokens - 1` cap mechanics first (Aug 14), adding a replay-landing stop. @jschmied measured it not moving his numbers on GB10; the retention-aware stops here subsume the landing stop (the replay boundary is always a chunk end).
- **#52371** pins the *lookup-side* face of these defects (manager-level xfail tests). This PR is the store side: it makes states exist where lookups can reach them, and does not change lookup behavior — the two are complementary (verified: #52371's pins are unaffected by this change).
- **#50897** (lookahead-aware hashing) is lookup-side infrastructure; disjoint files, complementary.
- **#52216** made 0 the retention default; this PR does not change that default, it makes the store side consistent with it.

## Test Plan

- `tests/v1/core/test_mamba_align_chunk_split.py`, 7 new regressions: dense stops without checkpoints; the last boundary stays reachable under `use_eagle`; manager-level state placement at every boundary; **retention-aware stops** at the default interval (aligned and unaligned prompts: only the eagle-reachable and replay boundaries are chunk ends), at a positive segment interval, and under dense retention; and an end-to-end manager test in align geometry (attention block = mamba block, as the engine forces) that at retention 0 with EAGLE the pool keeps exactly the replay-boundary and eagle-reachable states and an identical second request hits 3 blocks — with a negative control that zeroes the margin and reproduces the old behaviour (one state, zero hit). All fail on unpatched `main` (the retention tests need scheduler and coordinator attributes `main` does not have; the negative control is what shows the manager test discriminating).
- Expectation updates: `test_mamba_align_split_partial_tail_schedule[1|4]` moves to the one-block-per-step staircase (docstring updated); `test_hybrid_cache_mamba_align_shared_prefix_detection`'s junction stop is subsumed; the split stubs in those files gain the two new scheduler attributes with dense defaults. The checkpoint-path (#52789) tests pass unchanged.
- Suites: `tests/v1/core/` + `tests/v1/kv_connector/unit/offloading_connector/` on this network-restricted CPU box: 681 passed, 127 failed — every failure classified by signature and all pre-existing on this box: 76 `KVCacheTensor.__init__() ... 'shared_by'` and 48 `ModelConfig` validation errors (offline model inspection) — the same counts and signatures as the unmodified tree in the earlier run — 3 engine-core boots, and 2 `assert 0 == 16` in `TestMambaHybridOffloadServing` re-verified to fail identically with this PR's production files reverted (the #52771 defect). No failure attributable to this change.
- Behavior note: no model-output change — chunked-prefill results are invariant to chunk split points by the existing invariant; this PR only changes where steps pause. Under the default retention a prefill takes at most one more scheduler step than before this PR (the kept boundary the back-off used to skip); under dense retention it is (blocks crossed − previous chunk count), measured cost above.

## AI assistance disclosure

Developed with AI assistance (Claude Code). I reviewed every changed line and all results myself; the failure modes were measured on live serving (A100, 0.27.1 wheel) before the fix was written, independently confirmed on GB10 hardware by @jschmied in #52897, and the retention-interval coupling was found by @jschmied while validating this PR.