### PR TITLE
[Core] Announce zero prefix-cache retention on sparse-KV models

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3,6 +3,7 @@
 """Compare the with and without prefix caching."""
 
 import copy
+import logging
 from collections.abc import Callable
 from dataclasses import replace
 from math import lcm
@@ -4334,3 +4335,35 @@ def test_swa_shared_prefix_reuse_under_zero_retention():
     assert last_req_hit(retention=0, pin=False) == 0
     # retention=0 with the pin keeps the junction window -> reuse restored.
     assert last_req_hit(retention=0, pin=True) == 4 * block_size
+
+
+def test_zero_retention_is_announced_on_sparse_models(caplog):
+    """The default retains only semantic checkpoints, which is silent otherwise.
+
+    A sparse group files a state at every boundary it crosses and only the
+    semantic ones are hashed, so the rest can never serve a hit -- while the
+    prefix-cache hit-rate metric still reports non-zero. Nothing in the log said
+    so, and the neighbouring derived default (`mamba_cache_mode='align'`) is
+    announced, so this pins the missing half of that pair.
+    """
+    block_size = 16
+    config = _make_hybrid_kv_cache_config(block_size, 32, ["full", "mamba_align"])
+
+    def log_for(retention_interval, enable_caching=True):
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="vllm.v1.core.kv_cache_coordinator"):
+            make_kv_cache_manager(
+                config,
+                max_model_len=8192,
+                enable_caching=enable_caching,
+                hash_block_size=block_size,
+                retention_interval=retention_interval,
+            )
+        return "retain only semantic checkpoints" in caplog.text
+
+    # The default, on a model that actually has a sparse group.
+    assert log_for(0)
+    # Not noise: a periodic interval retains those states, and with caching off
+    # retention cannot affect anything.
+    assert not log_for(block_size)
+    assert not log_for(0, enable_caching=False)

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -33,6 +33,7 @@ def _validate_prefix_cache_retention_interval(
     retention_interval: int | None,
     scheduler_block_size: int,
     kv_cache_config: KVCacheConfig,
+    enable_caching: bool,
 ) -> None:
     if retention_interval is None:
         return
@@ -58,6 +59,18 @@ def _validate_prefix_cache_retention_interval(
             f"prefix_cache_retention_interval ({retention_interval}) "
             "must be non-negative and a multiple of scheduler_block_size "
             f"({scheduler_block_size})."
+        )
+
+    if retention_interval == 0 and enable_caching:
+        # Silent otherwise: unretained boundary states are filed and never
+        # hashed, while the prefix-cache hit rate still reports non-zero.
+        logger.info(
+            "prefix_cache_retention_interval is 0, so sliding-window and Mamba "
+            "groups retain only semantic checkpoints (the latest replay boundary "
+            "and shared-prefix junctions). Other boundary states are not "
+            "reusable. Set prefix_cache_retention_interval to a multiple of the "
+            "scheduler block size (%d) to retain them periodically.",
+            scheduler_block_size,
         )
 
 
@@ -154,7 +167,10 @@ class KVCacheCoordinator(ABC):
         # 0 = keep only the latest replay boundary; None = dense;
         self.retention_interval = kv_cache_config.prefix_cache_retention_interval
         _validate_prefix_cache_retention_interval(
-            self.retention_interval, self.scheduler_block_size, kv_cache_config
+            self.retention_interval,
+            self.scheduler_block_size,
+            kv_cache_config,
+            enable_caching,
         )
 
     def get_num_blocks_to_allocate(


### PR DESCRIPTION
## Purpose

`prefix_cache_retention_interval` defaults to **0**, which per its own docstring "retains only
semantic checkpoints, including the latest replay boundary and shared-prefix junctions". On a model
with sliding-window or Mamba groups, `reachable_block_mask` then masks `True` only for
`reachable_boundaries`: every other boundary state is filed and never hashed, so it can never serve
a hit.

**This costs measurable performance, not tidiness.** On our rig it is one extra cold prefill per
fresh prefix, and it caps what store-side work can achieve — while measuring #53479 the chunk carve
was provably correct and the hits did not move, because this default discards the states that PR
creates. Nothing in the log says the trade was made, and `Prefix cache hit rate` still reports
non-zero, so from outside it looks like the prompts simply do not share a prefix.

The asymmetry is what this closes. vLLM already announces the neighbouring derived default
(`model_executor/models/config.py`):

```
Mamba cache mode is set to 'align' for Qwen3_5ForConditionalGeneration by default
when prefix caching is enabled
```

and `_validate_prefix_cache_retention_interval` already inspects exactly the model shape needed. It
raises a detailed `ValueError` for the harmless case — a value set on a model where retention has no
effect — and returns silently for the harmful one, where the model *does* have a sparse group and
the interval is 0.

## Why this is not duplicating an existing PR

Checks run: `gh pr list --state open --search "53595 in:body"`,
`--search "prefix_cache_retention_interval"`, `--search "retention log warning mamba"`.

- **#52527** (`[Metrics] Report shared-prefix tokens lost to a missing sparse-retention checkpoint`)
  describes the same invisibility and is the closer neighbour. It adds a **runtime metric**:
  per-request signal that reuse was found and then discarded, in `stats.py` / `loggers.py`. This PR
  adds a **startup statement**: the configuration will discard, before any request is served, where
  it cannot be missed. Complementary rather than competing — the metric answers "did I lose reuse
  just now", the log answers "will I". If maintainers prefer one, #52527 is the more substantial
  change and this can be dropped.
- **#51886** adds retention support to `OffloadingConnector`; different feature, no overlap.

## Change

One `logger.info` at startup, gated on prefix caching being enabled **and** the model actually
having a sliding-window or Mamba group **and** the interval being 0. It names the consequence and
the knob. `enable_caching` is threaded into the validator; that is the only new argument.

## Tests

```
python -m pytest tests/v1/core/test_prefix_caching.py -k zero_retention_is_announced
# 1 passed
python -m pytest tests/v1/core/test_prefix_caching.py
# 91 passed, 1 failed (test_hybrid_local_kv_retention_interval_survives_recycling,
#   pre-existing on this checkout: MLAAttentionSpec has no 'tokens_per_state' in the
#   installed build; fails identically without this patch)
ruff check / ruff format --check on both changed files: clean
```

Reverting the source change fails the new test, which asserts the line appears at the default and
does **not** appear with a periodic interval or with caching disabled.

**Model evaluation:** not applicable. The change emits one log line and alters no scheduling,
caching, or sampling behaviour; no output, accuracy or serving path is touched.

## Measured

GB10 / sm_121a, `Qwen3.8-27B-NVFP4` (hybrid GDN), MTP `n=3`, block size 1600. Production code,
nothing patched, only the interval changed:

| | default (0) | interval = block size |
|---|---|---|
| 7 292-token prompt, first hit on request | **3** | **2** |
| 6 592 (block-aligned), first hit | 3 | 3 |
| hit amounts | 3 296 / 4 944 | unchanged |

Reported as #53595.

*AI assistance was used for this change (Claude Code): the investigation, patch and tests were
produced with it and are reviewed by me.*
