### PR TITLE
[DSV4][SM90] add dsv4 fp8 weight use mega_moe backend

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -80,8 +80,12 @@ from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
 )
 from vllm.models.deepseek_v4.nvidia.flashmla import DeepseekV4FlashMLAAttention
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
+from vllm.models.deepseek_v4.nvidia.sm90_mega_moe import (
+    DeepseekV4MegaMoESM90Experts,
+)
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.utils.deep_gemm import mega_moe_topology
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.ubatching import dbo_current_ubatch_id
@@ -774,12 +778,31 @@ class DeepseekV4MoE(nn.Module):
             raise NotImplementedError(
                 "DeepSeek V4 MegaMoE currently supports sqrtsoftplus routing only."
             )
-        if self.use_mega_moe and getattr(config, "expert_dtype", "fp4") != "fp4":
-            raise NotImplementedError(
-                "DeepSeek V4 MegaMoE only supports fp4 experts; got expert_dtype="
-                f"{config.expert_dtype!r}. Drop --kernel-config moe_backend="
-                "deep_gemm_mega_moe for this checkpoint."
+        self.expert_dtype = getattr(config, "expert_dtype", "fp4")
+        if self.use_mega_moe:
+            device_capability = typing.cast(
+                typing.Any, current_platform.get_device_capability()
             )
+            device_capability_major = device_capability.major
+            if self.expert_dtype == "fp4" and device_capability_major >= 10:
+                raise NotImplementedError(
+                    "DeepSeek V4 MegaMoE fp4 experts require SM100 GPUs. "
+                    "Drop --kernel-config moe_backend=deep_gemm_mega_moe or "
+                    "use an fp8 checkpoint on this GPU. "
+                    f"{device_capability_major} {self.expert_dtype}"
+                )
+            if self.expert_dtype == "fp8" and device_capability_major != 9:
+                raise NotImplementedError(
+                    "DeepSeek V4 MegaMoE fp8 experts require SM90 (Hopper) "
+                    "GPUs; got compute capability "
+                    f"{device_capability_major}.x. Drop --kernel-config "
+                    "moe_backend=deep_gemm_mega_moe for this GPU."
+                )
+            if self.expert_dtype not in ("fp4", "fp8"):
+                raise NotImplementedError(
+                    "DeepSeek V4 MegaMoE only supports fp4 (SM100) and fp8 "
+                    f"(SM90) experts; got expert_dtype={self.expert_dtype!r}."
+                )
 
         self.gate = GateLinear(
             input_size=config.hidden_size,
@@ -840,6 +863,7 @@ class DeepseekV4MoE(nn.Module):
         prefix: str,
     ) -> None:
         self.ep_group = get_ep_group()
+        mega_moe_topology(self.ep_group)
         self.ep_size = self.ep_group.world_size
         self.ep_rank = self.ep_group.rank_in_group
 
@@ -872,8 +896,12 @@ class DeepseekV4MoE(nn.Module):
             and not envs.VLLM_DISABLE_DSV4_MEGAMOE_SHARED_EXPERT_FUSION
             and (self.use_sequence_parallel or self.tp_size == 1)
         )
