### PR TITLE
[Bugfix] Handle excluded lm_head re-tying and unavailable cast weights

### DIFF
--- a/tests/model_executor/model_loader/test_weight_tying.py
+++ b/tests/model_executor/model_loader/test_weight_tying.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -84,3 +85,17 @@ def test_no_retie_without_checkpoint_override():
     maybe_retie_word_embeddings(model, make_model_config())
 
     assert model.lm_head.weight is not model.embed_tokens.weight
+
+
+@pytest.mark.cpu_test
+@pytest.mark.usefixtures("dist_init")
+def test_excluded_lm_head_is_retied():
+    """A head excluded from quantization (e.g. via ModelOpt exclude_modules)
+    carries UnquantizedLinearMethod; its weight is plain, so it must be
+    eligible for re-tying like an UnquantizedEmbeddingMethod head."""
+    model = UntiedModel()
+    model.lm_head.quant_method = UnquantizedLinearMethod()
+
+    maybe_retie_word_embeddings(model, make_model_config(untied_by_checkpoint=True))
+
+    assert model.lm_head.weight is model.embed_tokens.weight

--- a/tests/v1/sample/test_head_dtype.py
+++ b/tests/v1/sample/test_head_dtype.py
@@ -241,3 +241,65 @@ def test_fp32_head_e2e_no_nan():
                 assert math.isfinite(position[token_id].logprob)
                 # No returned logprob is NaN.
                 assert not any(math.isnan(lp.logprob) for lp in position.values())
+
+
+def _real_bf16_lm_head(vocab_size: int, hidden_size: int, weight: torch.Tensor):
+    from unittest import mock
+
+    world_size_getter = (
+        "vllm.model_executor.layers.vocab_parallel_embedding."
+        "get_tensor_model_parallel_world_size"
+    )
+    with mock.patch(world_size_getter, return_value=2):
+        lm_head = ParallelLMHead(
+            vocab_size,
+            hidden_size,
+            params_dtype=torch.bfloat16,
+            disable_tp=True,
+        )
+    lm_head.weight_loader(lm_head.weight, weight)
+    return lm_head
+
+
+def test_fp32_head_accepts_excluded_unquantized_linear_head(default_vllm_config):
+    # An lm_head *excluded* from quantization (e.g. a ModelOpt exclude_modules
+    # config) carries UnquantizedLinearMethod rather than
+    # UnquantizedEmbeddingMethod. Both hold plain weights; the cast path must
+    # accept the excluded head. Exercises the real layer with post-load
+    # processing, which on some CPU builds frees the weight — in that case the
+    # guard must refuse cleanly (see test below) rather than crash in a kernel.
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    vocab_size, hidden_size = 64, 16
+    lp = _build_processor(vocab_size)
+    lp.head_dtype = torch.float32
+
+    weight = torch.randn(vocab_size, hidden_size, dtype=torch.bfloat16)
+    lm_head = _real_bf16_lm_head(vocab_size, hidden_size, weight)
+    lm_head.quant_method = UnquantizedLinearMethod()
+    lm_head.quant_method.process_weights_after_loading(lm_head)
+
+    hidden_states = torch.randn(4, hidden_size, dtype=torch.bfloat16)
+    weight_after = getattr(lm_head, "weight", None)
+    if weight_after is not None and weight_after.ndim == 2:
+        logits = lp._get_logits(hidden_states, lm_head, None)
+        assert logits.dtype == torch.float32
+        expected = torch.nn.functional.linear(hidden_states.float(), weight.float())
+        torch.testing.assert_close(logits, expected)
+    else:
+        # CPU fused-GEMM dispatch freed the weight; the guard must name the
+        # condition instead of crashing on an empty tensor.
+        with pytest.raises(ValueError, match="materialized"):
+            lp._get_logits(hidden_states, lm_head, None)
+
+
+def test_fp32_head_rejects_dematerialized_weight(default_vllm_config):
+    # dispatch_cpu_unquantized_gemm(remove_weight=True) replaces lm_head.weight
+    # with an empty tensor after fusing the GEMM; the cast path reads .weight
+    # directly and must refuse cleanly rather than crash in the kernel.
+    lp = _build_processor(64)
+    lp.head_dtype = torch.float32
+    lm_head = _FakeLmHead(torch.empty(0))
+
+    with pytest.raises(ValueError, match="materialized"):
+        lp._get_logits(torch.randn(4, 16, dtype=torch.bfloat16), lm_head, None)

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -15,10 +15,9 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
-from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
+    is_unquantized_method,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
@@ -145,15 +144,19 @@ class LogitsProcessor(PluggableLayer):
                 lm_head, hidden_states, bias=embedding_bias
             )
 
