### PR TITLE
[BugFix][ROCM] DFlash2 fix sliding-window prefix attention NaNs

### DIFF
--- a/tests/kernels/attention/test_prefix_prefill.py
+++ b/tests/kernels/attention/test_prefix_prefill.py
@@ -608,6 +608,133 @@ def test_contexted_kv_attention_cached_kv_block_table_boundary(device: str) -> N
 
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @torch.inference_mode()
+def test_noncausal_sliding_window_ignores_evicted_nan_blocks(device: str) -> None:
+    """Evicted context blocks must not poison sliding-window attention."""
+    set_random_seed(0)
+    torch.set_default_device(device)
+    torch.accelerator.set_device_index(device)
+
+    dtype = torch.bfloat16
+    batch_size = 2
+    num_heads = 4
+    num_kv_heads = 2
+    head_size = 32
+    block_size = 32
+    query_len = 8
+    context_len = 96
+    sliding_window = 32
+
+    query = torch.randn(batch_size * query_len, num_heads, head_size, dtype=dtype)
+    key = torch.randn(batch_size * query_len, num_kv_heads, head_size, dtype=dtype)
+    value = torch.randn_like(key)
+    output = torch.empty_like(query)
+
+    # The first two logical context blocks have been evicted. Their stale
+    # physical IDs may now belong to another cache group with a different
+    # dtype, while the final context block remains resident.
+    block_table = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=torch.int32)
+
+    num_physical_blocks = 9
+    x = 8
+    k_cache = torch.zeros(
+        num_physical_blocks,
+        num_kv_heads,
+        head_size // x,
+        block_size,
+        x,
+        dtype=dtype,
+    )
+    v_cache = torch.zeros(
+        num_physical_blocks,
+        num_kv_heads,
+        head_size,
+        block_size,
+        dtype=dtype,
+    )
+    evicted_blocks = torch.tensor([1, 2, 5, 6])
+    k_cache[evicted_blocks].fill_(float("nan"))
+    v_cache[evicted_blocks].fill_(float("nan"))
+
+    contexts_k = []
+    contexts_v = []
+    for req in range(batch_size):
+        context_k = torch.randn(context_len, num_kv_heads, head_size, dtype=dtype)
+        context_v = torch.randn_like(context_k)
+        contexts_k.append(context_k)
+        contexts_v.append(context_v)
+
+        resident_k = context_k[-block_size:]
+        resident_v = context_v[-block_size:]
+        physical_block = int(block_table[req, 2].item())
+        k_cache[physical_block].copy_(
+            resident_k.view(block_size, num_kv_heads, head_size // x, x).permute(
+                1, 2, 0, 3
+            )
+        )
+        v_cache[physical_block].copy_(resident_v.permute(1, 2, 0))
+
+    query_start_loc = torch.arange(
+        0,
+        (batch_size + 1) * query_len,
+        query_len,
+        dtype=torch.int32,
+    )
+    seq_lens = torch.full((batch_size,), context_len + query_len, dtype=torch.int32)
+    scale = torch.tensor(1.0, dtype=torch.float32)
+
+    context_attention_fwd(
+        query,
+        key,
+        value,
+        output,
+        "auto",
+        k_cache,
+        v_cache,
+        block_table,
+        query_start_loc,
+        seq_lens,
+        context_len + query_len,
+        query_len,
+        scale,
+        scale,
+        sliding_window=sliding_window,
+        causal=False,
+    )
+
+    output_ref = torch.empty_like(output)
+    for req in range(batch_size):
+        start = req * query_len
+        end = start + query_len
+        q = query[start:end].transpose(0, 1).unsqueeze(0)
+        k = torch.cat((contexts_k[req], key[start:end]), dim=0)
+        v = torch.cat((contexts_v[req], value[start:end]), dim=0)
+        k = k.repeat_interleave(num_heads // num_kv_heads, dim=1)
+        v = v.repeat_interleave(num_heads // num_kv_heads, dim=1)
+        k = k.transpose(0, 1).unsqueeze(0)
+        v = v.transpose(0, 1).unsqueeze(0)
+
+        query_positions = torch.arange(query_len) + context_len
+        key_positions = torch.arange(context_len + query_len)
+        valid = query_positions[:, None] - key_positions[None, :] < sliding_window
+        attn_mask = torch.where(valid, 0.0, float("-inf")).to(dtype)
+        output_ref[start:end] = (
+            F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_mask,
+                dropout_p=0.0,
+            )
+            .squeeze(0)
+            .transpose(0, 1)
+        )
+
+    assert torch.isfinite(output).all()
+    torch.testing.assert_close(output, output_ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@torch.inference_mode()
 def test_contexted_kv_attention_cached_kv_alibi_unsupported(device: str) -> None:
     # The cached-K/V (k=None) path is not supported together with ALiBi; the
     # entry point must reject it up-front with a clear NotImplementedError

--- a/vllm/v1/attention/ops/prefix_prefill.py
+++ b/vllm/v1/attention/ops/prefix_prefill.py
@@ -239,15 +239,21 @@ def _fwd_kernel(
         # (handles cross-block tiles via B_Loc). Same addressing is reused for
         # the current-chunk cache read below.
         token_indices = start_n + offs_bs_n
-        # Context tokens are always followed by the current chunk, so the tile
-        # never steps past this batch's block-table row; the block-table load
-        # stays unmasked (MASK_BLOCK_TABLE=False) and offs_bs_n is an unused
-        # placeholder for token_valid.
+        context_token_valid = token_indices < cur_batch_ctx_len
+        if SLIDING_WINDOW > 0:
+            # Every query in this tile is at or after earliest_q_pos. Context
+            # older than its sliding window is invalid for the entire tile and
+            # must not be loaded: an evicted block can map to stale/NaN storage,
+            # and zero attention probability does not neutralize 0 * NaN.
+            earliest_q_pos = cur_batch_ctx_len + block_start_loc
+            context_token_valid = context_token_valid & (
+                earliest_q_pos - token_indices < SLIDING_WINDOW
+            )
         off_k, off_v = _paged_kv_cache_offsets(
             B_Loc,
             cur_batch,
             token_indices,
-            offs_bs_n,
+            context_token_valid,
             offs_d,
             cur_kv_head,
             x,
@@ -263,6 +269,7 @@ def _fwd_kernel(
             stride_v_cache_d,
             stride_v_cache_bl,
             PHYSICAL_BLOCK_SIZE,
+            MASK_BLOCK_TABLE=SLIDING_WINDOW > 0,
         )
 
         if (
@@ -271,10 +278,15 @@ def _fwd_kernel(
         ):
             k_load = tl.load(
                 K_cache + off_k,
-                mask=dim_mask[:, None]
-                & ((start_n + offs_bs_n[None, :]) < cur_batch_ctx_len),
+                mask=dim_mask[:, None] & context_token_valid[None, :],
                 other=0.0,
             )  # [D,N]
+        elif SLIDING_WINDOW > 0:
+            k_load = tl.load(
+                K_cache + off_k,
+                mask=context_token_valid[None, :],
+                other=0.0,
+            )
         else:
             k_load = tl.load(K_cache + off_k)
 
@@ -324,10 +336,15 @@ def _fwd_kernel(
         ):
             v_load = tl.load(
                 V_cache + off_v,
-                mask=dim_mask[None, :]
-                & ((start_n + offs_bs_n[:, None]) < cur_batch_ctx_len),
+                mask=dim_mask[None, :] & context_token_valid[:, None],
                 other=0.0,
             )  # [N,D]
+        elif SLIDING_WINDOW > 0:
+            v_load = tl.load(
+                V_cache + off_v,
+                mask=context_token_valid[:, None],
+                other=0.0,
+            )
         else:
             v_load = tl.load(V_cache + off_v)
 


### PR DESCRIPTION
## Purpose

  Fix NaNs in ROCm prefix attention when DFlash2 uses sliding-window attention with a hybrid target model. #53323 

  Out-of-window positions can reference stale physical KV-cache blocks containing non-finite values. Masking those positions only after attention computation allows `0 * NaN` to propagate. This change masks block-table and K/V loads before they participate in attention math.

  A regression test covers stale nonzero block IDs containing NaNs.

  ## Test Plan

  ```bash
  pytest -q tests/kernels/attention/test_prefix_prefill.py \
    -k sliding_window_masks_stale_nan_blocks
```

  ### DFlash2 with ROCm attention

  Start the server:

  ```bash
  HIP_VISIBLE_DEVICES=6 \
  VLLM_ROCM_USE_AITER=1 \
  AITER_JIT_DIR=/home/yzhen/aiter_jit_v300_pinned \
  vllm serve /data/users/yzhen/models/Qwen3.8-27B \
    --served-model-name Qwen3.8-27B-DFlash2-ROCM-FIX \
    --host 127.0.0.1 \
    --port 8016 \
    --tensor-parallel-size 1 \
    --dtype bfloat16 \
    --max-model-len 65536 \
    --gpu-memory-utilization 0.35 \
    --max-num-seqs 16 \
    --max-num-batched-tokens 4096 \
    --enable-chunked-prefill \
    --no-enable-prefix-caching \
    --async-scheduling \
    --generation-config vllm \
    --attention-backend ROCM_AITER_FA \
    --speculative-config \
    '{"method":"dflash","model":"/data/users/yzhen/models/Qwen3.8-27B-DFlash2","num_speculative_tokens":7,"attention_backend":"ROCM_ATTN"}' \
    --trust-remote-code
  ```

  Run a long-input benchmark:

  ```bash
  vllm bench serve \
    --backend vllm \
    --base-url http://127.0.0.1:8016 \
    --endpoint /v1/completions \
    --model /data/users/yzhen/models/Qwen3.8-27B \
    --served-model-name Qwen3.8-27B-DFlash2-ROCM-FIX \
    --dataset-name random \
    --random-input-len 5000 \
    --random-output-len 256 \
    --random-range-ratio 0 \
    --num-prompts 64 \
    --request-rate inf \
    --max-concurrency 4 \
    --ignore-eos \
    --temperature 0 \
    --seed 12
  ```

  Run the full GSM8K evaluation:

  ```bash
  python tests/evals/gsm8k/gsm8k_eval.py \
    --host http://127.0.0.1 \
    --port 8016 \
    --num-questions 1319 \
    --num-shots 5 \
    --max-tokens 256 \
    --temperature 0 \
    --seed 42 \
    --max-concurrency 16
  ```

  For the control run, restart the same server with the draft attention backend changed to:

  ```text
  "attention_backend":"TRITON_ATTN"
  ```

  Then rerun the identical benchmark and GSM8K commands.

  ## Test Result

  ### Regression test

  ```text
  ..                                                                       [100%]
  =============================== warnings summary ===============================
  tests/kernels/attention/test_prefix_prefill.py: 14 warnings
    torch/jit/_script.py:365: DeprecationWarning:
    `torch.jit.script_method` is deprecated.

  2 passed, 416 deselected, 14 warnings in 10.73s
  ```

  ### DFlash2 with ROCm attention

  ```text
  ============ Serving Benchmark Result ============
  Successful requests:                     64
  Failed requests:                         0
  Maximum request concurrency:             4
  Benchmark duration (s):                  38.94
  Total input tokens:                      320000
  Total generated tokens:                  16384
  Request throughput (req/s):              1.64
  Output token throughput (tok/s):         420.70
  Peak output token throughput (tok/s):    183.00
  Peak concurrent requests:                7.00
  Total token throughput (tok/s):          8637.43
  ---------------Time to First Token----------------
  Mean TTFT (ms):                          499.69
  Median TTFT (ms):                        382.38
  P99 TTFT (ms):                           1755.13
  -----Time per Output Token (excl. 1st token)------
  Mean TPOT (ms):                          7.50
  Median TPOT (ms):                        6.16
  P99 TPOT (ms):                           21.75
  ---------------Inter-token Latency----------------
  Mean ITL (ms):                           36.83
  Median ITL (ms):                         21.79
  P99 ITL (ms):                            253.45
  ---------------Speculative Decoding---------------
  Acceptance rate (%):                     56.71
  Acceptance length:                       4.97
  Drafts:                                  3324
  Draft tokens:                            23268
  Accepted tokens:                         13196
  Per-position acceptance (%):
    Position 0:                            73.68
    Position 1:                            64.68
    Position 2:                            60.23
    Position 3:                            52.74
    Position 4:                            50.51
    Position 5:                            48.23
    Position 6:                            46.93
  ==================================================
  ```

  Full GSM8K result:

  ```text
  Results:
  Accuracy: 0.776
  Invalid responses: 0.002
  Total latency: 137.533 s
  Questions per second: 9.590
  Total output tokens: 212148
  Output tokens per second: 1542.521
  ```

  No NaN or non-finite-value errors appeared during the 64-request benchmark or the 1,319-question evaluation.

  ### Triton attention control

  ```text
  ============ Serving Benchmark Result ============
  Successful requests:                     64
  Failed requests:                         0
  Maximum request concurrency:             4
  Benchmark duration (s):                  37.95
  Total input tokens:                      320000
  Total generated tokens:                  16384
  Request throughput (req/s):              1.69
  Output token throughput (tok/s):         431.76
  Peak output token throughput (tok/s):    133.00
  Peak concurrent requests:                7.00
  Total token throughput (tok/s):          8864.62
  ---------------Time to First Token----------------
  Mean TTFT (ms):                          499.14
  Median TTFT (ms):                        381.37
  P99 TTFT (ms):                           1228.79
  -----Time per Output Token (excl. 1st token)------
  Mean TPOT (ms):                          7.24
  Median TPOT (ms):                        5.80
  P99 TPOT (ms):                           19.74
  ---------------Inter-token Latency----------------
  Mean ITL (ms):                           36.98
  Median ITL (ms):                         20.59
  P99 ITL (ms):                            253.15
  ---------------Speculative Decoding---------------
  Acceptance rate (%):                     59.54
  Acceptance length:                       5.17
  Drafts:                                  3194
  Draft tokens:                            22358
  Accepted tokens:                         13312
  Per-position acceptance (%):
    Position 0:                            76.86
    Position 1:                            66.78
    Position 2:                            62.59
    Position 3:                            55.82
    Position 4:                            53.98
    Position 5:                            51.50
    Position 6:                            49.25
  ==================================================
  ```

  Full GSM8K result:

  ```text
  Results:
  Accuracy: 0.781
  Invalid responses: 0.002
  Total latency: 134.918 s
  Questions per second: 9.776
  Total output tokens: 211718
  Output tokens per second: 1569.234
  ```

  ## AI Assistance Disclosure

  OpenAI Codex assisted with debugging, implementation, and test execution. I reviewed and validated all changes and results.

