### PR TITLE
[Bugfix][Multimodal] Guard Qwen3-VL video sampling against zero source fps

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1595,3 +1595,14 @@ def test_glm46v_duration_estimation_from_fps():
     assert len(indices) > 0
     assert len(indices) % 2 == 0
     assert all(0 <= idx < 90 for idx in indices)
+
+
+@pytest.mark.parametrize("backend", [Qwen2VLVideoBackend, Qwen3VLVideoBackend])
+def test_qwen_vl_video_zero_original_fps_raises(backend):
+    """A clip with unknown/variable fps (``original_fps == 0``) must raise a
+    clear ValueError instead of a ZeroDivisionError."""
+    source = VideoSourceMetadata(total_frames_num=120, original_fps=0.0, duration=0.0)
+    target = VideoTargetMetadata(num_frames=-1, fps=2, max_duration=300)
+
+    with pytest.raises(ValueError, match="known source fps"):
+        backend.compute_frames_index_to_sample(source, target)

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -339,6 +339,14 @@ class Qwen3VLVideoBackend(VideoBackend):
         min_frames = kwargs.get("min_frames", 4)
         max_frames = kwargs.get("max_frames", 768)
 
+        # vLLM reports original_fps == 0 for clips with unknown/variable fps
+        # (VFR, malformed, streaming); fail loudly instead of dividing by zero.
+        if original_fps <= 0:
+            raise ValueError(
+                "Qwen3-VL video sampling needs a known source fps, but the "
+                "container reported 0 (variable or unknown frame rate)."
+            )
+
         # Refer to:
         # https://github.com/huggingface/transformers/blob/v5.9.0/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py#L119-L125
         num_frames = int(total_frames_num / original_fps * fps)


### PR DESCRIPTION
## Summary

`Qwen3VLVideoBackend.compute_frames_index_to_sample` computes:

```python
num_frames = int(total_frames_num / original_fps * fps)
```

without guarding `original_fps`. vLLM reports `original_fps == 0` for clips with an unknown/variable frame rate (VFR, malformed, streaming), so those inputs crash with an opaque `ZeroDivisionError` deep in the video loader.

The sibling `Qwen2VLVideoBackend` (same file) already handles this and raises a clear `ValueError` — its guard even documents that vLLM reports `original_fps == 0` for such clips. The Qwen3-VL backend was missing the same guard.

## Reproduction (before fix)

Calling both backends with a clip reporting `original_fps == 0`:

```
Qwen2-VL backend (has guard):
  -> ValueError: Qwen2-VL video sampling needs a known source fps, but the container reported 0 (variable or unknown frame rate).
Qwen3-VL backend (no guard):
  -> ZeroDivisionError: float division by zero
```

## After fix

```
Qwen2-VL backend (has guard):
  -> ValueError: Qwen2-VL video sampling needs a known source fps, but the container reported 0 (variable or unknown frame rate).
Qwen3-VL backend (no guard):
  -> ValueError: Qwen3-VL video sampling needs a known source fps, but the container reported 0 (variable or unknown frame rate).
```

## Fix

Add the same `original_fps <= 0` guard used by `Qwen2VLVideoBackend`, raising a descriptive `ValueError` instead of dividing by zero.

## Tests

```
.venv/bin/python -m pytest tests/multimodal/test_video.py -k zero_original_fps -v
# 2 passed  (Qwen2VLVideoBackend + Qwen3VLVideoBackend)
```

Linters: `ruff-check`, `ruff-format`, `mypy-3.12` all pass on the changed files.

(Note: some `glm46v` cases in this test file fail locally only due to a missing optional `av`/PyAV dependency and HF network access in my sandbox — unrelated to this change, which only touches `Qwen3VLVideoBackend`.)

## Not a duplicate

No open/closed PR adds an `original_fps`/zero-fps guard to the Qwen3-VL video backend. The two open PRs touching `compute_frames_index_to_sample` address different issues (empty frame indices #52102; explicit index selection #46153). Verified via `gh pr list --search`.

AI assistance was used to prepare this change.
