### PR TITLE
[Bugfix][Tokenizer] Avoid retaining pool overflow copies

### DIFF
--- a/tests/tokenizers_/test_hf.py
+++ b/tests/tokenizers_/test_hf.py
@@ -1,17 +1,47 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import copy as copy_module
 import pickle
+import queue
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
+from types import SimpleNamespace
 
 import pytest
-from transformers import AutoTokenizer
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import AutoTokenizer, TokenizersBackend
 
+import vllm.tokenizers.hf as hf_module
 from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers.hf import (
     ThreadSafeHFTokenizerMixin,
     get_cached_tokenizer,
     maybe_make_thread_pool,
 )
+
+
+def _make_local_tokenizer() -> TokenizersBackend:
+    backend = Tokenizer(WordLevel({"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    backend.pre_tokenizer = Whitespace()
+    return TokenizersBackend(tokenizer_object=backend, unk_token="[UNK]")
+
+
+def _make_pooled_tokenizer(monkeypatch, encode, copies: int = 1):
+    deepcopy_calls: list[None] = []
+
+    def counted_deepcopy(_):
+        deepcopy_calls.append(None)
+        return SimpleNamespace(encode=encode)
+
+    monkeypatch.setattr(
+        hf_module,
+        "copy",
+        SimpleNamespace(copy=copy_module.copy, deepcopy=counted_deepcopy),
+    )
+    return maybe_make_thread_pool(_make_local_tokenizer(), copies), deepcopy_calls
 
 
 @pytest.mark.parametrize("model_id", ["openai-community/gpt2", "zai-org/chatglm3-6b"])
@@ -65,3 +95,52 @@ def test_thread_pool_tokenizer_pickle(model_id: str):
 
     # Idempotence: wrapping an already-pooled tokenizer returns it unchanged.
     assert maybe_make_thread_pool(pooled_tokenizer) is pooled_tokenizer
+
+
+def test_thread_pool_discards_overflow_copies(monkeypatch: pytest.MonkeyPatch):
+    active_barrier = [threading.Barrier(1)]
+
+    def blocking_encode(_):
+        active_barrier[0].wait(timeout=10)
+        return [1]
+
+    pooled_tokenizer, deepcopy_calls = _make_pooled_tokenizer(
+        monkeypatch, blocking_encode
+    )
+    assert len(deepcopy_calls) == 1
+
+    def run_burst(workers: int):
+        active_barrier[0] = threading.Barrier(workers)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            outputs = list(
+                executor.map(lambda _: pooled_tokenizer.encode("hello"), range(workers))
+            )
+        assert outputs == [[1]] * workers
+
+    run_burst(3)
+    assert len(deepcopy_calls) == 3
+
+    run_burst(3)
+    assert len(deepcopy_calls) == 5
+
+
+def test_thread_pool_returns_copy_when_call_raises_queue_empty(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    should_raise = True
+
+    def encode_that_raises_once(_):
+        nonlocal should_raise
+        if should_raise:
+            should_raise = False
+            raise queue.Empty("raised by tokenizer")
+        return [1]
+
+    pooled_tokenizer, deepcopy_calls = _make_pooled_tokenizer(
+        monkeypatch, encode_that_raises_once
+    )
+    with pytest.raises(queue.Empty, match="raised by tokenizer"):
+        pooled_tokenizer.encode("hello")
+
+    assert pooled_tokenizer.encode("hello") == [1]
+    assert len(deepcopy_calls) == 1

--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -33,6 +33,8 @@ def maybe_make_thread_pool(tokenizer: _T, copies: int = 1):
       This doesn't include ``_tokenizer`` property nor any mutation
       methods like ``add_special_tokens`` or ``add_tokens``.
     - Adjacent method calls could happen on different deep copies.
+    - Calls beyond ``copies`` use temporary deep copies that are not
+      retained in the pool.
     """
     if not isinstance(tokenizer, TokenizersBackend) or isinstance(
         tokenizer, ThreadSafeHFTokenizerMixin
@@ -49,12 +51,16 @@ def maybe_make_thread_pool(tokenizer: _T, copies: int = 1):
     def _borrow_from_pool():
         try:
             tok = tokenizer_pool.get_nowait()
-            yield tok
+            from_pool = True
         except queue.Empty:
             tok = copy.deepcopy(og_tokenizer)
+            from_pool = False
+
+        try:
             yield tok
         finally:
-            tokenizer_pool.put(tok)
+            if from_pool:
+                tokenizer_pool.put(tok)
 
     class TokenizerPool(tokenizer.__class__, ThreadSafeHFTokenizerMixin):  # type: ignore
         def apply_chat_template(self, *args, **kwargs):


### PR DESCRIPTION
## Purpose

`maybe_make_thread_pool` preallocates tokenizer copies, but its unbounded queue also retained every temporary copy created when the pool was exhausted. A single concurrency burst could therefore permanently grow the idle pool to its historical peak; real fast-tokenizer copies can retain substantial native memory.

This change keeps the configured copies in the pool and treats extra concurrent borrows as temporary: they remain non-blocking, but are released when the call finishes. It also narrows the `queue.Empty` handler to acquisition, so a wrapped tokenizer method that raises `queue.Empty` is propagated instead of being mistaken for a pool miss.

Duplicate check: no open PR or issue was found for overflow-copy retention. #47509 adds another consumer of this helper, #47583 optimizes encoding above the pool, and #41721 touches another part of `tokenizers/hf.py`; none implements this fix.

AI assistance disclosure: OpenAI Codex assisted with implementation, tests, duplicate-work review, and benchmark analysis. This PR is opened as a draft pending the submitter's line-by-line review.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/tokenizers_/test_hf.py

uvx --from pre-commit pre-commit run --files \
  vllm/tokenizers/hf.py tests/tokenizers_/test_hf.py
```

The regression test uses two barrier-synchronized bursts. With one configured copy and three concurrent calls, the old implementation creates three copies in the first burst and reuses all three in the second (`3 -> 3`); the new implementation discards the two overflow copies, so the second burst creates them again (`3 -> 5`). A separate test covers propagation of `queue.Empty` from the tokenizer body and verifies that the configured copy is returned.

For memory behavior, I used the `Qwen/Qwen3.5-0.8B` tokenizer at revision `2fc06364715b967f1860aea9cf38778875588b17` on an Intel Xeon Platinum 8559C. The pool capacity was 2 and a barrier held 8 real deep-copied tokenizers concurrently. Each arm ran in a fresh process; GC and `malloc_trim(0)` were run before USS samples. This measures post-burst residency, not burst latency.

## Test Result

- `tests/tokenizers_/test_hf.py`: **5 passed**
- All pre-commit hooks for the two changed files passed, including Ruff, formatting, mypy, SPDX, forbidden imports, and configuration checks.
- Pickle reconstruction and idempotent wrapping remain covered by the existing test.

| Implementation | Pool USS | Peak USS | USS after burst | Post-burst delta from pool |
|---|---:|---:|---:|---:|
| `main` | 1042.4 MiB | 1578.8 MiB | 1579.1 MiB | +536.7 MiB |
| this PR | 1034.6 MiB | 1684.2 MiB | 1088.6 MiB | +54.0 MiB |

Both arms created 8 copies during the forced burst. Native allocator retention makes the exact USS recovery variable (a repeat of the new path ended only 6.9 MiB above the configured pool), while the deterministic concurrency test verifies that the retained pool returns to exactly 2 copies.

No model evaluation is required because this changes copy lifetime only; tokenization results and the public tokenizer interface are unchanged.
