### PR TITLE
[Bugfix] Parse tool properties from root and nested schema combinators

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -3,6 +3,7 @@
 """Tests for DeepSeek V4-specific parser engine semantics."""
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -647,6 +648,48 @@ class TestImplicitReasoningEnd:
 
 
 class TestWrapperUnwrapping:
+    @pytest.mark.parametrize(
+        "args", ['{"city":"Berlin"}', '{"arguments":{},"city":"Berlin"}']
+    )
+    def test_ordinary_arguments_skip_property_lookup(self, args):
+        get_properties = MagicMock(side_effect=AssertionError("unnecessary lookup"))
+        assert (
+            _unwrap_wrapper_args(args, [_make_tool("f", {})], "f", get_properties)
+            == args
+        )
+        get_properties.assert_not_called()
+
+    @pytest.mark.parametrize("declared_wrapper", [False, True])
+    def test_streaming_wrapper_reuses_cached_declared_names(
+        self, monkeypatch, declared_wrapper
+    ):
+        from vllm.parser import deepseek_v4
+        from vllm.parser.engine import parser_engine
+
+        tool = _make_tool("f", {"city": {"type": "string"}})
+        if declared_wrapper:
+            tool.function.parameters["anyOf"] = [
+                {"properties": {"arguments": {"type": "object"}}},
+                {},
+            ]
+        lookup = MagicMock(wraps=parser_engine.find_tool_properties)
+        monkeypatch.setattr(parser_engine, "find_tool_properties", lookup)
+        monkeypatch.setattr(deepseek_v4, "find_tool_properties", lookup)
+        request = _test_request(tools=[tool])
+        parser = DeepSeekV4Parser(
+            make_mock_tokenizer({}),
+            tools=[tool],
+            chat_template_kwargs={"thinking": False},
+        )
+        text = _tool_calls(_invoke("f", ("arguments", "false", '{"city":"Berlin"}')))
+        results = simulate_tool_streaming(parser, request, list(text))
+        results.append((parser.finish_streaming(), text))
+        expected: dict = {"city": "Berlin"}
+        if declared_wrapper:
+            expected = {"arguments": expected}
+        assert json.loads(collect_tool_arguments(results)) == expected
+        assert lookup.call_count == 1
+
     def test_unwrap_arguments_wrapper(self):
         from vllm.entrypoints.openai.chat_completion.protocol import (
             ChatCompletionToolsParam,
@@ -723,6 +766,31 @@ class TestWrapperUnwrapping:
             "get_weather",
         )
         assert json.loads(result) == {"arguments": {"location": "Beijing"}}
+
+    @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+    @pytest.mark.parametrize("wrapper", ["arguments", "input"])
+    def test_no_unwrap_when_wrapper_declared_in_alternative(self, combinator, wrapper):
+        tool = _make_tool("f", {"city": {"type": "string"}})
+        tool.function.parameters[combinator] = [
+            {"properties": {wrapper: {"type": "object"}}, "required": [wrapper]},
+            {"required": ["city"]},
+        ]
+        args = json.dumps({wrapper: {"city": "Berlin"}})
+        assert _unwrap_wrapper_args(args, [tool], "f") == args
+
+    @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+    def test_unwrap_when_inner_names_declared_in_nested_alternatives(self, combinator):
+        tool = _make_tool("f", {})
+        tool.function.parameters["allOf"] = [
+            {
+                combinator: [
+                    {"properties": {name: {"type": "string"}}, "required": [name]}
+                    for name in ("city", "zip_code")
+                ]
+            }
+        ]
+        result = _unwrap_wrapper_args('{"arguments": {"city": "Berlin"}}', [tool], "f")
+        assert json.loads(result) == {"city": "Berlin"}
 
     def test_unwrap_json_string_inner(self):
         from vllm.entrypoints.openai.chat_completion.protocol import (

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -925,40 +925,50 @@ class TestFixArgTypes:
             "choice": 7
         }
 
-    def test_malformed_root_combinator_preserves_direct_coercion(self):
+    def test_malformed_combinators_preserve_other_properties(self):
         tool = _make_tool("f", {})
         tool.function.parameters = {
-            "properties": {"count": {"type": "integer"}},
+            "properties": {
+                "count": {"type": "integer"},
+                "value": {"type": "integer", "anyOf": 1},
+            },
             "anyOf": 1,
             "allOf": [{"properties": [1]}],
         }
         engine = _make_engine(tools=[tool])
-        result = engine._fix_arg_types('{"count": "42"}', "f")
-        assert json.loads(result) == {"count": 42}
+        result = engine._fix_arg_types('{"count": "42", "value": "42"}', "f")
+        assert json.loads(result) == {"count": 42, "value": "42"}
 
     def test_array_item_coercion(self):
-        tool = _make_tool(
-            "f",
-            {
-                "nums": {
-                    "type": "array",
-                    "items": {"type": "number"},
-                    "allOf": [{"allOf": [{"items": {"type": "integer"}}]}],
+        for combinator in ("allOf", "anyOf", "oneOf"):
+            tool = _make_tool(
+                "f",
+                {
+                    "nums": {
+                        combinator: [
+                            {
+                                "type": "array",
+                                "items": {"type": "number"},
+                                "allOf": [{"items": {"type": "integer"}}],
+                            }
+                        ],
+                    },
                 },
-            },
-        )
-        engine = _make_engine(tools=[tool])
-        result = engine._fix_arg_types('{"nums": ["42", "5"]}', "f")
-        parsed = json.loads(result)
-        assert parsed["nums"] == [42, 5]
+            )
+            engine = _make_engine(tools=[tool])
+            result = engine._fix_arg_types(json.dumps({"nums": '["42", "5"]'}), "f")
+            parsed = json.loads(result)
+            assert parsed["nums"] == [42, 5]
 
     def test_array_mixed_item_types(self):
         tool = _make_tool(
             "f",
             {
                 "vals": {
-                    "type": "array",
-                    "items": {"type": "number"},
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "number"}},
+                        {"type": "null"},
+                    ],
                 },
             },
         )

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -669,6 +669,12 @@ class TestFixArgTypes:
         result = engine._fix_arg_types('{"val": null}', "f")
         assert '"val": "null"' in result
 
