### PR TITLE
[Bugfix][Spec Decode] Don't pad a resumed decode request past max_model_len

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6134,3 +6134,66 @@ def test_encoder_input_skipped_when_connector_already_has_the_item(ec_role: str)
 
     assert output.num_scheduled_tokens[req_id] > 0
     assert not output.scheduled_encoder_inputs.get(req_id)
+
+
+@pytest.mark.parametrize("num_spec_tokens", [1, 3])
+def test_resumed_decode_padded_to_spec_width_respects_max_model_len(num_spec_tokens):
+    """A resumed decode request must not be padded past ``max_model_len``.
+
+    The waiting path pads a resumed decode request out to ``1 + num_spec_tokens``
+    input positions to preserve a full cudagraph. Its guard allowed
+    ``num_computed_tokens + num_new_tokens == max_model_len``, but the step then
+    samples up to ``1 + num_spec_tokens`` tokens, so ``_bookkeeping_sync``'s
+    ``end_idx <= max_model_len`` assertion fails by one. The running path already
+    reserves ``num_sampled_tokens_per_step``; this checks the two agree.
+    """
+    max_num_seqs = 16
+    scheduler = create_scheduler(
+        num_speculative_tokens=num_spec_tokens,
+        speculative_method="ngram",
+        enable_prefix_caching=False,
+        block_size=16,
+        num_blocks=4096,
+        max_num_batched_tokens=8192,
+        max_num_seqs=max_num_seqs,
+    )
+    # The cap this path consults comes from model_config, not scheduler_config.
+    max_model_len = scheduler.max_model_len
+
+    # A request in decode, so the waiting loop sees scheduled_running_reqs
+    # non-empty and prefill_scheduled False -- the padding preconditions.
+    (running,) = create_requests(1, num_tokens=8, max_tokens=10000, req_ids=["running"])
+    scheduler.add_request(running)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["running"],
+            req_id_to_index={"running": 0},
+            sampled_token_ids=[[100]],
+        ),
+    )
+
+    # A resumed request with a single uncomputed token, at the one value of
+    # num_computed_tokens where padding overruns: the guard admits
+    # C + (1 + K) <= max_model_len while the runner needs C + 2 + K <=
+    # max_model_len, so they differ at C == max_model_len - 1 - K. Reached in
+    # practice when a preempted request is resumed with its prefix recovered
+    # from the prefix cache or an offload tier.
+    num_computed = max_model_len - 1 - num_spec_tokens
+    (resumed,) = create_requests(
+        1, num_tokens=num_computed + 1, max_tokens=10000, req_ids=["resumed"]
+    )
+    scheduler.add_request(resumed)
+    resumed.status = RequestStatus.PREEMPTED
+    resumed.num_computed_tokens = num_computed
+
+    output = scheduler.schedule()
+    num_scheduled = output.num_scheduled_tokens.get("resumed", 0)
+    num_spec = len(output.scheduled_spec_decode_tokens.get("resumed", ()))
+
+    # The runner writes token_ids_cpu[start:start + num_sampled_ids] with
+    # start == num_tokens_no_spec and num_sampled_ids up to 1 + num_spec.
+    assert resumed.num_tokens + 1 + num_spec <= max_model_len
+    # ...and the request must still make progress rather than be starved.
+    assert num_scheduled >= 1

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -964,14 +964,34 @@ class Scheduler(SchedulerInterface):
                         and num_new_tokens == 1
                         and (scheduled_running_reqs and not prefill_scheduled)
                     ):
-                        num_new_tokens = 1 + self.num_spec_tokens
+                        padded_num_new_tokens = 1 + self.num_spec_tokens
+                        # Reserve room for the token(s) this step will sample.
+                        # The running-request path above already subtracts
+                        # ``num_sampled_tokens_per_step``; without the same
+                        # reservation here, a resumed decode request within
+                        # ``num_spec_tokens`` of ``max_model_len`` is padded into
+                        # a step that samples past the cap, and
+                        # ``_bookkeeping_sync``'s ``end_idx <= max_model_len``
+                        # assertion takes down the engine.
+                        # Fall back to an un-padded step rather than breaking:
+                        # unlike the token-budget case this condition does not
+                        # clear on a later step (``num_computed_tokens`` cannot
+                        # advance while the request is unscheduled), so breaking
+                        # would starve the request instead of letting it emit its
+                        # final token and stop on length.
                         if (
-                            num_new_tokens > request_token_budget
-                            or num_computed_tokens + num_new_tokens > self.max_model_len
+                            num_computed_tokens
+                            + padded_num_new_tokens
+                            + self.num_sampled_tokens_per_step
+                            > self.max_model_len
                         ):
