### PR TITLE
[ROCm] Allow full CUDA graphs with DCP for the a2a backend

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -901,8 +901,14 @@ class RocmPlatform(Platform):
         parallel_config = vllm_config.parallel_config
 
         if compilation_config.cudagraph_mode.has_full_cudagraphs():
-            # decode context parallel does not support full cudagraphs
-            if parallel_config.decode_context_parallel_size > 1:
+            # Decode context parallel does not support full cudagraphs, except
+            # for the all-to-all ("a2a") backend: its Triton pack/unpack kernels
+            # and private-pool send/recv buffers are capture-safe, matching CUDA
+            # (which does not downgrade this path).
+            if (
+                parallel_config.decode_context_parallel_size > 1
+                and parallel_config.dcp_comm_backend != "a2a"
+            ):
                 logger.warning_once(
                     "Decode context parallel (DCP) is enabled, which is "
                     "incompatible with full CUDA graphs. "


### PR DESCRIPTION
## Summary

The ROCm platform (`vllm/platforms/rocm.py`) unconditionally downgrades
`cudagraph_mode` to `PIECEWISE` whenever decode context parallel (DCP) is
enabled. This is broader than necessary.

The all-to-all (`a2a`) DCP reduce path
(`vllm/v1/attention/ops/dcp.py::dcp_a2a_lse_reduce`) is built from Triton
(`@triton.jit`) pack/unpack kernels over private-pool `torch.empty` send/recv
buffers that are explicitly designed to be full-cudagraph capture-safe (see the
comment in `_dcp_a2a_send_recv_buffers`). CUDA already runs this exact path
under full CUDA graphs — `cuda.py` has no equivalent downgrade. Only the
`ag_rs` and prefill-context-parallel (PCP) paths need the PIECEWISE fallback on
ROCm.

This gates the DCP downgrade on `dcp_comm_backend != "a2a"`, bringing ROCm to
parity with CUDA for the a2a backend. CUDA behavior is unchanged; `ag_rs`
(default) and PCP still downgrade to PIECEWISE.

## Not a duplicate

Searched open PRs/issues for DCP + CUDA graph + ROCm (e.g. #48248 FlashInfer
A2A backend, #53001 Aiter non-causal draft, #46249 NCCL cudagraph eager-break).
None modify the ROCm DCP cudagraph-mode override.

## Test plan / results

Hardware: AMD MI355x (gfx950), Kimi-K3, TP8/DCP8, `--dcp-comm-backend a2a`
(non-direct path, `VLLM_USE_DIRECT_DCP_A2A=0`), TRITON_MLA, fp8 KV,
`--compilation-config` `cudagraph_mode=FULL_AND_PIECEWISE`.

- Before: boot logs `Overriding cudagraph_mode to PIECEWISE`; FULL cudagraph
  captures = 0.
- After: no override; boot captures full graphs (`Capturing CUDA graphs
  (FULL)`), `Graph capturing finished ~4 GiB`/worker, no illegal memory access,
  engine healthy.

`vllm bench serve` (random, 8192-in / 1024-out, 40 prompts, max-concurrency 8):

| metric | PIECEWISE (before) | FULL cudagraph (after) |
|---|---|---|
| Successful | 40/40 | 40/40 |
| Output tok/s | 53.3 | 191 (peak 216) |
| Total tok/s | 479 | 1723 |
| Mean TPOT | 148.5 ms | 40.0 ms |
| Mean ITL | 148.5 ms | 40.0 ms |
| Mean TTFT | 1721 ms | 1883 ms |
| Duration | 769 s | 214 s |

~3.6x throughput / 3.7x TPOT. Output is unchanged and coherent (spot-check:
"The capital of France is" -> " Paris."). TTFT is unchanged because prefill is
not cudagraph-captured.

Note: the "CUDA already runs this path under full graphs" statement is based on
`cuda.py` having no DCP cudagraph downgrade; it was validated on ROCm hardware,
not re-verified on NVIDIA.

## AI assistance

This change was developed with AI assistance (Claude). The submitter has
reviewed every changed line and run the tests above.



---

_Re-opened as a fresh PR; supersedes the earlier closed #53587 (same change, rebased onto current main)._
