### PR TITLE
[Bugfix] Ignore q_scale for FlashInfer native BF16 queries

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -803,6 +803,31 @@ def test_flashinfer_xqa_bmm1_scale_matches_decode_q_dtype():
     AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
     reason="FlashInfer is not available.",
 )
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    [
+        (torch.float16, 1.0),
+        (torch.bfloat16, 1.0),
+        (torch.float8_e4m3fn, 2.0),
+        (torch.float8_e5m2, 2.0),
+    ],
+)
+def test_flashinfer_query_scale_matches_query_dtype(dtype, expected):
+    """Native attention should only apply q_scale when Q is FP8."""
+    from vllm.v1.attention.backends import flashinfer as flashinfer_backend
+
+    class MockLayer:
+        _q_scale_float = 2.0
+
+    impl = object.__new__(flashinfer_backend.FlashInferImpl)
+
+    assert impl.get_query_scale(MockLayer, dtype) == expected
+
+
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
 def test_flashinfer_xqa_draft_masks():
     from vllm.v1.attention.backends import flashinfer as flashinfer_backend
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1872,6 +1872,12 @@ class FlashInferImpl(AttentionImpl):
         else:
             self.sinks.copy_(source_sinks)
 
+    @staticmethod
+    def get_query_scale(layer: torch.nn.Module, q_data_type: torch.dtype) -> float:
+        if q_data_type in (torch.float8_e4m3fn, torch.float8_e5m2):
+            return layer._q_scale_float
+        return 1.0
+
     def get_xqa_bmm1_scale(self, layer: torch.nn.Module, q_data_type: torch.dtype):
         bmm1_scale = self.scale
         if is_quantized_kv_cache(self.kv_cache_dtype):
@@ -2163,7 +2169,9 @@ class FlashInferImpl(AttentionImpl):
                             prefill_query,
                             kv_cache_for_fi,
                             self.sinks,
-                            self.scale * layer._q_scale_float * layer._k_scale_float,
+                            self.scale
+                            * self.get_query_scale(layer, prefill_query.dtype)
+                            * layer._k_scale_float,
                             v_scale=layer._v_scale_float,
                             out=out_prefill,
                         )
@@ -2171,7 +2179,7 @@ class FlashInferImpl(AttentionImpl):
                         prefill_wrapper.run(
                             prefill_query,
                             kv_cache_for_fi,
-                            q_scale=layer._q_scale_float,
+                            q_scale=self.get_query_scale(layer, prefill_query.dtype),
                             k_scale=layer._k_scale_float,
                             v_scale=layer._v_scale_float,
                             out=out_prefill,
@@ -2337,7 +2345,7 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_for_fi,
-                        q_scale=layer._q_scale_float,
+                        q_scale=self.get_query_scale(layer, decode_query.dtype),
                         k_scale=layer._k_scale_float,
                         v_scale=layer._v_scale_float,
                         out=output_tmp,
@@ -2355,7 +2363,7 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_for_fi,
-                        q_scale=layer._q_scale_float,
+                        q_scale=self.get_query_scale(layer, decode_query.dtype),
                         k_scale=layer._k_scale_float,
                         v_scale=layer._v_scale_float,
                         out=out_decode,


### PR DESCRIPTION
## Purpose

Fixes #53481.

FlashInfer's native prefill and decode wrappers always received `layer._q_scale_float`, even when the query tensor was already dequantized to BF16 or FP16. For checkpoints with a calibrated non-unity Q scale, FlashInfer therefore scaled a model-dtype query a second time and corrupted attention output.

On `mistralai/Ministral-3-3B-Instruct-2512`, the first layer had a BF16 query and `q_scale=0.02774658203125`. Capturing the real layer-0 tensors produced the following evidence:

- Direct FlashInfer without `q_scale` vs. PyTorch reference: max absolute error `0.0009765625`.
- vLLM native FlashInfer vs. PyTorch reference: max absolute error `0.3743896484375`.
- Direct FlashInfer with the erroneous `q_scale` vs. vLLM output: max absolute error `0.0`.

This change passes the calibrated Q scale only for FP8 E4M3/E5M2 queries and uses `1.0` for FP16/BF16 queries. It covers native prefill, native prefill with attention sinks, and native decode.

This is not a duplicate of #48016. That PR fixes scale bookkeeping in the TRTLLM prefill and trtllm-gen decode paths; this PR fixes the separate native `BatchPrefillWithPagedKVCacheWrapper` and `BatchDecodeWithPagedKVCacheWrapper` paths exercised by #53481 on SM120.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/attention/test_attention_backends.py \
  -k 'flashinfer_query_scale or flashinfer_xqa_bmm1_scale' -q

.venv/bin/pre-commit run --files \
  vllm/v1/attention/backends/flashinfer.py \
  tests/v1/attention/test_attention_backends.py

git diff --check
```

Model evaluation used the offline configuration from #53481 with `mistralai/Ministral-3-3B-Instruct-2512`, BF16, `max_model_len=8192`, eager mode, greedy decoding, and the prompt `What is two plus two?`. The only changed runtime setting between the red and green one-token runs was this patch.

## Test Result

- Unit tests: `5 passed, 131 deselected`.
- All pre-commit hooks for the two changed files passed, including Ruff, formatting, typos, mypy, SPDX, and repository policy checks.
- `git diff --check` passed.
- RTX 5090 (SM120), CUDA 13.0, PyTorch 2.13.0+cu130, FlashInfer 0.6.17:
  - Baseline native FlashInfer, one token: token `2405`, text `'t`.
  - Patched native FlashInfer, one token: token `1531`, text ` The`.
  - Patched native FlashInfer, 64 tokens: starts with `The answer is four` and remains coherent.
  - Triton attention control, 64 tokens: starts with `The answer is four` and remains coherent.

AI assistance was used for diagnosis, implementation suggestions, test preparation, and PR text. I reviewed every changed line, ran and verified all results reported above, understand the implementation, and accept responsibility for maintaining the change and addressing reviewer feedback.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan with commands.
- [x] The test results with before/after and end-to-end evidence.
- [x] No documentation update is needed for this bug fix.
</details>
