### PR TITLE
[DSV4]fix run dsv4 fp8 weight

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -243,11 +243,14 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         )
 
         self.kv_norm = RMSNorm(self.head_dim, self.eps)
+        wo_a_quant_config = (
+            None if getattr(config, "wo_a_dtype", None) == "bf16" else quant_config
+        )
         self.wo_a = ColumnParallelLinear(
             self.n_heads * self.head_dim // self.n_groups,
             self.n_groups * self.o_lora_rank,
             bias=False,
-            quant_config=quant_config,
+            quant_config=wo_a_quant_config,
             return_bias=False,
             prefix=f"{prefix}.wo_a",
         )

--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -200,7 +200,7 @@ class DeepseekV4FlashInferMLAAttention(DeepseekV4Attention):
         return deep_gemm_fp8_o_proj(
             o,
             positions,
-            self.rotary_emb.cos_sin_cache,
+            self.rotary_emb,
             self.wo_a,
             self.wo_b,
             n_groups=self.n_local_groups,
@@ -573,7 +573,7 @@ class DeepseekV4FlashInferSM120Attention(DeepseekV4Attention):
         return deep_gemm_fp8_o_proj(
             o,
             positions,
-            self.rotary_emb.cos_sin_cache,
+            self.rotary_emb,
             self.wo_a,
             self.wo_b,
             n_groups=self.n_local_groups,

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -62,7 +62,7 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
         return deep_gemm_fp8_o_proj(
             o,
             positions,
-            self.rotary_emb.cos_sin_cache,
+            self.rotary_emb,
             self.wo_a,
             self.wo_b,
             n_groups=self.n_local_groups,

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -28,7 +28,7 @@ def compute_fp8_einsum_recipe() -> tuple[tuple[int, int, int], bool]:
 def deep_gemm_fp8_o_proj(
     o: torch.Tensor,
     positions: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
+    rotary_emb: nn.Module,
     wo_a: nn.Module,
     wo_b: nn.Module,
     *,
@@ -45,10 +45,17 @@ def deep_gemm_fp8_o_proj(
     Shared by the FlashMLA and FlashInfer CUDA backends. ``einsum_recipe`` /
     ``tma_aligned_scales`` come from ``compute_fp8_einsum_recipe``.
     """
+    if not hasattr(wo_a, "weight_scale") and not hasattr(wo_a, "weight_scale_inv"):
+        o_bf16, _ = rotary_emb.forward_native(positions, o, None, inverse=True)
+        o_bf16 = o_bf16.view(o.shape[0], n_groups, -1)
+        wo_a_weight = wo_a.weight.view(n_groups, o_lora_rank, -1)
+        z = torch.einsum("tgd,grd->tgr", o_bf16, wo_a_weight)
+        return wo_b(z.flatten(1))
+
     o_fp8, o_scale = fused_inv_rope_fp8_quant(
         o,
         positions,
-        cos_sin_cache,
+        rotary_emb.cos_sin_cache,
         n_groups=n_groups,
         heads_per_group=heads_per_group,
         nope_dim=nope_dim,


### PR DESCRIPTION



## Purpose

When running `https://huggingface.co/sgl-project/DeepSeek-V4-Flash-FP8` this fp8 weight dsv4 model, vllm wile not generate any data.
because this model weight and `https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash` is diffrent, this is primarily reflected in the `wo_a` weight layer of the attention mechanism.

- This is `DeepSeek-V4-Flash-FP8` model `wo_a` layer weight.
<img width="2620" height="236" alt="image" src="https://github.com/user-attachments/assets/465a326f-d0ae-426d-aae2-31c34e5d2083" />

- This is `DeepSeek-V4-Flash` model `wo_a` layer weight.
<img width="2568" height="184" alt="image" src="https://github.com/user-attachments/assets/776269ae-400b-4f8e-bb4b-cd8d06ace0d1" />

 This `DeepSeek-V4-Flash` model includes an additional "scale" weight component, but the `DeepSeek-V4-Flash-FP8` model lacks it; consequently, it uses empty padding, causing it to malfunction.

After applying this fix PR, it outputs content correctly.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

