### PR TITLE
[Bugfix][Spec Decode] Fix prompt_logprobs corruption from CUDA graph output buffer reuse by padded drafter

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -194,6 +194,60 @@ def model_runner():
 model_runner_2 = model_runner
 
 
+@pytest.mark.parametrize(
+    ("num_prompt_logprobs", "scheduled_tokens", "draft_before_bookkeeping"),
+    [
+        ({}, {"req": 4}, True),
+        ({"other": 0}, {"req": 4}, True),
+        ({"req": 0}, {"req": 4}, False),
+    ],
+)
+def test_bookkeeping_hidden_states_reuses_target_output_without_conflict(
+    num_prompt_logprobs: dict[str, int],
+    scheduled_tokens: dict[str, int],
+    draft_before_bookkeeping: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.num_prompt_logprobs = num_prompt_logprobs
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens=scheduled_tokens,
+        total_num_scheduled_tokens=4,
+    )
+    hidden_states = torch.arange(30).reshape(6, 5)
+
+    bookkeeping_hidden_states = runner._get_bookkeeping_hidden_states(
+        hidden_states,
+        scheduler_output,
+        draft_before_bookkeeping,
+    )
+
+    assert bookkeeping_hidden_states is hidden_states
+
+
+def test_bookkeeping_hidden_states_are_protected_from_drafter_reuse():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.num_prompt_logprobs = {"req": 0}
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"req": 4},
+        total_num_scheduled_tokens=4,
+    )
+    hidden_states = torch.arange(30).reshape(6, 5)
+    expected = hidden_states[:4].clone()
+
+    bookkeeping_hidden_states = runner._get_bookkeeping_hidden_states(
+        hidden_states,
+        scheduler_output,
+        draft_before_bookkeeping=True,
+    )
+    hidden_states.add_(100)
+
+    assert bookkeeping_hidden_states.shape == (4, 5)
+    assert bookkeeping_hidden_states.untyped_storage().data_ptr() != (
+        hidden_states.untyped_storage().data_ptr()
+    )
+    assert torch.equal(bookkeeping_hidden_states, expected)
+
+
 def _schedule_new_request(*req_ids: str) -> SchedulerOutput:
     new_reqs = []
     num_scheduled_tokens = {}

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4613,6 +4613,20 @@ class GPUModelRunner(
             <= self.effective_drafter_max_model_len
         )
 
