### PR TITLE
[Bugfix][Performance] Restore WNA16 CUDA dispatch and trim MoE workspace

### DIFF
--- a/tests/kernels/moe/test_triton_moe_no_act_mul.py
+++ b/tests/kernels/moe/test_triton_moe_no_act_mul.py
@@ -155,8 +155,8 @@ def test_triton_experts_no_mul_activation(
 
     # Verify workspace shapes are correct for no_mul activation
     # workspace1 should handle activation_out_dim = N (not N//2)
-    assert ws1_shape == (m, topk, max(n, k)), (
-        f"workspace1 shape mismatch: expected {(m, topk, max(n, k))}, got {ws1_shape}"
+    assert ws1_shape == (m, topk, n), (
+        f"workspace1 shape mismatch: expected {(m, topk, n)}, got {ws1_shape}"
     )
     # workspace2 should handle max(N, K) for intermediate_cache1/cache3
     assert ws2_shape == (m, topk, max(n, k)), (
@@ -207,7 +207,7 @@ def test_workspace_shapes_no_mul_vs_gated():
     """Test that workspace shapes differ correctly between gated and non-gated."""
     from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
 
-    M, N, K, topk = 64, 256, 128, 2
+    M, N, K, topk = 64, 256, 512, 2
 
     experts = TritonExperts(
         moe_config=make_dummy_moe_config(),
@@ -224,15 +224,16 @@ def test_workspace_shapes_no_mul_vs_gated():
 
     # For no_mul: activation_out_dim = N
     # For gated: activation_out_dim = N // 2
-    # workspace1 should use max(activation_out_dim, K)
+    # workspace1 only holds the activation output. The separate output view
+    # accounts for K when the shared allocation is created.
     activation_out_dim_no_mul = N
     activation_out_dim_gated = N // 2
 
-    assert ws1_no_mul[2] == max(activation_out_dim_no_mul, K), (
-        f"no_mul workspace1 last dim should be max({activation_out_dim_no_mul}, {K})"
+    assert ws1_no_mul[2] == activation_out_dim_no_mul, (
+        f"no_mul workspace1 last dim should be {activation_out_dim_no_mul}"
     )
-    assert ws1_gated[2] == max(activation_out_dim_gated, K), (
-        f"gated workspace1 last dim should be max({activation_out_dim_gated}, {K})"
+    assert ws1_gated[2] == activation_out_dim_gated, (
+        f"gated workspace1 last dim should be {activation_out_dim_gated}"
     )
 
     # Output shapes should be the same

--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -12,12 +12,19 @@ from compressed_tensors.quantization import (
     QuantizationType,
 )
 
+from vllm.model_executor.layers.fused_moe import fused_moe
+from vllm.model_executor.layers.fused_moe.experts import triton_moe
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+    CudaOrTritonWNA16Experts,
+    TritonWNA16Experts,
+)
 from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
     WNA16MoEBackend,
     _backend_incompatibility_reason,
     _convert_moe_wna16_humming_tensors,
     convert_to_wna16_moe_kernel_format,
     map_wna16_backend,
+    select_wna16_moe_backend,
 )
 from vllm.model_executor.layers.quantization import moe_wna16
 from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
@@ -26,11 +33,133 @@ from vllm.model_executor.layers.quantization.moe_wna16 import (
     MoeWNA16Config,
     MoeWNA16Method,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import kInt4Static
 from vllm.platforms import current_platform
 
 
 def test_map_wna16_backend_supports_triton():
     assert map_wna16_backend("triton") == WNA16MoEBackend.TRITON
+
+
+@pytest.mark.parametrize(
+    ("moe_backend", "expected_cls"),
+    [
+        ("auto", CudaOrTritonWNA16Experts),
+        ("triton", TritonWNA16Experts),
+    ],
+)
+def test_moe_wna16_auto_preserves_cuda_dispatch(monkeypatch, moe_backend, expected_cls):
+    from tests.kernels.moe.utils import make_dummy_moe_config
+    from vllm.model_executor.layers.fused_moe.oracle import int_wna16
+
+    moe_config = make_dummy_moe_config()
+    moe_config.moe_backend = moe_backend
+    quant_config = MoeWNA16Config(
+        linear_quant_method="gptq",
+        weight_bits=4,
+        group_size=128,
+        has_zp=False,
+        lm_head_quantized=False,
+        modules_to_not_convert=None,
+        full_config={},
+    )
+
+    monkeypatch.setattr(
+        int_wna16,
+        "_get_priority_backends",
+        lambda: [WNA16MoEBackend.TRITON],
+    )
+    for experts_cls in (CudaOrTritonWNA16Experts, TritonWNA16Experts):
+        monkeypatch.setattr(
+            experts_cls,
+            "is_supported_config",
+            lambda *args, **kwargs: (True, None),
+        )
+
+    backend, experts_cls = select_wna16_moe_backend(
+        config=moe_config,
+        weight_key=kInt4Static,
+        quant_config=quant_config,
+        may_have_zp=False,
+        may_have_bias=False,
+    )
+
+    assert backend == WNA16MoEBackend.TRITON
+    assert experts_cls is expected_cls
+
+
+@pytest.mark.parametrize(
+    ("experts_cls", "num_tokens", "expected_kernel"),
+    [
+        (CudaOrTritonWNA16Experts, 192, "cuda"),
+        (CudaOrTritonWNA16Experts, 193, "triton"),
+        (TritonWNA16Experts, 1, "triton"),
+    ],
+)
+def test_moe_wna16_runtime_kernel_dispatch(
+    monkeypatch, experts_cls, num_tokens, expected_kernel
+):
+    experts = object.__new__(experts_cls)
+    experts.quant_config = SimpleNamespace(
+        block_shape=[0, 128],
+        per_act_token_quant=False,
+        use_int4_w4a16=True,
+        use_int8_w8a16=False,
+    )
+    calls = []
+
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        fused_moe,
+        "invoke_fused_moe_wna16_cuda_kernel",
+        lambda *args, **kwargs: calls.append("cuda"),
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "invoke_fused_moe_wna16_triton_kernel",
+        lambda *args, **kwargs: calls.append("triton"),
+    )
+    monkeypatch.setattr(
+        triton_moe,
+        "invoke_fused_moe_wna16_triton_kernel",
+        lambda *args, **kwargs: calls.append("triton"),
+    )
+
+    num_experts = 256
+    a = torch.empty(num_tokens, 1)
+    b = torch.empty(num_experts, 1, 1)
+    experts._invoke_wna16_kernel(
+        a,
+        b,
+        torch.empty(num_tokens, 8, 1),
+        torch.empty(num_experts, 1, 1),
+        None,
+        None,
+        torch.empty(1, dtype=torch.int32),
+        torch.empty(1, dtype=torch.int32),
+        torch.empty(1, dtype=torch.int32),
+        False,
+        8,
+        {"BLOCK_SIZE_M": 16},
+        None,
+    )
+
+    assert calls == [expected_kernel]
+
+
+def test_wna16_default_config_matches_kernel_dispatch(monkeypatch):
+    monkeypatch.setattr(
+        fused_moe,
+        "should_moe_wna16_use_cuda",
+        lambda *args, **kwargs: True,
+    )
+    args = (1, 256, 512, 3072, 8, "int4_w4a16", [0, 128])
+
+    auto_config = fused_moe.get_default_config(*args, allow_cuda_wna16=True)
+    triton_config = fused_moe.get_default_config(*args, allow_cuda_wna16=False)
+
+    assert auto_config["BLOCK_SIZE_M"] == 1
+    assert triton_config["BLOCK_SIZE_M"] == 16
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -20,6 +20,7 @@ from vllm.model_executor.layers.fused_moe.experts.lora_experts_mixin import (
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import (
     _prepare_expert_assignment,
+    dispatch_fused_moe_kernel,
     invoke_fused_moe_triton_kernel,
     invoke_fused_moe_wna16_triton_kernel,
     try_get_optimal_moe_config,
@@ -213,7 +214,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         activation: MoEActivation,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
         activation_out_dim = self.adjust_N_for_activation(N, activation)
-        workspace1 = (M, topk, max(activation_out_dim, K))
+        workspace1 = (M, topk, activation_out_dim)
         workspace2 = (M, topk, max(N, K))
         output = (M, K)
         return (workspace1, workspace2, output)
@@ -567,6 +568,8 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
 
 
 class TritonWNA16Experts(TritonExperts):
+    allow_cuda_wna16 = False
+
     @staticmethod
     def _supports_current_device() -> bool:
         return current_platform.is_cuda_alike() or current_platform.is_xpu()
@@ -610,6 +613,41 @@ class TritonWNA16Experts(TritonExperts):
         return not (
             moe_parallel_config.use_fi_nvl_two_sided_kernels
             or moe_parallel_config.use_fi_nvl_one_sided_kernels
+        )
+
+    def _invoke_wna16_kernel(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        c: torch.Tensor,
+        b_scale: torch.Tensor | None,
+        b_zp: torch.Tensor | None,
+        topk_weights: torch.Tensor | None,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        num_tokens_post_padded: torch.Tensor,
+        mul_routed_weight: bool,
+        top_k: int,
+        config: dict[str, int],
+        compute_type: tl.dtype,
+    ) -> None:
+        invoke_fused_moe_wna16_triton_kernel(
+            a,
+            b,
+            c,
+            b_scale,
+            b_zp,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            top_k,
+            config,
+            compute_type=compute_type,
+            use_int8_w8a16=self.quant_config.use_int8_w8a16,
+            use_int4_w4a16=self.quant_config.use_int4_w4a16,
+            block_shape=self.block_shape,
         )
 
     def apply(
@@ -666,6 +704,7 @@ class TritonWNA16Experts(TritonExperts):
             self.quant_config.config_name(hidden_states.dtype),
             num_tokens,
             block_shape=self.block_shape,
+            allow_cuda_wna16=self.allow_cuda_wna16,
         )
 
         if hidden_states.dtype == torch.bfloat16:
@@ -696,7 +735,7 @@ class TritonWNA16Experts(TritonExperts):
             topk_ids, config["BLOCK_SIZE_M"], num_align_experts, expert_map
         )
 
-        invoke_fused_moe_wna16_triton_kernel(
+        self._invoke_wna16_kernel(
             hidden_states,
             w1,
             intermediate_cache1,
@@ -709,10 +748,7 @@ class TritonWNA16Experts(TritonExperts):
             False,  # mul_routed_weights
             top_k_num,
             config,
-            compute_type=compute_type,
-            use_int8_w8a16=self.quant_config.use_int8_w8a16,
-            use_int4_w4a16=self.quant_config.use_int4_w4a16,
-            block_shape=self.block_shape,
+            compute_type,
         )
 
         self.activation(
@@ -729,7 +765,7 @@ class TritonWNA16Experts(TritonExperts):
             self.block_shape,
         )
 
-        invoke_fused_moe_wna16_triton_kernel(
+        self._invoke_wna16_kernel(
             qintermediate_cache2,
             w2,
             intermediate_cache3,
@@ -742,11 +778,69 @@ class TritonWNA16Experts(TritonExperts):
             not apply_router_weight_on_input,
             1,
             config,
-            compute_type=compute_type,
-            use_int8_w8a16=self.quant_config.use_int8_w8a16,
-            use_int4_w4a16=self.quant_config.use_int4_w4a16,
-            block_shape=self.block_shape,
+            compute_type,
         )
 
         # separate function is required for MoE + LoRA
         self.moe_sum(intermediate_cache3, output)
+
+
+class CudaOrTritonWNA16Experts(TritonWNA16Experts):
+    """WNA16 experts with shape-dependent CUDA/Triton dispatch."""
+
+    allow_cuda_wna16 = True
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return current_platform.is_cuda()
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return weight_key in (
+            kInt4Static,
+            kInt4Static32,
+            kInt4StaticAsym,
+            kInt4Static32Asym,
+        )
+
+    def _invoke_wna16_kernel(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        c: torch.Tensor,
+        b_scale: torch.Tensor | None,
+        b_zp: torch.Tensor | None,
+        topk_weights: torch.Tensor | None,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        num_tokens_post_padded: torch.Tensor,
+        mul_routed_weight: bool,
+        top_k: int,
+        config: dict[str, int],
+        compute_type: tl.dtype,
+    ) -> None:
+        dispatch_fused_moe_kernel(
+            a,
+            b,
+            c,
+            None,
+            b_scale,
+            b_zp,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            top_k,
+            config,
+            compute_type=compute_type,
+            use_fp8_w8a8=False,
+            use_int8_w8a8=False,
+            use_int8_w8a16=self.quant_config.use_int8_w8a16,
+            use_int4_w4a16=self.quant_config.use_int4_w4a16,
+            per_channel_quant=self.per_act_token_quant,
+            block_shape=self.block_shape,
+        )

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1304,6 +1304,7 @@ def get_default_config(
     topk: int,
     dtype: str | None,
     block_shape: list[int] | None = None,
+    allow_cuda_wna16: bool = True,
 ) -> dict[str, int]:
     if envs.VLLM_BATCH_INVARIANT:
         return {
@@ -1356,7 +1357,9 @@ def get_default_config(
         # only set BLOCK_SIZE_M
         # BLOCK_SIZE_N and BLOCK_SIZE_K would be set later
         bit = 4 if dtype == "int4_w4a16" else 8
-        use_moe_wna16_cuda = should_moe_wna16_use_cuda(M * topk, block_shape[1], E, bit)
+        use_moe_wna16_cuda = allow_cuda_wna16 and should_moe_wna16_use_cuda(
+            M * topk, block_shape[1], E, bit
+        )
         if use_moe_wna16_cuda:
             config = {
                 "BLOCK_SIZE_M": min(16, next_power_of_2(M)),
@@ -1426,6 +1429,7 @@ def try_get_optimal_moe_config(
     dtype: str | None,
     M: int,
     block_shape: list[int] | None = None,
+    allow_cuda_wna16: bool = True,
 ) -> dict[str, int]:
     from vllm.model_executor.layers.fused_moe import get_config
 
@@ -1447,7 +1451,16 @@ def try_get_optimal_moe_config(
             config = configs[min(configs.keys(), key=lambda x: abs(x - M))]
         else:
             # Else use the default config
-            config = get_default_config(M, E, N, w1_shape[2], top_k, dtype, block_shape)
+            config = get_default_config(
+                M,
+                E,
+                N,
+                w1_shape[2],
+                top_k,
+                dtype,
+                block_shape,
+                allow_cuda_wna16=allow_cuda_wna16,
+            )
     return config
 
 

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     MarlinExpertsBase,
 )
 from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+    CudaOrTritonWNA16Experts,
     TritonWNA16Experts,
 )
 from vllm.model_executor.layers.fused_moe.experts.trtllm_mxint4_moe import (
@@ -276,6 +277,8 @@ def select_wna16_moe_backend(
     # Select kernels in order of backend.
     AVAILABLE_BACKENDS = _get_priority_backends()
 
+    from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
+
     for backend in AVAILABLE_BACKENDS:
         reason = _backend_incompatibility_reason(
             backend,
@@ -289,7 +292,12 @@ def select_wna16_moe_backend(
             logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
             continue
         activation_key = None  # always BF16 activation for WNA16 MoE
-        for k_cls in backend_to_kernel_cls(backend):
+        kernel_classes = backend_to_kernel_cls(backend)
+        if backend == WNA16MoEBackend.TRITON and isinstance(
+            quant_config, MoeWNA16Config
+        ):
+            kernel_classes = [CudaOrTritonWNA16Experts, *kernel_classes]
+        for k_cls in kernel_classes:
             supported, reason = k_cls.is_supported_config(
                 k_cls, config, weight_key, activation_key, activation_format
             )
@@ -384,6 +392,7 @@ def make_wna16_moe_kernel(
     allowed_experts: tuple[type[mk.FusedMoEExperts], ...] = (
         MarlinExperts,
         BatchedMarlinExperts,
+        CudaOrTritonWNA16Experts,
         TritonWNA16Experts,
         TrtLlmMxint4ExpertsMonolithic,
         XPUExpertsWNA16,


### PR DESCRIPTION
## Purpose

Addresses the decode-path and memory regressions reported in #53241.

PR #44120 migrated `MoeWNA16Method` to the modular MoE kernel, but the new
`TritonWNA16Experts.apply()` path called the Triton WNA16 kernel directly. The
legacy serving path selected the dedicated CUDA W4A16 kernel when
`num_valid_tokens / num_experts <= 6`; losing that dispatch regressed the small
decode batches used by Qwen3.5-122B-A10B on RTX 3090.

The modular Triton workspace also reserved
`max(activation_out_dim, hidden_size)` for a buffer that only stores the
activation output. The final hidden-size output already shares this allocation
through the workspace manager's explicit `max()` calculation. For the reported
TP=4 shape (`M=16384`, `topk=8`, activation width 256, hidden width 3072), the
redundant dimension costs 672 MiB of simultaneously live BF16 workspace.

This PR:

- adds an auto-only `CudaOrTritonWNA16Experts` implementation that reuses the
  existing runtime dispatcher;
- keeps an explicit `--moe-backend triton` request on the pure Triton path;
- makes default tile selection agree with the selected runtime path; and
- sizes the activation workspace to its actual activation width.

Duplicate-work checks found no open PR for #53241, modular WNA16 CUDA dispatch,
or the oversized Triton activation workspace. PRs #48574, #52899, and #53005
touch the legacy WNA16 kernel/tuner but do not restore the modular serving
dispatch or change workspace sizing.

## Test Plan

```bash
.venv/bin/python -m pytest tests/quantization/test_moe_wna16.py -v

.venv/bin/pre-commit run --files \
  vllm/model_executor/layers/fused_moe/experts/triton_moe.py \
  vllm/model_executor/layers/fused_moe/fused_moe.py \
  vllm/model_executor/layers/fused_moe/oracle/int_wna16.py \
  tests/quantization/test_moe_wna16.py \
  tests/kernels/moe/test_triton_moe_no_act_mul.py

.venv/bin/pre-commit run mypy-3.12 --all-files --hook-stage manual
```

RTX 3090 kernel A/B used the CUDA 12.4-compatible vLLM 0.8.5 kernel harness
with the issue's TP=4 expert shape:

- 256 experts, top-k 8;
- hidden size 3072;
- per-rank intermediate size 256 (`w13` output width 512);
- GPTQ INT4, group size 128;
- BF16 activations; and
- 5 warmups plus 30 timed iterations per point, repeated three times.

Model evaluation used
`Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4`, greedy decoding, and the complete
1,319-example GSM8K test set. The same process-level dispatcher override forced
the dedicated CUDA W4A16 kernel or the Triton W4A16 kernel while leaving all
other model and engine settings unchanged.

## Test Result

CPU/unit checks:

- `tests/quantization/test_moe_wna16.py`: 16 passed, 5 GPU-only skipped.
- changed-files pre-commit: passed.
- Python 3.12 full-repository mypy: passed.

RTX 3090, Torch 2.6.0+cu124, median of three runs:

| Input tokens | CUDA W4A16 | Triton W4A16 | CUDA speedup |
|---:|---:|---:|---:|
| 1 | 0.272 ms | 0.473 ms | 1.74x |
| 8 | 0.372 ms | 0.658 ms | 1.77x |
| 64 | 1.445 ms | 2.294 ms | 1.59x |
| 192 | 2.412 ms | 2.228 ms | 0.92x |

The existing policy switches to Triton above 192 input tokens for this shape;
at 193 tokens, auto and forced-Triton outputs were identical. CUDA/Triton max
absolute output differences ranged from 0.0078 to 0.0156, with relative RMS
differences below 1% for the randomized BF16 kernel comparison.

Model-level GSM8K evaluation:

| Kernel | Correct | Accuracy | Output throughput |
|---|---:|---:|---:|
| CUDA W4A16 | 571 / 1,319 | 43.29% | 463.9 tok/s |
| Triton W4A16 | 562 / 1,319 | 42.61% | 468.7 tok/s |

The paired correctness table was: 464 both correct, 650 both wrong, 107
CUDA-only correct, and 98 Triton-only correct. A two-sided exact McNemar test
gave `p=0.576`, so the kernel change caused no statistically significant
accuracy regression. The model-level throughput is effectively comparable for
this different E=60 model and high-concurrency evaluation; the issue's E=256
c1/c8 performance is represented by the shape-matched kernel benchmark above.

## AI assistance

AI assistance was used during development, validation, and preparation of the
initial write-up. The submitter reviewed every changed line and verified the
reported commands and results.
