### PR TITLE
[Bugfix][Perf][Attention] Enable masked NVFP4 XQA on SM120

### DIFF
--- a/tests/kernels/attention/test_flashinfer_trtllm_attention.py
+++ b/tests/kernels/attention/test_flashinfer_trtllm_attention.py
@@ -516,6 +516,7 @@ def test_flashinfer_xqa_nvfp4_spec_decode_with_baseline() -> None:
     mask_u32 = ((1 << torch.arange(1, q_len + 1)) - 1).to(torch.uint32)
     mask = mask_u32.view(torch.uint16).reshape(q_len, 2)
     mask = mask.unsqueeze(0).expand(batch_size, -1, -1).contiguous()
+    workspace.zero_()
 
     flashinfer.decode.xqa_batch_decode_with_kv_cache(
         query=query,

--- a/tests/kernels/attention/test_flashinfer_trtllm_attention.py
+++ b/tests/kernels/attention/test_flashinfer_trtllm_attention.py
@@ -451,6 +451,90 @@ def test_flashinfer_trtllm_decode_varlen(
     torch.testing.assert_close(output, output_trtllm, atol=atol, rtol=rtol)
 
 
+@torch.inference_mode
+def test_flashinfer_xqa_nvfp4_spec_decode_with_baseline() -> None:
+    """NVFP4 XQA accepts the packed causal mask used by spec decode."""
+    torch.set_default_device("cuda")
+    set_random_seed(42)
+
+    batch_size = 3
+    q_len = 8
+    num_qo_heads, num_kv_heads = 24, 4
+    head_size = 256
+    block_size = 16
+    num_blocks = 512
+    sm_scale = float(1.0 / (head_size**0.5))
+
+    query = torch.randn(
+        batch_size * q_len,
+        num_qo_heads,
+        head_size,
+        dtype=torch.bfloat16,
+    )
+    kv_cache = torch.randn(
+        num_blocks,
+        2,
+        num_kv_heads,
+        block_size,
+        head_size,
+        dtype=torch.bfloat16,
+    )
+    kv_cache, kv_cache_sf, kv_scale, ref_kv_cache, _ = make_quantized_kv_cache(
+        kv_cache, FP4_DTYPE, block_size, head_size
+    )
+
+    seq_lens = torch.tensor([257, 769, 1024], dtype=torch.int32)
+    max_num_blocks = round_up(int(seq_lens.max()), block_size) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (batch_size, max_num_blocks), dtype=torch.int32
+    )
+    kv_indptr, kv_indices, kv_last_page_lens = build_paged_kv_metadata(
+        seq_lens, block_tables, block_size
+    )
+    q_indptr = torch.arange(0, (batch_size + 1) * q_len, q_len, dtype=torch.int32)
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.int8)
+
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        float_workspace_buffer=workspace, kv_layout="HND", backend="fa2"
+    )
+    wrapper.plan(
+        qo_indptr=q_indptr,
+        paged_kv_indptr=kv_indptr,
+        paged_kv_indices=kv_indices,
+        paged_kv_last_page_len=kv_last_page_lens,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_size,
+        page_size=block_size,
+        causal=True,
+        sm_scale=sm_scale,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    reference = wrapper.run(query, ref_kv_cache)
+    output = torch.empty_like(query)
+    mask_u32 = ((1 << torch.arange(1, q_len + 1)) - 1).to(torch.uint32)
+    mask = mask_u32.view(torch.uint16).reshape(q_len, 2)
+    mask = mask.unsqueeze(0).expand(batch_size, -1, -1).contiguous()
+
+    flashinfer.decode.xqa_batch_decode_with_kv_cache(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=int(seq_lens.max()),
+        bmm1_scale=kv_scale * sm_scale,
+        bmm2_scale=kv_scale,
+        out=output,
+        kv_layout="HND",
+        q_len_per_req=q_len,
+        mask=mask,
+        kv_cache_sf=kv_cache_sf,
+    )
+    torch.testing.assert_close(reference, output, atol=0.5, rtol=0.5)
+
+
 @pytest.mark.parametrize("dtype", DTYPE)
 @pytest.mark.parametrize("quant_dtypes", QUANT_DTYPES)
 @pytest.mark.parametrize("batch_size", BATCH_SIZE)

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -1087,6 +1087,97 @@ def test_flashinfer_sm120_nvfp4_xqa_uses_model_dtype_for_decode(monkeypatch):
     AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
     reason="FlashInfer is not available.",
 )
