### PR TITLE
[Frontend] Move cli_args.py and dp_supervisor.py out openai folder

### DIFF
--- a/docs/mkdocs/gen_files/generate_argparse.py
+++ b/docs/mkdocs/gen_files/generate_argparse.py
@@ -179,7 +179,7 @@ LaunchSubcommandBase = auto_mock("vllm.entrypoints.cli.launch", "LaunchSubcomman
 launch_description = auto_mock("vllm.entrypoints.cli.launch", "DESCRIPTION")
 RenderSubcommand = auto_mock("vllm.entrypoints.cli.launch", "RenderSubcommand")
 sweep_subcommands = auto_mock("vllm.benchmarks.sweep.cli", "SUBCOMMANDS")
-openai_cli_args = auto_mock("vllm.entrypoints.openai", "cli_args")
+openai_cli_args = auto_mock("vllm.entrypoints.launchers", "cli_args")
 run_batch = auto_mock("vllm.entrypoints.launchers", "run_batch")
 
 if TYPE_CHECKING:

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -869,7 +869,7 @@ class TestDpDeviceIdSharding:
         against its inherited device-control env var."""
         import argparse
 
-        from vllm.entrypoints.openai.dp_supervisor import _build_device_ids
+        from vllm.entrypoints.launchers.dp_supervisor import _build_device_ids
 
         args = argparse.Namespace(
             tensor_parallel_size=2, pipeline_parallel_size=1, device_ids=None
@@ -881,7 +881,7 @@ class TestDpDeviceIdSharding:
         """User-provided --device-ids are sharded across DP children."""
         import argparse
 
-        from vllm.entrypoints.openai.dp_supervisor import _build_device_ids
+        from vllm.entrypoints.launchers.dp_supervisor import _build_device_ids
 
         args = argparse.Namespace(
             tensor_parallel_size=2, pipeline_parallel_size=1, device_ids=[4, 5, 6, 7]

--- a/tests/entrypoints/cohere/test_registry_and_args.py
+++ b/tests/entrypoints/cohere/test_registry_and_args.py
@@ -18,7 +18,7 @@ import typing
 import pytest
 
 from vllm.config.model import TokenizerMode
-from vllm.entrypoints.openai.cli_args import BaseFrontendArgs, make_arg_parser
+from vllm.entrypoints.launchers.cli_args import BaseFrontendArgs, make_arg_parser
 from vllm.renderers.registry import RENDERER_REGISTRY
 from vllm.tokenizers.registry import TokenizerRegistry
 from vllm.utils.argparse_utils import FlexibleArgumentParser

--- a/tests/entrypoints/launchers/test_cli_args.py
+++ b/tests/entrypoints/launchers/test_cli_args.py
@@ -5,11 +5,13 @@ import json
 
 import pytest
 
-from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
+from tests.utils import VLLM_PATH
+from vllm.entrypoints.launchers.cli_args import (
+    make_arg_parser,
+    validate_parsed_serve_args,
+)
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
 from vllm.utils.argparse_utils import FlexibleArgumentParser
-
-from ...utils import VLLM_PATH
 
 LORA_MODULE = {
     "name": "module2",

--- a/tests/entrypoints/launchers/test_dp_supervisor.py
+++ b/tests/entrypoints/launchers/test_dp_supervisor.py
@@ -32,8 +32,8 @@ import pytest
 import uvicorn
 from fastapi import FastAPI, Response
 
-import vllm.entrypoints.openai.dp_supervisor as dp_sup
-from vllm.entrypoints.openai.dp_supervisor import (
+import vllm.entrypoints.launchers.dp_supervisor as dp_sup
+from vllm.entrypoints.launchers.dp_supervisor import (
     CHILD_EXIT_GRACE_S,
     DPSupervisor,
     _build_vllm_dp_server_args,

--- a/tests/plugins_tests/test_endpoint_plugins.py
+++ b/tests/plugins_tests/test_endpoint_plugins.py
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from vllm_add_dummy_endpoint_plugin import DummyAdminEndpointPlugin
 
 from vllm.entrypoints.launchers.app import build_app
-from vllm.entrypoints.openai.cli_args import make_arg_parser
+from vllm.entrypoints.launchers.cli_args import make_arg_parser
 from vllm.plugins import load_endpoint_plugins
 from vllm.plugins.endpoint_plugins.interface import (
     EndpointPlugin,

--- a/vllm/entrypoints/cli/launch.py
+++ b/vllm/entrypoints/cli/launch.py
@@ -7,11 +7,11 @@ import inspect
 import uvloop
 
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.launchers.render.entry import run_launch_fastapi
-from vllm.entrypoints.openai.cli_args import (
+from vllm.entrypoints.launchers.cli_args import (
     make_arg_parser,
     validate_parsed_serve_args,
 )
+from vllm.entrypoints.launchers.render.entry import run_launch_fastapi
 from vllm.entrypoints.serve.utils.api_utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -11,8 +11,11 @@ import vllm
 import vllm.envs as envs
 from vllm.entrypoints.cli.types import CLISubcommand
 from vllm.entrypoints.launchers.api_server.entry import run_server, setup_server
-from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
-from vllm.entrypoints.openai.dp_supervisor import run_dp_supervisor
+from vllm.entrypoints.launchers.cli_args import (
+    make_arg_parser,
+    validate_parsed_serve_args,
+)
+from vllm.entrypoints.launchers.dp_supervisor import run_dp_supervisor
 from vllm.entrypoints.serve.utils.api_utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext

--- a/vllm/entrypoints/launchers/api_server/entry.py
+++ b/vllm/entrypoints/launchers/api_server/entry.py
@@ -204,12 +204,13 @@ async def run_server_worker(
 def main():
     import uvloop
 
-    from vllm.entrypoints.openai.cli_args import (
+    from vllm.entrypoints.serve.utils.api_utils import cli_env_setup
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    from ..cli_args import (
         make_arg_parser,
         validate_parsed_serve_args,
     )
-    from vllm.entrypoints.serve.utils.api_utils import cli_env_setup
-    from vllm.utils.argparse_utils import FlexibleArgumentParser
 
     # NOTE(simon):
     # This section should be in sync with vllm/entrypoints/cli/main.py for CLI

--- a/vllm/entrypoints/launchers/cli_args.py
+++ b/vllm/entrypoints/launchers/cli_args.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-This file contains the command line arguments for the vLLM's
-OpenAI-compatible server. It is kept in a separate file for documentation
-purposes.
+This file contains the command line arguments for the vLLM's online server.
+It is kept in a separate file for documentation purposes.
 """
 
 import argparse
@@ -20,13 +19,14 @@ from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
     validate_chat_template,
 )
