### PR TITLE
[Bugfix][MiniMax] Reset Lamport workspace after wake-up

### DIFF
--- a/tests/kernels/core/test_minimax_reduce_rms.py
+++ b/tests/kernels/core/test_minimax_reduce_rms.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for MiniMax QK RMS-norm: NCCL reference vs Lamport fused kernel."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 import torch.nn as nn
@@ -18,6 +20,40 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.network_utils import get_open_port
 from vllm.utils.torch_utils import set_random_seed
+
+
+def test_lamport_workspace_reset_restores_protocol_state(monkeypatch):
+    from vllm.model_executor.layers.minimax_rms_norm import lamport_workspace
+
+    sentinel_resets = []
+    monkeypatch.setattr(
+        lamport_workspace,
+        "_lamport_fill_neg_zero",
+        lambda ptr, size: sentinel_resets.append((ptr, size)),
+    )
+    owner = object.__new__(lamport_workspace.LamportWorkspace)
+    owner.world_size = 2
+    owner.comm_size = 16
+    owner._lamport = SimpleNamespace(local_ptr=123, serialize=lambda: [11, 22])
+    owner._flag_buf = torch.tensor([7, 8, 9], dtype=torch.int32)
+    owner._layout_buf = torch.tensor([99, 99], dtype=torch.int64)
+    owner._workspace = torch.full((8,), -1, dtype=torch.int64)
+
+    owner.reset()
+
+    assert sentinel_resets == [(123, 48)]
+    assert torch.equal(owner._flag_buf, torch.zeros(3, dtype=torch.int32))
+    assert torch.equal(owner._layout_buf, torch.tensor([0, 16]))
+    assert owner._workspace.tolist() == [
+        0,
+        0,
+        0,
+        0,
+        11,
+        22,
+        owner._flag_buf.data_ptr(),
+        owner._layout_buf.data_ptr(),
+    ]
 
 
 @ensure_current_vllm_config()

--- a/tests/model_executor/test_sleep_mode_tensor_ownership.py
+++ b/tests/model_executor/test_sleep_mode_tensor_ownership.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEExperts
+
+
+def test_kernel_buffer_registration_reuses_captured_storage() -> None:
+    layer = nn.Module()
+    owner = SimpleNamespace()
+    original = torch.tensor([1.0, 2.0])
+
+    registered = FusedMoEExperts._register_persistent_buffer(
+        owner, layer, "scale", original
+    )
+    pointer = registered.data_ptr()
+    replacement = FusedMoEExperts._register_persistent_buffer(
+        owner, layer, "scale", torch.tensor([3.0, 4.0])
+    )
+
+    assert replacement.data_ptr() == pointer
+    assert torch.equal(replacement, torch.tensor([3.0, 4.0]))
+    assert "_moe_scale" not in layer.state_dict()
+
+    restored = torch.tensor([5.0, 6.0])
+    layer._buffers["_moe_scale"] = restored
+    FusedMoEExperts.rebind_sleep_buffers(owner, layer)
+    assert owner.scale is restored

--- a/tests/model_executor/test_sleep_mode_tensor_ownership.py
+++ b/tests/model_executor/test_sleep_mode_tensor_ownership.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn
 
 from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEExperts
+from vllm.model_executor.layers.quantization.humming import HummingMoEMethod
 
 
 def test_kernel_buffer_registration_reuses_captured_storage() -> None:
@@ -30,3 +31,35 @@ def test_kernel_buffer_registration_reuses_captured_storage() -> None:
     layer._buffers["_moe_scale"] = restored
     FusedMoEExperts.rebind_sleep_buffers(owner, layer)
     assert owner.scale is restored
+
+
+def test_weight_wake_hooks_reset_module_and_quant_state() -> None:
+    from vllm.v1.worker.gpu_worker import _run_post_weights_wake_up_hooks
+
+    events: list[str] = []
+
+    class QuantMethod:
+        def post_weights_wake_up(self, layer: nn.Module) -> None:
+            events.append("quant")
+
+    class Layer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.quant_method = QuantMethod()
+
+        def post_weights_wake_up(self) -> None:
+            events.append("module")
+
+    model = nn.Sequential(Layer())
+    _run_post_weights_wake_up_hooks(model)
+
+    assert events == ["module", "quant"]
+
+
+def test_humming_moe_can_be_prepared_for_repeated_reload() -> None:
+    method = object.__new__(HummingMoEMethod)
+    method.processed = True
+
+    method.prepare_for_reload(SimpleNamespace())
+
+    assert not method.processed

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -1301,6 +1301,23 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         self.group_size = group_size
         self._permute_scratch: MoEPermuteScratch | None = None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        for name in (
+            "a_strides1",
+            "a_strides2",
+            "b_strides1",
+            "b_strides2",
+            "c_strides1",
+            "c_strides2",
+            "s_strides1",
+            "s_strides2",
+        ):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
+
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_b12x_moe.py
@@ -156,6 +156,12 @@ class FlashInferB12xExperts(mk.FusedMoEExpertsModular):
             k=k2,
             num_groups=num_experts_w2,
         )