+def test_flashinfer_xqa_isolated_stream_fork_and_join(monkeypatch):
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    events: list[tuple[str, ...]] = []
+
+    class FakeStream:
+        def __init__(self, name):
+            self.name = name
+
+        def wait_stream(self, stream):
+            events.append((self.name, "wait", stream.name))
+
+    class FakeStreamContext:
+        def __enter__(self):
+            events.append(("side", "enter"))
+
+        def __exit__(self, *_):
+            events.append(("side", "exit"))
+
+    current = FakeStream("current")
+    side = FakeStream("side")
+    monkeypatch.setattr(
+        flashinfer_backend.envs,
+        "VLLM_FLASHINFER_XQA_USE_ISOLATED_STREAM",
+        True,
+    )
+    monkeypatch.setattr(
+        flashinfer_backend.torch.cuda, "current_stream", lambda: current
+    )
+    monkeypatch.setattr(
+        flashinfer_backend.torch.cuda, "stream", lambda stream: FakeStreamContext()
+    )
+    monkeypatch.setattr(flashinfer_backend, "_get_xqa_isolated_stream", lambda: side)
+
+    with flashinfer_backend._xqa_isolated_stream_scope(enabled=True):
+        events.append(("body",))
+
+    assert events == [
+        ("side", "wait", "current"),
+        ("side", "enter"),
+        ("body",),
+        ("side", "exit"),
+        ("current", "wait", "side"),
+    ]
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+@pytest.mark.parametrize(("configured", "enabled"), [(False, True), (True, False)])
+def test_flashinfer_xqa_isolated_stream_disabled_is_noop(
+    monkeypatch, configured, enabled
+):
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    monkeypatch.setattr(
+        flashinfer_backend.envs,
+        "VLLM_FLASHINFER_XQA_USE_ISOLATED_STREAM",
+        configured,
+    )
+    monkeypatch.setattr(
+        flashinfer_backend,
+        "_get_xqa_isolated_stream",
+        lambda: pytest.fail("isolated stream must not be created"),
+    )
+
+    with flashinfer_backend._xqa_isolated_stream_scope(enabled):
+        pass
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+def test_flashinfer_xqa_isolated_stream_requires_eager_warmup(monkeypatch):
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    monkeypatch.setattr(flashinfer_backend, "_xqa_isolated_stream", None)
+    monkeypatch.setattr(
+        flashinfer_backend.torch.cuda, "is_current_stream_capturing", lambda: True
+    )
+
+    with pytest.raises(RuntimeError, match="eager XQA warmup"):
+        flashinfer_backend._get_xqa_isolated_stream()
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_flashinfer_attention_sinks_refreshed_after_reload(dtype):
     from vllm.v1.attention.backends import flashinfer as flashinfer_backend

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -1058,6 +1058,35 @@ def test_flashinfer_trtllm_gen_padded_decode_uses_varlen_offsets(
     AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
     reason="FlashInfer is not available.",
 )
