### PR TITLE
[Bugfix][Parser] Terminate streamed tool arguments the flush cannot extend

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -1593,29 +1593,88 @@ class TestArgDeltaWithConverter:
 
 
 class TestSafeArgPrefix:
-    """Unit tests for ParserEngine._safe_arg_prefix."""
+    """Unit tests for ParserEngine._safe_arg_prefix.
+
+    A trailing value that cannot stream (non-string, or a string for a key the
+    schema may coerce) is withheld together with its ``"key": `` separator:
+    the flush can drop an unfinished parameter, and a prefix ending on the
+    separator then has no valid completion.
+    """
 
     @pytest.mark.parametrize(
         "json_str, expected",
         [
-            ('{"a": 1}', '{"a": '),
-            ('{"a": 1, "b": 2}', '{"a": 1, "b": '),
+            ('{"a": 1}', ""),
+            ('{"a": 1, "b": 2}', '{"a": 1'),
             ('{"a": "hello", "b": "world"}', '{"a": "hello", "b": "world'),
-            ('{"obj": {"x": 1}, "b": 2}', '{"obj": {"x": 1}, "b": '),
-            ('{"url": "http://x:80", "b": 1}', '{"url": "http://x:80", "b": '),
-            ('{"a": 1', '{"a": '),
+            ('{"obj": {"x": 1}, "b": 2}', '{"obj": {"x": 1}'),
+            ('{"url": "http://x:80", "b": 1}', '{"url": "http://x:80"'),
+            ('{"a": 1', ""),
             ("{}", ""),
             ("{", ""),
             ("", ""),
-            ('{"k":1}', '{"k":'),
-            ('{"k": 1, "v":2}', '{"k": 1, "v":'),
+            ('{"k":1}', ""),
+            ('{"k": 1, "v":2}', '{"k": 1'),
             ('{"k":"value"}', '{"k":"value'),
             ('{"k":"unterminated', '{"k":"unterminated'),
             (r'{"k":"escaped \" quote"}', r'{"k":"escaped \" quote'),
+            # A complete trailing value followed by a separator is kept whole.
+            ('{"a": "x", "b": 2, ', '{"a": "x", "b": 2'),
+            # Unfinished containers are withheld with their key.
+            ('{"a": "x", "obj": {"b": ', '{"a": "x"'),
+            ('{"a": "x", "items": [1, ', '{"a": "x"'),
+            # A streamed string never ends inside an escape sequence.
+            ('{"t": "ab\\', '{"t": "ab'),
+            ('{"t": "ab\\u12', '{"t": "ab'),
+            ('{"t": "ab\\u12ab', '{"t": "ab\\u12ab'),
+            ('{"t": "ab\\n', '{"t": "ab\\n'),
         ],
     )
     def test_safe_arg_prefix(self, json_str, expected):
         assert ParserEngine._safe_arg_prefix(json_str) == expected
+
+    def test_schema_typed_trailing_string_is_withheld_with_its_key(self):
+        # ``count`` may be coerced to a number, so its value cannot stream and
+        # the separator must not be left dangling either.
+        json_str = '{"path": "README.md", "count": "1'
+        assert (
+            ParserEngine._safe_arg_prefix(json_str, {"path"}) == '{"path": "README.md"'
+        )
+
+
+class TestJsonPrefixTerminator:
+    """Unit tests for ParserEngine._json_prefix_terminator.
+
+    Every non-empty suffix must make the prefix parse; a prefix with no valid
+    completion yields "" so the caller can decline to close it.
+    """
+
+    @pytest.mark.parametrize(
+        "prefix, expected",
+        [
+            ('{"a": "x', '"}'),
+            ('{"a": "x\\', '\\"}'),
+            ('{"a": [', "]}"),
+            ('{"a": {"b": "x', '"}}'),
+            # A dangling separator is completed with null, the one value every
+            # schema type accepts.
+            ('{"count": ', "null}"),
+            ('{"a": "x", "b": ', "null}"),
+            ('{"a": {"b": ', "null}}"),
+            ('{"a": "x", "items": [1, ', "null]}"),
+            # An object after a comma cannot be completed without inventing a key.
+            ('{"a": 1, ', ""),
+            # A partial escape cannot be completed without inventing characters.
+            ('{"t": "ab\\u12', ""),
+            ('{"flag": tr', ""),
+            ("", ""),
+        ],
+    )
+    def test_json_prefix_terminator(self, prefix, expected):
+        suffix = ParserEngine._json_prefix_terminator(prefix)
+        assert suffix == expected
+        if suffix:
+            json.loads(prefix + suffix)
 
 
 # ── Coercion instability regression tests ────────────────────────

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -44,6 +44,67 @@ def parser(mock_tokenizer):
     )
 
 
