### PR TITLE
[Elastic EP] Initialize new groups without warmup collectives

### DIFF
--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -264,7 +264,6 @@ class ElasticEPScalingExecutor:
         self._prepare_eplb_communicator(get_standby_eplb_group())
         if new_dp_size > old_dp_size:
             self.transfer_weights(old_dp_size, new_dp_size)
-        self._warm_target_groups(get_standby_dp_group(), get_standby_ep_group())
 
     def _prepare_eplb_communicator(self, eplb_group) -> None:
         assert eplb_group is not None
@@ -320,15 +319,6 @@ class ElasticEPScalingExecutor:
                 expert_weights=model.expert_weights,
             )
         torch.accelerator.synchronize()
-
-    def _warm_target_groups(self, dp_group, ep_group) -> None:
-        assert dp_group is not None and ep_group is not None
-        stream = torch.Stream(device=dp_group.device)
-        with stream:
-            tensor = torch.zeros(1, dtype=torch.int32, device=dp_group.device)
-            for group in (dp_group, ep_group):
-                torch.distributed.all_reduce(tensor, group=group.device_group)
-                stream.synchronize()
 
     def broadcast_expert_mapping(self) -> None:
         standby_dp_group = get_standby_dp_group()
@@ -676,7 +666,6 @@ class ElasticEPScalingExecutor:
             expert_weights=expert_weights,
         )
         torch.accelerator.synchronize()
-        self._warm_target_groups(get_dp_group(), get_ep_group())
 
     def receive_expert_mapping(self) -> torch.Tensor:
         dp_group = get_dp_group()

--- a/vllm/distributed/elastic_ep/standby_state.py
+++ b/vllm/distributed/elastic_ep/standby_state.py
@@ -79,7 +79,12 @@ def create_standby_groups(
     standby_dp_ranks = all_ranks.transpose(1, 3).reshape(-1, new_dp_size).unbind(0)
     standby_dp_ranks = [x.tolist() for x in standby_dp_ranks]
     _STANDBY_DP = _init_stateless_group(
-        standby_dp_ranks, "dp", master_ip, backend, coord_store=coord_store
+        standby_dp_ranks,
+        "dp",
+        master_ip,
+        backend,
+        coord_store=coord_store,
+        device_id=world_group.device,
     )
 
     standby_ep_ranks = (
@@ -87,7 +92,13 @@ def create_standby_groups(
     )
     standby_ep_ranks = [x.tolist() for x in standby_ep_ranks]
     _STANDBY_EP = _init_stateless_group(
-        standby_ep_ranks, "ep", master_ip, backend, coord_store, use_all2all=use_all2all
+        standby_ep_ranks,
+        "ep",
+        master_ip,
+        backend,
+        coord_store,
+        use_all2all=use_all2all,
+        device_id=world_group.device,
     )
 
     if enable_eplb:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1340,6 +1340,7 @@ def _init_stateless_group(
     coord_store: Store,
     use_device_communicator: bool = True,
     use_all2all: bool = False,
+    device_id: torch.device | None = None,
 ) -> "StatelessGroupCoordinator":
     """Create a StatelessGroupCoordinator with the given parameters."""
     from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
@@ -1356,6 +1357,7 @@ def _init_stateless_group(
         global_rank=world.rank,
         global_world_size=world.world_size,
         use_all2all=use_all2all,
+        device_id=device_id,
     )
 
 
@@ -1914,6 +1916,7 @@ def initialize_model_parallel(
             parallel_config.data_parallel_master_ip,
             backend,
             coord_store=coord_store,
+            device_id=get_world_group().device,
         )
     else:
         _DP = init_model_parallel_group(
@@ -1944,6 +1947,7 @@ def initialize_model_parallel(
                 backend,
                 coord_store=coord_store,
                 use_all2all=use_all2all,
+                device_id=get_world_group().device,
             )
         else:
             _EP = init_model_parallel_group(

--- a/vllm/distributed/stateless_coordinator.py
+++ b/vllm/distributed/stateless_coordinator.py
@@ -80,6 +80,7 @@ class StatelessGroupCoordinator(GroupCoordinator):
         global_rank: int = 0,
         global_world_size: int = 1,
         use_all2all: bool = False,
+        device_id: torch.device | None = None,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -131,6 +132,7 @@ class StatelessGroupCoordinator(GroupCoordinator):
                     backend=backend,
                     group_name=f"{self.unique_name}_device",
                     listen_socket=socks[0] if socks else None,
+                    device_id=device_id,
                 )
                 cpu_group = stateless_init_torch_distributed_process_group(
                     host=host,

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -582,6 +582,7 @@ def stateless_init_torch_distributed_process_group(
     group_name: str | None = None,
     return_store: bool = False,
     listen_socket: socket.socket | None = None,
+    device_id: torch.device | None = None,
 ) -> ProcessGroup | tuple[ProcessGroup, Store]:
     """
     A replacement for `torch.distributed.init_process_group` that does not
@@ -670,6 +671,7 @@ def stateless_init_torch_distributed_process_group(
             group_rank=group_rank,
             group_size=group_size,
             timeout=timeout,
+            device_id=device_id,
         )
 
     if group_name is not None:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -591,6 +591,7 @@ class CudaPlatformBase(Platform):
         group_rank: int,
         group_size: int,
         timeout: timedelta,
+        device_id: torch.device | None = None,
     ) -> ProcessGroup:
         assert is_nccl_available()
         pg: ProcessGroup = ProcessGroup(
@@ -609,9 +610,12 @@ class CudaPlatformBase(Platform):
         backend_type = ProcessGroup.BackendType.NCCL
         device = torch.device("cuda")
         pg._set_default_backend(backend_type)
+        pg.bound_device_id = device_id
         backend_class._set_sequence_number_for_group()
 
         pg._register_backend(device, backend_type, backend_class)
+        if device_id is not None:
+            backend_class.eager_connect_single_device(device_id)
         return pg
 
     @classmethod

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -1173,6 +1173,7 @@ class Platform:
         group_rank: int,
         group_size: int,
         timeout: timedelta,
+        device_id: torch.device | None = None,
     ) -> "ProcessGroup":
         """
         Init platform-specific torch distributed process group.

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -1009,6 +1009,7 @@ class RocmPlatform(Platform):
         group_rank: int,
         group_size: int,
         timeout: timedelta,
+        device_id: torch.device | None = None,
     ) -> ProcessGroup:
         assert is_nccl_available()
         pg: ProcessGroup = ProcessGroup(
@@ -1027,9 +1028,12 @@ class RocmPlatform(Platform):
         backend_type = ProcessGroup.BackendType.NCCL
         device = torch.device("cuda")
         pg._set_default_backend(backend_type)
+        pg.bound_device_id = device_id
         backend_class._set_sequence_number_for_group()
 
         pg._register_backend(device, backend_type, backend_class)
+        if device_id is not None:
+            backend_class.eager_connect_single_device(device_id)
         return pg
 
     @classmethod


### PR DESCRIPTION
Elastic EP previously force-initialized communication groups for the target configuration by running a warmup collective on each new group. These collectives overlap with forward-pass collectives from the main serving thread, which seems to be problematic with ROCm HIP graphs (see #53010).

PyTorch's NCCL process group exposes an API to eagerly initialize a communicator without running a collective. Use that API when creating Elastic EP groups.

**Edit: this still underperforms target group warmup, and downtime grows with full-size models and bigger EP sizes, so we need to find another solution for AMD**