### PR TITLE
[Bugfix][Tool Parser] Fix Hermes streaming args (brace-match) + spec-decode x tool-calling gate

### DIFF
--- a/tests/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/tool_parsers/test_hermes_tool_parser.py
@@ -248,6 +248,44 @@ def test_hermes_streaming_content_then_tool_call_with_stream_interval(
     assert json.loads(args_str) == {"city": "NYC"}
 
 
+@pytest.mark.parametrize("stream_interval", [1, 2, 3, 5, 8])
+def test_hermes_streaming_stray_tool_call_marker(
+    qwen_tokenizer: TokenizerLike,
+    any_chat_request: ChatCompletionRequest,
+    stream_interval: int,
+) -> None:
+    """A stray <tool_call> marker before the real one must not corrupt the
+    streamed arguments JSON.
+
+    Some models emit a spurious <tool_call> then continue generating prose
+    before the real <tool_call>{...}</tool_call> (speculative decoding makes
+    this more frequent). The first (unclosed) marker then pairs with the later
+    </tool_call>, so the extracted region is not valid JSON; the old is_complete
+    check therefore left the outer '}' in the arguments, streaming '{...}}' which
+    fails json.loads with "Extra data". The reassembled arguments must still be
+    valid JSON regardless of the stray marker or the stream interval.
+    """
+    text = (
+        "<tool_call> hmm, wait, let me reconsider the format.\n"
+        '<tool_call>{"name": "get_weather", '
+        '"arguments": {"city": "New York City", "unit": "celsius"}}'
+        "</tool_call>"
+    )
+    parser = Hermes2ProToolParser(qwen_tokenizer)
+    deltas = _simulate_streaming(
+        qwen_tokenizer, parser, any_chat_request, text, stream_interval
+    )
+
+    tool_calls = [tc for d in deltas if d.tool_calls for tc in d.tool_calls]
+    assert tool_calls, "Expected at least one tool call delta"
+    assert tool_calls[0].function.name == "get_weather"
+    args_str = "".join(tc.function.arguments or "" for tc in tool_calls)
+    assert json.loads(args_str) == {
+        "city": "New York City",
+        "unit": "celsius",
+    }
+
+
 @pytest.mark.parametrize("stream_interval", [1, 2, 4])
 def test_hermes_streaming_multiple_tool_calls_with_stream_interval(
     qwen_tokenizer: TokenizerLike,

--- a/tests/tool_use/test_spec_decode_tool_calling.py
+++ b/tests/tool_use/test_spec_decode_tool_calling.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Feature-combination gate: speculative decoding x tool calling.
+
+Enabling speculative decoding must never silently disable tool calling. That combination
+is
+what production agentic deployments actually run, and a regression in it is invisible to
+both
+the per-parser unit tests (which never boot an engine) and the tool-calling e2e tests
+(which
+never enable spec-dec) -- so it is only catchable by exercising the two together.
+
+The suite boots the same tool-calling server twice, with speculative decoding OFF and
+with
+ngram speculative decoding ON (ngram needs no draft model, so this stays cheap), and
+asserts:
+
+  1. a tool-eliciting request returns a well-formed tool call in BOTH configurations,
+     and
+  2. under the spec-dec configuration the drafter was *actually exercised*
+     (``vllm:spec_decode_num_draft_tokens_total > 0``).
+
+Assertion 2 is what keeps the gate honest: without it a silently-inactive drafter would
+let
+the test pass while proving nothing about the combination.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+
+from tests.utils import RemoteOpenAIServer
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+BASE_ARGS: list[str] = [
+    "--enforce-eager",
+    "--max-model-len",
+    "4096",
+    "--enable-auto-tool-choice",
+    "--tool-call-parser",
+    "hermes",
+]
+
+NGRAM_SPEC_CONFIG = {
+    "method": "ngram",
+    "num_speculative_tokens": 4,
+    "prompt_lookup_max": 4,
+    "prompt_lookup_min": 1,
+}
+
+# ngram drafts from repeated n-grams in the context, so the prompt deliberately repeats
+# the
+# phrasing the answer will reuse -- this is what makes the drafter fire on a short
+# request.
+PROMPT = (
+    "The weather in San Francisco. The weather in San Francisco. "
+    "What is the weather in San Francisco? Use the get_weather tool for San Francisco."
+)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+CONFIGS: dict[str, list[str]] = {
+    "spec_decode_off": BASE_ARGS,
+    "spec_decode_ngram": BASE_ARGS
+    + ["--speculative-config", json.dumps(NGRAM_SPEC_CONFIG)],
+}
+
+
+@pytest.fixture(scope="module", params=list(CONFIGS))
+def spec_decode_server(request):
+    with RemoteOpenAIServer(MODEL, CONFIGS[request.param]) as remote_server:
+        yield request.param, remote_server
+
+
+# The counter is registered as "vllm:spec_decode_num_draft_tokens"; the text exposition
+# conventionally appends "_total" for counters. Accept either spelling so this does not
+# depend
+# on the exposition detail, while still ignoring sibling series (e.g. "..._created").
+_DRAFT_TOKENS_METRIC = "vllm:spec_decode_num_draft_tokens"
+
+
+def _spec_decode_draft_tokens(remote_server: RemoteOpenAIServer) -> float:
+    """Total speculative draft tokens reported by the Prometheus endpoint.
+
+    Sums every matching series: a multi-engine or tensor-parallel deployment emits one
+    labelled series per engine, and reading only the first would under-count. The value
+    is
+    taken as the first field after the label block, because the text format allows an
+    optional trailing timestamp that must not be mistaken for the counter.
+    """
+    metrics = requests.get(remote_server.url_for("metrics"), timeout=30).text
+    total = 0.0
+    for line in metrics.splitlines():
+        if not line.startswith(_DRAFT_TOKENS_METRIC):
+            continue
+        rest = line[len(_DRAFT_TOKENS_METRIC) :]
+        if rest.startswith("_total"):
+            rest = rest[len("_total") :]
+        if rest[:1] not in ("{", " "):  # e.g. "_created" -> a different series
+            continue
+        if rest.lstrip().startswith("{"):
+            rest = rest[rest.index("}") + 1 :]
+        fields = rest.split()
+        if fields:
+            total += float(fields[0])
+    return total
+
+
+@pytest.mark.asyncio
+async def test_tool_calling_survives_speculative_decoding(spec_decode_server):
+    """A tool call must still be produced with speculative decoding enabled."""
+    config_name, remote_server = spec_decode_server
+    async with remote_server.get_async_client() as client:
+        chat_completion = await client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": PROMPT}],
+            tools=TOOLS,
+            tool_choice="required",
+            temperature=0.0,
+            max_completion_tokens=128,
+        )
+
+    choice = chat_completion.choices[0]
+    tool_calls = choice.message.tool_calls
+    assert tool_calls, f"{config_name}: no tool call was produced"
+    assert choice.finish_reason == "tool_calls"
+
+    call = tool_calls[0]
+    assert call.function.name == "get_weather"
+    arguments = json.loads(call.function.arguments)
+    assert "city" in arguments, (
+        f"{config_name}: tool arguments missing 'city': {arguments}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_speculative_decoding_was_actually_exercised(spec_decode_server):
+    """Calibration: the spec-dec configuration must really draft tokens.
+
+    Without this the parity assertion above could pass with an inactive drafter, proving
+    nothing about the feature combination.
+    """
+    config_name, remote_server = spec_decode_server
+    if config_name == "spec_decode_off":
+        # Control arm: proves the counter discriminates rather than being always-on.
+        assert _spec_decode_draft_tokens(remote_server) == 0.0
+        pytest.skip("drafting check is not applicable without speculative decoding")
+
+    async with remote_server.get_async_client() as client:
+        for _ in range(3):
+            await client.chat.completions.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": PROMPT}],
+                tools=TOOLS,
+                tool_choice="required",
+                temperature=0.0,
+                max_completion_tokens=128,
+            )
+
+    assert _spec_decode_draft_tokens(remote_server) > 0.0, (
+        "speculative decoding was configured but drafted no tokens; the "
+        "spec-dec x tool-calling combination was not actually exercised"
+    )

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -176,17 +176,49 @@ class Hermes2ProToolParser(ToolParser):
         """Extract tool arguments from the tool call JSON.
 
         Given {"name": "f", "arguments": {"x": 1}}, returns '{"x": 1}'.
-        When is_complete, strips the trailing '}' that closes the outer
-        object (not the arguments). For partial JSON, returns as-is.
+
+        The arguments value is extracted by brace/bracket matching (ignoring
+        braces inside strings), so exactly the value is returned regardless of
+        whether the surrounding object is complete. This is robust to a trailing
+        outer '}' AND to stray text or extra <tool_call> markers the model may
+        emit around the JSON (e.g. under speculative decoding), which otherwise
+        make an is_complete check on the whole region fail and leak the outer '}'
+        into the arguments -> invalid JSON. A partial (still-unbalanced) value is
+        returned as-is for incremental streaming.
         """
         match = re.search(r'"arguments"\s*:\s*', tc_json)
         if not match:
             return None
         raw = tc_json[match.end() :]
-        if is_complete:
-            raw = raw.rstrip()
-            if raw.endswith("}"):
-                raw = raw[:-1].rstrip()
+        if not raw or raw[0] not in "{[":
+            # Scalar arguments value (rare): fall back to the trailing-'}' strip.
+            if is_complete:
+                raw = raw.rstrip()
+                if raw.endswith("}"):
+                    raw = raw[:-1].rstrip()
+            return raw
+        open_ch = raw[0]
+        close_ch = "}" if open_ch == "{" else "]"
+        depth = 0
+        in_str = False
+        esc = False
+        for i, c in enumerate(raw):
+            if in_str:
+                if esc:
+                    esc = False
+                elif c == "\\":
+                    esc = True
+                elif c == '"':
+                    in_str = False
+                continue
+            if c == '"':
+                in_str = True
+            elif c == open_ch:
+                depth += 1
+            elif c == close_ch:
+                depth -= 1
+                if depth == 0:
+                    return raw[: i + 1]
         return raw
 
     def _compute_args_diff(


### PR DESCRIPTION
> **Update:** this PR now also carries the concrete **fix** for the first bug this gate catches — the Hermes streaming tool parser corrupting arguments JSON under speculative decoding. Kept together because the gate exists precisely to catch this class.

## The fix (Hermes streaming arguments)

Under speculative decoding a model more often emits a **stray `<tool_call>` marker** before the real one and rambles in between. `_extract_tool_call_jsons` then pairs the first (spurious) marker with the later `</tool_call>`, so the extracted region is not valid JSON; `_extract_tool_args` was stripping the outer `}` only when the whole region parsed (`is_complete`), so it left the brace in and streamed `{...}}` → the client's `json.loads` fails with `Extra data`.

Fix: extract the arguments value by **string-aware brace/bracket matching**, independent of `is_complete` and surrounding prose. A regression test (`test_hermes_streaming_stray_tool_call_marker`) fails before and passes after, at every stream interval. Reproduced end-to-end with `XiaomiMiMo/MiMo-7B-RL` + MTP and verified on the captured parser stream.

---

## The gate (original)


## Purpose

Enabling speculative decoding must never silently disable or corrupt tool calling — the
combination has broken in practice on real models, forcing operators to choose between
the two. Nothing exercises it today: per-parser tests never boot an engine, and the
tool-calling e2e tests never enable speculation.

Adds `tests/tool_use/test_spec_decode_tool_calling.py`, which boots the same
tool-calling server with speculative decoding off and with ngram speculation on (ngram
needs no draft model, so the gate stays cheap) and asserts (1) a well-formed,
schema-conformant tool call in both configurations, and (2) that speculation was
*actually exercised* (`vllm:spec_decode_num_draft_tokens` > 0, and 0 in the control
arm). Assertion 2 keeps the gate honest: a drafter that never engaged would pass while
proving nothing.

Test-only; requires a GPU and a small model, so it suits a nightly or opt-in tier
rather than a blocking gate.

## Test Plan

Run on 1 GPU: `pytest tests/tool_use/test_spec_decode_tool_calling.py -v`

## Test Result

| Run | Result |
|---|---|
| As filed (GB200, recent dev build, Qwen/Qwen2.5-0.5B-Instruct) | 3 passed, 1 skipped (control-arm skip by design) |
| Planted defect — speculative config silently dropped from the ngram arm | exactly 1 failed: the engagement assertion; tool-calling assertions stayed green |

Counter helper sums every engine-labelled series, accepts the exposition with or
without `_total`, ignores `_created`, and returns 0 when the series is absent (the
counters are only registered when speculation is configured).

ruff 0.14.0 (`check` + `format --check`) clean.

Searched open PRs and the tree for existing spec-decode x tool-calling e2e coverage: none found (nearest is a drafting feature, not a test). Written with AI assistance (Claude); I have reviewed and validated every line. Model evaluation results: N/A (test-only change).
