### PR TITLE
[Bugfix][Tokenizer] Replace bare asserts in the DeepSeek V4 encoder

### DIFF
--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -403,3 +403,27 @@ def test_deepseek_v4_matches_reference_golden_fixtures(case_id, kwargs):
 
     expected = (FIXTURES_DIR / f"test_output_{case_id}.txt").read_text()
     assert prompt == expected
+
+
+def test_deepseek_v4_rejects_empty_developer_content():
+    with pytest.raises(ValueError):
+        _tokenizer().apply_chat_template(
+            [{"role": "developer", "content": ""}],
+            tokenize=False,
+            enable_thinking=True,
+            reasoning_effort="low",
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"thinking_mode": "bogus"},
+        {"thinking_mode": "thinking", "reasoning_effort": "turbo"},
+    ],
+)
+def test_deepseek_v4_encode_messages_rejects_invalid_arguments(kwargs):
+    from vllm.tokenizers.deepseek_v4_encoding import encode_messages
+
+    with pytest.raises(ValueError):
+        encode_messages([{"role": "user", "content": "Hello"}], **kwargs)

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -225,8 +225,12 @@ def render_message(
     Returns:
         Encoded string for this message.
     """
-    assert 0 <= index < len(messages)
-    assert thinking_mode in ["chat", "thinking"], f"Invalid thinking_mode `{thinking_mode}`"
+    if not (0 <= index < len(messages)):
+        raise ValueError(
+            f"Index {index} out of range for messages list of length {len(messages)}"
+        )
+    if thinking_mode not in ["chat", "thinking"]:
+        raise ValueError(f"Invalid thinking_mode `{thinking_mode}`")
 
     prompt = ""
     msg = messages[index]
@@ -248,10 +252,11 @@ def render_message(
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
     reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
-    assert reasoning_effort in REASONING_EFFORT_PROMPTS, (
-        f"Invalid reasoning effort: {reasoning_effort}, expected one of "
-        f"{list(REASONING_EFFORT_PROMPTS)}"
-    )
+    if reasoning_effort not in REASONING_EFFORT_PROMPTS:
+        raise ValueError(
+            f"Invalid reasoning effort: {reasoning_effort}, expected one of "
+            f"{list(REASONING_EFFORT_PROMPTS)}"
+        )
     if index == 0 and thinking_mode == "thinking":
         prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
 
@@ -263,7 +268,8 @@ def render_message(
             prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
 
     elif role == "developer":
-        assert content, f"Invalid message for role `{role}`: {msg}"
+        if not content:
+            raise ValueError(f"Invalid message for role `{role}`: {msg}")
 
         content_developer = USER_SP_TOKEN
         content_developer += content
@@ -362,7 +368,10 @@ def render_message(
     task = messages[index].get("task")
     if task is not None:
         # Task special token for internal classification tasks
-        assert task in VALID_TASKS, f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+        if task not in VALID_TASKS:
+            raise ValueError(
+                f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+            )
         task_sp_token = DS_TASK_SP_TOKENS[task]
 
         if task != "action":


### PR DESCRIPTION
## Purpose

`vllm/tokenizers/deepseek_v4_encoding.py` still validates with bare `assert`. Its sibling encoder dropped them in #32884, and V4 landed afterwards carrying the old style.

Two consequences.

An `AssertionError` is neither a `ValueError` nor a `VLLMError`, so `create_error_response` falls through to its `else` branch and answers 500. Sending an empty `developer` message through the served chat-template path:

```text
v4 : AssertionError -> HTTP 500
v32: ValueError     -> HTTP 400
```

Under `python -O` the asserts disappear, and with them every check in this function. A malformed message then flows into the renderer instead of being rejected.

This converts all five to `ValueError`, matching the wording #32884 used for V3.2.

### Reachability

Of the five, one is reachable through `apply_chat_template`: the empty `developer` content check shown above. The tokenizer wrapper normalizes `reasoning_effort` before the encoder sees it, and `task` does not come from request kwargs, so those two are internal invariants today. I checked each one. The `-O` argument applies to all five either way.

## Test Plan

```
pytest tests/tokenizers_/test_deepseek_v4.py
ruff check <changed files>
ruff format --check <changed files>
```

`test_deepseek_v4_rejects_empty_developer_content` drives the served path through `apply_chat_template`. `test_deepseek_v4_encode_messages_rejects_invalid_arguments` covers the two internal invariants by calling `encode_messages` directly.

## Test Result

With the fix:

```
35 passed
```

With `deepseek_v4_encoding.py` reverted and the tests kept:

```
3 failed, 32 passed
```

`ruff check` and `ruff format --check` pass on both files with the `v0.14.0` pinned in `.pre-commit-config.yaml`. A newer ruff reports two pre-existing `ISC004` findings at lines 165 and 170 of the test file, which are unrelated to this change and also appear on an unmodified checkout.

I did not run the rest of `tests/tokenizers_/`; those cases pull tokenizers from the Hub and my machine cannot reach the gated repos.

No accuracy or performance testing. This changes which exception type the encoder raises for input it already rejected.

## Note

AI assistance was used for this change. I reviewed every changed line, ran the tests above, and can explain the change.
