### PR TITLE
[ROCm][MLA] Enable sparse MLA Gluon kernel from Aiter

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -144,6 +144,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_AITER_MLA_ASM_PADDING: Literal["auto", "gluon", "asm"] = "auto"
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
+    VLLM_ROCM_USE_AITER_TRITON_SPARSE_MLA: bool = False
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
     VLLM_ROCM_USE_AITER_FP8BMM: bool = True
     VLLM_ROCM_USE_AITER_FP4BMM: bool = True
@@ -1315,6 +1316,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is disabled.
     "VLLM_ROCM_USE_AITER_FP4_ASM_GEMM": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_FP4_ASM_GEMM", "False").lower() in ("true", "1")
+    ),
+    # Whether the sparse (top-k gathered) MLA attention runs on aiter's Gluon
+    # kernel instead of the asm decode. Gluon is gfx950-only.
+    # By default is disabled.
+    "VLLM_ROCM_USE_AITER_TRITON_SPARSE_MLA": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_TRITON_SPARSE_MLA", "False").lower()
+        in ("true", "1")
     ),
     # Whether to use aiter rope.
     # By default is disabled.

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig, get_current_vllm_config
@@ -37,6 +39,20 @@ from vllm.v1.worker.workspace import current_workspace_manager
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
 logger = init_logger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _gluon_sparse_mla_supported() -> bool:
+    """aiter's Gluon gathered-MLA kernel is built and tuned for gfx950 only."""
+    try:
+        from aiter.ops.triton.attention.sparse_mla import (  # noqa: F401
+            sparse_mla_fwd,
+        )
+
+        from vllm.platforms.rocm import on_gfx950
+    except Exception:  # noqa: BLE001
+        return False
+    return on_gfx950()
 
 
 @triton.jit
@@ -698,6 +714,44 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         (self.q_concat_buffer,) = current_workspace_manager().get_simultaneous(
             (q_concat_shape, vllm_config.model_config.dtype),
         )
