### PR TITLE
[Spec Decode] Add bounded attention with full KV retention for EAGLE3 drafts

### DIFF
--- a/docs/features/speculative_decoding/README.md
+++ b/docs/features/speculative_decoding/README.md
@@ -86,6 +86,7 @@ only apply to model-based methods such as `draft_model`, `mtp`, `eagle3`, and
 | `num_speculative_tokens` | `integer > 0` | `None` | Number of speculative tokens to propose per step. Required for methods that do not infer it from model metadata. |
 | `draft_tensor_parallel_size` | `integer >= 1` | `None` | Tensor parallel size for the draft model. |
 | `max_model_len` | `integer >= 1` | `None` | Maximum context length for the draft model. |
+| `draft_attention_window` | `integer >= 1` | `None` | Limit EAGLE3 draft attention to recent tokens while retaining the full draft KV cache. |
 | `parallel_drafting` | `boolean` | `false` | Enable parallel draft token generation. Only compatible with EAGLE and draft-model methods. |
 | `rejection_sample_method` | `string` | `standard` | `standard`, `synthetic`, or `block`. |
 | `synthetic_acceptance_rates` | `list[float]` | `None` | Per-position unconditional acceptance rates for `synthetic` rejection sampling. Each entry in `[0, 1]`; length must equal `num_speculative_tokens`; must be non-increasing. |

