### PR TITLE
[Perf][GLM-5.2] Reuse Sparse Physical Indices via Attention Metadata with DCP

### DIFF
--- a/tests/kernels/test_fused_deepseek_v32_norm_rope.py
+++ b/tests/kernels/test_fused_deepseek_v32_norm_rope.py
@@ -234,6 +234,63 @@ def test_fused_norm_rope(num_tokens: int, index_interleave: bool, mla_dtype: str
     assert (topk == -1).all(), "topk buffer not cleared on indexer layer"
 
 
+def test_fused_norm_rope_normalizes_query_without_local_cache_slots():
+    """DCP non-owner ranks still need valid query shards for query AllGather."""
+    torch.manual_seed(7)
+    dev = "cuda"
+    num_tokens = 4
+    max_pos = 16
+    pos = torch.arange(num_tokens, device=dev, dtype=torch.int64)
+
+    q_c = torch.randn(num_tokens, Q_LORA, device=dev, dtype=torch.bfloat16)
+    kv_c = torch.randn(num_tokens, KV_LORA, device=dev, dtype=torch.bfloat16)
+    k_pe = torch.randn(num_tokens, ROPE_DIM, device=dev, dtype=torch.bfloat16)
+    qw = torch.randn(Q_LORA, device=dev, dtype=torch.bfloat16)
+    kvw = torch.randn(KV_LORA, device=dev, dtype=torch.bfloat16)
+    ik = torch.randn(num_tokens, INDEX_HEAD_DIM, device=dev, dtype=torch.bfloat16)
+    ikw = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    ikb = torch.randn(INDEX_HEAD_DIM, device=dev, dtype=torch.float32)
+    cos_sin = make_cos_sin(max_pos, ROPE_DIM, dev)
+
+    mla_cache = torch.zeros(
+        1, max_pos, KV_LORA + ROPE_DIM, device=dev, dtype=torch.bfloat16
+    )
+    idx_row = INDEX_HEAD_DIM + INDEX_HEAD_DIM // 128 * 4
+    idx_cache = torch.zeros(1, max_pos, idx_row, device=dev, dtype=torch.uint8)
+    no_local_slots = torch.full((num_tokens,), -1, device=dev, dtype=torch.int64)
+    topk = torch.full((num_tokens, 2048), 7, device=dev, dtype=torch.int32)
+
+    q_out = K.fused_norm_rope(
+        pos,
+        q_c,
+        qw,
+        EPS,
+        kv_c,
+        kvw,
+        EPS,
+        k_pe,
+        cos_sin,
+        ik,
+        ikw,
+        ikb,
+        EPS,
+        cos_sin,
+        topk,
+        slot_mapping=no_local_slots,
+        indexer_k_cache=idx_cache,
+        mla_kv_cache=mla_cache,
+        mla_kv_cache_dtype="auto",
+        mla_k_scale=None,
+        has_indexer=True,
+        index_rope_interleave=True,
+    )
+
+    assert_bf16(q_out, rms_norm(q_c, qw), "q_c rmsnorm without local cache slots")
+    assert not mla_cache.any(), "non-owner rank wrote the MLA KV cache"
+    assert not idx_cache.any(), "non-owner rank wrote the indexer KV cache"
+    assert (topk == -1).all(), "topk buffer not cleared on non-owner rank"
+
+
 @pytest.mark.parametrize("num_tokens", [1, 17, 512])
 def test_fused_norm_rope_no_indexer(num_tokens: int):
     """Shared (no-indexer) layer: q + kv/MLA only; top-k buffer untouched."""

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -51,6 +51,9 @@ from vllm.v1.attention.backends.mla.flashmla_sparse import (
     triton_convert_req_index_to_global_index,
 )
 from vllm.v1.attention.backends.mla.indexer import split_indexer_prefill_chunks
+from vllm.v1.attention.backends.mla.sparse_utils import (
+    triton_filter_and_convert_dcp_index,
+)
 from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
     split_prefill_chunks,
@@ -809,30 +812,48 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
         ),
         block_table=torch.arange(40, dtype=torch.int32, device=device).view(4, 10),
         block_size=block_size,
+        physical_topk_indices=torch.empty(
+            num_mqa_tokens,
+            num_topk_tokens,
+            dtype=torch.int32,
+            device=device,
+        ),
+        physical_topk_valid_counts=torch.empty(
+            num_mqa_tokens, dtype=torch.int32, device=device
+        ),
+        physical_topk_is_valid=False,
     )
     assert attn_metadata.req_id_per_token.shape[0] == num_batch_tokens
 
     q = torch.zeros(num_mqa_tokens, 4, 576, dtype=torch.bfloat16, device=device)
     kv_cache = torch.zeros(40, block_size, 576, dtype=torch.bfloat16, device=device)
