### PR TITLE
[Bugfix][KVConnector] Key ExampleConnector storage on block hashes

### DIFF
--- a/tests/v1/kv_connector/unit/test_example_connector_keying.py
+++ b/tests/v1/kv_connector/unit/test_example_connector_keying.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ExampleConnector keys external KV on the request's block hashes.
+
+Regression tests for #53495: a connector that re-derives its storage key
+from raw prompt tokens drops every dimension that partitions the in-engine
+prefix cache. Each isolation assertion is paired with its positive control
+so a broken store path cannot pass by never hitting.
+"""
+
+import tempfile
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+import torch
+
+from tests.v1.kv_connector.unit.utils import create_vllm_config, make_kv_cache_config
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.example_connector import (
+    ExampleConnector,
+)
+from vllm.lora.request import LoRARequest
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
+from vllm.v1.request import Request
+
+BLOCK_SIZE = 16
+NUM_FULL_BLOCKS = 3
+PROMPT_LEN = NUM_FULL_BLOCKS * BLOCK_SIZE + 5
+CACHED_TOKENS = NUM_FULL_BLOCKS * BLOCK_SIZE
+EMBED_DIM = 8
+NUM_KV_HEADS = 2
+HEAD_DIM = 4
+
+
+@pytest.fixture(autouse=True)
+def _init_hash():
+    init_none_hash(sha256)
+
+
+@pytest.fixture
+def connector() -> Iterator[ExampleConnector]:
+    with tempfile.TemporaryDirectory() as path:
+        vllm_config = create_vllm_config(
+            block_size=BLOCK_SIZE,
+            kv_connector="ExampleConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={"shared_storage_path": path},
+        )
+        yield ExampleConnector(
+            vllm_config, KVConnectorRole.SCHEDULER, make_kv_cache_config(BLOCK_SIZE)
+        )
+
+
+def make_request(request_id: str, **overrides: Any) -> Request:
+    kwargs: dict[str, Any] = {
+        "request_id": request_id,
+        "prompt_token_ids": [i // BLOCK_SIZE for i in range(PROMPT_LEN)],
+        "sampling_params": SamplingParams(max_tokens=17),
+        "pooling_params": None,
+        "block_hasher": get_request_block_hasher(BLOCK_SIZE, sha256),
+    }
+    kwargs.update(overrides)
+    return Request(**kwargs)
+
+
+def with_cache_salt(variant: str) -> dict[str, Any]:
+    return {"cache_salt": f"salt-{variant}"}
+
+
+def with_lora(variant: str) -> dict[str, Any]:
+    return {
+        "lora_request": LoRARequest(
+            lora_name=f"lora-{variant}", lora_int_id=7, lora_path="/nonexistent"
+        )
+    }
+
+
+def with_prompt_embeds(variant: str) -> dict[str, Any]:
+    return {
+        "prompt_token_ids": None,
+        "prompt_embeds": torch.full((PROMPT_LEN, EMBED_DIM), float(ord(variant[0]))),
+    }
+
+
+DIMENSIONS: list[Callable[[str], dict[str, Any]]] = [
+    with_cache_salt,
+    with_lora,
+    with_prompt_embeds,
+]
+
+
+def schedule_and_store(connector: ExampleConnector, request: Request) -> None:
+    """Run one scheduling step and the worker save for ``request``."""
+    connector.update_state_after_alloc(request, None, num_external_tokens=0)
+    new_req = NewRequestData(
+        req_id=request.request_id,
+        prompt_token_ids=request.prompt_token_ids,
+        mm_features=[],
+        sampling_params=request.sampling_params,
+        pooling_params=None,
+        block_ids=(list(range(NUM_FULL_BLOCKS + 1)),),
+        num_computed_tokens=0,
+        lora_request=request.lora_request,
+        prompt_embeds=request.prompt_embeds,
+    )
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[new_req],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={request.request_id: PROMPT_LEN},
+        total_num_scheduled_tokens=PROMPT_LEN,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        preempted_req_ids=set(),
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    meta = connector.build_connector_meta(scheduler_output)
+    assert len(meta.requests) == 1 and meta.requests[0].is_store
+    assert meta.requests[0].slot_mapping.shape == (CACHED_TOKENS,)
+    connector.bind_connector_metadata(meta)
+    kv_layer = torch.zeros(NUM_FULL_BLOCKS + 1, NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM)
+    connector.save_kv_layer("layer0", kv_layer, attn_metadata=None)
+    connector.clear_connector_metadata()
+
+
+def lookup(connector: ExampleConnector, request: Request) -> int:
+    matched, _ = connector.get_num_new_matched_tokens(request, 0)
+    return matched
+
+
+@pytest.mark.parametrize("dimension", DIMENSIONS, ids=lambda f: f.__name__)
+def test_same_value_hits(connector: ExampleConnector, dimension):
+    schedule_and_store(connector, make_request("first", **dimension("x")))
+    assert lookup(connector, make_request("second", **dimension("x"))) == CACHED_TOKENS
+
+
+@pytest.mark.parametrize("dimension", DIMENSIONS, ids=lambda f: f.__name__)
+def test_different_value_misses(connector: ExampleConnector, dimension):
+    schedule_and_store(connector, make_request("first", **dimension("x")))
+    assert lookup(connector, make_request("other", **dimension("y"))) == 0
+
+
+def test_unset_value_misses_set_value(connector: ExampleConnector):
+    schedule_and_store(connector, make_request("plain"))
+    assert lookup(connector, make_request("salted", cache_salt="s")) == 0
+    assert lookup(connector, make_request("plain2")) == CACHED_TOKENS
+
+
+def test_short_prompt_is_never_cached(connector: ExampleConnector):
+    short = make_request("short", prompt_token_ids=list(range(BLOCK_SIZE)))
+    assert lookup(connector, short) == 0
+    connector.update_state_after_alloc(short, None, num_external_tokens=0)
+    assert connector._pending == {}
+
+
+def test_hit_reports_tokens_beyond_computed(connector: ExampleConnector):
+    schedule_and_store(connector, make_request("first"))
+    matched, _ = connector.get_num_new_matched_tokens(
+        make_request("second"), BLOCK_SIZE
+    )
+    assert matched == CACHED_TOKENS - BLOCK_SIZE

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
@@ -16,7 +16,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
-from vllm.utils.hashing import safe_hash
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -31,24 +30,22 @@ logger = init_logger(__name__)
 
 @dataclass
 class ReqMeta:
-    # Request tokens
-    token_ids: torch.Tensor
-    # Slot mappings, should have the same length as token_ids
+    # Key of the cached prefix, derived once on the scheduler side from the
+    # request's block hashes. The worker never re-derives it.
+    cache_key: str
+    # Slot mappings, one per cached token
     slot_mapping: torch.Tensor
     # Is store or load
     is_store: bool
-    mm_hashes: list[str]
 
     @staticmethod
     def make_meta(
-        token_ids: list[int],
+        cache_key: str,
+        num_tokens: int,
         block_ids: list[int],
         block_size: int,
         is_store: bool,
-        mm_hashes: list[str],
     ) -> "ReqMeta":
-        valid_num_tokens = align_to_block_size(len(token_ids), block_size)
-        token_ids_tensor = torch.tensor(token_ids)[:valid_num_tokens]
         block_ids_tensor = torch.tensor(block_ids)
         num_blocks = block_ids_tensor.shape[0]
         block_offsets = torch.arange(0, block_size)
@@ -56,12 +53,11 @@ class ReqMeta:
             block_offsets.reshape((1, block_size))
             + block_ids_tensor.reshape((num_blocks, 1)) * block_size
         )
-        slot_mapping = slot_mapping.flatten()[:valid_num_tokens]
+        slot_mapping = slot_mapping.flatten()[:num_tokens]
         return ReqMeta(
-            token_ids=token_ids_tensor,
+            cache_key=cache_key,
             slot_mapping=slot_mapping,
             is_store=is_store,
-            mm_hashes=mm_hashes,
         )
 
 
@@ -71,14 +67,14 @@ class ExampleConnectorMetadata(KVConnectorMetadata):
 
     def add_request(
         self,
-        token_ids: list[int],
+        cache_key: str,
+        num_tokens: int,
         block_ids: list[int],
         block_size: int,
         is_store: bool,
-        mm_hashes: list[str],
     ) -> None:
         self.requests.append(
-            ReqMeta.make_meta(token_ids, block_ids, block_size, is_store, mm_hashes)
+            ReqMeta.make_meta(cache_key, num_tokens, block_ids, block_size, is_store)
         )
 
 
@@ -101,6 +97,16 @@ class ExampleConnector(KVConnectorBase_V1):
         )
         self._block_size = vllm_config.cache_config.block_size
         self._requests_need_load: dict[str, Request] = {}
+        # Scheduler side: cache key and cached-token count per request, set in
+        # update_state_after_alloc and consumed by build_connector_meta.
+        self._pending: dict[str, tuple[str, int]] = {}
+        self._hash_block_size = self._block_size
+        if role == KVConnectorRole.SCHEDULER and kv_cache_config is not None:
+            from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
+
+            _, self._hash_block_size = resolve_kv_cache_block_sizes(
+                kv_cache_config, vllm_config
+            )
         self._storage_path = self._kv_transfer_config.get_from_extra_config(
             "shared_storage_path", "/tmp"
         )
@@ -178,9 +184,7 @@ class ExampleConnector(KVConnectorBase_V1):
                 if kv_cache_layer is None:
                     continue
 
-                filename = self._generate_filename_debug(
-                    layer_name, request.token_ids, request.mm_hashes
-                )
+                filename = self._layer_filename(request.cache_key, layer_name)
                 # Deliberate bulk load in this reference connector.
                 with gpu_sync_allowed():
                     kv_cache_cpu = safetensors.torch.load_file(filename)["kv_cache"]
@@ -244,8 +248,8 @@ class ExampleConnector(KVConnectorBase_V1):
         assert isinstance(connector_metadata, ExampleConnectorMetadata)
         for request in connector_metadata.requests:
             if request.is_store:
-                filename = self._generate_filename_debug(
-                    layer_name, request.token_ids, request.mm_hashes
+                filename = self._layer_filename(
+                    request.cache_key, layer_name, create_folder=True
                 )
                 kv_cache = extract_kv_from_layer(kv_layer, request.slot_mapping)
                 with gpu_sync_allowed():
@@ -275,22 +279,18 @@ class ExampleConnector(KVConnectorBase_V1):
         """
         # NOTE: in this debug implementation, we assume that the prompt is
         # cached_prompt + newly_generated_single_token
