### PR TITLE
[Bugfix] Avoid MCP events for Harmony browser calls

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -637,7 +637,7 @@ class TestHarmonyPreambleStreaming:
         mcp_segment = self._make_segment(
             channel="commentary", recipient="repo_browser.list"
         )
-        events = emit_content_delta_events(mcp_segment, StreamingState())
+        events = emit_content_delta_events(mcp_segment, StreamingState(), frozenset())
         assert "response.mcp_call.in_progress" in [event.type for event in events]
 
     def test_preamble_done_emits_text_done_events(self) -> None:

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -604,6 +604,42 @@ class TestHarmonyPreambleStreaming:
         type_names = [e.type for e in events]
         assert "response.output_text.delta" not in type_names
 
+    def test_browser_stream_uses_web_search_lifecycle(self) -> None:
+        """Browser calls use web-search events instead of MCP events."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_content_delta_events,
+            emit_tool_action_events,
+        )
+
+        browser_segment = self._make_segment(
+            channel="commentary", recipient="browser.search"
+        )
+        assert emit_content_delta_events(browser_segment, StreamingState()) == []
+
+        previous = self._make_previous_item(
+            channel="commentary",
+            recipient="browser.search",
+            text='{"query": "vLLM"}',
+        )
+        previous.author.role = "assistant"
+        tool_server = MagicMock(spec=ToolServer)
+        tool_server.has_tool.return_value = True
+
+        events = emit_tool_action_events(previous, StreamingState(), tool_server)
+        assert [event.type for event in events] == [
+            "response.output_item.added",
+            "response.web_search_call.in_progress",
+            "response.web_search_call.searching",
+            "response.web_search_call.completed",
+            "response.output_item.done",
+        ]
+
+        mcp_segment = self._make_segment(
+            channel="commentary", recipient="repo_browser.list"
+        )
+        events = emit_content_delta_events(mcp_segment, StreamingState())
+        assert "response.mcp_call.in_progress" in [event.type for event in events]
+
     def test_preamble_done_emits_text_done_events(self) -> None:
         """Completed preamble should emit text done + content_part done +
         output_item done, same shape as final channel."""

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -128,10 +128,11 @@ def is_mcp_tool_by_namespace(
     """
     Determine if a tool call is an MCP tool based on recipient prefix.
 
-    Inverse of :func:`is_function_recipient` — everything that is not
-    a function call is an MCP tool.
+    Browser recipients use the dedicated web-search event lifecycle and
+    must not be treated as MCP tools. All other non-function recipients
+    are MCP tools.
     """
-    if recipient is None:
+    if recipient is None or recipient.startswith("browser."):
         return False
     return not is_function_recipient(recipient, allowed_function_tool_names)
 


### PR DESCRIPTION
## Purpose

Harmony browser recipients (browser.*) currently fall through the inverse function-recipient check and are streamed as MCP calls. When the item completes, the dedicated web-search lifecycle is also emitted, so clients can observe mixed MCP and web-search events for one browser call. This change excludes reserved browser recipients from MCP namespace classification while preserving ordinary non-function namespaces as MCP tools.

## Test Plan

- python -m pytest tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_browser_stream_uses_web_search_lifecycle -q
- ruff check vllm/entrypoints/openai/responses/streaming_events.py tests/entrypoints/openai/responses/test_serving_responses.py
- ruff format --check vllm/entrypoints/openai/responses/streaming_events.py tests/entrypoints/openai/responses/test_serving_responses.py
- python -m py_compile vllm/entrypoints/openai/responses/streaming_events.py tests/entrypoints/openai/responses/test_serving_responses.py

## Test Result

- Ruff check: passed
- Ruff format check: passed
- Python bytecode compilation: passed
- Isolated delta/done routing smoke test: passed
- Focused pytest collection is blocked locally because the installed PyTorch 2.4.1 does not provide torch.library.infer_schema, which current vLLM imports.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan is provided.
- [x] Test results and the local environment limitation are documented.
- [x] No documentation update is required for this internal streaming event fix.

</details>