### PR TITLE
[V1][Scheduler] Add streaming prompt prefill support

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -274,6 +274,7 @@ def make_scheduler_output(
             req_ids=cached_req_ids,
             resumed_req_ids=set(),
             new_token_ids=[[] for _ in cached_req_ids],
+            new_prompt_token_ids=[[] for _ in cached_req_ids],
             all_token_ids={},
             new_block_ids=cached_new_block_ids,
             num_computed_tokens=[0] * len(cached_req_ids),

--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vllm.engine.protocol import StreamingInput
+from vllm.exceptions import VLLMValidationError
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.core_client import DPLBAsyncMPClient
 from vllm.v1.engine.output_processor import RequestOutputCollector
 
 
@@ -170,3 +172,50 @@ async def test_generate_with_async_generator():
     assert outputs[2].finished is True
     # Both inputs were processed
     assert inputs_received == ["Hello", " world"]
+
+
+@pytest.mark.asyncio
+async def test_add_streaming_prompt_request_rejects_multiple_outputs():
+    llm = MagicMock(spec=AsyncLLM)
+    llm.errored = False
+    llm.add_streaming_prompt_request = AsyncLLM.add_streaming_prompt_request.__get__(
+        llm, AsyncLLM
+    )
+    llm._validate_streaming_input_sampling_params = (
+        AsyncLLM._validate_streaming_input_sampling_params
+    )
+
+    request = MagicMock()
+    request.params = SamplingParams(n=2)
+
+    with pytest.raises(VLLMValidationError, match="n > 1"):
+        await llm.add_streaming_prompt_request(request)
+
+
+@pytest.mark.asyncio
+async def test_dplb_streaming_prompt_utilities_route_to_owning_engine():
+    client = object.__new__(DPLBAsyncMPClient)
+    request_id = "streaming-prompt"
+    engine = b"\x01\x00"
+    client.reqs_in_flight = {request_id: engine}
+    client._call_utility_async = AsyncMock(return_value={"ok": True})
+
+    append_result = await client.append_streaming_prompt_tokens_async(
+        request_id, [4, 5]
+    )
+    finalize_result = await client.finalize_streaming_prompt_async(request_id)
+    metrics_result = await client.get_streaming_prompt_metrics_async(request_id)
+
+    assert append_result == {"ok": True}
+    assert finalize_result == {"ok": True}
+    assert metrics_result == {"ok": True}
+    client._call_utility_async.assert_any_await(
+        "append_streaming_prompt_tokens", request_id, [4, 5], engine=engine
+    )
+    client._call_utility_async.assert_any_await(
+        "finalize_streaming_prompt", request_id, engine=engine
+    )
+    client._call_utility_async.assert_any_await(
+        "get_streaming_prompt_metrics", request_id, engine=engine
+    )
+    assert client._call_utility_async.await_count == 3

--- a/tests/v1/streaming_input/test_gpu_model_runner_streaming.py
+++ b/tests/v1/streaming_input/test_gpu_model_runner_streaming.py
@@ -6,6 +6,7 @@
 from unittest.mock import Mock
 
 import pytest
+import torch
 
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
@@ -18,6 +19,17 @@ from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 # Not cpu_test: InputBatch allocates pinned (UVA) memory, which requires a
 # CUDA device even though the batch tensors live on the CPU.
+
+
+def test_streaming_prompt_prefill_only_request_discarded_before_finalize():
+    mask = GPUModelRunner._compute_discard_request_mask(
+        req_ids=["normal_req", "streaming_prompt_req", "partial_prefill_req"],
+        num_tokens=[5, 5, 8],
+        optimistic_seq_lens_cpu=torch.tensor([5, 5, 7], dtype=torch.int32),
+        prefill_only_req_ids={"streaming_prompt_req"},
+    )
+
+    assert mask.tolist() == [False, True, True]
 
 
 @pytest.fixture

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -106,6 +106,92 @@ class TestStreamingScheduler(unittest.TestCase):
         assert next_request.status == RequestStatus.WAITING
         assert len(scheduler.requests["test_request"].streaming_queue) == 1
 
+    def test_streaming_prompt_append_finalize_lifecycle(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(
+            request_id="streaming_prompt",
+            resumable=False,
+            prompt_token_ids=[1, 2, 3],
+        )
+
+        scheduler.add_streaming_prompt_request(request)
+
+        assert request.streaming_prompt
+        assert not request.streaming_prompt_finalized
+        assert request.status == RequestStatus.WAITING
+
+        scheduler.append_streaming_prompt_tokens("streaming_prompt", [4, 5])
+
+        assert request.prompt_token_ids == [1, 2, 3, 4, 5]
+        assert request.num_prompt_tokens == 5
+        assert request.streaming_prompt_appended_tokens == 2
+
+        scheduler.finalize_streaming_prompt("streaming_prompt")
+
+        assert request.streaming_prompt_finalized
+
+    def test_streaming_prompt_schedule_holds_final_prompt_token(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(
+            request_id="streaming_prompt",
+            resumable=False,
+            prompt_token_ids=[1, 2, 3, 4],
+        )
+        scheduler.add_streaming_prompt_request(request)
+
+        first = scheduler.schedule()
+
+        assert first.num_scheduled_tokens["streaming_prompt"] == 3
+        assert first.prefill_only_req_ids == {"streaming_prompt"}
+        assert request.status == RequestStatus.RUNNING
+        assert request.num_computed_tokens == 3
+
+        second = scheduler.schedule()
+
+        assert "streaming_prompt" not in second.num_scheduled_tokens
+        assert request.status == RequestStatus.WAITING_FOR_STREAMING_PROMPT
+
+        scheduler.finalize_streaming_prompt("streaming_prompt")
+        third = scheduler.schedule()
+
+        assert third.num_scheduled_tokens["streaming_prompt"] == 1
+        assert third.prefill_only_req_ids == set()
+
+    def test_streaming_prompt_append_requeues_waiting_request(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(
+            request_id="streaming_prompt",
+            resumable=False,
+            prompt_token_ids=[1, 2, 3, 4],
+        )
+        scheduler.add_streaming_prompt_request(request)
+
+        scheduler.schedule()
+        scheduler.schedule()
+
+        assert request.status == RequestStatus.WAITING_FOR_STREAMING_PROMPT
+
+        scheduler.append_streaming_prompt_tokens("streaming_prompt", [5, 6])
+        scheduled = scheduler.schedule()
+
+        assert request.status == RequestStatus.RUNNING
+        assert scheduled.num_scheduled_tokens["streaming_prompt"] == 2
+        assert scheduled.prefill_only_req_ids == {"streaming_prompt"}
+        assert request.num_computed_tokens == 5
+
+    def test_streaming_prompt_rejects_append_after_finalize(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(
+            request_id="streaming_prompt",
+            resumable=False,
+            prompt_token_ids=[1, 2, 3],
+        )
+        scheduler.add_streaming_prompt_request(request)
+        scheduler.finalize_streaming_prompt("streaming_prompt")
+
+        with self.assertRaises(RuntimeError):
+            scheduler.append_streaming_prompt_tokens("streaming_prompt", [4])
+
     def test_update_request_as_session_max_token(self):
         scheduler = create_scheduler()
 

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -179,6 +179,42 @@ class TestStreamingScheduler(unittest.TestCase):
         assert scheduled.prefill_only_req_ids == {"streaming_prompt"}
         assert request.num_computed_tokens == 5
 
+    def test_streaming_prompt_cached_append_sends_new_prompt_tokens(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(
+            request_id="streaming_prompt",
+            resumable=False,
+            prompt_token_ids=[1, 2, 3, 4],
+        )
+        scheduler.add_streaming_prompt_request(request)
+
+        first = scheduler.schedule()
+
+        assert first.scheduled_new_reqs[0].prompt_token_ids == [1, 2, 3, 4]
+        assert first.num_scheduled_tokens["streaming_prompt"] == 3
+        assert request.num_computed_tokens == 3
+
+        scheduler.append_streaming_prompt_tokens("streaming_prompt", [5, 6])
+        second = scheduler.schedule()
+
+        assert second.scheduled_new_reqs == []
+        assert second.scheduled_cached_reqs.req_ids == ["streaming_prompt"]
+        assert second.scheduled_cached_reqs.new_prompt_token_ids == [[5, 6]]
+        assert second.num_scheduled_tokens["streaming_prompt"] == 2
+        assert second.prefill_only_req_ids == {"streaming_prompt"}
+
+    def test_streaming_prompt_append_rejects_max_model_len_overflow(self):
+        scheduler = create_scheduler()
+        request = DummyRequest(
+            request_id="streaming_prompt",
+            resumable=False,
+            prompt_token_ids=[1] * (scheduler.max_model_len - 1),
+        )
+        scheduler.add_streaming_prompt_request(request)
+
+        with self.assertRaises(ValueError):
+            scheduler.append_streaming_prompt_tokens("streaming_prompt", [2])
+
     def test_streaming_prompt_rejects_append_after_finalize(self):
         scheduler = create_scheduler()
         request = DummyRequest(

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -240,6 +240,7 @@ def _schedule_cached_requests(
             req_ids=req_ids,
             resumed_req_ids=set(),
             new_token_ids=new_token_ids,
+            new_prompt_token_ids=[[] for _ in req_ids],
             all_token_ids={},
             new_block_ids=[None] * len(req_ids),
             num_computed_tokens=num_computed_tokens,
@@ -566,6 +567,7 @@ def test_update_states_request_resumed(model_runner, dist_init):
         req_ids=[req_id],
         resumed_req_ids=set(),
         new_token_ids=[[]],
+        new_prompt_token_ids=[[]],
         all_token_ids={},
         new_block_ids=[([0],)],
         num_computed_tokens=[0],
@@ -590,6 +592,51 @@ def test_update_states_request_resumed(model_runner, dist_init):
     assert _is_req_added(model_runner, req_id)
     assert _is_req_scheduled(model_runner, req_id)
     assert _is_req_state_block_table_match(model_runner, req_id)
+
+
+def test_update_states_streaming_prompt_append_updates_token_buffers(
+    model_runner, dist_init
+):
+    req_id = "req_0"
+    model_runner._update_states(_schedule_new_request(req_id))
+
+    cached_req_data = CachedRequestData(
+        req_ids=[req_id],
+        resumed_req_ids=set(),
+        new_token_ids=[[]],
+        new_prompt_token_ids=[[4, 5]],
+        all_token_ids={},
+        new_block_ids=[None],
+        num_computed_tokens=[3],
+        num_output_tokens=[0],
+    )
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=cached_req_data,
+        num_scheduled_tokens={req_id: 2},
+        total_num_scheduled_tokens=2,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    model_runner._update_states(scheduler_output)
+
+    req_state = model_runner.requests[req_id]
+    req_index = model_runner.input_batch.req_id_to_index[req_id]
+    assert req_state.prompt_token_ids == [1, 2, 3, 4, 5]
+    assert req_state.num_prompt_tokens == 5
+    assert model_runner.input_batch.num_prompt_tokens[req_index] == 5
+    assert model_runner.input_batch.token_ids_cpu[req_index, :5].tolist() == [
+        1,
+        2,
+        3,
+        4,
+        5,
+    ]
+    assert model_runner.input_batch.is_token_ids[req_index, :5].all()
 
 
 def test_get_nans_in_logits(model_runner, dist_init, monkeypatch):

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -4,6 +4,7 @@
 import contextlib
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 
@@ -296,3 +297,60 @@ def test_capture_model_profile_only_skips_lock(monkeypatch):
     runner.capture_model(profile_only=True)
 
     assert lock_calls == []
+
+
+def test_update_requests_streaming_prompt_append_updates_v2_req_state():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+
+    class _ReqStates:
+        req_id_to_index = {"req-1": 0}
+        num_computed_tokens_np = np.zeros(1, dtype=np.int32)
+        prefill_len = SimpleNamespace(np=np.array([5], dtype=np.int32))
+        num_computed_prefill_tokens = np.zeros(1, dtype=np.int32)
+        max_seq_len = np.array([9], dtype=np.int32)
+
+        def __init__(self):
+            self.appended: list[tuple[str, list[int]]] = []
+            self.applied = False
+
+        def append_prompt_token_ids(self, req_id: str, token_ids: list[int]) -> None:
+            self.appended.append((req_id, token_ids))
+            self.prefill_len.np[0] += len(token_ids)
+            self.max_seq_len[0] += len(token_ids)
+
+        def apply_staged_writes(self) -> None:
+            self.applied = True
+
+    class _BlockTables:
+        def __init__(self):
+            self.appended: list[tuple[int, tuple[list[int]], bool]] = []
+
+        def append_block_ids(
+            self, req_index: int, new_block_ids: tuple[list[int]], overwrite: bool
+        ) -> None:
+            self.appended.append((req_index, new_block_ids, overwrite))
+
+    runner.req_states = _ReqStates()
+    runner.block_tables = _BlockTables()
+    runner.kv_block_zeroer = None
+
+    scheduler_output = SimpleNamespace(
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=["req-1"],
+            num_computed_tokens=[3],
+            new_block_ids=[([7],)],
+            new_prompt_token_ids=[[11, 12]],
+        ),
+        block_table_updates=None,
+        new_block_ids_to_zero=[],
+        kv_cache_block_copies={},
+    )
+
+    GPUModelRunner.update_requests(runner, scheduler_output)
+
+    assert runner.req_states.num_computed_tokens_np[0] == 3
+    assert runner.req_states.num_computed_prefill_tokens[0] == 3
+    assert runner.req_states.max_seq_len[0] == 11
+    assert runner.req_states.appended == [("req-1", [11, 12])]
+    assert runner.req_states.applied
+    assert runner.block_tables.appended == [(0, ([7],), False)]

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -295,6 +295,7 @@ class TestAnnotateProfile:
             req_ids=["gen1"],
             resumed_req_ids=set(),
             new_token_ids=[],
+            new_prompt_token_ids=[[]],
             all_token_ids={},
             new_block_ids=[],
             num_computed_tokens=[10],

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -137,6 +137,9 @@ class CachedRequestData:
     # NOTE(woosuk): new_token_ids is only used for pipeline parallelism.
     # When PP is not used, new_token_ids will be empty.
     new_token_ids: list[list[int]]
+    # Prompt token IDs appended to cached streaming-prompt requests since the
+    # last time they were sent to the worker.
+    new_prompt_token_ids: list[list[int]]
     # MRV1-only: For requests not scheduled in the last step, propagate the token ids
     # to the connector. Won't contain requests scheduled in the prior step.
     all_token_ids: dict[str, list[int]]
@@ -147,6 +150,7 @@ class CachedRequestData:
     # Version of dataclass repr with token IDs obfuscated.
     def anon_repr(self) -> str:
         new_token_ids_lens = [len(toks) for toks in self.new_token_ids]
+        new_prompt_token_ids_lens = [len(toks) for toks in self.new_prompt_token_ids]
         all_token_ids_lens = {
             req_id: len(toks) for req_id, toks in self.all_token_ids.items()
         }
@@ -155,6 +159,7 @@ class CachedRequestData:
             f"req_ids={self.req_ids},"
             f"resumed_req_ids={self.resumed_req_ids},"
             f"new_token_ids_lens={new_token_ids_lens},"
+            f"new_prompt_token_ids_lens={new_prompt_token_ids_lens},"
             f"all_token_ids_lens={all_token_ids_lens},"
             f"new_block_ids={self.new_block_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
@@ -189,6 +194,7 @@ class CachedRequestData:
             req_ids=[],
             resumed_req_ids=set(),
             new_token_ids=[],
+            new_prompt_token_ids=[],
             all_token_ids={},
             new_block_ids=[],
             num_computed_tokens=[],

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -259,6 +259,10 @@ class SchedulerOutput:
     free_encoder_mm_hashes: list[str]
 
     scheduled_encoder_input_stats: ScheduledEncoderInputStats | None = None
+
+    # Requests scheduled only to populate prompt KV. Workers must not return
+    # sampled output tokens for these requests in this scheduler step.
+    prefill_only_req_ids: set[str] = field(default_factory=set)
 
     # Request IDs that are preempted in this step.
     # Only used for v2 model runner.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -411,6 +411,25 @@ class Scheduler(SchedulerInterface):
         # async KV loads). Their remaining-block reservation gates async loads.
         self._inflight_prefills: set[Request] = set()
 
+    @staticmethod
+    def _is_unfinalized_streaming_prompt(request: Request) -> bool:
+        return request.streaming_prompt and not request.streaming_prompt_finalized
+
+    @staticmethod
+    def _streaming_prompt_prefill_budget(
+        request: Request, num_computed_tokens: int
+    ) -> int | None:
+        """Return max schedulable prompt tokens before streaming-prompt finalize.
+
+        An unfinalized streaming-prompt request keeps the final prompt token
+        unscheduled. That preserves the normal first-token path after
+        finalize_streaming_prompt() while still allowing earlier prompt chunks to
+        populate KV cache.
+        """
+        if not Scheduler._is_unfinalized_streaming_prompt(request):
+            return None
+        return max(request.num_prompt_tokens - 1 - num_computed_tokens, 0)
+
     def _mamba_block_aligned_split(
         self,
         request: Request,
@@ -673,6 +692,16 @@ class Scheduler(SchedulerInterface):
                 - request.num_computed_tokens
                 - self.num_sampled_tokens_per_step,
             )
+            streaming_prompt_budget = self._streaming_prompt_prefill_budget(
+                request, request.num_computed_tokens
+            )
+            if streaming_prompt_budget is not None:
+                num_new_tokens = min(num_new_tokens, streaming_prompt_budget)
+                if num_new_tokens == 0:
+                    request.status = RequestStatus.WAITING_FOR_STREAMING_PROMPT
+                    self.running.pop(req_index)
+                    self._enqueue_waiting_request(request)
+                    continue
 
             # Apply Mamba alignment before encoder caps.
             if self.need_mamba_block_aligned_split:
@@ -1079,6 +1108,16 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, request_token_budget)
+                    streaming_prompt_budget = self._streaming_prompt_prefill_budget(
+                        request, num_computed_tokens
+                    )
+                    if streaming_prompt_budget is not None:
+                        num_new_tokens = min(num_new_tokens, streaming_prompt_budget)
+                        if num_new_tokens == 0:
+                            request_queue.pop_request()
+                            request.status = RequestStatus.WAITING_FOR_STREAMING_PROMPT
+                            step_skipped_waiting.prepend_request(request)
+                            continue
                     assert num_new_tokens > 0
 
                     # Apply Mamba alignment before encoder caps.
@@ -1405,11 +1444,20 @@ class Scheduler(SchedulerInterface):
                 scheduled_encoder_inputs
             )
 
+        prefill_only_req_ids = {
+            req.request_id
+            for req in itertools.chain(
+                scheduled_new_reqs, scheduled_resumed_reqs, scheduled_running_reqs
+            )
+            if self._is_unfinalized_streaming_prompt(req)
+        }
+
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
             num_scheduled_tokens=num_scheduled_tokens,
             total_num_scheduled_tokens=total_num_scheduled_tokens,
+            prefill_only_req_ids=prefill_only_req_ids,
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
             scheduled_encoder_inputs=scheduled_encoder_inputs,
             scheduled_encoder_input_stats=scheduled_encoder_input_stats,
@@ -2322,6 +2370,7 @@ class Scheduler(SchedulerInterface):
             RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR,
             RequestStatus.WAITING_FOR_REMOTE_KVS,
             RequestStatus.WAITING_FOR_STREAMING_REQ,
+            RequestStatus.WAITING_FOR_STREAMING_PROMPT,
         )
 
     def _enqueue_waiting_request(self, request: Request) -> None:
@@ -2513,6 +2562,52 @@ class Scheduler(SchedulerInterface):
                 self.connector.on_new_request(request)
             if self.log_stats:
                 request.record_event(EngineCoreEventType.QUEUED)
+
+    def add_streaming_prompt_request(self, request: Request) -> None:
+        """Add a request whose prompt may grow before decode starts."""
+        request.streaming_prompt = True
+        request.streaming_prompt_finalized = False
+        self.add_request(request)
+
+    def append_streaming_prompt_tokens(
+        self, request_id: str, token_ids: list[int]
+    ) -> None:
+        request = self.requests[request_id]
+        request.append_streaming_prompt_token_ids(token_ids)
+        if request.status == RequestStatus.WAITING_FOR_STREAMING_PROMPT:
+            request.status = RequestStatus.WAITING
+            self.skipped_waiting.remove_requests({request})
+            self.waiting.add_request(request)
+            if self.log_stats:
+                request.record_event(EngineCoreEventType.QUEUED)
+
+    def finalize_streaming_prompt(self, request_id: str) -> None:
+        request = self.requests[request_id]
+        if not request.streaming_prompt:
+            raise RuntimeError(f"{request_id} is not a streaming-prompt request")
+        request.streaming_prompt_finalized = True
+        if request.status == RequestStatus.WAITING_FOR_STREAMING_PROMPT:
+            request.status = RequestStatus.WAITING
+            self.skipped_waiting.remove_requests({request})
+            self.waiting.add_request(request)
+            if self.log_stats:
+                request.record_event(EngineCoreEventType.QUEUED)
+
+    def get_streaming_prompt_metrics(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        request = self.requests[request_id]
+        return {
+            "streaming_prompt": request.streaming_prompt,
+            "streaming_prompt_finalized": request.streaming_prompt_finalized,
+            "num_prompt_tokens": request.num_prompt_tokens,
+            "num_tokens": request.num_tokens,
+            "num_computed_tokens": request.num_computed_tokens,
+            "appended_tokens": request.streaming_prompt_appended_tokens,
+            "num_output_tokens": request.num_output_tokens,
+            "status": request.status.name,
+            "is_finished": request.is_finished(),
+        }
 
     def finish_requests(
         self, request_ids: str | Iterable[str] | None, finished_status: RequestStatus
@@ -3007,6 +3102,14 @@ class Scheduler(SchedulerInterface):
 
         if request.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
             assert not request.streaming_queue
+            return False
+
+        if request.status == RequestStatus.WAITING_FOR_STREAMING_PROMPT:
+            if request.streaming_prompt_finalized or (
+                request.num_computed_tokens < request.num_prompt_tokens - 1
+            ):
+                request.status = RequestStatus.WAITING
+                return True
             return False
 
         raise AssertionError(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1593,6 +1593,8 @@ class Scheduler(SchedulerInterface):
             # Drop from the in-flight-prefill set once it's no longer prefilling.
             if not request.is_prefill_chunk:
                 self._inflight_prefills.discard(request)
+            if request.streaming_prompt_appended_tokens:
+                request.streaming_prompt_appended_tokens = 0
 
         # Snapshot block IDs for routed experts before forward starts.
         # A concurrent schedule() may preempt requests and free blocks
@@ -1669,6 +1671,7 @@ class Scheduler(SchedulerInterface):
     ) -> CachedRequestData:
         req_ids: list[str] = []
         new_token_ids: list[list[int]] = []
+        new_prompt_token_ids: list[list[int]] = []
         new_block_ids: list[tuple[list[int], ...] | None] = []
         all_token_ids: dict[str, list[int]] = {}
         num_computed_tokens: list[int] = []
@@ -1695,6 +1698,13 @@ class Scheduler(SchedulerInterface):
                     req.num_computed_tokens : req.num_computed_tokens + num_tokens
                 ]
                 new_token_ids.append(token_ids)
+            if req.streaming_prompt and req.streaming_prompt_appended_tokens:
+                assert req.prompt_token_ids is not None
+                new_prompt_token_ids.append(
+                    req.prompt_token_ids[-req.streaming_prompt_appended_tokens :]
+                )
+            else:
+                new_prompt_token_ids.append([])
             if idx >= num_running_reqs:
                 resumed_req_ids.add(req_id)
             if not self.use_v2_model_runner:  # noqa: SIM102
@@ -1712,6 +1722,7 @@ class Scheduler(SchedulerInterface):
             req_ids=req_ids,
             resumed_req_ids=resumed_req_ids,
             new_token_ids=new_token_ids,
+            new_prompt_token_ids=new_prompt_token_ids,
             all_token_ids=all_token_ids,
             new_block_ids=new_block_ids,
             num_computed_tokens=num_computed_tokens,
@@ -2573,6 +2584,13 @@ class Scheduler(SchedulerInterface):
         self, request_id: str, token_ids: list[int]
     ) -> None:
         request = self.requests[request_id]
+        new_prompt_len = request.num_prompt_tokens + len(token_ids)
+        if new_prompt_len >= self.max_model_len:
+            raise ValueError(
+                f"Appending {len(token_ids)} streaming prompt token(s) would "
+                f"make the decoder prompt length {new_prompt_len}, which is "
+                f"not smaller than max_model_len {self.max_model_len}."
+            )
         request.append_streaming_prompt_token_ids(token_ids)
         if request.status == RequestStatus.WAITING_FOR_STREAMING_PROMPT:
             request.status = RequestStatus.WAITING

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -291,6 +291,7 @@ class EngineCoreRequestType(enum.Enum):
     ABORT = b"\x01"
     START_DP_WAVE = b"\x02"
     UTILITY = b"\x03"
+    ADD_STREAMING_PROMPT = b"\x06"
     # Sentinel used within EngineCoreProc.
     EXECUTOR_FAILED = b"\x04"
     # Sentinel to wake up input_queue.get() during shutdown.

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -523,6 +523,7 @@ class AsyncLLM(EngineClient):
         """Add a request whose prompt can be appended before decode starts."""
         if self.errored:
             raise EngineDeadError()
+        self._validate_streaming_input_sampling_params(request.params)
 
         self.input_processor.assign_request_id(request)
         self._run_output_handler()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -497,6 +497,7 @@ class AsyncLLM(EngineClient):
         parent_req: ParentRequest | None,
         index: int,
         queue: RequestOutputCollector,
+        streaming_prompt: bool = False,
     ):
         if parent_req is None and not self.output_processor.has_request(
             request.request_id
@@ -507,10 +508,50 @@ class AsyncLLM(EngineClient):
         self.output_processor.add_request(request, prompt, parent_req, index, queue)
 
         # Add the EngineCoreRequest to EngineCore (separate process).
-        await self.engine_core.add_request_async(request)
+        if streaming_prompt:
+            await self.engine_core.add_streaming_prompt_request_async(request)
+        else:
+            await self.engine_core.add_request_async(request)
 
         if self.log_requests:
-            logger.info("Added request %s.", request.request_id)
+            request_kind = "streaming prompt request" if streaming_prompt else "request"
+            logger.info("Added %s %s.", request_kind, request.request_id)
+
+    async def add_streaming_prompt_request(
+        self, request: EngineCoreRequest, prompt_text: str | None = None
+    ) -> RequestOutputCollector:
+        """Add a request whose prompt can be appended before decode starts."""
+        if self.errored:
+            raise EngineDeadError()
+
+        self.input_processor.assign_request_id(request)
+        self._run_output_handler()
+
+        queue = RequestOutputCollector(request.params.output_kind, request.request_id)
+        await self._add_request(
+            request, prompt_text, None, 0, queue, streaming_prompt=True
+        )
+        return queue
+
+    async def append_streaming_prompt_tokens(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        """Append prompt tokens to a streaming-prompt request."""
+        return await self.engine_core.append_streaming_prompt_tokens_async(
+            request_id, token_ids
+        )
+
+    async def finalize_streaming_prompt(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        """Finalize prompt growth and allow normal decode to start."""
+        return await self.engine_core.finalize_streaming_prompt_async(request_id)
+
+    async def get_streaming_prompt_metrics(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        """Return scheduler-side streaming-prompt metrics."""
+        return await self.engine_core.get_streaming_prompt_metrics_async(request_id)
 
     async def _add_streaming_input_request(
         self,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -487,6 +487,27 @@ class EngineCore:
             # to free any pre-admission KV-transfer resources.
             self.abort_requests([request.request_id])
 
+    def add_streaming_prompt_request(self, request: Request, request_wave: int = 0):
+        """Add a request whose prompt may grow before decode starts."""
+        request.streaming_prompt = True
+        request.streaming_prompt_finalized = False
+        self.add_request(request, request_wave)
+
+    def append_streaming_prompt_tokens(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        self.scheduler.append_streaming_prompt_tokens(request_id, token_ids)
+        return self.get_streaming_prompt_metrics(request_id)
+
+    def finalize_streaming_prompt(self, request_id: str) -> dict[str, int | bool | str]:
+        self.scheduler.finalize_streaming_prompt(request_id)
+        return self.get_streaming_prompt_metrics(request_id)
+
+    def get_streaming_prompt_metrics(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        return self.scheduler.get_streaming_prompt_metrics(request_id)
+
     def abort_requests(self, request_ids: list[str]):
         """Abort requests from the scheduler."""
 
@@ -1541,6 +1562,11 @@ class EngineCoreProc(EngineCore):
             if self._reject_add_in_shutdown(req):
                 return
             self.add_request(req, request_wave)
+        elif request_type == EngineCoreRequestType.ADD_STREAMING_PROMPT:
+            req, request_wave = request
+            if self._reject_add_in_shutdown(req):
+                return
+            self.add_streaming_prompt_request(req, request_wave)
         elif request_type == EngineCoreRequestType.ABORT:
             self.abort_requests(request)
         elif request_type == EngineCoreRequestType.UTILITY:
@@ -1753,7 +1779,10 @@ class EngineCoreProc(EngineCore):
 
                     # Deserialize the request data.
                     request: Any
-                    if request_type == EngineCoreRequestType.ADD:
+                    if request_type in (
+                        EngineCoreRequestType.ADD,
+                        EngineCoreRequestType.ADD_STREAMING_PROMPT,
+                    ):
                         req: EngineCoreRequest = add_request_decoder.decode(data_frames)
                         try:
                             request = self.preprocess_add_request(req)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -177,6 +177,22 @@ class EngineCoreClient(ABC):
     def add_request(self, request: EngineCoreRequest) -> None:
         raise NotImplementedError
 
+    def add_streaming_prompt_request(self, request: EngineCoreRequest) -> None:
+        raise NotImplementedError
+
+    def append_streaming_prompt_tokens(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        raise NotImplementedError
+
+    def finalize_streaming_prompt(self, request_id: str) -> dict[str, int | bool | str]:
+        raise NotImplementedError
+
+    def get_streaming_prompt_metrics(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        raise NotImplementedError
+
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
         raise NotImplementedError
 
@@ -265,6 +281,26 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def add_request_async(self, request: EngineCoreRequest) -> None:
+        raise NotImplementedError
+
+    async def add_streaming_prompt_request_async(
+        self, request: EngineCoreRequest
+    ) -> None:
+        raise NotImplementedError
+
+    async def append_streaming_prompt_tokens_async(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        raise NotImplementedError
+
+    async def finalize_streaming_prompt_async(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        raise NotImplementedError
+
+    async def get_streaming_prompt_metrics_async(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
         raise NotImplementedError
 
     async def profile_async(
@@ -369,6 +405,23 @@ class InprocClient(EngineCoreClient):
     def add_request(self, request: EngineCoreRequest) -> None:
         req, request_wave = self.engine_core.preprocess_add_request(request)
         self.engine_core.add_request(req, request_wave)
+
+    def add_streaming_prompt_request(self, request: EngineCoreRequest) -> None:
+        req, request_wave = self.engine_core.preprocess_add_request(request)
+        self.engine_core.add_streaming_prompt_request(req, request_wave)
+
+    def append_streaming_prompt_tokens(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        return self.engine_core.append_streaming_prompt_tokens(request_id, token_ids)
+
+    def finalize_streaming_prompt(self, request_id: str) -> dict[str, int | bool | str]:
+        return self.engine_core.finalize_streaming_prompt(request_id)
+
+    def get_streaming_prompt_metrics(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        return self.engine_core.get_streaming_prompt_metrics(request_id)
 
     def abort_requests(self, request_ids: list[str]) -> None:
         if len(request_ids) > 0:
@@ -978,6 +1031,26 @@ class SyncMPClient(MPClient):
             self.engines_running = True
         self._send_input(EngineCoreRequestType.ADD, request)
 
+    def add_streaming_prompt_request(self, request: EngineCoreRequest) -> None:
+        if self.is_dp:
+            self.engines_running = True
+        self._send_input(EngineCoreRequestType.ADD_STREAMING_PROMPT, request)
+
+    def append_streaming_prompt_tokens(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        return self.call_utility(
+            "append_streaming_prompt_tokens", request_id, token_ids
+        )
+
+    def finalize_streaming_prompt(self, request_id: str) -> dict[str, int | bool | str]:
+        return self.call_utility("finalize_streaming_prompt", request_id)
+
+    def get_streaming_prompt_metrics(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        return self.call_utility("get_streaming_prompt_metrics", request_id)
+
     def abort_requests(self, request_ids: list[str]) -> None:
         if request_ids and not self.resources.engine_dead:
             self._send_input(EngineCoreRequestType.ABORT, request_ids)
@@ -1220,6 +1293,30 @@ class AsyncMPClient(MPClient):
         request.client_index = self.client_index
         await self._send_input(EngineCoreRequestType.ADD, request)
         self._ensure_output_queue_task()
+
+    async def add_streaming_prompt_request_async(
+        self, request: EngineCoreRequest
+    ) -> None:
+        request.client_index = self.client_index
+        await self._send_input(EngineCoreRequestType.ADD_STREAMING_PROMPT, request)
+        self._ensure_output_queue_task()
+
+    async def append_streaming_prompt_tokens_async(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        return await self.call_utility_async(
+            "append_streaming_prompt_tokens", request_id, token_ids
+        )
+
+    async def finalize_streaming_prompt_async(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        return await self.call_utility_async("finalize_streaming_prompt", request_id)
+
+    async def get_streaming_prompt_metrics_async(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        return await self.call_utility_async("get_streaming_prompt_metrics", request_id)
 
     async def abort_requests_async(self, request_ids: list[str]) -> None:
         if request_ids and not self.resources.engine_dead:
@@ -1493,6 +1590,26 @@ class DPAsyncMPClient(AsyncMPClient):
         to_await = self._send_input(EngineCoreRequestType.ADD, request, chosen_engine)
         if not self.engines_running:
             # Notify coordinator that we're sending a request
+            req_msg = msgspec.msgpack.encode(("FIRST_REQ", chosen_engine))
+            await self.first_req_send_socket.send(req_msg)
+
+        await to_await
+
+        self._ensure_output_queue_task()
+
+    async def add_streaming_prompt_request_async(
+        self, request: EngineCoreRequest
+    ) -> None:
+        self._ensure_stats_update_task()
+
+        request.current_wave = self.current_wave
+        request.client_index = self.client_index
+
+        chosen_engine = self.get_core_engine_for_request(request)
+        to_await = self._send_input(
+            EngineCoreRequestType.ADD_STREAMING_PROMPT, request, chosen_engine
+        )
+        if not self.engines_running:
             req_msg = msgspec.msgpack.encode(("FIRST_REQ", chosen_engine))
             await self.first_req_send_socket.send(req_msg)
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1724,6 +1724,36 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             )
         )[0]
 
+    async def _call_streaming_prompt_utility_async(
+        self, method: str, request_id: str, *args
+    ) -> dict[str, int | bool | str]:
+        if engine := self.reqs_in_flight.get(request_id):
+            return await self._call_utility_async(
+                method, request_id, *args, engine=engine
+            )
+        return await super().call_utility_async(method, request_id, *args)
+
+    async def append_streaming_prompt_tokens_async(
+        self, request_id: str, token_ids: list[int]
+    ) -> dict[str, int | bool | str]:
+        return await self._call_streaming_prompt_utility_async(
+            "append_streaming_prompt_tokens", request_id, token_ids
+        )
+
+    async def finalize_streaming_prompt_async(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        return await self._call_streaming_prompt_utility_async(
+            "finalize_streaming_prompt", request_id
+        )
+
+    async def get_streaming_prompt_metrics_async(
+        self, request_id: str
+    ) -> dict[str, int | bool | str]:
+        return await self._call_streaming_prompt_utility_async(
+            "get_streaming_prompt_metrics", request_id
+        )
+
     @staticmethod
     async def process_engine_outputs(
         self: "DPLBAsyncMPClient", outputs: EngineCoreOutputs

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -230,6 +230,16 @@ class Request:
         # None entry in the queue means finished.
         self.streaming_queue: deque[StreamingUpdate | None] | None = None
 
+        # Streaming prompt prefill state.
+        #
+        # A streaming-prompt request can grow its prompt before decode starts.
+        # The scheduler may prefill appended prompt tokens while decode is not
+        # finalized, but workers must not return user-visible sampled tokens
+        # until finalize_streaming_prompt() is called.
+        self.streaming_prompt = False
+        self.streaming_prompt_finalized = True
+        self.streaming_prompt_appended_tokens = 0
+
         # If True, request should be aborted immediately after being added to
         # the scheduler so the connector's request_finished hook runs.
         self.abort_immediately = abort_immediately
@@ -360,6 +370,25 @@ class Request:
             return self.request_id < other.request_id
         return id(self) < id(other)
 
+    def append_streaming_prompt_token_ids(self, token_ids: list[int]) -> None:
+        """Append prompt tokens to an unfinalized streaming-prompt request."""
+        if not self.streaming_prompt:
+            raise RuntimeError("append requires a streaming-prompt request")
+        if self.streaming_prompt_finalized:
+            raise RuntimeError("cannot append tokens after streaming prompt finalize")
+        if self.prompt_token_ids is None:
+            raise RuntimeError("streaming prompt append requires prompt_token_ids")
+        if self.prompt_embeds is not None:
+            raise RuntimeError("streaming prompt append does not support prompt_embeds")
+        if not token_ids:
+            return
+
+        self.prompt_token_ids.extend(token_ids)
+        self._all_token_ids.extend(token_ids)
+        self.num_prompt_tokens = len(self.prompt_token_ids)
+        self.streaming_prompt_appended_tokens += len(token_ids)
+        self.update_block_hashes()
+
 
 class RequestStatus(enum.IntEnum):
     """Status of a request."""
@@ -368,6 +397,7 @@ class RequestStatus(enum.IntEnum):
     WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR = enum.auto()
     WAITING_FOR_REMOTE_KVS = enum.auto()
     WAITING_FOR_STREAMING_REQ = enum.auto()
+    WAITING_FOR_STREAMING_PROMPT = enum.auto()
     RUNNING = enum.auto()
     PREEMPTED = enum.auto()
     # Note: anything after PREEMPTED will be considered

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1147,15 +1147,25 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if (idx := self.req_states.req_id_to_index.get(req_id)) is not None:
                 self.block_tables.append_block_ids(idx, block_ids, overwrite=True)
         num_computed_tokens_np = self.req_states.num_computed_tokens_np
-        for req_id, num_computed_tokens, req_new_block_ids in zip(
-            reqs.req_ids, reqs.num_computed_tokens, reqs.new_block_ids
+        prompt_tokens_appended = False
+        for req_id, num_computed_tokens, req_new_block_ids, new_prompt_token_ids in zip(
+            reqs.req_ids,
+            reqs.num_computed_tokens,
+            reqs.new_block_ids,
+            reqs.new_prompt_token_ids,
         ):
             req_index = self.req_states.req_id_to_index[req_id]
             num_computed_tokens_np[req_index] = num_computed_tokens
+            if new_prompt_token_ids:
+                self.req_states.append_prompt_token_ids(req_id, new_prompt_token_ids)
+                prompt_tokens_appended = True
             if req_new_block_ids is not None and req_id not in table_updates:
                 self.block_tables.append_block_ids(
                     req_index, req_new_block_ids, overwrite=False
                 )
+
+        if prompt_tokens_appended:
+            self.req_states.apply_staged_writes()
 
         # Update CPU num_computed_prefill_tokens.
         np.minimum(

--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -116,6 +116,25 @@ class RequestState:
 
         self.draft_tokens[req_idx].zero_()
 
+    def append_prompt_token_ids(self, req_id: str, token_ids: list[int]) -> None:
+        if not token_ids:
+            return
+
+        req_idx = self.req_id_to_index[req_id]
+        start = int(self.prompt_len.np[req_idx])
+        end = start + len(token_ids)
+        if end > self.max_model_len:
+            raise ValueError(
+                f"Appending {len(token_ids)} prompt tokens to request {req_id} "
+                f"would exceed max_model_len ({end} > {self.max_model_len})."
+            )
+
+        self.all_token_ids.stage_write(req_idx, start, token_ids)
+        self.prompt_len.np[req_idx] = end
+        self.prefill_len.np[req_idx] = end
+        self.total_len.stage_write_elem(req_idx, end)
+        self.max_seq_len[req_idx] += len(token_ids)
+
     def apply_staged_writes(self) -> None:
         self.prompt_len.copy_to_uva()
         self.prefill_len.copy_to_uva()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1788,6 +1788,27 @@ class GPUModelRunner(
         for i, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
             prev_positions[i] = prev_req_id_to_index.get(req_id, -1)
 
+    @staticmethod
+    def _compute_discard_request_mask(
+        req_ids: list[str],
+        num_tokens: list[int],
+        optimistic_seq_lens_cpu: torch.Tensor,
+        prefill_only_req_ids: set[str],
+    ) -> np.ndarray:
+        """Return requests whose sampled tokens must be discarded.
+
+        A request is discarded when the current step did not reach the end of
+        its known tokens, or when the scheduler explicitly marks it as
+        prefill-only. Streaming-prompt requests use the latter path to compute
+        KV cache while preventing decode before finalize.
+        """
+        num_tokens_np = np.array(num_tokens, dtype=np.int32)
+        prefill_only_mask = np.array(
+            [req_id in prefill_only_req_ids for req_id in req_ids],
+            dtype=bool,
+        )
+        return (optimistic_seq_lens_cpu.numpy() < num_tokens_np) | prefill_only_mask
+
     def _prepare_input_ids(
         self,
         scheduler_output: "SchedulerOutput",
@@ -2102,13 +2123,15 @@ class GPUModelRunner(
         prev_req_id_to_index = self.input_batch.prev_req_id_to_index
         self._compute_prev_positions(num_reqs)
 
-        num_tokens = [self.requests[r].num_tokens for r in self.input_batch.req_ids]
-        num_tokens_np = np.array(num_tokens, dtype=np.int32)
-
-        # Record which requests should not be sampled,
-        # so that we could clear the sampled tokens before returning
-        self.discard_request_mask.np[:num_reqs] = (
-            self.optimistic_seq_lens_cpu[:num_reqs].numpy() < num_tokens_np
+        # Record which requests should not be sampled, so that we can clear the
+        # sampled tokens before returning. The scheduler can explicitly mark
+        # streaming-prompt requests as prefill-only before finalize.
+        req_ids = self.input_batch.req_ids[:num_reqs]
+        self.discard_request_mask.np[:num_reqs] = self._compute_discard_request_mask(
+            req_ids,
+            [self.requests[r].num_tokens for r in req_ids],
+            self.optimistic_seq_lens_cpu[:num_reqs],
+            scheduler_output.prefill_only_req_ids,
         )
         self.discard_request_mask.copy_to_gpu(num_reqs)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1379,6 +1379,26 @@ class GPUModelRunner(
             resumed_from_preemption = req_id in req_data.resumed_req_ids
             num_output_tokens = req_data.num_output_tokens[i]
             req_index = self.input_batch.req_id_to_index.get(req_id)
+            new_prompt_token_ids = req_data.new_prompt_token_ids[i]
+            if new_prompt_token_ids:
+                if req_state.prompt_token_ids is None:
+                    raise ValueError(
+                        "Streaming prompt append requires prompt token IDs "
+                        f"for request {req_id}"
+                    )
+                start_idx = req_state.num_prompt_tokens
+                end_idx = start_idx + len(new_prompt_token_ids)
+                req_state.prompt_token_ids.extend(new_prompt_token_ids)
+                req_state.num_prompt_tokens = end_idx
+                if req_index is not None:
+                    self.input_batch.token_ids_cpu[req_index, start_idx:end_idx] = (
+                        new_prompt_token_ids
+                    )
+                    self.input_batch.is_token_ids[req_index, start_idx:end_idx] = True
+                    self.input_batch.num_prompt_tokens[req_index] = end_idx
+                    self.input_batch.num_tokens_no_spec[req_index] = (
+                        req_state.num_tokens
+                    )
 
             if req_state.prev_num_draft_len and self.use_async_scheduling:
                 # prev_num_draft_len is used in async scheduling mode with


### PR DESCRIPTION
## Purpose

This PR adds a low-level streaming prompt prefill path for vLLM V1.

A streaming-prompt request can be added before its full prompt is finalized. New prompt token IDs can then be appended incrementally, allowing the scheduler and worker to prefill available prompt chunks into KV cache while preventing user-visible decode until the prompt is finalized.

## Motivation

Some upstream systems produce prompt content incrementally rather than all at once. A typical example is a multi-agent pipeline, where a downstream model request depends on output generated by an upstream model.

Today, the downstream request can only be submitted after the full prompt is available:

```text
upstream decode -> downstream prefill -> downstream decode
```

With streaming prompt prefill, the downstream request can be registered early and prefill available prompt chunks while the upstream producer is still generating:

```text
upstream decode
        overlaps with downstream prefill
finalize -> downstream decode
```

This is intended as a serving-layer building block for upstream producers that can stream prompt content into vLLM and overlap prompt prefill with upstream generation.

## Behavior

The main behavior is:

- Add a streaming prompt request through the EngineCore client path.
- Append prompt token IDs before finalize.
- Schedule unfinalized streaming prompt requests as prefill-only.
- Hold back the final prompt token before finalize so normal first-token decode starts only after `finalize_streaming_prompt`.
- Mark prefill-only requests in `SchedulerOutput` so GPU workers discard sampled tokens for those steps.
- Finalize the request to resume normal decode.

## Correctness invariants

The implementation is designed around these invariants:

1. A streaming prompt request must not emit user-visible output before `finalize_streaming_prompt`.
2. Appended prompt token IDs must preserve the same token order as a normal full-prompt request.
3. Prefill-only scheduler steps must not expose sampled tokens to users.
4. After finalize, decoding proceeds through the normal scheduler and worker path.
5. Abort/cancel paths should release request state in the same way as normal requests.

## Non-goals

This PR does not change sampling, tokenization, model weights, or model output quality logic. It also does not make speculative changes to high-level OpenAI-compatible APIs in this PR. The goal here is to introduce the low-level V1 request lifecycle needed for incremental prompt-token append and prefill-only scheduling before finalize.

## Duplicate-work check

I searched open PRs for `streaming prompt prefill`, `incremental prefill`, and `append prompt tokens`.

Related open PRs such as #50692 and #50741 appear to address existing streaming update/session bugs. This PR is different: it introduces a low-level V1 request path that allows prompt token IDs to be appended before finalize, prefilled as prompt-only work, and then decoded only after explicit finalization.

## External validation

I also validated this path with an external multi-agent pipeline benchmark. The pipeline version preserved prompt-token consistency and exact output in the tested configuration, while reducing downstream first-token wait by overlapping upstream decode with downstream prefill.

This external benchmark is not included as a vLLM model-quality evaluation because this change affects scheduling/serving mechanics rather than model weights, sampling algorithms, or output selection.

## AI assistance

AI assistance was used to help draft and iterate on this change. I reviewed the changed files and ran the tests listed below.

## Test Plan

- Python compile check for modified files.
- Ruff check for modified files.
- Ruff format check for modified files.
- `git diff --check`.
- Full CUDA extension build and editable install in Docker.
- Targeted streaming input tests.

## Test Result

```text
Successfully built vllm
Successfully installed vllm-0.0.0.dev0
```

```text
python3 -m pytest tests/v1/streaming_input -q --tb=short
19 passed, 20 warnings in 9.37s
```

```text
python3 -m ruff check <modified files>
All checks passed!
```

```text
python3 -m ruff format --check <modified files>
10 files already formatted
```
