### PR TITLE
[Bugfix][Core] Log minimum cacheable prefix size

### DIFF
--- a/docs/features/automatic_prefix_caching.md
+++ b/docs/features/automatic_prefix_caching.md
@@ -23,3 +23,5 @@ We describe two example workloads, where APC can provide huge performance benefi
 ## Limits
 
 APC in general does not reduce the performance of vLLM. With that being said, APC only reduces the time of processing the queries (the prefilling phase) and does not reduce the time of generating new tokens (the decoding phase). So APC does not bring performance gain when vLLM spends most of the time generating answers to the queries (e.g. when the length of the answer is long), or new queries do not share the same prefix with any of existing queries (so that the computation cannot be reused).
+
+APC only reuses complete prefix-cache match units. At startup, vLLM logs the effective minimum cacheable prefix in tokens. Shared prefixes shorter than this value cannot produce cache hits. Hybrid attention/SSM models can use a much larger match unit than attention-only models because their attention and recurrent-state cache pages must be aligned. The logged value reflects the effective `--prefix-match-unit` when one is configured.

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -2816,6 +2817,56 @@ def _grouping_config():
         scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
         speculative_config=None,
         cache_config=cache_config,
+    )
+
+
+@pytest.mark.parametrize(
+    ("prefix_match_unit", "minimum_cacheable_prefix"),
+    [(None, 1920), (32, 32)],
+)
+def test_resolve_kv_cache_block_sizes_logs_minimum_cacheable_prefix(
+    prefix_match_unit, minimum_cacheable_prefix
+):
+    block_size = 1920
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["attention"],
+                new_kv_cache_spec(block_size=block_size),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                new_mamba_spec(
+                    block_size=block_size,
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=block_size,
+            enable_prefix_caching=True,
+            prefix_match_unit=prefix_match_unit,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        kv_transfer_config=None,
+    )
+
+    with patch.object(kv_cache_utils.logger, "info_once") as info_once:
+        resolved_sizes = kv_cache_utils.resolve_kv_cache_block_sizes(
+            kv_cache_config,
+            vllm_config,
+        )
+
+    assert resolved_sizes == (block_size, minimum_cacheable_prefix)
+    info_once.assert_called_once_with(
+        "Prefix caching enabled: minimum cacheable prefix is %d tokens "
+        "(prefix cache match unit); shared prefixes shorter than this "
+        "cannot produce cache hits.",
+        minimum_cacheable_prefix,
     )
 
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -720,9 +720,22 @@ def resolve_kv_cache_block_sizes(
     dcp = vllm_config.parallel_config.decode_context_parallel_size
     groups = kv_cache_config.kv_cache_groups
 
+    def resolved_sizes(
+        scheduler_block_size: int,
+        hash_block_size: int,
+    ) -> tuple[int, int]:
+        if cache_config.enable_prefix_caching:
+            logger.info_once(
+                "Prefix caching enabled: minimum cacheable prefix is %d tokens "
+                "(prefix cache match unit); shared prefixes shorter than this "
+                "cannot produce cache hits.",
+                hash_block_size,
+            )
+        return scheduler_block_size, hash_block_size
+
     if len(groups) <= 1:
         bs = cache_config.block_size * dcp
-        return bs, bs
+        return resolved_sizes(bs, bs)
 
     group_block_sizes = [
         resolve_dcp_kv_block_size(g.kv_cache_spec, dcp) for g in groups
@@ -734,7 +747,7 @@ def resolve_kv_cache_block_sizes(
     # to the scheduler block size.
     connector_enabled = vllm_config.kv_transfer_config is not None
     if not (cache_config.enable_prefix_caching or connector_enabled):
-        return scheduler_block_size, scheduler_block_size
+        return resolved_sizes(scheduler_block_size, scheduler_block_size)
 
     # Mamba groups outside align mode break divisibility; back off to the
     # scheduler block size. Read the mode from the resolved group spec because
@@ -744,7 +757,7 @@ def resolve_kv_cache_block_sizes(
         for group in groups
         for spec in iter_layer_specs(group.kv_cache_spec)
     ):
-        return scheduler_block_size, scheduler_block_size
+        return resolved_sizes(scheduler_block_size, scheduler_block_size)
 
     hashing_sizes = [
         block_size
@@ -787,7 +800,7 @@ def resolve_kv_cache_block_sizes(
             "must align with each spec's per-state compression. "
             f"Got alignments={sorted(prefix_alignments)}."
         )
-    return scheduler_block_size, hash_block_size
+    return resolved_sizes(scheduler_block_size, hash_block_size)
 
 
 def get_request_block_hasher(


### PR DESCRIPTION
## Purpose

Fixes #53749.

Prefix caching currently reports that it is enabled without exposing the
minimum prefix length that can produce a cache hit. This is especially
confusing for hybrid attention/SSM models, where cache-page alignment can
increase the effective match unit from the usual small block size to thousands
of tokens.

This change logs the resolved prefix-cache match unit after KV cache group
sizes, backend alignment, context parallelism, and `--prefix-match-unit` have
been accounted for.

This is not a duplicate of #50486. That PR warns when a user-provided
`--block-size` has no effect. This PR reports the final `hash_block_size` used
for prefix-cache matching, regardless of how it was derived.

## Changes

- Log the effective minimum cacheable prefix when prefix caching is enabled.
- Test both the default hybrid block size and an explicit finer
  `prefix_match_unit`.
- Document whole match-unit reuse and the impact of large hybrid-model cache
  blocks.
- Keep cache allocation, prefix matching, model execution, metrics, and API
  behavior unchanged.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py -v \
  -k logs_minimum_cacheable_prefix

.venv/bin/pre-commit run --files \
  vllm/v1/core/kv_cache_utils.py \
  tests/v1/core/test_kv_cache_utils.py \
  docs/features/automatic_prefix_caching.md
```

An additional full-file test run was attempted:

```bash
.venv/bin/python -m pytest tests/v1/core/test_kv_cache_utils.py -q --tb=short
```

## Test Result

```text
2 passed, 86 deselected
```

All applicable pre-commit hooks passed, including Ruff, mypy, typos,
Markdownlint, and the repository-specific checks.

The additional full-file run completed with 66 passed and 22 failed. All
failures were environment-related: tests attempted to download
`Qwen/Qwen3-0.6B` or other Hugging Face configuration into
`~/.cache/huggingface`, which is not writable in the local sandbox
(`PermissionError: [Errno 1] Operation not permitted`). The new tests passed
independently.

## Model Evaluation

Not required. This change only adds startup logging, unit coverage, and
documentation. It does not affect model outputs, accuracy, scheduling, cache
allocation, or serving behavior.

## Duplicate-work Check

- No open PR references #53749.
- No open PR matched the search term `minimum cacheable prefix`.
- #50486 addresses a distinct `--block-size` override warning.
