### PR TITLE
[Bugfix] Handle parenthesized Gemma4 tool calls

### DIFF
--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -285,7 +285,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
 def _gemma4_arg_converter(raw_args: str, partial: bool) -> str:
     """Convert Gemma4 custom arg format to a JSON string."""
     text = raw_args.strip()
-    if text.endswith("}"):
+    if text.endswith("}") or text.endswith(")") and text.count("(") < text.count(")"):
         text = text[:-1]
 
     parsed = _parse_gemma4_args(text, partial=partial)
@@ -304,6 +304,7 @@ def gemma4_config() -> ParserEngineConfig:
             "TOOL_END": TOOL_CALL_END,
             "CALL_PREFIX": "call:",
             "OPEN_BRACE": "{",
+            "OPEN_PAREN": "(",
         },
         token_id_terminals={
             "THINK_START": CHANNEL_START,
@@ -350,6 +351,14 @@ def gemma4_config() -> ParserEngineConfig:
             (ParserState.TOOL_NAME, "OPEN_BRACE"): Transition(
                 ParserState.TOOL_ARGS,
                 (),
+            ),
+            (ParserState.TOOL_NAME, "OPEN_PAREN"): Transition(
+                ParserState.TOOL_ARGS,
+                (),
+            ),
+            (ParserState.TOOL_NAME, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
             ),
             (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
                 ParserState.CONTENT,


### PR DESCRIPTION
## Purpose

Fixes #53642. Gemma4 may emit tool calls as `call:name(...)`, but the parser only accepted `{...}`. It remained in `TOOL_NAME`, corrupting the name and absorbing later calls. This adds parenthesis handling and a safe tool-end transition.

## Reproducer

```python
output = '<|tool_call>call:terminal(command:<|"|>ls -a<|"|>)<tool_call|>'
result = parser.extract_tool_calls(output, request)
```

### Output on Main 

```text
[('terminal(command:<|"|>ls -a<|"|>)<tool_call|>', {})]
```

### Output on Branch

```text
[('terminal', {'command': 'ls -a'})]
```

## Test Plan and Results

```bash
.venv/bin/python -m pytest \
  tests/tool_parsers/test_gemma4_tool_parser.py \
  tests/parser/engine/test_gemma4_streaming_reasoning.py -q
```

```text
111 passed
```

## AI assistance

OpenAI Codex (GPT-5) assisted with root-cause analysis, and implementation.