### PR TITLE
fix(parser): attach structural tag when parsers share an engine

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -998,6 +998,98 @@ def test_parser_manager_rejects_non_engine_adapter_metadata():
     )
 
 
+def test_parser_manager_shared_engine_keeps_registered_tool_parser(monkeypatch):
+    """Shared-engine fast path keeps the registered tool parser.
+
+    Regression test for #53745: when the reasoning and tool parsers map to
+    the same engine, get_parser collapsed them into the raw engine class
+    whose tool_parser_cls is the generic adapter without
+    structural_tag_model. The registered tool parser must survive so strict
+    tool calling can attach the xgrammar structural tag.
+    """
+
+    class _FakeStructuralTag:
+        def model_dump(self):
+            return {"type": "structural_tag", "model": "qwen_3_coder"}
+
+    class _TaggedToolParser(_CombinedToolAdapter):
+        structural_tag_model = "qwen_3_coder"
+
+        def get_structural_tag(self, request, *, reasoning=False):
+            return _FakeStructuralTag()
+
+    monkeypatch.setattr(
+        ParserManager,
+        "get_reasoning_parser",
+        classmethod(lambda cls, name: _CombinedReasoningAdapter),
+    )
+    monkeypatch.setattr(
+        ParserManager,
+        "get_tool_parser",
+        classmethod(lambda cls, name, enabled, model: _TaggedToolParser),
+    )
+
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="combined",
+        reasoning_parser_name="combined",
+        enable_auto_tools=True,
+    )
+
+    assert parser_cls is not None
+    assert issubclass(parser_cls, _CombinedTestEngine)
+    assert parser_cls.tool_parser_cls is _TaggedToolParser
+
+    parser = parser_cls(make_mock_tokenizer(_VOCAB))
+    tool = _make_tool("f", {"arg": {"type": "string"}})
+
+    # tool_choice="auto" attaches the tag
+    request = _make_delegating_request()
+    request.tools = [tool]
+    request.tool_choice = "auto"
+    adjusted = parser.adjust_request(request)
+    assert adjusted.structured_outputs is not None
+    assert adjusted.structured_outputs.structural_tag is not None
+    assert "qwen_3_coder" in adjusted.structured_outputs.structural_tag
+
+    # tool_choice="required" attaches the tag too
+    request = _make_delegating_request()
+    request.tools = [tool]
+    request.tool_choice = "required"
+    adjusted = parser.adjust_request(request)
+    assert adjusted.structured_outputs is not None
+    assert adjusted.structured_outputs.structural_tag is not None
+
+    # tool_choice="none" must not attach a tag
+    request = _make_delegating_request()
+    request.tools = [tool]
+    request.tool_choice = "none"
+    request.structured_outputs = None
+    adjusted = parser.adjust_request(request)
+    assert adjusted.structured_outputs is None
+
+
+def test_parser_manager_qwen3_shared_engine_resolves_registered_tool_parser():
+    """qwen3 + qwen3_coder resolves to the registered Qwen3EngineToolParser.
+
+    Mirrors the reported #53745 configuration: both names map to
+    Qwen3Parser, so get_parser must surface the registered tool parser
+    carrying structural_tag_model = "qwen_3_coder" rather than the generic
+    Qwen3ParserToolAdapter.
+    """
+    from vllm.parser.qwen3 import Qwen3Parser
+    from vllm.tool_parsers.qwen3_engine_tool_parser import Qwen3EngineToolParser
+
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name="qwen3_coder",
+        reasoning_parser_name="qwen3",
+        enable_auto_tools=True,
+    )
+
+    assert parser_cls is not None
+    assert issubclass(parser_cls, Qwen3Parser)
+    assert parser_cls.tool_parser_cls is Qwen3EngineToolParser
+
+
 def test_reasoning_adapter_counts_after_final_non_streaming_parse():
     parser = _CombinedReasoningAdapter(make_mock_tokenizer(_VOCAB))
     request = _make_delegating_request()

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -12,8 +12,12 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 import regex as re
+from openai.types.responses import ToolChoiceFunction
 
 from vllm.entrypoints.chat_utils import get_tool_call_id_type, make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionNamedToolChoiceParam,
