### PR TITLE
[Bugfix] Return HTTP 400 for unsupported tool_choice on Harmony Responses path

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1232,3 +1232,38 @@ class TestAutoToolStreaming:
         assert len(function_done) == 1
         assert function_done[0].item.name == "get_weather"
         assert function_done[0].item.arguments == tool_args
+
+
+class TestMakeRequestWithHarmony:
+    """Tests for tool_choice handling on the Harmony request path."""
+
+    @pytest.fixture
+    def serving_responses_instance(self):
+        """Create a real OpenAIServingResponses instance for testing"""
+        engine_client = MagicMock()
+
+        model_config = MagicMock()
+        model_config.max_model_len = 100
+        model_config.hf_config.model_type = "test"
+        model_config.get_diff_sampling_param.return_value = {}
+        engine_client.model_config = model_config
+
+        engine_client.input_processor = MagicMock()
+        engine_client.renderer = MagicMock()
+
+        return OpenAIServingResponses(
+            engine_client=engine_client,
+            models=MagicMock(),
+            online_renderer=MagicMock(),
+            request_logger=None,
+            chat_template=None,
+            chat_template_content_format="auto",
+            tool_server=MagicMock(spec=ToolServer),
+        )
+
+    def test_unsupported_tool_choice_raises_value_error(
+        self, serving_responses_instance
+    ):
+        request = ResponsesRequest(input="hi", tool_choice="required")
+        with pytest.raises(ValueError, match="tool_choice"):
+            serving_responses_instance._make_request_with_harmony(request, None)

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -744,7 +744,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         prev_response: ResponsesResponse | None,
     ):
         if request.tool_choice not in ("auto", "none"):
-            raise NotImplementedError(
+            raise ValueError(
                 "Only 'auto' or 'none' tool_choice is supported "
                 "in response API with Harmony"
             )


### PR DESCRIPTION
## Purpose

On the Responses API with a Harmony model (e.g. `gpt-oss`), a `tool_choice` other than `"auto"` or `"none"` — a forced/named function tool, or `tool_choice: "required"` — is rejected with `NotImplementedError`, which maps to **HTTP 501**. This is invalid client input and should return a **4xx**, not a 5xx: a 5xx trips server-error alarms/on-call and signals that the service is broken rather than that the request is malformed.

This raises `ValueError` instead (mapped to HTTP 400 by the global error handler), consistent with how an unsupported tool *type* is already rejected as a 400 when building the Harmony developer message.

Fixes #53626

## Test Plan

Added `TestMakeRequestWithHarmony::test_unsupported_tool_choice_raises_value_error`, which asserts that `_make_request_with_harmony` raises `ValueError` for `tool_choice="required"`.

## Test Result

Covered by CI. Locally: `ruff check` / `ruff format --check` pass on the changed files.
