### PR TITLE
[Spec Decode] Let the speculator build its own draft prefill attention metadata

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -78,6 +78,45 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         """
         return True
 
+    def prepare_attn(
+        self,
+        input_batch: InputBatch,
+        batch_desc: BatchExecutionDescriptor,
+    ) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor]]:
+        """Build attention metadata and slot mappings for the draft prefill pass.
+
+        The draft prefill keeps the target batch's padded query layout, so the
+        metadata is built from the input batch through the drafter's own
+        attention groups rather than reusing the target model's metadata.
+        """
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = batch_desc.num_reqs or num_reqs
+        self.block_tables.gather_block_tables(
+            input_batch.idx_mapping,
+            num_reqs_padded=num_reqs_padded,
+        )
+        # Slot mappings must use input_batch.positions: the drafter's own
+        # positions buffer is stale at rejected token slots, which would
+        # produce KV writes into live cache slots.
+        slot_mappings_tensor = self.block_tables.compute_slot_mappings(
+            input_batch.idx_mapping,
+            input_batch.query_start_loc,
+            input_batch.positions,
+            batch_desc.num_tokens,
+        )
+        slot_mappings = build_slot_mappings_by_layer(
+            slot_mappings_tensor, self.kv_cache_config
+        )
+        attn_metadata = self._build_draft_attn_metadata(
+            num_reqs=num_reqs,
+            num_reqs_padded=num_reqs_padded,
+            num_tokens_padded=batch_desc.num_tokens,
+            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+            step=0,
+            query_start_loc_np=input_batch.query_start_loc_np,
+        )
+        return attn_metadata, slot_mappings
+
     def set_attn(
         self,
         model_state: ModelState,
@@ -156,20 +195,26 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # For FULL graphs, the entire routine is recorded as one graph.
         # For PIECEWISE, only the model's compiled regions are captured
         # and the rest (compute_logits, gumbel_sample) runs eagerly.
-        # Draft prefill reuses the target model's attention metadata at
-        # runtime, so capture builds its dummy metadata through the target
-        # model runner's builders and buffers.
+        # Capture must build its dummy metadata through the same builders and
+        # buffers the runtime metadata comes from: the target model runner's
+        # when reusing the target's metadata, the drafter's own otherwise.
         assert self.prefill_cudagraph_manager is not None
         if self.prefill_cudagraph_manager.use_breakable_cg:
             self.prefill_cudagraph_manager.init_breakable_cg_runner(self.model)
 
+        if self.reuse_target_attn_metadata:
+            prefill_input_buffers = self.target_input_buffers
+            prefill_attn_groups = self.target_attn_groups
+        else:
+            prefill_input_buffers = self.input_buffers
+            prefill_attn_groups = self.attn_groups
         self.on_prefill_begin(self.max_num_reqs)
         self.prefill_cudagraph_manager.capture(
             self._prefill,
             self.model_state,
-            self.target_input_buffers,
+            prefill_input_buffers,
             self.block_tables,
-            self.target_attn_groups,
+            prefill_attn_groups,
             self.kv_cache_config,
             progress_bar_desc="Capturing prefill CUDA graphs",
         )
@@ -237,9 +282,12 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         # NOTE(woosuk): To avoid CPU-GPU synchronization without CPU knowing the
         # number of rejected tokens, we maintain the size of input_ids and
         # hidden_states the same as the target model's. This means, we pad each
-        # request's query length to include any rejected positions. By doing so,
-        # we can also reuse the attention metadata (e.g., query_start_loc,
-        # seq_lens) of the target model.
+        # request's query length to include any rejected positions. By doing
+        # so, we can also reuse the attention metadata (e.g., query_start_loc,
+        # seq_lens) of the target model — unless the target batch was
+        # transformed (reuse_target_attn_metadata is False), in which case
+        # prepare_attn rebuilds it over the same padded layout through the
+        # drafter's own attention groups.
         if aux_hidden_states:
             assert self.method == "eagle3"
             hidden_states = self.model.combine_hidden_states(
@@ -289,6 +337,19 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             need_eager=is_profile,
         )
 
+        # When the drafter cannot reuse the target's metadata, build it here —
+        # even for FULL replay, since builder.build() refreshes the persistent
+        # state the captured graph reads, mirroring the decode steps.
+        prefill_attn_metadata: dict[str, Any] | None = attn_metadata
+        prefill_slot_mappings: dict[str, torch.Tensor] | None = slot_mappings
+        if not self.reuse_target_attn_metadata:
+            if dummy_run and skip_attn_for_dummy_run:
+                prefill_attn_metadata, prefill_slot_mappings = None, None
+            else:
+                prefill_attn_metadata, prefill_slot_mappings = self.prepare_attn(
+                    input_batch, prefill_batch_desc
+                )
+
         self._prepare_eplb_forward(num_tokens)
 
         self.on_prefill_begin(num_reqs)
@@ -297,14 +358,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             assert self.prefill_cudagraph_manager is not None
             self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
         else:
-            # The target model's attention metadata and slot mappings
-            # can directly be used for draft prefill, because of the
-            # identical batch shape and KV cache layout.
             self._prefill(
                 num_reqs,
                 prefill_batch_desc.num_tokens,
-                attn_metadata,
-                slot_mappings,
+                prefill_attn_metadata,
+                prefill_slot_mappings,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
                 mm_inputs=mm_inputs,

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -74,6 +74,15 @@ class DraftModelSpeculator(BaseSpeculator):
         self.vllm_config = vllm_config
         self.device = device
 
+        # Reuse the target model's attention metadata and slot mappings for
+        # the draft prefill pass (identical padded batch layout and KV cache
+        # slots, so rebuilding them is redundant work). Features that
+        # transform the target batch between the target forward and the
+        # drafter (e.g. a PCP-sharded target with a replicated drafter) must
+        # clear this so the drafter builds its own metadata from the input
+        # batch; cudagraph capture follows the same choice of builders.
+        self.reuse_target_attn_metadata = True
+
         assert vllm_config.speculative_config is not None
         self.speculative_config = vllm_config.speculative_config
         self.method = self.speculative_config.method


### PR DESCRIPTION
> **Stack:** 1. #53660 (this PR) -> 2. #53661 (PCP+MTP, based on this branch)

## Purpose

The autoregressive speculator's prefill pass reuses the target model's attention metadata dict and slot mappings. That reuse is valid because of the identical padded batch layout and KV-cache slots, and it is paired with a capture-time coupling: draft prefill CUDA-graph capture builds its dummy metadata through the *target runner's* builders and buffers so capture and runtime stay consistent.

This cross-model contract breaks whenever a feature transforms the target batch between the target forward and the drafter. The immediate motivator is prefill context parallelism (#53427): under PCP the target batch is rank-sharded while the replicated drafter must see the global batch, so the target's metadata describes the wrong layout.

This PR adds the capability for the drafter to build its own prefill metadata, gated so the default path is unchanged:

- `AutoRegressiveSpeculator.prepare_attn()` builds the draft prefill attention metadata and slot mappings from the input batch through the drafter's own attention groups, mirroring how the decode steps already build theirs (naming mirrors the model runner's / `PCPManager`'s `prepare_attn`). It runs before FULL-graph replay as well, since `builder.build()` refreshes the persistent state the captured graph reads.
- A new `reuse_target_attn_metadata` flag (default `True`) selects between reusing the target's metadata (existing behavior, zero added work) and building via `prepare_attn()`. Batch-transforming features clear the flag; #53661 does so for the replicated-PCP drafter.
- Prefill CUDA-graph capture follows the same flag, so capture and runtime always build through the same builders and buffers in either mode.
- In `prepare_attn()`, slot mappings are computed from `input_batch.positions` rather than the drafter's positions buffer: `prepare_prefill_inputs` only copies accepted tokens, so the drafter's buffer is stale at rejected slots, which would emit KV writes into live cache slots.

With the flag at its default, this PR is behavior- and cost-neutral: no extra kernels, no extra metadata builds.

## Why this is not duplicating existing work

#53427 adds equivalent metadata construction wired through the PCP manager, two model-runner call sites, and a widened `_build_draft_attn_metadata` signature. This PR was written from scratch as the outcome of maintainer review of #53427: it places the same construction where it architecturally belongs (the speculator), behind an explicit gate, so #53427's PCP support reduces to a small config/partitioning diff (see #53661, which credits the original author).

## Test Plan

- `pytest tests/v1/worker/test_gpu_autoregressive_speculator.py tests/v1/spec_decode/test_eagle_draft_attn_metadata.py tests/v1/worker/test_gpu_extract_hidden_states_speculator.py`
- `pre-commit run` (ruff, mypy) on changed files
- Default (reuse) path: unchanged from main; covered by existing spec-decode suites
- `prepare_attn()` path: exercised under PCP in #53661's GPU validation (GLM-4.7-Flash, MTP K=3, PCP4 — see that PR's results)

## Test Result

- Unit tests: 26 passed across the four suites above; lint/mypy: pass
- Reuse path (default, B300, greedy, 8 prompts x 64 tokens): Qwen3-8B + `RedHatAI/Qwen3-8B-speculator.eagle3` reproduces the pre-change run byte-for-byte (acceptance 0.3537, 738 drafted, identical outputs); GLM-4.7-Flash + MTP K=3 (MLA) acceptance 0.353 — statistically identical to the build-path run (0.350)
- `prepare_attn()` path: validated under PCP in #53661, including a GSM8K accuracy/acceptance comparison vs TP4 (see that PR's results)

---

AI assistance: this PR was implemented with Claude Code under my direction and review; I reviewed every changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

