### PR TITLE
[Bugfix][Kimi K3] Skip absent metadata during CUDA graph profiling

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
 from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     fused_recurrent_kda_packed_decode as fused_recurrent_kda_packed_decode_amd,
 )
+from vllm.models.kimi_k3.nvidia import kda as nvidia_kda
 from vllm.models.kimi_k3.nvidia.kda import (
     _flashkda_prefill,
     _store_cache_checkpoints_kernel,
@@ -57,6 +58,19 @@ PACKED_DECODE_IMPLS = {
     "nvidia": fused_recurrent_kda_packed_decode,
     "amd": fused_recurrent_kda_packed_decode_amd,
 }
+
+
+def test_kda_warmup_skips_missing_metadata(monkeypatch):
+    monkeypatch.setattr(
+        nvidia_kda,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata={}),
+    )
+    layer = object.__new__(nvidia_kda.KimiK3DeltaAttention)
+    object.__setattr__(layer, "prefix", "language_model.model.layers.0.self_attn")
+    empty = torch.empty(0, device=DEVICE)
+
+    assert layer._forward(empty, empty, empty, empty, empty) is None
 
 
 def test_kda_recoverssm_config_state_layout():

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -313,7 +313,9 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             return
 
         assert isinstance(attn_metadata_raw, dict)
-        attn_metadata_narrowed = attn_metadata_raw[self.prefix]
+        attn_metadata_narrowed = attn_metadata_raw.get(self.prefix)
+        if attn_metadata_narrowed is None:
+            return
         assert isinstance(attn_metadata_narrowed, GDNAttentionMetadata)
         m = attn_metadata_narrowed
         has_initial_state = m.has_initial_state

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -658,7 +658,9 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         )
 
         assert isinstance(attn_metadata_raw, dict)
-        attn_metadata_narrowed = attn_metadata_raw[self.prefix]
+        attn_metadata_narrowed = attn_metadata_raw.get(self.prefix)
+        if attn_metadata_narrowed is None:
+            return
         assert isinstance(attn_metadata_narrowed, KimiK3KDAMetadata)
         m = attn_metadata_narrowed
         has_initial_state = m.has_initial_state


### PR DESCRIPTION
## Summary

PR #53306 makes CUDA graph memory profiling omit Mamba-family attention groups from dummy-run metadata. The generic GDN implementations were updated to treat a missing per-layer metadata entry as a warmup path, but the dedicated Kimi K3 NVIDIA and AMD KDA implementations still indexed the entry directly.

That raises `KeyError: 'language_model.model.layers.0.self_attn'` while initializing Kimi K3. Main CI reproduced it twice in the exact H200 Extra Initialization shard:

- https://buildkite.com/vllm/ci/builds/85298#01a03290-1976-4ce2-ad50-22e62ba39776
- https://buildkite.com/vllm/ci/builds/85311#01a033c4-8ae4-445c-91e7-051d43f59170

Use the same missing-entry guard as the generic GDN paths and add a regression test for the empty-metadata warmup case.

## Duplicate-work check

Searched open issues and PRs for the exact Kimi K3 `KeyError`, missing attention metadata, and CUDA graph profiling fixes. No existing fix addresses this path.

## Validation

- `uv run --no-project --python 3.12 python -m py_compile vllm/models/kimi_k3/nvidia/kda.py vllm/models/kimi_k3/amd/kda.py tests/models/kimi_k3/test_kda.py`
- `uvx pre-commit run ruff-check --files vllm/models/kimi_k3/nvidia/kda.py vllm/models/kimi_k3/amd/kda.py tests/models/kimi_k3/test_kda.py`
- `uvx pre-commit run ruff-format --files vllm/models/kimi_k3/nvidia/kda.py vllm/models/kimi_k3/amd/kda.py tests/models/kimi_k3/test_kda.py`

The exact GPU regression job will be run in Buildkite before merge. No model eval is needed because this changes only the dummy profiling/warmup path and preserves real attention metadata execution.

## AI assistance

AI assistance was used to analyze the CI failures, identify the missed KDA implementations, and prepare the patch. The submitter reviewed every changed line and the validation results.
