### PR TITLE
[Bugfix][LoRA] Implement get_expert_mapping for Gemma 4 MoE models

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1349,19 +1349,14 @@ class Gemma4Model(nn.Module, EagleModelMixin):
             return hidden_states, aux_hidden_states
         return hidden_states
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        """Expert weight mapping, also required by the fused-MoE LoRA path.
 
-        # MoE expert weight mapping: checkpoint can have either:
-        #   1. 3D packed tensors (exploded in _weight_iterator to per-expert 2D)
-        #   2. Already per-expert 2D weights (if quantized)
+        `LoRAModelManager` calls `get_expert_mapping()` on MoE models; without it, serving any
+        LoRA against a MoE Gemma 4 raises
+        `AttributeError: To support LoRA for MoE model, 'get_expert_mapping' must be implemented`
+        before the engine finishes starting. `load_weights` calls this so the two cannot diverge.
+        """
         # Map to MoERunner parameters:
         #   moe.experts.{id}.gate_proj → MoERunner w1 (shard of w13)
         #   moe.experts.{id}.up_proj   → MoERunner w3 (shard of w13)
@@ -1392,9 +1387,28 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                 shard_id,
             ) in dot_suffix_expert_params_mapping
         ]
-        expert_params_mapping = (
+        return (
             dot_suffix_expert_params_mapping + underscore_suffix_expert_params_mapping
         )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        # MoE expert weight mapping: checkpoint can have either:
+        #   1. 3D packed tensors (exploded in _weight_iterator to per-expert 2D)
+        #   2. Already per-expert 2D weights (if quantized)
+        # Map to MoERunner parameters:
+        #   moe.experts.{id}.gate_proj → MoERunner w1 (shard of w13)
+        #   moe.experts.{id}.up_proj   → MoERunner w3 (shard of w13)
+        #   moe.experts.{id}.down_proj → MoERunner w2
+        expert_params_mapping = self.get_expert_mapping()
         params_dict = dict(self.named_parameters())
         # Include buffers (e.g. layer_scalar) so they can be loaded too
         params_dict.update(dict(self.named_buffers()))
@@ -1601,6 +1615,9 @@ class Gemma4ForCausalLM(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)
+
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.model.get_expert_mapping()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # Checkpoint weight names use "language_model." prefix (from the

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -2156,6 +2156,9 @@ class Gemma4ForConditionalGeneration(
     # Weight loading
     # ------------------------------------------------------------------ #
 
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return self.language_model.get_expert_mapping()
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # Some checkpoints have vestigial embed_vision.embedding and
         # embed_audio.embedding weights from the Gemma3n architecture


### PR DESCRIPTION
## Purpose

Serving **any** LoRA adapter against a **MoE Gemma 4** model currently fails at engine start:

```
INFO  [utils.py:101] MoE model detected. Using fused MoE LoRA implementation.
AttributeError: To support LoRA for MoE model, 'get_expert_mapping' must be implemented
```

`LoRAModelManager` calls `get_expert_mapping()` on MoE models. `Gemma4Model`, `Gemma4ForCausalLM` and `Gemma4ForConditionalGeneration` don't implement it — although all three already declare `SupportsLoRA`, and `Gemma4ForCausalLM` also declares `MixtureOfExperts`.

The mapping itself **already exists**: `Gemma4Model.load_weights` builds it as a local, in exactly the `(param_name, weight_name, expert_id, shard_id)` shape the hook returns. This PR exposes it as a method, has `load_weights` call it so the two cannot diverge, and delegates from the two top-level classes — the pattern `qwen3_moe.py`, `deepseek_v2.py`, `glm4_moe.py` and `gpt_oss.py` already follow.

Fixes #53470.

Related but **separate**: #39815 / #39816 (module aliasing zeroing LoRA weights) and #41754. Those cause a *silently inert* adapter once the engine is running; this one is a hard failure before it starts. On a MoE Gemma 4 you need both.

## Test Plan

- `unsloth/gemma-4-26b-a4b-it` (Gemma 4 26B-A4B, 128 experts), r=16 adapter
- NVIDIA GB10 (DGX Spark), aarch64, sm_121
- `vllm serve <model> --enable-lora --max-lora-rank 16 --lora-modules test=/adapter`
- Before: `AttributeError` at engine start, nothing serves
- After: engine starts, adapter loads, generations differ from base

## Test Result

Engine starts and serves normally. With #39816 also applied, the adapter scores **17/17 on our feature-spec evaluation — identical to the same LoRA merged into the base and served via llama.cpp**, which is the equivalence result we were after.

`get_expert_mapping()` returns exactly what `load_weights` previously built inline, including both the dot-suffix and underscore-suffix strategies, so weight loading behaviour is unchanged by construction.

Only `gemma4.py` and `gemma4_mm.py` are touched — `gemma4_unified.py`, `gemma4_dspark.py` and `gemma4_mtp.py` declare neither `SupportsLoRA` nor an expert mapping, so they are out of scope here.

I have a reproducible aarch64 + MoE setup and am happy to test follow-ups on it.