-    topk_indices = torch.randint(
-        0,
-        block_size * 10,
-        (num_mqa_tokens, num_topk_tokens),
+    topk_indices = torch.arange(
+        num_mqa_tokens * num_topk_tokens,
         dtype=torch.int32,
         device=device,
-    )
+    ).view(num_mqa_tokens, num_topk_tokens)
 
     captured = {}
 
     def _stub_kernel(q, kv, indices, lengths):
         captured["indices"] = indices
-        return torch.zeros(q.shape[0], q.shape[1], 512, dtype=q.dtype, device=q.device)
+        return (
+            torch.zeros(q.shape[0], q.shape[1], 512, dtype=q.dtype, device=q.device),
+            None,
+        )
 
-    stub_impl = SimpleNamespace(_bf16_flash_mla_kernel=_stub_kernel)
-
-    out = FlashMLASparseImpl._forward_bf16_kv(
-        stub_impl, q, kv_cache, topk_indices, attn_metadata
+    stub_impl = SimpleNamespace(
+        _bf16_flash_mla_kernel=_stub_kernel,
+        kv_cache_dtype="auto",
+        topk_indices_buffer=topk_indices,
+        dcp_world_size=1,
+        need_to_return_lse_for_decode=False,
     )
+    stub_impl._forward_bf16_kv = MethodType(
+        FlashMLASparseImpl._forward_bf16_kv, stub_impl
+    )
+
+    out, _ = FlashMLASparseImpl.forward_mqa(stub_impl, q, kv_cache, attn_metadata, None)
 
     assert out.shape[0] == num_mqa_tokens
     assert captured["indices"].shape[0] == num_mqa_tokens
@@ -843,6 +864,10 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
         block_size,
         num_topk_tokens,
     )
+    torch.testing.assert_close(captured["indices"], reference, rtol=0, atol=0)
+
+    topk_indices.zero_()
+    FlashMLASparseImpl.forward_mqa(stub_impl, q, kv_cache, attn_metadata, None)
     torch.testing.assert_close(captured["indices"], reference, rtol=0, atol=0)
 
 
@@ -1302,6 +1327,25 @@ def test_triton_convert_returns_valid_counts(num_topk_tokens: int):
 
     torch.testing.assert_close(valid_counts, expected_valid_tensor, rtol=0, atol=0)
 
+    output_buffer = torch.empty_like(token_indices)
+    valid_counts_buffer = torch.full_like(expected_valid_tensor, -1)
+    buffered_result, buffered_valid_counts = triton_convert_req_index_to_global_index(
+        req_id,
+        block_table,
+        token_indices,
+        BLOCK_SIZE=block_size,
+        NUM_TOPK_TOKENS=num_topk_tokens,
+        return_valid_counts=True,
+        output=output_buffer,
+        valid_counts_out=valid_counts_buffer,
+    )
+    assert buffered_result.data_ptr() == output_buffer.data_ptr()
+    assert buffered_valid_counts.data_ptr() == valid_counts_buffer.data_ptr()
+    torch.testing.assert_close(buffered_result, result, rtol=0, atol=0)
+    torch.testing.assert_close(
+        buffered_valid_counts, expected_valid_tensor, rtol=0, atol=0
+    )
+
     # Test that return_valid_counts=False returns only the indices
     result_only = triton_convert_req_index_to_global_index(
         req_id,
@@ -1487,6 +1531,11 @@ def test_flashmla_fp8_paths_accept_decode_subset(monkeypatch, use_mixed_batch: b
         ),
         block_table=torch.empty(1, 1, dtype=torch.int32, device=DEVICE_TYPE),
         block_size=64,
+        physical_topk_indices=torch.empty_like(topk_indices),
+        physical_topk_valid_counts=torch.empty(
+            num_decode_tokens, dtype=torch.int32, device=DEVICE_TYPE
+        ),
+        physical_topk_is_valid=False,
     )
     impl = SimpleNamespace(
         kv_cache_dtype="fp8_ds_mla",
@@ -1621,10 +1670,17 @@ def test_fp8_mixed_batch_dcp_neutralizes_empty_rows(monkeypatch):
         device=DEVICE_TYPE,
     )
 
+    convert_calls = 0
+
+    def convert_indices(*args, **kwargs):  # noqa: ARG001
+        nonlocal convert_calls
+        convert_calls += 1
+        return kwargs["output"].copy_(local_indices)
+
     monkeypatch.setattr(
         "vllm.v1.attention.backends.mla.flashmla_sparse."
         "triton_filter_and_convert_dcp_index",
-        lambda *args, **kwargs: local_indices,
+        convert_indices,
     )
 
     def run_kernel(**kwargs):
@@ -1647,16 +1703,27 @@ def test_fp8_mixed_batch_dcp_neutralizes_empty_rows(monkeypatch):
         block_table=torch.empty(1, 1, dtype=torch.int32, device=DEVICE_TYPE),
         block_size=64,
         cp_kv_cache_interleave_size=1,