+        self.qk_rope_head_dim: int = mla_args["qk_rope_head_dim"]
+
+        # Run the gathered attention on aiter's Gluon kernel instead of the asm
+        # decode. It takes num_heads < 16 natively, gfx950 only.
+        self.use_gluon_sparse_mla = False
+        if envs.VLLM_ROCM_USE_AITER_TRITON_SPARSE_MLA:
+            reason = self._gluon_sparse_mla_unsupported_reason(vllm_config)
+            if reason is not None:
+                logger.warning_once(
+                    "VLLM_ROCM_USE_AITER_TRITON_SPARSE_MLA=1 requested, but %s; "
+                    "using the asm sparse decode instead.",
+                    reason,
+                )
+            else:
+                from aiter.ops.triton.attention.sparse_mla import sparse_mla_fwd
+
+                self._sparse_mla_fwd = sparse_mla_fwd
+                self.use_gluon_sparse_mla = True
+
+    def _gluon_sparse_mla_unsupported_reason(
+        self, vllm_config: VllmConfig
+    ) -> str | None:
+        """Why the Gluon kernel cannot serve this configuration, or None.
+
+        Every case here falls back to the asm decode, so enabling the flag can
+        only change which kernel runs, never whether a working setup starts.
+        """
+        if not _gluon_sparse_mla_supported():
+            return "this device has no Gluon gathered-MLA build (requires gfx950)"
+        cache_dtype = self.kv_cache_dtype
+        if cache_dtype == "auto":
+            cache_dtype = str(vllm_config.model_config.dtype).removeprefix("torch.")
+        if cache_dtype not in ("bfloat16", "fp8", "fp8_e4m3"):
+            return f"kv-cache dtype {cache_dtype!r} is neither bfloat16 nor e4m3 fp8"
+        # Context parallelism merges each rank's partials with a per-token LSE.
+        if self.dcp_world_size > 1 or self.pcp_world_size > 1:
+            return "context parallelism needs an LSE this kernel cannot return"
+        return None
 
     def _forward_mla(
         self,
@@ -746,6 +800,54 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
 
         return AiterMLAHelper.get_mla_unpadded_o(self.num_heads, output)
 
+    def _forward_mla_gluon(
+        self,
+        layer: AttentionLayer,
+        q: torch.Tensor,  # [sq, heads, d_qk], not head-padded
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: ROCMAiterMLASparseMetadata,
+    ) -> torch.Tensor:
+        """The same MQA operator as _forward_mla, on aiter's Gluon kernel.
+
+        sparse_mla_fwd follows mla_decode_fwd's calling convention, so the
+        metadata passes straight through. Three things the asm path needs
+        and this one does not:
+
+        - q head padding: the kernel runs num_heads < 16 natively.
+        - the persistent work-stealing metadata: never read, since the
+          split-K count comes from the shapes.
+        - query length: every query token gets its own entry, so
+          speculative decoding only makes the batch longer.
+
+        Every launch decision comes from shapes and dtypes, with no host
+        reads of device tensors, so this is CUDA-graph capturable.
+        """
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        output = torch.empty(
+            [q.shape[0], self.num_heads, self.kv_lora_rank],
+            dtype=attn_metadata.attn_out_dtype,
+            device=q.device,
+        )
+        # fp8 q arrives already quantized with the layer's static scale, and the
+        # cache is fp8 in the same case, so both dots run on the fp8 matrix core
+        # with no dequant.
+        q_is_fp8 = q.dtype == current_platform.fp8_dtype()
+        self._sparse_mla_fwd(
+            q[:num_actual_tokens],
+            # The same flattening rocm_aiter_ops.mla_decode_fwd applies
+            kv_c_and_k_pe_cache.view(-1, 1, 1, q.shape[-1]),
+            attn_metadata.paged_kv_indptr,
+            attn_metadata.paged_kv_indices,
+            self.scale,
+            kv_scale=layer._k_scale,
+            kv_lora_rank=self.kv_lora_rank,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+            dot_precision="fp8" if q_is_fp8 else "bf16",
+            q_scale=layer._q_scale if q_is_fp8 else None,
+            out=output[:num_actual_tokens],
+        )
+        return output
+
     def forward_mqa(
         self,
         q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
@@ -790,9 +892,14 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
                 original_q_shape = q.shape
                 q, _ = ops.scaled_fp8_quant(q.view(q.shape[0], -1), layer._q_scale)
                 q = q.view(original_q_shape)
-        mla_padded_q = AiterMLAHelper.get_mla_padded_q(self.num_heads, q)
-        attn_out = self._forward_mla(
-            layer, mla_padded_q, kv_c_and_k_pe_cache, attn_metadata
-        )
+        if self.use_gluon_sparse_mla:
+            attn_out = self._forward_mla_gluon(
+                layer, q, kv_c_and_k_pe_cache, attn_metadata
+            )
+        else:
+            mla_padded_q = AiterMLAHelper.get_mla_padded_q(self.num_heads, q)
+            attn_out = self._forward_mla(
+                layer, mla_padded_q, kv_c_and_k_pe_cache, attn_metadata
+            )
 
         return attn_out, None

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -716,15 +716,15 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         )
         self.qk_rope_head_dim: int = mla_args["qk_rope_head_dim"]
 
-        # Run the gathered attention on aiter's Gluon kernel instead of the asm
-        # decode. It takes num_heads < 16 natively, gfx950 only.
+        # Run the gathered attention on aiter's Gluon kernel instead of_forward_mla. 
+        # It takes num_heads < 16 natively, gfx950 only.
         self.use_gluon_sparse_mla = False
         if envs.VLLM_ROCM_USE_AITER_TRITON_SPARSE_MLA:
             reason = self._gluon_sparse_mla_unsupported_reason(vllm_config)
             if reason is not None:
                 logger.warning_once(
                     "VLLM_ROCM_USE_AITER_TRITON_SPARSE_MLA=1 requested, but %s; "
-                    "using the asm sparse decode instead.",
+                    "using the _forward_mla instead.",
                     reason,
                 )
             else:
@@ -737,9 +737,7 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         self, vllm_config: VllmConfig
     ) -> str | None:
         """Why the Gluon kernel cannot serve this configuration, or None.
-
-        Every case here falls back to the asm decode, so enabling the flag can
-        only change which kernel runs, never whether a working setup starts.
+        Every case here falls back to the _forward_mla
         """
         if not _gluon_sparse_mla_supported():
             return "this device has no Gluon gathered-MLA build (requires gfx950)"
