### PR TITLE
[Bugfix] Fix speculative CUDA graph profiling pool

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
@@ -43,6 +43,23 @@ class _FakeCudaGraphManager:
         return self._needs_capture
 
 
+class _FakeSpeculator:
+    def __init__(self, managers: list[_FakeCudaGraphManager]) -> None:
+        self.managers = managers
+        self.cleared = False
+
+    def get_cudagraph_managers(self) -> list[_FakeCudaGraphManager]:
+        # Model the interface that lets profiling discover every manager
+        # owned by a concrete speculator implementation.
+        return self.managers
+
+    def clear_cudagraph_managers(self) -> None:
+        # Model the profiling teardown that discards managers created for the
+        # temporary profiling pass.
+        self.managers.clear()
+        self.cleared = True
+
+
 def _make_profiling_runner(
     cudagraph_mode: CUDAGraphMode,
     *,
@@ -51,11 +68,17 @@ def _make_profiling_runner(
     piecewise_only: bool = False,
     captured_bytes: int = 7 << 30,
     mem_samples: list[int] | None = None,
+    speculator_managers: list[_FakeCudaGraphManager] | None = None,
 ) -> Any:
     runner: Any = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
     runner.compilation_config = SimpleNamespace(cudagraph_mode=cudagraph_mode)
     runner.cudagraph_manager = _FakeCudaGraphManager(
         needs_capture, num_full_descs, piecewise_only
+    )
+    runner.speculator = (
+        _FakeSpeculator(speculator_managers)
+        if speculator_managers is not None
+        else None
     )
     runner.vllm_config = SimpleNamespace()
 
@@ -284,3 +307,81 @@ def test_profile_cudagraph_memory_redirects_wrapper_pools(monkeypatch):
         assert wrapper.graph_pool == GLOBAL_POOL
     finally:
         cgu.CUDAGraphWrapper._all_instances.discard(wrapper)
+
+
+def test_profile_cudagraph_memory_redirects_speculator_pools(monkeypatch):
+    """All CUDA graph managers must use the throwaway profiling pool."""
+    _patch_module(monkeypatch)
+
+    speculator_managers = [
+        _FakeCudaGraphManager(needs_capture=True, num_full_descs=2),
+        _FakeCudaGraphManager(needs_capture=True, num_full_descs=2),
+    ]
+    runner = _make_profiling_runner(
+        CUDAGraphMode.FULL_AND_PIECEWISE,
+        speculator_managers=speculator_managers,
+    )
+
+    captured_pools: list[Any] = []
+
+    def _capture_model() -> int:
+        captured_pools.append(runner.cudagraph_manager.pool)
+        captured_pools.extend(
+            graph_manager.pool for graph_manager in speculator_managers
+        )
+        return 1 << 30
+
+    runner.capture_model = _capture_model
+
+    cgu.profile_cudagraph_memory(runner)
+
+    # Profiling graphs from both the target model and speculator must stay out
+    # of the persistent global pool; otherwise their later destruction can
+    # leave the global pool with use_count == 0 and break the real capture.
+    assert captured_pools == [
+        THROWAWAY_POOL,
+        THROWAWAY_POOL,
+        THROWAWAY_POOL,
+    ]
+
+
+def test_teardown_profiling_state_clears_speculator_cudagraph_managers(
+    monkeypatch,
+):
+    """Profiling CUDA graph managers must be discarded before real capture."""
+    speculator_managers = [
+        _FakeCudaGraphManager(needs_capture=True, num_full_descs=2),
+        _FakeCudaGraphManager(needs_capture=True, num_full_descs=2),
+    ]
+    speculator = _FakeSpeculator(speculator_managers)
+
+    runner = mrv2.GPUModelRunner.__new__(mrv2.GPUModelRunner)
+    runner.speculator = speculator
+    runner.cudagraph_manager = _FakeCudaGraphManager(
+        needs_capture=True, num_full_descs=2
+    )
+    runner.kv_caches = {}
+    runner.attn_groups = []
+    runner.kv_cache_config = object()
+    runner.model_state = SimpleNamespace(supports_mm_inputs=False)
+    runner.compilation_config = SimpleNamespace(static_forward_context={})
+    runner.cache_config = SimpleNamespace(num_gpu_blocks=1)
+    runner.lora_config = None
+
+    monkeypatch.setattr(cgu.torch.accelerator, "synchronize", lambda: None)
+    monkeypatch.setattr(cgu.torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(cgu.gc, "collect", lambda: None)
+    monkeypatch.setattr(
+        runner,
+        "maybe_remove_all_loras",
+        lambda _lora_config: None,
+    )
+
+    cgu._teardown_profiling_state(runner)
+
+    # The profiling managers capture against the temporary KV-cache state,
+    # so they must be released before initialize_kv_cache() creates fresh
+    # managers for the real runtime capture.
+    assert runner.cudagraph_manager is None
+    assert speculator.cleared
+    assert speculator.managers == []

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -729,13 +729,19 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
     manager = runner.cudagraph_manager
     assert manager is not None
 
+    managers = [manager]
+    if runner.speculator is not None:
+        managers.extend(runner.speculator.get_cudagraph_managers())
+
     # Don't count profiling captures; the real capture_model() runs later.
     saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
     saved_capture_triggers = compilation_counter.num_gpu_runner_capture_triggers
     all_wrappers: list[Any] = []
     original_pools: dict[int, Any] = {}
     try:
-        if not manager.needs_capture():
+        if not managers or not any(
+            graph_manager.needs_capture() for graph_manager in managers
+        ):
             return 0
         # Capture all profiling graphs into a throwaway pool so their memory
         # is reclaimed on teardown rather than retained by the persistent
@@ -744,18 +750,24 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
         # captured into the global pool and then discarded drop its use_count
         # to 0, and the real capture on the same pool trips the c10 allocator's
         # create_or_incref_pool assert ("use_count > 0 INTERNAL ASSERT FAILED").
-        manager.pool = current_platform.graph_pool_handle()
-        if manager.use_breakable_cg:
-            # The breakable runner is otherwise created lazily during capture,
-            # after the pool swap below, and would capture into the global
-            # pool. Create it now so its pool gets swapped too.
-            manager.init_breakable_cg_runner(runner.model)
+        throwaway_pool = current_platform.graph_pool_handle()
+        # All graph managers participate in capture_model(), including managers
+        # owned by the speculator. Profiling captures must use the throwaway pool
+        # so their destruction cannot leave the persistent global pool in an
+        # invalid state for the real capture.
+        for graph_manager in managers:
+            graph_manager.pool = throwaway_pool
+            if graph_manager.use_breakable_cg:
+                # The breakable runner is otherwise created lazily during capture,
+                # after the pool swap below, and would capture into the global
+                # pool. Create it now so its pool gets swapped too.
+                graph_manager.init_breakable_cg_runner(runner.model)
         all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
             BreakableCUDAGraphWrapper._all_instances
         )
         for wrapper in all_wrappers:
             original_pools[id(wrapper)] = wrapper.graph_pool
-            wrapper.graph_pool = manager.pool
+            wrapper.graph_pool = throwaway_pool
         manager._max_full_descs_to_capture = _FULL_GRAPH_PROFILING_SAMPLES
         mem_samples: list[int] = []
         manager._capture_mem_samples = mem_samples
@@ -831,6 +843,10 @@ def _teardown_profiling_state(runner: "GPUModelRunner") -> None:
         del runner.kv_cache_config
     # Dropping the manager releases the profiling graphs and throwaway pool.
     runner.cudagraph_manager = None
+    # Profiling managers are recreated during the real KV-cache initialization,
+    # so discard the speculator's profiling managers along with the main manager.
+    if runner.speculator is not None:
+        runner.speculator.clear_cudagraph_managers()
     # Release encoder graphs captured during profiling; the real
     # capture_model() re-captures them.
     if runner.model_state.supports_mm_inputs:

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -144,6 +144,20 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             decode_query_len=1,
         )
 
