### PR TITLE
[CI][Docs] Fix decode/prefill consistency test prefix construction; add GLM-4-9B and Phi-4 to batch-invariant tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -108,7 +108,8 @@ Batch invariance has been tested and verified on the following models:
 - **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
-- **Phi series**: `microsoft/Phi-3.5-mini-instruct`
+- **GLM-4 series**: `zai-org/glm-4-9b-chat`
+- **Phi series**: `microsoft/Phi-3.5-mini-instruct`, `microsoft/phi-4`
 - **Granite 3.1 (MoE)**: `ibm-granite/granite-3.1-1b-a400m-instruct`, `ibm-granite/granite-3.1-3b-a800m-instruct`
 - **Granite 3.1 (Dense)**: `ibm-granite/granite-3.1-2b-instruct`, `ibm-granite/granite-3.1-8b-instruct`
 - **EXAONE 4.0 series**: `LGAI-EXAONE/EXAONE-4.0-1.2B`, `LGAI-EXAONE/EXAONE-4.0.1-32B`, `LGAI-EXAONE/EXAONE-4.0-32B`

--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -742,39 +742,27 @@ def test_decode_logprobs_match_prefill_logprobs(
         print(f"[Prompt {prompt_idx}] Generated {len(token_ids)} tokens: {token_ids}")
         print(f"[Prompt {prompt_idx}] Decode logprobs: {decode_logprobs.tolist()}")
 
-        # Step 2: For each token position, run prefill and compare
+        # Step 2: For each token position, run prefill and compare.
+        #
+        # Build the prefix directly from token ids rather than reconstructing
+        # it from text. A `decode -> encode` round trip is not lossless for
+        # many BPE tokenizers (e.g. Qwen2.5-Coder merges adjacent tokens like
+        # `'.' + '#'` into `'.#'` after detokenization), which would silently
+        # change the token-level prefix and produce false mismatches in the
+        # comparisons below. Using `prompt_token_ids + decode_token_ids[:i]`
+        # guarantees the prefill request sees exactly the same token prefix
+        # as the decode path. As a side effect, this also avoids an O(N^2)
+        # extra `llm.generate` call per token that the previous text-based
+        # reconstruction needed.
+        prompt_token_ids = list(decode_output.prompt_token_ids or [])
+
         print(f"\n[Prompt {prompt_idx}] Verifying each token via prefill...")
 
         for token_idx in range(len(token_ids)):
-            # Construct the prefix up to (but not including) this token
+            # Construct the prefix up to (but not including) this token using
+            # token ids directly.
             current_token = token_ids[token_idx]
-
-            # We need to detokenize to get the text prefix
-            # For this, we'll use the tokenizer from the LLM
-            # However, the LLM API doesn't expose tokenizer easily, so we'll
-            # construct the prefix by decoding from the original prompt
-
-            # Get text up to this point by using the output text
-            # This is approximate but should work for verification
-            if token_idx == 0:
-                prefix_prompt = prompt
-            else:
-                # Use the partial output text up to this token
-                # We'll need to construct this from the full output
-                prefix_output = decode_output.outputs[0]
-                # Get the text for tokens 0 to token_idx-1
-                # Unfortunately, we don't have per-token text, so we'll use
-                # a different approach: run prefill with prompt + tokens[0:token_idx]
-
-                # Actually, we need to get the actual text. Let's use a workaround:
-                # Run a generation with max_tokens = token_idx to get that prefix
-                prefix_sp = SamplingParams(
-                    temperature=0.0,
-                    max_tokens=token_idx,
-                    logprobs=1,
-                )
-                prefix_output = llm.generate([prompt], prefix_sp, use_tqdm=False)[0]
-                prefix_prompt = prompt + prefix_output.outputs[0].text
+            prefix_token_ids = prompt_token_ids + list(token_ids[:token_idx])
 
             # Now run prefill with max_tokens=1 to get the logprob of the next token
             prefill_sp = SamplingParams(
@@ -785,19 +773,23 @@ def test_decode_logprobs_match_prefill_logprobs(
 
             print(
                 f"  [Token {token_idx}] Running prefill for prefix "
-                f"(len={len(prefix_prompt)})..."
+                f"(num_tokens={len(prefix_token_ids)})..."
             )
-            prefill_output = llm.generate([prefix_prompt], prefill_sp, use_tqdm=False)[
-                0
-            ]
-            prefill_logprobs, prefill_token_ids = _extract_step_logprobs(prefill_output)
+            prefill_output = llm.generate(
+                [{"prompt_token_ids": prefix_token_ids}],
+                prefill_sp,
+                use_tqdm=False,
+            )[0]
+            prefill_logprobs, prefill_token_ids_out = _extract_step_logprobs(
+                prefill_output
+            )
 
             if prefill_logprobs is None:
                 print(f"  [Token {token_idx}] Warning: No prefill logprobs available")
                 continue
 
             # The first token from prefill should match the current token
-            prefill_token = prefill_token_ids[0]
+            prefill_token = prefill_token_ids_out[0]
             prefill_logprob = prefill_logprobs[0].item()
             decode_logprob = decode_logprobs[token_idx].item()
 
@@ -822,7 +814,7 @@ def test_decode_logprobs_match_prefill_logprobs(
                         "decode_logprob": decode_logprob,
                         "prefill_logprob": prefill_logprob,
                         "prompt_text": prompt[:100],
-                        "prefix_text": prefix_prompt[:100],
+                        "prefix_token_ids": prefix_token_ids[:50],
                     }
                 )
                 print(f"  [Token {token_idx}] ✗ TOKEN MISMATCH!")
@@ -842,7 +834,7 @@ def test_decode_logprobs_match_prefill_logprobs(
                         "prefill_logprob": prefill_logprob,
                         "diff": diff,
                         "prompt_text": prompt[:100],
-                        "prefix_text": prefix_prompt[:100],
+                        "prefix_token_ids": prefix_token_ids[:50],
                         "decode_all_tokens": token_ids,
                         "decode_all_logprobs": decode_logprobs.tolist(),
                     }
@@ -879,7 +871,7 @@ def test_decode_logprobs_match_prefill_logprobs(
             for i, fail in enumerate(failures[:5]):  # Show first 5 failures per prompt
                 print(f"\n  [Failure {i + 1}] Token position {fail['token_idx']}:")
                 print(f"    Reason: {fail['reason']}")
-                print(f"    Prefix text: '{fail['prefix_text']}...'")
+                print(f"    Prefix token ids: {fail['prefix_token_ids']}...")
                 print(
                     f"    Decode:  token={fail['decode_token']}, "
                     f"logprob={fail['decode_logprob']:.10f}"


### PR DESCRIPTION
## Purpose

Two related changes, both following the review on this PR:

1. **Fix a soundness bug in `tests/v1/determinism/test_batch_invariance.py::test_decode_logprobs_match_prefill_logprobs`.** The test rebuilt each prefill prefix from *text* and re-encoded it; `encode(decode(ids))` is not lossless for BPE tokenizers, so the "prefill" could evaluate a different token sequence than decode did and report false mismatches. The prefix is now built directly from token ids (`prompt_token_ids + decode_token_ids[:i]`), which also removes an O(N²) extra `llm.generate` per decoded token. This is the fix from #43317 (@Evangade), carried here at the maintainer's request after that PR went stale; the standalone tokenizer regression test from #43317 is dropped per the review there. Original report by @xRay2016 in #27433.
2. **Add `zai-org/glm-4-9b-chat` and `microsoft/phi-4` to the tested-model list**, following the [invitation to submit model validations without a separate issue](https://github.com/vllm-project/vllm/pull/53247#issuecomment-5374419058).

Why the fix matters here: GLM was originally removed from this PR because the official suite reported a decode/prefill mismatch. Root cause (see the comments below): the model emits `'.'` + `'Here'` as `[13, 8419]`, which re-encodes to the single token `89329` (`'.Here'`), so the text-based prefix diverged from position 11 onward. With token-id prefixes GLM is fully green. Any model whose greedy output hits a BPE merge point can false-fail the unfixed test the same way.

Not a duplicate: #43317 proposes the same test fix but has had no author activity since the May review and is marked stale; this PR carries that commit with its original authorship and sign-off instead of opening another PR.

## Test Plan

Official suite, `VLLM_BATCH_INVARIANT=1`, vLLM 0.28.0 (cu129 wheel), torch 2.13.0, Triton 3.7.1, RTX 4090 D (sm89) and H20 (sm90):

```bash
VLLM_TEST_MODEL=<model> pytest tests/v1/determinism/test_batch_invariance.py -v
```

Plus a controlled A/B of the prefix construction on GLM (same engine instance, 4 prompts × 16 positions, FLASH_ATTN, compiled) and the fixed test re-run on GLM and on the default model.

## Test Result

| Model | RTX 4090 D (sm89), v0.28.0 | H20 (sm90), v0.28.0 | H100 NVL (sm90), nightly 0.28.1rc1.dev580 — run by @yuvalluria ([Phi-4](https://github.com/vllm-project/vllm/pull/53692#issuecomment-5618510438), [GLM](https://github.com/vllm-project/vllm/pull/53692#issuecomment-5619365843)) | RTX PRO 6000 Blackwell (sm120), v0.29.0 cu130 wheel, driver 580.159 |
|---|---|---|---|---|
| `Qwen/Qwen3-1.7B` (suite default), fixed test | 1 passed; full file 19 passed | — | — | full file **19/19 passed** (17:58) |
| `microsoft/phi-4` | not run (24 GB) | 19/19 passed | 19/19 passed (fixed test file) | **19/19 passed** (25:45) |
| `zai-org/glm-4-9b-chat` (unfixed test) | 12/19 — 6 needle cells OOM on 24 GB at init, 1 = the decode/prefill false mismatch | 18/19 — the decode/prefill false mismatch | — | — |
| `zai-org/glm-4-9b-chat`, prefix A/B (unfixed vs token-id) | text re-encode: 59/64; token ids: **64/64 bitwise** | — | — | — |
| `zai-org/glm-4-9b-chat`, fixed test | 1 passed (was FAILED before the fix) | — | **19/19 passed**, incl. `test_decode_logprobs_match_prefill_logprobs[FLASH_ATTN]` | full file **19/19 passed** (24:38), incl. `test_decode_logprobs_match_prefill_logprobs[FLASH_ATTN]` |

sm120 notes: all three backends the suite parametrizes (FLASH_ATTN, TRITON_ATTN, FLEX_ATTENTION) start and pass under `VLLM_BATCH_INVARIANT=1` on this GPU; no reruns were needed (0 flaky retries). This is, as far as the tracker shows, the first run of the determinism suite on an sm120 part.

AI assistance was used for implementation (Claude, Codex); every changed line was reviewed and every command above was run by the human submitter, except the H100 NVL column, which was run and posted by @yuvalluria.