### PR TITLE
[Perf][KV Offload] Skip canonical mappings for packed KV caches

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -66,9 +66,6 @@ class OffloadingConnectorWorker:
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         kv_cache_config = self.kv_cache_config
         num_blocks = kv_cache_config.num_blocks
-        mappings = derive_canonical_mappings(
-            self.vllm_config, kv_cache_config, kv_caches
-        )
 
         # layer_name -> (num_blocks, page_size_bytes) tensor
         tensors_per_block: dict[str, tuple[torch.Tensor, ...]] = {}
@@ -149,6 +146,10 @@ class OffloadingConnectorWorker:
                 )
             )
             return
+
+        mappings = derive_canonical_mappings(
+            self.vllm_config, kv_cache_config, kv_caches
+        )
 
         block_tensors: list[CanonicalKVCacheTensor] = []
         block_data_refs: dict[str, list[CanonicalKVCacheRef]] = defaultdict(list)


### PR DESCRIPTION
# [Perf][KV Offload] Skip canonical mappings for packed KV caches

## Summary

Skip canonical page-mapping derivation for packed KV cache layouts in
`OffloadingConnectorWorker`.

Packed layouts transfer each scheduler block as one contiguous packed region,
so per-layer canonical mappings are not used on that path. The mapping is now
derived only after the packed-layout fast path. Non-packed layouts keep the
existing behavior.

## Motivation

After the KV-cache layout standardization in [#51718](https://github.com/vllm-project/vllm/pull/51718),
`register_kv_caches()` derived canonical mappings before classifying the cache
layout. This made packed KV registration perform work that the packed transfer
path immediately discarded and could expose packed physical layouts to mapping
logic intended for individual pages.

## Scope

This applies when a layer view has a block stride larger than its page size,
including packed per-block layouts used by DeepSeek-V4 and Dots3Note. Ordinary
layer-compact KV layouts are unchanged.

## Why this is not duplicate work

- [#50717](https://github.com/vllm-project/vllm/pull/50717) skips NIXL block-size
  synchronization for packed KV caches; it changes a different initialization
  path.
- [#51689](https://github.com/vllm-project/vllm/pull/51689) and
  [#51690](https://github.com/vllm-project/vllm/pull/51690) change the canonical
  portability gate, not packed worker registration.
- This change is a focused follow-up to the layout behavior introduced by
  merged [#51718](https://github.com/vllm-project/vllm/pull/51718).

## Testing

Static checks passed:

```bash
uvx ruff check \
  vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
uvx ruff format --check \
  vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
git diff --check
```

Focused unit test:

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/offloading_connector/test_worker.py -q
```

Result: **6 passed, 2 skipped** in 1.10s.

## Benchmark

This is an initialization-only optimization. A CPU microbenchmark compared the
current path with the previous path that derived mappings before registering a
64-layer packed cache. Results are median `register_kv_caches()` time:

| TP size | Previous | Current | Saved |
|---:|---:|---:|---:|
| 1 | 1.72 ms | 0.31 ms | 1.41 ms |
| 4 | 5.84 ms | 0.30 ms | 5.54 ms |
| 8 | 11.31 ms | 0.33 ms | 10.98 ms |

The benchmark uses a synthetic CPU configuration; it does not measure token
generation throughput. Model evaluation is not applicable: this changes
KV-offload registration and does not change model architecture, weights, or
output computation.

## AI assistance

AI assistance was used for investigation and implementation. The submitting
author will review every changed line and the final test results before
submitting the PR.