+                            pass
+                        elif padded_num_new_tokens > request_token_budget:
                             # Prefer to not schedule than schedule un-padded here.
                             break
-                        pad_spec_decode = True
+                        else:
+                            num_new_tokens = padded_num_new_tokens
+                            pad_spec_decode = True
 
                     threshold = self.scheduler_config.long_prefill_token_threshold
                     if 0 < threshold < num_new_tokens:


### PR DESCRIPTION
## Purpose

Fixes an engine-killing assertion when speculative decoding meets the context limit:

```
RuntimeError: Sampled token IDs exceed the max model length.
              Total number of tokens: 262145 > max_model_len: 262144
```

Seen twice in one day on a long-context production deployment (`max_model_len` 262144, MTP with
`num_speculative_tokens: 1`, prefix caching + CPU KV offload), under two different configurations.

![before/after](https://raw.githubusercontent.com/yifjiang/vllm/pr-assets/spec-pad-boundary.gif)

## Root cause

Two paths size a decode step, and they disagree by one token.

The **running** path reserves room for the token the step will sample —
[`scheduler.py#L593-L600`](https://github.com/vllm-project/vllm/blob/a447955acad919a6902d65f0af2d4f76c0335ed3/vllm/v1/core/sched/scheduler.py#L593-L600):

```python
num_new_tokens = min(
    num_new_tokens,
    self.max_model_len - request.num_computed_tokens - self.num_sampled_tokens_per_step,
)
```

The **waiting** path, padding a *resumed* decode request out to spec width for a full cudagraph,
does not — [`scheduler.py#L967-L974`](https://github.com/vllm-project/vllm/blob/a447955acad919a6902d65f0af2d4f76c0335ed3/vllm/v1/core/sched/scheduler.py#L967-L974):

```python
num_new_tokens = 1 + self.num_spec_tokens
if (num_new_tokens > request_token_budget
        or num_computed_tokens + num_new_tokens > self.max_model_len):   # permits ==
    break
pad_spec_decode = True
```

`pad_spec_decode` schedules real spec slots
([`#L1161-L1164`](https://github.com/vllm-project/vllm/blob/a447955acad919a6902d65f0af2d4f76c0335ed3/vllm/v1/core/sched/scheduler.py#L1161-L1164)), so the step samples up to
`1 + K` tokens and the assertion in `_bookkeeping_sync` fires
([`gpu_model_runner.py#L3903-L3909`](https://github.com/vllm-project/vllm/blob/a447955acad919a6902d65f0af2d4f76c0335ed3/vllm/v1/worker/gpu_model_runner.py#L3903-L3909)).

With `C = num_computed_tokens` and `K = num_spec_tokens`:

```
guard admits :  C + 1 + K <= max_model_len
runner needs :  C + 2 + K <= max_model_len
```

One apart, so it fires at exactly `C == max_model_len - 1 - K` and always overruns by one.

Reaching it needs speculative decoding, plus a **resumed** request holding a single uncomputed token
(preempted and brought back with its prefix recovered — routine with prefix caching or a KV-offload
tier), sitting at that one position.

## Fix

Reserve `num_sampled_tokens_per_step` here too, so both paths agree.

On failure, fall back to an un-padded step rather than `break`. Unlike the token-budget case, this
condition never clears on a later step — `num_computed_tokens` cannot advance while the request is
unscheduled — so a bare guard fix would convert the crash into an indefinitely starved request. The
cost is one cudagraph miss on the final step of a request that is about to stop on length.

## Test

`test_resumed_decode_padded_to_spec_width_respects_max_model_len`, parametrized over
`num_spec_tokens` ∈ {1, 3}. Scheduler-only, no model execution. Places the request at the derived
boundary and asserts both that the step cannot overrun **and** that it is still scheduled.

Measured before/after (`max_model_len` 2048):

```
            C     scheduled  spec   end_idx
before  K=1 2046      2        1     2049  > 2048   FAIL
before  K=3 2044      4        3     2049  > 2048   FAIL
after   K=1 2046      1        0     2048  = 2048   pass
after   K=3 2044      1        0     2046  < 2048   pass
```

Existing `tests/v1/core/test_scheduler.py`: 129 passed. Run on v0.26.0, where this hunk is identical
to `main`; I have not run `main`'s full suite locally.

Separate from #52807 (offloading connector) — different subsystem, different failure.
