### PR TITLE
[Spec Decode] Support PCP-sharded MTP prefill

### DIFF
--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -284,19 +284,16 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
     assert actual_feedback_hidden is hidden
 
 
-def test_pcp_input_buffers_allow_two_segments_per_request():
+def test_set_pcp_manager_keeps_speculator_owned_buffers():
     speculator = object.__new__(_TestSpeculator)
-    speculator.max_num_reqs = 6
-    speculator.max_num_tokens = 32
-    speculator.device = torch.device("cpu")
+    input_buffers = object()
+    speculator.input_buffers = input_buffers
 
     manager = Mock()
     speculator.set_pcp_manager(manager)
 
     assert speculator.pcp_manager is manager
-    assert speculator.input_buffers.max_num_reqs == 12
-    assert speculator.input_buffers.query_start_loc.shape == (13,)
-    assert speculator.input_buffers.seq_lens.shape == (12,)
+    assert speculator.input_buffers is input_buffers
 
 
 def test_pcp_prefill_restores_logits_and_feedback_before_sampling():
@@ -307,7 +304,11 @@ def test_pcp_prefill_restores_logits_and_feedback_before_sampling():
     global_feedback = torch.tensor([[3.0], [7.0], [4.0], [8.0]])
     manager = Mock()
     padding = torch.tensor([False, True])
-    manager.local_batch = SimpleNamespace(is_padding=padding)
+    local_batch = SimpleNamespace(
+        input_ids=torch.arange(2),
+        positions=torch.arange(2),
+        is_padding=padding,
+    )
     manager.restore_hidden_states.side_effect = [global_logits, global_feedback]
     speculator.pcp_manager = manager
     speculator._run_model = Mock(return_value=(local_logits, local_feedback))
@@ -320,7 +321,7 @@ def test_pcp_prefill_restores_logits_and_feedback_before_sampling():
     speculator.draft_tokens = torch.zeros((2, 1), dtype=torch.int64)
     speculator.hidden_states = torch.zeros((4, 1))
     speculator.input_buffers = SimpleNamespace(
-        positions=torch.zeros(4, dtype=torch.int64)
+        positions=torch.arange(4, dtype=torch.int64)
     )
     speculator.sample_draft = Mock(return_value=torch.tensor([11, 22]))
     speculator._prefill(
@@ -331,7 +332,7 @@ def test_pcp_prefill_restores_logits_and_feedback_before_sampling():
         num_tokens_across_dp=None,
         cudagraph_runtime_mode=CUDAGraphMode.NONE,
         mm_inputs=None,
-        global_positions=torch.tensor([0, 1, 2, 3]),
+        pcp_local_batch=local_batch,
     )
 
     assert torch.equal(speculator.draft_tokens[:, 0], torch.tensor([11, 22]))
@@ -341,6 +342,8 @@ def test_pcp_prefill_restores_logits_and_feedback_before_sampling():
         speculator.sample_draft.call_args.args[0], torch.tensor([[5.0], [6.0]])
     )
     assert torch.equal(speculator._run_model.call_args.kwargs["is_padding"], padding)
+    assert speculator._run_model.call_args.kwargs["input_ids"] is local_batch.input_ids
+    assert speculator._run_model.call_args.kwargs["positions"] is local_batch.positions
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -284,6 +284,21 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
     assert actual_feedback_hidden is hidden
 
 
+def test_pcp_input_buffers_allow_two_segments_per_request():
+    speculator = object.__new__(_TestSpeculator)
+    speculator.max_num_reqs = 6
+    speculator.max_num_tokens = 32
+    speculator.device = torch.device("cpu")
+
+    manager = Mock()
+    speculator.set_pcp_manager(manager)
+
+    assert speculator.pcp_manager is manager
+    assert speculator.input_buffers.max_num_reqs == 12
+    assert speculator.input_buffers.query_start_loc.shape == (13,)
+    assert speculator.input_buffers.seq_lens.shape == (12,)
+
+
 def test_pcp_prefill_restores_logits_and_feedback_before_sampling():
     speculator = object.__new__(_TestSpeculator)
     local_logits = torch.tensor([[1.0], [2.0]])

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -284,6 +284,50 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
     assert actual_feedback_hidden is hidden
 
 
+def test_pcp_prefill_restores_logits_and_feedback_before_sampling():
+    speculator = object.__new__(_TestSpeculator)
+    local_logits = torch.tensor([[1.0], [2.0]])
+    local_feedback = torch.tensor([[3.0], [4.0]])
+    global_logits = torch.tensor([[1.0], [5.0], [2.0], [6.0]])
+    global_feedback = torch.tensor([[3.0], [7.0], [4.0], [8.0]])
+    manager = Mock()
+    padding = torch.tensor([False, True])
+    manager.local_batch = SimpleNamespace(is_padding=padding)
+    manager.restore_hidden_states.side_effect = [global_logits, global_feedback]
+    speculator.pcp_manager = manager
+    speculator._run_model = Mock(return_value=(local_logits, local_feedback))
+    speculator.last_token_indices = torch.tensor([1, 3])
+    speculator.idx_mapping = torch.tensor([0, 1])
+    speculator.temperature = torch.zeros(2)
+    speculator.seeds = torch.zeros(2, dtype=torch.int64)
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.draft_logits = None
+    speculator.draft_tokens = torch.zeros((2, 1), dtype=torch.int64)
+    speculator.hidden_states = torch.zeros((4, 1))
+    speculator.input_buffers = SimpleNamespace(
+        positions=torch.zeros(4, dtype=torch.int64)
+    )
+    speculator.sample_draft = Mock(return_value=torch.tensor([11, 22]))
+    speculator._prefill(
+        num_reqs=2,
+        num_tokens=2,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+        mm_inputs=None,
+        global_positions=torch.tensor([0, 1, 2, 3]),
+    )
+
+    assert torch.equal(speculator.draft_tokens[:, 0], torch.tensor([11, 22]))
+    assert torch.equal(speculator.hidden_states[:2], torch.tensor([[7.0], [8.0]]))
+    assert torch.equal(speculator.input_buffers.positions[:2], torch.tensor([1, 3]))
+    assert torch.equal(
+        speculator.sample_draft.call_args.args[0], torch.tensor([[5.0], [6.0]])
+    )
+    assert torch.equal(speculator._run_model.call_args.kwargs["is_padding"], padding)
+
+
 @pytest.mark.parametrize(
     (
         "method_name",
@@ -332,6 +376,44 @@ def test_multi_step_decode_replays_captured_graph_as_expected(
 
     assert generate_draft.call_count == expected_eager_calls
     assert run_fullgraph.call_count == expected_graph_replays
+
+
+def test_pcp_multi_step_drafts_are_marked_as_decode(monkeypatch):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.num_speculative_steps = 2
+    speculator.current_draft_step = torch.tensor(0)
+    speculator.input_buffers = SimpleNamespace(
+        positions=torch.arange(2),
+        query_start_loc=torch.arange(3),
+    )
+    speculator.idx_mapping = torch.arange(2)
+    speculator.block_tables = SimpleNamespace(
+        compute_slot_mappings=Mock(return_value=torch.arange(2))
+    )
+    speculator.kv_cache_config = object()
+    speculator.pcp_manager = object()
+    speculator._build_draft_attn_metadata = Mock(return_value={})
+    speculator._generate_draft = Mock()
+    monkeypatch.setattr(
+        spec_module, "build_slot_mappings_by_layer", Mock(return_value={})
+    )
+
+    speculator._multi_step_decode(
+        num_reqs=2,
+        skip_attn=False,
+        batch_desc=BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.NONE,
+            num_tokens=2,
+            num_reqs=2,
+        ),
+        seq_lens_cpu_upper_bound=torch.ones(2, dtype=torch.int32),
+        num_tokens_across_dp=None,
+    )
+
+    is_prefilling = speculator._build_draft_attn_metadata.call_args.kwargs[
+        "is_prefilling"
+    ]
+    assert torch.equal(is_prefilling, torch.zeros(2, dtype=torch.bool))
 
 
 def test_update_draft_decode_metadata_updates_fa3_scheduler_metadata(

--- a/tests/v1/worker/test_gpu_pcp_manager.py
+++ b/tests/v1/worker/test_gpu_pcp_manager.py
@@ -7,11 +7,14 @@ import numpy as np
 import pytest
 import torch
 
+from vllm.config.compilation import CUDAGraphMode
 from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
-pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+requires_cuda = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Requires CUDA"
+)
 
 
 def _make_batch(
@@ -97,6 +100,7 @@ def _make_manager(device: torch.device, req_states: SimpleNamespace) -> PCPManag
     )
 
 
+@requires_cuda
 def test_pcp_partitions_mtp_decode_batch():
     device = torch.device("cuda")
     req_states, global_batch = _make_batch(
@@ -119,6 +123,7 @@ def test_pcp_partitions_mtp_decode_batch():
     assert local_batch.expanded_local_pos.tolist() == [0, 1, 2, 3, 0, 1]
 
 
+@requires_cuda
 def test_pcp_partitions_mixed_prefill_and_mtp_decode_batch():
     device = torch.device("cuda")
     req_states, global_batch = _make_batch(
@@ -149,3 +154,46 @@ def test_pcp_partitions_mixed_prefill_and_mtp_decode_batch():
     assert local_batch.logits_indices.tolist() == [0, 1, 2, 3, 5, 7]
     assert local_batch.expanded_idx_mapping.tolist() == [0, 0, 0, 0, 1, 1]
     assert local_batch.expanded_local_pos.tolist() == [0, 1, 2, 3, 0, 0]
+
+
+def _make_validation_config(
+    *, multi_module_mtp: bool, cudagraph_mode: CUDAGraphMode
+) -> SimpleNamespace:
+    speculative_config = SimpleNamespace(
+        method="mtp",
+        use_multi_module_mtp=lambda: multi_module_mtp,
+    )
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            pipeline_parallel_size=1,
+        ),
+        model_config=SimpleNamespace(
+            use_mla=True,
+            is_encoder_decoder=False,
+            hf_text_config=SimpleNamespace(),
+        ),
+        lora_config=None,
+        speculative_config=speculative_config,
+        compilation_config=SimpleNamespace(cudagraph_mode=cudagraph_mode),
+    )
+
+
+def test_pcp_rejects_multi_module_mtp():
+    config = _make_validation_config(
+        multi_module_mtp=True,
+        cudagraph_mode=CUDAGraphMode.NONE,
+    )
+
+    with pytest.raises(NotImplementedError, match="single-module MTP"):
+        PCPManager.validate_config(config, supports_mm_inputs=False)
+
+
+def test_pcp_mtp_rejects_cuda_graphs():
+    config = _make_validation_config(
+        multi_module_mtp=False,
+        cudagraph_mode=CUDAGraphMode.PIECEWISE,
+    )
+
+    with pytest.raises(NotImplementedError, match="does not support CUDA graphs"):
+        PCPManager.validate_config(config, supports_mm_inputs=False)

--- a/tests/v1/worker/test_gpu_pcp_manager.py
+++ b/tests/v1/worker/test_gpu_pcp_manager.py
@@ -8,12 +8,11 @@ import pytest
 import torch
 
 from vllm.config.compilation import CUDAGraphMode
-from vllm.platforms import current_platform
-from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
 requires_cuda = pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Requires CUDA"
+    not torch.cuda.is_available(), reason="Requires CUDA"
 )
 
 
@@ -23,110 +22,104 @@ def _make_batch(
     num_computed_tokens: np.ndarray,
     prefill_lens: np.ndarray,
     num_draft_tokens_per_req: np.ndarray,
-) -> tuple[SimpleNamespace, InputBatch]:
+) -> InputBatch:
     num_reqs = len(num_scheduled_tokens)
     query_start_loc_np = np.zeros(num_reqs + 1, dtype=np.int32)
     np.cumsum(num_scheduled_tokens, out=query_start_loc_np[1:])
     num_tokens = int(query_start_loc_np[-1])
