### PR TITLE
[Kimi-K3] Optimize C=1 MLA concat/cache PDL handoff

### DIFF
--- a/csrc/libtorch_stable/fused_kimi_k3_mla_key_concat_kv_cache_kernel.cu
+++ b/csrc/libtorch_stable/fused_kimi_k3_mla_key_concat_kv_cache_kernel.cu
@@ -661,7 +661,8 @@ __global__ void fusedKimiK3MLAKeyConcatDsMlaInsertKernel(
 // run right before forward_mqa. Q_FP8 quantizes mqa_q; KV_FP8 quantizes the
 // plain per-tensor cache. (ds_mla cache uses the separate kernel below.)
 // ────────────────────────────────────────────────────────────────────────────
-template <typename scalar_t, bool Q_FP8, bool KV_FP8, bool APPLY_ROPE>
+template <typename scalar_t, bool Q_FP8, bool KV_FP8, bool APPLY_ROPE,
+          bool C1_PDL = false>
 __global__ void fusedKimiK3MLADecodeQConcatKVCacheKernel(
     const scalar_t* __restrict__ ql_nope, int64_t const qn_tok_stride,
     int64_t const qn_head_stride, const scalar_t* __restrict__ q_pe,
@@ -687,14 +688,17 @@ __global__ void fusedKimiK3MLADecodeQConcatKVCacheKernel(
   int const slotIdx = globalWarpIdx % slotsPerToken;
   if (tokenIdx >= num_tokens) return;
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  cudaGridDependencySynchronize();
-#endif
-
   const float* rope_cache = nullptr;
   if constexpr (APPLY_ROPE) {
     rope_cache = cos_sin_cache + position_ids[tokenIdx] * kQkRopeHeadDim;
   }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaGridDependencySynchronize();
+  if constexpr (C1_PDL) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
+#endif
 
   if (slotIdx < num_heads) {
     float const qsi = Q_FP8 ? __ldg(q_scale_inv) : 1.0f;
@@ -719,12 +723,14 @@ __global__ void fusedKimiK3MLADecodeQConcatKVCacheKernel(
   }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  cudaTriggerProgrammaticLaunchCompletion();
+  if constexpr (!C1_PDL) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
 #endif
 }
 
 // Decode epilogue for fp8_ds_mla: concat mqa_q (bf16) + ds_mla cache insert.
-template <typename scalar_t, bool APPLY_ROPE>
+template <typename scalar_t, bool APPLY_ROPE, bool C1_PDL = false>
 __global__ void fusedKimiK3MLADecodeQConcatDsMlaKernel(
     const scalar_t* __restrict__ ql_nope, int64_t const qn_tok_stride,
     int64_t const qn_head_stride, const scalar_t* __restrict__ q_pe,
@@ -746,14 +752,17 @@ __global__ void fusedKimiK3MLADecodeQConcatDsMlaKernel(
   int const slotIdx = globalWarpIdx % slotsPerToken;
   if (tokenIdx >= num_tokens) return;
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  cudaGridDependencySynchronize();
-#endif
-
   const float* rope_cache = nullptr;
   if constexpr (APPLY_ROPE) {
     rope_cache = cos_sin_cache + position_ids[tokenIdx] * kQkRopeHeadDim;
   }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaGridDependencySynchronize();
+  if constexpr (C1_PDL) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
+#endif
 
   if (slotIdx < num_heads) {
     writeLatent576<scalar_t, false, APPLY_ROPE>(
@@ -774,7 +783,9 @@ __global__ void fusedKimiK3MLADecodeQConcatDsMlaKernel(
   }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-  cudaTriggerProgrammaticLaunchCompletion();
+  if constexpr (!C1_PDL) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
 #endif
 }
 
@@ -1367,33 +1378,41 @@ void fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
 
   VLLM_STABLE_DISPATCH_HALF_TYPES(
       dt, "fused_kimi_k3_mla_decode_q_concat_kv_cache_insert", [&] {
-        auto launch = [&](auto kernel) {
-          kk3::launchPdl(
-              kernel, num_tokens, num_heads, stream,
-              reinterpret_cast<scalar_t const*>(ql_nope.const_data_ptr()),
-              ql_nope.stride(0), ql_nope.stride(1),
-              reinterpret_cast<scalar_t const*>(q_pe.const_data_ptr()),
-              q_pe.stride(0), q_pe.stride(1),
-              reinterpret_cast<scalar_t const*>(kv_c_normed.const_data_ptr()),
-              kv_c_normed.stride(0),
-              reinterpret_cast<scalar_t const*>(k_pe.const_data_ptr()),
-              k_pe.stride(0), mqa_q.mutable_data_ptr(), mqa_q.stride(0),
-              mqa_q.stride(1), k_cache.mutable_data_ptr(), k_cache.stride(0),
-              k_cache.stride(1), slot_mapping.const_data_ptr<int64_t>(),
-              nullptr, nullptr, num_tokens, num_heads,
-              static_cast<int>(cache_block_size),
-              apply_rope ? position_ids.value().const_data_ptr<int64_t>()
-                         : nullptr,
-              apply_rope ? reinterpret_cast<float const*>(
-                               cos_sin_cache.value().const_data_ptr())
-                         : nullptr);
+        auto dispatch = [&](auto optimize_token) {
+          constexpr bool OPTIMIZE = decltype(optimize_token)::value;
+          auto launch = [&](auto kernel) {
+            kk3::launchPdl(
+                kernel, num_tokens, num_heads, stream,
+                reinterpret_cast<scalar_t const*>(ql_nope.const_data_ptr()),
+                ql_nope.stride(0), ql_nope.stride(1),
+                reinterpret_cast<scalar_t const*>(q_pe.const_data_ptr()),
+                q_pe.stride(0), q_pe.stride(1),
+                reinterpret_cast<scalar_t const*>(kv_c_normed.const_data_ptr()),
+                kv_c_normed.stride(0),
+                reinterpret_cast<scalar_t const*>(k_pe.const_data_ptr()),
+                k_pe.stride(0), mqa_q.mutable_data_ptr(), mqa_q.stride(0),
+                mqa_q.stride(1), k_cache.mutable_data_ptr(), k_cache.stride(0),
+                k_cache.stride(1), slot_mapping.const_data_ptr<int64_t>(),
+                nullptr, nullptr, num_tokens, num_heads,
+                static_cast<int>(cache_block_size),
+                apply_rope ? position_ids.value().const_data_ptr<int64_t>()
+                           : nullptr,
+                apply_rope ? reinterpret_cast<float const*>(
+                                 cos_sin_cache.value().const_data_ptr())
+                           : nullptr);
+          };
+          if (apply_rope) {
+            launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<
+                   scalar_t, false, false, true, OPTIMIZE>);
+          } else {
+            launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<
+                   scalar_t, false, false, false, OPTIMIZE>);
+          }
         };
-        if (apply_rope) {
-          launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<scalar_t, false,
-                                                               false, true>);
+        if (num_tokens == 1) {
+          dispatch(std::true_type{});
         } else {
-          launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<scalar_t, false,
-                                                               false, false>);
+          dispatch(std::false_type{});
         }
       });
 }
@@ -1442,34 +1461,42 @@ void fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert(
 
   VLLM_STABLE_DISPATCH_HALF_TYPES(
       dt, "fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert", [&] {
-        auto launch = [&](auto kernel) {
-          kk3::launchPdl(
-              kernel, num_tokens, num_heads, stream,
-              reinterpret_cast<scalar_t const*>(ql_nope.const_data_ptr()),
-              ql_nope.stride(0), ql_nope.stride(1),
-              reinterpret_cast<scalar_t const*>(q_pe.const_data_ptr()),
-              q_pe.stride(0), q_pe.stride(1),
-              reinterpret_cast<scalar_t const*>(kv_c_normed.const_data_ptr()),
-              kv_c_normed.stride(0),
-              reinterpret_cast<scalar_t const*>(k_pe.const_data_ptr()),
-              k_pe.stride(0), mqa_q.mutable_data_ptr(), mqa_q.stride(0),
-              mqa_q.stride(1), k_cache.mutable_data_ptr(), k_cache.stride(0),
-              k_cache.stride(1), slot_mapping.const_data_ptr<int64_t>(),
-              q_scale_inv.const_data_ptr<float>(),
-              cache_scale_inv.const_data_ptr<float>(), num_tokens, num_heads,
-              static_cast<int>(cache_block_size),
-              apply_rope ? position_ids.value().const_data_ptr<int64_t>()
-                         : nullptr,
-              apply_rope ? reinterpret_cast<float const*>(
-                               cos_sin_cache.value().const_data_ptr())
-                         : nullptr);
+        auto dispatch = [&](auto optimize_token) {
+          constexpr bool OPTIMIZE = decltype(optimize_token)::value;
+          auto launch = [&](auto kernel) {
+            kk3::launchPdl(
+                kernel, num_tokens, num_heads, stream,
+                reinterpret_cast<scalar_t const*>(ql_nope.const_data_ptr()),
+                ql_nope.stride(0), ql_nope.stride(1),
+                reinterpret_cast<scalar_t const*>(q_pe.const_data_ptr()),
+                q_pe.stride(0), q_pe.stride(1),
+                reinterpret_cast<scalar_t const*>(kv_c_normed.const_data_ptr()),
+                kv_c_normed.stride(0),
+                reinterpret_cast<scalar_t const*>(k_pe.const_data_ptr()),
+                k_pe.stride(0), mqa_q.mutable_data_ptr(), mqa_q.stride(0),
+                mqa_q.stride(1), k_cache.mutable_data_ptr(), k_cache.stride(0),
+                k_cache.stride(1), slot_mapping.const_data_ptr<int64_t>(),
+                q_scale_inv.const_data_ptr<float>(),
+                cache_scale_inv.const_data_ptr<float>(), num_tokens, num_heads,
+                static_cast<int>(cache_block_size),
+                apply_rope ? position_ids.value().const_data_ptr<int64_t>()
+                           : nullptr,
+                apply_rope ? reinterpret_cast<float const*>(
+                                 cos_sin_cache.value().const_data_ptr())
+                           : nullptr);
+          };
+          if (apply_rope) {
+            launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<
+                   scalar_t, true, true, true, OPTIMIZE>);
+          } else {
+            launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<
+                   scalar_t, true, true, false, OPTIMIZE>);
+          }
         };
-        if (apply_rope) {
-          launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<scalar_t, true,
-                                                               true, true>);
+        if (num_tokens == 1) {
+          dispatch(std::true_type{});
         } else {
-          launch(kk3::fusedKimiK3MLADecodeQConcatKVCacheKernel<scalar_t, true,
-                                                               true, false>);
+          dispatch(std::false_type{});
         }
       });
 }
@@ -1508,33 +1535,43 @@ void fused_kimi_k3_mla_decode_q_concat_ds_mla_insert(
 
   VLLM_STABLE_DISPATCH_HALF_TYPES(
       dt, "fused_kimi_k3_mla_decode_q_concat_ds_mla_insert", [&] {
-        auto launch = [&](auto kernel) {
-          kk3::launchPdl(
-              kernel, num_tokens, num_heads, stream,
-              reinterpret_cast<scalar_t const*>(ql_nope.const_data_ptr()),
-              ql_nope.stride(0), ql_nope.stride(1),
-              reinterpret_cast<scalar_t const*>(q_pe.const_data_ptr()),
-              q_pe.stride(0), q_pe.stride(1),
-              reinterpret_cast<scalar_t const*>(kv_c_normed.const_data_ptr()),
-              kv_c_normed.stride(0),
-              reinterpret_cast<scalar_t const*>(k_pe.const_data_ptr()),
-              k_pe.stride(0),
-              reinterpret_cast<scalar_t*>(mqa_q.mutable_data_ptr()),
-              mqa_q.stride(0), mqa_q.stride(1),
-              reinterpret_cast<uint8_t*>(k_cache.mutable_data_ptr()),
-              k_cache.stride(0), k_cache.stride(1),
-              slot_mapping.const_data_ptr<int64_t>(), num_tokens, num_heads,
-              static_cast<int>(cache_block_size),
-              apply_rope ? position_ids.value().const_data_ptr<int64_t>()
-                         : nullptr,
-              apply_rope ? reinterpret_cast<float const*>(
-                               cos_sin_cache.value().const_data_ptr())
-                         : nullptr);
+        auto dispatch = [&](auto optimize_token) {
+          constexpr bool OPTIMIZE = decltype(optimize_token)::value;
+          auto launch = [&](auto kernel) {
+            kk3::launchPdl(
+                kernel, num_tokens, num_heads, stream,
+                reinterpret_cast<scalar_t const*>(ql_nope.const_data_ptr()),
+                ql_nope.stride(0), ql_nope.stride(1),
+                reinterpret_cast<scalar_t const*>(q_pe.const_data_ptr()),
+                q_pe.stride(0), q_pe.stride(1),
+                reinterpret_cast<scalar_t const*>(kv_c_normed.const_data_ptr()),
+                kv_c_normed.stride(0),
+                reinterpret_cast<scalar_t const*>(k_pe.const_data_ptr()),
+                k_pe.stride(0),
+                reinterpret_cast<scalar_t*>(mqa_q.mutable_data_ptr()),
+                mqa_q.stride(0), mqa_q.stride(1),
+                reinterpret_cast<uint8_t*>(k_cache.mutable_data_ptr()),
+                k_cache.stride(0), k_cache.stride(1),
+                slot_mapping.const_data_ptr<int64_t>(), num_tokens, num_heads,
+                static_cast<int>(cache_block_size),
+                apply_rope ? position_ids.value().const_data_ptr<int64_t>()
+                           : nullptr,
+                apply_rope ? reinterpret_cast<float const*>(
+                                 cos_sin_cache.value().const_data_ptr())
+                           : nullptr);
+          };
+          if (apply_rope) {
+            launch(kk3::fusedKimiK3MLADecodeQConcatDsMlaKernel<scalar_t, true,
+                                                               OPTIMIZE>);
+          } else {
+            launch(kk3::fusedKimiK3MLADecodeQConcatDsMlaKernel<scalar_t, false,
+                                                               OPTIMIZE>);
+          }
         };
-        if (apply_rope) {
-          launch(kk3::fusedKimiK3MLADecodeQConcatDsMlaKernel<scalar_t, true>);
+        if (num_tokens == 1) {
+          dispatch(std::true_type{});
         } else {
-          launch(kk3::fusedKimiK3MLADecodeQConcatDsMlaKernel<scalar_t, false>);
+          dispatch(std::false_type{});
         }
       });
 }

--- a/tests/kernels/attention/test_kimi_k3_mla_key_concat_kv_cache.py
+++ b/tests/kernels/attention/test_kimi_k3_mla_key_concat_kv_cache.py
@@ -222,6 +222,52 @@ def test_decode_concat_ignores_negative_slots_for_cache(cache_format: str) -> No
     _assert_cache_matches_reference(mixed_cache, reference_cache, initial_cache)
 
 
+@pytest.mark.parametrize("cache_format", ["bf16", "fp8", "fp8_ds_mla"])
+def test_decode_concat_c1_pdl_matches_reference(cache_format: str) -> None:
+    """Exercise the automatically selected C=1 PDL specialization."""
+    inputs = {name: value[:1] for name, value in _inputs().items()}
+    slots = torch.tensor([0], device="cuda", dtype=torch.int64)
+    scale_inv = torch.ones(1, device="cuda", dtype=torch.float32)
+    kwargs = {
+        "ds_mla": cache_format == "fp8_ds_mla",
+        "q_scale_inv": scale_inv if cache_format == "fp8" else None,
+        "cache_scale_inv": scale_inv if cache_format == "fp8" else None,
+    }
+    initial_cache = _make_cache(cache_format)
+    cache = initial_cache.clone()
+    reference_cache = initial_cache.clone()
+    if cache_format == "fp8_ds_mla":
+        ops.concat_and_cache_mla(
+            inputs["kv_c"],
+            inputs["k_pe"],
+            reference_cache,
+            slots,
+            cache_format,
+            scale_inv,
+        )
+    else:
+        latent = torch.cat((inputs["kv_c"], inputs["k_pe"]), dim=-1)
+        reference_cache.view(-1, CACHE_ENTRY)[0].copy_(
+            latent[0].to(reference_cache.dtype)
+        )
+
+    output = fused_mla_decode_q_concat_kv_cache_insert(
+        inputs["ql_nope"],
+        inputs["q_pe"],
+        inputs["kv_c"],
+        inputs["k_pe"],
+        cache,
+        slots,
+        **kwargs,
+    )
+
+    expected = _latent_query(inputs["ql_nope"], inputs["q_pe"])
+    if cache_format == "fp8":
+        expected = expected.to(torch.float8_e4m3fn)
+    assert torch.equal(output, expected)
+    assert torch.equal(cache, reference_cache)
+
+
 def test_ds_mla_cache_insert_bit_compatible_with_reference() -> None:
     """Fused ds_mla insertion must match the reference bit-for-bit."""
     torch.manual_seed(0)

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -150,7 +150,6 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         self.scale = self.qk_head_dim**-0.5
         self.rms_norm_eps = config.rms_norm_eps
         self.layer_name = prefix
-
         self.rotary_emb: RotaryEmbedding | None = None
         if use_rope:
             rope_parameters = dict(config.rope_parameters)


### PR DESCRIPTION
## Purpose

Optimize the Kimi-K3 single-token, non-speculative MLA projection-to-concat/cache-to-attention handoff.

This PR:

- introduces an optimized PDL specialization for the BF16, FP8, and DS-MLA decode concat/cache kernels;
- performs predecessor-independent metadata preparation before the dependency wait;
- triggers dependent launch as soon as the required predecessor dependency has been satisfied;
- selects the specialization only when speculative decoding is disabled and runtime token count is one;
- leaves prefill and larger-token decode behavior unchanged.

This is an independent PR based directly on commit `2ec6f0d71e`; it does not include the residual/router or KDA PRs.

## Test Plan

- Build and install the modified native CUDA extension.
- Compare PDL off/on outputs and cache mutations bit-for-bit for BF16, FP8, and DS-MLA cache formats.
- Run TP8 Kimi-K3 serving with 32 requests, prompt length 128, output length 512, concurrency 1, FP8 KV cache, and speculative decoding disabled.

## Test Result

- Native specialization correctness: `6 passed` on GB300.
- TP8 e2e: `32/32` successful requests.
- Mean TPOT: `8.46919 ms -> 8.43639 ms` (`0.39%` speedup).
- Stable-step mean after skipping the first 64 steps per request and applying a 5xMAD filter: `8.46267 ms -> 8.42874 ms` (`0.40%` speedup).
- Output throughput: `116.681 -> 117.097 tok/s` (`0.36%` increase).
