### PR TITLE
[Kernel][Perf] Tune fused_moe FP8 config for Qwen3.5 on L40S (+7%)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=NVIDIA_L40S,dtype=fp8_w8a8.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=NVIDIA_L40S,dtype=fp8_w8a8.json
@@ -1,0 +1,171 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "16384": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "32768": {
+        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    }
+}


### PR DESCRIPTION
## Purpose

Add a tuned Triton fused MoE configuration for the E=256,N=512 FP8 W8A8 shape on a single NVIDIA L40S for Qwen3.5.

This is a configuration-only performance change and does not change model numerics or model code.

## Test Result

Kernel time comparison on NVIDIA L40S (Triton 3.6.0):

| M | Default (us) | Tuned (us) | Speedup |
|---:|---:|---:|---:|
| 2 | 31.92 | 29.98 | +6.08% |
| 4 | 78.61 | 76.57 | +2.60% |
| 8 | 276.79 | 259.57 | +6.22% |
| 16 | 485.35 | 455.32 | +6.19% |
| 32 | 771.95 | 730.29 | +5.40% |
| 64 | 1034.79 | 974.49 | +5.83% |
| 128 | 1203.54 | 1113.81 | +7.46% |
| 256 | 1249.71 | 1167.44 | +6.58% |
| 512 | 1304.43 | 1214.92 | +6.86% |
| 1024 | 1389.43 | 1303.19 | +6.21% |
| 2048 | 1591.11 | 1502.44 | +5.57% |
| 4096 | 2015.45 | 1904.68 | +5.50% |
| 8192 | 2926.05 | 2772.23 | +5.26% |
| 16384 | 4868.18 | 4854.88 | +0.27% |
| 32768 | 9399.84 | 9198.10 | +2.15% |

Across the 15 measured points, the tuned config wins 15/15. The sum of the measured kernel times is reduced from 28627.15 us to 27557.91 us, a 3.74% reduction. The median improves by 6.58%.

## Test Plan

- `jq empty vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=NVIDIA_L40S,dtype=fp8_w8a8.json`
- Verified the checked-in JSON matches the benchmark config used in catalog_service.
- `git diff --check`
- Kernel benchmark results are included above.
- End-to-end model evaluation was not run; this change only adds a tuned kernel configuration.

## Duplicate-work Check

- PR #53710 targets E=128,N=768 for Qwen3-VL on L40S; this PR targets E=256,N=512 for Qwen3.5.
- PR #43506 targets E=256,N=512 on H100,H200,B200; it does not target L40S.
- Open PR searches found no existing PR for the E=256,N=512 L40S configuration.

AI assistance was used to prepare this change. The human submitter is responsible for reviewing the changed file and benchmark results.

Generated with [Devin](https://devin.ai)