-
-        self.experts = DeepseekV4MegaMoEExperts(
+        experts_cls = (
+            DeepseekV4MegaMoESM90Experts
+            if self.expert_dtype == "fp8"
+            else DeepseekV4MegaMoEExperts
+        )
+        self.experts = experts_cls(
             vllm_config,
             num_experts=self.n_physical_experts,
             num_local_experts=self.n_local_physical_experts,

--- a/vllm/models/deepseek_v4/nvidia/sm90_mega_moe.py
+++ b/vllm/models/deepseek_v4/nvidia/sm90_mega_moe.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+
+import vllm.envs as envs
+from vllm.config import VllmConfig
+from vllm.distributed import get_ep_group
+from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.model_executor.layers.fused_moe.router.base_router import (
+    eplb_map_to_physical_and_record,
+)
+from vllm.model_executor.utils import set_weight_attrs
+from vllm.utils.math_utils import cdiv
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
+
+if TYPE_CHECKING:
+    from vllm.models.deepseek_v4.nvidia.model import DeepseekV4MLP
+
+
+class DeepseekV4MegaMoESM90Experts(nn.Module):
+    """SM90 (Hopper) FP8 MegaMoE experts."""
+
+    _symm_buffer_cache: dict[tuple[int, int, int, int, int, int, int], object] = {}
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        num_experts: int,
+        num_local_experts: int,
+        experts_start_idx: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        prefix: str = "",
+        num_logical_experts: int | None = None,
+        num_shared_experts: int | None = None,
+    ):
+        super().__init__()
+        self.prefix = prefix
+        self.num_experts = num_experts
+        self.num_local_experts = num_local_experts
+        self.experts_start_idx = experts_start_idx
+        self.experts_end_idx = experts_start_idx + num_local_experts
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.block_size = 128
+
+        self.num_logical_experts = (
+            num_logical_experts if num_logical_experts is not None else num_experts
+        )
+
+        self.eplb_state = EplbLayerState()
+
+        weight_attrs = {"weight_loader": self.weight_loader}
+        self.w13_weight = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                2 * intermediate_size,
+                hidden_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w13_weight, weight_attrs)
+
+        self.w13_weight_scale_inv = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                cdiv(2 * intermediate_size, self.block_size),
+                cdiv(hidden_size, self.block_size),
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w13_weight_scale_inv, weight_attrs)
+        self.w13_weight_scale_inv.quant_method = "block"
+
+        self.w2_weight = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                hidden_size,
+                intermediate_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w2_weight, weight_attrs)
+
+        self.w2_weight_scale_inv = nn.Parameter(
+            torch.zeros(
+                num_local_experts,
+                cdiv(hidden_size, self.block_size),
+                cdiv(intermediate_size, self.block_size),
+                dtype=torch.float32,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(self.w2_weight_scale_inv, weight_attrs)
+        self.w2_weight_scale_inv.quant_method = "block"
+
+        self._transformed_l1_weights: tuple[torch.Tensor, torch.Tensor] | None = None
+        self._transformed_l2_weights: tuple[torch.Tensor, torch.Tensor] | None = None
+        self._cum_local_expert_recv_stats: torch.Tensor | None = None
+
+        compilation_config = vllm_config.compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def _map_global_expert_id(self, expert_id: int) -> list[int]:
+        physical_ids: list[int] = []
+        for physical_id in range(self.experts_start_idx, self.experts_end_idx):
+            if physical_id % self.num_logical_experts == expert_id:
+                physical_ids.append(physical_id - self.experts_start_idx)
+        return physical_ids
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        weight_name: str,
+        shard_id: str,
+        expert_id: int,
+        return_success: bool = False,
+    ) -> bool | None:
+        local_expert_ids = self._map_global_expert_id(expert_id)
+        if not local_expert_ids:
+            return False if return_success else None
+
+        is_scale = "weight_scale" in weight_name
+        loaded_any = False
+        for local_expert_id in local_expert_ids:
+            expert_data = param.data[local_expert_id]
+            if shard_id in ("w1", "w3"):
+                if "w13_" not in weight_name:
+                    continue
+                dim0 = (
+                    2 * self.intermediate_size
+                    if not is_scale
+                    else cdiv(2 * self.intermediate_size, self.block_size)
+                )
+                shard_len = dim0 // 2
+                shard_offset = 0 if shard_id == "w1" else shard_len
+                expert_data = expert_data.narrow(0, shard_offset, shard_len)
+            elif shard_id == "w2":
+                if "w2_" not in weight_name:
+                    continue
+            else:
+                raise ValueError(f"Unsupported expert shard id: {shard_id}")
+
+            if expert_data.shape != loaded_weight.shape:
+                raise ValueError(
+                    f"DeepSeek V4 SM90 MegaMoE expert weight shape mismatch for "
+                    f"{weight_name}: parameter shard {tuple(expert_data.shape)} "
+                    f"vs checkpoint {tuple(loaded_weight.shape)}"
+                )
+            expert_data.copy_(loaded_weight)
+            loaded_any = True
+
+        if return_success:
+            return loaded_any
+        return None
+
+    def _check_runtime_supported(self) -> None:
+        device = self.w13_weight.device
+        if torch.cuda.get_device_capability(device)[0] != 9:
+            raise NotImplementedError(
+                "DeepSeek V4 SM90 MegaMoE requires Hopper (SM90) GPUs."
+            )
+        if self.hidden_size % 128 != 0 or self.intermediate_size % 128 != 0:
+            raise ValueError(
+                "DeepSeek V4 SM90 MegaMoE requires hidden and intermediate "
+                "sizes to be multiples of 128."
+            )
+        if self.intermediate_size // 64 > 64:
+            raise NotImplementedError(
+                "DeepSeek V4 SM90 MegaMoE requires intermediate_size <= 4096, "
+                f"got {self.intermediate_size}."
+            )
+        from vllm.utils.deep_gemm import deep_gemm_supports_sm90_mega_moe
+
+        if not deep_gemm_supports_sm90_mega_moe():
+            raise RuntimeError(
+                "The installed DeepGEMM build does not expose the SM90 "
+                "all-FP8 MegaMoE API (fp8_mega_moe_sm90 / "
+                "get_symm_buffer_for_sm90_mega_moe / "
+                "transform_weights_for_mega_moe_sm90). --kernel-config "
+                "moe_backend=deep_gemm_mega_moe on Hopper needs a DeepGEMM "
+                "build from https://github.com/lengrongfu/DeepGEMM "
+                "(branch claude/pr36-mega-moe-port) -- it isn't in "
+                "upstream deepseek-ai/DeepGEMM or on PyPI."
+            )
+
+    def finalize_weights(self, shared_experts: DeepseekV4MLP | None = None) -> None:
+        if self._transformed_l1_weights is not None:
+            return
+
+        self._check_runtime_supported()
+        from vllm.utils.deep_gemm import _import_deep_gemm
+
+        deep_gemm = _import_deep_gemm()
+        self._transformed_l1_weights, self._transformed_l2_weights = (
+            deep_gemm.transform_weights_for_mega_moe_sm90(
+                (self.w13_weight.data, self.w13_weight_scale_inv.data),
+                (self.w2_weight.data, self.w2_weight_scale_inv.data),
+            )
+        )
+        self._cum_local_expert_recv_stats = torch.zeros(
+            self.num_local_experts,
+            dtype=torch.int32,
+            device=self.w13_weight.device,
+        )
+        self.w13_weight = None
+        self.w2_weight = None
+
+    @property
+    def has_fused_shared_experts(self) -> bool:
+        return False
+
+    def get_symm_buffer(self):
+        from vllm.utils.deep_gemm import _import_deep_gemm
+
+        deep_gemm = _import_deep_gemm()
+        group = get_ep_group().device_group
+        device = torch.accelerator.current_device_index()
+        key = (
+            id(group),
+            device,
+            self.num_experts,
+            self.max_num_tokens,
+            self.top_k,
+            self.hidden_size,
+            self.intermediate_size,
+        )
+        symm_buffer = self._symm_buffer_cache.get(key)
+        if symm_buffer is None:
+            symm_buffer = deep_gemm.get_symm_buffer_for_sm90_mega_moe(
+                group,
+                self.num_experts,
+                self.max_num_tokens,
+                self.top_k,
+                self.hidden_size,
+                self.intermediate_size,
+            )
+            self._symm_buffer_cache[key] = symm_buffer
+        return symm_buffer
+
+    def set_eplb_state(
+        self,
+        moe_layer_idx: int,
+        expert_load_view: torch.Tensor,
+        logical_to_physical_map: torch.Tensor,
+        logical_replica_count: torch.Tensor,
+    ) -> None:
+        self.eplb_state.set_layer_state(
+            moe_layer_idx,
+            expert_load_view,
+            logical_to_physical_map,
+            logical_replica_count,
+        )
+
+    def get_expert_weights(self) -> list[torch.Tensor]:
+        self.finalize_weights()
+        assert self._transformed_l1_weights is not None
+        assert self._transformed_l2_weights is not None
+
+        def _to_eplb_view(name: str, tensor: torch.Tensor) -> torch.Tensor:
+            assert tensor.shape[0] == self.num_local_experts
+            if tensor.is_contiguous():
+                return tensor.view(self.num_local_experts, -1)
+            if (
+                tensor.dim() == 3
+                and tensor.stride(1) == 1
+                and tensor.stride(2) == tensor.shape[1]
+            ):
+                contiguous = torch.transpose(tensor, 1, 2)
+                assert contiguous.is_contiguous()
+                return contiguous.view(self.num_local_experts, -1)
+            raise AssertionError(
+                f"DSv4 EPLB {name}: non-contiguous expert tensor with "
+                f"unexpected layout shape={tuple(tensor.shape)} "
+                f"stride={tuple(tensor.stride())} dtype={tensor.dtype}"
+            )
+
+        return [
+            _to_eplb_view("l1_packed", self._transformed_l1_weights[0]),
+            _to_eplb_view("l1_scale", self._transformed_l1_weights[1]),
+            _to_eplb_view("l2_weight", self._transformed_l2_weights[0]),
+            _to_eplb_view("l2_scale", self._transformed_l2_weights[1]),
+        ]
+
+    def update_expert_map(self) -> None:
+        pass
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        *,
+        activation_clamp: float | None,
+        fast_math: bool = True,
+    ) -> torch.Tensor:
+        if hidden_states.shape[0] > self.max_num_tokens:
+            raise ValueError(
+                f"DeepSeek V4 SM90 MegaMoE got {hidden_states.shape[0]} tokens, "
+                f"but the symmetric buffer was sized for {self.max_num_tokens}."
+            )
+        y = torch.empty_like(hidden_states, dtype=torch.bfloat16)
+
+        from vllm.utils.deep_gemm import _import_deep_gemm
+
+        deep_gemm = _import_deep_gemm()
+        symm_buffer = self.get_symm_buffer()
+        num_tokens = hidden_states.shape[0]
+        is_padding = None
+        if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
+            is_padding = get_forward_context().is_padding
+            if is_padding is not None:
+                is_padding = is_padding[:num_tokens]
+        if is_padding is not None:
+            topk_ids = torch.where(is_padding.unsqueeze(1), -1, topk_ids)
+            topk_weights = torch.where(is_padding.unsqueeze(1), 0.0, topk_weights)
+
+        eplb_state = self.eplb_state
+        if eplb_state.logical_to_physical_map is not None:
+            assert eplb_state.expert_load_view is not None
+            assert eplb_state.logical_replica_count is not None
+            assert eplb_state.should_record_tensor is not None
+            topk_ids = eplb_map_to_physical_and_record(
+                topk_ids=topk_ids,
+                expert_load_view=eplb_state.expert_load_view,
+                logical_to_physical_map=eplb_state.logical_to_physical_map,
+                logical_replica_count=eplb_state.logical_replica_count,
+                record_enabled=eplb_state.should_record_tensor,
+                num_unpadded_tokens=eplb_state.num_unpadded_tokens_tensors[
+                    dbo_current_ubatch_id()
+                ]
+                if eplb_state.num_unpadded_tokens_tensors is not None
+                else None,
+            )
+
+        x_fp8, x_sf = deep_gemm.utils.per_token_cast_to_fp8(
+            hidden_states, use_ue8m0=False, gran_k=128
+        )
+        symm_buffer.x[:num_tokens].copy_(x_fp8)
+        symm_buffer.x_sf[:num_tokens].copy_(x_sf)
+        symm_buffer.topk_idx[:num_tokens].copy_(topk_ids.to(torch.int64))
+        symm_buffer.topk_weights[:num_tokens].copy_(topk_weights.to(torch.float32))
+
+        self.finalize_weights()
+        assert self._transformed_l1_weights is not None
+        assert self._transformed_l2_weights is not None
+        deep_gemm.fp8_mega_moe_sm90(
+            y,
+            self._transformed_l1_weights,
+            self._transformed_l2_weights,
+            symm_buffer,
+            cumulative_local_expert_recv_stats=self._cum_local_expert_recv_stats,
+            activation_clamp=activation_clamp,
+            fast_math=fast_math,
+        )
+        return y
+
+
+DeepseekV4MegaMoESM90Experts.weight_loader.supports_moe_loading = True  # type: ignore[attr-defined]

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -203,6 +203,21 @@ def _import_deep_gemm():
     return None
 
 
