### PR TITLE
[Bugfix][MRV2][LoRA] Fix prompt logprobs mapping

### DIFF
--- a/tests/v1/sample/test_prompt_logprobs_lora_mapping.py
+++ b/tests/v1/sample/test_prompt_logprobs_lora_mapping.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.lora.ops.triton_ops.lora_kernel_metadata import LoRAKernelMeta
+from vllm.v1.outputs import LogprobsTensors
+from vllm.v1.worker.gpu.sample import prompt_logprob
+
+
+def test_prompt_logprobs_lora_mapping_is_restored(monkeypatch) -> None:
+    token_lora_indices = torch.tensor([0, 1] * 512 + [0], dtype=torch.int32)
+    sampler_indices = torch.tensor([2, 3], dtype=torch.int32)
+    wrapper = SimpleNamespace(
+        token_lora_indices=token_lora_indices,
+        sampler_indices=sampler_indices,
+        prompt_mapping_meta=LoRAKernelMeta.make(4, 1025, "cpu"),
+    )
+    wrapper.prompt_mapping_meta.prepare_tensors(sampler_indices)
+    original_mapping = wrapper.prompt_mapping_meta.token_lora_mapping[:2].clone()
+    seen_mappings = []
+
+    def logits_fn(hidden_states: torch.Tensor) -> torch.Tensor:
+        seen_mappings.append(
+            wrapper.prompt_mapping_meta.token_lora_mapping[
+                : hidden_states.shape[0]
+            ].clone()
+        )
+        return torch.zeros((hidden_states.shape[0], 8))
+
+    def fake_compute_topk_scores(
+        logits: torch.Tensor,
+        num_logprobs: int,
+        target_token_ids: torch.Tensor,
+        **kwargs,
+    ) -> LogprobsTensors:
+        return LogprobsTensors(
+            logprob_token_ids=target_token_ids[:, None],
+            logprobs=torch.zeros((logits.shape[0], 1)),
+            selected_token_ranks=torch.ones(logits.shape[0], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(prompt_logprob, "compute_topk_scores", fake_compute_topk_scores)
+    prompt_logprob.compute_prompt_logprobs_with_chunking(
+        torch.arange(1025),
+        torch.zeros((1025, 2)),
+        logits_fn,
+        0,
+        lora_wrapper=wrapper,
+    )
+
+    assert [mapping.numel() for mapping in seen_mappings] == [1024, 1]
+    assert torch.equal(seen_mappings[0], token_lora_indices[:1024])
+    assert torch.equal(seen_mappings[1], token_lora_indices[1024:])
+    assert torch.equal(
+        wrapper.prompt_mapping_meta.token_lora_mapping[:2], original_mapping
+    )

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -15,6 +15,7 @@ from vllm.lora.layers import (
     BaseLayerWithLoRA,
     FusedMoE3DWithLoRA,
     FusedMoEWithLoRA,
+    LogitsProcessorWithLoRA,
     LoRAMapping,
     LoRAMappingType,
 )
@@ -736,6 +737,21 @@ class LoRAModelManager:
             self.lora_config.target_modules,
             self.packed_modules_mapping,
         )
+
+    def get_lm_punica_wrapper(self) -> PunicaWrapperBase:
+        """Return the Punica wrapper for the language model."""
+        if not self.supports_mm:
+            return self.punica_wrapper_mapping[DEFAULT_LANGUAGE_WRAPPER_KEY]
+        return self.punica_wrapper_mapping[self.mm_mapping.language_model[0]]
+
+    def get_lora_logits_wrapper(self) -> PunicaWrapperBase | None:
+        """Return the LM wrapper only when LoRA targets the logits processor."""
+        if not any(
+            isinstance(module, LogitsProcessorWithLoRA)
+            for module in self.modules.values()
+        ):
+            return None
+        return self.get_lm_punica_wrapper()
 
     def _get_punica_wrapper(self, module_name: str) -> PunicaWrapperBase | None:
         """

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -17,6 +17,7 @@ from vllm.lora.model_manager import (
     create_lora_manager,
 )
 from vllm.lora.peft_helper import PEFTHelper
+from vllm.lora.punica_wrapper import PunicaWrapperBase
 from vllm.lora.request import LoRARequest
 from vllm.lora.utils import get_adapter_absolute_path
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
@@ -200,6 +201,9 @@ class WorkerLoRAManager:
             self._adapter_manager.supports_mm
             and self._adapter_manager.supports_tower_connector_lora
         )
+
+    def get_lora_logits_wrapper(self) -> PunicaWrapperBase | None:
+        return self._adapter_manager.get_lora_logits_wrapper()
 
     def _apply_adapters(self, adapter_requests: set[Any]) -> None:
         existing_adapters = self.list_adapters()

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -453,6 +453,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.prompt_logprobs_worker = PromptLogprobsWorker(
                 self.max_num_reqs,
                 logprobs_mode=self.model_config.logprobs_mode,
+                lora_wrapper=(
+                    self.lora_manager.get_lora_logits_wrapper()
+                    if self.lora_config
+                    else None
+                ),
             )
             self.structured_outputs_worker = StructuredOutputsWorker(
                 max_num_logits=self.max_num_reqs * self.decode_query_len,

--- a/vllm/v1/worker/gpu/sample/prompt_logprob.py
+++ b/vllm/v1/worker/gpu/sample/prompt_logprob.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
@@ -8,15 +9,25 @@ import torch
 from vllm.config.model import LogprobsMode
 from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
+from vllm.utils.gpu_sync_debug import gpu_sync_allowed
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_scores
 
+if TYPE_CHECKING:
+    from vllm.lora.punica_wrapper import PunicaWrapperBase
+
 
 class PromptLogprobsWorker:
-    def __init__(self, max_num_reqs: int, logprobs_mode: LogprobsMode = "raw_logprobs"):
+    def __init__(
+        self,
+        max_num_reqs: int,
+        logprobs_mode: LogprobsMode = "raw_logprobs",
+        lora_wrapper: "PunicaWrapperBase | None" = None,
+    ):
         self.max_num_reqs = max_num_reqs
         self.logprobs_mode = logprobs_mode
+        self.lora_wrapper = lora_wrapper
 
         self.uses_prompt_logprobs = np.zeros(self.max_num_reqs, dtype=bool)
         self.num_prompt_logprobs = np.zeros(self.max_num_reqs, dtype=np.int32)
@@ -85,6 +96,7 @@ class PromptLogprobsWorker:
                 logits_fn,
                 max_num_prompt_logprobs,
                 self.logprobs_mode,
+                self.lora_wrapper,
             )
         )
 
@@ -202,6 +214,7 @@ def compute_prompt_logprobs_with_chunking(
     logits_fn: Callable[[torch.Tensor], torch.Tensor],
     num_prompt_logprobs: int,
     logprobs_mode: LogprobsMode = "raw_logprobs",
+    lora_wrapper: "PunicaWrapperBase | None" = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # Since materializing the full prompt logits can take too much memory,
     # we compute it in chunks.
@@ -211,24 +224,42 @@ def compute_prompt_logprobs_with_chunking(
     ranks = []
     logits_mode = logprobs_mode in ("raw_logits", "processed_logits")
     prompt_token_ids = prompt_token_ids.to(torch.int64)
-    for start_idx in range(0, prompt_token_ids.shape[0], CHUNK_SIZE):
-        end_idx = start_idx + CHUNK_SIZE
-        # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
-        prompt_logits = logits_fn(prompt_hidden_states[start_idx:end_idx])
-        requested_num = (
-            prompt_logits.shape[-1]
-            if num_prompt_logprobs == -1
-            else num_prompt_logprobs
-        )
-        result = compute_topk_scores(
-            prompt_logits,
-            requested_num,
-            prompt_token_ids[start_idx:end_idx],
-            logits_mode=logits_mode,
-        )
-        token_ids.append(result.logprob_token_ids)
-        scores.append(result.logprobs)
-        ranks.append(result.selected_token_ranks)
+    # CPU Punica wrappers do not expose prompt_mapping_meta.
+    prompt_mapping_meta = (
+        getattr(lora_wrapper, "prompt_mapping_meta", None)
+        if lora_wrapper is not None
+        else None
+    )
+    try:
+        for start_idx in range(0, prompt_token_ids.shape[0], CHUNK_SIZE):
+            end_idx = start_idx + CHUNK_SIZE
+            # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
+            if prompt_mapping_meta is not None:
+                assert lora_wrapper is not None
+                with gpu_sync_allowed():
+                    prompt_mapping_meta.prepare_tensors(
+                        lora_wrapper.token_lora_indices[start_idx:end_idx]
+                    )
+            prompt_logits = logits_fn(prompt_hidden_states[start_idx:end_idx])
+            requested_num = (
+                prompt_logits.shape[-1]
+                if num_prompt_logprobs == -1
+                else num_prompt_logprobs
+            )
+            result = compute_topk_scores(
+                prompt_logits,
+                requested_num,
+                prompt_token_ids[start_idx:end_idx],
+                logits_mode=logits_mode,
+            )
+            token_ids.append(result.logprob_token_ids)
+            scores.append(result.logprobs)
+            ranks.append(result.selected_token_ranks)
+    finally:
+        if prompt_mapping_meta is not None:
+            assert lora_wrapper is not None
+            with gpu_sync_allowed():
+                prompt_mapping_meta.prepare_tensors(lora_wrapper.sampler_indices)
 
     token_ids = torch.cat(token_ids, dim=0) if len(token_ids) > 1 else token_ids[0]
     scores = torch.cat(scores, dim=0) if len(scores) > 1 else scores[0]


### PR DESCRIPTION
## Purpose

Model Runner V2 splits prompt logprobs computation into smaller chunks to reduce GPU memory usage. However, the lm_head LoRA metadata was not rebuilt for each chunk and continued to use the full-batch mapping.

This PR rebuilds the token-level LoRA metadata for every prompt-logprobs chunk, ensuring that the correct LoRA mapping is applied and preventing incorrect logits or CUDA memory access errors.


## Test Plan

Tested Qwen3.5-4B with Model Runner V2 on one NVIDIA GPU using eight distinct `lm_head` LoRA adapters. We sent 32 concurrent requests with `logprobs=5` and `prompt_logprobs=5`, using 1025 total prompt tokens. With vLLM's default 1024-token chunk size, the prompt was split into `1024 + 1` chunks. Serial and concurrent results were compared to verify LoRA mapping. 

This PR extends the V1 fix from #51597 to Model Runner V2.

## Test Result

On unpatched `main` at `d9fbe526c0`, the average logprob difference was `0.52–0.55`, with a maximum difference of `25.3`. 

On `fix/mrv2-lora-prompt-logprobs-mapping` at `b4964b1bd8`, the average difference decreased to `0.059–0.063`, with a maximum below `0.92`, close to the no-LoRA baseline. No NaN values, CUDA illegal memory accesses, EngineCore crashes, or request failures were observed.






---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


