### PR TITLE
[ROCm][Perf] Bound the decode paged-MQA-logits sanitize to the top-k read region

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_sparse_logits_scrub.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sparse_logits_scrub.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the bounded decode paged-MQA-logits scrub.
+
+``out_logits`` is a ``[rows, max_model_len]`` fp32 workspace that is reused
+across steps, so whatever the paged-MQA-logits kernel does not write still
+holds values from earlier steps -- including NaN, which the top-k histogram
+cannot rank. vllm#49714 scrubbed the whole workspace with
+``nan_to_num_(-inf)``; ``scrub_decode_logits`` scrubs only the window the
+top-k actually reads.
+
+The property that matters is that the two agree everywhere the top-k looks:
+``top_k_per_row_decode`` scans row ``r`` over
+``[0, seq_len[r // next_n] - next_n + r % next_n + 1)``. These tests pin that
+window against ``nan_to_num_(-inf)`` for both the 1-D and 2-D ``seq_lens``
+forms, pin the sub-crossover fallback to the old path, and pin the launch grid
+to the row count so CUDA-graph capture stays valid across steps.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.ops import rocm_aiter_mla_sparse as sparse_ops
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="the bounded decode-logits scrub is a ROCm path",
+)
+
+NEG_INF = float("-inf")
+
+
+def _row_end(seq_lens: torch.Tensor, row: int, next_n: int) -> int:
+    """The bound ``top_k_per_row_decode`` reads, in plain Python."""
+    if seq_lens.dim() == 2:
+        end = int(seq_lens.view(-1)[row])
+    else:
+        end = int(seq_lens[row // next_n]) - next_n + (row % next_n) + 1
+    return max(end, 0)
+
+
+def _poisoned(rows: int, cols: int) -> torch.Tensor:
+    """A workspace holding every value the scrub has to decide on."""
+    torch.manual_seed(0)
+    x = torch.randn(rows, cols, dtype=torch.float32, device="cuda")
+    flat = x.view(-1)
+    flat[0::7] = float("nan")
+    flat[1::11] = float("inf")
+    flat[2::13] = NEG_INF
+    return x
+
+
+@pytest.mark.parametrize("next_n", [1, 2])
+@pytest.mark.parametrize("seq_lens_2d", [False, True])
+def test_matches_nan_to_num_over_the_read_window(next_n, seq_lens_2d):
+    batch, cols = 5, 4096
+    rows = batch * next_n
+    logits = _poisoned(rows, cols)
+    reference = logits.clone().nan_to_num_(NEG_INF)
+
+    # Lengths that exercise the edges: one empty, one full-width, and one that
+    # would go negative for the first row of a multi-token block.
+    lens = torch.tensor([0, 1, 37, 2048, cols], dtype=torch.int32, device="cuda")
+    if seq_lens_2d:
+        seq_lens = torch.stack(
+            [(lens - next_n + i + 1).clamp(min=0) for i in range(next_n)], dim=1
+        ).contiguous()
+    else:
+        seq_lens = lens
+
+    # Force the Triton path: the real crossover needs a 40MB workspace.
+    with patch.object(sparse_ops, "_SCRUB_MIN_ELEMS", 0):
+        sparse_ops.scrub_decode_logits(logits, seq_lens, next_n)
+
+    for row in range(rows):
+        end = _row_end(seq_lens, row, next_n)
+        torch.testing.assert_close(
+            logits[row, :end], reference[row, :end], rtol=0, atol=0, equal_nan=True
+        )
+
+
+def test_leaves_the_unread_tail_alone():
+    """Nothing past the top-k bound is touched -- it is never read."""
+    next_n, cols = 1, 4096
+    logits = _poisoned(4, cols)
+    before = logits.clone()
+    seq_lens = torch.tensor([16, 512, 0, cols], dtype=torch.int32, device="cuda")
+
+    with patch.object(sparse_ops, "_SCRUB_MIN_ELEMS", 0):
+        sparse_ops.scrub_decode_logits(logits, seq_lens, next_n)
+
+    for row in range(logits.shape[0]):
+        end = _row_end(seq_lens, row, next_n)
+        torch.testing.assert_close(
+            logits[row, end:], before[row, end:], rtol=0, atol=0, equal_nan=True
+        )
+
+
+def test_nan_maps_to_neg_inf_not_neg_flt_max():
+    """Every case is decided against the original value, as nan_to_num_ does."""
+    next_n = 1
+    logits = torch.tensor(
+        [[float("nan"), float("inf"), NEG_INF, 1.5]],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    seq_lens = torch.tensor([4], dtype=torch.int32, device="cuda")
+
+    with patch.object(sparse_ops, "_SCRUB_MIN_ELEMS", 0):
+        sparse_ops.scrub_decode_logits(logits, seq_lens, next_n)
+
+    flt_max = torch.finfo(torch.float32).max
+    assert logits[0, 0].item() == NEG_INF
+    assert logits[0, 1].item() == flt_max
+    assert logits[0, 2].item() == -flt_max
+    assert logits[0, 3].item() == 1.5
+
+
+def test_below_the_crossover_runs_the_old_path():
+    """Small batches stay bit-identical to today's code, kernel never launched."""
+    next_n, cols = 1, 1024
+    logits = _poisoned(4, cols)
+    reference = logits.clone().nan_to_num_(NEG_INF)
+    seq_lens = torch.tensor([8, 8, 8, 8], dtype=torch.int32, device="cuda")
+
+    assert logits.numel() < sparse_ops._SCRUB_MIN_ELEMS
+    with patch.object(sparse_ops, "_scrub_decode_logits_kernel") as kernel:
+        sparse_ops.scrub_decode_logits(logits, seq_lens, next_n)
+    kernel.__getitem__.assert_not_called()
+
+    torch.testing.assert_close(logits, reference, rtol=0, atol=0, equal_nan=True)
+
+
+def test_empty_workspace_is_a_no_op():
+    logits = torch.empty(0, 4096, dtype=torch.float32, device="cuda")
+    seq_lens = torch.empty(0, dtype=torch.int32, device="cuda")
+    with patch.object(sparse_ops, "_scrub_decode_logits_kernel") as kernel:
+        sparse_ops.scrub_decode_logits(logits, seq_lens, 1)
+    kernel.__getitem__.assert_not_called()
+
+
+def test_grid_depends_only_on_the_row_count():
+    """The grid is a shape, so CUDA-graph capture stays valid across steps."""
+    next_n, rows, cols = 1, 64, 4096
+    logits = torch.zeros(rows, cols, dtype=torch.float32, device="cuda")
+
+    grids = []
+
+    class _Spy:
+        def __getitem__(self, grid):
+            grids.append(grid)
+            return lambda *a, **kw: None
+
+    with (
+        patch.object(sparse_ops, "_SCRUB_MIN_ELEMS", 0),
+        patch.object(sparse_ops, "_scrub_decode_logits_kernel", _Spy()),
+    ):
+        for fill in (1, 977, cols):
+            seq_lens = torch.full((rows,), fill, dtype=torch.int32, device="cuda")
+            sparse_ops.scrub_decode_logits(logits, seq_lens, next_n)
+
+    assert len(grids) == 3
+    assert len(set(grids)) == 1, grids
+    assert grids[0][0] == rows

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -595,6 +595,77 @@ def paged_mqa_logits_module():
     return None
 
 
+_SANITIZE_FLT_MAX = torch.finfo(torch.float32).max
+_SANITIZE_BLOCK = 1024
+_SANITIZE_TARGET_PROGRAMS = 2048
+_SANITIZE_MAX_CHUNKS = 32
+# Below this the full nan_to_num_ is cheaper than a kernel launch.
+_SANITIZE_MIN_ELEMS = 10 * 1024 * 1024
+
+
+@triton.jit
+def _sanitize_decode_logits_kernel(
+    logits_ptr,
+    seq_lens_ptr,
+    stride_row,
+    stride_col,
+    next_n,
+    FLT_MAX: tl.constexpr,
+    SEQ_LENS_2D: tl.constexpr,
+    BLOCK: tl.constexpr,
+    CHUNKS_PER_ROW: tl.constexpr,
+):
+    row = tl.program_id(0)
+    chunk = tl.program_id(1)
+
+    # Mirror top_k_per_row_decode's read bound exactly.
+    if SEQ_LENS_2D:
+        row_end = tl.load(seq_lens_ptr + row)
+    else:
+        row_end = tl.load(seq_lens_ptr + row // next_n) - next_n + (row % next_n) + 1
+    row_end = tl.maximum(row_end, 0)
+
+    base = logits_ptr + row.to(tl.int64) * stride_row
+    for start in range(chunk * BLOCK, row_end, CHUNKS_PER_ROW * BLOCK):
+        offs = start + tl.arange(0, BLOCK)
+        mask = offs < row_end
+        ptrs = base + offs.to(tl.int64) * stride_col
+        x = tl.load(ptrs, mask=mask, other=0.0)
+        y = tl.where(x != x, float("-inf"), x)  # NaN -> -inf (not -FLT_MAX)
+        y = tl.where(x == float("inf"), FLT_MAX, y)
+        y = tl.where(x == float("-inf"), -FLT_MAX, y)
+        tl.store(ptrs, y, mask=mask)
+
+
+def sanitize_decode_logits(
+    out_logits: torch.Tensor,
+    context_lens: torch.Tensor,
+    next_n: int,
+) -> None:
+    """Sanitize only the window top_k_per_row_decode reads (vllm#49714)."""
+    rows = out_logits.shape[0]
+    if rows == 0:
+        return
+    if out_logits.numel() < _SANITIZE_MIN_ELEMS:
+        out_logits.nan_to_num_(float("-inf"))
+        return
+    chunks_per_row = max(
+        1, min(_SANITIZE_MAX_CHUNKS, _SANITIZE_TARGET_PROGRAMS // rows)
+    )
+    _sanitize_decode_logits_kernel[(rows, chunks_per_row)](
+        out_logits,
+        context_lens,
+        out_logits.stride(0),
+        out_logits.stride(1),
+        next_n,
+        FLT_MAX=_SANITIZE_FLT_MAX,
+        SEQ_LENS_2D=context_lens.dim() == 2,
+        BLOCK=_SANITIZE_BLOCK,
+        CHUNKS_PER_ROW=chunks_per_row,
+        num_warps=4,
+    )
+
+
 def rocm_fp8_paged_mqa_logits(
     q_fp8: torch.Tensor,
     kv_cache_fp8: torch.Tensor,
@@ -657,7 +728,7 @@ def rocm_fp8_paged_mqa_logits(
                 KVBlockSize=block_size,
                 WavePerEU=2,
             )
-            out_logits.nan_to_num_(float("-inf"))
+            sanitize_decode_logits(out_logits, context_lens, next_n)
             return out_logits
         deepgemm_fp8_paged_mqa_logits_stage1 = (
             aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits_stage1


### PR DESCRIPTION
## Summary

After [vllm#49714](https://github.com/vllm-project/vllm/pull/49714), every decode step runs `nan_to_num_(-inf)` over the full
`[rows, max_model_len]` logits workspace. On GLM-5.2 `max_model_len` is 258048,
so this costs 43 us per call regardless of how short the context is.

The top-k only reads the front of each row. This PR sanitizes just that slice
using a small Triton kernel, and falls back to `nan_to_num_` below 10M elements
where a kernel launch isn't worth it.

## Safety

- The sanitized region is a superset of what the top-k reads, so the result is
  identical.
- NaN/Inf handling matches `nan_to_num_(-inf)` exactly: NaN -> `-inf`,
  `+inf` -> `FLT_MAX`, `-inf` -> `-FLT_MAX`.
- The launch grid depends only on the row count (a shape), so CUDA graph capture
  stays valid.

## Results

MI355X TP=4, ISL 1024 / OSL 256 / concurrency 256. Same image, same bench
arguments, with and without this commit.

One decode step, rank 0. Both panels show the same 130 us window:

![decode-step timeline, before and after](https://raw.githubusercontent.com/amd-sriram/vllm/f87421d965c40b2d39e1cdbf1e4b5acac23348ff/figures/fig_pr7_timeline.png)

The sanitize sits between `paged_mqa_logits` and the top-k. Before: 44.4 us.
After: 4.6 us.

Over the whole run, rank 0:

| | before | after |
|---|---:|---:|
| sanitize launches | 9,885 | 9,870 |
| avg per call | 43.13 us | 4.59 us |
| total GPU time | 426.3 ms | **51.9 ms** |
| % of GPU kernel time | 1.82% | **0.21%** |

Same launch count, each call does less work. Rank 1 matches (427 ms -> 50 ms).

## Model-level e2e results

### Test conditions

| | |
|---|---|
| Hardware | MI355X (gfx950), TP=4 |
| Model | `amd/GLM-5.2-MXFP4`, fp8 KV cache |
| Stack | vLLM `cb810483`, AITER `c76aca0a` |
| Server | `--async-scheduling --max-num-seqs 256 --max-num-batched-tokens 16384 --block-size 64 --no-enable-prefix-caching --max-model-len 258048`, `index_topk_freq=4` |
| Env | `VLLM_ROCM_USE_AITER=1`, `VLLM_ROCM_USE_AITER_SPARSE_INDEXER=1`, `AITER_USE_FLYDSL_MOE_SORTING=1`, `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4` |
| Perf | `vllm bench serve`, random dataset, `--ignore-eos --request-rate inf`, ISL 1024 and 8192, OSL 1024, concurrency 1-256 (16 points) |
| Accuracy | `lm_eval` gsm8k 5-shot, chat template, thinking enabled |
| Baseline | same image with only this PR reverted |

### Serving sweep

| ISL | conc | base tok/s | PR tok/s | &Delta; tput | base TPOT ms | PR TPOT ms | &Delta; TPOT |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1024 | 1 | 89.1 | 88.9 | -0.2% | 9.92 | 9.95 | +0.3% |
| 1024 | 4 | 345.4 | 344.8 | -0.2% | 11.16 | 11.18 | +0.2% |
| 1024 | 8 | 572.9 | 573.3 | +0.1% | 12.89 | 12.89 | +0.0% |
| 1024 | 16 | 875.5 | 877.8 | +0.3% | 16.51 | 16.48 | -0.2% |
| 1024 | 32 | 1324.9 | 1320.5 | -0.3% | 20.75 | 20.86 | +0.5% |
| 1024 | 64 | 1978.9 | 2011.1 | +1.6% | 27.79 | 27.21 | -2.1% |
| 1024 | 128 | 2885.0 | 2956.1 | +2.5% | 36.71 | 35.66 | -2.9% |
| 1024 | 256 | 4112.5 | 4245.5 | **+3.2%** | 53.83 | 52.08 | **-3.3%** |
| 8192 | 1 | 94.8 | 94.5 | -0.3% | 10.22 | 10.24 | +0.2% |
| 8192 | 4 | 310.0 | 310.0 | +0.0% | 12.13 | 12.13 | +0.0% |
| 8192 | 8 | 479.0 | 477.6 | -0.3% | 15.13 | 15.08 | -0.3% |
| 8192 | 16 | 674.7 | 672.9 | -0.3% | 21.19 | 21.30 | +0.5% |
| 8192 | 32 | 955.2 | 954.9 | -0.0% | 29.35 | 29.41 | +0.2% |
| 8192 | 64 | 1270.1 | 1280.8 | +0.8% | 44.66 | 44.30 | -0.8% |
| 8192 | 128 | 1628.5 | 1650.0 | +1.3% | 69.43 | 68.54 | -1.3% |
| 8192 | 256 | 1898.1 | 1926.7 | +1.5% | 117.89 | 115.59 | -2.0% |

Geomean: +0.6% throughput, -0.7% TPOT. The gain is proportional to batch size
because the saved work is per row per decode step. It's flat in the noise below
concurrency 32 (workspace under ~41 rows = 10M elements) and rises to +3.2% at
concurrency 256.

### Accuracy

| task | baseline | with PR |
|---|---:|---:|
| gsm8k strict-match | 0.9530 | 0.9492 |
| gsm8k flexible-extract | 0.9568 | 0.9530 |

Within run-to-run variation (+/-0.006).

## Tests

```bash
pytest tests/kernels/attention/test_rocm_aiter_mla_sparse_logits_sanitize.py
```

9 cases passing on MI355X: correct window, untouched tail, NaN/Inf mapping,
sub-crossover fallback, and static grid.
