### PR TITLE
[Bugfix] Fix Qwen3-VL and Cosmos3-Edge text architectures for CPU and pipeline parallelism

### DIFF
--- a/vllm/model_executor/models/cosmos3_edge.py
+++ b/vllm/model_executor/models/cosmos3_edge.py
@@ -575,7 +575,9 @@ class Cosmos3EdgeForConditionalGeneration(
 
         with self._mark_language_model(vllm_config):
             self.language_model = Cosmos3EdgeForCausalLM(
-                vllm_config=vllm_config,
+                vllm_config=vllm_config.with_hf_config(
+                    config.text_config, architectures=["NemotronHForCausalLM"]
+                ),
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 


### PR DESCRIPTION

## Purpose

Fix engine initialization failures for Qwen3-VL, Qwen3-VL-MoE, and
Cosmos3-Edge when vLLM constructs an inner language-model configuration from a
nested text config.

This PR builds on the Qwen3-VL fix in #43272 and extends the same model-side
architecture handling to Cosmos3-Edge.

The issue is exposed by:

- CPU initialization, including `pipeline_parallel_size=1`.
- Pipeline-parallel capability validation when
  `pipeline_parallel_size > 1`, including CUDA PP=2.

CUDA PP=1 can avoid both failing validation paths and may appear to work even
though the inner model configuration has no architecture.

## Root Cause

The top-level multimodal checkpoint configs contain valid architectures, but
their nested text configs do not:

| Model | Nested `model_type` | Nested `architectures` | Required architecture |
| --- | --- | --- | --- |
| Qwen3-VL | `qwen3_vl_text` | `None` | `Qwen3ForCausalLM` |
| Qwen3-VL-MoE | `qwen3_vl_moe_text` | `None` | `Qwen3MoeForCausalLM` |
| Cosmos3-Edge | `cosmos3_edge_text` | `None` | `NemotronHForCausalLM` |

These custom text `model_type` values are not present in Transformers'
`MODEL_FOR_CAUSAL_LM_MAPPING_NAMES`. Calling `with_hf_config(text_config)`
therefore cannot infer the inner causal-LM architecture, and the rebuilt
`ModelConfig` receives an empty `architectures` list.

### CPU failure path

CPU platform initialization queries `model_config.use_mla` while selecting its
attention and cache behavior:

```text
VllmConfig.with_hf_config(text_config)
  -> inner ModelConfig.architectures = []
  -> VllmConfig.__post_init__
     -> CpuPlatform.check_and_update_config
        -> model_config.use_mla
           -> ModelConfig.using_transformers_backend
              -> ModelConfig._get_transformers_backend_cls
                 -> self.architectures[0]
                    -> IndexError: list index out of range
```

### Pipeline-parallel failure path

When PP is greater than one, vLLM must resolve the inner language model to
verify that it supports pipeline parallelism:

```text
VllmConfig.with_hf_config(text_config)
  -> inner ModelConfig.architectures = []
  -> VllmConfig.__post_init__
     -> ModelConfig.verify_with_parallel_config
        -> ModelRegistry.is_pp_supported_model([])
           -> ModelRegistry.inspect_model_cls([])
              -> ValueError: No model architectures are specified
```

Depending on validation order, PP initialization may instead reach the same
`self.architectures[0]` access and raise `IndexError`. Both errors have the same
root cause.

## Changes

Pass each nested text model's architecture explicitly at the language-model
construction boundary.

### Qwen3-VL

```diff
 self.language_model = Qwen3LLMForCausalLM(
-    vllm_config=vllm_config.with_hf_config(config.text_config),
+    vllm_config=vllm_config.with_hf_config(
+        config.text_config, architectures=["Qwen3ForCausalLM"]
+    ),
     prefix=maybe_prefix(prefix, "language_model"),
 )
```

### Qwen3-VL-MoE

```diff
 self.language_model = Qwen3MoeLLMForCausalLM(
-    vllm_config=vllm_config.with_hf_config(config.text_config),
+    vllm_config=vllm_config.with_hf_config(
+        config.text_config, architectures=["Qwen3MoeForCausalLM"]
+    ),
     prefix=maybe_prefix(prefix, "language_model"),
 )
```

### Cosmos3-Edge

```diff
 self.language_model = Cosmos3EdgeForCausalLM(
-    vllm_config=vllm_config,
+    vllm_config=vllm_config.with_hf_config(
+        config.text_config, architectures=["NemotronHForCausalLM"]
+    ),
     prefix=maybe_prefix(prefix, "language_model"),
 )
```

This follows the same model-side pattern already used by other multimodal
models whose nested text configs need an explicit vLLM architecture.

## Why This Is a Model-Side Fix

Only the model implementation can reliably identify the vLLM architecture
represented by a custom nested config. A generic empty-list guard in
`ModelConfig._get_transformers_backend_cls()` would avoid one CPU `IndexError`,
but it would not provide the architecture required by PP capability validation
or other model-registry consumers.

## Other Models Audited

Similar-looking nested-config calls are not necessarily affected. A model has
this issue only when the nested config has no usable `architectures` value and
its `model_type` has no Transformers causal-LM mapping.

- `stepfun-ai/Step3-VL-10B` uses a standard `Qwen3Config` with
  `Qwen3ForCausalLM`; CPU PP=1 and PP=2 validation passed without this fix.
- MOSS-Transcribe-Diarize explicitly initializes its text model as
  `Qwen3ForCausalLM`; it does not have this missing-text-architecture issue.

Based on the tested checkpoints, the confirmed affected models are the
Qwen3-VL family and Cosmos3-Edge.

## Test Plan

Use local Qwen3-VL, Qwen3-VL-MoE, and Cosmos3-Edge checkpoints to validate
configuration reconstruction and model initialization on CPU and CUDA.

Verify that the inner configurations resolve to:

```text
Qwen3-VL       -> ["Qwen3ForCausalLM"]
Qwen3-VL-MoE   -> ["Qwen3MoeForCausalLM"]
Cosmos3-Edge   -> ["NemotronHForCausalLM"]
```

## Test Results

- Before the fix:
  - Qwen3-VL and Qwen3-VL-MoE reproduce the empty-architecture failure on CPU.
  - Cosmos3-Edge reproduces the empty-architecture failure on CPU.
  - CUDA PP=2 fails during inner-model PP capability validation.
- After the fix:
  - CPU PP=1 passes.
  - CPU PP=2 configuration validation passes.
  - CUDA PP=1 passes.
  - CUDA PP=2 passes on a separate CUDA machine.
- Targeted unit/configuration tests and Ruff checks pass.

The CUDA PP=1 result is included as a regression check. It could already avoid
the failing validation paths before the fix, so its previous success did not
indicate that the nested configuration was valid.

