### PR TITLE
[Test][VLM] Add batch-invariance tests for Qwen3-VL

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -433,6 +433,7 @@ steps:
     - pip install pytest-timeout pytest-forked
     - pytest -v -s v1/determinism/test_batch_invariance.py
     - pytest -v -s v1/determinism/test_rms_norm_batch_invariant.py
+    - pytest -v -s v1/determinism/test_batch_invariance_vlm.py
     - VLLM_TEST_MODEL=deepseek-ai/DeepSeek-V2-Lite-Chat pytest -v -s v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle -k TRITON_MLA
     - VLLM_TEST_MODEL=Qwen/Qwen3-30B-A3B-Thinking-2507-FP8 pytest -v -s v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle -k FLASH_ATTN
     - pytest -v -s v1/determinism/test_nvfp4_batch_invariant.py

--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -102,6 +102,7 @@ Batch invariance has been tested and verified on the following models:
 
 - **DeepSeek series**: `deepseek-ai/DeepSeek-V3`, `deepseek-ai/DeepSeek-V3-0324`, `deepseek-ai/DeepSeek-R1`, `deepseek-ai/DeepSeek-V3.1`
 - **Qwen3 (Dense)**: `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`, `Qwen/Qwen3-4B-AWQ`, `Qwen/Qwen3-8B-AWQ`
