### PR TITLE
Add support for loading dflash2 model in speculators format

### DIFF
--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -130,6 +130,30 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
     )
 
 
+@register_speculator("dflash2")
+def update_dflash2(config_dict: dict, pre_trained_config: dict) -> None:
+    """
+    Apply DFlash2 specific configuration transformations to the `dict` used
+    to construct the Transformers PreTrainedConfig.
+
+    DFlash2 extends DFlash with a grouped convolution layer and a
+    low-rank candidate selector head. It reuses the same DFlash runtime
+    (method="dflash") but has its own architecture (DFlash2DraftModel)
+    and additional config fields for the convolution and selector.
+    """
+    update_dflash(config_dict, pre_trained_config)
+    pre_trained_config["architectures"] = ["DFlash2DraftModel"]
+
+    for key in (
+        "conv_kernel_size",
+        "conv_group_size",
+        "selector_rank",
+        "selector_top_k",
+    ):
+        if config_dict.get(key) is not None:
+            pre_trained_config["dflash_config"][key] = config_dict[key]
+
+
 @register_speculator("dspark")
 def update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
     """

--- a/vllm/transformers_utils/configs/speculators/base.py
+++ b/vllm/transformers_utils/configs/speculators/base.py
@@ -134,4 +134,6 @@ class SpeculatorsConfig(PretrainedConfig):
         }
         if result["method"] == "peagle":
             result.update({"method": "eagle3", "parallel_drafting": True})
+        elif result["method"] == "dflash2":
+            result["method"] = "dflash"
         return result


### PR DESCRIPTION



## Purpose

Add speculators format loading logic for dflash2. 

Note: we use `dflash2` in the speculators config to denote the algorithm, but overwrite with `dflash` in vllm to match vllm conventions. 

## Test Plan

Successfully served a model produced by https://github.com/vllm-project/speculators/pull/1006 in vllm using this change. 

## Test Result

Speculator served. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

