### PR TITLE
[Bugfix][Distributed] Retain shared memory handle until after barrier in in_the_same_node_as

### DIFF
--- a/tests/distributed/test_shm_barrier.py
+++ b/tests/distributed/test_shm_barrier.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import unittest.mock as mock
+from multiprocessing import shared_memory
+import pytest
+import torch
+import torch.distributed as dist
+
+from vllm.distributed.parallel_state import in_the_same_node_as
+from vllm.distributed.utils import StatelessProcessGroup
+
+
+def test_in_the_same_node_as_retains_shm_until_after_barrier():
+    """
+    Ensure the creator's shared memory handle is not closed before the
+    process-group barrier executes, preventing a race condition where peer
+    ranks open a named shared memory segment on Windows after the creator
+    closed its handle.
+    """
+    events = []
+
+    class MockStatelessProcessGroup:
+        rank = 0
+        world_size = 1
+
+        def broadcast_obj(self, obj, src=0):
+            return obj
+
+        def barrier(self):
+            events.append("barrier")
+
+    original_shm_init = shared_memory.SharedMemory.__init__
+    original_shm_close = shared_memory.SharedMemory.close
+    original_shm_unlink = shared_memory.SharedMemory.unlink
+
+    def mock_close(self):
+        events.append("shm_close")
+        return original_shm_close(self)
+
+    def mock_unlink(self):
+        events.append("shm_unlink")
+        return original_shm_unlink(self)
+
+    with mock.patch.object(shared_memory.SharedMemory, "close", mock_close), \
+         mock.patch.object(shared_memory.SharedMemory, "unlink", mock_unlink):
+        pg = MockStatelessProcessGroup()
+        result = in_the_same_node_as(pg, source_rank=0)
+
+    assert result == [True]
+    # Barrier MUST occur before shm_close and shm_unlink
+    assert "barrier" in events
+    assert "shm_close" in events
+    barrier_idx = events.index("barrier")
+    close_idx = events.index("shm_close")
+    assert barrier_idx < close_idx, f"Barrier at {barrier_idx} was not before close at {close_idx}. Events: {events}"

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2240,19 +2240,19 @@ def in_the_same_node_as(
                     is_in_the_same_node[rank] = 1
     except Exception as e:
         logger.error("Error ignored in is_in_the_same_node: %s", e)
+
+    try:
+        if isinstance(pg, ProcessGroup):
+            torch.distributed.barrier(group=pg)
+        else:
+            pg.barrier()
     finally:
-        if shm:
-            shm.close()
-
-    if isinstance(pg, ProcessGroup):
-        torch.distributed.barrier(group=pg)
-    else:
-        pg.barrier()
-
-    # clean up the shared memory segment
-    with contextlib.suppress(OSError):
-        if rank == source_rank and shm:
-            shm.unlink()
+        # clean up the shared memory segment after all ranks have reached the barrier
+        with contextlib.suppress(OSError):
+            if shm:
+                shm.close()
+            if rank == source_rank and shm:
+                shm.unlink()
 
     if isinstance(pg, ProcessGroup):
         torch.distributed.all_reduce(is_in_the_same_node, group=pg)


### PR DESCRIPTION
Fixes #53718

### Description
In `in_the_same_node_as`, the creator's `SharedMemory` handle was previously closed in the `finally` block before the process group barrier. On platforms like Windows where named shared memory objects may be cleaned up as soon as all open handles in the creating process are closed before peer ranks have attached, this causes a race condition leading to failed initialization.

This PR defers closing and unlinking the shared memory segment until after all ranks have synchronized at the barrier, ensuring that peer ranks can safely access the mapping.

### Testing
Added regression unit test `tests/distributed/test_shm_barrier.py` asserting that the barrier occurs before the creator's `shm.close()` and `shm.unlink()`.