### PR TITLE
[Feature][Model Loading] Add --verify-weights flag to detect corrupted checkpoint tensors

### DIFF
--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -93,6 +93,14 @@ class LoadConfig:
     model_loader_extra_config: dict | TensorizerConfig = Field(default_factory=dict)
     """Extra config for model loader. This will be passed to the model loader
     corresponding to the chosen load_format."""
+    verify_weights: bool = False
+    """If True, verify the integrity of each weight tensor after loading from
+    the checkpoint. Checks for NaN, Inf, and all-zero values that may indicate
+    corrupted or incomplete weight files. Adds a small overhead to model
+    loading but can catch silently corrupted weights before they cause subtle
+    inference errors. Note that this cannot detect all forms of corruption
+    (e.g., valid-but-incorrect values); use external sha256 verification
+    for full integrity checking."""
     device: str | None = None
     """Device to which model weights will be loaded, default to
     device_config.device"""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -445,6 +445,7 @@ class EngineArgs:
     )
     safetensors_prefetch_num_threads: int = LoadConfig.safetensors_prefetch_num_threads
     safetensors_prefetch_block_size: int = LoadConfig.safetensors_prefetch_block_size
+    verify_weights: bool = LoadConfig.verify_weights
     load_format: str | LoadFormats = LoadConfig.load_format
     config_format: str = ModelConfig.config_format
     dtype: ModelDType = ModelConfig.dtype
@@ -959,6 +960,15 @@ class EngineArgs:
         )
         load_group.add_argument(
             "--model-loader-extra-config", **load_kwargs["model_loader_extra_config"]
+        )
+        load_group.add_argument(
+            "--verify-weights",
+            action="store_true",
+            default=False,
+            help="Verify weight tensors for NaN/Inf/all-zero after loading. "
+            "Useful for detecting corrupted checkpoint files. "
+            "Note: cannot detect all corruption types; use sha256 for full "
+            "integrity verification.",
         )
         load_group.add_argument("--ignore-patterns", **load_kwargs["ignore_patterns"])
         load_group.add_argument("--use-tqdm-on-load", **load_kwargs["use_tqdm_on_load"])
@@ -1846,6 +1856,7 @@ class EngineArgs:
             safetensors_prefetch_num_threads=self.safetensors_prefetch_num_threads,
             safetensors_prefetch_block_size=self.safetensors_prefetch_block_size,
             model_loader_extra_config=self.model_loader_extra_config,
+            verify_weights=self.verify_weights,
             ignore_patterns=self.ignore_patterns,
             use_tqdm_on_load=self.use_tqdm_on_load,
             pt_load_map_location=self.pt_load_map_location,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -962,13 +962,7 @@ class EngineArgs:
             "--model-loader-extra-config", **load_kwargs["model_loader_extra_config"]
         )
         load_group.add_argument(
-            "--verify-weights",
-            action="store_true",
-            default=False,
-            help="Verify weight tensors for NaN/Inf/all-zero after loading. "
-            "Useful for detecting corrupted checkpoint files. "
-            "Note: cannot detect all corruption types; use sha256 for full "
-            "integrity verification.",
+            "--verify-weights", **load_kwargs["verify_weights"]
         )
         load_group.add_argument("--ignore-patterns", **load_kwargs["ignore_patterns"])
         load_group.add_argument("--use-tqdm-on-load", **load_kwargs["use_tqdm_on_load"])

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -295,6 +295,7 @@ class DefaultModelLoader(BaseModelLoader):
                         safetensors_prefetch_block_size=(
                             self.load_config.safetensors_prefetch_block_size
                         ),
+                        verify_weights=self.load_config.verify_weights,
                     )
         else:
             if extra_config.get("enable_multithread_load"):

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -8,6 +8,7 @@ import fnmatch
 import glob
 import hashlib
 import json
+import math
 import os
 import tempfile
 import threading
