### PR TITLE
[Bugfix][Model] Gemma4 MM: fall back gracefully when torch.accelerator has no device (fixes TPU/JAX vision crash)

### DIFF
--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -286,3 +286,41 @@ def test_encoder_chunk_no_free_memory_falls_back_to_one():
         )
         == 1
     )
+
+
+# ``torch.accelerator.get_memory_info()`` requires a PyTorch-native
+# accelerator backend. On out-of-tree platforms that run torch models through
+# a non-PyTorch runtime (e.g. the TPU backend, where this model executes via
+# torchax on JAX) the call raises ``RuntimeError: PyTorch is not linked with
+# support for jax devices``, which used to kill the engine on the first image
+# request. ``_accelerator_memory_info`` reports ``(0, 0)`` instead, which
+# ``_encoder_chunk`` maps to the always-memory-safe chunk size of 1.
+
+_accelerator_memory_info = Gemma4ForConditionalGeneration._accelerator_memory_info
+
+
+def test_accelerator_memory_info_passes_through(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        torch.accelerator,
+        "get_memory_info",
+        lambda: (3 * GiB_bytes, 22 * GiB_bytes),
+    )
+    assert _accelerator_memory_info() == (3 * GiB_bytes, 22 * GiB_bytes)
+
+
+def test_accelerator_memory_info_unsupported_platform_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def raise_unsupported():
+        raise RuntimeError("PyTorch is not linked with support for jax devices")
+
+    monkeypatch.setattr(torch.accelerator, "get_memory_info", raise_unsupported)
+
+    free, total = _accelerator_memory_info()
+
+    assert (free, total) == (0, 0)
+    # A zero budget must degrade to the minimal chunk size, not crash.
+    assert (
+        _encoder_chunk(_VIDEO_PATCHES_PER_FRAME, free, total, _POSITION_EMBEDDING_SIZE)
+        == 1
+    )

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1248,6 +1248,33 @@ class Gemma4ForConditionalGeneration(
         cost = patches_per_item * 4 * position_embedding_size * 8
         return max(1, budget // cost) if cost > 0 else 1
 
+    @staticmethod
+    def _accelerator_memory_info() -> tuple[int, int]:
+        """Free/total accelerator memory in bytes, or ``(0, 0)`` if unknown.
+
+        ``torch.accelerator.get_memory_info()`` only works when PyTorch
+        itself drives the current accelerator. On out-of-tree platforms
+        that execute torch models through a non-PyTorch runtime — e.g.
+        vLLM's TPU backend (vllm-project/tpu-inference), where this model
+        runs via torchax on JAX — there is no PyTorch accelerator behind
+        the device and the call raises (``RuntimeError: PyTorch is not
+        linked with support for jax devices``), which previously killed
+        the whole engine on the first image request. Report "unknown"
+        ``(0, 0)`` instead: ``_encoder_chunk`` treats a zero budget as
+        its minimal, always-memory-safe chunk size of 1, trading encoder
+        batching for correctness on platforms where the heuristic has no
+        data.
+        """
+        try:
+            return torch.accelerator.get_memory_info()
+        except RuntimeError:
+            logger.warning_once(
+                "torch.accelerator.get_memory_info() is not supported on "
+                "this platform; multimodal encoder inputs will be encoded "
+                "in chunks of 1 (memory-based chunk sizing disabled)."
+            )
+            return (0, 0)
+
     # ------------------------------------------------------------------ #
     # Image processing
     # ------------------------------------------------------------------ #
@@ -1331,7 +1358,7 @@ class Gemma4ForConditionalGeneration(
             if self._enable_mm_lora:
                 max_batch_size = len(items)
             else:
-                free, total = torch.accelerator.get_memory_info()
+                free, total = self._accelerator_memory_info()
                 max_batch_size = min(
                     len(items),
                     self._encoder_chunk(
@@ -1448,7 +1475,7 @@ class Gemma4ForConditionalGeneration(
             fc_list = list(frame_counts)
 
         total_frames = pixel_values.shape[0]
-        free, total = torch.accelerator.get_memory_info()
+        free, total = self._accelerator_memory_info()
         max_batch_size = min(
             total_frames,
             self._encoder_chunk(


### PR DESCRIPTION
## Purpose

Fix an engine-killing crash for Gemma4 multimodal on platforms whose accelerator is not driven by PyTorch itself — concretely the TPU backend ([vllm-project/tpu-inference](https://github.com/vllm-project/tpu-inference)), which executes this model via torchax on JAX.

`Gemma4ForConditionalGeneration._process_image_input` and `_process_video_input` size memory-safe vision-encoder chunks from `torch.accelerator.get_memory_info()`. That call requires a PyTorch-native accelerator backend; on the TPU backend there is no PyTorch accelerator behind the device, so the first request containing an image raises and takes the whole engine down. Captured live 2026-08-24 on GKE TPU v6e (`google/gemma-4-26B-A4B-it` bf16, `vllm/vllm-tpu` nightly image, `MODEL_IMPL_TYPE=vllm`):

```text
File "/workspace/vllm/vllm/model_executor/models/gemma4_mm.py", line 1296, in _process_image_input
  free, total = torch.accelerator.get_memory_info()
RuntimeError: PyTorch is not linked with support for jax devices
```

→ `EngineDeadError`, HTTP 500 for every subsequent request, pod restart (~15–25 min XLA recompile). A second identical call sits in `_process_video_input`.

### Fix

Platform-generic graceful degradation — no TPU/JAX special-casing:

- A guarded `_accelerator_memory_info()` helper wraps the call and returns `(0, 0)` ("unknown") when the platform cannot answer, with a `warning_once`.
- `_encoder_chunk` already treats a non-positive budget as chunk size 1 — the minimal, always-memory-safe fallback — so unknown-memory platforms encode multimodal inputs one item at a time instead of crashing. Platforms where `torch.accelerator` works are unchanged.

The trade is encoder batching for correctness on platforms where the memory heuristic has no data; chunk size 1 is exactly the value the heuristic itself falls back to whenever it cannot establish a positive budget.

Reported in vllm-project/tpu-inference#3454 (the TPU backend owns the serving context in which this crashes).

## Test Plan

- New unit tests in `tests/models/multimodal/processing/test_gemma4.py` (hardware-free, next to the existing `_encoder_chunk` tests): mock `torch.accelerator.get_memory_info` to raise `RuntimeError` and assert the `(0, 0)` fallback plus the resulting chunk size of 1; plus a pass-through test for platforms where the call works.
- Live validation on GKE TPU v6e-4 (Spot `ct6e-standard-4t`), serving `google/gemma-4-26B-A4B-it` bf16 with `MODEL_IMPL_TYPE=vllm`: this exact patch is deployed as a file overlay over the vendored vLLM checkout in the `vllm/vllm-tpu` image (vLLM pin d626108) via the pieces-app/tpu-inference branch [`fix/gemma4-vision-jax-memory-info`](https://github.com/pieces-app/tpu-inference/tree/fix/gemma4-vision-jax-memory-info). Before: any image request → `EngineDeadError`. A built-image validation run (patch baked into the image rather than overlaid) is in flight; this PR stays **draft** until that result lands.

## Test Result

```text
$ pytest tests/models/multimodal/processing/test_gemma4.py -k "encoder_chunk or accelerator_memory_info" -q
7 passed, 21 deselected
```

`ruff check` / `ruff format --check` / `typos` (pre-commit pinned versions) pass on both touched files.

---

*AI-assisted contribution (Claude Code); commit carries `Co-Authored-By` attribution and has been human-reviewed line by line, with the fix validated live on TPU v6e as described above.*