-    idx_mapping_np = np.arange(num_reqs, dtype=np.intp)
-    idx_mapping = torch.arange(num_reqs, dtype=torch.int64, device=device)
-
-    num_logits_per_req = num_draft_tokens_per_req + 1
-    cu_num_logits_np = np.zeros(num_reqs + 1, dtype=np.int32)
-    np.cumsum(num_logits_per_req, out=cu_num_logits_np[1:])
-
+    buffers = InputBuffers(num_reqs, num_tokens, device)
+    batch = InputBatch.make_dummy(num_reqs, num_tokens, buffers)
+    batch.num_scheduled_tokens = num_scheduled_tokens
+    batch.num_draft_tokens = int(num_draft_tokens_per_req.sum())
+    batch.num_draft_tokens_per_req = num_draft_tokens_per_req
+    batch.query_start_loc_np = query_start_loc_np
+    batch.query_start_loc.copy_(torch.from_numpy(query_start_loc_np).to(device))
+    batch.num_computed_tokens_np = num_computed_tokens
+    batch.prefill_len_np = prefill_lens
+    batch.num_computed_prefill_tokens_np = np.minimum(num_computed_tokens, prefill_lens)
+    batch.is_prefilling_np = num_computed_tokens < prefill_lens
+    batch.has_prefill = bool(batch.is_prefilling_np.any())
+    batch.seq_lens.copy_(
+        torch.from_numpy(num_computed_tokens + num_scheduled_tokens).to(device)
+    )
     positions = np.concatenate(
         [
             np.arange(computed, computed + scheduled, dtype=np.int64)
             for computed, scheduled in zip(num_computed_tokens, num_scheduled_tokens)
         ]
     )
-    input_ids = torch.arange(1000, 1000 + num_tokens, dtype=torch.int32, device=device)
-    seq_lens = torch.from_numpy(num_computed_tokens + num_scheduled_tokens).to(device)
-    query_start_loc = torch.from_numpy(query_start_loc_np).to(device)
-    cu_num_logits = torch.from_numpy(cu_num_logits_np).to(device)
-
-    req_states = SimpleNamespace(
-        last_sampled_tokens=torch.tensor([[101], [102]], device=device),
-        prefill_len=SimpleNamespace(gpu=torch.from_numpy(prefill_lens).to(device)),
-        draft_tokens=torch.tensor([[201, 202, 203], [211, 212, 213]], device=device),
-    )
-    input_batch = InputBatch(
-        req_ids=[f"req-{i}" for i in range(num_reqs)],
-        num_reqs=num_reqs,
-        num_reqs_after_padding=num_reqs,
-        idx_mapping=idx_mapping,
-        idx_mapping_np=idx_mapping_np,
-        expanded_idx_mapping=idx_mapping,
-        expanded_local_pos=torch.zeros(num_reqs, dtype=torch.int32, device=device),
-        num_scheduled_tokens=num_scheduled_tokens,
-        num_tokens=num_tokens,
-        num_tokens_after_padding=num_tokens,
-        num_draft_tokens=int(num_draft_tokens_per_req.sum()),
-        num_draft_tokens_per_req=num_draft_tokens_per_req,
-        query_start_loc=query_start_loc,
-        query_start_loc_np=query_start_loc_np,
-        seq_lens=seq_lens,
-        seq_lens_cpu_upper_bound=torch.from_numpy(
-            num_computed_tokens + num_scheduled_tokens
-        ),
-        dcp_local_seq_lens=None,
-        num_computed_tokens_np=num_computed_tokens,
-        prefill_len_np=prefill_lens,
-        num_computed_prefill_tokens_np=np.minimum(num_computed_tokens, prefill_lens),
-        is_prefilling_np=num_computed_tokens < prefill_lens,
-        has_prefill=bool(np.any(num_computed_tokens < prefill_lens)),
-        max_seq_len_np=None,
-        input_ids=input_ids,
-        positions=torch.from_numpy(positions).to(device),
-        is_padding=torch.zeros(num_tokens, dtype=torch.bool, device=device),
-        logits_indices=torch.empty(0, dtype=torch.int64, device=device),
-        cu_num_logits=cu_num_logits,
-        cu_num_logits_np=cu_num_logits_np,
-        has_structured_output_reqs=False,
-        prompt_lens=None,
-    )
-    return req_states, input_batch
+    batch.positions.copy_(torch.from_numpy(positions).to(device))
+    batch.input_ids.copy_(torch.arange(1000, 1000 + num_tokens, device=device))
+    batch.is_padding.fill_(False)
+    return batch
 
 
-def _make_manager(device: torch.device, req_states: SimpleNamespace) -> PCPManager:
+def _make_manager(device: torch.device) -> PCPManager:
     return PCPManager(
         pcp_world_size=2,
         pcp_rank=0,
         device=device,
-        req_states=req_states,
         max_num_reqs=2,
         max_num_tokens=16,
     )
 
 
+def test_local_batch_is_scoped_to_its_global_batch():
+    manager = object.__new__(PCPManager)
+    global_batch = object()
+    local_batch = object()
+    manager._global_batch = global_batch
+    manager._local_batch = local_batch
+
+    assert manager.local_batch_for(global_batch) is local_batch  # type: ignore[arg-type]
+    assert manager.local_batch_for(object()) is None  # type: ignore[arg-type]
+
+
+def test_draft_ids_reuse_consumed_local_input_buffer():
+    manager = object.__new__(PCPManager)
+    manager._local_gather_idx = torch.tensor([2, 0])
+    local_batch = SimpleNamespace(input_ids=torch.full((2,), -1))
+    manager._local_batch = local_batch
+
+    localized = manager.localize_input_ids_for_draft(
+        torch.tensor([10, 11, 12]),
+        local_batch,  # type: ignore[arg-type]
+    )
+
+    assert localized.data_ptr() == local_batch.input_ids.data_ptr()
+    assert local_batch.input_ids.tolist() == [12, 10]
+
+
 @requires_cuda
 def test_pcp_partitions_mtp_decode_batch():
     device = torch.device("cuda")