+class TestUnclosedParameterFlush:
+    def test_unclosed_parameter_still_streams_valid_json(self, parser, mock_request):
+        """A tool call cut off mid-parameter must not stream unparseable JSON.
+
+        ``_safe_arg_prefix`` streams unterminated string values on the
+        understanding that the flush closes them. When the model reopens a tool
+        call without closing the current parameter, the non-partial
+        re-derivation drops that parameter, so it is neither longer than nor a
+        prefix of what was already streamed. ``_flush_arg_converter`` then had
+        nothing to append and the stream ended with ``finish_reason`` set while
+        ``arguments`` was still cut off mid-string, which no JSON parser
+        accepts. Observed in production on Qwen3.8-27B at temperature 1.0.
+
+        Fed one character at a time because that is the worst case for the
+        prefix invariant, and because the boundary that triggers this lands
+        inside a literal the incremental lexer would otherwise hold.
+        """
+        raw = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\nREADME.md\n</parameter>\n"
+            "<parameter=content>\n# Title\n\n"
+            "body text that continues for a while\n\n"
+            # The model reopens a tool call without closing <parameter=content>.
+            "<tool_call>\n<function=write_file>"
+        )
+        results = simulate_tool_streaming(parser, mock_request, list(raw))
+        finish = parser.finish_streaming()
+        if finish is not None:
+            results.append((finish, ""))
+
+        args = collect_tool_arguments(results)
+        assert args, "no arguments were streamed"
+        assert args.startswith('{"path": "README.md"'), args[:60]
+        json.loads(args)
+
+    def test_truncated_parameter_still_streams_valid_json(self, parser, mock_request):
+        """The same defect with no stray markup: generation simply stops.
+
+        This is the common trigger. A length stop, a stop string or a client
+        disconnect ends the stream partway through a parameter value, with no
+        second ``<tool_call>`` and nothing malformed in the model output. The
+        flush re-derives without the still-open parameter and again has nothing
+        to append, so the client is handed a string that was never closed.
+        """
+        raw = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\nREADME.md\n</parameter>\n"
+            "<parameter=content>\n# Title\n\n"
+            "body text that stops mid-sen"
+        )
+        results = simulate_tool_streaming(parser, mock_request, list(raw))
+        finish = parser.finish_streaming()
+        if finish is not None:
+            results.append((finish, ""))
+
+        args = collect_tool_arguments(results)
+        assert args, "no arguments were streamed"
+        assert args.startswith('{"path": "README.md"'), args[:60]
+        json.loads(args)
+
+
 class TestNonStreaming:
     def test_no_tool_calls(self, parser, mock_request):
         result = parser.extract_tool_calls(

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -46,7 +46,7 @@ def parser(mock_tokenizer):
 
 class TestUnclosedParameterFlush:
     def test_unclosed_parameter_still_streams_valid_json(self, parser, mock_request):
-        """A tool call cut off mid-parameter must not stream unparseable JSON.
+        """A tool call cut off mid-parameter must not stream unparsable JSON.
 
         ``_safe_arg_prefix`` streams unterminated string values on the
         understanding that the flush closes them. When the model reopens a tool

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -104,6 +104,55 @@ class TestUnclosedParameterFlush:
         assert args.startswith('{"path": "README.md"'), args[:60]
         json.loads(args)
 
+    @pytest.fixture
+    def tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "count": {"type": "integer"},
+                        },
+                    },
+                },
+            }
+        ]
+
+    @pytest.fixture
+    def parser_with_tools(self, mock_tokenizer, tools):
+        return ParserEngine(
+            mock_tokenizer,
+            tools=tools,
+            parser_engine_config=qwen3_config(thinking=False),
+        )
+
+    def test_truncated_typed_parameter_still_streams_valid_json(
+        self, parser_with_tools, mock_request
+    ):
+        """Truncation inside a schema-typed (non-string) parameter.
+
+        The number cannot stream, so before the fix the prefix ended on the
+        separator, ``{"path": "README.md", "count": ``, and the flush had no
+        completion for it.
+        """
+        raw = (
+            "<tool_call>\n<function=write_file>\n"
+            "<parameter=path>\nREADME.md\n</parameter>\n"
+            "<parameter=count>\n12"
+        )
+        results = simulate_tool_streaming(parser_with_tools, mock_request, list(raw))
+        finish = parser_with_tools.finish_streaming()
+        if finish is not None:
+            results.append((finish, ""))
+
+        args = collect_tool_arguments(results)
+        assert args, "no arguments were streamed"
+        assert json.loads(args)["path"] == "README.md"
+
 
 class TestNonStreaming:
     def test_no_tool_calls(self, parser, mock_request):

