### PR TITLE
Add FlashInfer fused decode for Qwen GDN on sm120

### DIFF
--- a/tests/kernels/mamba/test_gdn_flashinfer_fused_decode.py
+++ b/tests/kernels/mamba/test_gdn_flashinfer_fused_decode.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Capability-check tests for the FlashInfer fused GDN decode route.
+
+The route must only activate when the installed FlashInfer exports both
+``gdn_fused_decode_step`` and a routing probe that understands
+``conv_state_layout``. Anything older keeps the stock path bit-for-bit
+unchanged, and there are three distinct "older or broken" cases the resolver
+has to survive, all of which must fail CLOSED:
+
+* a FlashInfer that predates the op — ``import flashinfer`` succeeds and the
+  **attribute is missing**, which is the whole reason the resolver reads it
+  with a ``getattr`` default and then checks for ``None``;
+* a FlashInfer whose probe predates conv-state-layout awareness;
+* a FlashInfer that cannot be imported at all (a broken/partial install),
+  which must not propagate out of layer construction.
+
+The route adds no backend name and no config surface: support is the only
+gate, and it is asked per step, so a probe that declines every geometry must
+NOT stop the route from resolving. The single exception is the fallback
+control ``VLLM_ENABLE_QWEN_GDN_FUSED_DECODE=0``, which holds the route off
+entirely so the layer runs the pre-integration decode op -- that is what
+makes a one-build A/B possible, and it must log a marker distinct from
+"unavailable" so an off arm cannot be confused with a missing install.
+
+The custom op wrapping the route must be registered as a piecewise-cudagraph
+splitting op.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+from vllm import envs
+from vllm.config import CompilationConfig
+from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as mod
+
+
+class _Cfg:
+    """Duck-typed VllmConfig: the resolver only reads additional_config."""
+
+    def __init__(self, additional_config: dict | None = None):
+        self.additional_config = additional_config or {}
+
+
+def _probe_with_layout(batch_size, *, conv_state_layout="SD", **kwargs):
+    return True
+
+
+def _probe_without_layout(batch_size, hidden_size=0, device=None):
+    return True
+
+
+def _declining_probe(batch_size, *, conv_state_layout="SD", **kwargs):
+    """What a layout-aware probe returns for an unsupported geometry."""
+    return False
+
+
+def _fake_flashinfer(with_api: bool = True, probe=_probe_with_layout) -> dict:
+    """sys.modules patch for a fake flashinfer install.
+
+    FlashInfer exports the op at the top level, so ``with_api=False`` models
+    a FlashInfer that predates it: the package imports fine and the two
+    attributes are simply absent.
+    """
+    root = types.ModuleType("flashinfer")
+    if with_api:
+        root.gdn_fused_decode_step = lambda *args, **kwargs: None
+        root.gdn_fused_decode_step_supported = probe
+    return {"flashinfer": root}
+
+
+@patch.object(mod.current_platform, "is_cuda", return_value=True)
+def test_resolver_requires_the_flashinfer_api(_):
+    """A FlashInfer without the op -> stock path, via a MISSING ATTRIBUTE.
+
+    This is the shape of "too old" now that the op is a top-level export:
+    ``import flashinfer`` succeeds on every FlashInfer ever released, so the
+    import cannot be the gate. The resolver reads the two names with a
+    ``getattr`` default and returns ``None`` when either is absent — drop
+    that check and an old install would resolve to ``(None, None)`` and blow
+    up on the first decode step instead of keeping the stock chain.
+    """
+    with patch.dict(sys.modules, _fake_flashinfer(with_api=False), clear=False):
+        assert mod._resolve_gdn_fused_decode_step(_Cfg()) is None
+    with patch.dict(sys.modules, _fake_flashinfer(), clear=False):
+        resolved = mod._resolve_gdn_fused_decode_step(_Cfg())
+        assert resolved is not None
+        step, supported = resolved
+        assert callable(step)
+        assert callable(supported)
+
+
+@patch.object(mod.current_platform, "is_cuda", return_value=True)
+def test_resolver_requires_both_names(_):
+    """Half an API is not an API: either name missing keeps the stock path."""
+    for present in ("gdn_fused_decode_step", "gdn_fused_decode_step_supported"):
+        root = types.ModuleType("flashinfer")
+        setattr(root, present, _probe_with_layout)
+        with patch.dict(sys.modules, {"flashinfer": root}, clear=False):
+            assert mod._resolve_gdn_fused_decode_step(_Cfg()) is None, present
+
+
+@patch.object(mod.current_platform, "is_cuda", return_value=True)
+def test_resolver_survives_an_unimportable_flashinfer(_):
+    """A build where ``import flashinfer`` itself raises keeps the stock path.
+
+    Rare, but it is the branch the ``try`` still exists for: a partial or
+    broken install must land on the stock chain, not propagate an exception
+    out of layer construction. ``None`` in ``sys.modules`` is CPython's way
+    of making an import raise ``ImportError``.
+    """
+    with patch.dict(sys.modules, {"flashinfer": None}, clear=False):
+        assert mod._resolve_gdn_fused_decode_step(_Cfg()) is None
+
+
+@patch.object(mod.current_platform, "is_cuda", return_value=True)
+def test_resolver_adds_no_config_surface(_):
+    """No backend name, no knob: an unrelated additional_config cannot turn
+    the route on or off. Support is the gate."""
+    with patch.dict(sys.modules, _fake_flashinfer(), clear=False):
+        for additional_config in ({}, {"gdn_decode_backend": "triton"}, None):
+            resolved = mod._resolve_gdn_fused_decode_step(_Cfg(additional_config))
+            assert resolved is not None
+
+
+@patch.object(mod.current_platform, "is_cuda", return_value=True)
+def test_fallback_control_holds_the_route_off(_):
+    """VLLM_ENABLE_QWEN_GDN_FUSED_DECODE=0 keeps the stock chain on a build
+    that is fully capable -- the one-build A/B baseline, and the field
+    fallback for a bad fusion."""
+    with (
+        patch.dict(sys.modules, _fake_flashinfer(), clear=False),
+        patch.object(envs, "VLLM_ENABLE_QWEN_GDN_FUSED_DECODE", False),
+    ):
+        assert mod._resolve_gdn_fused_decode_step(_Cfg()) is None
+    # ...and the default leaves it on, so the control cannot silently be
+    # the reason a measurement saw no dispatch.
+    with (
+        patch.dict(sys.modules, _fake_flashinfer(), clear=False),
+        patch.object(envs, "VLLM_ENABLE_QWEN_GDN_FUSED_DECODE", True),
+    ):
+        assert mod._resolve_gdn_fused_decode_step(_Cfg()) is not None
+
+
+def test_resolver_requires_cuda():
+    with (
+        patch.object(mod.current_platform, "is_cuda", return_value=False),
+        patch.dict(sys.modules, _fake_flashinfer(), clear=False),
+    ):
+        assert mod._resolve_gdn_fused_decode_step(_Cfg()) is None
+
+
+@patch.object(mod.current_platform, "is_cuda", return_value=True)
+def test_resolver_requires_layout_aware_probe(_):
+    """A probe that predates conv_state_layout assumes a dim-first conv pool
+    and must keep the route unavailable (vLLM defaults to state-first)."""
+    with patch.dict(
+        sys.modules, _fake_flashinfer(probe=_probe_without_layout), clear=False
+    ):
+        assert mod._resolve_gdn_fused_decode_step(_Cfg()) is None
+
+
+@patch.object(mod.current_platform, "is_cuda", return_value=True)
+def test_resolver_is_capability_only(_):
+    """A probe that declines every geometry still resolves: the route is
+    chosen once per layer, and each decode step asks the probe again before
+    dispatching, falling back to the stock path. Support is per step, so it
+    cannot be answered once at construction."""
+    with patch.dict(sys.modules, _fake_flashinfer(probe=_declining_probe), clear=False):
+        resolved = mod._resolve_gdn_fused_decode_step(_Cfg())
+        assert resolved is not None
+        assert resolved[1](1, conv_state_layout="SD") is False
+
+
+def test_fused_core_op_is_a_splitting_op():
+    """qwen_gdn_attention_core_fi reads per-step forward context/metadata on
+    the host and must never be inlined into PIECEWISE cudagraph pieces."""
+    assert "vllm::qwen_gdn_attention_core_fi" in CompilationConfig._attention_ops

