### PR TITLE
[Rust Frontend] Add /v1/embeddings support

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5999,6 +5999,7 @@ dependencies = [
  "asynk-strim-attr",
  "auto_enums",
  "axum",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "educe",

--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -13,6 +13,7 @@ use super::utility::UtilityOutput;
 use crate::error::{Error, Result, ext_value_decode};
 use crate::protocol::logprobs::MaybeWireLogprobs;
 use crate::protocol::stats::{PrefillStats, SchedulerStats};
+use crate::protocol::tensor::WireTensor;
 use crate::protocol::{OpaqueValue, decode_msgpack};
 
 /// The stop reason associated with a finished output.
@@ -90,7 +91,7 @@ pub struct EngineCoreOutput {
     #[serde(default)]
     pub new_prompt_logprobs_tensors: Option<MaybeWireLogprobs>,
     #[serde(default)]
-    pub pooling_output: Option<OpaqueValue>,
+    pub pooling_output: Option<WireTensor>,
     #[serde(default)]
     pub finish_reason: Option<EngineCoreFinishReason>,
     #[serde(default)]
@@ -150,6 +151,11 @@ impl EngineCoreOutput {
         self.new_prompt_logprobs_tensors = (self.new_prompt_logprobs_tensors.take())
             .map(|value| value.resolve(frames, "new_prompt_logprobs_tensors"))
             .transpose()?;
+        if let Some(pooling_output) = &mut self.pooling_output {
+            pooling_output
+                .resolve_aux_frame(frames)
+                .map_err(|message| ext_value_decode!("pooling_output: {message}"))?;
+        }
         Ok(())
     }
 }
@@ -382,6 +388,7 @@ mod tests {
 
     use super::*;
     use crate::protocol::output::EngineCoreOutput;
+    use crate::protocol::tensor::{WireArrayData, WireNdArray};
     use crate::protocol::{decode_msgpack, encode_msgpack};
 
     #[test]
@@ -409,6 +416,34 @@ mod tests {
         assert_eq!(
             decoded.finished_requests,
             Some(BTreeSet::from(["req-1".to_string()]))
+        );
+    }
+
+    #[test]
+    fn engine_core_outputs_resolve_multipart_pooling_tensor() {
+        let raw = [0.25_f32, -0.5].into_iter().flat_map(f32::to_ne_bytes).collect::<Vec<_>>();
+        let outputs: EngineCoreOutputs = RequestBatchOutputs {
+            outputs: vec![EngineCoreOutput {
+                request_id: "embed-1".to_string(),
+                pooling_output: Some(WireNdArray {
+                    dtype: "float32".to_string(),
+                    shape: vec![2],
+                    data: WireArrayData::AuxIndex(1),
+                }),
+                finish_reason: Some(EngineCoreFinishReason::Stop),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .into();
+        let first_frame = encode_msgpack(&outputs).expect("encode outputs");
+
+        let decoded = decode_engine_core_outputs(&[first_frame, raw]).expect("decode outputs");
+        let output = &decoded.as_request_batch().expect("request batch").outputs[0];
+
+        assert_eq!(
+            output.pooling_output.as_ref().unwrap().to_f32_vec().unwrap(),
+            vec![0.25, -0.5]
         );
     }
 

--- a/rust/src/engine-core-client/src/protocol/request.rs
+++ b/rust/src/engine-core-client/src/protocol/request.rs
@@ -66,6 +66,42 @@ pub struct ReasoningParserKwargs {
     pub chat_template_kwargs: HashMap<String, serde_json::Value>,
 }
 
+/// Pooling parameters sent to the Python engine-core.
+///
+/// The tuple field order mirrors Python's array-like `PoolingParams` struct.
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct EngineCorePoolingParams {
+    pub use_activation: Option<bool>,
+    pub dimensions: Option<u32>,
+    pub step_tag_id: Option<u32>,
+    pub returned_token_ids: Option<Vec<u32>>,
+    pub task: Option<String>,
+    pub requires_token_ids: bool,
+    pub skip_reading_prefix_cache: Option<bool>,
+    pub late_interaction_params: Option<OpaqueValue>,
+    pub extra_kwargs: Option<OpaqueValue>,
+    pub output_kind: u8,
+}
+
+impl EngineCorePoolingParams {
+    /// Build parameters for the OpenAI embeddings endpoint.
+    pub fn embeddings(dimensions: Option<u32>, use_activation: Option<bool>) -> Self {
+        Self {
+            // Python's verified embed parameters default activation on.
+            use_activation: Some(use_activation.unwrap_or(true)),
+            dimensions,
+            step_tag_id: None,
+            returned_token_ids: None,
+            task: Some("embed".to_string()),
+            requires_token_ids: false,
+            skip_reading_prefix_cache: Some(false),
+            late_interaction_params: None,
+            extra_kwargs: None,
+            output_kind: 2,
+        }
+    }
+}
+
 /// Engine-core add-request payload sent from frontend to engine.
 ///
 /// Original Python definition:
@@ -77,9 +113,7 @@ pub struct EngineCoreRequest {
     /// Multimodal features attached to the request.
     pub mm_features: Option<MmFeatures>,
     pub sampling_params: Option<EngineCoreSamplingParams>,
-    /// Pooling parameters are preserved in the schema but not yet strongly
-    /// typed.
-    pub pooling_params: Option<OpaqueValue>,
+    pub pooling_params: Option<EngineCorePoolingParams>,
     pub arrival_time: f64,
     #[serde(default)]
     pub lora_request: Option<lora::LoraRequest>,
@@ -158,6 +192,50 @@ mod tests {
     use rmpv::Value;
 
     use super::*;
+
+    #[test]
+    fn embedding_pooling_params_match_python_tuple_layout() {
+        let params = EngineCorePoolingParams::embeddings(Some(128), Some(false));
+        let value = rmpv::ext::to_value(params).expect("encode pooling params");
+
+        expect_test::expect![[r#"
+            Array(
+                [
+                    Boolean(
+                        false,
+                    ),
+                    Integer(
+                        PosInt(
+                            128,
+                        ),
+                    ),
+                    Nil,
+                    Nil,
+                    String(
+                        Utf8String {
+                            s: Ok(
+                                "embed",
+                            ),
+                        },
+                    ),
+                    Boolean(
+                        false,
+                    ),
+                    Boolean(
+                        false,
+                    ),
+                    Nil,
+                    Nil,
+                    Integer(
+                        PosInt(
+                            2,
+                        ),
+                    ),
+                ],
+            )
+        "#]]
+        .assert_debug_eq(&value);
+    }
     use crate::protocol::multimodal::{
         MmBatchedField, MmFeatureSpec, MmField, MmFieldElem, MmKwargValue, PlaceholderRange,
     };

--- a/rust/src/engine-core-client/src/protocol/tensor.rs
+++ b/rust/src/engine-core-client/src/protocol/tensor.rs
@@ -166,6 +166,66 @@ impl WireNdArray {
     pub(crate) fn extract_aux_frame(&mut self, aux_frames: &mut Vec<Bytes>, threshold: usize) {
         self.data.extract_aux_frame(aux_frames, threshold);
     }
+
+    /// Resolve an auxiliary-frame reference into owned raw bytes.
+    pub(crate) fn resolve_aux_frame<Frame>(&mut self, frames: &[Frame]) -> Result<(), String>
+    where
+        Frame: AsRef<[u8]>,
+    {
+        let WireArrayData::AuxIndex(index) = &self.data else {
+            return Ok(());
+        };
+        let index = *index;
+        let frame = frames
+            .get(index)
+            .ok_or_else(|| format!("tensor auxiliary frame index {index} is out of range"))?;
+        self.data = WireArrayData::RawView(Bytes::copy_from_slice(frame.as_ref()));
+        Ok(())
+    }
+
+    /// Decode a floating-point tensor into float32 values.
+    pub fn to_f32_vec(&self) -> Result<Vec<f32>, String> {
+        let data = self
+            .data
+            .as_raw_view()
+            .ok_or_else(|| "tensor auxiliary frame was not resolved".to_string())?;
+        let numel = self
+            .shape
+            .checked_numel()
+            .ok_or_else(|| format!("tensor shape product overflows usize: {:?}", self.shape))?;
+
+        let values = match self.dtype.as_str() {
+            "float32" => decode_chunks(data, numel, f32::from_ne_bytes),
+            "float16" => decode_chunks(data, numel, |bytes| {
+                f16::from_bits(u16::from_ne_bytes(bytes)).to_f32()
+            }),
+            "bfloat16" => decode_chunks(data, numel, |bytes| {
+                bf16::from_bits(u16::from_ne_bytes(bytes)).to_f32()
+            }),
+            dtype => return Err(format!("unsupported pooling output dtype {dtype:?}")),
+        }?;
+        Ok(values)
+    }
+}
+
+fn decode_chunks<const N: usize, T>(
+    data: &[u8],
+    numel: usize,
+    decode: impl Fn([u8; N]) -> T,
+) -> Result<Vec<T>, String> {
+    let expected_len = numel
+        .checked_mul(N)
+        .ok_or_else(|| "tensor byte length overflows usize".to_string())?;
+    if data.len() != expected_len {
+        return Err(format!(
+            "tensor data length {} does not match expected byte length {expected_len}",
+            data.len()
+        ));
+    }
+    Ok(data
+        .chunks_exact(N)
+        .map(|chunk| decode(chunk.try_into().expect("chunks_exact ensures length")))
+        .collect())
 }
 
 /// Validate that the number of elements implied by the shape matches the length
@@ -343,5 +403,34 @@ mod tests {
     fn constructors_validate_shape_product() {
         let err = WireNdArray::from_f32(vec![2, 2], vec![1.0, 2.0]).unwrap_err();
         assert!(err.contains("does not match shape"));
+    }
+
+    #[test]
+    fn floating_point_tensors_decode_to_f32() {
+        let f32_tensor = WireNdArray::from_f32(vec![2], vec![1.0, -2.5]).unwrap();
+        assert_eq!(f32_tensor.to_f32_vec().unwrap(), vec![1.0, -2.5]);
+
+        let f16_tensor =
+            WireNdArray::from_f16(vec![2], vec![f16::from_f32(1.0), f16::from_f32(-2.5)]).unwrap();
+        assert_eq!(f16_tensor.to_f32_vec().unwrap(), vec![1.0, -2.5]);
+
+        let bf16_tensor =
+            WireNdArray::from_bf16(vec![2], vec![bf16::from_f32(1.0), bf16::from_f32(-2.5)])
+                .unwrap();
+        assert_eq!(bf16_tensor.to_f32_vec().unwrap(), vec![1.0, -2.5]);
+    }
+
+    #[test]
+    fn resolve_aux_frame_uses_one_based_message_index() {
+        let mut tensor = WireNdArray {
+            dtype: "float32".to_string(),
+            shape: vec![2],
+            data: WireArrayData::AuxIndex(1),
+        };
+        let bytes = [1.0_f32, -2.5].into_iter().flat_map(f32::to_ne_bytes).collect::<Vec<_>>();
+
+        tensor.resolve_aux_frame(&[Vec::new(), bytes]).unwrap();
+
+        assert_eq!(tensor.to_f32_vec().unwrap(), vec![1.0, -2.5]);
     }
 }

--- a/rust/src/server/Cargo.toml
+++ b/rust/src/server/Cargo.toml
@@ -9,6 +9,7 @@ anyhow.workspace = true
 asynk-strim-attr.workspace = true
 auto_enums.workspace = true
 axum.workspace = true
+base64.workspace = true
 educe.workspace = true
 futures.workspace = true
 http-body.workspace = true

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -83,6 +83,7 @@ fn build_router_with_options(
         .route("/v1/models", get(openai::list_models))
         .route("/v1/completions", post(openai::completions))
         .route("/v1/chat/completions", post(openai::chat_completions))
+        .route("/v1/embeddings", post(openai::embeddings))
         // vLLM specific endpoints
         .route("/tokenize", post(tokenize::tokenize))
         .route("/detokenize", post(tokenize::detokenize))

--- a/rust/src/server/src/routes/openai/embeddings.rs
+++ b/rust/src/server/src/routes/openai/embeddings.rs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+mod types;
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
+use futures::{StreamExt as _, TryStreamExt as _, stream};
+use thiserror_ext::AsReport as _;
+use uuid::Uuid;
+use vllm_engine_core_client::protocol::output::EngineCoreFinishReason;
+use vllm_engine_core_client::protocol::request::{EngineCorePoolingParams, EngineCoreRequest};
+use vllm_llm::current_unix_timestamp_secs;
+use vllm_text::tokenizer::Tokenizer;
+
+use self::types::{
+    EmbeddingData, EmbeddingInput, EmbeddingRequest, EmbeddingResponse, EmbeddingResponseData,
+    EncodingFormat, TruncationSide,
+};
+use super::utils::types::Usage;
+use super::utils::validated_json::ValidatedJson;
+use crate::error::{ApiError, bail_invalid_request, server_error};
+use crate::state::AppState;
+use crate::utils::{resolve_request_context, unix_timestamp};
+
+struct PreparedInput {
+    token_ids: Vec<u32>,
+    engine_request: EngineCoreRequest,
+}
+
+/// Serve one OpenAI-compatible embeddings request through engine-core pooling.
+pub async fn embeddings(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    ValidatedJson(body): ValidatedJson<EmbeddingRequest>,
+) -> Response {
+    match embeddings_inner(&state, &headers, body).await {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn embeddings_inner(
+    state: &AppState,
+    headers: &HeaderMap,
+    request: EmbeddingRequest,
+) -> Result<EmbeddingResponse, ApiError> {
+    validate_encoding_options(&request)?;
+    let requested_model = request.model.as_deref().unwrap_or(state.primary_model_name());
+    let lora_resolution = state.resolve_model_with_loras(Some(requested_model)).await;
+    if !lora_resolution.model_names.iter().any(|name| name == requested_model) {
+        return Err(ApiError::model_not_found(requested_model.to_string()));
+    }
+
+    let ctx = resolve_request_context(headers, request.request_id.as_deref());
+    let response_id = format!("embd-{}", ctx.request_id);
+    let response_model = lora_resolution
+        .lora_request
+        .as_ref()
+        .map(|request| request.lora_name.clone())
+        .unwrap_or_else(|| state.primary_model_name().to_string());
+    let tokenizer = state.chat.text().tokenizer();
+    let inputs = prepare_inputs(
+        request.input,
+        tokenizer.as_ref(),
+        request.add_special_tokens,
+    )?;
+    if inputs.is_empty() {
+        bail_invalid_request!(param = "input", "input must not be empty.");
+    }
+
+    let max_model_len = state.engine_core_client().max_model_len() as usize;
+    let prompt_vocab_size = tokenizer.vocab_size().max(state.chat.text().model_vocab_size());
+    let mut prepared = Vec::with_capacity(inputs.len());
+    for (index, token_ids) in inputs.into_iter().enumerate() {
+        let token_ids = validate_and_truncate(
+            token_ids,
+            prompt_vocab_size,
+            max_model_len,
+            request.truncate_prompt_tokens,
+            request.truncation_side.unwrap_or_default(),
+        )?;
+        let external_request_id = format!("{response_id}-{index}");
+        let random_suffix = Uuid::new_v4().simple().to_string();
+        let engine_request_id = format!("{external_request_id}-{}", &random_suffix[..8]);
+        prepared.push(PreparedInput {
+            token_ids: token_ids.clone(),
+            engine_request: EngineCoreRequest {
+                request_id: engine_request_id,
+                prompt_token_ids: Some(token_ids),
+                mm_features: None,
+                sampling_params: None,
+                pooling_params: Some(EngineCorePoolingParams::embeddings(
+                    request.dimensions,
+                    request.use_activation,
+                )),
+                arrival_time: current_unix_timestamp_secs(),
+                lora_request: lora_resolution.lora_request.clone(),
+                cache_salt: request.cache_salt.clone(),
+                data_parallel_rank: ctx.data_parallel_rank,
+                prompt_embeds: None,
+                prompt_is_token_ids: None,
+                client_index: 0,
+                current_wave: 0,
+                priority: ctx.priority.or(request.priority).unwrap_or(0),
+                trace_headers: None,
+                resumable: false,
+                external_req_id: Some(external_request_id),
+                reasoning_ended: None,
+                reasoning_parser_kwargs: None,
+                abort_immediately: false,
+                session_id: ctx.session_id.clone(),
+            },
+        });
+    }
+
+    let client = state.engine_core_client();
+    let encoding_format = request.encoding_format;
+    let results = stream::iter(prepared.into_iter().enumerate())
+        .map(|(index, prepared)| async move {
+            let prompt_tokens = prepared.token_ids.len();
+            let mut outputs = client.call(prepared.engine_request).await.map_err(|error| {
+                server_error!(
+                    "failed to submit embedding request: {}",
+                    error.to_report_string()
+                )
+            })?;
+            let mut embedding = None;
+            while let Some(output) = outputs.next().await {
+                let output = output.map_err(|error| {
+                    server_error!("embedding stream failed: {}", error.to_report_string())
+                })?;
+                if output.finish_reason == Some(EngineCoreFinishReason::Error) {
+                    return Err(server_error!("embedding request failed in engine-core"));
+                }
+                if let Some(tensor) = &output.pooling_output {
+                    if tensor.shape.len() != 1 {
+                        return Err(server_error!(
+                            "embedding output must be one-dimensional, got {:?}",
+                            tensor.shape
+                        ));
+                    }
+                    embedding = Some(tensor.to_f32_vec().map_err(|message| {
+                        server_error!("failed to decode embedding output: {message}")
+                    })?);
+                }
+            }
+            let embedding = embedding
+                .ok_or_else(|| server_error!("embedding stream completed without output"))?;
+            Ok::<_, ApiError>((
+                index,
+                prompt_tokens,
+                encode_embedding(embedding, encoding_format),
+            ))
+        })
+        .buffer_unordered(32)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let prompt_tokens = results.iter().map(|(_, count, _)| count).sum();
+    let mut data = results
+        .into_iter()
+        .map(|(index, _, embedding)| EmbeddingResponseData {
+            object: "embedding",
+            index,
+            embedding,
+        })
+        .collect::<Vec<_>>();
+    data.sort_unstable_by_key(|item| item.index);
+
+    Ok(EmbeddingResponse {
+        id: response_id,
+        object: "list",
+        created: unix_timestamp(),
+        model: response_model,
+        data,
+        usage: Usage::from_counts(prompt_tokens, 0, None),
+    })
+}
+
+fn validate_encoding_options(request: &EmbeddingRequest) -> Result<(), ApiError> {
+    // TODO: Validate `dimensions` against the model's Matryoshka configuration
+    // once the Rust text backend exposes pooler metadata.
+    if request.dimensions == Some(0) {
+        bail_invalid_request!(
+            param = "dimensions",
+            "dimensions must be greater than zero."
+        );
+    }
+    if request.embed_dtype.as_deref().is_some_and(|value| value != "float32") {
+        bail_invalid_request!(
+            param = "embed_dtype",
+            "The Rust frontend currently supports only embed_dtype=\"float32\"."
+        );
+    }
+    if request.endianness.as_deref().is_some_and(|value| value != "native") {
+        bail_invalid_request!(
+            param = "endianness",
+            "The Rust frontend currently supports only endianness=\"native\"."
+        );
+    }
+    Ok(())
+}
+
+fn prepare_inputs(
+    input: EmbeddingInput,
+    tokenizer: &dyn Tokenizer,
+    add_special_tokens: bool,
+) -> Result<Vec<Vec<u32>>, ApiError> {
+    match input {
+        EmbeddingInput::TokenIds(token_ids) => Ok(vec![token_ids]),
+        EmbeddingInput::TokenIdBatch(batch) => Ok(batch),
+        EmbeddingInput::Text(text) => Ok(vec![tokenize(tokenizer, &text, add_special_tokens)?]),
+        EmbeddingInput::TextBatch(texts) => texts
+            .into_iter()
+            .map(|text| tokenize(tokenizer, &text, add_special_tokens))
+            .collect(),
+    }
+}
+
+fn tokenize(
+    tokenizer: &dyn Tokenizer,
+    text: &str,
+    add_special_tokens: bool,
+) -> Result<Vec<u32>, ApiError> {
+    tokenizer
+        .encode(text, add_special_tokens)
+        .map_err(|error| server_error!("failed to tokenize embedding input: {error}"))
+}
+
+fn validate_and_truncate(
+    mut token_ids: Vec<u32>,
+    vocab_size: usize,
+    max_model_len: usize,
+    truncate_prompt_tokens: Option<i64>,
+    truncation_side: TruncationSide,
+) -> Result<Vec<u32>, ApiError> {
+    if token_ids.is_empty() {
+        bail_invalid_request!(param = "input", "input token IDs must not be empty.");
+    }
+    if let Some(token_id) = token_ids.iter().find(|&&id| id as usize >= vocab_size) {
+        bail_invalid_request!(
+            param = "input",
+            "Token id {token_id} is out of vocabulary; vocabulary size is {vocab_size}."
+        );
+    }
+    let truncate_to = match truncate_prompt_tokens {
+        None => None,
+        Some(-1) => Some(max_model_len),
+        Some(value) if value > 0 => Some(value as usize),
+        Some(_) => {
+            bail_invalid_request!(
+                param = "truncate_prompt_tokens",
+                "truncate_prompt_tokens must be -1 or a positive integer."
+            );
+        }
+    };
+    if let Some(limit) = truncate_to
+        && token_ids.len() > limit
+    {
+        match truncation_side {
+            TruncationSide::Right => token_ids.truncate(limit),
+            TruncationSide::Left => {
+                let start = token_ids.len() - limit;
+                token_ids.drain(..start).for_each(drop);
+            }
+        }
+    }
+    if token_ids.len() > max_model_len {
+        bail_invalid_request!(
+            param = "input",
+            "This model's maximum context length is {max_model_len} tokens, but the embedding input has {} tokens.",
+            token_ids.len()
+        );
+    }
+    Ok(token_ids)
+}
+
+fn encode_embedding(embedding: Vec<f32>, format: EncodingFormat) -> EmbeddingData {
+    match format {
+        EncodingFormat::Float => EmbeddingData::Float(embedding),
+        EncodingFormat::Base64 => {
+            let bytes = embedding.into_iter().flat_map(f32::to_ne_bytes).collect::<Vec<_>>();
+            EmbeddingData::Base64(base64::engine::general_purpose::STANDARD.encode(bytes))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+
+    use super::*;
+
+    #[test]
+    fn truncation_preserves_the_requested_side() {
+        assert_eq!(
+            validate_and_truncate(vec![1, 2, 3, 4], 10, 10, Some(2), TruncationSide::Right)
+                .unwrap(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            validate_and_truncate(vec![1, 2, 3, 4], 10, 10, Some(2), TruncationSide::Left).unwrap(),
+            vec![3, 4]
+        );
+    }
+
+    #[test]
+    fn base64_embedding_uses_native_float32_bytes() {
+        let EmbeddingData::Base64(encoded) =
+            encode_embedding(vec![1.0, -2.5], EncodingFormat::Base64)
+        else {
+            panic!("expected base64 embedding")
+        };
+
+        let decoded = base64::engine::general_purpose::STANDARD.decode(encoded).unwrap();
+        let expected = [1.0_f32, -2.5].into_iter().flat_map(f32::to_ne_bytes).collect::<Vec<_>>();
+        assert_eq!(decoded, expected);
+    }
+}

--- a/rust/src/server/src/routes/openai/embeddings/types.rs
+++ b/rust/src/server/src/routes/openai/embeddings/types.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+use crate::routes::openai::utils::types::{Normalizable, Usage, default_true};
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum EmbeddingInput {
+    TokenIds(Vec<u32>),
+    TokenIdBatch(Vec<Vec<u32>>),
+    Text(String),
+    TextBatch(Vec<String>),
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum EncodingFormat {
+    #[default]
+    Float,
+    Base64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum TruncationSide {
+    Left,
+    #[default]
+    Right,
+}
+
+#[derive(Debug, Clone, Deserialize, Validate)]
+pub(crate) struct EmbeddingRequest {
+    pub model: Option<String>,
+    pub input: EmbeddingInput,
+    #[serde(default)]
+    pub encoding_format: EncodingFormat,
+    pub dimensions: Option<u32>,
+    pub use_activation: Option<bool>,
+    #[serde(default = "default_true")]
+    pub add_special_tokens: bool,
+    pub truncate_prompt_tokens: Option<i64>,
+    pub truncation_side: Option<TruncationSide>,
+    pub request_id: Option<String>,
+    pub priority: Option<i32>,
+    pub cache_salt: Option<String>,
+    pub embed_dtype: Option<String>,
+    pub endianness: Option<String>,
+}
+
+impl Normalizable for EmbeddingRequest {}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct EmbeddingResponseData {
+    pub object: &'static str,
+    pub index: usize,
+    pub embedding: EmbeddingData,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub(super) enum EmbeddingData {
+    Float(Vec<f32>),
+    Base64(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct EmbeddingResponse {
+    pub id: String,
+    pub object: &'static str,
+    pub created: u64,
+    pub model: String,
+    pub data: Vec<EmbeddingResponseData>,
+    pub usage: Usage,
+}

--- a/rust/src/server/src/routes/openai/mod.rs
+++ b/rust/src/server/src/routes/openai/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod chat_completions;
 mod completions;
+mod embeddings;
 mod models;
 pub(crate) mod utils;
 
@@ -10,4 +11,5 @@ pub use chat_completions::chat_completions;
 pub(crate) use chat_completions::{ChatCompletionRequest, lower_chat_request};
 pub use completions::completions;
 pub(crate) use completions::{CompletionRequest, lower_completion_request};
+pub use embeddings::embeddings;
 pub use models::list_models;

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -37,6 +37,7 @@ use vllm_engine_core_client::protocol::output::{
     UtilityCallOutput,
 };
 use vllm_engine_core_client::protocol::request::EngineCoreRequest;
+use vllm_engine_core_client::protocol::tensor::WireNdArray;
 use vllm_engine_core_client::protocol::utility::{UtilityOutput, UtilityResultEnvelope};
 use vllm_engine_core_client::test_utils::{
     IpcNamespace, spawn_mock_engine_task, spawn_mock_engine_task_with_ready,
@@ -888,6 +889,126 @@ where
 
 async fn test_app_with_engine_handle() -> (axum::Router, MockEngineTask) {
     test_app_with_stream_output_specs(default_stream_output_specs()).await
+}
+
+async fn test_app_with_embedding_output() -> (axum::Router, MockEngineTask) {
+    let ipc = IpcNamespace::new().expect("create ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
+    let engine_id = b"engine-openai-embeddings".to_vec();
+    let engine_task = MockEngineTask::new(spawn_mock_engine_task(
+        handshake_address.clone(),
+        engine_id,
+        move |dealer, push| {
+            boxed_test_future(async move {
+                let add = recv_engine_message(dealer).await;
+                let request: EngineCoreRequest =
+                    rmp_serde::from_slice(&add[1]).expect("decode request");
+                assert!(request.sampling_params.is_none());
+                let pooling = request.pooling_params.as_ref().expect("pooling params");
+                assert_eq!(pooling.task.as_deref(), Some("embed"));
+                assert_eq!(pooling.dimensions, Some(2));
+                assert_eq!(pooling.use_activation, Some(false));
+                assert_eq!(
+                    request.prompt_token_ids.as_deref(),
+                    Some([FAKE_BOS_TOKEN_ID, b'h' as u32, b'i' as u32].as_slice())
+                );
+                send_outputs(
+                    push,
+                    RequestBatchOutputs {
+                        outputs: vec![EngineCoreOutput {
+                            request_id: request.request_id,
+                            pooling_output: Some(
+                                WireNdArray::from_f32(vec![2], vec![0.25, -0.5])
+                                    .expect("embedding tensor"),
+                            ),
+                            finish_reason: Some(EngineCoreFinishReason::Stop),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }
+                    .into(),
+                )
+                .await;
+            })
+        },
+    ));
+
+    let client = EngineCoreClient::connect(
+        EngineCoreClientConfig::new_single(handshake_address)
+            .with_model_name("test-model")
+            .with_local_input_output_addresses(
+                Some(ipc.input_endpoint()),
+                Some(ipc.output_endpoint()),
+            ),
+    )
+    .await
+    .expect("connect client");
+    let chat = ChatLlm::from_shared_backend(test_llm(client), Arc::new(FakeChatBackend::new()));
+    (
+        build_router(Arc::new(AppState::new(
+            vec!["Qwen/Qwen1.5-0.5B-Chat".to_string()],
+            chat,
+        ))),
+        engine_task,
+    )
+}
+
+#[tokio::test]
+async fn embeddings_returns_openai_response_and_pooling_usage() {
+    let (mut app, engine_task) = test_app_with_embedding_output().await;
+    let response = app
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/embeddings")
+                .header("content-type", "application/json")
+                .header("x-request-id", "embedding-request")
+                .body(Body::from(
+                    json!({
+                        "model": "Qwen/Qwen1.5-0.5B-Chat",
+                        "input": "hi",
+                        "dimensions": 2,
+                        "use_activation": false,
+                        "encoding_format": "float"
+                    })
+                    .to_string(),
+                ))
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    let mut value: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    value["created"] = json!("<timestamp>");
+    expect_test::expect![[r#"
+        Object {
+            "id": String("embd-embedding-request"),
+            "object": String("list"),
+            "created": String("<timestamp>"),
+            "model": String("Qwen/Qwen1.5-0.5B-Chat"),
+            "data": Array [
+                Object {
+                    "object": String("embedding"),
+                    "index": Number(0),
+                    "embedding": Array [
+                        Number(0.25),
+                        Number(-0.5),
+                    ],
+                },
+            ],
+            "usage": Object {
+                "prompt_tokens": Number(3),
+                "total_tokens": Number(3),
+                "completion_tokens": Number(0),
+                "prompt_tokens_details": Null,
+            },
+        }
+    "#]]
+    .assert_debug_eq(&value);
+
+    engine_task.finish().await;
 }
 
 async fn test_app_with_stream_output_specs(


### PR DESCRIPTION
## Purpose
Right now, with `VLLM_USE_RUST_FRONTEND=1`, hitting `/v1/embeddings` just returns a `404` Not Found. 

In order to use Rust‑Frontend’s high‑performance features,  we add OpenAI-compatible `/v1/embeddings` support when using `VLLM_USE_RUST_FRONTEND=1`.

This supports text and token inputs, batched requests, float/base64 encoding, dimensions, LoRA, and usage reporting.
Part of #44280.

With `H100` and `Qwen/Qwen3-Embedding-4B`, the Rust Frontend achieves, on 100 QPS, a 50% reduction in end‑to‑end (E2E) latency compared to the Python Frontend:
<img width="1375" height="285" alt="7e898e1a-ee68-41c7-a662-7711f6bb46de" src="https://github.com/user-attachments/assets/7b243acc-d636-4ba2-a6b9-ff0ce35832e7" />

## Test Plan
  - `cargo check -p vllm-server`
  - `cargo clippy -p vllm-server --all-targets -- -D warnings`
  - `cargo test -p vllm-engine-core-client` (103 passed)
  - `cargo test -p vllm-server embeddings` (3 passed)
  - `cargo fmt --check`
  - `git diff --check`

## Test Result
Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

