### PR TITLE
[Bugfix][Tool Parser] HY-V3: don't report tools_called with empty tool_calls

### DIFF
--- a/tests/tool_parsers/test_hy_v3_tool_parser.py
+++ b/tests/tool_parsers/test_hy_v3_tool_parser.py
@@ -62,6 +62,13 @@ class TestHYV3ExtractToolCalls:
         assert not r.tools_called
         assert r.content == out
 
+    def test_empty_tool_calls_wrapper(self, hy_v3_tool_parser, mock_request):
+        out = "hello<tool_calls></tool_calls>"
+        r = hy_v3_tool_parser.extract_tool_calls(out, request=mock_request)
+        assert not r.tools_called
+        assert r.tool_calls == []
+        assert r.content == out
+
     def test_zero_arg_inline(self, hy_v3_tool_parser, mock_request):
         out = (
             "<tool_calls><tool_call>get_current_date<tool_sep></tool_call></tool_calls>"

--- a/vllm/tool_parsers/hy_v3_tool_parser.py
+++ b/vllm/tool_parsers/hy_v3_tool_parser.py
@@ -382,6 +382,11 @@ class HYV3ToolParser(ToolParser):
             try:
                 tool_calls = self._extract_tool_calls(model_output, request)
 
+                if not tool_calls:
+                    return ExtractedToolCallInformation(
+                        tools_called=False, tool_calls=[], content=model_output
+                    )
+
                 s_index = model_output.find(self.tool_calls_start_token)
                 content = model_output[:s_index] if s_index != -1 else model_output
                 return ExtractedToolCallInformation(


### PR DESCRIPTION
## Purpose

`HYV3ToolParser.extract_tool_calls` (Hunyuan HY-V3 tool parser) reports
`tools_called=True` whenever the `<tool_calls>` wrapper token appears in the
model output — even when no tool call is actually parsed. `_extract_tool_calls`
can legitimately return an empty list for malformed/truncated inner blocks (and
its `except` path returns `[]`), so the wrapper token alone should not be
treated as a tool call.

The result is `tools_called=True` with an empty `tool_calls` list, which makes
downstream consumers that gate on `tools_called` take the tool-call path with
zero calls. Other parsers (e.g. `dots_tool_parser`) gate on whether any calls
were parsed.

## Fix

Return `tools_called=False` (with the original content) when
`_extract_tool_calls` yields no calls.

## Reproduction

```
out = "hello<tool_calls></tool_calls>"

# before
tool_calls  : []
tools_called: True      # bug

# after
tool_calls  : []
tools_called: False
content     : hello<tool_calls></tool_calls>
```

## Verification

```
$ .venv/bin/python -m pytest tests/tool_parsers/test_hy_v3_tool_parser.py \
    -k "empty_tool_calls or no_tool_call" -v
...
TestHYV3ExtractToolCalls::test_no_tool_call PASSED
TestHYV3ExtractToolCalls::test_empty_tool_calls_wrapper PASSED
TestHYV3ExtractToolCallsStreaming::test_no_tool_call_streaming PASSED
3 passed
```

Lint/type checks (pre-commit): `ruff`, `ruff format`, `mypy-3.10`, SPDX — all
pass on the changed files.

## Not a duplicate

No open or merged PR on `vllm-project/vllm` targets `tools_called` behavior in
`hy_v3_tool_parser.py`.

## Scope

One bug, one root cause: a 5-line guard in `extract_tool_calls` plus a single
regression test. No change to the happy path (well-formed tool calls still
return `tools_called=True`).

---

AI assistance was used to help identify, reproduce, and fix this bug; the change
has been reviewed and verified locally.