+        fp8_use_mixed_batch=True,
+        physical_topk_indices=torch.empty_like(local_indices),
+        physical_topk_valid_counts=torch.empty(
+            num_tokens, dtype=torch.int32, device=DEVICE_TYPE
+        ),
+        physical_topk_is_valid=False,
     )
     impl = SimpleNamespace(
+        kv_cache_dtype="fp8_ds_mla",
+        topk_indices_buffer=local_indices,
         dcp_world_size=2,
         dcp_rank=0,
         need_to_return_lse_for_decode=True,
         _fp8_flash_mla_kernel=run_kernel,
     )
+    impl._forward_fp8_kv_mixed_batch = MethodType(
+        FlashMLASparseImpl._forward_fp8_kv_mixed_batch, impl
+    )
 
-    out, lse = FlashMLASparseImpl._forward_fp8_kv_mixed_batch(
-        impl, q, torch.empty(0, device=DEVICE_TYPE), local_indices, metadata
+    out, lse = FlashMLASparseImpl.forward_mqa(
+        impl, q, torch.empty(0, device=DEVICE_TYPE), metadata, None
     )
 
     assert torch.equal(out[1], torch.zeros_like(out[1]))
@@ -1667,3 +1734,50 @@ def test_fp8_mixed_batch_dcp_neutralizes_empty_rows(monkeypatch):
     assert out.is_contiguous()
     assert not out.isnan().any()
     assert not lse.isnan().any()
+
+    local_indices.zero_()
+    FlashMLASparseImpl.forward_mqa(
+        impl, q, torch.empty(0, device=DEVICE_TYPE), metadata, None
+    )
+    assert convert_calls == 1
+
+
+@pytest.mark.parametrize("compact_valid_to_front", [False, True])
+def test_dcp_convert_reuses_output_buffers(compact_valid_to_front: bool):
+    device = torch.device(DEVICE_TYPE)
+    num_topk_tokens = 128
+    req_id = torch.zeros(2, dtype=torch.int32, device=device)
+    block_table = torch.arange(8, dtype=torch.int32, device=device).view(1, 8)
+    token_indices = torch.arange(
+        2 * num_topk_tokens, dtype=torch.int32, device=device
+    ).view(2, num_topk_tokens)
+
+    expected, expected_counts = triton_filter_and_convert_dcp_index(
+        req_id,
+        block_table,
+        token_indices,
+        dcp_size=2,
+        dcp_rank=0,
+        NUM_TOPK_TOKENS=num_topk_tokens,
+        return_valid_counts=True,
+        compact_valid_to_front=compact_valid_to_front,
+    )
+    output = torch.empty_like(token_indices)
+    valid_counts = torch.full((2,), -1, dtype=torch.int32, device=device)
+    actual, actual_counts = triton_filter_and_convert_dcp_index(
+        req_id,
+        block_table,
+        token_indices,
+        dcp_size=2,
+        dcp_rank=0,
+        NUM_TOPK_TOKENS=num_topk_tokens,
+        return_valid_counts=True,
+        compact_valid_to_front=compact_valid_to_front,
+        output=output,
+        valid_counts_out=valid_counts,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    assert actual_counts.data_ptr() == valid_counts.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual_counts, expected_counts, rtol=0, atol=0)

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -512,29 +512,46 @@ class DeepseekV32Attention(MLAAttention):
             if isinstance(mqa_q_arg, tuple):
                 mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
             mqa_q_arg = get_tp_group().all_gather(mqa_q_arg, dim=1)
+        elif not self.use_pcp and self.impl.dcp_world_size > 1:
+            # TODO: Use dcp_manager.query_gather after #52377 adds an
+            # oversized-input fallback for sparse mixed batches.
+            assert self.dcp_manager is not None
+            if isinstance(mqa_q_arg, tuple):
+                mqa_q_arg = torch.cat(mqa_q_arg, dim=-1)
+            mqa_q_arg = self.dcp_manager.group.all_gather(mqa_q_arg, dim=1)
         attn_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
             mqa_q_arg, kv_cache, attn_metadata, self
         )
 
-        if self.use_pcp and self.impl.dcp_world_size > 1:
+        if self.impl.dcp_world_size > 1:
             assert lse is not None and self.dcp_manager is not None
