### PR TITLE
[Test] Conformance suite for KV-cache key partitioning

### DIFF
--- a/tests/v1/core/conformance/dimensions.py
+++ b/tests/v1/core/conformance/dimensions.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+import pytest
 import torch
 
 from vllm.lora.request import LoRARequest
@@ -50,6 +51,10 @@ class Dimension:
 
     name: str
     build: Callable[[str], dict[str, Any]]
+    #: Set when the *negative* arm is a known open bug, so the suite records
+    #: it as a strict xfail instead of a failure. Strict, so whichever fix
+    #: lands turns it into a loud XPASS rather than quiet dead weight.
+    negative_bug: str | None = None
 
 
 def _cache_salt(variant: str) -> dict[str, Any]:
@@ -60,6 +65,20 @@ def _lora_name(variant: str) -> dict[str, Any]:
     return {
         "lora_request": LoRARequest(
             lora_name=f"lora-{variant}", lora_int_id=7, lora_path="/nonexistent"
+        )
+    }
+
+
+def _lora_version(variant: str) -> dict[str, Any]:
+    """Same adapter name and id, different adapter content.
+
+    ``load_inplace`` replaces an adapter's weights while keeping its name and
+    reusing its ``lora_int_id`` (``entrypoints/openai/models/serving.py``), so
+    the name alone does not identify what the blocks were computed with.
+    """
+    return {
+        "lora_request": LoRARequest(
+            lora_name="pinned", lora_int_id=7, lora_path=f"/adapters/{variant}"
         )
     }
 
@@ -75,6 +94,17 @@ def _prompt_embeds(variant: str) -> dict[str, Any]:
 DIMENSIONS: list[Dimension] = [
     Dimension("cache_salt", _cache_salt),
     Dimension("lora_name", _lora_name),
+    Dimension(
+        "lora_version",
+        _lora_version,
+        negative_bug=(
+            "#42125: the LoRA extra key is the adapter *name* "
+            "(kv_cache_utils.py:_gen_lora_extra_hash_keys), so an in-place "
+            "reload keeps the key while replacing the weights and the blocks "
+            "the old adapter computed are served for the new one. Fixed by "
+            "#48352."
+        ),
+    ),
     Dimension("prompt_embeds", _prompt_embeds),
 ]
 
@@ -116,3 +146,16 @@ def make_kv_cache_manager(num_blocks: int = 64) -> KVCacheManager:
         scheduler_block_size=BLOCK_SIZE,
         log_stats=True,
     )
+
+
+def negative_params() -> list:
+    """``DIMENSIONS`` as pytest params, with known open bugs marked xfail."""
+    out = []
+    for dim in DIMENSIONS:
+        marks = (
+            [pytest.mark.xfail(strict=True, reason=dim.negative_bug)]
+            if dim.negative_bug
+            else []
+        )
+        out.append(pytest.param(dim, id=dim.name, marks=marks))
+    return out

--- a/tests/v1/core/conformance/dimensions.py
+++ b/tests/v1/core/conformance/dimensions.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared vocabulary for the KV-cache key-partitioning conformance suite.
+
+A *partitioning dimension* is any request attribute that must separate the
+KV-cache keyspace: two requests that differ in it must never reuse each
+other's blocks, and two requests that agree in it must (the positive
+control that keeps the negative assertion meaningful).
+
+Each :class:`Dimension` builds ``Request`` keyword arguments from a variant
+label, so a test can produce "same" and "different" pairs without knowing
+how the dimension is encoded into block hashes. Nothing here inspects the
+extra-key tuple, which keeps the suite independent of the encoding.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from vllm.lora.request import LoRARequest
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import get_request_block_hasher
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+from vllm.v1.request import Request
+
+BLOCK_SIZE = 16
+NUM_FULL_BLOCKS = 3
+# Sized past a block boundary so no arm can pass by never hashing a full block.
+PROMPT_LEN = NUM_FULL_BLOCKS * BLOCK_SIZE + 5
+EMBED_DIM = 8
+
+
+@dataclass(frozen=True)
+class Dimension:
+    """A request attribute that must partition the KV-cache keyspace.
+
+    Attributes:
+        name: Stable identifier, used as the pytest id.
+        build: Maps a variant label to ``Request`` kwargs. Equal labels must
+            yield requests that may share blocks; different labels must not.
+    """
+
+    name: str
+    build: Callable[[str], dict[str, Any]]
+
+
+def _cache_salt(variant: str) -> dict[str, Any]:
+    return {"cache_salt": f"salt-{variant}"}
+
+
+def _lora_name(variant: str) -> dict[str, Any]:
+    return {
+        "lora_request": LoRARequest(
+            lora_name=f"lora-{variant}", lora_int_id=7, lora_path="/nonexistent"
+        )
+    }
+
+
+def _prompt_embeds(variant: str) -> dict[str, Any]:
+    fill = float(sum(map(ord, variant)))
+    return {
+        "prompt_token_ids": None,
+        "prompt_embeds": torch.full((PROMPT_LEN, EMBED_DIM), fill),
+    }
+
+
+DIMENSIONS: list[Dimension] = [
+    Dimension("cache_salt", _cache_salt),
+    Dimension("lora_name", _lora_name),
+    Dimension("prompt_embeds", _prompt_embeds),
+]
+
+
+def make_request(request_id: str, **overrides: Any) -> Request:
+    """Build a request whose prompt spans ``NUM_FULL_BLOCKS`` full blocks."""
+    kwargs: dict[str, Any] = {
+        "request_id": request_id,
+        "prompt_token_ids": [i // BLOCK_SIZE for i in range(PROMPT_LEN)],
+        "sampling_params": SamplingParams(max_tokens=17),
+        "pooling_params": None,
+        "block_hasher": get_request_block_hasher(BLOCK_SIZE, sha256),
+    }
+    kwargs.update(overrides)
+    return Request(**kwargs)
+
+
+def make_kv_cache_manager(num_blocks: int = 64) -> KVCacheManager:
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=BLOCK_SIZE,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            )
+        ],
+    )
+    return KVCacheManager(
+        config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=BLOCK_SIZE,
+        scheduler_block_size=BLOCK_SIZE,
+        log_stats=True,
+    )

