### PR TITLE
[Bugfix] Guard completion logprobs when sampled token missing from top logprobs

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion_logprobs.py
+++ b/tests/entrypoints/openai/completion/test_completion_logprobs.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+from vllm.entrypoints.openai.completion.serving import OpenAIServingCompletion
+from vllm.logprobs import Logprob
+
+
+def _serving() -> OpenAIServingCompletion:
+    serving = OpenAIServingCompletion.__new__(OpenAIServingCompletion)
+    serving.return_tokens_as_token_ids = False
+    return serving
+
+
+def test_completion_logprobs_handles_sampled_token_absent_from_step():
+    """The sampled token can be missing from a step's top-logprobs dict (e.g.
+    when the top logprobs are all special tokens). The completion path must
+    not raise KeyError, mirroring the chat path guard added in #17637; that
+    fix only landed on the chat surface.
+    """
+    serving = _serving()
+    tokenizer = MagicMock()
+    tokenizer.decode.return_value = "<special>"
+
+    # Sampled token 5 is not a key in the step's top-logprobs dict.
+    top_logprobs: list[dict[int, Logprob] | None] = [
+        {
+            1: Logprob(logprob=-0.1, rank=1, decoded_token="a"),
+            2: Logprob(logprob=-0.2, rank=2, decoded_token="b"),
+        }
+    ]
+
+    result = serving._create_completion_logprobs(
+        token_ids=[5],
+        top_logprobs=top_logprobs,
+        num_output_top_logprobs=2,
+        tokenizer=tokenizer,
+    )
+
+    assert result.tokens == ["<special>"]
+    assert result.token_logprobs == [None]
+    assert result.top_logprobs == [None]
+    tokenizer.decode.assert_called_once_with(5)

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -677,7 +677,7 @@ class OpenAIServingCompletion(GenerateBaseServing):
         )
         for i, token_id in enumerate(token_ids):
             step_top_logprobs = top_logprobs[i]
-            if step_top_logprobs is None:
+            if step_top_logprobs is None or step_top_logprobs.get(token_id) is None:
                 if should_return_as_token_id:
                     token = format_token_id_placeholder(token_id)
                 else:


### PR DESCRIPTION
## Purpose

`_create_completion_logprobs` indexes the per-step top-logprobs dict with the sampled token id:

```python
step_top_logprobs = top_logprobs[i]
if step_top_logprobs is None:
    ...
else:
    step_token = step_top_logprobs[token_id]   # KeyError if token_id absent
```

The sampled token can be **absent** from that dict (e.g. when the step's top logprobs are all special tokens), so `step_top_logprobs[token_id]` raises `KeyError` and the completion request fails with a 500.

The chat path already handles this — #17637 ("fix KeyError on top logprobs are special tokens") changed the guard to:

```python
if step_top_logprobs is None or step_top_logprobs.get(token_id) is None:
```

but that fix only touched `serving_chat.py`; the completion path (`_create_completion_logprobs`) was never updated and still has the original crashing form.

## Fix

Mirror the chat guard in `_create_completion_logprobs` so a missing sampled token falls back to decoding the token with a null logprob (the existing `step_top_logprobs is None` branch), instead of raising.

## Not a duplicate

- `#17637` fixed only the chat surface (1 file, `serving_chat.py`).
- `gh pr list --search "completion logprobs KeyError"` / `"17637"` — no open PR addresses the completion path.

## Test plan

Added `tests/entrypoints/openai/completion/test_completion_logprobs.py`, a focused unit test that builds a step whose top-logprobs dict does not contain the sampled token and asserts `_create_completion_logprobs` returns the decoded token with `None` logprob instead of raising.

Verified fix-absent/fix-present directly (macOS torch teardown makes a full `pytest` process exit noisily, so the method was exercised directly):

```
FIX-ABSENT : KeyError(5) raised
FIX-PRESENT: tokens=['<special>'], token_logprobs=[None], top_logprobs=[None]  (no error)
```

`ruff check` / `ruff format` on the changed files: clean. Behaviour matches the chat path, so no output/accuracy change for the normal (token-present) case — the guard only affects the previously-crashing case.

## AI assistance

AI assistance (Claude Code) was used to locate this cross-surface inconsistency and reproduce it; every changed line was reviewed and the test was run locally by the submitter.
