### PR TITLE
[Bugfix][Spec Decode] Order input prep after the previous step's spec-decode postprocess

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -485,6 +485,102 @@ def test_set_active_mm_loras_builds_tower_and_connector_mappings():
     assert connector_mapping.index_mapping == ((7,) * 14 + (7,) * 13 + (0,) * 12)
 
 
+class _RecordingEvent:
+    """Stand-in for torch.Event that records the order it was waited on."""
+
+    def __init__(self, name: str, log: list[str]):
+        self.name = name
+        self.log = log
+
+    def synchronize(self):
+        self.log.append(f"wait:{self.name}")
+
+    def record(self):
+        self.log.append(f"record:{self.name}")
+
+
+def test_synchronize_input_prep_waits_for_spec_decode_postprocess():
+    """The persistent batch must not be mutated while the postprocess still runs.
+
+    prepare_inputs_event is recorded when input prep ends, so it orders nothing
+    against the spec-decode postprocess that runs after the model forward. That
+    postprocess reads the block tables and staged index buffers and writes the
+    accepted counts, all of which _update_states rewrites on entry to this
+    context, so its event has to be waited on before the body.
+    """
+    log: list[str] = []
+    runner = SimpleNamespace(
+        prepare_inputs_event=_RecordingEvent("prepare_inputs", log),
+        num_accepted_tokens_event=_RecordingEvent("accepted_counts", log),
+    )
+
+    with GPUModelRunner.synchronize_input_prep(runner):
+        log.append("update_states")
+
+    # Order between the two waits does not matter; both preceding the body does.
+    assert log.index("wait:accepted_counts") < log.index("update_states")
+    assert log.index("wait:prepare_inputs") < log.index("update_states")
+    assert log[-1] == "record:prepare_inputs"
+
+
+def test_synchronize_input_prep_without_spec_decode_is_unchanged():
+    log: list[str] = []
+    runner = SimpleNamespace(
+        prepare_inputs_event=_RecordingEvent("prepare_inputs", log),
+        num_accepted_tokens_event=None,
+    )
+
+    with GPUModelRunner.synchronize_input_prep(runner):
+        log.append("update_states")
+
+    assert log == ["wait:prepare_inputs", "update_states", "record:prepare_inputs"]
+
+
+def test_synchronize_input_prep_is_a_noop_without_overlapped_steps():
+    runner = SimpleNamespace(
+        prepare_inputs_event=None, num_accepted_tokens_event=Mock()
+    )
+
+    with GPUModelRunner.synchronize_input_prep(runner):
+        pass
+
+    runner.num_accepted_tokens_event.synchronize.assert_not_called()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test_synchronize_input_prep_lands_prior_d2h_before_batch_mutation():
+    """Same contract on real events: the postprocess D2H must have landed.
+
+    The postprocess copies accepted counts into a pinned tensor that condense()
+    then compacts on the host. Unordered, the DMA lands after those host writes
+    and silently overwrites them. torch.cuda._sleep holds the copy in flight so
+    the ordering is observable rather than dependent on bus timing.
+    """
+    counts_gpu = torch.tensor([4, 3, 2, 1], dtype=torch.int32, device="cuda")
+    pinned = torch.tensor([4, 3, 2, 1], dtype=torch.int32).pin_memory()
+
+    prepare_inputs_event = torch.cuda.Event()
+    prepare_inputs_event.record()  # previous step finished reading input buffers
+    torch.cuda._sleep(400_000_000)  # ... its model forward is still running
+    accepted_event = torch.cuda.Event()
+    pinned.copy_(counts_gpu, non_blocking=True)  # the postprocess D2H
+    accepted_event.record()
+
+    runner = SimpleNamespace(
+        prepare_inputs_event=prepare_inputs_event,
+        num_accepted_tokens_event=accepted_event,
+    )
+
+    with GPUModelRunner.synchronize_input_prep(runner):
+        # What condense()/_update_states do: compact a finished row away, then
+        # initialize the row of a newly admitted request.
+        pinned[0] = pinned[3]
+        pinned[3] = 1
+
+    torch.cuda.synchronize()
+    assert pinned.tolist() == [1, 3, 2, 1]
+
+
 def test_update_states_new_request(model_runner, dist_init):
     req_id = "req_0"
 

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -536,15 +536,31 @@ def test_synchronize_input_prep_without_spec_decode_is_unchanged():
     assert log == ["wait:prepare_inputs", "update_states", "record:prepare_inputs"]
 
 
