### PR TITLE
[Bugfix][ROCm] Capture CUDA graphs on the current stream

### DIFF
--- a/vllm/v1/spec_decode/gemma4.py
+++ b/vllm/v1/spec_decode/gemma4.py
@@ -17,6 +17,7 @@ from vllm.config import VllmConfig, get_layers_from_vllm_config, replace
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.utils.torch_utils import current_stream
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
@@ -130,7 +131,7 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
             torch.accelerator.synchronize()
 
             g = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(g):
+            with torch.cuda.graph(g, stream=current_stream()):
                 static_output = masked_emb.get_top_tokens(
                     static_input,
                     lm_head_weight,

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -20,6 +20,7 @@ from vllm.model_executor.models.interfaces import (
 from vllm.model_executor.models.utils import scatter_output_slices
 from vllm.model_executor.models.vision import get_load_balance_assignment
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+from vllm.utils.torch_utils import current_stream
 from vllm.v1.worker.encoder_cudagraph_defs import (
     EncoderCudaGraphConfig,
     EncoderItemSpec,
@@ -270,7 +271,10 @@ class EncoderCudaGraphManager:
             output_buffer = torch.empty_like(output)
 
         graph = torch.cuda.CUDAGraph()
-        with torch.inference_mode(), torch.cuda.graph(graph, pool=self.graph_pool):
+        with (
+            torch.inference_mode(),
+            torch.cuda.graph(graph, pool=self.graph_pool, stream=current_stream()),
+        ):
             output = self.model.encoder_cudagraph_forward({**values}, path=path)
             output_buffer.copy_(output)
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -31,6 +31,7 @@ from vllm.model_executor.offloader.base import get_offloader
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils.math_utils import round_up
+from vllm.utils.torch_utils import current_stream
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
@@ -377,7 +378,9 @@ class CudaGraphManager:
                         if self._capture_mem_samples is not None:
                             torch.accelerator.synchronize()
                             free_before = torch.accelerator.get_memory_info()[0]
-                        with torch.cuda.graph(graph, self.pool):
+                        with torch.cuda.graph(
+                            graph, self.pool, stream=current_stream()
+                        ):
                             forward_fn(CUDAGraphMode.NONE)
                             # Join offloader's copy stream after forward to avoid
                             # unjoined stream error. The last layer's start_prefetch


### PR DESCRIPTION
## Purpose

`torch.cuda.graph()` lazily creates its own class-level internal capture stream
when no `stream=` is passed. Three capture sites still rely on that fallback, so
the graph gets recorded on a stream that never ran warmup, and any backend that
keeps per-stream state misses its lookup during capture.

For the main site this also contradicts its own enclosing context manager. MRV2
captures inside `with graph_capture(device=...)`, which does:

```python
with torch.cuda.stream(stream), maybe_ca_context, maybe_aiter_context:
    yield graph_capture_context
```

The context manager picks a stream and lets the custom all-reduce / aiter
all-reduce backends establish per-stream state on it — and then
`torch.cuda.graph(graph, self.pool)` captures somewhere else entirely.

`vllm/compilation/cuda_graph.py` has passed `stream=current_stream()` since
#29207 ("use the same stream for cuda graph capture and replay for NCCL") for
exactly this reason. This PR makes the three remaining sites consistent:

- `vllm/v1/worker/gpu/cudagraph_utils.py` (MRV2 FULL / PIECEWISE capture)
- `vllm/v1/worker/encoder_cudagraph.py`
- `vllm/v1/spec_decode/gemma4.py`

### Symptom

On ROCm gfx950 (MI355X, TP8) serving Kimi-K3 with the V2 model runner — the
default for K3 on ROCm since #51653 — FULL cudagraph capture aborts:

```
[AITER] aiter/csrc/opus_gemm/opus_gemm.cu:487 splitk workspace not initialized
for the current CUDA stream. Call aiter.opus_gemm_workspace_init() inside
`with torch.cuda.stream(s):` (and warm with the largest expected gemm) before
HIP graph capture.
```

aiter's gfx942/gfx950 a16w16 split-K path keeps its partial-sum workspace in a
registry keyed by stream (`splitk_ws_registry`, `R.map.find(s)`), and creation is
disallowed during capture, so a stream that was never warmed eagerly fails hard.
aiter documents the contract in `aiter/tuned_gemm.py`: the registry "still needs
an eager warm before capture ... warm it via `aiter.opus_gemm_workspace_init()`
**on the capture stream**". vLLM's warmup does run on the `graph_capture()`
stream, so the contract is satisfied — until `torch.cuda.graph()` switches
streams underneath it.

### Risk

`current_stream()` never returns the default stream: when no stream has been set
it creates and sets a dedicated per-process stream, precisely because the default
stream cannot be used for cudagraph capture. So the three sites are safe
regardless of whether they run inside `graph_capture()`. On CUDA this is the same
stream the capture already runs under, matching what
`vllm/compilation/cuda_graph.py` has done for eight months.

## Test Plan

Kimi-K3-MXFP4, TP8, gfx950, stock aiter (`AITER_CONFIG_GEMM_BF16` unset, so aiter
merges its shipped tables into `/tmp/aiter_configs/bf16_tuned_gemm.csv`
automatically), default `cudagraph_mode` (`FULL_AND_PIECEWISE`):

```bash
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MLA=1 VLLM_ROCM_USE_AITER_MOE=1 \
vllm serve /path/to/Kimi-K3-MXFP4 \
  --trust-remote-code --tensor-parallel-size 8 \
  --max-model-len 131072 --kv-cache-dtype fp8 \
  --max-num-seqs 128 --max-num-batched-tokens 4096 \
  --compilation-config '{"custom_ops":["+fused_rms_norm_gated","none"]}'
```

Bases: vLLM `88e1b11313`, aiter `987203ba5`.

## Test Result

Both arms measured on vLLM `06ecec7a84`, differing only by this patch:

| arm | FULL capture | `splitk workspace not initialized` | engine |
|---|---|---|---|
| before | 8/19 | 26 | `EngineCore failed to start` |
| after | 19/19 | 0 | `Application startup complete` |

The opus split-K path really is what FULL capture exercises. Re-running with
`AITER_LOG_TUNED_CONFIG=1` (aiter gates the "config found" log line behind it;
only the "not found" line is unconditional) shows 176 tuned-GEMM lookups
resolving to `libtype=opus` split-K kernels at `cu_num=256`:

```
M:32,  N:8448, K:7168  padded_M=32   opus_gemm_flatmm_splitk_256x32x96x64_...
M:64,  N:8448, K:7168  padded_M=64   opus_gemm_flatmm_splitk_256x64x96x128_...
M:256, N:1536, K:7168  padded_M=256  opus_gemm_flatmm_splitk_256x64x96x64_...
```

These are decode-sized GEMMs, i.e. exactly what FULL graphs capture. The merged
default table holds 27 such gfx950 `cu_num=256` opus split-K entries. Note the
lookup is memoized (`@functools.lru_cache` on `get_GEMM_A16W16_config`), so the
log lines appear only on first resolution during warmup/PIECEWISE and not again
during FULL capture.

Accuracy is unaffected — the change only selects which stream capture runs on,
not what is computed. gsm8k (1319 questions, 5-shot, exact-match) on a tree
carrying this patch: 0.9644 ± 0.0051.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
