### PR TITLE
[Bugfix][Build] Declare fused_gdn_decode_post_conv_mtp behind the GDN guard, not KDA

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -392,7 +392,9 @@ void fused_kda_decode(
     torch::stable::Tensor& out, std::optional<double> lower_bound,
     std::optional<torch::stable::Tensor> output_gate,
     std::optional<torch::stable::Tensor> norm_weight, double norm_eps);
+#endif
 
+#ifdef VLLM_ENABLE_FUSED_GDN_DECODE
 void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a,
     torch::stable::Tensor const& b, torch::stable::Tensor const& a_log,
@@ -403,7 +405,6 @@ void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor& state, torch::stable::Tensor const& output_gate,
     torch::stable::Tensor const& norm_weight, torch::stable::Tensor& out,
     double scale, double norm_eps);
-
 #endif
 
 #ifdef VLLM_ENABLE_KIMI_K3_ATTN_RES


### PR DESCRIPTION
## The bug

Building from source on Ampere or Ada fails:

```
csrc/libtorch_stable/torch_bindings.cpp:811:23: error:
  'fused_gdn_decode_post_conv_mtp' was not declared in this scope
    811 |   TORCH_BOX(&fused_gdn_decode_post_conv_mtp));
```

`fused_gdn_decode_post_conv_mtp` is defined in `csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu`,
and both its registration (`torch_bindings.cpp:537`) and its implementation (`:809`) sit behind
`VLLM_ENABLE_FUSED_GDN_DECODE`. Its declaration in `ops.h`, however, sits inside the
`VLLM_ENABLE_FUSED_KDA_DECODE` block, next to `fused_kda_decode`.

The two guards do not cover the same architectures:

| guard | archs |
|---|---|
| `FUSED_KDA_DECODE_ARCHS` | `9.0a;10.0f;12.0f` |
| `FUSED_GDN_DECODE_ARCHS` | `8.0;8.6;8.9;9.0a;10.0f;12.0f` |

On Hopper and Blackwell both are set and the mismatch is invisible. On SM 8.0, 8.6 and 8.9 only the
GDN guard is set — the binding compiles, the declaration does not, and the build fails. That covers
A100, A6000, RTX 3090, RTX 4090 and L40S.

## The fix

Move the declaration into its own `VLLM_ENABLE_FUSED_GDN_DECODE` block, so it matches the definition
and both use sites. No functional change where both guards are already set.

## Reproduction

L40S (SM 8.9), CUDA 13.0, `TORCH_CUDA_ARCH_LIST=8.9`, `v0.28.0` from source:

- without this change: fails at `[5/378] Building CXX object … torch_bindings.cpp.o`
- with it: the build proceeds past that target and completes

The same mismatch is present on `main` as of today.