-def test_synchronize_input_prep_is_a_noop_without_overlapped_steps():
+def test_synchronize_input_prep_waits_for_postprocess_without_async_scheduling():
+    """Pipeline parallelism overlaps steps without async scheduling.
+
+    max_concurrent_batches is the PP size even with async scheduling off, so
+    the batch queue runs the next step's _update_states while the previous
+    step's postprocess is still in flight, yet prepare_inputs_event exists only
+    under async scheduling. The accepted-count wait must not depend on it.
+    """
+    log: list[str] = []
     runner = SimpleNamespace(
-        prepare_inputs_event=None, num_accepted_tokens_event=Mock()
+        prepare_inputs_event=None,
+        num_accepted_tokens_event=_RecordingEvent("accepted_counts", log),
     )
 
     with GPUModelRunner.synchronize_input_prep(runner):
-        pass
+        log.append("update_states")
 
-    runner.num_accepted_tokens_event.synchronize.assert_not_called()
+    assert log == ["wait:accepted_counts", "update_states"]
+
+
+def test_synchronize_input_prep_is_a_noop_without_spec_decode_or_overlap():
+    runner = SimpleNamespace(prepare_inputs_event=None, num_accepted_tokens_event=None)
+
+    with GPUModelRunner.synchronize_input_prep(runner):
+        pass
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -563,7 +563,10 @@ def test_synchronize_input_prep_is_a_noop_without_spec_decode_or_overlap():
         pass
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not hasattr(torch.cuda, "_sleep"),
+    reason="needs a CUDA device and torch.cuda._sleep",
+)
 def test_synchronize_input_prep_lands_prior_d2h_before_batch_mutation():
     """Same contract on real events: the postprocess D2H must have landed.
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3943,6 +3943,14 @@ class GPUModelRunner(
         # This is required in the async scheduling case because
         # the CPU->GPU transfer happens async.
         self.prepare_inputs_event.synchronize()
+        # prepare_inputs_event is recorded when input prep ends, so it says
+        # nothing about the spec-decode postprocess that runs after the model.
+        # That postprocess reads the persistent block tables and staged index
+        # buffers and writes the accepted counts, all of which _update_states
+        # mutates as soon as this context is entered. Wait for it here; the
+        # later wait in _prepare_inputs is already past those mutations.
+        if self.num_accepted_tokens_event is not None:
+            self.num_accepted_tokens_event.synchronize()
         try:
             yield
         finally:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3935,6 +3935,18 @@ class GPUModelRunner(
 
     @contextmanager
     def synchronize_input_prep(self):
+        # prepare_inputs_event is recorded when input prep ends, so it says
+        # nothing about the spec-decode postprocess that runs after the model.
+        # That postprocess reads the persistent block tables and staged index
+        # buffers and writes the accepted counts, all of which _update_states
+        # mutates as soon as this context is entered. Wait for it here; the
+        # later wait in _prepare_inputs is already past those mutations.
+        # Steps overlap under async scheduling and under the pipeline-parallel
+        # batch queue alike, and only the former creates prepare_inputs_event,
+        # so this wait cannot hang off that event's existence.
+        if self.num_accepted_tokens_event is not None:
+            self.num_accepted_tokens_event.synchronize()
+
         if self.prepare_inputs_event is None:
             yield
             return
@@ -3943,14 +3955,6 @@ class GPUModelRunner(
         # This is required in the async scheduling case because
         # the CPU->GPU transfer happens async.
         self.prepare_inputs_event.synchronize()
-        # prepare_inputs_event is recorded when input prep ends, so it says
-        # nothing about the spec-decode postprocess that runs after the model.
-        # That postprocess reads the persistent block tables and staged index
-        # buffers and writes the accepted counts, all of which _update_states
-        # mutates as soon as this context is entered. Wait for it here; the
-        # later wait in _prepare_inputs is already past those mutations.
-        if self.num_accepted_tokens_event is not None:
-            self.num_accepted_tokens_event.synchronize()
         try:
             yield
         finally:


### PR DESCRIPTION
## Purpose

Under async scheduling (or any configuration with `max_concurrent_batches > 1`) with a hybrid model plus spec decode, `_update_states` starts rewriting state that the previous step's spec-decode postprocess is still reading and writing on the GPU. Nothing orders the two.

`synchronize_input_prep()` waits on `prepare_inputs_event`. That event is recorded in the context's own `finally` (`gpu_model_runner.py:3949`), so it marks the end of input prep, before the model forward. It says nothing about `_update_states_after_model_execute` -> `mamba_utils.postprocess_mamba_align_gpu`, which runs after the forward.

The only wait that does order that postprocess is `num_accepted_tokens_event.synchronize()` at `gpu_model_runner.py:2173`, inside `_prepare_inputs`. In `execute_model`, `_update_states` is line 4322 and `_prepare_inputs` is line 4365, both inside the same `synchronize_input_prep` block. So `_update_states` runs first, with nothing between it and the previous step's postprocess.

What that postprocess is using at that moment (`mamba_utils.py:1416-1441`):

- the persistent per-group block tables bound at `initialize_from_forward_context`
- the staged mamba state-index, num-scheduled, num-computed and num-draft GPU buffers
- a D2H of the accepted counts into the pinned `input_batch.num_accepted_tokens_cpu_tensor`

`_update_states` rewrites all of it: block-table rows, `condense()` compaction, and the rows of newly admitted requests.

Line numbers throughout are as of the base commit, 79bb395ee.

This waits on `num_accepted_tokens_event` at the top of the context, before the body touches any of it. The existing wait at line 2173 stays, because it is still needed when `prepare_inputs_event` is `None`, and it is already satisfied by the time it is reached. The change is a no-op when spec decode is off (the event is `None`) and when steps cannot overlap (`synchronize_input_prep` early-returns).

Reported, diagnosed and fixed by @noonghunna, who wrote the change and produced the field evidence below. Co-authored on the commit.

**Scope, narrowed after review.** Reproduced and closed on sm_86 and sm_120. On sm_121a (GB10) an illegal memory access occurs with and without this patch on a different model and traffic shape (@swesty, below) and has not been shown to be this race. On sm_121 the race precondition itself is measured present in over 99% of steady-state steps wherever the XQA decode kernel is selected, and the reproducer runs clean on both arms. This is an ordering fix for the hazard the probe measures, not a claim about every Xid 31 on hybrid GDN + MTP.

### Field evidence (@noonghunna, 2x RTX 3090, TP=2, Ampere sm_86, PCIe-only)

vLLM v0.27.1, GDN + MTP n=4, fp8 KV, `mamba_cache_mode=align`, prefix caching and async scheduling on, same growing-conversation reproducer across all three arms:

| Arm | Result |
|---|---|
| stock v0.27.1 | crash at 10,873 generated tokens, `illegal memory access` |
| + #51599 only | crash at 8,446 generated tokens |
| + this ordering | clean to 42,769 generated over 80 turns, 0 Xid (ended on a context-length 400, not a crash) |

`synchronize_input_prep` is byte-identical between v0.27.1 (lines 3865-3877) and main (3937-3949), and the record and wait sites sit in the same relative positions, so the result transfers to main without reinterpretation.

Two caveats on that data, both @noonghunna's and both worth stating:

- The crashing baseline is a **retired** checkpoint export. Their shipped re-export no longer fires this crash within a 57k-generation soak; they had to run the retired export, which left `mtp.layers` out of `block_name_to_quantize`, to get a reliable crashing baseline. That bears on how easy the race is to hit, not on whether it is one.
- The traceback in the crashing arms surfaces at an input-prep `async_tensor_h2d`. An illegal memory access is asynchronous and sticky, so that frame is the first CUDA call that checked the error rather than necessarily the kernel that raised it. No faulting site is attributed in this PR for that reason; the ordering gap above is what the code supports.

### Hardware coverage

| arch | result | source |
|---|---|---|
| sm_86 (2x RTX 3090, TP=2) | reproduced and closed: stock crashes at 10,873 generated tokens, with this ordering clean to 42,769 over 80 turns | @noonghunna, table above |
| sm_120 (RTX 5090) | reproduced and closed | #50021 thread |
| sm_121a (GB10) | illegal memory access with and without this patch (Qwen3.6-35B-A3B, MTP k=3, `/v1/responses`, `--max-num-seqs 4`); five unpatched crashes 08-04 to 08-25, one patched crash 08-26; not shown to be this race | @swesty, [08-26](https://github.com/vllm-project/vllm/pull/53613#issuecomment-5432347477) and [09-02](https://github.com/vllm-project/vllm/pull/53613#issuecomment-5517435765) |
| sm_121 (GB10, five hosts, ten arms) | race precondition present in 99.1-99.5% of steady-state steps on the eight arms that select the XQA decode kernel, 0.5-0.6% on the one host that cannot reach NVIDIA's artifactory and falls back to `flashinfer-native`; reproducer clean to 20k generated tokens on every arm, both sides, zero illegal accesses | this PR, [direct check](https://github.com/vllm-project/vllm/pull/53613#issuecomment-5538393416) |

### Relationship to other open PRs

- **#51599** (closes #51571) fixes the other half of this area: `condense()` writes into the pinned accepted-count tensor while the D2H is in flight, and it moves that copy to a runner-owned buffer. That is real and independent and should land. It isolates one destination; it does not order the postprocess against `_update_states`, and on the reporter's rig it does not stop this crash. Complementary, not competing.
- **#47644** fixes the same class of hazard for reused pinned *input* buffers under the PP batch queue.
- **#42574** defers this same wait for throughput, and describes the resulting `event.synchronize()` in `_prepare_inputs` as "essentially free" because the GPU has long since finished the copy. Its own nsys numbers say otherwise about the wait's size (`cudaEventSynchronize` host time 0.041s -> 4.106s at unchanged GPU kernel time), and the direct measurement below puts that wait at ~170 ms per step on this rig. Worth reconciling: what this PR adds is ~1.7 ms on top of it, but the two changes touch the same synchronize and should be read together.

The V2 model runner is not affected and is not touched. It has no `synchronize_input_prep`, keeps the accepted counts and the mamba state indices GPU-resident (`vllm/v1/worker/gpu/model_states/mamba_hybrid.py`), and runs the align migration as a fused kernel before the forward (`preprocess_state`) rather than as a postprocess after it.

Not a duplicate: no open PR carries this change. Searched `synchronize_input_prep`, `num_accepted_tokens_event` and `50021 in:body`; #51599 is the nearest and is discussed above.

## Test Plan

New regressions in `tests/v1/worker/test_gpu_model_runner.py`:

- `test_synchronize_input_prep_waits_for_spec_decode_postprocess` - recording events assert the accepted-count wait precedes the body.
- `test_synchronize_input_prep_lands_prior_d2h_before_batch_mutation` - real `torch.cuda.Event`s with `torch.cuda._sleep` holding the postprocess D2H in flight; the host writes that `condense()` makes inside the context must survive it.
- `test_synchronize_input_prep_without_spec_decode_is_unchanged` and `test_synchronize_input_prep_is_a_noop_without_overlapped_steps` - the two no-op paths.

```bash
.venv/bin/python -m pytest -q tests/v1/worker/test_gpu_model_runner.py
```

Throughput A/B on one GB10, Qwen3.8-27B-NVFP4, MTP n=4, fp8 KV, prefix caching, `--async-scheduling`, align auto-selected, `--max-model-len 32768`:

```bash
vllm bench serve --backend vllm --dataset-name random \
  --random-input-len 1024 --random-output-len 512 \
  --num-prompts 200 --max-concurrency 8
```

The change is pure Python, so the arms toggle by checking the one file in and out of the working tree against a single install. A warmup arm is run first and discarded so no arm pays for a cold compile cache, and `main` is run twice to bound run-to-run drift.

## Test Result

Red/green on NVIDIA GB10 (sm_121), driver 580.173.02, torch 2.13.0+cu132, tree at 93490dcd:

- with the fix: `4 passed`
- with the fix reverted and the tests kept: `2 failed, 2 passed`. `test_synchronize_input_prep_waits_for_spec_decode_postprocess` fails, and `test_synchronize_input_prep_lands_prior_d2h_before_batch_mutation` fails with `assert [4, 3, 2, 1] == [1, 3, 2, 1]`: the in-flight D2H landed after `condense()` and destroyed the host writes. The two no-op tests pass on both arms, which is what they are there to show.
- full file with the fix: `48 passed`

### Follow-up at 34471bf8d and 9440c495a (review findings)

`max_concurrent_batches` is the pipeline-parallel size even with async scheduling off, so the batch queue overlaps steps there too, while `prepare_inputs_event` exists only under async scheduling. The accepted-count wait now sits ahead of that event's early return so the PP path reaches it. The test that asserted the wait must not happen without `prepare_inputs_event` encoded the gap and is replaced by a PP-shaped case and a true no-op case. The real-event test's skipif also now requires `hasattr(torch.cuda, "_sleep")`.

Red/green on kebab-spark-2 (GB10): with the pre-fix source and the new tests, 1 failed and 48 passed; with the fix, 49 passed, the real-CUDA-event ordering test included.

### Direct check for the race, sm_121 (GB10)

A twelve-line measurement patch (not in this PR) at the top of `synchronize_input_prep`, before any wait, counts the steps where the previous step's spec-decode postprocess D2H had not landed when `_update_states` began. Five GB10s, ten arms, arms alternated per host. Full table and the patch itself are [in the thread](https://github.com/vllm-project/vllm/pull/53613#issuecomment-5538393416); the summary is in Hardware coverage above.

The one host that read 0.6% instead of 99% did so because it has no route to `https://edge.urm.nvidia.com/artifactory/...`, so `has_nvidia_artifactory()` returns False (vllm/utils/flashinfer.py:367), `supports_trtllm_attention()` returns False (:395), and the decode kernel resolves to `flashinfer-native` instead of XQA. Proved on a fifth host by forcing `FLASHINFER_CUBINS_REPOSITORY` at an unroutable address, one variable, everything else identical: `xqa` 99.9% unlanded, `flashinfer-native` 0.0%. Forcing `cudagraph_mode=PIECEWISE` while keeping XQA changes nothing (99.5% vs 99.9%), so the graph mode is not the mechanism; the decode backend is.

### Throughput

One GB10 (sm_121), Qwen3.8-27B-NVFP4, MTP n=4, fp8 KV, prefix caching,
`--async-scheduling`, `mamba_cache_mode=align` (auto-selected for this model when
prefix caching is on), `--max-model-len 32768`, `--gpu-memory-utilization 0.6`.
`vllm bench serve`, random dataset, 1024 in / 512 out, concurrency 8. Arms toggle
the one file in and out of a single install, so nothing else differs. A warmup
arm runs first and is discarded so no measured arm pays for a cold compile cache,
and each build is run twice.

| Arm | Build | Prompts | Output tok/s | Mean TPOT (ms) | Accepted tokens |
|---|---|---|---|---|---|
| warmup (discarded) | with fix | 200 | 98.29 | 74.64 | 67,833 |
| main | without | 200 | 103.04 | 73.53 | 68,679 |
| fix | with | 200 | 95.29 | 79.36 | 65,975 |
| main2 | without | 200 | 99.63 | 75.11 | 67,863 |
| instrumented main | without | 60 | 92.92 | 77.08 | 19,891 |
| instrumented fix | with | 60 | 97.64 | 73.76 | 20,428 |

**This end-to-end benchmark cannot resolve the question.** The 200-prompt arms
favor `without` by 3 to 5 percent; the 60-prompt arms favor `with` by 5 percent.
The sign flips, so the run-to-run noise is larger than the effect. Draft
acceptance also varies between arms (position 0 ranges 61.95 to 65.36 across the
200-prompt arms) and moves throughput with it, which a synchronization change
cannot cause.

So the cost was measured directly instead, by timing both accepted-count waits in
a measurement-only build (instrumentation only, not part of this PR):

| Build | Wait site | Steady-state mean per step |
|---|---|---|
| main | `_prepare_inputs`, line 2173 | **170.1 ms** |
| this PR | top of `synchronize_input_prep` | **171.8 ms** |
| this PR | `_prepare_inputs`, line 2173 | **2.4 us** (already satisfied) |

Steady state taken as the delta between consecutive 250-call reports, which is
stable to better than 0.3 percent: main 169.90 / 170.11 / 170.27 ms, this PR
171.72 / 171.72 / 171.73 / 171.82 ms.

Total accepted-count wait per step: **170.1 ms on main, 171.8 ms here, so +1.7 ms
(+1.0 percent)**. That 1.7 ms is exactly the host work between the top of the
context and line 2173 - `_update_states` and the early part of `_prepare_inputs` -
which main overlaps with GPU time and this PR does not.

Two things follow, and both matter more than the headline number:

- The wait is not new and is not small. main already blocks the host about 170 ms
  per step on this event, because under async scheduling the host runs a full step
  ahead of the GPU. Anything built on the assumption that this synchronize is
  nearly free (#42574) should be read against 170 ms, not against zero.
- The 1.7 ms is the price of ordering `_update_states` after the postprocess, and
  it is not avoidable by moving the wait: `_update_states` mutates host-side
  buffers, so no stream-side ordering substitutes for a host wait. The only
  cheaper shape is #51599's, isolating every buffer the postprocess and
  `_update_states` share rather than ordering them - which is free but has to be
  complete to be correct, and today it is not.

## Notes

AI assistance (Claude Code) was used for the code reading, the tests and this description. The submitter reviewed every changed line and ran the tests above. The crash data in the table is @noonghunna's, produced on their hardware.