-        # Therefore, we use prompt_token_ids[:-1] to determine the folder name
+        # Therefore, we cache prompt_token_ids[:-1] aligned to a block.
 
         # NOTE: in current v1 scheduler, the num_computed_tokens is aligned
         # with the block granularity. And it expects the returned blocks and
         # num_computed_tokens to also be aligned with the block granularity.
-        if not self._found_match_for_request(request):
+        cache_key, num_cached_tokens = self._cache_key(request)
+        if cache_key is None or not self._found_match(cache_key):
             return 0, False
 
         logger.info("External Cache Hit!")
 
-        # Now, first num_tokens_to_check tokens are hit, we need to prepare
-        # the metadata for the worker connector to correctly load the KV
-        token_ids = request.prompt_token_ids or []
-        num_tokens_to_check = align_to_block_size(len(token_ids) - 1, self._block_size)
-
-        return num_tokens_to_check - num_computed_tokens, False
+        return num_cached_tokens - num_computed_tokens, False
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
@@ -298,9 +298,13 @@ class ExampleConnector(KVConnectorBase_V1):
         """
         Update KVConnector state after block allocation.
 
-        If blocks were allocated, add to _requests_need_load,
-        such that we load the KVs in the next forward pass.
+        Record the request's cache key for build_connector_meta. If blocks
+        were allocated, add to _requests_need_load, such that we load the
+        KVs in the next forward pass.
         """