+def test_flashinfer_sm120_nvfp4_xqa_uses_model_dtype_for_decode(monkeypatch):
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    builder = object.__new__(flashinfer_backend.FlashInferMetadataBuilder)
+    builder.cache_dtype = "nvfp4"
+    builder.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    builder.vllm_config = SimpleNamespace(
+        attention_config=SimpleNamespace(disable_flashinfer_q_quantization=False)
+    )
+    monkeypatch.setattr(
+        flashinfer_backend.current_platform,
+        "is_device_capability",
+        lambda capability: False,
+    )
+    monkeypatch.setattr(
+        flashinfer_backend.current_platform,
+        "is_device_capability_family",
+        lambda capability: capability == 120,
+    )
+    monkeypatch.setattr(flashinfer_backend, "force_use_trtllm_attention", lambda: None)
+
+    assert builder.get_q_data_type(is_prefill=False) == torch.bfloat16
+    assert builder.get_q_data_type(is_prefill=True) == flashinfer_backend.FP8_DTYPE
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_flashinfer_attention_sinks_refreshed_after_reload(dtype):
     from vllm.v1.attention.backends import flashinfer as flashinfer_backend

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -219,6 +219,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+    VLLM_FLASHINFER_XQA_USE_ISOLATED_STREAM: bool = False
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
@@ -1755,6 +1756,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Control the workspace buffer size for the FlashInfer backend.
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
+    ),
+    # Run SM120 NVFP4 XQA decode on an isolated CUDA stream.
+    "VLLM_FLASHINFER_XQA_USE_ISOLATED_STREAM": lambda: bool(
+        int(os.getenv("VLLM_FLASHINFER_XQA_USE_ISOLATED_STREAM", "0"))
     ),
     # Control the maximum number of tokens per expert supported by the
     # NVFP4 MoE CUTLASS Kernel. This value is used to create a buffer for

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -942,9 +942,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # if cache_config requests a quantized dtype globally.
         cache_dtype = self.cache_dtype
 
-        # On SM90/SM12x, XQA decode requires BF16/FP16-Q even with FP8 KV cache.
-        # FI native prefill on SM90 still uses FP8-Q in that case; SM12x prefill
-        # is fa2-only and keeps the model dtype (handled below).
+        # On SM90/SM12x, XQA decode requires BF16/FP16-Q even with FP8 or NVFP4
+        # KV cache. FI native prefill on SM90 still uses FP8-Q in that case;
+        # SM12x prefill is fa2-only and keeps the model dtype (handled below).
         if (
             (
                 current_platform.is_device_capability(90)
@@ -952,7 +952,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             )
             and not is_prefill
             and force_use_trtllm_attention() is not False
-            and cache_dtype.startswith("fp8")
+            and (
+                cache_dtype.startswith("fp8")
+                or (
+                    current_platform.is_device_capability_family(120)
+                    and cache_dtype.startswith("nvfp4")
+                )
+            )
         ):
             return self.model_config.dtype
 
@@ -2138,7 +2144,6 @@ class FlashInferImpl(AttentionImpl):
         use_dcp = self.dcp_world_size > 1
         if decode_with_xqa:
             assert not use_dcp
-            assert not self.is_kvcache_nvfp4
             assert self.o_sf_scale is None
             assert output.dtype != FP4_DTYPE
 
@@ -2482,7 +2487,9 @@ class FlashInferImpl(AttentionImpl):
 
                     flashinfer_xqa_batch_decode_with_kv_cache(
                         query=decode_query,
-                        kv_cache=kv_cache_tuple,
+                        kv_cache=(
+                            nvfp4_kv_data if self.is_kvcache_nvfp4 else kv_cache_tuple
+                        ),
                         workspace_buffer=workspace_buffer,
                         block_tables=block_tables_decode,
                         seq_lens=seq_lens_decode,
@@ -2495,6 +2502,9 @@ class FlashInferImpl(AttentionImpl):
                         kv_layout=get_flashinfer_layout_string(self.kv_cache_layout),
                         q_len_per_req=q_len_per_req,
                         mask=attn_metadata.decode.mask,
+                        kv_cache_sf=(
+                            nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
+                        ),
                         q_cu_seq_lens=attn_metadata.decode.q_cu_seq_lens,
                     )
                     return output_padded

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Attention layer with FlashInfer."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from enum import Enum
 from functools import partial
