### PR TITLE
[Bugfix][MM] Fix JinaVL processing cache order

### DIFF
--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -390,14 +390,6 @@ def test_processing_correctness(
             "OpenVLA uses a custom vLLM processor because its HF remote "
             "processor is incompatible with current Transformers."
         )
-    if model_id == "jinaai/jina-reranker-m0":
-        pytest.skip(
-            "JinaVL reverses the multi-modal item order inside "
-            "_apply_hf_processor_main to match its document-before-query "
-            "score template, which breaks the positional correspondence "
-            "between multi-modal kwargs and hashes assumed by the "
-            "processing cache. Needs a fix that keeps both consistent."
-        )
     if model_id == "mistralai/Voxtral-Mini-4B-Realtime-2602":
         pytest.skip(
             "Voxtral Realtime doesn't make use of any place-holder "

--- a/tests/models/multimodal/processing/test_qwen2_vl.py
+++ b/tests/models/multimodal/processing/test_qwen2_vl.py
@@ -4,13 +4,64 @@
 import pytest
 import torch
 from packaging.version import Version
+from PIL import Image
 from transformers import __version__ as TRANSFORMERS_VERSION
 
 from vllm.model_executor.models.vision import FusedInputNorm
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.cache import MultiModalProcessorOnlyCache
+from vllm.multimodal.inputs import batched_tensors_equal
 
 from ....conftest import ImageTestAssets
 from ...utils import build_model_context
+
+
+def test_jina_vl_processing_order() -> None:
+    """Jina's document-first prompt keeps cached features and hashes aligned."""
+    ctx = build_model_context(
+        "jinaai/jina-reranker-m0",
+        runner="pooling",
+        limit_mm_per_prompt={"image": 2},
+        mm_processor_cache_gb=1,
+    )
+    cache = MultiModalProcessorOnlyCache(ctx.model_config)
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config,
+        tokenizer=ctx.tokenizer,
+        cache=cache,
+    )
+
+    placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    query_image = Image.new("RGB", (128, 160), color=(255, 0, 0))
+    document_image = Image.new("RGB", (192, 128), color=(0, 255, 0))
+
+    def process(images: list[Image.Image]):
+        return processor(
+            placeholder * len(images),
+            mm_items=processor.info.parse_mm_data({"image": images}),
+        )
+
+    query = process([query_image])
+    document = process([document_image])
+    pair = process([query_image, document_image])
+
+    pair_items = pair["mm_kwargs"]["image"]
+    assert pair["mm_hashes"]["image"] == [
+        document["mm_hashes"]["image"][0],
+        query["mm_hashes"]["image"][0],
+    ]
+    assert batched_tensors_equal(
+        pair_items[0].get_data(),
+        document["mm_kwargs"]["image"][0].get_data(),
+    )
+    assert batched_tensors_equal(
+        pair_items[1].get_data(),
+        query["mm_kwargs"]["image"][0].get_data(),
+    )
+    assert [item.length for item in pair["mm_placeholders"]["image"]] == [
+        document["mm_placeholders"]["image"][0].length,
+        query["mm_placeholders"]["image"][0].length,
+    ]
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/models/jina_vl.py
+++ b/vllm/model_executor/models/jina_vl.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 
 import torch
 import torch.nn as nn
-from transformers import BatchFeature
 
 from vllm.config import ModelConfig, VllmConfig
 from vllm.inputs import TokensPrompt
@@ -12,7 +11,12 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import ColumnParallelLinear, RowParallelLinear
 from vllm.model_executor.layers.pooler import DispatchPooler
 from vllm.multimodal import MULTIMODAL_REGISTRY
-from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.inputs import MultiModalKwargsItems
+from vllm.multimodal.processing.processor import (
+    MultiModalProcessingInfo,
+    ProcessorInputs,
+    TimingContext,
+)
 from vllm.sequence import IntermediateTensors
 
 from .interfaces import SupportsCrossEncoding, SupportsMultiModal, SupportsScoreTemplate
@@ -55,28 +59,40 @@ class JinaVLScorer(nn.Module):
 
 
 class JinaVLMultiModalProcessor(Qwen2VLMultiModalProcessor):
