### PR TITLE
[Perf][MM] Deduplicate field metadata in EngineCore IPC

### DIFF
--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm.multimodal.inputs import (
     MultiModalBatchedField,
+    MultiModalFieldConfig,
     MultiModalFieldElem,
     MultiModalFlatField,
     MultiModalKwargsItem,
@@ -102,6 +103,10 @@ class MyRequest(msgspec.Struct):
     mm: list[MultiModalKwargsItems] | None
 
 
+class MyItemRequest(msgspec.Struct):
+    mm: list[MultiModalKwargsItem | None]
+
+
 def test_multimodal_kwargs():
     e1 = MultiModalFieldElem(
         torch.zeros(1000, dtype=torch.bfloat16),
@@ -158,6 +163,127 @@ def test_multimodal_kwargs():
     mm_data = mm.get_data()
     decoded_data = decoded.get_data()
     assert all(nested_equal(mm_data[k], decoded_data[k]) for k in mm_data)
+
+
+def _make_repeated_flat_field_items(num_items: int) -> MultiModalKwargsItems:
+    sizes = torch.ones(num_items, dtype=torch.int64)
+    config = MultiModalFieldConfig.flat_from_sizes(
+        "image", sizes, dim=1, keep_on_cpu=True
+    )
+    return MultiModalKwargsItems.from_hf_inputs(
+        {"pixels": torch.arange(2 * num_items).view(2, num_items)},
+        {"pixels": config},
+    )
+
+
+def test_multimodal_field_deduplication():
+    mm = _make_repeated_flat_field_items(128)
+    fields = [item["pixels"].field for item in mm["image"]]
+    assert all(field is fields[0] for field in fields)
+
+    legacy = MsgpackEncoder(size_threshold=2**62).encode(mm)
+    encoder = MsgpackEncoder(
+        size_threshold=2**62,
+        use_mm_field_refs=True,
+    )
+    encoded = encoder.encode(mm)
+
+    # The first occurrence defines the field using the legacy wire format;
+    # subsequent occurrences reference its per-message table index.
+    legacy_raw = msgspec.msgpack.decode(legacy[0])
+    assert all(
+        isinstance(item["pixels"]["field"], list) for item in legacy_raw["image"]
+    )
+    raw = msgspec.msgpack.decode(encoded[0])
+    encoded_fields = [item["pixels"]["field"] for item in raw["image"]]
+    assert isinstance(encoded_fields[0], list)
+    assert encoded_fields[1:] == [0] * 127
+
+    # This input triggers the former quadratic duplication of the 128 slices.
+    assert len(encoded[0]) * 4 < len(legacy[0])
+
+    decoded = MsgpackDecoder(MultiModalKwargsItems).decode(encoded)
+    decoded_fields = [item["pixels"].field for item in decoded["image"]]
+    assert all(field is decoded_fields[0] for field in decoded_fields)
+    assert isinstance(decoded_fields[0], MultiModalFlatField)
+    assert decoded_fields[0].dim == 1
+    assert decoded_fields[0].keep_on_cpu
+    assert torch.equal(decoded.get_data()["pixels"], mm.get_data()["pixels"])
+
+
+def test_multimodal_field_deduplication_across_items():
+    mm = _make_repeated_flat_field_items(3)
+    request = MyItemRequest([*mm["image"], None])
+
+    encoded = MsgpackEncoder(use_mm_field_refs=True).encode(request)
+    decoded = MsgpackDecoder(MyItemRequest).decode(encoded)
+
+    assert decoded.mm[-1] is None
+    fields = [item["pixels"].field for item in decoded.mm if item is not None]
+    assert all(field is fields[0] for field in fields)
+
+
+def test_multimodal_field_deduplication_uses_identity():
+    fields = [
+        MultiModalFlatField(slices=[slice(0, 1)]),
+        MultiModalFlatField(slices=[slice(0, 1)]),
+    ]
+    mm = MultiModalKwargsItems(
+        {
+            "image": [
+                MultiModalKwargsItem({"pixels": MultiModalFieldElem(float(i), field)})
+                for i, field in enumerate(fields)
+            ]
+        }
+    )
+
+    encoded = MsgpackEncoder(use_mm_field_refs=True).encode(mm)
+    raw = msgspec.msgpack.decode(encoded[0])
+    encoded_fields = [item["pixels"]["field"] for item in raw["image"]]
+    assert all(isinstance(field, list) for field in encoded_fields)
+
+    decoded = MsgpackDecoder(MultiModalKwargsItems).decode(encoded)
+    assert decoded["image"][0]["pixels"].field is not (
+        decoded["image"][1]["pixels"].field
+    )
+
+
+def test_multimodal_field_tables_reset_between_messages():
+    mm = _make_repeated_flat_field_items(2)
+    encoder = MsgpackEncoder(
+        size_threshold=2**62,
+        use_mm_field_refs=True,
+    )
+    decoder = MsgpackDecoder(MultiModalKwargsItems)
+
+    first = encoder.encode(mm)
+    first_decoded = decoder.decode(first)
+    assert first_decoded["image"][0]["pixels"].field is (
+        first_decoded["image"][1]["pixels"].field
+    )
+
+    # Reuse both instances and exercise encode_into plus raw-bytes decode.
+    second = encoder.encode_into(mm, bytearray())
+    raw = msgspec.msgpack.decode(second[0])
+    assert isinstance(raw["image"][0]["pixels"]["field"], list)
+    assert raw["image"][1]["pixels"]["field"] == 0
+    second_decoded = decoder.decode(second[0])
+    second_fields = [item["pixels"].field for item in second_decoded["image"]]
+    assert second_fields[0] is second_fields[1]
+    assert second_fields[0] is not (first_decoded["image"][0]["pixels"].field)
+
+
+@pytest.mark.parametrize("field_ref", [-1, 0, True])
+def test_invalid_multimodal_field_reference(field_ref: int):
+    payload = msgspec.msgpack.encode(
+        {
+            "image": [
+                {"pixels": {"data": 1.0, "field": field_ref}},
+            ]
+        }
+    )
+    with pytest.raises(msgspec.ValidationError, match="Invalid multi-modal field"):
+        MsgpackDecoder(MultiModalKwargsItems).decode(payload)
 
 
 def nested_equal(a: NestedTensors, b: NestedTensors):

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -629,7 +629,15 @@ class MPClient(EngineCoreClient):
                 if mm_tensor_ipc == "torch_shm" and tensor_queue is not None:
                     tensor_ipc_sender = TensorIpcSender(tensor_queue)
 
-            self.encoder = MsgpackEncoder(oob_tensor_consumer=tensor_ipc_sender)
+            # Client and EngineCore run the same version, so the internal wire
+            # can safely use per-message references for repeated MM fields.
+            self.encoder = MsgpackEncoder(
+                oob_tensor_consumer=tensor_ipc_sender,
+                use_mm_field_refs=(
+                    model_config is not None
+                    and model_config.multimodal_config is not None
+                ),
+            )
             self.decoder = MsgpackDecoder(EngineCoreOutputs)
 
             dp_size = parallel_config.data_parallel_size

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -144,12 +144,17 @@ class MsgpackEncoder:
 
     When a ``oob_tensor_consumer`` is provided, tensors (CUDA and CPU) will be
     offered to it for out-of-band handling.
+
+    ``use_mm_field_refs`` replaces repeated multi-modal field definitions with
+    per-message references. It is intended for same-version internal IPC; keep
+    it disabled for externally exchanged payloads.
     """
 
     def __init__(
         self,
         size_threshold: int | None = None,
         oob_tensor_consumer: OOBTensorConsumer | None = None,
+        use_mm_field_refs: bool = False,
     ):
         if size_threshold is None:
             size_threshold = envs.VLLM_MSGPACK_ZERO_COPY_THRESHOLD
@@ -160,6 +165,8 @@ class MsgpackEncoder:
         self.aux_buffers: list[bytestr] | None = None
         self.size_threshold = size_threshold
         self.oob_tensor_consumer = oob_tensor_consumer
+        self.use_mm_field_refs = use_mm_field_refs
+        self.mm_field_cache: dict[int, tuple[BaseMultiModalField, int]] | None = None
         if envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
             _log_insecure_serialization_warning()
 
@@ -167,6 +174,8 @@ class MsgpackEncoder:
         try:
             if self.oob_tensor_consumer is not None:
                 self.oob_tensor_consumer.new_message()
+            if self.use_mm_field_refs:
+                self.mm_field_cache = {}
             self.aux_buffers = bufs = [b""]
             bufs[0] = self.encoder.encode(obj)
             # This `bufs` list allows us to collect direct pointers to backing
@@ -176,17 +185,21 @@ class MsgpackEncoder:
             return bufs
         finally:
             self.aux_buffers = None
+            self.mm_field_cache = None
 
     def encode_into(self, obj: Any, buf: bytearray) -> Sequence[bytestr]:
         try:
             if self.oob_tensor_consumer is not None:
                 self.oob_tensor_consumer.new_message()
+            if self.use_mm_field_refs:
+                self.mm_field_cache = {}
             self.aux_buffers = [buf]
             bufs = self.aux_buffers
             self.encoder.encode_into(obj, buf)
             return bufs
         finally:
             self.aux_buffers = None
+            self.mm_field_cache = None
 
     def enc_hook(self, obj: Any) -> Any:
         if isinstance(obj, torch.Tensor):
@@ -298,7 +311,19 @@ class MsgpackEncoder:
             return nt
         return [self._encode_nested_tensors(x) for x in nt]
 
-    def _encode_mm_field(self, field: BaseMultiModalField):
+    def _encode_mm_field(
+        self, field: BaseMultiModalField
+    ) -> int | tuple[str, dict[str, Any]]:
+        if self.mm_field_cache is not None:
+            field_id = id(field)
+            cached = self.mm_field_cache.get(field_id)
+            if cached is not None:
+                cached_field, field_index = cached
+                assert cached_field is field
+                return field_index
+
+            self.mm_field_cache[field_id] = (field, len(self.mm_field_cache))
+
         # Figure out the factory name for the field type.
         name = MMF_CLASS_TO_FACTORY.get(field.__class__)
         if not name:
@@ -333,19 +358,22 @@ class MsgpackDecoder:
             *args, ext_hook=self.ext_hook, dec_hook=self.dec_hook
         )
         self.aux_buffers: Sequence[bytestr] = ()
+        self.mm_fields: list[BaseMultiModalField] | None = None
         self.oob_tensor_provider = oob_tensor_provider
         if envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
             _log_insecure_serialization_warning()
 
     def decode(self, bufs: bytestr | Sequence[bytestr]) -> Any:
-        if isinstance(bufs, bytestr):  # type: ignore
-            return self.decoder.decode(bufs)
-
-        self.aux_buffers = bufs
+        self.mm_fields = None
         try:
+            if isinstance(bufs, bytestr):  # type: ignore
+                return self.decoder.decode(bufs)
+
+            self.aux_buffers = bufs
             return self.decoder.decode(bufs[0])
         finally:
             self.aux_buffers = ()
+            self.mm_fields = None
 
     def dec_hook(self, t: type, obj: Any) -> Any:
         # Given native types in `obj`, convert to type `t`.
@@ -441,16 +469,30 @@ class MsgpackDecoder:
         if obj["data"] is not None:
             obj["data"] = self._decode_nested_tensors(obj["data"])
 
-        # Reconstruct the field processor using MultiModalFieldConfig
-        factory_meth_name, factory_kw = obj["field"]
-        factory_meth = getattr(MultiModalFieldConfig, factory_meth_name)
+        field = obj["field"]
+        if type(field) is int:
+            if self.mm_fields is None or field < 0 or field >= len(self.mm_fields):
+                raise ValueError(f"Invalid multi-modal field reference: {field}")
+            decoded_field = self.mm_fields[field]
+        else:
+            if not isinstance(field, (list, tuple)) or len(field) != 2:
+                raise TypeError(f"Invalid multi-modal field definition: {field!r}")
 
-        # Special case: decode the union "slices" field of
-        # MultiModalFlatField
-        if factory_meth_name == "flat":
-            factory_kw["slices"] = self._decode_nested_slices(factory_kw["slices"])
+            # Reconstruct the field processor using MultiModalFieldConfig
+            factory_meth_name, factory_kw = field
+            factory_meth = getattr(MultiModalFieldConfig, factory_meth_name)
 
-        obj["field"] = factory_meth("", **factory_kw).field
+            # Special case: decode the union "slices" field of
+            # MultiModalFlatField
+            if factory_meth_name == "flat":
+                factory_kw["slices"] = self._decode_nested_slices(factory_kw["slices"])
+
+            decoded_field = factory_meth("", **factory_kw).field
+            if self.mm_fields is None:
+                self.mm_fields = []
+            self.mm_fields.append(decoded_field)
+
+        obj["field"] = decoded_field
         return MultiModalFieldElem(**obj)
 
     def _decode_nested_tensors(self, obj: Any) -> NestedTensors:


### PR DESCRIPTION
## Purpose

`MultiModalKwargsItems` can contain many elements that share one `BaseMultiModalField`. The existing msgpack path serializes that field definition—including all flat-field slices—for every element. For `N` flat items, this repeats `N` slices `N` times, so field metadata and serialization work grow quadratically.

This PR adds an opt-in, per-message field table. The first occurrence keeps the legacy field definition; later occurrences of the same field object use an integer reference. The decoder accepts both forms and resets its table after every message, including error paths.

The new format is enabled only for multimodal `MPClient` → EngineCore IPC, where both endpoints run the same vLLM version. It remains disabled by default, so external scale-out payloads and other callers keep the legacy wire format. Text-only clients do not allocate the field table.

Duplicate check: searches for `_encode_mm_field`, `use_mm_field_refs`, and multimodal msgpack metadata found no PR implementing this optimization. Related work such as #49462 and #51349 changes tensor transport, while this PR only deduplicates field metadata.

AI assistance disclosure: OpenAI Codex assisted with investigation, implementation, tests, benchmarking, and drafting. This PR is opened as a draft and will not be marked ready until the submitter completes line-by-line review.

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/v1/test_serial_utils.py

CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest -q \
  tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py \
  tests/v1/test_tensor_ipc_queue.py

uvx --from pre-commit pre-commit run --files \
  vllm/v1/serial_utils.py \
  vllm/v1/engine/core_client.py \
  tests/v1/test_serial_utils.py
```

The tests cover legacy payloads, definition/reference round trips, object-identity deduplication, cached `None` features, message-table reset for `encode`, `encode_into`, and both decoder inputs, plus invalid negative, missing, and boolean references.

## Test Result

- `tests/v1/test_serial_utils.py`: **19 passed**
- Scale-out MM serde and CPU tensor IPC: **13 passed, 3 skipped** (CUDA cases intentionally disabled)
- All pre-commit hooks for the three changed files passed, including Ruff, formatting, mypy, SPDX, forbidden imports, and configuration checks.

Real typed `EngineCoreRequest` CPU microbenchmark with 256 MM items:

| Metric | Legacy definitions | Field references | Improvement |
|---|---:|---:|---:|
| Main payload | 435,258 B | 34,398 B | 12.65x smaller |
| Encode median | 68.09 ms | 1.52 ms | 44.75x |
| Decode median | 28.77 ms | 2.24 ms | 12.85x |

Method: Intel Xeon Platinum 8559C, one logical CPU, one Torch thread, 10 warmups, alternating AB/BA order, GC disabled inside timed regions, and 25 samples per arm. Tensors were kept inline with a high zero-copy threshold, so this measures typed msgpack payload and field-metadata CPU cost—not tensor IPC or end-to-end serving latency.

Model evaluations were not run because the change only affects internal request serialization. Round-trip and IPC tests verify equivalent decoded request data.
