### PR TITLE
[CI] Fix nixl harness teardown: TERM grace before SIGKILL

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
@@ -122,7 +122,18 @@ cleanup_instances() {
   echo "Cleaning up any running vLLM instances..."
   pkill -f "toy_proxy_server.py" || true
   pkill -TERM -f "vllm serve" || true
-  sleep 3
+  # CI test-selection traces these jobs with subprocess coverage
+  # (sigterm=true): servers flush coverage only if they get to handle
+  # SIGTERM. "vllm serve" matches the serve parent only; spawned EngineCore
+  # workers exit through the parent's shutdown() (terminate, 5s join, then
+  # kill-process-tree). Give the parent a 10s polling window to finish that
+  # gracefully. The SIGKILL below must keep matching ONLY the serve parent:
+  # it is the leak backstop for a wedged parent, and widening it to workers
+  # would kill them mid-flush and discard coverage.
+  for _ in $(seq 1 10); do
+    pgrep -f "vllm serve" > /dev/null || break
+    sleep 1
+  done
   pkill -9 -f "vllm serve" || true
   sleep 2
   wait_for_gpu_memory_release

--- a/tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
@@ -105,7 +105,16 @@ cleanup_instances() {
   echo "Cleaning up..."
   # shellcheck disable=SC2046  # word splitting is intentional for multiple PIDs
   kill $(jobs -pr) 2>/dev/null || true
-  sleep 1
+  # CI test-selection traces these jobs with subprocess coverage
+  # (sigterm=true): processes only flush coverage if they handle SIGTERM.
+  # vLLM's own shutdown() terminates workers and joins them with a 5s
+  # timeout before killing the tree, so give TERM a 10s polling window.
+  # Keep the SIGKILL patterns narrow (serve parent / proxy only): they are
+  # the leak backstop, and widening them to workers kills them mid-flush.
+  for _ in $(seq 1 10); do
+    pgrep -f "vllm serve.*${MODEL_NAME}" > /dev/null 2>&1 || break
+    sleep 1
+  done
   # shellcheck disable=SC2046
   kill -9 $(jobs -pr) 2>/dev/null || true
   pkill -9 -f "vllm serve.*${MODEL_NAME}" 2>/dev/null || true


### PR DESCRIPTION
## Why

The nixl integration harnesses tear down servers with SIGTERM followed almost immediately by SIGKILL — 3s in `run_accuracy_test.sh`, 1s in `spec_decode_acceptance_test.sh`. vLLM's own `shutdown()` terminates EngineCore workers, then joins them with a **5s** timeout before killing the process tree. Killing the serve parent inside that window orphans the workers, which can hold GPU memory past the job.

This also blocks CI trace-instrumentation of these jobs: subprocess coverage flushes on SIGTERM (`sigterm=true`), and a SIGKILL landing mid-shutdown discards that data.

## What

SIGTERM first, then poll up to 10s for the serve parent to exit (returns as soon as it's gone — no flat sleep), SIGKILL only as the leak backstop for a wedged parent. Comments in both scripts record why the window exceeds vLLM's 5s grace and why the `-9` patterns must stay narrow (matching only the serve parent / proxy — widening them to workers would kill workers mid-flush).

No behavior change for healthy jobs beyond up-to-10s faster-or-equal cleanup; wedged servers still get SIGKILLed.

## AI-assistance disclosure (per AGENTS.md)

- **AI assistance was used** in creating this change (drafted and tested by an AI agent working under human direction).
- **Not a duplicate:** no existing PR addresses this teardown timing; found during CI trace-instrumentation work.
- **Tests:** `bash -n` syntax-checked; semantics reviewed against vLLM's `shutdown()` worker-grace path. Behavior-preserving for healthy jobs (up to 10s earlier-or-equal cleanup; wedged servers still SIGKILLed).
- **Model evaluation:** not applicable (CI teardown change; no output/accuracy/serving surface).
