### PR TITLE
[Perf] Add tuning configs for SM103 Kimi k3 nvfp4 DEP projection GEMM

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+
 import torch
 
 import vllm.envs as envs
@@ -29,6 +30,26 @@ from .BlockScaledMMLinearKernel import (
 )
 
 
+def _launch_fp8_gemm_nt(
+    A: torch.Tensor,
+    As: torch.Tensor,
+    B: torch.Tensor,
+    Bs: torch.Tensor,
+    output: torch.Tensor,
+    use_deep_gemm_e8m0: bool,
+    block_size_multiple_of: tuple[int, int] | None = None,
+) -> None:
+    torch.ops.vllm.fp8_gemm_nt_op(
+        A,
+        As,
+        B,
+        Bs,
+        output,
+        use_deep_gemm_e8m0,
+        block_size_multiple_of,
+    )
+
+
 class DeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     def __init__(self, config: FP8ScaledMMLinearLayerConfig):
         super().__init__(config)
@@ -42,6 +63,11 @@ class DeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             tma_aligned_scales=envs.VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES,
             column_major_scales=True,
         )
+        self._block_size_multiple_plan: dict[int, tuple[int, int]] = {}
+
+    def set_block_size_multiple_plan(self, plan: dict[int, tuple[int, int]]) -> None:
+        """Select restricted DeepGEMM layout candidates."""
+        self._block_size_multiple_plan = dict(plan)
 
     @classmethod
     def is_supported(cls, compute_capability=None):
@@ -119,7 +145,16 @@ class DeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             dtype=out_dtype,
             device=A.device,
         )
-        torch.ops.vllm.fp8_gemm_nt_op(A, As, B, Bs, output, self.use_deep_gemm_e8m0)
+        block_size_multiple_of = self._block_size_multiple_plan.get(A.shape[0])
+        _launch_fp8_gemm_nt(
+            A,
+            As,
+            B,
+            Bs,
+            output,
+            self.use_deep_gemm_e8m0,
+            block_size_multiple_of,
+        )
         return output
 
 
@@ -130,12 +165,19 @@ def _fp8_gemm_nt_op(
     weight_scale: torch.Tensor,
     output: torch.Tensor,
     use_deep_gemm_e8m0: bool,
+    block_size_multiple_of: list[int] | None = None,
 ) -> None:
+    block_size_multiple = (
+        None
+        if block_size_multiple_of is None
+        else (block_size_multiple_of[0], block_size_multiple_of[1])
+    )
     fp8_gemm_nt(
         (q_input, input_scale),
         (weight, weight_scale),
         output,
         is_deep_gemm_e8m0_used=use_deep_gemm_e8m0,
+        block_size_multiple_of=block_size_multiple,
     )
 
 
@@ -146,6 +188,7 @@ def _fp8_gemm_nt_op_fake(
     weight_scale: torch.Tensor,
     output: torch.Tensor,
     use_deep_gemm_e8m0: bool,
+    block_size_multiple_of: list[int] | None = None,
 ) -> None:
     return None
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -30,26 +30,6 @@ from .BlockScaledMMLinearKernel import (
 )
 
 
-def _launch_fp8_gemm_nt(
-    A: torch.Tensor,
-    As: torch.Tensor,
-    B: torch.Tensor,
-    Bs: torch.Tensor,
-    output: torch.Tensor,
-    use_deep_gemm_e8m0: bool,
-    block_size_multiple_of: tuple[int, int] | None = None,
-) -> None:
-    torch.ops.vllm.fp8_gemm_nt_op(
-        A,
-        As,
-        B,
-        Bs,
-        output,
-        use_deep_gemm_e8m0,
-        block_size_multiple_of,
-    )
-
-
 class DeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     def __init__(self, config: FP8ScaledMMLinearLayerConfig):
         super().__init__(config)
@@ -146,7 +126,7 @@ class DeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             device=A.device,
         )
         block_size_multiple_of = self._block_size_multiple_plan.get(A.shape[0])
-        _launch_fp8_gemm_nt(
+        torch.ops.vllm.fp8_gemm_nt_op(
             A,
             As,
             B,
@@ -167,17 +147,12 @@ def _fp8_gemm_nt_op(
     use_deep_gemm_e8m0: bool,
     block_size_multiple_of: list[int] | None = None,
 ) -> None:
-    block_size_multiple = (
-        None
-        if block_size_multiple_of is None
-        else (block_size_multiple_of[0], block_size_multiple_of[1])
-    )
     fp8_gemm_nt(
         (q_input, input_scale),
         (weight, weight_scale),
         output,
         is_deep_gemm_e8m0_used=use_deep_gemm_e8m0,
-        block_size_multiple_of=block_size_multiple,
+        block_size_multiple_of=block_size_multiple_of,
     )
 
 

--- a/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
@@ -30,12 +30,19 @@ from vllm.model_executor.kernels.linear.cute_dsl.skinny_gemm import (
     SkinnyGemmConfig,
     shape_dynamic_skinny_gemm,
 )
+from vllm.model_executor.kernels.linear.scaled_mm.deep_gemm import (
+    DeepGemmFp8BlockScaledMMKernel,
+)
 from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptFp8PbWoLinearMethod,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     UnquantizedEmbeddingMethod,
 )
 from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import supports_block_size_multiple_of
 
 Backend = Literal["cute", "dsv3_fused_a"]
 # A resolved per-token-count call: the backend plus its CuTe config (None for
@@ -485,6 +492,16 @@ KIMI_K3_PROJECTIONS_SM100: dict[tuple[int, int], ProjectionSpec] = {
     ),
 }
 
