### PR TITLE
[Bugfix] Do not read falsy request values as unset in the API layer

### DIFF
--- a/tests/entrypoints/unit_tests/test_falsy_request_params.py
+++ b/tests/entrypoints/unit_tests/test_falsy_request_params.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Falsy-but-explicit request values must not be read as "field omitted".
+
+Each case below covers a request field typed ``X | None`` whose consumer used a
+truthiness test, so a caller-supplied falsy value took the branch reserved for
+an omitted field.
+
+This extends the falsy-field coverage of #48098 to the chat template and stream
+option paths.
+"""
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.pooling.embed.protocol import EmbeddingChatRequest
+from vllm.entrypoints.serve.tokenize.protocol import TokenizeChatRequest
+from vllm.exceptions import VLLMValidationError
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+SERVER_TEMPLATE = "{{ 'server default' }}"
+
+CHAT_BODY = {"model": "qwen", "messages": [{"role": "user", "content": "hello"}]}
+
+CHAT_TEMPLATE_MODELS = [
+    ChatCompletionRequest,
+    TokenizeChatRequest,
+    EmbeddingChatRequest,
+]
+
+STREAM_OPTION_BODIES = [
+    (ChatCompletionRequest, CHAT_BODY),
+    (CompletionRequest, {"model": "qwen", "prompt": "hello"}),
+]
+IDS = [model.__name__ for model, _ in STREAM_OPTION_BODIES]
+
+
+@pytest.mark.parametrize(
+    "request_model", CHAT_TEMPLATE_MODELS, ids=lambda m: m.__name__
+)
+def test_empty_chat_template_is_not_replaced_by_the_server_default(request_model):
+    """``chat_template: ""`` must reach the renderer as the caller wrote it.
+
+    ``OnlineRenderer.validate_chat_template`` already counts ``""`` as a
+    caller-supplied template and refuses it unless
+    ``--trust-request-chat-template`` is set, so substituting the server
+    template afterwards renders a prompt the caller never asked for.
+    """
+    request = request_model.model_validate({**CHAT_BODY, "chat_template": ""})
+
+    chat_params = request.build_chat_params(SERVER_TEMPLATE, "auto")
+
+    assert chat_params.chat_template == ""
+
+
+@pytest.mark.parametrize(
+    "request_model", CHAT_TEMPLATE_MODELS, ids=lambda m: m.__name__
+)
+def test_omitted_chat_template_still_falls_back_to_the_server_default(request_model):
+    request = request_model.model_validate(dict(CHAT_BODY))
+
+    chat_params = request.build_chat_params(SERVER_TEMPLATE, "auto")
+
+    assert chat_params.chat_template == SERVER_TEMPLATE
+
+
+@pytest.mark.parametrize(("request_model", "body"), STREAM_OPTION_BODIES, ids=IDS)
+def test_empty_stream_options_are_refused_without_streaming(request_model, body):
+    """``stream_options: {}`` is still ``stream_options``.
+
+    The field is meaningless outside a streaming request, and an empty object
+    is no more meaningful there than a populated one.
+    """
+    with pytest.raises(VLLMValidationError, match="stream_options"):
+        request_model.model_validate({**body, "stream": False, "stream_options": {}})
+
+
+@pytest.mark.parametrize(("request_model", "body"), STREAM_OPTION_BODIES, ids=IDS)
+def test_empty_stream_options_are_accepted_with_streaming(request_model, body):
+    request = request_model.model_validate(
+        {**body, "stream": True, "stream_options": {}}
+    )
+
+    assert request.stream_options is not None
+
+
+@pytest.mark.parametrize(("request_model", "body"), STREAM_OPTION_BODIES, ids=IDS)
+def test_omitted_stream_options_are_accepted_without_streaming(request_model, body):
+    request = request_model.model_validate({**body, "stream": False})
+
+    assert request.stream_options is None

--- a/tests/renderers/test_tokenize_params.py
+++ b/tests/renderers/test_tokenize_params.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""``TokenizeParams.with_kwargs`` overrides that are spelled as ``False``.
+
+``padding`` and ``truncation`` accept the HuggingFace spellings documented at
+https://huggingface.co/docs/transformers/en/pad_truncation, where ``False`` and
+``"do_not_pad"`` / ``"do_not_truncate"`` mean the same thing. The two spellings
+must therefore produce the same ``TokenizeParams``.
+"""
+
+import pytest
+
+from vllm.renderers import TokenizeParams
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.fixture
+def params() -> TokenizeParams:
+    return TokenizeParams(
+        max_total_tokens=1024,
+        max_output_tokens=16,
+        pad_prompt_tokens=64,
+        truncate_prompt_tokens=128,
+    )
+
+
+@pytest.mark.parametrize("truncation", [False, "do_not_truncate"])
+def test_disabling_truncation_clears_truncate_prompt_tokens(params, truncation):
+    assert params.with_kwargs(truncation=truncation).truncate_prompt_tokens is None
+
+
+@pytest.mark.parametrize("padding", [False, "do_not_pad"])
+def test_disabling_padding_clears_pad_prompt_tokens(params, padding):
+    assert params.with_kwargs(padding=padding).pad_prompt_tokens is None
+
+
+def test_enabling_truncation_still_uses_the_input_budget(params):
+    child = params.with_kwargs(truncation=True)
+
+    assert child.truncate_prompt_tokens == params.max_input_tokens
+
+
+def test_padding_to_max_length_still_uses_the_input_budget(params):
+    child = params.with_kwargs(padding="max_length")
+
+    assert child.pad_prompt_tokens == params.max_input_tokens
+
+
+def test_omitting_the_overrides_preserves_the_parent_values(params):
+    child = params.with_kwargs(add_special_tokens=False)
+
+    assert child.truncate_prompt_tokens == 128
+    assert child.pad_prompt_tokens == 64

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -588,7 +588,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             extra_kwargs["enable_thinking"] = self.reasoning_effort != "none"
 
         return ChatParams(
-            chat_template=self.chat_template or default_template,
+            chat_template=(
+                default_template if self.chat_template is None else self.chat_template
+            ),
             chat_template_content_format=default_template_content_format,
             chat_template_kwargs=merge_kwargs(
                 self.chat_template_kwargs,
@@ -787,7 +789,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     def validate_stream_options(cls, data):
         if not isinstance(data, dict):
             return data
-        if data.get("stream_options") and not data.get("stream"):
+        if data.get("stream_options") is not None and not data.get("stream"):
             raise VLLMValidationError(
                 "Stream options can only be defined when `stream=True`.",
                 parameter="stream_options",

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -544,7 +544,7 @@ class CompletionRequest(OpenAIBaseModel):
     def validate_stream_options(cls, data):
         if not isinstance(data, dict):
             return data
-        if data.get("stream_options") and not data.get("stream"):
+        if data.get("stream_options") is not None and not data.get("stream"):
             raise VLLMValidationError(
                 "Stream options can only be defined when `stream=True`.",
                 parameter="stream_options",

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -254,7 +254,9 @@ class ChatRequestOptionsMixin(OpenAIBaseModel):
         default_template_content_format: ChatTemplateContentFormatOption,
     ) -> ChatParams:
         return ChatParams(
-            chat_template=self.chat_template or default_template,
+            chat_template=(
+                default_template if self.chat_template is None else self.chat_template
+            ),
             chat_template_content_format=default_template_content_format,
             chat_template_kwargs=merge_kwargs(
                 self.chat_template_kwargs,

--- a/vllm/entrypoints/serve/tokenize/protocol.py
+++ b/vllm/entrypoints/serve/tokenize/protocol.py
@@ -135,7 +135,9 @@ class TokenizeChatRequest(OpenAIBaseModel):
         default_template_content_format: ChatTemplateContentFormatOption,
     ) -> ChatParams:
         return ChatParams(
-            chat_template=self.chat_template or default_template,
+            chat_template=(
+                default_template if self.chat_template is None else self.chat_template
+            ),
             chat_template_content_format=default_template_content_format,
             chat_template_kwargs=merge_kwargs(
                 self.chat_template_kwargs,

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -270,7 +270,7 @@ class TokenizeParams:
         )
 
         # https://huggingface.co/docs/transformers/en/pad_truncation
-        if padding := tokenization_kwargs.pop("padding", None):
+        if (padding := tokenization_kwargs.pop("padding", None)) is not None:
             if padding == "max_length":
                 pad_prompt_tokens = max_length
             elif padding in (False, "do_not_pad"):
@@ -279,7 +279,7 @@ class TokenizeParams:
                 # To emit the below warning
                 tokenization_kwargs["padding"] = padding
 
-        if truncation := tokenization_kwargs.pop("truncation", None):
+        if (truncation := tokenization_kwargs.pop("truncation", None)) is not None:
             if truncation in (True, "longest_first"):
                 truncate_prompt_tokens = max_length
             elif truncation in (False, "do_not_truncate"):


### PR DESCRIPTION
## Purpose

Three request parameters in the OpenAI-compatible entrypoints are typed `X | None`
but read through a truthiness test, so a caller who explicitly sends a falsy value
lands on the branch reserved for an omitted field.

I found these by sweeping every `x or default` and `if x` guard over caller-supplied
optional fields in `vllm/entrypoints/**/protocol.py` and in the `ChatParams` and
`TokenizeParams` those methods build. Most of the sites in that sweep turned out to
be harmless, because the field default is already the falsy value or the two values
are semantically identical. The three below are not, and each one has a unit test
that fails on `main` and passes with this change.

### 1. `chat_template: ""` is replaced by the server template

`build_chat_params` used `self.chat_template or default_template` in three request
models — `ChatCompletionRequest`, `TokenizeChatRequest`, and the pooling
`ChatRequestOptionsMixin` shared by the embedding, classify, pooling and score
requests. An empty string is falsy, so the caller quietly gets the server default
template rendered instead of the template they sent.

The two halves of the same feature disagree about what `""` means.
`OnlineRenderer.validate_chat_template` tests `request_chat_template is not None`,
so `chat_template: ""` already counts as a caller-supplied template and is refused
with a 400 when `--trust-request-chat-template` is not set. When the flag is set,
the same value is silently discarded a few frames later.
`ChatParams.get_apply_chat_template_kwargs` forwards `""` unchanged once it arrives,
so the assignment in `build_chat_params` is the only place that drops it.

After this change `""` reaches the renderer and the caller sees the result of the
template they actually sent. Omitting the field still falls back to the server
template, which the tests also cover.

### 2. `stream_options: {}` bypasses the non-streaming rejection

`validate_stream_options` in the chat completion and completion protocols used
`if data.get("stream_options") and not data.get("stream")`. A populated
`stream_options` with `stream=false` is rejected and an empty one is accepted, so
whether the guard fires depends on how many keys the client happened to serialize.
The field is meaningless outside a streaming request either way.

### 3. `padding=False` and `truncation=False` are ignored by `TokenizeParams.with_kwargs`

`with_kwargs` accepts the HuggingFace spellings documented at
https://huggingface.co/docs/transformers/en/pad_truncation, where `False` and
`"do_not_pad"` are equivalent. Both walrus guards test truthiness, which makes the
`elif padding in (False, "do_not_pad")` and `elif truncation in (False,
"do_not_truncate")` branches unreachable for the boolean spelling. The value is
popped out of `tokenization_kwargs` and then dropped, so the caller does not even
get the "not supported by vLLM Renderer" warning that other unhandled values
produce.

Observed on `main` with
`TokenizeParams(max_total_tokens=1024, max_output_tokens=16, pad_prompt_tokens=64, truncate_prompt_tokens=128)`

| call | `truncate_prompt_tokens` | `pad_prompt_tokens` |
| --- | --- | --- |
| `with_kwargs(truncation=False)` | 128, unchanged | |
| `with_kwargs(truncation="do_not_truncate")` | None | |
| `with_kwargs(padding=False)` | | 64, unchanged |
| `with_kwargs(padding="do_not_pad")` | | None |

This path is reachable from `LLM.generate` and `LLM.encode` through
`tokenization_kwargs`, and from the pooling and scoring IO processors.

### Behaviour changes a reviewer should weigh

Two of the fixes tighten behaviour for requests that are accepted today.

- `chat_template: ""` now renders with the empty template rather than the server
  default. A caller relying on the old fallback would need to drop the field.
- `stream_options: {}` with `stream: false` now returns 400 instead of 200, which
  matches what the same request already does with a non-empty `stream_options`.

Both are cases where the current behaviour contradicts a guard elsewhere in the
same code path, so I think aligning them is right, but they are the parts worth a
second opinion.

### Why this is not duplicating an existing PR

I checked issues and PRs in all states for `chat_template empty`,
`trust-request-chat-template`, `chat_template or default`, `build_chat_params`,
`stream_options`, `tokenization_kwargs truncation`, `do_not_truncate`,
`padding do_not_pad`, `TokenizeParams with_kwargs`, `falsy`, and
`empty string silently`, and reviewed the changed-file list of every open PR those
searches surfaced.

- **#49320 (open)** fixes falsy handling of `logprob_token_ids` in the same two
  protocol files. Different field, different functions, and this PR does not touch
  `logprob_token_ids` or `check_logprobs` at all.
- **#42482 (open)** rewrites `TokenizeParams.max_input_tokens` and the tail of
  `with_kwargs`. It leaves both walrus guards exactly as they are, so the defect
  here survives that PR. The two hunks sit about twenty lines apart and the change
  rebases onto it cleanly.
- **#51157 (open)** adds default padding behaviour in `vllm/renderers/base.py` and
  a new `tests/renderers/test_default_padding.py`. It does not touch `with_kwargs`.
  This PR puts its renderer tests in a separate new file for the same reason.
- **#50195, #52163, #50300, #46196** all touch chat template handling, and none of
  them touches `build_chat_params` or the request-versus-default resolution.

No open PR and no open issue covers any of the three cases.

Closest merged precedent for the class of defect is **#48098**, which resolved an
explicit `null` to the documented default in the Responses API. **#50816**,
**#45491** and **#46175** are the same shape for `cache_salt`, `max_tokens` and
`logprobs`.

## Test Plan

```bash
uv venv --python 3.12
source .venv/bin/activate
VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto

.venv/bin/python -m pytest \
  tests/entrypoints/unit_tests/test_falsy_request_params.py \
  tests/renderers/test_tokenize_params.py -v
```

Regression check over the neighbouring suites that do not need a running server.

```bash
.venv/bin/python -m pytest \
  tests/entrypoints/unit_tests/ \
  tests/entrypoints/openai/chat_completion/test_thinking_token_budget_validation.py \
  tests/renderers/test_tokenize_params.py -q
```

Lint, on the changed files only.

```bash
pre-commit run ruff-check --files <changed files>
pre-commit run ruff-format --files <changed files>
pre-commit run typos --files <changed files>
```

The new tests are pure Pydantic and dataclass unit tests. They need no engine, no
GPU and no tokenizer download, and they run in about a tenth of a second. Both new
files carry `pytestmark = pytest.mark.skip_global_cleanup`, matching
`tests/entrypoints/unit_tests/test_non_object_body_validation.py`.
`tests/entrypoints/unit_tests` and `tests/renderers` are both already collected by
CI, so the new files run without a pipeline change.

## Test Result

19 new tests pass with the change.

```
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_chat_template_is_not_replaced_by_the_server_default[ChatCompletionRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_chat_template_is_not_replaced_by_the_server_default[TokenizeChatRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_chat_template_is_not_replaced_by_the_server_default[EmbeddingChatRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_omitted_chat_template_still_falls_back_to_the_server_default[ChatCompletionRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_omitted_chat_template_still_falls_back_to_the_server_default[TokenizeChatRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_omitted_chat_template_still_falls_back_to_the_server_default[EmbeddingChatRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_stream_options_are_refused_without_streaming[ChatCompletionRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_stream_options_are_refused_without_streaming[CompletionRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_stream_options_are_accepted_with_streaming[ChatCompletionRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_stream_options_are_accepted_with_streaming[CompletionRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_omitted_stream_options_are_accepted_without_streaming[ChatCompletionRequest] PASSED
tests/entrypoints/unit_tests/test_falsy_request_params.py::test_omitted_stream_options_are_accepted_without_streaming[CompletionRequest] PASSED
tests/renderers/test_tokenize_params.py::test_disabling_truncation_clears_truncate_prompt_tokens[False] PASSED
tests/renderers/test_tokenize_params.py::test_disabling_truncation_clears_truncate_prompt_tokens[do_not_truncate] PASSED
tests/renderers/test_tokenize_params.py::test_disabling_padding_clears_pad_prompt_tokens[False] PASSED
tests/renderers/test_tokenize_params.py::test_disabling_padding_clears_pad_prompt_tokens[do_not_pad] PASSED
tests/renderers/test_tokenize_params.py::test_enabling_truncation_still_uses_the_input_budget PASSED
tests/renderers/test_tokenize_params.py::test_padding_to_max_length_still_uses_the_input_budget PASSED
tests/renderers/test_tokenize_params.py::test_omitting_the_overrides_preserves_the_parent_values PASSED

19 passed in 0.11s
```

Reverting only the `vllm/` half of the commit and keeping the tests gives 7 targeted
failures, one per defective site, and leaves the 12 control cases green.

```
FAILED tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_chat_template_is_not_replaced_by_the_server_default[ChatCompletionRequest]
FAILED tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_chat_template_is_not_replaced_by_the_server_default[TokenizeChatRequest]
FAILED tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_chat_template_is_not_replaced_by_the_server_default[EmbeddingChatRequest]
FAILED tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_stream_options_are_refused_without_streaming[ChatCompletionRequest]
FAILED tests/entrypoints/unit_tests/test_falsy_request_params.py::test_empty_stream_options_are_refused_without_streaming[CompletionRequest]
FAILED tests/renderers/test_tokenize_params.py::test_disabling_truncation_clears_truncate_prompt_tokens[False]
FAILED tests/renderers/test_tokenize_params.py::test_disabling_padding_clears_pad_prompt_tokens[False]
7 failed, 12 passed in 0.14s
```

Neighbouring suites, same environment.

```
138 passed, 1 skipped, 25 errors in 700.77s
```

All 25 errors are fixture setup failures in tests that launch a real vLLM server
subprocess or need an accelerator. They occur identically on unmodified `main` in
this environment. No test moved from pass to fail.

Lint on the changed files.

```
ruff check...............................................................Passed
ruff format..............................................................Passed
typos....................................................................Passed
```

`mypy` reports 8 pre-existing errors in
`vllm/entrypoints/openai/chat_completion/protocol.py` at line 564, inside
`_materialize_tool_calls_after`, which this PR does not touch. They reproduce
unchanged on `main`.

### Model evaluation

No `tests/evals/` run and no `vllm bench` run. This change cannot move model output
or accuracy for any request that is handled correctly today, because every altered
branch is one that a correctly formed request never reaches. The only requests whose
behaviour changes are the two listed under "Behaviour changes a reviewer should
weigh", and both of those are validation or template-selection outcomes rather than
sampling outcomes. Happy to run an eval if a reviewer disagrees with that reading.

### Environment note

Developed and tested on CPU-only macOS on Apple Silicon. The protocol and renderer
layer imports without a compiled build, so the new tests ran against the source tree
with `requirements/common.txt` plus `torch` installed in a `uv` virtualenv. The
server-backed suites in `tests/entrypoints/openai/` cannot start here, which is why
the regression run above shows setup errors rather than results for those.

## AI assistance

AI assistance was used for this change. I used Claude Code to sweep the entrypoints
protocol layer for this class of defect, to draft the fix and the tests, and to
draft this description. I reviewed every changed line, ran the tests in both
directions myself, and I am able to explain and defend each of the three cases. The
commit carries a `Co-authored-by` trailer for the agent.