### PR TITLE
[ROCm][Perf] Fuse MiniMax-M3 sparse cache insertion with AITER

### DIFF
--- a/tests/kernels/attention/test_minimax_m3.py
+++ b/tests/kernels/attention/test_minimax_m3.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Correctness tests for MiniMax M3 sparse prefill attention kernels."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -984,6 +986,107 @@ def test_aiter_sparse_pa_rejects_multiple_kv_heads(monkeypatch):
 
     with pytest.raises(ValueError, match="num_kv_heads == 1"):
         sparse_attn_mod.minimax_m3_use_aiter_sparse_pa(2)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="MiniMax-M3 AITER sparse PA is ROCm-only",
+)
+def test_aiter_sparse_pa_slot_mapping_keeps_split_cache_slots(monkeypatch):
+    """Separate K/V planes use the allocator's original slot numbering."""
+    import vllm.models.minimax_m3.amd.model as model_mod
+
+    def fail_forward_context():
+        pytest.fail("split cache planes must not read page-16 metadata")
+
+    monkeypatch.setattr(model_mod, "get_forward_context", fail_forward_context)
+    slot_mapping = torch.tensor([-1, 0, 127, 128])
+    cache = torch.empty(16)
+
+    actual = model_mod.MiniMaxM3SparseAttention._normalize_aiter_sparse_pa_slot_mapping(
+        SimpleNamespace(), slot_mapping, cache, cache
+    )
+
+    assert actual is slot_mapping
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="MiniMax-M3 AITER sparse PA is ROCm-only",
+)
+def test_aiter_sparse_pa_slot_mapping_reuses_page16_metadata(monkeypatch):
+    """Block-contiguous K/V storage reuses the graph-safe page-16 mapping."""
+    import vllm.models.minimax_m3.amd.model as model_mod
+
+    slot_mapping = torch.tensor([-1, 0, 127, 128])
+    page16_slot_mapping = torch.tensor([-1, 0, 127, 256])
+    layer_name = "model.layers.0.self_attn"
+    metadata = model_mod.MiniMaxM3SparseMetadata(
+        seq_lens=torch.empty(0, dtype=torch.int32),
+        max_seq_len=0,
+        slot_mapping=slot_mapping,
+        num_actual_tokens=slot_mapping.numel(),
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=0,
+        num_prefill_tokens=0,
+        page16_slot_mapping=page16_slot_mapping,
+    )
+    monkeypatch.setattr(
+        model_mod,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata={layer_name: metadata}),
+    )
+    attention = SimpleNamespace(
+        layer_name=layer_name,
+        kv_cache=torch.empty(1, 2, BLOCK_SIZE, 2 * HEAD_DIM),
+    )
+
+    actual = model_mod.MiniMaxM3SparseAttention._normalize_aiter_sparse_pa_slot_mapping(
+        attention,
+        slot_mapping,
+        torch.empty(16),
+        torch.empty(8),
+    )
+
+    assert actual is page16_slot_mapping
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm(),
+    reason="MiniMax-M3 AITER sparse PA is ROCm-only",
+)
+def test_aiter_sparse_pa_slot_mapping_rebases_without_metadata(monkeypatch):
+    """Eager or shape-mismatched batches rebuild the page-16 mapping."""
+    import vllm.models.minimax_m3.amd.model as model_mod
+
+    slot_mapping = torch.tensor([-1, 0, 127, 128])
+    page16_slot_mapping = torch.tensor([-1, 0, 127, 256])
+    monkeypatch.setattr(
+        model_mod,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata=None),
+    )
+
+    def rebase_slots(actual_slot_mapping, block_size):
+        assert actual_slot_mapping is slot_mapping
+        assert block_size == BLOCK_SIZE
+        return page16_slot_mapping
+
+    monkeypatch.setattr(model_mod, "minimax_m3_rebase_slots_to_page16", rebase_slots)
+    attention = SimpleNamespace(
+        layer_name="model.layers.0.self_attn",
+        kv_cache=torch.empty(1, 2, BLOCK_SIZE, 2 * HEAD_DIM),
+    )
+
+    actual = model_mod.MiniMaxM3SparseAttention._normalize_aiter_sparse_pa_slot_mapping(
+        attention,
+        slot_mapping,
+        torch.empty(16),
+        torch.empty(8),
+    )
+
+    assert actual is page16_slot_mapping
 
 
 def test_indexer_cache_squeezes_to_contiguous_3d():

