### PR TITLE
[Frontend] Optional post-generation hook on EndpointPlugin

### DIFF
--- a/docs/design/endpoint_plugins.md
+++ b/docs/design/endpoint_plugins.md
@@ -27,6 +27,15 @@ class EndpointPlugin(Protocol):
 - `attach_router`: registers routes on `app`
 - `init_state`: initializes per app state the routes read at request time
 
+Plugins may also implement an **optional** `post_generation` hook (not part of the
+runtime-checkable protocol, so existing route-only plugins keep working). The
+OpenAI chat and completion serving paths call it once at end-of-sequence with a
+[`ScoringContext`][vllm.plugins.endpoint_plugins.post_generation.ScoringContext]
+and merge returned scores onto `RequestOutput.metadata["external_scores"]`.
+Set `blocking = True` and return `{"block": true, "replacement": "..."}` (or omit
+`replacement` to refuse) to replace or reject the response. See [Post-generation
+hooks](#post-generation-hooks).
+
 ## The two phase lifecycle
 
 Routes are registered before the engine exists. This means the interface has to expose two hooks that run at two different points in server startup:
@@ -123,6 +132,40 @@ my_admin_api = "my_pkg.endpoints:MyAdminEndpointPlugin"  # adds the HTTP route
 ```
 
 Do not expect a single endpoint plugin to also mutate engine/worker state. If your route needs a worker side method that doesn't already exist then add it via a paired `general_plugins` entry point.
+
+## Post-generation hooks
+
+Safety, grounding, and audit classifiers need the **detokenized** completion. They
+should not run as logits processors. Implement `async def post_generation(self, ctx)`
+on the same `EndpointPlugin` instance:
+
+```python
+class GroundingPlugin:
+    name = "grounding"
+    required_tasks = ("generate",)
+    blocking = True
+    timeout_ms = 1000
+
+    def attach_router(self, app):
+        return  # HTTP routes optional
+
+    async def init_state(self, engine_client, state, args):
+        return
+
+    async def post_generation(self, ctx):
+        # ctx.generated_text, ctx.prompt_token_ids, ctx.vllm_xargs, ...
+        if "forbidden" in ctx.generated_text:
+            return {"block": True, "replacement": "I can't help with that."}
+        return {"score": 0.01}
+```
+
+The hook is invoked from `GenerateBaseServing` after the final `RequestOutput`
+(`finished=True`) and before OpenAI serialization. Streaming still flushes tokens
+as they are produced; a blocking refusal can only replace the last SSE chunk /
+final response. Mid-stream mutation is out of scope.
+
+Allowlist the plugin with `VLLM_PLUGINS` like any other endpoint plugin. Nothing
+loads in engine-core or GPU workers.
 
 ## Path-prefix convention
 

--- a/docs/design/endpoint_plugins.md
+++ b/docs/design/endpoint_plugins.md
@@ -161,8 +161,10 @@ class GroundingPlugin:
 
 The hook is invoked from `GenerateBaseServing` after the final `RequestOutput`
 (`finished=True`) and before OpenAI serialization. Streaming still flushes tokens
-as they are produced; a blocking refusal can only replace the last SSE chunk /
-final response. Mid-stream mutation is out of scope.
+as they are produced. A blocking plugin with `replacement` rewrites the
+non-streaming body; in streaming it cannot unsend tokens, so the server emits a
+final SSE error instead of silently dropping the block. Mid-stream mutation is
+out of scope.
 
 Allowlist the plugin with `VLLM_PLUGINS` like any other endpoint plugin. Nothing
 loads in engine-core or GPU workers.

--- a/tests/plugins_tests/test_post_generation_hooks.py
+++ b/tests/plugins_tests/test_post_generation_hooks.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for optional EndpointPlugin.post_generation hooks (RFC #43999)."""
+
+import asyncio
+
+import pytest
+
+from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.plugins.endpoint_plugins.interface import EndpointPlugin
+from vllm.plugins.endpoint_plugins.post_generation import (
+    apply_post_generation_hooks,
+)
+
+
+def _request_output(text: str = "hello world") -> RequestOutput:
+    return RequestOutput(
+        request_id="req-1",
+        prompt="hi",
+        prompt_token_ids=[1, 2],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text=text,
+                token_ids=[3, 4],
+                cumulative_logprob=None,
+                logprobs=None,
+                finish_reason="stop",
+            )
+        ],
+        finished=True,
+    )
+
+
+class _AnnotatePlugin:
+    name = "annotate"
+    blocking = False
+
+    async def post_generation(self, ctx):
+        return {"score": 0.25, "generated_text": ctx.generated_text}
+
+
+class _BlockPlugin:
+    name = "blocker"
+    blocking = True
+
+    async def post_generation(self, ctx):
+        if "secret" in ctx.generated_text:
+            return {"block": True, "replacement": "refused"}
+        return {"block": False}
+
+
+class _RefusePlugin:
+    name = "refuser"
+    blocking = True
+
+    async def post_generation(self, ctx):
+        return {"block": True, "message": "not allowed"}
+
+
+class _TimeoutPlugin:
+    name = "slow"
+    blocking = True
+    timeout_ms = 10
+
+    async def post_generation(self, ctx):
+        await asyncio.sleep(1)
+        return {"block": True}
+
+
+class _TimeoutAnnotatePlugin:
+    name = "slow_annotate"
+    blocking = False
+    timeout_ms = 10
+
+    async def post_generation(self, ctx):
+        await asyncio.sleep(1)
+        return {"score": 1}
+
+
+class _RouteOnlyPlugin:
+    name = "route_only"
+    required_tasks = None
+
+    def attach_router(self, app):
+        return
+
+    async def init_state(self, engine_client, state, args):
+        return
+
+
+def test_route_only_plugin_still_satisfies_protocol():
+    assert isinstance(_RouteOnlyPlugin(), EndpointPlugin)
+
+
+@pytest.mark.asyncio
+async def test_no_plugins_is_noop():
+    output = _request_output()
+    outcome = await apply_post_generation_hooks([], output)
+    assert not outcome.blocked
+    assert output.metadata is None
+    assert output.outputs[0].text == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_route_only_plugin_is_skipped():
+    output = _request_output()
+    outcome = await apply_post_generation_hooks(
+        [_RouteOnlyPlugin()], output
+    )
+    assert not outcome.blocked
+    assert output.metadata is None
+
+
+@pytest.mark.asyncio
+async def test_annotation_scores_are_stored_on_metadata():
+    output = _request_output()
+    outcome = await apply_post_generation_hooks([_AnnotatePlugin()], output)
+    assert not outcome.blocked
+    assert output.metadata["external_scores"]["annotate"]["score"] == 0.25
+    assert (
+        output.metadata["external_scores"]["annotate"]["generated_text"]
+        == "hello world"
+    )
+
+
+@pytest.mark.asyncio
+async def test_blocking_plugin_replaces_text():
+    output = _request_output("leaked secret")
+    outcome = await apply_post_generation_hooks([_BlockPlugin()], output)
+    assert outcome.blocked
+    assert outcome.replacement == "refused"
+    assert output.outputs[0].text == "refused"
+
+
+@pytest.mark.asyncio
+async def test_blocking_plugin_without_replacement_refuses():
+    output = _request_output()
+    outcome = await apply_post_generation_hooks([_RefusePlugin()], output)
+    assert outcome.blocked
+    assert outcome.replacement is None
+    assert outcome.error_message == "not allowed"
+
+
+@pytest.mark.asyncio
+async def test_blocking_timeout_fail_closed():
+    output = _request_output()
+    outcome = await apply_post_generation_hooks([_TimeoutPlugin()], output)
+    assert outcome.blocked
+    assert "timed out" in (outcome.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_annotation_timeout_fail_open():
+    output = _request_output()
+    outcome = await apply_post_generation_hooks(
+        [_TimeoutAnnotatePlugin()], output
+    )
+    assert not outcome.blocked
+    assert output.outputs[0].text == "hello world"

--- a/tests/plugins_tests/test_post_generation_hooks.py
+++ b/tests/plugins_tests/test_post_generation_hooks.py
@@ -9,7 +9,9 @@ import pytest
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.plugins.endpoint_plugins.interface import EndpointPlugin
 from vllm.plugins.endpoint_plugins.post_generation import (
+    PostGenerationOutcome,
     apply_post_generation_hooks,
+    refusal_message,
 )
 
 
@@ -159,3 +161,20 @@ async def test_annotation_timeout_fail_open():
     )
     assert not outcome.blocked
     assert output.outputs[0].text == "hello world"
+
+
+def test_non_streaming_replacement_is_not_a_refusal():
+    outcome = PostGenerationOutcome(blocked=True, replacement="refused")
+    assert refusal_message(outcome, streaming=False) is None
+
+
+def test_streaming_block_with_replacement_is_a_refusal():
+    outcome = PostGenerationOutcome(blocked=True, replacement="refused")
+    message = refusal_message(outcome, streaming=True)
+    assert message is not None
+    assert "already-streamed" in message
+
+
+def test_streaming_block_without_replacement_uses_error_message():
+    outcome = PostGenerationOutcome(blocked=True, error_message="not allowed")
+    assert refusal_message(outcome, streaming=True) == "not allowed"

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -335,15 +335,19 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
             plugins, request_output, vllm_xargs
         )
 
-    def post_generation_refusal_response(self, outcome) -> ErrorResponse | None:
-        if outcome.blocked and outcome.replacement is None:
-            return self.create_error_response(
-                outcome.error_message
-                or "Request blocked by post-generation hook",
-                err_type="RefusalError",
-                status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            )
-        return None
+    def post_generation_refusal_response(
+        self, outcome, *, streaming: bool = False
+    ) -> ErrorResponse | None:
+        from vllm.plugins.endpoint_plugins.post_generation import refusal_message
+
+        message = refusal_message(outcome, streaming=streaming)
+        if message is None:
+            return None
+        return self.create_error_response(
+            message,
+            err_type="RefusalError",
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        )
 
     @staticmethod
     def _get_decoded_token(

--- a/vllm/entrypoints/generate/base/serving.py
+++ b/vllm/entrypoints/generate/base/serving.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass, field
 from http import HTTPStatus
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
 from fastapi import Request
 from pydantic import ConfigDict
@@ -308,6 +308,42 @@ class GenerateBaseServing(BaseServing, BeamSearchOnlineMixin):
                         request.request_id,
                         exc_info=True,
                     )
+
+    async def apply_post_generation_hooks(
+        self,
+        raw_request: Request | None,
+        request_output: "RequestOutput",
+        vllm_xargs: dict[str, Any] | None,
+    ):
+        """Run optional EndpointPlugin.post_generation hooks (RFC #43999).
+
+        No-ops when ``raw_request`` is missing or no endpoint plugins are
+        loaded. Mutates ``request_output`` in place (text replacement and
+        ``metadata["external_scores"]``).
+        """
+        from vllm.plugins.endpoint_plugins.post_generation import (
+            PostGenerationOutcome,
+            apply_post_generation_hooks as run_post_generation_hooks,
+        )
+
+        if raw_request is None:
+            return PostGenerationOutcome()
+        plugins = getattr(raw_request.app.state, "endpoint_plugins", None) or []
+        if not plugins:
+            return PostGenerationOutcome()
+        return await run_post_generation_hooks(
+            plugins, request_output, vllm_xargs
+        )
+
+    def post_generation_refusal_response(self, outcome) -> ErrorResponse | None:
+        if outcome.blocked and outcome.replacement is None:
+            return self.create_error_response(
+                outcome.error_message
+                or "Request blocked by post-generation hook",
+                err_type="RefusalError",
+                status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            )
+        return None
 
     @staticmethod
     def _get_decoded_token(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -909,7 +909,9 @@ class OpenAIServingChat(GenerateBaseServing):
                 hook_outcome = await self.apply_post_generation_hooks(
                     raw_request, last_res, request.vllm_xargs
                 )
-                refusal = self.post_generation_refusal_response(hook_outcome)
+                refusal = self.post_generation_refusal_response(
+                    hook_outcome, streaming=True
+                )
                 if refusal is not None:
                     err_chunk = self.create_streaming_error_response(
                         refusal.error.message,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -402,6 +402,7 @@ class OpenAIServingChat(GenerateBaseServing):
                 request_metadata,
                 chat_template_kwargs=chat_template_kwargs,
                 mm_token_counts=mm_token_counts,
+                raw_request=raw_request,
             )
 
         return await self.chat_completion_full_generator(
@@ -414,6 +415,7 @@ class OpenAIServingChat(GenerateBaseServing):
             request_metadata,
             parser=parser,
             mm_token_counts=mm_token_counts,
+            raw_request=raw_request,
         )
 
     def get_chat_request_role(self, request: ChatCompletionRequest) -> str:
@@ -460,6 +462,7 @@ class OpenAIServingChat(GenerateBaseServing):
         request_metadata: RequestResponseMetadata,
         chat_template_kwargs: dict[str, Any] | None = None,
         mm_token_counts: dict[str, int] | None = None,
+        raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None]:
         created_time = int(time.time())
         chunk_object_type: Final = "chat.completion.chunk"
@@ -902,6 +905,19 @@ class OpenAIServingChat(GenerateBaseServing):
                         delta=False,
                     )
 
+            if last_res is not None:
+                hook_outcome = await self.apply_post_generation_hooks(
+                    raw_request, last_res, request.vllm_xargs
+                )
+                refusal = self.post_generation_refusal_response(hook_outcome)
+                if refusal is not None:
+                    err_chunk = self.create_streaming_error_response(
+                        refusal.error.message,
+                        err_type=refusal.error.type or "RefusalError",
+                        status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    )
+                    yield f"data: {err_chunk}\n\n"
+
         except GenerationError as e:
             yield f"data: {self._convert_generation_error_to_streaming_response(e)}\n\n"
         except Exception as e:
@@ -922,6 +938,7 @@ class OpenAIServingChat(GenerateBaseServing):
         request_metadata: RequestResponseMetadata,
         parser: Parser | None = None,
         mm_token_counts: dict[str, int] | None = None,
+        raw_request: Request | None = None,
     ) -> ErrorResponse | ChatCompletionResponse:
         created_time = int(time.time())
         final_res: RequestOutput | None = None
@@ -938,6 +955,13 @@ class OpenAIServingChat(GenerateBaseServing):
                 err_type="InternalServerError",
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
+
+        hook_outcome = await self.apply_post_generation_hooks(
+            raw_request, final_res, request.vllm_xargs
+        )
+        refusal = self.post_generation_refusal_response(hook_outcome)
+        if refusal is not None:
+            return refusal
 
         choices: list[ChatCompletionResponseChoice] = []
         total_reasoning_tokens = 0

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -5,6 +5,7 @@ import asyncio
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
+from http import HTTPStatus
 from typing import cast
 
 from fastapi import Request
@@ -237,6 +238,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 num_prompts=num_prompts,
                 tokenizer=tokenizer,
                 request_metadata=request_metadata,
+                raw_request=raw_request,
             )
 
         # Non-streaming response
@@ -253,6 +255,13 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 # with the inputs token IDs
                 if final_res.prompt is None:
                     final_res.prompt = self._extract_prompt_text(engine_inputs[i])
+
+                hook_outcome = await self.apply_post_generation_hooks(
+                    raw_request, final_res, request.vllm_xargs
+                )
+                refusal = self.post_generation_refusal_response(hook_outcome)
+                if refusal is not None:
+                    return refusal
 
             final_res_batch_checked = cast(list[RequestOutput], final_res_batch)
 
@@ -292,6 +301,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
         num_prompts: int,
         tokenizer: TokenizerLike | None,
         request_metadata: RequestResponseMetadata,
+        raw_request: Request | None = None,
     ) -> AsyncGenerator[str, None]:
         num_choices = 1 if request.n is None else request.n
         previous_text_lens = [0] * num_choices * num_prompts
@@ -494,6 +504,19 @@ class OpenAIServingCompletion(GenerateBaseServing):
 
             # report to FastAPI middleware aggregate usage across all choices
             request_metadata.final_usage_info = final_usage_info
+
+            if last_res is not None:
+                hook_outcome = await self.apply_post_generation_hooks(
+                    raw_request, last_res, request.vllm_xargs
+                )
+                refusal = self.post_generation_refusal_response(hook_outcome)
+                if refusal is not None:
+                    err_chunk = self.create_streaming_error_response(
+                        refusal.error.message,
+                        err_type=refusal.error.type or "RefusalError",
+                        status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    )
+                    yield f"data: {err_chunk}\n\n"
 
         except GenerationError as e:
             yield f"data: {self._convert_generation_error_to_streaming_response(e)}\n\n"

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -509,7 +509,9 @@ class OpenAIServingCompletion(GenerateBaseServing):
                 hook_outcome = await self.apply_post_generation_hooks(
                     raw_request, last_res, request.vllm_xargs
                 )
-                refusal = self.post_generation_refusal_response(hook_outcome)
+                refusal = self.post_generation_refusal_response(
+                    hook_outcome, streaming=True
+                )
                 if refusal is not None:
                     err_chunk = self.create_streaming_error_response(
                         refusal.error.message,

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -128,6 +128,8 @@ class RequestOutput:
             prefix-cache writes for this request.
         kv_transfer_params: The params for remote K/V transfer.
         ec_transfer_params: The params for remote encoder-cache transfer.
+        metadata: Optional serving-layer extras (e.g. post-generation
+            classifier scores). Not serialized into the OpenAI JSON.
     """
 
     def __init__(
@@ -147,6 +149,7 @@ class RequestOutput:
         *,
         kv_transfer_params: dict[str, Any] | None = None,
         ec_transfer_params: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
         # Forward compatibility, code that uses args added in new release can
         # still run with older versions of vLLM without breaking.
         **kwargs: Any,
@@ -169,6 +172,7 @@ class RequestOutput:
         self.num_cache_creation_tokens = num_cache_creation_tokens
         self.kv_transfer_params = kv_transfer_params
         self.ec_transfer_params = ec_transfer_params
+        self.metadata = metadata
 
     def add(self, next_output: "RequestOutput", aggregate: bool) -> None:
         """Merge subsequent RequestOutput into this one"""
@@ -176,6 +180,10 @@ class RequestOutput:
         self.finished |= next_output.finished
         self.kv_transfer_params = next_output.kv_transfer_params
         self.ec_transfer_params = next_output.ec_transfer_params
+        if next_output.metadata:
+            if self.metadata is None:
+                self.metadata = {}
+            self.metadata.update(next_output.metadata)
 
         for next_completion in next_output.outputs:
             for i, completion in enumerate(self.outputs):

--- a/vllm/plugins/endpoint_plugins/interface.py
+++ b/vllm/plugins/endpoint_plugins/interface.py
@@ -87,6 +87,16 @@ class EndpointPlugin(Protocol):
         """
         ...
 
+    # Optional. Classifier / guardrail plugins may implement:
+    #
+    #   name: str
+    #   blocking: bool
+    #   timeout_ms: int
+    #   async def post_generation(self, ctx: ScoringContext) -> dict[str, Any]
+    #
+    # See `vllm/plugins/endpoint_plugins/post_generation.py`. The method is
+    # not part of this Protocol so existing route-only plugins keep working.
+
 
 def attach_endpoint_plugins(
     app: FastAPI, supported_tasks: tuple["SupportedTask", ...]

--- a/vllm/plugins/endpoint_plugins/post_generation.py
+++ b/vllm/plugins/endpoint_plugins/post_generation.py
@@ -160,3 +160,24 @@ async def apply_post_generation_hooks(
         outcome.scores = dict(external)
 
     return outcome
+
+
+def refusal_message(
+    outcome: PostGenerationOutcome, *, streaming: bool = False
+) -> str | None:
+    """HTTP refusal text, or ``None`` if the request should proceed.
+
+    Non-streaming replacements already mutated ``RequestOutput.text``, so they
+    are not refusals. Streaming cannot unsend tokens, so any block is a refusal.
+    """
+    if not outcome.blocked:
+        return None
+    if outcome.replacement is not None and not streaming:
+        return None
+    if streaming and outcome.replacement is not None:
+        return (
+            outcome.error_message
+            or "Request blocked by post-generation hook "
+            "(replacement cannot be applied to already-streamed content)"
+        )
+    return outcome.error_message or "Request blocked by post-generation hook"

--- a/vllm/plugins/endpoint_plugins/post_generation.py
+++ b/vllm/plugins/endpoint_plugins/post_generation.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Optional end-of-sequence hook for `vllm.endpoint_plugins`.
+
+Classifier / guardrail plugins implement ``async def post_generation`` on an
+``EndpointPlugin``. The serving layer invokes it once after the final
+``RequestOutput`` and before OpenAI serialization (RFC #43999). Plugins that
+only attach HTTP routes omit the method and are skipped.
+
+This runs in the API server process only. Endpoint plugins are already gated
+by ``VLLM_PLUGINS`` and are not loaded in engine-core or worker processes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from vllm.outputs import RequestOutput
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_MS = 1000
+
+
+@dataclass
+class ScoringContext:
+    """Detokenized generation plus request extras for a post-generation hook."""
+
+    request_id: str
+    prompt: str | None
+    generated_text: str
+    finish_reason: str | None
+    prompt_token_ids: list[int] | None
+    output_token_ids: list[int]
+    vllm_xargs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PostGenerationOutcome:
+    """Result of running all loaded post-generation hooks."""
+
+    blocked: bool = False
+    replacement: str | None = None
+    error_message: str | None = None
+    scores: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def scoring_context_from_request_output(
+    request_output: RequestOutput,
+    vllm_xargs: Mapping[str, Any] | None = None,
+) -> ScoringContext:
+    outputs = request_output.outputs
+    generated_text = "\n".join(output.text for output in outputs)
+    finish_reason = outputs[0].finish_reason if outputs else None
+    output_token_ids: list[int] = []
+    for output in outputs:
+        output_token_ids.extend(int(tid) for tid in output.token_ids)
+    return ScoringContext(
+        request_id=request_output.request_id,
+        prompt=request_output.prompt,
+        generated_text=generated_text,
+        finish_reason=finish_reason,
+        prompt_token_ids=request_output.prompt_token_ids,
+        output_token_ids=output_token_ids,
+        vllm_xargs=dict(vllm_xargs or {}),
+    )
+
+
+def _apply_replacement(request_output: RequestOutput, replacement: str) -> None:
+    for output in request_output.outputs:
+        output.text = replacement
+
+
+async def apply_post_generation_hooks(
+    plugins: Sequence[Any],
+    request_output: RequestOutput,
+    vllm_xargs: Mapping[str, Any] | None = None,
+) -> PostGenerationOutcome:
+    """Run optional ``post_generation`` methods on loaded endpoint plugins.
+
+    Annotation scores are stored on ``request_output.metadata["external_scores"]``.
+    A blocking plugin may replace generated text or refuse the request.
+    """
+    outcome = PostGenerationOutcome()
+    if not plugins:
+        return outcome
+
+    ctx = scoring_context_from_request_output(request_output, vllm_xargs)
+    scores: dict[str, dict[str, Any]] = {}
+
+    for plugin in plugins:
+        hook = getattr(plugin, "post_generation", None)
+        if hook is None:
+            continue
+
+        name = getattr(plugin, "name", plugin.__class__.__name__)
+        blocking = bool(getattr(plugin, "blocking", False))
+        timeout_ms = getattr(plugin, "timeout_ms", DEFAULT_TIMEOUT_MS)
+        try:
+            timeout_s = max(float(timeout_ms), 0.0) / 1000.0
+        except (TypeError, ValueError):
+            timeout_s = DEFAULT_TIMEOUT_MS / 1000.0
+
+        try:
+            raw = await asyncio.wait_for(hook(ctx), timeout=timeout_s)
+        except TimeoutError:
+            logger.warning(
+                "Post-generation hook %r timed out after %.0f ms",
+                name,
+                timeout_s * 1000,
+            )
+            if blocking:
+                outcome.blocked = True
+                outcome.error_message = f"post-generation hook {name!r} timed out"
+                break
+            continue
+        except Exception:
+            logger.exception("Post-generation hook %r failed", name)
+            if blocking:
+                outcome.blocked = True
+                outcome.error_message = f"post-generation hook {name!r} failed"
+                break
+            continue
+
+        if not isinstance(raw, dict):
+            logger.warning(
+                "Post-generation hook %r returned %s, expected dict",
+                name,
+                type(raw).__name__,
+            )
+            continue
+
+        scores[name] = raw
+        if blocking and raw.get("block"):
+            outcome.blocked = True
+            replacement = raw.get("replacement")
+            if isinstance(replacement, str):
+                outcome.replacement = replacement
+                _apply_replacement(request_output, replacement)
+            else:
+                message = raw.get("message")
+                outcome.error_message = (
+                    message
+                    if isinstance(message, str) and message
+                    else f"blocked by post-generation hook {name!r}"
+                )
+            break
+
+    if scores:
+        metadata = request_output.metadata
+        if metadata is None:
+            metadata = {}
+            request_output.metadata = metadata
+        external = metadata.setdefault("external_scores", {})
+        external.update(scores)
+        outcome.scores = dict(external)
+
+    return outcome


### PR DESCRIPTION
## Purpose

Implements the MVP in #43999 as an **optional hook on `EndpointPlugin`**, following @DarkLight1337's guidance (no new plugin group).

Production classifiers (safety, PII, grounding) need the detokenized completion. Today they monkey-patch `build_app()`, subclass serving handlers, or sit behind a reverse proxy. Endpoint plugins already load only in the API server process and are gated by `VLLM_PLUGINS`, so a second model is not imported onto GPU workers.

### Behavior

- Route-only plugins keep working (`post_generation` is not part of the runtime-checkable protocol).
- Chat and completion serving invoke the hook once at EOS, before OpenAI serialization.
- Annotation scores land on `RequestOutput.metadata["external_scores"]` and are **not** added to the OpenAI JSON.
- A blocking plugin may replace the generated text or refuse with HTTP 422.
- Annotation timeouts fail-open; blocking timeouts fail-closed.
- Streaming still flushes tokens as they are produced; a refusal can only affect the last SSE chunk / final response.

Out of scope: mid-stream mutation, resample/retry, KV-cache access, Responses/Anthropic.

## Test Plan

```bash
pytest tests/plugins_tests/test_post_generation_hooks.py -q
```

## Test Result

Added unit tests for no-op, annotation metadata, block+replace, refuse without replacement, blocking timeout (fail-closed), and annotation timeout (fail-open). Existing `DummyAdminEndpointPlugin` protocol tests are unchanged.

I could not run the full vLLM pytest stack on this machine (torch extras). CI should be the authority.

## AI assistance

Cursor was used to implement the hook and tests. I reviewed the serving call sites (chat + completion, stream + non-stream) so only EOS uses the new method.

Made with [Cursor](https://cursor.com)