+        for name in ("_fc2_input_scale", "w1_sf_mma", "w2_sf_mma"):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -67,6 +67,18 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         if self.quant_config.use_nvfp4_w4a4:
             layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
             layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        for name in (
+            "gemm1_alpha",
+            "gemm1_beta",
+            "gemm1_clamp_limit",
+            "fake_input_scale",
+        ):
+            if hasattr(self, name):
+                setattr(
+                    self,
+                    name,
+                    self._register_persistent_buffer(layer, name, getattr(self, name)),
+                )
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -132,6 +132,14 @@ class TrtLlmFp8ExpertsBase:
         else:
             self.gemm1_clamp_limit = None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        for name in ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit"):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
+
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -120,6 +120,14 @@ class TrtLlmMxfp4ExpertsBase:
             )
             self.gemm1_clamp_limit = None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        for name in ("gemm1_alpha", "gemm1_beta", "gemm1_clamp_limit"):
+            setattr(
+                self,
+                name,
+                self._register_persistent_buffer(layer, name, getattr(self, name)),
+            )
+
     @staticmethod
     def _supports_current_device() -> bool:
         p = current_platform

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -68,6 +68,10 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         """
         return False
 
+    def post_weights_reload(self, layer: "RoutedExperts") -> None:
+        if self.moe_kernel is not None:
+            self.moe_kernel.fused_experts.rebind_sleep_buffers(layer)
+
     def maybe_roundup_sizes(
         self,
         hidden_size: int,

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -517,6 +517,44 @@ class FusedMoEExperts(ABC):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
         pass
 
+    def _register_persistent_buffer(
+        self, layer: torch.nn.Module, name: str, tensor: torch.Tensor | None
+    ) -> torch.Tensor | None:
+        """Attach kernel-owned constants to the layer's sleep lifecycle.
+
+        Expert implementations are not ``nn.Module`` objects, so a tensor kept
+        only on ``self`` is invisible to level-2 sleep buffer recovery. Reuse
+        existing storage during reload to preserve CUDA-graph pointers.
+        """
+        if tensor is None:
+            return None
+        buffer_name = f"_moe_{name}"
+        sleep_buffers = getattr(self, "_sleep_buffer_names", None)
+        if sleep_buffers is None:
+            sleep_buffers = self._sleep_buffer_names = {}
+        sleep_buffers[name] = buffer_name
+        existing = layer._buffers.get(buffer_name)
+        if existing is None:
+            layer.register_buffer(buffer_name, tensor, persistent=False)
+            return tensor
+        if (
+            existing.shape != tensor.shape
+            or existing.dtype != tensor.dtype
+            or existing.device != tensor.device
+        ):
+            raise RuntimeError(
+                f"Cannot replace sleep-managed MoE buffer {buffer_name}: "
+                f"existing={existing.shape}/{existing.dtype}/{existing.device}, "
+                f"new={tensor.shape}/{tensor.dtype}/{tensor.device}"
+            )
+        existing.copy_(tensor)
+        return existing
+
+    def rebind_sleep_buffers(self, layer: torch.nn.Module) -> None:
+        """Rebind helper aliases after layerwise reload restores old storage."""
+        for name, buffer_name in getattr(self, "_sleep_buffer_names", {}).items():
+            setattr(self, name, layer._buffers[buffer_name])
+
     @staticmethod
     def is_monolithic() -> bool:
         raise NotImplementedError("Implemented by subclasses.")

--- a/vllm/model_executor/layers/minimax_rms_norm/lamport_workspace.py
+++ b/vllm/model_executor/layers/minimax_rms_norm/lamport_workspace.py
@@ -209,6 +209,23 @@ class LamportWorkspace:
 
         self._workspace = torch.tensor(ptrs, dtype=torch.int64, device="cuda")
 
+    def reset(self) -> None:
+        """Restore the protocol state in place after sleep-mode remapping."""
+        _lamport_fill_neg_zero(self._lamport.local_ptr, 3 * self.comm_size)
+        self._flag_buf.zero_()
+        self._layout_buf.copy_(
+            torch.tensor(
+                [0, self.comm_size], dtype=torch.int64, device=self._layout_buf.device
+            )
+        )
+        ptrs = [0] * (2 * self.world_size)
+        ptrs += self._lamport.serialize()
+        ptrs.append(self._flag_buf.data_ptr())
+        ptrs.append(self._layout_buf.data_ptr())
+        self._workspace.copy_(
+            torch.tensor(ptrs, dtype=torch.int64, device=self._workspace.device)
+        )
+
     @property
     def workspace(self) -> torch.Tensor:
         """Device tensor (int64) that can be passed to the kernel