--- a/tests/kernels/mamba/test_gdn_flashinfer_fused_decode_routing.py
+++ b/tests/kernels/mamba/test_gdn_flashinfer_fused_decode_routing.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Routing-structure guards for the FlashInfer fused GDN decode step.
+
+The FlashInfer fused decode step is homed *inside* vLLM's own fused-norm
+packed GDN decode route: it replaces the conv1d + gated delta-rule chain
+that route runs for plain (non-speculative) decode, which is exactly the
+regime vLLM's own fused GDN decode kernel does not serve. That home is a
+structural property of ``forward_cuda``, and structure is what breaks when
+the surrounding route is rewritten upstream. There are two ways to break it,
+and both are silent at import time:
+
+* **broken** -- ``forward_cuda`` skips the ``in_proj_ba`` GEMV (the fused
+  step folds it in) on a path that then reads ``ba``;
+* **dead** -- a branch returns before the FlashInfer core op is reached, so
+  the route is wired but never runs.
+
+These tests read the module as source and prove neither happens, by
+enumerating the feasible paths through ``forward_cuda`` under every truth
+assignment of its routing predicates. They are deliberately import-free:
+no torch, no vLLM, no GPU, no CUDA build -- so they run in any environment
+and they run *fast*, which is the point of a guard that has to survive
+every upstream rewrite of this file.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_MODULE = (
+    _REPO
+    / "vllm"
+    / "model_executor"
+    / "layers"
+    / "mamba"
+    / "gdn"
+    / "qwen_gdn_linear_attn.py"
+)
+
+# The predicate that selects vLLM's fused-norm packed core op, and the one
+# that selects the FlashInfer step inside it.
+_PACKED = "use_fused_gdn_decode"
+_FI = "use_fi_fused_decode"
+
+_FI_OP = "qwen_gdn_attention_core_fi"
+_PACKED_OP = "qwen_gdn_attention_core_fused_norm_packed"
+_LEGACY_OP = "qwen_gdn_attention_core"
+
+# Locals whose definite assignment matters. ``ba`` is the one the FlashInfer
+# route skips, and skipping it is what an upstream routing rewrite can turn
+# into a latent NameError on the first decode step.
+_TRACKED = frozenset({"ba", "b", "a", "z", "mixed_qkv", _PACKED, _FI})
+
+
+def _class_def(module: ast.Module, name: str) -> ast.ClassDef:
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found")
+
+
+def _method(cls: ast.ClassDef, name: str) -> ast.FunctionDef:
+    for node in cls.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"method {name} not found on {cls.name}")
+
+
+def _attr_chain(node: ast.AST) -> str:
+    """Dotted source text of an attribute/name expression, else ''."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return ""
+    parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _calls(node: ast.AST) -> list[str]:
+    return [_attr_chain(n.func) for n in ast.walk(node) if isinstance(n, ast.Call)]
+
+
+def _loads(node: ast.AST) -> set[str]:
+    return {
+        n.id
+        for n in ast.walk(node)
+        if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+    }
+
+
+def _targets(stmt: ast.stmt) -> list[str]:
+    names: list[str] = []
+    if isinstance(stmt, ast.Assign):
+        for target in stmt.targets:
+            if isinstance(target, ast.Name):
+                names.append(target.id)
+            elif isinstance(target, ast.Tuple):
+                names.extend(e.id for e in target.elts if isinstance(e, ast.Name))
+    elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+        names.append(stmt.target.id)
+    return names
+
+
+def _conjuncts(fn: ast.FunctionDef) -> dict[str, list[str]]:
+    """``{target: [names]}`` for every ``target = n1 and n2 and ...``.
+
+    These are the implications between the routing predicates: they are what
+    makes ``use_fi_fused_decode`` and ``use_fused_gdn_decode`` a nest rather
+    than two independent booleans. Without them the enumeration would
+    explore states the code cannot be in and report phantom failures.
+    """
+    out: dict[str, list[str]] = {}
+    for stmt in ast.walk(fn):
+        if not isinstance(stmt, ast.Assign):
+            continue
+        value = stmt.value
+        if not (isinstance(value, ast.BoolOp) and isinstance(value.op, ast.And)):
+            continue
+        names = [v.id for v in value.values if isinstance(v, ast.Name)]
+        for target in _targets(stmt):
+            out[target] = names
+    return out
+
+
+class _State:
+    """Truth assignment for the routing predicates on one path."""
+
+    def __init__(self, implies: dict[str, list[str]], known: dict[str, bool]):
+        self.implies = implies
+        self.known = dict(known)
+
+    def copy(self) -> _State:
+        return _State(self.implies, self.known)
+
+    def get(self, name: str) -> bool | None:
+        if name in self.known:
+            return self.known[name]
+        if any(self.known.get(n) is False for n in self.implies.get(name, ())):
+            return False
+        return None
+
+    def set(self, name: str, truth: bool) -> None:
+        self.known[name] = truth
+        if truth:
+            # `x = a and b` is True only when every conjunct is.
+            for conjunct in self.implies.get(name, ()):
+                if conjunct not in self.known:
+                    self.known[conjunct] = True
+
+    def eval(self, expr: ast.AST) -> bool | None:
+        if isinstance(expr, ast.Name):
+            return self.get(expr.id)
+        if isinstance(expr, ast.UnaryOp) and isinstance(expr.op, ast.Not):
+            inner = self.eval(expr.operand)
+            return None if inner is None else not inner
+        if isinstance(expr, ast.BoolOp):
+            values = [self.eval(v) for v in expr.values]
+            if isinstance(expr.op, ast.And):
+                if any(v is False for v in values):
+                    return False
+                return True if all(v is True for v in values) else None
+            if any(v is True for v in values):
+                return True
+            return False if all(v is False for v in values) else None
+        return None
+
+    def constrain(self, expr: ast.AST, truth: bool) -> None:
+        if isinstance(expr, ast.Name):
+            self.set(expr.id, truth)
+        elif isinstance(expr, ast.UnaryOp) and isinstance(expr.op, ast.Not):
+            self.constrain(expr.operand, not truth)
+        elif isinstance(expr, ast.BoolOp) and isinstance(expr.op, ast.And) and truth:
+            for value in expr.values:
+                self.constrain(value, True)
+
+
+class _Path:
+    """One feasible control-flow path through a function body."""
+
+    def __init__(self, state: _State):
+        self.state = state
+        self.bound: set[str] = set()
+        self.calls: list[str] = []
+        self.unbound_reads: list[str] = []
+        self.returned = False
+
+    def fork(self) -> _Path:
+        other = _Path(self.state.copy())
+        other.bound = set(self.bound)
+        other.calls = list(self.calls)
+        other.unbound_reads = list(self.unbound_reads)
+        return other
+
+    def predicates(self) -> dict[str, bool]:
+        return {k: v for k, v in self.state.known.items() if k in (_PACKED, _FI)}
+
+
+def _walk(body: list[ast.stmt], path: _Path, out: list[_Path]) -> None:
+    for i, stmt in enumerate(body):
+        if isinstance(stmt, ast.If):
+            truth = path.state.eval(stmt.test)
+            rest = list(body[i + 1 :])
+            if truth is not False:
+                branch = path.fork()
+                branch.state.constrain(stmt.test, True)
+                _walk(list(stmt.body) + rest, branch, out)
+            if truth is not True:
+                branch = path.fork()
+                branch.state.constrain(stmt.test, False)
+                _walk(list(stmt.orelse) + rest, branch, out)
+            return
+        # Straight-line statement: reads happen before bindings.
+        for name in sorted(_loads(stmt) & _TRACKED):
+            if name not in path.bound:
+                path.unbound_reads.append(name)
+        path.calls.extend(_calls(stmt))
+        for target in _targets(stmt):
+            if isinstance(stmt, ast.Assign):
+                value = path.state.eval(stmt.value)
+                if value is not None:
+                    path.state.set(target, value)
+            path.bound.add(target)
+        if isinstance(stmt, ast.Return):
+            path.returned = True
+            break
+    out.append(path)
+
+
+def _paths(fn: ast.FunctionDef) -> list[_Path]:
+    out: list[_Path] = []
+    _walk(fn.body, _Path(_State(_conjuncts(fn), {})), out)
+    return out
+
+
+@pytest.fixture(scope="module")
+def module_ast() -> ast.Module:
+    assert _MODULE.is_file(), f"module not found: {_MODULE}"
+    return ast.parse(_MODULE.read_text(), filename=str(_MODULE))
+
+
+@pytest.fixture(scope="module")
+def forward_cuda(module_ast: ast.Module) -> ast.FunctionDef:
+    return _method(_class_def(module_ast, "QwenGatedDeltaNetAttention"), "forward_cuda")
+
+
+def test_no_path_reads_a_projection_it_skipped(forward_cuda):
+    """``ba`` is never read on a path that skipped the ``in_proj_ba`` GEMV.
+
+    This is the "broken" failure mode: the FlashInfer route folds the b/a
+    projection into the fused step, so ``forward_cuda`` skips it -- and a
+    branch inserted above the FlashInfer call site that reads ``ba`` turns
+    that skip into a NameError on the first decode step.
+    """
+    offenders = [
+        (p.predicates(), p.unbound_reads)
+        for p in _paths(forward_cuda)
+        if p.unbound_reads
+    ]
+    assert not offenders, f"unbound local read on some path: {offenders}"
+
+
+def test_the_flashinfer_route_is_reachable(forward_cuda):
+    """Some feasible path actually reaches the FlashInfer core op.
+
+    This is the "dead" failure mode: a branch that returns above the call
+    site leaves the route wired, logged, and never executed -- which reads
+    as "the fusion did nothing" in a measurement rather than as a bug.
+    """
+    reaching = [
+        p for p in _paths(forward_cuda) if any(c.endswith(_FI_OP) for c in p.calls)
+    ]
+    assert reaching, "no feasible path through forward_cuda reaches the op"
+    for path in reaching:
+        assert path.state.get(_FI) is True
+        # The home: the FlashInfer step lives inside vLLM's packed route.
+        assert path.state.get(_PACKED) is True
+
+
+def test_vllms_own_routes_are_still_reachable(forward_cuda):
+    """vLLM keeps what it owns: both of its core ops stay reachable.
+
+    The FlashInfer step substitutes for exactly one leaf. If no path with
+    the route off reaches the packed op, or none reaches the legacy op, the
+    integration has taken over more than it replaces.
+    """
+    paths = _paths(forward_cuda)
+    packed = [p for p in paths if any(c.endswith(_PACKED_OP) for c in p.calls)]
+    legacy = [
+        p
+        for p in paths
+        if any(c.endswith(_LEGACY_OP) and not c.endswith(_PACKED_OP) for c in p.calls)
+    ]
+    assert packed, f"vLLM's {_PACKED_OP} is no longer reachable"
+    assert legacy, f"vLLM's {_LEGACY_OP} is no longer reachable"
+    for path in packed:
+        assert path.state.get(_FI) is not True
+
+
+def test_the_route_cannot_outlive_the_packed_route(forward_cuda):
+    """``use_fi_fused_decode`` implies ``use_fused_gdn_decode``, structurally.
+
+    The FlashInfer step is a CUDA decode kernel homed under vLLM's packed
+    decode route, so ``VLLM_GDN_DECODE_KERNEL=triton`` -- which turns that
+    route off -- must turn this one off too. That is what keeps "triton" an
+    exact reproduction of the pre-fusion decode chain, which is what a
+    control arm in an A/B is for.
+    """
+    assigns = [
+        stmt
+        for stmt in ast.walk(forward_cuda)
+        if isinstance(stmt, ast.Assign) and _FI in _targets(stmt)
+    ]
+    assert len(assigns) == 1, f"expected one {_FI} assignment, got {len(assigns)}"
+    value = assigns[0].value
+    assert isinstance(value, ast.BoolOp) and isinstance(value.op, ast.And), (
+        f"{_FI} must be an `and` of the packed-route predicate and the probe"
+    )
+    assert _PACKED in _loads(value), f"{_FI} must be conjoined with {_PACKED}"
+
+
+def test_the_fused_branch_applies_the_gated_rms_norm(module_ast):
+    """The packed route owns the norm, so the substituted leaf applies it.
+
+    ``_forward_core_fi`` replaces the core computation only. Dropping the
+    gated RMSNorm would be a silent accuracy bug that no shape check
+    catches, so assert both branches: the fused one norms in place, and the
+    fallback hands the step back to vLLM's ``_forward_core_fused_norm``
+    (which norms itself) after projecting the b/a ``forward_cuda`` skipped.
+    """
+    fn = _method(
+        _class_def(module_ast, "QwenGatedDeltaNetAttention"), "_forward_core_fi"
+    )
+    paths = _paths(fn)
+    fused = [p for p in paths if any("_fi_fused_decode_step" in c for c in p.calls)]
+    assert fused, "_forward_core_fi never calls the FlashInfer step"
+    for path in fused:
+        assert any("_rms_norm_gated_cuda" in c for c in path.calls), (
+            "the fused branch must apply the gated RMSNorm the packed route owns"
+        )
+
+    handed_back = [
+        p for p in paths if any(c.endswith("_forward_core_fused_norm") for c in p.calls)
+    ]
+    assert handed_back, (
+        "the non-fused path must hand the step back to _forward_core_fused_norm"
+    )
+    for path in handed_back:
+        assert not any("_fi_fused_decode_step" in c for c in path.calls)
+        assert any(c.endswith("in_proj_ba") for c in path.calls), (
+            "the non-fused path must project the b/a forward_cuda skipped"
+        )
+
+
+def test_the_core_op_is_a_cudagraph_splitting_op():
+    """The op reads per-step metadata on the host: never inline it."""
+    compilation = _REPO / "vllm" / "config" / "compilation.py"
+    assert f'"vllm::{_FI_OP}"' in compilation.read_text()

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -194,6 +194,10 @@ def test_fused_forward_uses_packed_entrypoint() -> None:
     layer = types.SimpleNamespace(
         prefix=PREFIX,
         enable_fused_gdn_decode=True,
+        # The FlashInfer fused decode step is homed inside this same packed
+        # route; unresolved (None) is what a build whose FlashInfer does not
+        # export gdn_fused_decode_step has, and it must leave this path alone.
+        _fi_fused_decode_step=None,
         norm=types.SimpleNamespace(
             weight=torch.empty(V, dtype=torch.bfloat16, device=device)
         ),

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -770,6 +770,7 @@ class CompilationConfig:
         "vllm::linear_attention",
         "vllm::qwen_gdn_attention_core",
         "vllm::qwen_gdn_attention_core_fused_norm_packed",
+        "vllm::qwen_gdn_attention_core_fi",
         "vllm::gdn_attention_core_xpu",
         "vllm::olmo_hybrid_gdn_full_forward",
         "vllm::sparse_attn_indexer",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
     VLLM_USE_HW_AGNOSTIC: bool = False
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
     VLLM_GDN_DECODE_KERNEL: Literal["cuda", "triton"] = "cuda"
+    VLLM_ENABLE_QWEN_GDN_FUSED_DECODE: bool = True
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
@@ -1209,6 +1210,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "cuda",
         ["cuda", "triton"],
         case_sensitive=False,
+    ),
+    # Fallback control for the Qwen GDN fused decode step: set to 0 to keep
+    # the GDN decode chain vLLM would otherwise run, even where FlashInfer
+    # reports the shape supported. This is NOT a backend choice (there is no
+    # new backend -- the fused step activates inside vLLM's own fused-norm
+    # packed GDN decode route when the support probe says yes); it exists so
+    # a bad fusion can be turned off in the field, and so both arms of an A/B
+    # can run one build. VLLM_GDN_DECODE_KERNEL=triton also holds it off: the
+    # fused step is a CUDA decode kernel.
+    "VLLM_ENABLE_QWEN_GDN_FUSED_DECODE": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_QWEN_GDN_FUSED_DECODE", "1"))
     ),
     # Disable pynccl (using torch.distributed instead)
     "VLLM_DISABLE_PYNCCL": lambda: (

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen3-Next/Qwen3.5 model."""
 
