### PR TITLE
[Platform] Read device capability from torch, not NVML, once CUDA is initialized

### DIFF
--- a/tests/cuda/test_cuda_context.py
+++ b/tests/cuda/test_cuda_context.py
@@ -94,6 +94,8 @@ def test_get_device_capability_uses_visible_device_ordinal(monkeypatch):
         "device_control_id_to_physical_device_id",
         classmethod(lambda _cls, device_id: int(device_id)),
     )
+    # Pin the NVML path: with CUDA initialized the platform reads torch instead.
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: False)
     monkeypatch.setattr(pynvml, "nvmlInit", lambda: None)
     monkeypatch.setattr(pynvml, "nvmlShutdown", lambda: None)
     monkeypatch.setattr(
@@ -106,13 +108,90 @@ def test_get_device_capability_uses_visible_device_ordinal(monkeypatch):
         "nvmlDeviceGetCudaComputeCapability",
         lambda _handle: (9, 0),
     )
-    NvmlCudaPlatform.get_device_capability.cache_clear()
+    NvmlCudaPlatform._get_nvml_device_capability.cache_clear()
 
     capability = NvmlCudaPlatform.get_device_capability(device_id=1)
 
     assert capability is not None
     assert capability.to_int() == 90
     assert seen_indices == [1]
+
+
+def test_get_device_capability_prefers_torch_when_cuda_initialized(monkeypatch):
+    """Once CUDA is initialized, capability must come from the torch ordinal.
+
+    NVML enumerates in PCI bus order while the CUDA runtime defaults to
+    FASTEST_FIRST, so on hosts with heterogeneous GPUs (e.g. DGX Station:
+    GB300 sm103 compute GPU + RTX PRO display GPU at a lower PCI bus id)
+    NVML index 0 is a different physical device than torch's cuda:0. Reading
+    NVML here made FlashInfer gate TRTLLM attention on the display GPU's
+    sm12x capability while the model ran on the GB300.
+    """
+    from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
+
+    seen_torch_ordinals: list[int] = []
+
+    def record_torch(device_id: int) -> tuple[int, int]:
+        seen_torch_ordinals.append(device_id)
+        return (10, 3)
+
+    def fail_handle(index: int) -> str:
+        raise AssertionError(
+            "NVML must not be queried once CUDA is initialized; "
+            f"got nvmlDeviceGetHandleByIndex({index})"
+        )
+
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", record_torch)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByIndex", fail_handle)
+    # Pin a non-identity visible->physical mapping: the torch arm must pass
+    # the visible ordinal through to torch unmapped, never remap it via
+    # CUDA_VISIBLE_DEVICES the way the NVML arm does.
+    monkeypatch.setenv(NvmlCudaPlatform.device_control_env_var, "2,3")
+    NvmlCudaPlatform._get_torch_device_capability.cache_clear()
+    NvmlCudaPlatform._get_nvml_device_capability.cache_clear()
+    try:
+        capability = NvmlCudaPlatform.get_device_capability(device_id=1)
+
+        assert capability is not None
+        assert (capability.major, capability.minor) == (10, 3)
+        assert seen_torch_ordinals == [1]
+    finally:
+        NvmlCudaPlatform._get_torch_device_capability.cache_clear()
+
+
+def test_get_device_capability_pre_init_value_does_not_shadow_torch(monkeypatch):
+    """A capability cached pre-CUDA-init (NVML) must not shadow the post-init
+    torch answer for the same ordinal once CUDA comes up."""
+    from vllm.platforms.cuda import NvmlCudaPlatform, pynvml
+
+    cuda_initialized = False
+
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: cuda_initialized)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device_id: (10, 3))
+    monkeypatch.setattr(
+        NvmlCudaPlatform,
+        "visible_device_id_to_physical_device_id",
+        classmethod(lambda _cls, device_id: int(device_id)),
+    )
+    monkeypatch.setattr(pynvml, "nvmlInit", lambda: None)
+    monkeypatch.setattr(pynvml, "nvmlShutdown", lambda: None)
+    monkeypatch.setattr(pynvml, "nvmlDeviceGetHandleByIndex", lambda index: "handle")
+    monkeypatch.setattr(
+        pynvml, "nvmlDeviceGetCudaComputeCapability", lambda _handle: (12, 0)
+    )
+    NvmlCudaPlatform._get_torch_device_capability.cache_clear()
+    NvmlCudaPlatform._get_nvml_device_capability.cache_clear()
+    try:
+        before = NvmlCudaPlatform.get_device_capability(device_id=0)
+        cuda_initialized = True
+        after = NvmlCudaPlatform.get_device_capability(device_id=0)
+
+        assert before is not None and (before.major, before.minor) == (12, 0)
+        assert after is not None and (after.major, after.minor) == (10, 3)
+    finally:
+        NvmlCudaPlatform._get_torch_device_capability.cache_clear()
+        NvmlCudaPlatform._get_nvml_device_capability.cache_clear()
 
 
 def _stub_nvml(monkeypatch) -> dict[str, int]:
