### PR TITLE
Exclude the cpu backend from vLLM's active-Triton-driver count (#53530)

### DIFF
--- a/tests/test_triton_utils.py
+++ b/tests/test_triton_utils.py
@@ -26,8 +26,8 @@ def _has_triton_for_backends(**drivers: bool) -> bool:
     triton_mod = types.ModuleType("triton")
     triton_mod.__spec__ = importlib.machinery.ModuleSpec("triton", None)
     backends_mod = types.ModuleType("triton.backends")
-    backends_mod.backends = backends
-    triton_mod.backends = backends_mod
+    backends_mod.__dict__["backends"] = backends
+    triton_mod.__dict__["backends"] = backends_mod
 
     patched_modules = {"triton": triton_mod, "triton.backends": backends_mod}
     try:

--- a/tests/test_triton_utils.py
+++ b/tests/test_triton_utils.py
@@ -1,11 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib
 import sys
 import types
 from unittest import mock
 
+from vllm.triton_utils import importing as triton_importing
 from vllm.triton_utils.importing import TritonLanguagePlaceholder, TritonPlaceholder
+
+
+def _has_triton_for_backends(**drivers: bool) -> bool:
+    """Re-evaluate ``HAS_TRITON`` against a synthetic ``triton.backends`` map.
+
+    ``drivers`` maps backend name to whether its driver reports itself active.
+    """
+    backends = {}
+    for name, is_active in drivers.items():
+        driver = mock.Mock()
+        driver.is_active.return_value = is_active
+        backend = mock.Mock()
+        backend.driver = driver
+        backends[name] = backend
+
+    triton_mod = types.ModuleType("triton")
+    triton_mod.__spec__ = importlib.machinery.ModuleSpec("triton", None)
+    backends_mod = types.ModuleType("triton.backends")
+    backends_mod.backends = backends
+    triton_mod.backends = backends_mod
+
+    patched_modules = {"triton": triton_mod, "triton.backends": backends_mod}
+    try:
+        with (
+            mock.patch.dict(sys.modules, patched_modules),
+            mock.patch.dict("os.environ", {}, clear=True),
+        ):
+            return importlib.reload(triton_importing).HAS_TRITON
+    finally:
+        # Restore the module state derived from the real environment.
+        importlib.reload(triton_importing)
 
 
 def test_triton_placeholder_is_module():
@@ -75,6 +108,24 @@ def test_triton_placeholder_language_from_parent():
     triton = TritonPlaceholder()
     lang = triton.language
     assert isinstance(lang, TritonLanguagePlaceholder)
+
+
+def test_cpu_backend_does_not_disable_triton():
+    # The cpu backend's driver is always active, so counting it alongside a GPU
+    # backend used to yield 2 active drivers and disable Triton entirely.
+    assert _has_triton_for_backends(amd=True, cpu=True) is True
+
+
+def test_single_gpu_backend_keeps_triton():
+    assert _has_triton_for_backends(amd=True) is True
+
+
+def test_multiple_active_gpu_backends_disable_triton():
+    assert _has_triton_for_backends(amd=True, nvidia=True) is False
+
+
+def test_cpu_backend_alone_disables_triton():
+    assert _has_triton_for_backends(cpu=True) is False
 
 
 def test_no_triton_fallback():

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -23,8 +23,15 @@ if HAS_TRITON:
         # It's generally expected that x.driver exists and has
         # an is_active method.
         # The `x.driver and` check adds a small layer of safety.
+        # The "cpu" backend's driver reports itself active unconditionally, so
+        # it must be excluded here or every GPU host looks like it has 2 active
+        # drivers. Triton's own driver selection skips it for the same reason
+        # (see triton.runtime.driver._create_driver): CPU is only ever used
+        # when explicitly selected.
         active_drivers = [
-            x.driver for x in backends.values() if x.driver and x.driver.is_active()
+            x.driver
+            for name, x in backends.items()
+            if name != "cpu" and x.driver and x.driver.is_active()
         ]
 
         # Check if we're in a distributed environment where CUDA_VISIBLE_DEVICES


### PR DESCRIPTION
Summary by human (minjang)

We (Meta) internally have the Triton CPU backend for Triton. So, on a GPU machine, you will see two active drivers as the CPU driver always returns True. This is a quick fix to address a potential additional driver in Triton.


---

## The issue
- D116904949 added the Triton CPU backend to `third-party/triton/beta`, and `CPUDriver.is_active()` returns `True` unconditionally (`third_party/cpu/backend/driver.py:477`). `vllm/triton_utils/importing.py` counts every backend whose driver is active, so on a GPU host it now sees 2 active drivers (`amd` + `cpu`), logs `Triton is installed but 2 active driver(s) found (expected 1)`, and sets `HAS_TRITON = False` — replacing `triton` with `TritonPlaceholder`.
- On ROCm the only attention backend is `TRITON_ATTN`, whose `do_kv_cache_update` calls `triton.next_power_of_2`, which the placeholder does not define. Every vLLM engine core on MI300X therefore dies at startup with `AttributeError: module 'triton' has no attribute 'next_power_of_2'` -> `RuntimeError: Engine core initialization failed`.

## The fix
- Skip the `cpu` backend when counting active drivers, matching what Triton itself already does in `triton.runtime.driver._create_driver` (CPU is only used when explicitly selected via `TRITON_CPU_BACKEND` / `TRITON_DEFAULT_BACKEND`).
- This restores the exact pre-D116904949 result on every host shape: a single active GPU driver keeps Triton enabled, two active GPU drivers still disable it, and a CPU-only host still disables it.
- Add regression tests in `tests/test_triton_utils.py` covering the `amd`+`cpu`, single-GPU, two-GPU, and cpu-only backend sets.


Test Plan:
## How we tested
- `arc f` (no linters to run) and `arc lint` -> `ok No lint issues.` on both changed files; `python3 -m py_compile` on the test file passes.
- Executed the edited `importing.py` in isolation against synthetic `triton.backends` maps (stubbed `vllm.logger`, mocked drivers, cleared env) and compared against the same harness run on the pre-fix file from `remote/master`:
  - pre-fix: `{amd:True, cpu:True} -> HAS_TRITON=False` (reproduces the production failure), `{cpu:True} -> True`
  - post-fix: `{amd:True, cpu:True} -> True`, `{amd:True} -> True`, `{amd:True, nvidia:True} -> False`, `{cpu:True} -> False`
- Evidence that this is the live break: `inferno.pipeline.flows.verticals_llm_foundation_amd:496` (built 2026-08-22 23:25, before D116904949 landed at 2026-08-23 00:28) succeeded in https://www.internalfb.com/intern/fblearner/details/1131061852/ with no "active driver" line in its worker log; `:497` (built 2026-08-23 06:23, now tagged `stable`) failed with all 16 workers dead in https://www.internalfb.com/intern/fblearner/details/1131256370/. Both ran the same vLLM `0.17.0rc0.dev202+g006aea17d` and both selected `TRITON_ATTN`.
- `tests/test_triton_utils.py` is not covered by any Buck target (OSS pytest-only), so the new tests were not run by an internal test runner; the equivalent assertions were verified via the isolation harness above.

Differential Revision: D117139659

Pulled By: minjang