+    def _get_bookkeeping_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        scheduler_output: "SchedulerOutput",
+        draft_before_bookkeeping: bool,
+    ) -> torch.Tensor:
+        if not draft_before_bookkeeping or not any(
+            req_id in scheduler_output.num_scheduled_tokens
+            for req_id in self.num_prompt_logprobs
+        ):
+            return hidden_states
+        # A padded model drafter can reuse the target CUDA graph output buffer.
+        return hidden_states[: scheduler_output.total_num_scheduled_tokens].clone()
+
     @torch.inference_mode
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
@@ -4690,6 +4704,7 @@ class GPUModelRunner(
 
         spec_config = self.speculative_config
         draft_after_bookkeeping = False
+        bookkeeping_hidden_states = hidden_states
         if spec_config is not None:
             # Decide whether to run the drafter or zero out draft tokens.
             input_fits_in_drafter = self._input_fits_in_drafter(
@@ -4705,6 +4720,11 @@ class GPUModelRunner(
             use_gpu_toks = (
                 drafter_runs_model_forward
                 and not spec_config.disable_padded_drafter_batch
+            )
+            bookkeeping_hidden_states = self._get_bookkeeping_hidden_states(
+                hidden_states,
+                scheduler_output,
+                draft_before_bookkeeping=use_gpu_toks,
             )
             if use_gpu_toks:
                 # EAGLE/DraftModel speculative decoding can use the GPU sampled tokens
@@ -4791,7 +4811,7 @@ class GPUModelRunner(
                 scheduler_output,
                 sampler_output,
                 logits,
-                hidden_states,
+                bookkeeping_hidden_states,
                 scheduler_output.total_num_scheduled_tokens,
             )
 


### PR DESCRIPTION
## Purpose

FIX #53488

When speculative decoding runs a padded GPU drafter (MTP/EAGLE-style), `prompt_logprobs` are silently corrupted for requests executed through piecewise CUDA graphs, while the same server without `--speculative-config` scores every request correctly.

### Root cause

In the V1 GPU model runner, the padded GPU drafter runs **before** `_bookkeeping_sync()`:

```text
target model forward   -> hidden_states backed by a reusable CUDA graph output buffer
sample
padded drafter forward -> reuses/overwrites that graph output buffer
bookkeeping            -> _get_prompt_logprobs_dict() computes prompt logits
                          from the already-overwritten hidden_states
```

All CUDA graphs share one global memory pool, so the drafter's forward can reclaim the memory backing the target model's graph output. Prompt logprobs are then computed from draft-model output instead of the target hidden states.

This exactly explains the sharp boundary reported in #53488:

- Prompts at or below the CUDA graph capture limit (PIECEWISE) are corrupted.
- Prompts immediately above the limit (cudagraph_mode NONE, eager output) are correct.
- Generation is unaffected, since sampling consumes logits before the drafter runs.

I reproduced this on different hardware from the reporter (RTX 5880 Ada, x86_64, vs. their aarch64 GB10) with one of their exact checkpoints, confirming DEBUG-log `cudagraph_mode` flips PIECEWISE→NONE precisely at the corruption boundary (512→513 tokens with `--max-cudagraph-capture-size 512`).

### Fix

Add `_get_bookkeeping_hidden_states()`: only when (1) a GPU model drafter will run before bookkeeping and (2) the current batch contains a request still needing prompt logprobs, snapshot the unpadded scheduled slice of the target hidden states (`hidden_states[:total_num_scheduled_tokens].clone()`) before the drafter is enqueued, and pass the snapshot to `_bookkeeping_sync()`.

All other paths are zero-cost and unchanged:

- Requests without prompt logprobs incur no clone.
- No speculative decoding: unchanged.
- CPU / post-bookkeeping drafters and GPU n-gram drafting: unchanged.
- The padded drafter fast path itself is untouched.

### Not a duplicate

Draft PR #53506 is explicitly "not a fix": it adds scheduler chunk-accounting test coverage for multi-module MTP prefill lookahead and does not touch the GPU model runner, prompt-logprob computation, or CUDA graph buffer lifetime. The reporter's checkpoint has a single MTP layer (`use_multi_module_mtp()` is False), so it does not take that path. No other open PR fixes #53488.

## Test Plan

Unit (new regression tests, red before the fix / green after):

```bash
pytest tests/v1/worker/test_gpu_model_runner.py -k bookkeeping_hidden_states -v
```

Static checks:

```bash
pre-commit run --files vllm/v1/worker/gpu_model_runner.py tests/v1/worker/test_gpu_model_runner.py
pre-commit run mypy-3.12 --hook-stage manual --files vllm/v1/worker/gpu_model_runner.py
```

End-to-end: `cyankiwi/Qwen3.8-27B-AWQ-BF16-INT4` (one of the issue's exact checkpoints) on RTX 5880 Ada. Plain vs. MTP (`{"method":"mtp","num_speculative_tokens":3}`) servers with identical flags (`--max-model-len 32768 --no-enable-prefix-caching --enable-chunked-prefill --max-num-batched-tokens 2048 --max-num-scheduled-tokens 2048 --max-cudagraph-capture-size 512`). 18 deterministic prompts spanning 448–1714 tokens scored via `/v1/completions` with `"max_tokens": 1, "temperature": 0, "prompt_logprobs": 0`, strictly verifying identical prompt token IDs and greedy output token IDs between servers.

## Test Result

Unit: `4 passed, 44 deselected`. Pre-commit and mypy-3.12: all applicable hooks passed.

E2E, MTP/plain mean-NLL ratio per prompt length:

| Prompt tokens | cudagraph_mode | Before fix | After fix |
|---:|---|---:|---:|
| 448 | PIECEWISE | 6.9254x | 1.00098x |
| 457 | PIECEWISE | 55.5964x | 0.99734x |
| 480 | PIECEWISE | 5.8075x | 0.99874x |
| 496 | PIECEWISE | 6.9857x | 1.00104x |
| 511 | PIECEWISE | 6.9448x | 1.00192x |
| 512 | PIECEWISE | 6.9607x | 1.00194x |
| 513 | NONE | 0.99910x | 0.99910x |
| 520 | NONE | 1.00026x | 1.00026x |
| 525 | NONE | 0.99902x | 0.99902x |
| 544 | NONE | 1.00051x | 1.00051x |
| 600 | NONE | 1.00055x | 1.00055x |
| 1714 | NONE | 0.99892x | 0.99892x |

Across all 18 prompts the ratio range goes from `0.99892x – 55.59636x` (before) to `0.99734x – 1.00194x` (after). Plain-server numbers are bit-identical before and after the fix (no regression on the non-speculative path), and greedy generation token IDs remain identical between Plain and MTP servers. The worst case (457 tokens) drops from PPL ≈ 2.2e8 back to 1.41, matching plain.

Reproduction script, server logs, and all 72 raw API responses are available on request.

AI assistance was used for reproduction, root-cause analysis, implementation, and testing. I have reviewed every changed line and take responsibility for the change end-to-end.