-            seq_lens = (
-                attn_metadata.decode.seq_lens
-                if attn_metadata.decode is not None
-                else cast(torch.Tensor, attn_metadata.seq_lens)[  # type: ignore[attr-defined]
-                    : attn_metadata.num_decodes
+            seq_lens: torch.Tensor | None
+            query_start_loc: torch.Tensor | None
+            if self.use_pcp:
+                if attn_metadata.decode is not None:
+                    seq_lens = attn_metadata.decode.seq_lens
+                else:
+                    all_seq_lens = cast(
+                        torch.Tensor,
+                        attn_metadata.seq_lens,  # type: ignore[attr-defined]
+                    )
+                    seq_lens = all_seq_lens[: attn_metadata.num_decodes]
+                query_start_loc = attn_metadata.query_start_loc[
+                    : attn_metadata.num_decodes + 1
                 ]
-            )
-            query_start_loc = attn_metadata.query_start_loc[
-                : attn_metadata.num_decodes + 1
-            ]
+            else:
+                # The backend emits (0, -inf) for empty local shards, so no
+                # PCP-only empty-shard metadata is needed.
+                seq_lens = None
+                query_start_loc = None
             attn_out = self.dcp_manager.combine(
                 attn_out,
                 lse,
-                seq_lens=seq_lens,
-                query_start_loc=query_start_loc,
+                seq_lens=seq_lens,  # type: ignore[arg-type]
+                query_start_loc=query_start_loc,  # type: ignore[arg-type]
             )
-            attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
+            if self.use_pcp:
+                attn_out = finalize_mla_pcp_decode(attn_out, self.num_heads)
 
         # NOTE(woosuk): While the below does not need to be in the eager region,
         # we put it here to avoid copying the attention output. Move this back to the

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -180,22 +180,29 @@ def _fused_norm_rope_kernel(
             )
         return
 
-    if slot_mapping_ptr is None:
-        if kv_out_ptr is None and kpe_out_ptr is None and index_k_out_ptr is None:
-            return
-    elif tl.load(slot_mapping_ptr + tok_idx) < 0:
-        # Padding
-        return
-
     if pid == 2:
-        # Q RMS norm
+        # Q RMS norm. Runs for every row: under DCP a negative slot only
+        # means another rank owns this token's KV slot, but the query is
+        # still needed on every rank (queries are not sharded), so the
+        # slot-based skip below must not gate it. Padding rows do harmless
+        # row-local extra work (no position load, no cache write).
         q_block = tl.arange(0, Q_BLOCK_SIZE)
         q_mask = q_block < Q_DIM
         q_c = tl.load(q_c_ptr + tok_idx * q_c_stride + q_block, mask=q_mask, other=0.0)
         q_c_rms_w = tl.load(q_rms_norm_w_ptr + q_block, mask=q_mask)
         q_c = _rms_norm(q_c, q_c_rms_w, q_rms_eps, Q_DIM)
         tl.store(q_c_out_ptr + tok_idx * q_c_out_stride + q_block, q_c, mask=q_mask)
-    elif pid == 1:
+        return
+
+    if slot_mapping_ptr is None:
+        if kv_out_ptr is None and kpe_out_ptr is None and index_k_out_ptr is None:
+            return
+    elif tl.load(slot_mapping_ptr + tok_idx) < 0:
+        # Padding, or (under DCP) a token whose KV slot another rank owns:
+        # skip the K-side norms and cache writes.
+        return
+
+    if pid == 1:
         # KV RMS Norm + KV RoPE + MLA concat_and_cache.
         # Merged so the normed kv_c and RoPE'd k_pe can be written
         # to the MLA KV cache directly without a separate kernel.

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -35,6 +35,7 @@ from vllm.v1.kv_cache_interface import AttentionSpec
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
+    from vllm.v1.attention.backend import CommonAttentionMetadata
 
 logger = init_logger(__name__)
 
@@ -229,6 +230,9 @@ class FlashInferMLASparseMetadata(AttentionMetadata):
     block_size: int = 64
     topk_tokens: int = 2048
     cp_kv_cache_interleave_size: int = 1
+    physical_topk_indices: torch.Tensor | None = None
+    physical_topk_valid_counts: torch.Tensor | None = None
+    physical_topk_is_valid: bool = False
 
 
 class FlashInferMLASparseMetadataBuilder(
@@ -248,6 +252,14 @@ class FlashInferMLASparseMetadataBuilder(
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
 
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.physical_topk_indices = torch.empty(
+            (max_num_tokens, self.topk_tokens), dtype=torch.int32, device=device
+        )
+        self.physical_topk_valid_counts = torch.empty(
+            max_num_tokens, dtype=torch.int32, device=device
+        )
+
         num_q_heads = vllm_config.model_config.get_num_attention_heads(
             vllm_config.parallel_config
         )
@@ -259,6 +271,17 @@ class FlashInferMLASparseMetadataBuilder(
             supports_spec_as_decode=True,
             supports_dcp_with_varlen=True,
         )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: "CommonAttentionMetadata",
+        fast_build: bool = False,
+    ) -> FlashInferMLASparseMetadata:
+        metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        metadata.physical_topk_indices = self.physical_topk_indices
+        metadata.physical_topk_valid_counts = self.physical_topk_valid_counts
+        return metadata
 
 
 # Global workspace buffer (lazily initialized)
@@ -360,27 +383,47 @@ class FlashInferMLASparseImpl(SparseMLACommonImpl[FlashInferMLASparseMetadata]):
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        if self.dcp_world_size > 1:
-            topk_indices_physical, seq_lens = triton_filter_and_convert_dcp_index(
-                attn_metadata.req_id_per_token[:num_actual_toks],
-                attn_metadata.block_table,
-                topk_indices,
-                dcp_size=self.dcp_world_size,
-                dcp_rank=self.dcp_rank,
-                cp_kv_cache_interleave_size=(attn_metadata.cp_kv_cache_interleave_size),
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-                return_valid_counts=True,
-            )
+        assert attn_metadata.physical_topk_indices is not None
+        assert attn_metadata.physical_topk_valid_counts is not None
+        physical_indices = attn_metadata.physical_topk_indices[:num_actual_toks]
+        valid_counts = attn_metadata.physical_topk_valid_counts[:num_actual_toks]
+        wrote_fresh_topk = getattr(layer, "indexer", None) is not None and not getattr(
+            layer, "skip_topk", False
+        )
+        if wrote_fresh_topk or not attn_metadata.physical_topk_is_valid:
+            if self.dcp_world_size > 1:
+                topk_indices_physical, seq_lens = triton_filter_and_convert_dcp_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    dcp_size=self.dcp_world_size,
+                    dcp_rank=self.dcp_rank,
+                    cp_kv_cache_interleave_size=(
+                        attn_metadata.cp_kv_cache_interleave_size
+                    ),
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                    return_valid_counts=True,
+                    output=physical_indices,
+                    valid_counts_out=valid_counts,
+                )
+            else:
+                topk_indices_physical, seq_lens = (
+                    triton_convert_req_index_to_global_index(
+                        attn_metadata.req_id_per_token[:num_actual_toks],
+                        attn_metadata.block_table,
+                        topk_indices,
+                        BLOCK_SIZE=attn_metadata.block_size,
+                        NUM_TOPK_TOKENS=topk_indices.shape[1],
+                        return_valid_counts=True,
+                        output=physical_indices,
+                        valid_counts_out=valid_counts,
+                    )
+                )
+            attn_metadata.physical_topk_is_valid = True
         else:
-            topk_indices_physical, seq_lens = triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[:num_actual_toks],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-                return_valid_counts=True,
-            )
+            topk_indices_physical = physical_indices
+            seq_lens = valid_counts
 
         if self._workspace_buffer is None:
             self._workspace_buffer = _get_workspace_buffer(q.device)

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``."""
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -118,16 +118,22 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
-            triton_convert_req_index_to_global_index(
+        assert attn_metadata.physical_topk_indices is not None
+        topk_indices_physical = attn_metadata.physical_topk_indices[:num_actual_toks]
+        wrote_fresh_topk = getattr(layer, "indexer", None) is not None and not getattr(
+            layer, "skip_topk", False
+        )
+        if wrote_fresh_topk or not attn_metadata.physical_topk_is_valid:
+            topk_indices_physical = triton_convert_req_index_to_global_index(
                 attn_metadata.req_id_per_token[:num_actual_toks],
                 attn_metadata.block_table,
                 topk_indices,
                 BLOCK_SIZE=attn_metadata.block_size,
                 NUM_TOPK_TOKENS=topk_indices.shape[1],
-            ),
-        )
+                output=topk_indices_physical,
+            )
+            assert isinstance(topk_indices_physical, torch.Tensor)
+            attn_metadata.physical_topk_is_valid = True
 
         output = q.new_empty(
             (num_actual_toks, self.num_heads, self.kv_lora_rank),

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -205,6 +205,9 @@ class FlashMLASparseMetadata(AttentionMetadata):
 
     fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
     fp8_use_mixed_batch: bool = False
+    physical_topk_indices: torch.Tensor | None = None
+    physical_topk_valid_counts: torch.Tensor | None = None
+    physical_topk_is_valid: bool = False
 
 
 def get_prefill_workspace_size(max_model_len: int):
@@ -234,6 +237,14 @@ class FlashMLASparseMetadataBuilder(
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         cache_config = vllm_config.cache_config
         parallel_config = vllm_config.parallel_config
+
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.physical_topk_indices = torch.empty(
+            (max_num_tokens, self.topk_tokens), dtype=torch.int32, device=device
+        )
+        self.physical_topk_valid_counts = torch.empty(
+            max_num_tokens, dtype=torch.int32, device=device
+        )
 
         num_q_heads = self.model_config.get_num_attention_heads(parallel_config)
         if current_platform.is_device_capability_family(100):
@@ -522,6 +533,8 @@ class FlashMLASparseMetadataBuilder(
         fast_build: bool = False,
     ) -> FlashMLASparseMetadata:
         metadata = super().build(common_prefix_len, common_attn_metadata, fast_build)
+        metadata.physical_topk_indices = self.physical_topk_indices
+        metadata.physical_topk_valid_counts = self.physical_topk_valid_counts
 
         metadata.fp8_use_mixed_batch = self.fp8_use_mixed_batch
         if self.use_fp8_kv_cache:
@@ -625,23 +638,10 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         q: torch.Tensor,
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
-        attn_metadata: FlashMLASparseMetadata,
+        topk_length: torch.Tensor,
+        block_size: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill). req_id_per_token covers the whole batch; slice it
-        # to the MQA tokens (q may exclude prefill tokens routed to dense MHA).
-        kv_rows, block_stride_rows = flat_kv_row_view(
-            kv_c_and_k_pe_cache, attn_metadata.block_size
-        )
-        topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            BLOCK_STRIDE_ROWS=block_stride_rows,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-            return_valid_counts=True,
-        )
+        kv_rows, _ = flat_kv_row_view(kv_c_and_k_pe_cache, block_size)
 
         return self._bf16_flash_mla_kernel(
             q,
@@ -655,6 +655,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         q: torch.Tensor,
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
+        topk_length: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
     ) -> torch.Tensor:
         fp8_metadata = attn_metadata.fp8_extra_metadata
@@ -666,36 +667,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         assert num_prefill_tokens in (0, fp8_metadata.num_prefill_tokens), (
             "FP8 sparse MLA expects either the decode subset or the full batch"
         )
-
-        prefill_request_ids = None
-        prefill_workspace_starts = None
-        has_prefill_workspace = False
-        if num_prefill_tokens > 0:
-            assert fp8_metadata.prefill is not None
-            prefill_request_ids = fp8_metadata.prefill.request_ids
-            prefill_workspace_starts = fp8_metadata.prefill.workspace_starts
-            has_prefill_workspace = True
-
-        # Convert per-request indices to global slots (decode) or workspace
-        # offsets (prefill).
-        # For FP8 cache: prefill uses workspace mapping (upconverted to BF16)
-        # For BF16 cache: always use global cache slots (no workspace)
-        # prefill_workspace_starts has been adjusted in-place per chunk so
-        # prefill indices automatically come out chunk-local
-        topk_indices, topk_length = triton_convert_req_index_to_global_index(
-            attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-            attn_metadata.block_table,
-            topk_indices,
-            BLOCK_SIZE=attn_metadata.block_size,
-            NUM_TOPK_TOKENS=topk_indices.shape[1],
-            HAS_PREFILL_WORKSPACE=has_prefill_workspace,
-            prefill_workspace_request_ids=prefill_request_ids,
-            prefill_workspace_starts=prefill_workspace_starts,
-            return_valid_counts=True,
-        )
-
-        fp8_metadata = attn_metadata.fp8_extra_metadata
-        assert isinstance(fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode)
 
         def _fp8_decode(
             q: torch.Tensor,
@@ -776,34 +747,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
 
         The lse is only returned when DCP needs it, otherwise None.
         """
