### PR TITLE
[Bugfix] Support NVIDIA short-form UUID in CUDA_VISIBLE_DEVICES (#51677)

### DIFF
--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -192,5 +192,91 @@ def test_has_device_capability_comparisons(monkeypatch):
         NvmlCudaPlatform.get_device_capability.cache_clear()
 
 
+def _stub_nvml_uuids(monkeypatch, uuids: list[str]) -> None:
+    """Stub NVML to a fixed list of physical devices identified by full UUID."""
+    from vllm.platforms.cuda import pynvml
+
+    def get_handle_by_uuid(uuid: str) -> str:
+        if uuid in uuids:
+            return f"handle-{uuids.index(uuid)}"
+        raise pynvml.NVMLError_NotFound()
+
+    monkeypatch.setattr(pynvml, "nvmlInit", lambda: None)
+    monkeypatch.setattr(pynvml, "nvmlShutdown", lambda: None)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByUUID", get_handle_by_uuid)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetIndex", lambda h: int(h.split("-")[-1]))
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetCount", lambda: len(uuids))
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByIndex", lambda i: f"handle-{i}")
+    monkeypatch.setattr(
+        pynvml, "nvmlDeviceGetUUID", lambda h: uuids[int(h.split("-")[-1])]
+    )
+
+
+def test_device_control_id_accepts_full_uuid(monkeypatch):
+    """A full 36-char UUID resolves via `nvmlDeviceGetHandleByUUID` directly."""
+    from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
+
+    uuids = [
+        "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb",
+        "GPU-bcd51234-1122-3344-5566-778899aabbcc",
+    ]
+    _stub_nvml_uuids(monkeypatch, uuids)
+
+    seen: list[str] = []
+    real_by_uuid = pynvml.nvmlDeviceGetHandleByUUID
+
+    def spy_by_uuid(u: str) -> str:
+        seen.append(u)
+        return real_by_uuid(u)
+
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByUUID", spy_by_uuid)
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id(uuids[1]) == 1
+    assert seen == [uuids[1]]
+
+
+def test_device_control_id_accepts_integer(monkeypatch):
+    """A bare integer bypasses NVML entirely."""
+    from vllm.platforms.cuda import NvmlCudaPlatform
+
+    _stub_nvml_uuids(monkeypatch, [])
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("3") == 3
+
+
+def test_device_control_id_resolves_short_form_uuid(monkeypatch):
+    """NVIDIA-documented short-form `GPU-<prefix>` must resolve to the matching
+    physical device instead of crashing.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/51677:
+    `pynvml.nvmlDeviceGetHandleByUUID` requires an exact 36-char UUID and has
+    no prefix fallback, so short forms (which NVIDIA documents as valid for
+    `CUDA_VISIBLE_DEVICES`) raised `NVMLError_NotFound` and crashed engine init.
+    """
+    from vllm.platforms.cuda import NvmlCudaPlatform
+
+    uuids = [
+        "GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb",
+        "GPU-bcd51234-1122-3344-5566-778899aabbcc",
+        "GPU-c0d51234-4444-5555-6666-777788889999",
+    ]
+    _stub_nvml_uuids(monkeypatch, uuids)
+
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-af7b61d8") == 0
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-c0d51234") == 2
+    # Even a single distinguishing character after `GPU-` should resolve
+    # unambiguously — matches nvidia-smi / CUDA runtime behaviour.
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-b") == 1
+
+
+def test_device_control_id_unknown_uuid_still_raises(monkeypatch):
+    """An unknown UUID (no exact and no prefix match) still surfaces the NVML error."""
+    from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
+
+    uuids = ["GPU-af7b61d8-21af-baea-6a19-42a1f9f7c3cb"]
+    _stub_nvml_uuids(monkeypatch, uuids)
+
+    with pytest.raises(pynvml.NVMLError_NotFound):
+        NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-deadbeef")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -278,5 +278,58 @@ def test_device_control_id_unknown_uuid_still_raises(monkeypatch):
         NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-deadbeef")
 
 
