### PR TITLE
[Bugfix][Multimodal] Reject malformed base64 audio with 400 instead of 500

### DIFF
--- a/tests/multimodal/media/test_audio.py
+++ b/tests/multimodal/media/test_audio.py
@@ -46,6 +46,18 @@ def test_audio_media_io_load_base64(dummy_audio_bytes):
     assert out[1] == 16000
 
 
+def test_audio_media_io_load_base64_rejects_malformed(dummy_audio_bytes):
+    """Malformed base64 must surface as a ValueError so the server answers 400.
+    Without strict decoding the bad characters are dropped, the garbage reaches
+    libsndfile, and the client gets a 500 instead."""
+    encoded = base64.b64encode(dummy_audio_bytes).decode("utf-8")
+    malformed = encoded[:8] + "!!!@@@###" + encoded[8:]
+
+    audio_io = AudioMediaIO()
+    with pytest.raises(ValueError):
+        audio_io.load_base64("audio/wav", malformed)
+
+
 def test_audio_media_io_load_file(audio_assets: AudioTestAssets):
     audio_io = AudioMediaIO()
     path = audio_assets[0].get_local_path()

--- a/vllm/multimodal/media/audio.py
+++ b/vllm/multimodal/media/audio.py
@@ -309,7 +309,7 @@ class AudioMediaIO(MediaIO[tuple[npt.NDArray, float]]):
                 parameter="audio_filesize_mb",
                 value=(len(data) * 3 / 4) / MiB_bytes,
             )
-        return self.load_bytes(pybase64.b64decode(data))
+        return self.load_bytes(pybase64.b64decode(data, validate=True))
 
     def load_file(self, filepath: Path) -> tuple[npt.NDArray, float]:
         self._validate_encoded_size(filepath.stat().st_size)


### PR DESCRIPTION
## Purpose

A malformed base64 audio payload returns HTTP 500. The same payload sent as an image returns 400.

`AudioMediaIO.load_base64` decodes without strict validation:

```python
return self.load_bytes(pybase64.b64decode(data))
```

`pybase64` then drops any character outside the base64 alphabet and decodes whatever is left. The mangled bytes reach libsndfile, which raises `LibsndfileError`. That inherits from `RuntimeError`, so `create_error_response` falls through to its `else` branch and answers 500.

The other three media loaders pass `validate=True`, so a bad payload raises `binascii.Error`, which inherits from `ValueError` and maps to 400.

Running the same malformed string through both loaders on current main:

```text
malformed base64 audio : LibsndfileError -> HTTP 500
malformed base64 image : Error           -> HTTP 400
```

A client sending a corrupt upload should not see a server error, and it should not differ by media type.

`ImageMediaIO`, `ImageEmbeddingMediaIO` and `AudioEmbeddingMediaIO` already pass `validate=True`. `VideoMediaIO` delegates to `ImageMediaIO`. Audio was the only loader left.

### Related, not fixed here

A genuinely corrupt audio or image file, where the base64 is valid but the decoded bytes are not media, still returns 500: `LibsndfileError` and PIL's `UnidentifiedImageError` are neither `ValueError` nor `VLLMError`. Mapping decode failures to a client error means deciding between 400 and 422 and touching the connector, so I left it out. Happy to open an issue if that is worth tracking.

## Test Plan

```
pytest tests/multimodal/media/test_audio.py
pytest tests/multimodal/media/ --ignore=tests/multimodal/media/test_video.py
ruff check <changed files>
ruff format --check <changed files>
```

`test_audio_media_io_load_base64_rejects_malformed` builds a valid payload, splices non-alphabet characters into it, and asserts the loader raises `ValueError`.

## Test Result

`test_audio.py` with the fix:

```
11 passed, 1 failed
```

The failure is `test_audio_media_io_from_video`, which needs video assets my machine does not have. It fails the same way on an unmodified checkout.

The new test with `audio.py` reverted to main:

```
E  Failed: DID NOT RAISE ValueError
```

Wider media suite, with the fix:

```
71 failed, 43 passed
```

Unmodified checkout, same command:

```
71 failed, 42 passed
```

Same failures either way, from missing `cv2` and from tests that reach the network. The extra pass is the new test.

`ruff check` and `ruff format --check` pass on both files.

I ran no accuracy or performance tests. This rejects input that already failed, one step earlier and with the right status code.

## Note

AI assistance was used for this change. I reviewed every changed line, ran the tests above, and can explain the change.
