### PR TITLE
[ROCm][MLA] Full CUDA graphs + LSE-returning asm decode for AITER MLA under DCP

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -901,8 +901,14 @@ class RocmPlatform(Platform):
         parallel_config = vllm_config.parallel_config
 
         if compilation_config.cudagraph_mode.has_full_cudagraphs():
-            # decode context parallel does not support full cudagraphs
-            if parallel_config.decode_context_parallel_size > 1:
+            # Decode context parallel does not support full cudagraphs, except
+            # for the all-to-all ("a2a") backend: its Triton pack/unpack kernels
+            # and private-pool send/recv buffers are capture-safe, matching CUDA
+            # (which does not downgrade this path).
+            if (
+                parallel_config.decode_context_parallel_size > 1
+                and parallel_config.dcp_comm_backend != "a2a"
+            ):
                 logger.warning_once(
                     "Decode context parallel (DCP) is enabled, which is "
                     "incompatible with full CUDA graphs. "

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -353,8 +353,14 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
 
         # Keep metadata sizing consistent with the padded tensor shape passed
         # to mla_decode_fwd.
+        # ---ASM-DCP-LSE--- size/schedule the persistent decode metadata for
+        # the DCP-gathered head count. Under DCP the decode query is
+        # all-gathered to num_heads*dcp_world_size heads before forward_mqa,
+        # and the asm persistent decode folds that count down to gqa=16; the
+        # reduce buffers must be sized for the folded (gathered) work count.
+        _dcp_effective_heads = self.num_heads * max(1, self.dcp_world_size)
         self._num_attention_heads = AiterMLAHelper.get_actual_mla_num_heads(
-            self.num_heads
+            _dcp_effective_heads
         )
         kv_cache_dtype_str = getattr(vllm_config.cache_config, "cache_dtype", "auto")
         if kv_cache_dtype_str in ("fp8", "fp8_e4m3", "fp8_e5m2"):
@@ -994,6 +1000,7 @@ class AiterMLAHelper:
 
 
 class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
+    can_return_lse_for_decode: bool = True
     def __init__(
         self,
         num_heads: int,
@@ -1350,6 +1357,57 @@ class AiterMLAImpl(MLACommonImpl[AiterMLAMetadata]):
                 min_kv_seq_len=int(row_len.min()),
             )
             return o, None
+
+        if self.dcp_world_size > 1:
+            # ---ASM-DCP-LSE--- mqa_q was all-gathered upstream to
+            # (B, num_heads*dcp_world_size, L+P). That count is a multiple of
+            # 16, so the asm persistent decode runs it directly (folding
+            # gqa->16). get_mla_padded_q must be skipped: it assumes q carries
+            # only self.num_heads. Request LSE so MLADCPManager.combine can do
+            # the exact cross-rank softmax reduction.
+            if type(q) is tuple:
+                q = torch.cat(q, dim=-1)
+            assert isinstance(q, torch.Tensor)
+            B = q.shape[0]
+            gathered_heads = q.shape[1]
+            o = torch.empty(
+                B,
+                gathered_heads,
+                self.kv_lora_rank,
+                dtype=attn_metadata.decode.attn_out_dtype,
+                device=q.device,
+            )
+            if decode.max_qo_len > 1 and not decode.has_persistent_metadata:
+                o.zero_()
+            kv_buffer = kv_c_and_k_pe_cache.unsqueeze(2)
+            dcp_mla_kwargs = dict(
+                q_scale=layer._q_scale,
+                kv_scale=layer._k_scale,
+            )
+            if attn_metadata.work_meta_data is not None:
+                dcp_mla_kwargs.update(
+                    work_meta_data=attn_metadata.work_meta_data,
+                    work_indptr=attn_metadata.work_indptr,
+                    work_info_set=attn_metadata.work_info_set,
+                    reduce_indptr=attn_metadata.reduce_indptr,
+                    reduce_final_map=attn_metadata.reduce_final_map,
+                    reduce_partial_map=attn_metadata.reduce_partial_map,
+                )
+            from aiter.mla import mla_decode_fwd as _aiter_mla_decode_fwd
+            _, dcp_lse = _aiter_mla_decode_fwd(
+                q,
+                kv_buffer.view(-1, 1, 1, q.shape[-1]),
+                o,
+                decode.qo_indptr,
+                decode.paged_kv_indptr,
+                decode.paged_kv_indices,
+                decode.paged_kv_last_page_len,
+                decode.max_qo_len,
+                sm_scale=self.scale,
+                return_lse=True,
+                **dcp_mla_kwargs,
+            )
+            return o, dcp_lse
 
         if type(q) is tuple:
             q = torch.cat(q, dim=-1)


### PR DESCRIPTION
## Summary

Two ROCm changes that together enable `ROCM_AITER_MLA` with **decode context
parallel (DCP)** and FULL CUDA graphs on gfx950:

**1. Allow full CUDA graphs with DCP for the a2a backend** (`platforms/rocm.py`)
The ROCm platform unconditionally downgrades `cudagraph_mode` to `PIECEWISE`
whenever DCP is enabled. The all-to-all (`a2a`) DCP reduce path
(`dcp_a2a_lse_reduce`) is Triton pack/unpack kernels over private-pool
`torch.empty` send/recv buffers that are full-cudagraph capture-safe, and CUDA
already runs it under full graphs. Gate the downgrade on
`dcp_comm_backend != "a2a"` so ROCm reaches parity with CUDA. (`ag_rs`/PCP still
downgrade.) _Previously proposed standalone in the now-closed #53587 / #53814._

**2. Wire AITER MLA asm decode to return LSE for DCP** (`rocm_aiter_mla.py`)
Under DCP the decode query is all-gathered to `num_heads * dcp_world_size` heads
before `forward_mqa` (12 → 96 on Kimi-K3 TP8/DCP8). The gluon decode rejects >16
heads, so the **asm persistent decode** is the only route: aiter folds
`nhead ∈ [32,128]` down to `gqa=16`.
- Builder sizes the persistent decode metadata for the DCP-gathered head count.
- `forward_mqa` adds a `dcp_world_size > 1` branch feeding the gathered `q` to
  `aiter.mla.mla_decode_fwd(return_lse=True)` (the LSE `MLADCPManager.combine`
  needs), bypassing `get_mla_padded_q` and the no-LSE vLLM custom op.
  `can_return_lse_for_decode` is set on `AiterMLAImpl`.

The gluon decode paths are left unchanged: under the gathered 96-head DCP config
they are not selected (>16 heads), so only the asm path returns LSE. Scope is
kept to exactly the asm decode + platform gate.

## ⚠️ Draft — dependency

Requires an aiter `mla_decode_fwd` that accepts `return_lse=True`; draft until
that lands. (Reaching FULL cudagraphs for the DSpark spec-decode group also
benefits from #51171, but this change does not depend on it and applies to
`main` on its own.)

## Test plan / results

AMD MI355x (gfx950), Kimi-K3, TP8/DCP8, `--attention-backend ROCM_AITER_MLA`,
`--dcp-comm-backend a2a`, `FULL_AND_PIECEWISE` cudagraphs:
- Boots and captures full CUDA graphs; generation coherent; gsm8k (bf16 KV) = 1.0.
- Agentic conc40 trace-replay vs `TRITON_MLA`+DCP → ~2.9x mean TPOT, ~2x total
  throughput, 0 faults / 0 errors.
- a2a full-cudagraph gate alone (part 1), conc8 8192/1024: 53 → 191 tok/s (3.6x),
  TPOT 148 → 40 ms (3.7x).

_AI assistance was used for this change._