### PR TITLE
[CI] Fix torch-nightly Rust frontend version mismatch

### DIFF
--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -3,6 +3,7 @@ depends_on:
   - image-build
 steps:
 - label: ":nvidia: (H200) Rust Frontend OpenAI Coverage"
+  key: rust-frontend-openai-coverage
   timeout_in_minutes: 30
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -38,6 +39,7 @@ steps:
   - pytest -v -s v1/sample/test_logprobs_e2e.py -k "test_prompt_logprobs_e2e_server"
 
 - label: ":nvidia: (H200) Rust Frontend Serve/Admin Coverage"
+  key: rust-frontend-serve-admin-coverage
   timeout_in_minutes: 25
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -521,6 +521,9 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # Build the vLLM wheel
 RUN --mount=type=cache,target=/opt/uv/cache \
     --mount=type=bind,source=.git,target=.git \
+    if [ "${PYTORCH_NIGHTLY}" = "1" ]; then \
+        export SETUPTOOLS_SCM_PRETEND_METADATA="{dirty=false}"; \
+    fi && \
     if [ "${vllm_target_device}" = "cuda" ]; then \
         export VLLM_USE_PRECOMPILED=1; \
         export VLLM_PRECOMPILED_WHEEL_LOCATION=$(ls /precompiled-wheels/*.whl); \

--- a/tests/tools/test_docker_build_metadata_args.py
+++ b/tests/tools/test_docker_build_metadata_args.py
@@ -153,6 +153,17 @@ def test_vllm_openai_image_embeds_metadata_contract() -> None:
         assert expected in dockerfile
 
 
+def test_torch_nightly_wheel_ignores_intentional_source_mutations() -> None:
+    dockerfile = (REPO_ROOT / "docker" / "Dockerfile").read_text()
+    build_stage = dockerfile.split("FROM base AS build", maxsplit=1)[1]
+    build_stage = build_stage.split("\nFROM ", maxsplit=1)[0]
+    wheel_build = build_stage.split("# Build the vLLM wheel", maxsplit=1)[1]
+    wheel_build = wheel_build.split("# Record the wheel checksum", maxsplit=1)[0]
+
+    assert 'if [ "${PYTORCH_NIGHTLY}" = "1" ]; then' in wheel_build
+    assert 'SETUPTOOLS_SCM_PRETEND_METADATA="{dirty=false}"' in wheel_build
+
+
 def test_rocm_ci_base_bake_embeds_content_hash_label() -> None:
     bake_file = (REPO_ROOT / "docker" / "docker-bake-rocm.hcl").read_text()
 


### PR DESCRIPTION
## Summary

- suppress the intentional dirty-tree marker while the torch-nightly wheel is built
- keep the Python package version identical to the Rust frontend version embedded earlier in the Docker build
- add a regression check for the nightly wheel-build contract
- add stable selector keys for the two affected Rust frontend CI jobs

## Root cause

The torch-nightly Docker path runs `use_existing_torch.py --prefix`, which edits tracked requirement files before `setup.py bdist_wheel`. `setuptools-scm` therefore appends a `.dYYYYMMDD` dirty suffix to the Python package version. The Rust frontend is built in a separate stage with `dirty=false`, so its embedded version has no suffix.

This deterministically failed both Rust frontend version assertions in torch-nightly #84579, #84994, and #85477. The latest failures were:

- H200 Rust Frontend OpenAI Coverage: `test_uds.py::test_show_version`
- H200 Rust Frontend Serve/Admin Coverage: `test_basic.py::test_show_version`

The nightly-only metadata override preserves git-derived commit/version information and only removes the artificial dirty flag caused by the build's own dependency rewrite.

## Why this is not duplicate work

I searched open issues/PRs for the torch-nightly Rust version mismatch, `rust_frontend_version`, `VLLM_RS_BUILD_VERSION`, and `SETUPTOOLS_SCM_PRETEND_METADATA`. No open change fixes this failure. #53290 changes Rust-stage caching and relinking, but it does not change the later torch-nightly Python wheel build where the dirty suffix is introduced.

## Validation

- `/home/ubuntu/vllm/.venv/bin/python -m pytest --confcutdir=tests/tools tests/tools/test_docker_build_metadata_args.py -v`: 9 passed
- `uv tool run pre-commit run --files docker/Dockerfile .buildkite/test_areas/rust_frontend.yaml tests/tools/test_docker_build_metadata_args.py`: passed
- `git diff --check`: passed
- stable CI selector uniqueness check: passed
- local `setuptools-scm` reproduction: dirty build `...+gd9fbe526c.d20260825`; with the nightly override `...+gd9fbe526c`
- exact torch-nightly targeted Buildkite #85484 at `d26fc039`: passed; both selected H200 Rust frontend jobs passed exit 0, including `test_uds.py::test_show_version` and `test_basic.py::test_show_version` with matching clean Python/Rust version `0.26.1rc1.dev1190+gd26fc039e`
- the OpenAI job's original attempt and first retry failed in the H200 environment hook before checkout/plugin execution because it tried an unsuffixed image, so no test ran in either; a narrow exact-commit marker enabled the valid replacement and was removed after it passed
- Docker daemon parse/build was unavailable on this host due socket permissions
- no model evaluations were run because this changes build metadata only and does not affect model output, accuracy, or serving behavior

## AI assistance

AI assistance was used to investigate the CI failures, implement the fix, and run validation. The human submitter must review every changed line and confirm the exact torch-nightly CI result before merging.
