### PR TITLE
[Bugfix][Frontend] Preserve prefix cache for inline system turns

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -992,6 +992,78 @@ class TestInlineSystemMessageInMessagesArray:
         assert result.messages[1]["content"] == "Real system content."
 
 
+class TestInlineSystemMessageMerge:
+    def test_inline_system_is_rerolled_and_merged_with_user_turns(self):
+        request = _make_request(
+            [
+                {"role": "user", "content": "Q"},
+                {"role": "system", "content": "LATESYS"},
+                {"role": "user", "content": "Q2"},
+            ]
+        )
+
+        result = _convert(request, merge_inline_system=True)
+
+        assert result.messages == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Q"},
+                    {"type": "text", "text": "LATESYS"},
+                    {"type": "text", "text": "Q2"},
+                ],
+            }
+        ]
+
+    def test_inline_system_with_top_level_system_stays_after_prefix(self):
+        request = _make_request(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "system", "content": "Be concise."},
+            ],
+            system="Top-level prompt.",
+        )
+
+        result = _convert(request, merge_inline_system=True)
+
+        assert result.messages == [
+            {"role": "system", "content": "Top-level prompt."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    {"type": "text", "text": "Be concise."},
+                ],
+            },
+        ]
+
+    def test_inline_system_block_content_is_converted_to_user_text(self):
+        request = _make_request(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "Part one. "},
+                        {"type": "text", "text": "Part two."},
+                    ],
+                },
+            ]
+        )
+
+        result = _convert(request, merge_inline_system=True)
+
+        assert result.messages == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    {"type": "text", "text": "Part one. Part two."},
+                ],
+            }
+        ]
+
+
 # ======================================================================
 # Streaming conversion: message_stream_converter
 # ======================================================================

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -145,8 +145,8 @@ class AnthropicServingMessages(OpenAIServingChat):
         """Auto-detect whether the chat template requires system-first ordering.
 
         Renders a [system, user, system, user] conversation against the
-        template; if it raises (e.g. Qwen's ``loop.first`` guard), the
-        model needs inline system messages merged into the leading block.
+        template; if it raises (e.g. Qwen's ``loop.first`` guard), inline
+        system messages are converted to user messages before rendering.
         """
         if not chat_template:
             return True
@@ -200,11 +200,7 @@ class AnthropicServingMessages(OpenAIServingChat):
         """Convert Anthropic message format to OpenAI format"""
         openai_messages: list[dict[str, Any]] = []
 
-        cls._convert_system_message(
-            anthropic_request,
-            openai_messages,
-            merge_inline_system=merge_inline_system,
-        )
+        cls._convert_system_message(anthropic_request, openai_messages)
         cls._convert_messages(
             anthropic_request.messages,
             openai_messages,
@@ -222,8 +218,6 @@ class AnthropicServingMessages(OpenAIServingChat):
         cls,
         anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest,
         openai_messages: list[dict[str, Any]],
-        *,
-        merge_inline_system: bool = False,
     ) -> None:
         """Convert Anthropic system message to OpenAI format"""
         system_parts: list[str] = []
@@ -240,17 +234,6 @@ class AnthropicServingMessages(OpenAIServingChat):
                         if block.text.startswith("x-anthropic-billing-header"):
                             continue
                         system_parts.append(block.text)
-
-        # When the template requires system-first ordering, extract inline
-        # system messages from the messages array and merge them into the
-        # top-level block so the template doesn't reject them.
-        if merge_inline_system:
-            for msg in anthropic_request.messages:
-                if msg.role != "system":
-                    continue
-                text = cls._extract_system_text(msg)
-                if text:
-                    system_parts.append(text)
 
         if system_parts:
             openai_messages.append({"role": "system", "content": "".join(system_parts)})
@@ -287,11 +270,18 @@ class AnthropicServingMessages(OpenAIServingChat):
             # doesn't strip billing headers and may produce messages with
             # no "content" key.
             if msg.role == "system":
-                if merge_inline_system:
-                    continue  # already merged into top-level by _convert_system_message
                 text = cls._extract_system_text(msg)
                 if text:
-                    openai_messages.append({"role": "system", "content": text})
+                    if merge_inline_system:
+                        cls._append_user_message(
+                            openai_messages,
+                            {
+                                "role": "user",
+                                "content": [{"type": "text", "text": text}],
+                            },
+                        )
+                    else:
+                        openai_messages.append({"role": "system", "content": text})
                 continue
 
             openai_msg: dict[str, Any] = {"role": msg.role}  # type: ignore
@@ -302,7 +292,34 @@ class AnthropicServingMessages(OpenAIServingChat):
                 cls._convert_message_content(msg, openai_msg, openai_messages)
 
             if not (msg.role == "user" and "content" not in openai_msg):
-                openai_messages.append(openai_msg)
+                if msg.role == "user" and merge_inline_system:
+                    cls._append_user_message(openai_messages, openai_msg)
+                else:
+                    openai_messages.append(openai_msg)
+
+    @classmethod
+    def _append_user_message(
+        cls,
+        openai_messages: list[dict[str, Any]],
+        message: dict[str, Any],
+    ) -> None:
+        """Append a user message, merging it with an adjacent user turn."""
+        if openai_messages and openai_messages[-1]["role"] == "user":
+            previous = openai_messages[-1]
+            previous_content = previous["content"]
+            message_content = message["content"]
+            if isinstance(previous_content, str) and isinstance(message_content, str):
+                previous["content"] = previous_content + message_content
+                return
+
+            if isinstance(previous_content, str):
+                previous_content = [{"type": "text", "text": previous_content}]
+            if isinstance(message_content, str):
+                message_content = [{"type": "text", "text": message_content}]
+            previous["content"] = [*previous_content, *message_content]
+            return
+
+        openai_messages.append(message)
 
     @classmethod
     def _convert_message_content(


### PR DESCRIPTION
## Summary

When Anthropic inline `system` turns are sent to a template that requires system-first ordering, convert those turns to `user` messages in place and merge adjacent user messages. This keeps the prompt role-compatible without moving each per-turn reminder into the leading system prefix. Templates that support inline system turns keep the existing preserve-in-place behavior.

## Duplicate-work check

- Checked issue #53393 comments and open PR searches before editing.
- #52978 handles trailing-system hoisting into the leading system block; this patch does not hoist trailing messages.
- #47681 proposes a shared merge-by-default policy; this patch is limited to the Anthropic system-first fallback and preserves inline roles otherwise.
- The distinction was also documented in [issue #53393](https://github.com/vllm-project/vllm/issues/53393#issuecomment-5390176004).

## Test plan

- `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -v --noconftest` — 64 passed.
- `.venv/bin/pre-commit run --files vllm/entrypoints/anthropic/serving.py tests/entrypoints/anthropic/test_anthropic_messages_conversion.py` — all hooks passed, including ruff, format, mypy, and repository checks.
- The standard pytest invocation could not load the CUDA extension because this host lacks `libcudart.so.13`; the CPU-targeted run covers this request-conversion suite.
- No GPU/model evaluation was run because this change only affects Anthropic request conversion.

## AI assistance

AI assistance was used to investigate the issue, prepare the implementation and tests, and run validation. The human submitter should review every changed line and be able to explain and defend the behavior before merge.