### PR TITLE
[Bugfix] Honor default_proposal_method when selecting the speculators proposal method

### DIFF
--- a/tests/transformers_utils/test_speculators_plural_proposal_methods.py
+++ b/tests/transformers_utils/test_speculators_plural_proposal_methods.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Selection among plural speculators proposal_methods.
+
+The speculators schema declares proposal_methods as a list and names the
+active one via default_proposal_method. vLLM drafts with a single method:
+the config layer must honor default_proposal_method (falling back to the
+first entry for configs that predate the field) and must not silently
+discard the other declared methods.
+"""
+
+import pytest
+
+from vllm.transformers_utils.configs.speculators.base import SpeculatorsConfig
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _config(
+    proposal_methods: list[dict], default_proposal_method: str | None = "eagle3"
+) -> dict:
+    spec_config = {
+        "proposal_methods": proposal_methods,
+        "verifier": {"name_or_path": "meta-llama/Llama-3.1-8B-Instruct"},
+    }
+    if default_proposal_method is not None:
+        spec_config["default_proposal_method"] = default_proposal_method
+    return {
+        "speculators_model_type": "eagle3",
+        "speculators_config": spec_config,
+        "transformer_layer_config": {},
+    }
+
+
+def test_single_method_unchanged():
+    result = SpeculatorsConfig.extract_vllm_speculative_config(
+        _config([{"proposal_type": "eagle3", "speculative_tokens": 5}])
+    )
+    assert result["num_speculative_tokens"] == 5
+    assert result["method"] == "eagle3"
+
+
+def test_default_proposal_method_selects_non_first_entry():
+    # The named default wins even when it is not entry [0].
+    result = SpeculatorsConfig.extract_vllm_speculative_config(
+        _config(
+            [
+                {"proposal_type": "suffix", "speculative_tokens": 8},
+                {"proposal_type": "eagle3", "speculative_tokens": 5},
+            ],
+            default_proposal_method="eagle3",
+        )
+    )
+    assert result["num_speculative_tokens"] == 5
+
+
+def test_missing_default_falls_back_to_first(caplog_vllm):
+    # A distinct ignored-method name keeps this emission out of
+    # warning_once's dedup cache shared with the other tests.
+    result = SpeculatorsConfig.extract_vllm_speculative_config(
+        _config(
+            [
+                {"proposal_type": "eagle3", "speculative_tokens": 5},
+                {"proposal_type": "ngram", "speculative_tokens": 8},
+            ],
+            default_proposal_method=None,
+        )
+    )
+    assert result["num_speculative_tokens"] == 5
+    assert "ignoring" in caplog_vllm.text
+    assert "ngram" in caplog_vllm.text
+
+
+def test_unmatched_default_falls_back_to_first(caplog_vllm):
+    result = SpeculatorsConfig.extract_vllm_speculative_config(
+        _config(
+            [{"proposal_type": "eagle3", "speculative_tokens": 5}],
+            default_proposal_method="greedy",
+        )
+    )
+    assert result["num_speculative_tokens"] == 5
+    assert "matches no entry" in caplog_vllm.text
+
+
+def test_non_selected_method_without_speculative_tokens_tolerated():
+    # speculative_tokens is a field of concrete method types, not the base
+    # schema: a non-selected entry without it must not fail engine start.
+    result = SpeculatorsConfig.extract_vllm_speculative_config(
+        _config(
+            [
+                {"proposal_type": "eagle3", "speculative_tokens": 5},
+                {"proposal_type": "suffix"},
+            ],
+            default_proposal_method="eagle3",
+        )
+    )
+    assert result["num_speculative_tokens"] == 5
+
+
+def test_entry_without_proposal_type_rejected():
+    with pytest.raises(ValueError, match="proposal_type"):
+        SpeculatorsConfig.extract_vllm_speculative_config(
+            _config(
+                [
+                    {"proposal_type": "eagle3", "speculative_tokens": 5},
+                    {"speculative_tokens": 8},
+                ]
+            )
+        )
+
+
+def test_empty_methods_rejected():
+    with pytest.raises(ValueError, match="non-empty list"):
+        SpeculatorsConfig.extract_vllm_speculative_config(_config([]))
+
+
+def test_selected_method_missing_speculative_tokens_rejected():
+    with pytest.raises(ValueError, match="speculative_tokens"):
+        SpeculatorsConfig.extract_vllm_speculative_config(
+            _config([{"proposal_type": "eagle3"}])
+        )

--- a/vllm/transformers_utils/configs/speculators/base.py
+++ b/vllm/transformers_utils/configs/speculators/base.py
@@ -6,10 +6,13 @@ from typing import Any
 
 from transformers import PretrainedConfig
 
+from vllm.logger import init_logger
 from vllm.transformers_utils.configs.speculators.algos import (
     SUPPORTED_SPECULATORS_TYPES,
 )
 from vllm.transformers_utils.utils import without_trust_remote_code
+
+logger = init_logger(__name__)
 
 
 class SpeculatorsConfig(PretrainedConfig):
@@ -77,14 +80,27 @@ class SpeculatorsConfig(PretrainedConfig):
 
     @classmethod
     def validate_speculators_config(cls, config_dict: dict[str, Any]) -> None:
+        spec_config = config_dict.get("speculators_config")
+        if not isinstance(spec_config, dict):
+            raise ValueError("Invalid speculators config structure")
+        methods = spec_config.get("proposal_methods")
+        if not isinstance(methods, list) or not methods:
+            raise ValueError(
+                "speculators_config.proposal_methods must be a non-empty list"
+            )
+        # The schema is plural: every entry must at least be a mapping that
+        # names its proposal_type. Fields specific to concrete method types
+        # (e.g. speculative_tokens) are checked only on the selected method.
+        for method in methods:
+            if not isinstance(method, dict) or "proposal_type" not in method:
+                raise ValueError(
+                    "Each entry in proposal_methods must be a mapping with a "
+                    f"'proposal_type'. Got: {method}"
+                )
         try:
-            spec_config = config_dict["speculators_config"]
-            methods = spec_config["proposal_methods"]
-            first_method = methods[0]
-            _ = first_method["speculative_tokens"]
             _ = spec_config["verifier"]["name_or_path"]
             _ = config_dict["speculators_model_type"]
-        except (KeyError, IndexError, TypeError) as e:
+        except (KeyError, TypeError) as e:
             raise ValueError("Invalid speculators config structure") from e
 
         if "transformer_layer_config" not in config_dict:
@@ -114,17 +130,51 @@ class SpeculatorsConfig(PretrainedConfig):
         # Extract speculators configuration
         spec_config = config_dict["speculators_config"]
 
-        # Currently we only support one proposal method
         proposal_methods = spec_config.get("proposal_methods")
         if not proposal_methods:
             raise ValueError("No proposal methods found in speculators config")
 
-        first_method = proposal_methods[0]
-        num_speculative_tokens = first_method.get("speculative_tokens")
+        # The schema names the active method via default_proposal_method;
+        # select it, falling back to the first entry for configs that
+        # predate the field. vLLM drafts with a single method.
+        default_method = spec_config.get("default_proposal_method")
+        selected = next(
+            (
+                method
+                for method in proposal_methods
+                if method.get("proposal_type") == default_method
+            ),
+            proposal_methods[0],
+        )
+        if default_method is not None and selected.get("proposal_type") != (
+            default_method
+        ):
+            logger.warning_once(
+                "default_proposal_method '%s' matches no entry in "
+                "proposal_methods; falling back to the first entry '%s'.",
+                default_method,
+                str(selected.get("proposal_type", "<unnamed>")),
+            )
+        if len(proposal_methods) > 1:
+            ignored = ", ".join(
+                str(method.get("proposal_type", "<unnamed>"))
+                for method in proposal_methods
+                if method is not selected
+            )
+            logger.warning_once(
+                "Speculators config declares %d proposal methods; vLLM "
+                "drafts with one. Selected '%s'; ignoring: %s.",
+                len(proposal_methods),
+                str(selected.get("proposal_type", "<unnamed>")),
+                ignored,
+            )
+
+        num_speculative_tokens = selected.get("speculative_tokens")
 
         if num_speculative_tokens is None:
             raise ValueError(
-                f"Missing 'speculative_tokens' in proposal method. Got: {first_method}"
+                "Missing 'speculative_tokens' in the selected proposal "
+                f"method. Got: {selected}"
             )
 
         # Build base vLLM speculative configuration


### PR DESCRIPTION
## Purpose

The speculators schema names the active proposal method via `default_proposal_method` — a required field with a pydantic membership validator, carried by published speculators checkpoints — but vLLM never reads it (`grep -rn default_proposal_method vllm/` → zero hits outside one test fixture) and always drafts with `proposal_methods[0]`.

This PR selects the proposal method by `default_proposal_method`, falling back to the first entry for configs that predate the field, and logs the non-selected methods via `logger.warning_once` instead of discarding them silently. Non-selected entries get shape checks only (a mapping naming its `proposal_type`): `speculative_tokens` belongs to concrete method types, not the base schema, so it is required only on the selected method.

**Behavior is byte-for-byte unchanged for every published checkpoint** — all carry a single proposal method, for which selection, validation outcome, and the resulting config are identical to today. (`configs/speculators/` is a source_file_dependency of the spec-decode E2E lanes; no acceptance-rate change is possible from this diff.)

## Why not duplicating an existing PR

`gh pr list --repo vllm-project/vllm --state open --search "default_proposal_method"` → no PR implements this selection (2026-08-24). Adjacent open work: #44566 derives `num_speculative_tokens` from the draft config (same file, different field — happy to rebase over it if it lands first), #51338 infers the *algorithm* from checkpoint contents (different mechanism).

## Test Plan

`pytest tests/transformers_utils/test_speculators_plural_proposal_methods.py tests/transformers_utils/test_speculators_override.py tests/transformers_utils/test_speculators_dspark_config.py` — 8 new tests including: selecting a non-first entry named by `default_proposal_method`, unmatched-default fallback with warning, non-selected entry without `speculative_tokens` tolerated, entry without `proposal_type` rejected, and single-method configs unchanged; plus both sibling suites for regression.

## Test Result

`17 passed`. ruff check/format: Passed · mypy-3.12 (hook-stage manual): Passed.

## Disclosure

AI assistance was used in preparing this change; the submitter has reviewed every changed line and run the tests above.
