### PR TITLE
[Kernel][Perf] Tune fused_moe FP8 config for Qwen3-VL on L40S (+8% at batch 4-512)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=128,N=768,device_name=NVIDIA_L40S,dtype=fp8_w8a8.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=128,N=768,device_name=NVIDIA_L40S,dtype=fp8_w8a8.json
@@ -1,0 +1,171 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "16": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "48": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "96": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "16384": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "32768": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
## Purpose

Add a tuned Triton fused MoE configuration for the `E=128, N=768` FP8 W8A8 shape on a single NVIDIA L40S (`TP=1`, expert parallel disabled).

The configuration was generated with `benchmarks/kernels/benchmark_moe.py --tune`. The `M=8192` entry intentionally retains the default configuration because the tuned candidate was slightly slower for that batch size.

## Test plan

Tuned with `benchmarks/kernels/benchmark_moe.py --tune` on a single NVIDIA L40S with `--tp-size 1 --dtype fp8_w8a8` and no expert parallelism. The model shape resolved by the benchmark is `E=128, N=768`.

After tuning, the JSON was loaded from the vLLM `fused_moe/configs/` directory and the benchmark was re-run for all tested token counts.

## Test Result

Per-`M` kernel time comparison on NVIDIA L40S (Triton 3.6.0):

| M | Default (us) | Tuned (us) | Speedup |
|---:|---:|---:|---:|
| 2 | 39.06 | 37.79 | +3.3% |
| 4 | 204.56 | 190.41 | +6.9% |
| 8 | 376.96 | 347.98 | +7.7% |
| 16 | 592.31 | 552.82 | +6.7% |
| 32 | 800.43 | 742.22 | +7.3% |
| 64 | 902.75 | 839.49 | +7.0% |
| 128 | 947.23 | 870.36 | +8.1% |
| 256 | 978.59 | 897.68 | +8.3% |
| 512 | 1034.18 | 948.74 | +8.3% |
| 1024 | 1126.08 | 1052.11 | +6.6% |
| 2048 | 1375.40 | 1286.40 | +6.5% |
| 4096 | 1916.23 | 1846.43 | +3.6% |
| 8192 | 3195.68 | 3195.68 | 0.0% |
| 16384 | 6156.80 | 5957.29 | +3.2% |
| 32768 | 11825.06 | 11119.07 | +6.0% |

The `M=8192` entry uses the default configuration in this PR because the tuned candidate measured 3208.80 us versus 3195.68 us for default. The other tuned entries are retained based on the measurements above.

This is a configuration-only performance change and doesn't change model numerics. End-to-end model evaluation wasn't run locally; the results above are kernel-level measurements.

## Duplicate-work check

This isn't duplicating #44830: that PR targets `E=512, N=128` FP8 blockwise MoE on NVIDIA H100, while this PR targets `E=128, N=768` FP8 W8A8 on NVIDIA L40S. Open PR and issue searches found no existing PR for this shape/device combination.

AI assistance was used to prepare this change. The human submitter is responsible for reviewing the changed file and the benchmark results.

Generated with [Devin](https://devin.ai)
