### PR TITLE
[Benchmark] Fix MoE tuner cache cleanup and OOM recovery

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -6,6 +6,7 @@ import gc
 import json
 import os
 import time
+from collections.abc import Callable
 from contextlib import nullcontext
 from datetime import datetime
 from itertools import product
@@ -44,37 +45,51 @@ _CACHE_CLEAR_INTERVAL_ENV = "VLLM_MOE_TUNE_CACHE_CLEAR_INTERVAL"
 TRITON_CACHE_CLEAR_INTERVAL = int(os.environ.get(_CACHE_CLEAR_INTERVAL_ENV, "50"))
 
 
+def _clear_triton_jit_cache():
+    """Clear in-memory compiled kernels across supported Triton versions."""
+    runtime_cache = getattr(getattr(triton, "runtime", None), "cache", None)
+    clear_runtime_cache = getattr(runtime_cache, "clear", None)
+    if callable(clear_runtime_cache):
+        clear_runtime_cache()
+        return
+
+    runtime_jit = getattr(getattr(triton, "runtime", None), "jit", None)
+    jit_registry = getattr(runtime_jit, "_triton_jit_function_registry", {})
+    for jit_function in jit_registry.values():
+        device_caches = getattr(jit_function, "device_caches", None)
+        if device_caches is not None:
+            device_caches.clear()
+
+
 def clear_triton_cache():
     """Clear Triton JIT compilation cache and Python/CUDA memory.
 
     This helps prevent OOM during tuning with large models (many experts).
     """
-    # Force Python garbage collection
-    gc.collect()
-
-    # Clear CUDA memory cache
-    if torch.cuda.is_available():
-        torch.accelerator.empty_cache()
-
-    # Try to clear Triton's runtime cache
+    # Clear Triton's in-memory kernel cache before releasing CUDA allocations.
     try:
-        if (
-            hasattr(triton, "runtime")
-            and hasattr(triton.runtime, "cache")
-            and hasattr(triton.runtime.cache, "clear")
-        ):
-            triton.runtime.cache.clear()
-    except ImportError:
-        # Triton not installed, skip cache clearing
-        pass
-    except AttributeError:
-        # Triton version doesn't have expected cache API
-        pass
+        _clear_triton_jit_cache()
     except Exception as e:
         print(f"Warning: Failed to clear Triton cache: {e}")
 
-    # Additional garbage collection after clearing caches
+    # Release objects that were only reachable from the JIT cache.
     gc.collect()
+
+    if torch.cuda.is_available():
+        torch.accelerator.empty_cache()
+
+
+def _run_with_oom_recovery(run_config: Callable[[], float]) -> float:
+    """Clear accumulated tuning state and retry one OOM once."""
+    try:
+        return run_config()
+    except torch.OutOfMemoryError:
+        # Leave the exception scope before clearing so its traceback no longer
+        # keeps the failed attempt's CUDA tensors alive.
+        pass
+
+    clear_triton_cache()
+    return run_config()
 
 
 def ensure_divisibility(numerator, denominator, text):
@@ -632,20 +647,22 @@ class BenchmarkWorker:
         ):
             for idx, config in enumerate(tqdm(search_space)):
                 try:
