### PR TITLE
[6/N] Share HiSparse host cache across TP ranks

### DIFF
--- a/docs/design/hisparse.md
+++ b/docs/design/hisparse.md
@@ -65,6 +65,11 @@ across TP ranks, so this stores one physical copy instead of one copy per rank.
 Each rank still submits its own identical DMA to preserve its local CUDA stream
 ordering. Other executor and parallel layouts retain private per-rank pools.
 
+The shared layout backs the per-replica logical capacity with one physical pool;
+the private layout allocates one physical pool per rank. Physical pool size
+includes block-stride alignment. `num_gpu_blocks_override`, when set, overrides
+the planned Host block count and can exceed the configured budget.
+
 ## Code boundary
 
 ```text

--- a/docs/design/hisparse.md
+++ b/docs/design/hisparse.md
@@ -59,6 +59,12 @@ sees only device pools.
 The source group has `block_pool_id=None`; device-pool consumers must narrow it
 before indexing, so host ownership cannot masquerade as a numeric GPU pool.
 
+For single-node MP tensor parallelism, every TP worker maps the same pinned host
+pool and uses the same block and layer offsets. MLA source KV is replicated
+across TP ranks, so this stores one physical copy instead of one copy per rank.
+Each rank still submits its own identical DMA to preserve its local CUDA stream
+ordering. Other executor and parallel layouts retain private per-rank pools.
+
 ## Code boundary
 
 ```text

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
+import vllm.v1.kv_offload.sparse.hisparse_runtime as hisparse_runtime_module
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
 from vllm.config.attention import HiSparseConfig
 from vllm.config.kv_events import KVEventsConfig
@@ -85,16 +86,47 @@ def _private_hisparse_parallel_config():
     )
 
 
+def _shared_hisparse_parallel_config():
+    return SimpleNamespace(
+        tensor_parallel_size=2,
+        pipeline_parallel_size=1,
+        prefill_context_parallel_size=1,
+        decode_context_parallel_size=1,
+        world_size=2,
+        distributed_executor_backend="mp",
+        nnodes_within_dp=1,
+        data_parallel_index=0,
+    )
+
+
 @pytest.mark.parametrize(
-    ("block_size", "main_sizes", "indexer_sizes", "gpu_block_size"),
+    (
+        "block_size",
+        "main_sizes",
+        "indexer_sizes",
+        "gpu_block_size",
+        "shared_host_pool",
+        "num_gpu_blocks_override",
+    ),
     [
-        (256, (64,), (64,), 64),
-        (64, (32, 64), (16, 32), 32),
+        (64, (64,), (64,), 64, True, None),
+        (128, (64,), (64,), 64, False, None),
+        (256, (64,), (64,), 64, False, 7),
+        (64, (32, 64), (16, 32), 32, False, 7),
     ],
 )
 def test_hisparse_hma_uses_backend_gpu_block_size(
-    block_size, main_sizes, indexer_sizes, gpu_block_size
+    monkeypatch,
+    block_size,
+    main_sizes,
+    indexer_sizes,
+    gpu_block_size,
+    shared_host_pool,
+    num_gpu_blocks_override,
 ):
+    monkeypatch.setattr(
+        hisparse_runtime_module.current_platform, "is_cuda_alike", lambda: True
+    )
     specs = {
         "model.layers.0.self_attn": MLAAttentionSpec(
             block_size=block_size,
@@ -124,9 +156,10 @@ def test_hisparse_hma_uses_backend_gpu_block_size(
             hf_config=SimpleNamespace(index_topk=128),
             max_model_len=block_size,
         ),
-        cache_config=SimpleNamespace(num_gpu_blocks_override=7),
-        parallel_config=_private_hisparse_parallel_config(),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=num_gpu_blocks_override),
+        parallel_config=_shared_hisparse_parallel_config(),
     )