@@ -810,7 +808,7 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         """The same MQA operator as _forward_mla, on aiter's Gluon kernel.
 
         sparse_mla_fwd follows mla_decode_fwd's calling convention, so the
-        metadata passes straight through. Three things the asm path needs
+        metadata passes straight through. Three things the _forward_mla path needs
         and this one does not:
 
         - q head padding: the kernel runs num_heads < 16 natively.


### PR DESCRIPTION
`ROCMAiterMLASparseBackend` extended to enable Aiter's gluon backend, hidden behind a flag, off by default.

## Purpose
The main goal is to improve performance for GLM 5.2 on MI355 by accelerating the sparse MLA attention using the new gluon backend, both for decode and prefill.

Model used for testing: GLM-5.2-MXFP4 from https://huggingface.co/amd/GLM-5.2-MXFP4
TP8, MI355

## Test Plan
A/B test using GSM8K accuracy check.

## Test Result

`gsm8k`, 5-shot, `--apply_chat_template`, all 1319 test items, `num_concurrent=256`

| filter | baseline | gluon | delta |
|---|---|---|---|
| flexible-extract | 0.9477 ± 0.0061 | 0.9484 ± 0.0061 | +0.08 pp |
| strict-match | 0.9386 ± 0.0066 | 0.9409 ± 0.0065 | +0.23 pp |

## Performance

`vllm bench serve`, NP = 10×C on TP8, MI355.

**ISL 8192 / OSL 1024 — prefill-heavy**

| C | out tok/s baseline | gluon | Δ | med TTFT baseline | gluon | Δ | med TPOT baseline | gluon | Δ |
|--:|--:|--:|:--|--:|--:|:--|--:|--:|:--|
| 4 | 232.1 | 243.4 | **+4.9%** | 945.5 | 860.4 | **-9.0%** | 16.3 | 15.6 | **-4.2%** |
| 8 | 406.4 | 427.3 | **+5.2%** | 1270.9 | 1129.0 | **-11.2%** | 18.4 | 17.6 | **-4.2%** |
| 16 | 647.6 | 694.2 | **+7.2%** | 1240.6 | 1111.5 | **-10.4%** | 23.5 | 21.9 | **-6.8%** |
| 32 | 1011.2 | 1078.3 | **+6.6%** | 1275.4 | 1116.6 | **-12.5%** | 30.2 | 28.4 | **-6.1%** |
| 64 | 1396.2 | 1516.1 | **+8.6%** | 1279.2 | 1120.2 | **-12.4%** | 44.1 | 41.0 | **-6.9%** |
| 128 | 1857.3 | 2013.1 | **+8.4%** | 1282.9 | 1133.3 | **-11.7%** | 66.8 | 61.6 | **-7.8%** |

**ISL 1024 / OSL 1024 — decode-heavy**

| C | out tok/s baseline | gluon | Δ | med TTFT baseline | gluon | Δ | med TPOT baseline | gluon | Δ |
|--:|--:|--:|:--|--:|--:|:--|--:|--:|:--|
| 4 | 255.4 | 270.8 | **+6.0%** | 200.4 | 180.4 | **-10.0%** | 15.5 | 14.6 | **-5.5%** |
| 8 | 472.6 | 497.0 | **+5.2%** | 428.3 | 330.6 | **-22.8%** | 16.6 | 15.8 | **-4.6%** |
| 16 | 834.4 | 871.9 | **+4.5%** | 359.1 | 430.3 | **+19.8%** | 18.8 | 17.9 | **-4.5%** |
| 32 | 1506.6 | 1556.7 | **+3.3%** | 627.4 | 542.9 | **-13.5%** | 20.7 | 20.0 | **-3.3%** |
| 64 | 2406.5 | 2510.3 | **+4.3%** | 719.5 | 625.0 | **-13.1%** | 25.8 | 24.9 | **-3.6%** |
| 128 | 3994.5 | 4175.1 | **+4.5%** | 765.8 | 687.5 | **-10.2%** | 31.2 | 29.9 | **-4.1%** |


Requires https://github.com/ROCm/aiter/pull/4919 to land to enable.

Used claude-code during development.