--- a/tests/parser/engine/test_qwen3.py
+++ b/tests/parser/engine/test_qwen3.py
@@ -46,20 +46,11 @@ def parser(mock_tokenizer):
 
 class TestUnclosedParameterFlush:
     def test_unclosed_parameter_still_streams_valid_json(self, parser, mock_request):
-        """A tool call cut off mid-parameter must not stream unparsable JSON.
+        """A tool call reopened mid-parameter must still stream parsable JSON.
 
-        ``_safe_arg_prefix`` streams unterminated string values on the
-        understanding that the flush closes them. When the model reopens a tool
-        call without closing the current parameter, the non-partial
-        re-derivation drops that parameter, so it is neither longer than nor a
-        prefix of what was already streamed. ``_flush_arg_converter`` then had
-        nothing to append and the stream ended with ``finish_reason`` set while
-        ``arguments`` was still cut off mid-string, which no JSON parser
-        accepts. Observed in production on Qwen3.8-27B at temperature 1.0.
-
-        Fed one character at a time because that is the worst case for the
-        prefix invariant, and because the boundary that triggers this lands
-        inside a literal the incremental lexer would otherwise hold.
+        The flush re-derives without the open parameter, so it cannot extend
+        the streamed prefix; the prefix has to be closed instead. Fed one
+        character at a time, the worst case for the prefix invariant.
         """
         raw = (
             "<tool_call>\n<function=write_file>\n"
@@ -80,14 +71,7 @@ class TestUnclosedParameterFlush:
         json.loads(args)
 
     def test_truncated_parameter_still_streams_valid_json(self, parser, mock_request):
-        """The same defect with no stray markup: generation simply stops.
-
-        This is the common trigger. A length stop, a stop string or a client
-        disconnect ends the stream partway through a parameter value, with no
-        second ``<tool_call>`` and nothing malformed in the model output. The
-        flush re-derives without the still-open parameter and again has nothing
-        to append, so the client is handed a string that was never closed.
-        """
+        """The common trigger: generation simply stops inside a parameter."""
         raw = (
             "<tool_call>\n<function=write_file>\n"
             "<parameter=path>\nREADME.md\n</parameter>\n"

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -978,11 +978,70 @@ class ParserEngine(Parser):
         prev = slot.streamed_json
         if final_json and len(final_json) > len(prev):
             if prev and not final_json.startswith(prev):
-                return None
+                return self._close_streamed_json(slot, prev)
             diff = final_json[len(prev) :]
             slot.streamed_json = final_json
             return diff
+        if prev:
+            return self._close_streamed_json(slot, prev)
         return None
+
+    def _close_streamed_json(self, slot: ToolCallSlot, prev: str) -> str | None:
+        """Terminate an argument prefix the flush cannot extend.
+
+        ``_safe_arg_prefix`` deliberately streams unterminated string values for
+        prefix-stable keys, on the understanding that the flush completes them.
+        If the model never closes a parameter, the non-partial re-derivation
+        drops that parameter entirely, so it is neither longer than nor a prefix
+        of what was already sent. Returning ``None`` there ends the stream with
+        ``finish_reason`` set while the client holds a half-written string, which
+        no JSON parser accepts. Close what was already sent instead: the client
+        gets the truncated value rather than an unparseable message.
+        """
+        suffix = self._json_prefix_terminator(prev)
+        if not suffix:
+            return None
+        slot.streamed_json = prev + suffix
+        return suffix
+
+    @staticmethod
+    def _json_prefix_terminator(prefix: str) -> str:
+        """Return the shortest suffix that makes ``prefix`` parse, or ``""``."""
+        in_string = False
+        escape = False
+        stack: list[str] = []
+        for c in prefix:
+            if escape:
+                escape = False
+                continue
+            if in_string:
+                if c == "\\":
+                    escape = True
+                elif c == '"':
+                    in_string = False
+                continue
+            if c == '"':
+                in_string = True
+            elif c == "{":
+                stack.append("}")
+            elif c == "[":
+                stack.append("]")
+            elif c in "}]" and stack:
+                stack.pop()
+        suffix = ""
+        if escape:
+            # A trailing escape would swallow the quote that closes the string.
+            suffix += "\\"
+        if in_string:
+            suffix += '"'
+        suffix += "".join(reversed(stack))
+        if not suffix:
+            return ""
+        try:
+            json.loads(prefix + suffix)
+        except (json.JSONDecodeError, ValueError):
+            return ""
+        return suffix
 
     _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]*)"')
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -996,7 +996,7 @@ class ParserEngine(Parser):
         of what was already sent. Returning ``None`` there ends the stream with
         ``finish_reason`` set while the client holds a half-written string, which
         no JSON parser accepts. Close what was already sent instead: the client
-        gets the truncated value rather than an unparseable message.
+        gets the truncated value rather than an unparsable message.
         """
         suffix = self._json_prefix_terminator(prev)
         if not suffix:

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -292,6 +292,7 @@ class ParserEngine(Parser):
         the closing tag arrives.
         """
         last_colon = -1
+        last_comma = -1
         last_key: str | None = None
         pending_key: str | None = None
         in_string = False
@@ -321,27 +322,50 @@ class ParserEngine(Parser):
                 last_colon = i
                 last_key = pending_key
                 pending_key = None
+            elif c == "," and depth == 1:
+                last_comma = i
         if last_colon < 0:
             return ""
         end = last_colon + 1
         while end < len(json_str) and json_str[end] in (" ", "\t", "\n", "\r"):
             end += 1
-        if end >= len(json_str) or json_str[end] != '"':
-            return json_str[:end]
-        if string_keys is not None and last_key not in string_keys:
-            return json_str[:end]
+        if (
+            end >= len(json_str)
+            or json_str[end] != '"'
+            or (string_keys is not None and last_key not in string_keys)
+        ):
+            # The trailing value cannot stream. Stop after the last complete
+            # top-level value rather than after ``"key": ``: the flush can
+            # drop an unfinished parameter, and a prefix that ends on the
+            # separator then has no valid completion.
+            return json_str[:last_comma] if last_comma >= 0 else ""
 
         escape = False
+        escape_start = -1
+        hex_left = 0
         for i in range(end + 1, len(json_str)):
             c = json_str[i]
+            if hex_left:
+                hex_left -= 1
+                if hex_left == 0:
+                    escape_start = -1
+                continue
             if escape:
                 escape = False
+                if c == "u":
+                    hex_left = 4
+                else:
+                    escape_start = -1
                 continue
             if c == "\\":
                 escape = True
+                escape_start = i
                 continue
             if c == '"':
                 return json_str[:i]
+        if escape_start >= 0:
+            # Never end on a partial escape: ``\u12`` has no valid completion.
+            return json_str[:escape_start]
         return json_str
 
     @staticmethod
@@ -1034,6 +1058,16 @@ class ParserEngine(Parser):
             suffix += "\\"
         if in_string:
             suffix += '"'
+        else:
+            # A dangling separator has no value to close; ``null`` is the one
+            # placeholder every schema type accepts. An object cannot be
+            # completed after a comma without inventing a key, so that case
+            # falls through to the parse check below and yields no suffix.
+            tail = prefix.rstrip()
+            if tail.endswith(":") or (
+                tail.endswith(",") and stack and stack[-1] == "]"
+            ):
+                suffix += "null"
         suffix += "".join(reversed(stack))
         if not suffix:
             return ""

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -1059,10 +1059,13 @@ class ParserEngine(Parser):
         if in_string:
             suffix += '"'
         else:
-            # A dangling separator has no value to close; ``null`` is the one
-            # placeholder every schema type accepts. An object cannot be
-            # completed after a comma without inventing a key, so that case
-            # falls through to the parse check below and yields no suffix.
+            # A dangling separator has no value to close. ``null`` is used
+            # purely to make the prefix PARSE: the client is being handed a
+            # truncated call either way, and a null placeholder may still fail
+            # the tool's schema, which is strictly better than arguments no
+            # JSON parser accepts. An object cannot be completed after a comma
+            # without inventing a key, so that case falls through to the parse
+            # check below and yields no suffix.
             tail = prefix.rstrip()
             if tail.endswith(":") or (
                 tail.endswith(",") and stack and stack[-1] == "]"


### PR DESCRIPTION
## Purpose

A streaming tool call can end with `finish_reason` set while `arguments` is cut off mid-string. Any client that calls `json.loads` on the accumulated arguments fails on it. Reproduced live on Qwen3.8-27B in 7 of 25 requests sent straight at the worker, no proxy in the path.

`_safe_arg_prefix` (`parser_engine.py:283`) deliberately streams unterminated string values for prefix-stable keys. Its own docstring carries the contract: "String values for keys in `string_keys` are prefix-stable, so stream their unterminated content instead of buffering long arguments until the closing tag arrives." Something has to close them, and that something is the flush.

`_flush_arg_converter` (`parser_engine.py:963`) re-derives the arguments with `partial=False`. Every in-tree `arg_converter` builds its result from completed parameters and folds the still-open one in under `if partial:`. So when generation ends while a parameter is open, the non-partial re-derivation **drops that parameter**, and the result is neither longer than nor a prefix of what was already streamed. Both guards fail, the function returns `None`, and nothing ever terminates the prefix the client is holding.

This is not conditional on the model misbehaving. Anything that ends generation with a parameter open reaches it: a `max_tokens` stop, a stop string, or a malformed continuation.

### Blast radius, measured

Each converter called directly with one complete parameter and one open parameter:

| converter | configs | behavior at `partial=False` |
|---|---|---|
| `_qwen3_arg_converter` | qwen3 | drops the open parameter, 64 chars -> 21 |
| `_minimax_m2_arg_converter` | minimax_m2 | drops the open parameter, 64 -> 21 |
| `_glm47_arg_converter` | glm47_moe | drops the open parameter, 64 -> 21 |
| `_dsml_arg_converter` | deepseek_v4, deepseek_v32 | drops the open parameter, 64 -> 21 |
| `_inkling_arg_converter` | inkling | returns the same unterminated span, so the flush has nothing to append |
| `_gemma4_arg_converter` | gemma4 | not affected, keeps the open parameter |

Six of the seven configs that set an `arg_converter` reach the defect. gemma4 does not, which is why the fix sits at the engine's guard rather than in any converter. Parsers with no `arg_converter` (kimi_k2, ling3, nemotron_v3, mistral) return early and are unaffected.

The two shapes need two branches, and both are in this change: the four dropping converters fail the `startswith` guard, and inkling fails the length guard by returning exactly what was already sent.

### The fix

Close what was already streamed instead of emitting nothing. `_json_prefix_terminator` scans the prefix for an open escape, an open string and unbalanced brackets, appends the shortest suffix that makes it parse, and verifies with `json.loads` before returning it. If it cannot make the prefix parse it returns `""` and the old `None` behavior stands, so this can only turn an unparseable message into a parseable one.

The client gets the truncated value rather than an unparseable message. Truncation is already the semantics here, since the model never produced the rest.

### Relationship to other open work

- **#46303** fixes the other half of the truncation case, and the two are complementary. It keeps `finish_reason: length` for a `max_tokens`-truncated streaming tool call instead of reporting `tool_calls`. That corrects the label; the `arguments` payload is still unparseable without this change, because #46303 touches only `chat_completion/serving.py`. All 7 of my captures report `finish_reason: tool_calls`, so #46303 is the right fix for that half and I am not duplicating it.
- **#48706** is the nearest neighbor and is not the same defect. It fixes the coercion-instability class in `_safe_arg_prefix`, where a non-string middle field is coerced at flush time and breaks the `startswith` invariant. Its diff touches `_safe_arg_prefix` only. It cannot cover this case, because string-typed keys are streamed unterminated *by design* on the path it preserves. The two compose: #48706 keeps the prefix from going stale, this keeps a prefix that can never be extended from being left open.
- **#47137** documents the same trigger class from the other side, content/markup divergence when generation terminates via `max_tokens` or a stop string before the tool call is promoted. Different code path, same class of cutoff.
- **#47761** reports the same error string from `qwen3_coder` on the ParserEngine path. I am not claiming it: the reporter sees it on v0.23.0 as well as v0.24.0, and `vllm/parser/engine/parser_engine.py` does not exist at v0.23.0, so at least part of their report has a different cause.

Not a duplicate: no open PR touches `_flush_arg_converter`. Searched `_flush_arg_converter`, `streamed_json`, "tool arguments unterminated", "parser engine flush arguments" and "unterminated tool call arguments" against open PRs, and the four nearest are discussed above.

## Test Plan

Two regressions in `tests/parser/engine/test_qwen3.py`, one per trigger:

- `test_unclosed_parameter_still_streams_valid_json` - the model reopens `<tool_call>` without closing the current parameter.
- `test_truncated_parameter_still_streams_valid_json` - generation simply stops mid-value, no stray markup at all.

Both feed one character at a time, which is the worst case for the prefix invariant and the only way to hit the boundary reliably. An earlier version of the first test used natural chunk boundaries and passed with the fix reverted, because `<tool_call>` arrived as a complete literal and the incremental lexer transitioned cleanly.

Sweeping every single split point of both inputs makes the boundary explicit:

| input | length | split points | unparseable, unpatched | unparseable, patched |
|---|---|---|---|---|
| reopened `<tool_call>` | 174 | 173 | 12 | 0 |
| plain truncation | 131 | 130 | 12 | 0 |

In both cases the 12 reproducing boundaries are exactly positions 1 to 12, inside the opening `<tool_call>\n` literal, which is what forces the lexer to hold the prefix across the chunk edge. Char-by-char feeding reproduces on both and is what the committed tests use.

```bash
python -m pytest -q tests/parser/engine/test_qwen3.py
python -m pytest -q tests/parser/
```

## Test Result

```
unpatched engine, both tests kept:  2 failed, 51 deselected
                                    json.decoder.JSONDecodeError:
                                    Unterminated string starting at: line 1 column 34 (char 33)
                                    args = '{"path": "README.md", "content": "# Title\n\nbody text that stops mid-sen'
patched:                            53 passed
whole parser suite, patched:        4054 passed, 24 errors in 146.39s
```

The 24 errors are all `tests/parser/test_harmony.py::TestAdjustRequest` and are a missing dependency in my test image, not this change. Control on the same tree with the engine reverted: `40 passed, 24 errors`, the same 24.

The red arm reproduces the exact error string seen in production, including the column.

### Field evidence

Qwen3.8-27B-NVFP4, temperature 1.0, top_p 0.95, `max_tokens` 3000, one `write_file` tool with `path` and `content` string properties, prompt asking for a 40-line markdown document. Requests sent directly to the vLLM worker, so no router, gateway or proxy is in the path. 7 of 25 requests produced unparseable `arguments`:

| run | finish_reason | arguments len | frames | stray markup in arguments |
|---|---|---|---|---|
| 01 | tool_calls | 1930 | 156 | no |
| 02 | tool_calls | 948 | 88 | yes |
| 05 | tool_calls | 4409 | 349 | no |
| 07 | tool_calls | 2688 | 218 | no |
| 16 | tool_calls | 640 | 54 | yes |
| 20 | tool_calls | 2127 | 187 | no |
| 24 | tool_calls | 4263 | 343 | no |

All 7 fail with `Unterminated string`. 5 of the 7 carry no stray markup at all: the document just stops, which is what a `max_tokens` cutoff looks like from the client side. Run 05 ends `... confirm the handler module is importable from the worker environment.` with no closing quote and no closing brace.

Two caveats on that rate, because it is not a field rate. `max_tokens: 3000` against a prompt asking for 40+ lines manufactures length stops, so 7 of 25 overstates what a caller with a large budget would see. And the harness only persisted failures, so the 7 files are the failures out of runs indexed 0 to 24, not a sample of all outcomes.

### Live end-to-end validation (matched patched vs unpatched arms)

Unit tests establish the mechanism; this establishes that the fix removes the defect from a real server.

Host kebab-spark-3, NVIDIA GB10 (sm_121), aarch64. vLLM `0.26.1rc1.dev1164+g794b7b354`, editable install of this branch. Model `unsloth/Qwen3.8-27B-NVFP4`, snapshot `a767244d27bd`, on local NVMe. Identical server flags in all four runs:

```
vllm serve <model> --served-model-name qwen38 --port 8300 \
  --gpu-memory-utilization 0.6 --max-model-len 8192 \
  --enable-auto-tool-choice --tool-call-parser qwen3_xml --trust-remote-code
```

The parser actually selected was read from the live interpreter rather than the log: `qwen3_xml -> Qwen3EngineToolParser`, `_parser_engine_cls = vllm.parser.qwen3.Qwen3Parser`, `issubclass(Qwen3Parser, ParserEngine) = True`, `_flush_arg_converter` present. So the changed code is on the path.

Arms were switched by applying and reverting the isolated `parser_engine.py` diff on ONE install (pure Python, no rebuild), restarting the server between arms, and asserting the patch state from the running venv each time via `hasattr(Qwen3Parser, "_close_streamed_json")`.

**Run A, the sampling parameters from the field capture** (temperature 1.0, top_p 0.95, `max_tokens` 3000):

| arm | malformed `arguments` | N |
|---|---|---|
| unpatched | 4 | 40 |
| patched | 0 | 40 |

All 4 unpatched failures carry the identical signature `Unterminated string starting at: line 1 column 34 (char 33)`, char 33 being the opening quote of the `content` value. The final SSE frame of each is an ordinary mid-word content delta carrying `finish_reason`, with no closing flush delta at all:

```
{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":" to"}}]},
  "finish_reason":"tool_calls","stop_reason":null}]}
```

**Run A's patched arm is reported for completeness and is not sufficient on its own.** None of its 40 requests reached the token cap (max 1251 argument deltas, every content value ended cleanly), so that arm never exercised the trigger. In the unpatched arm 8 of 40 did reach the cap: 4 during reasoning before any tool call (empty `arguments`), and 4 inside an open `<parameter=>`, all 4 of which were malformed. Conditional on the trigger, that is 4 of 4.

**Run B, trigger forced on every request.** Identical to Run A except `max_tokens` 400 and `chat_template_kwargs: {"enable_thinking": false}`, applied to BOTH arms. Removing the variable-length reasoning block makes the cap land inside the tool call rather than inside reasoning:

| arm | malformed `arguments` | N |
|---|---|---|
| unpatched | **40** | 40 |
| patched | **0** | 40 |

All 80 requests truncated at the cap (SSE frame counts 341 to 364 against `max_tokens` 400), so the triggering condition held on every one. All 40 unpatched failures were again exactly `Unterminated string starting at: line 1 column 34 (char 33)`. All 40 patched responses parse, with shape `{"path": "README.md", "content": ...}`, content truncated mid-token (1340 / 1495 / 1759 chars for min / median / max) and a final delta of exactly `"}`.

Separately, the 4 malformed `arguments` strings captured in unpatched Run A were fed to `_json_prefix_terminator` directly: each yields terminator `"}` and then parses, preserving `path` and the truncated `content` (1247 to 3708 chars).

0 malformed in 80 patched requests, against 4 of 40 at the natural rate and 40 of 40 with the trigger forced.

### The finish_reason makes this harder to notice than it sounds

On every failure in both runs, `finish_reason` was `"tool_calls"` and `stop_reason` was `null` - never `"length"`. `vllm/entrypoints/openai/chat_completion/serving.py:762` overrides `finish_reason` to `tool_calls` whenever a tool call was streamed, regardless of the engine's real stop reason. So a client sees a normal, successful-looking terminal state next to `arguments` cut off mid-value, with nothing in the response indicating truncation. #46303 fixes that half; this fixes the payload.


## Model evaluation

None applies, and the reason is worth stating rather than leaving as a silent omission. This change runs after generation, in the parser's end-of-stream flush, and only decides whether an argument prefix that was already streamed gets terminated. It cannot affect sampling, logits or model output, and accuracy benchmarks do not exercise tool-call streaming at all.

The question that does matter is whether it alters output on well-formed tool calls. Measured directly: six well-formed Qwen3 tool calls (single parameter, two parameters, embedded quotes and newlines and backslashes, JSON braces inside the value, an empty value, multibyte content), each fed as a whole string, character by character, and at every single split point - 794 stream variants in total - through both the patched and the unpatched engine. The streamed `arguments` are byte-identical between the two arms in all 794 variants.

Two honest notes on that number. 84 of the 794 variants produce non-empty arguments, and all 84 are valid JSON; the whole-string and character-by-character feeds produce the complete correct JSON for all six inputs. The remaining variants emit nothing, in both arms alike - a pre-existing interaction between a two-chunk split landing mid-literal and the incremental lexer, which this PR does not touch and does not change.

## Notes

AI assistance (Claude Code) was used for the code reading, the converter measurements, the tests and this description. The submitter reviewed every changed line and ran the tests above.
