### PR TITLE
[CI][Ray] Fix flaky multi-node assignment test after placement-group teardown

### DIFF
--- a/tests/distributed/test_multi_node_assignment.py
+++ b/tests/distributed/test_multi_node_assignment.py
@@ -62,17 +62,17 @@ def test_multi_node_assignment() -> None:
         for worker in workers:
             ray.kill(worker)
 
-        # Same teardown as production. Removal is async, so wait until this
-        # node has enough free GPUs for the next iteration (all workers are
-        # pinned here).
         ray.util.remove_placement_group(config.placement_group)
+
         gpus_needed = len(workers)
         deadline = time.monotonic() + 60
         node_id = ray.get_runtime_context().get_node_id()
+        wait_interval = 1
         while time.monotonic() < deadline:
             free_gpus = available_resources_per_node().get(node_id, {}).get("GPU", 0)
             if free_gpus >= gpus_needed:
                 break
-            time.sleep(0.05)
+            wait_interval *= 2
+            time.sleep(wait_interval)
         else:
             raise TimeoutError("placement group resources were not released")

--- a/tests/distributed/test_multi_node_assignment.py
+++ b/tests/distributed/test_multi_node_assignment.py
@@ -67,12 +67,13 @@ def test_multi_node_assignment() -> None:
         gpus_needed = len(workers)
         deadline = time.monotonic() + 60
         node_id = ray.get_runtime_context().get_node_id()
-        wait_interval = 1
-        while time.monotonic() < deadline:
+        while True:
             free_gpus = available_resources_per_node().get(node_id, {}).get("GPU", 0)
             if free_gpus >= gpus_needed:
                 break
-            wait_interval *= 2
-            time.sleep(wait_interval)
-        else:
-            raise TimeoutError("placement group resources were not released")
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("placement group resources were not released")
+
+            time.sleep(min(1, remaining))

--- a/tests/distributed/test_multi_node_assignment.py
+++ b/tests/distributed/test_multi_node_assignment.py
@@ -11,6 +11,7 @@ pytest distributed/test_multi_node_assignment.py
 """
 
 import os
+import time
 
 import pytest
 import ray
@@ -19,7 +20,7 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from vllm import initialize_ray_cluster
 from vllm.config import ParallelConfig
 from vllm.utils.network_utils import get_ip
-from vllm.v1.executor.ray_utils import _wait_until_pg_removed
+from vllm.v1.executor.ray_utils import available_resources_per_node
 
 VLLM_MULTI_NODE = os.getenv("VLLM_MULTI_NODE", "0") == "1"
 
@@ -61,4 +62,17 @@ def test_multi_node_assignment() -> None:
         for worker in workers:
             ray.kill(worker)
 
-        _wait_until_pg_removed(config.placement_group)
+        # Same teardown as production. Removal is async, so wait until this
+        # node has enough free GPUs for the next iteration (all workers are
+        # pinned here).
+        ray.util.remove_placement_group(config.placement_group)
+        gpus_needed = len(workers)
+        deadline = time.monotonic() + 60
+        node_id = ray.get_runtime_context().get_node_id()
+        while time.monotonic() < deadline:
+            free_gpus = available_resources_per_node().get(node_id, {}).get("GPU", 0)
+            if free_gpus >= gpus_needed:
+                break
+            time.sleep(0.05)
+        else:
+            raise TimeoutError("placement group resources were not released")

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -517,24 +517,6 @@ def _wait_until_pg_ready(current_placement_group: "PlacementGroup"):
             ) from None
 
 
-def _wait_until_pg_removed(current_placement_group: "PlacementGroup"):
-    ray.util.remove_placement_group(current_placement_group)
-    s = time.time()
-    wait_interval = 10
-    while time.time() - s < PG_WAIT_TIMEOUT:
-        pg = ray.util.get_current_placement_group()
-        if pg is None:
-            break
-
-        # Exponential backoff for warning print.
-        wait_interval *= 2
-        logger.info(
-            "Waiting for removing a placement group of specs for %d seconds.",
-            int(time.time() - s),
-        )
-        time.sleep(wait_interval)
-
-
 def initialize_ray_cluster(
     parallel_config: ParallelConfig,
     ray_address: str | None = None,


### PR DESCRIPTION


## Purpose

Fix (L4) Distributed 2-Node: https://buildkite.com/vllm/ci/builds/85292/table?jid=01a0325b-fb78-46c0-9447-2f923556a46b&tab=output (`tests/distributed/test_multi_node_assignment.py`)

The test waited via `_wait_until_pg_removed`, which production never called (production only calls `remove_placement_group`). The helper polled `get_current_placement_group()`, which is always `None` on the driver, so it returned immediately. The next `initialize_ray_cluster` then failed with "Current node has no GPU available."

This change drops the unused helper. The test now matches production teardown and waits until `available_resources_per_node` shows enough free GPUs on the driver for the next iteration (tp=2, all workers pinned here).

**Alternative:** implement `_wait_until_pg_removed` correctly in `ray_utils.py`. Checking Ray's Global Control Store (GCS) for `REMOVED` is not enough: Ray can record the placement group as removed before the per-node raylets return the reserved resources.

```python
def _wait_until_pg_removed(placement_group):
    ray.util.remove_placement_group(placement_group)
    deadline = time.time() + PG_WAIT_TIMEOUT
    pg_id = placement_group.id.hex()
    while time.time() < deadline:
        table = placement_group_table(placement_group)
        table_says_removed = not table or table.get("state") == "REMOVED"
        still_reserved = any(
            pg_id in name
            for resources in available_resources_per_node().values()
            for name in resources
        )
        if table_says_removed and not still_reserved:
            return
        time.sleep(0.05)
    raise TimeoutError("placement group resources were not released")
```

## Test Plan

```sh
VLLM_MULTI_NODE=1 pytest tests/distributed/test_multi_node_assignment.py
```

## Test Result

```
1 passed, 14 warnings in 74.30s (0:01:14)
```

AI assistance used.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

