### PR TITLE
[Bugfix] Don't route TOWER/CONNECTOR LoRA mappings to the language wrapper

### DIFF
--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -383,6 +383,14 @@ class LoRAModelManager:
             target_prefix = self.mm_mapping.tower_model[0]
         elif mapping.type == LoRAMappingType.CONNECTOR and self.mm_mapping.connector:
             target_prefix = self.mm_mapping.connector[0]
+        elif mapping.type in (LoRAMappingType.TOWER, LoRAMappingType.CONNECTOR):
+            # A TOWER/CONNECTOR mapping for a model that has no such modules
+            # must not fall through to the language wrapper: these mappings are
+            # sized to the encoder token count, so routing one here overwrites
+            # the decode-step metadata and the next language-model forward
+            # reads it against a much smaller batch -- an illegal memory
+            # access inside the LoRA kernels.
+            return
         else:
             target_prefix = self.mm_mapping.language_model[0]
 


### PR DESCRIPTION
## Summary

With `enable_tower_connector_lora` on, `_set_adapter_mapping` routes a TOWER or CONNECTOR `LoRAMapping` to the language-model punica wrapper whenever the model's `get_mm_mapping()` has no matching module prefixes — the dispatch falls through to the final `else`. Since `_execute_mm_encoder` emits a CONNECTOR mapping whenever `get_num_mm_connector_tokens` is present (and the `SupportsMultiModal` protocol supplies a default), a model with a tower but **no connector** gets an encoder-token-sized CONNECTOR mapping written over the language wrapper's decode-step metadata every step.

The next language-model forward then runs a small decode batch against metadata sized for thousands of encoder tokens, and crashes with an illegal memory access inside the LoRA triton kernels:

```
File ".../vllm/lora/ops/triton_ops/lora_shrink_op.py", line 225, in _lora_shrink
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

## Repro shape

Encoder-decoder ASR model (Whisper-style: audio encoder tower + text decoder, no connector) wired into tower LoRA via `get_mm_mapping()` returning `language_model="model.decoder."`, `tower_model="model.encoder."`. Mixed per-request adapters, greedy decode:

- decode crashes identically at batch 2 and batch 32 (not a sizing issue)
- a metadata trace shows the sequence directly:

```
update wrapper=LM    type=LANGUAGE   tokens=8      <- correct decode mapping
update wrapper=TOWER type=TOWER      tokens=3000   <- correct encoder mapping
update wrapper=LM    type=CONNECTOR  tokens=3000   <- clobbers the LM wrapper
```

## Fix

Drop a TOWER/CONNECTOR mapping whose type has no matching module prefixes instead of letting it fall through to the language wrapper. With this guard the crash is gone and per-request tower adapters produce correct outputs on the same workload (32/32 requests routed to their own adapter).

## Notes

- The alternative of suppressing the CONNECTOR emission in `_execute_mm_encoder` would also work, but the dispatch-side guard protects every current and future caller.
- A related follow-up (not in this PR): `_execute_mm_encoder`'s `hasattr(self.model, "get_num_mm_connector_tokens")` check is always true through the protocol default, so the connector block runs — and crashes on the default's `None` return — for models without a connector.