+def test_short_uuid_uniquely_matches(monkeypatch):
+    """A short-form UUID that identifies exactly one GPU resolves to its index."""
+    from vllm.platforms.cuda import NvmlCudaPlatform
+
+    uuids = [
+        "GPU-abc12345-1111-2222-3333-444455556666",
+        "GPU-def45678-1111-2222-3333-444455556666",
+        "GPU-789abcde-1111-2222-3333-444455556666",
+        "GPU-fed32100-1111-2222-3333-444455556666",
+    ]
+    _stub_nvml_uuids(monkeypatch, uuids)
+
+    assert NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-def") == 1
+
+
+def test_short_uuid_ambiguous_raises(monkeypatch):
+    """An ambiguous short-form prefix matches multiple GPUs → raise ValueError.
+
+    NVIDIA documents `CUDA_VISIBLE_DEVICES=GPU-<prefix>` as valid ONLY when the
+    prefix uniquely identifies one GPU. Silently binding to the first match
+    would attach vLLM to the wrong device.
+    """
+    from vllm.platforms.cuda import NvmlCudaPlatform
+
+    uuids = [
+        "GPU-abc12345-1111-2222-3333-444455556666",
+        "GPU-abcdef99-1111-2222-3333-444455556666",
+        "GPU-78900000-1111-2222-3333-444455556666",
+        "GPU-00011122-1111-2222-3333-444455556666",
+    ]
+    _stub_nvml_uuids(monkeypatch, uuids)
+
+    with pytest.raises(ValueError) as excinfo:
+        NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-abc")
+    msg = str(excinfo.value)
+    assert "Ambiguous" in msg
+    assert "[0, 1]" in msg
+
+
+def test_short_uuid_no_match_reraises(monkeypatch):
+    """Zero matches must re-raise the original `NVMLError_NotFound`."""
+    from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
+
+    uuids = [
+        "GPU-abc12345-1111-2222-3333-444455556666",
+        "GPU-def45678-1111-2222-3333-444455556666",
+    ]
+    _stub_nvml_uuids(monkeypatch, uuids)
+
+    with pytest.raises(pynvml.NVMLError_NotFound):
+        NvmlCudaPlatform.device_control_id_to_physical_device_id("GPU-xyz")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -735,8 +735,20 @@ class NvmlCudaPlatform(CudaPlatformBase):
         try:
             return int(device_id)
         except ValueError:
+            pass
+        try:
             handle = pynvml.nvmlDeviceGetHandleByUUID(device_id)
             return pynvml.nvmlDeviceGetIndex(handle)
+        except pynvml.NVMLError_NotFound:
+            # NVIDIA documents `CUDA_VISIBLE_DEVICES=GPU-<prefix>` as a valid
+            # short form (see https://docs.nvidia.com/deploy/topics/topic_5_2_1.html),
+            # but `nvmlDeviceGetHandleByUUID` requires an exact 36-char match.
+            # Fall back to a prefix scan so vLLM behaves like CUDA/PyTorch/nvidia-smi.
+            for i in range(pynvml.nvmlDeviceGetCount()):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                if pynvml.nvmlDeviceGetUUID(handle).startswith(device_id):
+                    return i
+            raise
 
     @classmethod
     @cache

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -744,11 +744,25 @@ class NvmlCudaPlatform(CudaPlatformBase):
             # short form (see https://docs.nvidia.com/deploy/topics/topic_5_2_1.html),
             # but `nvmlDeviceGetHandleByUUID` requires an exact 36-char match.
             # Fall back to a prefix scan so vLLM behaves like CUDA/PyTorch/nvidia-smi.
-            for i in range(pynvml.nvmlDeviceGetCount()):
-                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-                if pynvml.nvmlDeviceGetUUID(handle).startswith(device_id):
-                    return i
-            raise
+            # NVIDIA only accepts a short prefix when it uniquely identifies one
+            # device; collect every match and reject ambiguity instead of
+            # silently binding to the first one.
+            matches = [
+                i
+                for i in range(pynvml.nvmlDeviceGetCount())
+                if pynvml.nvmlDeviceGetUUID(
+                    pynvml.nvmlDeviceGetHandleByIndex(i)
+                ).startswith(device_id)
+            ]
+            if len(matches) == 1:
+                return matches[0]
+            if not matches:
+                raise
+            raise ValueError(
+                f"Ambiguous short UUID {device_id!r}: "
+                f"matches physical devices {matches}. "
+                f"Provide a longer prefix that uniquely identifies one GPU."
+            ) from None
 
     @classmethod
     @cache


