### PR TITLE
[DCP][Mooncake] Harden hybrid prefix-cache external hits

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -78,31 +78,47 @@ def make_full_mamba_manager(
     num_blocks: int = 32,
     use_eagle: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
+    include_draft_eagle_group: bool = False,
 ):
-    kv_cache_config = KVCacheConfig(
-        num_blocks=num_blocks,
-        kv_cache_tensors=[],
-        kv_cache_groups=[
+    kv_cache_groups = [
+        KVCacheGroupSpec(
+            ["full"],
+            FullAttentionSpec(
+                block_size=full_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["mamba"],
+            MambaSpec(
+                block_size=mamba_block_size,
+                shapes=(1, 1),
+                dtypes=(torch.float32,),
+                mamba_cache_mode="align",
+                num_prefill_checkpoint_blocks=num_prefill_checkpoint_blocks,
+            ),
+        ),
+    ]
+    if include_draft_eagle_group:
+        kv_cache_groups.append(
             KVCacheGroupSpec(
-                ["full"],
+                ["draft"],
                 FullAttentionSpec(
                     block_size=full_block_size,
                     num_kv_heads=1,
                     head_size=1,
                     dtype=torch.float32,
+                    non_causal=True,
                 ),
-            ),
-            KVCacheGroupSpec(
-                ["mamba"],
-                MambaSpec(
-                    block_size=mamba_block_size,
-                    shapes=(1, 1),
-                    dtypes=(torch.float32,),
-                    mamba_cache_mode="align",
-                    num_prefill_checkpoint_blocks=num_prefill_checkpoint_blocks,
-                ),
-            ),
-        ],
+                is_eagle_group=True,
+            )
+        )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=kv_cache_groups,
     )
     scheduler_block_size = lcm(
         full_block_size * dcp_world_size,
@@ -131,6 +147,107 @@ def test_dcp_full_attention_enables_partial_hash_hits():
 
     assert manager.coordinator.enable_partial_hash_hits
     assert manager.coordinator._cache_hit_alignment_tokens == hash_block_size
+
+
+def test_dcp_fine_hit_retention_uses_hash_alignment_for_mamba():
+    """DCP must not floor Mamba's replay checkpoint to the enlarged full-attn
+    scheduler block.
+
+    Full-attention's effective block is 8 tokens under DCP4 while replicated
+    Mamba and hashing stay at 2. With latest-only retention, a 7-token prompt
+    has a reusable 6-token boundary. Flooring that boundary to 8 drops the
+    only Mamba checkpoint and collapses the reconciled hybrid hit to zero.
+    """
+    hash_block_size = 2
+    manager = make_full_mamba_manager(
+        dcp_world_size=4,
+        hash_block_size=hash_block_size,
+        full_block_size=hash_block_size,
+        mamba_block_size=hash_block_size,
+        num_blocks=64,
+    )
+    manager.coordinator.retention_interval = 0
+
+    token_ids = list(range(7))
+    req0 = make_request("0", token_ids, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
+    assert num_computed == 0
+    assert manager.allocate_slots(req0, 6, 0, computed_blocks) is not None
+    manager.free(req0)
+    manager.new_step_starts()
+
+    req1 = make_request("1", token_ids, hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(req1)
+    assert num_computed == 6
+
+
+@pytest.mark.parametrize(
+    ("hash_block_size", "expected_hit", "expected_chunk_ends"),
+    [
+        (128, 6144, [4608, 6144, 7552, 7621]),
+        (1536, 4608, [4608, 7621]),
+    ],
+)
+def test_dcp_eagle_retention_primes_first_mamba_consumer(
+    hash_block_size: int,
+    expected_hit: int,
+    expected_chunk_ends: list[int],
+):
+    """The first consumer reuses the EAGLE-adjusted Mamba checkpoint."""
+    block_size = 1536
+    manager = make_full_mamba_manager(
+        dcp_world_size=8,
+        hash_block_size=hash_block_size,
+        full_block_size=block_size,
+        mamba_block_size=block_size,
+        num_blocks=128,
+        use_eagle=True,
+        include_draft_eagle_group=True,
+    )
+    manager.coordinator.retention_interval = 0
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        max_num_scheduled_tokens=8192,
+        scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
+        use_eagle=True,
+        hash_block_size=hash_block_size,
+        mamba_partial_cache_hit=hash_block_size < block_size,
+    )
+
+    token_ids = list(range(7621))
+    producer = make_request("producer", token_ids, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(producer)
+    assert num_computed == 0
+    chunk_ends = []
+    while producer.num_computed_tokens < len(token_ids):
+        num_new_tokens = Scheduler._mamba_block_aligned_split(
+            scheduler,
+            producer,
+            len(token_ids) - producer.num_computed_tokens,
+        )
+        assert num_new_tokens > 0
+        assert (
+            manager.allocate_slots(
+                producer,
+                num_new_tokens,
+                num_computed,
+                computed_blocks,
+            )
+            is not None
+        )
+        producer.num_computed_tokens += num_new_tokens
+        chunk_ends.append(producer.num_computed_tokens)
+        computed_blocks = None
+        num_computed = 0
+        manager.new_step_starts()
+    assert chunk_ends == expected_chunk_ends
+
+    manager.free(producer)
+    manager.new_step_starts()
+
+    first_consumer = make_request("consumer", token_ids, hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(first_consumer)
+    assert num_computed == expected_hit
 
 
 @pytest.mark.parametrize("dcp_world_size", [1, 4])

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -774,8 +774,17 @@ def test_take_partial_tail_offloads_returns_cow_target(dcp_world_size: int):
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
 
-    # Step A registered the partial tail but has not CoW'd yet: no offload.
-    assert manager.take_partial_tail_offloads() == {}
+    # Step A registered the partial tail but has not CoW'd yet, so the mamba
+    # group has nothing durable to hand off. Under DCP the full-attention group
+    # does: its boundary block needs no CoW because KV below the boundary is
+    # append-only.
+    step_a_offloads = manager.take_partial_tail_offloads().get("0", [])
+    assert [entry for entry in step_a_offloads if entry[0] == 1] == []
+    if dcp_world_size > 1:
+        assert [entry[0] for entry in step_a_offloads] == [0]
+        assert [entry[2] for entry in step_a_offloads] == [6]
+    else:
+        assert step_a_offloads == []
 
     partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
     source_block = manager.block_pool.get_cached_block(

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -212,6 +212,7 @@ def test_dcp_eagle_retention_primes_first_mamba_consumer(
         use_eagle=True,
         hash_block_size=hash_block_size,
         mamba_partial_cache_hit=hash_block_size < block_size,
+        mamba_has_prefill_checkpoint_blocks=False,
     )
 
     token_ids = list(range(7621))

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -119,6 +119,20 @@ def make_full_mamba_manager(
     )
 
 
+def test_dcp_full_attention_enables_partial_hash_hits():
+    hash_block_size = 2
+    manager = make_full_mamba_manager(
+        dcp_world_size=2,
+        hash_block_size=hash_block_size,
+        full_block_size=hash_block_size,
+        mamba_block_size=hash_block_size,
+        num_blocks=64,
+    )
+
+    assert manager.coordinator.enable_partial_hash_hits
+    assert manager.coordinator._cache_hit_alignment_tokens == hash_block_size
+
+
 @pytest.mark.parametrize("dcp_world_size", [1, 4])
 def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
     """Chunk ends with partial hits on: block-aligned chunks, one extra stop
@@ -618,43 +632,26 @@ def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
     assert moved[0].block_id == cow_copy.dst_block_id
 
 
-def test_take_partial_tail_offloads_returns_cow_target():
+@pytest.mark.parametrize("dcp_world_size", [1, 2, 4])
+def test_take_partial_tail_offloads_returns_cow_target(dcp_world_size: int):
     """The connector offload hand-off exposes the mamba CoW *target* block Y
     (the durable boundary state), not the overwritten source X, and only at
     the CoW step."""
     hash_block_size = 2
     block_size = 2 * hash_block_size
-    kv_cache_config = KVCacheConfig(
-        num_blocks=24,
-        kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["full"],
-                FullAttentionSpec(
-                    block_size=hash_block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            ),
-            KVCacheGroupSpec(
-                ["mamba"],
-                MambaSpec(
-                    block_size=block_size,
-                    shapes=(1, 1),
-                    dtypes=(torch.float32,),
-                    mamba_cache_mode="align",
-                    num_prefill_checkpoint_blocks=1,
-                ),
-            ),
-        ],
-    )
-    manager = make_kv_cache_manager(
-        kv_cache_config=kv_cache_config,
-        max_model_len=8192,
-        enable_caching=True,
+    manager = make_full_mamba_manager(
+        dcp_world_size=dcp_world_size,
         hash_block_size=hash_block_size,
+        full_block_size=hash_block_size,
+        mamba_block_size=block_size,
+        num_blocks=24,
+        num_prefill_checkpoint_blocks=1,
     )
+    full_manager, mamba_manager = manager.coordinator.single_type_managers
+    assert full_manager.dcp_world_size == dcp_world_size
+    assert full_manager.block_size == hash_block_size * dcp_world_size
+    assert mamba_manager.dcp_world_size == 1
+    assert mamba_manager.block_size == block_size
 
     req0 = make_request("0", [0, 0, 1, 1, 2, 2], hash_block_size, sha256)
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1294,6 +1294,21 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
+    dcp = 8
+    full = FullAttentionSpec(
+        block_size=16, num_kv_heads=1, head_size=1, dtype=torch.float32
+    )
+    mla = new_mla_spec()
+    mamba = new_mamba_spec()
+    uniform_mla = UniformTypeKVCacheSpecs(block_size=16, kv_cache_specs={"layer": mla})
+    assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(full, dcp) == dcp
+    assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(mla, dcp) == dcp
+    assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(uniform_mla, dcp) == dcp
+    assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(mamba, dcp) == 1
+    assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(full, 1) == 1
+
+
 @pytest.mark.parametrize(
     "layer_type,dcp_size,expected_width",
     [

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -232,6 +232,83 @@ def make_kv_cache_config_three_types(
     )
 
 
+def test_prefix_cache_hit_uses_per_group_dcp_geometry():
+    """Prefix lookup must use each group's DCP size, not the process-wide one.
+
+    Target and draft MLA are both sharded (DCP=8); Mamba stays replicated
+    (DCP=1). Hits then align to the sharded full-attention block, not the
+    unsharded page size.
+    """
+    block_size = 16
+    dcp = 8
+    sharded_block = block_size * dcp
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["target_mla"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["draft_mla"],
+                MLAAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                ),
+            ),
+        ],
+    )
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        scheduler_block_size=sharded_block,
+        dcp_world_size=dcp,
+    )
+    target_mgr, draft_mgr, mamba_mgr = manager.coordinator.single_type_managers
+    assert target_mgr.dcp_world_size == dcp
+    assert draft_mgr.dcp_world_size == dcp
+    assert mamba_mgr.dcp_world_size == 1
+    assert target_mgr.block_size == sharded_block
+    assert draft_mgr.block_size == sharded_block
+    assert mamba_mgr.block_size == block_size
+
+    hash_fn = sha256
+    common_token_ids = [i for i in range(2) for _ in range(sharded_block)]
+    req0 = make_request("0", common_token_ids + [99] * 7, block_size, hash_fn)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        req0, len(req0.prompt_token_ids), 0, computed_blocks
+    )
+    assert blocks is not None
+
+    req1 = make_request("1", common_token_ids + [100] * 5, block_size, hash_fn)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+    assert num_computed_tokens == 2 * sharded_block
+    assert [len(group) for group in computed_blocks.blocks] == [2, 2, 16]
+
+    manager.free(req0)
+    manager.free(req1)
+
+
 @pytest.mark.parametrize("hash_fn", [sha256, sha256_cbor])
 def test_prefill(hash_fn):
     block_size = 16

--- a/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
@@ -368,12 +368,19 @@ def test_hybrid_load_failure_uses_runtime_manager_block_sizes(
         block_ids_by_group[invalid_group][invalid_idx],
     }
 
-    affected, _, _ = scheduler._update_requests_with_invalid_blocks(
-        [request],
-        invalid_block_ids,
-        num_scheduled_tokens={},
-        evict_blocks=False,
+    affected, total_affected_tokens, blocks_to_evict = (
+        scheduler._update_requests_with_invalid_blocks(
+            [request],
+            invalid_block_ids,
+            num_scheduled_tokens={},
+            evict_blocks=True,
+        )
     )
 
     assert affected == {"hybrid-request"}
     assert request.num_computed_tokens == expected_computed_tokens
+    assert total_affected_tokens == 62_976 - expected_computed_tokens
+    assert blocks_to_evict == {
+        *block_ids_by_group[0][expected_computed_tokens // 1_536 :],
+        *block_ids_by_group[1][expected_computed_tokens // 24_576 :],
+    }

--- a/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
@@ -337,3 +337,43 @@ def test_async_progressive_load_failure(
         assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
         assert scheduler.failed_recving_kv_req_ids == {request.request_id}
         assert scheduler.connector.get_num_new_matched_tokens.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "invalid_group,invalid_idx,expected_computed_tokens",
+    [
+        (0, 4, 0),
+        (1, 1, 24_576),
+    ],
+)
+def test_hybrid_load_failure_uses_runtime_manager_block_sizes(
+    scheduler: Scheduler,
+    invalid_group: int,
+    invalid_idx: int,
+    expected_computed_tokens: int,
+):
+    """Hybrid recovery must use DCP-scaled manager block sizes and align the
+    shared computed-token boundary for every cache group."""
+    managers = [Mock(block_size=1_536), Mock(block_size=24_576)]
+    scheduler.kv_cache_manager.coordinator.single_type_managers = managers
+    scheduler.block_size = 24_576
+
+    block_ids_by_group = (
+        list(range(100, 141)),
+        list(range(200, 203)),
+    )
+    scheduler.kv_cache_manager.get_block_ids = Mock(return_value=block_ids_by_group)
+    request = Mock(request_id="hybrid-request", num_computed_tokens=62_976)
+    invalid_block_ids = {
+        block_ids_by_group[invalid_group][invalid_idx],
+    }
+
+    affected, _, _ = scheduler._update_requests_with_invalid_blocks(
+        [request],
+        invalid_block_ids,
+        num_scheduled_tokens={},
+        evict_blocks=False,
+    )
+
+    assert affected == {"hybrid-request"}
+    assert request.num_computed_tokens == expected_computed_tokens

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -19,7 +19,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
     worker,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    MooncakeLookupResult,
     MooncakeStoreConnectorMetadata,
+    PartialHitBoundary,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
     MooncakeStoreConnectorStats,
@@ -359,7 +361,9 @@ def test_lookup_key_client_lookup_prepends_typed_tag():
 
     # Blocking lookup (non_block defaults to False) runs on the executor and
     # returns the resolved hit length.
-    assert client.lookup("req0", num_tokens=128, block_hashes=[]) == 5
+    result = client.lookup("req0", num_tokens=128, block_hashes=[])
+    assert result is not None
+    assert result.hit_length == 5
 
     sent_frames = fake_socket.send_multipart.call_args[0][0]
     assert sent_frames[0] == protocol.LOOKUP_MSG
@@ -394,7 +398,7 @@ def _poll_lookup(client, req_id, num_tokens=128, block_hashes=(), timeout=5.0):
     while time.monotonic() < deadline:
         result = client.lookup(req_id, num_tokens, list(block_hashes), non_block=True)
         if result is not None:
-            return result
+            return result.hit_length
         time.sleep(0.005)
     return None
 
@@ -502,11 +506,13 @@ def test_get_num_new_matched_tokens_async_defers_then_reports():
 
     # Lookup ready with a hit -> report need_to_allocate + async-load flag.
     hit = 3 * block_size
-    mock_client.lookup.return_value = hit
+    boundary = PartialHitBoundary(group_id=0, num_tokens=4 * block_size)
+    mock_client.lookup.return_value = MooncakeLookupResult(hit, (boundary,))
     need, load_async = sched.get_num_new_matched_tokens(request, 0)
     assert need == hit
     assert load_async == sched.load_async
     assert sched.load_specs["r1"].kvpool_cached_tokens == hit
+    assert sched.load_specs["r1"].partial_hit_boundaries == (boundary,)
 
 
 def test_protocol_tags_are_distinct_and_non_empty():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -21,7 +21,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store import (
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     MooncakeLookupResult,
     MooncakeStoreConnectorMetadata,
-    PartialHitBoundary,
+    TailKeyBoundary,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
     MooncakeStoreConnectorStats,
@@ -506,13 +506,13 @@ def test_get_num_new_matched_tokens_async_defers_then_reports():
 
     # Lookup ready with a hit -> report need_to_allocate + async-load flag.
     hit = 3 * block_size
-    boundary = PartialHitBoundary(group_id=0, num_tokens=4 * block_size)
+    boundary = TailKeyBoundary(group_id=0, num_tokens=4 * block_size)
     mock_client.lookup.return_value = MooncakeLookupResult(hit, (boundary,))
     need, load_async = sched.get_num_new_matched_tokens(request, 0)
     assert need == hit
     assert load_async == sched.load_async
     assert sched.load_specs["r1"].kvpool_cached_tokens == hit
-    assert sched.load_specs["r1"].partial_hit_boundaries == (boundary,)
+    assert sched.load_specs["r1"].tail_key_boundaries == (boundary,)
 
 
 def test_protocol_tags_are_distinct_and_non_empty():
@@ -523,6 +523,20 @@ def test_protocol_tags_are_distinct_and_non_empty():
         assert isinstance(tag, bytes)
         assert len(tag) > 0
     assert protocol.RESP_OK != protocol.RESP_ERR
+
+
+def test_lookup_response_round_trip_preserves_tail_keys():
+    result = MooncakeLookupResult(
+        hit_length=20,
+        tail_key_boundaries=(
+            TailKeyBoundary(group_id=0, num_tokens=24),
+            TailKeyBoundary(group_id=1, num_tokens=20),
+        ),
+    )
+
+    assert protocol.decode_lookup_response(protocol.encode_lookup_response(result)) == (
+        result
+    )
 
 
 def test_scheduler_reset_connector_cache_invokes_connector_reset():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_connector.py
@@ -5,6 +5,8 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_events import BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -31,6 +33,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
 
@@ -71,6 +74,32 @@ def _make_block_stored() -> BlockStored:
         lora_id=None,
         medium="cpu",
         lora_name=None,
+    )
+
+
+def test_validate_accepts_dcp_hybrid_full_attention_and_mamba():
+    vllm_config = MagicMock()
+    vllm_config.cache_config.block_size = 1536
+    vllm_config.parallel_config.prefill_context_parallel_size = 1
+    vllm_config.parallel_config.decode_context_parallel_size = 8
+    full_spec = FullAttentionSpec(
+        block_size=192, num_kv_heads=8, head_size=64, dtype=None
+    )
+    mamba_spec = MambaSpec(
+        block_size=1536,
+        shapes=((2, 512), (3, 32, 32)),
+        dtypes=(torch.float32, torch.float32),
+        mamba_cache_mode="align",
+        num_speculative_blocks=1,
+    )
+    kv_cache_config = MagicMock()
+    kv_cache_config.kv_cache_groups = [
+        KVCacheGroupSpec(["attention"], full_spec),
+        KVCacheGroupSpec(["mamba"], mamba_spec),
+    ]
+
+    mooncake_store_connector.MooncakeStoreConnector._validate_kv_cache_config(
+        vllm_config, kv_cache_config
     )
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 from math import lcm
 
 import torch
@@ -9,6 +10,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator imp
     ExternalCachedBlockPool,
     MooncakeStoreCoordinator,
     partial_hash_hits_enabled,
+    unwrap_kv_cache_spec,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     chunk_hashes_for_block_size,
@@ -19,6 +21,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     MambaSpec,
     SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
 )
 
 
@@ -82,6 +85,52 @@ def test_resolve_dcp_kv_block_size_replicates_mamba():
     ]
 
     assert [resolve_dcp_kv_block_size(g.kv_cache_spec, 8) for g in groups] == [128, 128]
+
+
+def test_uniform_group_uses_effective_dcp_geometry_for_cache_hits():
+    inner = _full(block_size=16)
+    raw_groups = [
+        KVCacheGroupSpec(
+            ["attention"],
+            UniformTypeKVCacheSpecs(
+                block_size=16,
+                kv_cache_specs={"attention": inner},
+            ),
+        )
+    ]
+    # Mirror the worker's per-group scaling.
+    groups = [
+        dataclasses.replace(
+            g,
+            kv_cache_spec=dataclasses.replace(
+                g.kv_cache_spec,
+                block_size=resolve_dcp_kv_block_size(g.kv_cache_spec, 8),
+            ),
+        )
+        for g in raw_groups
+    ]
+    effective_inner = unwrap_kv_cache_spec(groups[0].kv_cache_spec)
+
+    coord = MooncakeStoreCoordinator(
+        groups,
+        scheduler_block_size=128,
+        hash_block_size=16,
+        dcp_world_size=8,
+    )
+    hashes = _hashes(8)
+    cached = ExternalCachedBlockPool(16, {(0, bytes(hashes[-1]))})
+
+    _masks, hit = coord.find_longest_cache_hit(
+        hashes,
+        max_length=128,
+        cached_block_pool=cached,
+    )
+
+    assert hit == 128
+    assert groups[0].kv_cache_spec.block_size == 128
+    assert effective_inner.block_size == 128
+    # The effective view must not mutate the model's original layer spec.
+    assert inner.block_size == 16
 
 
 # ----- ExternalCachedBlockPool -----

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -8,11 +8,12 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
     ExternalCachedBlockPool,
     MooncakeStoreCoordinator,
+    partial_hash_hits_enabled,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     chunk_hashes_for_block_size,
 )
-from vllm.v1.core.kv_cache_utils import BlockHash
+from vllm.v1.core.kv_cache_utils import BlockHash, resolve_dcp_kv_block_size
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -43,6 +44,44 @@ def _make_coord(groups, hash_block_size, use_eagle=False, retention_interval=Non
         use_eagle=use_eagle,
         retention_interval=retention_interval,
     )
+
+
+def test_partial_hash_hits_enabled_for_dcp_full_attention_geometry():
+    groups = [
+        KVCacheGroupSpec(["attention"], _full(block_size=3072)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(block_size=1536)),
+    ]
+
+    assert not partial_hash_hits_enabled(groups, hash_block_size=1536)
+    assert partial_hash_hits_enabled(
+        groups,
+        hash_block_size=1536,
+        dcp_world_size=8,
+    )
+
+
+def test_partial_hash_hits_enabled_scales_dcp_geometry_exactly_once():
+    # The predicate is handed the raw config groups and derives the effective
+    # block size itself, so scheduler and worker cannot scale a different
+    # number of times and disagree.
+    raw = [KVCacheGroupSpec(["attention"], _full(block_size=8))]
+
+    assert resolve_dcp_kv_block_size(raw[0].kv_cache_spec, 8) == 64
+    # One effective block is exactly one hash block, so there is no sub-block
+    # tail to hit.
+    assert not partial_hash_hits_enabled(raw, hash_block_size=64, dcp_world_size=8)
+    # Two hash blocks per effective block does leave a tail.
+    wider = [KVCacheGroupSpec(["attention"], _full(block_size=16))]
+    assert partial_hash_hits_enabled(wider, hash_block_size=64, dcp_world_size=8)
+
+
+def test_resolve_dcp_kv_block_size_replicates_mamba():
+    groups = [
+        KVCacheGroupSpec(["attention"], _full(block_size=16)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(block_size=128)),
+    ]
+
+    assert [resolve_dcp_kv_block_size(g.kv_cache_spec, 8) for g in groups] == [128, 128]
 
 
 # ----- ExternalCachedBlockPool -----

--- a/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
@@ -254,10 +254,10 @@ def test_e2e_swa_plus_full_save_then_lookup_hits():
     worker.store = store
 
     # Both groups stored all 4 blocks -> full hit.
-    assert worker.lookup(num_tokens=65, block_hashes=hs) == 64
+    assert worker.lookup(num_tokens=65, block_hashes=hs).hit_length == 64
     # Exact-multiple prompt: the full hit is re-derived one block lower,
     # where both groups' stored blocks still cover the SWA window.
-    assert worker.lookup(num_tokens=64, block_hashes=hs) == 48
+    assert worker.lookup(num_tokens=64, block_hashes=hs).hit_length == 48
 
     # Evict SWA's first two blocks (outside its window of 32 tokens = 2 blocks).
     swa_keys_outside_window = [
@@ -270,12 +270,12 @@ def test_e2e_swa_plus_full_save_then_lookup_hits():
 
     # SWA window=32 -> only last 2 blocks must be present in SWA group.
     # Full has all 4. Coordinator should still return 64.
-    assert worker.lookup(num_tokens=65, block_hashes=hs) == 64
+    assert worker.lookup(num_tokens=65, block_hashes=hs).hit_length == 64
     # Exact-multiple prompt after eviction: the boundary one block lower
     # needs SWA block 1, which is gone — no usable stored boundary remains
     # (the pre-fix arithmetic clamp would have returned 48 and livelocked
     # on load failure -> recompute -> same lookup).
-    assert worker.lookup(num_tokens=64, block_hashes=hs) == 0
+    assert worker.lookup(num_tokens=64, block_hashes=hs).hit_length == 0
 
 
 def test_recv_skips_swa_blocks_before_window():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
@@ -433,8 +433,23 @@ def test_sub_block_partial_tail_offload_reads_cow_block():
     # The surrounding metadata may describe a longer resumed replay, but the
     # handoff identifies the exact state boundary to persist.
     hs = [BlockHash(bytes([i + 1]) * 4) for i in range(5)]
+    # DCP can expose the append-only full-attention boundary one step before
+    # Mamba creates its CoW block. That first handoff must not store anything
+    # under the shared boundary hash from Mamba's still-mutable request block.
+    step_a = ReqMeta(
+        req_id="r0",
+        token_len_chunk=0,
+        block_ids=([1], [2]),
+        block_hashes=hs,
+        can_save=True,
+        num_prompt_tokens=20,
+        partial_tail_offloads=[(0, 1, 12)],
+    )
+    assert send._maybe_offload_partial_tail(step_a)
+    assert store.puts == {}
+
     mamba_cow_block = 7
-    req = ReqMeta(
+    step_b = ReqMeta(
         req_id="r0",
         token_len_chunk=0,
         block_ids=([1], [2]),
@@ -444,7 +459,7 @@ def test_sub_block_partial_tail_offload_reads_cow_block():
         partial_tail_offloads=[(1, mamba_cow_block, 12)],
     )
 
-    send._maybe_offload_partial_tail(req)
+    assert send._maybe_offload_partial_tail(step_b)
 
     # boundary = 12 // 4 * 4 = 12 -> keyed by hs[12 // 4 - 1] = hs[2].
     partial_hash = hs[2]

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -7,6 +7,7 @@ import pytest
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     LoadSpec,
+    MooncakeLookupResult,
     MooncakeStoreWorkerMetadata,
     ReqMeta,
     RequestTracker,
@@ -685,9 +686,9 @@ class _StubLookupClient:
         num_tokens: int,
         block_hashes: list[bytes],
         non_block: bool = False,
-    ) -> int:
+    ) -> MooncakeLookupResult:
         self.num_tokens.append(num_tokens)
-        return self._hit_tokens
+        return MooncakeLookupResult(self._hit_tokens)
 
 
 def test_full_external_hit_keeps_kvpool_cached_tokens_block_aligned():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -31,9 +31,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     LoadSpec,
-    PartialHitBoundary,
+    MooncakeLookupResult,
     PoolKey,
     ReqMeta,
+    TailKeyBoundary,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.metrics import (
     MooncakeStoreConnectorStats,
@@ -151,7 +152,7 @@ def _make_load_req(
     *,
     token_len: int,
     vllm_cached_tokens: int = 0,
-    partial_hit_boundaries: tuple[PartialHitBoundary, ...] = (),
+    tail_key_boundaries: tuple[TailKeyBoundary, ...] = (),
 ) -> ReqMeta:
     return ReqMeta(
         req_id=req_id,
@@ -163,7 +164,7 @@ def _make_load_req(
             kvpool_cached_tokens=token_len,
             can_load=True,
             token_len=token_len,
-            partial_hit_boundaries=partial_hit_boundaries,
+            tail_key_boundaries=tail_key_boundaries,
         ),
     )
 
@@ -1448,7 +1449,7 @@ def test_recv_thread_keys_chunk_by_lookup_selected_boundary():
         "req-a",
         [b"a0", b"a1", b"a2"],
         token_len=32,
-        partial_hit_boundaries=(PartialHitBoundary(group_id=0, num_tokens=48),),
+        tail_key_boundaries=(TailKeyBoundary(group_id=0, num_tokens=48),),
     )
 
     thread._handle_request(req)
@@ -2771,7 +2772,10 @@ def test_lookup_full_hit_reuses_existing_boundary():
     worker = _make_bare_worker(block_size=16)
     worker.store.batch_is_exist.return_value = [1, 1]
 
-    assert worker.lookup(32, [b"h0", b"h1"]).hit_length == 16
+    assert worker.lookup(32, [b"h0", b"h1"]) == MooncakeLookupResult(
+        hit_length=16,
+        tail_key_boundaries=(TailKeyBoundary(group_id=0, num_tokens=16),),
+    )
     assert worker.store.batch_is_exist.call_count == 1
 
 
@@ -2860,8 +2864,9 @@ def test_lookup_plan_resolves_group_tail_keys_from_existing_hashes():
     # truncation is the one keyed at the 24-token boundary (hashes[5]), which
     # the load path cannot derive from hit_length.
     assert result.hit_length == 20
-    assert result.partial_hit_boundaries == (
-        PartialHitBoundary(group_id=0, num_tokens=24),
+    assert result.tail_key_boundaries == (
+        TailKeyBoundary(group_id=0, num_tokens=24),
+        TailKeyBoundary(group_id=1, num_tokens=20),
     )
 
 
@@ -2923,8 +2928,9 @@ def test_lookup_plan_recovers_tail_key_after_multi_chunk_convergence():
     result = worker.lookup(49, hashes)
 
     assert result.hit_length == 20
-    assert result.partial_hit_boundaries == (
-        PartialHitBoundary(group_id=0, num_tokens=32),
+    assert result.tail_key_boundaries == (
+        TailKeyBoundary(group_id=0, num_tokens=32),
+        TailKeyBoundary(group_id=1, num_tokens=20),
     )
 
 

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -31,6 +31,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     ChunkedTokenDatabase,
     KeyMetadata,
     LoadSpec,
+    PartialHitBoundary,
     PoolKey,
     ReqMeta,
 )
@@ -150,6 +151,7 @@ def _make_load_req(
     *,
     token_len: int,
     vllm_cached_tokens: int = 0,
+    partial_hit_boundaries: tuple[PartialHitBoundary, ...] = (),
 ) -> ReqMeta:
     return ReqMeta(
         req_id=req_id,
@@ -161,6 +163,7 @@ def _make_load_req(
             kvpool_cached_tokens=token_len,
             can_load=True,
             token_len=token_len,
+            partial_hit_boundaries=partial_hit_boundaries,
         ),
     )
 
@@ -305,15 +308,16 @@ def _patch_worker_runtime(
     local_ip: str = "10.0.0.7",
     tp_rank: int = 0,
     tp_size: int = 1,
+    pcp_size: int = 1,
     dcp_size: int = 1,
 ) -> None:
-    single_rank_group = SimpleNamespace(world_size=1, rank_in_group=0)
+    pcp_group = SimpleNamespace(world_size=pcp_size, rank_in_group=0)
     # DCP groups are contiguous splits of the TP group (see
     # parallel_state.py), so dcp_rank == tp_rank % dcp_size.
     dcp_group = SimpleNamespace(world_size=dcp_size, rank_in_group=tp_rank % dcp_size)
     monkeypatch.setattr(worker, "get_tensor_model_parallel_rank", lambda: tp_rank)
     monkeypatch.setattr(worker, "get_tensor_model_parallel_world_size", lambda: tp_size)
-    monkeypatch.setattr(worker, "get_pcp_group", lambda: single_rank_group)
+    monkeypatch.setattr(worker, "get_pcp_group", lambda: pcp_group)
     monkeypatch.setattr(worker, "get_dcp_group", lambda: dcp_group)
     monkeypatch.setattr(worker, "get_ip", lambda: local_ip)
     monkeypatch.setattr(worker, "LookupKeyServer", MagicMock())
@@ -1431,6 +1435,29 @@ def test_recv_thread_uses_single_batch_when_no_disk_offload_budget(monkeypatch):
     ]
     assert sizes == [[256], [256], [256]]
     store.batch_get_replica_desc.assert_not_called()
+
+
+def test_recv_thread_keys_chunk_by_lookup_selected_boundary():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.return_value = [256, 256]
+    thread = _make_store_recving_thread(store)
+
+    # 32-token hit over 16-token chunks: chunk 1 would default to the hash at
+    # the 32-token boundary (a1); the lookup matched the 48-token one (a2).
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=32,
+        partial_hit_boundaries=(PartialHitBoundary(group_id=0, num_tokens=48),),
+    )
+
+    thread._handle_request(req)
+
+    keys = store.batch_get_into_multi_buffers.call_args.args[0]
+    assert keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+    ]
 
 
 def test_recv_thread_logs_tier_summary_when_enabled(monkeypatch, caplog_vllm):
@@ -2668,12 +2695,12 @@ def test_lookup_rejects_boundary_missing_one_mamba_shard():
     # 33 tokens for two 16-token blocks: the hit stops below the request end,
     # so the full-hit re-derivation stays out of the shard accounting.
     worker.store.batch_is_exist.side_effect = lambda keys: [1] * len(keys)
-    assert worker.lookup(33, [b"h0", b"h1"]) == 32
+    assert worker.lookup(33, [b"h0", b"h1"]).hit_length == 32
 
     worker.store.batch_is_exist.side_effect = lambda keys: [
         0 if "tp_rank:1" in k and "group:1" in k else 1 for k in keys
     ]
-    assert worker.lookup(33, [b"h0", b"h1"]) == 0
+    assert worker.lookup(33, [b"h0", b"h1"]).hit_length == 0
 
 
 def test_lookup_requires_all_dcp_rank_namespaces():
@@ -2684,7 +2711,7 @@ def test_lookup_requires_all_dcp_rank_namespaces():
     _refresh_group_tp_replication_factors(worker)
     worker.store.batch_is_exist.return_value = [1, 1, 0, 1]
 
-    assert worker.lookup(16, [b"a0"]) == 0
+    assert worker.lookup(16, [b"a0"]).hit_length == 0
     assert worker.store.batch_is_exist.call_args.args[0] == [
         "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130",
         "test-model@tp_rank:1@pcp0@dcp1@pp_rank:0@group:0@6130",
@@ -2696,7 +2723,7 @@ def test_lookup_requires_all_dcp_rank_namespaces():
 def test_lookup_partial_prefix_returns_first_hit_length():
     worker = _make_bare_worker()
     worker.store.batch_is_exist.return_value = [1, 1, 0]
-    assert worker.lookup(48, [b"a0", b"a1", b"a2"]) == 32
+    assert worker.lookup(48, [b"a0", b"a1", b"a2"]).hit_length == 32
 
 
 def test_lookup_partial_tail_uses_hash_alignment():
@@ -2736,7 +2763,7 @@ def test_lookup_partial_tail_uses_hash_alignment():
     _refresh_group_tp_replication_factors(worker)
     worker.store.batch_is_exist.return_value = [0, 0, 1, 0, 0, 1]
 
-    assert worker.lookup(13, [b"h0", b"h1", b"h2"]) == 12
+    assert worker.lookup(13, [b"h0", b"h1", b"h2"]).hit_length == 12
 
 
 def test_lookup_full_hit_reuses_existing_boundary():
@@ -2744,7 +2771,7 @@ def test_lookup_full_hit_reuses_existing_boundary():
     worker = _make_bare_worker(block_size=16)
     worker.store.batch_is_exist.return_value = [1, 1]
 
-    assert worker.lookup(32, [b"h0", b"h1"]) == 16
+    assert worker.lookup(32, [b"h0", b"h1"]).hit_length == 16
     assert worker.store.batch_is_exist.call_count == 1
 
 
@@ -2765,8 +2792,140 @@ def test_lookup_full_hit_with_eagle_pops_once_not_twice():
     # 64-token exact-multiple prompt, all 4 blocks stored: one eagle pop
     # gives 48; a spurious re-derivation (anchored at 48) would pop again
     # and return 32.
-    assert worker.lookup(64, [b"h0", b"h1", b"h2", b"h3"]) == 48
+    assert worker.lookup(64, [b"h0", b"h1", b"h2", b"h3"]).hit_length == 48
     assert worker.store.batch_is_exist.call_count == 1
+
+
+def test_lookup_plan_resolves_group_tail_keys_from_existing_hashes():
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    worker = _make_bare_worker(block_size=16)
+    full = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    worker._kv_cache_groups = [
+        KVCacheGroupSpec(["full"], full),
+        KVCacheGroupSpec(["mamba"], mamba),
+    ]
+    worker.hash_block_size = 4
+    worker.token_dbs = [
+        ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=16,
+            hash_block_size=4,
+        )
+        for group_id in range(2)
+    ]
+    worker.coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        worker._kv_cache_groups,
+        scheduler_block_size=16,
+        hash_block_size=4,
+        use_eagle=True,
+    )
+    _refresh_group_tp_replication_factors(worker)
+    hashes = [BlockHash(f"h{i}".encode()) for i in range(6)]
+    present = {
+        (0, bytes(hashes[3])),
+        (0, bytes(hashes[5])),
+        (1, bytes(hashes[4])),
+        # A later Mamba state also exists, but its exact hit-boundary hash
+        # must win and therefore needs no override.
+        (1, bytes(hashes[5])),
+    }
+
+    def exists(keys):
+        return [
+            int(
+                any(
+                    f"@group:{group_id}@{block_hash.hex()}" in key
+                    for group_id, block_hash in present
+                )
+            )
+            for key in keys
+        ]
+
+    worker.store.batch_is_exist.side_effect = exists
+
+    result = worker.lookup(25, hashes)
+
+    # The eagle drop trims the hit to 20 tokens, but the block that survives
+    # truncation is the one keyed at the 24-token boundary (hashes[5]), which
+    # the load path cannot derive from hit_length.
+    assert result.hit_length == 20
+    assert result.partial_hit_boundaries == (
+        PartialHitBoundary(group_id=0, num_tokens=24),
+    )
+
+
+def test_lookup_plan_recovers_tail_key_after_multi_chunk_convergence():
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    worker = _make_bare_worker(block_size=16)
+    full = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    worker._kv_cache_groups = [
+        KVCacheGroupSpec(["full"], full),
+        KVCacheGroupSpec(["mamba"], mamba),
+    ]
+    worker.hash_block_size = 4
+    worker.token_dbs = [
+        ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=16,
+            hash_block_size=4,
+        )
+        for group_id in range(2)
+    ]
+    worker.coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        worker._kv_cache_groups,
+        scheduler_block_size=16,
+        hash_block_size=4,
+    )
+    _refresh_group_tp_replication_factors(worker)
+    hashes = [BlockHash(f"h{i}".encode()) for i in range(12)]
+    present = {
+        (0, bytes(hashes[3])),
+        (0, bytes(hashes[7])),
+        (0, bytes(hashes[11])),
+        (1, bytes(hashes[4])),
+    }
+
+    def exists(keys):
+        return [
+            int(
+                any(
+                    f"@group:{group_id}@{block_hash.hex()}" in key
+                    for group_id, block_hash in present
+                )
+            )
+            for key in keys
+        ]
+
+    worker.store.batch_is_exist.side_effect = exists
+
+    result = worker.lookup(49, hashes)
+
+    assert result.hit_length == 20
+    assert result.partial_hit_boundaries == (
+        PartialHitBoundary(group_id=0, num_tokens=32),
+    )
 
 
 def test_lookup_full_hit_swa_degrades_when_no_stored_boundary_is_usable():
@@ -2790,7 +2949,7 @@ def test_lookup_full_hit_swa_degrades_when_no_stored_boundary_is_usable():
     )
     worker.store.batch_is_exist.return_value = [0, 0, 1, 1]
 
-    assert worker.lookup(64, [b"h0", b"h1", b"h2", b"h3"]) == 0
+    assert worker.lookup(64, [b"h0", b"h1", b"h2", b"h3"]).hit_length == 0
     assert worker.store.batch_is_exist.call_count == 1
 
 
@@ -2811,7 +2970,7 @@ def test_lookup_swa_single_group_returns_full_when_tail_window_present():
         hash_block_size=worker.hash_block_size,
     )
     worker.store.batch_is_exist.return_value = [0, 0, 1, 1]
-    assert worker.lookup(65, [b"h0", b"h1", b"h2", b"h3"]) == 64
+    assert worker.lookup(65, [b"h0", b"h1", b"h2", b"h3"]).hit_length == 64
 
 
 def test_lookup_checks_all_potential_swa_hit_boundaries():
@@ -2865,7 +3024,7 @@ def test_lookup_checks_all_potential_swa_hit_boundaries():
         [f"h{i}".encode() for i in range(12)],
     )
 
-    assert result == 32
+    assert result.hit_length == 32
     keys = worker.store.batch_is_exist.call_args.args[0]
     assert len(keys) == 6
     swa_keys = [key for key in keys if "@group:1@" in key]
@@ -3385,7 +3544,7 @@ def test_lookup_records_mooncake_metrics():
     result = worker.lookup(33, [b"a0", b"a1"])
     stats = worker.get_kv_connector_stats()
 
-    assert result == 32
+    assert result.hit_length == 32
     assert isinstance(stats, MooncakeStoreConnectorStats)
     assert len(stats.data["lookup_exists"]) == 1
     assert stats.data["lookup_exists"][0]["num_keys"] == 2

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -728,6 +728,93 @@ def _make_partial_tail_req(block_ids: list[int]) -> ReqMeta:
     )
 
 
+def test_partial_tail_waits_for_durable_mamba_source():
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheGroupSpec,
+        MambaSpec,
+    )
+
+    def put_sizes(keys, addrs, sizes, config):
+        return [sum(size) for size in sizes]
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = put_sizes
+
+    full = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [
+            KVCacheGroupSpec(["full"], full),
+            KVCacheGroupSpec(["mamba"], mamba),
+        ],
+        scheduler_block_size=16,
+        hash_block_size=4,
+    )
+    full_db = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=0),
+        block_size=16,
+        hash_block_size=4,
+    )
+    full_db.set_kv_caches_base_addr([0x1000])
+    full_db.set_block_len([256])
+    mamba_db = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0, group_id=1),
+        block_size=16,
+        hash_block_size=4,
+    )
+    mamba_db.set_kv_caches_base_addr([0x2000])
+    mamba_db.set_block_len([512])
+    thread = _make_store_sending_thread(
+        store,
+        coord=coord,
+        token_databases=[full_db, mamba_db],
+    )
+    block_hashes = [b"a0", b"a1", b"a2"]
+
+    # Step A exposes the append-only full-attention block before Mamba has
+    # created its durable CoW source. Nothing may be stored under the shared
+    # boundary key yet, because the live Mamba block remains writable.
+    assert thread._maybe_offload_partial_tail(
+        ReqMeta(
+            req_id="req-a",
+            token_len_chunk=0,
+            block_ids=([1], [2]),
+            block_hashes=block_hashes,
+            can_save=True,
+            partial_tail_offloads=[(0, 1, 12)],
+        )
+    )
+    store.batch_is_exist.assert_not_called()
+    store.batch_put_from_multi_buffers.assert_not_called()
+
+    # Step B supplies Mamba's CoW target. The full-attention request block is
+    # append-only and safe to read, while Mamba must use the explicit CoW block.
+    assert thread._maybe_offload_partial_tail(
+        ReqMeta(
+            req_id="req-a",
+            token_len_chunk=0,
+            block_ids=([1], [2]),
+            block_hashes=block_hashes,
+            can_save=True,
+            partial_tail_offloads=[(1, 7, 12)],
+        )
+    )
+
+    keys, addrs, _sizes, _config = store.batch_put_from_multi_buffers.call_args.args
+    assert keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:1@6132",
+    ]
+    assert addrs == [[0x1000 + 256], [0x2000 + 7 * 512]]
+
+
 def test_partial_tail_offload_skips_null_source_blocks():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
@@ -1780,7 +1867,54 @@ def test_recv_thread_stops_after_first_failing_disk_offload_sub_batch():
     thread._handle_request(req)
 
     assert store.batch_get_into_multi_buffers.call_count == 1
-    assert thread.get_and_clear_block_ids_with_load_errors() == {0, 1}
+    assert thread.get_and_clear_block_ids_with_load_errors() == {0, 1, 2}
+
+
+def test_recv_thread_invalidates_unattempted_blocks_after_rotated_failure():
+    store = MagicMock()
+    # tp_rank=2 rotates [block0, block1, block2] to [block2, block0, block1].
+    # The first two-key batch loads block0 but fails block2; block1 is never
+    # attempted and must also be invalidated.
+    store.batch_get_into_multi_buffers.return_value = [-10, 256]
+    thread = _make_store_recving_thread(
+        store,
+        tp_rank=2,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_SPLIT,
+    )
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 1
+    assert store.batch_get_into_multi_buffers.call_args.args[0] == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6132",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130",
+    ]
+    assert thread.get_and_clear_block_ids_with_load_errors() == {1, 2}
+
+
+def test_recv_thread_invalidates_unattempted_blocks_after_split_exception():
+    store = MagicMock()
+    store.batch_get_into_multi_buffers.side_effect = RuntimeError("boom")
+    thread = _make_store_recving_thread(
+        store,
+        disk_offload_buffer_budget_bytes=_DISK_OFFLOAD_BUDGET_FOR_SPLIT,
+    )
+    req = _make_load_req(
+        "req-a",
+        [b"a0", b"a1", b"a2"],
+        token_len=48,
+    )
+
+    thread._handle_request(req)
+
+    assert store.batch_get_into_multi_buffers.call_count == 1
+    assert thread.get_and_clear_finished_requests() == {"req-a"}
+    assert thread.get_and_clear_block_ids_with_load_errors() == {0, 1, 2}
 
 
 def test_recv_thread_skips_split_when_budget_holds_all_keys():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -454,6 +454,49 @@ def test_store_sending_thread_records_mooncake_metrics():
     assert stats.data["save_put"][0]["status"] == "ok"
 
 
+def test_store_sending_thread_splits_large_put_into_bounded_waves(monkeypatch):
+    store = MagicMock()
+    store.batch_is_exist.return_value = [0, 0]
+    store.batch_put_from_multi_buffers.side_effect = [[256], [256]]
+    thread = _make_store_sending_thread(store)
+    monkeypatch.setattr(worker, "_MOONCAKE_SAVE_BATCH_BYTES", 300)
+
+    _run_store_req(thread, _make_store_req("req-a", [b"a0", b"a1"]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 2
+    put_keys = [
+        call.args[0] for call in store.batch_put_from_multi_buffers.call_args_list
+    ]
+    assert put_keys == [
+        ["test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6130"],
+        ["test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6131"],
+    ]
+
+
+def test_store_sending_thread_emits_events_for_successful_waves_on_retry(
+    monkeypatch,
+):
+    store = MagicMock()
+    store.batch_is_exist.side_effect = [[0, 0], [1, 0]]
+    store.batch_put_from_multi_buffers.side_effect = [[256], [-200], [256]]
+    thread = _make_store_sending_thread(store)
+    thread.enable_kv_event = True
+    monkeypatch.setattr(worker, "_MOONCAKE_SAVE_BATCH_BYTES", 300)
+
+    _run_store_req(thread, _make_store_req("req-a", [b"a0", b"a1"]))
+    first_event = thread.get_kv_events()[0]
+
+    assert first_event.block_hashes == [maybe_convert_block_hash(BlockHash(b"a0"))]
+    assert first_event.parent_block_hash is None
+
+    thread._clear_store_pressure()
+    _run_store_req(thread, _make_store_req("req-a", [b"a0", b"a1"]))
+    second_event = thread.get_kv_events()[0]
+
+    assert second_event.block_hashes == [maybe_convert_block_hash(BlockHash(b"a1"))]
+    assert second_event.parent_block_hash == maybe_convert_block_hash(BlockHash(b"a0"))
+
+
 def test_process_tokens_uses_mask_num_as_start_chunk():
     db = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0),
@@ -647,10 +690,15 @@ def _make_partial_tail_send_thread(
     enable_group_semantics=False,
     supports_group_ids=False,
 ):
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    spec = FullAttentionSpec(block_size=4, num_kv_heads=8, head_size=64, dtype=None)
     coord = SimpleNamespace(
         enable_partial_hash_hits=True,
         hash_block_size=4,
         lcm_block_size=16,
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec)],
+        eagle_group_ids=set(),
     )
     db = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0),
@@ -761,6 +809,24 @@ def test_store_sending_thread_skips_null_sparse_group_blocks():
     assert all(addr[0] >= 0x2000 for key, addr in zip(keys, addrs) if "@group:1" in key)
 
 
+def test_partial_tail_offload_allows_single_key_larger_than_batch_target(
+    monkeypatch,
+):
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = [[256], [256], [256]]
+    thread = _make_partial_tail_send_thread(store)
+    monkeypatch.setattr(worker, "_MOONCAKE_SAVE_BATCH_BYTES", 128)
+
+    assert thread._maybe_offload_partial_tail(_make_partial_tail_req([1, 2, 3]))
+
+    assert store.batch_put_from_multi_buffers.call_count == 3
+    assert all(
+        len(call.args[0]) == 1
+        for call in store.batch_put_from_multi_buffers.call_args_list
+    )
+
+
 def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
     store = MagicMock()
     store.batch_is_exist.return_value = [1, 0, 0]
@@ -787,6 +853,53 @@ def test_partial_tail_offload_replaces_stale_group_ids_after_filtering():
     ]
 
 
+def test_eagle_partial_tail_marker_does_not_alias_complete_block_data():
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.return_value = [256, 1]
+    spec = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
+    coord = SimpleNamespace(
+        enable_partial_hash_hits=True,
+        hash_block_size=4,
+        lcm_block_size=16,
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec)],
+        eagle_group_ids={0},
+    )
+    db = ChunkedTokenDatabase(
+        KeyMetadata("test-model", 0, 0, 0, 0),
+        block_size=16,
+        hash_block_size=4,
+    )
+    db.set_kv_caches_base_addr([0x1000])
+    db.set_block_len([256])
+    thread = _make_store_sending_thread(
+        store,
+        coord=coord,
+        token_databases=[db],
+        block_size=16,
+    )
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2],),
+        block_hashes=[b"a0", b"a1", b"a2", b"a3", b"a4"],
+        can_save=True,
+        partial_tail_offloads=[(0, 2, 20)],
+    )
+
+    assert thread._maybe_offload_partial_tail(req)
+
+    keys, addrs, sizes, _config = store.batch_put_from_multi_buffers.call_args.args
+    assert keys == [
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6133",
+        "test-model@tp_rank:0@pcp0@dcp0@pp_rank:0@group:0@6134",
+    ]
+    assert addrs == [[0x1000 + 256], [0x1000 + 2 * 256]]
+    assert sizes == [[256], [1]]
+
+
 def test_partial_tail_offload_honors_active_pressure_gate():
     store = MagicMock()
     thread = _make_partial_tail_send_thread(store)
@@ -802,7 +915,11 @@ def test_partial_tail_offload_honors_active_pressure_gate():
 def test_partial_tail_put_failure_activates_pressure_gate():
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
-    store.batch_put_from_multi_buffers.return_value = [256, -200, 256]
+    # One status per key, all reporting store pressure, so the retries are
+    # exhausted and the gate closes.
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a, **k: (
+        [worker.MOONCAKE_NO_AVAILABLE_HANDLE] * len(keys)
+    )
     thread = _make_partial_tail_send_thread(store)
 
     _run_store_req(thread, _make_partial_tail_req([1, 2, 3]))
@@ -811,8 +928,52 @@ def test_partial_tail_put_failure_activates_pressure_gate():
     assert thread._skip_store_requests == {"req-a"}
     assert thread._saved_offset.get("req-a", 0) == 0
 
+    calls_after_first = store.batch_put_from_multi_buffers.call_count
+    assert calls_after_first == worker._MOONCAKE_SAVE_PRESSURE_RETRIES + 1
+
+    # The gate keeps the next job off the store entirely.
     _run_store_req(thread, _make_partial_tail_req([1, 2, 3]))
+    assert store.batch_put_from_multi_buffers.call_count == calls_after_first
+
+
+def test_partial_tail_put_rejects_mismatched_status_count():
+    """A response that is not one status per key cannot be read positionally.
+
+    Without this the pressure retry narrows the batch to the failed keys and
+    then indexes the next response by the same positions, which raises
+    IndexError inside the KV send thread.
+    """
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    # One status too many for the wave, on the very first put.
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a, **k: (
+        [256] * (len(keys) + 1)
+    )
+    thread = _make_partial_tail_send_thread(store)
+
+    req = _make_partial_tail_req([1, 2, 3])
+    assert thread._maybe_offload_partial_tail(req) is False
     assert store.batch_put_from_multi_buffers.call_count == 1
+    assert thread._store_pressure_active is False
+
+
+def test_partial_tail_pressure_retry_survives_mismatched_status_count():
+    """The retry narrows the batch, so a stale-length response must not index
+    past it."""
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    # Length matches the first wave, then stays stale after the retry narrows
+    # the batch to the single failed key.
+    store.batch_put_from_multi_buffers.return_value = [
+        256,
+        worker.MOONCAKE_NO_AVAILABLE_HANDLE,
+        256,
+    ]
+    thread = _make_partial_tail_send_thread(store)
+
+    req = _make_partial_tail_req([1, 2, 3])
+    assert thread._maybe_offload_partial_tail(req) is False
+    assert store.batch_put_from_multi_buffers.call_count == 2
 
 
 def test_store_sending_thread_delta_start_rank_saves_second_local_chunk():
@@ -2100,8 +2261,8 @@ def test_store_sending_thread_only_stores_swa_blocks_in_window():
 
     store = MagicMock()
     store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
-    store.batch_put_from_multi_buffers.side_effect = (
-        lambda keys, addrs, sizes, *_args: ([256] * len(keys))
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *_args: (
+        [256] * len(keys)
     )
 
     full_spec = FullAttentionSpec(
@@ -3173,6 +3334,18 @@ def test_register_kv_caches_shared_storage(layout: KVCacheLayout):
         assert db.kv_caches_base_addr == [raw.data_ptr()]
         assert db.block_len == [num_layers * spec.page_size_bytes]
     worker.store.register_buffer.assert_called_once_with(raw.data_ptr(), raw.nbytes)
+
+
+def test_register_kv_caches_refuses_unregistered_region():
+    """A region the engine cannot register would make every transfer touching
+    it fail while the engine still looked healthy, so startup must refuse."""
+    num_blocks = 10
+    worker = _make_bare_worker(num_gpu_blocks=num_blocks)
+    worker.store.register_buffer.return_value = -600
+
+    tensor = torch.zeros(num_blocks, 64, dtype=torch.float16)
+    with pytest.raises(RuntimeError, match="max_mr_size"):
+        _register_with_mocked_threads(worker, {"layer0": tensor})
 
 
 def test_register_kv_caches_separate_head_groups():

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -465,6 +465,7 @@ def make_kv_cache_config(
     mamba_enabled: bool = False,
     sw_size: int = 128,
     num_blocks: int = 100,
+    mamba_cache_mode: Literal["all", "align", "none"] = "none",
 ) -> KVCacheConfig:
     kv_cache_groups = [
         KVCacheGroupSpec(
@@ -498,6 +499,7 @@ def make_kv_cache_config(
                     block_size=block_size,
                     shapes=((16,), (16,)),
                     dtypes=(torch.float16,),
+                    mamba_cache_mode=mamba_cache_mode,
                 ),
             )
         )

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
@@ -1833,3 +1834,118 @@ def test_cp_lazy_target_blocks_scaling(cp_world_size: int) -> None:
             f"cp_world_size={cp_world_size}: target_cp={target_cp} should be "
             f"less than target_base={target_base}"
         )
+
+
+def test_dcp_mixed_attention_mamba_store_and_load_geometry() -> None:
+    """DCP scales attention blocks but keeps replicated Mamba blocks unscaled."""
+    dcp_world_size = 2
+    attention_block_size = BLOCK_SIZE
+    mamba_block_size = 4 * BLOCK_SIZE
+    hash_block_size = attention_block_size * dcp_world_size
+    scheduler_block_size = mamba_block_size
+    num_gpu_blocks = 16
+
+    attention_spec = FullAttentionSpec(
+        block_size=attention_block_size,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+    )
+    mamba_spec = MambaSpec(
+        block_size=mamba_block_size,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    groups = [
+        KVCacheGroupSpec(["attention"], attention_spec),
+        KVCacheGroupSpec(["mamba"], mamba_spec),
+    ]
+    tensors = [
+        KVCacheTensor(
+            size=spec.page_size_bytes * num_gpu_blocks,
+            shared_by=group.layer_names,
+        )
+        for group, spec in zip(groups, (attention_spec, mamba_spec))
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_gpu_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=groups,
+    )
+    vllm_config = _make_cp_vllm_config(dcp_world_size=dcp_world_size)
+    cpu_capacity_bytes = sum(tensor.size for tensor in tensors)
+    sched = SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=cpu_capacity_bytes,
+        scheduler_block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+    )
+    assert not sched.cpu_coordinator.enable_partial_hash_hits
+    gpu_pool = BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    sched.bind_gpu_block_pool(gpu_pool)
+
+    req = _make_cp_request(num_blocks=2, virtual_block_size=hash_block_size)
+    attention_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool,
+        req,
+        num_blocks=2,
+        virtual_block_size=hash_block_size,
+        group_id=0,
+    )
+    mamba_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool,
+        req,
+        num_blocks=1,
+        virtual_block_size=mamba_block_size,
+        group_id=1,
+    )
+    kv_blocks = KVCacheBlocks(blocks=(attention_blocks, mamba_blocks))
+    req.num_computed_tokens = scheduler_block_size
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+
+    store_meta = sched.build_connector_meta(
+        make_scheduler_output(
+            {req.request_id: scheduler_block_size},
+            new_reqs={req.request_id: kv_blocks.get_block_ids()},
+        )
+    )
+    assert len(store_meta.store_gpu_blocks) == 3
+    simulate_store_completion(sched, store_meta.store_event)
+
+    req2 = Request(
+        request_id="req-dcp-mixed-load",
+        prompt_token_ids=req.prompt_token_ids,
+        sampling_params=req.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(req2, num_computed_tokens=0)
+    assert hit_tokens == scheduler_block_size
+    assert is_async is True
+
+    load_blocks = KVCacheBlocks(
+        blocks=(
+            gpu_pool.get_new_blocks(2),
+            gpu_pool.get_new_blocks(1),
+        )
+    )
+    sched.update_state_after_alloc(
+        req2,
+        load_blocks,
+        num_external_tokens=scheduler_block_size,
+    )
+    load_meta = sched.build_connector_meta(
+        make_scheduler_output(
+            {req2.request_id: 1},
+            new_reqs={req2.request_id: load_blocks.get_block_ids()},
+        )
+    )
+    assert len(load_meta.load_gpu_blocks) == 3
+    assert len(load_meta.load_cpu_blocks) == 3

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1864,7 +1864,9 @@ def test_dcp_mixed_attention_mamba_store_and_load_geometry() -> None:
     tensors = [
         KVCacheTensor(
             size=spec.page_size_bytes * num_gpu_blocks,
-            shared_by=group.layer_names,
+            layers=group.layer_names,
+            layer_stride=spec.page_size_bytes * num_gpu_blocks,
+            block_stride=spec.page_size_bytes,
         )
         for group, spec in zip(groups, (attention_spec, mamba_spec))
     ]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -109,11 +109,8 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
                     f"{cache_block_size} (mamba_cache_mode != 'align')"
                 )
         pcp = vllm_config.parallel_config.prefill_context_parallel_size
-        dcp = vllm_config.parallel_config.decode_context_parallel_size
-        if len(kv_cache_config.kv_cache_groups) > 1 and pcp * dcp > 1:
-            unsupported.append(
-                f"PCP/DCP > 1 (pcp={pcp}, dcp={dcp}) with hybrid attention"
-            )
+        if len(kv_cache_config.kv_cache_groups) > 1 and pcp > 1:
+            unsupported.append(f"PCP > 1 (pcp={pcp}) with hybrid attention")
         if unsupported:
             raise ValueError(
                 "MooncakeStoreConnector does not support: " + "; ".join(unsupported)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -93,12 +93,22 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def _validate_kv_cache_config(
         vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
     ) -> None:
-        from vllm.v1.kv_cache_interface import CrossAttentionSpec, MambaSpec
+        from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
+            unwrap_kv_cache_spec,
+        )
+        from vllm.v1.kv_cache_interface import (
+            CrossAttentionSpec,
+            FullAttentionSpec,
+            MambaSpec,
+        )
 
         unsupported: list[str] = []
         cache_block_size = vllm_config.cache_config.block_size
+        pcp = vllm_config.parallel_config.prefill_context_parallel_size
+        dcp = vllm_config.parallel_config.decode_context_parallel_size
+        is_hybrid = len(kv_cache_config.kv_cache_groups) > 1
         for g_idx, g in enumerate(kv_cache_config.kv_cache_groups):
-            spec = g.kv_cache_spec
+            spec = unwrap_kv_cache_spec(g.kv_cache_spec)
             if isinstance(spec, CrossAttentionSpec):
                 unsupported.append(f"group {g_idx}: CrossAttentionSpec")
             # Enforce Mamba align mode
@@ -108,8 +118,15 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
                     f"{spec.block_size} != cache_config.block_size="
                     f"{cache_block_size} (mamba_cache_mode != 'align')"
                 )
-        pcp = vllm_config.parallel_config.prefill_context_parallel_size
-        if len(kv_cache_config.kv_cache_groups) > 1 and pcp > 1:
+            # DCP only shards full attention and replicates Mamba; no other
+            # spec has DCP-aware external block geometry.
+            if (
+                is_hybrid
+                and dcp > 1
+                and not isinstance(spec, (FullAttentionSpec, MambaSpec))
+            ):
+                unsupported.append(f"group {g_idx}: {type(spec).__name__} with DCP > 1")
+        if is_hybrid and pcp > 1:
             unsupported.append(f"PCP > 1 (pcp={pcp}) with hybrid attention")
         if unsupported:
             raise ValueError(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -55,6 +55,12 @@ class ExternalCachedBlockPool:
             return [self._present_block] * len(group_ids)
         return None
 
+    def contains(self, group_id: int, block_hash: BlockHash) -> bool:
+        """Return whether a group has a loadable key for this hash."""
+        return (
+            self._exists is not None and (group_id, bytes(block_hash)) in self._exists
+        )
+
 
 class MooncakeStoreCoordinator:
     """Mirror of ``HybridKVCacheCoordinator.find_longest_cache_hit`` over an
@@ -67,6 +73,7 @@ class MooncakeStoreCoordinator:
         hash_block_size: int,
         use_eagle: bool = False,
         retention_interval: int | None = None,
+        dcp_world_size: int = 1,
     ) -> None:
         assert all(
             g.kv_cache_spec.block_size % hash_block_size == 0 for g in kv_cache_groups
@@ -83,7 +90,7 @@ class MooncakeStoreCoordinator:
         self.hash_block_size = hash_block_size
         self.lcm_block_size = scheduler_block_size
         self.enable_partial_hash_hits = partial_hash_hits_enabled(
-            kv_cache_groups, hash_block_size
+            kv_cache_groups, hash_block_size, dcp_world_size
         )
         self.use_eagle = use_eagle
         # Mirror vLLM core's KVCacheCoordinator.retention_interval.
@@ -376,10 +383,11 @@ class MooncakeStoreCoordinator:
         # Truncate full-attention hit_blocks to final converged length;
         # other specs already trim themselves inside their hit logic. cdiv keeps
         # the partial tail block when hit_length is not block-aligned.
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            num_blocks = cdiv(hit_length, first_group.spec.block_size)
-            for group_id in first_group.group_ids:
+        for group in self.attention_groups:
+            if not isinstance(group.spec, FullAttentionSpec):
+                continue
+            num_blocks = cdiv(hit_length, group.spec.block_size)
+            for group_id in group.group_ids:
                 full_blks = hit_blocks_by_group[group_id]
                 assert full_blks is not None
                 del full_blks[num_blocks:]
@@ -398,15 +406,17 @@ def _unwrap_spec(spec: KVCacheSpec) -> KVCacheSpec:
 
 
 def partial_hash_hits_enabled(
-    kv_cache_groups: list[KVCacheGroupSpec], hash_block_size: int
+    kv_cache_groups: list[KVCacheGroupSpec],
+    hash_block_size: int,
+    dcp_world_size: int = 1,
 ) -> bool:
-    """Mirror of core's ``HybridKVCacheCoordinator.enable_partial_hash_hits``
-    (its dcp == 1 clause holds: the connector rejects hybrid + DCP/PCP > 1).
-    Single copy on purpose — scheduler and coordinator must not disagree.
-    """
+    """Match core's DCP-aware Mamba partial-hit condition."""
     return any(
         isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
         and spec.mamba_cache_mode == "align"
-        and spec.block_size > hash_block_size
+        and (
+            (dcp_world_size == 1 and spec.block_size > hash_block_size)
+            or (dcp_world_size > 1 and spec.block_size >= hash_block_size)
+        )
         for g in kv_cache_groups
     )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """External-store cache-hit coordinator for MooncakeStoreConnector."""
 
+import dataclasses
 from collections.abc import Sequence
 from typing import cast
 
@@ -402,7 +403,14 @@ class MooncakeStoreCoordinator:
 
 def unwrap_kv_cache_spec(spec: KVCacheSpec) -> KVCacheSpec:
     if isinstance(spec, UniformTypeKVCacheSpecs):
-        return next(iter(spec.kv_cache_specs.values()))
+        inner_spec = next(iter(spec.kv_cache_specs.values()))
+        # Worker-side UniformTypeKVCacheSpecs retain their per-layer specs when
+        # effective_kv_cache_groups() scales the outer DCP geometry. Preserve
+        # that effective block size when dispatching to the inner spec's cache
+        # manager; otherwise lookup/mask geometry disagrees with token_dbs.
+        if inner_spec.block_size != spec.block_size:
+            inner_spec = dataclasses.replace(inner_spec, block_size=spec.block_size)
+        return inner_spec
     return spec
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -14,6 +14,7 @@ from vllm.v1.core.kv_cache_coordinator import SpecGroup
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    resolve_dcp_kv_block_size,
 )
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -111,7 +112,7 @@ class MooncakeStoreCoordinator:
         """
         attention_groups: list[SpecGroup] = []
         for i, g in enumerate(self.kv_cache_groups):
-            spec = _unwrap_spec(g.kv_cache_spec)
+            spec = unwrap_kv_cache_spec(g.kv_cache_spec)
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
             assert manager_cls is not None, (
                 f"No manager registered for KVCacheSpec {spec}"
@@ -249,7 +250,7 @@ class MooncakeStoreCoordinator:
         )
         masks: list[list[bool] | None] = []
         for g_idx, g in enumerate(self.kv_cache_groups):
-            spec = _unwrap_spec(g.kv_cache_spec)
+            spec = unwrap_kv_cache_spec(g.kv_cache_spec)
             end_chunk = aligned_token_len // spec.block_size
             start_chunk = min(end_chunk, max(0, cdiv(start_token, spec.block_size)))
             manager_cls = KVCacheSpecRegistry.get_manager_class(spec)
@@ -399,24 +400,39 @@ class MooncakeStoreCoordinator:
         )
 
 
-def _unwrap_spec(spec: KVCacheSpec) -> KVCacheSpec:
+def unwrap_kv_cache_spec(spec: KVCacheSpec) -> KVCacheSpec:
     if isinstance(spec, UniformTypeKVCacheSpecs):
         return next(iter(spec.kv_cache_specs.values()))
     return spec
 
 
 def partial_hash_hits_enabled(
-    kv_cache_groups: list[KVCacheGroupSpec],
+    kv_cache_groups: Sequence[KVCacheGroupSpec],
     hash_block_size: int,
     dcp_world_size: int = 1,
 ) -> bool:
-    """Match core's DCP-aware Mamba partial-hit condition."""
-    return any(
-        isinstance(spec := _unwrap_spec(g.kv_cache_spec), MambaSpec)
-        and spec.mamba_cache_mode == "align"
-        and (
-            (dcp_world_size == 1 and spec.block_size > hash_block_size)
-            or (dcp_world_size > 1 and spec.block_size >= hash_block_size)
-        )
-        for g in kv_cache_groups
-    )
+    """Mirror of core's ``HybridKVCacheCoordinator.enable_partial_hash_hits``.
+
+    Geometry comes from ``resolve_dcp_kv_block_size`` so the comparisons read
+    the same ``block_size`` core compares against: DCP scales full-attention
+    blocks and leaves replicated Mamba state alone. Single copy on purpose --
+    scheduler and coordinator must not disagree.
+    """
+    for g in kv_cache_groups:
+        spec = unwrap_kv_cache_spec(g.kv_cache_spec)
+        block_size = resolve_dcp_kv_block_size(g.kv_cache_spec, dcp_world_size)
+        if isinstance(spec, MambaSpec):
+            # TP needs hashing finer than the Mamba block; DCP accepts equality
+            # because it scales the full-attention block instead.
+            if spec.mamba_cache_mode == "align" and (
+                block_size > hash_block_size
+                or (dcp_world_size > 1 and block_size == hash_block_size)
+            ):
+                return True
+        elif (
+            dcp_world_size > 1
+            and isinstance(spec, FullAttentionSpec)
+            and block_size > hash_block_size
+        ):
+            return True
+    return False

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -300,6 +300,41 @@ class ChunkedTokenDatabase:
             yield start_idx, end_idx, h
 
 
+@dataclass(frozen=True)
+class PartialHitBoundary:
+    """Key override for the block containing a group's converged hit boundary.
+
+    Attributes:
+        group_id: KV-cache group whose boundary-block key needs an override.
+        num_tokens: Token boundary whose prefix hash identifies the matched
+            stored block. The loader uses
+            ``block_hashes[num_tokens // hash_block_size - 1]`` instead of the
+            hash implied by ``MooncakeLookupResult.hit_length``. This changes
+            only the load key, not the reusable prefix.
+    """
+
+    group_id: int
+    num_tokens: int
+
+
+@dataclass
+class MooncakeLookupResult:
+    """Lookup result used to build the subsequent load request.
+
+    Attributes:
+        hit_length: Longest prefix that every KV-cache group can reuse after
+            their individual cache hits converge.
+        partial_hit_boundaries: Per-group key overrides for blocks containing
+            the converged hit boundary. Fine-grained prefix matching can make
+            ``hit_length`` end inside a physical block whose stored key uses a
+            later hash boundary. These entries preserve the matched keys; empty
+            when every load key can be derived from ``hit_length``.
+    """
+
+    hit_length: int
+    partial_hit_boundaries: tuple[PartialHitBoundary, ...] = ()
+
+
 @dataclass
 class LoadSpec:
     """Specification for loading KV cache from external store."""
@@ -308,6 +343,7 @@ class LoadSpec:
     kvpool_cached_tokens: int
     can_load: bool
     token_len: int = 0
+    partial_hit_boundaries: tuple[PartialHitBoundary, ...] = ()
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -301,11 +301,11 @@ class ChunkedTokenDatabase:
 
 
 @dataclass(frozen=True)
-class PartialHitBoundary:
-    """Key override for the block containing a group's converged hit boundary.
+class TailKeyBoundary:
+    """Hash boundary used to key a group's tail block in the store.
 
     Attributes:
-        group_id: KV-cache group whose boundary-block key needs an override.
+        group_id: KV-cache group containing the tail block.
         num_tokens: Token boundary whose prefix hash identifies the matched
             stored block. The loader uses
             ``block_hashes[num_tokens // hash_block_size - 1]`` instead of the
@@ -324,15 +324,13 @@ class MooncakeLookupResult:
     Attributes:
         hit_length: Longest prefix that every KV-cache group can reuse after
             their individual cache hits converge.
-        partial_hit_boundaries: Per-group key overrides for blocks containing
-            the converged hit boundary. Fine-grained prefix matching can make
-            ``hit_length`` end inside a physical block whose stored key uses a
-            later hash boundary. These entries preserve the matched keys; empty
-            when every load key can be derived from ``hit_length``.
+        tail_key_boundaries: Hash boundary used to store each cache group's
+            tail block when ``hit_length`` does not identify its store key.
+            There is one entry per group for every nonzero hit.
     """
 
     hit_length: int
-    partial_hit_boundaries: tuple[PartialHitBoundary, ...] = ()
+    tail_key_boundaries: tuple[TailKeyBoundary, ...] = ()
 
 
 @dataclass
@@ -343,7 +341,7 @@ class LoadSpec:
     kvpool_cached_tokens: int
     can_load: bool
     token_len: int = 0
-    partial_hit_boundaries: tuple[PartialHitBoundary, ...] = ()
+    tail_key_boundaries: tuple[TailKeyBoundary, ...] = ()
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -406,10 +406,11 @@ class ReqMeta:
     # serve that purpose: it is reused once a preempted request resumes, so it
     # would release the wrong job's blocks.
     store_job_id: int | None = None
-    # Core-provided per-mamba-group
-    # (group_id, cow_block_id, boundary_tokens) for this request's partial tail.
-    # Present only on the producer's CoW step; drives the connector's offload
-    # (the FA group's block is derived from block_ids and boundary_tokens).
+    # Core-provided (group_id, durable_block_id, boundary_tokens) handoffs for
+    # this request's partial tail. Mamba contributes its CoW block; under DCP,
+    # full attention may contribute its append-only request block one step
+    # earlier. The worker must wait for every partial Mamba group to provide a
+    # CoW source before persisting the shared boundary.
     partial_tail_offloads: list[tuple[int, int, int]] | None = None
 
     @staticmethod

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/protocol.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/protocol.py
@@ -16,7 +16,9 @@ Wire format (REQ/REP over IPC):
                    fixed-size block hash (0 when there are no hashes)
           frame 3: raw block hashes concatenated back-to-back (each hash_len
                    bytes); the server splits on hash_len
-        Response: [hit_count: u32 big-endian, 4 bytes]
+        Response: hit_length (u32 big-endian, first 4 bytes), followed by zero
+                  or more 8-byte load boundaries. Each entry is group_id (u32),
+                  then boundary_tokens (u32).
 
       msg_type == RESET_MSG:
           (no payload frames)
@@ -31,6 +33,11 @@ Mirrors the named-tag convention used by the NIXL connector (see
 ``vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py``).
 """
 
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    MooncakeLookupResult,
+    PartialHitBoundary,
+)
+
 # Request message-type tags. Frame 0 of every request.
 LOOKUP_MSG: bytes = b"lookup"
 RESET_MSG: bytes = b"reset"
@@ -38,3 +45,37 @@ RESET_MSG: bytes = b"reset"
 # Single-byte response status codes for admin commands.
 RESP_OK: bytes = b"\x01"
 RESP_ERR: bytes = b"\x00"
+
+# group_id (u32), boundary_tokens (u32).
+PARTIAL_HIT_BOUNDARY_ENTRY_SIZE: int = 8
+
+
+def encode_lookup_response(result: MooncakeLookupResult) -> bytes:
+    hit_length = result.hit_length.to_bytes(4, "big")
+    if not result.partial_hit_boundaries:
+        return hit_length
+
+    payload = bytearray(hit_length)
+    for boundary in result.partial_hit_boundaries:
+        payload.extend(boundary.group_id.to_bytes(4, "big"))
+        payload.extend(boundary.num_tokens.to_bytes(4, "big"))
+    return bytes(payload)
+
+
+def decode_lookup_response(payload: bytes) -> MooncakeLookupResult:
+    if len(payload) < 4 or (len(payload) - 4) % PARTIAL_HIT_BOUNDARY_ENTRY_SIZE:
+        raise ValueError("Invalid Mooncake lookup response")
+
+    hit_length = int.from_bytes(payload[:4], "big")
+    if len(payload) == 4:
+        return MooncakeLookupResult(hit_length)
+
+    boundaries = []
+    for offset in range(4, len(payload), PARTIAL_HIT_BOUNDARY_ENTRY_SIZE):
+        boundaries.append(
+            PartialHitBoundary(
+                group_id=int.from_bytes(payload[offset : offset + 4], "big"),
+                num_tokens=int.from_bytes(payload[offset + 4 : offset + 8], "big"),
+            )
+        )
+    return MooncakeLookupResult(hit_length, tuple(boundaries))

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/protocol.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/protocol.py
@@ -17,8 +17,8 @@ Wire format (REQ/REP over IPC):
           frame 3: raw block hashes concatenated back-to-back (each hash_len
                    bytes); the server splits on hash_len
         Response: hit_length (u32 big-endian, first 4 bytes), followed by zero
-                  or more 8-byte load boundaries. Each entry is group_id (u32),
-                  then boundary_tokens (u32).
+                  or more 8-byte tail-key boundaries. Each entry is group_id
+                  (u32), then boundary_tokens (u32).
 
       msg_type == RESET_MSG:
           (no payload frames)
@@ -35,7 +35,7 @@ Mirrors the named-tag convention used by the NIXL connector (see
 
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     MooncakeLookupResult,
-    PartialHitBoundary,
+    TailKeyBoundary,
 )
 
 # Request message-type tags. Frame 0 of every request.
@@ -47,23 +47,23 @@ RESP_OK: bytes = b"\x01"
 RESP_ERR: bytes = b"\x00"
 
 # group_id (u32), boundary_tokens (u32).
-PARTIAL_HIT_BOUNDARY_ENTRY_SIZE: int = 8
+TAIL_KEY_BOUNDARY_ENTRY_SIZE: int = 8
 
 
 def encode_lookup_response(result: MooncakeLookupResult) -> bytes:
     hit_length = result.hit_length.to_bytes(4, "big")
-    if not result.partial_hit_boundaries:
+    if not result.tail_key_boundaries:
         return hit_length
 
     payload = bytearray(hit_length)
-    for boundary in result.partial_hit_boundaries:
+    for boundary in result.tail_key_boundaries:
         payload.extend(boundary.group_id.to_bytes(4, "big"))
         payload.extend(boundary.num_tokens.to_bytes(4, "big"))
     return bytes(payload)
 
 
 def decode_lookup_response(payload: bytes) -> MooncakeLookupResult:
-    if len(payload) < 4 or (len(payload) - 4) % PARTIAL_HIT_BOUNDARY_ENTRY_SIZE:
+    if len(payload) < 4 or (len(payload) - 4) % TAIL_KEY_BOUNDARY_ENTRY_SIZE:
         raise ValueError("Invalid Mooncake lookup response")
 
     hit_length = int.from_bytes(payload[:4], "big")
@@ -71,9 +71,9 @@ def decode_lookup_response(payload: bytes) -> MooncakeLookupResult:
         return MooncakeLookupResult(hit_length)
 
     boundaries = []
-    for offset in range(4, len(payload), PARTIAL_HIT_BOUNDARY_ENTRY_SIZE):
+    for offset in range(4, len(payload), TAIL_KEY_BOUNDARY_ENTRY_SIZE):
         boundaries.append(
-            PartialHitBoundary(
+            TailKeyBoundary(
                 group_id=int.from_bytes(payload[offset : offset + 4], "big"),
                 num_tokens=int.from_bytes(payload[offset + 4 : offset + 8], "big"),
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -75,7 +75,9 @@ class MooncakeStoreScheduler:
             kv_cache_config, vllm_config
         )
         self.enable_partial_hash_hits = partial_hash_hits_enabled(
-            kv_cache_config.kv_cache_groups, self._hash_block_size
+            kv_cache_config.kv_cache_groups,
+            self._hash_block_size,
+            vllm_config.parallel_config.decode_context_parallel_size,
         )
 
         # Per-request state
@@ -114,15 +116,16 @@ class MooncakeStoreScheduler:
         if request.num_tokens < align:
             return 0, False
 
-        num_external_hit_tokens = self.client.lookup(
+        lookup_result = self.client.lookup(
             request.request_id,
             request.num_tokens,
             request.block_hashes,
             non_block=self.lookup_async,
         )
-        if num_external_hit_tokens is None:
+        if lookup_result is None:
             # Lookup not ready yet; scheduler will retry on a later step.
             return None, False
+        num_external_hit_tokens = lookup_result.hit_length
 
         if num_external_hit_tokens < num_computed_tokens:
             need_to_allocate = 0
@@ -144,6 +147,7 @@ class MooncakeStoreScheduler:
             vllm_cached_tokens=num_computed_tokens,
             kvpool_cached_tokens=num_external_hit_tokens,
             can_load=False,
+            partial_hit_boundaries=lookup_result.partial_hit_boundaries,
         )
 
         return need_to_allocate, self.load_async

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -147,7 +147,7 @@ class MooncakeStoreScheduler:
             vllm_cached_tokens=num_computed_tokens,
             kvpool_cached_tokens=num_external_hit_tokens,
             can_load=False,
-            partial_hit_boundaries=lookup_result.partial_hit_boundaries,
+            tail_key_boundaries=lookup_result.tail_key_boundaries,
         )
 
         return need_to_allocate, self.load_async

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -378,11 +378,12 @@ class MooncakeStoreScheduler:
                 if req_meta is not None:
                     meta.add_request(req_meta)
 
-        # Flush partial-tail offloads in the step they arrive: the CoW copy is
-        # enqueued before the connector event records, so this step's event
-        # fences the cow block. Ride the request's save meta when present, else
-        # emit an offload-only ReqMeta (token_len_chunk=0 skips the normal
-        # save; can_save=True takes the normal enqueue path).
+        # Flush partial-tail handoffs in the step they arrive. When a handoff
+        # references a CoW block, its copy is enqueued before the connector
+        # event records, so this step's event fences that block. Ride the
+        # request's save meta when present, else emit an offload-only ReqMeta
+        # (token_len_chunk=0 skips the normal save; can_save=True takes the
+        # normal enqueue path).
         step_partial_tails = getattr(scheduler_output, "partial_tail_offloads", None)
         if step_partial_tails and not is_consumer:
             pending = dict(step_partial_tails)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -74,10 +74,11 @@ class MooncakeStoreScheduler:
         self._block_size, self._hash_block_size = resolve_kv_cache_block_sizes(
             kv_cache_config, vllm_config
         )
+        dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         self.enable_partial_hash_hits = partial_hash_hits_enabled(
             kv_cache_config.kv_cache_groups,
             self._hash_block_size,
-            vllm_config.parallel_config.decode_context_parallel_size,
+            dcp_world_size,
         )
 
         # Per-request state

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -47,9 +47,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  
     MooncakeLookupResult,
     MooncakeStoreConnectorMetadata,
     MooncakeStoreWorkerMetadata,
-    PartialHitBoundary,
     PoolKey,
     ReqMeta,
+    TailKeyBoundary,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.protocol import (  # noqa: E501
     LOOKUP_MSG,
@@ -1184,12 +1184,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         # Skip chunks the consumer's per-group spec wouldn't populate
         # locally (e.g. SWA pre-window) even if the producer stored them.
         load_mask_per_group = self.coord.load_mask(req_meta.block_hashes, token_len)
-        # Groups whose tail chunk is keyed at a boundary other than the one
-        # process_tokens derives from token_len (see PartialHitBoundary).
-        partial_hit_boundaries = {
+        tail_key_boundaries = {
             boundary.group_id: boundary.num_tokens
             for boundary in (
-                req_meta.load_spec.partial_hit_boundaries  # type: ignore[union-attr]
+                req_meta.load_spec.tail_key_boundaries  # type: ignore[union-attr]
             )
         }
 
@@ -1206,10 +1204,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 chunk_idx = start // db.block_size
                 if chunk_idx >= len(mask) or not mask[chunk_idx]:
                     continue
-                # ``end == token_len`` identifies the tail chunk, the only one
-                # whose key can differ.
                 boundary_tokens = (
-                    partial_hit_boundaries.get(g_idx) if end == token_len else None
+                    tail_key_boundaries.get(g_idx) if end == token_len else None
                 )
                 if boundary_tokens is not None:
                     block_hash = req_meta.block_hashes[
@@ -1993,7 +1989,7 @@ class MooncakeStoreWorker:
             self.hash_block_size,
             exists_set,
         )
-        hit_masks, hit_length = self.coord.find_longest_cache_hit(
+        _, hit_length = self.coord.find_longest_cache_hit(
             block_hashes,
             token_len,
             cached_block_pool,
@@ -2002,63 +1998,52 @@ class MooncakeStoreWorker:
             usable_length = self.coord.align_lookup_length(num_tokens - 1)
             if usable_length <= 0:
                 return MooncakeLookupResult(0)
-            hit_masks, hit_length = self.coord.find_longest_cache_hit(
+            _, hit_length = self.coord.find_longest_cache_hit(
                 block_hashes,
                 usable_length,
                 cached_block_pool,
             )
         return MooncakeLookupResult(
             hit_length,
-            self._partial_hit_boundaries(
+            self._tail_key_boundaries(
                 block_hashes,
-                hit_masks,
                 hit_length,
                 cached_block_pool,
             ),
         )
 
-    def _partial_hit_boundaries(
+    def _tail_key_boundaries(
         self,
         block_hashes: Sequence[BlockHash],
-        hit_masks: tuple[list[bool], ...],
         hit_length: int,
         cached_block_pool: ExternalCachedBlockPool,
-    ) -> tuple[PartialHitBoundary, ...]:
-        """Return stored-key overrides for partially reused physical blocks.
+    ) -> tuple[TailKeyBoundary, ...]:
+        """Return the hash boundary used to store each group's tail block.
 
         With fine-grained prefix matching, ``hit_length`` may fall within a
-        physical cache block and may not align with the hash boundary used to
-        store that block. For each affected KV-cache group, return the token
-        boundary whose hash was used as the store key.
+        physical cache block whose store key uses a later hash boundary. Exact
+        matches are recorded too, so every nonzero hit has one entry per group.
         """
-        if not self.coord.enable_partial_hash_hits or hit_length <= 0:
+        if hit_length <= 0:
             return ()
 
         boundaries = []
         hit_boundary_hash_idx = hit_length // self.hash_block_size - 1
         for group_id, db in enumerate(self.token_dbs):
             chunk_id = cdiv(hit_length, db.block_size) - 1
-            mask = hit_masks[group_id]
-            if chunk_id < 0 or chunk_id >= len(mask) or not mask[chunk_id]:
-                continue
-            if cached_block_pool.contains(
+            boundary_tokens = hit_length
+            if self.coord.enable_partial_hash_hits and not cached_block_pool.contains(
                 group_id, block_hashes[hit_boundary_hash_idx]
             ):
-                continue
-            next_chunk_hash_idx = min(
-                (chunk_id + 1) * db.block_size // self.hash_block_size,
-                len(block_hashes),
-            )
-            # Search the remaining hash boundaries in this physical cache block.
-            for hash_idx in range(hit_boundary_hash_idx + 1, next_chunk_hash_idx):
-                if cached_block_pool.contains(group_id, block_hashes[hash_idx]):
-                    boundaries.append(
-                        PartialHitBoundary(
-                            group_id,
-                            (hash_idx + 1) * self.hash_block_size,
-                        )
-                    )
-                    break
+                next_chunk_hash_idx = min(
+                    (chunk_id + 1) * db.block_size // self.hash_block_size,
+                    len(block_hashes),
+                )
+                for hash_idx in range(hit_boundary_hash_idx + 1, next_chunk_hash_idx):
+                    if cached_block_pool.contains(group_id, block_hashes[hash_idx]):
+                        boundary_tokens = (hash_idx + 1) * self.hash_block_size
+                        break
+            boundaries.append(TailKeyBoundary(group_id, boundary_tokens))
         return tuple(boundaries)
 
     def get_kv_events(self) -> list[BlockStored]:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -12,6 +12,7 @@ and MooncakeDistributedStore integration.
 
 import dataclasses
 import json
+import logging
 import os
 import queue
 import socket
@@ -39,6 +40,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import rdma_utils
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
     ExternalCachedBlockPool,
     MooncakeStoreCoordinator,
+    unwrap_kv_cache_spec,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  # noqa: E501
     BlobBlockHashes,
@@ -71,6 +73,7 @@ from vllm.v1.core.kv_cache_utils import (
     resolve_kv_cache_block_sizes,
 )
 from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -115,6 +118,10 @@ def _make_mooncake_group_id(metadata: KeyMetadata, chunk_hash: str) -> str:
 
 # Mirrors FileStorageConfig::local_buffer_size in Mooncake C++.
 DEFAULT_MOONCAKE_DISK_STAGING_BUFFER_BYTES = 1280 * 1024 * 1024
+# Bound each rank's PUT wave so concurrent TP ranks fit in a standalone
+# owner's registered memory while completed waves are offloaded to disk.
+_MOONCAKE_SAVE_BATCH_BYTES = 64 * 1024 * 1024
+_MOONCAKE_SAVE_PRESSURE_RETRIES = 5
 
 # Mirrors DirectIO alignment in Mooncake's AllocateBatch.
 _DIRECT_IO_ALIGNMENT = 4096
@@ -687,6 +694,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         keys: list[str] = []
         addrs: list[list[int]] = []
         sizes: list[list[int]] = []
+        seen_keys: set[str] = set()
         group_ids: list[str] | None = (
             [] if self.enable_group_semantics and self.supports_group_ids else None
         )
@@ -705,38 +713,67 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 if block_idx % put_step != put_step_rank:
                     continue
                 valid_end = min((block_idx + 1) * db.block_size, boundary)
-                key_hash = req_meta.block_hashes[valid_end // hash_block_size - 1]
+                spec = unwrap_kv_cache_spec(
+                    self.coord.kv_cache_groups[g_idx].kv_cache_spec
+                )
+                key_ends: Sequence[tuple[int, bool]] = ((valid_end, False),)
                 if (
-                    g_idx in mamba_offloads
+                    isinstance(spec, FullAttentionSpec)
+                    and db.block_size > hash_block_size
+                    and g_idx in self.coord.eagle_group_ids
                     and valid_end == boundary
                     and boundary % db.block_size != 0
+                    and valid_end > hash_block_size
                 ):
-                    block_id = mamba_offloads[g_idx]
-                else:
-                    if block_idx >= len(group_blocks):
-                        continue
-                    block_id = group_blocks[block_idx]
-                if block_id == NULL_BLOCK_ID:
-                    logger.debug(
-                        "Skipping unavailable partial-tail source block "
-                        "(req=%s, group=%d, block=%d)",
-                        req_meta.req_id,
-                        g_idx,
-                        block_idx,
+                    # Only the incomplete boundary block needs Eagle's marker.
+                    # Emitting markers for earlier complete blocks aliases
+                    # their real block-end keys and can poison future loads.
+                    key_ends = (
+                        (valid_end - hash_block_size, False),
+                        (valid_end, True),
                     )
-                    continue
-                addr, size = db.prepare_value_for_block(block_id)
-                key = db.key_for(key_hash)
-                keys.append(key)
-                addrs.append(addr)
-                sizes.append(size)
-                if group_ids is not None:
-                    group_ids.append(
-                        _make_mooncake_group_id(
-                            db.metadata,
-                            key.rsplit("@", 1)[-1],
+                for key_end, marker_only in key_ends:
+                    key_hash = req_meta.block_hashes[key_end // hash_block_size - 1]
+                    if (
+                        g_idx in mamba_offloads
+                        and key_end == boundary
+                        and boundary % db.block_size != 0
+                    ):
+                        block_id = mamba_offloads[g_idx]
+                    else:
+                        source_block_idx = (key_end - 1) // db.block_size
+                        if source_block_idx >= len(group_blocks):
+                            continue
+                        block_id = group_blocks[source_block_idx]
+                    if block_id == NULL_BLOCK_ID:
+                        logger.debug(
+                            "Skipping unavailable partial-tail source block "
+                            "(req=%s, group=%d, block=%d)",
+                            req_meta.req_id,
+                            g_idx,
+                            block_idx,
                         )
-                    )
+                        continue
+                    addr, size = db.prepare_value_for_block(block_id)
+                    if marker_only:
+                        addr = addr[:1]
+                        size = [1]
+                    key = db.key_for(key_hash)
+                    # The Eagle load boundary can equal the previous complete
+                    # block's normal key. Keep the first full-data entry once.
+                    if key in seen_keys:
+                        continue
+                    seen_keys.add(key)
+                    keys.append(key)
+                    addrs.append(addr)
+                    sizes.append(size)
+                    if group_ids is not None:
+                        group_ids.append(
+                            _make_mooncake_group_id(
+                                db.metadata,
+                                key.rsplit("@", 1)[-1],
+                            )
+                        )
 
         if not keys:
             return True
@@ -758,6 +795,15 @@ class KVCacheStoreSendingThread(KVTransferThread):
             )
             return False
         self._record_operation("save_exists", exists_start, len(keys))
+        logger.debug(
+            "Partial-tail existence check req=%s keys=%d present=%d "
+            "states=%s first_key=%s",
+            req_meta.req_id,
+            len(keys),
+            sum(e == 1 for e in exists),
+            sorted(set(exists)),
+            keys[0],
+        )
         missing = [i for i, e in enumerate(exists) if e != 1]
         if not missing:
             return True
@@ -769,52 +815,124 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if req_meta.current_event is not None:
             # Fence the CoW block copy enqueued earlier this step.
             req_meta.current_event.synchronize()
-        if group_ids is not None:
-            assert len(group_ids) == len(keys)
-            self.replicate_config.group_ids = group_ids
-        batch_bytes = _sum_batch_bytes(sizes)
-        put_start = time.perf_counter()
-        try:
-            res = self.store.batch_put_from_multi_buffers(
-                keys, addrs, sizes, self.replicate_config
-            )
-        except Exception as e:
-            self._record_operation(
-                "save_put",
-                put_start,
-                len(keys),
-                num_bytes=batch_bytes,
-                status="error",
-                num_failed_keys=len(keys),
-            )
+        raw_put_budget = max(
+            _MOONCAKE_SAVE_BATCH_BYTES,
+            max(_estimate_disk_offload_staging_bytes(size) for size in sizes),
+        )
+        put_batches, oversized_key = _split_disk_offload_load_batches(
+            keys,
+            addrs,
+            sizes,
+            _MOONCAKE_SAVE_BATCH_BYTES,
+            raw_put_budget,
+        )
+        if oversized_key is not None:
             logger.error(
-                "Failed to put partial-tail keys for request %s: %s",
-                req_meta.req_id,
-                e,
+                "Failed to create partial-tail PUT batches; key %s exceeds "
+                "the computed raw budget",
+                oversized_key,
             )
             return False
 
-        failed = [i for i, value in enumerate(res) if value < 0]
-        self._record_operation(
-            "save_put",
-            put_start,
-            len(keys),
-            num_bytes=batch_bytes,
-            status="partial_failure" if failed else "ok",
-            num_failed_keys=len(failed),
-        )
-        if failed:
-            failed_codes = {res[i] for i in failed}
-            logger.warning(
-                "Partial-tail put failed for request %s: %d/%d keys failed (codes=%s)",
-                req_meta.req_id,
-                len(failed),
-                len(keys),
-                failed_codes,
+        group_id_offset = 0
+        for batch_keys, batch_addrs, batch_sizes in put_batches:
+            batch_group_ids = (
+                None
+                if group_ids is None
+                else group_ids[group_id_offset : group_id_offset + len(batch_keys)]
             )
-            if MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes:
-                self._mark_request_skipped_for_pressure(req_meta)
-            return False
+            group_id_offset += len(batch_keys)
+            pending_keys = batch_keys
+            pending_addrs = batch_addrs
+            pending_sizes = batch_sizes
+            pending_group_ids = batch_group_ids
+
+            for attempt in range(_MOONCAKE_SAVE_PRESSURE_RETRIES + 1):
+                if pending_group_ids is not None:
+                    self.replicate_config.group_ids = pending_group_ids
+                batch_bytes = _sum_batch_bytes(pending_sizes)
+                put_start = time.perf_counter()
+                try:
+                    res = self.store.batch_put_from_multi_buffers(
+                        pending_keys,
+                        pending_addrs,
+                        pending_sizes,
+                        self.replicate_config,
+                    )
+                except Exception as e:
+                    self._record_operation(
+                        "save_put",
+                        put_start,
+                        len(pending_keys),
+                        num_bytes=batch_bytes,
+                        status="error",
+                        num_failed_keys=len(pending_keys),
+                    )
+                    logger.error(
+                        "Failed to put partial-tail keys for request %s: %s",
+                        req_meta.req_id,
+                        e,
+                    )
+                    return False
+
+                if len(res) != len(pending_keys):
+                    # A per-key status is the only thing that makes the retry
+                    # subset below well defined, so a mismatched response is a
+                    # failure rather than something to index into.
+                    self._record_operation(
+                        "save_put",
+                        put_start,
+                        len(pending_keys),
+                        num_bytes=batch_bytes,
+                        status="error",
+                        num_failed_keys=len(pending_keys),
+                    )
+                    logger.error(
+                        "Mooncake returned %d partial-tail statuses for %d keys "
+                        "(request %s); treating the batch as failed",
+                        len(res),
+                        len(pending_keys),
+                        req_meta.req_id,
+                    )
+                    return False
+
+                failed = [i for i, value in enumerate(res) if value < 0]
+                self._record_operation(
+                    "save_put",
+                    put_start,
+                    len(pending_keys),
+                    num_bytes=batch_bytes,
+                    status="partial_failure" if failed else "ok",
+                    num_failed_keys=len(failed),
+                )
+                if not failed:
+                    break
+
+                failed_codes = {res[i] for i in failed}
+                if (
+                    failed_codes == {MOONCAKE_NO_AVAILABLE_HANDLE}
+                    and attempt < _MOONCAKE_SAVE_PRESSURE_RETRIES
+                ):
+                    pending_keys = [pending_keys[i] for i in failed]
+                    pending_addrs = [pending_addrs[i] for i in failed]
+                    pending_sizes = [pending_sizes[i] for i in failed]
+                    if pending_group_ids is not None:
+                        pending_group_ids = [pending_group_ids[i] for i in failed]
+                    time.sleep(0.02 * (attempt + 1))
+                    continue
+
+                logger.warning(
+                    "Partial-tail put failed for request %s: %d/%d keys "
+                    "failed after %d attempt(s) (codes=%s)",
+                    req_meta.req_id,
+                    len(failed),
+                    len(pending_keys),
+                    attempt + 1,
+                    failed_codes,
+                )
+                if MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes:
+                    self._mark_request_skipped_for_pressure(req_meta)
+                return False
 
         if self._clear_store_pressure():
             logger.info(
@@ -995,17 +1113,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 addrs.extend(group_addrs)
                 sizes.extend(group_sizes)
 
+            token_ids_end = token_ids_start + len(event_token_ids or ())
             if self.enable_kv_event:
-                new_block_hashes = [
-                    maybe_convert_block_hash(bh) for bh in kv_event_block_hashes
-                ]
-                token_ids_end = token_ids_start + len(event_token_ids or ())
-
-            for idx, (s, e, g_idx) in enumerate(
-                zip(starts, ends, group_indices, strict=True)
-            ):
-                db = self.token_databases[g_idx]
-                if self.enable_kv_event:
+                for idx, (s, e, g_idx) in enumerate(
+                    zip(starts, ends, group_indices, strict=True)
+                ):
+                    db = self.token_databases[g_idx]
                     token_ids = (
                         event_token_ids[s - token_ids_start : e - token_ids_start]
                         if event_token_ids is not None
@@ -1014,7 +1127,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
                         else []
                     )
                     stored_event = BlockStored(
-                        block_hashes=[new_block_hashes[idx]],
+                        block_hashes=[
+                            maybe_convert_block_hash(kv_event_block_hashes[idx])
+                        ],
                         # Derive the direct predecessor from the unfiltered
                         # request chain. Adjacent PUTs need not be adjacent in
                         # that chain after Store dedup, masks, or TP striding.
@@ -1037,81 +1152,137 @@ class KVCacheStoreSendingThread(KVTransferThread):
             if current_event is not None:
                 current_event.synchronize()
 
-            if group_ids is not None:
-                assert len(group_ids) == len(keys)
-                self.replicate_config.group_ids = group_ids
-
-            batch_bytes = _sum_batch_bytes(sizes)
-            put_start = time.perf_counter()
-            try:
-                res = self.store.batch_put_from_multi_buffers(
-                    keys,
-                    addrs,
-                    sizes,
-                    self.replicate_config,
+            raw_put_budget = max(
+                _MOONCAKE_SAVE_BATCH_BYTES,
+                max(_estimate_disk_offload_staging_bytes(size) for size in sizes),
+            )
+            put_batches, oversized_key = _split_disk_offload_load_batches(
+                keys,
+                addrs,
+                sizes,
+                _MOONCAKE_SAVE_BATCH_BYTES,
+                raw_put_budget,
+            )
+            if oversized_key is not None:
+                logger.error(
+                    "Failed to create PUT batches; key %s exceeds the "
+                    "computed raw budget",
+                    oversized_key,
                 )
+                return
+
+            all_succeeded = True
+            group_id_offset = 0
+            event_offset = 0
+            for batch_keys, batch_addrs, batch_sizes in put_batches:
+                batch_group_ids = (
+                    None
+                    if group_ids is None
+                    else group_ids[group_id_offset : group_id_offset + len(batch_keys)]
+                )
+                group_id_offset += len(batch_keys)
+                if batch_group_ids is not None:
+                    self.replicate_config.group_ids = batch_group_ids
+
+                batch_bytes = _sum_batch_bytes(batch_sizes)
+                put_start = time.perf_counter()
+                try:
+                    res = self.store.batch_put_from_multi_buffers(
+                        batch_keys,
+                        batch_addrs,
+                        batch_sizes,
+                        self.replicate_config,
+                    )
+                except Exception as e:
+                    self._record_operation(
+                        "save_put",
+                        put_start,
+                        len(batch_keys),
+                        num_bytes=batch_bytes,
+                        status="error",
+                        num_failed_keys=len(batch_keys),
+                    )
+                    logger.error("Failed to put key %s, error: %s", batch_keys, e)
+                    all_succeeded = False
+                    break
+
+                if len(res) != len(batch_keys):
+                    # Statuses are matched to keys positionally, including when
+                    # deciding which KV events may be published, so a
+                    # mismatched response cannot be interpreted per key.
+                    self._record_operation(
+                        "save_put",
+                        put_start,
+                        len(batch_keys),
+                        num_bytes=batch_bytes,
+                        status="error",
+                        num_failed_keys=len(batch_keys),
+                    )
+                    logger.error(
+                        "Mooncake returned %d statuses for %d keys (request %s); "
+                        "treating the batch as failed",
+                        len(res),
+                        len(batch_keys),
+                        req_id,
+                    )
+                    all_succeeded = False
+                    break
+
                 failed = [i for i, v in enumerate(res) if v < 0]
+                if self.enable_kv_event and stored_events:
+                    batch_events = stored_events[
+                        event_offset : event_offset + len(batch_keys)
+                    ]
+                    successful_events = [
+                        event for i, event in enumerate(batch_events) if i not in failed
+                    ]
+                    if successful_events:
+                        self.update_kv_event(successful_events)
+                event_offset += len(batch_keys)
                 self._record_operation(
                     "save_put",
                     put_start,
-                    len(keys),
+                    len(batch_keys),
                     num_bytes=batch_bytes,
                     status="partial_failure" if failed else "ok",
                     num_failed_keys=len(failed),
                 )
-                if failed:
-                    failed_codes = set(res[i] for i in failed)
-                    if self.enable_kv_event:
-                        failed_indices = set(failed)
-                        stored_events = [
-                            event
-                            for i, event in enumerate(stored_events)
-                            if i not in failed_indices
-                        ]
-                    logger.warning(
-                        "batch_put failed: %d/%d keys failed "
-                        "(codes=%s, batch_bytes=%d, num_keys=%d), "
-                        "first_key=%s",
-                        len(failed),
-                        len(keys),
-                        failed_codes,
-                        batch_bytes,
-                        len(keys),
-                        keys[0] if keys else "N/A",
-                    )
-                    if (
-                        MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
-                        and not self._mark_request_skipped_for_pressure(req_meta)
-                    ):
-                        logger.warning(
-                            "Detected Mooncake CPU/disk offloading pressure "
-                            "(NO_AVAILABLE_HANDLE); skipping future store "
-                            "batches for request %s until a later store "
-                            "batch succeeds",
-                            req_id,
-                        )
-                else:
-                    self._record_saved(req_meta, token_len)
-                    save_completed = True
-                    if self._clear_store_pressure():
-                        logger.info(
-                            "Mooncake CPU/disk offloading pressure cleared "
-                            "after a successful store batch"
-                        )
-            except Exception as e:
-                self._record_operation(
-                    "save_put",
-                    put_start,
-                    len(keys),
-                    num_bytes=batch_bytes,
-                    status="error",
-                    num_failed_keys=len(keys),
-                )
-                logger.error("Failed to put key %s, error: %s", keys, e)
-                stored_events.clear()
+                if not failed:
+                    continue
 
-            if self.enable_kv_event and stored_events:
-                self.update_kv_event(stored_events)
+                all_succeeded = False
+                failed_codes = {res[i] for i in failed}
+                logger.warning(
+                    "batch_put failed: %d/%d keys failed "
+                    "(codes=%s, batch_bytes=%d, num_keys=%d), first_key=%s",
+                    len(failed),
+                    len(batch_keys),
+                    failed_codes,
+                    batch_bytes,
+                    len(batch_keys),
+                    batch_keys[0] if batch_keys else "N/A",
+                )
+                if (
+                    MOONCAKE_NO_AVAILABLE_HANDLE in failed_codes
+                    and not self._mark_request_skipped_for_pressure(req_meta)
+                ):
+                    logger.warning(
+                        "Detected Mooncake CPU/disk offloading pressure "
+                        "(NO_AVAILABLE_HANDLE); skipping future store batches "
+                        "for request %s until a later store batch succeeds",
+                        req_id,
+                    )
+                break
+
+            if all_succeeded:
+                self._record_saved(req_meta, token_len)
+                save_completed = True
+                if self._clear_store_pressure():
+                    logger.info(
+                        "Mooncake CPU/disk offloading pressure cleared after "
+                        "a successful store batch"
+                    )
+
         finally:
             if self.enable_kv_event and token_len:
                 self._update_retry_token_ids(
@@ -1539,6 +1710,14 @@ class MooncakeStoreWorker:
             retention_interval=kv_cache_config.prefix_cache_retention_interval,
             dcp_world_size=self.dcp_size,
         )
+        logger.info(
+            "Mooncake cache geometry: scheduler_block=%d hash_block=%d "
+            "partial_hash_hits=%s group_blocks=%s",
+            self.block_size,
+            self.hash_block_size,
+            self.coord.enable_partial_hash_hits,
+            [g.kv_cache_spec.block_size for g in self._kv_cache_groups],
+        )
         # One ChunkedTokenDatabase per group; addresses populated in
         # register_kv_caches once the kv-cache layout is known. Each group's
         # key namespace is its TP shard id: ranks holding identical bytes
@@ -1655,6 +1834,7 @@ class MooncakeStoreWorker:
         addrs: list[int] = []
         block_lens: list[int] = []
 
+        unregistered: list[int] = []
         for cache in kv_caches.values():
             cache = group_kernel_blocks(cache, self.num_blocks)
             cache_storage = cache.untyped_storage()
@@ -1671,6 +1851,7 @@ class MooncakeStoreWorker:
                         region_len,
                         ret,
                     )
+                    unregistered.append(region_len)
 
             if not is_non_overlapping_and_dense(cache[0]):
                 # A block is scattered across per-head regions; each region's
@@ -1710,6 +1891,22 @@ class MooncakeStoreWorker:
             len(addrs),
             self.num_blocks,
         )
+
+        if unregistered:
+            # An unregistered region is one the transfer engine cannot read or
+            # write, so every store and load touching it fails (TRANSFER_FAIL)
+            # while the engine still reports itself healthy and simply serves
+            # zero external hits. Fail here instead: a store that can never
+            # transfer is worse than a refused start. The usual cause is a
+            # client-side cap below the largest KV region, so name it.
+            raise RuntimeError(
+                f"Mooncake could not register {len(unregistered)} of "
+                f"{len(seen_storage_ptrs)} KV cache regions (largest failure "
+                f"{max(unregistered)} bytes). The store cannot transfer "
+                "unregistered memory, so the external tier would silently "
+                "never hit. Check that max_mr_size (MC_MAX_MR_SIZE) is at "
+                "least the largest KV region."
+            )
 
         for db in self.token_dbs:
             db.set_kv_caches_base_addr(addrs)
@@ -1994,6 +2191,19 @@ class MooncakeStoreWorker:
             token_len,
             cached_block_pool,
         )
+        if logger.isEnabledFor(logging.DEBUG):
+            # Summarizing ``res`` costs a pass over every candidate key, so keep
+            # it off the lookup hot path unless debug logging is on.
+            logger.debug(
+                "Mooncake lookup result tokens=%d keys=%d present=%d "
+                "group_hashes=%d hit=%d states=%s",
+                token_len,
+                len(candidate_keys),
+                sum(e == 1 for e in res),
+                len(exists_set),
+                hit_length,
+                sorted(set(res)),
+            )
         if hit_length >= num_tokens:
             usable_length = self.coord.align_lookup_length(num_tokens - 1)
             if usable_length <= 0:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -687,9 +687,30 @@ class KVCacheStoreSendingThread(KVTransferThread):
             return True
         if boundary // hash_block_size - 1 >= len(req_meta.block_hashes):
             return True
-        mamba_offloads = {
+        offload_blocks_by_group = {
             group_id: block_id for group_id, block_id, _ in partial_tail_offloads
         }
+
+        # A partial Mamba block is mutable until core redirects the request to
+        # its CoW copy. A DCP full-attention handoff can arrive one step before
+        # that CoW handoff, so do not fall back to the live request block for a
+        # partial Mamba boundary. The later Mamba handoff will retry the whole
+        # boundary; append-only full-attention groups are safe to read then.
+        for g_idx, db in enumerate(self.token_databases):
+            spec = unwrap_kv_cache_spec(self.coord.kv_cache_groups[g_idx].kv_cache_spec)
+            if (
+                isinstance(spec, MambaSpec)
+                and boundary % db.block_size != 0
+                and g_idx not in offload_blocks_by_group
+            ):
+                logger.debug(
+                    "Deferring partial-tail offload for request %s at token %d "
+                    "until Mamba group %d has a durable CoW source",
+                    req_meta.req_id,
+                    boundary,
+                    g_idx,
+                )
+                return True
 
         keys: list[str] = []
         addrs: list[list[int]] = []
@@ -735,11 +756,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 for key_end, marker_only in key_ends:
                     key_hash = req_meta.block_hashes[key_end // hash_block_size - 1]
                     if (
-                        g_idx in mamba_offloads
+                        g_idx in offload_blocks_by_group
                         and key_end == boundary
                         and boundary % db.block_size != 0
                     ):
-                        block_id = mamba_offloads[g_idx]
+                        block_id = offload_blocks_by_group[g_idx]
                     else:
                         source_block_idx = (key_end - 1) // db.block_size
                         if source_block_idx >= len(group_blocks):
@@ -1446,9 +1467,16 @@ class KVCacheStoreRecvingThread(KVTransferThread):
 
         current_batch_keys: list[str] = key_list_c
         current_batch_block_ids: list[int] = block_id_list_c
+        current_batch_idx = 0
         batch_bytes = 0
         try:
-            for batch_keys, batch_addrs, batch_sizes, batch_block_ids in load_batches:
+            for batch_idx, (
+                batch_keys,
+                batch_addrs,
+                batch_sizes,
+                batch_block_ids,
+            ) in enumerate(load_batches):
+                current_batch_idx = batch_idx
                 current_batch_keys = batch_keys
                 current_batch_block_ids = batch_block_ids
                 batch_bytes = _sum_batch_bytes(batch_sizes)
@@ -1480,8 +1508,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     num_failed_keys=len(failed),
                 )
                 if failed:
+                    unattempted_block_ids = [
+                        block_id
+                        for _, _, _, remaining_block_ids in load_batches[
+                            batch_idx + 1 :
+                        ]
+                        for block_id in remaining_block_ids
+                    ]
                     self._add_load_error_block_ids(
-                        [block_id for _, _, block_id in failed]
+                        [block_id for _, _, block_id in failed] + unattempted_block_ids
                     )
                     logger.warning(
                         "Failed to get %d Mooncake keys from sub-batch "
@@ -1492,7 +1527,16 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     )
                     break
         except Exception as e:
-            self._add_load_error_block_ids(current_batch_block_ids)
+            unattempted_block_ids = [
+                block_id
+                for _, _, _, remaining_block_ids in load_batches[
+                    current_batch_idx + 1 :
+                ]
+                for block_id in remaining_block_ids
+            ]
+            self._add_load_error_block_ids(
+                current_batch_block_ids + unattempted_block_ids
+            )
             self._record_operation(
                 "load_get",
                 load_get_start,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -2021,8 +2021,9 @@ class MooncakeStoreWorker:
         """Return the hash boundary used to store each group's tail block.
 
         With fine-grained prefix matching, ``hit_length`` may fall within a
-        physical cache block whose store key uses a later hash boundary. Exact
-        matches are recorded too, so every nonzero hit has one entry per group.
+        physical cache block and may not align with the hash boundary used to
+        store that block. For each KV-cache group, return the token boundary
+        whose hash was used as the store key.
         """
         if hit_length <= 0:
             return ()
@@ -2032,9 +2033,12 @@ class MooncakeStoreWorker:
         for group_id, db in enumerate(self.token_dbs):
             chunk_id = cdiv(hit_length, db.block_size) - 1
             boundary_tokens = hit_length
-            if self.coord.enable_partial_hash_hits and not cached_block_pool.contains(
+            contains_hit_boundary = cached_block_pool.contains(
                 group_id, block_hashes[hit_boundary_hash_idx]
-            ):
+            )
+            if not self.coord.enable_partial_hash_hits:
+                assert contains_hit_boundary
+            elif not contains_hit_boundary:
                 next_chunk_hash_idx = min(
                     (chunk_id + 1) * db.block_size // self.hash_block_size,
                     len(block_hashes),
@@ -2043,6 +2047,11 @@ class MooncakeStoreWorker:
                     if cached_block_pool.contains(group_id, block_hashes[hash_idx]):
                         boundary_tokens = (hash_idx + 1) * self.hash_block_size
                         break
+                else:
+                    raise AssertionError(
+                        f"No tail key found for cache group {group_id} at "
+                        f"hit length {hit_length}"
+                    )
             boundaries.append(TailKeyBoundary(group_id, boundary_tokens))
         return tuple(boundaries)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -2038,7 +2038,7 @@ class MooncakeStoreWorker:
             )
             if not self.coord.enable_partial_hash_hits:
                 assert contains_hit_boundary
-            elif not contains_hit_boundary:
+            if not contains_hit_boundary:
                 next_chunk_hash_idx = min(
                     (chunk_id + 1) * db.block_size // self.hash_block_size,
                     len(block_hashes),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -44,8 +44,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (  
     BlobBlockHashes,
     ChunkedTokenDatabase,
     KeyMetadata,
+    MooncakeLookupResult,
     MooncakeStoreConnectorMetadata,
     MooncakeStoreWorkerMetadata,
+    PartialHitBoundary,
     PoolKey,
     ReqMeta,
 )
@@ -54,6 +56,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.protocol import
     RESET_MSG,
     RESP_ERR,
     RESP_OK,
+    decode_lookup_response,
+    encode_lookup_response,
 )
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
@@ -63,6 +67,7 @@ from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     maybe_convert_block_hash,
+    resolve_dcp_kv_block_size,
     resolve_kv_cache_block_sizes,
 )
 from vllm.v1.kv_cache_interface import (
@@ -1179,6 +1184,14 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         # Skip chunks the consumer's per-group spec wouldn't populate
         # locally (e.g. SWA pre-window) even if the producer stored them.
         load_mask_per_group = self.coord.load_mask(req_meta.block_hashes, token_len)
+        # Groups whose tail chunk is keyed at a boundary other than the one
+        # process_tokens derives from token_len (see PartialHitBoundary).
+        partial_hit_boundaries = {
+            boundary.group_id: boundary.num_tokens
+            for boundary in (
+                req_meta.load_spec.partial_hit_boundaries  # type: ignore[union-attr]
+            )
+        }
 
         addr_list: list[list[int]] = []
         size_list: list[list[int]] = []
@@ -1193,6 +1206,15 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 chunk_idx = start // db.block_size
                 if chunk_idx >= len(mask) or not mask[chunk_idx]:
                     continue
+                # ``end == token_len`` identifies the tail chunk, the only one
+                # whose key can differ.
+                boundary_tokens = (
+                    partial_hit_boundaries.get(g_idx) if end == token_len else None
+                )
+                if boundary_tokens is not None:
+                    block_hash = req_meta.block_hashes[
+                        boundary_tokens // db.hash_block_size - 1
+                    ]
                 key_list.append(db.key_for(block_hash))
                 chunks.append((start, end))
             g_addrs, g_sizes, g_block_ids = db.prepare_values(
@@ -1494,20 +1516,18 @@ class MooncakeStoreWorker:
             )
             return
 
-        # Single-group + PCP/DCP > 1: scale the lone group's spec.block_size to
-        # self.block_size (= scheduler_block_size) so the coordinator's
-        # ``block_size % hash_block_size == 0`` invariant holds.
-        groups = list(kv_cache_config.kv_cache_groups)
-        if len(groups) == 1 and groups[0].kv_cache_spec.block_size != self.block_size:
-            g = groups[0]
-            groups = [
-                dataclasses.replace(
-                    g,
+        # Scale kv group's spec to the token span used under DCP.
+        groups = []
+        for group in kv_cache_config.kv_cache_groups:
+            block_size = resolve_dcp_kv_block_size(group.kv_cache_spec, self.dcp_size)
+            if block_size != group.kv_cache_spec.block_size:
+                group = dataclasses.replace(
+                    group,
                     kv_cache_spec=dataclasses.replace(
-                        g.kv_cache_spec, block_size=self.block_size
+                        group.kv_cache_spec, block_size=block_size
                     ),
                 )
-            ]
+            groups.append(group)
         self._kv_cache_groups: list[KVCacheGroupSpec] = groups
         spec_cfg = getattr(vllm_config, "speculative_config", None)
         use_eagle = bool(
@@ -1521,6 +1541,7 @@ class MooncakeStoreWorker:
             hash_block_size=self.hash_block_size,
             use_eagle=use_eagle,
             retention_interval=kv_cache_config.prefix_cache_retention_interval,
+            dcp_world_size=self.dcp_size,
         )
         # One ChunkedTokenDatabase per group; addresses populated in
         # register_kv_caches once the kv-cache layout is known. Each group's
@@ -1881,7 +1902,9 @@ class MooncakeStoreWorker:
             return None
         return MooncakeStoreWorkerMetadata(completed_saves=completed_saves)
 
-    def lookup(self, num_tokens: int, block_hashes: Sequence[BlockHash]) -> int:
+    def lookup(
+        self, num_tokens: int, block_hashes: Sequence[BlockHash]
+    ) -> MooncakeLookupResult:
         """Check how many prefix tokens exist in the store.
 
         Checks across all rank-specific key namespaces that may be loaded. A
@@ -1889,11 +1912,11 @@ class MooncakeStoreWorker:
         the last token is recomputed for sampling.
         """
         if self._capacity_only:
-            return 0
+            return MooncakeLookupResult(0)
 
         token_len = self.coord.align_lookup_length(num_tokens)
         if not block_hashes or token_len <= 0:
-            return 0
+            return MooncakeLookupResult(0)
 
         # Build per-(group, hash) candidate keys expanded across rank namespaces.
         # candidate_meta stores the (group, hash_bytes) for key slice.
@@ -1934,7 +1957,7 @@ class MooncakeStoreWorker:
                 candidate_meta.append((g_idx, bytes(h)))
 
         if not candidate_keys:
-            return 0
+            return MooncakeLookupResult(0)
 
         lookup_start = time.perf_counter()
         try:
@@ -1953,7 +1976,7 @@ class MooncakeStoreWorker:
                 num_failed_keys=len(candidate_keys),
             )
             logger.error("Remote connection failed in lookup: %s", e)
-            return 0
+            return MooncakeLookupResult(0)
 
         # A (group, hash) is "present" only when every namespace that will be
         # loaded has it (per-group count: sharded groups need every rank's
@@ -1970,7 +1993,7 @@ class MooncakeStoreWorker:
             self.hash_block_size,
             exists_set,
         )
-        _masks, hit_length = self.coord.find_longest_cache_hit(
+        hit_masks, hit_length = self.coord.find_longest_cache_hit(
             block_hashes,
             token_len,
             cached_block_pool,
@@ -1978,13 +2001,65 @@ class MooncakeStoreWorker:
         if hit_length >= num_tokens:
             usable_length = self.coord.align_lookup_length(num_tokens - 1)
             if usable_length <= 0:
-                return 0
-            _masks, hit_length = self.coord.find_longest_cache_hit(
+                return MooncakeLookupResult(0)
+            hit_masks, hit_length = self.coord.find_longest_cache_hit(
                 block_hashes,
                 usable_length,
                 cached_block_pool,
             )
-        return hit_length
+        return MooncakeLookupResult(
+            hit_length,
+            self._partial_hit_boundaries(
+                block_hashes,
+                hit_masks,
+                hit_length,
+                cached_block_pool,
+            ),
+        )
+
+    def _partial_hit_boundaries(
+        self,
+        block_hashes: Sequence[BlockHash],
+        hit_masks: tuple[list[bool], ...],
+        hit_length: int,
+        cached_block_pool: ExternalCachedBlockPool,
+    ) -> tuple[PartialHitBoundary, ...]:
+        """Return stored-key overrides for partially reused physical blocks.
+
+        With fine-grained prefix matching, ``hit_length`` may fall within a
+        physical cache block and may not align with the hash boundary used to
+        store that block. For each affected KV-cache group, return the token
+        boundary whose hash was used as the store key.
+        """
+        if not self.coord.enable_partial_hash_hits or hit_length <= 0:
+            return ()
+
+        boundaries = []
+        hit_boundary_hash_idx = hit_length // self.hash_block_size - 1
+        for group_id, db in enumerate(self.token_dbs):
+            chunk_id = cdiv(hit_length, db.block_size) - 1
+            mask = hit_masks[group_id]
+            if chunk_id < 0 or chunk_id >= len(mask) or not mask[chunk_id]:
+                continue
+            if cached_block_pool.contains(
+                group_id, block_hashes[hit_boundary_hash_idx]
+            ):
+                continue
+            next_chunk_hash_idx = min(
+                (chunk_id + 1) * db.block_size // self.hash_block_size,
+                len(block_hashes),
+            )
+            # Search the remaining hash boundaries in this physical cache block.
+            for hash_idx in range(hit_boundary_hash_idx + 1, next_chunk_hash_idx):
+                if cached_block_pool.contains(group_id, block_hashes[hash_idx]):
+                    boundaries.append(
+                        PartialHitBoundary(
+                            group_id,
+                            (hash_idx + 1) * self.hash_block_size,
+                        )
+                    )
+                    break
+        return tuple(boundaries)
 
     def get_kv_events(self) -> list[BlockStored]:
         if self.enable_kv_events and self.kv_send_thread is not None:
@@ -2017,7 +2092,7 @@ class LookupKeyServer:
     """ZMQ server on worker rank 0 for the LookupKey admin channel.
 
     Handles two request types, tagged at frame 0:
-    - ``LOOKUP_MSG``: prefix-cache hit query, returns hit count.
+    - ``LOOKUP_MSG``: prefix-cache hit query, returns its load plan.
     - ``RESET_MSG``: drains the send thread queue, then runs
       ``store.remove_all(force=True)``. Caller must have paused the
       scheduler first.
@@ -2054,7 +2129,7 @@ class LookupKeyServer:
                     blob = all_frames[3].buffer
                     block_hashes = BlobBlockHashes(blob, hash_len)
                     result = self.store_worker.lookup(num_tokens, block_hashes)
-                    self.socket.send(result.to_bytes(4, "big"))
+                    self.socket.send(encode_lookup_response(result))
 
                 elif msg_type == RESET_MSG:
                     try:
@@ -2114,9 +2189,11 @@ class LookupKeyClient:
         self.executor = ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="MooncakeLookupClient"
         )
-        self.futures: dict[str, Future[int]] = {}
+        self.futures: dict[str, Future[MooncakeLookupResult]] = {}
 
-    def _lookup(self, num_tokens: int, block_hashes: list[BlockHash]) -> int:
+    def _lookup(
+        self, num_tokens: int, block_hashes: list[BlockHash]
+    ) -> MooncakeLookupResult:
         hash_len = len(block_hashes[0]) if block_hashes else 0
         all_frames = (
             LOOKUP_MSG,
@@ -2126,7 +2203,7 @@ class LookupKeyClient:
         )
         self.socket.send_multipart(all_frames, copy=False)
         resp = self.socket.recv()
-        return int.from_bytes(resp, "big")
+        return decode_lookup_response(resp)
 
     def lookup(
         self,
@@ -2134,7 +2211,7 @@ class LookupKeyClient:
         num_tokens: int,
         block_hashes: list[BlockHash],
         non_block: bool = False,
-    ) -> int | None:
+    ) -> MooncakeLookupResult | None:
         """If non_block is True, will return None until the result is ready,
         so the caller retries on a later step."""
         future = self.futures.get(req_id)
@@ -2147,7 +2224,7 @@ class LookupKeyClient:
             return future.result()
         except Exception as e:
             logger.error("Async Mooncake lookup failed for %s: %s", req_id, e)
-            return 0
+            return MooncakeLookupResult(0)
         finally:
             del self.futures[req_id]
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -908,14 +908,14 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if is_simple_hybrid:
                 break
 
-        # Truncate full attention blocks to final hit_length (if present)
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            group_block_size = self.single_type_managers[
-                first_group.group_ids[0]
-            ].block_size
+        # Truncate every full-attention group (target and draft) blocks
+        # to final hit_length.
+        for group in self.attention_groups:
+            if not isinstance(group.spec, FullAttentionSpec):
+                continue
+            group_block_size = self.single_type_managers[group.group_ids[0]].block_size
             num_blocks = cdiv(hit_length, group_block_size)
-            for group_id in first_group.group_ids:
+            for group_id in group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
                     hit_length_by_group[group_id] = hit_length

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -659,6 +659,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     "cache managers require block-aligned lookups: %s.",
                     ", ".join(sorted(unsupported_partial_hit_managers)),
                 )
+        cache_hit_alignment_tokens = self._cache_hit_alignment_tokens
+        for manager in self.single_type_managers:
+            manager.cache_hit_alignment_tokens = cache_hit_alignment_tokens
         self.verify_and_split_kv_cache_groups()
 
     @property
@@ -734,8 +737,31 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             return num_tokens
         return round_down(num_tokens, self.scheduler_block_size)
 
+    def _eagle_replay_boundaries(self, request: Request) -> tuple[int, ...]:
+        """Return Mamba states needed after the dense group applies EAGLE."""
+        max_hit_length = round_down(
+            request.num_prompt_tokens - 1,
+            self._cache_hit_alignment_tokens,
+        )
+        replay_boundaries: set[int] = set()
+        for group in self.attention_groups:
+            if not isinstance(group.spec, FullAttentionSpec) or not group.use_eagle:
+                continue
+            manager = self.single_type_managers[group.group_ids[0]]
+            drop_tokens = manager.block_size
+            if (
+                self.enable_partial_hash_hits
+                and manager.supports_fine_grained_hash_lookup
+                and manager.block_size > self.hash_block_size
+            ):
+                drop_tokens = self.hash_block_size
+            if (replay_boundary := max_hit_length - drop_tokens) > 0:
+                replay_boundaries.add(replay_boundary)
+        return tuple(sorted(replay_boundaries))
+
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         cached_num_computed_tokens = self._align_cacheable(num_computed_tokens)
+        eagle_replay_boundaries = self._eagle_replay_boundaries(request)
         for manager in self.single_type_managers:
             num_tokens_to_cache = cached_num_computed_tokens
             # EAGLE groups match one block past each aligned boundary and drop
@@ -754,14 +780,18 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     num_finalized_computed_tokens,
                     cached_num_finalized_computed_tokens + manager.block_size,
                 )
-            # The manager already knows the fine hit granularity
-            # (``scheduler_block_size``); retention is passed separately so it
-            # can keep both the coarse segment tails and the fine replay
-            # boundary (which needs the fine value).
+            # The manager already knows its cache-hit alignment. Retention is
+            # passed separately so it can keep coarse segment tails and fine
+            # replay boundaries.
             manager.cache_blocks(
                 request,
                 num_tokens_to_cache,
                 retention_interval=self.retention_interval,
+                extra_reachable_boundaries=(
+                    eagle_replay_boundaries
+                    if isinstance(manager.kv_cache_spec, MambaSpec)
+                    else ()
+                ),
             )
 
     def find_longest_cache_hit(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -11,6 +11,7 @@ from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    dcp_world_size_for_kv_cache_spec,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
@@ -141,7 +142,9 @@ class KVCacheCoordinator(ABC):
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
                 kv_cache_group_id=i,
-                dcp_world_size=dcp_world_size,
+                dcp_world_size=dcp_world_size_for_kv_cache_spec(
+                    kv_cache_group.kv_cache_spec, dcp_world_size
+                ),
                 pcp_world_size=pcp_world_size,
                 scheduler_block_size=self.scheduler_block_size,
                 needs_kv_cache_zeroing=self.kv_cache_config.needs_kv_cache_zeroing,
@@ -506,11 +509,9 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             num_prefill_lookahead=num_prefill_lookahead,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
-        self.block_size = self.kv_cache_spec.block_size
-        self.dcp_world_size = dcp_world_size
+        self.dcp_world_size = self.single_type_managers[0].dcp_world_size
         self.pcp_world_size = pcp_world_size
-        if dcp_world_size > 1:
-            self.block_size *= dcp_world_size
+        self.block_size = self.single_type_managers[0].block_size
         # For models using only Mamba, block_size is set to max_model_len when
         # prefix caching is disabled, and hash_block_size validation is skipped.
         assert not enable_caching or (hash_block_size == self.block_size), (
@@ -843,11 +844,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     kv_cache_spec=spec,
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self._cache_hit_alignment_tokens,
-                    dcp_world_size=(
-                        self.dcp_world_size
-                        if isinstance(spec, FullAttentionSpec)
-                        else 1
-                    ),
+                    dcp_world_size=self.single_type_managers[
+                        first_group_id
+                    ].dcp_world_size,
+                    pcp_world_size=self.single_type_managers[
+                        first_group_id
+                    ].pcp_world_size,
                 )
                 if drop_eagle_block:
                     eagle_verified.add(idx)
@@ -904,6 +906,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hit_lengths: list[int] = [0] * num_groups
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
+            manager = self.single_type_managers[group_ids[0]]
             blocks, group_hit = manager_cls.find_longest_cache_hit(
                 block_hashes=block_hashes,
                 max_length=max_cache_hit_length,
@@ -912,6 +915,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 kv_cache_spec=spec,
                 drop_eagle_block=use_eagle,
                 alignment_tokens=self._cache_hit_alignment_tokens,
+                dcp_world_size=manager.dcp_world_size,
+                pcp_world_size=manager.pcp_world_size,
             )
             for gid, blks in zip(group_ids, blocks):
                 hit_blocks[gid] = blks

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -635,7 +635,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             )
             for g in kv_cache_config.kv_cache_groups
         )
-        self.enable_partial_hash_hits = has_partial_mamba_group
+        has_dcp_partial_full_attention_group = dcp_world_size > 1 and any(
+            isinstance(g.kv_cache_spec, FullAttentionSpec)
+            and manager.block_size > hash_block_size
+            for g, manager in zip(
+                kv_cache_config.kv_cache_groups, self.single_type_managers
+            )
+        )
+        self.enable_partial_hash_hits = (
+            has_partial_mamba_group or has_dcp_partial_full_attention_group
+        )
         if self.enable_partial_hash_hits:
             unsupported_partial_hit_managers = {
                 type(manager).__name__

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -859,13 +859,16 @@ class KVCacheManager:
 
         Returns ``{request_id: [(group_id, block_id, boundary_tokens), ...]}``
         for the durable boundary blocks of producers' last-prompt-boundary
-        partial tails. Only mamba "align" groups contribute; empty otherwise.
-        A KV connector reads the referenced blocks and offloads them so a later
+        partial tails. Mamba "align" groups contribute the CoW block that
+        preserved their boundary state; full-attention groups under DCP
+        contribute the request's own boundary block, which is a durable source
+        because KV below the boundary is append-only. Empty otherwise. A KV
+        connector reads the referenced blocks and offloads them so a later
         request can hit the sub-block prefix.
 
-        Each handed-off block lives off the request block table, so it is
-        pinned here and unpinned when the request's blocks are freed — for a
-        producer with saved tokens, after the connector reports sends done.
+        Each handed-off block is pinned here and unpinned when the request's
+        blocks are freed — for a producer with saved tokens, after the
+        connector reports sends done.
         """
         offloads: dict[str, list[tuple[int, int, int]]] = {}
         for mgr in self.coordinator.single_type_managers:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -647,6 +647,28 @@ def hash_block_tokens(
     )
 
 
+def dcp_world_size_for_kv_cache_spec(spec: KVCacheSpec, dcp_world_size: int) -> int:
+    """Return the DCP size that owns this group's block geometry.
+
+    Full-attention KV (including MLA) is sharded across DCP ranks, so prefix
+    hashing and manager ``block_size`` use the process DCP size. Other specs
+    keep replicated per-rank state (Mamba, sliding window, chunked-local) and
+    must keep ``dcp_world_size=1`` even when the process runs with DCP > 1.
+
+    Draft MLA groups on the sharded DSpark path are ``FullAttentionSpec`` /
+    ``MLAAttentionSpec`` and therefore keep the process DCP size. A replicated
+    draft group would need a different spec, not this helper.
+    """
+    if dcp_world_size <= 1:
+        return 1
+    inner = spec
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        inner = next(iter(spec.kv_cache_specs.values()))
+    if isinstance(inner, FullAttentionSpec):
+        return dcp_world_size
+    return 1
+
+
 def resolve_kv_cache_block_sizes(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -669,6 +669,11 @@ def dcp_world_size_for_kv_cache_spec(spec: KVCacheSpec, dcp_world_size: int) -> 
     return 1
 
 
+def resolve_dcp_kv_block_size(spec: KVCacheSpec, dcp_world_size: int) -> int:
+    """Return the token span of a cache block under DCP."""
+    return spec.block_size * dcp_world_size_for_kv_cache_spec(spec, dcp_world_size)
+
+
 def resolve_kv_cache_block_sizes(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,
@@ -696,10 +701,7 @@ def resolve_kv_cache_block_sizes(
         return bs, bs
 
     group_block_sizes = [
-        g.kv_cache_spec.block_size * dcp
-        if isinstance(g.kv_cache_spec, AttentionSpec)
-        else g.kv_cache_spec.block_size
-        for g in groups
+        resolve_dcp_kv_block_size(g.kv_cache_spec, dcp) for g in groups
     ]
     scheduler_block_size = math.lcm(*group_block_sizes)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2926,68 +2926,89 @@ class Scheduler(SchedulerInterface):
         # these requests must be rescheduled, but only the first will recompute
         # it. This set tracks blocks already marked for recomputation.
         marked_invalid_block_ids: set[int] = set()
+        managers = self.kv_cache_manager.coordinator.single_type_managers
+        # num_computed_tokens is a single cross-group value, so it can only be
+        # truncated to an alignment every group agrees on. Groups whose own
+        # block is finer than the scheduler block lose a little already-computed
+        # work; a per-group boundary would leave the other groups misaligned.
+        common_block_alignment = self.block_size
         for request in requests:
-            is_affected = False
-            marked_invalid_block = False
             req_id = request.request_id
-            # TODO (davidb): add support for hybrid memory allocator
-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
             # tokens
             req_num_computed_tokens = (
                 request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
             )
 
-            req_num_computed_blocks = (
-                req_num_computed_tokens + self.block_size - 1
-            ) // self.block_size
-            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
-                if block_id not in invalid_block_ids:
-                    continue
+            invalid_positions: list[tuple[int, int]] = []
+            for manager, req_block_ids in zip(
+                managers,
+                req_block_ids_by_group,
+            ):
+                group_block_size = manager.block_size
+                req_num_computed_blocks = (
+                    req_num_computed_tokens + group_block_size - 1
+                ) // group_block_size
+                invalid_positions.extend(
+                    (idx * group_block_size, block_id)
+                    for idx, block_id in enumerate(
+                        req_block_ids[:req_num_computed_blocks]
+                    )
+                    if block_id in invalid_block_ids
+                )
 
-                is_affected = True
+            if not invalid_positions:
+                continue
 
-                if block_id in marked_invalid_block_ids:
-                    # This invalid block is shared with a previous request
-                    # and was already marked for recomputation.
-                    # This means this request can still consider this block
-                    # as computed when rescheduled.
-                    # Currently this only applies to sync loading; Async
-                    # loading does not yet support block sharing
-                    continue
+            unmarked_positions = [
+                (token_idx, block_id)
+                for token_idx, block_id in invalid_positions
+                if block_id not in marked_invalid_block_ids
+            ]
+            marked_invalid_block_ids.update(
+                block_id for _, block_id in invalid_positions
+            )
 
-                marked_invalid_block_ids.add(block_id)
-
-                if marked_invalid_block:
-                    # This request has already marked an invalid block for
-                    # recomputation and updated its num_computed_tokens.
-                    continue
-
-                marked_invalid_block = True
-                # Truncate the computed tokens at the first failed block
-                request.num_computed_tokens = idx * self.block_size
-                num_affected_tokens = (
+            if unmarked_positions:
+                # Truncate at the earliest failed token boundary across all
+                # hybrid KV-cache groups.
+                earliest_invalid_token = min(
+                    token_idx for token_idx, _ in unmarked_positions
+                )
+                request.num_computed_tokens = (
+                    earliest_invalid_token
+                    - earliest_invalid_token % common_block_alignment
+                )
+                total_affected_tokens += (
                     req_num_computed_tokens - request.num_computed_tokens
                 )
-                total_affected_tokens += num_affected_tokens
 
-                # collect invalid block and all downstream dependent blocks
                 if evict_blocks:
-                    blocks_to_evict.update(req_block_ids[idx:])
+                    # Every group can depend on tokens after the failed
+                    # boundary, so evict each group's downstream blocks.
+                    for manager, req_block_ids in zip(
+                        managers,
+                        req_block_ids_by_group,
+                    ):
+                        first_invalid_idx = (
+                            request.num_computed_tokens // manager.block_size
+                        )
+                        blocks_to_evict.update(req_block_ids[first_invalid_idx:])
+            else:
+                # All invalid blocks are shared with previous requests and
+                # will be recomputed by them. Revert to considering only
+                # cached tokens as computed.
+                aligned_computed_tokens = (
+                    req_num_computed_tokens
+                    - req_num_computed_tokens % common_block_alignment
+                )
+                total_affected_tokens += (
+                    request.num_computed_tokens - aligned_computed_tokens
+                )
+                request.num_computed_tokens = aligned_computed_tokens
 
-            if is_affected:
-                if not marked_invalid_block:
-                    # All invalid blocks of this request are shared with
-                    # previous requests and will be recomputed by them.
-                    # Revert to considering only cached tokens as computed.
-                    # Currently this only applies to sync loading; Async
-                    # loading does not yet support block sharing
-                    total_affected_tokens += (
-                        request.num_computed_tokens - req_num_computed_tokens
-                    )
-                    request.num_computed_tokens = req_num_computed_tokens
-
-                affected_req_ids.add(request.request_id)
+            affected_req_ids.add(request.request_id)
 
         return affected_req_ids, total_affected_tokens, blocks_to_evict
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -442,6 +442,10 @@ class Scheduler(SchedulerInterface):
             if self.mamba_partial_cache_hit
             else 0
         )
+        eagle_replay_boundary = 0
+        if self.use_eagle and tail_boundary:
+            eagle_hit_boundary = tail_boundary - self.hash_block_size
+            eagle_replay_boundary = eagle_hit_boundary // block_size * block_size
         stops = (
             # Same invariant: a chunk starting mid-block stops at the boundary
             # rather than running past it.
@@ -453,6 +457,10 @@ class Scheduler(SchedulerInterface):
             tail_boundary
             if last_cache_position < tail_boundary < request.num_prompt_tokens
             else 0,
+            # Fine-grained EAGLE drops one hash unit from the dense-group hit.
+            # Materialize the Mamba state at the block boundary from which the
+            # reconciled hybrid hit can replay.
+            eagle_replay_boundary,
             # Marconi shared-prefix junction, block-floored (a sub-block
             # junction's state is not separately cacheable): cache its state
             # so sibling requests sharing the prefix can reuse it.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -71,6 +71,11 @@ class SingleTypeKVCacheManager(ABC):
                 block until the request finishes.
         """
         self.scheduler_block_size = scheduler_block_size
+        # Prefix-cache retention normally follows the scheduler's shared
+        # alignment. Hybrid fine-grained lookup can lower that boundary to the
+        # hash block size; the coordinator updates this after it verifies that
+        # every participating manager supports the finer lookup.
+        self.cache_hit_alignment_tokens = scheduler_block_size
         # The block size for this manager; used for actual block allocation.
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -426,6 +431,7 @@ class SingleTypeKVCacheManager(ABC):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_reachable_boundaries: Sequence[int] = (),
     ) -> None:
         """
         Cache the blocks for the request.
@@ -438,6 +444,8 @@ class SingleTypeKVCacheManager(ABC):
                 keeps dense checkpointing; ``0`` keeps only the latest replay
                 boundary; a positive multiple of ``scheduler_block_size`` keeps
                 a tail once per that-sized segment. Only SWA acts on it.
+            extra_reachable_boundaries: Additional token positions whose state
+                must remain reusable after cross-group cache-hit reconciliation.
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
@@ -451,11 +459,12 @@ class SingleTypeKVCacheManager(ABC):
         reachable_boundaries = [request.num_prompt_tokens - 1]
         if request.shared_prefix_boundary:
             reachable_boundaries.append(request.shared_prefix_boundary)
+        reachable_boundaries.extend(extra_reachable_boundaries)
 
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
             end_block=num_full_blocks,
-            alignment_tokens=self.scheduler_block_size,
+            alignment_tokens=self.cache_hit_alignment_tokens,
             kv_cache_spec=self.kv_cache_spec,
             use_eagle=self.use_eagle,
             retention_interval=retention_interval,
@@ -783,8 +792,14 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_reachable_boundaries: Sequence[int] = (),
     ) -> None:
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_reachable_boundaries=extra_reachable_boundaries,
+        )
         hash_block_size = self.block_pool.hash_block_size
         if self.block_size == hash_block_size:
             return
@@ -1712,9 +1727,15 @@ class MambaManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_reachable_boundaries: Sequence[int] = (),
     ) -> None:
         num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        super().cache_blocks(
+            request,
+            num_tokens,
+            retention_interval=retention_interval,
+            extra_reachable_boundaries=extra_reachable_boundaries,
+        )
         num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
         if self.mamba_cache_mode == "align":
             partial_hash = self._cache_partial_tail_block(request, num_tokens)
@@ -1807,6 +1828,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         request: Request,
         num_tokens: int,
         retention_interval: int | None = None,
+        extra_reachable_boundaries: Sequence[int] = (),
     ) -> None:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -421,9 +421,9 @@ class SingleTypeKVCacheManager(ABC):
 
         Entries are ``(req_id, group_id, block, boundary_tokens)``.
 
-        Only mamba "align" populates this. The block lives off the request
-        block table, so the caller must pin it until the connector has read
-        it — nothing else keeps it alive once the CoW retention is released.
+        Mamba "align" contributes a CoW block that lives off the request block
+        table; DCP full attention contributes its append-only request block.
+        The caller must pin either source until the connector has read it.
         """
         pending = self._pending_partial_tail_offloads
         self._pending_partial_tail_offloads = []

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import ClassVar
 
+from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
@@ -31,6 +32,8 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
+
+logger = init_logger(__name__)
 
 
 class SingleTypeKVCacheManager(ABC):
@@ -126,6 +129,11 @@ class SingleTypeKVCacheManager(ABC):
         self._pending_partial_tail_offloads: list[
             tuple[str, int, KVCacheBlock, int]
         ] = []
+        # DCP full-attention tails do not need CoW, but still need a one-shot
+        # hand-off to an external connector after the prompt boundary is filled.
+        # The queue above is drained every step, so dedup needs its own record
+        # that survives until the request is freed.
+        self._external_partial_tail_boundaries: set[tuple[str, int]] = set()
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -352,11 +360,28 @@ class SingleTypeKVCacheManager(ABC):
             # Replacing in place keeps the length-based allocation below
             # correct; the extra block was reserved by
             # get_num_blocks_to_allocate.
-            block_idx, source_block = self._partial_hit_reqs.pop(request_id)
-            cow_block = self.block_pool.get_new_blocks(1)[0]
-            self._apply_cow(request_id, block_idx, source_block, cow_block)
-            self.new_block_ids.append(cow_block.block_id)
-            cow_blocks.append(cow_block)
+            block_idx, _ = self._partial_hit_reqs.pop(request_id)
+            req_blocks = self.req_to_blocks[request_id]
+            if block_idx < len(req_blocks):
+                # The cached source can be replaced before allocation. Copy
+                # from the block currently owned by this request so a stale
+                # record can never leave a shared block writable in place.
+                source_block = req_blocks[block_idx]
+                cow_block = self.block_pool.get_new_blocks(1)[0]
+                self._apply_cow(request_id, block_idx, source_block, cow_block)
+                self.new_block_ids.append(cow_block.block_id)
+                cow_blocks.append(cow_block)
+            else:
+                # get_num_blocks_to_allocate reserved a block for this CoW, so
+                # a record pointing past the table means the partial hit was
+                # dropped elsewhere. Harmless, but it wastes the reservation.
+                logger.debug(
+                    "Skipping CoW for request %s: partial-hit block %d is past "
+                    "its %d allocated blocks.",
+                    request_id,
+                    block_idx,
+                    len(req_blocks),
+                )
 
         req_blocks = self.req_to_blocks[request_id]
         num_required_blocks = cdiv(num_tokens, self.block_size)
@@ -520,6 +545,16 @@ class SingleTypeKVCacheManager(ABC):
         req_blocks = self.req_to_blocks.pop(request_id, [])
         self.num_cached_block.pop(request_id, None)
         self._partial_hit_reqs.pop(request_id, None)
+        self._external_partial_tail_boundaries = {
+            entry
+            for entry in self._external_partial_tail_boundaries
+            if entry[0] != request_id
+        }
+        self._pending_partial_tail_offloads = [
+            entry
+            for entry in self._pending_partial_tail_offloads
+            if entry[0] != request_id
+        ]
         return req_blocks
 
     def free(self, request_id: str) -> None:
@@ -827,13 +862,30 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
-        self.block_pool.cache_partial_block(
+        partial_hash = self.block_pool.cache_partial_block(
             request=request,
             block=blocks[block_idx],
             num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
+        boundary_key = (request.request_id, boundary_tokens)
+        if (
+            partial_hash is not None
+            and self.dcp_world_size > 1
+            and boundary_key not in self._external_partial_tail_boundaries
+        ):
+            # Unlike Mamba align mode, full-attention KV is append-only inside
+            # the block, so the request block itself is a durable DMA source.
+            self._external_partial_tail_boundaries.add(boundary_key)
+            self._pending_partial_tail_offloads.append(
+                (
+                    request.request_id,
+                    self.kv_cache_group_id,
+                    blocks[block_idx],
+                    boundary_tokens,
+                )
+            )
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -1705,13 +1757,6 @@ class MambaManager(SingleTypeKVCacheManager):
             self.last_state_block_idx.pop(request_id, None)
             self._num_checkpoint_blocks.pop(request_id, None)
             self._producer_partial_tail_reqs.pop(request_id, None)
-            # A hand-off whose request died in this same scheduling pass must
-            # not reach the connector: its unpin hook (free) has already run.
-            self._pending_partial_tail_offloads = [
-                entry
-                for entry in self._pending_partial_tail_offloads
-                if entry[0] != request_id
-            ]
         return super().pop_blocks_for_free(request_id)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -138,6 +138,9 @@ class SimpleCPUOffloadScheduler:
             scheduler_block_size=self.block_size,
             hash_block_size=self.hash_block_size,
         )
+        # CPU transfers and block IDs are physical-block-aligned. Keep external
+        # lookups coarse even when the GPU coordinator supports fine DCP hits.
+        self.cpu_coordinator.enable_partial_hash_hits = False
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
         # GPU block pool reference - bound after scheduler builds kv_cache_manager
         self._gpu_block_pool: BlockPool | None = None
@@ -342,7 +345,6 @@ class SimpleCPUOffloadScheduler:
 
         # Build transfer pairs across all groups.
         total_computed_tokens = num_computed_tokens + num_external_tokens
-        kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
 
         # The scheduler may have accepted fewer blocks than
         # get_num_new_matched_tokens() reported.
@@ -351,9 +353,7 @@ class SimpleCPUOffloadScheduler:
         # the rest will be released along with the temp pin below.
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-            )
+            g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
             assert num_external_tokens % g_block_size == 0, (
                 f"num_external_tokens={num_external_tokens} not aligned to "
                 f"group {g} block_size={g_block_size}"
@@ -372,9 +372,7 @@ class SimpleCPUOffloadScheduler:
                 continue
 
             # Number of blocks in the computed range for this group.
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-            )
+            g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
             n_computed_g = cdiv(total_computed_tokens, g_block_size)
 
             # Back-trace: ext blocks sit at the tail of the computed range.
@@ -591,9 +589,7 @@ class SimpleCPUOffloadScheduler:
                 already_stored_g = state.num_stored_blocks[g]
                 group_gpu_ids = block_ids_by_group[g]
 
-                g_block_size = (
-                    kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-                )
+                g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
                 ready_blocks_g = aligned_tokens // g_block_size
                 scannable = group_gpu_ids[already_stored_g:ready_blocks_g]
 


### PR DESCRIPTION
## Summary

Harden MooncakeStoreConnector for Kimi-K3 hybrid DCP prefix-cache reuse.

This PR is the Mooncake external-cache layer of the Kimi-K3 DCP split. It assumes the runtime DCP support from #51705 and the core hybrid cache geometry from #53598.

## Problem

Kimi-K3 under DCP has multiple cache groups with different physical layouts: attention / MLA KV is DCP-sharded, replicated Mamba state is not DCP-sharded, local cache hits can be finer than externally transferable block regions, and external loads can fail partially and must not leave a request with mismatched group state.

Mooncake previously treated the external tier too much like a single-layout KV cache. Under hybrid DCP, that can either keep the external tier cold or load blocks that are valid for one group but invalid for another.

## Implementation Details

- **Grouped external-cache metadata:** Mooncake requests carry group-aware block metadata so sharded attention groups and replicated Mamba groups are handled independently.
- **External hit geometry:** The connector uses the same group geometry as the core cache manager, preserving the distinction between scheduler hash blocks and physical transfer blocks.
- **Safe partial coverage:** Split external loads invalidate every unattempted or failed block beyond the safe prefix boundary, so a partial external hit falls back to recompute instead of returning mixed-prefix KV.
- **Recovery semantics:** Failed loads truncate the request to a boundary every group agrees on and evict downstream group blocks.
- **Bounded PUT waves:** External PUT work is bounded so concurrent TP ranks fit inside the registered-memory owner. A batch is published only after the corresponding KV regions are actually stored.
- **Rank-local transfer compatibility:** The connector supports rank-local binding and preferred segments, matching the expected single-node external-cache ownership model.
- **No draft requirement:** The standalone validation target for this PR is no-draft DCP + core + Mooncake. Drafted Mooncake validation depends on additional PRs and is intentionally not claimed here.

## Non-Goals

- DSpark/DCP runtime attention changes are in #51705.
- Core hybrid prefix-cache geometry is in #53598.
- The full drafted Mooncake stack is integration-only until the dependent PRs land.

## Split

- Runtime DSpark/DCP support: #51705.
- Core hybrid DCP prefix-cache geometry: #53598.
- Mooncake external-cache hardening: this PR.

## Validation

Validated the no-draft DCP + core + Mooncake stack with DCP=8, prefix caching enabled, and MooncakeStoreConnector enabled.

- Smoke: passed with an end-to-end `/v1/completions` request.
- GSM8K full: 1270/1319, 96.29%, errors=0.
- Prefix cache cold/hot/reuse: cold path started at 0 hits; shared-prefix reuse reached `prefix_cache_hits_total=96768` and `prefix_cache_queries_total=189492`.
- Mooncake external-cache cold/hot/reuse: after forcing local-prefix eviction with unique long prompts, target reuse increased `external_prefix_cache_hits_total` from 0 to 3072 and recorded successful Mooncake `load_get` operations: 8 calls, 32 keys, 679477248 bytes, failed_keys=0.
- Mooncake store write path: successful `save_put` traffic was observed with failed_keys=0 during the shared-prefix and eviction probes.

## Related

Related: #51705
Related: #53598