@@ -142,13 +221,15 @@ def _stub_nvml(monkeypatch) -> dict[str, int]:
         "device_control_id_to_physical_device_id",
         classmethod(lambda _cls, device_id: int(device_id)),
     )
+    # Pin the NVML path: with CUDA initialized the platform reads torch instead.
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: False)
     monkeypatch.setattr(
         pynvml, "nvmlDeviceGetHandleByIndex", lambda index: f"handle-{index}"
     )
     monkeypatch.setattr(
         pynvml, "nvmlDeviceGetCudaComputeCapability", lambda _handle: (9, 0)
     )
-    NvmlCudaPlatform.get_device_capability.cache_clear()
+    NvmlCudaPlatform._get_nvml_device_capability.cache_clear()
     return calls
 
 
@@ -174,7 +255,7 @@ def test_has_device_capability_does_not_reinit_nvml(monkeypatch):
         assert calls["init"] == 1
         assert calls["shutdown"] == 1
     finally:
-        NvmlCudaPlatform.get_device_capability.cache_clear()
+        NvmlCudaPlatform._get_nvml_device_capability.cache_clear()
 
 
 def test_has_device_capability_comparisons(monkeypatch):
@@ -189,7 +270,7 @@ def test_has_device_capability_comparisons(monkeypatch):
         assert not NvmlCudaPlatform.has_device_capability(100)
         assert not NvmlCudaPlatform.has_device_capability((10, 0))
     finally:
-        NvmlCudaPlatform.get_device_capability.cache_clear()
+        NvmlCudaPlatform._get_nvml_device_capability.cache_clear()
 
 
 if __name__ == "__main__":

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -739,9 +739,33 @@ class NvmlCudaPlatform(CudaPlatformBase):
             return pynvml.nvmlDeviceGetIndex(handle)
 
     @classmethod
+    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
+        # device_id is a visible (torch.cuda) ordinal, but NVML enumerates
+        # devices in PCI bus order while the CUDA runtime defaults to
+        # CUDA_DEVICE_ORDER=FASTEST_FIRST, so on hosts with heterogeneous
+        # GPUs the same ordinal can name different physical devices in the
+        # two namespaces. Once CUDA is initialized in this process, torch is
+        # authoritative for visible ordinals; reading it then does not
+        # trigger the CUDA initialization this class exists to avoid.
+        if torch.cuda.is_initialized():
+            return cls._get_torch_device_capability(device_id)
+        return cls._get_nvml_device_capability(device_id)
+
+    @classmethod
+    @cache
+    def _get_torch_device_capability(
+        cls, device_id: int = 0
+    ) -> DeviceCapability | None:
+        try:
+            major, minor = torch.cuda.get_device_capability(device_id)
+            return DeviceCapability(major=major, minor=minor)
+        except (RuntimeError, AssertionError):
+            return None
+
+    @classmethod
     @cache
     @with_nvml_context
-    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
+    def _get_nvml_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         try:
             physical_device_id = cls.visible_device_id_to_physical_device_id(device_id)
             handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)


### PR DESCRIPTION
## Purpose

On machines that mix GPU models, `NvmlCudaPlatform.get_device_capability()` can return the capability of the wrong GPU, which silently disables capability-gated fast paths for the GPU the model is actually running on.

