### PR TITLE
[Kimi Bug] Fix k3 torch.AcceleratorError: CUDA error: an illegal memory access was encountered

### DIFF
--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -823,6 +823,8 @@ def _teardown_profiling_state(runner: "GPUModelRunner") -> None:
     """Release the profiling KV cache and captured graphs while keeping model
     weights, so the real ``initialize_kv_cache`` starts from a clean slate."""
     torch.accelerator.synchronize()
+    if hasattr(runner.model_state, "_mamba_ctx"):
+        runner.model_state._mamba_ctx = None
     if hasattr(runner, "kv_caches"):
         runner.kv_caches.clear()
     if hasattr(runner, "attn_groups"):


### PR DESCRIPTION
## Purpose

A combined bug with #53306 and #52388

After profiling, we should release _mamba_ctx, this pr fixes the issue

## Test

```bash
vllm serve moonshotai/Kimi-K3   --trust-remote-code   -tp 8   --load-format fastsafetensors   --enable-prefix-caching   --reasoning-parser kimi_k3   --enable-auto-tool-choice   --tool-call-parser kimi_k3   --host 0.0.0.0   --port 30000

# main
(Worker_TP2 pid=3840590) 
(Worker_TP7 pid=3840595)     torch._C._accelerator_synchronizeDevice(device_index)
(Worker_TP0 pid=3840588)     raise SystemExit()
(Worker_TP1 pid=3840589)     return zmq_poll(self.sockets, timeout=timeout)
(Worker_TP6 pid=3840594) torch.AcceleratorError: CUDA error: an illegal memory access was encountered
(Worker_TP5 pid=3840593)     torch.accelerator.synchronize()
(Worker_TP2 pid=3840590) During handling of the above exception, another exception occurred:
(Worker_TP1 pid=3840589)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP7 pid=3840595) torch.AcceleratorError: CUDA error: an illegal memory access was encountered
(Worker_TP6 pid=3840594) Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(Worker_TP0 pid=3840588) SystemExit
(Worker_TP5 pid=3840593)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/accelerator/__init__.py", line 270, in synchronize
(Worker_TP2 pid=3840590) 
(Worker_TP1 pid=3840589)   File "zmq/backend/cython/_zmq.py", line 1680, in zmq.backend.cython._zmq.zmq_poll
(Worker_TP7 pid=3840595) Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(Worker_TP6 pid=3840594) CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(Worker_TP7 pid=3840595) CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(Worker_TP5 pid=3840593)     torch._C._accelerator_synchronizeDevice(device_index)
(Worker_TP0 pid=3840588) 
(Worker_TP2 pid=3840590) Traceback (most recent call last):
(Worker_TP1 pid=3840589)     _check_rc(rc)
(Worker_TP6 pid=3840594) For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(Worker_TP7 pid=3840595) For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(Worker_TP0 pid=3840588) During handling of the above exception, another exception occurred:
(Worker_TP5 pid=3840593) torch.AcceleratorError: CUDA error: an illegal memory access was encountered
(Worker_TP1 pid=3840589)     ^^^^^^^^^^^

# now
(APIServer pid=3218033) INFO:     Started server process [3218033]
(APIServer pid=3218033) INFO:     Waiting for application startup.
(APIServer pid=3218033) INFO:     Application startup complete.
```