-        # A quant config that excludes lm_head hands out UnquantizedLinearMethod
-        # rather than UnquantizedEmbeddingMethod, so accept both: either way the
-        # weight is plain and `lm_head.weight` can be cast directly.
-        if not isinstance(
-            lm_head.quant_method, (UnquantizedEmbeddingMethod, UnquantizedLinearMethod)
+        # The cast paths below read lm_head.weight directly, so the method
+        # must be unquantized (either method class: an excluded head carries
+        # UnquantizedLinearMethod) AND the weight must still be materialized —
+        # CPU builds may free it after dispatching a fused GEMM
+        # (dispatch_cpu_unquantized_gemm(remove_weight=True)).
+        weight = getattr(lm_head, "weight", None)
+        if not is_unquantized_method(lm_head.quant_method) or (
+            weight is None or weight.ndim != 2
         ):
             raise ValueError(
                 "A head_dtype different from the model dtype is only "
-                "supported for an unquantized lm_head."
+                "supported for an unquantized lm_head with materialized "
+                "weights."
             )
         if (
             self.head_dtype == torch.float32

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -84,6 +84,20 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
         return layer
 
 
+def is_unquantized_method(quant_method: object) -> bool:
+    """Whether an embedding/lm_head quant method is unquantized.
+
+    A layer excluded from quantization (e.g. via a ModelOpt exclude_modules
+    config) carries UnquantizedLinearMethod rather than
+    UnquantizedEmbeddingMethod; both hold plain, unpacked weights.
+    """
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    return isinstance(
+        quant_method, (UnquantizedEmbeddingMethod, UnquantizedLinearMethod)
+    )
+
+
 def pad_vocab_size(vocab_size: int, pad_to: int = DEFAULT_VOCAB_PADDING_SIZE) -> int:
     """Pad the vocab size to the given value."""
     return ((vocab_size + pad_to - 1) // pad_to) * pad_to

--- a/vllm/model_executor/model_loader/weight_tying.py
+++ b/vllm/model_executor/model_loader/weight_tying.py
@@ -11,8 +11,8 @@ from vllm.config import ModelConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
-    UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
+    is_unquantized_method,
 )
 
 logger = init_logger(__name__)
@@ -47,14 +47,16 @@ def _get_untied_lm_head(model: nn.Module) -> _UntiedLMHead | None:
     another name, and online quantization creates them after loading, so
     neither their contents nor whether they were loaded can be established here.
     Note that this is a property of the layer, not of the model: most quantized
-    models leave the `lm_head` and the input embeddings unquantized.
+    models leave the `lm_head` and the input embeddings unquantized — and an
+    lm_head *excluded* from quantization carries `UnquantizedLinearMethod`,
+    which counts as unquantized here.
     """
     heads = list[tuple[str, ParallelLMHead]]()
     embeddings = list[VocabParallelEmbedding]()
     for name, module in model.named_modules():
         if not isinstance(module, VocabParallelEmbedding):
             continue
-        if not isinstance(module.quant_method, UnquantizedEmbeddingMethod):
+        if not is_unquantized_method(module.quant_method):
             continue
         if isinstance(module, ParallelLMHead):
             heads.append((name, module))


### PR DESCRIPTION
## Purpose

After #54160 admitted unquantized-linear heads in the `head_dtype` cast
path, two cases remain:

1. `_get_untied_lm_head` still recognizes only
   `UnquantizedEmbeddingMethod`. A head excluded from quantization carries
   `UnquantizedLinearMethod`, so an otherwise eligible head can be excluded
   from weight re-tying and its memory reclaim. This PR recognizes both
   method classes there.
2. The cast path reads `lm_head.weight` directly. Some CPU fused-GEMM
   configurations release that weight after loading. This PR requires a
   materialized 2-D weight before casting and raises a descriptive
   `ValueError` when it is unavailable.

The shared `is_unquantized_method()` helper expresses method classification;
weight availability is a separate check in `LogitsProcessor`. Existing
materialized heads supported by the cast path remain supported.

## Related work

- #54160 merged the cast-path method acceptance. This PR retains it, adds
  the materialized-weight check, and updates weight re-tying.
- #52883 changes a separate DFlash2 candidate-selector call site.
- #55494 adds a packed-BF16 head wrapper and unwraps its fallback at the
  same cast/re-tying sites. It does not add the two residual behaviors here;
  these overlapping sites will need reconciliation when either PR lands.

## Validation and limits

Recorded local validation for head `66ab2231c`:

- `tests/v1/sample/test_head_dtype.py`: 9 CPU tests passed. The added tests
  exercise a real excluded `ParallelLMHead` through post-loading weight
  processing and check casting or clean refusal, plus refusal for an
  unavailable weight.
- Local ruff and mypy checks passed.
- GB10 smoke: `LLM(model="facebook/opt-125m",
  hf_overrides={"head_dtype": "float32"}, enforce_eager=True)` followed by
  greedy generation completed. This is a basic cast-path smoke, not an
  end-to-end excluded-ModelOpt-head test.

Additional local validation at `38f7bcef2`: `.venv/bin/python -m pytest tests/model_executor/model_loader/test_weight_tying.py` — 5 passed (1 new). `test_excluded_lm_head_is_retied` verifies that an `UnquantizedLinearMethod` head shares the embedding's Parameter after re-tying. Substituting origin/main's `weight_tying.py` into this branch produced 1 failure in that new test and 4 passes; restoring the branch implementation produced 5 passes. The existing quantized-head and no-override controls are unchanged. This isolates the re-tying predicate; it is not an end-to-end ModelOpt loading test.

At the September 10 check, DCO and formatting passed; the pre-run eligibility
check failed and pre-commit was skipped. These local results do not establish
that upstream CI has run successfully.

## Disclosure

AI assistance was used in preparing the change. The submitter reviewed the
changed lines and ran the recorded validation above.

