### PR TITLE
[Bugfix][Scheduler] Handle missing req_id in update_from_output gracefully

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3435,6 +3435,120 @@ def test_abort_request_when_structured_output_fsm_cannot_advance():
     assert engine_core_output.finish_reason == FinishReason.ERROR
 
 
+def test_missing_req_id_in_model_runner_output_fails_request():
+    """When a scheduled request is missing from the model runner output
+    (e.g. a worker OOM killed execution partway through), the scheduler
+    should fail that request gracefully instead of crashing the engine
+    with a KeyError."""
+    scheduler = object.__new__(Scheduler)
+    sampling_params = SamplingParams(max_tokens=10)
+    sampling_params.update_from_generation_config({}, EOS_TOKEN_ID)
+
+    # Two requests: "present" will be in model runner output,
+    # "missing" will be scheduled but absent from model runner output.
+    present_req = Request(
+        request_id="present",
+        prompt_token_ids=[0, 1, 2],
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    present_req.status = RequestStatus.RUNNING
+    present_req.num_computed_tokens = present_req.num_tokens
+
+    missing_req = Request(
+        request_id="missing",
+        prompt_token_ids=[0, 1, 2],
+        sampling_params=sampling_params,
+        pooling_params=None,
+    )
+    missing_req.status = RequestStatus.RUNNING
+    missing_req.num_computed_tokens = missing_req.num_tokens
+
+    scheduler.perf_metrics = None
+    scheduler.connector = None
+    scheduler.ec_connector = None
+    scheduler.structured_output_manager = Mock()
+    scheduler.structured_output_manager.should_advance.return_value = False
+    scheduler.requests = {
+        "present": present_req,
+        "missing": missing_req,
+    }
+    scheduler.running = [present_req, missing_req]
+    scheduler.waiting = Mock()
+    scheduler.kv_cache_manager = Mock()
+    scheduler.kv_cache_manager.take_events.return_value = None
+    scheduler.kv_cache_manager.estimate_cached_tokens.return_value = 0
+    scheduler.kv_event_publisher = Mock()
+    scheduler.finished_req_ids = set()
+    scheduler.finished_req_ids_dict = None
+    scheduler.grammar_compile_error_reqs = set()
+    scheduler.vllm_config = Mock()
+    scheduler.vllm_config.model_config.enable_return_routed_experts = False
+    scheduler.enable_return_routed_experts = False
+    scheduler.return_sampling_mask = False
+    scheduler.recompute_kv_load_failures = False
+    scheduler.defer_block_free = False
+    scheduler.make_stats = Mock(return_value=None)
+    scheduler.max_model_len = 128
+
+    def free_request(req: Request, delay_free_blocks: bool = False):
+        scheduler.finished_req_ids.add(req.request_id)
+        scheduler.requests.pop(req.request_id, None)
+        return None, None
+
+    scheduler._free_request = Mock(side_effect=free_request)
+
+    # Schedule both requests.
+    output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={"present": 1, "missing": 1},
+        total_num_scheduled_tokens=2,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    # Model runner output only contains "present" — "missing" is absent.
+    model_runner_output = ModelRunnerOutput(
+        req_ids=["present"],
+        req_id_to_index={"present": 0},
+        sampled_token_ids=[[42]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    # Before the fix this would raise KeyError and kill EngineCore.
+    engine_core_outputs = scheduler.update_from_output(output, model_runner_output)
+
+    # "missing" should be finished with error.
+    assert missing_req.status == RequestStatus.FINISHED_ERROR
+    assert "missing" not in scheduler.requests
+
+    # "present" should have been processed normally.
+    present_outputs = [
+        o
+        for outs in engine_core_outputs.values()
+        for o in outs.outputs
+        if o.request_id == "present"
+    ]
+    assert len(present_outputs) == 1
+    assert present_outputs[0].new_token_ids == [42]
+
+    # "missing" should have an error output.
+    missing_outputs = [
+        o
+        for outs in engine_core_outputs.values()
+        for o in outs.outputs
+        if o.request_id == "missing"
+    ]
+    assert len(missing_outputs) == 1
+    assert missing_outputs[0].finish_reason == FinishReason.ERROR
+
+
 @pytest.mark.parametrize("use_v2_model_runner", [False, True])
 @pytest.mark.parametrize(
     "use_ec_connector, ec_role", [(False, None), (True, "ec_consumer")]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1823,6 +1823,7 @@ class Scheduler(SchedulerInterface):
         # to avoid expensive operations inside the loop.
         stopped_running_reqs: set[Request] = set()
         stopped_preempted_reqs: set[Request] = set()
+        missing_output_req_ids: set[str] | None = None
         for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
             assert num_tokens_scheduled > 0
             request = self.requests.get(req_id)
@@ -1851,7 +1852,20 @@ class Scheduler(SchedulerInterface):
             if output_is_stale and request.drop_stale_output:
                 continue
 
-            req_index = model_runner_output.req_id_to_index[req_id]
+            req_index = model_runner_output.req_id_to_index.get(req_id)
+            if req_index is None:
+                # The model runner did not produce output for this request
+                # (e.g. a worker OOM killed execution partway through).
+                # Fail the request instead of crashing the engine.
+                logger.error(
+                    "Request %s was scheduled but missing from model "
+                    "runner output. Failing the request.",
+                    req_id,
+                )
+                if missing_output_req_ids is None:
+                    missing_output_req_ids = set()
+                missing_output_req_ids.add(req_id)
+                continue
             generated_token_ids = (
                 sampled_token_ids[req_index] if sampled_token_ids else []
             )
@@ -2087,6 +2101,8 @@ class Scheduler(SchedulerInterface):
         self.grammar_compile_error_reqs.clear()
         if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
             error_req_ids.update(failed_kv_load_req_ids)
+        if missing_output_req_ids:
+            error_req_ids.update(missing_output_req_ids)
 
         if error_req_ids:
             error_reqs = self.finish_requests(


### PR DESCRIPTION
## Purpose

Addresses §5 of #53787.

When a scheduled request is absent from the model runner output (e.g. a worker OOM killed execution partway through), `update_from_output` raises an unhandled `KeyError` at `scheduler.py:1854`:

```
req_index = model_runner_output.req_id_to_index[req_id]
KeyError: 'chatcmpl-95f443c92d6709b3-a7e574bd'
EngineCore encountered a fatal error.
```

This crashes the entire `EngineCore` and kills all in-flight requests, even though only one request was affected.

## Fix

- Use `.get()` instead of `[]` for the `req_id_to_index` lookup.
- If a `req_id` is missing, log an error, collect it, and `continue` — skipping the rest of the loop body for that request.
- After the loop, feed the missing `req_id`s into the existing `error_req_ids` set so they are finished with `FINISHED_ERROR` and a proper `EngineCoreOutput` is emitted to the client.

The engine stays alive, other requests in the batch are unaffected, and the failed request returns an error to its caller.

## Test Plan

Added `test_missing_req_id_in_model_runner_output_fails_request` which schedules two requests but makes the `ModelRunnerOutput` contain only one. Verifies:
- The missing request is finished with `FINISHED_ERROR`
- The present request is processed normally
- No `KeyError` is raised

```bash
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_missing_req_id_in_model_runner_output_fails_request -v
# 1 passed

.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_abort_request_when_structured_output_fsm_cannot_advance tests/v1/core/test_scheduler.py::test_grammar_compile_error_finishes_only_request -v
# 3 passed (existing tests unaffected)

pre-commit run ruff-check --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
# passed

pre-commit run ruff-format --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
# passed
```

## AI Assistance

AI assistance was used for code exploration and implementation. The submitter has reviewed every changed line.