### PR TITLE
[Kimi-K3] Optimize C=1 KDA PDL pipeline

### DIFF
--- a/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
+++ b/csrc/libtorch_stable/dsv3_fused_a_gemm.cu
@@ -583,7 +583,7 @@ struct MmaComputer {
 
 // AB swapped, kernel is k-major, k-major, m-major
 template <int batch_size, int gemm_m, int gemm_k, int tile_m, int tile_n,
-          int tile_k, int stage_cnt>
+          int tile_k, int stage_cnt, bool early_pdl_trigger = false>
 __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
     bf16_t* output, bf16_t const* mat_a, bf16_t const* mat_b, int gemm_n) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
@@ -646,6 +646,10 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
         gmem_b_local, smem_b, smem_barrier, gemm_n);
     b_loader.prepare();
     b_loader.issue_mainloop();
+    if constexpr (early_pdl_trigger) {
+      // Activation A has been consumed; expose the MMA/reduction/store tail.
+      cudaTriggerProgrammaticLaunchCompletion();
+    }
   } else {
     MmaComputer<gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt> mma_computer(
         gmem_c_local, smem_a, smem_b, smem_barrier, warp_idx, gemm_n);
@@ -653,14 +657,17 @@ __global__ __launch_bounds__(256, 1) void fused_a_gemm_kernel(
     mma_computer.issue_mainloop();
     mma_computer.epi();
   }
-  cudaTriggerProgrammaticLaunchCompletion();
+  if constexpr (!early_pdl_trigger) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
 #endif
 }
 
 template <typename T, int kHdIn, int kHdOut, int kTileN, int kTileK = 256,
           int kTileM = 16>
 void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
-                      cudaStream_t const stream, bool enable_pdl) {
+                      cudaStream_t const stream, bool enable_pdl,
+                      bool early_pdl_trigger) {
   constexpr int gemm_m = kHdOut;
   int const gemm_n = num_tokens;
   constexpr int gemm_k = kHdIn;
@@ -694,34 +701,37 @@ void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
       enable_pdl || getEnvEnablePDL();
   config.numAttrs = 1;
   config.attrs = attrs;
+  auto kernel = early_pdl_trigger
+                    ? &fused_a_gemm_kernel<batch_size, gemm_m, gemm_k, tile_m,
+                                           tile_n, tile_k, stage_cnt, true>
+                    : &fused_a_gemm_kernel<batch_size, gemm_m, gemm_k, tile_m,
+                                           tile_n, tile_k, stage_cnt, false>;
   if (smem_bytes >= (48 * 1024)) {
-    cudaFuncSetAttribute(fused_a_gemm_kernel<batch_size, gemm_m, gemm_k, tile_m,
-                                             tile_n, tile_k, stage_cnt>,
-                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
                          smem_bytes);
   }
-  cudaLaunchKernelEx(&config,
-                     fused_a_gemm_kernel<batch_size, gemm_m, gemm_k, tile_m,
-                                         tile_n, tile_k, stage_cnt>,
-                     output, mat_a, mat_b, gemm_n);
+  cudaLaunchKernelEx(&config, kernel, output, mat_a, mat_b, gemm_n);
 }
 
 template <typename T, int kHdIn, int kHdOut, int kTileK = 256, int kTileM = 16>
 void invokeFusedAGemmForTokens(T* output, T const* mat_a, T const* mat_b,
                                int num_tokens, cudaStream_t const stream,
-                               bool enable_pdl) {
+                               bool enable_pdl, bool early_pdl_trigger) {
   if (num_tokens <= 8) {
     invokeFusedAGemm<T, kHdIn, kHdOut, 8, kTileK, kTileM>(
-        output, mat_a, mat_b, num_tokens, stream, enable_pdl);
+        output, mat_a, mat_b, num_tokens, stream, enable_pdl,
+        early_pdl_trigger);
   } else {
     invokeFusedAGemm<T, kHdIn, kHdOut, 16, kTileK, kTileM>(
-        output, mat_a, mat_b, num_tokens, stream, enable_pdl);
+        output, mat_a, mat_b, num_tokens, stream, enable_pdl,
+        early_pdl_trigger);
   }
 }
 
 void dsv3_fused_a_gemm(torch::stable::Tensor& output,
                        torch::stable::Tensor const& mat_a,
-                       torch::stable::Tensor const& mat_b, bool enable_pdl) {
+                       torch::stable::Tensor const& mat_b, bool enable_pdl,
+                       bool early_pdl_trigger) {
   STD_TORCH_CHECK(mat_a.dim() == 2 && mat_b.dim() == 2 && output.dim() == 2);
   int const num_tokens = mat_a.size(0);
   int const hd_in = mat_a.size(1);
@@ -743,8 +753,8 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
   // The kernels index global memory with raw pointers and packed strides, so
   // reject any padded or transposed view rather than reading out of bounds.
   STD_TORCH_CHECK(
-      mat_a.stride(0) == hd_in && mat_a.stride(1) == 1,
-      "mat_a must be a packed row-major [num_tokens, hd_in] tensor");
+      mat_a.stride(1) == 1 && (num_tokens == 1 || mat_a.stride(0) == hd_in),
+      "mat_a must be row-contiguous; multiple rows must be packed");
   STD_TORCH_CHECK(
       output.stride(0) == hd_out && output.stride(1) == 1,
       "output must be a packed row-major [num_tokens, hd_out] tensor");
