### PR TITLE
[Model] Fold Nemotron latent MoE scale into routing weights

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -127,10 +127,11 @@ class NemotronHMoE(nn.Module):
     def __init__(
         self,
         config: NemotronHConfig,
-        model_config: ModelConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         parallel_config: ParallelConfig | None = None,
         prefix: str = "",
+        *,
+        model_config: ModelConfig | None = None,
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -127,6 +127,7 @@ class NemotronHMoE(nn.Module):
     def __init__(
         self,
         config: NemotronHConfig,
+        model_config: ModelConfig | None,
         quant_config: QuantizationConfig | None = None,
         parallel_config: ParallelConfig | None = None,
         prefix: str = "",
@@ -225,7 +226,13 @@ class NemotronHMoE(nn.Module):
             routed_input_transform=self.fc1_latent_proj,
             routed_output_transform=self.fc2_latent_proj,
             routed_scaling_factor=self.routed_scaling_factor,
-            apply_routed_scale_to_output=True,
+            # BF16 can fold the scale into routing weights before the latent
+            # projection. FP16 retains the overflow-protected output path.
+            apply_routed_scale_to_output=(
+                not self.use_latent_moe
+                or model_config is None
+                or model_config.dtype != torch.bfloat16
+            ),
             router_logits_dtype=self.gate.out_dtype,
         )
 
@@ -328,6 +335,7 @@ class NemotronHMoEDecoderLayer(nn.Module):
 
         self.mixer = NemotronHMoE(
             layer_config,
+            model_config=model_config,
             quant_config=quant_config,
             parallel_config=parallel_config,
             prefix=f"{prefix}.mixer",

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -127,7 +127,7 @@ class NemotronHMoE(nn.Module):
     def __init__(
         self,
         config: NemotronHConfig,
-        model_config: ModelConfig | None,
+        model_config: ModelConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         parallel_config: ParallelConfig | None = None,
         prefix: str = "",
@@ -226,8 +226,8 @@ class NemotronHMoE(nn.Module):
             routed_input_transform=self.fc1_latent_proj,
             routed_output_transform=self.fc2_latent_proj,
             routed_scaling_factor=self.routed_scaling_factor,
-            # BF16 can fold the scale into routing weights before the latent
-            # projection. FP16 retains the overflow-protected output path.
+            # BF16 latent MoE can fold the factor into routing weights and
+            # avoid a post-MoE scale. FP16 retains the overflow-protected path.
             apply_routed_scale_to_output=(
                 not self.use_latent_moe
                 or model_config is None


### PR DESCRIPTION
## Summary

Fold Nemotron-H's routed scaling factor into the existing grouped-top-k
routing weights for BF16 latent MoE, instead of launching a separate
post-MoE scale kernel.

FP16 keeps the existing output-scaling path because it provides overflow
protection. Non-latent MoE and direct constructors without a `ModelConfig`
retain the previous behavior.

## Rationale

Nemotron-3 Ultra has 48 latent-MoE layers. On BF16, both placements implement
the same real-valued scaling before the latent output projection, but putting
the factor in grouped top-k reuses work already performed by the router.

Two same-node, opposite-order Nsight comparisons on 4xGB200 with the latest
official vLLM nightly show:

- 48 scale launches removed per decode step/rank;
- 51.12 us of scale-kernel time removed;
- no measurable grouped-top-k regression;
- 57.74 us observed saving across grouped top-k, scaling, and latent
  projection/add, or 0.342% of baseline summed GPU kernel time.

A four-block end-to-end TP1/DP4/EP4 Ultra NVFP4 comparison had directionally
consistent but statistically inconclusive point estimates: +0.35% output
throughput and -0.26% server mean TPOT. The PR does not claim a statistically
significant E2E gain.

## Numerical behavior

The BF16 rounding order changes: the candidate scales packed BF16 routing
weights before FP32 expert accumulation, while the baseline scales the
combined BF16 latent output. Focused tests show identical expert IDs, routing
weight error at most 5.96e-8, and 0.361-0.378% normalized RMSE on simulated
packed-BF16 expert output.

Full five-shot GSM8K on all 1,319 questions:

- baseline: 94.39%;
- candidate: 94.24%;
- paired delta: -0.15 percentage point;
- 95% bootstrap interval: [-0.83, +0.53] points;
- exact McNemar p=0.832;
- zero invalid outputs.

No model-quality regression is detected.

## Validation

- `pre-commit run --files vllm/model_executor/models/nemotron_h.py`: passed
  under Python 3.12, including Ruff, formatting, mypy, SPDX, forbidden-import,
  CUDA-API, and repository-specific checks.
- `.venv/bin/python -m py_compile vllm/model_executor/models/nemotron_h.py`:
  passed.
- GB200 CUDA-graph smoke at token counts 1, 4, 16, 32, 64, and 256: passed,
  with stable output pointers and bitwise-stable replay.
- The focused smoke was repeated on the latest official vLLM nightly with
  PyTorch `2.13.0+cu129`: passed with the same error bounds.
- Full Nemotron-3 Ultra NVFP4 serving on that nightly, TP1/DP4/EP4 with the
  default all-gather/reduce-scatter path and 50,000-token requests: passed.
- Same-node route-repeat control: candidate-vs-baseline routing divergence is
  no larger than baseline-vs-baseline variation with production Mamba cache
  stochastic rounding.

## Duplicate check

Open vLLM PRs and issues were searched for `apply_routed_scale_to_output`,
Nemotron latent-MoE scaling, and equivalent routed-weight folding. No
duplicate implementation was found.

## AI assistance

OpenAI Codex assisted with code exploration, implementation, experiment
automation, and report drafting. The submitter reviewed the complete diff and
the reported correctness, model-evaluation, and performance evidence.
