### PR TITLE
[Perf][SpecDecode] Preserve active runtime-K width in GDN metadata

### DIFF
--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -221,3 +221,13 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
     assert meta.spec_query_start_loc.shape == (batch.batch_size + 1,)
     assert meta.num_accepted_tokens is not None
     assert meta.num_accepted_tokens.shape == (batch.batch_size,)
+
+
+def test_full_cudagraph_spec_metadata_uses_active_runtime_k_width():
+    """A runtime K3 step on a max-K7 server exposes four state columns."""
+    builder = _create_gdn_builder(num_speculative_tokens=7, full_cuda_graph=True)
+    batch = BatchSpec(seq_lens=[80] * 8, query_lens=[4] * 8)
+    meta = _build(builder, batch, num_decode_draft_tokens=[3] * 8)
+
+    assert meta.spec_state_indices_tensor is not None
+    assert meta.spec_state_indices_tensor.shape == (batch.batch_size, 4)

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -228,6 +228,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         )
 
         spec_sequence_masks_cpu: torch.Tensor | None = None
+        active_spec_width = 0
         if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
             spec_sequence_masks = None
             num_spec_decodes = 0
@@ -265,6 +266,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             assert spec_sequence_masks_cpu is not None
             non_spec_sequence_masks_cpu = ~spec_sequence_masks_cpu
             query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+            active_spec_width = int(
+                query_lens_cpu[spec_sequence_masks_cpu].max().item()
+            )
+            assert 1 < active_spec_width <= self.num_spec + 1
 
             # Use CPU tensors to avoid CPU-GPU sync
             non_spec_query_lens_cpu = query_lens_cpu[non_spec_sequence_masks_cpu]
@@ -305,7 +310,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 )
                 # Filter by spec_sequence_masks to exclude padded sequences
                 spec_state_indices_tensor = block_table_tensor[
-                    spec_sequence_masks_cpu, : self.num_spec + 1
+                    spec_sequence_masks_cpu, :active_spec_width
                 ]
                 non_spec_state_indices_tensor = None
                 # Padded sequences are always at the back, so the first
@@ -326,7 +331,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_token_indx = index[num_non_spec_tokens:]
 
                 spec_state_indices_tensor = block_table_tensor[
-                    spec_sequence_masks_cpu, : self.num_spec + 1
+                    spec_sequence_masks_cpu, :active_spec_width
                 ]
                 non_spec_state_indices_tensor = block_table_tensor[
                     non_spec_sequence_masks_cpu, 0
@@ -435,10 +440,13 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             and num_spec_decode_tokens <= self.decode_cudagraph_max_bs
         ):
             assert spec_sequence_masks is not None
-            self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+            assert active_spec_width > 0
+            self.spec_state_indices_tensor[:num_spec_decodes, :active_spec_width].copy_(
                 spec_state_indices_tensor, non_blocking=True
             )
-            spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
+            spec_state_indices_tensor = self.spec_state_indices_tensor[
+                :batch_size, :active_spec_width
+            ]
             spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
 
             self.spec_sequence_masks[:num_spec_decodes].copy_(


### PR DESCRIPTION
## Purpose

When a server is compiled for max K7 but runtime speculative decoding selects
K3, `GDNAttentionMetadataBuilder` selects four active block-table columns and
then expands the metadata back to the full eight-column staging buffer during
FULL cudagraph preparation. The recurrent GDN kernel derives its query width
from `spec_state_indices_tensor.size(-1)`, so it retains the max-K shape even
though only the active columns were refreshed.

This change derives the active speculative width from the CPU query lengths,
uses it for both block-table selections, and preserves that width through the
FULL-graph staging copy and returned view. The preallocated buffer remains
max-K-sized; only the exposed view changes.

## Why this is not duplicate work

#52559 adds graph-aware adaptive K selection for DFlash but does not modify
`GDNAttentionMetadataBuilder`; its description identifies hybrid-GDN target
verification as separate follow-up work. This PR is a focused complementary
fix and is useful with the dynamic-K infrastructure already on current `main`.

#53426 only skips the draft sync forward when K resolves to zero and does not
change GDN metadata width. Searches for `GDN active width speculative` and
`spec_state_indices_tensor runtime K` found no matching open PR.

## Tests

Current `main` at `8c2bbe00d`, Python 3.12, precompiled editable install:

```bash
.venv/bin/python -m pytest -q tests/v1/attention/test_gdn_metadata_builder.py
# 10 passed

.venv/bin/pre-commit run --files \
  vllm/v1/attention/backends/gdn_attn.py \
  tests/v1/attention/test_gdn_metadata_builder.py
# passed
```

The regression constructs a max-K7 FULL-graph builder, supplies an active K3
batch, and verifies that request-indexed state metadata has shape `(8, 4)`.

## Model evaluation and performance evidence

On the semantically equivalent v0.27.1 backport, RTX 5090 / SM120,
Qwen3.8-27B NVFP4, max K7 with runtime K3, and eight active requests:

- before: 212.17 aggregate decode tok/s;
- active-width view: 298.91 tok/s (+40.9%);
- the post-c8 c1 probe improved from 40.13 to 66.91 tok/s.

This does not close the remaining gap to a true K3-compiled graph; it only
removes the accidental max-K GDN state width from runtime-K steps.

## AI assistance

AI assistance was used for implementation, review, testing, and documentation.
The human submitter reviewed every changed line, ran the listed tests, and is
responsible for the contribution.
