### PR TITLE
[Core] Skip common-prefix block scan for single requests

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -199,6 +199,73 @@ def test_circular_buffer_allocates_one_block_for_the_request_lifetime():
     assert manager.req_to_blocks[request_id] == blocks
 
 
+def get_full_attention_manager(full_attention_spec, block_pool):
+    return FullAttentionManager(
+        full_attention_spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=full_attention_spec.block_size,
+    )
+
+
+def test_full_attention_skips_common_prefix_scan_for_single_request():
+    block_size = 2
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    manager = get_full_attention_manager(spec, block_pool)
+
+    class NonIterableBlockTable(list[KVCacheBlock]):
+        def __iter__(self):
+            raise AssertionError("single-request block table should not be scanned")
+
+    manager.req_to_blocks["request"] = NonIterableBlockTable(
+        [KVCacheBlock(1, ref_cnt=1)]
+    )
+
+    assert manager.get_num_common_prefix_blocks("request") == 0
+
+
+def test_full_attention_counts_common_prefix_for_multiple_requests():
+    block_size = 2
+    spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    manager = get_full_attention_manager(spec, block_pool)
+
+    shared_blocks = [
+        KVCacheBlock(1, ref_cnt=2),
+        KVCacheBlock(2, ref_cnt=2),
+    ]
+    manager.req_to_blocks["request-1"] = [
+        *shared_blocks,
+        KVCacheBlock(3, ref_cnt=1),
+    ]
+    manager.req_to_blocks["request-2"] = [
+        *shared_blocks,
+        KVCacheBlock(4, ref_cnt=1),
+    ]
+
+    assert manager.get_num_common_prefix_blocks("request-1") == 2
+
+
 def test_sliding_window_records_new_blocks_for_zeroing():
     block_size = 2
     spec = SlidingWindowSpec(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -826,10 +826,15 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         )
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        num_reqs = len(self.req_to_blocks)
+        # Cascade attention cannot benefit from a single allocated request.
+        if num_reqs <= 1:
+            return 0
+
         blocks = self.req_to_blocks[running_request_id]
         num_common_blocks = 0
         for block in blocks:
-            if block.ref_cnt == len(self.req_to_blocks):
+            if block.ref_cnt == num_reqs:
                 num_common_blocks += 1
             else:
                 break


### PR DESCRIPTION
## Purpose

Fixes #53683.

`FullAttentionManager.get_num_common_prefix_blocks()` scans the allocated
block table even when only one request has allocated KV cache. Cascade
attention cannot benefit from a cross-request common prefix in that case, so
the scan adds scheduler CPU work without affecting execution.

This PR returns zero before traversing the block table when at most one request
is allocated.

I searched open PRs by issue number and by single-request common-prefix
keywords before opening this PR. I did not find another PR implementing this
change.

## Changes

- Return early from `get_num_common_prefix_blocks()` for a single allocated
  request.
- Reuse the request count in the multi-request block scan.
- Add a regression test that fails if the single-request block table is
  traversed.
- Add coverage confirming that multi-request common-prefix counting is
  unchanged.

## Test Plan

- Reproduce the unnecessary traversal with the new focused regression test
  before changing the implementation.
- Run both new focused tests after the implementation change.
- Run the complete single-type KV cache manager test file.
- Run pre-commit hooks on both modified files.

## Test Result

- Before the implementation change, the focused regression test failed as
  expected with `single-request block table should not be scanned`.
- `.venv/bin/python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py::test_full_attention_skips_common_prefix_scan_for_single_request tests/v1/core/test_single_type_kv_cache_manager.py::test_full_attention_counts_common_prefix_for_multiple_requests -v`: 2 passed.
- `.venv/bin/python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v`: 15 passed.
- `.venv/bin/pre-commit run --files vllm/v1/core/single_type_kv_cache_manager.py tests/v1/core/test_single_type_kv_cache_manager.py`: all applicable hooks passed.
- Model serving evaluation was not run. The available macOS arm64 environment
  cannot install the precompiled cu130 wheel, and its local CPU extension build
  fails because the configured compiler cannot find C++ standard library
  headers.

No documentation update is required because this is an internal scheduler
optimization with no user-facing API or configuration change.