-                    kernel_time = benchmark_config(
-                        config,
-                        num_tokens,
-                        num_experts,
-                        shard_intermediate_size,
-                        hidden_size,
-                        topk,
-                        dtype,
-                        use_fp8_w8a8,
-                        use_int8_w8a16,
-                        use_int4_w4a16,
-                        num_iters=20,
-                        block_quant_shape=block_quant_shape,
-                        use_deep_gemm=use_deep_gemm,
+                    kernel_time = _run_with_oom_recovery(
+                        lambda config=config: benchmark_config(
+                            config,
+                            num_tokens,
+                            num_experts,
+                            shard_intermediate_size,
+                            hidden_size,
+                            topk,
+                            dtype,
+                            use_fp8_w8a8,
+                            use_int8_w8a16,
+                            use_int4_w4a16,
+                            num_iters=20,
+                            block_quant_shape=block_quant_shape,
+                            use_deep_gemm=use_deep_gemm,
+                        )
                     )
                 except triton.runtime.autotuner.OutOfResources:
                     # Some configurations may be invalid and fail to compile.

--- a/tests/benchmarks/test_moe_tuner_cache.py
+++ b/tests/benchmarks/test_moe_tuner_cache.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks.kernels import benchmark_moe
+
+
+def test_clear_triton_jit_cache_uses_runtime_cache(monkeypatch):
+    clear_calls = []
+    runtime = SimpleNamespace(
+        cache=SimpleNamespace(clear=lambda: clear_calls.append(True))
+    )
+    monkeypatch.setattr(benchmark_moe, "triton", SimpleNamespace(runtime=runtime))
+
+    benchmark_moe._clear_triton_jit_cache()
+
+    assert clear_calls == [True]
+
+
+def test_clear_triton_jit_cache_uses_jit_registry(monkeypatch):
+    first_device_cache = {"cuda:0": object()}
+    second_device_cache = {"cuda:0": object(), "cuda:1": object()}
+    registry = {
+        "first": SimpleNamespace(device_caches=first_device_cache),
+        "second": SimpleNamespace(device_caches=second_device_cache),
+    }
+    runtime = SimpleNamespace(
+        jit=SimpleNamespace(_triton_jit_function_registry=registry)
+    )
+    monkeypatch.setattr(benchmark_moe, "triton", SimpleNamespace(runtime=runtime))
+
+    benchmark_moe._clear_triton_jit_cache()
+
+    assert first_device_cache == {}
+    assert second_device_cache == {}
+
+
+def test_clear_triton_cache_releases_references_before_allocator(monkeypatch):
+    clear_order = []
+    monkeypatch.setattr(
+        benchmark_moe,
+        "_clear_triton_jit_cache",
+        lambda: clear_order.append("triton"),
+    )
+    monkeypatch.setattr(benchmark_moe.gc, "collect", lambda: clear_order.append("gc"))
+    monkeypatch.setattr(benchmark_moe.torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        benchmark_moe.torch.accelerator,
+        "empty_cache",
+        lambda: clear_order.append("allocator"),
+    )
+
+    benchmark_moe.clear_triton_cache()
+
+    assert clear_order == ["triton", "gc", "allocator"]
+
+
+def test_run_with_oom_recovery_clears_and_retries_once(monkeypatch):
+    events = []
+
+    def run_config():
+        events.append("run")
+        if events == ["run"]:
+            raise benchmark_moe.torch.OutOfMemoryError("synthetic OOM")
+        return 1.25
+
+    monkeypatch.setattr(
+        benchmark_moe,
+        "clear_triton_cache",
+        lambda: events.append("clear"),
+    )
+
+    result = benchmark_moe._run_with_oom_recovery(run_config)
+
+    assert result == 1.25
+    assert events == ["run", "clear", "run"]
+
+
+def test_run_with_oom_recovery_propagates_second_oom(monkeypatch):
+    events = []
+
+    def run_config():
+        events.append("run")
+        raise benchmark_moe.torch.OutOfMemoryError("persistent OOM")
+
+    monkeypatch.setattr(
+        benchmark_moe,
+        "clear_triton_cache",
+        lambda: events.append("clear"),
+    )
+
+    with pytest.raises(benchmark_moe.torch.OutOfMemoryError):
+        benchmark_moe._run_with_oom_recovery(run_config)
+
+    assert events == ["run", "clear", "run"]


### PR DESCRIPTION
## Purpose

Long MoE tuning searches can still OOM because `clear_triton_cache()` probes `triton.runtime.cache.clear()`, which is not callable in Triton 3.7.1. Compiled kernels remain referenced by `JITFunction.device_caches`, so the worker accumulates memory across configurations.

This change:

- clears both the legacy Triton runtime cache and the Triton 3.7 JIT-function device caches;
- releases JIT references before Python GC and the CUDA allocator cache;
- retries the one configuration that encounters `torch.OutOfMemoryError` after leaving the exception scope and cleaning accumulated state;
- propagates a second OOM instead of hiding a configuration that cannot fit.

This updates the periodic cleanup introduced by #31604. #53394 independently mentions the Triton 3.7 cache no-op, but only adds a tuning-config JSON and does not modify the tuner or implement OOM recovery.

A final open-issue and open-PR search for `benchmark_moe`, `clear_triton_cache`, `device_caches`, `Kimi-K2`, and OOM found no overlapping implementation.

## Test Plan

```text
FLASHINFER_DISABLE_VERSION_CHECK=1 PYTHONPATH=/opt/vllm-tuner-oom \
  .venv/bin/python -m pytest tests/benchmarks/test_moe_tuner_cache.py \
  --confcutdir=tests/benchmarks -q
```

The focused tests cover the legacy cache API, Triton 3.7 JIT registry fallback, cleanup order, recovery after one OOM, and propagation of a persistent second OOM.

Static checks:

```text
pre-commit run ruff-check --files benchmarks/kernels/benchmark_moe.py tests/benchmarks/test_moe_tuner_cache.py
pre-commit run ruff-format --files benchmarks/kernels/benchmark_moe.py tests/benchmarks/test_moe_tuner_cache.py
pre-commit run typos --files benchmarks/kernels/benchmark_moe.py tests/benchmarks/test_moe_tuner_cache.py
python -m py_compile benchmarks/kernels/benchmark_moe.py tests/benchmarks/test_moe_tuner_cache.py
git diff --check
```

## Test Result

- Focused unit tests: `5 passed in 6.76s`
- Ruff check, Ruff format, typos, `py_compile`, and `git diff --check`: passed

GPU reproduction used vLLM `7f4a1b7e246c`, Triton 3.7.1, and one NVIDIA GeForce RTX 5090. The target benchmark file is unchanged on current main.

| Version | M | Result | Tuning time |
|---|---:|---:|---:|
| baseline | 1 | OOM at 362/1,920 | - |
| baseline | 2 | OOM at 367/1,920 | - |
| baseline | 4 | OOM at 366/1,920 | - |
| baseline | 8 | OOM at 366/1,920 | - |
| patched, default interval 50 | 1 | 1,920/1,920, rc=0 | 284.73 s |
| patched, default interval 50 | 2 | 1,920/1,920, rc=0 | 361.10 s |

Both patched runs exercised allocator-pressure recovery, returned zero, and wrote valid tuning-config JSON files. M=1 and M=2 completed 3,840/3,840 configurations.

This only changes a benchmark/tuning utility; it does not affect model outputs or serving, so no model evaluation is applicable.

## AI assistance disclosure

AI assistance was used during issue research, patch drafting, and test planning. I reviewed every changed line and the listed test results, and I can explain and defend the change end to end.