### PR TITLE
[Bugfix][KVConnector] Don't crash scheduler on stale KV transfer completions

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4905,6 +4905,45 @@ def test_delayed_kv_connector_free_keeps_scheduler_active():
     assert not scheduler.has_finished_requests()
 
 
+def test_stale_finished_recving_is_ignored():
+    """A late finished_recving report for an already-removed request must not
+    crash the engine (see issue #53049: MultiConnector lacks per-connector
+    dedup for async loads, so a slow connector can report a completion for a
+    request the scheduler already finished via a faster connector)."""
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(
+            finished_recving={"unknown-request"}
+        ),
+    )
+
+    # Should not raise; the stale report is simply ignored.
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert "unknown-request" not in scheduler.finished_recving_kv_req_ids
+
+
+def test_stale_finished_sending_is_ignored():
+    """A late finished_sending report for an already-removed request must not
+    crash the engine (symmetric to the finished_recving case in #53049)."""
+    scheduler = create_scheduler(use_kv_connector=True)
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=KVConnectorOutput(
+            finished_sending={"unknown-request"}
+        ),
+    )
+
+    # Should not raise; the stale report is simply ignored.
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+
 def test_scheduler_kv_connector_stats():
     """Test worker-side, scheduler-side, and combined KV connector stats."""
 

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4916,9 +4916,7 @@ def test_stale_finished_recving_is_ignored():
     model_runner_output = ModelRunnerOutput(
         req_ids=[],
         req_id_to_index={},
-        kv_connector_output=KVConnectorOutput(
-            finished_recving={"unknown-request"}
-        ),
+        kv_connector_output=KVConnectorOutput(finished_recving={"unknown-request"}),
     )
 
     # Should not raise; the stale report is simply ignored.
@@ -4935,9 +4933,7 @@ def test_stale_finished_sending_is_ignored():
     model_runner_output = ModelRunnerOutput(
         req_ids=[],
         req_id_to_index={},
-        kv_connector_output=KVConnectorOutput(
-            finished_sending={"unknown-request"}
-        ),
+        kv_connector_output=KVConnectorOutput(finished_sending={"unknown-request"}),
     )
 
     # Should not raise; the stale report is simply ignored.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2871,12 +2871,8 @@ class Scheduler(SchedulerInterface):
             logger.debug("Finished recving KV transfer for request %s", req_id)
             req = self.requests.get(req_id)
             if req is None:
-                # A late/stale KV transfer completion may be reported for a
-                # request the scheduler has already removed (e.g. when multiple
-                # connectors load the same request and the faster one already
-                # completed it). This is state-wise harmless, so warn and skip
-                # instead of crashing the engine with an assertion error.
-                logger.warning(
+                # A slower connector may finish after the request was removed.
+                logger.warning_once(
                     "Got finished recving KV transfer for request %s that is "
                     "no longer being tracked by the scheduler; ignoring.",
                     req_id,
@@ -2891,7 +2887,7 @@ class Scheduler(SchedulerInterface):
             logger.debug("Finished sending KV transfer for request %s", req_id)
             req = self.requests.get(req_id)
             if req is None:
-                logger.warning(
+                logger.warning_once(
                     "Got finished sending KV transfer for request %s that is "
                     "no longer being tracked by the scheduler; ignoring.",
                     req_id,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2869,17 +2869,35 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                # A late/stale KV transfer completion may be reported for a
+                # request the scheduler has already removed (e.g. when multiple
+                # connectors load the same request and the faster one already
+                # completed it). This is state-wise harmless, so warn and skip
+                # instead of crashing the engine with an assertion error.
+                logger.warning(
+                    "Got finished recving KV transfer for request %s that is "
+                    "no longer being tracked by the scheduler; ignoring.",
+                    req_id,
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                self._free_blocks(req)
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Got finished sending KV transfer for request %s that is "
+                    "no longer being tracked by the scheduler; ignoring.",
+                    req_id,
+                )
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose

Fixes #53049.

`MultiConnector` can report an asynchronous KV-transfer completion after the scheduler has already removed the request. The existing assertions then terminate the engine with `EngineDeadError`.

This PR implements the issue’s defense-in-depth direction only: stale `finished_recving` and `finished_sending` entries are warned about once and ignored. It does not claim to solve the underlying MultiConnector load coordination or NIXL memory-safety problem, which requires the full NIXL + LMCache P/D topology to validate.

## Test plan

Added focused scheduler regression tests:

- `test_stale_finished_recving_is_ignored`
- `test_stale_finished_sending_is_ignored`

Both construct a completion for a request absent from the scheduler and verify that `update_from_output` does not raise.

Latest local verification for `6bcdca65f1`:

- `pre-commit run ruff-check --files ...` — passed
- `pre-commit run ruff-format --files ...` — passed
- `python -m py_compile ...` — passed
- `git diff --check` — passed
- Targeted pytest was not completed locally because the available macOS environment did not contain the full vLLM test dependency set.
- Large-model NIXL + LMCache P/D E2E was not run because that topology and GPU environment were unavailable.

## Contribution checks

- Duplicate search: no open PR addressing #53049 or the same scheduler stale-completion guard was found when this change was prepared.
- Model evaluation: not applicable; this changes scheduler error handling only and does not alter model output or accuracy.
- AI assistance: TRAE was used for codebase inspection, regression-test preparation, and review follow-up. I reviewed the complete diff and take responsibility for the change.