### PR TITLE
[Bugfix] Avoid double-scaling DeepSeek YaRN max model length

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ from vllm.config import (
 from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.config.kernel import IrOpPriorityConfig
 from vllm.config.load import LoadConfig
+from vllm.config.model import _get_and_verify_max_len
 from vllm.config.utils import get_field
 from vllm.config.vllm import OPTIMIZATION_LEVEL_TO_CONFIG, OptimizationLevel
 from vllm.platforms import current_platform
@@ -952,6 +953,32 @@ def test_get_and_verify_max_len(
     else:
         actual_max_len = model_config.get_and_verify_max_len(max_model_len)
         assert actual_max_len == expected_max_len
+
+
+@pytest.mark.parametrize("rope_type", ["yarn", "deepseek_yarn"])
+def test_get_and_verify_max_len_yarn_uses_original_context(rope_type):
+    resolved = _get_and_verify_max_len(
+        hf_config=SimpleNamespace(
+            model_type="deepseek_v3",
+            rope_parameters={
+                "rope_type": rope_type,
+                "factor": 32.0,
+                "original_max_position_embeddings": 32_768,
+            },
+        ),
+        model_arch_config=SimpleNamespace(
+            derived_max_model_len_and_key=(
+                1_048_576,
+                "max_position_embeddings",
+            )
+        ),
+        tokenizer_config=None,
+        max_model_len=None,
+        disable_sliding_window=False,
+        sliding_window=None,
+    )
+
+    assert resolved == 1_048_576
 
 
 class MockConfig:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2398,7 +2398,7 @@ def _get_and_verify_max_len(
                 # NOTE: This assumes all layer types have the same scaling factor.
                 scaling_factor = rp.get("factor", scaling_factor)
 
-                if rope_type == "yarn":
+                if rope_type in ("yarn", "deepseek_yarn"):
                     derived_max_model_len = rp["original_max_position_embeddings"]
         if scaling_factor is None:
             # Fallback the factor to 1.0 if a user assigned `null`


### PR DESCRIPTION
## Description

DeepSeek YaRN checkpoints can declare the post-scaling context in `max_position_embeddings` together with the pre-scaling context in `rope_parameters.original_max_position_embeddings` and a `factor`. The triggering [checkpoint config](https://huggingface.co/Inferact/Kimi-K3-DSpark-Block5/blob/a202601f9043e965516e3965d02322a1b8f10310/config.json) declares:

```text
max_position_embeddings = 1,048,576
original_max_position_embeddings = 32,768
factor = 32
rope_type = "deepseek_yarn"
```

`_get_and_verify_max_len` already resets the derived length to the original context before applying `factor` for `rope_type="yarn"`. It did not do so for the `deepseek_yarn` type already supported by vLLM's rotary dispatcher, causing the expanded `max_position_embeddings` to be multiplied again:

```text
1,048,576 * 32 = 33,554,432
```

Treat `deepseek_yarn` like `yarn` during max-length derivation. The corrected result is:

```text
32,768 * 32 = 1,048,576
```

This does not change RoPE frequencies, scaling parameters, cache contents, or inference math.

## Not a duplicate

I searched open issues and PRs for `deepseek_yarn`, `derived_max_model_len`, YaRN scaling, and double-scaling before opening this draft.

- #44738 reduces rotary cache allocation when runtime `max_model_len` is shorter; it does not change model-length derivation.
- #51156 bounds speculative draft length by the target before logging. That can mask this value for a shorter target, but does not fix standalone derivation or a target whose limit exceeds the real DeepSeek YaRN cache length.

No open PR found by those searches applies this alias fix.

## Testing

Focused regression test:

```text
.venv/bin/python -m pytest tests/test_config.py \
  -k get_and_verify_max_len_yarn_uses_original_context -q

2 passed, 189 deselected
```

Repository hooks on both changed files:

```text
pre-commit run --files vllm/config/model.py tests/test_config.py

All applicable hooks passed, including ruff check, ruff format, mypy, SPDX, and repository-specific configuration checks.
```

Exact configuration validation:

| RoPE type | Before | After | Expected |
|---|---:|---:|---:|
| `yarn` | 1,048,576 | 1,048,576 | 1,048,576 |
| `deepseek_yarn` | 33,554,432 | 1,048,576 | 1,048,576 |

No generation evaluation was run because the patch changes only configuration-derived length metadata and does not alter tensors or model output. The current speculative setup already clamps the final draft length to 1,048,576, so its generated output is unchanged; this patch corrects the underlying derivation for all callers.

## AI assistance

This draft PR was prepared with AI assistance from OpenAI Codex. Human review of every changed line and the test evidence is required before marking it ready for review.
