### PR TITLE
[Bugfix][Frontend] Apply the stop string limit to Cohere requests

### DIFF
--- a/tests/entrypoints/cohere/test_protocol.py
+++ b/tests/entrypoints/cohere/test_protocol.py
@@ -16,6 +16,7 @@ types plus a few local additions:
 import pytest
 from pydantic import ValidationError
 
+import vllm.envs as envs
 from vllm.entrypoints.cohere.protocol import (
     AssistantMessageResponse,
     CitationEndEvent,
@@ -92,6 +93,24 @@ class TestCohereChatV2Request:
                 model="m",
                 messages=[{"role": "user", "content": "hi"}],
                 tool_choice="ANY",  # not REQUIRED/NONE
+            )
+
+    def test_stop_sequences_bounded_by_env_limit(self):
+        messages = [{"role": "user", "content": "hi"}]
+        limit = envs.VLLM_MAX_STOP_STRINGS
+
+        req = CohereChatV2Request(
+            model="m",
+            messages=messages,
+            stop_sequences=[f"s{i}" for i in range(limit)],
+        )
+        assert len(req.stop_sequences) == limit
+
+        with pytest.raises(ValidationError):
+            CohereChatV2Request(
+                model="m",
+                messages=messages,
+                stop_sequences=[f"s{i}" for i in range(limit + 1)],
             )
 
 

--- a/vllm/entrypoints/cohere/protocol.py
+++ b/vllm/entrypoints/cohere/protocol.py
@@ -25,7 +25,7 @@ See https://docs.cohere.com/reference/chat for the upstream spec.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from cohere import types as _sdk
 from cohere.types import (
@@ -46,6 +46,7 @@ from cohere.types import (
 )
 from pydantic import BaseModel, Field, field_validator
 
+import vllm.envs as envs
 from vllm.exceptions import VLLMValidationError
 
 # Re-export the SDK wire-format types alongside our local extensions so
@@ -152,7 +153,9 @@ class CohereChatV2Request(BaseModel):
     response_format: ResponseFormatV2 | None = None
     safety_mode: ChatRequestSafetyMode | None = None
     max_tokens: int | None = None
-    stop_sequences: list[str] | None = None
+    stop_sequences: (
+        Annotated[list[str], Field(max_length=envs.VLLM_MAX_STOP_STRINGS)] | None
+    ) = None
 
     # Sampling
     temperature: float | None = None


### PR DESCRIPTION
## Purpose

`VLLM_MAX_STOP_STRINGS` caps how many stop strings one request may carry. #51447 added it to keep a single request from loading the sampler with unbounded work. The Cohere Chat V2 endpoint does not apply it.

`CohereChatV2Request.stop_sequences` is a plain `list[str]`, and `vllm/entrypoints/cohere/serving.py:554` hands it to `SamplingParams` as `stop=request.stop_sequences`. Nothing counts the entries on the way through, and `SamplingParams` has no backstop of its own, so the protocol layer is the only place this limit exists.

With the default limit of 4:

```text
anthropic: rejected 1000 stop sequences
cohere   : accepted 1000 stop sequences
```

`AnthropicMessagesRequest` and the shared OpenAI engine protocol both wrap the field in `Annotated[list[str], Field(max_length=envs.VLLM_MAX_STOP_STRINGS)]`. This applies the same annotation to Cohere.

Every stop string is matched against generated text on each step, so the count drives per-step work for the life of the request.

## Test Plan

```
pytest tests/entrypoints/cohere/test_protocol.py
pytest tests/entrypoints/cohere/
ruff check <changed files>
ruff format --check <changed files>
```

`test_stop_sequences_bounded_by_env_limit` reads the limit from `envs`, accepts a request holding exactly that many stop sequences, and expects a `ValidationError` at one more. Reading the value keeps the test correct if the default changes.

## Test Result

Protocol tests with the fix:

```
21 passed
```

With `protocol.py` reverted and the test kept:

```
1 failed, 20 passed
```

Whole Cohere suite, with the fix:

```
11 failed, 169 passed, 2 errors
```

Unmodified checkout, same command:

```
11 failed, 168 passed, 2 errors
```

The failures and collection errors match on both sides. They come from `pytest_asyncio` and `uvicorn` missing on my machine. The extra pass is the new test.

`ruff check` and `ruff format --check` pass on both files using the `v0.14.0` pinned in `.pre-commit-config.yaml`.

No accuracy or performance testing. This rejects a request shape that was already meant to be rejected.

## Note

AI assistance was used for this change. I reviewed every changed line, ran the tests above, and can explain the change.