+# SM103 layout tuning for Kimi-K3 FP8_PB_WO projection GEMMs. Each value
+# is passed to DeepGEMM's set_block_size_multiple_of to constrain candidate
+# (block_m, block_n) tile sizes during kernel selection.
+KIMI_K3_FP8_PB_WO_BLOCK_SIZE_PLANS_SM103: dict[
+    tuple[int, int], dict[int, tuple[int, int]]
+] = {
+    (12288, 128): {m: (256, 1) for m in range(17, 257)},
+    (7168, 12288): {m: (256, 1) for m in range(17, 257)},
+}
+
 
 def _backend_for(
     spec: ProjectionSpec, num_tokens: int, has_residual: bool
@@ -697,6 +714,24 @@ def enable_kimi_k3_low_latency_gemm(
     warmup_configs: set[SkinnyGemmConfig] = set()
     residual_warmup_configs: set[SkinnyGemmConfig] = set()
     for child in module.modules():
+        if (
+            _is_sm103()
+            and not envs.VLLM_BATCH_INVARIANT
+            and isinstance(child, LinearBase)
+            and isinstance(child.quant_method, ModelOptFp8PbWoLinearMethod)
+        ):
+            kernel = child.quant_method.w8a8_block_fp8_linear
+            plan = KIMI_K3_FP8_PB_WO_BLOCK_SIZE_PLANS_SM103.get(
+                tuple(child.weight.shape)
+            )
+            if (
+                plan is not None
+                and isinstance(kernel, DeepGemmFp8BlockScaledMMKernel)
+                and supports_block_size_multiple_of()
+            ):
+                kernel.set_block_size_multiple_plan(plan)
+            continue
+
         is_linear = (
             isinstance(child, LinearBase)
             and type(child.quant_method) is UnquantizedLinearMethod

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -334,7 +334,7 @@ def supports_block_size_multiple_of() -> bool:
 
 @contextlib.contextmanager
 def _block_size_multiple_scope(
-    value: tuple[int, int] | None,
+    value: list[int] | tuple[int, int] | None,
 ):
     """Apply a block-size constraint for one normal GEMM launch.
 
@@ -346,6 +346,8 @@ def _block_size_multiple_scope(
             yield
             return
 
+        assert len(value) == 2
+        value = tuple(value)
         if any(multiple <= 0 for multiple in value):
             raise ValueError("block-size multiples must be positive")
 

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import importlib
 import os
+import threading
 from collections.abc import Callable
 from enum import Enum
 from typing import Any, NoReturn
@@ -28,6 +29,7 @@ _DEEPGEMM_BLACKWELL_EXCLUDED_MODEL_TYPES: set[str] = {
     "qwen3_5_text",
     "qwen3_5_moe_text",
 }
+_BLOCK_SIZE_MULTIPLE_LOCK = threading.Lock()
 
 
 def should_auto_disable_deep_gemm(model_type: str | None) -> bool:
@@ -323,6 +325,40 @@ def set_num_sms(num_sms: int) -> None:
     dg.set_num_sms(num_sms)
 
 
+def supports_block_size_multiple_of() -> bool:
+    """Return whether DeepGEMM exposes block-size candidate constraints."""
+    _lazy_init()
+    dg = _import_deep_gemm()
+    return dg is not None and hasattr(dg, "set_block_size_multiple_of")
+
+
+@contextlib.contextmanager
+def _block_size_multiple_scope(
+    value: tuple[int, int] | None,
+):
+    """Apply a block-size constraint for one normal GEMM launch.
+
+    DeepGEMM exposes only a process-wide setter, so all normal GEMM launches
+    are serialized and constrained calls restore the default before returning.
+    """
+    with _BLOCK_SIZE_MULTIPLE_LOCK:
+        if value is None:
+            yield
+            return
+
+        if any(multiple <= 0 for multiple in value):
+            raise ValueError("block-size multiples must be positive")
+
+        dg = _import_deep_gemm()
+        if dg is None or not hasattr(dg, "set_block_size_multiple_of"):
+            raise RuntimeError("DeepGEMM block-size constraints are not available")
+        dg.set_block_size_multiple_of(value)
+        try:
+            yield
+        finally:
+            dg.set_block_size_multiple_of((1, 1))
+
+
 def get_mk_alignment_for_contiguous_layout() -> list[int]:
     _lazy_init()
     if _get_mk_alignment_for_contiguous_layout_impl is None:
@@ -461,7 +497,9 @@ def fp8_gemm_nt(*args, **kwargs):
         del kwargs["is_deep_gemm_e8m0_used"]
     else:
         use_ue8m0 = is_deep_gemm_e8m0_used()
-    return _fp8_gemm_nt_impl(*args, disable_ue8m0_cast=not use_ue8m0, **kwargs)
+    block_size_multiple_of = kwargs.pop("block_size_multiple_of", None)
+    with _block_size_multiple_scope(block_size_multiple_of):
+        return _fp8_gemm_nt_impl(*args, disable_ue8m0_cast=not use_ue8m0, **kwargs)
 
 
 def fp8_einsum(*args, **kwargs):
@@ -783,6 +821,7 @@ __all__ = [
     "is_deep_gemm_supported",
     "get_num_sms",
     "set_num_sms",
+    "supports_block_size_multiple_of",
     "should_use_deepgemm_for_fp8_linear",
     "get_col_major_tma_aligned_tensor",
     "get_mk_alignment_for_contiguous_layout",


### PR DESCRIPTION
## Purpose
Add tuning configs for DeepGEMM fp8 GEMM for `o_proj` and `k_b_proj` in Kimi K3 nvfp4 by leveraging DeepGEMM's `set_block_size_multiple_of` knob, which controls the tile sizes for the GEMM.

#### Microbenchmark result:
```
| M | o_proj before | After | Speedup |
|--:|--------------:|------:|--------:|
| 17  | 17.09 μs | 13.34 μs | 1.28x |
| 20  | 17.09 μs | 13.36 μs | 1.28x |
| 24  | 17.42 μs | 13.34 μs | 1.31x |
| 32  | 17.19 μs | 13.35 μs | 1.29x |
| 40  | 17.89 μs | 13.24 μs | 1.35x |
| 48  | 18.18 μs | 13.30 μs | 1.37x |
| 56  | 18.01 μs | 13.27 μs | 1.36x |
| 64  | 17.96 μs | 13.30 μs | 1.35x |
| 80  | 19.14 μs | 18.26 μs | 1.05x |
| 96  | 19.23 μs | 18.20 μs | 1.06x |
| 112 | 19.92 μs | 18.48 μs | 1.08x |
| 128 | 19.62 μs | 18.45 μs | 1.06x |
| 144 | 21.14 μs | 20.60 μs | 1.03x |
| 160 | 20.90 μs | 20.57 μs | 1.02x |
| 176 | 20.83 μs | 20.60 μs | 1.01x |
| 192 | 21.23 μs | 20.79 μs | 1.02x |
| 208 | 21.80 μs | 20.81 μs | 1.05x |
| 224 | 21.48 μs | 20.80 μs | 1.03x |
| 240 | 20.53 μs | 20.41 μs | 1.01x |
| 256 | 20.66 μs | 20.44 μs | 1.01x |

| M | f_b_proj before | After | Speedup |
|--:|----------------:|------:|--------:|
| 17  | 3.00 μs | 2.72 μs | 1.11x |
| 20  | 3.01 μs | 2.70 μs | 1.11x |
| 24  | 2.95 μs | 2.65 μs | 1.11x |
| 32  | 2.95 μs | 2.64 μs | 1.12x |
| 40  | 3.09 μs | 2.70 μs | 1.14x |
| 48  | 3.09 μs | 2.68 μs | 1.15x |
| 56  | 3.30 μs | 2.66 μs | 1.24x |
| 64  | 3.29 μs | 2.65 μs | 1.24x |
| 80  | 3.39 μs | 2.80 μs | 1.21x |
| 96  | 3.66 μs | 2.74 μs | 1.33x |
| 112 | 3.80 μs | 2.75 μs | 1.39x |
| 128 | 4.11 μs | 2.71 μs | 1.51x |
| 144 | 4.26 μs | 3.97 μs | 1.07x |
| 160 | 4.49 μs | 3.95 μs | 1.14x |
| 176 | 4.62 μs | 4.01 μs | 1.15x |
| 192 | 4.91 μs | 3.96 μs | 1.24x |
| 208 | 4.99 μs | 3.91 μs | 1.28x |
| 224 | 5.28 μs | 3.89 μs | 1.36x |
| 240 | 5.33 μs | 3.91 μs | 1.37x |
| 256 | 4.91 μs | 3.86 μs | 1.27x |
```

## Test Plan

## Test Result
- Validated kimi k3 nvfp4 DEP16 GSM8k accuracy

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