--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -18,6 +18,7 @@ The MiniMax-M3-preview config selects a single set of branches:
 """
 
 from collections.abc import Iterable
+from functools import cache
 
 import torch
 from torch import nn
@@ -118,6 +119,17 @@ from vllm.v1.kv_cache_interface import (
 )
 
 logger = init_logger(__name__)
+
+
+@cache
+def _aiter_fused_cache_insert_available() -> bool:
+    try:
+        from aiter.ops.minimax_m3_fused_qknorm_rope import (  # noqa: F401
+            minimax_m3_qknorm_rope_cache_shuffle_insert,
+        )
+    except ImportError:
+        return False
+    return True
 
 
 def _sparse_attention_layer_ids(config: PretrainedConfig) -> set[int]:
@@ -724,6 +736,9 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             raise ValueError(f"Duplicate layer name: {self.layer_name}")
         compilation_config.static_forward_context[self.layer_name] = self
         self.kv_cache = torch.tensor([])  # replaced by bind_kv_cache
+        self.use_aiter_fused_cache_insert = (
+            self.use_aiter_sparse_pa and _aiter_fused_cache_insert_available()
+        )
 
     def get_attn_backend(self) -> type[MiniMaxM3SparseBackend]:
         return self.attn_backend
@@ -802,6 +817,170 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         self._ensure_aiter_sparse_pa_kv_cache()
         return self.kv_cache_k, self.kv_cache_v
 
+    def _normalize_aiter_sparse_pa_slot_mapping(
+        self,
+        slot_mapping: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+    ) -> torch.Tensor:
+        if value_cache.shape[0] == key_cache.shape[0]:
+            return slot_mapping
+
+        attn_metadata = get_forward_context().attn_metadata
+        page16_slot_mapping = None
+        if isinstance(attn_metadata, dict):
+            main_md = attn_metadata[self.layer_name]
+            assert isinstance(main_md, MiniMaxM3SparseMetadata)
+            page16_slot_mapping = main_md.page16_slot_mapping
+        if (
+            page16_slot_mapping is None
+            or page16_slot_mapping.shape != slot_mapping.shape
+        ):
+            page16_slot_mapping = minimax_m3_rebase_slots_to_page16(
+                slot_mapping, self.kv_cache.shape[2]
+            )
+        return page16_slot_mapping
+
+    def _run_aiter_fused_cache_insert(
+        self,
+        qkv: torch.Tensor,
+        positions: torch.Tensor,
+        q: torch.Tensor,
+        index_q: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+        index_slot_mapping: torch.Tensor | None,
+        *,
+        skip_index_branch: bool,
+    ) -> None:
+        """Run AITER's fused QK-norm, RoPE, and page-16 cache insertion."""
+        from aiter.ops.minimax_m3_fused_qknorm_rope import (
+            minimax_m3_qknorm_rope_cache_shuffle_insert,
+        )
+
+        key_cache, value_cache = self.get_aiter_sparse_pa_kv_cache()
+        slot_mapping = self._normalize_aiter_sparse_pa_slot_mapping(
+            slot_mapping, key_cache, value_cache
+        )
+        index_cache = None
+        if not skip_index_branch:
+            index_cache = self.indexer.index_cache.kv_cache
+            if index_cache.numel() == 0:
+                raise RuntimeError("MiniMax-M3 index cache is not bound")
+
+        kv_cache_dtype = (
+            self.kv_cache_dtype
+            if is_quantized_kv_cache(self.kv_cache_dtype)
+            else "auto"
+        )
+        minimax_m3_qknorm_rope_cache_shuffle_insert(
+            qkv,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.rotary_emb.cos_sin_cache,
+            positions,
+            self.num_heads,
+            self.num_kv_heads,
+            self.num_idx_heads,
+            self.rotary_emb.rotary_dim,
+            self.q_norm.variance_epsilon,
+            slot_mapping,
+            key_cache,
+            value_cache,
+            q,
+            index_q_norm_weight=(
+                None if skip_index_branch else self.index_q_norm.weight
+            ),
+            index_k_norm_weight=(
+                None if skip_index_branch else self.index_k_norm.weight
+            ),
+            index_slot_mapping=index_slot_mapping,
+            index_cache=index_cache,
+            index_q_out=index_q,
+            kv_cache_dtype=kv_cache_dtype,
+            k_scale=getattr(self, "_k_scale", None),
+            v_scale=getattr(self, "_v_scale", None),
+            skip_index_branch=skip_index_branch,
+        )
+
+    def _run_aiter_sparse_pa_preprocessing(
+        self,
+        qkv: torch.Tensor,
+        positions: torch.Tensor,
+        q: torch.Tensor,
+        index_q: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+        index_slot_mapping: torch.Tensor | None,
+        *,
+        skip_index_branch: bool,
+    ) -> None:
+        """Prepare queries and caches for the AITER sparse-attention path."""
+        if self.use_aiter_fused_cache_insert:
+            self._run_aiter_fused_cache_insert(
+                qkv,
+                positions,
+                q,
+                index_q,
+                slot_mapping,
+                index_slot_mapping,
+                skip_index_branch=skip_index_branch,
+            )
+            return
+
+        if skip_index_branch:
+            ops.fused_minimax_m3_qknorm_rope_kv_insert(
+                qkv,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                self.rotary_emb.cos_sin_cache,
+                positions,
+                self.num_heads,
+                self.num_kv_heads,
+                self.rotary_emb.rotary_dim,
+                self.q_norm.variance_epsilon,
+                num_index_heads=self.num_idx_heads,
+                q_out=q,
+                skip_index_branch=True,
+            )
+        else:
+            ops.fused_minimax_m3_qknorm_rope_kv_insert(
+                qkv,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                self.rotary_emb.cos_sin_cache,
+                positions,
+                self.num_heads,
+                self.num_kv_heads,
+                self.rotary_emb.rotary_dim,
+                self.q_norm.variance_epsilon,
+                self.index_q_norm.weight,
+                self.index_k_norm.weight,
+                self.num_idx_heads,
+                q_out=q,
+                index_q_out=index_q,
+                kv_cache_dtype=self.kv_cache_dtype,
+            )
+
+        num_tokens = qkv.shape[0]
+        k_start = self.q_size
+        v_start = k_start + self.kv_size
+        k = qkv[:, k_start:v_start].view(num_tokens, self.num_kv_heads, self.head_dim)
+        v = qkv[:, v_start : v_start + self.kv_size].view(
+            num_tokens, self.num_kv_heads, self.head_dim
+        )
+        index_k = None
+        if not skip_index_branch:
+            index_k_start = v_start + self.kv_size + self.index_q_size
+            index_k = qkv[:, index_k_start : index_k_start + self.idx_head_dim].view(
+                num_tokens, self.idx_head_dim
+            )
+        self._insert_aiter_sparse_pa_kv(
+            k,
+            v,
+            index_k,
+            slot_mapping,
+            index_slot_mapping,
+        )
+
     def _insert_aiter_sparse_pa_kv(
         self,
         k: torch.Tensor,
@@ -819,21 +998,9 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         )
 
         key_cache, value_cache = self.get_aiter_sparse_pa_kv_cache()
