### PR TITLE
[Bugfix][Humming] Recover locks after sleep and reload

### DIFF
--- a/tests/model_executor/test_sleep_mode_tensor_ownership.py
+++ b/tests/model_executor/test_sleep_mode_tensor_ownership.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEExperts
+
+
+def test_kernel_buffer_registration_reuses_captured_storage() -> None:
+    layer = nn.Module()
+    owner = SimpleNamespace()
+    original = torch.tensor([1.0, 2.0])
+
+    registered = FusedMoEExperts._register_persistent_buffer(
+        owner, layer, "scale", original
+    )
+    pointer = registered.data_ptr()
+    replacement = FusedMoEExperts._register_persistent_buffer(
+        owner, layer, "scale", torch.tensor([3.0, 4.0])
+    )
+
+    assert replacement.data_ptr() == pointer
+    assert torch.equal(replacement, torch.tensor([3.0, 4.0]))
+    assert "_moe_scale" not in layer.state_dict()
+
+    restored = torch.tensor([5.0, 6.0])
+    layer._buffers["_moe_scale"] = restored
+    FusedMoEExperts.rebind_sleep_buffers(owner, layer)
+    assert owner.scale is restored

--- a/tests/model_executor/test_sleep_mode_tensor_ownership.py
+++ b/tests/model_executor/test_sleep_mode_tensor_ownership.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn
 
 from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEExperts
+from vllm.model_executor.layers.quantization.humming import HummingMoEMethod
 
 
 def test_kernel_buffer_registration_reuses_captured_storage() -> None:
@@ -30,3 +31,35 @@ def test_kernel_buffer_registration_reuses_captured_storage() -> None:
     layer._buffers["_moe_scale"] = restored
     FusedMoEExperts.rebind_sleep_buffers(owner, layer)
     assert owner.scale is restored
+
+
+def test_weight_wake_hooks_reset_module_and_quant_state() -> None:
+    from vllm.v1.worker.gpu_worker import _run_post_weights_wake_up_hooks
+
+    events: list[str] = []
+
+    class QuantMethod:
+        def post_weights_wake_up(self, layer: nn.Module) -> None:
+            events.append("quant")
+
+    class Layer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.quant_method = QuantMethod()
+
+        def post_weights_wake_up(self) -> None:
+            events.append("module")
+
+    model = nn.Sequential(Layer())
+    _run_post_weights_wake_up_hooks(model)
+
+    assert events == ["module", "quant"]
+
+
+def test_humming_moe_can_be_prepared_for_repeated_reload() -> None:
+    method = object.__new__(HummingMoEMethod)
+    method.processed = True
+
+    method.prepare_for_reload(SimpleNamespace())
+
+    assert not method.processed

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -1301,6 +1301,23 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         self.group_size = group_size
         self._permute_scratch: MoEPermuteScratch | None = None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        for name in (
+            "a_strides1",
+            "a_strides2",
+            "b_strides1",
+            "b_strides2",
+            "c_strides1",
+            "c_strides2",
+            "s_strides1",
+            "s_strides2",
+        ):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
+
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -156,6 +156,12 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             k=k2,
             num_groups=num_experts_w2,
         )
+        for name in ("_fc2_input_scale", "w1_sf_mma", "w2_sf_mma"):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -67,6 +67,18 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         if self.quant_config.use_nvfp4_w4a4:
             layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
             layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        for name in (
+            "gemm1_alpha",
+            "gemm1_beta",
+            "gemm1_clamp_limit",
+            "fake_input_scale",
+        ):
+            if hasattr(self, name):
+                setattr(
+                    self,
+                    name,
+                    self._register_persistent_buffer(layer, name, getattr(self, name)),
+                )
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -132,6 +132,14 @@ class TrtLlmFp8ExpertsBase:
         else:
             self.gemm1_clamp_limit = None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        for name in ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit"):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
+
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -120,6 +120,14 @@ class TrtLlmMxfp4ExpertsBase:
             )
             self.gemm1_clamp_limit = None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        for name in ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit"):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