-        if self.dcp_world_size > 1:
-            # The indexer emits global token ids; keep this rank's shard and
-            # convert to local slots. compact_valid_to_front=False keeps the
-            # scattered -1s, which the fp8 kernel masks natively and the
-            # empty-row neutralization below relies on. req_id is sliced to
-            # topk_indices rows (the converter grids from req_id).
-            topk_indices = triton_filter_and_convert_dcp_index(
-                attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-                attn_metadata.block_table,
-                topk_indices,
-                dcp_size=self.dcp_world_size,
-                dcp_rank=self.dcp_rank,
-                cp_kv_cache_interleave_size=attn_metadata.cp_kv_cache_interleave_size,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-                compact_valid_to_front=False,
-            )
-        else:
-            # Convert per-request indices to global slots (decode) or workspace
-            # offsets (prefill).
-            topk_indices = triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[: topk_indices.shape[0]],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-            )
-
         assert attn_metadata.fp8_extra_metadata is not None
         assert isinstance(
             attn_metadata.fp8_extra_metadata, FlashMLASparseMetadata.FP8KernelMetadata
@@ -940,22 +883,99 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
         use_fp8_cache = self.kv_cache_dtype == "fp8_ds_mla"
+        fp8_use_mixed_batch = use_fp8_cache and attn_metadata.fp8_use_mixed_batch
+        refresh_physical_topk = getattr(
+            layer, "indexer", None
+        ) is not None and not getattr(layer, "skip_topk", False)
+
+        assert attn_metadata.physical_topk_indices is not None
+        physical_indices = attn_metadata.physical_topk_indices[:num_actual_toks]
+        topk_length = None
+        if not fp8_use_mixed_batch:
+            assert attn_metadata.physical_topk_valid_counts is not None
+            topk_length = attn_metadata.physical_topk_valid_counts[:num_actual_toks]
+
+        if refresh_physical_topk or not attn_metadata.physical_topk_is_valid:
+            if self.dcp_world_size > 1:
+                converted = triton_filter_and_convert_dcp_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    dcp_size=self.dcp_world_size,
+                    dcp_rank=self.dcp_rank,
+                    cp_kv_cache_interleave_size=(
+                        attn_metadata.cp_kv_cache_interleave_size
+                    ),
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                    compact_valid_to_front=False,
+                    output=physical_indices,
+                )
+            else:
+                prefill_request_ids = None
+                prefill_workspace_starts = None
+                has_prefill_workspace = False
+                if use_fp8_cache and not fp8_use_mixed_batch:
+                    fp8_metadata = attn_metadata.fp8_extra_metadata
+                    assert isinstance(
+                        fp8_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode
+                    )
+                    if num_actual_toks > fp8_metadata.num_decode_tokens:
+                        assert fp8_metadata.prefill is not None
+                        prefill_request_ids = fp8_metadata.prefill.request_ids
+                        prefill_workspace_starts = fp8_metadata.prefill.workspace_starts
+                        has_prefill_workspace = True
+
+                block_stride_rows = None
+                if not use_fp8_cache:
+                    _, block_stride_rows = flat_kv_row_view(
+                        kv_c_and_k_pe_cache, attn_metadata.block_size
+                    )
+                converted = triton_convert_req_index_to_global_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    BLOCK_STRIDE_ROWS=block_stride_rows,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                    HAS_PREFILL_WORKSPACE=has_prefill_workspace,
+                    prefill_workspace_request_ids=prefill_request_ids,
+                    prefill_workspace_starts=prefill_workspace_starts,
+                    return_valid_counts=not fp8_use_mixed_batch,
+                    output=physical_indices,
+                    valid_counts_out=topk_length,
+                )
+            if fp8_use_mixed_batch:
+                assert isinstance(converted, torch.Tensor)
+                topk_indices = converted
+            else:
+                assert isinstance(converted, tuple)
+                topk_indices, topk_length = converted
+            attn_metadata.physical_topk_is_valid = True
+        else:
+            topk_indices = physical_indices
 
         lse: torch.Tensor | None = None
 
         if not use_fp8_cache:
