### PR TITLE
[Perf][DSv4] Use native CUDA SwiGLU clamp kernel for Humming MoE (throughput +1.40%)

### DIFF
--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.activation import (
     SwigluStepAndMul,
     swiglustep_and_mul_triton,
 )
+from vllm.model_executor.layers.fused_moe.utils import swiglu_limit_func
 from vllm.utils.torch_utils import set_random_seed
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -119,6 +120,20 @@ def test_act_and_mul(
 
 
 SWIGLU_LIMITS = [3.0, 7.0, 15.0]
+
+
+@torch.inference_mode()
+def test_swiglu_limit_func_without_routing_uses_output_buffer() -> None:
+    x = torch.randn(7, 1024, dtype=torch.bfloat16, device="cuda")
+    output = torch.empty(7, 512, dtype=x.dtype, device=x.device)
+
+    swiglu_limit_func(output, x, swiglu_limit=7.0)
+    gate, up = x.chunk(2, dim=-1)
+    expected = torch.nn.functional.silu(gate.clamp(max=7.0)) * up.clamp(
+        min=-7.0, max=7.0
+    )
+
+    torch.testing.assert_close(output, expected, atol=2e-2, rtol=2e-2)
 
 
 @pytest.mark.parametrize("swiglu_limit", SWIGLU_LIMITS)

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -647,6 +647,8 @@ def swiglu_limit_func(
     # requires topk_ids. Fall back to the torch implementation otherwise.
     if topk_ids is not None:
         _swiglu_limit_pad_aware(output, input, topk_ids, swiglu_limit, expert_map)
+    elif current_platform.is_cuda():
+        torch.ops._C.silu_and_mul_with_clamp(output, input, swiglu_limit, 1.0, 0.0)
     else:
         _swiglu_limit_torch(output, input, swiglu_limit)
 


### PR DESCRIPTION



## Purpose
Use native CUDA SwiGLU clamp kernel for Humming MoE

## Test Plan
```
vllm serve deepseek-ai/DeepSeek-V4-Flash-0731 \
  --trust-remote-code --kv-cache-dtype fp8 --block-size 256 \
  --enable-expert-parallel --tensor-parallel-size 4 \
  --tokenizer-mode deepseek_v4 --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice --reasoning-parser deepseek_v4 \
  --no-enable-prefix-caching --max-num-batched-tokens 16384 \
  --load-format instanttensor --moe-backend humming --port 8001
```
```
vllm bench serve --backend vllm \
  --base-url http://127.0.0.1:8001 --endpoint /v1/completions \
  --model deepseek-ai/DeepSeek-V4-Flash-0731 \
  --tokenizer-mode deepseek_v4 --trust-remote-code \
  --dataset-name random --random-input-len 1024 \
  --random-output-len 128 --random-range-ratio 0 \
  --num-prompts 64 --max-concurrency 16 --request-rate inf \
  --ignore-eos --temperature 0 --seed 123 --save-result
```
## Test Result
```
| Variant | Output token/s (three trials) | Mean | Total token/s mean | TTFT mean | TPOT mean |
|---|---|---:|---:|---:|---:|
| Baseline | 667.07, 653.91, 663.19 | 661.39 | 5952.52 | 1361.48 ms | 13.648 ms |
| Optimized | 672.95, 668.88, 670.09 | 670.64 | 6035.75 | 1325.21 ms | 13.598 ms |

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

