### PR TITLE
[KV Connector][Mooncake] Send disaggregated KV as whole pages when la…

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import contextlib
+import dataclasses
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,10 +23,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     MooncakeXferMetadata,
     MooncakeXferResponse,
     MooncakeXferResponseStatus,
+    PageTransferGeometry,
     PullReqMeta,
     SendBlockMeta,
     TransferRegion,
     _align_transfer_regions,
+    _compute_page_transfer_geometry,
     _compute_sender_transfer_plan,
     _validate_asymmetric_region_lengths,
     get_mooncake_bootstrap_addr,
@@ -35,6 +38,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import
     MooncakeBootstrapServer,
 )
 from vllm.utils.network_utils import get_open_port
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -361,6 +365,217 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
         assert src_ptrs == expected_by_pp_rank[pp_rank]["src_ptrs"]
         assert dst_ptrs == expected_by_pp_rank[pp_rank]["dst_ptrs"]
         assert lengths == [2 * block_len, 2 * block_len]
+
+
+def _make_page_layout_worker(tp_size: int = 1):
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = True
+    worker.is_kv_producer = True
+    worker.tp_rank = 0
+    worker.tp_size = tp_size
+    worker.use_mla = False
+    worker.kv_cache_config = _make_test_kv_cache_config()
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.transfer_topo = SimpleNamespace(
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=4,
+    )
+    return worker
+
+
+def _page_regions(origin: int, page: int, slot_lens: list[int], group_index: int = 0):
+    """Regions of one KV group laid out as consecutive slots inside one page."""
+    regions = []
+    offset = 0
+    for layer_index, slot_len in enumerate(slot_lens):
+        regions.append(
+            TransferRegion(
+                layer_name=f"model.layers.{layer_index}.self_attn",
+                layer_index=layer_index,
+                base_addr=origin + offset,
+                block_len=page,
+                kv_block_len=slot_len,
+                group_index=group_index,
+            )
+        )
+        offset += slot_len
+    return regions
+
+
+def _xfer_meta(remote_regions, req_blocks, remote_tp_size: int = 1):
+    return MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=remote_tp_size,
+        remote_tp_rank=0,
+        req_blocks=req_blocks,
+        kv_caches_base_addr=[r.base_addr for r in remote_regions],
+        block_lens=[r.block_len for r in remote_regions],
+        kv_block_lens=[r.kv_block_len for r in remote_regions],
+        registered_layer_names=[r.layer_name for r in remote_regions],
+        registered_layer_indices=[r.layer_index for r in remote_regions],
+        registered_group_indices=[r.group_index for r in remote_regions],
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_transfer_params_sends_whole_pages_per_block_run():
+    """Layers sharing one page per block collapse into one descriptor per
+    contiguous block run instead of one per (layer, block)."""
+    page = 4096
+    slot_lens = [1024, 1024, 512]  # three layers, page has 1536 B of padding
+    local_regions = _page_regions(0x10000, page, slot_lens)
+    remote_regions = _page_regions(0x80000, page, slot_lens)
+    worker = _make_page_layout_worker()
+    worker.registered_group_indices = [0, 0, 0]
+
+    transfer_id = "xfer-page"
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-page",
+        transfer_id=transfer_id,
+        # Two contiguous runs: [3, 4, 5] and [9, 10].
+        local_block_ids=[[3, 4, 5, 9, 10]],
+        ready=asyncio.Event(),
+    )
+    xfer_meta = _xfer_meta(
+        remote_regions, {"d-req-page": (transfer_id, [[20, 21, 22, 30, 31]])}
+    )
+
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        ready_reqs=[("d-req-page", send_meta)],
+        agent_meta=xfer_meta,
+        local_regions=local_regions,
+        remote_regions=remote_regions,
+    )
+
+    assert err_reqs == []
+    assert err_msg is None
+    assert src_ptrs == [0x10000 + 3 * page, 0x10000 + 9 * page]
+    assert dst_ptrs == [0x80000 + 20 * page, 0x80000 + 30 * page]
+    assert lengths == [3 * page, 2 * page]
+
+
+@pytest.mark.asyncio
+async def test_build_transfer_params_page_path_skips_null_blocks(monkeypatch):
+    page = 4096
+    slot_lens = [1024, 1024]
+    local_regions = _page_regions(0x10000, page, slot_lens)
+    remote_regions = _page_regions(0x80000, page, slot_lens)
+    worker = _make_page_layout_worker()
+    worker.registered_group_indices = [0, 0]
+
+    transfer_id = "xfer-null"
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-null",
+        transfer_id=transfer_id,
+        local_block_ids=[[NULL_BLOCK_ID, 7, 8]],
+        ready=asyncio.Event(),
+    )
+    xfer_meta = _xfer_meta(
+        remote_regions, {"d-req-null": (transfer_id, [[NULL_BLOCK_ID, 40, 41]])}
+    )
+
+    src_ptrs, dst_ptrs, lengths, _, _ = await worker._build_transfer_params(
+        ready_reqs=[("d-req-null", send_meta)],
+        agent_meta=xfer_meta,
+        local_regions=local_regions,
+        remote_regions=remote_regions,
+    )
+
+    assert src_ptrs == [0x10000 + 7 * page]
+    assert dst_ptrs == [0x80000 + 40 * page]
+    assert lengths == [2 * page]
+
+    # Kill switch restores the per-layer descriptors.
+    monkeypatch.setattr(envs, "VLLM_MOONCAKE_PAGE_TRANSFER", False)
+    worker = _make_page_layout_worker()
+    worker.registered_group_indices = [0, 0]
+    src_ptrs, dst_ptrs, lengths, _, _ = await worker._build_transfer_params(
+        ready_reqs=[("d-req-null", send_meta)],
+        agent_meta=xfer_meta,
+        local_regions=local_regions,
+        remote_regions=remote_regions,
+    )
+    # Per-layer path: one descriptor per (layer, block), null block included,
+    # since the layer slot (1024 B) is smaller than the block stride (page).
+    assert len(src_ptrs) == 2 * 3
+    assert lengths == [1024] * 6
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "layer_stride_differs",
+        "slot_crosses_page",
+        "remote_offsets_differ",
+        "remote_has_extra_layer",
+        "heterogeneous_tp",
+    ],
+)
+def test_page_transfer_geometry_falls_back_when_layout_does_not_qualify(case):
+    page = 4096
+    slot_lens = [1024, 1024]
+    local_regions = _page_regions(0x10000, page, slot_lens)
+    remote_regions = _page_regions(0x80000, page, slot_lens)
+    local_counts = {0: 2}
+    remote_counts = {0: 2}
+    remote_tp_size = 1
+
+    if case == "layer_stride_differs":
+        local_regions[1] = dataclasses.replace(local_regions[1], block_len=page // 2)
+    elif case == "slot_crosses_page":
+        local_regions[1] = dataclasses.replace(local_regions[1], kv_block_len=page)
+        remote_regions[1] = dataclasses.replace(remote_regions[1], kv_block_len=page)
+    elif case == "remote_offsets_differ":
+        remote_regions[1] = dataclasses.replace(
+            remote_regions[1], base_addr=0x80000 + 2048
+        )
+    elif case == "remote_has_extra_layer":
+        remote_counts = {0: 3}
+    elif case == "heterogeneous_tp":
+        # A TP-2 consumer holds half of each layer's KV per rank.
+        remote_tp_size = 2
+        remote_regions = [
+            dataclasses.replace(region, kv_block_len=region.kv_block_len // 2)
+            for region in remote_regions
+        ]
+
+    def transfer_plan(local_region, remote_region):
+        return _compute_sender_transfer_plan(
+            local_tp_rank=0,
+            local_tp_size=1,
+            remote_tp_rank=0,
+            remote_tp_size=remote_tp_size,
+            local_kv_block_len=local_region.kv_block_len,
+            remote_kv_block_len=remote_region.kv_block_len,
+            producer_cache_replicated=False,
+        )
+
+    assert (
+        _compute_page_transfer_geometry(
+            local_regions, remote_regions, local_counts, remote_counts, transfer_plan
+        )
+        == {}
+    )
+
+    # The unmodified layout qualifies.
+    good_local = _page_regions(0x10000, page, slot_lens)
+    good_remote = _page_regions(0x80000, page, slot_lens)
+    if case != "heterogeneous_tp":
+        assert _compute_page_transfer_geometry(
+            good_local, good_remote, {0: 2}, {0: 2}, transfer_plan
+        ) == {
+            0: PageTransferGeometry(
+                page=page, local_origin=0x10000, remote_origin=0x80000
+            )
+        }
 
 
 @pytest.mark.asyncio

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -4,7 +4,8 @@ import asyncio
 import logging
 import threading
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import IntEnum
@@ -243,6 +244,125 @@ def _can_coalesce_block_transfers(
         and transfer_len == local_region_block_len
         and transfer_len == remote_region_block_len
     )
+
+
+@dataclass(frozen=True)
+class PageTransferGeometry:
+    """Whole-page transfer geometry for one KV-cache group.
+
+    With the unified paged KV layout every registered region (layer) of a
+    group stores one slot per block inside a common page whose width is the
+    block stride, so all layers of one block are physically contiguous. When
+    the remote worker registers the same slot offsets, a run of contiguous
+    blocks can be moved as a single ``run_len * page`` descriptor instead of
+    one descriptor per (layer, block).
+    """
+
+    page: int
+    local_origin: int
+    remote_origin: int
+
+
+def _compute_page_transfer_geometry(
+    local_regions: list[TransferRegion],
+    remote_regions: list[TransferRegion],
+    local_group_counts: dict[int, int],
+    remote_group_counts: dict[int, int],
+    transfer_plan: Callable[
+        [TransferRegion, TransferRegion], tuple[bool, int, int, int]
+    ],
+) -> dict[int, PageTransferGeometry]:
+    """Return the page geometry of every KV-cache group eligible for whole-page
+    transfers. Regions must already be aligned pairwise.
+
+    A group qualifies only when whole-page writes cannot touch data the local
+    rank does not own: every registered layer of the group (locally and
+    remotely, so no PP shard is missing) is part of the aligned regions, all
+    of them share one block stride (the page), every layer slot lies fully
+    inside the page at the same offset on both sides, and the per-region plan
+    is a full untranslated copy (no heterogeneous-TP slicing, no replicated
+    KV skip).
+    """
+    by_group: dict[int, list[tuple[TransferRegion, TransferRegion]]] = {}
+    for local_region, remote_region in zip(local_regions, remote_regions):
+        by_group.setdefault(local_region.group_index, []).append(
+            (local_region, remote_region)
+        )
+
+    geometry: dict[int, PageTransferGeometry] = {}
+    for group_index, pairs in by_group.items():
+        if len(pairs) != local_group_counts.get(group_index, -1) or len(
+            pairs
+        ) != remote_group_counts.get(group_index, -1):
+            continue
+        page = pairs[0][0].block_len
+        if page <= 0:
+            continue
+        local_origin = min(local_region.base_addr for local_region, _ in pairs)
+        remote_origin = min(remote_region.base_addr for _, remote_region in pairs)
+        eligible = True
+        for local_region, remote_region in pairs:
+            should_transfer, src_offset, dst_offset, transfer_len = transfer_plan(
+                local_region, remote_region
+            )
+            local_slot = local_region.base_addr - local_origin
+            remote_slot = remote_region.base_addr - remote_origin
+            if (
+                local_region.block_len != page
+                or remote_region.block_len != page
+                or not should_transfer
+                or src_offset != 0
+                or dst_offset != 0
+                or transfer_len != local_region.kv_block_len
+                or remote_region.kv_block_len != local_region.kv_block_len
+                or local_slot != remote_slot
+                or local_slot + local_region.kv_block_len > page
+            ):
+                eligible = False
+                break
+        if eligible:
+            geometry[group_index] = PageTransferGeometry(
+                page=page, local_origin=local_origin, remote_origin=remote_origin
+            )
+    return geometry
+
+
+def _append_page_transfers(
+    geometry: dict[int, PageTransferGeometry],
+    local_block_ids_by_group: list[list[int]],
+    remote_block_ids_by_group: list[list[int]],
+    src_ptrs: list[int],
+    dst_ptrs: list[int],
+    lengths: list[int],
+) -> set[int]:
+    """Emit one whole-page descriptor per contiguous block run for every group
+    in ``geometry`` and return the set of groups handled this way."""
+    handled: set[int] = set()
+    for group_index, geom in geometry.items():
+        if group_index >= len(local_block_ids_by_group):
+            continue
+        local_block_ids = local_block_ids_by_group[group_index]
+        remote_block_ids = remote_block_ids_by_group[group_index]
+        if not local_block_ids:
+            continue
+        # The null block carries no KV data; never overwrite its remote page.
+        pairs = [
+            (local_id, remote_id)
+            for local_id, remote_id in zip(local_block_ids, remote_block_ids)
+            if local_id != NULL_BLOCK_ID and remote_id != NULL_BLOCK_ID
+        ]
+        handled.add(group_index)
+        if not pairs:
+            continue
+        local_runs, remote_runs = group_concurrent_contiguous(
+            [local_id for local_id, _ in pairs],
+            [remote_id for _, remote_id in pairs],
+        )
+        for local_run, remote_run in zip(local_runs, remote_runs):
+            src_ptrs.append(geom.local_origin + local_run[0] * geom.page)
+            dst_ptrs.append(geom.remote_origin + remote_run[0] * geom.page)
+            lengths.append(len(local_run) * geom.page)
+    return handled
 
 
 def _validate_asymmetric_region_lengths(
@@ -1434,6 +1554,55 @@ class MooncakeConnectorWorker:
             for i, group in enumerate(block_ids)
         ]
 
+    def _page_transfer_geometry(
+        self,
+        agent_meta: MooncakeXferMetadata,
+        local_regions: list[TransferRegion],
+        remote_regions: list[TransferRegion],
+    ) -> dict[int, PageTransferGeometry]:
+        """Whole-page geometry per KV group for this remote worker (cached per
+        remote session; registered regions never change after startup)."""
+        remote_session = f"{agent_meta.remote_hostname}:{agent_meta.remote_port}"
+        cache = self.__dict__.setdefault("_page_transfer_geometry_cache", {})
+        if remote_session in cache:
+            return cache[remote_session]
+        geometry: dict[int, PageTransferGeometry] = {}
+        if agent_meta.registered_group_indices:
+
+            def transfer_plan(
+                local_region: TransferRegion, remote_region: TransferRegion
+            ) -> tuple[bool, int, int, int]:
+                return self._get_sender_transfer_plan(
+                    local_kv_block_len=local_region.kv_block_len,
+                    remote_kv_block_len=remote_region.kv_block_len,
+                    remote_tp_rank=agent_meta.remote_tp_rank,
+                    remote_tp_size=agent_meta.remote_tp_size,
+                )
+
+            geometry = _compute_page_transfer_geometry(
+                local_regions,
+                remote_regions,
+                Counter(self.registered_group_indices),
+                Counter(agent_meta.registered_group_indices),
+                transfer_plan,
+            )
+        if geometry:
+            logger.info(
+                "Mooncake whole-page KV transfer enabled towards %s for KV "
+                "groups %s (page=%d bytes)",
+                remote_session,
+                sorted(geometry),
+                next(iter(geometry.values())).page,
+            )
+        else:
+            logger.debug(
+                "Mooncake whole-page KV transfer not applicable towards %s; "
+                "using per-layer descriptors",
+                remote_session,
+            )
+        cache[remote_session] = geometry
+        return geometry
+
     async def _build_transfer_params(
         self,
         ready_reqs: list[tuple[ReqId, SendBlockMeta]],
@@ -1533,7 +1702,25 @@ class MooncakeConnectorWorker:
                 remote_block_ids_by_group
             )
 
+            # Groups whose layers share one page per block are sent as whole
+            # pages (one descriptor per contiguous block run) and skipped by
+            # the per-layer loop below.
+            page_groups: set[int] = set()
+            if envs.VLLM_MOONCAKE_PAGE_TRANSFER:
+                page_groups = _append_page_transfers(
+                    self._page_transfer_geometry(
+                        agent_meta, local_regions, remote_regions
+                    ),
+                    local_block_ids_by_group,
+                    remote_block_ids_by_group,
+                    src_ptrs,
+                    dst_ptrs,
+                    lengths,
+                )
+
             for local_region, remote_region in zip(local_regions, remote_regions):
+                if local_region.group_index in page_groups:
+                    continue
                 assert local_region.group_index == remote_region.group_index, (
                     "Aligned Mooncake transfer regions must belong to the same "
                     "KV group."

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -231,6 +231,7 @@ if TYPE_CHECKING:
     VLLM_EC_SIDE_CHANNEL_PORT: int = 5601
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
     VLLM_MOONCAKE_STORE_TIER_LOG: bool = False
+    VLLM_MOONCAKE_PAGE_TRANSFER: bool = True
     VLLM_MOONCAKE_LOAD_RECV_THREADS: int = 1
     VLLM_MOONCAKE_DISK_STAGING_USABLE_RATIO: float = 0.9
     MOONCAKE_PREFERRED_SEGMENT: str | None = None
@@ -1706,6 +1707,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for Mooncake handshake between remote agents.
     "VLLM_MOONCAKE_BOOTSTRAP_PORT": lambda: int(
         os.getenv("VLLM_MOONCAKE_BOOTSTRAP_PORT", "8998")
+    ),
+    # Send disaggregated-prefill KV as whole pages (one RDMA descriptor per
+    # contiguous block run) whenever all layers of a KV group share one page
+    # per block on both sides. Set to 0 to always emit per-layer descriptors.
+    "VLLM_MOONCAKE_PAGE_TRANSFER": lambda: (
+        os.getenv("VLLM_MOONCAKE_PAGE_TRANSFER", "True").lower() in ("true", "1")
     ),
     # Log per-batch memory/disk tier breakdown on external GETs.
     "VLLM_MOONCAKE_STORE_TIER_LOG": lambda: (


### PR DESCRIPTION
…yers share one page per block

With the unified paged KV layout every registered layer of a KV-cache group stores one slot per block inside a common page (the block stride), so all layers of a block are physically contiguous. MooncakeConnector still walks the layers one by one and emits one RDMA descriptor per (layer, block); the existing coalescing only fires when a region's transfer length equals its block stride, which never holds for a per-layer slot. A 128k-token DeepSeek-V4-Flash request therefore produced ~32k descriptors of ~16 KB per TP rank and the transfer ran at 9 GB/s per rank on a 400 Gb/s link.

Emit one descriptor per (KV group, contiguous block run) covering whole pages instead. A group qualifies when all of its registered layers on both sides are part of the aligned regions (no PP shard missing), share one block stride, sit at the same slot offsets fully inside the page, and the sender plan is a full untranslated copy (no heterogeneous-TP slicing, no replicated-KV skip). Null blocks are never written as pages. Everything else keeps the per-layer path; VLLM_MOONCAKE_PAGE_TRANSFER=0 disables the page path entirely.

Measured on 2x H200 (1P1D, TP4, fp8 KV, block 256, 8x 400 Gb/s RDMA):

  prompt   descriptors/rank   transfer time      per-rank bandwidth
  16k      4563 -> ~70        5.2 -> 2.1 ms      15.3 -> 39.8 GB/s
  64k      16405 -> 202       22.3 -> 6.5 ms     11.8 -> 41.2 GB/s
  128k     32173 -> 248       56.6 -> 12.3 ms    8.9 -> 41.7 GB/s

Whole pages move 2-7% more bytes than the per-layer slots for long prompts (page padding); 128k transfers now run at 86% of the single-NIC line rate. Needle-retrieval probes at depths 0.1-0.9 in 32k/128k prompts pass 10/10.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

