### PR TITLE
[CI][The Rock] Increase flex attention abs tol

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
+++ b/tests/entrypoints/pooling/scoring/test_cross_encoder_online_vision.py
@@ -50,7 +50,7 @@ BACKEND_ABS_TOL: dict[str, float] = {
     "auto": 0.007,
     "ROCM_AITER_FA": 0.005,
     "TRITON_ATTN": 0.009,
-    "FLEX_ATTENTION": 0.006,
+    "FLEX_ATTENTION": 0.00875,
 }
 
 # ROCm: disable prefix caching and eliminate batch variance to reduce


### PR DESCRIPTION
## Purpose
The `(MI355) Entrypoints Integration (Pooling)` test group fails reliably when running with `The Rock 7.14.`

The following accuracy errors were encountered:
```
FAILED entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_score_api_queries_str_documents_str[FLEX_ATTENTION] - AssertionError: [FLEX_ATTENTION] text_vs_text: score mismatch — actual=0.108924, expected=0.100404, rel_diff=0.0849, tol=0.045, abs_tol=0.006
FAILED entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_score_api_queries_str_documents_text_content[FLEX_ATTENTION] - AssertionError: [FLEX_ATTENTION] text_vs_text: score mismatch — actual=0.108924, expected=0.100404, rel_diff=0.0849, tol=0.045, abs_tol=0.006
FAILED entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_score_api_queries_str_documents_list[FLEX_ATTENTION] - AssertionError: [FLEX_ATTENTION] list[0]_text_vs_text: score mismatch — actual=0.108924, expected=0.100404, rel_diff=0.0849, tol=0.045, abs_tol=0.006
FAILED entryggpoints/pooling/scoring/test_cross_encoder_online_vision.py::test_rerank_api_queries_str_documents_list[FLEX_ATTENTION] - AssertionError: [FLEX_ATTENTION] rerank[0]_text_vs_text: score mismatch — actual=0.108924, expected=0.100404, rel_diff=0.0849, tol=0.045, abs_tol=0.006
FAILED entrypoints/pooling/scoring/test_cross_encoder_online_vision.py::test_score_api_queries_list_documents_list[FLEX_ATTENTION] - AssertionError: [FLEX_ATTENTION] paired[0]_text_vs_text: score mismatch — actual=0.108924, expected=0.100404, rel_diff=0.0849, tol=0.045, abs_tol=0.006

```

The absolute difference is always 0.00852. 

I created a new dockerfile that builds The Rock using the same pins for torch, `torchaudio`, `torchvision`, and `triton`.  The difference between the upstream image and this new image I made is the ROCm runtime. 

The test still failed, however, I copied the `libhipblaslt.so.1` library along with `liblt12_shim.so` from the` vllm/vllm-openai-rocm` docker image as well as the tensile libraries for hipblaslt `/opt/rocm-7.2.3/lib/hipblaslt/library/` directory and did `LD_PRELOAD` on those `.so `files and set the `HIPBLASLT_TENSILE_LIBPATH` to be the destination where I stored the tensile libraries.

The test passed, matching the same values as when using the ` vllm/vllm-openai-rocm` .

Since this worked, I tried making a `HIPBLASLT_TUNING_OVERRIDE_FILE` with the same kernel selections that were used in the ROCm 7.2.3 version of `hipblaslt`.

[flex_override.csv](https://github.com/user-attachments/files/31396404/flex_override.csv)

The test passed again matching the same values as  `vllm/vllm-openai-rocm` again.

It doesn't seem realistic to use override files like this for every test that fails, but at least it confirms that the tests were failing because the kernel selection in the The Rock 7.14 version of `hipblaslt` had changed.

One solution is to just set:

`"FLEX_ATTENTION": 0.00875,`

which lets the tests pass.

## Test Plan
`pytest -sv entrypoints/pooling/scoring/test_cross_encoder_online_vision.py`
## Test Result
`==== 44 passed, 16 warnings in 211.38s (0:03:31) =====`


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ X] The test plan, such as providing test command.
- [ X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