+            assert topk_length is not None
             attn_out, bf16_lse = self._forward_bf16_kv(
-                q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
+                q,
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                topk_length,
+                attn_metadata.block_size,
             )
             if self.need_to_return_lse_for_decode:
                 lse = bf16_lse
-        elif attn_metadata.fp8_use_mixed_batch:
+        elif fp8_use_mixed_batch:
             attn_out, lse = self._forward_fp8_kv_mixed_batch(
                 q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
             )
         else:
+            assert topk_length is not None
             attn_out = self._forward_fp8_kv_separate_prefill_decode(
-                q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
+                q, kv_c_and_k_pe_cache, topk_indices, topk_length, attn_metadata
             )
 
         return attn_out, lse

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -186,6 +186,8 @@ def triton_convert_req_index_to_global_index(
     prefill_workspace_request_ids: torch.Tensor | None = None,
     prefill_workspace_starts: torch.Tensor | None = None,
     return_valid_counts: bool = False,
+    output: torch.Tensor | None = None,
+    valid_counts_out: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     out[token_id, indice_id] =
@@ -208,6 +210,7 @@ def triton_convert_req_index_to_global_index(
 
     When return_valid_counts is True, also returns the count of valid (non -1)
     indices per row, computed during the same kernel pass (no extra overhead).
+    Callers may provide output and valid_counts_out to reuse existing buffers.
     """
     assert req_id.dtype == torch.int32
     assert block_table.dtype == torch.int32
@@ -239,13 +242,31 @@ def triton_convert_req_index_to_global_index(
     req_id_c = req_id.contiguous()
     block_table_c = block_table.contiguous()
     token_indices_c = token_indices.contiguous()
-    out = torch.empty_like(token_indices_c)
+    if output is None:
+        out = torch.empty_like(token_indices_c)
+    else:
+        assert output.shape == token_indices.shape
+        assert output.dtype == torch.int32
+        assert output.device == token_indices.device
+        out = output
 
     valid_counts: torch.Tensor | None = None
     if return_valid_counts:
         # Zero-init only matters for the atomic accumulation path.
-        alloc = torch.empty if single_tile else torch.zeros
-        valid_counts = alloc(num_tokens, dtype=torch.int32, device=token_indices.device)
+        if valid_counts_out is None:
+            alloc = torch.empty if single_tile else torch.zeros
+            valid_counts = alloc(
+                num_tokens, dtype=torch.int32, device=token_indices.device
+            )
+        else:
+            assert valid_counts_out.shape == (num_tokens,)
+            assert valid_counts_out.dtype == torch.int32
+            assert valid_counts_out.device == token_indices.device
+            valid_counts = valid_counts_out
+            if not single_tile:
+                valid_counts.zero_()
+    else:
+        assert valid_counts_out is None
 
     # Strides in elements
     bt_stride0, bt_stride1 = block_table_c.stride()
@@ -311,6 +332,8 @@ def triton_filter_and_convert_dcp_index(
     BLOCK_N: int = 128,
     return_valid_counts: bool = False,
     compact_valid_to_front: bool = True,
+    output: torch.Tensor | None = None,
+    valid_counts_out: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Filter global per-request indices to this DCP rank's local slots.
 
@@ -346,6 +369,8 @@ def triton_filter_and_convert_dcp_index(
             NUM_TOPK_TOKENS=NUM_TOPK_TOKENS,
             BLOCK_N=BLOCK_N,
             return_valid_counts=return_valid_counts,
+            output=output,
+            valid_counts_out=valid_counts_out,
         )
 
     num_tokens = req_id.shape[0]
@@ -364,7 +389,14 @@ def triton_filter_and_convert_dcp_index(
         NUM_TOPK_TOKENS, BLOCK_N, count_valid
     )
 
-    if compact_valid_to_front:
+    if output is not None:
+        assert output.shape == token_indices.shape
+        assert output.dtype == torch.int32
+        assert output.device == token_indices.device
+        out = output
+        if compact_valid_to_front:
+            out.fill_(-1)
+    elif compact_valid_to_front:
         out = torch.full_like(token_indices_c, -1)
     else:
         out = torch.empty_like(token_indices_c)
@@ -372,8 +404,20 @@ def triton_filter_and_convert_dcp_index(
     valid_counts: torch.Tensor | None = None
     if count_valid:
         # Zero-init only matters for the atomic accumulation path.
-        alloc = torch.empty if single_tile else torch.zeros
-        valid_counts = alloc(num_tokens, dtype=torch.int32, device=token_indices.device)
+        if valid_counts_out is None:
+            alloc = torch.empty if single_tile else torch.zeros
+            valid_counts = alloc(
+                num_tokens, dtype=torch.int32, device=token_indices.device
+            )
+        else:
+            assert valid_counts_out.shape == (num_tokens,)
+            assert valid_counts_out.dtype == torch.int32
+            assert valid_counts_out.device == token_indices.device
+            valid_counts = valid_counts_out
+            if not single_tile:
+                valid_counts.zero_()
+    else:
+        assert valid_counts_out is None
 
     bt_stride0, bt_stride1 = block_table_c.stride()
     ti_stride0, ti_stride1 = token_indices_c.stride()


### PR DESCRIPTION


## Purpose
 Reuse Sparse Physical Indices via Attention Metadata with DCP
## Test Plan
### Test Environment

- GPUs: 8 x NVIDIA H20
- Model: `zai-org/GLM-5.2-FP8`
- Tensor parallel size: 8
- Decode context parallel size: 8
- DCP communication backend: `ag_rs`
- Attention backend: `FLASHMLA_SPARSE`
- KV cache dtype: FP8
- Execution mode: eager
- Model configuration: `index_topk_freq=4`, `index_topk=2048`
- Requests per trial: 8
- Maximum concurrency: 8
- Input/output length per request: 590 / 256 tokens
- Measured trials per configuration: 3, after warmup

```
vllm serve \
  ZhipuAI/GLM-5.2-FP8 \
  --load-format instanttensor \
  --tensor-parallel-size 8 \
  --decode-context-parallel-size 8 \
  --dcp-comm-backend ag_rs \
  --max-model-len 16384 \
  --gpu-memory-utilization 0.9 \
  --trust-remote-code \
  --attention-backend FLASHMLA_SPARSE \
  --kv-cache-dtype fp8 \
  --port 8000

```
## Test Result
### Per-trial Results

| Configuration | Trial | Duration (s) | Request throughput (req/s) | Output throughput (tok/s) | Total throughput (tok/s) | Mean latency (s) |
|---|---:|---:|---:|---:|---:|---:|
| Cache | 1 | 49.917 | 0.1603 | 41.029 | 135.586 | 49.780 |
| Cache | 2 | 49.245 | 0.1625 | 41.588 | 137.435 | 49.170 |
| Cache | 3 | 49.263 | 0.1624 | 41.573 | 137.384 | 49.191 |
| No cache | 1 | 51.253 | 0.1561 | 39.959 | 132.052 | 51.202 |
| No cache | 2 | 51.026 | 0.1568 | 40.136 | 132.638 | 50.949 |
| No cache | 3 | 50.660 | 0.1579 | 40.426 | 133.596 | 50.587 |

Each measured trial completed all eight requests and generated 2,048 output
tokens. The three trials for each configuration therefore generated 6,144
output tokens.

### Averaged Results

| Metric | No cache | Cache | Change |
|---|---:|---:|---:|
| Batch duration | 50.980 s | 49.475 s | **-2.95%** |
| Request throughput | 0.1569 req/s | 0.1617 req/s | **+3.04%** |
| Output throughput | 40.174 tok/s | 41.396 tok/s | **+3.04%** |
| Total token throughput | 132.762 tok/s | 136.802 tok/s | **+3.04%** |
| Mean request latency | 50.913 s | 49.380 s | **-3.01%** |
| P50 request latency | 50.979 s | 49.474 s | **-2.95%** |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