The concrete case: a DGX Station has a GB300 (sm103) compute GPU and an RTX PRO 4000 (sm120) display GPU. NVML enumerates devices in PCI bus order, but the CUDA runtime defaults to `CUDA_DEVICE_ORDER=FASTEST_FIRST`, so NVML index 0 and `cuda:0` are different physical devices on this box. torch puts the model on the GB300, while every `current_platform` capability gate reads the display GPU and sees `(12, 0)`.

Downstream of that one wrong answer: `supports_trtllm_attention()` returns False, FlashInfer falls back and downgrades its cudagraph support, and with speculative decoding enabled `cudagraph_mode` collapses from `FULL` all the way to `NONE`. On our benchmark (Nemotron 3.5 Lightning NVFP4 + DSpark drafter, 32K prefix / 2K in / 256 out, batch 1) that's **70 tok/s instead of 748 tok/s** — a 10.7x regression with the out-of-the-box environment. Setting `CUDA_DEVICE_ORDER=PCI_BUS_ID` avoids it, but nothing tells you to, and vLLM's existing "Detected different devices in the system" warning doesn't stop the gates from probing the wrong device.

## Fix

Once `torch.cuda.is_initialized()` is true in the process (which it is in every GPU worker after `set_device`), answer `get_device_capability()` from `torch.cuda.get_device_capability(device_id)` instead of NVML. torch is authoritative for visible ordinals, and reading it after init can't trigger the CUDA initialization that `NvmlCudaPlatform` exists to avoid. The NVML path is unchanged for pre-init callers, and the two paths are cached separately so a value cached before init can't shadow the correct post-init answer.

Why not fix the NVML-side mapping instead: the FASTEST_FIRST permutation isn't observable without initializing CUDA, so a correct visible-to-physical translation simply can't be computed pre-init. Deferring to torch post-init is exact; pre-init callers keep NVML as a best effort, same as today.

Known limitations (pre-existing, unchanged here): pre-init callers on heterogeneous machines can still get the wrong device's capability, and callers that pass `device_id=0` while computing on `cuda:N` behave as before. In the serve path all perf-critical gates query post-init.

## Test Plan

- Two new mock-only tests in `tests/cuda/test_cuda_context.py` (no GPU or special topology needed in CI):
  - post-init queries must come from torch, with a poisoned NVML stub that fails the test if NVML is touched, and an ordinal-recording torch stub that verifies the ordinal is passed through unmapped even with a non-identity `CUDA_VISIBLE_DEVICES`;
  - a value cached pre-init (NVML) must not shadow the post-init torch answer for the same ordinal.
- Existing NVML-path tests (including the no-reinit test from #50393) pinned to the pre-init path and still passing.
- `ruff check` / `ruff format --check` clean on both files.

## Test Result

Validated on the affected hardware by overlaying the patched file onto a main-built container:

| config (mixed GB300 + RTX PRO node, no pinning) | decode tok/s | probe |
|---|---|---|
| stock | 70.2 | `arch=sm120`, TRTLLM attention refused, cudagraphs `FULL -> NONE` |
| this PR, same node and args | **747.9** | `arch=sm103`, TRTLLM attention on, FULL decode graphs |
| this PR + `CUDA_DEVICE_ORDER=PCI_BUS_ID` (control) | 743.1 | identical to the unpinned fixed run; matches historical pinned stock within 0.1% |

On a homogeneous GB200 node, stock and patched produce identical backend/cudagraph startup decisions and throughput within run-to-run noise, i.e. this is a no-op on homogeneous machines. The new tests pass in-container on sm103 and sm100.

## Related issues/PRs

Not a duplicate of the open NVML/UUID PRs (#41776, #35470 fix `CUDA_VISIBLE_DEVICES` UUID parsing; #53570 adds short-form UUID support and touches adjacent lines in both files, so whichever lands second needs a trivial rebase). #47892 established that `device_id` here is the torch-visible ordinal; this fixes the ordering assumption that contract still ran into, which can't be fixed inside NVML alone. #19741 (closed stale) reported this failure class on a mixed 5090/4090/3090 workstation.

## AI assistance disclosure

Developed with AI assistance (Claude Code): root cause tracing, the fix, and the hardware validation. I've reviewed every changed line and can defend the change end-to-end.

Signed-off-by: Rishi Puri <riship@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