-        if value_cache.shape[0] != key_cache.shape[0]:
-            attn_metadata = get_forward_context().attn_metadata
-            page16_slot_mapping = None
-            if isinstance(attn_metadata, dict):
-                main_md = attn_metadata[self.layer_name]
-                assert isinstance(main_md, MiniMaxM3SparseMetadata)
-                page16_slot_mapping = main_md.page16_slot_mapping
-            if (
-                page16_slot_mapping is None
-                or page16_slot_mapping.shape != slot_mapping.shape
-            ):
-                page16_slot_mapping = minimax_m3_rebase_slots_to_page16(
-                    slot_mapping, self.kv_cache.shape[2]
-                )
-            slot_mapping = page16_slot_mapping
+        slot_mapping = self._normalize_aiter_sparse_pa_slot_mapping(
+            slot_mapping, key_cache, value_cache
+        )
         kv_cache_dtype = (
             self.kv_cache_dtype
             if is_quantized_kv_cache(self.kv_cache_dtype)
@@ -891,34 +1058,14 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         if self.skip_index_topk:
             index_q = None
             if self.use_aiter_sparse_pa:
-                ops.fused_minimax_m3_qknorm_rope_kv_insert(
+                self._run_aiter_sparse_pa_preprocessing(
                     qkv,
-                    self.q_norm.weight,
-                    self.k_norm.weight,
-                    cos_sin_cache,
                     positions,
-                    self.num_heads,
-                    self.num_kv_heads,
-                    rotary_dim,
-                    eps,
-                    num_index_heads=self.num_idx_heads,
-                    q_out=q,
-                    skip_index_branch=True,
-                )
-                k_start = self.q_size
-                v_start = k_start + self.kv_size
-                k = qkv[:, k_start:v_start].view(
-                    num_tokens, self.num_kv_heads, self.head_dim
-                )
-                v = qkv[:, v_start : v_start + self.kv_size].view(
-                    num_tokens, self.num_kv_heads, self.head_dim
-                )
-                self._insert_aiter_sparse_pa_kv(
-                    k,
-                    v,
+                    q,
                     None,
                     main_slot_mapping,
                     None,
+                    skip_index_branch=True,
                 )
             else:
                 ops.fused_minimax_m3_qknorm_rope_kv_insert(
@@ -943,41 +1090,14 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             index_slot_mapping = fwd_slot_mapping[self.indexer.index_cache.prefix]
             index_q = qkv.new_empty((num_tokens, self.index_q_size))
             if self.use_aiter_sparse_pa:
-                ops.fused_minimax_m3_qknorm_rope_kv_insert(
+                self._run_aiter_sparse_pa_preprocessing(
                     qkv,
-                    self.q_norm.weight,
-                    self.k_norm.weight,
-                    cos_sin_cache,
                     positions,
-                    self.num_heads,
-                    self.num_kv_heads,
-                    rotary_dim,
-                    eps,
-                    self.index_q_norm.weight,
-                    self.index_k_norm.weight,
-                    self.num_idx_heads,
-                    q_out=q,
-                    index_q_out=index_q,
-                    kv_cache_dtype=self.kv_cache_dtype,
-                )
-                k_start = self.q_size
-                v_start = k_start + self.kv_size
-                index_k_start = v_start + self.kv_size + self.index_q_size
-                k = qkv[:, k_start:v_start].view(
-                    num_tokens, self.num_kv_heads, self.head_dim
-                )
-                v = qkv[:, v_start : v_start + self.kv_size].view(
-                    num_tokens, self.num_kv_heads, self.head_dim
-                )
-                index_k = qkv[
-                    :, index_k_start : index_k_start + self.idx_head_dim
-                ].view(num_tokens, self.idx_head_dim)
-                self._insert_aiter_sparse_pa_kv(
-                    k,
-                    v,
-                    index_k,
+                    q,
+                    index_q,
                     main_slot_mapping,
                     index_slot_mapping,
+                    skip_index_branch=False,
                 )
             else:
                 ops.fused_minimax_m3_qknorm_rope_kv_insert(


### PR DESCRIPTION
## Summary

- auto-detect AITER's `minimax_m3_qknorm_rope_cache_shuffle_insert` operation
- use it to fuse MiniMax-M3 sparse-layer QK normalization, RoPE, page-16 K/V insertion, and index-cache insertion
- share the existing page-16 slot-normalization path between the fused and unfused AITER writers
- retain the existing vLLM preprocessing plus `reshape_and_cache` / index-scatter path when an older AITER build does not provide the operation

This is the vLLM integration for [ROCm/AITER #4813](https://github.com/ROCm/aiter/pull/4813). It is confined to the AMD MiniMax-M3 implementation and does not change the CUDA path.

## Motivation

The current AITER sparse-paged-attention path runs three stages per sparse layer:

1. vLLM fused QK-norm/RoPE preprocessing
2. AITER `reshape_and_cache(..., asm_layout=True)` for K/V
3. a separate index-cache scatter

AITER #4813 combines those stages, avoids materializing and rereading normalized K/V through the packed projection buffer, and removes two launches from each sparse layer's hot path.

This PR does not skip the lightning indexer. The full index branch remains active unless vLLM's existing `skip_index_topk` policy explicitly selects the reuse path.

## Compatibility and fallback

- New AITER with #4813: the fused operation is selected automatically.
- Older AITER: the import probe returns false and the existing vLLM path runs unchanged.
- Both the full-index and existing skip-index branches are supported.
- BF16 and FP8 main K/V cache modes retain the existing scale contract.
- Both fused and unfused AITER insertion use the existing graph-safe page-16 slot mapping when K/V share block-contiguous storage, and rebuild it for eager or shape-mismatched batches.

No runtime GPU-architecture literal is added here. Before this draft is marked ready, AITER #4813 must either make the operation correct on every supported ROCm architecture where it is exported or expose a capability contract that vLLM can query.

## Existing work / non-duplication

- [AITER #4813](https://github.com/ROCm/aiter/pull/4813) owns the fused kernel. This PR only wires that public operation into vLLM and deliberately does not duplicate the kernel.
- [vLLM #52664](https://github.com/vllm-project/vllm/pull/52664) owns AITER indexer selection, FP8 index-query/cache dtype, score/top-k kernels, sparse tables, and related page-layout plumbing. This PR does not carry those changes; it only replaces cache preprocessing/insertion when the fused AITER operation is available.
- [vLLM #52849](https://github.com/vllm-project/vllm/pull/52849) is now in `main` and supplies the AITER paged-attention layout used here.
- [vLLM #48935](https://github.com/vllm-project/vllm/pull/48935) is closed and targets the NVIDIA/internal vLLM kernel path rather than AITER's shuffled page-16 layout.

Composition was checked locally by applying the current #52664 feature delta (`92b66b2bdf03`) to vLLM `main` (`6cddad414ee4`) and then applying this commit (`a05636aad5cd`). Both cherry-picks completed without conflict. In that combined tree, #52664 retains the FP8 `index_q` allocation and this PR contributes only fused preprocessing/insertion plus shared slot normalization.

## Dependency status

AITER #4813 is currently open at `3def474748bf` and is mergeable, but its overall AITER test gate is not green. This vLLM PR remains draft pending a stable AITER landing path and current-head ROCm correctness/evaluation.

## Validation

Current rebased vLLM commit:

```text
pre-commit run --files vllm/models/minimax_m3/amd/model.py tests/kernels/attention/test_minimax_m3.py   PASS
.venv/bin/python -m py_compile vllm/models/minimax_m3/amd/model.py tests/kernels/attention/test_minimax_m3.py   PASS
git diff --check origin/main...HEAD   PASS
```

Three focused regression tests were added for:

- preserving the original slot mapping for separate K/V planes
- reusing graph-safe page-16 metadata for block-contiguous K/V storage
- rebuilding the page-16 mapping for eager or shape-mismatched batches

The focused pytest module was not executed locally: this checkout is on macOS without a ROCm device or the full vLLM test environment, and collection stopped in `tests/conftest.py` because `tblib` was absent. It must be run on ROCm before the draft is marked ready.

Prior MI355X evidence, from the earlier vLLM/AITER integration before this rebase:

- direct fused-versus-existing-path smoke passed both the full-index and skip-index branches, with zero maximum absolute error for compared Q, K, V, and index outputs
- full real-target GSM8K completed 1,319/1,319 requests with zero HTTP errors and strict exact match `0.9696739954510993`
- controlled AgentX C1 improved median TPOT by 12.9%, median end-to-end latency by 9.8%, and aggregate output throughput by 4.8% to 5,294.14 generated tok/s/chip, with 147/147 measured requests and zero request errors

The GSM8K run also included the separately submitted ROCm unified-attention CUDA-graph metadata fix. These are historical integration results, not current-head signoff; the rebased commit and final AITER dependency still require ROCm reruns.

## AI assistance

OpenAI Codex assisted with code analysis, rebasing, focused test construction, static validation, compatibility checking against #52664, and drafting this description. The submitter must review every changed line and run the required ROCm tests before this draft is marked ready for review.
