### PR TITLE
docs: add GPU architecture compatibility matrix and expand KServe integration guide

### DIFF
--- a/docs/deployment/integrations/kserve.md
+++ b/docs/deployment/integrations/kserve.md
@@ -1,5 +1,122 @@
 # KServe
 
-vLLM can be deployed with [KServe](https://github.com/kserve/kserve) on Kubernetes for highly scalable distributed model serving.
+vLLM can be deployed with [KServe](https://github.com/kserve/kserve) on Kubernetes for scalable, production-grade model serving with built-in autoscaling, canary rollouts, and multi-model management.
 
-You can use vLLM with KServe's [Hugging Face serving runtime](https://kserve.github.io/website/docs/model-serving/generative-inference/overview) or via [`LLMInferenceService` that uses llm-d](https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-overview).
+You can use vLLM with KServe's [Hugging Face serving runtime](https://kserve.github.io/website/docs/model-serving/generative-inference/overview) or via [`LLMInferenceService` that uses llm-d](https://kserve.github.io/website/docs/model-serving/generative-inference/llmisvc/llmisvc-overview). This guide covers direct deployment using a custom `ServingRuntime`.
+
+For a general introduction to KServe concepts, see the [KServe documentation](https://kserve.github.io/website/latest/).
+
+## Prerequisites
+
+- Kubernetes 1.27+ or OpenShift 4.14+
+- KServe 0.12+ installed (Serverless or RawDeployment mode)
+- GPU nodes with NVIDIA device plugin configured
+
+## ServingRuntime configuration
+
+KServe uses a `ServingRuntime` custom resource to define how a model server is launched. The following example deploys vLLM using the `vllm/vllm-openai` image.
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: vllm-runtime
+spec:
+  supportedModelFormats:
+    - name: huggingface
+      version: "1"
+      autoSelect: true
+  containers:
+    - name: kserve-container
+      image: vllm/vllm-openai:latest
+      command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+      args:
+        - "--model=/mnt/models"
+        - "--served-model-name={{.Name}}"
+        - "--port=8080"
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      resources:
+        requests:
+          nvidia.com/gpu: "1"
+        limits:
+          nvidia.com/gpu: "1"
+  protocolVersions:
+    - v2
+    - grpc-v2
+```
+
+!!! warning "Use `python3`, not `python`, in the command"
+    The `vllm/vllm-openai` image installs vLLM into a virtualenv whose `python` binary is not on the default `PATH` when KServe launches the container. Using `command: ["python"]` results in `executable not found`. Always use `command: ["python3", "-m", ...]` or the full path `/opt/vllm/bin/python3`.
+
+## Deploy an InferenceService
+
+```yaml
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: llama-3-8b
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: huggingface
+      storageUri: "pvc://model-pvc/llama-3-8b"
+      runtime: vllm-runtime
+      resources:
+        requests:
+          nvidia.com/gpu: "1"
+        limits:
+          nvidia.com/gpu: "1"
+```
+
+Check the rollout status:
+
+```console
+kubectl get inferenceservice llama-3-8b
+```
+
+## OpenShift AI (RHOAI) specific notes
+
+### GPU architecture support
+
+OpenShift AI ships its own vLLM image (`rhaiis/vllm-cuda-rhel9`). This image may be compiled for a different set of CUDA compute capabilities than the upstream `vllm/vllm-openai` image. Notably, **Volta (sm_70, V100)** may not be included in vendor builds.
+
+If you see `cudaErrorNoKernelImageForDevice` at runtime, your GPU's compute capability is not compiled into the vendor image. Options:
+
+- Use the upstream `vllm/vllm-openai` image directly in your `ServingRuntime` (requires pulling from docker.io).
+- Request a custom build targeting your GPU's sm level from your platform team.
+- See the [GPU architecture support](../../getting_started/installation/gpu.md#nvidia-gpu-architecture-support) section for the compiled-architecture matrix.
+
+### Flash Attention on Volta GPUs
+
+Flash Attention 2 requires compute capability 8.0+ (Ampere or newer). On Volta (V100, sm_70), vLLM **silently disables Flash Attention** and falls back to PyTorch's Scaled Dot-Product Attention (SDPA). The log will contain:
+
+```text
+WARNING  vllm.attention.backends.flash_attn: Flash attention is not supported on Volta. Using PyTorch SDPA instead.
+```
+
+The model will run correctly, but throughput and memory efficiency will be lower than on Ampere+ GPUs. Plan GPU capacity accordingly if your deployment targets Volta hardware.
+
+### SecurityContext and fsGroup
+
+On OpenShift, pods run with a namespace-derived UID and fsGroup (e.g., `1000840000`). If you mount a PVC that was previously written by a pod with a different fsGroup, you may see `Permission denied` on the model files. Ensure any model-loading Job that pre-populates the PVC uses the same `securityContext.fsGroup` as the namespace.
+
+See the [KServe PVC documentation](https://kserve.github.io/website/latest/modelserving/storage/pvc/pvc/) for details on loader job patterns.
+
+## Sending inference requests
+
+Once the `InferenceService` is `Ready`, query the OpenAI-compatible endpoint:
+
+```console
+ISVC_URL=$(kubectl get inferenceservice llama-3-8b -o jsonpath='{.status.url}')
+
+curl ${ISVC_URL}/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama-3-8b",
+    "prompt": "San Francisco is a",
+    "max_tokens": 64
+  }'
+```

--- a/docs/getting_started/installation/gpu.md
+++ b/docs/getting_started/installation/gpu.md
@@ -46,6 +46,56 @@ vLLM is a Python library that supports the following GPU variants. Select your G
 
     --8<-- "docs/getting_started/installation/gpu.apple.inc.md:requirements"
 
+## NVIDIA GPU Architecture Support
+
+The official `vllm/vllm-openai` Docker images and pip wheels are compiled for a specific set of CUDA compute capabilities. If your GPU's architecture is **not** in the compiled set, you will get a runtime error (`cudaErrorNoKernelImageForDevice`) rather than a clear startup-time failure.
+
+### Compiled architecture matrix
+
+| CUDA version | Image / wheel variant | sm_70 Volta | sm_75 Turing | sm_80 Ampere | sm_86 Ampere | sm_89 Ada | sm_90 Hopper | sm_100 Blackwell |
+|---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| 12.8 | `vllm/vllm-openai:latest` (default) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| 12.6 | `--extra-index-url .../cu126` | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| 12.1 | `--extra-index-url .../cu121` | Yes | Yes | Yes | Yes | Yes | Yes | No |
+| 11.8 | `--extra-index-url .../cu118` | Yes | Yes | Yes | Yes | No | No | No |
+
+**GPU generations by compute capability:**
+
+| Generation | Compute capability | Representative GPUs |
+|---|---|---|
+| Volta | sm_70 | V100, Titan V |
+| Turing | sm_75 | T4, RTX 20xx, Quadro RTX |
+| Ampere | sm_80 | A100, A30 |
+| Ampere | sm_86 | A10, A40, RTX 30xx |
+| Ada Lovelace | sm_89 | L4, L40, RTX 40xx |
+| Hopper | sm_90 | H100, H200 |
+| Blackwell | sm_100 | B200, GB200 |
+
+!!! warning "Vendor-specific images may support fewer architectures"
+    Images distributed by platform vendors (e.g., Red Hat AI/RHOAI, NGC, cloud-provider registries) may be compiled with a different CUDA version or a narrower architecture list than the upstream `vllm/vllm-openai` image. A GPU that works with the upstream image may silently fail with a vendor image at runtime. Always verify the compiled architectures for third-party images using the diagnostic below.
+
+### Verify compiled architectures at runtime
+
+To check which compute capabilities are compiled into the installed vLLM binary:
+
+```console
+python -c "
+import torch, vllm
+print('vLLM version:', vllm.__version__)
+print('CUDA version:', torch.version.cuda)
+props = torch.cuda.get_device_properties(0)
+print(f'GPU: {props.name}  (sm_{props.major}{props.minor})')
+"
+```
+
+If you receive `cudaErrorNoKernelImageForDevice` at runtime, your GPU's compute capability is not included in the current build. Options:
+
+1. Switch to the official `vllm/vllm-openai` image which includes sm_70+.
+2. [Build vLLM from source](#build-from-source) targeting your GPU:
+   ```console
+   TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6" pip install -e .
+   ```
+
 ## Set up using Python
 
 ### Create a new Python environment


### PR DESCRIPTION
… guide





## Purpose

To fix documentation gaps discovered during production deployments of vLLM on KServe:

**1. GPU architecture compatibility matrix**

The official vLLM Docker images and pip wheels are compiled for specific CUDA compute capabilities (sm_70, sm_75, sm_80, etc.). When a GPU's architecture is **not** in the compiled set, vLLM fails at runtime with `cudaErrorNoKernelImageForDevice` rather than a clear startup-time error.

Currently, there is no documentation showing:
- Which CUDA versions include which GPU architectures
- Which GPU generations map to which compute capabilities
- How vendor-specific images (e.g., Red Hat AI, NGC) differ from upstream builds

This leads to multi-hour debugging sessions when deploying to Volta (V100) or other older GPU generations.

**Changes:**
- Added **NVIDIA GPU Architecture Support** section to `docs/getting_started/installation/gpu.md`
- Matrix mapping CUDA version → compiled architectures (sm_70 through sm_100)
- GPU generation table (Volta through Blackwell)
- Runtime diagnostic command to verify compiled architectures
- Warning about vendor-specific images potentially supporting fewer architectures

**2. KServe integration guide**

The existing `docs/deployment/integrations/kserve.md` was a 2-line stub pointing to the KServe website. This left three production deployment issues completely undocumented:

- The `vllm/vllm-openai` virtualenv `python` binary is not on the default `PATH` when KServe launches containers. Using `command: ["python"]` in a ServingRuntime fails with `executable not found`. The fix (`python3`) is nowhere in the docs.
- Flash Attention is silently disabled on Volta GPUs with only a log warning, impacting performance expectations.
- On managed platforms (e.g., OpenShift), namespace-derived `fsGroup` causes permission denied errors when mounting PVCs populated by external Jobs.

**Changes:**
- Replaced stub with full deployment guide including:
  - Complete `ServingRuntime` YAML example
  - `InferenceService` YAML example
  - **OpenShift AI (RHOAI) specific notes** section covering:
    - GPU architecture support differences in vendor images
    - Flash Attention fallback behavior on Volta
    - `fsGroup` and PVC permission requirements
  - Inference request example

## Test Plan

### Documentation build verification

```bash
# Clone the PR branch
git fetch origin pull/XXXX/head:docs-test
git checkout docs-test

# Build the docs locally with mkdocs
cd vllm
pip install mkdocs-material mkdocs-rss-plugin mkdocs-redirects
mkdocs serve

# Navigate to:
# - http://localhost:8000/getting_started/installation/gpu/
#   Verify "NVIDIA GPU Architecture Support" section renders with tables
# - http://localhost:8000/deployment/integrations/kserve/
#   Verify expanded KServe guide renders with YAML blocks and admonitions
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [X] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

