### PR TITLE
[CI] Fix the CRCR report step

### DIFF
--- a/.buildkite/test_areas/crcr_report.yaml
+++ b/.buildkite/test_areas/crcr_report.yaml
@@ -1,6 +1,14 @@
 group: CRCR Report
 # Runs only in the torch-nightly lane; the script exits 0 immediately otherwise,
-# following the same in-script gating as image_build.sh.
+# following the same in-script gating as image_build.sh. A pipeline-level
+# `if: build.env("TORCH_NIGHTLY") == "1"` does NOT work here: the generator drops
+# the key, and the step was still created on the stable lane (build 85453).
+#
+# No `device:` either. The generator derives the container image from the device
+# class, and the `-cpu` variant is published on neither lane: the stable lane
+# builds it too late for a step with no dependencies (build 85453), and the
+# torch-nightly lane does not build one at all (build 85477). Taking the default
+# image keeps this on the same tag every other step already pulls.
 #
 # ORDERING (needs confirmation against the pipeline generator): this must be the
 # last step to run, because it reads final job states from the Buildkite REST
@@ -12,21 +20,16 @@ group: CRCR Report
 # `wait` between groups, placing this group last is enough. If not, the more
 # robust option is an agent pre-exit hook or a follow-up scheduled step, since
 # `CONTINUE_ON_FAILURE=1` means failures must not stop the report either way.
+depends_on:
+  - image-build
 steps:
   - label: ":satellite: Report nightly results to CRCR"
     key: crcr-report
-    # Belt and braces with the script's own TORCH_NIGHTLY check: this keeps the
-    # step out of non-nightly builds entirely, while the script gate still holds
-    # if the generator ever drops this key.
-    if: build.env("TORCH_NIGHTLY") == "1"
     # Reporting is observability, never a gate: a relay outage, an expired
     # pipeline mapping or a missing secret must not turn the nightly red.
     soft_fail: true
     allow_dependency_failure: true
     timeout_in_minutes: 15
-    # Reporting is a couple of REST calls and a curl: no GPU needed, so keep it
-    # off the accelerator agents the test groups queue for.
-    device: cpu-small
     # No source_file_dependencies: this step is lane-gated, not change-gated,
     # so it must not be skipped by the file-based step selection.
     commands:


### PR DESCRIPTION
## Purpose

The CRCR report step has failed on **every** build since it landed, on both lanes, and in each case it dies in the docker plugin before `crcr-report.sh` runs. Forward fix.

## What is happening

**Stable lane — [build 85453](https://buildkite.com/vllm/ci/builds/85453):**

```
--- :docker: Pulling ...vllm-ci-postmerge-repo:4af586e185...-cpu
Error response from daemon: manifest ... not found: manifest unknown
```

at 06:02:52, two minutes into a build created at 06:00. Every other `(CPU)` job in that build passes, so the tag does get published -- just not that early. The step declares no dependencies, so it starts immediately and races the `Build CPU image` step.

**torch-nightly lane — [build 85477](https://buildkite.com/vllm/ci/builds/85477):**

```
--- :docker: Pulling ...vllm-ci-postmerge-repo:d9fbe526c0...-torch-nightly-cpu
Error response from daemon: manifest ... not found: manifest unknown
```

Here the image genuinely does not exist: `image_build.sh` delegates to `image_build_torch_nightly.sh` for `TORCH_NIGHTLY=1` and builds the CUDA image only. Sampling ~150 passing jobs in that build, every one pulls the same tag with no suffix: `d9fbe526c0...-torch-nightly`. Several pre-existing `(CPU)` steps fail there for the same reason, independently of this step.

## Changes

**Drop `device: cpu-small`.** The generator derives the container image from the device class, and the `-cpu` variant is unusable on both lanes for the two different reasons above. Without it the step takes the default image -- the tag every other step in the build already pulls.

**Drop `if: build.env("TORCH_NIGHTLY") == "1"`.** The generator does not forward the key, so it never gated anything: build 85453 has `TORCH_NIGHTLY` unset and the step was created regardless. Keeping it is worse than useless, since it reads as though the step cannot appear on non-nightly builds. Lane gating stays inside `crcr-report.sh`, where it demonstrably works.

**Add `depends_on: [image-build]`**, which every other group in `test_areas/` declares. Without it the step is schedulable from the start of the build.

The header comment records all three findings so the next person does not retry them.

## Not fixed here

`depends_on: [image-build]` stops the step racing the image, but it still does not make it run *last*, which is what reading final job states requires. That is the open question already noted in the file's comment, and it needs a different mechanism -- a `build.finished` follow-up or an agent pre-exit hook -- rather than more `depends_on`.

## Test plan

Cannot be verified pre-merge: the step is lane-gated and only produces output on `main` in the torch-nightly lane. After merge, the next `Full CI run torch nightly` should show the step pulling `<sha>-torch-nightly` and running the script rather than failing on the pull, and the stable nightly should show it exiting 0 with `TORCH_NIGHTLY != 1 -- not the nightly lane, nothing to report`.
