### PR TITLE
[CI] Increase Entrypoints Unit timeout after launcher suite growth

### DIFF
--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -5,7 +5,7 @@ steps:
 - label: ":nvidia: (H200) Entrypoints Unit"
   device: h200_35gb
   key: entrypoints-unit-tests
-  timeout_in_minutes: 25
+  timeout_in_minutes: 40
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:
   - vllm/entrypoints


### PR DESCRIPTION
## Summary

Raise the H200 Entrypoints Unit Buildkite timeout from 25 to 40 minutes.

PR #53500 moved `test_run_batch.py` under `tests/entrypoints/launchers`, increasing the launchers phase from 29 to 55 selected tests. The exact PR-head job passed all 55 tests but took 25m27s wall time, the first post-merge main job passed in 24m49s, and main #85369 was marked timed out at 26m01s even though all three phases completed successfully (129 passed / 1 skipped, 5 passed, and 55 passed).

This keeps the expanded coverage while restoring enough wall-clock headroom for normal runtime variance.

## Failure evidence

- Main #85369 exact job: https://buildkite.com/vllm/ci/builds/85369#01a034c9-c51c-4695-a829-60325d1b355d
- Culprit PR #53500 exact-head job (same 55-test coverage, passed at the budget boundary): https://buildkite.com/vllm/ci/builds/85319#01a033f6-41d3-4434-b276-cbc76f2eff71
- First post-merge main pass: https://buildkite.com/vllm/ci/builds/85338#01a0344e-1831-4823-95f5-d6db60734252

## Duplicate-work check

Searched open issues and PRs for `Entrypoints Unit timeout`, `entrypoints-unit-tests timeout`, and `run_batch timeout`; no existing fix was found.

## Validation

- Parsed `.buildkite/test_areas/entrypoints.yaml` with PyYAML and asserted the H200 step is 40 minutes while the AMD mirror remains unchanged at 35 minutes.
- `git diff --check`
- Precise unchanged main retry passed under the old cap in 24m43s with the full expanded suite (129 passed / 1 skipped, 5 passed, 55 passed): https://buildkite.com/vllm/ci/builds/85369#01a03526-8f26-4348-83f0-eb1d607da0d7
- Exact isolated PR-head H200 validation passed under the proposed 40-minute cap in 24m24s with the same full suite (129 passed / 1 skipped, 5 passed, 55 passed): https://buildkite.com/vllm/ci/builds/85380#01a0352d-c9b6-424b-953d-41cb39c31a88

## Model evaluation

Not applicable. This changes only a CI wall-clock timeout and does not affect model behavior or serving output.

## AI assistance

AI assistance was used to investigate the Buildkite timing evidence and prepare this change. The human submitter is responsible for reviewing and defending the change.