-    def _apply_hf_processor_main(
+    def _cached_apply_hf_processor(
         self,
-        mm_items: MultiModalDataItems,
-        hf_processor_mm_kwargs: Mapping[str, object],
-    ) -> BatchFeature:
-        valid_mm_items = mm_items.select(
-            {k for k, c in mm_items.get_all_counts().items() if c > 0}
-        )
-        mm_data, passthrough_data = self._get_hf_mm_data(valid_mm_items)
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> MultiModalProcessingInfo:
+        mm_info = super()._cached_apply_hf_processor(inputs, timing_ctx)
 
-        if not mm_data:
-            return BatchFeature(dict(passthrough_data))
-
-        for _, value in mm_data.items():
-            value.reverse()
-        processed_data = self.info.ctx.call_hf_processor(
-            self.info.get_hf_processor(**hf_processor_mm_kwargs),
-            mm_data,
-            hf_processor_mm_kwargs,
+        # Score inputs are query-first, while the prompt template is document-first.
+        mm_kwargs = MultiModalKwargsItems(
+            {
+                modality: list(reversed(items))
+                for modality, items in mm_info.kwargs.items()
+            }
         )
-        processed_data.update(passthrough_data)
-        return processed_data
+        mm_hashes = {
+            modality: list(reversed(hashes))
+            for modality, hashes in mm_info.hashes.items()
+        }
+        mm_prompt_updates = {
+            modality: [
+                [
+                    self._recompute_cached_prompt_update(update, item_idx)
+                    for update in updates
+                ]
+                for item_idx, updates in enumerate(reversed(item_updates))
+            ]
+            for modality, item_updates in mm_info.prompt_updates.items()
+        }
+
+        return MultiModalProcessingInfo(
+            kwargs=mm_kwargs,
+            hashes=mm_hashes,
+            prompt_updates=mm_prompt_updates,
+        )
 
 
 @MULTIMODAL_REGISTRY.register_processor(


### PR DESCRIPTION
## Purpose

JinaVL score inputs are collected query-first, while its score template places the document before the query. The processor historically handled this by reversing the raw multi-modal data before HF processing.

That changes the processed-kwargs order without changing the hash order. With the processing cache enabled, partial hits can therefore associate image features with the opposite hashes. The returned kwargs, hashes, and placeholder positions can also describe different images.

This change keeps processing and cache storage in the original order, then reverses the three correlated outputs together after cache merging. Prompt-update item indices are recomputed in the final order. It also enables the existing common cache-correctness coverage for JinaVL and adds a direct two-image alignment test.

This is a pre-existing issue from the original JinaVL support in #20260, not a regression from #53275. The earlier context is discussed in https://github.com/vllm-project/vllm/pull/53275#issuecomment-5392705144.

### Duplicate-work check

No issue currently tracks this bug. Immediately before opening this PR, these required searches returned no open PRs:

- `gh pr list --repo vllm-project/vllm --state open --search "53275 in:body"`
- `gh pr list --repo vllm-project/vllm --state open --search "JinaVL processing cache"`
- Additional searches for `JinaVL multimodal cache` and `jina-reranker cache` were also empty.

## Test Plan

```bash
.venv/bin/python -m pytest tests/models/multimodal/processing/test_qwen2_vl.py::test_jina_vl_processing_order tests/models/multimodal/processing/test_common.py -k "test_jina_vl_processing_order or jina-reranker-m0" -v

.venv/bin/python -m pytest tests/models/multimodal/processing/test_qwen2_vl.py tests/models/multimodal/processing/test_common.py -k "test_jina_vl_processing_order or jina-reranker-m0 or test_fused_input_norm_initialization_on_device or test_processor_override or test_get_image_size_with_most_features or test_mm_device_do_normalize" -v

.venv/bin/pre-commit run --files vllm/model_executor/models/jina_vl.py tests/models/multimodal/processing/test_common.py tests/models/multimodal/processing/test_qwen2_vl.py

.venv/bin/python -m pytest tests/models/multimodal/pooling/test_jinavl_reranker.py -q
```

## Test Result

- Targeted JinaVL processing/cache tests: **4 passed**.
- Extended Qwen2-VL/JinaVL processing regression set: **26 passed**.
- All applicable pre-commit hooks passed, including Ruff, formatting, mypy, SPDX, and forbidden-import checks.
- Model-output comparison suite: **5 skipped** because the file is currently globally skipped; `jinaai/jina-reranker-m0` remote code is incompatible with Transformers v5 due to the missing `all_tied_weights_keys`. No model-output eval result is claimed. The new tests exercise the real Jina HF processor and directly verify feature/hash/placeholder alignment without loading model weights.

## AI assistance disclosure

OpenAI Codex assisted with repository exploration, implementation, and test drafting. I reviewed every changed line, understand and can defend the cache-ordering change, and reviewed the test commands and results above.