--- a/tests/v1/core/conformance/test_connector_tier.py
+++ b/tests/v1/core/conformance/test_connector_tier.py
@@ -87,6 +87,9 @@ class ExampleConnectorHarness(ConnectorHarness):
         )
 
     def store(self, request: Request) -> None:
+        # The scheduler always reports the allocation before building the
+        # step's metadata, and connectors may key on it.
+        self.connector.update_state_after_alloc(request, None, num_external_tokens=0)
         new_req = NewRequestData(
             req_id=request.request_id,
             prompt_token_ids=request.prompt_token_ids,

--- a/tests/v1/core/conformance/test_connector_tier.py
+++ b/tests/v1/core/conformance/test_connector_tier.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Connector tier of the KV-cache key-partitioning conformance suite.
+
+Same invariant and same dimensions as the in-engine tier, asserted one tier
+out: after request A's KV is stored through a connector's own save path,
+``get_num_new_matched_tokens`` for request B must report A's blocks only
+when B agrees with A in every partitioning dimension. That method is the
+one lookup every connector implements and is pure scheduler side, so the
+tier runs on CPU with no model forward.
+
+A connector that keys external storage from ``request.block_hashes`` gets
+every dimension right for free; one that re-derives keys from raw tokens
+gets every dimension wrong. The ``KEYS_FROM_BLOCK_HASHES`` flag on each
+harness records which kind it is, and the expected failures follow from it.
+"""
+
+import tempfile
+from collections.abc import Iterator
+
+import pytest
+import torch
+
+from tests.v1.kv_connector.unit.utils import create_vllm_config, make_kv_cache_config
+from tests.v1.simple_kv_offload.test_scheduler import (
+    _alloc_and_register,
+    make_scheduler,
+    make_scheduler_output,
+    simulate_store_completion,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+from vllm.distributed.kv_transfer.kv_connector.v1.example_connector import (
+    ExampleConnector,
+)
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
+from vllm.v1.request import Request
+
+from .dimensions import (
+    BLOCK_SIZE,
+    DIMENSIONS,
+    NUM_FULL_BLOCKS,
+    PROMPT_LEN,
+    Dimension,
+    make_request,
+)
+
+FULL_PREFIX = NUM_FULL_BLOCKS * BLOCK_SIZE
+
+
+@pytest.fixture(autouse=True)
+def _init_hash():
+    init_none_hash(sha256)
+
+
+class ConnectorHarness:
+    """Store a request's KV through a connector, then look another one up."""
+
+    name: str
+    keys_from_block_hashes: bool
+
+    def store(self, request: Request) -> None:
+        raise NotImplementedError
+
+    def lookup(self, request: Request) -> int:
+        raise NotImplementedError
+
+
+class ExampleConnectorHarness(ConnectorHarness):
+    name = "ExampleConnector"
+    keys_from_block_hashes = False
+
+    def __init__(self, storage_path: str):
+        vllm_config = create_vllm_config(
+            block_size=BLOCK_SIZE,
+            kv_connector="ExampleConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={"shared_storage_path": storage_path},
+        )
+        self.connector = ExampleConnector(
+            vllm_config, KVConnectorRole.SCHEDULER, make_kv_cache_config(BLOCK_SIZE)
+        )
+
+    def store(self, request: Request) -> None:
+        new_req = NewRequestData(
+            req_id=request.request_id,
+            prompt_token_ids=request.prompt_token_ids,
+            mm_features=[],
+            sampling_params=request.sampling_params,
+            pooling_params=None,
+            block_ids=(list(range(NUM_FULL_BLOCKS)),),
+            num_computed_tokens=0,
+            lora_request=request.lora_request,
+        )
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=[new_req],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
+            num_scheduled_tokens={request.request_id: PROMPT_LEN},
+            total_num_scheduled_tokens=PROMPT_LEN,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
+            preempted_req_ids=set(),
+            finished_req_ids=set(),
+            free_encoder_mm_hashes=[],
+        )
+        connector = self.connector
+        connector.bind_connector_metadata(
+            connector.build_connector_meta(scheduler_output)
+        )
+        # save_kv_layer gathers from whatever paged buffer it is handed.
+        connector.save_kv_layer(
+            "layer0", torch.zeros(NUM_FULL_BLOCKS, 2, BLOCK_SIZE, 4), attn_metadata=None
+        )
+        connector.clear_connector_metadata()
+
+    def lookup(self, request: Request) -> int:
+        matched, _ = self.connector.get_num_new_matched_tokens(request, 0)
+        return matched
+
+
+class SimpleCPUOffloadHarness(ConnectorHarness):
+    name = "SimpleCPUOffloadConnector"
+    keys_from_block_hashes = True
+
+    def __init__(self):
+        self.fixture = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16)
+
+    def store(self, request: Request) -> None:
+        scheduler = self.fixture.scheduler
+        kv_blocks = _alloc_and_register(self.fixture, request, NUM_FULL_BLOCKS)
+        scheduler.update_state_after_alloc(request, kv_blocks, num_external_tokens=0)
+        scheduler_output = make_scheduler_output(
+            {request.request_id: FULL_PREFIX},
+            new_reqs={request.request_id: kv_blocks.get_block_ids()},
+        )
+        meta = scheduler.build_connector_meta(scheduler_output)
+        assert meta.store_event >= 0
+        simulate_store_completion(scheduler, meta.store_event)
+
+    def lookup(self, request: Request) -> int:
+        matched, _ = self.fixture.scheduler.get_num_new_matched_tokens(request, 0)
+        return matched
+
+
+HARNESSES = ["ExampleConnector", "SimpleCPUOffloadConnector"]
+
+
+@pytest.fixture
+def harness(request) -> Iterator[ConnectorHarness]:
+    if request.param == "ExampleConnector":
+        with tempfile.TemporaryDirectory() as path:
+            yield ExampleConnectorHarness(path)
+    else:
+        yield SimpleCPUOffloadHarness()
+
+
+def _cases(negative: bool) -> list:
+    """Cross harnesses with dimensions, marking the known re-derivation bugs."""
+    cases = []
+    for name in HARNESSES:
+        for dim in DIMENSIONS:
+            marks = []
+            if name == "ExampleConnector" and (negative or dim.name == "prompt_embeds"):
+                marks.append(
+                    pytest.mark.xfail(
+                        strict=True,
+                        reason="ExampleConnector keys storage on raw prompt "
+                        "tokens, so it drops every partitioning dimension and "
+                        "keys prompt_embeds requests on an empty prompt.",
+                    )
+                )
+            cases.append(pytest.param(name, dim, id=f"{name}-{dim.name}", marks=marks))
+    return cases
+
+
+@pytest.mark.parametrize("harness,dim", _cases(negative=False), indirect=["harness"])
+def test_same_value_reuses_external_blocks(harness: ConnectorHarness, dim: Dimension):
+    harness.store(make_request("first", **dim.build("x")))
+    assert harness.lookup(make_request("second", **dim.build("x"))) == FULL_PREFIX
+
+
+@pytest.mark.parametrize("harness,dim", _cases(negative=True), indirect=["harness"])
+def test_different_value_never_reuses_external_blocks(
+    harness: ConnectorHarness, dim: Dimension
+):
+    harness.store(make_request("first", **dim.build("x")))
+    assert harness.lookup(make_request("other", **dim.build("y"))) == 0

