### PR TITLE
[Test][Scheduler] Regression coverage for multi-module MTP prefill-lookahead chunking

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1304,6 +1304,46 @@ def test_draft_slots_budgeted_per_scheduled_request(tmp_path, monkeypatch):
     assert scheduler.schedule().num_scheduled_tokens == {"0": 10, "1": 4}
 
 
+def test_multi_module_mtp_prefill_lookahead_chunk_accounting():
+    """A multi-module MTP drafter reads num_speculative_tokens ahead at a
+    chunk boundary, so the scheduler must never end a prefill chunk with
+    fewer than that many tokens left (see `_reserve_prefill_lookahead`).
+    Regression test for issue #53488: verify the shortened first chunk and
+    the resulting second chunk together cover the whole prompt exactly once,
+    with no gap or double-counted token.
+    """
+    scheduler = create_scheduler(max_num_seqs=1, max_num_batched_tokens=12)
+    scheduler.use_eagle = True
+    scheduler.num_prefill_lookahead = 3
+
+    request = create_requests(num_requests=1, num_tokens=14, prompt_logprobs=0)[0]
+    scheduler.add_request(request)
+
+    # remaining = 14 - 0 - min(14, 12) = 2, which is < lookahead (3), so the
+    # first chunk is shrunk by (3 - 2) to leave exactly 3 tokens for the next.
+    output = scheduler.schedule()
+    first_chunk = output.num_scheduled_tokens[request.request_id]
+    assert first_chunk == 11
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[request.request_id],
+            req_id_to_index={request.request_id: 0},
+            sampled_token_ids=[[]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    assert request.num_computed_tokens == first_chunk
+
+    output = scheduler.schedule()
+    second_chunk = output.num_scheduled_tokens[request.request_id]
+
+    assert first_chunk + second_chunk == request.num_prompt_tokens
+
+
 # Note - these test cases mirror some of those in test_rejection_sampler.py
 @pytest.mark.parametrize(
     "spec_tokens,output_tokens,expected,expected_per_req",


### PR DESCRIPTION
## What this is

Investigation into #53488 (`prompt_logprobs` corrupted for some requests under MTP speculative decoding). This is **not a fix** — it's a checkpoint: a regression test that closes a real coverage gap found while root-causing the issue, opened as draft while I continue reproducing on a GPU with a real multi-layer MTP checkpoint.

## What I found

- `Scheduler._reserve_prefill_lookahead` only does real work when `num_prefill_lookahead > 1`, which only happens for multi-module MTP (`num_speculative_tokens > 1` with a multi-layer draft config) — exactly the reporter's config (`num_speculative_tokens=3`).
- No existing test sets `num_prefill_lookahead > 1`; the two closest tests (`test_mamba_align_eagle_schedules_encoder_at_boundary`, one other) hardcode `1`. So this lookahead-shortened-chunk regime is entirely untested.
- I traced the two most plausible root-cause candidates from the issue and ruled both out for the reporter's exact config:
  - `draft_slots` budget subtraction (`max_num_new_slots_for_drafting`) is provably `0` for plain `method="mtp"` — it can't be shrinking this request's budget.
  - The multi-module MTP speculator (`vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py`) uses its own private hidden-states buffer, not the base model's — no shared-buffer clobber.
- The new test here confirms the scheduler's own chunk-boundary bookkeeping (`num_computed_tokens` progression across a lookahead-shortened chunk) is also correct.

So the corruption most likely lives in how `_get_prompt_logprobs_dict` (or the V2 runner's `compute_prompt_logprobs_with_chunking`) reads hidden states for a chunk shaped by this lookahead reservation — but confirming the exact line needs a real GPU run against a multi-layer MTP checkpoint, which I don't have in this environment.

## Test plan

```
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -k test_multi_module_mtp_prefill_lookahead_chunk_accounting -v
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -q   # full file, 151 passed
pre-commit run --files tests/v1/core/test_scheduler.py          # clean
```

## Duplicate check

`gh issue view 53488 --repo vllm-project/vllm --comments` and `gh pr list --repo vllm-project/vllm --state open --search "53488 in:body"` — no open PR addresses this issue yet.

## AI assistance

Investigation and this test were written with AI assistance (Claude). I've reviewed the diff and reasoning above myself; I'm continuing the GPU-side root-cause work before this is ready for review.