@@ -289,6 +306,19 @@ def get_allreduce_workspace(
     process_group : optional
         ``torch.distributed`` process group.
     """
+    return get_allreduce_workspace_owner(
+        rank, world_size, comm_size, max_tokens, process_group
+    ).workspace
+
+
+def get_allreduce_workspace_owner(
+    rank: int,
+    world_size: int,
+    comm_size: int | None = None,
+    max_tokens: int = 16384,
+    process_group=None,
+) -> LamportWorkspace:
+    """Return the cached owner for sleep-aware workspace registration."""
     if comm_size is None:
         comm_size = LamportWorkspace.compute_comm_size_for_minimax(
             max_tokens, world_size, fused_qk=True
@@ -299,4 +329,4 @@ def get_allreduce_workspace(
         if key not in _workspace_cache:
             ws = LamportWorkspace(rank, world_size, comm_size, process_group)
             _workspace_cache[key] = ws
-        return _workspace_cache[key].workspace
+        return _workspace_cache[key]

--- a/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
+++ b/vllm/model_executor/layers/minimax_rms_norm/rms_norm_tp.py
@@ -306,9 +306,10 @@ class MiniMaxText01RMSNormTP(CustomOp):
         self.variance_epsilon = eps
 
         self.workspace = None
+        self._lamport_workspace_owner = None
         if _MINIMAX_FUSED_AR_RMS_QK is not None and self.tp_world > 1:
             from .lamport_workspace import (
-                get_allreduce_workspace,
+                get_allreduce_workspace_owner,
             )
 
             # The Lamport workspace exchanges CUDA IPC handles and enables peer
@@ -317,12 +318,23 @@ class MiniMaxText01RMSNormTP(CustomOp):
             # with P2P disabled in the driver), allocation raises. Fall back to
             # the eager allreduce + RMSNorm path instead of failing model load.
             try:
-                self.workspace = get_allreduce_workspace(
+                owner = get_allreduce_workspace_owner(
                     rank=self.tp_rank,
                     world_size=self.tp_world,
                     max_tokens=MINIMAX_QK_NORM_MAX_TOKEN_NUM,
                     process_group=get_tp_group().cpu_group,
                 )
+                self._lamport_workspace_owner = owner
+                self.register_buffer(
+                    "_lamport_flag_buf", owner._flag_buf, persistent=False
+                )
+                self.register_buffer(
+                    "_lamport_layout_buf", owner._layout_buf, persistent=False
+                )
+                self.register_buffer(
+                    "_lamport_workspace", owner._workspace, persistent=False
+                )
+                self.workspace = self._lamport_workspace
             except Exception as e:
                 logger.warning_once(
                     "Failed to initialize MiniMax fused allreduce+RMSNorm "
@@ -332,6 +344,10 @@ class MiniMaxText01RMSNormTP(CustomOp):
                     e,
                 )
                 self.workspace = None
+
+    def post_weights_wake_up(self) -> None:
+        if self._lamport_workspace_owner is not None:
+            self._lamport_workspace_owner.reset()
 
     @staticmethod
     def weight_loader(

--- a/vllm/model_executor/layers/quantization/humming.py
+++ b/vllm/model_executor/layers/quantization/humming.py
@@ -60,6 +60,23 @@ if TYPE_CHECKING:
     )
 
 
+def _register_sleep_buffer(
+    layer: torch.nn.Module, name: str, tensor: torch.Tensor
+) -> torch.Tensor:
+    existing = layer._buffers.get(name)
+    if existing is None:
+        layer.register_buffer(name, tensor, persistent=False)
+        return tensor
+    if (
+        existing.shape != tensor.shape
+        or existing.dtype != tensor.dtype
+        or existing.device != tensor.device
+    ):
+        raise RuntimeError(f"Cannot replace sleep-managed Humming buffer {name}")
+    existing.copy_(tensor)
+    return existing
+
+
 def prepare_param(tensor, name, extra_attrs):
     extra_attrs = extra_attrs.copy()
     scale_type = extra_attrs.pop("scale_type", None)
@@ -568,7 +585,17 @@ class HummingLinearMethod(LinearMethodBase):
             setattr(layer, name, param)
 
         self.compute_config = get_humming_linear_compute_config()
-        self.locks = torch.zeros(1024, dtype=torch.int32, device=layer.weight.device)
+        self.locks = _register_sleep_buffer(
+            layer,
+            "_humming_locks",
+            torch.zeros(1024, dtype=torch.int32, device=layer.weight.device),
+        )
+
+    def post_weights_wake_up(self, layer: torch.nn.Module) -> None:
+        self.locks.zero_()
+
+    def post_weights_reload(self, layer: torch.nn.Module) -> None:
+        self.locks = layer._buffers["_humming_locks"]
 
     def apply(
         self,
@@ -773,6 +800,24 @@ class HummingMoEMethod(FusedMoEMethodBase):
             self.experts_cls,
             routing_tables=layer._expert_routing_tables(),
         )
+        experts = self.moe_kernel.fused_experts
+        experts.locks = _register_sleep_buffer(
+            layer, "_humming_moe_locks", experts.locks
+        )
+
+    def prepare_for_reload(self, layer: RoutedExperts) -> None:
+        self.processed = False
+
+    def post_weights_wake_up(self, layer: RoutedExperts) -> None:
+        if self.moe_kernel is not None:
+            self.moe_kernel.fused_experts.locks.zero_()
+
+    def post_weights_reload(self, layer: RoutedExperts) -> None:
+        super().post_weights_reload(layer)
+        if self.moe_kernel is not None:
+            self.moe_kernel.fused_experts.locks = layer._buffers[
+                "_humming_moe_locks"
+            ]
 
     def apply(
         self,

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -107,6 +107,11 @@ def initialize_layerwise_reload(model: torch.nn.Module):
         if info.can_load():
             continue
 
+        quant_method = getattr(layer, "quant_method", None)
+        prepare_for_reload = getattr(quant_method, "prepare_for_reload", None)
+        if prepare_for_reload is not None:
+            prepare_for_reload(layer)
+
         # Save current tensors for later copying
         info.kernel_tensors = get_layer_params_buffers(layer)
         # snapshot now: restore_layer_on_meta drops alias buffers from the live set

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -406,6 +406,10 @@ def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadin
         buffer.data.copy_(getattr(layer, name))
 
     _place_kernel_tensors(layer, info)
+    quant_method = getattr(layer, "quant_method", None)
+    post_weights_reload = getattr(quant_method, "post_weights_reload", None)
+    if post_weights_reload is not None:
+        post_weights_reload(layer)
 
 
 def _place_kernel_tensors(layer: torch.nn.Module, info: LayerReloadingInfo):

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -93,6 +93,18 @@ from .utils import request_memory
 logger = init_logger(__name__)
 
 
+def _run_post_weights_wake_up_hooks(model: torch.nn.Module) -> None:
+    """Restore stateful module and quantization workspaces after remapping."""
+    for module in model.modules():
+        hook = getattr(module, "post_weights_wake_up", None)
+        if hook is not None:
+            hook()
+        quant_method = getattr(module, "quant_method", None)
+        hook = getattr(quant_method, "post_weights_wake_up", None)
+        if hook is not None:
+            hook(module)
+
+
 def _num_workspace_lanes(vllm_config: VllmConfig, use_v2_model_runner: bool) -> int:
     spec_config = vllm_config.speculative_config
     return (
@@ -255,6 +267,12 @@ class Worker(WorkerBase):
                     if name in self._sleep_saved_draft_buffers:
                         buffer.data.copy_(self._sleep_saved_draft_buffers[name].data)
             self._sleep_saved_draft_buffers = {}
+
+        if wake_weights:
+            _run_post_weights_wake_up_hooks(self.model_runner.model)
+            draft = self.get_draft_model()
+            if draft is not None:
+                _run_post_weights_wake_up_hooks(draft)
 
         if tags is None or "kv_cache" in tags:
             self.model_runner.post_kv_cache_wake_up()


### PR DESCRIPTION
## Purpose

Part of #53343. Split from #53344.

MiniMax fused RMS-QK uses a Lamport communication workspace containing flags, layout values, sentinels, and device pointers. Registered buffers can restore old bytes, but protocol state must instead be reset to a valid initial state after wake-up while preserving storage addresses captured by CUDA Graphs.

## Changes

- expose the cached `LamportWorkspace` owner while retaining the tensor-returning compatibility API;
- register flag, layout, and workspace tensors as non-persistent buffers;
- rebuild Lamport sentinels, flags, layout, and pointer arrays in place;
- invoke the reset through the module `post_weights_wake_up` hook;
- add a focused protocol-state reset test.

## Dependency

Depends on #53510 for the wake-hook dispatcher. #53510 itself depends on #53509.

This is a stacked PR. Merge order:

1. #53509
2. #53510
3. this MiniMax PR

GitHub will reduce the diff as the prerequisite PRs merge.

## Test Plan

```bash
pytest -q tests/kernels/core/test_minimax_reduce_rms.py -k lamport_workspace_reset
```

Changed files pass Ruff, `git diff --check`, and Python compilation. Distributed CUDA kernel validation is delegated to CI.

