### PR TITLE
[Bugfix] Avoid cloning target logits when logprobs are disabled

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -151,6 +151,34 @@ def test_perfect_match(rejection_sampler):
     assert torch.equal(output.sampled_token_ids, expected)
 
 
+def test_target_logits_not_cloned_without_logprobs(rejection_sampler, monkeypatch):
+    """Avoid preserving raw target logits when they cannot be consumed."""
+    spec_tokens = [[1, 2, 3]]
+    output_tokens = [[1, 2, 3, 4]]
+    metadata = create_sampling_metadata(all_greedy=True)
+    logits = create_logits_tensor(output_tokens)
+    bonus_token_tensor = torch.tensor([output_tokens[0][-1]], device=logits.device)
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
+    mock_sampler_output(rejection_sampler, bonus_token_tensor)
+
+    original_clone = torch.Tensor.clone
+
+    def fail_on_target_logits_clone(tensor, *args, **kwargs):
+        if tensor.shape == logits.shape:
+            pytest.fail("target logits were cloned without a logprobs request")
+        return original_clone(tensor, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "clone", fail_on_target_logits_clone)
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+    expected = torch.tensor([[1, 2, 3, 4]], dtype=torch.int, device=logits.device)
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
 def test_early_mismatch(rejection_sampler):
     """Test when there's an early mismatch in tokens"""
     spec_tokens = [[1, 2, 3]]

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -153,10 +153,15 @@ class RejectionSampler(nn.Module):
         # Use float32 for the target_logits.
         raw_target_logits = raw_target_logits.to(torch.float32)
         target_logits = raw_target_logits
-        if not self.is_processed_logprobs_mode:
+        if (
+            not self.is_processed_logprobs_mode
+            and sampling_metadata.max_num_logprobs is not None
+        ):
             # Clone raw_target_logits before applying processors to preserve
             # the original raw logits for logprobs computation, since
-            # apply_logits_processors modifies the tensor in-place.
+            # apply_logits_processors modifies the tensor in-place. When
+            # logprobs are not requested, preserving the raw logits is
+            # unnecessary and can duplicate several GiB at high concurrency.
             target_logits = target_logits.clone()
         target_logits = self.apply_logits_processors(
             target_logits, sampling_metadata, metadata


### PR DESCRIPTION
## Purpose

Avoid cloning the full target-logits tensor during speculative decoding when logprobs are not requested.

In raw-logprobs mode, the rejection sampler currently clones `raw_target_logits` before applying in-place logits processors. The raw tensor is only consumed by `_get_logprobs_tensors` when `sampling_metadata.max_num_logprobs` is not `None`. For no-logprobs requests, the clone therefore has no consumer.

This became a multi-GiB transient allocation with a large vocabulary and high concurrency. In a TP=4 Gemma-4-31B speculative-decoding workload, the clone requested approximately 2.45–3.63 GiB and terminated EngineCore with CUDA OOM.

The change preserves the clone when raw logprobs are requested and skips it otherwise. A regression test fails if a target-logits-shaped tensor is cloned on the no-logprobs path.

### Duplicate-work check

Open and historical PRs were searched for `rejection sampler logits clone`, `speculative decoding OOM logits`, and `target_logits clone`. The results concerned other rejection-sampling behavior or implementations; no PR was found that conditionally removes this raw target-logits clone.

### AI assistance

OpenAI Codex assisted with diagnosis, the initial patch and regression test, and this PR description. The human submitter reviewed and authorized the public submission and remains responsible for the change.

## Test Plan

```bash
.venv/bin/python -m py_compile \
  vllm/v1/sample/rejection_sampler.py \
  tests/v1/sample/test_rejection_sampler.py

git diff origin/main...HEAD --check

.venv/bin/python -m pytest -q \
  tests/v1/sample/test_rejection_sampler.py \
  -k target_logits_not_cloned_without_logprobs
```

The serving validation used 4× H200, TP=4, concurrency=256, a Gemma-4-31B target, and a compatible draft model.

## Test Result

- Python compilation: **PASS**
- `git diff --check`: **PASS**
- High-concurrency serving validation: **1,024/1,024 requests completed** without the rejection-sampler engine termination after removing this allocation. The run also contained a separate draft-model-side memory mitigation, so throughput changes are not attributed to this PR.
- Focused upstream pytest: **not collected in this checkout**. The available runtime has vLLM 0.19.0 binaries, while current `main` imports `vllm._C_stable_libtorch`; collection stopped with `ModuleNotFoundError`. CI should execute the added regression test against matching current-main binaries.

No model output or sampling semantics change is expected: raw logits continue to be preserved whenever logprobs are requested.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] Documentation update is not required for this internal allocation change.
</details>
