### PR TITLE
[Bugfix][ROCm] Preserve AITER unified-attention metadata during graph replay

### DIFF
--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -34,6 +34,26 @@ def mock_get_cdna_version():
         yield
 
 
+def test_aiter_unified_attention_capture_preserves_query_start_locations():
+    from vllm.v1.attention.backends.rocm_aiter_unified_attn import (
+        RocmAiterUnifiedAttentionBackend,
+        RocmAiterUnifiedAttentionMetadataBuilder,
+    )
+
+    builder = object.__new__(RocmAiterUnifiedAttentionMetadataBuilder)
+    metadata = MagicMock()
+    metadata.seq_lens = torch.tensor([1048576], dtype=torch.int32)
+    builder.build = MagicMock(return_value=metadata)
+    common = MagicMock()
+    common.query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+
+    actual = builder.build_for_cudagraph_capture(common)
+
+    assert RocmAiterUnifiedAttentionBackend.get_builder_cls() is type(builder)
+    assert actual.seq_lens.tolist() == [1]
+    assert common.query_start_loc.tolist() == [0, 1]
+
+
 @pytest.mark.parametrize(
     "env_vars, selected_backend, expected_backend_path",
     [

--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -34,24 +34,44 @@ def mock_get_cdna_version():
         yield
 
 
-def test_aiter_unified_attention_capture_preserves_query_start_locations():
+def test_aiter_unified_attention_uses_dedicated_metadata_builder():
     from vllm.v1.attention.backends.rocm_aiter_unified_attn import (
         RocmAiterUnifiedAttentionBackend,
+        RocmAiterUnifiedAttentionMetadataBuilder,
+    )
+    from vllm.v1.attention.backends.rocm_attn import (
+        RocmAttentionBackend,
+        RocmAttentionMetadataBuilder,
+    )
+
+    assert RocmAttentionBackend.get_builder_cls() is RocmAttentionMetadataBuilder
+    assert (
+        RocmAiterUnifiedAttentionBackend.get_builder_cls()
+        is RocmAiterUnifiedAttentionMetadataBuilder
+    )
+
+
+def test_aiter_unified_attention_capture_preserves_query_start_locations():
+    from vllm.v1.attention.backends.rocm_aiter_unified_attn import (
         RocmAiterUnifiedAttentionMetadataBuilder,
     )
 
     builder = object.__new__(RocmAiterUnifiedAttentionMetadataBuilder)
     metadata = MagicMock()
-    metadata.seq_lens = torch.tensor([1048576], dtype=torch.int32)
+    metadata.seq_lens = torch.tensor([1048576, 524288], dtype=torch.int32)
     builder.build = MagicMock(return_value=metadata)
     common = MagicMock()
-    common.query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+    expected_query_start_loc = torch.tensor([0, 2, 5], dtype=torch.int32)
+    common.query_start_loc = expected_query_start_loc.clone()
+    metadata.query_start_loc = common.query_start_loc
 
     actual = builder.build_for_cudagraph_capture(common)
 
-    assert RocmAiterUnifiedAttentionBackend.get_builder_cls() is type(builder)
-    assert actual.seq_lens.tolist() == [1]
-    assert common.query_start_loc.tolist() == [0, 1]
+    builder.build.assert_called_once_with(0, common)
+    assert actual is metadata
+    assert torch.equal(actual.seq_lens, torch.ones_like(actual.seq_lens))
+    assert actual.query_start_loc is common.query_start_loc
+    assert torch.equal(actual.query_start_loc, expected_query_start_loc)
 
 
 @pytest.mark.parametrize(

--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -15,7 +15,12 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
 from vllm.utils.torch_utils import is_quantized_kv_cache
-from vllm.v1.attention.backend import AttentionLayer, AttentionType, MultipleOf
+from vllm.v1.attention.backend import (
+    AttentionLayer,
+    AttentionType,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
 from vllm.v1.attention.backends.rocm_attn import (
     RocmAttentionBackend,
     RocmAttentionImpl,
@@ -25,6 +30,17 @@ from vllm.v1.attention.backends.rocm_attn import (
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheLayout
 
 logger = init_logger(__name__)
+
+
+class RocmAiterUnifiedAttentionMetadataBuilder(RocmAttentionMetadataBuilder):
+    def build_for_cudagraph_capture(
+        self, common_attn_metadata: CommonAttentionMetadata
+    ) -> RocmAttentionMetadata:
+        attn_metadata = self.build(0, common_attn_metadata)
+        # Avoid capturing the real maximum sequence length while preserving
+        # query_start_loc, which unified attention consumes during replay.
+        attn_metadata.seq_lens.fill_(1)
+        return attn_metadata
 
 
 class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
@@ -101,8 +117,8 @@ class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
         return False
 
     @staticmethod
-    def get_builder_cls() -> type["RocmAttentionMetadataBuilder"]:
-        return RocmAttentionMetadataBuilder
+    def get_builder_cls() -> type["RocmAiterUnifiedAttentionMetadataBuilder"]:
+        return RocmAiterUnifiedAttentionMetadataBuilder
 
     @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:


### PR DESCRIPTION
## Purpose

Fix graph-replay correctness for `ROCM_AITER_UNIFIED_ATTN`.

The generic ROCm metadata builder zeros
`common_attn_metadata.query_start_loc` during graph capture to protect the
legacy prefix-prefill kernel. AITER unified attention consumes that tensor
during replay, so sharing the generic capture path corrupts its query
boundaries.

This PR gives only the AITER unified-attention backend a dedicated metadata
builder. It retains the inexpensive capture-time `seq_lens = 1` behavior while
preserving `query_start_loc` for replay.

### Device and backend scope

- The production change is confined to
  `vllm/v1/attention/backends/rocm_aiter_unified_attn.py`.
- The generic `RocmAttentionMetadataBuilder` retains its existing behavior.
- CUDA, CPU, XPU, TPU, shared model-runner, and backend-selection code are not
  modified.
- The new builder is selected only by `RocmAiterUnifiedAttentionBackend`.

The regression tests separately verify the backend selection and capture-time
metadata behavior. They also assert that the generic ROCm backend continues to
select its original builder.

### Duplicate-work check

I searched open vLLM issues and PRs for `ROCM_AITER_UNIFIED_ATTN`,
`query_start_loc`, ROCm attention metadata, and graph replay. No open PR fixes
this backend-specific capture path.

Adjacent work is complementary:

- #40003 initializes stale `query_start_loc` entries produced by dummy batches
  in DP/disaggregated-prefill deployments. It changes `gpu_model_runner.py` and
  does not change attention-backend capture behavior.
- #53695 enables KV connectors for the same block-first unified-attention
  layout; it does not change graph-capture metadata.
- #52849 enables AITER paged-attention decode for MiniMax-M3 MTP/dense layers;
  it does not change unified-attention capture metadata.
- #52628 updates fused all-reduce draft metadata for DeepSeek V4; it does not
  change this attention backend.
- #51171 targets AITER MLA full graphs, a different backend and metadata
  implementation.

## Test Plan

```text
uvx --system-certs ruff check \
  vllm/v1/attention/backends/rocm_aiter_unified_attn.py \
  tests/v1/attention/test_rocm_attention_backends_selection.py

uvx --system-certs ruff format --check \
  vllm/v1/attention/backends/rocm_aiter_unified_attn.py \
  tests/v1/attention/test_rocm_attention_backends_selection.py

uvx --system-certs pre-commit run ruff-check --files \
  vllm/v1/attention/backends/rocm_aiter_unified_attn.py \
  tests/v1/attention/test_rocm_attention_backends_selection.py

uvx --system-certs pre-commit run ruff-format --files \
  vllm/v1/attention/backends/rocm_aiter_unified_attn.py \
  tests/v1/attention/test_rocm_attention_backends_selection.py

uvx --system-certs pre-commit run typos --files \
  vllm/v1/attention/backends/rocm_aiter_unified_attn.py \
  tests/v1/attention/test_rocm_attention_backends_selection.py

uv run --no-project --python 3.12 python -m py_compile \
  vllm/v1/attention/backends/rocm_aiter_unified_attn.py \
  tests/v1/attention/test_rocm_attention_backends_selection.py

git diff --check
```

Focused AMD CI test:

```text
.venv/bin/python -m pytest \
  tests/v1/attention/test_rocm_attention_backends_selection.py \
  -k aiter_unified_attention -v
```

## Test Result

Local source validation on the current PR head:

- Ruff check: passed.
- Ruff formatting check: passed.
- Pre-commit `ruff-check`: passed.
- Pre-commit `ruff-format`: passed.
- Pre-commit `typos`: passed.
- Python compilation: passed.
- `git diff --check`: passed.

The focused pytest is ROCm-gated and is pending upstream AMD CI.

MI355X model evaluation on the pinned integration stack:

- Before: AITER unified attention produced corrupted/NUL-heavy output and
  GSM8K exact match `0`.
- After: target-only and assembled EAGLE3 smoke tests passed.
- Full GSM8K: 1,319/1,319 requests completed.
- Strict exact match: `0.9696739954510993`.
- Flexible exact match: `0.9689158453373768`.

The fix was also exercised in the sustained MiniMax-M3 AgentX serving
configuration with graph replay enabled.

## AI assistance

OpenAI Codex assisted with root-cause isolation, duplicate-work research, test
preparation, and PR drafting. Both commits include Codex co-author attribution
and the human submitter's DCO sign-off. The PR remains a draft until the human
submitter has reviewed every changed line and can explain and defend the change
end-to-end, as required by `AGENTS.md`.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] Test commands are provided.
- [x] Local and model-evaluation results are provided.
- [x] No documentation update is needed for this backend-specific bug fix.

</details>