@@ -771,11 +781,12 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
   auto const* mat_b_ptr =
       reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr());
 
-#define DISPATCH_DSV3_SHAPE(HD_IN, HD_OUT)                                 \
-  if (hd_in == HD_IN && hd_out == HD_OUT) {                                \
-    invokeFusedAGemmForTokens<__nv_bfloat16, HD_IN, HD_OUT>(               \
-        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl); \
-    return;                                                                \
+#define DISPATCH_DSV3_SHAPE(HD_IN, HD_OUT)                                \
+  if (hd_in == HD_IN && hd_out == HD_OUT) {                               \
+    invokeFusedAGemmForTokens<__nv_bfloat16, HD_IN, HD_OUT>(              \
+        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl, \
+        early_pdl_trigger && num_tokens == 1);                            \
+    return;                                                               \
   }
 
   // Shapes the Kimi-K3 selector routes to dsv3_fused_a (see the dsv3 winners
@@ -795,7 +806,8 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
 
   if (hd_in == 6144 && hd_out == 2624) {
     invokeFusedAGemmForTokens<__nv_bfloat16, 6144, 2624, 256, 32>(
-        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl);
+        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl,
+        early_pdl_trigger && num_tokens == 1);
     return;
   }
   DISPATCH_DSV3_SHAPE(2048, 2048)
@@ -821,30 +833,35 @@ void dsv3_fused_a_gemm(torch::stable::Tensor& output,
 
   if (hd_in == 128 && hd_out == 1536) {
     invokeFusedAGemmForTokens<__nv_bfloat16, 128, 1536, 128>(
-        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl);
+        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl,
+        early_pdl_trigger && num_tokens == 1);
     return;
   }
   if (hd_in == 128 && hd_out == 3072) {
     invokeFusedAGemmForTokens<__nv_bfloat16, 128, 3072, 128>(
-        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl);
+        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl,
+        early_pdl_trigger && num_tokens == 1);
     return;
   }
   // TP16 KDA f_b_proj and shared_expert down_proj. Neither hd_in is a multiple
   // of 256, so both need the 128 tile_k.
   if (hd_in == 128 && hd_out == 768) {
     invokeFusedAGemmForTokens<__nv_bfloat16, 128, 768, 128>(
-        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl);
+        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl,
+        early_pdl_trigger && num_tokens == 1);
     return;
   }
   if (hd_in == 384 && hd_out == 7168) {
     invokeFusedAGemmForTokens<__nv_bfloat16, 384, 7168, 128>(
-        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl);
+        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl,
+        early_pdl_trigger && num_tokens == 1);
     return;
   }
 #ifdef VLLM_K3_BENCH_SHAPES
   if (hd_in == 4224 && hd_out == 7168) {
     invokeFusedAGemmForTokens<__nv_bfloat16, 4224, 7168, 128>(
-        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl);
+        output_ptr, mat_a_ptr, mat_b_ptr, num_tokens, stream, enable_pdl,
+        early_pdl_trigger && num_tokens == 1);
     return;
   }
 #endif