+def deep_gemm_supports_sm90_mega_moe() -> bool:
+    """Whether the resolved ``deep_gemm`` module has the SM90 (Hopper)
+    all-FP8 MegaMoE API (``fp8_mega_moe_sm90`` /
+    ``get_symm_buffer_for_sm90_mega_moe`` /
+    ``transform_weights_for_mega_moe_sm90``).
+    """
+    dg = _import_deep_gemm()
+    return (
+        dg is not None
+        and hasattr(dg, "fp8_mega_moe_sm90")
+        and hasattr(dg, "get_symm_buffer_for_sm90_mega_moe")
+        and hasattr(dg, "transform_weights_for_mega_moe_sm90")
+    )
+
+
 def _apply_pdl(mod, enable: bool = True) -> None:
     mod_name = getattr(mod, "__name__", str(mod))
     try:
@@ -766,6 +781,40 @@ def should_use_deepgemm_for_fp8_linear(
     )
 
 
+_validated_mega_moe_ep_groups: set[int] = set()
+
+
+def mega_moe_topology(ep_group) -> None:
+    group_key = id(ep_group.cpu_group)
+    if group_key in _validated_mega_moe_ep_groups:
+        return
+
+    visible_device_id = current_platform.logical_device_id_to_visible_device_id(
+        ep_group.device_index
+    )
+    physical_device_id = current_platform.visible_device_id_to_physical_device_id(
+        visible_device_id
+    )
+    device_id = torch.tensor([physical_device_id], dtype=torch.int, device="cpu")
+    gathered_device_ids = [
+        torch.zeros(1, dtype=torch.int, device="cpu")
+        for _ in range(ep_group.world_size)
+    ]
+    torch.distributed.all_gather(
+        gathered_device_ids, device_id, group=ep_group.cpu_group
+    )
+    physical_device_ids = [device.item() for device in gathered_device_ids]
+    if not current_platform.is_fully_connected(physical_device_ids):
+        raise RuntimeError(
+            "DeepSeek V4 MegaMoE requires every GPU in the expert-parallel "
+            "group to be connected by NVLink with native peer atomics. The EP "
+            f"group uses physical GPUs {physical_device_ids}, which are not in "
+            "one fully connected NVLink domain. Use a different MoE backend or "
+            "change the GPU topology."
+        )
+    _validated_mega_moe_ep_groups.add(group_key)
+
+
 __all__ = [
     "calc_diff",
     "DeepGemmQuantScaleFMT",
@@ -790,4 +839,5 @@ __all__ = [
     "pack_ue8m0_to_int",
     "get_mn_major_tma_aligned_packed_ue8m0_tensor",
     "get_k_grouped_mn_major_tma_aligned_packed_ue8m0_tensor",
+    "mega_moe_topology",
 ]


### PR DESCRIPTION



## Purpose

Adapting the `deep_gemm_mega_moe` functionality for the H200 on the `deepseek-v4-flash-fp8` model improves TTFT and total token throughput.

Conclusion: use this `deep_gemm_mega_moe` moe_backend after, ttft and total_token_throughput performance improvements range from 5% to 60%.

Ref: 
1. https://github.com/sgl-project/DeepGEMM/pull/36
2. https://github.com/sgl-project/sglang/pull/29016


## Test Plan

### 1. Prerequisites
 1. need https://github.com/vllm-project/vllm/pull/53503 this fix pr and current pr.
 2. need this https://github.com/deepseek-ai/DeepGEMM/pull/422 pr, or install this whl file `pip install ./deep_gemm-2.6.1+4012402-cp312-cp312-linux_x86_64.whl` ; There is still room for further optimization.
[deep_gemm-2.6.1+4012402-cp312-cp312-linux_x86_64.whl.zip](https://github.com/user-attachments/files/31361376/deep_gemm-2.6.1%2B4012402-cp312-cp312-linux_x86_64.whl.zip)

3. Download the sgl-project/DeepSeek-V4-Flash-FP8 and deepseek-ai/DeepSeek-V4-Flash model weights.

### 2. vllm Bench Sweep
- serve_hparams.json
```
[
    {
        "model": "/mnt/model/deepseek-ai/DeepSeek-V4-Flash-FP8/",
        "hf-overrides.expert_dtype": "fp8",
        "hf-overrides.wo_a_dtype": "bf16",
        "max-num-batched-tokens":"8192",
        "moe-backend":"deep_gemm_mega_moe"
    },
    {
        "model": "/mnt/model/deepseek-ai/DeepSeek-V4-Flash-FP8/",
        "hf-overrides.expert_dtype": "fp8",
        "hf-overrides.wo_a_dtype": "bf16",
        "max-num-batched-tokens":"8192"
    },
    {
        "model": "/mnt/model/deepseek-ai/DeepSeek-V4-Flash-0731/",
        "max-num-batched-tokens":"8192"
    }
]
```
- bench_hparams.json
```
[
    {
        "_benchmark_name": "prefill_0",
        "random_input_len": 1000,
        "random_output_len": 1
    },
    {
        "_benchmark_name": "prefill_1",
        "random_input_len": 2000,
        "random_output_len": 1
    },
    {
        "_benchmark_name": "prefill_2",
        "random_input_len": 4000,
        "random_output_len": 1
    },
    {
        "_benchmark_name": "prefill_3",
        "random_input_len": 8000,
        "random_output_len": 1
    },
    {
        "_benchmark_name": "prefill_4",
        "random_input_len": 16000,
        "random_output_len": 1
    },
    {
        "_benchmark_name": "prefill_5",
        "random_input_len": 32000,
        "random_output_len": 1
    },
    {
        "_benchmark_name": "prefill_6",
        "random_input_len": 64000,
        "random_output_len": 1
    },
    {
        "_benchmark_name": "decode_0",
        "random_input_len": 1,
        "random_output_len": 10
    },
    {
        "_benchmark_name": "decode_1",
        "random_input_len": 1,
        "random_output_len": 20
    },
    {
        "_benchmark_name": "decode_2",
        "random_input_len": 1,
        "random_output_len": 40
    },
    {
        "_benchmark_name": "decode_3",
        "random_input_len": 1,
        "random_output_len": 80
    },
    {
        "_benchmark_name": "decode_4",
        "random_input_len": 1,
        "random_output_len": 160
    },
    {
        "_benchmark_name": "decode_5",
        "random_input_len": 1,
        "random_output_len": 320
    },
    {
        "_benchmark_name": "decode_6",
        "random_input_len": 1,
        "random_output_len": 640
    },
    {
        "_benchmark_name": "prefill_decode_0",
        "random_input_len": 1000,
        "random_output_len": 10
    },
    {
        "_benchmark_name": "prefill_decode_1",
        "random_input_len": 2000,
        "random_output_len": 20
    },
    {
        "_benchmark_name": "prefill_decode_2",
        "random_input_len": 4000,
        "random_output_len": 40
    },
    {
        "_benchmark_name": "prefill_decode_3",
        "random_input_len": 8000,
        "random_output_len": 80
    },
    {
        "_benchmark_name": "prefill_decode_4",
        "random_input_len": 16000,
        "random_output_len": 160
    },
    {
        "_benchmark_name": "prefill_decode_5",
        "random_input_len": 32000,
        "random_output_len": 320
    },
    {
        "_benchmark_name": "prefill_decode_6",
        "random_input_len": 64000,
        "random_output_len": 640
    }
]
```

- sweep command
```
vllm bench sweep serve \
    --serve-cmd 'vllm serve --served-model-name public/test --trust-remote-code --data-parallel-size 2 --tensor-parallel-size 4 --no-enable-prefix-caching --enable-expert-parallel --kv-cache-dtype fp8 --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 --enable-auto-tool-choice --reasoning-parser deepseek_v4 --load-format fastsafetensors --gpu-memory-utilization 0.85' \
    --bench-cmd 'vllm bench serve --backend openai-chat --base-url http://localhost:8000 --model public/test --tokenizer /mnt/model/deepseek-ai/DeepSeek-V4-Flash-0731/ --tokenizer-mode deepseek_v4   --num-prompts 500 --max-concurrency 200 --dataset-name random --endpoint /v1/chat/completions --num-warmups 5' \
    --serve-params serve_hparams.json \
    --bench-params bench_hparams.json \
    --output-dir benchmarks/results_mxfp4 \
    --show-stdout \
    --server-ready-timeout 1800 \
    --num-runs 1
```

## Test Result

Presented below are the results from three sets of benchmark comparisons, showing how metrics such as TTFT, TPOT, and total token throughput varied with ISL across different control groups.

- These two graphs compare the performance results—specifically TTFT and total token throughput—as ISL increases, based on tests involving only the prefill phase.

<img width="48%" height="1024" alt="ChatGPT Image 2026年8月24日 10_39_56 (1)" src="https://github.com/user-attachments/assets/f2c62130-31b7-495e-a535-4810137ff5e7" />
<img width="48%" height="1024" alt="ChatGPT Image 2026年8月24日 10_39_56 (2)" src="https://github.com/user-attachments/assets/c4853447-92b7-4479-80d2-e99c143aa233" />

- These two graphs compare the performance results—specifically TPOT and total token throughput—as ISL increases, based on tests involving only the Decode phase.

<img width="48%" height="1024" alt="ChatGPT Image 2026年8月24日 10_39_57 (3)" src="https://github.com/user-attachments/assets/19aeea08-b0d6-4574-b446-c3db01dadc95" />
<img width="48%" height="1024" alt="ChatGPT Image 2026年8月24日 10_39_58 (4)" src="https://github.com/user-attachments/assets/0a7f7d87-3552-4780-8867-e9d26d880d06" />

- These three figures compare the performance results—specifically TTFT, TPOT, and total token throughput—as the number of ISLs increases, with PD non-separation.

<img width="33%" height="1024" alt="ChatGPT Image 2026年8月24日 10_39_58 (5)" src="https://github.com/user-attachments/assets/947323e2-0fae-4977-b40e-c6223f7bd414" />
<img width="33%" height="1024" alt="ChatGPT Image 2026年8月24日 10_39_58 (6)" src="https://github.com/user-attachments/assets/57dba458-de3e-4385-836d-58ae6af10638" />
<img width="33%" height="1024" alt="ChatGPT Image 2026年8月24日 10_39_59 (7)" src="https://github.com/user-attachments/assets/81e4fb55-89fb-4629-a950-b70cc2118d2c" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

