### PR TITLE
[Bugfix][XPU] Fix async output deadlock from blocking cross-stream event

### DIFF
--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -10,6 +10,7 @@ import torch
 
 import vllm.envs as envs
 from vllm.model_executor.layers.fused_moe.all2all_utils import get_ep_all2all_manager
+from vllm.platforms import current_platform
 from vllm.v1.outputs import (
     AsyncModelRunnerOutput,
     LogprobsTensors,
@@ -130,9 +131,20 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.sampler_output = sampler_output
         self.num_sampled_tokens = num_sampled_tokens
         self.routed_experts = routed_experts
-        # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
-        self.copy_event = torch.cuda.Event(blocking=True)
         self._has_fault: torch.Tensor | None = None
+
+        # On XPU, waiting on a blocking cross-stream event can miss its wakeup
+        # and hang forever while the device is idle. Drain the copy stream
+        # directly instead; the overlapping copy_stream pipeline is otherwise
+        # unchanged, and the CUDA/ROCm path keeps the blocking event.
+        self._is_xpu = current_platform.is_xpu()
+        if self._is_xpu:
+            self.copy_event = None
+            self._sync_stream = copy_stream
+        else:
+            # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
+            self.copy_event = torch.cuda.Event(blocking=True)
+            self._sync_stream = None
 
         with stream(copy_stream, main_stream):
             copy_stream.wait_stream(main_stream)
@@ -162,10 +174,14 @@ class AsyncOutput(AsyncModelRunnerOutput):
             if check_ep_fault:
                 has_fault = get_ep_all2all_manager().query_fault()
                 self._has_fault = has_fault.to("cpu", non_blocking=True)
-            self.copy_event.record(copy_stream)
+            if not self._is_xpu:
+                self.copy_event.record(copy_stream)
 
     def get_output(self) -> ModelRunnerOutput:
-        self.copy_event.synchronize()
+        if self.copy_event is not None:
+            self.copy_event.synchronize()
+        else:
+            self._sync_stream.synchronize()
 
         # NOTE(woosuk): The following code is to ensure compatibility with
         # the existing model runner.


### PR DESCRIPTION
## Purpose
On XPU, serving hangs after a few hundred decode steps and the engine dies. The worker stops making progress, then the logs show:

"No available shared memory broadcast block found in 60 seconds.
TimeoutError: RPC call to sample_tokens timed out.
vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue.
POST /v1/completions HTTP/1.1" 500 Internal Server Error"

Root cause: 
AsyncOutput overlaps the sampled-token device→host copy with the next step by using a dedicated output_copy_stream and awaiting completion with a blocking cross-stream event (copy_event.synchronize()). On XPU that host wait can miss its wakeup and block forever even though all GPU work has finished.

Evidence from a live hang:
py-spy shows the worker's main thread idle waiting for the next command (the forward was already enqueued), and the WorkerAsyncOutputCopy thread stuck in torch.xpu … synchronize() at async_utils.py get_output() → copy_event.synchronize().
xpu-smi shows the device idle (~50 W, low utilization) during the hang — no compute kernel is spinning; the wait simply never returns.
A plain stream drain (Stream.synchronize()) uses a reliable code path and does not exhibit this. So on XPU we keep the overlapping copy_stream pipeline unchanged and only swap the sync primitive:

```
self._is_xpu = current_platform.is_xpu()
if self._is_xpu:
    self.copy_event = None
    self._sync_stream = copy_stream
else:
    self.copy_event = torch.cuda.Event(blocking=True)
    self._sync_stream = None
...
def get_output(self):
    if self.copy_event is not None:
        self.copy_event.synchronize()
    else:
        self._sync_stream.synchronize()   # XPU: drain copy_stream instead
```

The CUDA/ROCm path is unchanged, and because the copy_stream overlap is preserved there is no throughput regression. Model outputs are unaffected (only the host-side completion wait changes; sampled tokens are identical).

## Test Plan
Serve an FP8 model on 2 Intel GPUs (XPU) and run the serving benchmark that previously wedged the engine:

```
# Server
VLLM_USE_V1=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
vllm serve LGAI-EXAONE/EXAONE-4.0-32B-FP8 --port 8170 --quantization fp8 \
  --tensor-parallel-size 2 --max-model-len 2048 --max-num-batched-tokens 2048 \
  --enforce-eager --block-size 64 --no-enable-prefix-caching \
  --gpu-memory-utilization 0.9 --trust-remote-code

# Client
vllm bench serve --model LGAI-EXAONE/EXAONE-4.0-32B-FP8 --dataset-name random \
  --num-prompts 20 --random-input-len 1024 --random-output-len 1024 \
  --max-concurrency 4 --port 8170 --num-warmups 10 --ignore-eos
```

## Test Result
Before: engine wedges mid-run — 0/20 successful, sample_tokens RPC timeout → EngineDeadError.
After: completes cleanly.

Successful requests:            20
Failed requests:                0
Total generated tokens:         20480
Output token throughput (tok/s): 49.6
Mean TPOT (ms):                 78.4

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
