### PR TITLE
[Bugfix] Avoid TCPStore port collision for co-located non-DP Ray engines

### DIFF
--- a/tests/distributed/test_ray_v2_executor.py
+++ b/tests/distributed/test_ray_v2_executor.py
@@ -128,6 +128,32 @@ def test_select_tcpstore_port_non_dp_uses_random(monkeypatch):
     assert RayExecutorV2._select_tcpstore_port(None, master_port=29500) == 54321
 
 
+def test_colocated_tcpstore_ports_differ():
+    """Two or more replicas on one host can collide on the same TCPStore port.
+    Their ports must differ and never be a low system port.
+    """
+    ports = []
+    real_select = RayExecutorV2._select_tcpstore_port
+
+    def record(local_dp_rank, master_port):
+        port = real_select(local_dp_rank, master_port)
+        ports.append(port)
+        return port
+
+    with patch.object(RayExecutorV2, "_select_tcpstore_port", staticmethod(record)):
+        first = RayExecutorV2(vllm_config=create_vllm_config())
+        try:
+            second = RayExecutorV2(vllm_config=create_vllm_config())
+            try:
+                assert len(ports) == 2
+                assert min(ports) >= 1024
+                assert ports[0] != ports[1]
+            finally:
+                second.shutdown()
+        finally:
+            first.shutdown()
+
+
 def test_select_tcpstore_port_full_window_uses_random(monkeypatch):
     """A fully occupied window falls back to a random port."""
 

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -329,9 +329,13 @@ class RayExecutorV2(MultiprocExecutor):
         # must be able to reach this address.
         dist_ip = bundle_assignments[0]["node_ip"]
         parallel_config = self.vllm_config.parallel_config
+        local_dp_rank = (
+            parallel_config.data_parallel_rank_local
+            if parallel_config.data_parallel_size > 1
+            else None
+        )
         port = self._select_tcpstore_port(
-            parallel_config.data_parallel_rank_local,
-            parallel_config.data_parallel_master_port,
+            local_dp_rank, parallel_config.data_parallel_master_port
         )
         distributed_init_method = get_distributed_init_method(dist_ip, port)
 


### PR DESCRIPTION
## Purpose
`_select_tcpstore_port` treats `local_dp_rank is None` as "no DP", but a non-DP config sets it to 0.

https://github.com/vllm-project/vllm/blob/342b8ebd8b/vllm/v1/executor/ray_executor_v2.py#L272
https://github.com/vllm-project/vllm/blob/342b8ebd8b/vllm/config/parallel.py#L920.

Every co-located engine then picks port 100; two replicas on one host race and one dies with `EADDRINUSE`. This PR fixs this by passing `None` when there's no DP group.

Ray Serve LLM tests do run 2 replicas × TP=2 per node, but Serve restarts the crashed replica, which then finds 100 taken and uses 101, and therefore the app goes healthy and the test passes.

## Test Plan
Two TP=2 servers started together on one host (4 GPUs):

```
vllm serve Qwen/Qwen3-0.6B --tensor-parallel-size 2 --distributed-executor-backend ray \
    --enforce-eager --max-model-len 2048 --gpu-memory-utilization 0.20 \
    --load-format dummy --port 8500 &

vllm serve Qwen/Qwen3-0.6B --tensor-parallel-size 2 --distributed-executor-backend ray \
    --enforce-eager --max-model-len 2048 --gpu-memory-utilization 0.20 \
    --load-format dummy --port 8501 &
```

Also added unit tests: `pytest tests/distributed/test_ray_v2_executor.py`.

## Test Result

- Before: Both logged `tcp://<ip>:100`; second died with `EADDRINUSE`.
- After: Ports 50851 and 47047, both served.

## AI Assistance
This PR is written with Claude Code assistance, and I've reviewed every line.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

