### PR TITLE
[feat]Add SLO-aware scheduling policy

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -617,6 +617,32 @@ def test_human_readable_other_args():
     assert args.max_num_batched_tokens == 2**10 * 4
 
 
+def test_slo_scheduler_cli_args_flow_to_scheduler_config():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "--scheduling-policy",
+            "slo",
+            "--slo-priority-bias=-10.0",
+            "--slo-short-request-token-threshold",
+            "2048",
+            "--slo-waiting-token-reserve-ratio",
+            "0.2",
+        ]
+    )
+    engine_args = EngineArgs.from_cli_args(args)
+
+    assert engine_args.slo_priority_bias == pytest.approx(-10.0)
+    assert engine_args.slo_short_request_token_threshold == 2048
+    assert engine_args.slo_waiting_token_reserve_ratio == 0.2
+
+    scheduler_config = engine_args.create_engine_config().scheduler_config
+    assert scheduler_config.policy == "slo"
+    assert scheduler_config.slo_priority_bias == pytest.approx(-10.0)
+    assert scheduler_config.slo_short_request_token_threshold == 2048
+    assert scheduler_config.slo_waiting_token_reserve_ratio == 0.2
+
+
 def test_numa_bind_args():
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
     args = parser.parse_args(

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 from concurrent.futures import Future
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -28,8 +28,16 @@ from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
 from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+from vllm.v1.core.sched.request_queue import (
+    FCFSRequestQueue,
+    SLORequestQueue,
+    SchedulingPolicy,
+    create_request_queue,
+)
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.sched.slo_policy import compute_waiting_token_reserve
 from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
 from vllm.v1.engine import FinishReason
 from vllm.v1.kv_cache_interface import (
@@ -120,6 +128,334 @@ def test_add_requests():
         scheduler.add_request(request)
         assert request.request_id in scheduler.requests
         assert len(scheduler.waiting) == i + 1
+
+
+def test_slo_policy_creates_slo_queue():
+    assert isinstance(create_request_queue(SchedulingPolicy.FCFS), FCFSRequestQueue)
+    assert isinstance(create_request_queue(SchedulingPolicy.SLO), SLORequestQueue)
+
+
+def test_slo_request_queue_orders_by_urgency():
+    low, high = create_requests(num_requests=2)
+    low.slo_urgency_score = 1.0
+    high.slo_urgency_score = 10.0
+
+    queue = SLORequestQueue()
+    queue.add_request(low)
+    queue.add_request(high)
+
+    assert queue.pop_request() == high
+    assert queue.pop_request() == low
+
+
+def test_slo_request_queue_handles_equal_score_and_arrival_time():
+    first, second = create_requests(num_requests=2, req_ids=["a", "b"])
+    first.slo_urgency_score = 1.0
+    second.slo_urgency_score = 1.0
+    second.arrival_time = first.arrival_time
+
+    queue = SLORequestQueue()
+    queue.add_request(first)
+    queue.add_request(second)
+
+    assert queue.pop_request() == first
+    assert queue.pop_request() == second
+
+
+def test_slo_request_queue_rebuilds_with_updated_scores():
+    low, high = create_requests(num_requests=2, req_ids=["low", "high"])
+    low.slo_urgency_score = 1.0
+    high.slo_urgency_score = 10.0
+    queue = SLORequestQueue()
+    queue.add_request(low)
+    queue.add_request(high)
+
+    low.slo_urgency_score = 20.0
+    queue.rebuild_with_updated_scores()
+
+    assert queue.pop_request() == low
+
+
+def test_slo_scheduler_sets_default_constraints():
+    scheduler = create_scheduler(policy="slo")
+    (request,) = create_requests(num_requests=1)
+
+    scheduler.add_request(request)
+
+    assert request.ttft_slo_ms == 20000.0
+
+
+@pytest.mark.parametrize(
+    ("priority_bias", "short_ttft_slo_ms", "long_ttft_slo_ms"),
+    [
+        (-10.0, 120000.0, 40000.0),
+        (-5.0, 73360.76817558299, 28340.19204389575),
+        (-2.0, 42743.48422496571, 20685.87105624143),
+        (-1.0, 40000.0, 20000.0),
+        (-0.25, 23125.0, 20000.0),
+        (0.0, 20000.0, 20000.0),
+        (0.25, 20000.0, 23125.0),
+        (1.0, 20000.0, 40000.0),
+        (2.0, 20685.87105624143, 42743.48422496571),
+        (5.0, 28340.19204389575, 73360.76817558299),
+        (10.0, 40000.0, 120000.0),
+    ],
+)
+def test_slo_scheduler_assigns_ttft_targets_by_priority_bias(
+    priority_bias: float, short_ttft_slo_ms: float, long_ttft_slo_ms: float
+):
+    scheduler = create_scheduler(
+        policy="slo",
+        slo_priority_bias=priority_bias,
+        slo_short_request_token_threshold=2048,
+    )
+    (short_request,) = create_requests(
+        num_requests=1, num_tokens=1536, req_ids=["short"]
+    )
+    (long_request,) = create_requests(
+        num_requests=1, num_tokens=6144, req_ids=["long"]
+    )
+
+    scheduler.add_request(short_request)
+    scheduler.add_request(long_request)
+
+    assert short_request.ttft_slo_ms == pytest.approx(short_ttft_slo_ms)
+    assert long_request.ttft_slo_ms == pytest.approx(long_ttft_slo_ms)
+
+
+def test_slo_scheduler_ignores_request_level_ttft_slo_override():
+    scheduler = create_scheduler(
+        policy="slo",
+        slo_priority_bias=1.0,
+        slo_short_request_token_threshold=2048,
+    )
+    (request,) = create_requests(num_requests=1, num_tokens=1536)
+    assert request.sampling_params is not None
+    request.sampling_params.extra_args = {"ttft_slo_ms": 1.0}
+
+    scheduler.add_request(request)
+
+    assert request.ttft_slo_ms == pytest.approx(20000.0)
+
+
+@pytest.mark.parametrize(
+    "invalid_priority_bias",
+    [-10.1, 10.1, float("nan"), float("inf"), float("-inf")],
+)
+def test_slo_scheduler_rejects_invalid_priority_bias(invalid_priority_bias: float):
+    with pytest.raises(ValueError):
+        create_scheduler(policy="slo", slo_priority_bias=invalid_priority_bias)
+
+
+@pytest.mark.parametrize("invalid_threshold", [0, -1])
+def test_slo_scheduler_rejects_invalid_short_request_threshold(
+    invalid_threshold: int,
+):
+    with pytest.raises(ValueError):
+        create_scheduler(
+            policy="slo",
+            slo_short_request_token_threshold=invalid_threshold,
+        )
+
+
+def test_slo_score_increases_with_wait_time():
+    scheduler = create_scheduler(policy="slo")
+    (request,) = create_requests(num_requests=1, num_tokens=100)
+    request.ttft_slo_ms = 1000.0
+    request.arrival_time = 100.0
+
+    earlier_score = scheduler._compute_slo_score(request, now=100.1)
+    later_score = scheduler._compute_slo_score(request, now=100.9)
+
+    assert later_score > earlier_score
+
+
+def test_slo_equal_deadline_prefers_shorter_uncomputed_prompt():
+    scheduler = create_scheduler(policy="slo")
+    (short_request,) = create_requests(num_requests=1, num_tokens=100)
+    (long_request,) = create_requests(num_requests=1, num_tokens=1000)
+    short_request.ttft_slo_ms = long_request.ttft_slo_ms = 1000.0
+    short_request.arrival_time = long_request.arrival_time = 100.0
+
+    short_score = scheduler._compute_slo_score(short_request, now=100.5)
+    long_score = scheduler._compute_slo_score(long_request, now=100.5)
+
+    assert short_score > long_score
+
+
+@pytest.mark.parametrize(
+    (
+        "waiting_token_reserve_ratio",
+        "running_count",
+        "running_decode_count",
+        "reserve_candidates",
+    ),
+    [
+        (0.0, 0, 0, [(10.0, 50)]),
+        (0.1, 0, 0, []),
+        (0.1, 4, 3, [(10.0, 50)]),
+    ],
+    ids=["zero_ratio", "no_candidates", "decode_majority"],
+)
+def test_slo_waiting_token_reserve_disabled(
+    waiting_token_reserve_ratio: float,
+    running_count: int,
+    running_decode_count: int,
+    reserve_candidates: list[tuple[float, int]],
+):
+    reserve = compute_waiting_token_reserve(
+        max_num_scheduled_tokens=100,
+        waiting_token_reserve_ratio=waiting_token_reserve_ratio,
+        running_count=running_count,
+        running_decode_count=running_decode_count,
+        reserve_candidates=reserve_candidates,
+    )
+
+    assert reserve == 0
+
+
+def test_slo_waiting_token_reserve_is_capped_by_ratio():
+    reserve = compute_waiting_token_reserve(
+        max_num_scheduled_tokens=100,
+        waiting_token_reserve_ratio=0.2,
+        running_count=2,
+        running_decode_count=1,
+        reserve_candidates=[(10.0, 50)],
+    )
+
+    assert reserve == 20
+
+
+def test_slo_waiting_token_reserve_is_capped_by_remaining_prompt():
+    reserve = compute_waiting_token_reserve(
+        max_num_scheduled_tokens=100,
+        waiting_token_reserve_ratio=0.2,
+        running_count=2,
+        running_decode_count=1,
+        reserve_candidates=[(10.0, 7)],
+    )
+
+    assert reserve == 7
+
+
+def test_slo_waiting_token_reserve_uses_most_urgent_candidate():
+    reserve = compute_waiting_token_reserve(
+        max_num_scheduled_tokens=100,
+        waiting_token_reserve_ratio=0.2,
+        running_count=2,
+        running_decode_count=1,
+        reserve_candidates=[(10.0, 7), (20.0, 50)],
+    )
+
+    assert reserve == 20
+
+
+def test_slo_score_refresh_uses_four_step_cadence():
+    scheduler = create_scheduler(policy="slo")
+    (request,) = create_requests(num_requests=1, num_tokens=100)
+    request.arrival_time = 60.0
+    scheduler.add_request(request)
+
+    with patch("vllm.v1.core.sched.scheduler.time.time", return_value=100.1):
+        scheduler._refresh_slo_scores_if_needed()
+    initial_score = request.slo_urgency_score
+
+    scheduler.current_step += 1
+    scheduler._mark_slo_score_dirty()
+    with patch("vllm.v1.core.sched.scheduler.time.time", return_value=100.9):
+        scheduler._refresh_slo_scores_if_needed()
+    assert request.slo_urgency_score == initial_score
+
+    scheduler.current_step += 3
+    with patch("vllm.v1.core.sched.scheduler.time.time", return_value=100.9):
+        scheduler._refresh_slo_scores_if_needed()
+    assert request.slo_urgency_score > initial_score
+
+
+def test_slo_queue_change_forces_immediate_score_refresh():
+    scheduler = create_scheduler(policy="slo")
+    first, second = create_requests(num_requests=2, num_tokens=100)
+    first.arrival_time = 60.0
+    second.arrival_time = 60.0
+    scheduler.add_request(first)
+
+    with patch("vllm.v1.core.sched.scheduler.time.time", return_value=100.1):
+        scheduler._refresh_slo_scores_if_needed()
+
+    scheduler.current_step += 1
+    scheduler.add_request(second)
+    with patch("vllm.v1.core.sched.scheduler.time.time", return_value=100.9):
+        scheduler._refresh_slo_scores_if_needed()
+
+    assert second.slo_urgency_score > 0.0
+    assert scheduler._slo_last_score_refresh_step == scheduler.current_step
+
+
+def test_fcfs_scheduler_ignores_slo_refresh_state():
+    scheduler = create_scheduler(policy="fcfs")
+
+    scheduler._mark_slo_score_dirty(force=True)
+    with patch("vllm.v1.core.sched.scheduler.time.time") as mock_time:
+        scheduler._refresh_slo_scores_if_needed()
+
+    assert isinstance(scheduler.waiting, FCFSRequestQueue)
+    assert not scheduler._slo_score_dirty
+    assert not scheduler._slo_force_score_refresh
+    mock_time.assert_not_called()
+
+
+def test_slo_waiting_admission_does_not_preempt_running_request():
+    scheduler = create_scheduler(
+        policy="slo",
+        max_num_seqs=1,
+        max_num_batched_tokens=200,
+        slo_priority_bias=-10.0,
+        slo_short_request_token_threshold=64,
+    )
+    (low,) = create_requests(num_requests=1, num_tokens=32, req_ids=["low"])
+    (high,) = create_requests(num_requests=1, num_tokens=128, req_ids=["high"])
+    high.arrival_time = low.arrival_time - 60.0
+
+    scheduler.add_request(low)
+    output = scheduler.schedule()
+    assert low.request_id in output.num_scheduled_tokens
+
+    model_output = ModelRunnerOutput(
+        req_ids=["low"],
+        req_id_to_index={"low": 0},
+        sampled_token_ids=[[100]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    scheduler.add_request(high)
+    output = scheduler.schedule()
+
+    assert "low" not in output.preempted_req_ids
+    assert low.status == RequestStatus.RUNNING
+    assert high.status == RequestStatus.WAITING
+    assert any(request.request_id == "low" for request in scheduler.running)
+    assert any(request.request_id == "high" for request in scheduler.waiting)
+
+
+def test_async_slo_scheduler_uses_slo_queue_and_schedules_request():
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        policy="slo",
+    )
+    (request,) = create_requests(num_requests=1, num_tokens=8)
+    request.arrival_time = 60.0
+    scheduler.add_request(request)
+
+    with patch("vllm.v1.core.sched.scheduler.time.time", return_value=100.1):
+        output = scheduler.schedule()
+
+    assert isinstance(scheduler, AsyncScheduler)
+    assert isinstance(scheduler.waiting, SLORequestQueue)
+    assert request.slo_urgency_score > 0.0
+    assert request.request_id in output.num_scheduled_tokens
 
 
 def test_finish_request():

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -16,6 +16,7 @@ from vllm.config import (
     SpeculativeConfig,
     VllmConfig,
 )
+from vllm.config.scheduler import SchedulerPolicy
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
     MultiModalKwargsItem,
@@ -73,6 +74,10 @@ def create_scheduler(
     use_v2_model_runner: bool | None = None,
     kv_cache_spec: KVCacheSpec | None = None,
     per_request_spec_decode_metrics: str = "none",
+    policy: SchedulerPolicy = "fcfs",
+    slo_priority_bias: float = 0.0,
+    slo_short_request_token_threshold: int = 2048,
+    slo_waiting_token_reserve_ratio: float = 0.10,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -105,6 +110,10 @@ def create_scheduler(
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        policy=policy,
+        slo_priority_bias=slo_priority_bias,
+        slo_short_request_token_threshold=slo_short_request_token_threshold,
+        slo_waiting_token_reserve_ratio=slo_waiting_token_reserve_ratio,
         # Ensure admission/preemption mechanics are deterministic
         watermark=0.0,
     )

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 RunnerType = Literal["generate", "pooling", "draft"]
-SchedulerPolicy = Literal["fcfs", "priority"]
+SchedulerPolicy = Literal["fcfs", "priority", "slo"]
 
 
 @config
@@ -102,7 +102,23 @@ class SchedulerConfig:
     - "fcfs" means first come first served, i.e. requests are handled in order 
       of arrival.
     - "priority" means requests are handled based on given priority (lower
-      value means earlier handling) and time of arrival deciding any ties)."""
+      value means earlier handling) and time of arrival deciding any ties).
+    - "slo" means requests are scheduled by TTFT SLO urgency, prioritizing
+      waiting requests closest to their first-token targets."""
+
+    slo_priority_bias: float = Field(default=0.0, ge=-10.0, le=10.0)
+    """Bias between short and long request TTFT targets in [-10, 10]. Positive
+    values prioritize short requests, negative values prioritize long requests,
+    and zero gives both classes a 20-second target. Magnitudes above one expand
+    both targets with smooth interpolation while preserving the selected
+    preference."""
+
+    slo_short_request_token_threshold: int = Field(default=2048, ge=1)
+    """Requests with prompt length at or below this threshold are treated as
+    short requests for TTFT SLO assignment."""
+
+    slo_waiting_token_reserve_ratio: float = Field(default=0.10, ge=0.0, le=1.0)
+    """Max fraction of step token budget to reserve for urgent waiting prefills."""
 
     disable_chunked_mm_input: bool = False
     """If set to true and chunked prefill is enabled, we do not want to

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -676,6 +676,13 @@ class EngineArgs:
     jit_monitor_verbose: bool = ObservabilityConfig.jit_monitor_verbose
     enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
+    slo_priority_bias: float = SchedulerConfig.slo_priority_bias
+    slo_short_request_token_threshold: int = (
+        SchedulerConfig.slo_short_request_token_threshold
+    )
+    slo_waiting_token_reserve_ratio: float = (
+        SchedulerConfig.slo_waiting_token_reserve_ratio
+    )
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
 
     pooler_config: PoolerConfig | None = ModelConfig.pooler_config
@@ -1557,6 +1564,17 @@ class EngineArgs:
             "--scheduling-policy", **scheduler_kwargs["policy"]
         )
         scheduler_group.add_argument(
+            "--slo-priority-bias", **scheduler_kwargs["slo_priority_bias"]
+        )
+        scheduler_group.add_argument(
+            "--slo-short-request-token-threshold",
+            **scheduler_kwargs["slo_short_request_token_threshold"],
+        )
+        scheduler_group.add_argument(
+            "--slo-waiting-token-reserve-ratio",
+            **scheduler_kwargs["slo_waiting_token_reserve_ratio"],
+        )
+        scheduler_group.add_argument(
             "--enable-chunked-prefill",
             **{
                 **scheduler_kwargs["enable_chunked_prefill"],
@@ -2346,6 +2364,9 @@ class EngineArgs:
             is_multimodal_model=model_config.is_multimodal_model,
             is_encoder_decoder=model_config.is_encoder_decoder,
             policy=self.scheduling_policy,
+            slo_priority_bias=self.slo_priority_bias,
+            slo_short_request_token_threshold=self.slo_short_request_token_threshold,
+            slo_waiting_token_reserve_ratio=self.slo_waiting_token_reserve_ratio,
             scheduler_cls=self.scheduler_cls,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
             scheduler_reserve_full_isl=self.scheduler_reserve_full_isl,

--- a/vllm/v1/core/sched/request_queue.py
+++ b/vllm/v1/core/sched/request_queue.py
@@ -7,6 +7,7 @@ from collections import deque
 from collections.abc import Iterable, Iterator
 from enum import Enum
 
+from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.request import Request
 
 
@@ -15,6 +16,7 @@ class SchedulingPolicy(Enum):
 
     FCFS = "fcfs"
     PRIORITY = "priority"
+    SLO = "slo"
 
 
 class RequestQueue(ABC):
@@ -198,11 +200,83 @@ class PriorityRequestQueue(RequestQueue):
             yield heapq.heappop(heap_copy)
 
 
+class SLORequestQueue(RequestQueue):
+    """A priority queue ordered by scheduler-computed SLO urgency."""
+
+    def __init__(self) -> None:
+        self._heap: list[tuple[float, float, str, Request]] = []
+
+    @staticmethod
+    def _make_entry(request: Request) -> tuple[float, float, str, Request]:
+        return (
+            -request.slo_urgency_score,
+            request.arrival_time,
+            request.request_id,
+            request,
+        )
+
+    def add_request(self, request: Request) -> None:
+        heapq.heappush(self._heap, self._make_entry(request))
+
+    def pop_request(self) -> Request:
+        if not self._heap:
+            raise IndexError("pop from empty SLO queue")
+        _, _, _, request = heapq.heappop(self._heap)
+        return request
+
+    def peek_request(self) -> Request:
+        if not self._heap:
+            raise IndexError("peek from empty SLO queue")
+        _, _, _, request = self._heap[0]
+        return request
+
+    def prepend_request(self, request: Request) -> None:
+        self.add_request(request)
+
+    def prepend_requests(self, requests: RequestQueue) -> None:
+        for request in requests:
+            self.add_request(request)
+
+    def remove_request(self, request: Request) -> None:
+        self._heap = [entry for entry in self._heap if entry[3] != request]
+        heapq.heapify(self._heap)
+
+    def remove_requests(self, requests: Iterable[Request]) -> None:
+        requests_to_remove = requests if isinstance(requests, set) else set(requests)
+        self._heap = [
+            entry for entry in self._heap if entry[3] not in requests_to_remove
+        ]
+        heapq.heapify(self._heap)
+
+    def iter_requests_unordered(self) -> Iterator[Request]:
+        for _, _, _, request in self._heap:
+            yield request
+
+    def rebuild_with_updated_scores(self) -> None:
+        with record_function_or_nullcontext("slo_queue: rebuild_with_updated_scores"):
+            self._heap = [self._make_entry(entry[3]) for entry in self._heap]
+            heapq.heapify(self._heap)
+
+    def __bool__(self) -> bool:
+        return bool(self._heap)
+
+    def __len__(self) -> int:
+        return len(self._heap)
+
+    def __iter__(self) -> Iterator[Request]:
+        heap_copy = self._heap[:]
+        while heap_copy:
+            _, _, _, request = heapq.heappop(heap_copy)
+            yield request
+
+
 def create_request_queue(policy: SchedulingPolicy) -> RequestQueue:
     """Create request queue based on scheduling policy."""
     if policy == SchedulingPolicy.PRIORITY:
         return PriorityRequestQueue()
     elif policy == SchedulingPolicy.FCFS:
         return FCFSRequestQueue()
+    elif policy == SchedulingPolicy.SLO:
+        return SLORequestQueue()
     else:
         raise ValueError(f"Unknown scheduling policy: {policy}")

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -48,8 +48,16 @@ from vllm.v1.core.sched.output import (
 )
 from vllm.v1.core.sched.request_queue import (
     RequestQueue,
+    SLORequestQueue,
     SchedulingPolicy,
     create_request_queue,
+)
+from vllm.v1.core.sched.slo_policy import (
+    SLO_PREFILL_LENGTH_BONUS,
+    compute_slo_score,
+    compute_waiting_token_reserve,
+    is_waiting_reserve_candidate,
+    set_request_slo_constraints,
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
@@ -68,6 +76,8 @@ from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputM
 from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
+
+SLO_SCORE_REFRESH_INTERVAL_STEPS = 4
 
 
 class Scheduler(SchedulerInterface):
@@ -197,6 +207,11 @@ class Scheduler(SchedulerInterface):
         # requests skipped in waiting flow due async deps or constraints.
         self.skipped_waiting = create_request_queue(self.policy)
         self.running: list[Request] = []
+        self._slo_score_dirty = self.policy == SchedulingPolicy.SLO
+        self._slo_force_score_refresh = self.policy == SchedulingPolicy.SLO
+        self._slo_score_refresh_interval_steps = SLO_SCORE_REFRESH_INTERVAL_STEPS
+        self._slo_last_score_refresh_step = -self._slo_score_refresh_interval_steps
+        self._slo_cached_waiting_token_reserve = 0
 
         # The request IDs that are finished in between the previous and the
         # current steps. This is used to notify the workers about the finished
@@ -523,6 +538,10 @@ class Scheduler(SchedulerInterface):
         if self._pause_state == PauseState.PAUSED_ALL:
             # Do not schedule any requests when paused.
             token_budget = 0
+        self._refresh_slo_scores_if_needed()
+        slo_waiting_token_reserve = self._get_cached_slo_waiting_token_reserve(
+            token_budget
+        )
 
         # Encoder-related.
         scheduled_encoder_inputs: dict[str, list[int]] = {}
@@ -545,7 +564,10 @@ class Scheduler(SchedulerInterface):
 
         # First, schedule the RUNNING requests.
         req_index = 0
-        while req_index < len(self.running) and token_budget > 0:
+        while (
+            req_index < len(self.running)
+            and token_budget > slo_waiting_token_reserve
+        ):
             request = self.running[req_index]
             if input_budget <= draft_slots:
                 break
@@ -586,7 +608,9 @@ class Scheduler(SchedulerInterface):
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(
-                num_new_tokens, token_budget, input_budget - draft_slots
+                num_new_tokens,
+                token_budget - slo_waiting_token_reserve,
+                input_budget - draft_slots,
             )
 
             # Make sure the input position does not exceed the max model len.
@@ -1401,6 +1425,7 @@ class Scheduler(SchedulerInterface):
         # Put the request back to the waiting queue.
         self.waiting.prepend_request(request)
         self.reset_preempted_req_ids.add(request.request_id)
+        self._mark_slo_score_dirty(force=True)
 
     def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
         # Advance the number of computed tokens for the request AFTER
@@ -1451,6 +1476,7 @@ class Scheduler(SchedulerInterface):
         # the scheduler output.
         self.finished_req_ids = set()
         self.reset_preempted_req_ids = set()
+        self._mark_slo_score_dirty()
 
     def _update_request_as_session(
         self, session: Request, update: StreamingUpdate
@@ -1488,12 +1514,19 @@ class Scheduler(SchedulerInterface):
         session.num_prompt_tokens = len(session.prompt_token_ids)
         session.arrival_time = update.arrival_time
         session.sampling_params = update.sampling_params
+        session.first_token_ts = None
+        if self.policy == SchedulingPolicy.SLO:
+            self._set_default_slo_constraints(session)
+            session.slo_urgency_score = self._compute_slo_score(
+                session, time.time()
+            )
         if session.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
             self.num_waiting_for_streaming_input -= 1
         session.status = RequestStatus.WAITING
 
         if self.log_stats:
             session.record_event(EngineCoreEventType.QUEUED)
+        self._mark_slo_score_dirty(force=True)
 
     def _make_cached_request_data(
         self,
@@ -2079,6 +2112,8 @@ class Scheduler(SchedulerInterface):
             # This is a rare case and unlikely to impact performance.
             self.waiting.remove_requests(stopped_preempted_reqs)
             self.skipped_waiting.remove_requests(stopped_preempted_reqs)
+        if stopped_running_reqs or stopped_preempted_reqs:
+            self._mark_slo_score_dirty(force=True)
 
         error_req_ids = set(self.grammar_compile_error_reqs)
         self.grammar_compile_error_reqs.clear()
@@ -2193,18 +2228,105 @@ class Scheduler(SchedulerInterface):
             self.skipped_waiting.add_request(request)
         else:
             self.waiting.add_request(request)
+        self._mark_slo_score_dirty(force=True)
 
     def _select_waiting_queue_for_scheduling(self) -> RequestQueue | None:
         if self.policy == SchedulingPolicy.FCFS:
             return self.skipped_waiting or self.waiting or None
 
-        # PRIORITY mode: compare queue heads when both queues are non-empty.
+        # Priority-based modes compare queue heads when both queues are non-empty.
         if self.waiting and self.skipped_waiting:
             waiting_req = self.waiting.peek_request()
             skipped_req = self.skipped_waiting.peek_request()
+            if self.policy == SchedulingPolicy.SLO:
+                waiting_key = (
+                    -waiting_req.slo_urgency_score,
+                    waiting_req.arrival_time,
+                    waiting_req.request_id,
+                )
+                skipped_key = (
+                    -skipped_req.slo_urgency_score,
+                    skipped_req.arrival_time,
+                    skipped_req.request_id,
+                )
+                return self.waiting if waiting_key <= skipped_key else self.skipped_waiting
             return self.waiting if waiting_req < skipped_req else self.skipped_waiting
 
         return self.waiting or self.skipped_waiting or None
+
+    def _set_default_slo_constraints(self, request: Request) -> None:
+        set_request_slo_constraints(request, self.scheduler_config)
+
+    def _compute_slo_score(self, request: Request, now: float) -> float:
+        return compute_slo_score(
+            request,
+            now,
+            self.max_model_len,
+            SLO_PREFILL_LENGTH_BONUS,
+        )
+
+    def _mark_slo_score_dirty(self, force: bool = False) -> None:
+        if self.policy == SchedulingPolicy.SLO:
+            self._slo_score_dirty = True
+            self._slo_force_score_refresh |= force
+
+    def _get_cached_slo_waiting_token_reserve(self, token_budget: int) -> int:
+        with record_function_or_nullcontext("schedule: slo_get_cached_reserve"):
+            if self.policy != SchedulingPolicy.SLO or token_budget <= 1:
+                return 0
+            if not self.waiting:
+                return 0
+            return min(self._slo_cached_waiting_token_reserve, token_budget - 1)
+
+    def _refresh_slo_scores_if_needed(self) -> None:
+        if self.policy != SchedulingPolicy.SLO or not self._slo_score_dirty:
+            return
+        if (
+            not self._slo_force_score_refresh
+            and self.current_step - self._slo_last_score_refresh_step
+            < self._slo_score_refresh_interval_steps
+        ):
+            return
+
+        with record_function_or_nullcontext("schedule: slo_refresh_scores"):
+            now = time.time()
+            reserve_candidates: list[tuple[float, int]] = []
+            for queue_name, queue in (
+                ("waiting", self.waiting),
+                ("skipped_waiting", self.skipped_waiting),
+            ):
+                if not isinstance(queue, SLORequestQueue):
+                    continue
+                for request in queue.iter_requests_unordered():
+                    score = self._compute_slo_score(request, now)
+                    request.slo_urgency_score = score
+                    if (
+                        queue_name != "waiting"
+                        or not is_waiting_reserve_candidate(
+                            request,
+                            score,
+                            now,
+                            SLO_PREFILL_LENGTH_BONUS,
+                        )
+                    ):
+                        continue
+                    remaining_prompt = max(
+                        request.num_prompt_tokens - request.num_computed_tokens,
+                        1,
+                    )
+                    reserve_candidates.append((score, remaining_prompt))
+                queue.rebuild_with_updated_scores()
+
+            self._slo_cached_waiting_token_reserve = compute_waiting_token_reserve(
+                self.max_num_scheduled_tokens,
+                self.scheduler_config.slo_waiting_token_reserve_ratio,
+                len(self.running),
+                sum(1 for request in self.running if not request.is_prefill_chunk),
+                reserve_candidates,
+            )
+            self._slo_score_dirty = False
+            self._slo_force_score_refresh = False
+            self._slo_last_score_refresh_step = self.current_step
 
     def _handle_stopped_request(self, request: Request) -> bool:
         """Return True if finished (can be False for resumable requests)."""
@@ -2233,6 +2355,8 @@ class Scheduler(SchedulerInterface):
         # to return empty token ids for the request.
         stopped = False
         for num_new, output_token_id in enumerate(new_token_ids, 1):
+            if request.first_token_ts is None:
+                request.first_token_ts = time.time()
             request.append_output_token_ids(output_token_id)
 
             # Check for stop and update request state.
@@ -2358,6 +2482,11 @@ class Scheduler(SchedulerInterface):
                 # Streaming-input session finished.
                 self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
         else:
+            if self.policy == SchedulingPolicy.SLO:
+                self._set_default_slo_constraints(request)
+                request.slo_urgency_score = self._compute_slo_score(
+                    request, time.time()
+                )
             if request.resumable:
                 request.streaming_queue = deque()
             self._enqueue_waiting_request(request)
@@ -2418,6 +2547,8 @@ class Scheduler(SchedulerInterface):
         if waiting_requests_to_remove:
             self.waiting.remove_requests(waiting_requests_to_remove)
             self.skipped_waiting.remove_requests(waiting_requests_to_remove)
+        if running_requests_to_remove or waiting_requests_to_remove:
+            self._mark_slo_score_dirty(force=True)
 
         # Second pass: set status and free requests
         for request in valid_requests:

--- a/vllm/v1/core/sched/slo_policy.py
+++ b/vllm/v1/core/sched/slo_policy.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+from vllm.v1.request import Request
+from vllm.v1.utils import record_function_or_nullcontext
+
+SLO_PREFILL_LENGTH_BONUS = 10.0
+SLO_TTFT_BASE_MS = 20_000.0
+SLO_TTFT_SHORT_MAX_MS = 40_000.0
+SLO_TTFT_LONG_MAX_MS = 120_000.0
+SLO_BIAS_FAVORED_LIMIT = 1.0
+SLO_BIAS_MAX = 10.0
+
+
+def _smoothstep(value: float) -> float:
+    value = min(max(value, 0.0), 1.0)
+    return value * value * (3.0 - 2.0 * value)
+
+
+def compute_request_ttft_slo_ms(
+    num_prompt_tokens: int,
+    priority_bias: float,
+    short_request_token_threshold: int,
+) -> float:
+    magnitude = abs(priority_bias)
+    if magnitude <= SLO_BIAS_FAVORED_LIMIT:
+        expansion = _smoothstep(magnitude)
+        favored_ttft_ms = SLO_TTFT_BASE_MS
+        nonfavored_ttft_ms = SLO_TTFT_BASE_MS + (
+            SLO_TTFT_SHORT_MAX_MS - SLO_TTFT_BASE_MS
+        ) * expansion
+    else:
+        normalized = (magnitude - SLO_BIAS_FAVORED_LIMIT) / (
+            SLO_BIAS_MAX - SLO_BIAS_FAVORED_LIMIT
+        )
+        expansion = _smoothstep(normalized)
+        favored_ttft_ms = SLO_TTFT_BASE_MS + (
+            SLO_TTFT_SHORT_MAX_MS - SLO_TTFT_BASE_MS
+        ) * expansion
+        nonfavored_ttft_ms = SLO_TTFT_SHORT_MAX_MS + (
+            SLO_TTFT_LONG_MAX_MS - SLO_TTFT_SHORT_MAX_MS
+        ) * expansion
+
+    short_is_favored = priority_bias >= 0
+    short_ttft_ms = favored_ttft_ms if short_is_favored else nonfavored_ttft_ms
+    long_ttft_ms = nonfavored_ttft_ms if short_is_favored else favored_ttft_ms
+    return short_ttft_ms if num_prompt_tokens <= short_request_token_threshold else long_ttft_ms
+
+
+def set_request_slo_constraints(request: Request, scheduler_config: Any) -> None:
+    request.ttft_slo_ms = compute_request_ttft_slo_ms(
+        request.num_prompt_tokens,
+        scheduler_config.slo_priority_bias,
+        scheduler_config.slo_short_request_token_threshold,
+    )
+
+
+def compute_slo_score(
+    request: Request,
+    now: float,
+    max_model_len: int,
+    prefill_length_bonus: float,
+) -> float:
+    with record_function_or_nullcontext("slo_policy: compute_slo_score"):
+        score = 0.0
+        if request.first_token_ts is None:
+            wait_time_ms = (now - request.arrival_time) * 1000.0
+            if request.ttft_slo_ms < float("inf") and request.ttft_slo_ms > 0:
+                score += 200.0 * max(0.0, wait_time_ms / request.ttft_slo_ms)
+
+        if (
+            request.num_computed_tokens == 0
+            and request.num_prompt_tokens > 0
+            and prefill_length_bonus > 0
+        ):
+            prompt_fraction = min(request.num_prompt_tokens / max_model_len, 1.0)
+            score += prefill_length_bonus * (1.0 - prompt_fraction)
+
+        return score
+
+
+def is_waiting_reserve_candidate(
+    request: Request,
+    score: float,
+    now: float,
+    prefill_length_bonus: float,
+) -> bool:
+    if request.first_token_ts is not None or request.ttft_slo_ms <= 0:
+        return False
+    if request.ttft_slo_ms == float("inf"):
+        return False
+
+    wait_time_ms = max(0.0, (now - request.arrival_time) * 1000.0)
+    if wait_time_ms < 0.6 * request.ttft_slo_ms:
+        return False
+    return score >= 0.8 * prefill_length_bonus
+
+
+def compute_waiting_token_reserve(
+    max_num_scheduled_tokens: int,
+    waiting_token_reserve_ratio: float,
+    running_count: int,
+    running_decode_count: int,
+    reserve_candidates: list[tuple[float, int]],
+) -> int:
+    with record_function_or_nullcontext("slo_policy: compute_waiting_token_reserve"):
+        if (
+            waiting_token_reserve_ratio <= 0
+            or not reserve_candidates
+            or running_decode_count > max(1, running_count // 2)
+        ):
+            return 0
+
+        reserve_cap = max(1, int(max_num_scheduled_tokens * waiting_token_reserve_ratio))
+        _score, remaining_prompt = max(reserve_candidates)
+        return min(remaining_prompt, reserve_cap)

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -94,6 +94,9 @@ class Request:
                 reasoning_parser_kwargs
             )
         self.arrival_time = arrival_time if arrival_time is not None else time.time()
+        self.ttft_slo_ms: float = float("inf")
+        self.slo_urgency_score: float = 0.0
+        self.first_token_ts: float | None = None
 
         self.status = RequestStatus.WAITING
         self.events: list[EngineCoreEvent] = []


### PR DESCRIPTION


## Purpose
Add an optional slo policy to the vLLM V1 scheduler. It gives the server a soft, auditable way to balance short and long requests by TTFT target, so short prompts are less likely to get stuck behind a long prefill while long prompts still age into service instead of starving.

The default FCFS and priority paths stay unchanged. The new policy only reorders waiting requests, does not preempt running requests, and is not a hard deadline mechanism.

### New knobs

Flag | Default | Meaning
-- | -- | --
--slo-priority-bias | 0 | Chooses the favored group and how far the short/long TTFT targets are separated ([-10, 10]). Positive favors short, negative favors long.
--slo-short-request-token-threshold | 2048 | Requests with num_prompt_tokens <= threshold are treated as short after tokenization and chat templating.
--slo-waiting-token-reserve-ratio | 0.10 | Caps how much of a step's token budget can be reserved for urgent waiting prefills. 0 disables reserve.

Recommended tuning order: threshold -> bias -> reserve, one knob at a time.

### What changed
1. SchedulerConfig and EngineArgs register, validate, and propagate the three service settings.
2. slo_policy.py maps bias to short/long TTFT targets with cubic smoothstep, computes urgency, and calculates the waiting-token reserve.
3. SLORequestQueue keeps waiting requests ordered by urgency with stable tie-breaking.
4. scheduler.py assigns SLO targets at admission, refreshes scores periodically, and integrates the reserve into token budgeting.
5. Tests cover CLI/config flow, queue ordering, target mapping, score refresh cadence, reserve behavior, and scheduler integration.

## Test Plan
Setup:

- model: /models/qwen, served as qwen3.5-27b-gptq-int4
- parallel mode: 1 GPU, no TP/PP, asynchronous scheduler
- scheduler capacity: max-num-seqs=32
- Normal / Full prompts: short 791 or 1558 tokens; long 3086 or 6168 tokens
- Heavy / Full prompts: short 1558 tokens; long 6168 tokens

The accompanying SLO evaluation package reports complete benchmark/audit coverage for the measured matrices.

The performance story is the useful part. All values are paired deltas of SLO versus FCFS on the same workload/case/repeat (21 pairs per workload/bias). Positive throughput means SLO is higher; negative TTFT means a shorter wait.


## Test Result
Workload | Bias | Paired samples | Throughput | Short TTFT mean | Short TTFT P95 | Short TTFT P99 | Long TTFT mean | Long TTFT P95
-- | -- | -- | -- | -- | -- | -- | -- | --
Normal | +0.5 | 21 | -0.49% | -42.47% | -34.40% | -34.11% | +37.18% | +20.15%
Normal | +1 | 21 | +0.93% | -47.51% | -43.31% | -41.14% | +41.74% | +18.64%
Normal | 0 | 21 | -0.59% | -8.94% | -5.96% | -6.14% | +6.56% | +1.24%
Normal | +10 | 21 | +1.23% | -49.25% | -45.41% | -42.82% | +41.66% | +16.98%
Normal | -10 | 21 | +0.72% | +30.14% | +24.89% | +24.45% | -13.18% | -22.21%
Normal | -1 | 21 | +1.42% | +24.29% | +23.72% | +23.12% | -10.60% | -18.48%
Normal | -0.5 | 21 | +0.96% | +18.99% | +19.14% | +22.56% | -9.00% | -15.99%
Heavy | +0.5 | 21 | +1.33% | -48.47% | -47.44% | -45.50% | +42.35% | +19.36%
Heavy | +1 | 21 | +1.99% | -54.32% | -51.69% | -50.73% | +47.91% | +18.78%
Heavy | 0 | 21 | -0.03% | -9.29% | -8.40% | -7.76% | +6.81% | +1.53%
Heavy | +10 | 21 | +1.02% | -55.23% | -51.91% | -50.51% | +51.31% | +19.87%
Heavy | -10 | 21 | +0.46% | +37.70% | +15.80% | +12.06% | -18.53% | -20.18%
Heavy | -1 | 21 | +0.29% | +38.55% | +15.88% | +12.26% | -19.47% | -21.14%
Heavy | -0.5 | 21 | +1.05% | +23.55% | +14.89% | +11.44% | -13.80% | -17.23%

- short-favoring settings (positive bias) cut short-request TTFT P99 by roughly 34-51% and short TTFT mean by roughly 42-55% across the measured Normal/Heavy matrices;
- long-favoring settings (negative bias) cut long-request TTFT P95 by roughly 16-22%;
- throughput stays close to flat, within roughly ±2% on every measured setting.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