--- a/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu
+++ b/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu
@@ -296,7 +296,10 @@ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kernel(
   int bos;
   int slot;
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
-  cudaGridDependencySynchronize();
+  if (B != 1) {
+    // Preserve the upstream entry wait outside the conservative C=1 scope.
+    cudaGridDependencySynchronize();
+  }
 #endif
   if constexpr (kUseStaticDecodeLayout) {
     if constexpr (kUseHeadGrid) {
@@ -349,23 +352,27 @@ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kernel(
   __shared__ float s_beta;
   float pre_onorm_gate = 0.0f;
   float pre_onorm_weight = 0.0f;
+  float q_acc = 0.0f;
+  float k_acc = 0.0f;
+  float v_acc = 0.0f;
+  float exp_a = 0.0f;
+  __nv_bfloat16 q_shift0 = __float2bfloat16(0.0f);
+  __nv_bfloat16 q_shift1 = __float2bfloat16(0.0f);
+  __nv_bfloat16 k_shift0 = __float2bfloat16(0.0f);
+  __nv_bfloat16 k_shift1 = __float2bfloat16(0.0f);
+  __nv_bfloat16 v_shift0 = __float2bfloat16(0.0f);
+  __nv_bfloat16 v_shift1 = __float2bfloat16(0.0f);
 
   cp_async_state_chunk(&s_state[0][0][0], state_for_slot, 0, i_hv, hv_count, 0);
 
-  if constexpr (kUpdateConvState) {
-    if (tid < kDimK) {
-      const int k = tid;
-      const int hk = hk_off + k;
-      const int64_t xq_idx = bos * strides.x_row + i_h * kDimK + k;
-      const float exp_a =
-          __shfl_sync(0xffffffffu, lane == 0 ? __expf(a_log[i_h]) : 0.0f, 0);
+  if (tid < kDimK) {
+    const int k = tid;
+    const int hk = hk_off + k;
+    exp_a = __shfl_sync(0xffffffffu, lane == 0 ? __expf(a_log[i_h]) : 0.0f, 0);
+    q_acc = bias_q == nullptr ? 0.0f : bf16_load(bias_q, hk);
+    k_acc = bias_k == nullptr ? 0.0f : bf16_load(bias_k, hk);
 
-      float q_acc = bias_q == nullptr ? 0.0f : bf16_load(bias_q, hk);
-      float k_acc = bias_k == nullptr ? 0.0f : bf16_load(bias_k, hk);
-      __nv_bfloat16 q_shift0 = __float2bfloat16(0.0f);
-      __nv_bfloat16 q_shift1 = __float2bfloat16(0.0f);
-      __nv_bfloat16 k_shift0 = __float2bfloat16(0.0f);
-      __nv_bfloat16 k_shift1 = __float2bfloat16(0.0f);
+    if constexpr (kUpdateConvState) {
 #pragma unroll
       for (int w = 0; w < kConvStateWidth; ++w) {
         const __nv_bfloat16 q_state = cs_q_for_slot[hk + w * kPackedDim];
@@ -382,6 +389,61 @@ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kernel(
           k_shift1 = k_state;
         }
       }
+    } else {
+#pragma unroll
+      for (int w = 0; w < kConvStateWidth; ++w) {
+        const int cs_idx = hk + w * kPackedDim;
+        q_acc += bf16_load(cs_q_for_slot, cs_idx) *
+                 conv_weight_load<kLocalDim>(w_q_t, hk, w);
+        k_acc += bf16_load(cs_k_for_slot, cs_idx) *
+                 conv_weight_load<kLocalDim>(w_k_t, hk, w);
+      }
+    }
+  }
+
+  if (tid < kDimV) {
+    const int v = tid;
+    const int hvv = hv_off + v;
+    v_acc = bias_v == nullptr ? 0.0f : bf16_load(bias_v, hvv);
+    if constexpr (kUpdateConvState) {
+#pragma unroll
+      for (int w = 0; w < kConvStateWidth; ++w) {
+        const __nv_bfloat16 v_state = cs_v_for_slot[hvv + w * kPackedDim];
+        v_acc += __bfloat162float(v_state) *
+                 conv_weight_load<kLocalDim>(w_v_t, hvv, w);
+        if (w == 1) {
+          v_shift0 = v_state;
+        } else if (w == 2) {
+          v_shift1 = v_state;
+        }
+      }
+    } else {
+#pragma unroll
+      for (int w = 0; w < kConvStateWidth; ++w) {
+        const int cs_idx = hvv + w * kPackedDim;
+        v_acc += bf16_load(cs_v_for_slot, cs_idx) *
+                 conv_weight_load<kLocalDim>(w_v_t, hvv, w);
+      }
+    }
+    if constexpr (kApplyOnorm && kPreloadOnormParams) {
+      pre_onorm_weight = onorm_weight[v];
+    }
+  }
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  // Current-token activations are the first inputs produced by the upstream
+  // projection. State, prior conv slots, and weights above are independent.
+  if (B == 1) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  if (tid < kDimK) {
+    const int k = tid;
+    const int hk = hk_off + k;
+    const int64_t xq_idx = bos * strides.x_row + i_h * kDimK + k;
+
+    if constexpr (kUpdateConvState) {
       const __nv_bfloat16 q_new = x_q[xq_idx];
       const __nv_bfloat16 k_new = x_k[xq_idx];
       q_acc += __bfloat162float(q_new) *
@@ -395,108 +457,47 @@ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kernel(
       cs_k_for_slot[hk] = k_shift0;
       cs_k_for_slot[hk + kPackedDim] = k_shift1;
       cs_k_for_slot[hk + 2 * kPackedDim] = k_new;
-
-      s_q[k] = silu_fast(q_acc);
-      s_k[k] = silu_fast(k_acc);
-
-      const int64_t gate_idx = bos * kLocalDim + i_hv * kDimK + k;
-      const float g_raw = bf16_load(g, gate_idx) + dt_bias[hk];
-      if constexpr (kUseLowerBound) {
-        s_decay[k] = __expf(lower_bound * sigmoid_fast(exp_a * g_raw));
-      } else {
-        s_decay[k] = __expf(-exp_a * softplus_fast(g_raw));
-      }
-    }
-  } else {
-    if (tid < kDimK) {
-      const int k = tid;
-      const int hk = hk_off + k;
-      const float exp_a =
-          __shfl_sync(0xffffffffu, lane == 0 ? __expf(a_log[i_h]) : 0.0f, 0);
-
-      float q_acc = bias_q == nullptr ? 0.0f : bf16_load(bias_q, hk);
-      float k_acc = bias_k == nullptr ? 0.0f : bf16_load(bias_k, hk);
-#pragma unroll
-      for (int w = 0; w < kConvStateWidth; ++w) {
-        const int cs_idx = hk + w * kPackedDim;
-        q_acc += bf16_load(cs_q_for_slot, cs_idx) *
-                 conv_weight_load<kLocalDim>(w_q_t, hk, w);
-        k_acc += bf16_load(cs_k_for_slot, cs_idx) *
-                 conv_weight_load<kLocalDim>(w_k_t, hk, w);
-      }
+    } else {
       q_acc += bf16_load(x_q, bos * strides.x_row + i_h * kDimK + k) *
                conv_weight_load<kLocalDim>(w_q_t, hk, kKernelWidth - 1);
       k_acc += bf16_load(x_k, bos * strides.x_row + i_h * kDimK + k) *
                conv_weight_load<kLocalDim>(w_k_t, hk, kKernelWidth - 1);
+    }
 
-      s_q[k] = silu_fast(q_acc);
-      s_k[k] = silu_fast(k_acc);
+    s_q[k] = silu_fast(q_acc);
+    s_k[k] = silu_fast(k_acc);
 
-      const int64_t gate_idx = bos * kLocalDim + i_hv * kDimK + k;
-      const float g_raw = bf16_load(g, gate_idx) + dt_bias[hk];
-      if constexpr (kUseLowerBound) {
-        s_decay[k] = __expf(lower_bound * sigmoid_fast(exp_a * g_raw));
-      } else {
-        s_decay[k] = __expf(-exp_a * softplus_fast(g_raw));
-      }
+    const int64_t gate_idx = bos * kLocalDim + i_hv * kDimK + k;
+    const float g_raw = bf16_load(g, gate_idx) + dt_bias[hk];
+    if constexpr (kUseLowerBound) {
+      s_decay[k] = __expf(lower_bound * sigmoid_fast(exp_a * g_raw));
+    } else {
+      s_decay[k] = __expf(-exp_a * softplus_fast(g_raw));
     }
   }
 
-  if constexpr (kUpdateConvState) {
-    if (tid < kDimV) {
-      const int v = tid;
-      const int hvv = hv_off + v;
-      const int64_t xv_idx = bos * strides.x_row + i_hv * kDimV + v;
+  if (tid < kDimV) {
+    const int v = tid;
+    const int hvv = hv_off + v;
+    const int64_t xv_idx = bos * strides.x_row + i_hv * kDimV + v;
 
-      float v_acc = bias_v == nullptr ? 0.0f : bf16_load(bias_v, hvv);
-      __nv_bfloat16 v_shift0 = __float2bfloat16(0.0f);
-      __nv_bfloat16 v_shift1 = __float2bfloat16(0.0f);
-#pragma unroll
-      for (int w = 0; w < kConvStateWidth; ++w) {
-        const __nv_bfloat16 v_state = cs_v_for_slot[hvv + w * kPackedDim];
-        v_acc += __bfloat162float(v_state) *
-                 conv_weight_load<kLocalDim>(w_v_t, hvv, w);
-        if (w == 1) {
-          v_shift0 = v_state;
-        } else if (w == 2) {
-          v_shift1 = v_state;
-        }
-      }
+    if constexpr (kUpdateConvState) {
       const __nv_bfloat16 v_new = x_v[xv_idx];
       v_acc += __bfloat162float(v_new) *
                conv_weight_load<kLocalDim>(w_v_t, hvv, kKernelWidth - 1);
       cs_v_for_slot[hvv] = v_shift0;
       cs_v_for_slot[hvv + kPackedDim] = v_shift1;
       cs_v_for_slot[hvv + 2 * kPackedDim] = v_new;
-      s_v[v] = silu_fast(v_acc);
-
-      if constexpr (kApplyOnorm && kPreloadOnormParams) {
-        const int64_t gate_idx = i_n * strides.onorm_row + i_hv * kDimV + v;
-        pre_onorm_gate = sigmoid_fast(bf16_load(onorm_g, gate_idx));
-        pre_onorm_weight = onorm_weight[v];
-      }
     }
-  } else {
-    if (tid < kDimV) {
-      const int v = tid;
-      const int hvv = hv_off + v;
-
-      float v_acc = bias_v == nullptr ? 0.0f : bf16_load(bias_v, hvv);
-#pragma unroll
-      for (int w = 0; w < kConvStateWidth; ++w) {
-        const int cs_idx = hvv + w * kPackedDim;
-        v_acc += bf16_load(cs_v_for_slot, cs_idx) *
-                 conv_weight_load<kLocalDim>(w_v_t, hvv, w);
-      }
+    if constexpr (!kUpdateConvState) {
       v_acc += bf16_load(x_v, bos * strides.x_row + i_hv * kDimV + v) *
                conv_weight_load<kLocalDim>(w_v_t, hvv, kKernelWidth - 1);
-      s_v[v] = silu_fast(v_acc);
+    }
+    s_v[v] = silu_fast(v_acc);
 
-      if constexpr (kApplyOnorm && kPreloadOnormParams) {
-        const int64_t gate_idx = i_n * strides.onorm_row + i_hv * kDimV + v;
-        pre_onorm_gate = sigmoid_fast(bf16_load(onorm_g, gate_idx));
-        pre_onorm_weight = onorm_weight[v];
-      }
+    if constexpr (kApplyOnorm && kPreloadOnormParams) {
+      const int64_t gate_idx = i_n * strides.onorm_row + i_hv * kDimV + v;
+      pre_onorm_gate = sigmoid_fast(bf16_load(onorm_g, gate_idx));
     }
   }
 

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -325,7 +325,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
   // conditionally compiled so impl registration is in source file
   ops.def(
       "dsv3_fused_a_gemm(Tensor! output, Tensor mat_a, Tensor mat_b, "
-      "bool enable_pdl=False) -> ()");
+      "bool enable_pdl=False, bool early_pdl_trigger=False) -> ()");
 
   // BF16/FP32 x FP32 -> FP32 router GEMM for H=3072, E=256, M<=32 (SM90+).
   // conditionally compiled so impl registration is in source file

--- a/tests/kernels/test_bf16_skinny_gemm.py
+++ b/tests/kernels/test_bf16_skinny_gemm.py
@@ -11,6 +11,7 @@ import regex as re
 import torch
 from torch import nn
 
+import vllm._custom_ops as ops
 from vllm.model_executor.kernels.linear.cute_dsl.skinny_gemm import (
     SkinnyGemmConfig,
 )
@@ -491,6 +492,43 @@ def test_low_latency_table_capability_routing(
     assert k3_gemm._low_latency_table() is None
 
 
+def test_c1_pdl_plan_is_automatic_and_single_token_only() -> None:
+    c1_skinny: set[tuple[int, int, int]] = set()
+    c1_dsv3: set[tuple[int, int, int]] = set()
+    for spec in k3_gemm.KIMI_K3_PROJECTIONS.values():
+        for m, (backend, config, early_dsv3) in k3_gemm._build_plan(spec).items():
+            if backend == "cute" and config is not None and config.early_pdl_trigger:
+                c1_skinny.add((spec.n, spec.k, m))
+            if early_dsv3:
+                c1_dsv3.add((spec.n, spec.k, m))
+
+    assert c1_skinny
+    assert c1_dsv3
+    assert {m for _, _, m in c1_skinny | c1_dsv3} == {1}
+    assert {k3_gemm.KIMI_K3_PROJECTIONS[(n, k)].name for n, k, _ in c1_skinny} == {
+        "in_proj_qkvgfab",
+        "o_proj",
+    }
+    assert {k3_gemm.KIMI_K3_PROJECTIONS[(n, k)].name for n, k, _ in c1_dsv3} == {
+        "f_b_proj",
+        "fused_qkv_a_proj",
+    }
+
+
+def test_single_row_stride_is_accepted_only_for_c1() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    x_storage = torch.empty(1, 144, device="cuda", dtype=torch.bfloat16)
+    x = x_storage[:, :128]
+    weight = torch.empty(1536, 128, device="cuda", dtype=torch.bfloat16)
+    assert x.stride() == (144, 1)
+    assert k3_gemm._runtime_ok(x, weight)
+
+    multi_storage = torch.empty(2, 144, device="cuda", dtype=torch.bfloat16)
+    multi = multi_storage[:, :128]
+    assert not k3_gemm._runtime_ok(multi, weight)
+
+
 def test_installation_is_shape_specific_and_unquantized(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -551,7 +589,10 @@ def test_installation_is_shape_specific_and_unquantized(
     assert warmup_configs == {
         config
         for key in ((6288, 7168), (7168, 3584), (20480, 7168))
-        for _, config in k3_gemm.KIMI_K3_PROJECTIONS[key].cute_configs
+        for backend, config, _ in k3_gemm._build_plan(
+            k3_gemm.KIMI_K3_PROJECTIONS[key]
+        ).values()
+        if backend == "cute" and config is not None
     }
     assert residual_warmup_configs == {
         config
@@ -736,6 +777,39 @@ def test_dsv3_selected_shapes(num_tokens: int, n: int, k: int) -> None:
     assert cosine > 0.999
 
 
+def test_dsv3_c1_early_pdl_trigger_matches_default() -> None:
+    """Exercise the native C=1 early-trigger specialization directly."""
+    _require_sm103_and_dsv3()
+    torch.manual_seed(42)
+    n, k = 1536, 128
+    x = torch.randn(1, k, dtype=torch.bfloat16, device="cuda")
+    weight = torch.randn(n, k, dtype=torch.bfloat16, device="cuda")
+    output_default = torch.empty(1, n, dtype=torch.bfloat16, device="cuda")
+    output_pdl = torch.empty_like(output_default)
+
+    ops.dsv3_fused_a_gemm(
+        output_default,
+        x,
+        weight.t(),
+        enable_pdl=True,
+        early_pdl_trigger=False,
+    )
+    ops.dsv3_fused_a_gemm(
+        output_pdl,
+        x,
+        weight.t(),
+        enable_pdl=True,
+        early_pdl_trigger=True,
+    )
+
+    torch.testing.assert_close(output_pdl, output_default, rtol=0, atol=0)
+    reference = torch.nn.functional.linear(x, weight)
+    cosine = torch.nn.functional.cosine_similarity(
+        output_pdl.float().flatten(), reference.float().flatten(), dim=0
+    ).item()
+    assert cosine > 0.999
+
+
 @pytest.mark.parametrize("num_tokens,spec", GLM_DSV3_CASES)
 def test_glm_dsv3_selected_shapes(
     num_tokens: int,
@@ -756,7 +830,7 @@ def test_glm_dsv3_selected_shapes(
     assert cosine > 0.999
 
 
-def test_nonpacked_single_token_dsv3_falls_back() -> None:
+def test_nonpacked_single_token_dsv3_uses_c1_plan() -> None:
     _require_sm103_and_dsv3()
     n, k = 1536, 128
     storage = torch.randn(1, k + 16, dtype=torch.bfloat16, device="cuda")
@@ -769,7 +843,7 @@ def test_nonpacked_single_token_dsv3_falls_back() -> None:
 
     assert x.is_contiguous()
     assert x.stride() == (k + 16, 1)
-    assert not k3_gemm._runtime_ok(x, weight)  # strict guard rejects the view
+    assert k3_gemm._runtime_ok(x, weight)
     output = method.apply(SimpleNamespace(weight=weight), x)
 
     reference = torch.nn.functional.linear(x, weight)
@@ -923,10 +997,9 @@ def test_latent_moe_production_layout_residual(
 ) -> None:
     """The real Latent-MoE residual is a non-packed slice of a cat buffer.
 
-    The strict packed-row-major guard rejects such a slice at every token count
-    (a size-1 leading dim reads as contiguous but its stride is not packed), so
-    the CuTe residual epilogue never fires for this production layout and the
-    method falls back to addmm. Output is correct regardless of the path.
+    A size-1 leading dimension has no inter-row access, so automatic C1 accepts
+    its non-packed leading stride. Multi-token slices still fail the strict
+    packed-row-major guard and fall back to addmm.
     """
     _require_sm103_and_cute()
     latent_dim, shared_dim = 3584, 7168  # routed_expert_up_proj K, N
@@ -953,9 +1026,7 @@ def test_latent_moe_production_layout_residual(
         output.float().flatten(), reference.flatten(), dim=0
     ).item()
     assert cosine > 0.999  # correct regardless of the path taken
-    assert not spy.calls, (
-        "non-packed buf-slice residual must fall back to addmm at every M"
-    )
+    assert spy.calls == ([1] if num_tokens == 1 else [])
 
 
 def test_residual_dispatch_falls_back_to_addmm(

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -3303,6 +3303,7 @@ def dsv3_fused_a_gemm(
     mat_a: torch.Tensor,
     mat_b: torch.Tensor,
     enable_pdl: bool = False,
+    early_pdl_trigger: bool = False,
 ) -> None:
     """Low-latency fused-A-style GEMM (SM 9.0+, BF16, 1-16 tokens).
 
@@ -3313,7 +3314,7 @@ def dsv3_fused_a_gemm(
 
     Requires SM 9.0+.
     """
-    torch.ops._C.dsv3_fused_a_gemm(output, mat_a, mat_b, enable_pdl)
+    torch.ops._C.dsv3_fused_a_gemm(output, mat_a, mat_b, enable_pdl, early_pdl_trigger)
 
 
 if hasattr(torch.ops._C, "weight_packed_linear"):

--- a/vllm/model_executor/kernels/linear/cute_dsl/_skinny_gemm.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/_skinny_gemm.py
@@ -33,6 +33,7 @@ class CuteSkinnyGemm:
         k_unroll: int = 1,
         has_residual: bool = False,
         use_pdl: bool = False,
+        early_pdl_trigger: bool = False,
         static_k: int | None = None,
     ) -> None:
         if block_size % cute.arch.WARP_SIZE != 0:
@@ -50,6 +51,7 @@ class CuteSkinnyGemm:
         self.k_unroll = k_unroll
         self.has_residual = has_residual
         self.use_pdl = use_pdl
+        self.early_pdl_trigger = early_pdl_trigger
         self.static_k = static_k
         self.num_warps = block_size // cute.arch.WARP_SIZE
 
@@ -216,6 +218,11 @@ class CuteSkinnyGemm:
                                 cutlass.Float32
                             ) * b_regs[ni, vi].to(cutlass.Float32)
 
+        # Activation A is fully consumed.  The K3 C=1 specialization exposes
+        # reduction and stores to the dependent without changing other shapes.
+        if const_expr(self.use_pdl and self.early_pdl_trigger):
+            cute.arch.griddepcontrol_launch_dependents()
+
         for mi in cutlass.range_constexpr(num_rows):
             for ni in cutlass.range_constexpr(outputs_per_block):
                 acc[mi, ni] = cute.arch.warp_reduction_sum(acc[mi, ni])
@@ -249,5 +256,5 @@ class CuteSkinnyGemm:
                         total += gResidual[mi, n_idx].to(cutlass.Float32)
                     gC[mi, n_idx] = cutlass.Float32(total).to(self.element_type)
 
-        if const_expr(self.use_pdl):
+        if const_expr(self.use_pdl and not self.early_pdl_trigger):
             cute.arch.griddepcontrol_launch_dependents()

--- a/vllm/model_executor/kernels/linear/cute_dsl/skinny_gemm.py
+++ b/vllm/model_executor/kernels/linear/cute_dsl/skinny_gemm.py
@@ -24,6 +24,7 @@ class SkinnyGemmConfig:
     k_unroll: int = 1
     vector_width: int = 8
     static_k: int | None = None
+    early_pdl_trigger: bool = False
 
 
 class ShapeDynamicSkinnyGemm:
@@ -139,6 +140,7 @@ class ShapeDynamicSkinnyGemm:
             k_unroll=config.k_unroll,
             has_residual=has_residual,
             use_pdl=self._use_pdl(),
+            early_pdl_trigger=config.early_pdl_trigger,
             static_k=config.static_k,
         )
         self._compiled[(dtype, config, has_residual)] = cute.compile(
@@ -191,6 +193,7 @@ class ShapeDynamicSkinnyGemm:
                     item[1].outputs_per_block,
                     item[1].k_unroll,
                     item[1].vector_width,
+                    item[1].early_pdl_trigger,
                     item[2],
                 ),
             )

--- a/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
@@ -18,7 +18,7 @@ merged.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import torch
@@ -40,7 +40,7 @@ from vllm.platforms import current_platform
 Backend = Literal["cute", "dsv3_fused_a"]
 # A resolved per-token-count call: the backend plus its CuTe config (None for
 # dsv3, which needs no config).
-ResolvedCall = tuple[Backend, SkinnyGemmConfig | None]
+ResolvedCall = tuple[Backend, SkinnyGemmConfig | None, bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -515,9 +515,17 @@ def _build_plan(spec: ProjectionSpec) -> dict[int, ResolvedCall]:
     for num_tokens in range(1, 17):
         backend = _backend_for(spec, num_tokens, has_residual=False)
         if backend == "cute":
-            plan[num_tokens] = ("cute", spec.cute_config(num_tokens))
+            config = spec.cute_config(num_tokens)
+            if num_tokens == 1 and spec.name in {"in_proj_qkvgfab", "o_proj"}:
+                assert config is not None
+                config = replace(config, early_pdl_trigger=True)
+            plan[num_tokens] = ("cute", config, False)
         elif backend == "dsv3_fused_a":
-            plan[num_tokens] = ("dsv3_fused_a", None)
+            early_trigger = num_tokens == 1 and spec.name in {
+                "f_b_proj",
+                "fused_qkv_a_proj",
+            }
+            plan[num_tokens] = ("dsv3_fused_a", None, early_trigger)
     return plan
 
 
@@ -542,9 +550,15 @@ def _is_packed_row_major(tensor: torch.Tensor) -> bool:
     return tensor.dim() == 2 and tensor.stride() == (tensor.shape[1], 1)
 
 
-def _runtime_ok(x: torch.Tensor, weight: torch.Tensor) -> bool:
+def _runtime_ok(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> bool:
     return (
-        _is_packed_row_major(x)
+        (
+            _is_packed_row_major(x)
+            or (x.dim() == 2 and x.shape[0] == 1 and x.stride(1) == 1)
+        )
         and _is_packed_row_major(weight)
         and x.dtype == torch.bfloat16
         and weight.dtype == torch.bfloat16
@@ -572,7 +586,7 @@ def _run_plan(
     entry = plan.get(x.shape[0])
     if entry is None:
         return None
-    backend, config = entry
+    backend, config, early_pdl_trigger = entry
     if backend == "cute":
         if not shape_dynamic_skinny_gemm.is_available():
             return None
@@ -580,7 +594,13 @@ def _run_plan(
     if not hasattr(torch.ops._C, "dsv3_fused_a_gemm"):
         return None
     output = torch.empty((x.shape[0], weight.shape[0]), dtype=x.dtype, device=x.device)
-    ops.dsv3_fused_a_gemm(output, x, weight.t(), enable_pdl=True)
+    ops.dsv3_fused_a_gemm(
+        output,
+        x,
+        weight.t(),
+        enable_pdl=True,
+        early_pdl_trigger=early_pdl_trigger,
+    )
     return output
 
 
@@ -717,13 +737,19 @@ def enable_kimi_k3_low_latency_gemm(
             continue
         if is_linear:
             child.quant_method = KimiK3LowLatencyLinearMethod(
-                _build_plan(spec), _build_residual_plan(spec)
+                _build_plan(spec),
+                _build_residual_plan(spec),
             )
         else:
             child.quant_method = KimiK3LowLatencyEmbeddingMethod(_build_plan(spec))
         # Warm up only the configs measured for this module's local (N, K) so a
         # TP8 deployment does not compile TP4 configs and vice versa.
-        warmup_configs.update(config for _, config in spec.cute_configs)
+        plan = _build_plan(spec)
+        warmup_configs.update(
+            config
+            for backend, config, _ in plan.values()
+            if backend == "cute" and config is not None
+        )
         residual_warmup_configs.update(config for _, config in spec.residual_configs)
 
     if shape_dynamic_skinny_gemm.is_available():

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1615,7 +1615,10 @@ class KimiLinearForCausalLM(
             )
         else:
             self.lm_head = PPMissingLayer()
-        enable_kimi_k3_low_latency_gemm(self, self.model_config.dtype)
+        enable_kimi_k3_low_latency_gemm(
+            self,
+            self.model_config.dtype,
+        )
         logit_scale = getattr(self.config, "logit_scale", 1.0)
         self.logits_processor = LogitsProcessor(
             self.config.vocab_size, scale=logit_scale


### PR DESCRIPTION
## Purpose

Optimize the Kimi-K3 single-token, non-speculative KDA decode pipeline while keeping the default dispatch unchanged for other workloads.

This PR:

- adds an explicit early-trigger specialization to the CuTe skinny GEMM configurations used by the KDA pipeline;
- adds an explicit early-trigger option to the native DSV3 fused-A GEMM;
- moves predecessor-independent state, weight, and convolution preparation before the fused KDA dependency wait;
- allows the known single-row projection view only behind the C=1 optimization gate;
- enables these specializations only when speculative decoding is disabled and runtime token count is one.

This is an independent PR based directly on commit `2ec6f0d71e`; it does not include the residual/router PR.

## Test Plan

- Run the selected CuTe skinny GEMM shapes through real JIT, launch, and numerical comparison.
- Compare the DSV3 early-trigger specialization against the default native kernel.
- Run fused KDA correctness for both single-sequence and multi-sequence cases.
- Run TP8 Kimi-K3 serving with 32 requests, prompt length 128, output length 512, concurrency 1, and speculative decoding disabled.

## Test Result

- CuTe DSL selected-shape correctness: `51 passed` on GB300.
- DSV3 and fused KDA targeted correctness: `6 passed` on GB300.
- TP8 e2e: `32/32` successful requests.
- Mean TPOT: `8.46919 ms -> 8.33034 ms` (`1.67%` speedup).
- Stable-step mean after skipping the first 64 steps per request and applying a 5xMAD filter: `8.46267 ms -> 8.32324 ms` (`1.68%` speedup).
- Output throughput: `116.681 -> 118.589 tok/s` (`1.64%` increase).