+    def get_cudagraph_managers(self) -> list[SpeculatorCudaGraphManager]:
+        return [
+            manager
+            for manager in (
+                self.prefill_cudagraph_manager,
+                self.decode_cudagraph_manager,
+            )
+            if manager is not None
+        ]
+
+    def clear_cudagraph_managers(self) -> None:
+        self.prefill_cudagraph_manager = None
+        self.decode_cudagraph_manager = None
+
     def capture(self) -> None:
         logger.info("Capturing model for speculator...")
         # Reset indices to zeros to prevent stale values from prior

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -137,6 +137,14 @@ class DFlashSpeculator(DraftModelSpeculator):
             decode_query_len=self.num_query_per_req,
         )
 
+    def get_cudagraph_managers(self) -> list[DFlashCudaGraphManager]:
+        if self.query_cudagraph_manager is None:
+            return []
+        return [self.query_cudagraph_manager]
+
+    def clear_cudagraph_managers(self) -> None:
+        self.query_cudagraph_manager = None
+
     def capture(self) -> None:
         logger.info("Capturing model for %s speculator...", self._speculator_name)
         # Padded sample rows must not scatter into a live request during capture.

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -110,6 +110,14 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
             self.num_speculative_steps + 1,
         )
 
+    def get_cudagraph_managers(self) -> list[SpeculatorCudaGraphManager]:
+        if self.cudagraph_manager is None:
+            return []
+        return [self.cudagraph_manager]
+
+    def clear_cudagraph_managers(self) -> None:
+        self.cudagraph_manager = None
+
     def capture(self) -> None:
         logger.info("Capturing model for multi-module MTP speculator...")
         # Reset indices to zeros to prevent stale values from prior

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -34,6 +34,14 @@ class BaseSpeculator(ABC):
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         pass
 