+        cache_key, num_cached_tokens = self._cache_key(request)
+        if cache_key is not None:
+            self._pending[request.request_id] = (cache_key, num_cached_tokens)
         if num_external_tokens > 0:
             self._requests_need_load[request.request_id] = request
 
@@ -320,15 +324,17 @@ class ExampleConnector(KVConnectorBase_V1):
 
         total_need_load = 0
         for new_req in scheduler_output.scheduled_new_reqs:
-            token_ids = new_req.prompt_token_ids or []
-            mm_hashes = [f.identifier for f in new_req.mm_features]
+            pending = self._pending.get(new_req.req_id)
+            if pending is None:
+                continue
+            cache_key, num_cached_tokens = pending
             if new_req.req_id in self._requests_need_load:
                 meta.add_request(
-                    token_ids=token_ids,
+                    cache_key=cache_key,
+                    num_tokens=num_cached_tokens,
                     block_ids=new_req.block_ids[0],
                     block_size=self._block_size,
                     is_store=False,
-                    mm_hashes=mm_hashes,
                 )
                 total_need_load += 1
             else:
@@ -336,13 +342,13 @@ class ExampleConnector(KVConnectorBase_V1):
                 # but a single request can have both store and load.
                 # NOTE(rob): for this debug implementation, we only cache
                 # the original prompt tokens.
