### PR TITLE
[Kimi K3 Bug] Fix kimi k3 KeyError: 'language_model.model.layers.0.self_attn'

### DIFF
--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -658,7 +658,10 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         )
 
         assert isinstance(attn_metadata_raw, dict)
-        attn_metadata_narrowed = attn_metadata_raw[self.prefix]
+        attn_metadata_narrowed = attn_metadata_raw.get(self.prefix)
+        if attn_metadata_narrowed is None:
+            # None in profile/warmup dummy runs
+            return
         assert isinstance(attn_metadata_narrowed, KimiK3KDAMetadata)
         m = attn_metadata_narrowed
         has_initial_state = m.has_initial_state


### PR DESCRIPTION
## Purpose

This bug is introduced by https://github.com/vllm-project/vllm/pull/53306

It skips Mamba-family attention metadata during profile/warmup dummy runs. This PR fixes the issue

## Test

```bash
vllm serve moonshotai/Kimi-K3 \
  --trust-remote-code \
  -tp 8 \
  --load-format fastsafetensors \
  --enable-prefix-caching \
  --reasoning-parser kimi_k3 \
  --enable-auto-tool-choice \
  --tool-call-parser kimi_k3 \
  --host 0.0.0.0 \
  --port 30000
```

Main

```bash
(Worker_TP5 pid=3131903) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     attn_metadata_narrowed = attn_metadata_raw[self.prefix]
(Worker_TP5 pid=3131903) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]                              ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
(Worker_TP3 pid=3131901) ERROR 08-24 13:18:52 [multiproc_executor.py:1050] KeyError: 'language_model.model.layers.0.self_attn'
(Worker_TP5 pid=3131903) ERROR 08-24 13:18:52 [multiproc_executor.py:1050] KeyError: 'language_model.model.layers.0.self_attn'
(Worker_TP3 pid=3131901) ERROR 08-24 13:18:52 [multiproc_executor.py:1050] 
(Worker_TP5 pid=3131903) ERROR 08-24 13:18:52 [multiproc_executor.py:1050] 
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/model.py", line 1367, in forward
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     hidden_states, prefix_sum, residual = layer(
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]                                           ^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     return self._call_impl(*args, **kwargs)
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1789, in _call_impl
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     return forward_call(*args, **kwargs)
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/model.py", line 1101, in forward
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     hidden_states = self._run_self_attn(positions, hidden_states)
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/model.py", line 1011, in _run_self_attn
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     return self.self_attn(
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]            ^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     return self._call_impl(*args, **kwargs)
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1789, in _call_impl
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     return forward_call(*args, **kwargs)
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/kda.py", line 628, in forward
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     self._forward(
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/vllm-source/vllm/compilation/breakable_cudagraph.py", line 97, in wrapper
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     return fn(*args, **kwargs)
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]   File "/home/yewentao256/vllm-source/vllm/models/kimi_k3/nvidia/kda.py", line 661, in _forward
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]     attn_metadata_narrowed = attn_metadata_raw[self.prefix]
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]                              ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050] KeyError: 'language_model.model.layers.0.self_attn'
(Worker_TP1 pid=3131899) ERROR 08-24 13:18:52 [multiproc_executor.py:1050]
```

Now

```bash
(APIServer pid=3218033) INFO:     Started server process [3218033]
(APIServer pid=3218033) INFO:     Waiting for application startup.
(APIServer pid=3218033) INFO:     Application startup complete.
```