--- a/docs/features/speculative_decoding/eagle.md
+++ b/docs/features/speculative_decoding/eagle.md
@@ -56,6 +56,29 @@ for output in outputs:
     print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
 ```
 
+### Bounded EAGLE3 draft attention
+
+EAGLE3 drafters can limit attention computation to recent tokens without
+evicting older draft KV blocks. Retaining the full draft cache preserves
+prefix-cache reuse when long-running sessions resume, while the attention
+backend still applies the configured window. For example:
+
+```python
+llm = LLM(
+    model="amd/MiniMax-M3-MXFP4",
+    speculative_config={
+        "model": "Inferact/MiniMax-M3-EAGLE3-GQA",
+        "num_speculative_tokens": 2,
+        "method": "eagle3",
+        "draft_attention_window": 32768,
+    },
+)
+```
+
+This option reduces draft attention work, not KV-cache memory. Its performance
+benefit depends on the attention backend and workload, so benchmark it against
+full-context draft attention for the intended traffic pattern.
+
 ## Pre-Trained Eagle Draft Models
 
 A variety of EAGLE draft models are available on the Hugging Face hub:

--- a/tests/model_executor/test_eagle_attention_window.py
+++ b/tests/model_executor/test_eagle_attention_window.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from transformers import PretrainedConfig
+
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.model_executor.models.llama_eagle3 import _configure_draft_attention_window
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+
+
+class _TestAttentionBackend:
+    @staticmethod
+    def customize_spec(spec):
+        return spec
+
+    @staticmethod
+    def get_supported_kernel_block_sizes():
+        return [128]
+
+    @staticmethod
+    def is_mla():
+        return False
+
+
+def _get_cache_spec(*, retain_full_kv_cache: bool):
+    layer = SimpleNamespace(
+        attn_type=AttentionType.DECODER,
+        kv_cache_dtype="auto",
+        kv_cache_torch_dtype=torch.float16,
+        head_size=128,
+        head_size_v=128,
+        num_kv_heads=8,
+        sliding_window=32768,
+        retain_full_kv_cache=retain_full_kv_cache,
+        attn_backend=_TestAttentionBackend,
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=128,
+            skip_page_size_padded=None,
+        )
+    )
+    return Attention.get_kv_cache_spec(layer, vllm_config)
+
+
+def test_eagle3_draft_attention_window_configures_all_layers():
+    config = PretrainedConfig(num_hidden_layers=2)
+    retain_full_kv_cache = _configure_draft_attention_window(config, 32768)
+
+    assert config.sliding_window == 32768
+    assert config.layer_types == ["sliding_attention", "sliding_attention"]
+    assert retain_full_kv_cache
+
+
+def test_eagle3_draft_attention_window_retains_full_kv_cache():
+    cache_spec = _get_cache_spec(retain_full_kv_cache=True)
+
+    assert isinstance(cache_spec, FullAttentionSpec)
+    assert cache_spec.sliding_window == 32768
+
+
+def test_default_sliding_attention_keeps_windowed_kv_cache():
+    cache_spec = _get_cache_spec(retain_full_kv_cache=False)
+
+    assert isinstance(cache_spec, SlidingWindowSpec)
+    assert cache_spec.sliding_window == 32768
+
+
+def test_eagle3_draft_attention_window_none_preserves_config():
+    config = PretrainedConfig(num_hidden_layers=1)
+    config.sliding_window = None
+    config.layer_types = ["full_attention"]
+
+    assert not _configure_draft_attention_window(config, None)
+    assert config.sliding_window is None
+    assert config.layer_types == ["full_attention"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -891,6 +891,30 @@ def test_max_num_new_slots_for_drafting(method, parallel_drafting, expected_slot
     assert speculative_config.max_num_new_slots_for_drafting == expected_slots
 
 
+def test_draft_attention_window_requires_eagle3():
+    with pytest.raises(
+        ValueError,
+        match="draft_attention_window is only supported with method='eagle3'",
+    ):
+        SpeculativeConfig(
+            model="ngram",
+            num_speculative_tokens=3,
+            draft_attention_window=32768,
+        )
+
+
+def test_draft_attention_window_changes_computation_hash():
+    speculative_config = SpeculativeConfig(
+        model="ngram",
+        num_speculative_tokens=3,
+    )
+    baseline_hash = speculative_config.compute_hash()
+
+    speculative_config.draft_attention_window = 32768
+
+    assert speculative_config.compute_hash() != baseline_hash
+
+
 @dataclass
 class _TestConfigFields:
     a: int

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -417,6 +417,9 @@ class SpeculativeConfig:
     max_model_len: int | None = Field(default=None, ge=1)
     """The maximum model length of the draft model. Used when testing the
     ability to skip speculation for some sequences."""
+    draft_attention_window: int | None = Field(default=None, ge=1)
+    """Limit EAGLE3 draft attention to the most recent tokens while retaining
+    the full draft KV cache for prefix reuse."""
     revision: str | None = None
     """The specific model version to use for the draft model. It can be a
     branch name, a tag name, or a commit id. If unspecified, will use the
@@ -622,6 +625,8 @@ class SpeculativeConfig:
             if layer_ids is not None:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
+
+        factors.append(self.draft_attention_window)
 
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
@@ -1670,6 +1675,11 @@ class SpeculativeConfig:
             raise ValueError(
                 "'tensor_parallel_size' is not a valid argument in the "
                 "speculative_config. Please pass 'draft_tensor_parallel_size' instead."
+            )
+
+        if self.draft_attention_window is not None and self.method != "eagle3":
+            raise ValueError(
+                "draft_attention_window is only supported with method='eagle3'."
             )
 
         if self.num_speculative_tokens is None:

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -327,6 +327,7 @@ class Attention(nn.Module, AttentionLayerBase):
         self.head_size_v = self.head_size if head_size_v is None else head_size_v
         self.num_kv_heads = num_kv_heads
         self.sliding_window = sliding_window
+        self.retain_full_kv_cache = False
         self.has_sink = extra_impl_args.get("sinks") is not None
 
         # NOTE: model_config may be None during certain tests
@@ -607,7 +608,7 @@ class Attention(nn.Module, AttentionLayerBase):
         # Should not be called for enc-dec attention.
         assert self.attn_type == AttentionType.DECODER
         quant_mode = get_kv_quant_mode(self.kv_cache_dtype)
-        if self.sliding_window is not None:
+        if self.sliding_window is not None and not self.retain_full_kv_cache:
             assert not self.attn_backend.is_mla(), (
                 "MLA is not supported for sliding window"
             )
@@ -652,6 +653,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 head_size_v=self.head_size_v,
                 dtype=self.kv_cache_torch_dtype,
                 kv_quant_mode=quant_mode,
+                sliding_window=self.sliding_window,
             )
 
 

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import torch
 import torch.nn as nn
-from transformers import LlamaConfig
+from transformers import LlamaConfig, PretrainedConfig
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig, get_current_vllm_config
@@ -32,6 +32,22 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _configure_draft_attention_window(
+    config: PretrainedConfig, draft_attention_window: int | None
+) -> bool:
+    if draft_attention_window is None:
+        return False
+    config.sliding_window = draft_attention_window
+    config.layer_types = ["sliding_attention"] * config.num_hidden_layers
+    logger.info(
+        "Using a %d-token sliding attention window with full KV retention "
+        "for all %d EAGLE3 draft layers.",
+        draft_attention_window,
+        config.num_hidden_layers,
+    )
+    return True
+
+
 class LlamaDecoderLayer(LlamaDecoderLayer):
     def __init__(
         self,
@@ -39,8 +55,10 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
         prefix: str = "",
         config: LlamaConfig | None = None,
         layer_idx: int = 0,
+        retain_full_kv_cache: bool = False,
     ) -> None:
         super().__init__(vllm_config, prefix=prefix, config=config)
+        self.self_attn.attn.retain_full_kv_cache = retain_full_kv_cache
 
         config = config or vllm_config.model_config.hf_config
         quant_config = self.get_quant_config(vllm_config)
@@ -137,6 +155,10 @@ class LlamaModel(nn.Module):
     ) -> None:
         super().__init__()
         self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        retain_full_kv_cache = _configure_draft_attention_window(
+            self.config,
+            vllm_config.speculative_config.draft_attention_window,
+        )
         self.vocab_size = self.config.vocab_size
 
         # Get drafter's quantization config
@@ -168,6 +190,7 @@ class LlamaModel(nn.Module):
                     prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
                     config=self.config,
                     layer_idx=layer_idx,
+                    retain_full_kv_cache=retain_full_kv_cache,
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
             ]


### PR DESCRIPTION
## Purpose

Allow EAGLE3 draft models to bound attention compute without evicting older draft KV blocks.

A normal sliding-window cache uses `SlidingWindowSpec`, which recycles blocks outside the window. That is efficient for monotonic decoding, but it is costly for agentic workloads that repeatedly resume long cached prefixes: the drafter must reconstruct evicted state before it can propose tokens again.

This PR adds an opt-in `draft_attention_window` field for `method="eagle3"`. The draft attention backend applies the configured window, while KV planning uses `FullAttentionSpec` and retains the complete draft cache. The target model and the default draft behavior are unchanged.

The earlier title said "Llama" because the shared implementation lives in `llama_eagle3.py`. That module is also the registry implementation for non-Llama EAGLE3 architectures, including MiniMax-derived checkpoints, so the public title and documentation now use EAGLE3 terminology. For the same filename reason, vLLM's Mergify rule automatically attaches the `llama` label; that label does not indicate that the feature is Llama-specific.

## Default-path and CUDA isolation

- The feature is inactive unless `draft_attention_window` is explicitly set with `method="eagle3"`.
- The shared Llama model implementation is no longer modified.
- No CUDA backend, kernel, dispatch, or platform-selection code is changed.
- A regression test verifies that ordinary sliding attention still produces `SlidingWindowSpec`; only the explicit EAGLE3 opt-in produces `FullAttentionSpec(sliding_window=...)`.
- There are no model-name, GPU-architecture, or platform allowlists.

## Existing work / non-duplication

As of 2026-08-29, open-PR searches for `draft_attention_window`, EAGLE3 sliding-window attention, bounded draft attention, and full-KV draft retention found no other implementation of this behavior.

- #50169 fixes allocation and grouping for window-evicting drafters. This PR intentionally retains the complete draft KV cache for resumed-prefix reuse.
- #50897 adds lookahead-aware EAGLE prefix hashing; it does not alter draft attention or KV retention.
- #54180 fixes ROCm AITER FA/EAGLE3 backend support; it does not alter cache semantics.
- #53833 and #52664 change MiniMax-M3 cache insertion and sparse-indexer kernels. They have no file overlap with this PR; an exact-head merge simulation with #53833 is clean.
- #43200 also edits `vllm/config/speculative.py` for DFlash metadata, but the file auto-merges and the feature is unrelated.

Several older related PR heads currently conflict with `main` independently. Exact-head merge-tree checks found no conflict in any file changed by this PR.

## Tests

Current rebased head: `658dce3a0c222af7185c7ae86ff74bf887a3acfb` on vLLM `main` `6cddad414ee46796f21aaf7b8643a6e7a00c09b5`.

Repository checks:

```text
pre-commit run --files <all changed files>  PASS
  ruff check / ruff format                 PASS
  typos / markdownlint                     PASS
  mypy                                     PASS
  SPDX / config / import checks             PASS
git diff --check                            PASS
```

Linux/ROCm container validation on an allocated MI355X node, with the three changed runtime files mounted by SHA-256 into `vllm/vllm-openai-rocm:v0.27.1`:

```text
tests/model_executor/test_eagle_attention_window.py  4 passed
SpeculativeConfig validation and computation hash    PASS
```

The focused tests cover configured and unset EAGLE3 behavior, retained-full-KV planning, and the unchanged default sliding-window cache path.

Prior downstream integration evidence for the same feature behavior used MiniMax-M3 EAGLE3 with a 32,768-token draft window and seven identical long-context AgentX turns:

| Comparison | Median request-time result |
| --- | ---: |
| Retained full draft KV vs window-evicting draft KV | 13.32% faster |
| Retained full draft KV vs full-context EAGLE3 control | 0.76% slower |

The first comparison demonstrates the resumed-prefix benefit. The second is included to avoid overstating the feature: bounded draft attention was not a standalone end-to-end win in that stack because target verification remained dominant. The option therefore remains off by default.

## AI assistance

OpenAI Codex assisted with rebase verification, patch cleanup, duplicate-work analysis, test preparation, and PR drafting. The branch remains a draft pending the submitter's line-by-line review and required upstream CI.
