### PR TITLE
[Kimi-K3] Split the KDA mixer out of piecewise CUDA graphs

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -256,6 +256,7 @@ def test_splitting_ops_dynamic():
     assert splitting_ops is not None
     assert {
         "vllm::qwen_gdn_attention_core_fused_norm_packed",
+        "vllm::kimi_k3_kda_attention",
     } <= set(splitting_ops)
 
     # When use_inductor_graph_partition=True

--- a/tests/models/kimi_k3/test_kda_attention_op.py
+++ b/tests/models/kimi_k3/test_kda_attention_op.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.config.compilation import CompilationConfig
+from vllm.models.kimi_k3.common import kda_attention_op  # noqa: F401
+
+
+def test_kimi_k3_kda_attention_is_registered_and_split() -> None:
+    assert hasattr(torch.ops.vllm, "kimi_k3_kda_attention")
+    assert "vllm::kimi_k3_kda_attention" in CompilationConfig._attention_ops

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -770,6 +770,7 @@ class CompilationConfig:
         "vllm::linear_attention",
         "vllm::qwen_gdn_attention_core",
         "vllm::qwen_gdn_attention_core_fused_norm_packed",
+        "vllm::kimi_k3_kda_attention",
         "vllm::gdn_attention_core_xpu",
         "vllm::olmo_hybrid_gdn_full_forward",
         "vllm::sparse_attn_indexer",

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -6,7 +6,6 @@ from einops import rearrange
 from torch import nn
 
 from vllm import _custom_ops as ops
-from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import VllmConfig
 from vllm.distributed import divide
 from vllm.forward_context import get_forward_context
@@ -51,8 +50,10 @@ from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     fused_recurrent_kda,
     fused_recurrent_kda_packed_decode,
 )
+from vllm.models.kimi_k3.common import kda_attention_op as _kda_attention_op  # noqa: F401
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
+from vllm.utils.torch_utils import _encode_layer_name
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 
@@ -287,17 +288,17 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             device=hidden_states.device,
         )
 
-        self._forward(
-            mixed_qkv=mixed_qkv,
-            g1=g1,
-            g2=g2,
-            beta=beta,
-            core_attn_out=core_attn_out,
+        torch.ops.vllm.kimi_k3_kda_attention(
+            mixed_qkv,
+            g1,
+            g2,
+            beta,
+            core_attn_out,
+            _encode_layer_name(self.prefix),
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
 
-    @eager_break_during_capture
     def _forward(
         self,
         mixed_qkv: torch.Tensor,

--- a/vllm/models/kimi_k3/common/kda_attention_op.py
+++ b/vllm/models/kimi_k3/common/kda_attention_op.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Opaque piecewise-split custom op for the Kimi-K3 KDA mixer.
+
+The KDA recurrence reads forward-context metadata, launches causal-conv / KDA
+kernels, and mutates the per-request conv/SSM cache in place. Tracing that
+stateful path through torch.compile (or capturing it as many eager Triton
+launches) is what made conc=1 decode launch-bound.
+
+Wrapping the mixer as one custom op, and listing it in
+``CompilationConfig._attention_ops``, is the same pattern as Qwen GDN
+(``qwen_gdn_attention_core``) and Bailing V3 KDA: inductor treats the mixer
+as opaque, piecewise CUDA graphs split here, and the surrounding in_proj /
+o_proj GEMMs stay inside captured graph segments.
+
+Input/output projections stay in the caller so they remain compiled.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _resolve_layer_name,
+    direct_register_custom_op,
+)
+
+
+def kimi_k3_kda_attention(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    g2: torch.Tensor,
+    beta: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    """Run the KDA mixer (conv + recurrence + gated RMSNorm) in-place."""
+    layer_name = _resolve_layer_name(layer_name)
+    forward_context: ForwardContext = get_forward_context()
+    layer = forward_context.no_compile_layers[layer_name]
+    layer._forward(
+        mixed_qkv=mixed_qkv,
+        g1=g1,
+        g2=g2,
+        beta=beta,
+        core_attn_out=core_attn_out,
+    )
+
+
+def kimi_k3_kda_attention_fake(
+    mixed_qkv: torch.Tensor,
+    g1: torch.Tensor,
+    g2: torch.Tensor,
+    beta: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="kimi_k3_kda_attention",
+    op_func=kimi_k3_kda_attention,
+    mutates_args=["core_attn_out"],
+    fake_impl=kimi_k3_kda_attention_fake,
+)

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -10,7 +10,6 @@ from torch import nn
 from torch.nn.parameter import Parameter
 
 from vllm import _custom_ops as ops
-from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import VllmConfig
 from vllm.distributed import divide, get_tensor_model_parallel_rank
 from vllm.forward_context import get_forward_context
@@ -39,6 +38,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.parameter import BasevLLMParameter, BlockQuantScaleParameter
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.models.kimi_k3.common import kda_attention_op as _kda_attention_op  # noqa: F401
 from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
@@ -47,6 +47,7 @@ from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import _encode_layer_name
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.kv_cache_interface import MambaSpec
@@ -625,19 +626,19 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
-        self._forward(
-            mixed_qkv=mixed_qkv,
-            g1=g1,
-            g2=g2,
-            beta=beta,
-            core_attn_out=core_attn_out,
+        torch.ops.vllm.kimi_k3_kda_attention(
+            mixed_qkv,
+            g1,
+            g2,
+            beta,
+            core_attn_out,
+            _encode_layer_name(self.prefix),
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         if self.gemm_rs_ar is not None and self.gemm_rs_ar.should_run(core_attn_out):
             return self.gemm_rs_ar(core_attn_out, self.o_proj.weight)
         return self.o_proj(core_attn_out)[0]
 
-    @eager_break_during_capture
     def _forward(
         self,
         mixed_qkv: torch.Tensor,


### PR DESCRIPTION
## Purpose

Kimi-K3 piecewise CUDA graphs already split at MLA (`vllm::unified_mla_attention_with_output`), but the KDA mixer (causal-conv + recurrent KDA + gated RMSNorm) was still traced as many eager Triton launches. `@eager_break_during_capture` on `_forward` is a no-op unless `VLLM_USE_BREAKABLE_CUDAGRAPH=1`, which the MI355X recipe does not set.

This is the conc=1 launch-bound path. Fusing only conv+KDA+norm into one HIP kernel did **not** move serving ITL (c1 p90 11.34 ms → 11.23 ms). The surrounding GEMMs never entered a CUDA graph because the mixer was not a splitting op.

## Changes

- Register `vllm::kimi_k3_kda_attention` (same pattern as Qwen GDN `qwen_gdn_attention_core` and Bailing V3 KDA).
- Add it to `CompilationConfig._attention_ops` so piecewise graphs split here by default.
- Call the op from AMD and NVIDIA `forward()`; keep `in_proj` / `f_b_proj` / `o_proj` in the caller so those GEMMs stay compiled.
- Drop `@eager_break_during_capture` from `_forward`.

`in_proj_qkvgfab` is already fused on main, so that is not part of this PR.

## Test plan

- [x] `tests/compile/test_config.py::test_splitting_ops_dynamic` includes the new op
- [x] `tests/models/kimi_k3/test_kda_attention_op.py` checks registration
- [ ] MI355X conc=1 serving ITL vs current nightly (follow-up on exclusive node)


Made with [Cursor](https://cursor.com)