### PR TITLE
[Core][Scheduler] Gracefully handle unexpected request status on KV transfer finish

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2937,13 +2937,20 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
+            if req_id not in self.requests:
+                continue
             req = self.requests[req_id]
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
-            else:
-                assert RequestStatus.is_finished(req.status)
+            elif RequestStatus.is_finished(req.status):
                 self._free_blocks(self.requests[req_id])
+            else:
+                logger.warning(
+                    "Request %s finished KV recv with unexpected status %s; "
+                    "skipping remote KV attachment",
+                    req_id,
+                    req.status,
+                )
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
             assert req_id in self.requests


### PR DESCRIPTION
### Motivation
When a worker-side KV transfer finishes recving, `_update_from_kv_xfer_finished()` verifies whether `req.status == RequestStatus.WAITING_FOR_REMOTE_KVS`. If not, it currently asserts `RequestStatus.is_finished(req.status)`.

If a request was cancelled, preempted, or transitioned out of `WAITING_FOR_REMOTE_KVS` while an asynchronous KV receive completed, this strict assertion fails and triggers a fatal `EngineDeadError` taking down `EngineCore` and aborting all in-flight requests.

### Solution
- Safely check `req_id in self.requests`.
- If `req.status == RequestStatus.WAITING_FOR_REMOTE_KVS`, add to `finished_recving_kv_req_ids`.
- If `RequestStatus.is_finished(req.status)`, free allocated blocks.
- Otherwise, log a warning and skip attaching remote KVs rather than asserting and crashing the whole engine.

Signed-off-by: sundeep8967 <sundeep8967@gmail.com>