### PR TITLE
test: add SageMaker logging handler regression test

### DIFF
--- a/tests/entrypoints/serve/sagemaker/test_sagemaker_logging.py
+++ b/tests/entrypoints/serve/sagemaker/test_sagemaker_logging.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+import logging
+import sys
+
+from fastapi import FastAPI
+
+
+def test_sagemaker_import_does_not_change_handler_level():
+    """
+    Regression test for issue #13634.
+
+    Importing SageMaker integration should not change existing
+    logging handler levels.
+    """
+
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+
+    root_logger = logging.getLogger()
+    old_handlers = root_logger.handlers[:]
+
+    try:
+        root_logger.handlers.clear()
+        root_logger.addHandler(handler)
+
+        sys.modules.pop(
+            "vllm.entrypoints.serve.sagemaker.api_router",
+            None,
+        )
+
+        api_router = importlib.import_module(
+            "vllm.entrypoints.serve.sagemaker.api_router"
+        )
+
+        app = FastAPI()
+
+        api_router.attach_router(app, ())
+
+        assert handler.level == logging.INFO
+
+    finally:
+        root_logger.handlers.clear()
+        root_logger.handlers.extend(old_handlers)


### PR DESCRIPTION



## Purpose

Adds a regression test for issue #13634 to ensure that importing the SageMaker integration does not modify existing logging handler levels.

This test covers the case where a user's existing logging configuration should remain unchanged after initializing the SageMaker router.

## Test Plan

Run the new regression test:

```bash
python -m pytest tests/entrypoints/serve/sagemaker/test_sagemaker_logging.py
```

## Test Result

Before this change:
- No regression test existed to verify that SageMaker initialization preserved existing logging handler levels.

After this change:

```text
1 passed
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