@@ -109,6 +111,39 @@ def _get_trtllm_workspace_buffer():
             envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE, dtype=torch.uint8, device="cuda"
         )
     return trtllm_workspace_buffer
+
+
+_xqa_isolated_stream: torch.cuda.Stream | None = None
+
+
+def _get_xqa_isolated_stream() -> torch.cuda.Stream:
+    """Return the process-stable stream used for NVFP4 XQA decode."""
+    global _xqa_isolated_stream
+    if _xqa_isolated_stream is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "VLLM_FLASHINFER_XQA_USE_ISOLATED_STREAM requires an eager "
+                "XQA warmup before CUDA graph capture."
+            )
+        _xqa_isolated_stream = torch.cuda.Stream()
+    return _xqa_isolated_stream
+
+
+@contextmanager
+def _xqa_isolated_stream_scope(enabled: bool) -> Iterator[None]:
+    """Run a kernel on the isolated XQA stream with capture-safe ordering."""
+    if not (envs.VLLM_FLASHINFER_XQA_USE_ISOLATED_STREAM and enabled):
+        yield
+        return
+
+    stream = _get_xqa_isolated_stream()
+    current = torch.cuda.current_stream()
+    stream.wait_stream(current)
+    try:
+        with torch.cuda.stream(stream):
+            yield
+    finally:
+        current.wait_stream(stream)
 
 
 def _pack_draft_block_bool_mask(
@@ -2485,28 +2520,33 @@ class FlashInferImpl(AttentionImpl):
                     )
                     q_len_per_req: int | None = attn_metadata.decode.q_len_per_req
 
-                    flashinfer_xqa_batch_decode_with_kv_cache(
-                        query=decode_query,
-                        kv_cache=(
-                            nvfp4_kv_data if self.is_kvcache_nvfp4 else kv_cache_tuple
-                        ),
-                        workspace_buffer=workspace_buffer,
-                        block_tables=block_tables_decode,
-                        seq_lens=seq_lens_decode,
-                        max_seq_len=attn_metadata.decode.max_seq_len,
-                        bmm1_scale=bmm1_scale,
-                        bmm2_scale=self.bmm2_scale,
-                        window_left=self.window_left,
-                        out=output_padded[:decode_query_tokens],
-                        sinks=self.sinks,
-                        kv_layout=get_flashinfer_layout_string(self.kv_cache_layout),
-                        q_len_per_req=q_len_per_req,
-                        mask=attn_metadata.decode.mask,
-                        kv_cache_sf=(
-                            nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
-                        ),
-                        q_cu_seq_lens=attn_metadata.decode.q_cu_seq_lens,
-                    )
+                    with _xqa_isolated_stream_scope(self.is_kvcache_nvfp4):
+                        flashinfer_xqa_batch_decode_with_kv_cache(
+                            query=decode_query,
+                            kv_cache=(
+                                nvfp4_kv_data
+                                if self.is_kvcache_nvfp4
+                                else kv_cache_tuple
+                            ),
+                            workspace_buffer=workspace_buffer,
+                            block_tables=block_tables_decode,
+                            seq_lens=seq_lens_decode,
+                            max_seq_len=attn_metadata.decode.max_seq_len,
+                            bmm1_scale=bmm1_scale,
+                            bmm2_scale=self.bmm2_scale,
+                            window_left=self.window_left,
+                            out=output_padded[:decode_query_tokens],
+                            sinks=self.sinks,
+                            kv_layout=get_flashinfer_layout_string(
+                                self.kv_cache_layout
+                            ),
+                            q_len_per_req=q_len_per_req,
+                            mask=attn_metadata.decode.mask,
+                            kv_cache_sf=(
+                                nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
+                            ),
+                            q_cu_seq_lens=attn_metadata.decode.q_cu_seq_lens,
+                        )
                     return output_padded
 
                 assert decode_with_trtllm_gen


