### PR TITLE
[MRv2][Bugfix] Initialize DCP metadata

### DIFF
--- a/tests/v1/worker/test_gpu_input_batch_v2.py
+++ b/tests/v1/worker/test_gpu_input_batch_v2.py
@@ -54,7 +54,7 @@ def test_make_dummy_distributes_remainder(num_reqs: int, num_tokens: int):
     )
 
 
-def test_prepare_dcp_local_seq_lens_for_batch(monkeypatch: pytest.MonkeyPatch):
+def test_maybe_prepare_dcp_local_seq_lens(monkeypatch: pytest.MonkeyPatch):
     buffers = InputBuffers(max_num_reqs=4, max_num_tokens=4, device=torch.device("cpu"))
     batch = InputBatch.make_dummy(2, 4, buffers)
     batch.num_reqs_after_padding = 4
@@ -76,18 +76,18 @@ def test_prepare_dcp_local_seq_lens_for_batch(monkeypatch: pytest.MonkeyPatch):
         cp_utils, "prepare_dcp_local_seq_lens", prepare_dcp_local_seq_lens
     )
 
-    cp_utils.prepare_dcp_local_seq_lens_for_batch(batch, buffers, 4, 1, 16)
+    cp_utils.maybe_prepare_dcp_local_seq_lens(batch, buffers, 4, 1, 16)
 
     assert batch.dcp_local_seq_lens is not None
     assert batch.dcp_local_seq_lens.data_ptr() == buffers.dcp_local_seq_lens.data_ptr()
     assert batch.dcp_local_seq_lens.tolist() == [1, 2, 0, 0]
 
 
-def test_prepare_dcp_local_seq_lens_for_batch_without_dcp():
+def test_maybe_prepare_dcp_local_seq_lens_without_dcp():
     buffers = InputBuffers(max_num_reqs=2, max_num_tokens=2, device=torch.device("cpu"))
     batch = InputBatch.make_dummy(1, 1, buffers)
     batch.dcp_local_seq_lens = buffers.dcp_local_seq_lens[:1]
 
-    cp_utils.prepare_dcp_local_seq_lens_for_batch(batch, buffers, 1, 0, 1)
+    cp_utils.maybe_prepare_dcp_local_seq_lens(batch, buffers, 1, 0, 1)
 
     assert batch.dcp_local_seq_lens is None

--- a/tests/v1/worker/test_gpu_input_batch_v2.py
+++ b/tests/v1/worker/test_gpu_input_batch_v2.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.worker.gpu import cp_utils
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 
 DEVICE = current_platform.device_type
@@ -51,3 +52,42 @@ def test_make_dummy_distributes_remainder(num_reqs: int, num_tokens: int):
     assert torch.equal(
         batch.query_start_loc.cpu(), torch.from_numpy(batch.query_start_loc_np)
     )
+
+
+def test_prepare_dcp_local_seq_lens_for_batch(monkeypatch: pytest.MonkeyPatch):
+    buffers = InputBuffers(max_num_reqs=4, max_num_tokens=4, device=torch.device("cpu"))
+    batch = InputBatch.make_dummy(2, 4, buffers)
+    batch.num_reqs_after_padding = 4
+
+    def prepare_dcp_local_seq_lens(
+        output: torch.Tensor,
+        seq_lens: torch.Tensor,
+        num_reqs: int,
+        dcp_size: int,
+        dcp_rank: int,
+        cp_interleave: int,
+    ) -> None:
+        assert output is buffers.dcp_local_seq_lens
+        assert seq_lens is batch.seq_lens
+        assert (num_reqs, dcp_size, dcp_rank, cp_interleave) == (2, 4, 1, 16)
+        output.copy_(torch.tensor([1, 2, 0, 0], dtype=output.dtype))
+
+    monkeypatch.setattr(
+        cp_utils, "prepare_dcp_local_seq_lens", prepare_dcp_local_seq_lens
+    )
+
+    cp_utils.prepare_dcp_local_seq_lens_for_batch(batch, buffers, 4, 1, 16)
+
+    assert batch.dcp_local_seq_lens is not None
+    assert batch.dcp_local_seq_lens.data_ptr() == buffers.dcp_local_seq_lens.data_ptr()
+    assert batch.dcp_local_seq_lens.tolist() == [1, 2, 0, 0]
+
+
+def test_prepare_dcp_local_seq_lens_for_batch_without_dcp():
+    buffers = InputBuffers(max_num_reqs=2, max_num_tokens=2, device=torch.device("cpu"))
+    batch = InputBatch.make_dummy(1, 1, buffers)
+    batch.dcp_local_seq_lens = buffers.dcp_local_seq_lens[:1]
+
+    cp_utils.prepare_dcp_local_seq_lens_for_batch(batch, buffers, 1, 0, 1)
+
+    assert batch.dcp_local_seq_lens is None

