### PR TITLE
[Bugfix] [PD]Correct HMA enabled log condition in NIXL base_scheduler

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -99,7 +99,7 @@ class NixlBaseConnectorScheduler:
         )
 
         logger.info("Initializing NIXL Scheduler %s", engine_id)
-        if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
+        if not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
             logger.info("Hybrid Memory Allocator is enabled with NIXL")
 
         # Background thread for handling new handshake requests.


### PR DESCRIPTION
The log message for Hybrid Memory Allocator being enabled was triggered when disable_hybrid_kv_cache_manager was True, which is the opposite of the intended condition.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix an inverted condition in `NixlBaseConnectorScheduler` (`base_scheduler.py`) that logged "Hybrid Memory Allocator is enabled with NIXL" when `disable_hybrid_kv_cache_manager` was `True`.

When `disable_hybrid_kv_cache_manager` is `True`, HMA is disabled. The log should only be emitted when HMA is enabled (`disable_hybrid_kv_cache_manager` is `False`), consistent with `_is_hma_required` in the same file and `is_hma_enabled` in `metadata.py`.

AI assistance: Used an AI coding assistant during development; all changes were reviewed manually.

## Test Plan

Manual verification of startup logs under both HMA settings:

1. Start vLLM with NIXL KV transfer and HMA enabled (`disable_hybrid_kv_cache_manager=False`).
2. Confirm startup logs include: `Hybrid Memory Allocator is enabled with NIXL`.
3. Start another instance with HMA disabled (`disable_hybrid_kv_cache_manager=True`).
4. Confirm that log line is **not** emitted.

Optional regression check for related NIXL/HMA tests:

```bash
pytest -s -v tests/v1/kv_connector/unit/test_nixl_connector_hma.py