+
     @staticmethod
     def _supports_current_device() -> bool:
         p = current_platform

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -68,6 +68,10 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         """
         return False
 
+    def post_weights_reload(self, layer: "RoutedExperts") -> None:
+        if self.moe_kernel is not None:
+            self.moe_kernel.fused_experts.rebind_sleep_buffers(layer)
+
     def maybe_roundup_sizes(
         self,
         hidden_size: int,

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -517,6 +517,44 @@ class FusedMoEExperts(ABC):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
         pass
 
+    def _register_persistent_buffer(
+        self, layer: torch.nn.Module, name: str, tensor: torch.Tensor | None
+    ) -> torch.Tensor | None:
+        """Attach kernel-owned constants to the layer's sleep lifecycle.
+
+        Expert implementations are not ``nn.Module`` objects, so a tensor kept
+        only on ``self`` is invisible to level-2 sleep buffer recovery. Reuse
+        existing storage during reload to preserve CUDA-graph pointers.
+        """
+        if tensor is None:
+            return None
+        buffer_name = f"_moe_{name}"
+        sleep_buffers = getattr(self, "_sleep_buffer_names", None)
+        if sleep_buffers is None:
+            sleep_buffers = self._sleep_buffer_names = {}
+        sleep_buffers[name] = buffer_name
+        existing = layer._buffers.get(buffer_name)
+        if existing is None:
+            layer.register_buffer(buffer_name, tensor, persistent=False)
+            return tensor
+        if (
+            existing.shape != tensor.shape
+            or existing.dtype != tensor.dtype
+            or existing.device != tensor.device
+        ):
+            raise RuntimeError(
+                f"Cannot replace sleep-managed MoE buffer {buffer_name}: "
+                f"existing={existing.shape}/{existing.dtype}/{existing.device}, "
+                f"new={tensor.shape}/{tensor.dtype}/{tensor.device}"
+            )
+        existing.copy_(tensor)
+        return existing
+
+    def rebind_sleep_buffers(self, layer: torch.nn.Module) -> None:
+        """Rebind helper aliases after layerwise reload restores old storage."""
+        for name, buffer_name in getattr(self, "_sleep_buffer_names", {}).items():
+            setattr(self, name, layer._buffers[buffer_name])
+
     @staticmethod
     def is_monolithic() -> bool:
         raise NotImplementedError("Implemented by subclasses.")

--- a/vllm/model_executor/layers/quantization/humming.py
+++ b/vllm/model_executor/layers/quantization/humming.py
@@ -60,6 +60,23 @@ if TYPE_CHECKING:
     )
 
 
+def _register_sleep_buffer(
+    layer: torch.nn.Module, name: str, tensor: torch.Tensor
+) -> torch.Tensor:
+    existing = layer._buffers.get(name)
+    if existing is None:
+        layer.register_buffer(name, tensor, persistent=False)
+        return tensor
+    if (
+        existing.shape != tensor.shape
+        or existing.dtype != tensor.dtype
+        or existing.device != tensor.device
+    ):
+        raise RuntimeError(f"Cannot replace sleep-managed Humming buffer {name}")
+    existing.copy_(tensor)
+    return existing
+
+
 def prepare_param(tensor, name, extra_attrs):
     extra_attrs = extra_attrs.copy()
     scale_type = extra_attrs.pop("scale_type", None)
@@ -568,7 +585,17 @@ class HummingLinearMethod(LinearMethodBase):
             setattr(layer, name, param)
 
         self.compute_config = get_humming_linear_compute_config()
-        self.locks = torch.zeros(1024, dtype=torch.int32, device=layer.weight.device)
+        self.locks = _register_sleep_buffer(
+            layer,
+            "_humming_locks",
+            torch.zeros(1024, dtype=torch.int32, device=layer.weight.device),
+        )
+
+    def post_weights_wake_up(self, layer: torch.nn.Module) -> None:
+        self.locks.zero_()
+
+    def post_weights_reload(self, layer: torch.nn.Module) -> None:
+        self.locks = layer._buffers["_humming_locks"]
 
     def apply(
         self,
@@ -773,6 +800,24 @@ class HummingMoEMethod(FusedMoEMethodBase):
             self.experts_cls,
             routing_tables=layer._expert_routing_tables(),
         )
+        experts = self.moe_kernel.fused_experts
+        experts.locks = _register_sleep_buffer(
+            layer, "_humming_moe_locks", experts.locks
+        )
+
+    def prepare_for_reload(self, layer: RoutedExperts) -> None:
+        self.processed = False
+
+    def post_weights_wake_up(self, layer: RoutedExperts) -> None:
+        if self.moe_kernel is not None:
+            self.moe_kernel.fused_experts.locks.zero_()
+
+    def post_weights_reload(self, layer: RoutedExperts) -> None:
+        super().post_weights_reload(layer)
+        if self.moe_kernel is not None:
+            self.moe_kernel.fused_experts.locks = layer._buffers[
+                "_humming_moe_locks"
+            ]
 
     def apply(
         self,

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -107,6 +107,11 @@ def initialize_layerwise_reload(model: torch.nn.Module):
         if info.can_load():
             continue
 
+        quant_method = getattr(layer, "quant_method", None)
+        prepare_for_reload = getattr(quant_method, "prepare_for_reload", None)
+        if prepare_for_reload is not None:
+            prepare_for_reload(layer)
+
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
         # snapshot now: restore_layer_on_meta drops alias buffers from the live set

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -406,6 +406,10 @@ def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadin
         buffer.data.copy_(getattr(layer, name))
 
     _place_kernel_tensors(layer, info)
+    quant_method = getattr(layer, "quant_method", None)
+    post_weights_reload = getattr(quant_method, "post_weights_reload", None)
+    if post_weights_reload is not None:
+        post_weights_reload(layer)
 
 
 def _place_kernel_tensors(layer: torch.nn.Module, info: LayerReloadingInfo):

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -93,6 +93,18 @@ from .utils import request_memory
 logger = init_logger(__name__)
 
 
+def _run_post_weights_wake_up_hooks(model: torch.nn.Module) -> None:
+    """Restore stateful module and quantization workspaces after remapping."""
+    for module in model.modules():
+        hook = getattr(module, "post_weights_wake_up", None)
+        if hook is not None:
+            hook()
+        quant_method = getattr(module, "quant_method", None)
+        hook = getattr(quant_method, "post_weights_wake_up", None)
+        if hook is not None:
+            hook(module)
+
+
 def _num_workspace_lanes(vllm_config: VllmConfig, use_v2_model_runner: bool) -> int:
     spec_config = vllm_config.speculative_config
     return (
@@ -255,6 +267,12 @@ class Worker(WorkerBase):
                     if name in self._sleep_saved_draft_buffers:
                         buffer.data.copy_(self._sleep_saved_draft_buffers[name].data)
             self._sleep_saved_draft_buffers = {}
+
+        if wake_weights:
+            _run_post_weights_wake_up_hooks(self.model_runner.model)
+            draft = self.get_draft_model()
+            if draft is not None:
+                _run_post_weights_wake_up_hooks(draft)
 
         if tags is None or "kv_cache" in tags:
             self.model_runner.post_kv_cache_wake_up()


### PR DESCRIPTION
## Purpose

Part of #53343. Split from #53344.

Humming keeps runtime locks and post-processing state on quantization/kernel helper objects. Registered buffers preserve bytes, but they do not reset the Humming `processed` state before a new reload, rebind helper aliases after layerwise storage restoration, or reset lock protocol state after wake-up.

## Changes

- register Humming Linear and MoE locks as non-persistent owning-layer buffers;
- add `prepare_for_reload` so Humming MoE post-processing runs once for each reload;
- rebind Linear and MoE lock aliases after original storage is restored;
- invoke module and quantization `post_weights_wake_up` hooks after registered buffers are restored;
- reset Humming locks in place after wake-up;
- cover hook ordering and repeated Humming reload preparation.

## Dependency

Depends on #53509 for the MoE `post_weights_reload` foundation and helper buffer rebinding.

This is a stacked PR. Review the Humming-specific commit after #53509; once #53509 merges, GitHub will reduce this PR to the remaining Humming changes.

## Test Plan

```bash
pytest -q tests/model_executor/test_sleep_mode_tensor_ownership.py
```

Changed files pass Ruff, `git diff --check`, and Python compilation. Humming kernel GPU validation is delegated to CI.
