### PR TITLE
[Bugfix] Register hybrid prefix-cache boundaries at hittable positions

### DIFF
--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -278,7 +278,10 @@ def test_unaligned_resume_never_runs_past_its_block(
     """
     prompt_len = 3602
     (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
-    tail_boundary = prompt_len // ATTN_BLOCK_SIZE * ATTN_BLOCK_SIZE
+    # Last hash boundary a lookup can reach, one unit lower under Eagle.
+    tail_boundary = (prompt_len - 1) // ATTN_BLOCK_SIZE * ATTN_BLOCK_SIZE - (
+        ATTN_BLOCK_SIZE if partial_hit and use_eagle else 0
+    )
 
     pos, ends = resume_at, []
     while pos < prompt_len:
@@ -307,3 +310,40 @@ def test_unaligned_resume_never_runs_past_its_block(
             f"intermediate chunk end {end} is neither block-aligned nor the "
             f"partial-tail boundary"
         )
+
+
+@pytest.mark.parametrize(
+    ("prompt_len", "use_eagle", "partial_hit", "expected_ends"),
+    [
+        # Block-aligned prompt: the stop is one block below n, not at n.
+        (3 * MAMBA_BLOCK_SIZE, False, False, [3200, 4800]),
+        # Eagle block drop backs it off one more block.
+        (3 * MAMBA_BLOCK_SIZE, True, False, [1600, 4800]),
+        # Nothing cacheable mid-prefill: a single terminal chunk.
+        (2 * MAMBA_BLOCK_SIZE, True, False, [3200]),
+        # Partial tail under Eagle: hash boundary below n - 1, minus one unit.
+        (3602, True, True, [1600, 3584, 3602]),
+        # Hash-aligned prompt: the tail stop is a block boundary.
+        (2 * MAMBA_BLOCK_SIZE + 2 * ATTN_BLOCK_SIZE, True, True, [1600, 3200, 3232]),
+    ],
+)
+def test_deliberate_stops_land_on_hittable_boundaries(
+    prompt_len: int,
+    use_eagle: bool,
+    partial_hit: bool,
+    expected_ends: list[int],
+) -> None:
+    """Every non-terminal chunk end must be a position a lookup can reach:
+    lookups are capped at n - 1, so flooring from n leaves block-aligned
+    prompts with state no request can hit."""
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
+    pos, ends = 0, []
+    while pos < prompt_len:
+        request.num_computed_tokens = pos
+        num_new = _split(
+            request, prompt_len - pos, use_eagle=use_eagle, partial_hit=partial_hit
+        )
+        assert num_new > 0
+        pos += num_new
+        ends.append(pos)
+    assert ends == expected_ends

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3311,7 +3311,8 @@ def test_hybrid_local_kv_retention_interval_aligns_in_manager():
     # The SWA manager uses the configured 64-token interval (a multiple of the
     # 32-token lcm_block_size) as its retention segment. For this 128-token
     # prompt, the retained SWA tails are the 64-token interval boundary, the
-    # 96-token replay boundary, and the 128-token interval boundary.
+    # 96-token replay boundary, the 120-token partial-tail boundary (the last
+    # hash boundary a lookup can reach), and the 128-token interval boundary.
     token_ids = [i for i in range(16) for _ in range(block_size)]
     req = make_request("0", token_ids, block_size, sha256)
     computed_blocks, _, _ = manager.get_computed_blocks(req)
@@ -3324,7 +3325,7 @@ def test_hybrid_local_kv_retention_interval_aligns_in_manager():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {7, 11, 15}
+    expected_swa_cached = {7, 11, 14, 15}
     for i in range(16):
         cached = pool.get_cached_block(req.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:
@@ -3537,7 +3538,8 @@ def test_hybrid_local_kv_retention_latest_only_reuses_replay_boundary():
     assert blocks is not None
 
     pool = manager.block_pool
-    expected_swa_cached = {11}
+    # The replay boundary (96) and the reachable partial-tail boundary (120).
+    expected_swa_cached = {11, 14}
     for i in range(16):
         cached = pool.get_cached_block(req0.block_hashes[i], kv_cache_group_ids=[1])
         if i in expected_swa_cached:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -71,6 +71,16 @@ from vllm.v1.utils import record_function_or_nullcontext
 logger = init_logger(__name__)
 
 
+def _last_hittable_boundary(num_tokens: int, unit: int, eagle_block_drop: bool) -> int:
+    """Last ``unit``-aligned position a prefix-cache hit can end at: lookups are
+    capped at ``num_tokens - 1`` (``get_computed_blocks``) and Eagle block drop
+    prunes one more unit. State registered above it is never reused."""
+    boundary = (num_tokens - 1) // unit * unit
+    if eagle_block_drop:
+        boundary = max(boundary - unit, 0)
+    return boundary
+
+
 class Scheduler(SchedulerInterface):
     def __init__(
         self,
@@ -418,12 +428,9 @@ class Scheduler(SchedulerInterface):
             return num_new_tokens
 
         block_size = self.cache_config.block_size
-        # The last block-aligned position whose state can be cached. With
-        # Eagle, FullAttn prunes the last matching block, so back off one
-        # block to avoid a Mamba cache miss.
-        last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle_block_drop:
-            last_cache_position = max(last_cache_position - block_size, 0)
+        last_cache_position = _last_hittable_boundary(
+            request.num_tokens, block_size, self.use_eagle_block_drop
+        )
 
         end = start + num_new_tokens
         use_internal_checkpoint = (
@@ -447,7 +454,11 @@ class Scheduler(SchedulerInterface):
 
         next_block_boundary = (start // block_size + 1) * block_size
         tail_boundary = (
-            request.num_prompt_tokens // self.hash_block_size * self.hash_block_size
+            _last_hittable_boundary(
+                request.num_prompt_tokens,
+                self.hash_block_size,
+                self.use_eagle_block_drop,
+            )
             if self.mamba_partial_cache_hit
             else 0
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -825,7 +825,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block are intentionally skipped.
         """
         hash_block_size = self.block_pool.hash_block_size
-        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
+        boundary_tokens = (
+            (request.num_prompt_tokens - 1) // hash_block_size * hash_block_size
+        )
         if boundary_tokens == 0 or boundary_tokens > num_tokens:
             return
         if boundary_tokens % self.block_size == 0:
@@ -1087,6 +1089,15 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
                 end = aligned // block_size + shift
                 for j in range(max(start_block, end - need), min(end_block, end)):
                     mask[j - start_block] = True
+                # The partial-tail entry sits on the hash boundary itself (the
+                # SWA block is the hash unit); keep the tail ending there too.
+                fine_end = boundary_tokens // block_size
+                if fine_end != end:
+                    for j in range(
+                        max(start_block, fine_end - need),
+                        min(end_block, fine_end),
+                    ):
+                        mask[j - start_block] = True
 
         return mask
 
@@ -1913,8 +1924,10 @@ class MambaManager(SingleTypeKVCacheManager):
         if num_tokens % hash_block_size != 0:
             return None
         latest_prompt_hash_boundary = (
-            request.num_prompt_tokens // hash_block_size
+            (request.num_prompt_tokens - 1) // hash_block_size
         ) * hash_block_size
+        if self.use_eagle:
+            latest_prompt_hash_boundary -= hash_block_size
         if num_tokens != latest_prompt_hash_boundary:
             return None
 


### PR DESCRIPTION
## Purpose

A prefix-cache lookup ends at `num_tokens - 1` at most (`get_computed_blocks`); Eagle block drop takes one more unit. The scheduler's Mamba tail split and `_cache_partial_tail_block` in the full-attention and Mamba managers floored from `num_tokens`, so a block-aligned prompt, or any prompt under Eagle, registered state one unit above the highest position a lookup can reach, and a resubmit fell back to the previous retention checkpoint.

Floor all three from `num_tokens - 1`. The scheduler's tail stop backs off one unit under `use_eagle_block_drop`, as its block stop already does (#53388 made the drop optional, so the predicate is the drop flag, not `use_eagle()`), and the SWA mask keeps the tail ending there so fine-grained hits reconcile. Two `test_prefix_caching.py` expectations gain SWA block 14 for that reason: the full-attention partial tail of their 128-token prompt now registers at 120 instead of the unreachable 128.

Replaces the first revision, which keyed the shift on `use_eagle()`. Keying on the drop flag also means the shift follows #54163 if that narrows the drop to eagle/eagle3/MTP: DFlash and DSpark prompts then stop being shifted with no change here. #53479 densifies Mamba states and drops the Eagle back-off; this PR fixes the registration/lookup mismatch and composes with it.

## Test

`pytest tests/v1/core/test_prefix_caching.py tests/v1/core/test_mamba_align_chunk_split.py` - 138 passed. New cases pin the chunk ends for block-aligned and partial-tail prompts with and without Eagle.

2x DGX Spark, TP=2, Qwen3.8-27B-NVFP4 hybrid, FLASHINFER, `--prefix-cache-retention-interval 4800`, block 800, no drafter (none boots on `main` until #54834). Divergent-tail resubmit of a 133k-token document, cold cache. Block-aligned prompt: `main` 89.8% prefix hits and 11.75 s TTFT, the lookup falling back to the previous retention checkpoint; this commit 99.4% and 1.02 s. Unaligned prompt: 99.5% and 0.87 s with and without it. On a lineage with a DFlash2 drafter and unified pages (block 1568) the fix is neutral at 97.7% to 98.6% hits either way, decode 12/12 at 175 tok/s; the first revision's ~0% -> 98% came from an earlier geometry of that lineage.

AI assistance was used; every line reviewed and the unit tests above run by me.
