### PR TITLE
[Bugfix][XPU] Fix async output deadlock from blocking cross-stream event

### DIFF
--- a/vllm/v1/worker/xpu_model_runner.py
+++ b/vllm/v1/worker/xpu_model_runner.py
@@ -13,6 +13,29 @@ from vllm.v1.worker.gpu.model_runner import (
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 
+class _XPUEvent(torch.xpu.Event):
+    """torch.xpu.Event that synchronizes by draining its recording stream.
+
+    torch.xpu.Event.synchronize() waits on a blocking cross-stream event that
+    can miss its wakeup on XPU and hang the worker; draining the stream the
+    event was recorded on is a reliable queue wait with the same completion
+    guarantee.
+    """
+
+    def record(self, stream=None) -> None:
+        if stream is None:
+            stream = torch.xpu.current_stream()
+        self._record_stream = stream
+        super().record(stream)
+
+    def synchronize(self) -> None:
+        stream = getattr(self, "_record_stream", None)
+        if stream is not None:
+            stream.synchronize()
+        else:
+            super().synchronize()
+
+
 class XPUModelRunner(GPUModelRunner):
     """A model runner for XPU devices."""
 
@@ -51,9 +74,11 @@ def _torch_cuda_wrapper():
     torch.cuda.set_stream = partial(torch.xpu.set_stream)
 
     # torch.xpu.Event does not accept the ``blocking`` kwarg that
-    # torch.cuda.Event supports, so drop it here.
+    # torch.cuda.Event supports, so drop it here. _XPUEvent also makes
+    # synchronize() drain the recording stream, avoiding a blocking
+    # cross-stream event wait that can hang on XPU.
     def _xpu_event(*args, blocking=None, **kwargs):
-        return torch.xpu.Event(*args, **kwargs)
+        return _XPUEvent(*args, **kwargs)
 
     torch.cuda.Event = _xpu_event
     if supports_xpu_graph():


### PR DESCRIPTION
## Purpose
On XPU, serving hangs after a few hundred decode steps and the engine dies. The worker stops making progress and the logs show:

> No available shared memory broadcast block found in 60 seconds.
> TimeoutError: RPC call to sample_tokens timed out.
> vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue.
> POST /v1/completions HTTP/1.1" 500 Internal Server Error

Root cause:
AsyncOutput awaits the sampled-token device→host copy with a blocking cross-stream event (copy_event.synchronize()), where copy_event is recorded on a dedicated output_copy_stream. On XPU this host wait can miss its wakeup and block forever even though the GPU work has finished.

Evidence from a live hang:
py-spy shows the worker's main thread idle waiting for the next command (the forward was already enqueued), and the WorkerAsyncOutputCopy thread stuck in torch.xpu … synchronize() at copy_event.synchronize().
xpu-smi shows the device idle (~50 W, low utilization) during the hang — no kernel is spinning; the wait simply never returns.
A plain stream drain (Stream.synchronize()) uses a reliable code path and does not exhibit this.

Fix (XPU-only):
The XPU model runner already redirects torch.cuda.Event → torch.xpu.Event via _xpu_event in _torch_cuda_wrapper. Return a small torch.xpu.Event subclass whose synchronize() drains the recording stream instead of waiting on the blocking cross-stream event:

```
class _XPUEvent(torch.xpu.Event):
    def record(self, stream=None) -> None:
        if stream is None:
            stream = torch.xpu.current_stream()
        self._record_stream = stream
        super().record(stream)

    def synchronize(self) -> None:
        stream = getattr(self, "_record_stream", None)
        if stream is not None:
            stream.synchronize()
        else:
            super().synchronize()
```
This keeps the change entirely in XPU-specific code (vllm/v1/worker/xpu_model_runner.py); the shared async-output path is untouched. Draining the recording stream waits for a superset of the event's work, so completion semantics are preserved. Model outputs are unaffected (only the host-side completion wait changes; sampled tokens are identical).

## Test Plan
Serve an FP8 model on 2 Intel GPUs (XPU) and run the serving benchmark that previously wedged the engine:

```
# Server
VLLM_USE_V1=1 VLLM_WORKER_MULTIPROC_METHOD=spawn \
vllm serve LGAI-EXAONE/EXAONE-4.0-32B-FP8 --port 8170 --quantization fp8 \
  --tensor-parallel-size 2 --max-model-len 2048 --max-num-batched-tokens 2048 \
  --enforce-eager --block-size 64 --no-enable-prefix-caching \
  --gpu-memory-utilization 0.9 --trust-remote-code

# Client
vllm bench serve --model LGAI-EXAONE/EXAONE-4.0-32B-FP8 --dataset-name random \
  --num-prompts 20 --random-input-len 1024 --random-output-len 1024 \
  --max-concurrency 4 --port 8170 --num-warmups 10 --ignore-eos
```

Also re-ran the server with --async-scheduling to confirm no regression.

## Test Result
Before: engine wedges mid-run — 0/20 successful, sample_tokens RPC timeout → EngineDeadError.
After: completes cleanly.

Successful requests:             20
Failed requests:                 0
Total generated tokens:          20480
Output token throughput (tok/s): 49.6
Mean TPOT (ms):                  78.4
Mean TTFT (ms):                  2283.9

With --async-scheduling: also 20/20, 49.6 tok/s, 78.4 ms TPOT — no regression. No sample_tokens timeouts, EngineDeadError, or 500s in either run. The CUDA/ROCm path is unaffected (the change lives only in XPU code).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