+    def test_int_param_not_changed(self):
+        tool = _make_tool("f", {"count": {"type": "integer"}})
+        engine = _make_engine(tools=[tool])
+        original = '{"count": 42}'
+        assert engine._fix_arg_types(original, "f") == original
+
     def test_integer_type_preserved_with_value_alternatives(self):
         tool = _make_tool(
             "f",
@@ -751,6 +757,43 @@ class TestFixArgTypes:
         assert parsed["active"] is True
         assert parsed["score"] == 3.14
 
+    def test_nested_object_coercion(self):
+        tool = _make_tool(
+            "f",
+            {"inner": {"type": "object", "properties": {"count": {"type": "integer"}}}},
+        )
+        engine = _make_engine(tools=[tool])
+        result = engine._fix_arg_types('{"inner": {"count": "42"}}', "f")
+        assert json.loads(result) == {"inner": {"count": 42}}
+
+    @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+    @pytest.mark.parametrize("encoded", [False, True])
+    @pytest.mark.parametrize("kind, expected", [("text", "1"), ("number", 1)])
+    def test_object_alternatives_preserve_property_constraints(
+        self, combinator, encoded, kind, expected
+    ):
+        schema = {
+            "type": "object",
+            "properties": {
+                "kind": {"type": "string"},
+                "value": {"type": ["string", "integer"]},
+            },
+            combinator: [
+                {
+                    "properties": {
+                        "kind": {"const": tag},
+                        "value": {"type": value_type},
+                    }
+                }
+                for tag, value_type in (("text", "string"), ("number", "integer"))
+            ],
+        }
+        engine = _make_engine(tools=[_make_tool("f", {"payload": schema})])
+        payload = {"kind": kind, "value": "1"}
+        args = {"payload": json.dumps(payload) if encoded else payload}
+        result = engine._fix_arg_types(json.dumps(args), "f")
+        assert json.loads(result) == {"payload": {"kind": kind, "value": expected}}
+
     def test_openai_strict_nested_anyof_coercion(self):
         """Coerce fields in OpenAI's user-or-address anyOf example."""
         tool = _make_tool(
@@ -794,10 +837,9 @@ class TestFixArgTypes:
             Draft202012Validator(schema).validate(parsed)
 
     @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
-    def test_nested_root_alternative_branch_properties(self, combinator):
-        """A property declared by one branch is coerced, one the branches type
-        differently is left alone since no branch is selected, and one all
-        branches agree on refines the direct schema."""
+    @pytest.mark.parametrize("closed", [False, True])
+    def test_nested_root_alternative_branch_properties(self, combinator, closed):
+        """Omitted properties supply hints only when the other branch forbids them."""
         tool = ChatCompletionToolsParam(
             type="function",
             function=FunctionDefinition(
@@ -829,6 +871,8 @@ class TestFixArgTypes:
                 },
             ),
         )
+        for branch in tool.function.parameters["allOf"][0][combinator]:
+            branch["additionalProperties"] = not closed
         engine = _make_engine(tools=[tool])
         result = engine._fix_arg_types(
             '{"kind": "a", "payload": "{\\"n\\": 1}", "value": "123", "count": "7"}',
@@ -836,7 +880,7 @@ class TestFixArgTypes:
         )
         assert json.loads(result) == {
             "kind": "a",
-            "payload": {"n": 1},
+            "payload": {"n": 1} if closed else '{"n": 1}',
             "value": "123",
             "count": "7",
         }
@@ -861,6 +905,13 @@ class TestFixArgTypes:
         "schema, value",
         [
             ({"anyOf": [{"type": "string"}, {"const": 42}]}, "123"),
+            (
+                {
+                    "type": ["string", "integer"],
+                    "anyOf": [{"enum": ["42"]}, False],
+                },
+                "42",
+            ),
             (
                 {
                     "$defs": {"Text": {"type": "string"}},
@@ -942,9 +993,17 @@ class TestFixArgTypes:
         }
         engine = _make_engine(tools=[tool])
         result = engine._fix_arg_types('{"count": "42", "value": "42"}', "f")
-        assert json.loads(result) == {"count": 42, "value": "42"}
+        assert json.loads(result) == {"count": 42, "value": 42}
 
     def test_array_item_coercion(self):
+        tool = _make_tool(
+            "f", {"nums": {"type": "array", "items": {"type": "integer"}}}
+        )
+        engine = _make_engine(tools=[tool])
+        result = engine._fix_arg_types('{"nums": ["42", "5"]}', "f")
+        assert json.loads(result) == {"nums": [42, 5]}
+
+    def test_array_item_coercion_through_combinators(self):
         for combinator in ("allOf", "anyOf", "oneOf"):
             tool = _make_tool(
                 "f",
@@ -965,6 +1024,49 @@ class TestFixArgTypes:
             parsed = json.loads(result)
             assert parsed["nums"] == [42, 5]
 
+    @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+    @pytest.mark.parametrize("encoded", [False, True])
+    @pytest.mark.parametrize(
+        "value, expected", [(["1", "x"], ["1", "x"]), (["1", "2"], [1, 2])]
+    )
+    def test_array_alternatives_keep_a_compatible_branch(
+        self, combinator, encoded, value, expected
+    ):
+        tool = _make_tool(
+            "f",
+            {
+                "value": {
+                    combinator: [
+                        {"type": "array", "items": {"type": item_type}}
+                        for item_type in ("string", "integer")
+                    ]
+                }
+            },
+        )
+        engine = _make_engine(tools=[tool])
+        args = {"value": json.dumps(value) if encoded else value}
+        result = engine._fix_arg_types(json.dumps(args), "f")
+        assert json.loads(result) == {"value": expected}
+
+    @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+    @pytest.mark.parametrize("encoded", [False, True])
+    def test_array_alternatives_preserve_false_items(self, combinator, encoded):
+        tool = _make_tool(
+            "f",
+            {
+                "value": {
+                    "type": "array",
+                    "items": {"type": ["string", "integer"]},
+                    combinator: [{"items": False}, {"items": {"type": "string"}}],
+                }
+            },
+        )
+        engine = _make_engine(tools=[tool])
+        value = ["1"]
+        args = {"value": json.dumps(value) if encoded else value}
+        result = engine._fix_arg_types(json.dumps(args), "f")
+        assert json.loads(result) == {"value": value}
+
     def test_draft7_tuple_array_decoding(self):
         tool = _make_tool(
             "f",
@@ -982,7 +1084,8 @@ class TestFixArgTypes:
         assert parsed == {"value": [42]}
         Draft7Validator(tool.function.parameters).validate(parsed)
 
-    def test_array_mixed_item_types(self):
+    @pytest.mark.parametrize("nullable", [False, True])
+    def test_array_mixed_item_types(self, nullable):
         tool = _make_tool(
             "f",
             {
@@ -994,10 +1097,102 @@ class TestFixArgTypes:
                 },
             },
         )
+        if not nullable:
+            tool.function.parameters["properties"]["vals"] = {
+                "type": "array",
+                "items": {"type": "number"},
+            }
         engine = _make_engine(tools=[tool])
         result = engine._fix_arg_types('{"vals": ["42", "3.14"]}', "f")
         parsed = json.loads(result)
         assert parsed["vals"] == [42, 3.14]
+
+    @pytest.mark.parametrize(
+        "schema, value, expected",
+        [
+            ({"type": "object", "required": ["a", "b"]}, '{"a": 1}', {"a": 1}),
+            ({"type": "integer", "minimum": 1}, "0", 0),
+            ({"type": "array", "minItems": 2}, "[1]", [1]),
+            ({"type": "object", "additionalProperties": False}, '{"z": 2}', {"z": 2}),
+            ({"type": "string", "maxLength": 2}, 12345, "12345"),
+        ],
+        ids=["required", "minimum", "minItems", "additionalProperties", "maxLength"],
+    )
+    def test_value_constraints_do_not_prevent_type_correction(
+        self, schema, value, expected
+    ):
+        engine = _make_engine(tools=[_make_tool("f", {"value": schema})])
+        result = engine._fix_arg_types(json.dumps({"value": value}), "f")
+        assert json.loads(result) == {"value": expected}
+
+    @pytest.mark.parametrize(
+        "schema, value, expected",
+        [
+            ({"type": "array", "items": [{"type": "integer"}]}, "[42]", [42]),
+            ({"type": "array", "items": []}, "[42]", [42]),
+            ({"type": "object", "properties": [1]}, '{"a": 1}', {"a": 1}),
+            ({"type": "string", "pattern": "["}, 42, "42"),
+        ],
+        ids=[
+            "undeclared_tuple",
+            "empty_tuple",
+            "malformed_properties",
+            "invalid_pattern",
+        ],
+    )
+    def test_unsupported_validation_keywords_do_not_raise(
+        self, schema, value, expected
+    ):
+        engine = _make_engine(tools=[_make_tool("f", {"value": schema})])
+        result = engine._fix_arg_types(json.dumps({"value": value}), "f")
+        assert json.loads(result) == {"value": expected}
+
+    def test_wide_allof_does_not_create_deep_property_schemas(self):
+        tool = _make_tool("f", {"count": {"type": "integer"}})
+        tool.function.parameters["allOf"] = [
+            {"properties": {"count": {"type": "integer"}}}
+        ] * 600
+        engine = _make_engine(tools=[tool])
+        assert json.loads(engine._fix_arg_types('{"count": "1"}', "f")) == {"count": 1}
+
+    def test_request_tools_replace_cached_type_hints(self):
+        engine = _make_engine(tools=[_make_tool("f", {"count": {"type": "integer"}})])
+        original = '{"count": "42"}'
+        assert json.loads(engine._fix_arg_types(original, "f")) == {"count": 42}
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[],
+            tools=[_make_tool("f", {"count": {"type": "string"}})],
+        )
+        engine._check_skip_tool_parsing(request)
+        assert engine._fix_arg_types(original, "f") == original
+
+    @pytest.mark.parametrize(
+        "before, after",
+        [(1, True), (1, 1.0), (0.0, -0.0), ({"n": 1}, {"n": True})],
+    )
+    def test_coercion_cache_distinguishes_json_representations(self, before, after):
+        tool = _make_tool("f", {"value": {"type": "string"}})
+        engine = _make_engine(tools=[tool])
+        cache: dict = {}
+        engine._fix_arg_types(json.dumps({"value": before}), "f", cache)
+        args = json.dumps({"value": after})
+        assert engine._fix_arg_types(args, "f", cache) == engine._fix_arg_types(
+            args, "f"
+        )
+
+    def test_coercion_cache_invalidates_with_tool_schema(self):
+        engine = _make_engine(tools=[_make_tool("f", {"value": {"type": "integer"}})])
+        cache: dict = {}
+        args = '{"value": "42"}'
+        assert json.loads(engine._fix_arg_types(args, "f", cache)) == {"value": 42}
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[],
+            tools=[_make_tool("f", {"value": {"type": "string"}})],
+        )
+        engine._check_skip_tool_parsing(request)
+        assert engine._fix_arg_types(args, "f", cache) == args
 
 
 # ── TestBuildExtractedResult ─────────────────────────────────────────
@@ -1680,26 +1875,28 @@ def _collect_arg_deltas(deltas: list) -> str:
     return "".join(parts)
 
 
-def _run_streaming_tool(engine, name: str, chunks: list[str]) -> dict:
+def _run_streaming_tool(engine, name: str, chunks: list[str], index: int = 0) -> dict:
     deltas = []
     deltas.append(
         engine._events_to_delta(
-            [SemanticEvent(EventType.TOOL_CALL_START, tool_index=0)]
+            [SemanticEvent(EventType.TOOL_CALL_START, tool_index=index)]
         )
     )
     deltas.append(
         engine._events_to_delta(
-            [SemanticEvent(EventType.TOOL_NAME, name, tool_index=0)]
+            [SemanticEvent(EventType.TOOL_NAME, name, tool_index=index)]
         )
     )
     for chunk in chunks:
         deltas.append(
             engine._events_to_delta(
-                [SemanticEvent(EventType.ARG_VALUE_CHUNK, chunk, tool_index=0)]
+                [SemanticEvent(EventType.ARG_VALUE_CHUNK, chunk, tool_index=index)]
             )
         )
     deltas.append(
-        engine._events_to_delta([SemanticEvent(EventType.TOOL_CALL_END, tool_index=0)])
+        engine._events_to_delta(
+            [SemanticEvent(EventType.TOOL_CALL_END, tool_index=index)]
+        )
     )
     return json.loads(_collect_arg_deltas(deltas))
 
@@ -1717,6 +1914,28 @@ class TestArgDeltaWithConverter:
         tool.function.parameters = {"oneOf": [{"properties": {"value": {"const": 42}}}]}
         engine = _make_engine(_converter_config(), tools=[tool])
         assert _run_streaming_tool(engine, "f", ["value=4", "2"]) == {"value": 42}
+
+    @pytest.mark.parametrize("tool_calls", [1, 2])
+    def test_streaming_reuses_unchanged_nested_argument(self, monkeypatch, tool_calls):
+        tool = _make_tool(
+            "f",
+            {
+                "payload": {"type": "object", "properties": {"n": {"type": "integer"}}},
+                "note": {"type": "string"},
+            },
+        )
+        engine = _make_engine(_converter_config(), tools=[tool])
+        coerce = MagicMock(wraps=ParserEngine._coerce_value)
+        monkeypatch.setattr(ParserEngine, "_coerce_value", coerce)
+        for index in range(tool_calls):
+            result = _run_streaming_tool(
+                engine, "f", ['payload={"n":"1"} ', "note=a", "bc"], index
+            )
+            assert result == {"payload": {"n": 1}, "note": "abc"}
+        assert (
+            sum(call.args[0] == '{"n":"1"}' for call in coerce.call_args_list)
+            == tool_calls
+        )
 
     def test_streaming_arg_deltas_prefix_monotonic(self):
         engine = _make_engine(_converter_config())
@@ -1846,7 +2065,7 @@ class TestArgDeltaWithConverter:
         calls: list[dict] = []
 
         def wrapped(properties: dict) -> set[str] | None:
-            calls.append(properties)
+            calls.append({key: hints.types for key, hints in properties.items()})
             return original(properties)
 
         monkeypatch.setattr(
@@ -1863,8 +2082,8 @@ class TestArgDeltaWithConverter:
 
         assert calls == [
             {
-                "name": {"type": "string"},
-                "count": {"type": "integer"},
+                "name": ["string"],
+                "count": ["integer"],
             }
         ]
 

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import regex as re
-from jsonschema import Draft202012Validator
+from jsonschema import Draft7Validator, Draft202012Validator
 
 from tests.parser.engine.conftest import make_mock_tokenizer
 from vllm.entrypoints.generate.base.protocol import (
@@ -964,6 +964,23 @@ class TestFixArgTypes:
             result = engine._fix_arg_types(json.dumps({"nums": '["42", "5"]'}), "f")
             parsed = json.loads(result)
             assert parsed["nums"] == [42, 5]
+
+    def test_draft7_tuple_array_decoding(self):
+        tool = _make_tool(
+            "f",
+            {"value": {"type": "array", "items": [{"$ref": "#/definitions/Count"}]}},
+        )
+        tool.function.parameters.update(
+            {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "definitions": {"Count": {"type": "integer"}},
+            }
+        )
+        engine = _make_engine(tools=[tool])
+        result = engine._fix_arg_types(json.dumps({"value": "[42]"}), "f")
+        parsed = json.loads(result)
+        assert parsed == {"value": [42]}
+        Draft7Validator(tool.function.parameters).validate(parsed)
 
     def test_array_mixed_item_types(self):
         tool = _make_tool(

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import regex as re
+from jsonschema import Draft202012Validator
 
 from tests.parser.engine.conftest import make_mock_tokenizer
 from vllm.entrypoints.generate.base.protocol import (
@@ -750,22 +751,47 @@ class TestFixArgTypes:
         assert parsed["active"] is True
         assert parsed["score"] == 3.14
 
-    def test_nested_object_coercion(self):
+    def test_openai_strict_nested_anyof_coercion(self):
+        """Coerce fields in OpenAI's user-or-address anyOf example."""
         tool = _make_tool(
             "f",
             {
-                "inner": {
-                    "type": "object",
-                    "properties": {
-                        "count": {"type": "integer"},
-                    },
+                "item": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "properties": properties,
+                            "required": list(properties),
+                            "additionalProperties": False,
+                        }
+                        for properties in (
+                            {"name": {"type": "string"}, "age": {"type": "number"}},
+                            {
+                                "number": {"type": "string"},
+                                "street": {"type": "string"},
+                                "city": {"type": "string"},
+                            },
+                        )
+                    ],
                 },
             },
         )
+        tool.function.strict = True
+        schema = tool.function.parameters
+        schema.update(required=["item"], additionalProperties=False)
+        Draft202012Validator.check_schema(schema)
         engine = _make_engine(tools=[tool])
-        result = engine._fix_arg_types('{"inner": {"count": "42"}}', "f")
-        parsed = json.loads(result)
-        assert parsed["inner"]["count"] == 42
+        for item, expected in (
+            ({"name": "Alice", "age": "42"}, {"name": "Alice", "age": 42}),
+            (
+                {"number": 123, "street": "Main St", "city": "Boston"},
+                {"number": "123", "street": "Main St", "city": "Boston"},
+            ),
+        ):
+            result = engine._fix_arg_types(json.dumps({"item": json.dumps(item)}), "f")
+            parsed = json.loads(result)
+            assert parsed == {"item": expected}
+            Draft202012Validator(schema).validate(parsed)
 
     @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
     def test_nested_root_alternative_branch_properties(self, combinator):

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -887,6 +887,7 @@ class TestFixArgTypes:
                     "type": "object",
                     "properties": {
                         "value": {"type": "integer"},
+                        "labels": {"type": "array", "items": {"type": "string"}},
                         "payload": {
                             "type": "object",
                             "properties": {"kept": {"type": "integer"}},
@@ -896,6 +897,7 @@ class TestFixArgTypes:
                         {
                             "properties": {
                                 "value": {"type": "number"},
+                                "labels": {"items": {"type": ["string", "integer"]}},
                                 "payload": {
                                     "properties": {"count": {"type": "integer"}}
                                 },
@@ -907,10 +909,13 @@ class TestFixArgTypes:
         )
         engine = _make_engine(tools=[tool])
         result = engine._fix_arg_types(
-            '{"value": "1.5", "payload": {"kept": "1", "count": "42"}}', "f"
+            '{"value": "1.5", "labels": ["42"], '
+            '"payload": {"kept": "1", "count": "42"}}',
+            "f",
         )
         assert json.loads(result) == {
             "value": "1.5",
+            "labels": ["42"],
             "payload": {"kept": 1, "count": 42},
         }
 
@@ -931,7 +936,8 @@ class TestFixArgTypes:
             {
                 "nums": {
                     "type": "array",
-                    "items": {"type": "integer"},
+                    "items": {"type": "number"},
+                    "allOf": [{"allOf": [{"items": {"type": "integer"}}]}],
                 },
             },
         )

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -766,26 +766,30 @@ class TestFixArgTypes:
 
     @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
     def test_root_alternative_branch_properties(self, combinator):
-        """A property declared by one branch is coerced; a property the
-        branches type differently is left alone since no branch is selected."""
+        """A property declared by one branch is coerced, one the branches type
+        differently is left alone since no branch is selected, and one all
+        branches agree on refines the direct schema."""
         tool = ChatCompletionToolsParam(
             type="function",
             function=FunctionDefinition(
                 name="f",
                 parameters={
                     "type": "object",
+                    "properties": {"count": {"type": ["string", "integer"]}},
                     combinator: [
                         {
                             "properties": {
                                 "kind": {"const": "a"},
                                 "payload": {"type": "object"},
                                 "value": {"type": "integer"},
+                                "count": {"type": "string"},
                             },
                         },
                         {
                             "properties": {
                                 "kind": {"const": "b"},
                                 "value": {"type": "string"},
+                                "count": {"type": "string"},
                             },
                         },
                     ],
@@ -794,12 +798,14 @@ class TestFixArgTypes:
         )
         engine = _make_engine(tools=[tool])
         result = engine._fix_arg_types(
-            '{"kind": "a", "payload": "{\\"n\\": 1}", "value": "123"}', "f"
+            '{"kind": "a", "payload": "{\\"n\\": 1}", "value": "123", "count": "7"}',
+            "f",
         )
         assert json.loads(result) == {
             "kind": "a",
             "payload": {"n": 1},
             "value": "123",
+            "count": "7",
         }
 
     def test_root_allof_refines_direct_property(self):

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -887,6 +887,7 @@ class TestFixArgTypes:
                     "type": "object",
                     "properties": {
                         "value": {"type": "integer"},
+                        "choice": {"type": ["string", "integer"]},
                         "labels": {"type": "array", "items": {"type": "string"}},
                         "payload": {
                             "type": "object",
@@ -897,6 +898,7 @@ class TestFixArgTypes:
                         {
                             "properties": {
                                 "value": {"type": "number"},
+                                "choice": {"enum": ["42", 7]},
                                 "labels": {"items": {"type": ["string", "integer"]}},
                                 "payload": {
                                     "properties": {"count": {"type": "integer"}}
@@ -909,14 +911,18 @@ class TestFixArgTypes:
         )
         engine = _make_engine(tools=[tool])
         result = engine._fix_arg_types(
-            '{"value": "1.5", "labels": ["42"], '
+            '{"value": "1.5", "choice": "42", "labels": ["42"], '
             '"payload": {"kept": "1", "count": "42"}}',
             "f",
         )
         assert json.loads(result) == {
             "value": "1.5",
+            "choice": "42",
             "labels": ["42"],
             "payload": {"kept": 1, "count": 42},
+        }
+        assert json.loads(engine._fix_arg_types('{"choice": "7"}', "f")) == {
+            "choice": 7
         }
 
     def test_malformed_root_combinator_preserves_direct_coercion(self):

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -878,52 +878,57 @@ class TestFixArgTypes:
         original = json.dumps({"value": value})
         assert engine._fix_arg_types(original, "f") == original
 
-    def test_root_allof_refines_direct_property(self):
-        tool = ChatCompletionToolsParam(
-            type="function",
-            function=FunctionDefinition(
-                name="f",
-                parameters={
-                    "type": "object",
-                    "properties": {
-                        "value": {"type": "integer"},
-                        "choice": {"type": ["string", "integer"]},
-                        "labels": {"type": "array", "items": {"type": "string"}},
-                        "payload": {
-                            "type": "object",
-                            "properties": {"kept": {"type": "integer"}},
-                        },
-                    },
-                    "allOf": [
-                        {
-                            "properties": {
-                                "value": {"type": "number"},
-                                "choice": {"enum": ["42", 7]},
-                                "labels": {"items": {"type": ["string", "integer"]}},
-                                "payload": {
-                                    "properties": {"count": {"type": "integer"}}
-                                },
-                            }
-                        }
-                    ],
-                },
+    @pytest.mark.parametrize(
+        "base, refinement, value, expected",
+        [
+            pytest.param(
+                {"type": "integer"},
+                {"type": "number"},
+                "1.5",
+                "1.5",
+                id="integer_intersection",
             ),
-        )
+            pytest.param(
+                {"type": ["string", "integer"]},
+                {"enum": ["42", 7]},
+                "42",
+                "42",
+                id="enum_preserves_string",
+            ),
+            pytest.param(
+                {"type": ["string", "integer"]},
+                {"enum": ["42", 7]},
+                "7",
+                7,
+                id="enum_coerces_allowed_integer",
+            ),
+            pytest.param(
+                {"type": "array", "items": {"type": "string"}},
+                {"items": {"type": ["string", "integer"]}},
+                ["42"],
+                ["42"],
+                id="array_item_intersection",
+            ),
+            pytest.param(
+                {
+                    "type": "object",
+                    "properties": {"kept": {"type": "integer"}},
+                },
+                {"properties": {"count": {"type": "integer"}}},
+                {"kept": "1", "count": "42"},
+                {"kept": 1, "count": 42},
+                id="nested_property_merge",
+            ),
+        ],
+    )
+    def test_root_allof_refines_direct_property(
+        self, base, refinement, value, expected
+    ):
+        tool = _make_tool("f", {"value": base})
+        tool.function.parameters["allOf"] = [{"properties": {"value": refinement}}]
         engine = _make_engine(tools=[tool])
-        result = engine._fix_arg_types(
-            '{"value": "1.5", "choice": "42", "labels": ["42"], '
-            '"payload": {"kept": "1", "count": "42"}}',
-            "f",
-        )
-        assert json.loads(result) == {
-            "value": "1.5",
-            "choice": "42",
-            "labels": ["42"],
-            "payload": {"kept": 1, "count": 42},
-        }
-        assert json.loads(engine._fix_arg_types('{"choice": "7"}', "f")) == {
-            "choice": 7
-        }
+        result = engine._fix_arg_types(json.dumps({"value": value}), "f")
+        assert json.loads(result) == {"value": expected}
 
     def test_malformed_combinators_preserve_other_properties(self):
         tool = _make_tool("f", {})

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -808,6 +808,43 @@ class TestFixArgTypes:
             "count": "7",
         }
 
+    def test_root_combinator_preserves_scalar_types(self):
+        tool = _make_tool("f", {})
+        tool.function.parameters = {
+            "oneOf": [
+                {
+                    "properties": {
+                        "version": {"const": 42},
+                        "count": {"description": "A count"},
+                    }
+                }
+            ]
+        }
+        engine = _make_engine(tools=[tool])
+        original = '{"version": 42, "count": 42}'
+        assert engine._fix_arg_types(original, "f") == original
+
+    @pytest.mark.parametrize(
+        "schema, value",
+        [
+            ({"anyOf": [{"type": "string"}, {"const": 42}]}, "123"),
+            (
+                {
+                    "$defs": {"Text": {"type": "string"}},
+                    "anyOf": [
+                        {"type": "integer"},
+                        {"$ref": "#/properties/value/$defs/Text"},
+                    ],
+                },
+                "true",
+            ),
+        ],
+    )
+    def test_constrained_or_unknown_alternative_preserves_strings(self, schema, value):
+        engine = _make_engine(tools=[_make_tool("f", {"value": schema})])
+        original = json.dumps({"value": value})
+        assert engine._fix_arg_types(original, "f") == original
+
     def test_root_allof_refines_direct_property(self):
         tool = ChatCompletionToolsParam(
             type="function",
@@ -815,7 +852,12 @@ class TestFixArgTypes:
                 name="f",
                 parameters={
                     "type": "object",
-                    "properties": {"payload": {"type": "object"}},
+                    "properties": {
+                        "payload": {
+                            "type": "object",
+                            "properties": {"kept": {"type": "integer"}},
+                        }
+                    },
                     "allOf": [
                         {
                             "properties": {
@@ -829,8 +871,19 @@ class TestFixArgTypes:
             ),
         )
         engine = _make_engine(tools=[tool])
-        result = engine._fix_arg_types('{"payload": {"count": "42"}}', "f")
-        assert json.loads(result) == {"payload": {"count": 42}}
+        result = engine._fix_arg_types('{"payload": {"kept": "1", "count": "42"}}', "f")
+        assert json.loads(result) == {"payload": {"kept": 1, "count": 42}}
+
+    def test_malformed_root_combinator_preserves_direct_coercion(self):
+        tool = _make_tool("f", {})
+        tool.function.parameters = {
+            "properties": {"count": {"type": "integer"}},
+            "anyOf": 1,
+            "allOf": [{"properties": [1]}],
+        }
+        engine = _make_engine(tools=[tool])
+        result = engine._fix_arg_types('{"count": "42"}', "f")
+        assert json.loads(result) == {"count": 42}
 
     def test_array_item_coercion(self):
         tool = _make_tool(
@@ -1574,6 +1627,12 @@ class TestArgDeltaWithConverter:
     converted JSON grows prefix-monotonically across streaming ticks.
     These tests exercise that path with a synthetic config.
     """
+
+    def test_root_schema_streaming_preserves_types(self):
+        tool = _make_tool("f", {})
+        tool.function.parameters = {"oneOf": [{"properties": {"value": {"const": 42}}}]}
+        engine = _make_engine(_converter_config(), tools=[tool])
+        assert _run_streaming_tool(engine, "f", ["value=4", "2"]) == {"value": 42}
 
     def test_streaming_arg_deltas_prefix_monotonic(self):
         engine = _make_engine(_converter_config())

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -764,6 +764,68 @@ class TestFixArgTypes:
         parsed = json.loads(result)
         assert parsed["inner"]["count"] == 42
 
+    @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
+    def test_root_alternative_branch_properties(self, combinator):
+        """A property declared by one branch is coerced; a property the
+        branches type differently is left alone since no branch is selected."""
+        tool = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="f",
+                parameters={
+                    "type": "object",
+                    combinator: [
+                        {
+                            "properties": {
+                                "kind": {"const": "a"},
+                                "payload": {"type": "object"},
+                                "value": {"type": "integer"},
+                            },
+                        },
+                        {
+                            "properties": {
+                                "kind": {"const": "b"},
+                                "value": {"type": "string"},
+                            },
+                        },
+                    ],
+                },
+            ),
+        )
+        engine = _make_engine(tools=[tool])
+        result = engine._fix_arg_types(
+            '{"kind": "a", "payload": "{\\"n\\": 1}", "value": "123"}', "f"
+        )
+        assert json.loads(result) == {
+            "kind": "a",
+            "payload": {"n": 1},
+            "value": "123",
+        }
+
+    def test_root_allof_refines_direct_property(self):
+        tool = ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(
+                name="f",
+                parameters={
+                    "type": "object",
+                    "properties": {"payload": {"type": "object"}},
+                    "allOf": [
+                        {
+                            "properties": {
+                                "payload": {
+                                    "properties": {"count": {"type": "integer"}}
+                                }
+                            }
+                        }
+                    ],
+                },
+            ),
+        )
+        engine = _make_engine(tools=[tool])
+        result = engine._fix_arg_types('{"payload": {"count": "42"}}', "f")
+        assert json.loads(result) == {"payload": {"count": 42}}
+
     def test_array_item_coercion(self):
         tool = _make_tool(
             "f",

--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -668,10 +668,13 @@ class TestFixArgTypes:
         result = engine._fix_arg_types('{"val": null}', "f")
         assert '"val": "null"' in result
 
-    def test_int_param_not_changed(self):
-        tool = _make_tool("f", {"count": {"type": "integer"}})
+    def test_integer_type_preserved_with_value_alternatives(self):
+        tool = _make_tool(
+            "f",
+            {"count": {"type": "integer", "anyOf": [{"minimum": 0}, {"maximum": -1}]}},
+        )
         engine = _make_engine(tools=[tool])
-        result = engine._fix_arg_types('{"count": 42}', "f")
+        result = engine._fix_arg_types('{"count": "42"}', "f")
         assert '"count": 42' in result
 
     def test_no_tools_returns_unchanged(self):
@@ -765,7 +768,7 @@ class TestFixArgTypes:
         assert parsed["inner"]["count"] == 42
 
     @pytest.mark.parametrize("combinator", ["anyOf", "oneOf"])
-    def test_root_alternative_branch_properties(self, combinator):
+    def test_nested_root_alternative_branch_properties(self, combinator):
         """A property declared by one branch is coerced, one the branches type
         differently is left alone since no branch is selected, and one all
         branches agree on refines the direct schema."""
@@ -776,22 +779,26 @@ class TestFixArgTypes:
                 parameters={
                     "type": "object",
                     "properties": {"count": {"type": ["string", "integer"]}},
-                    combinator: [
+                    "allOf": [
                         {
-                            "properties": {
-                                "kind": {"const": "a"},
-                                "payload": {"type": "object"},
-                                "value": {"type": "integer"},
-                                "count": {"type": "string"},
-                            },
-                        },
-                        {
-                            "properties": {
-                                "kind": {"const": "b"},
-                                "value": {"type": "string"},
-                                "count": {"type": "string"},
-                            },
-                        },
+                            combinator: [
+                                {
+                                    "properties": {
+                                        "kind": {"const": "a"},
+                                        "payload": {"type": "object"},
+                                        "value": {"type": "integer"},
+                                        "count": {"type": "string"},
+                                    },
+                                },
+                                {
+                                    "properties": {
+                                        "kind": {"const": "b"},
+                                        "value": {"type": "string"},
+                                        "count": {"type": "string"},
+                                    },
+                                },
+                            ]
+                        }
                     ],
                 },
             ),
@@ -853,17 +860,19 @@ class TestFixArgTypes:
                 parameters={
                     "type": "object",
                     "properties": {
+                        "value": {"type": "integer"},
                         "payload": {
                             "type": "object",
                             "properties": {"kept": {"type": "integer"}},
-                        }
+                        },
                     },
                     "allOf": [
                         {
                             "properties": {
+                                "value": {"type": "number"},
                                 "payload": {
                                     "properties": {"count": {"type": "integer"}}
-                                }
+                                },
                             }
                         }
                     ],
@@ -871,8 +880,13 @@ class TestFixArgTypes:
             ),
         )
         engine = _make_engine(tools=[tool])
-        result = engine._fix_arg_types('{"payload": {"kept": "1", "count": "42"}}', "f")
-        assert json.loads(result) == {"payload": {"kept": 1, "count": 42}}
+        result = engine._fix_arg_types(
+            '{"value": "1.5", "payload": {"kept": "1", "count": "42"}}', "f"
+        )
+        assert json.loads(result) == {
+            "value": "1.5",
+            "payload": {"kept": 1, "count": 42},
+        }
 
     def test_malformed_root_combinator_preserves_direct_coercion(self):
         tool = _make_tool("f", {})

--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -272,14 +272,14 @@ class TestExtractTypesFromSchema:
         result = set(extract_types_from_schema(schema))
         assert result == {"array", "object"}
 
-    def test_none_schema_defaults_to_string(self):
-        assert extract_types_from_schema(None) == ["string"]
+    def test_none_schema_has_no_types(self):
+        assert extract_types_from_schema(None) == []
 
-    def test_non_dict_schema_defaults_to_string(self):
-        assert extract_types_from_schema("string") == ["string"]
+    def test_non_dict_schema_has_no_types(self):
+        assert extract_types_from_schema("string") == []
 
-    def test_empty_dict_defaults_to_string(self):
-        assert extract_types_from_schema({}) == ["string"]
+    def test_empty_dict_has_no_types(self):
+        assert extract_types_from_schema({}) == []
 
     def test_nested_anyof(self):
         schema = {

--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -195,6 +195,12 @@ class TestCoerceToSchemaType:
         def test_array_type(self):
             assert coerce_to_schema_type("[1, 2, 3]", "array") == [1, 2, 3]
 
+        @pytest.mark.parametrize(
+            "schema_type, value", [("object", "[1]"), ("array", '{"a": 1}')]
+        )
+        def test_wrong_container_type_preserves_input(self, schema_type, value):
+            assert coerce_to_schema_type(value, schema_type) == value
+
         def test_invalid_json_fallback(self):
             assert coerce_to_schema_type("not json", "object") == "not json"
 
@@ -233,8 +239,9 @@ class TestExtractTypesFromSchema:
     def test_direct_type_string(self):
         assert extract_types_from_schema({"type": "string"}) == ["string"]
 
-    def test_direct_type_integer(self):
-        assert extract_types_from_schema({"type": "integer"}) == ["integer"]
+    @pytest.mark.parametrize("schema_type", ["integer", " INT "])
+    def test_direct_type_integer(self, schema_type):
+        assert extract_types_from_schema({"type": schema_type}) == ["integer"]
 
     def test_type_array(self):
         result = set(extract_types_from_schema({"type": ["string", "null"]}))

--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -13,7 +13,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
 from vllm.tool_parsers.utils import (
-    find_tool_properties,
+    find_tool_schema,
     get_json_schema_from_tools,
 )
 
@@ -378,14 +378,14 @@ class TestNonFunctionToolsSkipped:
     """Non-function tools (web_search, etc.) must be silently skipped
     by the tool-schema utilities instead of raising TypeError."""
 
-    def test_find_tool_properties_skips_web_search(self):
+    def test_find_tool_schema_skips_web_search(self):
         tools = [WEB_SEARCH_TOOL, FUNCTION_TOOL]
-        props = find_tool_properties(tools, "get_weather")
-        assert props == {"city": {"type": "string"}}
+        schema = find_tool_schema(tools, "get_weather")
+        assert schema == FUNCTION_TOOL.parameters
 
-    def test_find_tool_properties_only_non_function_tools(self):
-        props = find_tool_properties([WEB_SEARCH_TOOL], "get_weather")
-        assert props == {}
+    def test_find_tool_schema_only_non_function_tools(self):
+        schema = find_tool_schema([WEB_SEARCH_TOOL], "get_weather")
+        assert schema == {}
 
     def test_get_json_schema_with_mixed_tools(self):
         tools = [WEB_SEARCH_TOOL, FUNCTION_TOOL]

--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -13,7 +13,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
 from vllm.tool_parsers.utils import (
-    find_tool_schema,
+    find_tool_properties,
     get_json_schema_from_tools,
 )
 
@@ -378,14 +378,14 @@ class TestNonFunctionToolsSkipped:
     """Non-function tools (web_search, etc.) must be silently skipped
     by the tool-schema utilities instead of raising TypeError."""
 
-    def test_find_tool_schema_skips_web_search(self):
+    def test_find_tool_properties_skips_web_search(self):
         tools = [WEB_SEARCH_TOOL, FUNCTION_TOOL]
-        schema = find_tool_schema(tools, "get_weather")
-        assert schema == FUNCTION_TOOL.parameters
+        props = find_tool_properties(tools, "get_weather")
+        assert props == {"city": {"type": "string"}}
 
-    def test_find_tool_schema_only_non_function_tools(self):
-        schema = find_tool_schema([WEB_SEARCH_TOOL], "get_weather")
-        assert schema == {}
+    def test_find_tool_properties_only_non_function_tools(self):
+        props = find_tool_properties([WEB_SEARCH_TOOL], "get_weather")
+        assert props == {}
 
     def test_get_json_schema_with_mixed_tools(self):
         tools = [WEB_SEARCH_TOOL, FUNCTION_TOOL]

--- a/vllm/parser/deepseek_v32.py
+++ b/vllm/parser/deepseek_v32.py
@@ -140,4 +140,6 @@ class DeepSeekV32Parser(ParserEngine):
         if not self._tools:
             return result
         func_name = next((s.name for s in self._tool_slots if s.args == raw_args), None)
-        return _unwrap_wrapper_args(result, self._tools, func_name)
+        return _unwrap_wrapper_args(
+            result, self._tools, func_name, self._get_tool_type_hints
+        )

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import json
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -32,7 +33,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
-from vllm.tool_parsers.utils import find_tool_schema, get_schema_properties
+from vllm.tool_parsers.utils import find_tool_properties
 
 if TYPE_CHECKING:
     from vllm.tokenizers import TokenizerLike
@@ -108,6 +109,7 @@ def _unwrap_wrapper_args(
     args_json: str,
     tools: list[Tool] | None,
     func_name: str | None,
+    get_properties: Callable[[str], Mapping[str, object]] | None = None,
 ) -> str:
     if not tools or not func_name:
         return args_json
@@ -115,23 +117,28 @@ def _unwrap_wrapper_args(
         args = json.loads(args_json)
     except (json.JSONDecodeError, ValueError):
         return args_json
-    if not isinstance(args, dict):
+    if not isinstance(args, dict) or len(args) != 1:
         return args_json
-    properties = get_schema_properties(find_tool_schema(tools, func_name))
+    wrapper = next(iter(args))
+    if wrapper not in ("arguments", "input"):
+        return args_json
+    properties = (
+        get_properties(func_name)
+        if get_properties is not None
+        else find_tool_properties(tools, func_name)
+    )
     if not properties:
         return args_json
-    allowed = set(properties.keys())
-    for wrapper in ("arguments", "input"):
-        if set(args.keys()) != {wrapper} or wrapper in allowed:
-            continue
-        inner = args[wrapper]
-        if isinstance(inner, str):
-            try:
-                inner = json.loads(inner)
-            except json.JSONDecodeError:
-                return args_json
-        if isinstance(inner, dict) and set(inner.keys()).issubset(allowed):
-            return json.dumps(inner, ensure_ascii=False)
+    if wrapper in properties:
+        return args_json
+    inner = args[wrapper]
+    if isinstance(inner, str):
+        try:
+            inner = json.loads(inner)
+        except json.JSONDecodeError:
+            return args_json
+    if isinstance(inner, dict) and set(inner.keys()).issubset(properties):
+        return json.dumps(inner, ensure_ascii=False)
     return args_json
 
 
@@ -265,4 +272,6 @@ class DeepSeekV4Parser(ParserEngine):
         if not self._tools:
             return result
         func_name = next((s.name for s in self._tool_slots if s.args == raw_args), None)
-        return _unwrap_wrapper_args(result, self._tools, func_name)
+        return _unwrap_wrapper_args(
+            result, self._tools, func_name, self._get_tool_type_hints
+        )

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -32,7 +32,7 @@ from vllm.parser.engine.parser_engine_config import (
     ParserState,
     Transition,
 )
-from vllm.tool_parsers.utils import find_tool_properties
+from vllm.tool_parsers.utils import find_tool_schema, get_schema_properties
 
 if TYPE_CHECKING:
     from vllm.tokenizers import TokenizerLike
@@ -117,7 +117,7 @@ def _unwrap_wrapper_args(
         return args_json
     if not isinstance(args, dict):
         return args_json
-    properties = find_tool_properties(tools, func_name)
+    properties = get_schema_properties(find_tool_schema(tools, func_name))
     if not properties:
         return args_json
     allowed = set(properties.keys())

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -32,6 +32,7 @@ from vllm.tool_parsers.utils import (
     extract_types_from_schema,
     find_tool_name,
     find_tool_properties,
+    get_schema_properties,
 )
 
 if TYPE_CHECKING:
@@ -250,15 +251,13 @@ class ParserEngine(Parser):
             types = extract_types_from_schema(schema)
             coerced = coerce_to_schema_type(value, types) if types else value
             if coerced is not value:
+                if isinstance(coerced, (dict, list)):
+                    coerced, _ = ParserEngine._coerce_value(coerced, schema)
                 return coerced, True
             return value, False
 
         if isinstance(value, dict):
-            nested_props = schema.get("properties")
-            if isinstance(nested_props, dict):
-                _, changed = ParserEngine._coerce_dict(value, nested_props)
-                return value, changed
-            return value, False
+            return ParserEngine._coerce_dict(value, get_schema_properties(schema))
 
         if isinstance(value, list):
             items_schema = schema.get("items")

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -264,19 +264,30 @@ class ParserEngine(Parser):
             return ParserEngine._coerce_dict(value, get_schema_properties(schema))
 
         if isinstance(value, list):
-            item_schemas = []
-            pending = [schema]
+            # Preserve alternatives when projecting array schemas onto item hints.
+            items_schema: dict = {}
+            pending = [(schema, items_schema)]
             while pending:
-                member = pending.pop()
+                member, hints = pending.pop()
                 if not isinstance(member, dict):
                     continue
                 if isinstance(items := member.get("items"), dict):
-                    item_schemas.append(items)
-                if isinstance(all_of := member.get("allOf"), list):
-                    pending.extend(all_of)
-            if item_schemas:
+                    hints["allOf"] = [items]
+                for keyword in ("allOf", "anyOf", "oneOf"):
+                    if not isinstance(branches := member.get(keyword), list):
+                        continue
+                    branches = [
+                        branch
+                        for branch in branches
+                        if keyword == "allOf"
+                        or not (types := extract_types_from_schema(branch))
+                        or "array" in types
+                    ]
+                    branch_hints: list[dict] = [{} for _ in branches]
+                    hints.setdefault(keyword, []).extend(branch_hints)
+                    pending.extend(zip(branches, branch_hints))
+            if items_schema:
                 value = value.copy()
-                items_schema = {"allOf": item_schemas}
                 changed = False
                 for i, item in enumerate(value):
                     coerced, item_changed = ParserEngine._coerce_value(
@@ -313,7 +324,8 @@ class ParserEngine(Parser):
                     valid = Draft202012Validator(prop, registry=Registry()).is_valid(
                         coerced
                     )
-                except (Unresolvable, UnknownType):
+                except (Unresolvable, UnknownType, TypeError):
+                    # Malformed schema keyword values can raise TypeError.
                     valid = False
                 if not valid:
                     continue

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -260,8 +260,18 @@ class ParserEngine(Parser):
             return ParserEngine._coerce_dict(value, get_schema_properties(schema))
 
         if isinstance(value, list):
-            items_schema = schema.get("items")
-            if isinstance(items_schema, dict):
+            item_schemas = []
+            pending = [schema]
+            while pending:
+                member = pending.pop()
+                if not isinstance(member, dict):
+                    continue
+                if isinstance(items := member.get("items"), dict):
+                    item_schemas.append(items)
+                if isinstance(all_of := member.get("allOf"), list):
+                    pending.extend(all_of)
+            if item_schemas:
+                items_schema = {"allOf": item_schemas}
                 changed = False
                 for i, item in enumerate(value):
                     coerced, item_changed = ParserEngine._coerce_value(

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -248,7 +248,7 @@ class ParserEngine(Parser):
         """
         if isinstance(value, str):
             types = extract_types_from_schema(schema)
-            coerced = coerce_to_schema_type(value, types)
+            coerced = coerce_to_schema_type(value, types) if types else value
             if coerced is not value:
                 return coerced, True
             return value, False
@@ -275,6 +275,8 @@ class ParserEngine(Parser):
             return value, False
 
         types = extract_types_from_schema(schema)
+        if not types:
+            return value, False
         as_str = json.dumps(value, ensure_ascii=False)
         coerced = coerce_to_schema_type(as_str, types)
         if type(coerced) is not type(value) or coerced != value:
@@ -374,7 +376,7 @@ class ParserEngine(Parser):
 
         streamable: set[str] = set()
         for key, schema in properties.items():
-            if set(extract_types_from_schema(schema)) == {"string"}:
+            if set(extract_types_from_schema(schema)) <= {"string"}:
                 streamable.add(key)
         return streamable
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -12,6 +12,10 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 import regex as re
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import UnknownType
+from referencing import Registry
+from referencing.exceptions import Unresolvable
 
 from vllm.entrypoints.chat_utils import get_tool_call_id_type, make_tool_call_id
 from vllm.entrypoints.generate.base.protocol import (
@@ -271,6 +275,7 @@ class ParserEngine(Parser):
                 if isinstance(all_of := member.get("allOf"), list):
                     pending.extend(all_of)
             if item_schemas:
+                value = value.copy()
                 items_schema = {"allOf": item_schemas}
                 changed = False
                 for i, item in enumerate(value):
@@ -295,6 +300,7 @@ class ParserEngine(Parser):
     @staticmethod
     def _coerce_dict(args: dict, properties: dict) -> tuple[dict, bool]:
         """Coerce all values in *args* using *properties* schemas."""
+        args = args.copy()
         changed = False
         for key, value in args.items():
             prop = properties.get(key)
@@ -302,6 +308,15 @@ class ParserEngine(Parser):
                 continue
             coerced, val_changed = ParserEngine._coerce_value(value, prop)
             if val_changed:
+                try:
+                    # An empty registry prevents fetching external schema references.
+                    valid = Draft202012Validator(prop, registry=Registry()).is_valid(
+                        coerced
+                    )
+                except (Unresolvable, UnknownType):
+                    valid = False
+                if not valid:
+                    continue
                 args[key] = coerced
                 changed = True
         return args, changed
@@ -410,7 +425,7 @@ class ParserEngine(Parser):
         if not properties:
             return args_json
 
-        _, changed = self._coerce_dict(args, properties)
+        args, changed = self._coerce_dict(args, properties)
 
         if changed:
             return json.dumps(args, ensure_ascii=False)

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import regex as re
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import UnknownType
+from jsonschema.validators import validator_for
 from referencing import Registry
 from referencing.exceptions import Unresolvable
 
@@ -35,11 +36,13 @@ from vllm.tool_parsers.utils import (
     coerce_to_schema_type,
     extract_types_from_schema,
     find_tool_name,
-    find_tool_properties,
+    find_tool_schema,
     get_schema_properties,
 )
 
 if TYPE_CHECKING:
+    from jsonschema.protocols import Validator
+
     from vllm.entrypoints.openai.chat_completion.protocol import (
         ChatCompletionRequest,
     )
@@ -246,22 +249,23 @@ class ParserEngine(Parser):
     # ── Schema-aware type correction ─────────────────────────────────
 
     @staticmethod
-    def _coerce_value(value: object, schema: dict) -> tuple[object, bool]:
+    def _coerce_value(value: object, validator: Validator) -> tuple[object, bool]:
         """Coerce a single value according to its schema.
 
         Returns ``(coerced_value, changed)``.
         """
+        schema = validator.schema
         if isinstance(value, str):
             types = extract_types_from_schema(schema)
             coerced = coerce_to_schema_type(value, types) if types else value
             if coerced is not value:
                 if isinstance(coerced, (dict, list)):
-                    coerced, _ = ParserEngine._coerce_value(coerced, schema)
+                    coerced, _ = ParserEngine._coerce_value(coerced, validator)
                 return coerced, True
             return value, False
 
         if isinstance(value, dict):
-            return ParserEngine._coerce_dict(value, get_schema_properties(schema))
+            return ParserEngine._coerce_dict(value, validator)
 
         if isinstance(value, list):
             # Preserve alternatives when projecting array schemas onto item hints.
@@ -287,11 +291,12 @@ class ParserEngine(Parser):
                     hints.setdefault(keyword, []).extend(branch_hints)
                     pending.extend(zip(branches, branch_hints))
             if items_schema:
+                item_validator = validator.evolve(schema=items_schema)
                 value = value.copy()
                 changed = False
                 for i, item in enumerate(value):
                     coerced, item_changed = ParserEngine._coerce_value(
-                        item, items_schema
+                        item, item_validator
                     )
                     if item_changed:
                         value[i] = coerced
@@ -309,21 +314,20 @@ class ParserEngine(Parser):
         return value, False
 
     @staticmethod
-    def _coerce_dict(args: dict, properties: dict) -> tuple[dict, bool]:
-        """Coerce all values in *args* using *properties* schemas."""
+    def _coerce_dict(args: dict, validator: Validator) -> tuple[dict, bool]:
+        """Coerce properties while retaining the validator's draft and root context."""
+        properties = get_schema_properties(validator.schema)
         args = args.copy()
         changed = False
         for key, value in args.items():
             prop = properties.get(key)
             if not isinstance(prop, dict):
                 continue
-            coerced, val_changed = ParserEngine._coerce_value(value, prop)
+            prop_validator = validator.evolve(schema=prop)
+            coerced, val_changed = ParserEngine._coerce_value(value, prop_validator)
             if val_changed:
                 try:
-                    # An empty registry prevents fetching external schema references.
-                    valid = Draft202012Validator(prop, registry=Registry()).is_valid(
-                        coerced
-                    )
+                    valid = prop_validator.is_valid(coerced)
                 except (Unresolvable, UnknownType, TypeError):
                     # Malformed schema keyword values can raise TypeError.
                     valid = False
@@ -433,11 +437,15 @@ class ParserEngine(Parser):
         if not isinstance(args, dict):
             return args_json
 
-        properties = find_tool_properties(self._tools, func_name)
-        if not properties:
+        schema = find_tool_schema(self._tools, func_name)
+        if not schema:
             return args_json
 
-        args, changed = self._coerce_dict(args, properties)
+        # Keep the declared draft and root references without fetching external schemas.
+        validator = validator_for(schema, default=Draft202012Validator)(
+            schema, registry=Registry()
+        )
+        args, changed = self._coerce_dict(args, validator)
 
         if changed:
             return json.dumps(args, ensure_ascii=False)
@@ -905,7 +913,7 @@ class ParserEngine(Parser):
         slot.name = name
         slot.name_sent = True
         slot.string_keys = self._streamable_string_keys(
-            find_tool_properties(self._tools, name)
+            get_schema_properties(find_tool_schema(self._tools, name))
         )
         self._ensure_tool_id(slot, name)
         deltas.append(
@@ -963,7 +971,7 @@ class ParserEngine(Parser):
                 slot.name = name
                 slot.name_sent = True
                 slot.string_keys = self._streamable_string_keys(
-                    find_tool_properties(self._tools, name)
+                    get_schema_properties(find_tool_schema(self._tools, name))
                 )
                 self._ensure_tool_id(slot, name)
                 deltas.append(

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -7,16 +7,11 @@ extraction with a single :class:`StreamingParserEngine`.
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
 import regex as re
-from jsonschema import Draft202012Validator
-from jsonschema.exceptions import UnknownType
-from jsonschema.validators import validator_for
-from referencing import Registry
-from referencing.exceptions import Unresolvable
 
 from vllm.entrypoints.chat_utils import get_tool_call_id_type, make_tool_call_id
 from vllm.entrypoints.generate.base.protocol import (
@@ -33,16 +28,13 @@ from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
 from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
 from vllm.tool_parsers.utils import (
+    SchemaTypeHints,
     coerce_to_schema_type,
-    extract_types_from_schema,
     find_tool_name,
-    find_tool_schema,
-    get_schema_properties,
+    find_tool_properties,
 )
 
 if TYPE_CHECKING:
-    from jsonschema.protocols import Validator
-
     from vllm.entrypoints.openai.chat_completion.protocol import (
         ChatCompletionRequest,
     )
@@ -51,6 +43,8 @@ if TYPE_CHECKING:
     from vllm.tool_parsers.abstract_tool_parser import Tool
 
 logger = init_logger(__name__)
+
+_CoercionCache = dict[str, tuple[SchemaTypeHints, type, str, object, bool]]
 
 
 class ToolCallSlot:
@@ -62,6 +56,7 @@ class ToolCallSlot:
         "name_sent",
         "string_keys",
         "streamed_json",
+        "coercions",
     )
 
     def __init__(self) -> None:
@@ -72,6 +67,7 @@ class ToolCallSlot:
         self.name_sent: bool = False
         self.string_keys: set[str] | None = None
         self.streamed_json: str = ""
+        self.coercions: _CoercionCache = {}
 
     @property
     def args(self) -> str:
@@ -102,6 +98,7 @@ class ParserEngine(Parser):
     ) -> None:
         self.model_tokenizer = tokenizer
         self._tools = tools
+        self._tool_type_hints: dict[str, dict[str, SchemaTypeHints | None]] = {}
         self._stream_state = StreamState(
             tool_call_id_type=(
                 get_tool_call_id_type(model_config)
@@ -249,90 +246,68 @@ class ParserEngine(Parser):
     # ── Schema-aware type correction ─────────────────────────────────
 
     @staticmethod
-    def _coerce_value(value: object, validator: Validator) -> tuple[object, bool]:
+    def _coerce_value(value: object, hints: SchemaTypeHints) -> tuple[object, bool]:
         """Coerce a single value according to its schema.
 
         Returns ``(coerced_value, changed)``.
         """
-        schema = validator.schema
+        original = value
+        changed = False
         if isinstance(value, str):
-            types = extract_types_from_schema(schema)
-            coerced = coerce_to_schema_type(value, types) if types else value
-            if coerced is not value:
-                if isinstance(coerced, (dict, list)):
-                    coerced, _ = ParserEngine._coerce_value(coerced, validator)
-                return coerced, True
-            return value, False
+            value = coerce_to_schema_type(value, hints.types) if hints.types else value
+            changed = value is not original
 
+        decoded = value
         if isinstance(value, dict):
-            return ParserEngine._coerce_dict(value, validator)
+            value, nested_changed = ParserEngine._coerce_dict(value, hints.properties)
+            changed |= nested_changed
+        elif isinstance(value, list) and hints.items is not None:
+            value = value.copy()
+            for i, item in enumerate(value):
+                value[i], item_changed = ParserEngine._coerce_value(item, hints.items)
+                changed |= item_changed
+        elif not isinstance(original, (str, dict, list)) and hints.types:
+            value = coerce_to_schema_type(
+                json.dumps(value, ensure_ascii=False), hints.types
+            )
+            changed = type(value) is not type(original) or value != original
 
-        if isinstance(value, list):
-            # Preserve alternatives when projecting array schemas onto item hints.
-            items_schema: dict = {}
-            pending = [(schema, items_schema)]
-            while pending:
-                member, hints = pending.pop()
-                if not isinstance(member, dict):
-                    continue
-                if isinstance(items := member.get("items"), dict):
-                    hints["allOf"] = [items]
-                for keyword in ("allOf", "anyOf", "oneOf"):
-                    if not isinstance(branches := member.get(keyword), list):
-                        continue
-                    branches = [
-                        branch
-                        for branch in branches
-                        if keyword == "allOf"
-                        or not (types := extract_types_from_schema(branch))
-                        or "array" in types
-                    ]
-                    branch_hints: list[dict] = [{} for _ in branches]
-                    hints.setdefault(keyword, []).extend(branch_hints)
-                    pending.extend(zip(branches, branch_hints))
-            if items_schema:
-                item_validator = validator.evolve(schema=items_schema)
-                value = value.copy()
-                changed = False
-                for i, item in enumerate(value):
-                    coerced, item_changed = ParserEngine._coerce_value(
-                        item, item_validator
-                    )
-                    if item_changed:
-                        value[i] = coerced
-                        changed = True
-                return value, changed
-            return value, False
-
-        types = extract_types_from_schema(schema)
-        if not types:
-            return value, False
-        as_str = json.dumps(value, ensure_ascii=False)
-        coerced = coerce_to_schema_type(as_str, types)
-        if type(coerced) is not type(value) or coerced != value:
-            return coerced, True
-        return value, False
+        if (
+            changed
+            and hints.validator is not None
+            and not hints.validator.is_valid(value)
+        ):
+            if decoded is not original and hints.validator.is_valid(decoded):
+                return decoded, True
+            return original, False
+        return value, changed
 
     @staticmethod
-    def _coerce_dict(args: dict, validator: Validator) -> tuple[dict, bool]:
-        """Coerce properties while retaining the validator's draft and root context."""
-        properties = get_schema_properties(validator.schema)
+    def _coerce_dict(
+        args: dict,
+        properties: Mapping[str, SchemaTypeHints | None],
+        cache: _CoercionCache | None = None,
+    ) -> tuple[dict, bool]:
+        """Coerce properties, optionally reusing per-tool-call results."""
         args = args.copy()
         changed = False
         for key, value in args.items():
             prop = properties.get(key)
-            if not isinstance(prop, dict):
+            if prop is None:
                 continue
-            prop_validator = validator.evolve(schema=prop)
-            coerced, val_changed = ParserEngine._coerce_value(value, prop_validator)
+            raw = ""
+            cached = None
+            if cache is not None:
+                # JSON spelling distinguishes nested bool/int values and signed zero.
+                raw = value if isinstance(value, str) else json.dumps(value)
+                cached = cache.get(key)
+            if cached is not None and cached[:3] == (prop, type(value), raw):
+                coerced, val_changed = cached[3:]
+            else:
+                coerced, val_changed = ParserEngine._coerce_value(value, prop)
+                if cache is not None:
+                    cache[key] = (prop, type(value), raw, coerced, val_changed)
             if val_changed:
-                try:
-                    valid = prop_validator.is_valid(coerced)
-                except (Unresolvable, UnknownType, TypeError):
-                    # Malformed schema keyword values can raise TypeError.
-                    valid = False
-                if not valid:
-                    continue
                 args[key] = coerced
                 changed = True
         return args, changed
@@ -403,7 +378,9 @@ class ParserEngine(Parser):
         return json_str
 
     @staticmethod
-    def _streamable_string_keys(properties: dict) -> set[str] | None:
+    def _streamable_string_keys(
+        properties: Mapping[str, SchemaTypeHints | None],
+    ) -> set[str] | None:
         """Return keys whose trailing string values can safely stream.
 
         ``None`` means there is no schema, so all string values keep their
@@ -411,16 +388,27 @@ class ParserEngine(Parser):
         remain strings are safe to emit before the value is closed; fields
         coerced to bool/number/null/object/array may serialize differently.
         """
-        if not properties:
+        if not any(properties.values()):
             return None
 
         streamable: set[str] = set()
-        for key, schema in properties.items():
-            if set(extract_types_from_schema(schema)) <= {"string"}:
+        for key, hints in properties.items():
+            if hints is not None and set(hints.types) <= {"string"}:
                 streamable.add(key)
         return streamable
 
-    def _fix_arg_types(self, args_json: str, func_name: str) -> str:
+    def _get_tool_type_hints(self, name: str) -> dict[str, SchemaTypeHints | None]:
+        """Cache coercion hints and retain declared names for wrapper detection."""
+        if name not in self._tool_type_hints:
+            self._tool_type_hints[name] = {
+                key: SchemaTypeHints(schema) if isinstance(schema, dict) else None
+                for key, schema in find_tool_properties(self._tools, name).items()
+            }
+        return self._tool_type_hints[name]
+
+    def _fix_arg_types(
+        self, args_json: str, func_name: str, cache: _CoercionCache | None = None
+    ) -> str:
         """Correct parameter types using the tool schema.
 
         String values are coerced via :func:`coerce_to_schema_type`.
@@ -437,15 +425,11 @@ class ParserEngine(Parser):
         if not isinstance(args, dict):
             return args_json
 
-        schema = find_tool_schema(self._tools, func_name)
-        if not schema:
+        properties = self._get_tool_type_hints(func_name)
+        if not properties:
             return args_json
 
-        # Keep the declared draft and root references without fetching external schemas.
-        validator = validator_for(schema, default=Draft202012Validator)(
-            schema, registry=Registry()
-        )
-        args, changed = self._coerce_dict(args, validator)
+        args, changed = self._coerce_dict(args, properties, cache)
 
         if changed:
             return json.dumps(args, ensure_ascii=False)
@@ -468,8 +452,9 @@ class ParserEngine(Parser):
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> None:
         tools = getattr(request, "tools", None)
-        if tools:
+        if tools and tools is not self._tools:
             self._tools = tools
+            self._tool_type_hints.clear()
         if not self.skip_tool_parsing and not self._suppress_tool_calls:
             tool_choice = getattr(request, "tool_choice", None)
             if tool_choice == "none" and tools:
@@ -912,9 +897,7 @@ class ParserEngine(Parser):
         slot = self._tool_slots[idx]
         slot.name = name
         slot.name_sent = True
-        slot.string_keys = self._streamable_string_keys(
-            get_schema_properties(find_tool_schema(self._tools, name))
-        )
+        slot.string_keys = self._streamable_string_keys(self._get_tool_type_hints(name))
         self._ensure_tool_id(slot, name)
         deltas.append(
             DeltaToolCall(
@@ -971,7 +954,7 @@ class ParserEngine(Parser):
                 slot.name = name
                 slot.name_sent = True
                 slot.string_keys = self._streamable_string_keys(
-                    get_schema_properties(find_tool_schema(self._tools, name))
+                    self._get_tool_type_hints(name)
                 )
                 self._ensure_tool_id(slot, name)
                 deltas.append(
@@ -1052,7 +1035,7 @@ class ParserEngine(Parser):
             return None
 
         if slot.name:
-            current_json = self._fix_arg_types(current_json, slot.name)
+            current_json = self._fix_arg_types(current_json, slot.name, slot.coercions)
 
         prev = slot.streamed_json
         safe_json = self._safe_arg_prefix(current_json, slot.string_keys)
@@ -1085,7 +1068,7 @@ class ParserEngine(Parser):
             return None
 
         if final_json:
-            final_json = self._fix_arg_types(final_json, slot.name)
+            final_json = self._fix_arg_types(final_json, slot.name, slot.coercions)
 
         prev = slot.streamed_json
         if final_json and len(final_json) > len(prev):

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -269,24 +269,62 @@ def _extract_tool_info(
         raise TypeError(f"Unsupported tool type: {type(tool)}")
 
 
+def _dict_properties(schema: Any) -> dict[str, dict[str, Any]]:
+    """Property schemas of *schema* that are dicts; booleans carry no types."""
+    if not isinstance(schema, dict):
+        return {}
+    return {
+        name: prop
+        for name, prop in schema.get("properties", {}).items()
+        if isinstance(prop, dict)
+    }
+
+
+def _root_schema_properties(params: dict[str, Any]) -> dict[str, Any]:
+    """Property schemas declared directly or inside root combinators.
+
+    Root ``allOf`` members always apply, so their properties refine the
+    direct ``properties``. Which ``anyOf``/``oneOf`` branch applies depends
+    on argument values a streaming parser only sees incrementally, so a
+    branch property is used only when no other branch declares it
+    differently.
+    """
+    properties = dict(params.get("properties", {}))
+    for member in params.get("allOf", []):
+        for name, schema in _dict_properties(member).items():
+            base = properties.get(name)
+            properties[name] = base | schema if isinstance(base, dict) else schema
+    branches = [
+        _dict_properties(branch)
+        for keyword in ("anyOf", "oneOf")
+        for branch in params.get(keyword, [])
+    ]
+    for branch in branches:
+        for name, schema in branch.items():
+            if name not in properties and all(
+                other.get(name, schema) == schema for other in branches
+            ):
+                properties[name] = schema
+    return properties
+
+
 def find_tool_properties(
     tools: list[Tool] | None,
     tool_name: str,
 ) -> dict[str, Any]:
-    """Find a tool by name and return its properties dict, or {}."""
+    """Find a tool by name and return its parameter property schemas, or {}."""
     if not tools:
         return {}
     for tool in tools:
         if isinstance(tool, (FunctionTool, NamespaceTool)):
-            for name, params in iter_response_function_tool_info(tool):
-                if name == tool_name:
-                    return (params or {}).get("properties", {})
+            tool_info = iter_response_function_tool_info(tool)
+        elif _is_function_tool(tool):
+            tool_info = [_extract_tool_info(tool)]
+        else:
             continue
-        if not _is_function_tool(tool):
-            continue
-        name, params = _extract_tool_info(tool)
-        if name == tool_name:
-            return (params or {}).get("properties", {})
+        for name, params in tool_info:
+            if name == tool_name:
+                return _root_schema_properties(params or {})
     return {}
 
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -287,24 +287,24 @@ def _root_schema_properties(params: dict[str, Any]) -> dict[str, Any]:
     direct ``properties``. Which ``anyOf``/``oneOf`` branch applies depends
     on argument values a streaming parser only sees incrementally, so a
     branch property is used only when no other branch declares it
-    differently.
+    differently; it then always applies and refines the schema as well.
     """
-    properties = dict(params.get("properties", {}))
-    for member in params.get("allOf", []):
-        for name, schema in _dict_properties(member).items():
-            base = properties.get(name)
-            properties[name] = base | schema if isinstance(base, dict) else schema
     branches = [
         _dict_properties(branch)
         for keyword in ("anyOf", "oneOf")
         for branch in params.get(keyword, [])
     ]
-    for branch in branches:
-        for name, schema in branch.items():
-            if name not in properties and all(
-                other.get(name, schema) == schema for other in branches
-            ):
-                properties[name] = schema
+    shared = {
+        name: schema
+        for branch in branches
+        for name, schema in branch.items()
+        if all(other.get(name, schema) == schema for other in branches)
+    }
+    properties = dict(params.get("properties", {}))
+    for refinement in (*map(_dict_properties, params.get("allOf", [])), shared):
+        for name, schema in refinement.items():
+            base = properties.get(name)
+            properties[name] = base | schema if isinstance(base, dict) else schema
     return properties
 
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -271,13 +271,11 @@ def _extract_tool_info(
 
 def _dict_properties(schema: Any) -> dict[str, dict[str, Any]]:
     """Property schemas of *schema* that are dicts; booleans carry no types."""
-    if not isinstance(schema, dict):
+    if not isinstance(schema, dict) or not isinstance(
+        properties := schema.get("properties"), dict
+    ):
         return {}
-    return {
-        name: prop
-        for name, prop in schema.get("properties", {}).items()
-        if isinstance(prop, dict)
-    }
+    return {name: prop for name, prop in properties.items() if isinstance(prop, dict)}
 
 
 def _root_schema_properties(params: dict[str, Any]) -> dict[str, Any]:
@@ -289,10 +287,15 @@ def _root_schema_properties(params: dict[str, Any]) -> dict[str, Any]:
     branch property is used only when no other branch declares it
     differently; it then always applies and refines the schema as well.
     """
+    combinators = {
+        keyword: value
+        for keyword in ("anyOf", "oneOf", "allOf")
+        if isinstance(value := params.get(keyword), list)
+    }
     branches = [
         _dict_properties(branch)
         for keyword in ("anyOf", "oneOf")
-        for branch in params.get(keyword, [])
+        for branch in combinators.get(keyword, [])
     ]
     shared = {
         name: schema
@@ -300,11 +303,19 @@ def _root_schema_properties(params: dict[str, Any]) -> dict[str, Any]:
         for name, schema in branch.items()
         if all(other.get(name, schema) == schema for other in branches)
     }
-    properties = dict(params.get("properties", {}))
-    for refinement in (*map(_dict_properties, params.get("allOf", [])), shared):
+    direct = params.get("properties")
+    properties = dict(direct) if isinstance(direct, dict) else {}
+    for refinement in (*map(_dict_properties, combinators.get("allOf", [])), shared):
         for name, schema in refinement.items():
             base = properties.get(name)
-            properties[name] = base | schema if isinstance(base, dict) else schema
+            if isinstance(base, dict):
+                schema = base | schema
+                if isinstance(base.get("properties"), dict) and isinstance(
+                    schema.get("properties"), dict
+                ):
+                    # Refinements can add fields without replacing existing ones.
+                    schema["properties"] = base["properties"] | schema["properties"]
+            properties[name] = schema
     return properties
 
 
@@ -1042,15 +1053,16 @@ def make_valid_python(text: str) -> tuple[str, str] | None:
     return candidate, added_text
 
 
-def extract_types_from_schema(schema: Any) -> list[str]:
-    """Extract all possible type strings from a JSON Schema definition.
+def extract_types_from_schema(schema: Any, *, infer_const: bool = True) -> list[str]:
+    """Extract type hints for schema-aware argument coercion.
 
-    Handles ``type`` (string or list), ``enum`` value inference, and
-    recursive ``anyOf``/``oneOf``/``allOf``.  Returns ``["string"]``
-    when no type information can be determined.
+    Handles ``type`` (string or list), ``enum``/``const`` value inference,
+    and recursive ``anyOf``/``oneOf``/``allOf``. Returns an empty list
+    when types cannot be inferred safely. Constants are not inferred inside
+    alternatives: their primitive types would lose the value constraints.
     """
     if schema is None or not isinstance(schema, dict):
-        return ["string"]
+        return []
 
     types: set[str] = set()
 
@@ -1063,8 +1075,11 @@ def extract_types_from_schema(schema: Any) -> list[str]:
                 if isinstance(t, str):
                     types.add(t)
 
-    if "enum" in schema and isinstance(schema["enum"], list) and schema["enum"]:
-        for value in schema["enum"]:
+    values = (
+        [schema["const"]] if infer_const and "const" in schema else schema.get("enum")
+    )
+    if isinstance(values, list):
+        for value in values:
             if value is None:
                 types.add("null")
             elif isinstance(value, bool):
@@ -1083,9 +1098,14 @@ def extract_types_from_schema(schema: Any) -> list[str]:
     for choice_field in ("anyOf", "oneOf", "allOf"):
         if choice_field in schema and isinstance(schema[choice_field], list):
             for choice in schema[choice_field]:
-                types.update(extract_types_from_schema(choice))
+                choice_types = extract_types_from_schema(
+                    choice, infer_const=infer_const and choice_field == "allOf"
+                )
+                if not choice_types and choice_field in ("anyOf", "oneOf"):
+                    return []
+                types.update(choice_types)
 
-    return list(types) if types else ["string"]
+    return list(types)
 
 
 _TYPE_ALIASES: dict[str, str] = {

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -318,11 +318,11 @@ def get_schema_properties(params: Any) -> dict[str, Any]:
     return properties
 
 
-def find_tool_properties(
+def find_tool_schema(
     tools: list[Tool] | None,
     tool_name: str,
 ) -> dict[str, Any]:
-    """Find a tool by name and return its parameter property schemas, or {}."""
+    """Find a tool by name and return its complete parameter schema, or {}."""
     if not tools:
         return {}
     for tool in tools:
@@ -334,7 +334,7 @@ def find_tool_properties(
             continue
         for name, params in tool_info:
             if name == tool_name:
-                return get_schema_properties(params or {})
+                return params or {}
     return {}
 
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -11,6 +11,7 @@ from json import JSONDecodeError, JSONDecoder
 from typing import Any, TypeAlias
 
 import partial_json_parser
+from jsonschema import Draft202012Validator
 from openai.types.responses import (
     FunctionTool,
     NamespaceTool,
@@ -269,31 +270,24 @@ def _extract_tool_info(
         raise TypeError(f"Unsupported tool type: {type(tool)}")
 
 
-def _dict_properties(schema: Any) -> dict[str, dict[str, Any]]:
-    """Property schemas of *schema* that are dicts; booleans carry no types."""
-    if not isinstance(schema, dict) or not isinstance(
-        properties := schema.get("properties"), dict
-    ):
-        return {}
-    return {name: prop for name, prop in properties.items() if isinstance(prop, dict)}
-
-
-def _root_schema_properties(params: dict[str, Any]) -> dict[str, Any]:
+def _root_schema_properties(params: Any) -> dict[str, Any]:
     """Property schemas declared directly or inside root combinators.
 
     Root ``allOf`` members always apply, so their properties refine the
     direct ``properties``. Which ``anyOf``/``oneOf`` branch applies depends
     on argument values a streaming parser only sees incrementally, so a
     branch property is used only when no other branch declares it
-    differently; it then always applies and refines the schema as well.
+    differently. These are static coercion hints, not branch validation.
     """
+    if not isinstance(params, dict):
+        return {}
     combinators = {
         keyword: value
         for keyword in ("anyOf", "oneOf", "allOf")
         if isinstance(value := params.get(keyword), list)
     }
     branches = [
-        _dict_properties(branch)
+        _root_schema_properties(branch)
         for keyword in ("anyOf", "oneOf")
         for branch in combinators.get(keyword, [])
     ]
@@ -305,11 +299,16 @@ def _root_schema_properties(params: dict[str, Any]) -> dict[str, Any]:
     }
     direct = params.get("properties")
     properties = dict(direct) if isinstance(direct, dict) else {}
-    for refinement in (*map(_dict_properties, combinators.get("allOf", [])), shared):
+    for refinement in (
+        *map(_root_schema_properties, combinators.get("allOf", [])),
+        shared,
+    ):
         for name, schema in refinement.items():
+            if not isinstance(schema, dict):
+                continue
             base = properties.get(name)
             if isinstance(base, dict):
-                schema = base | schema
+                schema = base | schema | {"allOf": [base, schema]}
                 if isinstance(base.get("properties"), dict) and isinstance(
                     schema.get("properties"), dict
                 ):
@@ -1095,16 +1094,31 @@ def extract_types_from_schema(schema: Any, *, infer_const: bool = True) -> list[
             elif isinstance(value, dict):
                 types.add("object")
 
+    constraints = [types] if types else []
     for choice_field in ("anyOf", "oneOf", "allOf"):
         if choice_field in schema and isinstance(schema[choice_field], list):
-            for choice in schema[choice_field]:
-                choice_types = extract_types_from_schema(
-                    choice, infer_const=infer_const and choice_field == "allOf"
+            branch_types = [
+                set(
+                    extract_types_from_schema(
+                        choice, infer_const=infer_const and choice_field == "allOf"
+                    )
                 )
-                if not choice_types and choice_field in ("anyOf", "oneOf"):
-                    return []
-                types.update(choice_types)
+                for choice in schema[choice_field]
+            ]
+            if choice_field == "allOf":
+                constraints.extend(branch for branch in branch_types if branch)
+            elif branch_types and all(branch_types):
+                constraints.append(set.union(*branch_types))
 
+    if not constraints:
+        return []
+    # JSON Schema numbers include integers; conjunctions must preserve that subset.
+    for constraint in constraints:
+        if "number" in constraint:
+            constraint.add("integer")
+    types = set.intersection(*constraints)
+    if "number" in types:
+        types.discard("integer")
     return list(types)
 
 
@@ -1218,6 +1232,11 @@ def coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
     # inf/nan inside a parsed list/dict) which json.dumps would render as
     # invalid JSON (Infinity/NaN). Preserve the raw string instead.
     if not _is_json_finite(parsed):
+        return value
+    known_types = normalized_types.intersection(type_priority)
+    if known_types and not any(
+        Draft202012Validator.TYPE_CHECKER.is_type(parsed, t) for t in known_types
+    ):
         return value
     return parsed
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -270,10 +270,10 @@ def _extract_tool_info(
         raise TypeError(f"Unsupported tool type: {type(tool)}")
 
 
-def _root_schema_properties(params: Any) -> dict[str, Any]:
-    """Property schemas declared directly or inside root combinators.
+def get_schema_properties(params: Any) -> dict[str, Any]:
+    """Property schemas declared directly or inside object combinators.
 
-    Root ``allOf`` members always apply, so their properties refine the
+    ``allOf`` members always apply, so their properties refine the
     direct ``properties``. Which ``anyOf``/``oneOf`` branch applies depends
     on argument values a streaming parser only sees incrementally, so a
     branch property is used only when no other branch declares it
@@ -287,7 +287,7 @@ def _root_schema_properties(params: Any) -> dict[str, Any]:
         if isinstance(value := params.get(keyword), list)
     }
     branches = [
-        _root_schema_properties(branch)
+        get_schema_properties(branch)
         for keyword in ("anyOf", "oneOf")
         for branch in combinators.get(keyword, [])
     ]
@@ -300,7 +300,7 @@ def _root_schema_properties(params: Any) -> dict[str, Any]:
     direct = params.get("properties")
     properties = dict(direct) if isinstance(direct, dict) else {}
     for refinement in (
-        *map(_root_schema_properties, combinators.get("allOf", [])),
+        *map(get_schema_properties, combinators.get("allOf", [])),
         shared,
     ):
         for name, schema in refinement.items():
@@ -334,7 +334,7 @@ def find_tool_properties(
             continue
         for name, params in tool_info:
             if name == tool_name:
-                return _root_schema_properties(params or {})
+                return get_schema_properties(params or {})
     return {}
 
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -6,6 +6,7 @@ import json
 import keyword as _python_keyword
 import math
 import warnings
+from collections import defaultdict
 from dataclasses import dataclass
 from json import JSONDecodeError, JSONDecoder
 from typing import Any, TypeAlias
@@ -276,8 +277,9 @@ def get_schema_properties(params: Any) -> dict[str, Any]:
     ``allOf`` members always apply, so their properties refine the
     direct ``properties``. Which ``anyOf``/``oneOf`` branch applies depends
     on argument values a streaming parser only sees incrementally, so a
-    branch property is used only when no other branch declares it
-    differently. These are static coercion hints, not branch validation.
+    property needs agreement from every branch that can accept it. These
+    are static coercion hints, not branch validation. Branch-only names
+    without agreed hints are retained with a ``True`` schema.
     """
     if not isinstance(params, dict):
         return {}
@@ -286,43 +288,58 @@ def get_schema_properties(params: Any) -> dict[str, Any]:
         for keyword in ("anyOf", "oneOf", "allOf")
         if isinstance(value := params.get(keyword), list)
     }
-    branches = [
-        get_schema_properties(branch)
-        for keyword in ("anyOf", "oneOf")
-        for branch in combinators.get(keyword, [])
-    ]
-    shared = {
-        name: schema
-        for branch in branches
-        for name, schema in branch.items()
-        if all(other.get(name, schema) == schema for other in branches)
-    }
     direct = params.get("properties")
     properties = dict(direct) if isinstance(direct, dict) else {}
-    for refinement in (
+    refinements = [
+        properties,
         *map(get_schema_properties, combinators.get("allOf", [])),
-        shared,
-    ):
+    ]
+    for keyword in ("anyOf", "oneOf"):
+        branches = [
+            (
+                get_schema_properties(branch),
+                isinstance(branch, dict)
+                and branch.get("additionalProperties") is False
+                and not branch.get("patternProperties"),
+            )
+            for branch in combinators.get(keyword, [])
+            if branch is not False
+            and (not (types := extract_types_from_schema(branch)) or "object" in types)
+        ]
+        shared = {
+            name: schema for branch, _ in branches for name, schema in branch.items()
+        }
+        refinements.append(
+            {
+                name: schema
+                if all(
+                    other[name] == schema if name in other else closed
+                    for other, closed in branches
+                )
+                else True
+                for name, schema in shared.items()
+            }
+        )
+    constraints: dict[str, list[dict]] = defaultdict(list)
+    for refinement in refinements:
         for name, schema in refinement.items():
-            if not isinstance(schema, dict):
-                continue
-            base = properties.get(name)
-            if isinstance(base, dict):
-                schema = base | schema | {"allOf": [base, schema]}
-                if isinstance(base.get("properties"), dict) and isinstance(
-                    schema.get("properties"), dict
-                ):
-                    # Refinements can add fields without replacing existing ones.
-                    schema["properties"] = base["properties"] | schema["properties"]
-            properties[name] = schema
+            properties.setdefault(name, True)
+            if isinstance(schema, dict):
+                constraints[name].append(schema)
+    properties.update(
+        {
+            name: schemas[0] if len(schemas) == 1 else {"allOf": schemas}
+            for name, schemas in constraints.items()
+        }
+    )
     return properties
 
 
-def find_tool_schema(
+def find_tool_properties(
     tools: list[Tool] | None,
     tool_name: str,
 ) -> dict[str, Any]:
-    """Find a tool by name and return its complete parameter schema, or {}."""
+    """Find a tool by name and return its parameter property schemas, or {}."""
     if not tools:
         return {}
     for tool in tools:
@@ -334,7 +351,7 @@ def find_tool_schema(
             continue
         for name, params in tool_info:
             if name == tool_name:
-                return params or {}
+                return get_schema_properties(params)
     return {}
 
 
@@ -1060,7 +1077,7 @@ def extract_types_from_schema(schema: Any, *, infer_const: bool = True) -> list[
     when types cannot be inferred safely. Constants are not inferred inside
     alternatives: their primitive types would lose the value constraints.
     """
-    if schema is None or not isinstance(schema, dict):
+    if not isinstance(schema, dict):
         return []
 
     types: set[str] = set()
@@ -1068,11 +1085,15 @@ def extract_types_from_schema(schema: Any, *, infer_const: bool = True) -> list[
     if "type" in schema:
         type_value = schema["type"]
         if isinstance(type_value, str):
-            types.add(type_value)
-        elif isinstance(type_value, list):
-            for t in type_value:
-                if isinstance(t, str):
-                    types.add(t)
+            type_value = [type_value]
+        if isinstance(type_value, list):
+            types.update(
+                _TYPE_ALIASES.get(key, key)
+                for t in type_value
+                if isinstance(t, str)
+                for key in [t.strip().lower()]
+            )
+            types.intersection_update(_TYPE_PRIORITY)
 
     values = (
         [schema["const"]] if infer_const and "const" in schema else schema.get("enum")
@@ -1149,6 +1170,82 @@ _TYPE_ALIASES: dict[str, str] = {
 }
 
 
+_TYPE_PRIORITY = ("null", "integer", "number", "boolean", "object", "array", "string")
+
+
+class SchemaTypeHints:
+    """Prepare coercion hints once, without validating unrelated schema keywords."""
+
+    def __init__(self, schema: dict) -> None:
+        self.types = extract_types_from_schema(schema)
+        self.properties = {
+            name: SchemaTypeHints(prop)
+            for name, prop in get_schema_properties(schema).items()
+            if isinstance(prop, dict)
+        }
+
+        items_schema: dict = {}
+        constraints: dict = {}
+        has_items = False
+        needs_validation = False
+        # Project combinators onto item hints and type/enum/const constraints.
+        for projection in (items_schema, constraints):
+            pending: list[tuple[dict | bool, dict]] = [(schema, projection)]
+            while pending:
+                member, hints = pending.pop()
+                if member is False and projection is constraints:
+                    # The false schema admits no value.
+                    hints["enum"] = []
+                    needs_validation = True
+                if not isinstance(member, dict):
+                    continue
+                if projection is items_schema:
+                    if isinstance(items := member.get("items"), dict):
+                        hints["allOf"] = [items]
+                        has_items = True
+                else:
+                    # Keep child constraints inside their object/array alternatives.
+                    if isinstance(items := member.get("items"), (dict, bool)):
+                        pending.append((items, hints.setdefault("items", {})))
+                        needs_validation = True
+                    if isinstance(properties := member.get("properties"), dict):
+                        prop_hints: dict = {name: {} for name in properties}
+                        hints["properties"] = prop_hints
+                        pending.extend(zip(properties.values(), prop_hints.values()))
+                        needs_validation = True
+                    known = extract_types_from_schema({"type": member.get("type")})
+                    if known:
+                        hints["type"] = known
+                    if isinstance(member.get("enum"), list):
+                        hints["enum"] = member["enum"]
+                        needs_validation = True
+                    if "const" in member:
+                        hints["const"] = member["const"]
+                        needs_validation = True
+                for keyword in ("allOf", "anyOf", "oneOf"):
+                    if not isinstance(branches := member.get(keyword), list):
+                        continue
+                    if projection is items_schema and keyword != "allOf":
+                        branches = [
+                            branch
+                            for branch in branches
+                            if branch is not False
+                            and (
+                                not (types := extract_types_from_schema(branch))
+                                or "array" in types
+                            )
+                        ]
+                    branch_hints: list[dict] = [{} for _ in branches]
+                    if projection is constraints and keyword != "allOf":
+                        # Coercion considers allowed types, not oneOf branch counts.
+                        hints.setdefault("allOf", []).append({"anyOf": branch_hints})
+                    else:
+                        hints.setdefault(keyword, []).extend(branch_hints)
+                    pending.extend(zip(branches, branch_hints))
+        self.items = SchemaTypeHints(items_schema) if has_items else None
+        self.validator = Draft202012Validator(constraints) if needs_validation else None
+
+
 def coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
     """Best-effort coercion of a raw string value to a JSON Schema type.
 
@@ -1168,18 +1265,7 @@ def coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
         _TYPE_ALIASES.get(key, key) for t in schema_type for key in [t.strip().lower()]
     }
 
-    # Priority: null > integer > number > boolean > object > array > string
-    type_priority = [
-        "null",
-        "integer",
-        "number",
-        "boolean",
-        "object",
-        "array",
-        "string",
-    ]
-
-    for candidate_type in type_priority:
+    for candidate_type in _TYPE_PRIORITY:
         if candidate_type not in normalized_types:
             continue
 
@@ -1218,7 +1304,9 @@ def coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
                 parsed = json.loads(value)
             except (json.JSONDecodeError, ValueError, TypeError):
                 continue
-            if _is_json_finite(parsed):
+            if _is_json_finite(parsed) and Draft202012Validator.TYPE_CHECKER.is_type(
+                parsed, candidate_type
+            ):
                 return parsed
             # Non-finite floats (e.g. "[1e999]" -> [inf]) cannot be
             # serialized back to valid JSON; preserve the raw string.
@@ -1233,7 +1321,7 @@ def coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
     # invalid JSON (Infinity/NaN). Preserve the raw string instead.
     if not _is_json_finite(parsed):
         return value
-    known_types = normalized_types.intersection(type_priority)
+    known_types = normalized_types.intersection(_TYPE_PRIORITY)
     if known_types and not any(
         Draft202012Validator.TYPE_CHECKER.is_type(parsed, t) for t in known_types
     ):


### PR DESCRIPTION
## Overview

Tool parameters declared inside root or nested `allOf`, `anyOf`, and `oneOf` schemas can be missed during argument coercion. This change discovers conservative property hints in those schemas and reuses the existing scalar converters to repair nested objects and arrays in the shared Python parser engine.

For example, when `item` is an object with a string `name` and integer `age`, `{"item":"{\"name\":\"Alice\",\"age\":\"42\"}"}` becomes `{"item":{"name":"Alice","age":42}}`. Missing required fields or unrelated size and value bounds do not prevent an otherwise useful type repair.

## Behavior and implementation

- Direct properties retain their constraints. `allOf` refinements are collected in a flat list, avoiding artificial nesting as the number of sibling refinements grows.
- Alternative branches supply a property hint only when every branch that can accept that property agrees. Ambiguous declared names remain available for wrapper detection, without supplying unsafe coercion hints. Streaming does not select a branch from partially received sibling values.
- Decoded objects and arrays are recursively coerced. Cached compatibility checks preserve type, `enum`, and `const` constraints within their object/array alternatives; unrelated `required`, bounds, patterns, and `additionalProperties` validation does not gate repairs. `oneOf` is treated as a union for coercion compatibility, without enforcing exclusive match counts. Unsupported or malformed schema entries are handled conservatively; this is not full JSON Schema validation or new `$ref`/tuple-item inference.
- Schema hints are prepared once per tool for the effective tool set. Each streaming tool-call slot also retains the latest input and result for each argument, keyed by prepared schema, input type, and JSON spelling. Unchanged arguments reuse their results while later fields stream; changing values are recomputed. The cache is isolated between tool calls.
- DeepSeek V3.2/V4 check wrapper shape before looking up properties, and use cached declared names when needed. The shared `find_tool_properties` API remains available to K2 Horizon.

## Timing measurements

Local CPU measurements on macOS arm64, Python 3.14.6 and jsonschema 4.26.0; medians of seven batches, with tracing disabled during timing. Historical coercion methods and helpers were loaded from the listed revisions into the same interpreter. These measure parser work, excluding model generation and network I/O.

For a warm `_fix_arg_types` call with four properties (`name: string`, `unit: string enum`, `count: integer`, `active: boolean`) and input `{"name":"Berlin","unit":"celsius","count":"42","active":"true"}`:

| Implementation | Time per call |
| --- | ---: |
| Main baseline, `ae71862c51` | 4.31 µs |
| Earlier PR head, `cdcf42278b` | 14.63 µs |
| This PR, prepared hints without argument-result reuse | 3.31 µs |
| This PR, prepared hints and warmed argument-result cache | 2.29 µs |

The following public-parser streaming replays isolate the additional benefit of argument-result reuse and DeepSeek's cached wrapper lookup. The comparison column already caches schema hints; it is not the earlier PR head above. Times include parser construction and replay-helper overhead.

| Replay | Schema-hint caching alone | Full caching in this PR |
| --- | ---: | ---: |
| DeepSeek V4, four properties under 8 root alternatives | 1.12 ms | 0.75 ms |
| DeepSeek V4, four properties under 32 root alternatives | 1.71 ms | 0.81 ms |
| Qwen3, 8-alternative object followed by a 600-character string | 18.73 ms | 8.57 ms |
| Qwen3, 64-item `string[]`/`integer[]` alternative followed by a 600-character string | 77.48 ms | 18.73 ms |

DeepSeek uses 341 one-character chunks; Qwen3 uses four-character chunks (184 for the object, 270 for the array). The object matches the last discriminator branch; the array contains numeric strings. Measurements came from successive local runs, not interleaved samples.

Separate untimed counters show DeepSeek property lookups falling from 11 to 1 per replay. Both Qwen3 replays reduce repeated compatibility checks of the unchanged payload from 158 to 1; alternative visits fall from 1,264 to 8 for the object and from 316 to 2 for the array. JSON parsing, serialization, prefix checks, and validation of changing values still run. Warm timings exclude first-use schema preparation, and these results do not establish serving-throughput improvements.

This addresses object-combinator property discovery in the shared parser engine, extending beyond the older Qwen property-level `anyOf` work in #36032 and direct-property `$ref` resolution in #50933. AI assistance was used to develop this change.