-    req_states, global_batch = _make_batch(
+    global_batch = _make_batch(
         device,
         num_scheduled_tokens=np.array([4, 2], dtype=np.int32),
         num_computed_tokens=np.array([10, 20], dtype=np.int32),
         prefill_lens=np.array([5, 5], dtype=np.int32),
         num_draft_tokens_per_req=np.array([3, 1], dtype=np.int32),
     )
+    # Simulate the GPU request-state cursor advancing beyond the async CPU copy.
+    global_batch.positions.copy_(torch.tensor([30, 31, 32, 33, 40, 41]))
 
-    local_batch = _make_manager(device, req_states).partition_batch(global_batch)
+    local_batch = _make_manager(device).partition_batch(global_batch)
 
-    assert local_batch.num_draft_tokens == 4
-    assert local_batch.num_draft_tokens_per_req is not None
-    assert local_batch.num_draft_tokens_per_req.tolist() == [3, 1]
-    assert local_batch.cu_num_logits_np.tolist() == [0, 4, 6]
-    assert local_batch.input_ids.tolist() == [101, 201, 202, 203, 102, 211]
-    assert local_batch.logits_indices.tolist() == [0, 1, 2, 3, 4, 5]
-    assert local_batch.expanded_idx_mapping.tolist() == [0, 0, 0, 0, 1, 1]
-    assert local_batch.expanded_local_pos.tolist() == [0, 1, 2, 3, 0, 1]
+    assert local_batch.num_draft_tokens == 0
+    assert local_batch.num_draft_tokens_per_req is None
+    assert local_batch.cu_num_logits_np.tolist() == [0, 1, 2]
+    assert local_batch.input_ids.tolist() == list(range(1000, 1006))
+    assert local_batch.logits_indices.tolist() == [3, 5]
+    assert local_batch.expanded_idx_mapping.tolist() == [0, 1]
+    assert local_batch.expanded_local_pos.tolist() == [0, 0]
+    assert local_batch.positions.tolist() == [30, 31, 32, 33, 40, 41]
+    assert local_batch.seq_lens.tolist() == [34, 42]
 
 
 @requires_cuda
 def test_pcp_partitions_mixed_prefill_and_mtp_decode_batch():
     device = torch.device("cuda")
-    req_states, global_batch = _make_batch(
+    global_batch = _make_batch(
         device,
         num_scheduled_tokens=np.array([4, 8], dtype=np.int32),
         num_computed_tokens=np.array([10, 0], dtype=np.int32),
@@ -134,26 +127,25 @@ def test_pcp_partitions_mixed_prefill_and_mtp_decode_batch():
         num_draft_tokens_per_req=np.array([3, 0], dtype=np.int32),
     )
 
-    local_batch = _make_manager(device, req_states).partition_batch(global_batch)
+    local_batch = _make_manager(device).partition_batch(global_batch)
 
     assert local_batch.num_scheduled_tokens.tolist() == [4, 2, 2]
-    assert local_batch.num_draft_tokens == 3
-    assert local_batch.num_draft_tokens_per_req is not None
-    assert local_batch.num_draft_tokens_per_req.tolist() == [3, 0, 0]
-    assert local_batch.cu_num_logits_np.tolist() == [0, 4, 5, 6]
+    assert local_batch.num_draft_tokens == 0
+    assert local_batch.num_draft_tokens_per_req is None
+    assert local_batch.cu_num_logits_np.tolist() == [0, 1, 2, 3]
     assert local_batch.input_ids.tolist() == [
-        101,
-        201,
-        202,
-        203,
+        1000,
+        1001,
+        1002,
+        1003,
         1010,
         1011,
         1004,
         1005,
     ]
-    assert local_batch.logits_indices.tolist() == [0, 1, 2, 3, 5, 7]
-    assert local_batch.expanded_idx_mapping.tolist() == [0, 0, 0, 0, 1, 1]
-    assert local_batch.expanded_local_pos.tolist() == [0, 1, 2, 3, 0, 0]
+    assert local_batch.logits_indices.tolist() == [3, 5, 7]
+    assert local_batch.expanded_idx_mapping.tolist() == [0, 1, 1]
+    assert local_batch.expanded_local_pos.tolist() == [0, 0, 0]
 
 
 def _make_validation_config(
@@ -179,21 +171,22 @@ def _make_validation_config(
     )
 
 
-def test_pcp_rejects_multi_module_mtp():
+@pytest.mark.parametrize(
+    ("multi_module_mtp", "cudagraph_mode", "error"),
+    [
+        (True, CUDAGraphMode.NONE, "single-module MTP"),
+        (False, CUDAGraphMode.PIECEWISE, "does not support CUDA graphs"),
+    ],
+)
+def test_pcp_rejects_unsupported_mtp(
+    multi_module_mtp: bool,
+    cudagraph_mode: CUDAGraphMode,
+    error: str,
+):
     config = _make_validation_config(
-        multi_module_mtp=True,
-        cudagraph_mode=CUDAGraphMode.NONE,
+        multi_module_mtp=multi_module_mtp,
+        cudagraph_mode=cudagraph_mode,
     )
 
-    with pytest.raises(NotImplementedError, match="single-module MTP"):
-        PCPManager.validate_config(config, supports_mm_inputs=False)
-
-
-def test_pcp_mtp_rejects_cuda_graphs():
-    config = _make_validation_config(
-        multi_module_mtp=False,
-        cudagraph_mode=CUDAGraphMode.PIECEWISE,
-    )
-
-    with pytest.raises(NotImplementedError, match="does not support CUDA graphs"):
+    with pytest.raises(NotImplementedError, match=error):
         PCPManager.validate_config(config, supports_mm_inputs=False)

--- a/tests/v1/worker/test_gpu_pcp_manager.py
+++ b/tests/v1/worker/test_gpu_pcp_manager.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.pcp_manager import PCPManager
+
+pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+
+
+def _make_batch(
+    device: torch.device,
+    num_scheduled_tokens: np.ndarray,
+    num_computed_tokens: np.ndarray,
+    prefill_lens: np.ndarray,
+    num_draft_tokens_per_req: np.ndarray,
+) -> tuple[SimpleNamespace, InputBatch]:
+    num_reqs = len(num_scheduled_tokens)
+    query_start_loc_np = np.zeros(num_reqs + 1, dtype=np.int32)
+    np.cumsum(num_scheduled_tokens, out=query_start_loc_np[1:])
+    num_tokens = int(query_start_loc_np[-1])
+    idx_mapping_np = np.arange(num_reqs, dtype=np.intp)
+    idx_mapping = torch.arange(num_reqs, dtype=torch.int64, device=device)
+
+    num_logits_per_req = num_draft_tokens_per_req + 1
+    cu_num_logits_np = np.zeros(num_reqs + 1, dtype=np.int32)
+    np.cumsum(num_logits_per_req, out=cu_num_logits_np[1:])
+
+    positions = np.concatenate(
+        [
+            np.arange(computed, computed + scheduled, dtype=np.int64)
+            for computed, scheduled in zip(num_computed_tokens, num_scheduled_tokens)
+        ]
+    )
+    input_ids = torch.arange(1000, 1000 + num_tokens, dtype=torch.int32, device=device)
+    seq_lens = torch.from_numpy(num_computed_tokens + num_scheduled_tokens).to(device)
+    query_start_loc = torch.from_numpy(query_start_loc_np).to(device)
+    cu_num_logits = torch.from_numpy(cu_num_logits_np).to(device)
+
+    req_states = SimpleNamespace(
+        last_sampled_tokens=torch.tensor([[101], [102]], device=device),
+        prefill_len=SimpleNamespace(gpu=torch.from_numpy(prefill_lens).to(device)),
+        draft_tokens=torch.tensor([[201, 202, 203], [211, 212, 213]], device=device),
+    )
+    input_batch = InputBatch(
+        req_ids=[f"req-{i}" for i in range(num_reqs)],
+        num_reqs=num_reqs,
+        num_reqs_after_padding=num_reqs,
+        idx_mapping=idx_mapping,
+        idx_mapping_np=idx_mapping_np,
+        expanded_idx_mapping=idx_mapping,
+        expanded_local_pos=torch.zeros(num_reqs, dtype=torch.int32, device=device),
+        num_scheduled_tokens=num_scheduled_tokens,
+        num_tokens=num_tokens,
+        num_tokens_after_padding=num_tokens,
+        num_draft_tokens=int(num_draft_tokens_per_req.sum()),
+        num_draft_tokens_per_req=num_draft_tokens_per_req,
+        query_start_loc=query_start_loc,
+        query_start_loc_np=query_start_loc_np,
+        seq_lens=seq_lens,
+        seq_lens_cpu_upper_bound=torch.from_numpy(
+            num_computed_tokens + num_scheduled_tokens
+        ),
+        dcp_local_seq_lens=None,
+        num_computed_tokens_np=num_computed_tokens,
+        prefill_len_np=prefill_lens,
+        num_computed_prefill_tokens_np=np.minimum(num_computed_tokens, prefill_lens),
+        is_prefilling_np=num_computed_tokens < prefill_lens,
+        has_prefill=bool(np.any(num_computed_tokens < prefill_lens)),
+        max_seq_len_np=None,
+        input_ids=input_ids,
+        positions=torch.from_numpy(positions).to(device),
+        is_padding=torch.zeros(num_tokens, dtype=torch.bool, device=device),
+        logits_indices=torch.empty(0, dtype=torch.int64, device=device),
+        cu_num_logits=cu_num_logits,
+        cu_num_logits_np=cu_num_logits_np,
+        has_structured_output_reqs=False,
+        prompt_lens=None,
+    )
+    return req_states, input_batch
+
+
+def _make_manager(device: torch.device, req_states: SimpleNamespace) -> PCPManager:
+    return PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=device,
+        req_states=req_states,
+        max_num_reqs=2,
+        max_num_tokens=16,
+    )
+
+
+def test_pcp_partitions_mtp_decode_batch():
+    device = torch.device("cuda")
+    req_states, global_batch = _make_batch(
+        device,
+        num_scheduled_tokens=np.array([4, 2], dtype=np.int32),
+        num_computed_tokens=np.array([10, 20], dtype=np.int32),
+        prefill_lens=np.array([5, 5], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([3, 1], dtype=np.int32),
+    )
+
+    local_batch = _make_manager(device, req_states).partition_batch(global_batch)
+
+    assert local_batch.num_draft_tokens == 4
+    assert local_batch.num_draft_tokens_per_req is not None
+    assert local_batch.num_draft_tokens_per_req.tolist() == [3, 1]
+    assert local_batch.cu_num_logits_np.tolist() == [0, 4, 6]
+    assert local_batch.input_ids.tolist() == [101, 201, 202, 203, 102, 211]
+    assert local_batch.logits_indices.tolist() == [0, 1, 2, 3, 4, 5]
+    assert local_batch.expanded_idx_mapping.tolist() == [0, 0, 0, 0, 1, 1]
+    assert local_batch.expanded_local_pos.tolist() == [0, 1, 2, 3, 0, 1]
+
+
+def test_pcp_partitions_mixed_prefill_and_mtp_decode_batch():
+    device = torch.device("cuda")
+    req_states, global_batch = _make_batch(
+        device,
+        num_scheduled_tokens=np.array([4, 8], dtype=np.int32),
+        num_computed_tokens=np.array([10, 0], dtype=np.int32),
+        prefill_lens=np.array([5, 8], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([3, 0], dtype=np.int32),
+    )
+
+    local_batch = _make_manager(device, req_states).partition_batch(global_batch)
+
+    assert local_batch.num_scheduled_tokens.tolist() == [4, 2, 2]
+    assert local_batch.num_draft_tokens == 3
+    assert local_batch.num_draft_tokens_per_req is not None
+    assert local_batch.num_draft_tokens_per_req.tolist() == [3, 0, 0]
+    assert local_batch.cu_num_logits_np.tolist() == [0, 4, 5, 6]
+    assert local_batch.input_ids.tolist() == [
+        101,
+        201,
+        202,
+        203,
+        1010,
+        1011,
+        1004,
+        1005,
+    ]
+    assert local_batch.logits_indices.tolist() == [0, 1, 2, 3, 5, 7]
+    assert local_batch.expanded_idx_mapping.tolist() == [0, 0, 0, 0, 1, 1]
+    assert local_batch.expanded_local_pos.tolist() == [0, 1, 2, 3, 0, 0]

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2109,9 +2109,12 @@ class EngineArgs:
                 self.data_parallel_size
                 * self.pipeline_parallel_size
                 * self.tensor_parallel_size
+                * self.prefill_context_parallel_size
             )
             world_size_within_dp = (
-                self.pipeline_parallel_size * self.tensor_parallel_size
+                self.pipeline_parallel_size
+                * self.tensor_parallel_size
+                * self.prefill_context_parallel_size
             )
             if world_size % self.nnodes != 0:
                 raise ValueError(

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -381,9 +381,10 @@ def sparse_attn_indexer(
     # out-of-bounds reads in the kernel.
     # Keep PCP padding so every rank contributes the same all-gather shape.
     num_tokens = slot_mapping.shape[0]
-    if use_pcp:
-        num_tokens //= get_pcp_group().world_size
     if k is not None:
+        # MTP draft decodes are replicated and use an unexpanded slot mapping.
+        if use_pcp and num_tokens > k.shape[0]:
+            num_tokens //= get_pcp_group().world_size
         k = k[:num_tokens]
 
     if not skip_k_cache_insert:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -598,6 +598,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.block_tables,
             cls=self.pcp_manager_cls,
         )
+        if self.pcp_manager is not None and self.speculator is not None:
+            self.speculator.set_pcp_manager(self.pcp_manager)  # type: ignore[attr-defined]
         initialize_mamba_ssu_backend(
             self.vllm_config.mamba_config, self.kv_cache_config
         )
@@ -767,18 +769,31 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
+            spec_input_batch = input_batch
+            if self.pcp_manager is not None:
+                spec_hidden_states, spec_input_batch = (
+                    pcp.maybe_restore_pcp_for_sampling(
+                        self.pcp_manager,
+                        spec_hidden_states,
+                        input_batch,
+                    )
+                )
             with use_workspace_lane(self._draft_workspace_lane):
                 self.speculator.propose(
-                    input_batch=input_batch,
+                    input_batch=spec_input_batch,
                     attn_metadata=attn_metadata,
                     slot_mappings=slot_mappings_by_layer,
                     last_hidden_states=spec_hidden_states,
                     aux_hidden_states=aux_hidden_states,
                     num_sampled=torch.ones(
-                        input_batch.num_reqs, dtype=torch.int32, device=self.device
+                        spec_input_batch.num_reqs,
+                        dtype=torch.int32,
+                        device=self.device,
                     ),
                     num_rejected=torch.zeros(
-                        input_batch.num_reqs, dtype=torch.int32, device=self.device
+                        spec_input_batch.num_reqs,
+                        dtype=torch.int32,
+                        device=self.device,
                     ),
                     last_sampled=self.req_states.last_sampled_tokens,
                     next_prefill_tokens=self.req_states.next_prefill_tokens,
@@ -1803,9 +1818,22 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             return ModelRunnerOutput.with_ec_conn_output(output, ec_connector_output)
 
         # Last rank: sample tokens
+        local_hidden_states = hidden_states
+        spec_hidden_states = hidden_states
+        if self.speculator is not None and hasattr(
+            self.model, "get_mtp_target_hidden_states"
+        ):
+            pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
+            spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
         hidden_states, input_batch = pcp.maybe_restore_pcp_for_sampling(
             self.pcp_manager, hidden_states, input_batch
         )
+        if spec_hidden_states is local_hidden_states:
+            spec_hidden_states = hidden_states
+        elif self.pcp_manager is not None:
+            spec_hidden_states = self.pcp_manager.restore_hidden_states(
+                spec_hidden_states
+            )
 
         sampler_output, num_sampled, num_rejected = self.sample(
             hidden_states, input_batch, grammar_output
@@ -1877,14 +1905,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         if self.speculator is not None:
             assert self.sampler is not None
-            # Let the target override the hidden state fed to the drafter
-            # (e.g. DeepSeek V4 MTP needs the pre-hc_head residual). The
-            # target returns a persistent buffer sized at max_num_batched_tokens;
-            # slice to the active token count that propose() expects.
-            spec_hidden_states = hidden_states
-            if hasattr(self.model, "get_mtp_target_hidden_states"):
-                pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
-                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
             with use_workspace_lane(self._draft_workspace_lane):
                 draft_tokens = self.speculator.propose(
                     input_batch,
@@ -1905,6 +1925,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.adaptive_verification.record_confidences(
                     self.speculator.draft_token_confidence_probs, input_batch
                 )
+            kv_config = self.vllm_config.kv_transfer_config
+            if kv_config is not None and kv_config.is_kv_producer:
+                self.output_copy_stream.wait_stream(self.main_stream)
+                async_output.copy_event.record(self.output_copy_stream)
 
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -594,7 +594,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.vllm_config,
             self.device,
             self.supports_mm_inputs,
-            self.req_states,
             self.block_tables,
             cls=self.pcp_manager_cls,
         )
@@ -770,14 +769,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
             spec_input_batch = input_batch
-            if self.pcp_manager is not None:
-                spec_hidden_states, spec_input_batch = (
-                    pcp.maybe_restore_pcp_for_sampling(
-                        self.pcp_manager,
-                        spec_hidden_states,
-                        input_batch,
-                    )
-                )
             with use_workspace_lane(self._draft_workspace_lane):
                 self.speculator.propose(
                     input_batch=spec_input_batch,
@@ -1818,7 +1809,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             return ModelRunnerOutput.with_ec_conn_output(output, ec_connector_output)
 
         # Last rank: sample tokens
-        local_hidden_states = hidden_states
+        # Keep the target's rank-local representation for the sharded drafter.
+        # Sampling still restores the ordinary target hidden states globally.
         spec_hidden_states = hidden_states
         if self.speculator is not None and hasattr(
             self.model, "get_mtp_target_hidden_states"
@@ -1828,12 +1820,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         hidden_states, input_batch = pcp.maybe_restore_pcp_for_sampling(
             self.pcp_manager, hidden_states, input_batch
         )
-        if spec_hidden_states is local_hidden_states:
-            spec_hidden_states = hidden_states
-        elif self.pcp_manager is not None:
-            spec_hidden_states = self.pcp_manager.restore_hidden_states(
-                spec_hidden_states
-            )
 
         sampler_output, num_sampled, num_rejected = self.sample(
             hidden_states, input_batch, grammar_output

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -15,11 +15,7 @@ from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import (
     InputBatch,
     InputBuffers,
-    combine_sampled_and_draft_tokens,
-    expand_idx_mapping,
-    prepare_pos_seq_lens,
 )
-from vllm.v1.worker.gpu.states import RequestState
 
 logger = init_logger(__name__)
 
@@ -49,7 +45,6 @@ class PCPManager:
         pcp_world_size: int,
         pcp_rank: int,
         device: torch.device,
-        req_states: RequestState | None = None,
         max_num_reqs: int | None = None,
         max_num_tokens: int | None = None,
         block_tables: BlockTables | None = None,
@@ -67,7 +62,6 @@ class PCPManager:
         self._global_batch: InputBatch | None = None
         self._local_batch: InputBatch | None = None
         self._local_gather_idx: torch.Tensor | None = None
-        self._req_states = req_states
         self._block_tables = block_tables
         self._hidden_restore_idx: torch.Tensor | None = None
         self._padded_gather_idx: torch.Tensor | None = None
@@ -78,11 +72,6 @@ class PCPManager:
         self._input_buffers = (
             InputBuffers(max_num_local_reqs, max_num_tokens, device)
             if max_num_local_reqs is not None and max_num_tokens is not None
-            else None
-        )
-        self._local_req_idx = (
-            torch.arange(max_num_local_reqs, dtype=torch.int32, device=device)
-            if max_num_local_reqs is not None
             else None
         )
         self._local_block_tables: tuple[torch.Tensor, ...] | None
@@ -330,9 +319,7 @@ class PCPManager:
         return segments_by_rank, per_rank_num_tokens
 
     def partition_batch(self, input_batch: InputBatch) -> InputBatch:
-        assert self._req_states is not None
         assert self._input_buffers is not None
-        req_states = self._req_states
         input_buffers = self._input_buffers
 
         global_batch = input_batch
@@ -432,6 +419,14 @@ class PCPManager:
             local_gather_idx,
             out=input_buffers.input_ids[:num_local_tokens_padded],
         )
+        # Keep the GPU request-state cursor materialized by prepare_inputs().
+        # The CPU cursor can lag after speculative rejection.
+        torch.index_select(
+            global_batch.positions,
+            0,
+            local_gather_idx,
+            out=input_buffers.positions[:num_local_tokens_padded],
+        )
 
         local_query_start_loc_np = np.empty(
             input_buffers.max_num_reqs + 1, dtype=np.int32
@@ -446,17 +441,16 @@ class PCPManager:
         local_to_global_req_idx = async_copy_to_gpu(
             local_to_global_req_idx_np, device=self.device
         )
-        local_start_pos = async_copy_to_gpu(local_start_pos_np, device=self.device)
-
-        assert self._local_req_idx is not None
-        prepare_pos_seq_lens(
-            self._local_req_idx[:num_local_reqs],
-            local_query_start_loc,
-            local_start_pos,
-            input_buffers.positions,
-            input_buffers.seq_lens[:num_local_reqs],
-        )
         seq_lens = input_buffers.seq_lens[:num_local_reqs]
+        if num_local_tokens > 0:
+            local_end_positions = torch.index_select(
+                input_buffers.positions,
+                0,
+                local_query_start_loc[1:] - 1,
+            )
+            seq_lens.copy_(local_end_positions + 1)
+        else:
+            seq_lens.zero_()
         is_padding = input_buffers.is_padding[:num_local_tokens_padded]
         is_padding[:num_local_tokens].fill_(False)
         is_padding[num_local_tokens:].fill_(True)
@@ -468,65 +462,20 @@ class PCPManager:
                 is_padding, 0
             )
 
-        global_num_draft_tokens_per_req = global_batch.num_draft_tokens_per_req
-        if global_num_draft_tokens_per_req is None:
-            local_num_draft_tokens_per_req = None
-        else:
-            local_num_draft_tokens_per_req = global_num_draft_tokens_per_req[
-                local_to_global_batch_req_idx_np
-            ]
-            if num_local_tokens == 0:
-                local_num_draft_tokens_per_req.fill(0)
-
-        local_num_draft_tokens = (
-            int(local_num_draft_tokens_per_req.sum())
-            if local_num_draft_tokens_per_req is not None
-            else 0
-        )
-        total_num_logits = (
-            num_local_reqs + local_num_draft_tokens if num_local_tokens > 0 else 0
-        )
-        if total_num_logits == num_local_reqs:
+        total_num_logits = num_local_reqs if num_local_tokens > 0 else 0
+        if total_num_logits > 0:
             cu_num_logits_np = np.arange(num_local_reqs + 1, dtype=np.int32)
             cu_num_logits = torch.arange(
                 num_local_reqs + 1, device=self.device, dtype=torch.int32
-            )
-            expanded_idx_mapping = local_to_global_req_idx
-            expanded_local_pos = torch.zeros(
-                num_local_reqs, dtype=torch.int32, device=self.device
-            )
-        elif total_num_logits > 0:
-            assert local_num_draft_tokens_per_req is not None
-            local_num_logits_per_req = local_num_draft_tokens_per_req + 1
-            cu_num_logits_np = np.empty(num_local_reqs + 1, dtype=np.int32)
-            cu_num_logits_np[0] = 0
-            np.cumsum(local_num_logits_per_req, out=cu_num_logits_np[1:])
-            cu_num_logits = async_copy_to_gpu(cu_num_logits_np, device=self.device)
-            expanded_idx_mapping, expanded_local_pos = expand_idx_mapping(
-                local_to_global_req_idx,
-                total_num_logits,
-                cu_num_logits,
-                int(local_num_logits_per_req.max()),
             )
         else:
             cu_num_logits_np = np.zeros(num_local_reqs + 1, dtype=np.int32)
             cu_num_logits = torch.zeros(
                 num_local_reqs + 1, device=self.device, dtype=torch.int32
             )
-            expanded_idx_mapping = local_to_global_req_idx[:0]
-            expanded_local_pos = torch.empty(0, dtype=torch.int32, device=self.device)
-        logits_indices = combine_sampled_and_draft_tokens(
-            input_buffers.input_ids,
-            local_to_global_req_idx,
-            req_states.last_sampled_tokens,
-            local_query_start_loc,
-            seq_lens,
-            req_states.prefill_len.gpu,
-            req_states.draft_tokens,
-            cu_num_logits,
-            total_num_logits,
-            1,
-        )
+        # Local logits are never sampled. The complete hidden-state tensor is
+        # restored first and sampled with the untouched global InputBatch.
+        logits_indices = local_query_start_loc[1:] - 1
 
         local_prefill_len_np = global_batch.prefill_len_np[
             local_to_global_batch_req_idx_np
@@ -559,13 +508,15 @@ class PCPManager:
             num_reqs_after_padding=num_local_reqs,
             idx_mapping=local_to_global_req_idx,
             idx_mapping_np=local_to_global_req_idx_np,
-            expanded_idx_mapping=expanded_idx_mapping,
-            expanded_local_pos=expanded_local_pos,
+            expanded_idx_mapping=local_to_global_req_idx,
+            expanded_local_pos=torch.zeros(
+                num_local_reqs, dtype=torch.int32, device=self.device
+            ),
             num_scheduled_tokens=local_num_scheduled_tokens,
             num_tokens=num_local_tokens,
             num_tokens_after_padding=num_local_tokens_padded,
-            num_draft_tokens=local_num_draft_tokens,
-            num_draft_tokens_per_req=local_num_draft_tokens_per_req,
+            num_draft_tokens=0,
+            num_draft_tokens_per_req=None,
             query_start_loc=local_query_start_loc,
             query_start_loc_np=local_query_start_loc_np[: num_local_reqs + 1],
             seq_lens=seq_lens,
@@ -659,9 +610,10 @@ class PCPManager:
         gathered = get_pcp_group().all_gather(hidden_states, dim=0)
         return gathered[self._hidden_restore_idx]
 
-    @property
-    def local_batch(self) -> InputBatch:
-        assert self._local_batch is not None
+    def local_batch_for(self, global_batch: InputBatch) -> InputBatch | None:
+        """Return this step's local view, never a stale view from an older step."""
+        if global_batch is not self._global_batch:
+            return None
         return self._local_batch
 
     def localize_tensor(
@@ -678,6 +630,19 @@ class PCPManager:
             out=out[:num_local_tokens],
         )
         return out[:num_local_tokens]
+
+    def localize_input_ids_for_draft(
+        self,
+        global_input_ids: torch.Tensor,
+        local_batch: InputBatch,
+    ) -> torch.Tensor:
+        """Reuse the consumed target-input buffer for rank-local draft IDs.
+
+        The target forward has finished, no supported post-forward path reads
+        these local IDs, and partition_batch rematerializes them next step.
+        """
+        assert local_batch is self._local_batch
+        return self.localize_tensor(global_input_ids, local_batch.input_ids)
 
     def restore_for_sampling(
         self,
@@ -721,7 +686,6 @@ def maybe_build_pcp_manager(
     vllm_config: VllmConfig,
     device: torch.device,
     supports_mm_inputs: bool,
-    req_states: RequestState,
     block_tables: BlockTables,
     cls: type[PCPManager] = PCPManager,
 ) -> PCPManager | None:
@@ -740,7 +704,6 @@ def maybe_build_pcp_manager(
         pcp_world_size=pcp_size,
         pcp_rank=pcp_rank,
         device=device,
-        req_states=req_states,
         max_num_reqs=vllm_config.scheduler_config.max_num_seqs,
         max_num_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
         block_tables=block_tables,

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -148,10 +148,19 @@ class PCPManager:
         if vllm_config.lora_config is not None:
             raise NotImplementedError("MRV2 PCP does not support LoRA yet.")
         speculative_config = vllm_config.speculative_config
-        if speculative_config is not None and speculative_config.method != "mtp":
-            raise NotImplementedError(
-                "MRV2 PCP only supports MTP speculative decoding."
-            )
+        if speculative_config is not None:
+            if (
+                speculative_config.method != "mtp"
+                or speculative_config.use_multi_module_mtp()
+            ):
+                raise NotImplementedError(
+                    "MRV2 PCP only supports single-module MTP speculative decoding."
+                )
+            if vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+                raise NotImplementedError(
+                    "MRV2 PCP with MTP does not support CUDA graphs yet. "
+                    "Set -cc.cudagraph_mode=NONE."
+                )
         is_sparse_mla = hasattr(model_config.hf_text_config, "index_topk")
         if (
             is_sparse_mla

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -55,6 +55,7 @@ class PCPManager:
         dcp_world_size: int = 1,
         dcp_rank: int = 0,
         cp_interleave: int = 1,
+        prefill_only_mtp: bool = False,
     ) -> None:
         self.pcp_world_size = pcp_world_size
         self.pcp_rank = pcp_rank
@@ -62,8 +63,11 @@ class PCPManager:
         self.dcp_world_size = dcp_world_size
         self.dcp_rank = dcp_rank
         self.cp_interleave = cp_interleave
+        self.prefill_only_mtp = prefill_only_mtp
 
         self._global_batch: InputBatch | None = None
+        self._local_batch: InputBatch | None = None
+        self._local_gather_idx: torch.Tensor | None = None
         self._req_states = req_states
         self._block_tables = block_tables
         self._hidden_restore_idx: torch.Tensor | None = None
@@ -144,9 +148,10 @@ class PCPManager:
             raise NotImplementedError("MRV2 PCP does not support MM inputs yet.")
         if vllm_config.lora_config is not None:
             raise NotImplementedError("MRV2 PCP does not support LoRA yet.")
-        if vllm_config.speculative_config is not None:
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None and speculative_config.method != "mtp":
             raise NotImplementedError(
-                "MRV2 PCP does not support speculative decoding yet."
+                "MRV2 PCP only supports prefill-only MTP speculative decoding."
             )
         is_sparse_mla = hasattr(model_config.hf_text_config, "index_topk")
         if (
@@ -323,6 +328,14 @@ class PCPManager:
         input_buffers = self._input_buffers
         if input_batch.num_draft_tokens > 0:
             raise NotImplementedError("MRV2 PCP does not support spec decode yet.")
+        if (
+            self.prefill_only_mtp
+            and input_batch.num_reqs > 0
+            and (not input_batch.has_prefill or not input_batch.is_prefilling_np.all())
+        ):
+            raise NotImplementedError(
+                "MRV2 PCP with MTP only supports pure prefill batches."
+            )
 
         global_batch = input_batch
         self._global_batch = global_batch
@@ -414,6 +427,7 @@ class PCPManager:
         local_gather_idx = self._padded_gather_idx[
             rank_token_start : rank_token_start + num_local_tokens_padded
         ]
+        self._local_gather_idx = local_gather_idx
         torch.index_select(
             global_batch.input_ids,
             0,
@@ -504,7 +518,7 @@ class PCPManager:
             )
             dcp_local_seq_lens = input_buffers.dcp_local_seq_lens[:num_local_reqs]
 
-        return replace(
+        local_batch = replace(
             input_batch,
             req_ids=local_req_ids,
             num_reqs=num_local_reqs,
@@ -541,6 +555,8 @@ class PCPManager:
             cu_num_logits_np=cu_num_logits_np,
             prompt_lens=None,
         )
+        self._local_batch = local_batch
+        return local_batch
 
     def prepare_attn(
         self, input_batch: InputBatch
@@ -611,6 +627,26 @@ class PCPManager:
         gathered = get_pcp_group().all_gather(hidden_states, dim=0)
         return gathered[self._hidden_restore_idx]
 
+    @property
+    def local_batch(self) -> InputBatch:
+        assert self._local_batch is not None
+        return self._local_batch
+
+    def localize_tensor(
+        self,
+        tensor: torch.Tensor,
+        out: torch.Tensor,
+    ) -> torch.Tensor:
+        assert self._local_gather_idx is not None
+        num_local_tokens = self._local_gather_idx.shape[0]
+        torch.index_select(
+            tensor,
+            0,
+            self._local_gather_idx,
+            out=out[:num_local_tokens],
+        )
+        return out[:num_local_tokens]
+
     def restore_for_sampling(
         self,
         hidden_states: torch.Tensor,
@@ -679,4 +715,5 @@ def maybe_build_pcp_manager(
         dcp_world_size=dcp_size,
         dcp_rank=dcp_rank,
         cp_interleave=parallel_config.cp_kv_cache_interleave_size,
+        prefill_only_mtp=vllm_config.speculative_config is not None,
     )

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -16,6 +16,7 @@ from vllm.v1.worker.gpu.input_batch import (
     InputBatch,
     InputBuffers,
     combine_sampled_and_draft_tokens,
+    expand_idx_mapping,
     prepare_pos_seq_lens,
 )
 from vllm.v1.worker.gpu.states import RequestState
@@ -55,7 +56,6 @@ class PCPManager:
         dcp_world_size: int = 1,
         dcp_rank: int = 0,
         cp_interleave: int = 1,
-        prefill_only_mtp: bool = False,
     ) -> None:
         self.pcp_world_size = pcp_world_size
         self.pcp_rank = pcp_rank
@@ -63,7 +63,6 @@ class PCPManager:
         self.dcp_world_size = dcp_world_size
         self.dcp_rank = dcp_rank
         self.cp_interleave = cp_interleave
-        self.prefill_only_mtp = prefill_only_mtp
 
         self._global_batch: InputBatch | None = None
         self._local_batch: InputBatch | None = None
@@ -151,7 +150,7 @@ class PCPManager:
         speculative_config = vllm_config.speculative_config
         if speculative_config is not None and speculative_config.method != "mtp":
             raise NotImplementedError(
-                "MRV2 PCP only supports prefill-only MTP speculative decoding."
+                "MRV2 PCP only supports MTP speculative decoding."
             )
         is_sparse_mla = hasattr(model_config.hf_text_config, "index_topk")
         if (
@@ -326,16 +325,6 @@ class PCPManager:
         assert self._input_buffers is not None
         req_states = self._req_states
         input_buffers = self._input_buffers
-        if input_batch.num_draft_tokens > 0:
-            raise NotImplementedError("MRV2 PCP does not support spec decode yet.")
-        if (
-            self.prefill_only_mtp
-            and input_batch.num_reqs > 0
-            and (not input_batch.has_prefill or not input_batch.is_prefilling_np.all())
-        ):
-            raise NotImplementedError(
-                "MRV2 PCP with MTP only supports pure prefill batches."
-            )
 
         global_batch = input_batch
         self._global_batch = global_batch
@@ -470,17 +459,53 @@ class PCPManager:
                 is_padding, 0
             )
 
-        total_num_logits = num_local_reqs if num_local_tokens > 0 else 0
-        if total_num_logits > 0:
+        global_num_draft_tokens_per_req = global_batch.num_draft_tokens_per_req
+        if global_num_draft_tokens_per_req is None:
+            local_num_draft_tokens_per_req = None
+        else:
+            local_num_draft_tokens_per_req = global_num_draft_tokens_per_req[
+                local_to_global_batch_req_idx_np
+            ]
+            if num_local_tokens == 0:
+                local_num_draft_tokens_per_req.fill(0)
+
+        local_num_draft_tokens = (
+            int(local_num_draft_tokens_per_req.sum())
+            if local_num_draft_tokens_per_req is not None
+            else 0
+        )
+        total_num_logits = (
+            num_local_reqs + local_num_draft_tokens if num_local_tokens > 0 else 0
+        )
+        if total_num_logits == num_local_reqs:
             cu_num_logits_np = np.arange(num_local_reqs + 1, dtype=np.int32)
             cu_num_logits = torch.arange(
                 num_local_reqs + 1, device=self.device, dtype=torch.int32
+            )
+            expanded_idx_mapping = local_to_global_req_idx
+            expanded_local_pos = torch.zeros(
+                num_local_reqs, dtype=torch.int32, device=self.device
+            )
+        elif total_num_logits > 0:
+            assert local_num_draft_tokens_per_req is not None
+            local_num_logits_per_req = local_num_draft_tokens_per_req + 1
+            cu_num_logits_np = np.empty(num_local_reqs + 1, dtype=np.int32)
+            cu_num_logits_np[0] = 0
+            np.cumsum(local_num_logits_per_req, out=cu_num_logits_np[1:])
+            cu_num_logits = async_copy_to_gpu(cu_num_logits_np, device=self.device)
+            expanded_idx_mapping, expanded_local_pos = expand_idx_mapping(
+                local_to_global_req_idx,
+                total_num_logits,
+                cu_num_logits,
+                int(local_num_logits_per_req.max()),
             )
         else:
             cu_num_logits_np = np.zeros(num_local_reqs + 1, dtype=np.int32)
             cu_num_logits = torch.zeros(
                 num_local_reqs + 1, device=self.device, dtype=torch.int32
             )
+            expanded_idx_mapping = local_to_global_req_idx[:0]
+            expanded_local_pos = torch.empty(0, dtype=torch.int32, device=self.device)
         logits_indices = combine_sampled_and_draft_tokens(
             input_buffers.input_ids,
             local_to_global_req_idx,
@@ -525,15 +550,13 @@ class PCPManager:
             num_reqs_after_padding=num_local_reqs,
             idx_mapping=local_to_global_req_idx,
             idx_mapping_np=local_to_global_req_idx_np,
-            expanded_idx_mapping=local_to_global_req_idx,
-            expanded_local_pos=torch.zeros(
-                num_local_reqs, dtype=torch.int32, device=self.device
-            ),
+            expanded_idx_mapping=expanded_idx_mapping,
+            expanded_local_pos=expanded_local_pos,
             num_scheduled_tokens=local_num_scheduled_tokens,
             num_tokens=num_local_tokens,
             num_tokens_after_padding=num_local_tokens_padded,
-            num_draft_tokens=0,
-            num_draft_tokens_per_req=None,
+            num_draft_tokens=local_num_draft_tokens,
+            num_draft_tokens_per_req=local_num_draft_tokens_per_req,
             query_start_loc=local_query_start_loc,
             query_start_loc_np=local_query_start_loc_np[: num_local_reqs + 1],
             seq_lens=seq_lens,
@@ -715,5 +738,4 @@ def maybe_build_pcp_manager(
         dcp_world_size=dcp_size,
         dcp_rank=dcp_rank,
         cp_interleave=parallel_config.cp_kv_cache_interleave_size,
-        prefill_only_mtp=vllm_config.speculative_config is not None,
     )

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -43,7 +43,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
         self.inputs_embeds: torch.Tensor | None = None
         self.pcp_manager: PCPManager | None = None
-        self.pcp_input_ids: torch.Tensor | None = None
 
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
@@ -51,13 +50,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
     def set_pcp_manager(self, manager: "PCPManager") -> None:
         self.pcp_manager = manager
-        # DualChunkSwap can create two rank-local segments per global request.
-        self.input_buffers = InputBuffers(
-            max_num_reqs=2 * self.max_num_reqs,
-            max_num_tokens=self.max_num_tokens,
-            device=self.device,
-        )
-        self.pcp_input_ids = torch.empty_like(self.input_buffers.input_ids)
 
     def load_model(self, target_model: nn.Module) -> None:
         super().load_model(target_model)
@@ -260,10 +252,19 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
         else:
             hidden_states = last_hidden_states
-        if self.pcp_manager is None:
+        pcp_local_batch = (
+            self.pcp_manager.local_batch_for(input_batch)
+            if self.pcp_manager is not None
+            else None
+        )
+        if pcp_local_batch is None:
             self.hidden_states[:num_tokens_padded].copy_(hidden_states)
         else:
-            self.pcp_manager.localize_tensor(hidden_states, self.hidden_states)
+            # The target sampler needs globally restored hidden states, but the
+            # sharded drafter consumes the target's rank-local rows directly.
+            local_num_tokens = pcp_local_batch.num_tokens_after_padding
+            assert hidden_states.shape[0] == local_num_tokens
+            self.hidden_states[:local_num_tokens].copy_(hidden_states)
 
         self._copy_request_inputs(
             num_reqs,
@@ -286,23 +287,13 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         )
 
         prefill_input_batch = input_batch
-        if self.pcp_manager is not None:
-            local_batch = self.pcp_manager.local_batch
-            assert self.pcp_input_ids is not None
-            local_input_ids = self.pcp_manager.localize_tensor(
+        if pcp_local_batch is not None:
+            assert self.pcp_manager is not None
+            self.pcp_manager.localize_input_ids_for_draft(
                 self.input_buffers.input_ids[:num_tokens_padded],
-                self.pcp_input_ids,
+                pcp_local_batch,
             )
-            local_num_tokens = local_batch.num_tokens_after_padding
-            self.input_buffers.input_ids[:local_num_tokens].copy_(local_input_ids)
-            self.input_buffers.positions[:local_num_tokens].copy_(local_batch.positions)
-            self.input_buffers.query_start_loc[: local_batch.num_reqs + 1].copy_(
-                local_batch.query_start_loc
-            )
-            self.input_buffers.seq_lens[: local_batch.num_reqs].copy_(
-                local_batch.seq_lens
-            )
-            prefill_input_batch = local_batch
+            prefill_input_batch = pcp_local_batch
 
         # When all requests are decoding (no true prefills), each has
         # num_speculative_steps + 1 tokens, enabling FULL graph replay.
@@ -343,9 +334,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
                 mm_inputs=mm_inputs,
-                global_positions=(
-                    input_batch.positions if self.pcp_manager is not None else None
-                ),
+                pcp_local_batch=pcp_local_batch,
             )
         self.on_prefill_end(num_reqs)
 
@@ -404,7 +393,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_padding: torch.Tensor | None = None,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        input_ids = self.input_buffers.input_ids if input_ids is None else input_ids
+        positions = self.input_buffers.positions if positions is None else positions
         batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
         with set_forward_context(
             attn_metadata,
@@ -425,15 +418,15 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                     is_mm_embed.shape[0] if is_mm_embed is not None else num_tokens
                 )
                 self.inputs_embeds[:num_input_tokens] = self.model.embed_input_ids(
-                    self.input_buffers.input_ids[:num_input_tokens],
+                    input_ids[:num_input_tokens],
                     multimodal_embeddings=mm_embeds,
                     is_multimodal=is_mm_embed,
                 )
                 inputs_embeds = self.inputs_embeds[:num_tokens]
 
             model_inputs = dict(
-                input_ids=self.input_buffers.input_ids[:num_tokens],
-                positions=self.input_buffers.positions[:num_tokens],
+                input_ids=input_ids[:num_tokens],
+                positions=positions[:num_tokens],
                 hidden_states=self.hidden_states[:num_tokens],
                 inputs_embeds=inputs_embeds,
             )
@@ -465,11 +458,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
-        global_positions: torch.Tensor | None = None,
+        pcp_local_batch: InputBatch | None = None,
     ) -> None:
         is_padding = (
-            self.pcp_manager.local_batch.is_padding[:num_tokens]
-            if self.pcp_manager is not None
+            pcp_local_batch.is_padding[:num_tokens]
+            if pcp_local_batch is not None
             else None
         )
         last_hidden_states, hidden_states = self._run_model(
@@ -480,8 +473,15 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             mm_inputs=mm_inputs,
             is_padding=is_padding,
+            input_ids=(
+                pcp_local_batch.input_ids if pcp_local_batch is not None else None
+            ),
+            positions=(
+                pcp_local_batch.positions if pcp_local_batch is not None else None
+            ),
         )
-        if self.pcp_manager is not None:
+        if pcp_local_batch is not None:
+            assert self.pcp_manager is not None
             assert cudagraph_runtime_mode == CUDAGraphMode.NONE
             local_last_hidden_states = last_hidden_states
             local_hidden_states = hidden_states
@@ -495,11 +495,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
 
         last_token_indices = self.last_token_indices[:num_reqs]
-        positions = (
-            self.input_buffers.positions
-            if global_positions is None
-            else global_positions
-        )[last_token_indices]
+        positions = self.input_buffers.positions[last_token_indices]
         sample_hidden_states = last_hidden_states[last_token_indices]
         self.draft_tokens[:num_reqs, 0] = self.sample_draft(
             sample_hidden_states,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -25,6 +25,9 @@ from vllm.v1.worker.utils import AttentionGroup, get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu.pcp_manager import PCPManager
+
 
 class AutoRegressiveSpeculator(DraftModelSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
@@ -39,10 +42,16 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         )
 
         self.inputs_embeds: torch.Tensor | None = None
+        self.pcp_manager: PCPManager | None = None
+        self.pcp_input_ids: torch.Tensor | None = None
 
         self.prefill_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.decode_cudagraph_manager: SpeculatorCudaGraphManager | None = None
         self.use_fused_multi_step_decode = False
+
+    def set_pcp_manager(self, manager: "PCPManager") -> None:
+        self.pcp_manager = manager
+        self.pcp_input_ids = torch.empty_like(self.input_buffers.input_ids)
 
     def load_model(self, target_model: nn.Module) -> None:
         super().load_model(target_model)
@@ -225,10 +234,8 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
     ) -> torch.Tensor:
-        num_tokens = input_batch.num_tokens
         num_tokens_padded = input_batch.num_tokens_after_padding
         num_reqs = input_batch.num_reqs
-        max_query_len = input_batch.num_scheduled_tokens.max()
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
         self.draft_max_seq_len = min(
             max_seq_len + self.num_speculative_steps, self.max_model_len
@@ -247,7 +254,10 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             )
         else:
             hidden_states = last_hidden_states
-        self.hidden_states[:num_tokens_padded].copy_(hidden_states)
+        if self.pcp_manager is None:
+            self.hidden_states[:num_tokens_padded].copy_(hidden_states)
+        else:
+            self.pcp_manager.localize_tensor(hidden_states, self.hidden_states)
 
         self._copy_request_inputs(
             num_reqs,
@@ -269,27 +279,46 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.max_num_reqs,
         )
 
+        prefill_input_batch = input_batch
+        if self.pcp_manager is not None:
+            local_batch = self.pcp_manager.local_batch
+            assert self.pcp_input_ids is not None
+            local_input_ids = self.pcp_manager.localize_tensor(
+                self.input_buffers.input_ids[:num_tokens_padded],
+                self.pcp_input_ids,
+            )
+            local_num_tokens = local_batch.num_tokens_after_padding
+            self.input_buffers.input_ids[:local_num_tokens].copy_(local_input_ids)
+            self.input_buffers.positions[:local_num_tokens].copy_(local_batch.positions)
+            self.input_buffers.query_start_loc[: local_batch.num_reqs + 1].copy_(
+                local_batch.query_start_loc
+            )
+            self.input_buffers.seq_lens[: local_batch.num_reqs].copy_(
+                local_batch.seq_lens
+            )
+            prefill_input_batch = local_batch
+
         # When all requests are decoding (no true prefills), each has
         # num_speculative_steps + 1 tokens, enabling FULL graph replay.
         uniform_token_count = get_uniform_decode_token_count(
-            num_reqs,
+            prefill_input_batch.num_reqs,
             # Use the actual number of tokens without padding added by
             # the target model during FULL cudagraph.
-            num_tokens,
-            max_query_len,
-            input_batch.has_prefill,
+            prefill_input_batch.num_tokens,
+            prefill_input_batch.num_scheduled_tokens.max(),
+            prefill_input_batch.has_prefill,
         )
         prefill_batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.prefill_cudagraph_manager,
-            num_reqs,
-            num_tokens_padded,
+            prefill_input_batch.num_reqs,
+            prefill_input_batch.num_tokens_after_padding,
             uniform_token_count,
             dp_size=self.dp_size,
             dp_rank=self.dp_rank,
             need_eager=is_profile,
         )
 
-        self._prepare_eplb_forward(num_tokens)
+        self._prepare_eplb_forward(prefill_input_batch.num_tokens)
 
         self.on_prefill_begin(num_reqs)
         if prefill_batch_desc.cg_mode == CUDAGraphMode.FULL:
@@ -308,6 +337,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
                 mm_inputs=mm_inputs,
+                global_positions=(
+                    input_batch.positions if self.pcp_manager is not None else None
+                ),
             )
         self.on_prefill_end(num_reqs)
 
@@ -365,6 +397,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        is_padding: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
         with set_forward_context(
@@ -375,6 +408,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             num_tokens_across_dp=num_tokens_across_dp,
             slot_mapping=slot_mappings,
             batch_descriptor=batch_descriptor,
+            is_padding=is_padding,
         ):
             inputs_embeds = None
             if self.supports_mm_inputs:
@@ -425,11 +459,13 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         num_tokens_across_dp: torch.Tensor | None,
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        global_positions: torch.Tensor | None = None,
     ) -> None:
-        last_token_indices = self.last_token_indices[:num_reqs]
-        positions = self.input_buffers.positions[last_token_indices]
-        idx_mapping = self.idx_mapping[:num_reqs]
-
+        is_padding = (
+            self.pcp_manager.local_batch.is_padding[:num_tokens]
+            if self.pcp_manager is not None
+            else None
+        )
         last_hidden_states, hidden_states = self._run_model(
             num_tokens,
             attn_metadata,
@@ -437,13 +473,32 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             num_tokens_across_dp=num_tokens_across_dp,
             cudagraph_runtime_mode=cudagraph_runtime_mode,
             mm_inputs=mm_inputs,
+            is_padding=is_padding,
         )
-        sample_hidden_states = last_hidden_states[last_token_indices]
+        if self.pcp_manager is not None:
+            assert cudagraph_runtime_mode == CUDAGraphMode.NONE
+            local_last_hidden_states = last_hidden_states
+            local_hidden_states = hidden_states
+            last_hidden_states = self.pcp_manager.restore_hidden_states(
+                local_last_hidden_states
+            )
+            hidden_states = (
+                last_hidden_states
+                if local_last_hidden_states is local_hidden_states
+                else self.pcp_manager.restore_hidden_states(local_hidden_states)
+            )
 
+        last_token_indices = self.last_token_indices[:num_reqs]
+        positions = (
+            self.input_buffers.positions
+            if global_positions is None
+            else global_positions
+        )[last_token_indices]
+        sample_hidden_states = last_hidden_states[last_token_indices]
         self.draft_tokens[:num_reqs, 0] = self.sample_draft(
             sample_hidden_states,
             positions,
-            idx_mapping,
+            self.idx_mapping[:num_reqs],
             self.temperature,
             self.seeds,
             self.current_draft_step,
@@ -488,6 +543,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                     num_tokens_padded=batch_desc.num_tokens,
                     seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
                     step=step,
+                    is_prefilling=(
+                        torch.zeros(
+                            batch_desc.num_reqs or num_reqs,
+                            dtype=torch.bool,
+                        )
+                        if self.pcp_manager is not None
+                        else None
+                    ),
                 )
 
             self.current_draft_step.fill_(step)
@@ -536,6 +599,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 num_tokens_padded=batch_desc.num_tokens,
                 seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
                 step=1,
+                is_prefilling=(
+                    torch.zeros(
+                        batch_desc.num_reqs or num_reqs,
+                        dtype=torch.bool,
+                    )
+                    if self.pcp_manager is not None
+                    else None
+                ),
             )
 
         if batch_desc.cg_mode == CUDAGraphMode.FULL:

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -51,6 +51,12 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
     def set_pcp_manager(self, manager: "PCPManager") -> None:
         self.pcp_manager = manager
+        # DualChunkSwap can create two rank-local segments per global request.
+        self.input_buffers = InputBuffers(
+            max_num_reqs=2 * self.max_num_reqs,
+            max_num_tokens=self.max_num_tokens,
+            device=self.device,
+        )
         self.pcp_input_ids = torch.empty_like(self.input_buffers.input_ids)
 
     def load_model(self, target_model: nn.Module) -> None:

--- a/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
@@ -3,7 +3,6 @@
 
 import torch.nn as nn
 
-from vllm.v1.worker.gpu.pcp_manager import PCPManager
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
     AutoRegressiveSpeculator,
 )
@@ -12,10 +11,6 @@ from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
 class MTPSpeculator(AutoRegressiveSpeculator):
     share_mtp_topk_indices: bool = False
-
-    def set_pcp_manager(self, manager: PCPManager) -> None:
-        super().set_pcp_manager(manager)
-        self.share_mtp_topk_indices = False
 
     def load_draft_model(
         self,
@@ -33,7 +28,8 @@ class MTPSpeculator(AutoRegressiveSpeculator):
         # toggles skip_topk so step 0 computes MTP's own indices and
         # steps 1+ reuse them.
         self.share_mtp_topk_indices = (
-            getattr(draft_hf_config, "index_share_for_mtp_iteration", False)
+            self.vllm_config.parallel_config.prefill_context_parallel_size == 1
+            and getattr(draft_hf_config, "index_share_for_mtp_iteration", False)
             and hasattr(draft_model.model, "set_skip_topk")
             and hasattr(draft_model.model, "compact_topk_indices")
         )

--- a/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
@@ -3,6 +3,7 @@
 
 import torch.nn as nn
 
+from vllm.v1.worker.gpu.pcp_manager import PCPManager
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
     AutoRegressiveSpeculator,
 )
@@ -11,6 +12,10 @@ from vllm.v1.worker.gpu.spec_decode.eagle.utils import load_eagle_model
 
 class MTPSpeculator(AutoRegressiveSpeculator):
     share_mtp_topk_indices: bool = False
+
+    def set_pcp_manager(self, manager: PCPManager) -> None:
+        super().set_pcp_manager(manager)
+        self.share_mtp_topk_indices = False
 
     def load_draft_model(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -239,6 +239,7 @@ class DraftModelSpeculator(BaseSpeculator):
         causal: bool | Mapping[int, bool] = True,
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
+        is_prefilling: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
         if query_start_loc_np is not None:
             # Non-uniform query layout (e.g. multi-module MTP's mixed
@@ -294,6 +295,7 @@ class DraftModelSpeculator(BaseSpeculator):
             kv_cache_config=self.kv_cache_config,
             causal=causal,
             seq_lens_cpu_upper_bound=draft_seq_lens_cpu_upper_bound,
+            is_prefilling=is_prefilling,
         )
         return attn_metadata
 

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -406,10 +406,8 @@ def warmup_kernels(
         elif use_spec_decode:
             decode_steps.append(([0], [False]))
 
-        pcp_manager = getattr(model_runner, "pcp_manager", None)
-        if not (pcp_manager is not None and pcp_manager.prefill_only_mtp):
-            for step_indices, step_spec_flags in decode_steps:
-                _run_decode_step(step_indices, step_spec_flags)
+        for step_indices, step_spec_flags in decode_steps:
+            _run_decode_step(step_indices, step_spec_flags)
 
     # Clean up - process finish_req_ids.
     cleanup_output = SchedulerOutput.make_empty()

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -406,8 +406,10 @@ def warmup_kernels(
         elif use_spec_decode:
             decode_steps.append(([0], [False]))
 
-        for step_indices, step_spec_flags in decode_steps:
-            _run_decode_step(step_indices, step_spec_flags)
+        pcp_manager = getattr(model_runner, "pcp_manager", None)
+        if not (pcp_manager is not None and pcp_manager.prefill_only_mtp):
+            for step_indices, step_spec_flags in decode_steps:
+                _run_decode_step(step_indices, step_spec_flags)
 
     # Clean up - process finish_req_ids.
     cleanup_output = SchedulerOutput.make_empty()


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Related RFC: #25749

Add single-module MTP support to the MRV2 PCP path while preserving PCP's long-prefill scaling:

- keep both the target prefill and the first MTP draft pass PCP-sharded
- restore target and draft outputs to global sequence order only at their sampling boundaries
- run later MTP proposal steps as replicated decode queries
- support pure prefill, replicated decode, mixed prefill/decode, and scheduled draft-token verification batches
- preserve GPU-materialized token positions after speculative rejection instead of rebuilding them from a potentially stale CPU cursor
- reuse the PCP manager's consumed rank-local input buffer and target hidden states for draft prefill, avoiding a doubled request buffer, metadata copies, and a redundant hidden-state all-gather
- scope rank-local state to the exact global batch so dummy/profile and stale batches use the ordinary global draft path
- distinguish PCP-expanded target slot mappings from ordinary replicated-draft mappings in sparse MLA
- disable MTP top-k index sharing under PCP and wait for proposal cache writes before a KV producer publishes the result
- account for PCP ranks in multi-node world-size and per-DP-rank placement
- reject unsupported multi-module MTP and CUDA-graph configurations during startup

This relies only on the PCP implementation already present on vLLM main and is independent of the fused PCP norm/RoPE work.

### Relationship to #53427

This is a materially different execution design from #53427. That PR keeps the target PCP-sharded but runs a fully replicated drafter on every PCP rank and currently excludes sparse MLA. This change shards the prompt-sized MTP draft pass across PCP ranks, supports the GLM-5.2 sparse-MLA path, and avoids repeating long-prefill draft compute and cache writes on every rank. It adopts the same GPU-cursor correctness principle for rank-local positions, but not the replicated-drafter architecture.

### Scope

- single-module MTP only; multi-module MTP and other speculative methods remain unsupported with PCP
- CUDA graphs must be disabled for PCP+MTP
- no model-routing change or new kernel

## Test Plan

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest -vv \
  tests/v1/worker/test_gpu_autoregressive_speculator.py \
  tests/v1/worker/test_gpu_pcp_manager.py
git diff --check
```

Before marking the PR ready, rerun an exact distributed PCP4/MTP3 GLM-5.2 model configuration on the rebased head.

## Test Result

- clean merge-tree against vLLM main at `7ca336929c169fee1210dd5293029d78811fba27`
- focused post-simplification tests: **24 passed, 2 CUDA-only tests skipped**
- commit-time checks passed, including Ruff, mypy, forbidden-import checks, configuration validation, SPDX, and sign-off
- Python syntax compilation and `git diff --check` passed
- pre-rebase CUDA validation: **21 focused tests passed**
- pre-rebase GLM-5.2 E2E validation used TP1/PCP8/EP8 with modular MTP5 on 8x B300, FP8 KV cache, an 8K batched-token limit, and a 4K long-prefill threshold:
  - restored decode and mixed spec/non-spec warmups completed
  - a 3,073-token prompt generated 32/32 requested tokens in the pure-decode probe
  - a sustained stream generated 128/128 requested tokens while two concurrent 3,073-token prefills each generated 8/8 requested tokens
  - the scheduler recorded a real mixed PCP batch with two fresh prefills and one decode; both node logs had zero errors
  - MTP metrics recorded 219 accepted draft tokens during the probe

The exact rebased and simplified head has not yet been rerun in a distributed PCP4/MTP3 model configuration, which is why this PR is being opened as a draft.

## AI assistance

Codex assisted with the rebase audit, design comparison, simplification, regression tests, and PR description. The submitter reviewed the resulting changes and validation evidence.
