### PR TITLE
[RFC] Fuse Nemotron shared ReLU2 and static FP8 quantization

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -294,6 +294,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_DISABLE_DSV4_MEGAMOE_SHARED_EXPERT_FUSION: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
+    VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT: bool = False
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
@@ -2014,6 +2015,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # TODO(alexm-redhat): Tune to be more dynamic based on GPU type
     "VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD": lambda: int(
         int(os.getenv("VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD", 256))
+    ),
+    "VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT": lambda: bool(
+        int(os.getenv("VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT", "0"))
     ),
     # Token-count cutoff for multi-stream overlap of the attention input
     # GEMM with auxiliary GEMMs (e.g. fused_wqa_wkv overlapped with indexer

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -22,8 +22,10 @@ from collections.abc import Iterable, Mapping
 from itertools import islice
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
+import vllm.envs as envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.config.parallel import ParallelConfig
@@ -45,6 +47,11 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
     RowParallelLinear,
 )
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassFP8ScaledMMLinearKernel,
+)
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
 from vllm.model_executor.layers.mamba.mamba_utils import (
@@ -54,6 +61,11 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.modelopt import ModelOptFp8LinearMethod
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_fp8_min_max,
+    kFp8StaticTensorSym,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -81,6 +93,32 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.nemotron_h import NemotronHConfig
+
+
+@CustomOp.register("nemotron_h_relu2_fp8_quant")
+class NemotronHReLU2Fp8Quant(CustomOp):
+    """ReLU2 followed by static per-tensor FP8 quantization."""
+
+    def __init__(self) -> None:
+        # Shared experts execute inside the opaque MoE custom op. Compiling this
+        # native function explicitly keeps activation and quantization in one
+        # pointwise kernel.
+        super().__init__(compile_native=True)
+
+    def forward_native(
+        self, x: torch.Tensor, scale: torch.Tensor
+    ) -> torch.Tensor:
+        fp8_min, fp8_max = get_fp8_min_max()
+        activated = torch.square(F.relu(x))
+        return (
+            activated.to(torch.float32)
+            .mul(scale.to(torch.float32).reciprocal())
+            .clamp(fp8_min, fp8_max)
+            .to(torch.float8_e4m3fn)
+        )
+
+    def forward_cuda(self, x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+        return self.forward_native(x, scale)
 
 
 class NemotronHMLP(nn.Module):
@@ -115,10 +153,33 @@ class NemotronHMLP(nn.Module):
             prefix=f"{prefix}.down_proj",
         )
         self.act_fn = ReLUSquaredActivation()
+        self.relu2_fp8_quant = NemotronHReLU2Fp8Quant()
+        down_quant_method = self.down_proj.quant_method
+        self.use_fused_relu2_fp8_quant = (
+            envs.VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT
+            and self.down_proj.tp_size == 1
+            and isinstance(down_quant_method, ModelOptFp8LinearMethod)
+            and isinstance(
+                down_quant_method.fp8_linear, CutlassFP8ScaledMMLinearKernel
+            )
+            and down_quant_method.fp8_linear.input_quant_key()
+            == kFp8StaticTensorSym
+        )
 
     def forward(self, x: torch.Tensor):
         x, _ = self.up_proj(x)
-        x = self.act_fn(x)
+        if self.use_fused_relu2_fp8_quant:
+            input_scale = self.down_proj.input_scale
+            x_q = self.relu2_fp8_quant(x, input_scale)
+            x = QuantizedActivation(
+                data=x_q,
+                scale=input_scale,
+                orig_dtype=x.dtype,
+                orig_shape=x.shape,
+                quant_key=kFp8StaticTensorSym,
+            )
+        else:
+            x = self.act_fn(x)
         x, _ = self.down_proj(x)
         return x
 

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -93,6 +93,26 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.nemotron_h import NemotronHConfig
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _nemotron_h_relu2_fp8_quant_kernel(
+    x_ptr,
+    scale_ptr,
+    output_ptr,
+    num_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    relu = tl.where(x > 0.0, x, 0.0)
+    # Match the standalone ReLU2 kernel's BF16 output before quantization.
+    activated = (relu * relu).to(tl.bfloat16).to(tl.float32)
+    inv_scale = 1.0 / tl.load(scale_ptr)
+    quantized = tl.clamp(activated * inv_scale, -448.0, 448.0)
+    tl.store(output_ptr + offsets, quantized, mask=mask)
 
 
 @CustomOp.register("nemotron_h_relu2_fp8_quant")
@@ -100,16 +120,15 @@ class NemotronHReLU2Fp8Quant(CustomOp):
     """ReLU2 followed by static per-tensor FP8 quantization."""
 
     def __init__(self) -> None:
-        # Shared experts execute inside the opaque MoE custom op. Compiling this
-        # native function explicitly keeps activation and quantization in one
-        # pointwise kernel.
-        super().__init__(compile_native=True)
+        super().__init__(enforce_enable=True)
 
     def forward_native(
         self, x: torch.Tensor, scale: torch.Tensor
     ) -> torch.Tensor:
         fp8_min, fp8_max = get_fp8_min_max()
-        activated = torch.square(F.relu(x))
+        # The unfused path stores the ReLU2 result as BF16 before static FP8
+        # quantization. Preserve that rounding point in registers.
+        activated = torch.square(F.relu(x.to(torch.float32))).to(x.dtype)
         return (
             activated.to(torch.float32)
             .mul(scale.to(torch.float32).reciprocal())
@@ -118,7 +137,19 @@ class NemotronHReLU2Fp8Quant(CustomOp):
         )
 
     def forward_cuda(self, x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-        return self.forward_native(x, scale)
+        assert x.is_contiguous()
+        assert scale.numel() == 1
+        output = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+        block_size = 2048
+        grid = (triton.cdiv(x.numel(), block_size),)
+        _nemotron_h_relu2_fp8_quant_kernel[grid](
+            x,
+            scale,
+            output,
+            x.numel(),
+            BLOCK_SIZE=block_size,
+        )
+        return output
 
 
 class NemotronHMLP(nn.Module):

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -29,10 +29,14 @@ import vllm.envs as envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.config.parallel import ParallelConfig
-from vllm.logger import init_logger
 from vllm.distributed import get_ep_group, get_tensor_model_parallel_world_size
 from vllm.distributed.communication_op import tensor_model_parallel_all_gather
 from vllm.distributed.parallel_state import get_pp_group
+from vllm.logger import init_logger
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.kernels.linear.scaled_mm import (
+    FP8ScaledMMLinearKernel,
+)
 from vllm.model_executor.layers.activation import ReLUSquaredActivation
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
@@ -41,6 +45,7 @@ from vllm.model_executor.layers.fused_moe import (
     activation_without_mul,
     fused_moe_make_expert_params_mapping,
 )
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -48,11 +53,6 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
     RowParallelLinear,
 )
-from vllm.model_executor.custom_op import CustomOp
-from vllm.model_executor.kernels.linear.scaled_mm import (
-    FP8ScaledMMLinearKernel,
-)
-from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
 from vllm.model_executor.layers.mamba.mamba_utils import (
@@ -125,9 +125,7 @@ class NemotronHReLU2Fp8Quant(CustomOp):
     def __init__(self) -> None:
         super().__init__(enforce_enable=True)
 
-    def forward_native(
-        self, x: torch.Tensor, scale: torch.Tensor
-    ) -> torch.Tensor:
+    def forward_native(self, x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
         fp8_min, fp8_max = get_fp8_min_max()
         # The unfused path stores the ReLU2 result as BF16 before static FP8
         # quantization. Preserve that rounding point in registers.
@@ -196,9 +194,7 @@ class NemotronHMLP(nn.Module):
             down_quant_method.fp8_linear, FP8ScaledMMLinearKernel
         )
         quant_key = (
-            down_quant_method.fp8_linear.input_quant_key()
-            if fp8_scaled_mm
-            else None
+            down_quant_method.fp8_linear.input_quant_key() if fp8_scaled_mm else None
         )
         static_fp8 = quant_key == kFp8StaticTensorSym
         self.use_fused_relu2_fp8_quant = (

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -29,6 +29,7 @@ import vllm.envs as envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.config.parallel import ParallelConfig
+from vllm.logger import init_logger
 from vllm.distributed import get_ep_group, get_tensor_model_parallel_world_size
 from vllm.distributed.communication_op import tensor_model_parallel_all_gather
 from vllm.distributed.parallel_state import get_pp_group
@@ -94,6 +95,8 @@ from vllm.model_executor.models.utils import (
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.nemotron_h import NemotronHConfig
 from vllm.triton_utils import tl, triton
+
+logger = init_logger(__name__)
 
 
 @triton.jit
@@ -187,14 +190,34 @@ class NemotronHMLP(nn.Module):
         self.act_fn = ReLUSquaredActivation()
         self.relu2_fp8_quant = NemotronHReLU2Fp8Quant()
         down_quant_method = self.down_proj.quant_method
+        tp1 = self.down_proj.tp_size == 1
+        modelopt_fp8 = isinstance(down_quant_method, ModelOptFp8LinearMethod)
+        fp8_scaled_mm = modelopt_fp8 and isinstance(
+            down_quant_method.fp8_linear, FP8ScaledMMLinearKernel
+        )
+        quant_key = (
+            down_quant_method.fp8_linear.input_quant_key()
+            if fp8_scaled_mm
+            else None
+        )
+        static_fp8 = quant_key == kFp8StaticTensorSym
         self.use_fused_relu2_fp8_quant = (
             envs.VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT
-            and self.down_proj.tp_size == 1
-            and isinstance(down_quant_method, ModelOptFp8LinearMethod)
-            and isinstance(down_quant_method.fp8_linear, FP8ScaledMMLinearKernel)
-            and down_quant_method.fp8_linear.input_quant_key()
-            == kFp8StaticTensorSym
+            and tp1
+            and modelopt_fp8
+            and fp8_scaled_mm
+            and static_fp8
         )
+        if envs.VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT:
+            logger.info_once(
+                "Nemotron ReLU2+FP8 fusion guard: enabled=%s tp1=%s "
+                "quant_method=%s fp8_kernel=%s quant_key=%s",
+                self.use_fused_relu2_fp8_quant,
+                tp1,
+                type(down_quant_method).__name__,
+                type(getattr(down_quant_method, "fp8_linear", None)).__name__,
+                quant_key,
+            )
 
     def forward(self, x: torch.Tensor):
         x, _ = self.up_proj(x)

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -148,6 +148,7 @@ class NemotronHReLU2Fp8Quant(CustomOp):
             output,
             x.numel(),
             BLOCK_SIZE=block_size,
+            num_warps=4,
         )
         return output
 

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -48,8 +48,8 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.custom_op import CustomOp
-from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
-    CutlassFP8ScaledMMLinearKernel,
+from vllm.model_executor.kernels.linear.scaled_mm import (
+    FP8ScaledMMLinearKernel,
 )
 from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -191,9 +191,7 @@ class NemotronHMLP(nn.Module):
             envs.VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT
             and self.down_proj.tp_size == 1
             and isinstance(down_quant_method, ModelOptFp8LinearMethod)
-            and isinstance(
-                down_quant_method.fp8_linear, CutlassFP8ScaledMMLinearKernel
-            )
+            and isinstance(down_quant_method.fp8_linear, FP8ScaledMMLinearKernel)
             and down_quant_method.fp8_linear.input_quant_key()
             == kFp8StaticTensorSym
         )


### PR DESCRIPTION
## Summary

- fuse Nemotron shared-expert ReLU2 with static per-tensor FP8 quantization
- preserve the canonical BF16 rounding point in registers
- pass the resulting `QuantizedActivation` directly to the unchanged FP8 down projection
- keep the path behind `VLLM_EXPERIMENTAL_NEMOTRON_SHARED_RELU2_FP8_QUANT`

## Performance

NVIDIA Nemotron Ultra NVFP4 on one 4xGB200 node, TP1/DP4/EP4, CUDA graphs.

Kernel-level results at the production `M=32768` bucket:

- ReLU2/quantization boundary: `813.6 -> 140.5 us` (5.79x)
- complete shared MLP kernel time: `3655.3 -> 2968.4 us` (-18.79%)

Focused 50k-input prefill campaign, six paired independent server lifetimes:

| E2E metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| Mean TTFT | 10,619.2 ms | 10,478.5 ms | -1.34% |
| Aggregate token throughput | 71,558 tok/s | 72,525 tok/s | **+1.34%** |
| Request throughput | 1.4311 req/s | 1.4505 req/s | **+1.34%** |

The paired 95% interval for throughput is +0.05% to +2.64%. The TTFT interval still touches parity.

Production-shape 50k/2048 regression guard, six paired runs with eight prompts per rank:

| E2E metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| Mean TTFT | 8,911.5 ms | 8,606.8 ms | -3.62% |
| Mean TPOT | 15.796 ms | 15.791 ms | -0.01% |
| Aggregate token throughput | 19,523 tok/s | 19,970 tok/s | +2.74% |

The long-output campaign had two opposing throughput outliers. These are observed central means and establish no TPOT/decode regression, but they are too noisy to support a long-output throughput or TTFT claim.
