### PR TITLE
Fix draft model PP and drafter None guard for spec decode with PP

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1326,10 +1326,14 @@ class SpeculativeConfig:
     ) -> ParallelConfig:
         """Create a parallel config for use by the draft worker.
 
-        This is mostly a copy of the target parallel config, except the tp_size.
+        The drafter runs only on the last pipeline-parallel rank, so its
+        own pipeline parallel size is always 1.  Inheriting the target's
+        PP size causes ``verify_with_parallel_config`` to reject draft
+        models that do not implement ``SupportsPP`` — even though the
+        draft model is never split across PP ranks.
         """
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=target_parallel_config.pipeline_parallel_size,
+            pipeline_parallel_size=1,
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
             distributed_executor_backend=target_parallel_config.distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -707,6 +707,8 @@ class GPUModelRunner(
             self.rejection_sampler = RejectionSampler(
                 self.sampler, self.speculative_config, self.device
             )
+        elif self.speculative_config:
+            self.drafter = None
 
         self.num_spec_tokens = 0
         self.prev_num_spec_tokens = 0
@@ -2645,7 +2647,11 @@ class GPUModelRunner(
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
 
-            if self.speculative_config and spec_decode_common_attn_metadata is None:
+            if (
+                self.speculative_config
+                and self.drafter is not None
+                and spec_decode_common_attn_metadata is None
+            ):
                 if isinstance(
                     self.drafter,
                     (
@@ -2660,11 +2666,19 @@ class GPUModelRunner(
                 else:
                     spec_decode_common_attn_metadata = cm
             # Capture per-group block tables for multi-group proposers.
-            if self.speculative_config and isinstance(self.drafter, Step3p5MTPProposer):
+            if (
+                self.speculative_config
+                and self.drafter is not None
+                and isinstance(self.drafter, Step3p5MTPProposer)
+            ):
                 self.drafter.set_per_group_attn_metadata(
                     kv_cache_gid, cm.block_table_tensor, cm.slot_mapping
                 )
-            elif self.speculative_config and isinstance(self.drafter, Gemma4Proposer):
+            elif (
+                self.speculative_config
+                and self.drafter is not None
+                and isinstance(self.drafter, Gemma4Proposer)
+            ):
                 self.drafter.set_per_group_block_table(
                     kv_cache_gid, cm.block_table_tensor
                 )


### PR DESCRIPTION
## Problem

Speculative decoding is broken with pipeline parallelism (PP > 1) due to two bugs:

1. **Draft model inherits target PP size.** `create_draft_parallel_config` copies `pipeline_parallel_size` from the target, but the drafter runs only on the last PP rank — it is never split across PP ranks. This causes `verify_with_parallel_config` to reject draft models that do not implement `SupportsPP` (all MTP model families after #32150), making speculative decoding impossible with PP > 1.

2. **`self.drafter` is never assigned on non-last PP ranks.** The drafter instantiation block (line 634) is guarded by `get_pp_group().is_last_rank`, but subsequent references to `self.drafter` in `_initialize_attn_metadata` (lines 2648, 2663, 2667) are unguarded, causing `AttributeError` on those ranks.

## Fix

1. `vllm/config/speculative.py`: Set `pipeline_parallel_size=1` in `create_draft_parallel_config` instead of inheriting from the target.

2. `vllm/v1/worker/gpu_model_runner.py`: Add `elif self.speculative_config: self.drafter = None` for non-last PP ranks, and guard all `self.drafter` references in `_initialize_attn_metadata` with `self.drafter is not None`.

## Testing

Tested with GLM-5.2-Int4-Int8Mix on 7x A100 (PP=7, TP=1) with MTP speculative decoding (`num_speculative_tokens=1`). Without the fix, the server fails to start (NotImplementedError from verify_with_parallel_config). With the fix, the server starts and the drafter is correctly None on non-last PP ranks.

**Note:** MTP acceptance degradation was observed during long generation with PP=7 + sparse MLA backend. The baseboard fix (TP=2, PP=3) and 8th GPU (TP=8, PP=1) are being tested to determine if this is PP-specific or a sparse MLA backend issue. This PR fixes the startup crash, not the acceptance degradation.

## Checklist

- [x] Code follows vLLM style guidelines
- [x] Duplicate work checked (no open PRs found for "draft PP" or "drafter None guard")
- [x] AI assistance was used in developing this change

Co-authored-by: opencode <noreply@opencode.ai>
Signed-off-by: Michael <michaelgruuven@gmail.com>