### PR DESCRIPTION
## Purpose

Current `main` routes SM120 speculative decode through FlashInfer's dedicated
masked XQA API, but the forward path explicitly rejects NVFP4 KV. It also
selects FP8 query tensors for NVFP4, while the dedicated XQA API requires the
query and output dtypes to match for NVFP4 KV.

This change:

- uses the model dtype for SM120 NVFP4 XQA decode queries and outputs;
- passes the packed NVFP4 K/V data and scale-factor caches to the existing
  masked speculative-decode call; and
- adds an opt-in isolated CUDA stream for this path. The side stream is created
  during eager warmup and uses explicit fork/join waits, so FULL graph capture
  records the dependency edges. The option is default-off and scoped to NVFP4
  XQA.

The stream option addresses an execution-context slowdown observed only in the
integrated FULL-graph server: the same captured tensors replayed standalone
were fast.

## Why this is not duplicate work

- #49891 routes SM120 NVFP4 through native FlashInfer FA2 and explicitly
  disables XQA. This PR enables the complementary masked-XQA path already
  present on current `main`.
- #47979 adds uniform speculative decode to the native FlashInfer path; native
  decode needs `q_len_per_req`, while XQA additionally needs its packed causal
  mask.
- #46329 is also an FA2-based NVFP4 path and does not implement masked XQA or
  the isolated-stream execution fix.

Searches for `49010 in:body`, `NVFP4 masked XQA`, `XQA isolated stream`, and
`XQA dedicated stream` found no open PR implementing this path.

## Tests

Current `main` at `8c2bbe00d`, Python 3.12, precompiled editable install,
FlashInfer 0.6.17:

```bash
.venv/bin/python -m pytest -q \
  tests/v1/attention/test_attention_backends.py \
  -k 'sm120_nvfp4_xqa_uses_model_dtype_for_decode or xqa_isolated_stream'
# 5 passed, 132 deselected

.venv/bin/python -m pytest -q \
  tests/kernels/attention/test_flashinfer_trtllm_attention.py::test_flashinfer_xqa_nvfp4_spec_decode_with_baseline
# 1 passed on RTX 5090 / SM120 at q_len=8, head_dim=256

.venv/bin/pre-commit run --files \
  vllm/envs.py \
  vllm/v1/attention/backends/flashinfer.py \
  tests/v1/attention/test_attention_backends.py \
  tests/kernels/attention/test_flashinfer_trtllm_attention.py
# passed
```

The GPU regression compares BF16 FA2 attention against masked XQA over NVFP4
paged KV and covers the production geometry (24 Q heads, 4 KV heads,
head_dim=256, q_len=8).

## Model evaluation and performance evidence

The end-to-end evaluation used the semantically equivalent v0.27.1 backport,
not this current-main commit, on RTX 5090 / SM120 with Qwen3.8-27B NVFP4,
DFlash2 K7, NVFP4 target and draft KV, and FULL graphs:

- exact server tensors replayed standalone: 0.053-0.072 ms per XQA call at
  c3;
- integrated FULL graph before isolation: 1.437 ms per call at c3;
- integrated FULL graph with the isolated stream: 0.278 ms per call;
- 262K profile, three-run medians at c1/c3/c8:
  94.08 / 258.68 / 539.62 aggregate decode tok/s;
- 329,395-token KV capacity with an 8 GiB pool;
- 184,024-prompt-token needle recovered `MOONWEASEL-7` exactly;
- arithmetic canary returned 437.

The exact current-main GPU kernel correctness test is included above. The
end-to-end numbers are explicitly reported as backport evidence because no
current-main model image was built for this submission.

## AI assistance

AI assistance was used for implementation, review, testing, and documentation.
The human submitter reviewed every changed line, ran the listed tests, and is
responsible for the contribution.