+- **Qwen3-VL (Vision-Language)**: `Qwen/Qwen3-VL-2B-Instruct`, `Qwen/Qwen3-VL-4B-Instruct` (single image and video inputs)
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`
 - **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example

--- a/tests/v1/determinism/test_batch_invariance_vlm.py
+++ b/tests/v1/determinism/test_batch_invariance_vlm.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Batch-invariance regression tests for vision-language models (VLMs).
+
+Complements the text-only coverage in ``test_batch_invariance.py`` with
+multimodal inputs (single image and video). The VLM vision tower is composed
+almost entirely of linear layers and attention, so it shares the same cuBLAS
+split-k and attention sources of non-determinism as the language model. These
+tests assert that re-batching requests does not change the sampled tokens or
+their logprobs when batch invariance is enabled (see ``conftest.py``).
+"""
+
+import contextlib
+import os
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from utils import _extract_step_logprobs, skip_if_not_cuda
+
+from vllm import LLM, SamplingParams
+
+VLM_TEST_MODEL = os.getenv("VLLM_VLM_TEST_MODEL", "Qwen/Qwen3-VL-2B-Instruct")
+
+IMAGE_PROMPT = (
+    "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>"
+    "Describe this image.<|im_end|><|im_start|>assistant\n"
+)
+VIDEO_PROMPT = (
+    "<|im_start|>user\n<|vision_start|><|video_pad|><|vision_end|>"
+    "Describe this video.<|im_end|><|im_start|>assistant\n"
+)
+
+
+def _make_image(seed: int, size: int = 256) -> Image.Image:
+    rng = np.random.default_rng(seed)
+    return Image.fromarray(rng.integers(0, 255, (size, size, 3), dtype=np.uint8))
+
+
+def _make_video(seed: int, num_frames: int = 4, size: int = 128) -> list[Image.Image]:
+    return [_make_image(seed * 1000 + f, size) for f in range(num_frames)]
+
+
+def _video_metadata(num_frames: int) -> dict:
+    return {
+        "total_num_frames": num_frames,
+        "fps": 1.0,
+        "frames_indices": list(range(num_frames)),
+        "do_sample_frames": False,
+    }
+
+
+def _make_inputs(input_type: str, num_reqs: int) -> list[dict]:
+    """Build ``num_reqs`` distinct prompts of the requested modality."""
+    inputs = []
+    for i in range(num_reqs):
+        if input_type == "image":
+            mm_data = {"image": _make_image(1000 + i)}
+            prompt = IMAGE_PROMPT
+        else:
+            frames = _make_video(seed=1000 + i)
+            mm_data = {"video": (frames, _video_metadata(len(frames)))}
+            prompt = VIDEO_PROMPT
+        inputs.append({"prompt": prompt, "multi_modal_data": mm_data})
+    return inputs
+
+
+def _extract(outputs) -> list[tuple[torch.Tensor, list[int]]]:
+    """Return per-request (logprobs tensor, token ids) for all outputs."""
+    results = []
+    for out in outputs:
+        step_logprobs, token_ids = _extract_step_logprobs(out)
+        if step_logprobs is None:
+            pytest.skip(
+                "Logits are not available on RequestOutput; "
+                "enable logprobs return to run this test."
+            )
+        results.append((step_logprobs, token_ids))
+    return results
+
+
+def _assert_batch_invariant(llm: LLM, inputs: list[dict], sampling) -> None:
+    """Assert BS=1 and BS=N produce bitwise-identical logprobs and tokens."""
+    bs1 = [
+        _extract([llm.generate([inp], sampling, use_tqdm=False)[0]])[0]
+        for inp in inputs
+    ]
+    bsN = _extract(llm.generate(inputs, sampling, use_tqdm=False))
+
+    failures = []
+    for i, ((lp1, t1), (lpN, tN)) in enumerate(zip(bs1, bsN)):
+        if t1 != tN:
+            failures.append(f"req {i}: token mismatch bs1={t1} bsN={tN}")
+        elif not torch.equal(lp1, lpN):
+            d = (lp1 - lpN).abs().max().item()
+            failures.append(f"req {i}: logprob mismatch max_diff={d:.3e}")
+
+    if failures:
+        pytest.fail(
+            f"Batch invariance violated for {len(failures)}/{len(inputs)} "
+            f"requests:\n" + "\n".join(failures)
+        )
+
+
+def _new_llm(**kwargs) -> LLM:
+    return LLM(
+        model=VLM_TEST_MODEL,
+        dtype="bfloat16",
+        enforce_eager=True,
+        max_num_seqs=16,
+        gpu_memory_utilization=0.85,
+        **kwargs,
+    )
+
+
+@skip_if_not_cuda
+@pytest.mark.parametrize("input_type", ["image", "video"])
+def test_vlm_batch_invariance_bs1_vs_bsN(input_type: str):
+    num_reqs = 8 if input_type == "image" else 4
+    inputs = _make_inputs(input_type, num_reqs)
+    sampling = SamplingParams(temperature=0.0, max_tokens=8, seed=1234, logprobs=5)
+
+    llm = _new_llm()
+    try:
+        _assert_batch_invariant(llm, inputs, sampling)
+    finally:
+        with contextlib.suppress(Exception):
+            llm.shutdown()
+
+
+@skip_if_not_cuda
+@pytest.mark.parametrize("mm_encoder_attn_backend", ["FLASH_ATTN", "TORCH_SDPA"])
+def test_vlm_batch_invariance_vision_backends(mm_encoder_attn_backend: str):
+    inputs = _make_inputs("image", 8)
+    sampling = SamplingParams(temperature=0.0, max_tokens=8, seed=1234, logprobs=5)
+
+    llm = _new_llm(mm_encoder_attn_backend=mm_encoder_attn_backend)
+    try:
+        _assert_batch_invariant(llm, inputs, sampling)
+    finally:
+        with contextlib.suppress(Exception):
+            llm.shutdown()

--- a/tests/v1/determinism/test_batch_invariance_vlm.py
+++ b/tests/v1/determinism/test_batch_invariance_vlm.py
@@ -1,14 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Batch-invariance regression tests for vision-language models (VLMs).
-
-Complements the text-only coverage in ``test_batch_invariance.py`` with
-multimodal inputs (single image and video). The VLM vision tower is composed
-almost entirely of linear layers and attention, so it shares the same cuBLAS
-split-k and attention sources of non-determinism as the language model. These
-tests assert that re-batching requests does not change the sampled tokens or
-their logprobs when batch invariance is enabled (see ``conftest.py``).
-"""
+"""Batch-invariance regression tests for vision-language models (VLMs)."""
 
 import contextlib
 import os
@@ -33,63 +25,49 @@ VIDEO_PROMPT = (
 )
 
 
-def _make_image(seed: int, size: int = 256) -> Image.Image:
+def _make_image(seed: int, size: int) -> Image.Image:
     rng = np.random.default_rng(seed)
     return Image.fromarray(rng.integers(0, 255, (size, size, 3), dtype=np.uint8))
 
 
-def _make_video(seed: int, num_frames: int = 4, size: int = 128) -> list[Image.Image]:
-    return [_make_image(seed * 1000 + f, size) for f in range(num_frames)]
-
-
-def _video_metadata(num_frames: int) -> dict:
-    return {
-        "total_num_frames": num_frames,
-        "fps": 1.0,
-        "frames_indices": list(range(num_frames)),
-        "do_sample_frames": False,
-    }
-
-
 def _make_inputs(input_type: str, num_reqs: int) -> list[dict]:
-    """Build ``num_reqs`` distinct prompts of the requested modality."""
     inputs = []
     for i in range(num_reqs):
         if input_type == "image":
-            mm_data = {"image": _make_image(1000 + i)}
             prompt = IMAGE_PROMPT
+            mm_data = {"image": _make_image(1000 + i, size=256)}
         else:
-            frames = _make_video(seed=1000 + i)
-            mm_data = {"video": (frames, _video_metadata(len(frames)))}
+            frames = [_make_image(1000 + i + f, size=128) for f in range(4)]
             prompt = VIDEO_PROMPT
+            mm_data = {
+                "video": (
+                    frames,
+                    {
+                        "total_num_frames": len(frames),
+                        "fps": 1.0,
+                        "frames_indices": list(range(len(frames))),
+                        "do_sample_frames": False,
+                    },
+                )
+            }
         inputs.append({"prompt": prompt, "multi_modal_data": mm_data})
     return inputs
 
 
-def _extract(outputs) -> list[tuple[torch.Tensor, list[int]]]:
-    """Return per-request (logprobs tensor, token ids) for all outputs."""
-    results = []
-    for out in outputs:
-        step_logprobs, token_ids = _extract_step_logprobs(out)
-        if step_logprobs is None:
+def _assert_batch_invariant(llm: LLM, inputs: list[dict], sampling) -> None:
+    bs1 = [
+        _extract_step_logprobs(llm.generate([inp], sampling, use_tqdm=False)[0])
+        for inp in inputs
+    ]
+    bsN = [_extract_step_logprobs(out) for out in llm.generate(inputs, sampling)]
+
+    failures = []
+    for i, ((lp1, t1), (lpN, tN)) in enumerate(zip(bs1, bsN)):
+        if lp1 is None or lpN is None:
             pytest.skip(
                 "Logits are not available on RequestOutput; "
                 "enable logprobs return to run this test."
             )
-        results.append((step_logprobs, token_ids))
-    return results
-
-
-def _assert_batch_invariant(llm: LLM, inputs: list[dict], sampling) -> None:
-    """Assert BS=1 and BS=N produce bitwise-identical logprobs and tokens."""
-    bs1 = [
-        _extract([llm.generate([inp], sampling, use_tqdm=False)[0]])[0]
-        for inp in inputs
-    ]
-    bsN = _extract(llm.generate(inputs, sampling, use_tqdm=False))
-
-    failures = []
-    for i, ((lp1, t1), (lpN, tN)) in enumerate(zip(bs1, bsN)):
         if t1 != tN:
             failures.append(f"req {i}: token mismatch bs1={t1} bsN={tN}")
         elif not torch.equal(lp1, lpN):
@@ -103,39 +81,21 @@ def _assert_batch_invariant(llm: LLM, inputs: list[dict], sampling) -> None:
         )
 
 
-def _new_llm(**kwargs) -> LLM:
-    return LLM(
+@skip_if_not_cuda
+@pytest.mark.parametrize("input_type", ["image", "video"])
+@pytest.mark.parametrize("mm_encoder_attn_backend", ["FLASH_ATTN", "TORCH_SDPA"])
+def test_vlm_batch_invariance_bs1_vs_bsN(input_type: str, mm_encoder_attn_backend: str):
+    inputs = _make_inputs(input_type, num_reqs=4)
+    sampling = SamplingParams(temperature=0.0, max_tokens=8, seed=1234, logprobs=5)
+
+    llm = LLM(
         model=VLM_TEST_MODEL,
         dtype="bfloat16",
         enforce_eager=True,
         max_num_seqs=16,
         gpu_memory_utilization=0.85,
-        **kwargs,
+        mm_encoder_attn_backend=mm_encoder_attn_backend,
     )
-
-
-@skip_if_not_cuda
-@pytest.mark.parametrize("input_type", ["image", "video"])
-def test_vlm_batch_invariance_bs1_vs_bsN(input_type: str):
-    num_reqs = 8 if input_type == "image" else 4
-    inputs = _make_inputs(input_type, num_reqs)
-    sampling = SamplingParams(temperature=0.0, max_tokens=8, seed=1234, logprobs=5)
-
-    llm = _new_llm()
-    try:
-        _assert_batch_invariant(llm, inputs, sampling)
-    finally:
-        with contextlib.suppress(Exception):
-            llm.shutdown()
-
-
-@skip_if_not_cuda
-@pytest.mark.parametrize("mm_encoder_attn_backend", ["FLASH_ATTN", "TORCH_SDPA"])
-def test_vlm_batch_invariance_vision_backends(mm_encoder_attn_backend: str):
-    inputs = _make_inputs("image", 8)
-    sampling = SamplingParams(temperature=0.0, max_tokens=8, seed=1234, logprobs=5)
-
-    llm = _new_llm(mm_encoder_attn_backend=mm_encoder_attn_backend)
     try:
         _assert_batch_invariant(llm, inputs, sampling)
     finally:


### PR DESCRIPTION
## Summary

Adds regression coverage for **batch invariance of vision-language models (VLMs)**, addressing the gap left by issue #27059 ("Batch-invariant Inference Support for VLMs"), which was auto-closed by the stale bot with no associated PRs.

Batch invariance (`VLLM_BATCH_INVARIANT=1`) currently has end-to-end determinism tests only for text models (`tests/v1/determinism/test_batch_invariance.py`). The VLM vision tower is composed almost entirely of linear layers (patch embedding, MLP, QKV) and varlen attention, so it shares the same cuBLAS split-k and attention sources of non-determinism — but no test guards against a regression there.

This PR adds `tests/v1/determinism/test_batch_invariance_vlm.py`, which asserts BS=1 vs BS=N bitwise-identical logprobs/tokens for:

- **single image** (256×256)
- **video** (4 frames) — the strongest non-determinism signal observed in manual testing
- **vision-tower attention backends** (`FLASH_ATTN`, `TORCH_SDPA`)

and lists Qwen3-VL in the batch-invariance docs (`docs/features/batch_invariance.md`).

## Why this is not a duplicate

- No open PR adds VLM batch-invariance tests (`tests/v1/determinism/` currently contains text-model tests only).
- #27059 has zero linked PRs.

## Test plan

```bash
VLLM_VLM_TEST_MODEL=<path-to-Qwen3-VL-2B-Instruct> \
  pytest tests/v1/determinism/test_batch_invariance_vlm.py -v
```

Result (H20 / SM90):

```
4 passed, 18 warnings in 102.83s
```

- `ruff check`: pass
- `ruff format --check`: pass

## Model evaluation

This change is test-only (no runtime or model code changes), so it does not affect output, accuracy, or serving behavior. No model evaluation is required.

For context (verified manually, not asserted in CI to avoid a hardware-dependent flaky test): with `VLLM_BATCH_INVARIANT=0`, video inputs diverge at the token level (4/4), and with `=1` they are fully deterministic — confirming both that the test is sensitive and that the feature works. A Blackwell (SM120) variant reported in #27059 (Qwen3-VL-4B on RTX 5090, v0.11.2) could not be reproduced in this environment (Hopper only).