### PR TITLE
[Docs] Fix docstring continuation indentation in `routed_experts.py`

### DIFF
--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1040,13 +1040,13 @@ class RoutedExperts(PluggableLayer):
             num_experts: Number of logical (non-redundant) experts
             num_redundant_experts: Number of redundant experts
             lora_base_layer_prefix: LoRA ``base_layer.`` prefix for the
-              ``weight_name`` (checkpoint) side
+                ``weight_name`` (checkpoint) side
             lora_base_layer_prefix_on_param_name: same, for the ``param_name``
-              side. Independent because ``get_expert_mapping`` resolves
-              ``param_name`` via ``getattr`` against this layer's bare
-              ``w13_weight``/``w2_weight`` (no prefix), while
-              ``make_expert_params_mapping`` indexes the model-wide
-              ``params_dict`` (prefix included).
+                side. Independent because ``get_expert_mapping`` resolves
+                ``param_name`` via ``getattr`` against this layer's bare
+                ``w13_weight``/``w2_weight`` (no prefix), while
+                ``make_expert_params_mapping`` indexes the model-wide
+                ``params_dict`` (prefix included).
             include_fused: Prepend the fused pre-fused-checkpoint entries
 
         Returns:


### PR DESCRIPTION
## Purpose

The docs build emits Griffe warnings for `vllm/model_executor/layers/fused_moe/routed_experts.py`:

```
WARNING - griffe: vllm/model_executor/layers/fused_moe/routed_experts.py:1042: Confusing indentation for continuation line 13 in docstring, should be 4 * 2 = 8 spaces, not 6
... (lines 1044-1048)
```

The `lora_base_layer_prefix` and `lora_base_layer_prefix_on_param_name` argument descriptions in `build_expert_params_mapping` use a 2-space hanging indent for their continuation lines. Google-style docstrings expect 4, so Griffe cannot associate the continuation with the argument. This bumps them to 4 spaces; docstring text is unchanged.

Not duplicating an existing PR: `gh pr list --repo vllm-project/vllm --state open --search "routed_experts docstring"` and `--search "griffe docstring indentation"` return no PR touching these docstrings.

## Test Plan

`mkdocs build`, checking for warnings from this file.

## Test Result

Before: 6 Griffe warnings for `routed_experts.py`. After: none. No other warnings introduced.

No functional change, so no model evaluation is applicable.

---

AI assistance (Claude Code) was used for this change; I have reviewed every changed line.