### PR TITLE
[ROCm][CI] Skip ModernBERT FP8 MTEB test when no FP8 ScaledMM kernel exists

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -320,18 +320,6 @@ steps:
 
 #-----------------------------------------------------  mi250 · models / language  -----------------------------------------------------#
 
-- label: ":amd: (MI250) Language Models (MTEB)" # TBD
-  timeout_in_minutes: 180
-  mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
-  agent_pool: mi250_1
-  optional: true
-  working_dir: "/vllm-workspace/tests"
-  source_file_dependencies:
-  - vllm/
-  - tests/models/language/pooling_mteb_test
-  commands:
-  - pytest -v -s models/language/pooling_mteb_test
-
 - label: ":amd: (MI250) Language Models (PPL)" # TBD
   timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx90anightly, amdmi250]
@@ -1960,6 +1948,19 @@ steps:
   - pytest -v -s models/test_vision.py::test_simple_mrope_vision_model_spatial_merge
 
 #-----------------------------------------------------  mi300 · models / language  -----------------------------------------------------#
+
+- label: ":amd: (MI300) Language Models (MTEB)" # TBD
+  timeout_in_minutes: 180
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  dind: false
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/
+  - tests/models/language/pooling_mteb_test
+  commands:
+  - pytest -v -s models/language/pooling_mteb_test
 
 - label: ":amd: (MI300) Language Models (Extended Pooling)" # TBD
   timeout_in_minutes: 180

--- a/tests/models/language/pooling_mteb_test/test_modernbert_fp8.py
+++ b/tests/models/language/pooling_mteb_test/test_modernbert_fp8.py
@@ -5,8 +5,26 @@ import pytest
 
 from tests.models.utils import EmbedModelInfo
 from tests.quantization.utils import is_quant_method_supported
+from vllm.platforms import current_platform
 
 from .mteb_embed_utils import mteb_test_embed_models
+
+
+def _fp8_scaled_mm_unsupported() -> bool:
+    """Whether the ModernBERT online FP8 test should be skipped.
+
+    ``is_quant_method_supported("fp8")`` returns True on MI250 (gfx90a), but
+    serving a per-tensor FP8 linear layer on ROCm requires CDNA3+ or RDNA4,
+    so treat it as unsupported here.
+    """
+    if not is_quant_method_supported("fp8"):
+        return True
+    if current_platform.is_rocm():
+        from vllm.platforms.rocm import get_cdna_version, on_gfx12x
+
+        return get_cdna_version() <= 2 and not on_gfx12x()
+    return False
+
 
 MODEL_INFO = EmbedModelInfo(
     "Alibaba-NLP/gte-modernbert-base",
@@ -39,8 +57,8 @@ def _assert_modernbert_online_fp8(model) -> None:
 
 
 @pytest.mark.skipif(
-    not is_quant_method_supported("fp8"),
-    reason="FP8 is not supported on this GPU type.",
+    _fp8_scaled_mm_unsupported(),
+    reason="No FP8 ScaledMM kernel is available on this GPU type.",
 )
 def test_modernbert_online_fp8_mteb(hf_runner, vllm_runner, monkeypatch) -> None:
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")


### PR DESCRIPTION
## Purpose
`test_modernbert_online_fp8_mteb` fails on MI250 (gfx90a) with `ValueError: Failed to find a kernel that can implement the ScaledMM linear layer`. Its skip guard uses `is_quant_method_supported("fp8")`, which is True on gfx90a, but serving a per-tensor FP8 linear layer on ROCm requires CDNA3+ or RDNA4. 
This PR makes the guard mirror that requirement so the test skips instead of failing.
It also moves the Language Models (MTEB) job from MI250 to MI300, so the whole group runs on hardware that has the kernel.
## Test Plan
`pytest -v -rs tests/models/language/pooling_mteb_test/test_modernbert_fp8.py` on an MI250 (gfx90a)
## Test Result
**Before:**
  ValueError: Failed to find a kernel that can implement the ScaledMM linear layer. Reasons:
  ...
  ROCmFP8ScaledMMLinearKernel requires CDNA3+ (gfx942/gfx950) or RDNA4 (gfx12x).
  PerTensorTorchFP8ScaledMMLinearKernel requires a platform with torch FP8 scaled-MM support..
  ======================= 1 failed, 20 warnings in 10.48s ========================
**After:**
SKIPPED [1] tests/models/language/pooling_mteb_test/test_modernbert_fp8.py:59: No FP8 ScaledMM kernel is available on this GPU type.
======================= 1 skipped, 19 warnings in 2.43s ========================
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

