### PR TITLE
[Bugfix] BailingMoeV3 KDA: skip absent metadata during CUDA graph profiling

### DIFF
--- a/vllm/model_executor/models/bailing_moe_v3.py
+++ b/vllm/model_executor/models/bailing_moe_v3.py
@@ -813,7 +813,10 @@ class BailingMoeV3KimiDeltaAttention(PluggableLayer, MambaBase):
             return
 
         assert isinstance(attn_metadata_map, dict)
-        attn_metadata = attn_metadata_map[self.prefix]
+        attn_metadata = attn_metadata_map.get(self.prefix)
+        if attn_metadata is None:
+            # Profile/warmup dummy runs skip mamba-family metadata.
+            return
         assert isinstance(attn_metadata, GDNAttentionMetadata)
         has_initial_state = attn_metadata.has_initial_state
         spec_query_start_loc = attn_metadata.spec_query_start_loc


### PR DESCRIPTION
PR #53306 omits Mamba-family groups from dummy-run attention metadata. `BailingMoeV3KimiDeltaAttention` still indexed its entry directly, raising KeyError during V2 engine-init warmup dummy runs. Use the same missing-entry guard as the other GDN/KDA paths (see also #53581).

Co-authored-by: Kimi Code CLI