### PR TITLE
[Bugfix] NemotronHMTP: add hf_to_vllm_mapper so quant exclusions reach the MTP draft

### DIFF
--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.utils import (
+    WeightsMapper,
     make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
@@ -311,6 +312,16 @@ class NemotronHMultiTokenPredictor(nn.Module):
 
 class NemotronHMTP(nn.Module, SupportsPP):
     """NemotronH MTP model."""
+
+    # Quant configs name modules in checkpoint space ("language_model.mtp.layers.0*"),
+    # but this draft is built under "mtp" (maybe_prefix below). SupportsQuant only
+    # re-roots exclude_modules when the model defines a mapper, so without one the
+    # exclusions never match and the MTP experts are wrongly quantized. Mirrors the
+    # prefix handling load_weights() already does by hand.
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"language_model.": ""},
+        orig_to_new_substr={"embeddings": "embed_tokens"},
+    )
 
     packed_modules_mapping = {
         "qkv_proj": [


### PR DESCRIPTION
## Bug

Serving a ModelOpt **deny-list** checkpoint (`quant_algo: NVFP4` + `exclude_modules`) with MTP
speculative decoding fails at engine init:

```
drafter.load_model -> nemotron_h_mtp.py load_weights -> routed_experts.py _load_w13
RuntimeError: The size of tensor a (512) must match the size of tensor b (1024)
```

512 vs 1024 is the 2× NVFP4 packing ratio — the MTP routed experts are built quantized while the
checkpoint stores them unquantized.

## Cause

`SupportsQuant._maybe_apply_model_mapping()` re-roots a quant config's module lists from checkpoint
space into vLLM module space, but only when the model defines `hf_to_vllm_mapper`:

```python
if (hf_to_vllm_mapper := self.hf_to_vllm_mapper) is not None:
    self.quant_config.apply_vllm_mapper(hf_to_vllm_mapper.get_rename_mapper())
```

`NemotronHForCausalLM` defines one; `NemotronHMTP` did not. So `is_layer_excluded()` fnmatches
`"language_model.mtp.layers.0*"` against the draft's construction prefix
`"mtp.layers.0.mixer.experts"`, never matches, and nothing is excluded.

## Fix

Add the mapper, mirroring the prefix handling `load_weights()` already does by hand in the same file:

```python
hf_to_vllm_mapper = WeightsMapper(
    orig_to_new_prefix={"language_model.": ""},
    orig_to_new_substr={"embeddings": "embed_tokens"},
)
```

Only deny-list configs are affected. `MIXED_PRECISION` allow-list configs name quantized modules
explicitly, never name MTP, and were always correct — which is why only some checkpoints fail.

## Verification

4× GB200, `vllm 0.26.1rc1.dev1133`, a future Nemotron model (Nemotron-H hybrid, MoE + MTP), `--speculative_config.method mtp`.
All three in one session on one image:

| checkpoint | patched | result |
|---|---|---|
| NVFP4 deny-list | no | **fails** — 512 vs 1024 |
| NVFP4 deny-list | yes | serves, coherent, completes an AIPerf run |
| MIXED_PRECISION | yes | unchanged |

Before the fix that checkpoint never reached the benchmark client; it has since completed full
concurrency sweeps at two token shapes on both TP=4 and DP=4.

