### PR TITLE
[Bugfix][Model] Keep embedding modality through the Qwen3-Omni deepstack split

### DIFF
--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -389,5 +389,58 @@ def test_dspark_shares_target_embedding_with_smaller_draft_vocabulary():
     assert loaded_model.model.embed_tokens is target_embedding
 
 
+def test_interleaved_deepstack_split_keeps_embedding_modality():
+    """Regression for #53700: the deepstack torch.split must carry the
+    embedding's modality over to the main-scale split, otherwise the
+    interleaved audio-in-video merge cannot group embeddings by modality.
+    """
+    from vllm.model_executor.models.qwen3_omni_moe_thinker import (
+        Qwen3OmniMoeThinkerForConditionalGeneration,
+    )
+    from vllm.multimodal.utils import set_mm_embedding_modality
+
+    text_hidden = 8
+    multiscale_len = 2
+    thinker = Qwen3OmniMoeThinkerForConditionalGeneration.__new__(
+        Qwen3OmniMoeThinkerForConditionalGeneration
+    )
+    thinker.config = SimpleNamespace(
+        video_token_id=1003,
+        audio_token_id=1001,
+        image_token_id=1002,
+        text_config=SimpleNamespace(hidden_size=text_hidden),
+    )
+    embed_tokens = nn.Embedding(2000, text_hidden)
+    nn.init.zeros_(embed_tokens.weight)
+    thinker.language_model = SimpleNamespace(embed_input_ids=embed_tokens)
+    thinker.visual = SimpleNamespace(deepstack_visual_indexes=[0, 1])
+    thinker._set_deepstack_input_embeds = Mock()
+
+    # [text text][V V V V][A A A][V V][A A][text]
+    input_ids = torch.tensor(
+        [0, 0, 1003, 1003, 1003, 1003, 1001, 1001, 1001, 1003, 1003, 1001, 1001, 0]
+    )
+    is_multimodal = (input_ids == 1001) | (input_ids == 1003)
+
+    video_embed = set_mm_embedding_modality(
+        torch.full((6, text_hidden * (multiscale_len + 1)), 1.0), "video"
+    )
+    audio_embed = set_mm_embedding_modality(torch.full((5, text_hidden), 2.0), "audio")
+
+    out = thinker.embed_input_ids(
+        input_ids,
+        [video_embed, audio_embed],
+        is_multimodal=is_multimodal,
+    )
+
+    is_video = input_ids == 1003
+    is_audio = input_ids == 1001
+    assert out.shape == (len(input_ids), text_hidden)
+    assert torch.all(out[is_video] == 1.0)
+    assert torch.all(out[is_audio] == 2.0)
+    assert torch.all(out[~(is_video | is_audio)] == 0.0)
+    thinker._set_deepstack_input_embeds.assert_called_once()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -79,6 +79,7 @@ from vllm.multimodal.processing.processor import (
     PromptUpdate,
     PromptUpdateDetails,
 )
+from vllm.multimodal.utils import copy_mm_embedding_modality
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.processor import cached_processor_from_config
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
@@ -1880,7 +1881,12 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
                     embeddings_main, embeddings_multiscale = torch.split(
                         embeddings, [visual_dim, multi_dim], dim=-1
                     )
-                    multimodal_embeddings[index] = embeddings_main
+                    # torch.split returns fresh tensors; carry the modality
+                    # set at encoder gather over to the split main-scale
+                    # embedding for the interleaved merge below.
+                    multimodal_embeddings[index] = copy_mm_embedding_modality(
+                        embeddings, embeddings_main
+                    )
                     multimodal_embeddings_multiscale.append(embeddings_multiscale)
                     if not is_interleaved:
                         current_positions = mm_positions[


### PR DESCRIPTION
## Purpose

Fixes #53700.

With `use_audio_in_video=True`, the Qwen3-Omni deepstack path `torch.split()`s each visual embedding into main-scale and multiscale parts. The split returns fresh tensors, so the `modality` attribute attached during encoder gather is lost on `embeddings_main`, and the interleaved merge below then fails with `ValueError: Missing modality on multimodal embedding at index 0`, killing the rollout. Worked on 0.23.0, broken since the modality-aware interleaved merge in #46213.

The fix copies the modality onto the split with the existing `copy_mm_embedding_modality` helper, the same pattern `mm_pruning` and the model runner already use.

Not a duplicate: #46058 fixes a different interleaved crash (audio+image coexistence, no deepstack split involved), and nothing else open references #53700 or touches this split.

## Test Plan

New regression test in `tests/model_executor/test_qwen3_omni.py` builds the interleaved audio-in-video + deepstack case on a bare thinker instance and runs `embed_input_ids` through it.

```
.venv/bin/python -m pytest tests/model_executor/test_qwen3_omni.py -q
```

## Test Result

Without the fix the test raises the exact error from the issue (`Missing modality on multimodal embedding at index 0`); with the fix all 9 tests in the file pass. `ruff check` and `ruff format --check` clean on both touched files. Not run: GPU model tests (no GPU here); the change is one attribute copy on an existing tensor path.

AI assistance: this PR was prepared with help from Kimi K3 (investigation, patch, tests); I reviewed the diff and ran the tests above.