### PR DESCRIPTION
## Purpose

Fixes #51677.

`CUDA_VISIBLE_DEVICES=GPU-<prefix>` is a short-form UUID that NVIDIA documents as valid ([reference](https://docs.nvidia.com/deploy/topics/topic_5_2_1.html)); CUDA runtime, PyTorch, and `nvidia-smi` all resolve it. vLLM does not: `NvmlCudaPlatform.device_control_id_to_physical_device_id` calls `pynvml.nvmlDeviceGetHandleByUUID`, which requires an exact 36-char match and raises `NVMLError_NotFound` for any prefix. That crashes engine init before the model is even loaded (see the traceback in #51677).

This PR adds a prefix-scan fallback only when the exact lookup fails with `NotFound`: iterate `nvmlDeviceGetCount()`, compare each `nvmlDeviceGetUUID(handle).startswith(device_id)`, and return the matching index. Any other NVML error is left untouched, and an unknown UUID (no exact match, no prefix match) still surfaces `NVMLError_NotFound` — the fallback never silently returns a wrong index.

### Not a duplicate

- No open PR mentions `51677` (`GET /search/issues?q=repo:vllm-project/vllm+is:pr+is:open+51677` → 0 hits at the time of writing).
- Prior PR #51716 was closed by its own author on 2026-08-21 as "stale to free up capacity" (no maintainer review, not a rejection). Issue #51677 remains open and the reporter followed up on 2026-08-21 asking whether the fix is ready. My diff is smaller (+12 / −1 in `cuda.py`), reuses the existing `tests/cuda/test_cuda_context.py` file instead of creating a new module, and includes a regression test that fails on `main`.

## Test Plan

Unit tests in `tests/cuda/test_cuda_context.py` stub `pynvml` so the resolver is exercised without a real GPU:

- `test_device_control_id_accepts_full_uuid` — full 36-char UUID resolves via `nvmlDeviceGetHandleByUUID` directly, no fallback scan.
- `test_device_control_id_accepts_integer` — bare integer bypasses NVML entirely.
- `test_device_control_id_resolves_short_form_uuid` — **regression for #51677**: `GPU-af7b61d8`, `GPU-c0d51234`, and single-char `GPU-b` all resolve to the correct physical index.
- `test_device_control_id_unknown_uuid_still_raises` — an unknown UUID (no exact, no prefix match) still raises `NVMLError_NotFound`.

Commands:

```
uv venv --python 3.12 && source .venv/bin/activate
uv pip install -r requirements/lint.txt
pre-commit run --files vllm/platforms/cuda.py tests/cuda/test_cuda_context.py
pytest tests/cuda/test_cuda_context.py -v
```

## Test Result

```
tests/cuda/test_cuda_context.py::test_get_device_capability_uses_visible_device_ordinal PASSED
tests/cuda/test_cuda_context.py::test_has_device_capability_does_not_reinit_nvml PASSED
tests/cuda/test_cuda_context.py::test_has_device_capability_comparisons PASSED
tests/cuda/test_cuda_context.py::test_device_control_id_accepts_full_uuid PASSED
tests/cuda/test_cuda_context.py::test_device_control_id_accepts_integer PASSED
tests/cuda/test_cuda_context.py::test_device_control_id_resolves_short_form_uuid PASSED
tests/cuda/test_cuda_context.py::test_device_control_id_unknown_uuid_still_raises PASSED
7 passed, 4 skipped
```

The regression test fails on `main` (before the fix) with `vllm.third_party.pynvml.NVMLError_NotFound: Not Found` — the exact error the issue reports.

`pre-commit run --files vllm/platforms/cuda.py tests/cuda/test_cuda_context.py` — all hooks pass (ruff, ruff-format, typos, mypy 3.10, SPDX, forbidden imports, root lazy imports).

Model evaluation isn't affected: the change is confined to the `CUDA_VISIBLE_DEVICES` string→device-index resolver and doesn't touch any inference, sampling, or numerics code paths. No output/precision impact.

## AI-assisted disclosure

This PR was drafted with AI assistance and reviewed by the contributor before submission. Every hunk was read and reasoned about, the regression test was verified to fail on `main` and pass with the fix locally, and `pre-commit` runs clean.
