### PR TITLE
[Bugfix][Core] Restore constructor-only custom encoder cache manager support

### DIFF
--- a/tests/v1/core/test_encoder_cache_manager.py
+++ b/tests/v1/core/test_encoder_cache_manager.py
@@ -7,6 +7,7 @@ from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
+    create_encoder_cache_manager,
 )
 
 pytestmark = pytest.mark.cpu_test
@@ -32,6 +33,67 @@ class MockRequest:
 
 
 # ------------------ Unit Tests ------------------ #
+def test_create_encoder_cache_manager_supports_constructor_only_manager():
+    class ConstructorOnlyManager:
+        def __init__(self, cache_size: int):
+            self.cache_size = cache_size
+
+    manager = create_encoder_cache_manager(
+        ConstructorOnlyManager,
+        cache_size=10,
+        vllm_config=object(),
+    )
+
+    assert isinstance(manager, ConstructorOnlyManager)
+    assert manager.cache_size == 10
+
+
+def test_create_encoder_cache_manager_prefers_from_vllm_config():
+    vllm_config = object()
+
+    class ConfigAwareManager(EncoderCacheManager):
+        @classmethod
+        def from_vllm_config(cls, *, cache_size: int, vllm_config):
+            return cls(cache_size, vllm_config)
+
+        def __init__(self, cache_size: int, vllm_config):
+            self.cache_size = cache_size
+            self.vllm_config = vllm_config
+
+    manager = create_encoder_cache_manager(
+        ConfigAwareManager,
+        cache_size=10,
+        vllm_config=vllm_config,
+    )
+
+    assert isinstance(manager, ConfigAwareManager)
+    assert manager.cache_size == 10
+    assert manager.vllm_config is vllm_config
+
+
+def test_create_encoder_cache_manager_supports_create_manager():
+    vllm_config = object()
+
+    class FactoryManager:
+        @classmethod
+        def create_manager(cls, *, cache_size: int, vllm_config):
+            return cls(cache_size, vllm_config)
+
+        def __init__(self, cache_size: int, vllm_config):
+            self.cache_size = cache_size
+            self.vllm_config = vllm_config
+
+    manager = create_encoder_cache_manager(
+        FactoryManager,
+        cache_size=10,
+        vllm_config=vllm_config,
+    )
+
+    assert isinstance(manager, FactoryManager)
+    assert manager.cache_size == 10
+    assert manager.vllm_config is vllm_config
+
+
 def test_basic_allocate_and_reuse():
     cache = EncoderCacheManager(cache_size=10)
     req = MockRequest("r1", ["imgA"], [4])

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -3,7 +3,7 @@
 
 from collections import OrderedDict
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from vllm.config import VllmConfig
 from vllm.config.ec_manager_config import EncoderCacheManagerMetadata
@@ -14,6 +14,30 @@ if TYPE_CHECKING:
     from vllm.config import SchedulerConfig
 
 logger = init_logger(__name__)
+
+
+def create_encoder_cache_manager(
+    manager_cls: type[Any],
+    *,
+    cache_size: int,
+    vllm_config: VllmConfig,
+) -> Any:
+    """Create an encoder cache manager using its supported factory interface."""
+    from_vllm_config = getattr(manager_cls, "from_vllm_config", None)
+    if from_vllm_config is not None:
+        return from_vllm_config(
+            cache_size=cache_size,
+            vllm_config=vllm_config,
+        )
+
+    create_manager = getattr(manager_cls, "create_manager", None)
+    if create_manager is not None:
+        return create_manager(
+            cache_size=cache_size,
+            vllm_config=vllm_config,
+        )
+
+    return manager_cls(cache_size=cache_size)
 
 
 class EncoderCacheManager:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -34,6 +34,7 @@ from vllm.multimodal.utils import get_mm_features_in_window
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
+    create_encoder_cache_manager,
 )
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
@@ -255,8 +256,8 @@ class Scheduler(SchedulerInterface):
                 if self.is_encoder_decoder
                 else EncoderCacheManager
             )
-        self.encoder_cache_manager = manager_cls_obj.create_manager(
-            cache_size=encoder_cache_size, vllm_config=vllm_config
+        self.encoder_cache_manager = create_encoder_cache_manager(
+            manager_cls_obj, cache_size=encoder_cache_size, vllm_config=vllm_config
         )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False


### PR DESCRIPTION
## Purpose

[PR #51251](https://github.com/vllm-project/vllm/pull/51251) exposed custom encoder cache manager configuration through `EngineArgs` for online and offline inference and changed Scheduler to call `create_manager()` unconditionally. The underlying custom manager extension hooks were introduced by [PR #48218](https://github.com/vllm-project/vllm/pull/48218).

However, the same PR explicitly promised compatibility with custom managers that only implement:

```python
__init__(cache_size)
```

and optionally support:

```python
from_vllm_config(...)
```

Those managers currently cause EngineCore initialization to fail with:

```text
AttributeError:
type object 'CustomEncoderCacheManager'
has no attribute 'create_manager'
```

This change centralizes manager construction and supports all three construction paths:

- `from_vllm_config`;
- `create_manager`;
- the legacy `cache_size` constructor.

The default built-in encoder cache manager behavior is unchanged.

## Test Plan

```bash
pytest -q \
  tests/v1/core/test_encoder_cache_manager.py \
  tests/v1/core/test_scheduler.py \
  --disable-warnings

pre-commit run --files \
  vllm/v1/core/encoder_cache_manager.py \
  vllm/v1/core/sched/scheduler.py \
  tests/v1/core/test_encoder_cache_manager.py
```

## Reproduction

The custom manager must be importable in the serving environment and implement
the legacy constructor interface, for example `__init__(cache_size)`, without
implementing `create_manager`. Other scheduler-consumed manager methods are
omitted from this example for brevity:

```bash
vllm serve <MODEL_ID_OR_PATH> \
  --ec-manager-config \
  '{"encoder_cache_manager_cls":"your_package.ConstructorOnlyManager"}' \
  --tensor-parallel-size 1 \
  --enforce-eager \
  --max-model-len 128 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 128 \
  --gpu-memory-utilization 0.2
```

Before this change, the command fails during EngineCore initialization with:

```text
AttributeError: type object 'ConstructorOnlyManager' has no attribute 'create_manager'
```

After this change, the server starts successfully and accepts health checks and
completion requests.

Validation environment:

- a single-GPU serving instance;
- a supported decoder-only model;
- online `vllm serve`;
- an external constructor-only encoder cache manager;
- `/health`;
- `/v1/completions`.

## Test Result

```text
170 passed, 15 warnings
pre-commit: all hooks passed
```

Before the change, the same online configuration failed during EngineCore/Scheduler initialization with `AttributeError: ... has no attribute 'create_manager'`.

After the change, the server started successfully and a completion request returned HTTP 200.

No model evaluation is required because this change only affects encoder cache manager construction and does not change model computation, sampling, or output semantics.

## Duplicate-work check

No open vLLM PR was found addressing this construction compatibility regression.

- [PR #51228](https://github.com/vllm-project/vllm/pull/51228) fixes encoder-cache slot release accounting, not manager construction.
- [PR #48218](https://github.com/vllm-project/vllm/pull/48218) introduced the extension hooks but does not fix this regression.

## AI Assistance

AI assistance was used for code implementation and test orchestration.