@@ -834,6 +835,7 @@ def safetensors_weights_iterator(
     *,
     safetensors_prefetch_num_threads: int = DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS,
     safetensors_prefetch_block_size: int = DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
+    verify_weights: bool = False,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model safetensor files.
 
@@ -923,6 +925,8 @@ def safetensors_weights_iterator(
                 state_dict = load(f.read())
             for name, param in state_dict.items():
                 if not should_skip_weight(name, local_expert_ids):
+                    if verify_weights:
+                        verify_weight_tensor(name, param)
                     yield name, param
         elif safetensors_load_strategy == "torchao":
             # we can't load flattened torchao tensor subclasses directly into the model
@@ -953,6 +957,9 @@ def safetensors_weights_iterator(
                 unflattened_state_dict, leftover_state_dict = (
                     unflatten_tensor_state_dict(state_dict, metadata)
                 )
+            if verify_weights:
+                for name, param in unflattened_state_dict.items():
+                    verify_weight_tensor(name, param)
             yield from unflattened_state_dict.items()
         else:
             with safe_open(st_file, framework="pt") as f:
@@ -960,6 +967,8 @@ def safetensors_weights_iterator(
                     if should_skip_weight(name, local_expert_ids):
                         continue
                     param = f.get_tensor(name)
+                    if verify_weights:
+                        verify_weight_tensor(name, param)
                     yield name, param
 
 
@@ -1217,6 +1226,59 @@ def convert_pyslice_to_tensor(x: Any) -> torch.Tensor:
     if not isinstance(x, torch.Tensor):
         x = x[:]
     return x
+
+
+def verify_weight_tensor(name: str, tensor: torch.Tensor) -> None:
+    """Verify a loaded weight tensor for signs of corruption.
+
+    Uses a single ``tensor.abs().max()`` reduction to detect:
+    - NaN values (result is NaN; NaN propagates through max)
+    - Inf values (result is Inf)
+    - All-zero tensors (result is 0.0; only flagged for large tensors)
+
+    Raises ValueError if NaN/Inf is detected.
+    Logs warnings for all-zero tensors.
+
+    Note: This cannot detect valid-but-incorrect values (e.g., bit flips
+    that change a scale from 0.5 to 50.0). Use external sha256 verification
+    for full integrity checking.
+    """
+    if not tensor.is_floating_point() or tensor.numel() == 0:
+        return
+
+    # Single-pass: abs().max() covers NaN, Inf, and all-zero in one reduction.
+    # - NaN in tensor -> max_abs is NaN (NaN propagates through max)
+    # - Inf in tensor -> max_abs is Inf
+    # - All zeros     -> max_abs is 0.0
+    # - Normal        -> max_abs is a positive finite float
+    max_abs = tensor.abs().max().item()
+
+    if math.isnan(max_abs):
+        raise ValueError(
+            f"Weight tensor '{name}' contains NaN values. "
+            f"This indicates the checkpoint file may be corrupted. "
+            f"Please verify the file integrity (e.g., sha256) and "
+            f"re-download if necessary."
+        )
+
+    if math.isinf(max_abs):
+        raise ValueError(
+            f"Weight tensor '{name}' contains Inf values. "
+            f"This indicates the checkpoint file may be corrupted. "
+            f"Please verify the file integrity (e.g., sha256) and "
+            f"re-download if necessary."
+        )
+
+    # All-zero check — catches truncated or zeroed files.
+    # Skip small tensors (e.g., biases, norms) where zero is valid.
+    if tensor.numel() > 1024 and max_abs == 0.0:
+        logger.warning(
+            "Weight tensor '%s' is all zeros (numel=%d). "
+            "This may indicate a corrupted or truncated checkpoint. "
+            "If this is unexpected, verify the file integrity.",
+            name,
+            tensor.numel(),
+        )
 
 
 def default_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor) -> None:


### PR DESCRIPTION
## Purpose

vLLM's safetensors weight loading pipeline performs **no content-level validation** on weight tensors. The only checks are:

1. safetensors header JSON can be parsed (Rust level)
2. data_offsets don't exceed file size (Rust level)
3. tensor shape matches model expectation (Python level)
4. weight name completeness for non-quantized models (Python level)

If a checkpoint file is corrupted during transfer (network errors, storage failures, incomplete copies) but the header and shape are still valid, vLLM **silently loads corrupted weights** and produces incorrect inference results without any error or warning.

### Real-world impact

A customer deploying Qwen3.6-35B-A3B-w8a8 had a corrupted `quant_model_weights-00008-of-00010.safetensors` (sha256 mismatch, 4.28GB). vLLM loaded the corrupted weights without error, causing intermittent tool call argument truncation. Normal chat worked fine, making the issue extremely hard to diagnose.

### Proposed solution

Opt-in `--verify-weights` flag that checks each loaded floating-point tensor using a single `abs().max()` reduction (30x faster per-tensor than separate isnan+isinf+max passes; NaN propagates through max, so one pass covers all three cases):

- **NaN** → raises ValueError, blocks startup
- **Inf** → raises ValueError, blocks startup
- **All-zero** (tensors > 1024 elements) → logs warning (small biases/norms may legitimately be zero)

### Limitations

Cannot detect valid-but-incorrect values (e.g. bit flips changing `weight_scale` from 0.5 to 50.0). External sha256 verification is still recommended for full integrity checking, and the `--help` text says so.

### Three-layer defense

1. safetensors `safe_open()` — catches pure truncation (file shorter than expected), 0s overhead
2. `--verify-weights` — catches zero-padded truncation + NaN/Inf, ~3.4s overhead on a 40GB model
3. `sha256sum -c sha256sums.txt` — catches everything including mid-file bit flips, ~30-60s overhead

Usage: `vllm serve /path/to/model --verify-weights`

**Scope note:** verification hooks into the three `safetensors_weights_iterator` code paths (default / eager / torchao). It does not cover `.bin` (`pt_weights_iterator`), multithreaded safetensors loading, or RunAI streamer paths.

## Test Plan

On this branch (ported onto current `main`; changes are additive, default off):

```bash
ruff check vllm/config/load.py vllm/engine/arg_utils.py \
  vllm/model_executor/model_loader/default_loader.py \
  vllm/model_executor/model_loader/weight_utils.py
python -m py_compile <same 4 files>
```

Original functional validation (feature developed and benchmarked on Ascend Atlas 800T A3, Qwen3.6-35B-A3B-w8a8, 39.7GB / 10 shards / 93,951 tensors): NaN injection raises ValueError at startup; zero-padded shard triggers the all-zero warning; clean weights load normally.

## Test Result

- `ruff check` on all 4 changed files: **All checks passed**
- `py_compile` on all 4 changed files: OK
- Benchmark (Qwen3.6-35B-A3B-w8a8, Ascend):

| Metric | Value |
|---|---|
| Total verify time | 3.36s |
| Tensors checked | 63,201 float (30,750 int8 skipped) |
| Data verified | 7.35 GB |
| Throughput | 2.19 GB/s |
| Overhead vs actual load | ~7% (TP=8, 50s) / ~15% (TP=4, 23s) |

Single-reduction design matters: `isnan().any() + isinf().any() + abs().max()` (3 passes) measured 19.4s on the same model vs 3.4s for the single `abs().max()` pass — 5.8x end-to-end, up to 30x on a single 200MB BF16 tensor (484ms vs 16ms).

## Duplicate-work check

Searched open PRs/issues for "verify weights", "NaN corrupted checkpoint". Closest is #51350 (RL `weight_checker`, draft) — that targets hot-reload validation for RL training, not load-time checkpoint integrity; no overlap with this change.

## AI assistance

The feature and benchmark were developed by the submitter's team; the port onto current `main` (relocation of insertion points across refactors, CRLF-normalized patch application) and lint verification were done with AI assistance, and every changed line was reviewed by the human submitter.

@0hujun