-                if not self._found_match_for_prompt(token_ids, mm_hashes):
+                if not self._found_match(cache_key):
                     meta.add_request(
-                        token_ids=token_ids,
+                        cache_key=cache_key,
+                        num_tokens=num_cached_tokens,
                         block_ids=new_req.block_ids[0],
                         block_size=self._block_size,
                         is_store=True,
-                        mm_hashes=mm_hashes,
                     )
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
@@ -351,16 +357,10 @@ class ExampleConnector(KVConnectorBase_V1):
             if not resumed_from_preemption or req_id not in self._requests_need_load:
                 continue
 
-            num_computed_tokens = cached_reqs.num_computed_tokens[i]
-            num_new_tokens = scheduler_output.num_scheduled_tokens[req_id]
+            # A resumed request passes through update_state_after_alloc
+            # again, so its key is pending like a new request's.
+            cache_key, num_cached_tokens = self._pending[req_id]
             new_block_ids = cached_reqs.new_block_ids[i]
-
-            # NOTE(rob): cached_req_data does not have the full
-            # list of token ids (only new tokens). So we look it
-            # up in the actual request object.
-            request = self._requests_need_load[req_id]
-            total_tokens = num_computed_tokens + num_new_tokens
-            token_ids = request.all_token_ids[:total_tokens]
 
             # NOTE(rob): For resumed req, new_block_ids is all
             # of the block_ids for the request.
@@ -368,81 +368,53 @@ class ExampleConnector(KVConnectorBase_V1):
             block_ids = new_block_ids[0]
 
             meta.add_request(
-                token_ids=token_ids,
+                cache_key=cache_key,
+                num_tokens=num_cached_tokens,
                 block_ids=block_ids,
                 block_size=self._block_size,
                 is_store=False,
-                mm_hashes=[f.identifier for f in request.mm_features],
             )
             total_need_load += 1
 
         assert total_need_load == len(self._requests_need_load)
         self._requests_need_load.clear()
+        self._pending.clear()
         return meta
 
     # ==============================
     # Helper functions
     # ==============================
 
