### PR TITLE
[Bugfix][ROCm][Disagg] Do not re-advertise completed MoRIIO WRITE KV as a second remote load

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -413,6 +413,7 @@ class MoRIIOConnectorScheduler:
         self._reqs_need_save: dict[ReqId, tuple[Request, list[int]]] = {}
         # Snapshot of kv_transfer_params for chunked prefill recovery.
         self._req_kv_params: dict[ReqId, dict] = {}
+        self._completed_write_recvs: set[ReqId] = set()
 
         # For chunked prefill, we perform layer-wise access within the final chunk.
         # TODO: Perform transfer at end chunk.
@@ -502,6 +503,8 @@ class MoRIIOConnectorScheduler:
         token_ids = request.prompt_token_ids or []
         if self.mode == MoRIIOMode.WRITE:
             # MoriiO in write mode, no remote prefill
+            if request.request_id in self._completed_write_recvs:
+                return 0, False
 
             return len(token_ids) - num_computed_tokens, True
 
@@ -912,6 +915,7 @@ class MoRIIOConnectorScheduler:
         # Producer: must keep the mapping until we get notification that blocks can
         #   be freed, which may be several scheduler steps later.
         if not self.is_producer:
+            self._completed_write_recvs.discard(request_id)
             transfer_id = params.get("transfer_id") if params else None
             self.unmap_request_id(request_id, transfer_id=transfer_id)
         logger.debug(
@@ -1014,6 +1018,10 @@ class MoRIIOConnectorScheduler:
         no-op for them.
         """
         if not self.is_producer:
+            if self.mode == MoRIIOMode.WRITE:
+                self._completed_write_recvs.update(
+                    connector_output.finished_recving or ()
+                )
             return
 
         incoming = set(connector_output.finished_sending or ())


### PR DESCRIPTION
## Purpose

In MoRIIO WRITE mode the producer pushes KV to the decode engine, so the consumer has no remote prefill to pull. After a WRITE completes, the scheduler can call `get_num_new_matched_tokens` again with `num_computed_tokens == 0` — for example when a one-token prompt is rewound for sampling, or when a preempted request is rescheduled. The method then advertises a second async remote load, the request re-enters `WAITING_FOR_REMOTE_KVS`, and waits for a WRITE that will not repeat.

This change records completed WRITE receives on the consumer and returns `(0, False)` once the transfer has landed.

## Changes

`vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py` only:

* Track completed WRITE receives in `_completed_write_recvs` on the consumer scheduler, populated from `connector_output.finished_recving` in `update_connector_output`.
* Return `(0, False)` from `get_num_new_matched_tokens` once the request's transfer has landed.
* Discard the id in `request_finished`.

## Test Plan

MoRIIO **2P2D wide-EP** (DP16, WRITE) disaggregated serving, `ROUTER_TYPE=proxy`, `RUN_AFTER_HEALTH=accuracy`, image `vllm/vllm-openai-rocm:nightly`.

### MiniMax-M3-MXFP8 — 2P2D wide-EP DP16

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_RMSNORM=1
export VLLM_DP_DISABLE_BATCH_QUEUE=1
export ALL2ALL_BACKEND=allgather_reducescatter

# PREFILL — master (node0, DP ranks 0–7)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $PREFILL_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --no-async-scheduling \
    --no-disable-nccl-for-dp-synchronization \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'

# PREFILL — child (node1, headless, DP ranks 8–15)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $PREFILL_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --enforce-eager \
    --no-async-scheduling

# DECODE — master (node2, DP ranks 0–7)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    --host $DECODE_IP --port 20005 -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --no-async-scheduling \
    --no-disable-nccl-for-dp-synchronization \
    --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_port":"9711",
      "kv_connector_extra_config":{"proxy_ip":"'$PREFILL_IP'","proxy_port":"10001",
      "proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555",
      "handshake_port":"6301","notify_port":"61005"}}'

# DECODE — child (node3, headless, DP ranks 8–15)
vllm serve /data/models2/MiniMax-M3-MXFP8 \
    -tp 1 \
    --data-parallel-size 16 \
    --data-parallel-size-local 8 \
    --data-parallel-address $DECODE_IP \
    --data-parallel-rpc-port 13345 \
    --data-parallel-start-rank 8 \
    --headless \
    --enable-expert-parallel \
    --all2all-backend allgather_reducescatter \
    --trust-remote-code \
    --attention-backend TRITON_ATTN \
    --block-size 128 \
    --language-model-only \
    --kv-cache-dtype fp8 \
    --gpu-memory-utilization 0.85 \
    --no-async-scheduling
```

### GSM8K evaluation

```bash
lm_eval --model local-completions \
    --tasks gsm8k \
    --model_args "model=/data/models2/MiniMax-M3-MXFP8,base_url=http://127.0.0.1:10001/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,trust_remote_code=True,timeout=7200" \
    --limit 250
```

## Test Result

MiniMax-M3-MXFP8, MoRIIO 2P2D wide-EP DP16 (proxy). GSM8K flexible-extract, threshold 0.80.

| Variant | Health | GSM8K exact_match |
| --- | --- | --- |
| No fix (re-advertises completed WRITE) | Pass | — (one-token / preempted requests hang) |
| This fix | Pass | **0.8125** (PASS) |