+    def get_cudagraph_managers(self) -> list[Any]:
+        """Return the CUDA graph managers owned by this speculator."""
+        return []
+
+    def clear_cudagraph_managers(self) -> None:
+        """Release CUDA graph managers created for profiling."""
+        return None
+
     @abstractmethod
     def capture(self) -> None:
         pass


### PR DESCRIPTION
## Summary

Fix CUDA graph memory profiling when the GPU model runner owns additional CUDA graph managers through speculative decoding.

During `profile_cudagraph_memory()`, the main model's CUDA graph manager was redirected to a throwaway CUDA graph pool, but CUDA graph managers owned by speculative decoders could continue using the persistent global pool. Profiling graphs captured by those managers could then be released during the subsequent real KV-cache initialization, leaving the global CUDA graph pool with an invalid `use_count` and causing the PyTorch `CachingHostAllocator use_count > 0` assertion during the real CUDA graph capture.

This change:

- redirects all CUDA graph managers participating in `capture_model()` to the throwaway profiling pool;
- adds a generic interface for speculators that own additional CUDA graph managers;
- clears profiling-time speculator CUDA graph managers during profiling teardown so fresh managers are created for the real runtime capture;
- covers speculators with one or multiple CUDA graph managers without hard-coding specific speculator implementations into the profiling code;
- adds regression tests covering multiple speculator-owned managers and profiling teardown.

The fix is intended to cover DFlash/DSpark as well as other speculative decoding implementations that maintain separate CUDA graph managers.

## Testing

- `python -m pytest -q tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py -v`
  - 12 passed
- `pre-commit run --files ...`
  - all applicable checks passed
- `git diff --check`
  - passed

The local unit tests validate the vLLM-side CUDA graph manager/pool lifecycle. The original hardware-specific allocator failure was reported on B200/CUDA 12.8 and is not reproduced by the local CPU test environment.

## AI-assisted contribution

AI tools were used for repository exploration, code review, implementation assistance, and test development. I reviewed the resulting changes, verified the relevant code paths and lifecycle, and ran the applicable tests and pre-commit checks myself.

## Follow-up

I am continuing to verify the breakable CUDA graph manager lifecycle and will update this PR with any necessary follow-up corrections before marking it ready for review.
Fixes #53679