### PR TITLE
[Multimodal] Set ViT DP as default mm encoder TP mode

### DIFF
--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -224,22 +224,22 @@ do not configure CPU worker affinity.
 
 ### Batch-level DP for Multi-Modal Encoders
 
-By default, TP is used to shard the weights of multi-modal encoders just like for language decoders,
-in order to reduce the memory and compute load on each GPU.
+By default, the batched input data of multi-modal encoders is sharded across TP ranks
+(`mm_encoder_tp_mode="data"`), essentially performing batch-level DP, while the full
+encoder weights are hosted on each TP rank.
 
-However, since the size of multi-modal encoders is very small compared to language decoders,
-there is relatively little gain from TP. On the other hand, TP incurs significant communication
-overhead because of all-reduce being performed after every layer.
-
-Given this, it may be advantageous to instead shard the batched input data using TP, essentially
-performing batch-level DP. This has been shown to improve the throughput and TTFT by around 10% for
+This is because the size of multi-modal encoders is very small compared to language decoders,
+so there is relatively little gain from sharding their weights with TP. On the other hand, TP
+incurs significant communication overhead because of all-reduce being performed after every layer.
+Batch-level DP has been shown to improve the throughput and TTFT by around 10% for
 `tensor_parallel_size=8`. For vision encoders that use hardware-unoptimized Conv3D operations,
 batch-level DP can provide another 40% improvement compared to regular TP.
 
 Nevertheless, since the weights of the multi-modal encoder are replicated across each TP rank,
 there will be a minor increase in memory consumption and may cause OOM if you can barely fit the model already.
 
