### PR TITLE
[Bugfix][Kernel] Build fused GDN MTP decode for SM110

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1122,7 +1122,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     cuda_archs_loose_intersection(FUSED_KDA_DECODE_ARCHS
       "9.0a;10.0f;12.0f" "${CUDA_ARCHS}")
     cuda_archs_loose_intersection(FUSED_GDN_DECODE_ARCHS
-      "8.0;8.6;8.9;9.0a;10.0f;12.0f" "${CUDA_ARCHS}")
+      "8.0;8.6;8.9;9.0a;10.0f;11.0f;12.0f" "${CUDA_ARCHS}")
   endif()
   if(FUSED_KDA_DECODE_ARCHS)
     set(FUSED_KDA_DECODE_SRC


### PR DESCRIPTION
## Purpose

Fixes #53462.

CUDA 13 advertises SM110 as a supported vLLM build architecture, but
`FUSED_GDN_DECODE_ARCHS` skipped the SM11x family. In a multi-architecture
wheel, the fused GDN symbol is still registered because the source is built for
other architectures, so the runtime capability and symbol checks pass on
Jetson Thor. The first MTP post-conv launch then fails because the wheel has no
SM110 kernel image.

Add the CUDA 13 `11.0f` family target to the fused GDN decode source list.
`cuda_archs_loose_intersection` selects `11.0f` for a `11.0` build and
preserves an explicitly requested `11.0a` target. Existing SM80, SM86, SM89,
SM90, SM100, and SM120 targets are unchanged, and no kernel logic changes.
The existing `VLLM_GDN_DECODE_KERNEL=triton` fallback remains supported.

> [!IMPORTANT]
> The pre-existing `ops.h` declaration-guard mismatch is fixed upstream by
> [#52743](https://github.com/vllm-project/vllm/pull/52743), merged as
> `b2a6e9dc`. This PR only adds the SM110 GDN architecture target and does not
> duplicate the upstream header fix.

### Duplicate-work check

Before preparing this change, I ran:

```bash
gh issue view 53462 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "53462 in:body"
gh pr list --repo vllm-project/vllm --state open --search "fused GDN SM110a kernel image"
gh pr list --repo vllm-project/vllm --state open --search "FUSED_GDN_DECODE_ARCHS 11.0f"
```

At submission time, no other open PR referenced #53462 or added SM110 to the fused GDN decode target.

Rechecked on 2026-09-05: [#55365](https://github.com/vllm-project/vllm/pull/55365), opened on 2026-09-04, now proposes the identical one-line change. I cross-linked it and asked that review be consolidated on one PR; #53835 predates it and remains linked to the original bug report and full Thor evidence.

After Thor validation exposed the independent `ops.h` guard mismatch, I also
searched for existing work with:

```bash
gh pr list --repo vllm-project/vllm --state open \
  --search "VLLM_ENABLE_FUSED_GDN_DECODE ops.h"
```

That found #52743, #53375, #53807, and #54008. #52743 has now merged into
`main` as `b2a6e9dc` and supersedes the duplicate guard-fix work. This PR
therefore keeps only its one-line architecture change.

### Contribution roles

I led the contribution direction and acceptance criteria, reviewed and approved
the final design, reviewed and understood every changed line, and personally
ran the contributor-side checks below. I own the final design decision and the
submission. AI assistance was used for candidate discovery, duplicate-work searches, root-cause verification, and implementation preparation. On 2026-09-05, at my request, Codex rebased the already-reviewed one-line change onto a newer `main` and ran the maintenance checks recorded below. The current head retains the same one-line design; I remain responsible for understanding and defending it before merge.

## Test Plan

Contributor-side checks:

```bash
git diff --check
pre-commit run typos --files CMakeLists.txt
git diff -- CMakeLists.txt
```

SM110 hardware validation:

1. Build the CUDA 13 extension with `11.0` in `CUDA_ARCHS`.
2. Confirm the build reports fused GDN decode for `11.0f`.
3. Confirm the output library contains the full SM110f GDN MTP kernel set.
4. Run the Jetson Thor MTP K=3 reproduction from #53462 without forcing the
   Triton path.
5. Compare correctness, speculative acceptance, and throughput with the
   existing Triton fallback.

## Test Result

Maintenance checks on head `5c6fd7e4e58812fe3e95079a7643cc5cb674c802`, rebased on 2026-09-05 onto `main` at `16328c7a775ff20d17d9750096a094e8cf2b45f2`:

- `git diff --check 16328c7..5c6fd7e`: passed
- `uvx --from pre-commit pre-commit run typos --files CMakeLists.txt`: passed
- GitHub compare guard: exactly one modified file, 1 insertion and 1 deletion
- targeted `cmake -P` probe using the current `cmake/utils.cmake`: the unpatched list returns no SM110 target; the patched list returns `11.0f`; SM100 and SM120 remain `10.0f` and `12.0f`
- GitHub DCO check: passed

`uvx --from pytest --with cmake pytest -q tests/test_cmake_utils.py` was also attempted on the Windows maintenance host. All three pre-existing tests abort before their assertions because the generated CMake include path contains Windows backslashes (`\U` is parsed as an invalid CMake escape); this is an environment/test-portability limitation, not a failing assertion from this PR.

No CUDA 13 or SM110 hardware is available on the maintenance host. Since the Thor run below, `main` has changed the GDN implementation (including output-gate activation and cudagraph metadata work). The historical Thor results remain direct evidence for the one-line SM110 architecture-selection fix, but they are not a byte-identical validation of the entire current GDN tree. Fresh upstream CI and, ideally, a Thor rerun are still required for the new head.

### Jetson AGX Thor validation

Issue reporter @nyhhome validated the exact `CMakeLists.txt` change on Jetson
AGX Thor (SM110a, JetPack 7.1, CUDA 13.0.88) using the image and model from
#53462. Full reproducible details are in
[the hardware report](https://github.com/vllm-project/vllm/pull/53835#issuecomment-5434474879)
and its [numerical correction](https://github.com/vllm-project/vllm/pull/53835#issuecomment-5435011843).

Results:

- `TORCH_CUDA_ARCH_LIST="11.0"` configured fused GDN decode for `11.0f`.
- The patched library contained 220 `gdn_decode_post_conv_mtp_kernel` entries
  for `sm_110f`, matching the full SM100f/SM120f variant count.
- The unpatched control reproduced `no kernel image is available for execution
  on the device` on the first real request.
- The patched fused CUDA path returned HTTP 200, produced coherent output, and
  completed the full benchmark and quality capture with zero missing-kernel
  errors, Xids, or OOMs.
- Versus the existing Triton fallback, fused CUDA improved throughput by 15.9%
  on code, 19.9% on math, and 15.4% on prose.
- Speculative acceptance and perplexity remained comparable. In the corrected
  divergence analysis, patched CUDA + MTP had fewer hard divergences than both
  Triton + MTP and the no-spec Triton kernel-swap comparison.
- The fused path used more GPU-rail energy per token in this test; the Triton
  environment-variable fallback remains intentionally unchanged.

### Guard dependency

An SM110-only build with this architecture change reaches a pre-existing
mismatch: the GDN declaration in `csrc/libtorch_stable/ops.h` is guarded by the
KDA macro, while its registration is guarded by the GDN macro. This PR does not
introduce that defect; it makes the GDN-only SM110 configuration newly
reachable.

[#52743](https://github.com/vllm-project/vllm/pull/52743) merged as `b2a6e9dc`
and fixes the declaration guard in `main`. This PR contains only the GDN
architecture-list change.