+import inspect
 import os
 from typing import Literal
 
@@ -166,6 +167,93 @@ def _log_gdn_backend_decision(
             "FlashInfer GDN prefill is JIT-compiled; first run may take a "
             "while. Set --gdn-prefill-backend triton to skip JIT.",
         )
+
+
+def _resolve_gdn_fused_decode_step(vllm_config: VllmConfig):
+    """Resolve FlashInfer's fused GDN decode step for the non-spec decode path.
+
+    This is not a new backend and adds no backend name: on CUDA, the GDN
+    decode path already runs FlashInfer kernels, and this resolves the fused
+    single-step op that replaces several of them. Support is the only gate --
+    ``flashinfer.gdn_fused_decode_step_supported(...)`` answers it per step,
+    and a shape FlashInfer does not support keeps the existing decode chain
+    at full speed.
+
+    The step is homed inside vLLM's own fused-norm packed GDN decode route
+    (``qwen_gdn_attention_core_fused_norm_packed``): it replaces the conv1d
+    + gated delta-rule chain that route runs for plain decode, which is the
+    regime vLLM's own fused GDN decode kernel does not serve (that one needs
+    speculative tokens). Everything else -- prefill, spec/MTP decode, the
+    gated RMSNorm, the output projection -- stays with vLLM.
+
+    Resolves when the platform is CUDA and the installed FlashInfer exposes
+    both ``gdn_fused_decode_step`` and a routing probe accepting
+    ``conv_state_layout``. An older FlashInfer -- one without the op at all,
+    or with a probe revision predating conv-state-layout awareness -- keeps
+    the stock path bit-for-bit unchanged.
+
+    FlashInfer exports the op at the top level, so the capability check is a
+    ``getattr`` on the package rather than an import of a submodule. That is
+    still fail-closed, but for a different reason and it is worth stating:
+    ``import flashinfer`` succeeds on every FlashInfer, new or old, so the
+    absence of the op shows up as a **missing attribute**, and
+    ``getattr(..., None)`` plus the ``step is None or supported is None``
+    check below is what turns that into "keep the stock chain". Read the
+    attributes inside the ``try`` as well: a FlashInfer whose package init
+    raises on an incomplete install must land in the same branch, not
+    propagate out of layer construction.
+
+    ``VLLM_ENABLE_QWEN_GDN_FUSED_DECODE=0`` keeps the stock chain even where
+    FlashInfer reports the shape supported. It is a fallback control, not a
+    backend choice: it exists so a bad fusion can be turned off in the field
+    without redeploying a different build, and so both arms of an A/B can
+    run one build and differ only in this routing decision. With it unset
+    (the default) the route is on wherever it is supported.
+
+    Args:
+        vllm_config: The engine configuration (unused beyond keeping the
+            resolver's signature stable for callers and tests).
+
+    Returns:
+        ``(step, supported)`` callables, or ``None`` when the route is
+        unavailable -- in which case the layer wires vLLM's own core ops and
+        is byte-for-byte the unpatched path.
+    """
+    del vllm_config  # capability + fallback control only; no config surface
+    if not envs.VLLM_ENABLE_QWEN_GDN_FUSED_DECODE:
+        # Distinct from the "unavailable" message below: this one proves the
+        # integration IS present and was deliberately held off, which is what
+        # makes a stock-arm measurement attributable.
+        logger.info_once(
+            "FlashInfer fused GDN decode step held off by "
+            "VLLM_ENABLE_QWEN_GDN_FUSED_DECODE=0; using the stock GDN decode "
+            "chain."
+        )
+        return None
+    if not current_platform.is_cuda():
+        return None
+    try:
+        import flashinfer
+
+        step = getattr(flashinfer, "gdn_fused_decode_step", None)
+        supported = getattr(flashinfer, "gdn_fused_decode_step_supported", None)
+    except ImportError:
+        return None
+    if step is None or supported is None:
+        return None
+    # Probe revisions that predate conv-state-layout awareness assume a
+    # dim-first conv pool and would never dispatch (or worse, mis-gate)
+    # against vLLM's default state-first allocation: require the parameter.
+    try:
+        probe_params = inspect.signature(supported).parameters
+    except (TypeError, ValueError):
+        return None
+    if "conv_state_layout" not in probe_params and not any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in probe_params.values()
+    ):
+        return None
+    logger.info_once("Using FlashInfer fused GDN decode step when supported.")
+    return step, supported
 
 
 def fi_chunk_gated_delta_rule(
@@ -503,6 +591,20 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self.gdn_decode_kernel = "triton"
         self.enable_fused_gdn_decode = self.gdn_decode_kernel == "cuda"
         logger.info_once("GDN decode kernel: %s", self.gdn_decode_kernel)
+
+        # FlashInfer fused decode step (b/a projection + conv1d update + head
+        # split + gated delta rule in one op) for the packed non-spec decode
+        # path. Requires the non-interleaved (Qwen3.5-style) b/a layout.
+        self._fi_fused_decode_step = None
+        self._fi_fused_decode_supported = None
+        self._fi_w_ba: torch.Tensor | None = None
+        self._fi_conv_weight: torch.Tensor | None = None
+        self._fi_conv_bias: torch.Tensor | None = None
+        self._fi_setup_failed = False
+        if not self.gqa_interleaved_layout:
+            fused = _resolve_gdn_fused_decode_step(vllm_config)
+            if fused is not None:
+                self._fi_fused_decode_step, self._fi_fused_decode_supported = fused
 
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -887,25 +989,46 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # Part 1: Input Projection
         # ============================================================
         mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
 
         use_fused_gdn_decode = (
             self.enable_fused_gdn_decode
             and hidden_states.dtype == torch.bfloat16
             and self.norm.weight.dtype in (torch.bfloat16, torch.float32)
         )
+        # The FlashInfer fused decode step replaces the conv1d + gated
+        # delta-rule chain that the fused-norm packed core op runs for
+        # non-spec decode, and it folds the b/a projection GEMV in, so `ba`
+        # is projected inside the core op only on the steps that do not
+        # fuse. It is wired only where the packed core op is wired: the
+        # fused step is a CUDA decode kernel, so VLLM_GDN_DECODE_KERNEL
+        # ("triton") governs it too, and the legacy route below is
+        # untouched.
+        use_fi_fused_decode = (
+            use_fused_gdn_decode and self._fi_fused_decode_step is not None
+        )
+        if not use_fi_fused_decode:
+            ba, _ = self.in_proj_ba(hidden_states)
+
         if use_fused_gdn_decode:
             core_attn_out = torch.zeros(
                 (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
             )
-            torch.ops.vllm.qwen_gdn_attention_core_fused_norm_packed(
-                mixed_qkvz,
-                ba,
-                core_attn_out,
-                layer_name=_encode_layer_name(self.prefix),
-            )
+            if use_fi_fused_decode:
+                torch.ops.vllm.qwen_gdn_attention_core_fi(
+                    mixed_qkvz,
+                    hidden_states,
+                    core_attn_out,
+                    layer_name=_encode_layer_name(self.prefix),
+                )
+            else:
+                torch.ops.vllm.qwen_gdn_attention_core_fused_norm_packed(
+                    mixed_qkvz,
+                    ba,
+                    core_attn_out,
+                    layer_name=_encode_layer_name(self.prefix),
+                )
             output, _ = self.out_proj(core_attn_out.flatten(-2))
             return output
 
@@ -1893,6 +2016,187 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out[:num_actual_tokens],
         )
 
+    def _fi_fused_decode_setup(self) -> bool:
+        """One-time parameter staging for the FlashInfer fused decode route.
+
+        Validates the static parameter dtypes and stages the transposed b/a
+        projection weight (and a zero conv bias when the layer has none) in
+        the layout the fused op consumes. Never runs under CUDA graph
+        capture (the caller guarantees that).
+
+        Returns:
+            Whether the route is usable for this layer.
+        """
+        if self._fi_setup_failed:
+            return False
+        if self._fi_w_ba is not None:
+            return True
+        w_ba = getattr(self.in_proj_ba, "weight", None)
+        conv_w = self.conv1d.weight
+        conv_bias = self.conv1d.bias
+        supported = (
+            isinstance(w_ba, torch.Tensor)
+            and w_ba.dim() == 2
+            and w_ba.dtype == torch.bfloat16
+            and w_ba.shape[1] == self.hidden_size
+            and self.A_log.dtype == torch.float32
+            and self.dt_bias.dtype == torch.bfloat16
+            and conv_w.dtype == torch.bfloat16
+            and (conv_bias is None or conv_bias.dtype == torch.bfloat16)
+        )
+        if not supported:
+            self._fi_setup_failed = True
+            logger.info_once(
+                "FlashInfer fused GDN decode step disabled: unsupported "
+                "parameter dtypes/layout for this checkpoint."
+            )
+            return False
+        self._fi_conv_weight = conv_w.view(conv_w.size(0), conv_w.size(2)).contiguous()
+        self._fi_conv_bias = (
+            conv_bias
+            if conv_bias is not None
+            else torch.zeros(
+                self._fi_conv_weight.size(0),
+                dtype=torch.bfloat16,
+                device=self._fi_conv_weight.device,
+            )
+        )
+        self._fi_w_ba = w_ba.data.t().contiguous()
+        return True
+
+    def _forward_core_fi(
+        self,
+        mixed_qkvz: torch.Tensor,
+        hidden_states: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ) -> None:
+        """Fused-norm packed core attention with the FlashInfer decode step.
+
+        Same contract as :meth:`_forward_core_fused_norm_packed`, which it
+        stands in for, except that it receives ``hidden_states`` instead of a
+        pre-projected ``ba``: the FlashInfer step folds the b/a projection
+        GEMV in, so the projection happens here only on the steps that do not
+        fuse.
+
+        Non-spec decode steps whose geometry FlashInfer supports go through
+        ``flashinfer.gdn_fused_decode_step``, which folds the b/a
+        projection GEMV, the causal conv1d update, the q/k/v head split and
+        the gated delta-rule state update into one op writing directly into
+        ``core_attn_out``; the gated RMSNorm that the packed route owns is
+        then applied exactly as upstream applies it. That is the one regime
+        this route serves, and it is the regime upstream's own fused decode
+        kernel does not: ``_can_use_fused_gdn_mtp_decode`` requires
+        speculative tokens, so plain decode reaches the Triton conv +
+        recurrent chain this step replaces.
+
+        Every other step -- prefill-containing, spec/MTP decode, unsupported
+        geometries or dtypes, and cudagraph capture before the one-time
+        staging has run -- projects b/a here (the identical GEMV
+        ``forward_cuda`` skipped) and is handed straight back to
+        :meth:`_forward_core_fused_norm`, so upstream keeps everything it
+        owns, including its own fused MTP decode kernel and the norm.
+
+        The support probe is the only per-step gate; FlashInfer has no
+        on/off variable for this op. A deployment that wants vLLM's own
+        chain regardless sets ``VLLM_ENABLE_QWEN_GDN_FUSED_DECODE=0`` (which
+        stops the route from resolving at all, so this method is never
+        reached) or ``VLLM_GDN_DECODE_KERNEL=triton`` (which turns off the
+        packed route this one is homed under).
+        """
+        forward_context = get_forward_context()
+        attn_metadata_raw = forward_context.attn_metadata
+        qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+        if attn_metadata_raw is None:
+            self._warmup_prefill_kernels(mixed_qkvz[:, :qkv_size], 0)
+            return
+
+        assert isinstance(attn_metadata_raw, dict)
+        attn_metadata = attn_metadata_raw[self.prefix]  # type: ignore[index]
+        assert isinstance(attn_metadata, GDNAttentionMetadata)
+        mixed_qkv, output_gate_flat = mixed_qkvz.split(
+            [qkv_size, self.value_dim // self.tp_size], dim=-1
+        )
+        output_gate = output_gate_flat.reshape(
+            output_gate_flat.size(0), -1, self.head_v_dim
+        )
+
+        conv_dim_first = is_conv_state_dim_first()
+        if (
+            attn_metadata.spec_sequence_masks is None
+            and attn_metadata.num_prefills == 0
+            and attn_metadata.num_decodes > 0
+            and hidden_states.dtype == torch.bfloat16
+            and self.kv_cache[0].dtype == torch.bfloat16
+            and self.kv_cache[1].dtype == torch.float32
+            and self._fi_fused_decode_supported(
+                attn_metadata.num_actual_tokens,
+                hidden_size=self.hidden_size,
+                n_ba=self.in_proj_ba.output_size_per_partition,
+                qkv_dim=self.conv_dim // self.tp_size,
+                num_qk_heads=self.num_k_heads // self.tp_size,
+                num_v_heads=divide(self.num_v_heads, self.tp_size),
+                head_dim=self.head_k_dim,
+                conv_width=self.conv_kernel_size,
+                conv_state_len=self.conv_kernel_size - 1,
+                device=hidden_states.device,
+                conv_state_layout="DS" if conv_dim_first else "SD",
+            )
+            and (
+                self._fi_w_ba is not None
+                or (
+                    not torch.cuda.is_current_stream_capturing()
+                    and self._fi_fused_decode_setup()
+                )
+            )
+        ):
+            num_actual_tokens = attn_metadata.num_actual_tokens
+            state_indices = attn_metadata.non_spec_state_indices_tensor
+            out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
+            # The fused op consumes the conv pool as a (..., dim, state_len)
+            # logical view, like the stock conv kernels: the DS layout stores
+            # it that way directly, the (default) SD layout needs a transpose.
+            conv_state = (
+                self.kv_cache[0]
+                if conv_dim_first
+                else self.kv_cache[0].transpose(-1, -2)
+            )
+            self._fi_fused_decode_step(
+                hidden_states=hidden_states[:num_actual_tokens],
+                w_ba=self._fi_w_ba,
+                mixed_qkv=mixed_qkv[:num_actual_tokens],
+                conv_weight=self._fi_conv_weight,
+                conv_bias=self._fi_conv_bias,
+                conv_state=conv_state,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                scale=self.head_k_dim**-0.5,
+                ssm_state=self.kv_cache[1],
+                state_indices=state_indices[:num_actual_tokens],  # type: ignore[index]
+                use_qk_l2norm=True,
+                out=out_buf,
+            )
+            # The fused step computes the core only. The packed route owns
+            # the gated RMSNorm for every step it serves, so apply the same
+            # in-place norm the non-fused branch of _forward_core_fused_norm
+            # applies -- this route changes which kernels compute the core,
+            # not what the layer returns.
+            self._rms_norm_gated_cuda(
+                core_attn_out[:num_actual_tokens],
+                output_gate[:num_actual_tokens],
+                core_attn_out[:num_actual_tokens],
+            )
+            return
+
+        ba, _ = self.in_proj_ba(hidden_states)
+        b, a = self.split_ba(ba)
+        self._forward_core_fused_norm(
+            mixed_qkv=mixed_qkv,
+            b=b,
+            a=a,
+            output_gate=output_gate,
+            core_attn_out=core_attn_out,
+        )
+
 
 def qwen_gdn_attention_core(
     qkv_or_qkvz: torch.Tensor,
@@ -1970,6 +2274,31 @@ def qwen_gdn_attention_core_fused_norm_packed(
     )
 
 
+def qwen_gdn_attention_core_fi(
+    mixed_qkvz: torch.Tensor,
+    hidden_states: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    """Fused-norm packed core op with the FlashInfer fused decode step.
+
+    Same role as :func:`qwen_gdn_attention_core_fused_norm_packed`, which it
+    stands in for, but it receives ``hidden_states`` instead of pre-projected
+    ``ba``: supported non-spec decode steps run FlashInfer's fused decode op
+    (which folds the b/a projection GEMV), and every other step projects the
+    identical b/a inside the op and is handed back to
+    ``_forward_core_fused_norm``. ``core_attn_out`` is mutated in-place.
+    """
+    layer_name = _resolve_layer_name(layer_name)
+    forward_context: ForwardContext = get_forward_context()
+    self = forward_context.no_compile_layers[layer_name]
+    self._forward_core_fi(
+        mixed_qkvz=mixed_qkvz,
+        hidden_states=hidden_states,
+        core_attn_out=core_attn_out,
+    )
+
+
 def gdn_attention_core_fused_norm_packed_fake(
     mixed_qkvz: torch.Tensor,
     ba: torch.Tensor,
@@ -1979,11 +2308,29 @@ def gdn_attention_core_fused_norm_packed_fake(
     return
 
 
+def gdn_attention_core_fi_fake(
+    mixed_qkvz: torch.Tensor,
+    hidden_states: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    """Fake implementation for torch.compile."""
+    return
+
+
 direct_register_custom_op(
     op_name="qwen_gdn_attention_core_fused_norm_packed",
     op_func=qwen_gdn_attention_core_fused_norm_packed,
     mutates_args=["core_attn_out"],
     fake_impl=gdn_attention_core_fused_norm_packed_fake,
+)
+
+
+direct_register_custom_op(
+    op_name="qwen_gdn_attention_core_fi",
+    op_func=qwen_gdn_attention_core_fi,
+    mutates_args=["core_attn_out"],
+    fake_impl=gdn_attention_core_fi_fake,
 )
 
 


### PR DESCRIPTION


## Purpose

  Integrate FlashInfer's fused GDN decode step into vLLM's Qwen GDN path for supported plain, non-speculative CUDA decode workloads.

  [FlashInfer PR #4481](https://github.com/flashinfer-ai/flashinfer/pull/4481) introduced a fused operation that combines the following per-layer work:

  - The `b`/`a` projection GEMV.
  - Causal Conv1D state update.
  - Q/K/V head splitting and rearrangement.
  - Gate computation.
  - Gated delta-rule recurrent-state update.

  [FlashInfer PR #4708](https://github.com/flashinfer-ai/flashinfer/pull/4708) parameterizes the kernel geometry and adds support for the Qwen3.6-35B-A3B geometry.

  This PR routes supported decode steps through `flashinfer.gdn_fused_decode_step`. vLLM continues to own the gated RMSNorm and output projection. Prefill, mixed batches, speculative/MTP decode, unsupported geometries, and unsupported dtypes continue through the existing vLLM paths.

  This does not duplicate vLLM's existing fused GDN implementation: that path serves speculative/MTP decode, while this integration replaces the remaining plain-decode Conv1D and recurrent-update chain.

  The integration is capability-gated and fails closed:

  - FlashInfer must export both `gdn_fused_decode_step` and `gdn_fused_decode_step_supported`.
  - The support probe is evaluated for the actual device, geometry, batch size, and convolution-state layout.
  - Older FlashInfer installations and unsupported configurations retain the existing behavior.
  - `VLLM_ENABLE_QWEN_GDN_FUSED_DECODE=0` provides a one-build fallback to the stock chain.
  - `VLLM_GDN_DECODE_KERNEL=triton` also keeps this route disabled.
  - The new custom op is registered as a piecewise CUDA-graph splitting operation.

  No supported-model or example documentation update is required because this adds capability-gated internal routing rather than a new model or user-selectable backend. The fallback control and compatibility behavior are documented in `vllm/envs.py` and the implementation docstrings.

  AI assistance was used to prepare this change.

## Test Plan

  Run the focused unit and regression tests:

  ```bash
  .venv/bin/python -m pytest -q \
    tests/kernels/mamba/test_gdn_flashinfer_fused_decode.py \
    tests/kernels/mamba/test_gdn_flashinfer_fused_decode_routing.py \
    tests/kernels/mamba/test_gdn_fused_mtp.py
```

  On an RTX PRO 6000, run an end-to-end A/B comparison using the same build and workload:

  1. Run with fused decode enabled, which is the default.
  2. Run with VLLM_ENABLE_QWEN_GDN_FUSED_DECODE=0.
  3. Compare generated tokens or log probabilities and confirm the FlashInfer dispatch marker appears only in the enabled run.
  4. Measure inter-token latency at supported batch sizes for Qwen3.6-27B-NVFP4 and Qwen3.6-35B-A3B.
  5. Exercise both eager execution and CUDA-graph replay.

## Test Result

  Local validation:

  tests/kernels/mamba/test_gdn_flashinfer_fused_decode_routing.py
  6 passed in 0.10s

  ruff check
  All checks passed!

  ruff format --check
  6 files already formatted

  git diff --check
  Passed

  The full vLLM import/GPU suites and end-to-end A/B were not run during this validation window because no RTX PRO 6000 allocation was immediately available. They should be completed before merge.

  The underlying FlashInfer validation reported in PR #4481 used Qwen3.6-27B-NVFP4 on RTX PRO 6000 (SM120):

  - Minimum cosine similarity of 1.000000 for every served row.
  - All 48 teacher-forced chunks were bit-identical.
  - Paired dPPL difference was 0.000%.
  - Approximately 2% ITL improvement at concurrency 1 and 8% at concurrency 2 and 4.

  FlashInfer PR #4708 reports an end-to-end serving sweep for the Qwen3.6-35B-A3B geometry and registers supported decode batches 1, 2, and 4. These are FlashInfer dependency results, not a substitute for the pending vLLM end-to-end validation.

  ———
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

  - [x] The purpose and relationship to the enabling FlashInfer PRs are described.
  - [x] The focused unit, regression, and end-to-end test plans are provided.
  - [x] Completed results and outstanding GPU validation are reported separately.
  - [x] No supported-model or example documentation update is required.
</details>

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing (https://docs.vllm.ai/en/latest/contributing)