--- a/tests/v1/core/conformance/test_connector_tier.py
+++ b/tests/v1/core/conformance/test_connector_tier.py
@@ -169,7 +169,11 @@ def _cases(negative: bool) -> list:
     for name in HARNESSES:
         for dim in DIMENSIONS:
             marks = []
-            if name == "ExampleConnector" and (negative or dim.name == "prompt_embeds"):
+            if negative and dim.negative_bug:
+                marks.append(pytest.mark.xfail(strict=True, reason=dim.negative_bug))
+            elif name == "ExampleConnector" and (
+                negative or dim.name == "prompt_embeds"
+            ):
                 marks.append(
                     pytest.mark.xfail(
                         strict=True,

--- a/tests/v1/core/conformance/test_connector_tier.py
+++ b/tests/v1/core/conformance/test_connector_tier.py
@@ -17,6 +17,7 @@ harness records which kind it is, and the expected failures follow from it.
 
 import tempfile
 from collections.abc import Iterator
+from contextlib import contextmanager
 
 import pytest
 import torch
@@ -61,8 +62,18 @@ def _init_hash():
 class ConnectorHarness:
     """Store a request's KV through a connector, then look another one up."""
 
+    #: Registry key, and the connector name the coverage gate matches on.
     name: str
+    #: Whether the connector keys external storage from ``request.block_hashes``
+    #: rather than re-deriving from raw tokens. Drives the expected failures:
+    #: a re-deriver drops every partitioning dimension by construction.
     keys_from_block_hashes: bool
+
+    @classmethod
+    @contextmanager
+    def create(cls) -> Iterator["ConnectorHarness"]:
+        """Yield a ready harness, owning any scratch resources for its scope."""
+        raise NotImplementedError
 
     def store(self, request: Request) -> None:
         raise NotImplementedError
@@ -74,6 +85,12 @@ class ConnectorHarness:
 class ExampleConnectorHarness(ConnectorHarness):
     name = "ExampleConnector"
     keys_from_block_hashes = False
+
+    @classmethod
+    @contextmanager
+    def create(cls) -> Iterator["ExampleConnectorHarness"]:
+        with tempfile.TemporaryDirectory() as path:
+            yield cls(path)
 
     def __init__(self, storage_path: str):
         vllm_config = create_vllm_config(
@@ -131,6 +148,11 @@ class SimpleCPUOffloadHarness(ConnectorHarness):
     name = "SimpleCPUOffloadConnector"
     keys_from_block_hashes = True
 
+    @classmethod
+    @contextmanager
+    def create(cls) -> Iterator["SimpleCPUOffloadHarness"]:
+        yield cls()
+
     def __init__(self):
         self.fixture = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16)
 
@@ -151,37 +173,65 @@ class SimpleCPUOffloadHarness(ConnectorHarness):
         return matched
 
 
-HARNESSES = ["ExampleConnector", "SimpleCPUOffloadConnector"]
+#: The single name-to-harness manifest. The coverage gate reads this, so a
+#: connector counts as covered only when there is a harness that actually runs
+#: it: "covered" is executable by construction rather than by assertion.
+HARNESS_CLASSES: dict[str, type[ConnectorHarness]] = {
+    ExampleConnectorHarness.name: ExampleConnectorHarness,
+    SimpleCPUOffloadHarness.name: SimpleCPUOffloadHarness,
+}
+
+HARNESSES = list(HARNESS_CLASSES)
 
 
 @pytest.fixture
 def harness(request) -> Iterator[ConnectorHarness]:
-    if request.param == "ExampleConnector":
-        with tempfile.TemporaryDirectory() as path:
-            yield ExampleConnectorHarness(path)
-    else:
-        yield SimpleCPUOffloadHarness()
+    harness_cls = HARNESS_CLASSES.get(request.param)
+    # Without this, an unknown name would silently fall through to whichever
+    # harness the else-arm happened to name, and its cases would pass while
+    # testing a different connector entirely.
+    assert harness_cls is not None, (
+        f"no harness registered for {request.param!r}; "
+        f"known harnesses: {sorted(HARNESS_CLASSES)}"
+    )
+    with harness_cls.create() as ready:
+        yield ready
+
+
+def test_harness_manifest_keys_match_harness_names():
+    """The manifest key is what the gate matches against the connector
+    registry, so it has to be the connector's registered name."""
+    for name, harness_cls in HARNESS_CLASSES.items():
+        assert harness_cls.name == name
+
+
+#: Why a re-deriving connector fails an arm, and the fix that will flip it.
+#: Cited on the mark so whoever hits the XPASS knows which marks to delete,
+#: the same standard the coverage gate holds exempt re-derivers to.
+REDERIVATION_REASON = (
+    "#53496: ExampleConnector keys storage on raw prompt tokens, so it drops "
+    "every partitioning dimension and keys prompt_embeds requests on an empty "
+    "prompt."
+)
 
 
 def _cases(negative: bool) -> list:
     """Cross harnesses with dimensions, marking the known re-derivation bugs."""
     cases = []
-    for name in HARNESSES:
+    for name, harness_cls in HARNESS_CLASSES.items():
         for dim in DIMENSIONS:
             marks = []
-            if negative and dim.negative_bug:
-                marks.append(pytest.mark.xfail(strict=True, reason=dim.negative_bug))
-            elif name == "ExampleConnector" and (
+            # Re-derivation is checked first and deliberately: a re-deriver
+            # drops the dimension on its own, independently of any open bug in
+            # the engine's key. Marking such an arm with the engine bug would
+            # leave it xfailing against a reason that no longer holds once that
+            # bug is fixed, hiding the durable failure behind a stale one.
+            if not harness_cls.keys_from_block_hashes and (
                 negative or dim.name == "prompt_embeds"
             ):
-                marks.append(
-                    pytest.mark.xfail(
-                        strict=True,
-                        reason="ExampleConnector keys storage on raw prompt "
-                        "tokens, so it drops every partitioning dimension and "
-                        "keys prompt_embeds requests on an empty prompt.",
-                    )
-                )
+                marks.append(pytest.mark.xfail(strict=True, reason=REDERIVATION_REASON))
+            elif negative and dim.negative_bug:
+                marks.append(pytest.mark.xfail(strict=True, reason=dim.negative_bug))
             cases.append(pytest.param(name, dim, id=f"{name}-{dim.name}", marks=marks))
     return cases
 

--- a/tests/v1/core/conformance/test_key_partitioning.py
+++ b/tests/v1/core/conformance/test_key_partitioning.py
@@ -24,6 +24,7 @@ from .dimensions import (
     Dimension,
     make_kv_cache_manager,
     make_request,
+    negative_params,
 )
 
 FULL_PREFIX = NUM_FULL_BLOCKS * BLOCK_SIZE
@@ -61,7 +62,7 @@ def test_same_value_reuses_blocks(dim: Dimension):
     assert lookup(manager, second) == FULL_PREFIX
 
 
-@pytest.mark.parametrize("dim", DIMENSIONS, ids=lambda d: d.name)
+@pytest.mark.parametrize("dim", negative_params())
 def test_different_value_never_reuses_blocks(dim: Dimension):
     manager = make_kv_cache_manager()
     first = make_request("first", **dim.build("x"))

--- a/tests/v1/core/conformance/test_key_partitioning.py
+++ b/tests/v1/core/conformance/test_key_partitioning.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""In-engine tier of the KV-cache key-partitioning conformance suite.
+
+Invariant (RFC #53194): if two requests differ in any dimension that must
+partition the KV-cache keyspace, they must not reuse each other's blocks;
+if they agree, they must. Every negative arm has a positive control, and
+assertions are on what ``KVCacheManager`` hands back plus block-hash
+equality, never on how the dimension is encoded into the hash.
+"""
+
+import pytest
+
+from vllm.lora.request import LoRARequest
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.request import Request
+
+from .dimensions import (
+    BLOCK_SIZE,
+    DIMENSIONS,
+    NUM_FULL_BLOCKS,
+    Dimension,
+    make_kv_cache_manager,
+    make_request,
+)
+
+FULL_PREFIX = NUM_FULL_BLOCKS * BLOCK_SIZE
+
+
+@pytest.fixture(autouse=True)
+def _init_hash():
+    init_none_hash(sha256)
+
+
+def warm(manager: KVCacheManager, request: Request) -> None:
+    """Run ``request`` through lookup and allocation so its blocks get cached."""
+    computed, num_computed, _ = manager.get_computed_blocks(request)
+    assert num_computed == 0, "warm request must start cold"
+    blocks = manager.allocate_slots(
+        request, request.num_prompt_tokens, num_computed, computed
+    )
+    assert blocks is not None
+    request.num_computed_tokens = request.num_prompt_tokens
+
+
+def lookup(manager: KVCacheManager, request: Request) -> int:
+    """Number of prompt tokens the prefix cache would serve for ``request``."""
+    _, num_computed, _ = manager.get_computed_blocks(request)
+    return num_computed
+
+
+@pytest.mark.parametrize("dim", DIMENSIONS, ids=lambda d: d.name)
+def test_same_value_reuses_blocks(dim: Dimension):
+    manager = make_kv_cache_manager()
+    first = make_request("first", **dim.build("x"))
+    second = make_request("second", **dim.build("x"))
+    assert first.block_hashes == second.block_hashes
+    warm(manager, first)
+    assert lookup(manager, second) == FULL_PREFIX
+
+
+@pytest.mark.parametrize("dim", DIMENSIONS, ids=lambda d: d.name)
+def test_different_value_never_reuses_blocks(dim: Dimension):
+    manager = make_kv_cache_manager()
+    first = make_request("first", **dim.build("x"))
+    other = make_request("other", **dim.build("y"))
+    assert all(a != b for a, b in zip(first.block_hashes, other.block_hashes))
+    warm(manager, first)
+    assert lookup(manager, other) == 0
+
+
+@pytest.mark.parametrize("dim", DIMENSIONS, ids=lambda d: d.name)
+def test_unset_value_never_reuses_set_value(dim: Dimension):
+    manager = make_kv_cache_manager()
+    plain = make_request("plain")
+    tagged = make_request("tagged", **dim.build("x"))
+    warm(manager, plain)
+    assert lookup(manager, tagged) == 0
+    warm(manager, tagged)
+    assert lookup(manager, make_request("plain2")) == FULL_PREFIX
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#44701: cache_salt and lora_name are hashed without domain "
+    "separation, so equal strings collide. Fixed by #51899.",
+)
+def test_cross_dimension_equal_strings_never_reuse_blocks():
+    manager = make_kv_cache_manager()
+    salted = make_request("salted", cache_salt="shared")
+    lora = make_request(
+        "lora",
+        lora_request=LoRARequest(
+            lora_name="shared", lora_int_id=7, lora_path="/nonexistent"
+        ),
+    )
+    warm(manager, salted)
+    assert lookup(manager, lora) == 0
+    assert salted.block_hashes[0] != lora.block_hashes[0]

--- a/tests/v1/core/conformance/test_tier_coverage_gate.py
+++ b/tests/v1/core/conformance/test_tier_coverage_gate.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Coverage gate for the KV-cache key-partitioning conformance suite.
+
+A parametrized suite over known cache tiers has the same weakness as the
+per-fix tests it replaces: a tier added tomorrow is simply not in the list.
+This gate walks the KV-connector registry and fails on any connector that
+is neither exercised by the suite nor exempted with a written reason, so
+adding a connector without declaring how it partitions the keyspace breaks
+the build instead of passing silently.
+"""
+
+from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+
+# Connectors exercised by the connector tier, mapped to the test that does it.
+COVERED: dict[str, str] = {}
+
+# Connectors that cannot run in this suite, each with the reason. An entry
+# here is a declaration that the connector's keying is out of scope for CI,
+# which is the thing a reviewer should push back on.
+EXEMPT: dict[str, str] = {
+    "DecodeBenchConnector": "benchmark-only connector, never serves real KV",
+    "ExampleConnector": "connector tier pending",
+    "ExampleHiddenStatesConnector": "connector tier pending",
+    "FlexKVConnectorV1": "needs the flexkv package and a GPU",
+    "HF3FSKVConnector": "needs the hf3fs client",
+    "LMCacheConnectorV1": "needs the lmcache package",
+    "LMCacheMPConnector": "needs an lmcache MP server",
+    "MoRIIOConnector": "needs MoRI and a GPU",
+    "MooncakeConnector": "needs mooncake and a GPU",
+    "MooncakeStoreConnector": "needs a mooncake store",
+    "MultiConnector": "composes other connectors; keyed by its children",
+    "NixlConnector": "needs NIXL and a GPU",
+    "NixlPullConnector": "needs NIXL and a GPU",
+    "NixlPushConnector": "needs NIXL and a GPU",
+    "OffloadingConnector": "connector tier pending",
+    "SimpleCPUOffloadConnector": "connector tier pending",
+}
+
+
+def test_every_registered_connector_declares_partitioning():
+    registered = set(KVConnectorFactory._registry)
+    undeclared = registered - COVERED.keys() - EXEMPT.keys()
+    assert not undeclared, (
+        "KV connectors registered but neither covered by the key-partitioning "
+        f"suite nor exempted with a reason: {sorted(undeclared)}"
+    )
+    stale = (COVERED.keys() | EXEMPT.keys()) - registered
+    assert not stale, f"declared but no longer registered: {sorted(stale)}"
+    assert not COVERED.keys() & EXEMPT.keys()

--- a/tests/v1/core/conformance/test_tier_coverage_gate.py
+++ b/tests/v1/core/conformance/test_tier_coverage_gate.py
@@ -10,18 +10,22 @@ adding a connector without declaring how it partitions the keyspace breaks
 the build instead of passing silently.
 """
 
+import inspect
+
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 
-# Connectors exercised by the connector tier, mapped to the test that does it.
-COVERED: dict[str, str] = {}
+# Connectors exercised by the connector tier, mapped to the harness that does it.
+COVERED: dict[str, str] = {
+    "ExampleConnector": "test_connector_tier.ExampleConnectorHarness",
+    "SimpleCPUOffloadConnector": "test_connector_tier.SimpleCPUOffloadHarness",
+}
 
 # Connectors that cannot run in this suite, each with the reason. An entry
 # here is a declaration that the connector's keying is out of scope for CI,
 # which is the thing a reviewer should push back on.
 EXEMPT: dict[str, str] = {
     "DecodeBenchConnector": "benchmark-only connector, never serves real KV",
-    "ExampleConnector": "connector tier pending",
-    "ExampleHiddenStatesConnector": "connector tier pending",
+    "ExampleHiddenStatesConnector": "store-only; path is keyed per request id",
     "FlexKVConnectorV1": "needs the flexkv package and a GPU",
     "HF3FSKVConnector": "needs the hf3fs client",
     "LMCacheConnectorV1": "needs the lmcache package",
@@ -33,13 +37,27 @@ EXEMPT: dict[str, str] = {
     "NixlConnector": "needs NIXL and a GPU",
     "NixlPullConnector": "needs NIXL and a GPU",
     "NixlPushConnector": "needs NIXL and a GPU",
-    "OffloadingConnector": "connector tier pending",
-    "SimpleCPUOffloadConnector": "connector tier pending",
+    "OffloadingConnector": "keyed by request.block_hashes; CPU backend needs CUDA",
 }
 
 
+def _builtin_connectors() -> set[str]:
+    """Registered connectors that ship with vLLM.
+
+    Test modules register their own mock connectors into the same registry;
+    those are keyed by a module path under ``tests`` and are not this gate's
+    concern.
+    """
+    builtin = set()
+    for name, loader in KVConnectorFactory._registry.items():
+        module_path = inspect.getclosurevars(loader).nonlocals["module_path"]
+        if not module_path.startswith("tests."):
+            builtin.add(name)
+    return builtin
+
+
 def test_every_registered_connector_declares_partitioning():
-    registered = set(KVConnectorFactory._registry)
+    registered = _builtin_connectors()
     undeclared = registered - COVERED.keys() - EXEMPT.keys()
     assert not undeclared, (
         "KV connectors registered but neither covered by the key-partitioning "

--- a/tests/v1/core/conformance/test_tier_coverage_gate.py
+++ b/tests/v1/core/conformance/test_tier_coverage_gate.py
@@ -22,10 +22,16 @@ The shapes are the same two the connector tier already distinguishes via
 """
 
 import inspect
+import os.path
 from dataclasses import dataclass
 from enum import Enum
 
+import regex as re
+
+from vllm.distributed.kv_transfer import kv_connector
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+
+from .test_connector_tier import HARNESS_CLASSES
 
 
 class Keying(Enum):
@@ -70,10 +76,13 @@ class Exemption:
     bug: str | None = None
 
 
-# Connectors exercised by the connector tier, mapped to the harness that does it.
+# Connectors exercised by the connector tier, derived from the harness manifest
+# rather than restated. A hand-written list here could name a harness that does
+# not exist, or miss one that does, and the gate would still pass; deriving it
+# makes "covered" mean "a harness runs this connector" by construction.
 COVERED: dict[str, str] = {
-    "ExampleConnector": "test_connector_tier.ExampleConnectorHarness",
-    "SimpleCPUOffloadConnector": "test_connector_tier.SimpleCPUOffloadHarness",
+    name: f"test_connector_tier.{harness_cls.__name__}"
+    for name, harness_cls in HARNESS_CLASSES.items()
 }
 
 EXEMPT: dict[str, Exemption] = {
@@ -100,8 +109,10 @@ EXEMPT: dict[str, Exemption] = {
         "needs the hf3fs client",
         "v1/hf3fs/hf3fs_connector.py:1014 chains "
         "md5(f'{previous_hash}_{token_ids}') over request.prompt_token_ids; "
-        "the package contains no reference to cache_salt or lora at all",
-        bug="#53194",
+        "the connector directory contains no reference to cache_salt or lora "
+        "at all, so LoRA identity is dropped too, which is wider than the "
+        "cache_salt scope #51748 tracks",
+        bug="#51748",
     ),
     "LMCacheConnectorV1": Exemption(
         Keying.REDERIVES,
@@ -180,7 +191,21 @@ def _builtin_connectors() -> set[str]:
     """
     builtin = set()
     for name, loader in KVConnectorFactory._registry.items():
-        module_path = inspect.getclosurevars(loader).nonlocals["module_path"]
+        try:
+            module_path = inspect.getclosurevars(loader).nonlocals["module_path"]
+        except (TypeError, KeyError) as exc:
+            # Reading the loader closure couples this gate to how
+            # KVConnectorFactory.register_connector builds its registry
+            # entries. If that changes (a functools.partial, a renamed local),
+            # say so here rather than surfacing a bare KeyError that reads as
+            # "the conformance gate is broken".
+            raise AssertionError(
+                "cannot classify registered connector "
+                f"{name!r}: this gate reads the module path out of "
+                "KVConnectorFactory.register_connector's loader closure, and "
+                f"that closure no longer exposes it ({exc!r}). Update this "
+                "helper, or expose the module path on the factory."
+            ) from exc
         if not module_path.startswith("tests."):
             builtin.add(name)
     return builtin
@@ -198,6 +223,14 @@ def test_every_registered_connector_declares_partitioning():
     assert not COVERED.keys() & EXEMPT.keys()
 
 
+#: Root the evidence pointers are relative to, resolved from the package
+#: itself so the check does not depend on the working directory.
+CONNECTOR_ROOT = os.path.dirname(kv_connector.__file__)
+
+#: Leading token of an evidence string: ``path/to/file.py:123``.
+EVIDENCE_POINTER = re.compile(r"^(?P<path>[\w./-]+\.py):(?P<line>\d+)\b")
+
+
 def test_every_exemption_declares_a_keying_shape():
     """An exemption records why CI cannot run the connector; the shape claim
     is the part that survives the exemption and can be argued with."""
@@ -205,6 +238,27 @@ def test_every_exemption_declares_a_keying_shape():
         assert isinstance(exemption.keying, Keying), name
         assert exemption.blocked_by.strip(), f"{name} exempted with no reason"
         assert exemption.evidence.strip(), f"{name} declares a shape with no evidence"
+
+
+def test_exemption_evidence_points_at_a_file_that_still_exists():
+    """A shape claim is only reviewable if the reader can find what it was read
+    from, and this tree moves: the nixl split and the mooncake restructure are
+    both recent. So the leading ``path:line`` token must name a file that is
+    still there. Line numbers and wording are deliberately NOT checked --
+    pinning those would drag this file into every unrelated refactor -- but a
+    file that moves should fail here the day it moves."""
+    for name, exemption in EXEMPT.items():
+        match = EVIDENCE_POINTER.match(exemption.evidence)
+        assert match is not None, (
+            f"{name}: evidence must lead with a path:line pointer relative to "
+            f"{CONNECTOR_ROOT}, got {exemption.evidence[:60]!r}"
+        )
+        path = os.path.join(CONNECTOR_ROOT, match["path"])
+        assert os.path.exists(path), (
+            f"{name}: evidence points at {match['path']}, which no longer "
+            "exists. The connector moved, so re-read it and update both the "
+            "pointer and the shape claim it supports."
+        )
 
 
 def test_rederiving_connectors_are_not_silently_exempted():

--- a/tests/v1/core/conformance/test_tier_coverage_gate.py
+++ b/tests/v1/core/conformance/test_tier_coverage_gate.py
@@ -8,11 +8,67 @@ This gate walks the KV-connector registry and fails on any connector that
 is neither exercised by the suite nor exempted with a written reason, so
 adding a connector without declaring how it partitions the keyspace breaks
 the build instead of passing silently.
+
+Most connectors cannot run here: they need a GPU, a third-party package, or
+a live external store. That is a fact about CI, not about their keying, and
+an exemption that records only the missing dependency hides the claim that
+actually matters. So an exemption must ALSO declare the connector's
+:class:`Keying` shape. Exempt then means "CI cannot execute this", not
+"nobody has said what this does", and the declaration is a checked-in claim
+that the next person to touch the connector can be wrong about.
+
+The shapes are the same two the connector tier already distinguishes via
+``KEYS_FROM_BLOCK_HASHES``, plus the two honest non-answers.
 """
 
 import inspect
+from dataclasses import dataclass
+from enum import Enum
 
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+
+
+class Keying(Enum):
+    """How a connector derives the key for its external storage."""
+
+    #: Keys off ``request.block_hashes``, so every partitioning dimension the
+    #: engine hash mixes in is inherited for free. Correct exactly as far as
+    #: the engine hash is correct, and complete the moment it is.
+    FROM_BLOCK_HASHES = "keys external storage from request.block_hashes"
+    #: Builds its own key from raw token ids. Drops every partitioning
+    #: dimension unless each one is separately plumbed into the key, which
+    #: makes every new dimension an opt-in per path.
+    REDERIVES = "re-derives keys from raw token ids"
+    #: Does no prefix lookup at all: keyed per request id, or benchmark-only,
+    #: or delegates wholly to child connectors. The invariant does not apply.
+    NO_PREFIX_LOOKUP = "no prefix lookup; keyed per request id or delegating"
+    #: The key is built inside a third-party package that is not in this repo,
+    #: so the shape cannot be read here. Must record what the vLLM-side
+    #: adapter hands across, since that bounds which dimensions can reach it.
+    OPAQUE = "key construction lives in an out-of-repo package"
+
+
+@dataclass(frozen=True)
+class Exemption:
+    """A connector the suite cannot execute, and what it does anyway.
+
+    Attributes:
+        keying: The shape claim. This is the part a reviewer should argue
+            with; ``blocked_by`` is only why CI cannot check it.
+        blocked_by: What stops this connector from running in the suite.
+        evidence: Where the claim was read, as ``path:line``. For
+            ``OPAQUE``, what the adapter hands across the boundary instead.
+        bug: Required when ``keying`` is :attr:`Keying.REDERIVES`. A
+            re-deriver drops the partitioning dimensions by construction, so
+            it is a live instance of this RFC's bug class and may not be
+            exempted silently; it must point at the issue tracking it.
+    """
+
+    keying: Keying
+    blocked_by: str
+    evidence: str
+    bug: str | None = None
+
 
 # Connectors exercised by the connector tier, mapped to the harness that does it.
 COVERED: dict[str, str] = {
@@ -20,24 +76,98 @@ COVERED: dict[str, str] = {
     "SimpleCPUOffloadConnector": "test_connector_tier.SimpleCPUOffloadHarness",
 }
 
-# Connectors that cannot run in this suite, each with the reason. An entry
-# here is a declaration that the connector's keying is out of scope for CI,
-# which is the thing a reviewer should push back on.
-EXEMPT: dict[str, str] = {
-    "DecodeBenchConnector": "benchmark-only connector, never serves real KV",
-    "ExampleHiddenStatesConnector": "store-only; path is keyed per request id",
-    "FlexKVConnectorV1": "needs the flexkv package and a GPU",
-    "HF3FSKVConnector": "needs the hf3fs client",
-    "LMCacheConnectorV1": "needs the lmcache package",
-    "LMCacheMPConnector": "needs an lmcache MP server",
-    "MoRIIOConnector": "needs MoRI and a GPU",
-    "MooncakeConnector": "needs mooncake and a GPU",
-    "MooncakeStoreConnector": "needs a mooncake store",
-    "MultiConnector": "composes other connectors; keyed by its children",
-    "NixlConnector": "needs NIXL and a GPU",
-    "NixlPullConnector": "needs NIXL and a GPU",
-    "NixlPushConnector": "needs NIXL and a GPU",
-    "OffloadingConnector": "keyed by request.block_hashes; CPU backend needs CUDA",
+EXEMPT: dict[str, Exemption] = {
+    "DecodeBenchConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "benchmark-only connector, never serves real KV",
+        "v1/decode_bench_connector.py:213",
+    ),
+    "ExampleHiddenStatesConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "store-only; lookup is hard-coded to zero",
+        "v1/example_hidden_states_connector.py:450",
+    ),
+    "FlexKVConnectorV1": Exemption(
+        Keying.OPAQUE,
+        "needs the flexkv package and a GPU",
+        "v1/flexkv_connector.py:196 hands the whole Request to flexkv's "
+        "adapter, so block_hashes, prompt_token_ids, cache_salt and "
+        "lora_request are all reachable and which one is keyed on is "
+        "decided out of repo",
+    ),
+    "HF3FSKVConnector": Exemption(
+        Keying.REDERIVES,
+        "needs the hf3fs client",
+        "v1/hf3fs/hf3fs_connector.py:1014 chains "
+        "md5(f'{previous_hash}_{token_ids}') over request.prompt_token_ids; "
+        "the package contains no reference to cache_salt or lora at all",
+        bug="#53194",
+    ),
+    "LMCacheConnectorV1": Exemption(
+        Keying.REDERIVES,
+        "needs the lmcache package",
+        "v1/lmcache_integration/vllm_v1_adapter.py:1165 passes "
+        "request.prompt_token_ids to lookup(); cache_salt is never mapped "
+        "into request_configs and lora_request is never read",
+        bug="#53194",
+    ),
+    "LMCacheMPConnector": Exemption(
+        Keying.REDERIVES,
+        "needs an lmcache MP server",
+        "v1/lmcache_mp_connector.py:770 passes all_token_ids plus cache_salt "
+        "as a first-class kwarg, so the salt at least crosses the boundary; "
+        "LoRA identity does not, and whether the salt reaches the key or "
+        "only a namespace tag is decided inside lmcache",
+        bug="#53194",
+    ),
+    "MoRIIOConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "needs MoRI and a GPU",
+        "v1/moriio/moriio_connector.py:500 gates on do_remote_prefill and "
+        "keys transfers by request_id",
+    ),
+    "MooncakeConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "needs mooncake and a GPU",
+        "v1/mooncake/mooncake_connector.py:719 gates on do_remote_prefill; "
+        "state is keyed by ReqId",
+    ),
+    "MooncakeStoreConnector": Exemption(
+        Keying.FROM_BLOCK_HASHES,
+        "needs a mooncake store",
+        "v1/mooncake/store/data.py:189 keys objects as "
+        "f'{prefix}@{chunk_hash.hex()}' over the BlockHash handed in from "
+        "request.block_hashes at store/scheduler.py:120",
+    ),
+    "MultiConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "composes other connectors; keyed by its children",
+        "v1/multi_connector.py:393 returns the first child that hits and "
+        "builds no key of its own",
+    ),
+    "NixlConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "needs NIXL and a GPU",
+        "v1/nixl/connector.py:12 aliases NixlPullConnector",
+    ),
+    "NixlPullConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "needs NIXL and a GPU",
+        "v1/nixl/pull_scheduler.py:60 gates on do_remote_prefill and keys by "
+        "remote_request_id",
+    ),
+    "NixlPushConnector": Exemption(
+        Keying.NO_PREFIX_LOOKUP,
+        "needs NIXL and a GPU",
+        "v1/nixl/push_scheduler.py:118 gates on do_remote_prefill and keys "
+        "by request_id",
+    ),
+    "OffloadingConnector": Exemption(
+        Keying.FROM_BLOCK_HASHES,
+        "CPU backend needs CUDA",
+        "v1/offloading/scheduler.py:874 builds the key with "
+        "make_offload_key(request.block_hashes[hash_idx], group_idx)",
+    ),
 }
 
 
@@ -66,3 +196,29 @@ def test_every_registered_connector_declares_partitioning():
     stale = (COVERED.keys() | EXEMPT.keys()) - registered
     assert not stale, f"declared but no longer registered: {sorted(stale)}"
     assert not COVERED.keys() & EXEMPT.keys()
+
+
+def test_every_exemption_declares_a_keying_shape():
+    """An exemption records why CI cannot run the connector; the shape claim
+    is the part that survives the exemption and can be argued with."""
+    for name, exemption in EXEMPT.items():
+        assert isinstance(exemption.keying, Keying), name
+        assert exemption.blocked_by.strip(), f"{name} exempted with no reason"
+        assert exemption.evidence.strip(), f"{name} declares a shape with no evidence"
+
+
+def test_rederiving_connectors_are_not_silently_exempted():
+    """A re-deriver drops every partitioning dimension by construction, so it
+    is a live instance of the bug class this suite exists to catch. Not being
+    runnable in CI is not a reason to stop tracking it: the exemption has to
+    carry the issue, or this gate fails."""
+    untracked = [
+        name
+        for name, exemption in EXEMPT.items()
+        if exemption.keying is Keying.REDERIVES and not exemption.bug
+    ]
+    assert not untracked, (
+        "connectors that re-derive their own keys, and so drop every "
+        "partitioning dimension, must reference the issue tracking them "
+        f"rather than being exempted on a missing dependency: {untracked}"
+    )


### PR DESCRIPTION
## Purpose

Implements the tier axis of #53194, plus a registry coverage gate. Tests only; no production file is touched.

The RFC observes that every fix for a dropped partitioning dimension (`cache_salt`, `lora_name`, `prompt_embeds`, ...) has shipped with its own bespoke test, so the *next* dimension and the *next* cache tier get no coverage for free. I offered a split in https://github.com/vllm-project/vllm/issues/53194#issuecomment-5389653956: @Tejasvichand keeps the `dimension x entrypoint` HTTP matrix he volunteered for, and this PR takes the other half, `dimension x tier`, which needs no server.

The invariant under test, stated once in `dimensions.py` and applied everywhere: two requests that differ in a partitioning dimension must never reuse each other's blocks, and two that agree in it must. The positive control matters as much as the negative one, since a cache that never reuses anything trivially satisfies the safety half.

Adding a dimension is one `Dimension` entry and it is immediately asserted against every tier. Adding a tier is one harness. Nothing in the suite inspects the extra-key tuple, so it stays independent of how the keys are encoded and does not need updating when the encoding changes.

### The gate

A parametrized suite over a hardcoded list of tiers has exactly the weakness it is meant to replace: a connector added tomorrow simply is not in the list. `test_tier_coverage_gate.py` walks `KVConnectorFactory._registry` and fails on any built-in connector that is neither exercised by the suite nor exempted with a written reason. Registering a connector without declaring how it partitions the keyspace breaks the build rather than passing silently. Test-registered mock connectors are classified out by their loader's module path.

The exemption list is the part reviewers should push back on: today 14 of the 16 built-in connectors are exempt, almost all because they need a GPU or a third-party package. I would rather that be a visible list with reasons than an invisible gap.

It pushed back. @rishabhsinha17 pointed out on #53194 that a dependency reason ("needs a mooncake store") was standing in for a keying claim nobody had written down, so an exemption now also declares the connector's `Keying` shape with the `path:line` it was read from. Exempt means "CI cannot execute this", not "nobody has said what this does". Filling that table meant reading all fourteen, which is how `HF3FSKVConnector` ended up in it as a re-deriver: it chains `md5(f"{previous_hash}_{token_ids}")` over `request.prompt_token_ids` and its directory contains no reference to `cache_salt` or `lora` at all. The `cache_salt` half is #51748; the LoRA half is wider than that issue.

Two rules make the declarations load-bearing rather than decorative. A `REDERIVES` exemption must cite the issue tracking it, so a connector that drops every dimension cannot be parked behind a missing dependency. And `COVERED` is derived from the harness manifest rather than restated, so "covered" means a harness actually runs the connector instead of a string claiming one does.

### The xfails are the point

Every mark is `strict=True` at an explicit call site, so each fails the build the moment its bug is fixed and nobody remembers to delete it:

- `test_cross_dimension_equal_strings_never_reuse_blocks` reproduces #44701 on CPU: `cache_salt="shared"` and `lora_name="shared"` hash identically because the extra keys carry no domain separation. Fixed by #51899, so this mark comes off when that lands.
- The five `ExampleConnector` arms reproduce #53495, which I filed off the back of writing this suite. That connector re-derives its storage key from raw prompt tokens instead of consuming `request.block_hashes`, so it drops *every* dimension at once and keys `prompt_embeds` requests on an empty prompt. #53496 fixes it, and these marks come off with it.
- The `lora_version` arms reproduce #42125 in-engine, fixed by #48352.

The first thesis is the one the `ExampleConnector` contrast encodes: a connector must not re-derive the cache key, because consuming `request.block_hashes` is correct in every dimension, present and future, at no cost.

The `SimpleCPUOffloadConnector-lora_version` arm is the sharper one, and I owe the framing to @Tejasvichand. That connector consumes `request.block_hashes` faithfully, exactly as the paragraph above argues every connector should, and it *still* serves the previous adapter's blocks, because the canonical key it consumes is the one that dropped the dimension. Consuming the canonical key is necessary and not sufficient: a connector is complete precisely when the engine hash is, and no earlier. That is the argument for asserting both tiers rather than picking one, and it is why the connector tier is not merely the in-engine tier restated one layer out.

## Test Plan

```
pytest tests/v1/core/conformance/ -q
```

CPU-only, no GPU and no server. Runs in about 7 seconds.

## Test Result

```
26 passed, 8 xfailed in 7.3s
```

On this branch at 81803401, based on main at 299ebd09. The 8 xfails are the five `ExampleConnector` arms, the in-engine and `SimpleCPUOffloadConnector` `lora_version` arms, and the cross-dimension collision; all are `strict=True` at an explicit mark site rather than relying on an `xfail_strict` ini default, and all currently reproduce real bugs on main.

Independently reproduced by @Tejasvichand on macOS/arm64 at 24 passed / 8 xfailed for the tree at 3a3283a5, an architecture this repo's CI does not cover.

Verified against #53496 on an RTX A6000: with that fix applied, the 4 `ExampleConnector` arms XPASS (strict), which is the suite failing loudly and correctly, and is why those marks are tied to that PR merging (https://github.com/vllm-project/vllm/pull/53496#issuecomment-5402042290).

The gate currently passes, i.e. every built-in connector in the registry is either covered or has a written exemption.

`pre-commit run --files <changed files>` passes.

