### PR TITLE
[CI/Build] Add PPL test for Gemma-4

### DIFF
--- a/tests/models/language/generation_ppl_test/test_gemma.py
+++ b/tests/models/language/generation_ppl_test/test_gemma.py
@@ -10,6 +10,7 @@ MODELS = [
     GenerateModelInfo("google/gemma-2b", hf_ppl=21.48524284362793),
     GenerateModelInfo("google/gemma-2-2b", hf_ppl=102.59290313720703),
     GenerateModelInfo("google/gemma-3-4b-it", hf_ppl=27.79648208618164),
+    GenerateModelInfo("google/gemma-4-E2B-it", hf_ppl=16728.765625),
 ]
 
 


### PR DESCRIPTION

## Purpose
Add `google/gemma-4-E2B-it` to the WikiText PPL test to extend PPL coverage to Gemma 4.

The bf16 Hugging Face reference PPL is `16728.765625`.

## Test Plan

```bash
# The new entry (currently the last one in MODELS):
python -m pytest tests/models/language/generation_ppl_test/test_gemma.py -v -s -k model_info3
```

## Test Result

Passed locally on an RTX 3090 with bf16:
- vLLM PPL: 16407.470703125
- Hugging Face PPL: 16728.765625
- Difference: -1.9206%

```bash
1 passed, 3 deselected
```
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