-    def _found_match_for_request(
-        self,
-        request: "Request",
-    ) -> bool:
-        """Check if the cache is hit for the request."""
-        return self._found_match_for_prompt(
-            list(request.prompt_token_ids or []),
-            [f.identifier for f in request.mm_features],
-        )
+    def _cache_key(self, request: "Request") -> tuple[str | None, int]:
+        """Key the cached prefix on the request's own block hashes.
 
-    def _found_match_for_prompt(
-        self,
-        prompt_token_ids: list[int],
-        mm_hashes: list[str],
-    ) -> bool:
-        num_tokens_to_check = align_to_block_size(
-            len(prompt_token_ids) - 1, self._block_size
-        )
-        foldername = self._generate_foldername_debug(
-            torch.tensor(prompt_token_ids)[:num_tokens_to_check],
-            mm_hashes,
-            create_folder=False,
-        )
-        return os.path.exists(foldername)
+        The block hash chain already binds the tokens, ``cache_salt``, LoRA
+        identity, multimodal items and ``prompt_embeds`` content, so the
+        hash of the last cached block is the whole key. Deriving it from
+        raw tokens instead would drop every one of those dimensions.
 
-    def _generate_foldername_debug(
-        self,
-        token_ids: torch.Tensor,
-        mm_hashes: list[str],
-        create_folder=False,
-    ) -> str:
-        """Generate a folder name based on the hash of the bytes of the input
-        ids.
+        Returns:
+            The key and the number of cached tokens, or ``(None, 0)`` when
+            the prompt does not cover a full block.
         """
-        token_bytes = token_ids.numpy().tobytes()
-        # Add mm_hashes to the bytes being hashed to avoid path traversal and
-        # to create a canonical key.
-        if mm_hashes:
-            mm_str = "-".join(mm_hashes)
-            token_bytes += mm_str.encode("utf-8")
-        input_ids_hash = safe_hash(token_bytes, usedforsecurity=False).hexdigest()
+        num_cached_tokens = align_to_block_size(
+            request.num_prompt_tokens - 1, self._block_size
+        )
+        num_hashed_blocks = num_cached_tokens // self._hash_block_size
+        block_hashes = request.block_hashes
+        if num_hashed_blocks <= 0 or len(block_hashes) < num_hashed_blocks:
+            return None, 0
+        return block_hashes[num_hashed_blocks - 1].hex(), num_cached_tokens
 
-        foldername = os.path.join(self._storage_path, input_ids_hash)
+    def _found_match(self, cache_key: str) -> bool:
+        return os.path.exists(os.path.join(self._storage_path, cache_key))
+
+    def _layer_filename(
+        self, cache_key: str, layer_name: str, create_folder: bool = False
+    ) -> str:
+        foldername = os.path.join(self._storage_path, cache_key)
         if create_folder:
             os.makedirs(foldername, exist_ok=True)
-        return foldername
-
-    def _generate_filename_debug(
-        self,
-        layer_name: str,
-        token_ids: torch.Tensor,
-        mm_hashes: list[str],
-    ) -> str:
-        """Generate a file name based on the layer name and the hash
-        of the bytes of the input ids.
-        """
-        foldername = self._generate_foldername_debug(
-            token_ids, mm_hashes=mm_hashes, create_folder=True
-        )
         return os.path.join(foldername, f"{layer_name}.safetensors")
 
 


### PR DESCRIPTION
## Purpose

Fixes #53495.

`ExampleConnector` derived its storage key from the raw prompt token bytes, in three places: the scheduler-side lookup (`_found_match_for_request`), the metadata builder (`_found_match_for_prompt`), and again on the worker at save and load time (`_generate_filename_debug`). That key ignores `cache_salt`, LoRA identity and `prompt_embeds` content, so a request with a different salt or adapter was handed another request's KV (three full blocks in the reproduction), and `prompt_embeds` requests, whose `prompt_token_ids` is `None`, all keyed on the empty prompt and reported a negative match count (`align_to_block_size(-1, 16) == -16`).

The key is now derived once, on the scheduler side, from the hash of the last cached block in `request.block_hashes`. The block hash chain already binds tokens, `cache_salt`, LoRA, multimodal items and `prompt_embeds`, so nothing is re-derived: `update_state_after_alloc` records the key, `ReqMeta` carries it, and the worker only joins it to a path. Store and load now also agree on the cached-token count, which the old code aligned two different ways (`align(len)` on store, `align(len - 1)` on lookup), so prompts of length `k * block_size + 1` could never hit.

This is the pattern the connectors that already partition correctly use: `SimpleCPUOffloadConnector` and `OffloadingConnector` key on `request.block_hashes`. It is the same defect class as #51748 (HF3FS) and the one #53194 proposes a conformance suite for.

Net diff: +73 / -101 in the connector, no interface change outside `ReqMeta` / `ExampleConnectorMetadata.add_request`, which have no other in-tree callers (`ExampleHiddenStatesConnector` has its own metadata types).

## Test Plan

New `tests/v1/kv_connector/unit/test_example_connector_keying.py`, CPU only, no model: for each of `cache_salt`, LoRA and `prompt_embeds`, store request A through the connector's real scheduler and worker path (`update_state_after_alloc`, `build_connector_meta`, `save_kv_layer` on a CPU tensor), then assert `get_num_new_matched_tokens` for B is a full hit when B agrees with A and zero when it differs, plus unset-vs-set, a short-prompt case, and the `num_computed_tokens` offset.

Duplicate check run per AGENTS.md: no open PR references #53495 or touches `example_connector.py` keying; searched `ExampleConnector cache_salt`, `example_connector block_hashes`, `SharedStorageConnector cache_salt`.

## Test Result

```
VLLM_TARGET_DEVICE=cpu pytest tests/v1/kv_connector/unit/test_example_connector_keying.py -q
9 passed in 2.88s
```

On `main` the same cases give `48` for the different-salt and different-LoRA arms and `-16` for `prompt_embeds`.

Related existing tests, same result with and without the change: `tests/v1/kv_connector/unit/test_kv_connector_lifecycle.py`, `test_multi_connector.py` (one pre-existing failure from a gated HF repo, identical on `main`), `tests/v1/core/test_scheduler.py -k "connector or kv_transfer or external"` (27 pre-existing failures from model inspection on a CPU-only box, identical set on `main`).

The connector tier of the #53194 conformance suite (branch https://github.com/oneKn8/vllm/tree/kv-partitioning-conformance) marks the four ExampleConnector arms `xfail(strict=True)`; with this change they all XPASS, which is the intended flip.

`tests/v1/kv_connector/unit/test_example_connector.py` (the GPU e2e test asserting unique storage folders per image set) is unchanged; multimodal identifiers are part of the block hash, so the folder-count expectations hold. I cannot run it locally (no GPU), so I would appreciate a `ready` label for CI.

`pre-commit` passes on the changed files.

---

AI assistance was used for this change (Claude, via Claude Code); every line was reviewed and tested by me. Commit carries the `Co-authored-by` trailer.