-from vllm.entrypoints.launchers.utils.constants import (
-    H11_MAX_HEADER_COUNT_DEFAULT,
-    H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT,
-)
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
 from vllm.tool_parsers import ToolParserManager
 from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+from .utils.constants import (
+    H11_MAX_HEADER_COUNT_DEFAULT,
+    H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT,
+)
 
 
 class LoRAParserAction(argparse.Action):
@@ -449,7 +449,7 @@ def validate_parsed_serve_args(args: argparse.Namespace):
         )
 
     if args.data_parallel_multi_port_external_lb:
-        from vllm.entrypoints.openai.dp_supervisor import (
+        from vllm.entrypoints.launchers.dp_supervisor import (
             validate_multi_port_external_lb_args,
         )
 

--- a/vllm/entrypoints/launchers/dp_supervisor.py
+++ b/vllm/entrypoints/launchers/dp_supervisor.py
@@ -23,8 +23,6 @@ import uvloop
 from fastapi import FastAPI, Response
 
 import vllm.envs as envs
-from vllm.entrypoints.launchers.launcher import NoSignalServer
-from vllm.entrypoints.launchers.utils.server_utils import get_uvicorn_log_config
 from vllm.logger import init_logger
 from vllm.utils.system_utils import (
     decorate_logs,
@@ -32,6 +30,9 @@ from vllm.utils.system_utils import (
     set_process_title,
 )
 from vllm.v1.engine.utils import get_engine_process_shutdown_timeout
+
+from .launcher import NoSignalServer
+from .utils.server_utils import get_uvicorn_log_config
 
 logger = init_logger(__name__)
 

--- a/vllm/entrypoints/launchers/render/entry.py
+++ b/vllm/entrypoints/launchers/render/entry.py
@@ -101,12 +101,13 @@ async def run_launch_fastapi(args: argparse.Namespace) -> None:
 if __name__ == "__main__":
     import uvloop
 
-    from vllm.entrypoints.openai.cli_args import (
+    from vllm.entrypoints.serve.utils.api_utils import cli_env_setup
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    from ..cli_args import (
         make_arg_parser,
         validate_parsed_serve_args,
     )
-    from vllm.entrypoints.serve.utils.api_utils import cli_env_setup
-    from vllm.utils.argparse_utils import FlexibleArgumentParser
 
     cli_env_setup()
     parser = FlexibleArgumentParser(

--- a/vllm/entrypoints/launchers/run_batch.py
+++ b/vllm/entrypoints/launchers/run_batch.py
@@ -31,12 +31,10 @@ from vllm.config import config
 from vllm.connections import HTTPResponseSizeExceededError, global_http_connection
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.launchers.api_server.entry import init_app_state
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
-from vllm.entrypoints.openai.cli_args import BaseFrontendArgs
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorInfo,
     ErrorResponse,
@@ -70,6 +68,9 @@ from vllm.utils import random_uuid
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.mem_constants import MiB_bytes
 from vllm.version import __version__ as VLLM_VERSION
+
+from .api_server.entry import init_app_state
+from .cli_args import BaseFrontendArgs
 
 logger = init_logger(__name__)
 

--- a/vllm/entrypoints/serve/utils/api_utils.py
+++ b/vllm/entrypoints/serve/utils/api_utils.py
@@ -206,7 +206,7 @@ def get_max_tokens(
 
 
 def get_non_default_args(args: Namespace | EngineArgs) -> dict[str, Any]:
-    from vllm.entrypoints.openai.cli_args import make_arg_parser
+    from vllm.entrypoints.launchers.cli_args import make_arg_parser
 
     non_default_args = {}
 


### PR DESCRIPTION



## Purpose

Following #41907 #52131 #53500

> In the early days of vLLM (2023), there was only the OpenAI, so vLLM online serving was referred to as the OpenAI-Compatible Server. As we have entered 2026, generative AI has grown significantly, and more and more features have been added to vLLM online serving. 

We'd better move cli_args.py and dp_supervisor.py out openai folder

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