--- a/vllm/v1/worker/gpu/cp_utils.py
+++ b/vllm/v1/worker/gpu/cp_utils.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import TYPE_CHECKING
+
 import torch
 
 from vllm.triton_utils import tl, triton
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 
 
 def prepare_dcp_local_seq_lens(
@@ -30,6 +35,30 @@ def prepare_dcp_local_seq_lens(
         max_num_reqs,
         BLOCK_SIZE,
     )
+
+
+def prepare_dcp_local_seq_lens_for_batch(
+    input_batch: "InputBatch",
+    input_buffers: "InputBuffers",
+    dcp_size: int,
+    dcp_rank: int,
+    cp_interleave: int,
+) -> None:
+    if dcp_size == 1:
+        input_batch.dcp_local_seq_lens = None
+        return
+
+    prepare_dcp_local_seq_lens(
+        input_buffers.dcp_local_seq_lens,
+        input_batch.seq_lens,
+        input_batch.num_reqs,
+        dcp_size,
+        dcp_rank,
+        cp_interleave,
+    )
+    input_batch.dcp_local_seq_lens = input_buffers.dcp_local_seq_lens[
+        : input_batch.num_reqs_after_padding
+    ]
 
 
 @triton.jit

--- a/vllm/v1/worker/gpu/cp_utils.py
+++ b/vllm/v1/worker/gpu/cp_utils.py
@@ -37,7 +37,7 @@ def prepare_dcp_local_seq_lens(
     )
 
 
-def prepare_dcp_local_seq_lens_for_batch(
+def maybe_prepare_dcp_local_seq_lens(
     input_batch: "InputBatch",
     input_buffers: "InputBuffers",
     dcp_size: int,

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -34,7 +34,7 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
+from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens_for_batch
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
@@ -649,17 +649,13 @@ def prepare_inputs_to_capture(
         slot_mappings, kv_cache_config
     )
 
-    # HACK(woosuk): Special handling for DCP.
-    if block_tables.cp_size > 1:
-        prepare_dcp_local_seq_lens(
-            input_buffers.dcp_local_seq_lens,
-            input_batch.seq_lens,
-            num_reqs,
-            block_tables.cp_size,
-            block_tables.cp_rank,
-            block_tables.cp_interleave,
-        )
-        input_batch.dcp_local_seq_lens = input_buffers.dcp_local_seq_lens[:num_reqs]
+    prepare_dcp_local_seq_lens_for_batch(
+        input_batch,
+        input_buffers,
+        block_tables.cp_size,
+        block_tables.cp_rank,
+        block_tables.cp_interleave,
+    )
 
     # NOTE(woosuk): Attention metadata is required not just by standard attention
     # kernels, but also by specialized attention-like operations (e.g., Inkling's sconv,

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -34,7 +34,7 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens_for_batch
+from vllm.v1.worker.gpu.cp_utils import maybe_prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
@@ -649,7 +649,7 @@ def prepare_inputs_to_capture(
         slot_mappings, kv_cache_config
     )
 
-    prepare_dcp_local_seq_lens_for_batch(
+    maybe_prepare_dcp_local_seq_lens(
         input_batch,
         input_buffers,
         block_tables.cp_size,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1285,13 +1285,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             ),
         )
         input_batch = pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
-        prepare_dcp_local_seq_lens_for_batch(
-            input_batch,
-            self.input_buffers,
-            self.dcp_size,
-            self.dcp_rank,
-            self.cp_interleave,
-        )
         return input_batch
 
     def prepare_attn(
@@ -1510,13 +1503,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         self.kv_cache_config.num_blocks,
                         self.max_model_len,
                     )
-                prepare_dcp_local_seq_lens_for_batch(
-                    input_batch,
-                    self.input_buffers,
-                    self.dcp_size,
-                    self.dcp_rank,
-                    self.cp_interleave,
-                )
             else:
                 assert batch_desc.cg_mode != CUDAGraphMode.FULL, (
                     "Attention metadata must be prepared for dummy runs when using "
@@ -1528,6 +1514,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         attn_metadata = None
         slot_mappings_by_layer = None
         if not (dummy_run and skip_attn_for_dummy_run):
+            prepare_dcp_local_seq_lens_for_batch(
+                input_batch,
+                self.input_buffers,
+                self.dcp_size,
+                self.dcp_rank,
+                self.cp_interleave,
+            )
             assert slot_mappings is not None
             slot_mappings_by_layer = build_slot_mappings_by_layer(
                 slot_mappings, self.kv_cache_config

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -89,7 +89,7 @@ from vllm.v1.worker.gpu.buffer_utils import (
     async_copy_to_gpu,
     set_default_max_concurrency,
 )
-from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens_for_batch
+from vllm.v1.worker.gpu.cp_utils import maybe_prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
@@ -1514,7 +1514,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         attn_metadata = None
         slot_mappings_by_layer = None
         if not (dummy_run and skip_attn_for_dummy_run):
-            prepare_dcp_local_seq_lens_for_batch(
+            maybe_prepare_dcp_local_seq_lens(
                 input_batch,
                 self.input_buffers,
                 self.dcp_size,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -89,7 +89,7 @@ from vllm.v1.worker.gpu.buffer_utils import (
     async_copy_to_gpu,
     set_default_max_concurrency,
 )
-from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
+from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens_for_batch
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
@@ -1211,19 +1211,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
         seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
 
-        dcp_local_seq_lens = None
-        if self.use_dcp:
-            # Prepare dcp local seq_lens.
-            prepare_dcp_local_seq_lens(
-                self.input_buffers.dcp_local_seq_lens,
-                self.input_buffers.seq_lens,
-                num_reqs,
-                self.dcp_size,
-                self.dcp_rank,
-                self.cp_interleave,
-            )
-            dcp_local_seq_lens = self.input_buffers.dcp_local_seq_lens[:num_reqs_padded]
-
         # Some input token ids are directly read from the last sampled tokens
         # and draft tokens. Also, get the logits indices to sample tokens from.
         logits_indices = combine_sampled_and_draft_tokens(
@@ -1276,7 +1263,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             query_start_loc_np=query_start_loc_np,
             seq_lens=seq_lens,
             seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
-            dcp_local_seq_lens=dcp_local_seq_lens,
+            dcp_local_seq_lens=None,
             num_computed_tokens_np=num_computed_tokens_np,
             prefill_len_np=batch_req_state.prefill_len_np,
             num_computed_prefill_tokens_np=batch_req_state.num_computed_prefill_tokens_np,
@@ -1297,7 +1284,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 else None
             ),
         )
-        return pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
+        input_batch = pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
+        prepare_dcp_local_seq_lens_for_batch(
+            input_batch,
+            self.input_buffers,
+            self.dcp_size,
+            self.dcp_rank,
+            self.cp_interleave,
+        )
+        return input_batch
 
     def prepare_attn(
         self, input_batch: InputBatch
@@ -1515,6 +1510,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         self.kv_cache_config.num_blocks,
                         self.max_model_len,
                     )
+                prepare_dcp_local_seq_lens_for_batch(
+                    input_batch,
+                    self.input_buffers,
+                    self.dcp_size,
+                    self.dcp_rank,
+                    self.cp_interleave,
+                )
             else:
                 assert batch_desc.cg_mode != CUDAGraphMode.FULL, (
                     "Attention metadata must be prepared for dummy runs when using "

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -11,7 +11,6 @@ from vllm.logger import init_logger
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
-from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import (
     InputBatch,
     InputBuffers,
@@ -492,18 +491,6 @@ class PCPManager:
         seq_lens_cpu_upper_bound_np = np.zeros(num_local_reqs, dtype=np.int32)
         seq_lens_cpu_upper_bound_np[:] = local_start_pos_np + local_num_scheduled_tokens
 
-        dcp_local_seq_lens = None
-        if self.dcp_world_size > 1:
-            prepare_dcp_local_seq_lens(
-                input_buffers.dcp_local_seq_lens,
-                seq_lens,
-                num_local_reqs,
-                self.dcp_world_size,
-                self.dcp_rank,
-                self.cp_interleave,
-            )
-            dcp_local_seq_lens = input_buffers.dcp_local_seq_lens[:num_local_reqs]
-
         return replace(
             input_batch,
             req_ids=local_req_ids,
@@ -524,7 +511,7 @@ class PCPManager:
             query_start_loc_np=local_query_start_loc_np[: num_local_reqs + 1],
             seq_lens=seq_lens,
             seq_lens_cpu_upper_bound=torch.from_numpy(seq_lens_cpu_upper_bound_np),
-            dcp_local_seq_lens=dcp_local_seq_lens,
+            dcp_local_seq_lens=None,
             num_computed_tokens_np=local_start_pos_np,
             prefill_len_np=local_prefill_len_np,
             num_computed_prefill_tokens_np=local_num_computed_prefill_tokens_np,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -11,7 +11,7 @@ from vllm.v1.worker.gpu.attn_utils import (
     build_slot_mappings_by_layer,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
+from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens_for_batch
 from vllm.v1.worker.gpu.cudagraph_utils import (
     AttentionState,
     BatchExecutionDescriptor,
@@ -42,17 +42,13 @@ def _prepare_dflash_inputs_to_capture(
     attn_metadata = None
     if not skip_attn:
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
-        dcp_local_seq_lens = None
-        if block_tables.cp_size > 1:
-            prepare_dcp_local_seq_lens(
-                input_buffers.dcp_local_seq_lens,
-                input_buffers.seq_lens,
-                num_reqs,
-                block_tables.cp_size,
-                block_tables.cp_rank,
-                block_tables.cp_interleave,
-            )
-            dcp_local_seq_lens = input_buffers.dcp_local_seq_lens
+        prepare_dcp_local_seq_lens_for_batch(
+            input_batch,
+            input_buffers,
+            block_tables.cp_size,
+            block_tables.cp_rank,
+            block_tables.cp_interleave,
+        )
         attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
@@ -61,7 +57,7 @@ def _prepare_dflash_inputs_to_capture(
             query_start_loc_cpu=query_start_loc_cpu,
             max_query_len=num_tokens // num_reqs,
             seq_lens=input_batch.seq_lens,
-            dcp_local_seq_lens=dcp_local_seq_lens,
+            dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             max_seq_len=max_model_len,
             block_tables=input_block_tables,
             slot_mappings=slot_mappings,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -11,7 +11,7 @@ from vllm.v1.worker.gpu.attn_utils import (
     build_slot_mappings_by_layer,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens_for_batch
+from vllm.v1.worker.gpu.cp_utils import maybe_prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     AttentionState,
     BatchExecutionDescriptor,
@@ -42,7 +42,7 @@ def _prepare_dflash_inputs_to_capture(
     attn_metadata = None
     if not skip_attn:
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
-        prepare_dcp_local_seq_lens_for_batch(
+        maybe_prepare_dcp_local_seq_lens(
             input_batch,
             input_buffers,
             block_tables.cp_size,


### PR DESCRIPTION
## Purpose

`InputBatch.make_dummy()` sets `dcp_local_seq_lens=None`. With DCP enabled, dummy runs pass this value to attention metadata builders and crash.

We observed this in CI with TP=2 and DCP=2 during FlashInfer autotuning:

```text
Traceback (most recent call last):
  File "/usr/local/lib64/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 992, in worker_busy_loop
    output = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/tracing/otel.py", line 178, in sync_wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 635, in compile_or_warm_up_model
    kernel_warmup(self)
  File "/usr/local/lib64/python3.12/site-packages/vllm/model_executor/warmup/kernel_warmup.py", line 80, in kernel_warmup
    flashinfer_autotune(worker.model_runner)
  File "/usr/local/lib64/python3.12/site-packages/vllm/model_executor/warmup/kernel_warmup.py", line 139, in flashinfer_autotune
    runner._dummy_run(
  File "/usr/local/lib64/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/v1/worker/gpu/eplb_utils.py", line 40, in wrapper
    result = fn(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/v1/worker/gpu/model_runner.py", line 589, in _dummy_run
    self.execute_model(
  File "/usr/local/lib64/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/v1/worker/gpu/model_runner.py", line 1223, in execute_model
    attn_metadata = self.model_state.prepare_attn(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/v1/worker/gpu/model_states/default.py", line 181, in prepare_attn
    attn_metadata = build_attn_metadata(
                    ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/v1/worker/gpu/attn_utils.py", line 474, in build_attn_metadata
    metadata = attn_metadata_builder.build(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib64/python3.12/site-packages/vllm/model_executor/layers/attention/mla_attention.py", line 2177, in build
    seq_lens_device=seq_lens[:num_decodes],
                    ~~~~~~~~^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

This PR adds a helper that computes `dcp_local_seq_lens` into the persistent input buffer and assigns the padded view to the batch. It is called after batch finalization for normal and dummy execution, generic CUDA graph capture, and DFlash capture.

This replaces duplicated initialization in the existing call sites. Unlike #31166, it initializes the batch instead of repairing missing metadata in a consumer.

Fixes #30736.

## Test Plan

```text
$ pytest -q tests/v1/worker/test_gpu_input_batch_v2.py
......                                                                   [100%]
6 passed
```

The added unit tests cover DCP initialization, padded request views, and the non-DCP path. They fail without this change and pass with it. Our downstream fork CI is green.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is needed.
</details>
