### PR TITLE
[Bugfix][Model Runner] Bound dummy seq_lens by max_model_len

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_mode.py
+++ b/tests/v1/cudagraph/test_cudagraph_mode.py
@@ -6,7 +6,7 @@ import pytest
 
 from tests.utils import create_new_process_for_each_test
 from tests.v1.attention.utils import full_cg_backend_configs as backend_configs
-from vllm import LLM
+from vllm import LLM, TokensPrompt
 from vllm.config import CompilationConfig, CompilationMode
 from vllm.platforms import current_platform
 
@@ -64,6 +64,32 @@ def test_backend_and_cudagraph_mode_combo(backend_name, cudagraph_mode, supporte
             ),
         )
         llm.generate(["Hello, my name is"] * 10)
+
+
+@create_new_process_for_each_test("spawn")
+def test_full_cudagraph_capture_size_exceeds_max_model_len(monkeypatch):
+    """Dummy sequence lengths must fit within their block-table rows."""
+    monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "0")
+    max_model_len = 1024
+    capture_size = max_model_len + 8
+
+    llm = LLM(
+        model="Qwen/Qwen2-1.5B-Instruct",
+        max_num_seqs=256,
+        trust_remote_code=True,
+        gpu_memory_utilization=0.45,
+        load_format="dummy",
+        max_model_len=max_model_len,
+        max_num_batched_tokens=capture_size,
+        skip_tokenizer_init=True,
+        attention_config={"backend": "FLEX_ATTENTION"},
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.NONE,
+            cudagraph_mode="FULL",
+            cudagraph_capture_sizes=[capture_size],
+        ),
+    )
+    llm.generate([TokensPrompt(prompt_token_ids=[1])])
 
 
 # test cudagraph_mode with different compilation mode.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6134,6 +6134,12 @@ class GPUModelRunner(
                     seq_lens = max_query_len + dcp_dummy_context_len  # type: ignore[assignment]
                 else:
                     seq_lens = max_query_len  # type: ignore[assignment]
+                # Dummy requests cannot address KV blocks beyond their block
+                # table rows, which are sized for max_model_len.
+                if isinstance(seq_lens, torch.Tensor):
+                    seq_lens.clamp_max_(self.max_model_len)
+                else:
+                    seq_lens = min(seq_lens, self.max_model_len)
                 self.optimistic_seq_lens_cpu[:num_reqs] = seq_lens
                 self.optimistic_seq_lens_cpu[num_reqs:].fill_(0)
                 self.seq_lens.copy_(self.optimistic_seq_lens_cpu, non_blocking=True)


### PR DESCRIPTION
## Purpose

Fixes #53658.

V1 `GPUModelRunner._dummy_run` could assign every dummy request a sequence
length equal to the total CUDA graph capture size. When that capture size was
larger than `max_model_len`, a dummy request claimed more KV pages than its
block-table row could address. This could cause an out-of-bounds block-table
read in TRITON_ATTN or a page-mask shape mismatch in FLEX_ATTENTION.

This change:

- clamps scalar and tensor dummy sequence lengths to `max_model_len`;
- preserves the legal total capture size, which may exceed `max_model_len`
  because it represents multiple batched requests;
- adds a V1 FULL-cudagraph FLEX_ATTENTION regression test whose capture size
  exceeds the model length.

I checked open PRs by issue number and relevant keywords immediately before
publishing. I found no duplicate PR and no existing PR from this branch.

## Test Plan

1. Reproduce the unpatched block-table boundary with the standalone unified
   attention reproducer at 4096, 4097, and 4128 tokens for
   `max_model_len=4096`.
2. Run the new engine-level regression on an RTX 3090 with the V1 runner,
   FLEX_ATTENTION, FULL cudagraph mode, `max_model_len=1024`, and capture size
   1032.
3. Run the adjacent cudagraph dispatch and manager tests.
4. Run the relevant Ruff, formatting, and mypy pre-commit hooks, plus
   `git diff --check`.

## Test Result

- Unpatched baseline:
  - 4096 tokens: clean (`RC=0`)
  - 4097 tokens: `CUDA error: an illegal memory access was encountered`
    (`RC=1`)
  - 4128 tokens: `CUDA error: an illegal memory access was encountered`
    (`RC=1`)
- `CUDA_VISIBLE_DEVICES=5 .venv/bin/python -m pytest -q -s tests/v1/cudagraph/test_cudagraph_mode.py::test_full_cudagraph_capture_size_exceeds_max_model_len`
  - `1 passed, 14 warnings in 32.26s`
- `.venv/bin/python -m pytest -q tests/v1/cudagraph/test_cudagraph_dispatch.py tests/v1/cudagraph/test_cudagraph_manager.py`
  - `16 passed, 14 warnings in 35.37s`
- `pre-commit run ruff-check --files tests/v1/cudagraph/test_cudagraph_mode.py vllm/v1/worker/gpu_model_runner.py`
  - Passed
- `pre-commit run ruff-format --files tests/v1/cudagraph/test_cudagraph_mode.py vllm/v1/worker/gpu_model_runner.py`
  - Passed
- `pre-commit run mypy-3.12 --hook-stage manual --files tests/v1/cudagraph/test_cudagraph_mode.py vllm/v1/worker/gpu_model_runner.py`
  - Passed
- `git diff --check`
  - Passed

The umbrella changed-files pre-commit command did not complete because the
unrelated `actionlint` hook initialization hit `SSL: UNEXPECTED_EOF_WHILE_READING`;
a retry later hung and was stopped. The relevant Ruff, format, and mypy hooks
listed above completed successfully.

No model evaluation was run because this change only constrains invalid dummy
capture metadata and does not alter real-request model outputs.

AI assistance was used for issue analysis, implementation, and test execution.
I reviewed every changed line and verified the behavior and test results.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