-You can enable batch-level DP by setting `mm_encoder_tp_mode="data"`, for example:
+You can revert to sharding the encoder weights with TP by setting `mm_encoder_tp_mode="weights"`,
+for example:
 
 ```python
 from vllm import LLM
@@ -247,11 +247,12 @@ from vllm import LLM
 llm = LLM(
     model="Qwen/Qwen2.5-VL-72B-Instruct",
     tensor_parallel_size=4,
-    # When mm_encoder_tp_mode="data",
-    # the vision encoder uses TP=4 (not DP=1) to shard the input data,
+    # The default mm_encoder_tp_mode="data" makes the vision encoder use
+    # TP=4 (not DP=1) to shard the input data,
     # so the TP size becomes the effective DP size.
     # Note that this is independent of the DP size for language decoder which is used in expert parallel setting.
-    mm_encoder_tp_mode="data",
+    # Setting mm_encoder_tp_mode="weights" shards the encoder weights instead.
+    mm_encoder_tp_mode="weights",
     # The language decoder uses TP=4 to shard the weights regardless
     # of the setting of mm_encoder_tp_mode
 )
@@ -263,7 +264,8 @@ llm = LLM(
 
 Batch-level DP needs to be implemented on a per-model basis,
 and enabled by setting `supports_encoder_tp_data = True` in the model class.
-Regardless, you need to set `mm_encoder_tp_mode="data"` in engine arguments to use this feature.
+Models whose encoder does not support batch-level DP automatically fall back to
+`mm_encoder_tp_mode="weights"` with a warning.
 
 Known supported models (with corresponding benchmarks):
 

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -179,19 +179,19 @@ class MultiModalConfig:
 
     This is usually only valid in disaggregated Encoder process.
     """
-    mm_encoder_tp_mode: MMEncoderTPMode = "weights"
+    mm_encoder_tp_mode: MMEncoderTPMode = "data"
     """Indicates how to optimize multi-modal encoder inference using tensor
     parallelism (TP).
 
-    - `"weights"`: Within the same vLLM engine, split the weights of
-      each layer across TP ranks. (default TP behavior)
     - `"data"`: Within the same vLLM engine, split the batched input data
       across TP ranks to process the data in parallel, while hosting
       the full weights on each TP rank.
       This batch-level DP is not to be confused with API request-level
       DP (which is controlled by `--data-parallel-size`).
       This is only supported on a per-model basis and falls back to
-      `"weights"` if the encoder does not support DP."""
+      `"weights"` if the encoder does not support DP. (default)
+    - `"weights"`: Within the same vLLM engine, split the weights of
+      each layer across TP ranks."""
     mm_encoder_attn_backend: AttentionBackendEnum | None = None
     """Optional override for the multi-modal encoder attention backend when
     using vision transformers. Accepts any value from

--- a/vllm/model_executor/models/aria.py
+++ b/vllm/model_executor/models/aria.py
@@ -384,6 +384,8 @@ class AriaForConditionalGeneration(nn.Module, SupportsMultiModal):
     model to perform tasks that involve both image and text inputs.
     """
 
+    supports_encoder_tp_data = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             # mapping for new names in checkpoint saved after transformers v4.52

--- a/vllm/model_executor/models/bagel.py
+++ b/vllm/model_executor/models/bagel.py
@@ -329,6 +329,8 @@ class BagelForConditionalGeneration(
     The image generation part is not supported in vLLM.
     """
 
+    supports_encoder_tp_data = True
+
     # pos_embed is handled by the PositionEmbedding module
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={"vit_pos_embed.pos_embed": None}

--- a/vllm/model_executor/models/cohere2_vision.py
+++ b/vllm/model_executor/models/cohere2_vision.py
@@ -318,6 +318,8 @@ class Cohere2VisionMultiModalProcessor(
 class Cohere2VisionForConditionalGeneration(
     nn.Module, SupportsMultiModal, SupportsPP, SupportsQuant
 ):
+    supports_encoder_tp_data = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             "model.vision_tower.": "vision_tower.",

--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -526,6 +526,7 @@ class Gemma3ForConditionalGeneration(
         }
     )
 
+    supports_encoder_tp_data = True
     supports_tower_connector_lora = True
 
     @classmethod

--- a/vllm/model_executor/models/granite4_vision.py
+++ b/vllm/model_executor/models/granite4_vision.py
@@ -436,6 +436,8 @@ class Granite4VisionForConditionalGeneration(
     Both modes expect a LM-only adapter (no modules_to_save).
     """
 
+    supports_encoder_tp_data = True
+
     # LoRA class attributes (matches GraniteForCausalLM)
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -515,6 +515,7 @@ class Idefics3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsLo
         ],
     }
 
+    supports_encoder_tp_data = True
     supports_tower_connector_lora = True
 
     @classmethod

--- a/vllm/model_executor/models/kanana_v.py
+++ b/vllm/model_executor/models/kanana_v.py
@@ -581,6 +581,8 @@ class KananaVMultiModalProcessor(BaseMultiModalProcessor[KananaVProcessingInfo])
     dummy_inputs=KananaVDummyInputsBuilder,
 )
 class KananaVForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
+    supports_encoder_tp_data = True
+
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("image"):

--- a/vllm/model_executor/models/keye.py
+++ b/vllm/model_executor/models/keye.py
@@ -1487,6 +1487,8 @@ class BaseKeyeModule(nn.Module, SupportsMultiModal):
 class KeyeForConditionalGeneration(
     BaseKeyeModule, SupportsMultiModal, SupportsLoRA, SupportsPP, SupportsMRoPE
 ):
+    supports_encoder_tp_data = True
+
     def _build_projector(
         self,
         text_config: PretrainedConfig,

--- a/vllm/model_executor/models/keye_vl1_5.py
+++ b/vllm/model_executor/models/keye_vl1_5.py
@@ -512,6 +512,8 @@ class KeyeVL1_5DummyInputsBuilder(
 class KeyeVL1_5ForConditionalGeneration(
     BaseKeyeModule, SupportsMultiModal, SupportsLoRA, SupportsPP, SupportsMRoPE
 ):
+    supports_encoder_tp_data = True
+
     def _build_projector(
         self,
         text_config: PretrainedConfig,

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -613,6 +613,7 @@ class Lfm2VLForConditionalGeneration(
     IsHybrid,
 ):
     supports_tower_connector_lora = True
+    supports_encoder_tp_data = True
     merge_by_field_config = True
 
     hf_to_vllm_mapper = WeightsMapper(

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -521,6 +521,7 @@ class LlavaForConditionalGeneration(
     )
 
     supports_tower_connector_lora = True
+    supports_encoder_tp_data = True
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -235,6 +235,8 @@ class LlavaNextForConditionalGeneration(
     nn.Module, SupportsLoRA, SupportsMultiModal, SupportsPP
 ):
     supports_tower_connector_lora = True
+    supports_encoder_tp_data = True
+
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],

--- a/vllm/model_executor/models/llava_next_video.py
+++ b/vllm/model_executor/models/llava_next_video.py
@@ -324,6 +324,7 @@ class LlavaNextVideoForConditionalGeneration(
     )
 
     supports_tower_connector_lora = True
+    supports_encoder_tp_data = True
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm/model_executor/models/llava_onevision.py
+++ b/vllm/model_executor/models/llava_onevision.py
@@ -465,6 +465,8 @@ class LlavaOnevisionMultiModalProjector(nn.Module):
     dummy_inputs=LlavaOnevisionDummyInputsBuilder,
 )
 class LlavaOnevisionForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
+    supports_encoder_tp_data = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             # mapping for new names in checkpoint saved after transformers v4.52

--- a/vllm/model_executor/models/mimo_v2_omni.py
+++ b/vllm/model_executor/models/mimo_v2_omni.py
@@ -1190,6 +1190,8 @@ class MiMoV2OmniDummyInputsBuilder(BaseDummyInputsBuilder[MiMoV2OmniProcessingIn
     dummy_inputs=MiMoV2OmniDummyInputsBuilder,
 )
 class MiMoV2OmniForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, SupportsQuant):
+    supports_encoder_tp_data = True
+
     # To ensure correct weight loading and mapping.
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={

--- a/vllm/model_executor/models/mistral3.py
+++ b/vllm/model_executor/models/mistral3.py
@@ -414,6 +414,8 @@ class Mistral3ForConditionalGeneration(
     SupportsEagle,
     SupportsEagle3,
 ):
+    supports_encoder_tp_data = True
+
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],

--- a/vllm/model_executor/models/muse_glimmer.py
+++ b/vllm/model_executor/models/muse_glimmer.py
@@ -1370,6 +1370,8 @@ class MuseGlimmerModel(nn.Module, EagleModelMixin):
 class MuseGlimmerForCausalLM(
     nn.Module, SupportsLoRA, SupportsMultiModal, SupportsPP, SupportsEagle3
 ):
+    supports_encoder_tp_data = True
+
     # Weight-name normalization. Two checkpoint conventions are supported:
     #
     #   * HF MuseGlimmer export (``convert_muse_glimmer_weights_to_hf.py``): the

--- a/vllm/model_executor/models/ovis.py
+++ b/vllm/model_executor/models/ovis.py
@@ -408,6 +408,8 @@ class OvisMultiModalProcessor(BaseMultiModalProcessor[OvisProcessingInfo]):
     dummy_inputs=OvisDummyInputsBuilder,
 )
 class Ovis(nn.Module, SupportsMultiModal, SupportsPP):
+    supports_encoder_tp_data = True
+
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("image"):

--- a/vllm/model_executor/models/ovis2_5.py
+++ b/vllm/model_executor/models/ovis2_5.py
@@ -425,6 +425,8 @@ class Ovis2_5MultiModalProcessor(BaseMultiModalProcessor[Ovis2_5ProcessingInfo])
     dummy_inputs=Ovis2_5DummyInputsBuilder,
 )
 class Ovis2_5(nn.Module, SupportsMultiModal, SupportsPP):
+    supports_encoder_tp_data = True
+
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         if modality.startswith("image"):

--- a/vllm/model_executor/models/paligemma.py
+++ b/vllm/model_executor/models/paligemma.py
@@ -258,6 +258,7 @@ class PaliGemmaForConditionalGeneration(
         }
     )
 
+    supports_encoder_tp_data = True
     supports_tower_connector_lora = True
 
     @classmethod

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -562,6 +562,8 @@ class Phi3VMultiModalProcessor(BaseMultiModalProcessor[Phi3VProcessingInfo]):
     dummy_inputs=Phi3VDummyInputsBuilder,
 )
 class Phi3VForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, SupportsQuant):
+    supports_encoder_tp_data = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             "model.vision_embed_tokens.wte": "embed_tokens",

--- a/vllm/model_executor/models/phi4mm.py
+++ b/vllm/model_executor/models/phi4mm.py
@@ -1033,6 +1033,8 @@ class Phi4MMForCausalLM(nn.Module, SupportsLoRA, SupportsMultiModal):
     Implements the Phi-4-multimodal-instruct model in vLLM.
     """
 
+    supports_encoder_tp_data = True
+
     packed_modules_mapping = {
         "qkv_proj": [
             "qkv_proj",

--- a/vllm/model_executor/models/phi4siglip.py
+++ b/vllm/model_executor/models/phi4siglip.py
@@ -248,6 +248,8 @@ class Phi4SiglipImagePixelInputs(TensorSchema):
     dummy_inputs=Phi4SiglipDummyInputsBuilder,
 )
 class Phi4ForCausalLMV(nn.Module, SupportsMultiModal, SupportsPP):
+    supports_encoder_tp_data = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             "model.vision_tower.vision_tower.vision_model.head.": None,

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -332,6 +332,7 @@ class PixtralForConditionalGeneration(
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
 
+    supports_encoder_tp_data = True
     supports_tower_connector_lora = True
 
     @classmethod

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -1053,6 +1053,8 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
     SupportsMRoPE,
     Qwen2_5OmniConditionalGenerationMixin,
 ):
+    supports_encoder_tp_data = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             "thinker.lm_head.": "language_model.lm_head.",

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -472,6 +472,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
 )
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid):
     supports_multimodal_pruning = True
+    supports_encoder_tp_data = True
 
     hf_to_vllm_mapper = (
         Qwen3VLForConditionalGeneration.hf_to_vllm_mapper

--- a/vllm/model_executor/models/skyworkr1v.py
+++ b/vllm/model_executor/models/skyworkr1v.py
@@ -125,6 +125,8 @@ class SkyworkR1VProcessingInfo(BaseInternVLProcessingInfo):
     dummy_inputs=BaseInternVLDummyInputsBuilder,
 )
 class SkyworkR1VChatModel(nn.Module, SupportsMultiModal, SupportsPP):
+    supports_encoder_tp_data = True
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix=dict.fromkeys(
             [


### PR DESCRIPTION



## Purpose
- Since ViT is usually quite small, we can tune `mm_encoder_tp_mode="data"` to default for better model performance
- Also add missing `supports_encoder_tp_data = True`

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