+)
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
@@ -22,11 +26,13 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
 from vllm.parser.abstract_parser import Parser, StreamState
 from vllm.parser.engine.events import EventType, SemanticEvent
 from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
 from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+from vllm.sampling_params import StructuredOutputsParams
 from vllm.tool_parsers.utils import (
     coerce_to_schema_type,
     extract_types_from_schema,
@@ -205,6 +211,56 @@ class ParserEngine(Parser):
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:
         request.skip_special_tokens = False
+        if self.tool_parser_cls is not None:
+            request = self._apply_structural_tag(request)
+        return request
+
+    def _apply_structural_tag(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        """Attach the xgrammar structural tag for strict tool calling.
+
+        Mirrors ``DelegatingParser._apply_structural_tag`` but reads the
+        registered tool parser class directly, because engine-backed
+        parsers do not instantiate a separate tool parser.
+        """
+        tool_parser_cls = self.tool_parser_cls
+        if (
+            tool_parser_cls is None
+            or tool_parser_cls.structural_tag_model is None
+            or not request.tools
+        ):
+            return request
+
+        need_tool_calling = (
+            request.tool_choice == "auto"
+            or request.tool_choice == "required"
+            or isinstance(
+                request.tool_choice,
+                (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction),
+            )
+        )
+        if not need_tool_calling:
+            return request
+
+        # get_structural_tag only reads the structural_tag_model class
+        # attribute, so the class itself can act as self here.
+        structure_tag = tool_parser_cls.get_structural_tag(
+            tool_parser_cls,
+            request,
+            reasoning=False,  # type: ignore[arg-type]
+        )
+        if structure_tag is None:
+            return request
+
+        structural_tag = json.dumps(structure_tag.model_dump())
+        request.structured_outputs = StructuredOutputsParams(
+            structural_tag=structural_tag,
+        )
+        if isinstance(request, ResponsesRequest):
+            request.text = None
+        else:
+            request.response_format = None
         return request
 
     def _preprocess_feed(

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -140,6 +140,20 @@ class ParserManager:
         reasoning_engine_cls = cls._get_parser_engine_cls(reasoning_parser_cls)
         tool_engine_cls = cls._get_parser_engine_cls(tool_parser_cls)
         if reasoning_engine_cls is not None and reasoning_engine_cls is tool_engine_cls:
+            # Keep the single-engine fast path but preserve the registered
+            # tool parser, which may carry a structural tag for strict
+            # tool calling that the generic adapter lacks.
+            if (
+                tool_parser_cls is not None
+                and tool_parser_cls is not reasoning_engine_cls.tool_parser_cls
+            ):
+                engine_cls = reasoning_engine_cls
+                t_cls = tool_parser_cls
+
+                class _SharedEngineParser(engine_cls):
+                    tool_parser_cls = t_cls
+
+                return _SharedEngineParser
             return reasoning_engine_cls
 
         if reasoning_parser_name == "kimi_k3" or tool_parser_name == "kimi_k3":


### PR DESCRIPTION
## Summary

Fixes #53745. When the reasoning parser and the tool parser resolve to the same streaming parser engine (for example `--reasoning-parser qwen3 --tool-call-parser qwen3_coder`), vLLM attached no xgrammar structural tag, so strict tool calling was silently a no-op.

## Root cause

`ParserManager.get_parser` short-circuits when both parser names map to the same `ParserEngine` subclass and returns the raw engine class. That engine's `tool_parser_cls` is the generic adapter installed by `make_adapters()`, which does not carry `structural_tag_model`. Only the registered tool parser (for example `Qwen3EngineToolParser`) carries it. `ParserEngine.adjust_request` only sets `skip_special_tokens` and never applies the structural tag, which lives on `DelegatingParser._apply_structural_tag`.

Net effect: with a shared engine pair, `strict: true`, `tool_choice="required"`, and `VLLM_ENFORCE_STRICT_TOOL_CALLING` all produced unconstrained tool-call arguments, so a model misfire on a parameter name reached the client as malformed keys instead of being caught by the grammar.

## Fix

Keep the single-engine fast path, but:

- `ParserManager.get_parser`: when the engine's `tool_parser_cls` is the generic adapter and a more specific registered tool parser exists, preserve the registered one instead of returning the raw engine.
- `ParserEngine.adjust_request`: attach the structural tag for strict or required tool calls, mirroring `DelegatingParser._apply_structural_tag`.

This restores the v0.27.1 behavior for same-engine parser pairs while leaving composed parsers through `DelegatingParser` (for example `deepseek_r1` reasoning with `qwen3_coder` tool) unchanged.

The fix is generic: it also repairs the same latent bug for every other engine-backed pair whose registered tool parser carries a `structural_tag_model` (deepseek_v4, deepseek_v32, glm47_moe, minimax_m2, kimi_k2), not just qwen3.

## Tests

- 2 new tests in `tests/parser/engine/test_parser_engine.py`: a monkeypatched engine-path check and a real `qwen3` + `qwen3_coder` registry resolution check.
- 3940 existing + new tests pass across the parser engine, qwen3, qwen3_coder tool parser, deepseek_v4/v32, glm47_moe, kimi_k2, minimax_m2, mistral, structural_tag_registry, parse, streaming, and include_reasoning suites.
- ruff check and format, compileall, and git diff --check all clean.


Not a duplicate: no open PR addresses this fix (verified via `gh pr list` and the issue timeline before opening).