+    host_budget = 2**30
     indexer_spec = specs["model.layers.0.self_attn.indexer"]
     assert kv_cache_utils._hisparse_gpu_memory_usage(config, [group]) == (
         indexer_spec.max_memory_usage_bytes(config)
@@ -136,11 +169,29 @@ def test_hisparse_hma_uses_backend_gpu_block_size(
         config,
         group,
         available_memory=2**30,
-        host_budget=2**30,
+        host_budget=host_budget,
         log_layout=False,
     )
 
     host_group, indexer_group, *auxiliary_groups = cache_config.kv_cache_groups
+    assert cache_config.hisparse_shared_host_pool is shared_host_pool
+    host_page = host_group.kv_cache_spec.page_size_bytes
+    if shared_host_pool:
+        alignment = hisparse_runtime_module.SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+        expected_host_stride = (host_page + alignment - 1) // alignment * alignment
+    else:
+        expected_host_stride = host_page
+    assert cache_config.hisparse_host_block_stride == expected_host_stride
+    if num_gpu_blocks_override is None:
+        assert cache_config.hisparse_host_num_blocks == (
+            host_budget // expected_host_stride
+        )
+        assert cache_config.num_blocks_by_pool[0] > 0
+    else:
+        assert cache_config.num_blocks_by_pool == [num_gpu_blocks_override]
+        assert cache_config.hisparse_host_num_blocks == num_gpu_blocks_override
+    assert host_group.block_pool_id is None
+    assert indexer_group.block_pool_id == 0
     assert host_group.kv_cache_spec.block_size == block_size
     assert indexer_group.kv_cache_spec.block_size == gpu_block_size
     host_specs = host_group.kv_cache_spec.kv_cache_specs

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -72,6 +72,19 @@ from vllm.v1.request import Request
 pytestmark = pytest.mark.cpu_test
 
 
+def _private_hisparse_parallel_config():
+    return SimpleNamespace(
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        prefill_context_parallel_size=1,
+        decode_context_parallel_size=1,
+        world_size=1,
+        distributed_executor_backend="uni",
+        nnodes_within_dp=1,
+        data_parallel_index=0,
+    )
+
+
 @pytest.mark.parametrize(
     ("block_size", "main_sizes", "indexer_sizes", "gpu_block_size"),
     [
@@ -111,8 +124,8 @@ def test_hisparse_hma_uses_backend_gpu_block_size(
             hf_config=SimpleNamespace(index_topk=128),
             max_model_len=block_size,
         ),
-        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
         cache_config=SimpleNamespace(num_gpu_blocks_override=7),
+        parallel_config=_private_hisparse_parallel_config(),
     )
     indexer_spec = specs["model.layers.0.self_attn.indexer"]
     assert kv_cache_utils._hisparse_gpu_memory_usage(config, [group]) == (
@@ -207,6 +220,7 @@ def test_hisparse_hma_offloads_only_deepseek_v4_c4_layers():
         ),
         model_config=SimpleNamespace(hf_config=SimpleNamespace(index_topk=512)),
         cache_config=SimpleNamespace(num_gpu_blocks_override=7),
+        parallel_config=_private_hisparse_parallel_config(),
     )
 
     cache_config = kv_cache_utils._get_hisparse_hma_config(

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -609,6 +609,22 @@ def test_multi_worker_race_shared_memory_visible(iid):
         _cleanup_file(regions[0].mmap_path)
 
 
+def test_replicated_workers_share_the_same_slot(iid):
+    creator = _make_region(iid, rank=0)
+    joiner = _make_region(iid, rank=0)
+    creator_view = creator.create_next_canonical_view(PAGE_SIZE)
+    joiner_view = joiner.create_next_canonical_view(PAGE_SIZE)
+    try:
+        creator_view[2].fill_(37)
+
+        assert joiner_view[2].tolist() == [37] * PAGE_SIZE
+    finally:
+        del creator_view, joiner_view
+        joiner.cleanup()
+        creator.cleanup()
+        _cleanup_file(creator.mmap_path)
+
+
 def test_multiprocess_race_construct_and_write(iid):
     """N processes race to construct the same SharedOffloadRegion, each writes
     fill_value = rank+1 into their slot; parent verifies interleaved layout."""

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -183,6 +183,30 @@ def _mp_race_construct_and_write(
         done_queue.put({"rank": rank, "error": repr(e)})
 
 
+def _mp_read_replicated_slot(engine_id: str, result_queue) -> None:
+    try:
+        region = SharedOffloadRegion(
+            engine_id=engine_id,
+            num_blocks=3,
+            rank=0,
+            kv_bytes_per_block=PAGE_SIZE,
+            cpu_page_size=PAGE_SIZE,
+        )
+        view = region.create_next_canonical_view(PAGE_SIZE)
+        assert region.fd is not None
+        result_queue.put(
+            {
+                "inode": os.fstat(region.fd).st_ino,
+                "contents_match": view[2].tolist() == [37] * PAGE_SIZE,
+                "error": None,
+            }
+        )
+        del view
+        region.cleanup()
+    except Exception as e:
+        result_queue.put({"inode": None, "contents_match": False, "error": repr(e)})
+
+
 @pytest.fixture
 def iid():
     """Fresh instance ID for each test."""
@@ -625,6 +649,41 @@ def test_replicated_workers_share_the_same_slot(iid):
         _cleanup_file(creator.mmap_path)
 
 
+@pytest.mark.skip_global_cleanup
+@pytest.mark.skipif(not os.path.isdir("/dev/shm"), reason="requires /dev/shm")
+def test_replicated_workers_share_the_same_slot_across_processes(iid):
+    creator = _make_region(iid, num_blocks=3, rank=0)
+    creator_view = creator.create_next_canonical_view(PAGE_SIZE)
+    creator_view[2].fill_(37)
+    assert creator.fd is not None
+    creator_inode = os.fstat(creator.fd).st_ino
+
+    ctx = get_mp_context()
+    result_queue = ctx.Queue()
+    reader = ctx.Process(
+        target=_mp_read_replicated_slot,
+        args=(iid, result_queue),
+    )
+    reader.start()
+    try:
+        reader_result = result_queue.get(timeout=30)
+        assert reader_result["error"] is None
+        assert reader_result["inode"] == creator_inode
+        assert reader_result["contents_match"]
+    finally:
+        reader.join(timeout=10)
+        if reader.is_alive():
+            reader.terminate()
+            reader.join(timeout=10)
+        del creator_view
+        creator.cleanup()
+        _cleanup_file(creator.mmap_path)
+        result_queue.close()
+        result_queue.join_thread()
+
+    assert reader.exitcode == 0
+
+
 def test_multiprocess_race_construct_and_write(iid):
     """N processes race to construct the same SharedOffloadRegion, each writes
     fill_value = rank+1 into their slot; parent verifies interleaved layout."""
@@ -789,9 +848,51 @@ def test_wait_for_file_size_timeout(tmp_path):
         os.close(fd)
 
 
+@pytest.mark.skip_global_cleanup
+def test_wait_for_file_size_rejects_unlinked_file(tmp_path):
+    path = tmp_path / "unlinked.mmap"
+    fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        os.unlink(path)
+        with pytest.raises(RuntimeError, match="creator failed"):
+            _wait_for_file_size(fd, PAGE_SIZE, timeout=1.0)
+    finally:
+        os.close(fd)
+
+
 # ---------------------------------------------------------------------------
 # Constructor — capacity validation
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.skipif(not os.path.isdir("/dev/shm"), reason="requires /dev/shm")
+def test_creator_memory_check_runs_only_for_creator(iid):
+    checked_sizes: list[int] = []
+    creator = SharedOffloadRegion(
+        engine_id=iid,
+        num_blocks=4,
+        rank=0,
+        kv_bytes_per_block=PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+        creator_memory_check=checked_sizes.append,
+    )
+    joiner: SharedOffloadRegion | None = None
+    try:
+        joiner = SharedOffloadRegion(
+            engine_id=iid,
+            num_blocks=4,
+            rank=0,
+            kv_bytes_per_block=PAGE_SIZE,
+            cpu_page_size=PAGE_SIZE,
+            creator_memory_check=checked_sizes.append,
+        )
+        assert checked_sizes == [4 * PAGE_SIZE]
+    finally:
+        if joiner is not None:
+            joiner.cleanup()
+        creator.cleanup()
+        _cleanup_file(creator.mmap_path)
 
 
 def test_insufficient_space_raises_clear_error(monkeypatch):

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -42,6 +42,45 @@ class FakeHNDFlashAttentionBackend(FakeFlashAttentionBackend):
         return (0, 1, 3, 2, 4)
 
 
+def test_reshape_kv_cache_preserves_shared_host_row_stride():
+    num_blocks = 3
+    spec = FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=2,
+        dtype=torch.float32,
+    )
+    row_stride = spec.page_size_bytes + 32
+    backing = torch.zeros(num_blocks * row_stride, dtype=torch.int8)
+    raw_tensors = {
+        "layer": torch.as_strided(
+            backing,
+            size=(num_blocks, spec.page_size_bytes),
+            stride=(row_stride, 1),
+        )
+    }
+    attn_groups = [
+        AttentionGroup(
+            backend=FakeFlashAttentionBackend,
+            layer_names=["layer"],
+            kv_cache_spec=spec,
+            kv_cache_group_id=0,
+        )
+    ]
+
+    kv_cache = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "auto",
+        [spec.block_size],
+        {},
+    )["layer"]
+
+    assert kv_cache.shape == (num_blocks, 2, 2, 1, 2)
+    assert kv_cache.stride(0) == row_stride // spec.dtype.itemsize
+    assert kv_cache[1].storage_offset() == row_stride // spec.dtype.itemsize
+
+
 def test_reshape_padded_flash_attention_kv_cache_strides_by_page():
     num_blocks = 3
     spec = FullAttentionSpec(

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
+import pytest
 import torch
 
+import vllm.v1.worker.gpu.attn_utils as attn_utils_module
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -10,8 +14,110 @@ from vllm.v1.kv_cache_interface import (
     KVQuantMode,
     MambaSpec,
 )
-from vllm.v1.worker.gpu.attn_utils import _reshape_kv_cache
+from vllm.v1.worker.gpu.attn_utils import _allocate_kv_cache, _reshape_kv_cache
 from vllm.v1.worker.utils import AttentionGroup
+
+
+class _FakeSharedHostRegion:
+    def __init__(self) -> None:
+        self.cleanup_calls = 0
+
+    def cleanup(self) -> None:
+        self.cleanup_calls += 1
+
+
+def test_allocate_kv_cache_rolls_back_shared_region_on_device_failure(monkeypatch):
+    region = _FakeSharedHostRegion()
+    host_tensor = torch.empty(8, dtype=torch.int8)
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=[
+            SimpleNamespace(
+                size=host_tensor.numel(),
+                shared_by=["host"],
+                host_resident=True,
+                block_pool_id=None,
+                block_stride=0,
+            ),
+            SimpleNamespace(
+                size=8,
+                shared_by=["device"],
+                host_resident=False,
+                block_pool_id=0,
+                block_stride=0,
+            ),
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(layer_names=["host"]),
+            SimpleNamespace(layer_names=["device"]),
+        ],
+        hisparse_host_num_blocks=1,
+        hisparse_host_block_stride=4096,
+        hisparse_shared_host_pool=True,
+    )
+    monkeypatch.setattr(
+        attn_utils_module,
+        "allocate_hisparse_host_pools",
+        lambda *args, **kwargs: ([host_tensor], [], region),
+    )
+
+    def fail_device_allocation(*args, **kwargs):
+        raise RuntimeError("device allocation failed")
+
+    monkeypatch.setattr(attn_utils_module.torch, "zeros", fail_device_allocation)
+
+    with pytest.raises(RuntimeError, match="device allocation failed"):
+        _allocate_kv_cache(
+            kv_cache_config,
+            shared_layers={},
+            device=torch.device("cpu"),
+            vllm_config=SimpleNamespace(),
+        )
+
+    assert region.cleanup_calls == 1
+
+
+def test_init_kv_cache_rolls_back_shared_region_on_worker_failure(monkeypatch):
+    region = _FakeSharedHostRegion()
+    kv_cache_config = SimpleNamespace()
+    vllm_config = SimpleNamespace(
+        attention_config=SimpleNamespace(hisparse_config=SimpleNamespace()),
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        model_config=SimpleNamespace(max_model_len=1),
+        max_concurrent_batches=1,
+    )
+    monkeypatch.setattr(attn_utils_module, "get_shared_kv_cache_layers", lambda _: {})
+    monkeypatch.setattr(
+        attn_utils_module,
+        "_allocate_kv_cache",
+        lambda *args, **kwargs: ({}, [], region),
+    )
+    monkeypatch.setattr(
+        attn_utils_module,
+        "_reshape_kv_cache",
+        lambda *args, **kwargs: {},
+    )
+
+    def fail_worker_initialization(**kwargs):
+        raise RuntimeError("worker initialization failed")
+
+    monkeypatch.setattr(
+        attn_utils_module, "init_hisparse_worker", fail_worker_initialization
+    )
+
+    with pytest.raises(RuntimeError, match="worker initialization failed"):
+        attn_utils_module.init_kv_cache(
+            runner_kv_caches=[],
+            forward_context={},
+            kv_cache_config=kv_cache_config,
+            attn_groups=[],
+            device=torch.device("cpu"),
+            cache_dtype="auto",
+            kernel_block_sizes=[],
+            vllm_config=vllm_config,
+            block_tables=SimpleNamespace(),
+        )
+
+    assert region.cleanup_calls == 1
 
 
 class FakeFlashAttentionBackend:

--- a/tests/v1/worker/test_utils.py
+++ b/tests/v1/worker/test_utils.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 import torch
 
 import vllm.v1.kv_offload.sparse.hisparse_runtime as hisparse_runtime_module
@@ -54,6 +55,7 @@ def test_hisparse_shares_host_pool_only_for_local_tp(monkeypatch):
         assert not hisparse_runtime_module.use_shared_hisparse_host_pool(config)
 
 
+@pytest.mark.skip_global_cleanup
 def test_hisparse_shared_host_pool_uses_one_replicated_mmap(monkeypatch):
     class FakeSharedOffloadRegion:
         BLOCK_SIZE_ALIGNMENT = 4096
@@ -81,22 +83,25 @@ def test_hisparse_shared_host_pool_uses_one_replicated_mmap(monkeypatch):
             pass
 
     monkeypatch.setattr(
-        hisparse_runtime_module.current_platform, "is_cuda_alike", lambda: True
-    )
-    monkeypatch.setattr(
         hisparse_runtime_module, "SharedOffloadRegion", FakeSharedOffloadRegion
     )
     pinned: list[torch.Tensor] = []
     monkeypatch.setattr(hisparse_runtime_module, "pin_tensor", pinned.append)
     config = SimpleNamespace(
         instance_id="instance",
-        parallel_config=_hisparse_parallel_config(),
+        parallel_config=_hisparse_parallel_config(
+            tensor_parallel_size=1,
+            world_size=1,
+            distributed_executor_backend="uni",
+        ),
     )
 
-    pools, private_pools, region = (
-        hisparse_runtime_module.allocate_hisparse_host_pools(
-            config, [24, 40], num_blocks=4
-        )
+    pools, private_pools, region = hisparse_runtime_module.allocate_hisparse_host_pools(
+        config,
+        [24, 40],
+        num_blocks=4,
+        host_block_stride=4096,
+        use_shared_host_pool=True,
     )
 
     assert region is not None
@@ -107,6 +112,7 @@ def test_hisparse_shared_host_pool_uses_one_replicated_mmap(monkeypatch):
         "rank": 0,
         "kv_bytes_per_block": 4096,
         "cpu_page_size": 16,
+        "creator_memory_check": hisparse_runtime_module.check_hisparse_host_memory,
     }
     assert region.view_sizes == [6, 10]
     assert [pool.shape for pool in pools] == [(4, 6), (4, 10)]
@@ -125,6 +131,33 @@ def test_hisparse_worker_finish_step_counts_each_index_group_once():
     worker.leader_runtimes = [SimpleNamespace(index_group=group)]
 
     assert worker.finish_step() == HiSparseStats(7, 3, 48)
+
+
+def test_hisparse_host_pool_uses_resolved_private_mode(monkeypatch):
+    monkeypatch.setattr(
+        hisparse_runtime_module,
+        "allocate_pinned_host_pool",
+        lambda size: (
+            torch.empty(size, dtype=torch.int8),
+            torch.empty(size, dtype=torch.int8),
+        ),
+    )
+    config = SimpleNamespace(
+        instance_id="instance",
+        parallel_config=_hisparse_parallel_config(),
+    )
+
+    pools, private_pools, region = hisparse_runtime_module.allocate_hisparse_host_pools(
+        config,
+        [24, 40],
+        num_blocks=4,
+        host_block_stride=16,
+        use_shared_host_pool=False,
+    )
+
+    assert region is None
+    assert [pool.shape for pool in pools] == [(24,), (40,)]
+    assert [pool.shape for pool in private_pools] == [(24,), (40,)]
 
 
 def test_copy_cpu_kv_cache_logical_blocks_ignores_storage_padding():

--- a/tests/v1/worker/test_utils.py
+++ b/tests/v1/worker/test_utils.py
@@ -17,6 +17,103 @@ from vllm.v1.metrics.stats import HiSparseStats
 from vllm.v1.worker.utils import bind_kv_cache, copy_kv_cache_blocks_inplace
 
 
+def _hisparse_parallel_config(**overrides):
+    values = {
+        "tensor_parallel_size": 2,
+        "pipeline_parallel_size": 1,
+        "prefill_context_parallel_size": 1,
+        "decode_context_parallel_size": 1,
+        "world_size": 2,
+        "distributed_executor_backend": "mp",
+        "nnodes_within_dp": 1,
+        "data_parallel_index": 3,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_hisparse_shares_host_pool_only_for_local_tp(monkeypatch):
+    monkeypatch.setattr(
+        hisparse_runtime_module.current_platform, "is_cuda_alike", lambda: True
+    )
+    config = SimpleNamespace(parallel_config=_hisparse_parallel_config())
+
+    assert hisparse_runtime_module.use_shared_hisparse_host_pool(config)
+
+    unsupported = (
+        {"tensor_parallel_size": 1, "world_size": 1},
+        {"pipeline_parallel_size": 2, "world_size": 4},
+        {"prefill_context_parallel_size": 2, "world_size": 4},
+        {"decode_context_parallel_size": 2},
+        {"world_size": 4},
+        {"distributed_executor_backend": "ray"},
+        {"nnodes_within_dp": 2},
+    )
+    for overrides in unsupported:
+        config.parallel_config = _hisparse_parallel_config(**overrides)
+        assert not hisparse_runtime_module.use_shared_hisparse_host_pool(config)
+
+
+def test_hisparse_shared_host_pool_uses_one_replicated_mmap(monkeypatch):
+    class FakeSharedOffloadRegion:
+        BLOCK_SIZE_ALIGNMENT = 4096
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.total_size_bytes = kwargs["num_blocks"] * kwargs["kv_bytes_per_block"]
+            self.base_tensor = torch.empty(self.total_size_bytes, dtype=torch.int8)
+            self.is_pinned = False
+            self.view_sizes = []
+            self.offset = 0
+
+        def create_next_canonical_view(self, size):
+            self.view_sizes.append(size)
+            view = torch.as_strided(
+                self.base_tensor,
+                size=(self.kwargs["num_blocks"], size),
+                stride=(self.kwargs["kv_bytes_per_block"], 1),
+                storage_offset=self.offset,
+            )
+            self.offset += size
+            return view
+
+        def cleanup(self):
+            pass
+
+    monkeypatch.setattr(
+        hisparse_runtime_module.current_platform, "is_cuda_alike", lambda: True
+    )
+    monkeypatch.setattr(
+        hisparse_runtime_module, "SharedOffloadRegion", FakeSharedOffloadRegion
+    )
+    pinned: list[torch.Tensor] = []
+    monkeypatch.setattr(hisparse_runtime_module, "pin_tensor", pinned.append)
+    config = SimpleNamespace(
+        instance_id="instance",
+        parallel_config=_hisparse_parallel_config(),
+    )
+
+    pools, private_pools, region = (
+        hisparse_runtime_module.allocate_hisparse_host_pools(
+            config, [24, 40], num_blocks=4
+        )
+    )
+
+    assert region is not None
+    assert private_pools == []
+    assert region.kwargs == {
+        "engine_id": "hisparse_instance_dp3",
+        "num_blocks": 4,
+        "rank": 0,
+        "kv_bytes_per_block": 4096,
+        "cpu_page_size": 16,
+    }
+    assert region.view_sizes == [6, 10]
+    assert [pool.shape for pool in pools] == [(4, 6), (4, 10)]
+    assert pinned == [region.base_tensor]
+    assert region.is_pinned
+
+
 def test_hisparse_worker_finish_step_counts_each_index_group_once():
     worker = object.__new__(HiSparseWorker)
     worker._metrics_calls = hisparse_worker_module._METRICS_INTERVAL - 1
@@ -276,6 +373,30 @@ def test_hisparse_worker_preserves_directly_imported_indexer(monkeypatch):
     assert copied == [([4], [20])]
     worker._restore_staging_event.synchronize.assert_called_once_with()
     worker._restore_staging_event.record.assert_called_once_with(current_stream)
+
+
+def test_hisparse_worker_shutdown_releases_pinned_state(monkeypatch):
+    worker = object.__new__(HiSparseWorker)
+    worker.cache_handles = []
+    worker.pinned_host_pools = []
+    worker.indexer_source_layers = []
+    worker.shared_host_region = object()
+    released = False
+
+    def release_pinned_state(runtimes, pinned_host_pools, shared_host_region):
+        nonlocal released
+        assert runtimes == []
+        assert pinned_host_pools == []
+        assert shared_host_region is worker.shared_host_region
+        released = True
+
+    monkeypatch.setattr(
+        hisparse_worker_module, "release_pinned_state", release_pinned_state
+    )
+
+    worker.shutdown()
+
+    assert released
 
 
 def test_bind_kv_cache(default_vllm_config):

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -41,7 +41,10 @@ from vllm.v1.kv_cache_interface import (
     replace_as,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
-from vllm.v1.kv_offload.sparse.hisparse_runtime import ResolvedHiSparseConfig
+from vllm.v1.kv_offload.sparse.hisparse_runtime import (
+    ResolvedHiSparseConfig,
+    get_hisparse_host_block_stride,
+)
 from vllm.v1.request import Request
 from vllm.v1.utils import tensor_data
 
@@ -1657,7 +1660,8 @@ def _get_hisparse_hma_config(
     )
     gpu_stride = round_up(gpu_stride, hot_page_alignment)
     host_page = sum(spec.page_size_bytes for spec in source_specs.values())
-    host_num_blocks = host_budget // host_page
+    host_block_stride = get_hisparse_host_block_stride(vllm_config, host_page)
+    host_num_blocks = host_budget // host_block_stride
     gpu_num_blocks = available_memory // gpu_stride
     override = vllm_config.cache_config.num_gpu_blocks_override
     if override is not None:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -44,6 +44,7 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.kv_offload.sparse.hisparse_runtime import (
     ResolvedHiSparseConfig,
     get_hisparse_host_block_stride,
+    use_shared_hisparse_host_pool,
 )
 from vllm.v1.request import Request
 from vllm.v1.utils import tensor_data
@@ -1660,7 +1661,15 @@ def _get_hisparse_hma_config(
     )
     gpu_stride = round_up(gpu_stride, hot_page_alignment)
     host_page = sum(spec.page_size_bytes for spec in source_specs.values())
-    host_block_stride = get_hisparse_host_block_stride(vllm_config, host_page)
+    topology_supports_sharing = use_shared_hisparse_host_pool(vllm_config)
+    indexer_layout_supports_sharing = all(
+        spec.storage_block_size == gpu_indexer_specs[name].storage_block_size
+        for name, spec in indexer_specs.items()
+    )
+    shared_host_pool = topology_supports_sharing and indexer_layout_supports_sharing
+    host_block_stride = get_hisparse_host_block_stride(
+        host_page, use_shared_host_pool=shared_host_pool
+    )
     host_num_blocks = host_budget // host_block_stride
     gpu_num_blocks = available_memory // gpu_stride
     override = vllm_config.cache_config.num_gpu_blocks_override
@@ -1693,11 +1702,26 @@ def _get_hisparse_hma_config(
         for offset, names in sorted(gpu_layers_by_offset.items())
     )
     if log_layout:
+        if shared_host_pool:
+            host_pool_mode = "shared"
+            selection_reason = "topology_and_indexer_layout_shareable"
+        elif topology_supports_sharing:
+            host_pool_mode = "private"
+            selection_reason = "indexer_layout_not_shareable"
+        else:
+            host_pool_mode = "private"
+            selection_reason = "topology_not_shareable"
         logger.info(
-            "HiSparse HMA: %.1f GiB host source (%d blocks), %.1f GiB shared "
-            "GPU indexer/resident/hot pool (%d blocks, %d resident/hot groups).",
+            "HiSparse HMA: host pool mode=%s (%s), %.1f GiB logical, "
+            "%.1f GiB physical per pool (%d blocks, %d-byte stride); "
+            "%.1f GiB shared GPU indexer/resident/hot pool (%d blocks, "
+            "%d resident/hot groups).",
+            host_pool_mode,
+            selection_reason,
             host_num_blocks * host_page / 2**30,
+            host_num_blocks * host_block_stride / 2**30,
             host_num_blocks,
+            host_block_stride,
             gpu_num_blocks * gpu_stride / 2**30,
             gpu_num_blocks,
             len(hot_groups),
@@ -1715,6 +1739,8 @@ def _get_hisparse_hma_config(
             *gpu_other_regular_groups,
         ],
         hisparse_host_num_blocks=host_num_blocks,
+        hisparse_host_block_stride=host_block_stride,
+        hisparse_shared_host_pool=shared_host_pool,
         prefix_cache_retention_interval=getattr(
             vllm_config.cache_config, "prefix_cache_retention_interval", None
         ),
@@ -2291,6 +2317,14 @@ def generate_scheduler_kv_cache_config(
     )
     assert all(
         cfg.hisparse_host_num_blocks == kv_cache_configs[0].hisparse_host_num_blocks
+        for cfg in kv_cache_configs
+    )
+    assert all(
+        cfg.hisparse_host_block_stride == kv_cache_configs[0].hisparse_host_block_stride
+        for cfg in kv_cache_configs
+    )
+    assert all(
+        cfg.hisparse_shared_host_pool == kv_cache_configs[0].hisparse_shared_host_pool
         for cfg in kv_cache_configs
     )
     # All workers have the same kv_cache_config except layer names, so use

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -1078,6 +1078,12 @@ class KVCacheConfig:
     hisparse_host_num_blocks: int | None = None
     """Capacity of the dedicated HiSparse host-block manager, when enabled."""
 
+    hisparse_host_block_stride: int | None = None
+    """Physical bytes between consecutive HiSparse host blocks."""
+
+    hisparse_shared_host_pool: bool = False
+    """Whether local TP ranks share one physical HiSparse host pool."""
+
     @cached_property
     def transfer_group_ids(self) -> tuple[int, ...]:
         """IDs of cache groups that participate in external KV transfer."""
@@ -1123,6 +1129,17 @@ class KVCacheConfig:
             self.hisparse_host_num_blocks < 0
         ):
             raise ValueError("HiSparse host block-pool size must be non-negative.")
+        if self.hisparse_host_block_stride is not None and (
+            self.hisparse_host_block_stride <= 0
+        ):
+            raise ValueError("HiSparse host block stride must be positive.")
+        if self.hisparse_shared_host_pool and (
+            self.hisparse_host_num_blocks is None
+            or self.hisparse_host_block_stride is None
+        ):
+            raise ValueError(
+                "A shared HiSparse host pool requires host blocks and block stride."
+            )
         if self.num_blocks != self.num_blocks_by_pool[0]:
             raise ValueError(
                 "KVCacheConfig.num_blocks must equal num_blocks_by_pool[0]."

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -170,6 +170,12 @@ class SharedOffloadRegion:
         self._canonical_offset = 0
         self.is_pinned: bool = False
 
+    @property
+    def base_tensor(self) -> torch.Tensor:
+        if self._base is None:
+            raise RuntimeError("Shared offload region has been released.")
+        return self._base
+
     def create_next_worker_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
 

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -25,8 +25,13 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0) -> N
     """Spin-wait until the file reaches expected_size (creator truncated it)."""
     deadline = time.monotonic() + timeout
     while True:
-        if os.fstat(fd).st_size >= expected_size:
+        file_stat = os.fstat(fd)
+        if file_stat.st_size >= expected_size:
             return
+        if file_stat.st_nlink == 0:
+            raise RuntimeError(
+                "Shared offload region creator failed during initialization."
+            )
         if time.monotonic() > deadline:
             raise TimeoutError(
                 f"Timed out waiting for mmap file to reach {expected_size} bytes"
@@ -83,6 +88,8 @@ class SharedOffloadRegion:
         rank: int | None,
         kv_bytes_per_block: int,
         cpu_page_size: int,
+        *,
+        creator_memory_check: Callable[[int], None] | None = None,
     ) -> None:
         self.page_size = mmap.PAGESIZE
         assert kv_bytes_per_block % self.page_size == 0
@@ -109,7 +116,7 @@ class SharedOffloadRegion:
             self.fd = os.open(self.mmap_path, os.O_RDWR)
             try:
                 _wait_for_file_size(self.fd, self.total_size_bytes)
-            except (TimeoutError, OSError):
+            except (RuntimeError, TimeoutError, OSError):
                 os.close(self.fd)
                 raise
             logger.info("Opened existing mmap file %s", self.mmap_path)
@@ -119,9 +126,11 @@ class SharedOffloadRegion:
             # land on a 0-byte stub and spin in _wait_for_file_size
             # for the full 30 s timeout.
             try:
+                if creator_memory_check is not None:
+                    creator_memory_check(self.total_size_bytes)
                 check_shm_free_space(self.total_size_bytes)
                 os.ftruncate(self.fd, self.total_size_bytes)
-            except (RuntimeError, OSError):
+            except (ValueError, RuntimeError, OSError):
                 os.unlink(self.mmap_path)
                 os.close(self.fd)
                 raise

--- a/vllm/v1/kv_offload/sparse/hisparse_runtime.py
+++ b/vllm/v1/kv_offload/sparse/hisparse_runtime.py
@@ -16,6 +16,7 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import round_up
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
 
 logger = init_logger(__name__)
@@ -196,11 +197,82 @@ def allocate_pinned_host_pool(size: int) -> tuple[torch.Tensor, torch.Tensor]:
     return registered[:size], registered
 
 
+def use_shared_hisparse_host_pool(vllm_config: VllmConfig) -> bool:
+    """Whether replicated MLA host KV can share one local mmap."""
+    parallel = vllm_config.parallel_config
+    return (
+        current_platform.is_cuda_alike()
+        and parallel.tensor_parallel_size > 1
+        and parallel.pipeline_parallel_size == 1
+        and parallel.prefill_context_parallel_size == 1
+        and parallel.decode_context_parallel_size == 1
+        and parallel.world_size == parallel.tensor_parallel_size
+        and parallel.distributed_executor_backend == "mp"
+        and parallel.nnodes_within_dp == 1
+    )
+
+
+def get_hisparse_host_block_stride(
+    vllm_config: VllmConfig, page_size_bytes: int
+) -> int:
+    if use_shared_hisparse_host_pool(vllm_config):
+        return round_up(page_size_bytes, SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT)
+    return page_size_bytes
+
+
+def allocate_hisparse_host_pools(
+    vllm_config: VllmConfig,
+    tensor_sizes: list[int],
+    num_blocks: int,
+) -> tuple[list[torch.Tensor], list[torch.Tensor], SharedOffloadRegion | None]:
+    """Allocate private host tensors or one mmap shared by local TP ranks."""
+    if not use_shared_hisparse_host_pool(vllm_config):
+        check_hisparse_host_memory(sum(tensor_sizes))
+        private_pools = [allocate_pinned_host_pool(size) for size in tensor_sizes]
+        return (
+            [pool for pool, _ in private_pools],
+            [registered for _, registered in private_pools],
+            None,
+        )
+
+    page_sizes = []
+    for size in tensor_sizes:
+        if size % num_blocks:
+            raise ValueError(
+                f"HiSparse host tensor size {size} is not divisible by "
+                f"{num_blocks} blocks."
+            )
+        page_sizes.append(size // num_blocks)
+    page_size = sum(page_sizes)
+    region = SharedOffloadRegion(
+        engine_id=(
+            f"hisparse_{vllm_config.instance_id}_"
+            f"dp{vllm_config.parallel_config.data_parallel_index}"
+        ),
+        num_blocks=num_blocks,
+        rank=0,
+        kv_bytes_per_block=get_hisparse_host_block_stride(vllm_config, page_size),
+        cpu_page_size=page_size,
+    )
+    try:
+        pin_tensor(region.base_tensor)
+        region.is_pinned = True
+        pools = [
+            region.create_next_canonical_view(page_size) for page_size in page_sizes
+        ]
+    except Exception:
+        region.cleanup()
+        raise
+    return pools, [], region
+
+
 def release_pinned_state(
-    runtimes: list[HiSparseRuntime], pinned_host_pools: list[torch.Tensor]
+    runtimes: list[HiSparseRuntime],
+    pinned_host_pools: list[torch.Tensor],
+    shared_host_region: SharedOffloadRegion | None = None,
 ) -> None:
     """Synchronize and release registered host KV pools."""
-    if pinned_host_pools:
+    if pinned_host_pools or shared_host_region is not None:
         try:
             torch.accelerator.synchronize()
         except RuntimeError as e:
@@ -208,7 +280,7 @@ def release_pinned_state(
                 "HiSparse: CUDA context unusable at teardown (%s); leaving "
                 "%d host-pool tensors pinned for kernel exit reclaim.",
                 e,
-                len(pinned_host_pools),
+                len(pinned_host_pools) + int(shared_host_region is not None),
             )
             return
 
@@ -238,6 +310,8 @@ def release_pinned_state(
 
     for runtime in runtimes:
         del runtime._host_cache
+    if shared_host_region is not None:
+        shared_host_region.cleanup()
 
 
 def hisparse_prefill_staging_remap(

--- a/vllm/v1/kv_offload/sparse/hisparse_runtime.py
+++ b/vllm/v1/kv_offload/sparse/hisparse_runtime.py
@@ -213,9 +213,9 @@ def use_shared_hisparse_host_pool(vllm_config: VllmConfig) -> bool:
 
 
 def get_hisparse_host_block_stride(
-    vllm_config: VllmConfig, page_size_bytes: int
+    page_size_bytes: int, *, use_shared_host_pool: bool
 ) -> int:
-    if use_shared_hisparse_host_pool(vllm_config):
+    if use_shared_host_pool:
         return round_up(page_size_bytes, SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT)
     return page_size_bytes
 
@@ -224,9 +224,12 @@ def allocate_hisparse_host_pools(
     vllm_config: VllmConfig,
     tensor_sizes: list[int],
     num_blocks: int,
+    host_block_stride: int,
+    *,
+    use_shared_host_pool: bool,
 ) -> tuple[list[torch.Tensor], list[torch.Tensor], SharedOffloadRegion | None]:
     """Allocate private host tensors or one mmap shared by local TP ranks."""
-    if not use_shared_hisparse_host_pool(vllm_config):
+    if not use_shared_host_pool:
         check_hisparse_host_memory(sum(tensor_sizes))
         private_pools = [allocate_pinned_host_pool(size) for size in tensor_sizes]
         return (
@@ -251,8 +254,9 @@ def allocate_hisparse_host_pools(
         ),
         num_blocks=num_blocks,
         rank=0,
-        kv_bytes_per_block=get_hisparse_host_block_stride(vllm_config, page_size),
+        kv_bytes_per_block=host_block_stride,
         cpu_page_size=page_size,
+        creator_memory_check=check_hisparse_host_memory,
     )
     try:
         pin_tensor(region.base_tensor)
@@ -264,6 +268,13 @@ def allocate_hisparse_host_pools(
         region.cleanup()
         raise
     return pools, [], region
+
+
+def rollback_hisparse_shared_region(
+    region: SharedOffloadRegion | None,
+) -> None:
+    if region is not None:
+        region.cleanup()
 
 
 def release_pinned_state(

--- a/vllm/v1/kv_offload/sparse/hisparse_worker.py
+++ b/vllm/v1/kv_offload/sparse/hisparse_worker.py
@@ -39,6 +39,7 @@ from vllm.v1.worker.utils import copy_kv_cache_blocks_inplace
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
     from vllm.v1.worker.gpu.block_table import BlockTables
 
 
@@ -82,8 +83,10 @@ class HiSparseWorker:
         device: torch.device,
         pinned_host_pools: list[torch.Tensor],
         indexer_source_layers: list[Any],
+        shared_host_region: SharedOffloadRegion | None = None,
     ) -> None:
         self.cache_pairs = cache_pairs
+        self.shared_host_region = shared_host_region
         kernel_block_size = cache_pairs[0][0].shape[1]
         self.kernel_block_size = kernel_block_size
         self.blocks_per_kv_block = blocks_per_kv_block
@@ -403,7 +406,9 @@ class HiSparseWorker:
             layer.hisparse_indexer_source = None
         self.indexer_source_layers.clear()
         release_pinned_state(
-            [cache.runtime for cache in self.cache_handles], self.pinned_host_pools
+            [cache.runtime for cache in self.cache_handles],
+            self.pinned_host_pools,
+            self.shared_host_region,
         )
 
     def restore_prefix(
@@ -483,6 +488,7 @@ def init_hisparse_worker(
     max_concurrent_batches: int,
     device: torch.device,
     pinned_host_pools: list[torch.Tensor],
+    shared_host_region: SharedOffloadRegion | None,
 ) -> HiSparseWorker:
     tensor_configs = {
         name: tensor_config
@@ -516,14 +522,26 @@ def init_hisparse_worker(
         source_block_size = source_spec.storage_block_size
         assert source_block_size % kernel_block_size == 0
         blocks_per_kv_block = source_block_size // kernel_block_size
+        raw_tensor = raw_tensors[cache_name]
         kernel_page_stride = (
             gpu_indexer_spec.page_size_bytes // source_spec.dtype.itemsize
         )
         assert source_spec.page_size_bytes == (
             blocks_per_kv_block * gpu_indexer_spec.page_size_bytes
         )
+        if raw_tensor.ndim == 2:
+            if blocks_per_kv_block != 1:
+                raise ValueError(
+                    "Shared HiSparse host pools require one kernel page per "
+                    "scheduler block."
+                )
+            kernel_page_stride = (
+                raw_tensor.stride(0)
+                * raw_tensor.element_size()
+                // source_spec.dtype.itemsize
+            )
         source_cache = torch.as_strided(
-            raw_tensors[cache_name].view(source_spec.dtype),
+            raw_tensor.view(source_spec.dtype),
             size=(
                 host_num_blocks * blocks_per_kv_block,
                 kernel_block_size,
@@ -627,4 +645,5 @@ def init_hisparse_worker(
         device,
         pinned_host_pools,
         indexer_source_layers,
+        shared_host_region,
     )

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -32,8 +32,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_offload.sparse.hisparse_runtime import (
-    allocate_pinned_host_pool,
-    check_hisparse_host_memory,
+    allocate_hisparse_host_pools,
 )
 from vllm.v1.kv_offload.sparse.hisparse_worker import (
     HiSparseWorker,
@@ -48,6 +47,7 @@ from vllm.v1.worker.utils import (
 )
 
 if TYPE_CHECKING:
+    from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
     from vllm.v1.worker.gpu.block_table import BlockTables
 
 logger = init_logger(__name__)
@@ -220,22 +220,33 @@ def _allocate_kv_cache(
     kv_cache_config: KVCacheConfig,
     shared_layers: dict[str, str],
     device: torch.device,
-) -> tuple[dict[str, torch.Tensor], list[torch.Tensor]]:
-    host_bytes = sum(
-        tensor.size
-        for tensor in kv_cache_config.kv_cache_tensors
-        if tensor.host_resident
-    )
-    if host_bytes:
-        check_hisparse_host_memory(host_bytes)
+    vllm_config: VllmConfig,
+) -> tuple[
+    dict[str, torch.Tensor], list[torch.Tensor], "SharedOffloadRegion | None"
+]:
+    host_tensor_configs = [
+        tensor for tensor in kv_cache_config.kv_cache_tensors if tensor.host_resident
+    ]
+    shared_host_region = None
+    host_tensors: list[torch.Tensor] = []
+    pinned_host_pools: list[torch.Tensor] = []
+    if host_tensor_configs:
+        host_num_blocks = kv_cache_config.hisparse_host_num_blocks
+        assert host_num_blocks is not None
+        host_tensors, pinned_host_pools, shared_host_region = (
+            allocate_hisparse_host_pools(
+                vllm_config,
+                [tensor.size for tensor in host_tensor_configs],
+                host_num_blocks,
+            )
+        )
+    host_tensor_iter = iter(host_tensors)
 
     kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
     packed_backings: dict[int, torch.Tensor] = {}
-    pinned_host_pools: list[torch.Tensor] = []
     for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
         if kv_cache_tensor.host_resident:
-            tensor, registered_pool = allocate_pinned_host_pool(kv_cache_tensor.size)
-            pinned_host_pools.append(registered_pool)
+            tensor = next(host_tensor_iter)
         elif kv_cache_tensor.block_stride > 0:
             assert kv_cache_tensor.block_pool_id is not None
             # Allocate once; all packed tensors alias the same backing.
@@ -258,7 +269,7 @@ def _allocate_kv_cache(
     assert layer_names == (kv_cache_raw_tensors.keys() | shared_layers.keys()), (
         "Some layers are not correctly initialized"
     )
-    return kv_cache_raw_tensors, pinned_host_pools
+    return kv_cache_raw_tensors, pinned_host_pools, shared_host_region
 
 
 def _kv_first_layers_sharing_pool_with_mamba(
@@ -590,8 +601,8 @@ def init_kv_cache(
     block_tables: "BlockTables",
 ) -> tuple[dict[str, Any], "HiSparseWorker | None"]:
     shared_kv_cache_layers = get_shared_kv_cache_layers(vllm_config)
-    kv_cache_raw_tensors, pinned_host_pools = _allocate_kv_cache(
-        kv_cache_config, shared_kv_cache_layers, device
+    kv_cache_raw_tensors, pinned_host_pools, shared_host_region = _allocate_kv_cache(
+        kv_cache_config, shared_kv_cache_layers, device, vllm_config
     )
     flattened_attn_groups = list(group for groups in attn_groups for group in groups)
     kv_caches = _reshape_kv_cache(
@@ -615,6 +626,7 @@ def init_kv_cache(
             max_model_len=vllm_config.model_config.max_model_len,
             max_concurrent_batches=vllm_config.max_concurrent_batches,
             device=device,
+            shared_host_region=shared_host_region,
         )
     # Dual-attention models (e.g. LongCat-Flash) put two Attention modules per
     # decoder layer, so a layer name carries two integers (layer + module index).

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -33,6 +33,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_offload.sparse.hisparse_runtime import (
     allocate_hisparse_host_pools,
+    rollback_hisparse_shared_region,
 )
 from vllm.v1.kv_offload.sparse.hisparse_worker import (
     HiSparseWorker,
@@ -221,9 +222,7 @@ def _allocate_kv_cache(
     shared_layers: dict[str, str],
     device: torch.device,
     vllm_config: VllmConfig,
-) -> tuple[
-    dict[str, torch.Tensor], list[torch.Tensor], "SharedOffloadRegion | None"
-]:
+) -> tuple[dict[str, torch.Tensor], list[torch.Tensor], "SharedOffloadRegion | None"]:
     host_tensor_configs = [
         tensor for tensor in kv_cache_config.kv_cache_tensors if tensor.host_resident
     ]
@@ -232,44 +231,55 @@ def _allocate_kv_cache(
     pinned_host_pools: list[torch.Tensor] = []
     if host_tensor_configs:
         host_num_blocks = kv_cache_config.hisparse_host_num_blocks
+        host_block_stride = kv_cache_config.hisparse_host_block_stride
         assert host_num_blocks is not None
+        assert host_block_stride is not None
         host_tensors, pinned_host_pools, shared_host_region = (
             allocate_hisparse_host_pools(
                 vllm_config,
                 [tensor.size for tensor in host_tensor_configs],
                 host_num_blocks,
+                host_block_stride,
+                use_shared_host_pool=kv_cache_config.hisparse_shared_host_pool,
             )
         )
-    host_tensor_iter = iter(host_tensors)
-
     kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
     packed_backings: dict[int, torch.Tensor] = {}
-    for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-        if kv_cache_tensor.host_resident:
-            tensor = next(host_tensor_iter)
-        elif kv_cache_tensor.block_stride > 0:
-            assert kv_cache_tensor.block_pool_id is not None
-            # Allocate once; all packed tensors alias the same backing.
-            packed_backing = packed_backings.get(kv_cache_tensor.block_pool_id)
-            if packed_backing is None:
-                packed_backing = torch.zeros(
+    allocation_complete = False
+    try:
+        host_tensor_iter = iter(host_tensors)
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            if kv_cache_tensor.host_resident:
+                tensor = next(host_tensor_iter)
+            elif kv_cache_tensor.block_stride > 0:
+                assert kv_cache_tensor.block_pool_id is not None
+                # Allocate once; all packed tensors alias the same backing.
+                packed_backing = packed_backings.get(kv_cache_tensor.block_pool_id)
+                if packed_backing is None:
+                    packed_backing = torch.zeros(
+                        kv_cache_tensor.size, dtype=torch.int8, device=device
+                    )
+                    packed_backings[kv_cache_tensor.block_pool_id] = packed_backing
+                tensor = packed_backing
+            else:
+                tensor = torch.zeros(
                     kv_cache_tensor.size, dtype=torch.int8, device=device
                 )
-                packed_backings[kv_cache_tensor.block_pool_id] = packed_backing
-            tensor = packed_backing
-        else:
-            tensor = torch.zeros(kv_cache_tensor.size, dtype=torch.int8, device=device)
-        for layer_name in kv_cache_tensor.shared_by:
-            kv_cache_raw_tensors[layer_name] = tensor
+            for layer_name in kv_cache_tensor.shared_by:
+                kv_cache_raw_tensors[layer_name] = tensor
 
-    layer_names = set()
-    for group in kv_cache_config.kv_cache_groups:
-        for layer_name in group.layer_names:
-            layer_names.add(layer_name)
-    assert layer_names == (kv_cache_raw_tensors.keys() | shared_layers.keys()), (
-        "Some layers are not correctly initialized"
-    )
-    return kv_cache_raw_tensors, pinned_host_pools, shared_host_region
+        layer_names = set()
+        for group in kv_cache_config.kv_cache_groups:
+            for layer_name in group.layer_names:
+                layer_names.add(layer_name)
+        assert layer_names == (kv_cache_raw_tensors.keys() | shared_layers.keys()), (
+            "Some layers are not correctly initialized"
+        )
+        allocation_complete = True
+        return kv_cache_raw_tensors, pinned_host_pools, shared_host_region
+    finally:
+        if not allocation_complete:
+            rollback_hisparse_shared_region(shared_host_region)
 
 
 def _kv_first_layers_sharing_pool_with_mamba(
@@ -604,46 +614,59 @@ def init_kv_cache(
     kv_cache_raw_tensors, pinned_host_pools, shared_host_region = _allocate_kv_cache(
         kv_cache_config, shared_kv_cache_layers, device, vllm_config
     )
-    flattened_attn_groups = list(group for groups in attn_groups for group in groups)
-    kv_caches = _reshape_kv_cache(
-        attn_groups=flattened_attn_groups,
-        kv_cache_raw_tensors=kv_cache_raw_tensors,
-        kernel_block_sizes=kernel_block_sizes,
-        cache_dtype=cache_dtype,
-        shared_kv_cache_layers=shared_kv_cache_layers,
-        kv_cache_config=kv_cache_config,
-    )
     hisparse_worker = None
-    if vllm_config.attention_config.hisparse_config is not None:
-        hisparse_worker = init_hisparse_worker(
-            forward_context=forward_context,
-            kv_cache_config=kv_cache_config,
-            raw_tensors=kv_cache_raw_tensors,
-            kv_caches=kv_caches,
-            block_tables=block_tables,
-            pinned_host_pools=pinned_host_pools,
-            max_num_reqs=vllm_config.scheduler_config.max_num_seqs,
-            max_model_len=vllm_config.model_config.max_model_len,
-            max_concurrent_batches=vllm_config.max_concurrent_batches,
-            device=device,
-            shared_host_region=shared_host_region,
+    initialized = False
+    try:
+        flattened_attn_groups = list(
+            group for groups in attn_groups for group in groups
         )
-    # Dual-attention models (e.g. LongCat-Flash) put two Attention modules per
-    # decoder layer, so a layer name carries two integers (layer + module index).
-    num_attn_module = (
-        2
-        if vllm_config.model_config.hf_config.model_type
-        in ("longcat_flash", "longcat_flash_ngram")
-        else 1
-    )
-    bindable_caches = {
-        name: cache for name, cache in kv_caches.items() if name in forward_context
-    }
-    bind_kv_cache(bindable_caches, forward_context, runner_kv_caches, num_attn_module)
-    runner_kv_caches.extend(
-        cache for name, cache in kv_caches.items() if name not in forward_context
-    )
-    return kv_caches, hisparse_worker
+        kv_caches = _reshape_kv_cache(
+            attn_groups=flattened_attn_groups,
+            kv_cache_raw_tensors=kv_cache_raw_tensors,
+            kernel_block_sizes=kernel_block_sizes,
+            cache_dtype=cache_dtype,
+            shared_kv_cache_layers=shared_kv_cache_layers,
+            kv_cache_config=kv_cache_config,
+        )
+        if vllm_config.attention_config.hisparse_config is not None:
+            hisparse_worker = init_hisparse_worker(
+                forward_context=forward_context,
+                kv_cache_config=kv_cache_config,
+                raw_tensors=kv_cache_raw_tensors,
+                kv_caches=kv_caches,
+                block_tables=block_tables,
+                pinned_host_pools=pinned_host_pools,
+                max_num_reqs=vllm_config.scheduler_config.max_num_seqs,
+                max_model_len=vllm_config.model_config.max_model_len,
+                max_concurrent_batches=vllm_config.max_concurrent_batches,
+                device=device,
+                shared_host_region=shared_host_region,
+            )
+        # Dual-attention models (e.g. LongCat-Flash) put two Attention modules per
+        # decoder layer, so a layer name carries two integers (layer + module index).
+        num_attn_module = (
+            2
+            if vllm_config.model_config.hf_config.model_type
+            in ("longcat_flash", "longcat_flash_ngram")
+            else 1
+        )
+        bindable_caches = {
+            name: cache for name, cache in kv_caches.items() if name in forward_context
+        }
+        bind_kv_cache(
+            bindable_caches, forward_context, runner_kv_caches, num_attn_module
+        )
+        runner_kv_caches.extend(
+            cache for name, cache in kv_caches.items() if name not in forward_context
+        )
+        initialized = True
+        return kv_caches, hisparse_worker
+    finally:
+        if not initialized and shared_host_region is not None:
+            if hisparse_worker is None:
+                rollback_hisparse_shared_region(shared_host_region)
+            else:
+                hisparse_worker.shutdown()
 
 
 def build_slot_mappings_by_layer(


### PR DESCRIPTION
## Summary
This PR optimizes #51324 with the following improvements:
- Resolve shared/private Host pool mode in the KV cache planner.
- Fall back to private pools when the Indexer block layout cannot be represented
  by the shared mmap layout.
- Propagate the resolved mode and physical Host block stride through
  `KVCacheConfig`.
- Roll back the shared Host region when GPU KV allocation or HiSparse worker
  initialization fails.
- Check physical Host RAM only in the shared mmap creator process.
- Fail joiners promptly when the creator fails and unlinks an incomplete mmap.
- Add real multiprocess same-slot visibility coverage.
- Clarify logical versus physical `host_pool_gib` capacity and startup logging.

This is intentionally based on `feat/hisparse-metrics` so it remains the [3/N] change in the HiSparse stack.

cc @MatthewBonanni 