### PR TITLE
[ROCm][Perf][DeepSeek V4] FP8 shared-expert load-time requant for AITER fused MoE on gfx942

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -52,6 +52,13 @@ def is_shared_expert_quant_fse_compatible(
             return False, "DeepSeek-V4 has no quantization configuration"
 
         if not quant_config._is_quark_mxfp4_ocp(quantization_config):
+            # Native DeepSeek FP8 checkpoints (DSv4-Flash): routed experts
+            # are MXFP4 via expert_dtype=fp4; shared experts are FP8
+            # block-scale. The Quark MXFP4-OCP gate only covers AMD-Quark
+            # exports, which this checkpoint is not (quant_method=fp8, no
+            # layer_quant_config). Allow FSE so load-time requant can run.
+            if quantization_config.get("quant_method") in ("fp8", "deepseek_v4_fp8"):
+                return True, None
             return False, "DeepSeek-v4 FSE is only implemented/tested with Quark MXFP4"
 
         layer_idx = extract_layer_index(shared_expert_prefix)

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -91,11 +91,17 @@ def is_shared_expert_quant_fse_compatible(
         shared_weight_config = (
             layer_config or quantization_config.get("global_quant_config") or {}
         ).get("weight") or {}
-        if shared_weight_config.get("dtype") == "fp4":
+        shared_dtype = shared_weight_config.get("dtype")
+        if shared_dtype in ("fp4", "fp4x2"):
+            return True, None
+        # DSv4-Flash ships FP8 shared experts with MXFP4 routed experts.
+        # Load-time requant enables FSE without a heterogeneous MoE kernel.
+        if shared_dtype in ("fp8", "fp8_e4m3", "float8"):
             return True, None
         return (
             False,
-            f"DeepSeek-V4 shared experts at {shared_expert_prefix} are not MXFP4",
+            f"DeepSeek-V4 shared experts at {shared_expert_prefix} are not MXFP4 "
+            f"or FP8 (got {shared_dtype!r})",
         )
 
     if isinstance(quant_config, QuarkConfig):

--- a/vllm/models/deepseek_v4/amd/fp8_to_mxfp4_shared.py
+++ b/vllm/models/deepseek_v4/amd/fp8_to_mxfp4_shared.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Load-time FP8(block-scale) -> MXFP4 re-quant for DSv4 shared experts.
+
+DeepSeek-V4-Flash routes experts in MXFP4 but stores the always-on shared
+expert as FP8 (E4M3 + 128x128 block scale). To fold the shared expert into
+the routed grouped-GEMM, weights are converted to the MXFP4 checkpoint layout
+expected by routed expert slots, then loaded into slots
+``[n_routed .. n_routed+n_shared)``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def dequant_fp8_block(
+    weight: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    block: tuple[int, int] = (128, 128),
+) -> torch.Tensor:
+    """Dequantize a DeepSeek block-quantized FP8 weight to bf16."""
+    assert weight.dim() == 2, f"expected 2D weight, got {tuple(weight.shape)}"
+    out, inn = weight.shape
+    bn, bk = block
+    w = weight.to(torch.float32)
+    scale = weight_scale_inv.to(torch.float32)
+    scale = scale.repeat_interleave(bn, dim=0)[:out]
+    scale = scale.repeat_interleave(bk, dim=1)[:, :inn]
+    return (w * scale).to(torch.bfloat16)
+
+
+def quant_bf16_to_mxfp4(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """bf16 [out, in] -> (packed_uint8 [out, in//2], scale_uint8 [out, in//32])."""
+    from aiter.utility.fp4_utils import dynamic_mxfp4_quant
+
+    assert w_bf16.dim() == 2
+    orig_device = w_bf16.device
+    w = w_bf16.contiguous()
+    if w.device.type != "cuda":
+        w = w.cuda()
+    packed, scale = dynamic_mxfp4_quant(w, shuffle=False)
+    packed = packed.view(torch.uint8).to(orig_device).contiguous()
+    scale = scale.view(torch.uint8).to(orig_device).contiguous()
+    return packed, scale
+
+
+def convert_shared_fp8_to_mxfp4(
+    weight: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    block: tuple[int, int] = (128, 128),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """FP8 block-scale [out, in] -> MXFP4 (packed uint8, scale uint8)."""
+    return quant_bf16_to_mxfp4(dequant_fp8_block(weight, weight_scale_inv, block))

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -40,6 +40,9 @@ from vllm.model_executor.layers.mhc import (
     MHCPostOp,
     MHCPreOp,
 )
+from vllm.models.deepseek_v4.amd.fp8_to_mxfp4_shared import (
+    convert_shared_fp8_to_mxfp4,
+)
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.utils.config_utils import (
     is_shared_expert_quant_fse_compatible,
@@ -809,14 +812,33 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 f"n_shared_experts == 1, got {self.config.n_shared_experts}"
             )
 
+        shared_expert_buf: dict[tuple[str, str], dict[str, torch.Tensor]] = {}
+
         for name, loaded_weight in weights:
-            # Shared-expert fusion: redirect ``.ffn.shared_experts.w{1,2,3}``
-            # into appended routed-expert slot ``.ffn.experts.{n_routed}``
-            # so the MXFP4-quantized shared expert loads through the routed
-            # expert loader (grouped GEMM). Single shared expert only.
-            if ".ffn.shared_experts.w" in name and fuse_by_layer.get(
-                extract_layer_index(name), False
+            layer_idx = extract_layer_index(name)
+            fuse_layer = fuse_by_layer.get(layer_idx, False)
+            # FP8 shared experts: re-quantize to MXFP4 and load into appended slot.
+            if fuse_layer and ".shared_experts." in name and (
+                name.endswith(".weight_scale_inv")
+                or (
+                    name.endswith(".weight")
+                    and loaded_weight.dtype
+                    in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+                )
             ):
+                self._load_fused_shared_expert(
+                    name,
+                    loaded_weight,
+                    shared_expert_buf,
+                    params_dict,
+                    expert_mapping,
+                    loaded_params,
+                )
+                continue
+
+            # MXFP4 shared-expert fusion: redirect checkpoint names into the
+            # appended routed-expert slot for grouped GEMM.
+            if ".ffn.shared_experts.w" in name and fuse_layer:
                 name = name.replace(
                     ".ffn.shared_experts.w",
                     f".ffn.experts.{n_routed}.w",
@@ -897,6 +919,69 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     continue
 
         return loaded_params
+
+    _SHARED_PROJ_TO_SHARD = {"w1": "w1", "w3": "w3", "down_proj": "w2"}
+
+    def _load_fused_shared_expert(
+        self,
+        name: str,
+        loaded_weight: torch.Tensor,
+        buf: dict[tuple[str, str], dict[str, torch.Tensor]],
+        params_dict: dict[str, torch.nn.Parameter],
+        expert_mapping: list[tuple[str, str, int, str]],
+        loaded_params: set[str],
+    ) -> None:
+        """Fold FP8 shared-expert tensors into MXFP4 appended routed slots."""
+        proj = next(
+            (p for p in self._SHARED_PROJ_TO_SHARD if f".shared_experts.{p}." in name),
+            None,
+        )
+        if proj is None:
+            return
+        if name.endswith(".weight_scale_inv"):
+            half = "scale"
+        elif name.endswith(".weight"):
+            half = "weight"
+        else:
+            return
+
+        prefix = name.split(".shared_experts.")[0]
+        key = (prefix, proj)
+        slot = buf.setdefault(key, {})
+        slot[half] = loaded_weight
+        if "weight" not in slot or "scale" not in slot:
+            return
+
+        packed, scale = convert_shared_fp8_to_mxfp4(slot["weight"], slot["scale"])
+        del buf[key]
+
+        shard_id = self._SHARED_PROJ_TO_SHARD[proj]
+        expert_id = self.config.n_routed_experts
+        base = f"{prefix}.experts.{expert_id}.{shard_id}"
+
+        for tensor, suffix in ((packed, "weight"), (scale, "weight_scale")):
+            synth = f"{base}.{suffix}"
+            for param_name, weight_name, mapped_expert_id, mapped_shard_id in (
+                expert_mapping
+            ):
+                if weight_name not in synth or mapped_expert_id != expert_id:
+                    continue
+                name_mapped = synth.replace(weight_name, param_name)
+                if is_pp_missing_parameter(name_mapped, self):
+                    break
+                param = params_dict[name_mapped]
+                weight_loader = typing.cast(Callable[..., bool], param.weight_loader)
+                success = weight_loader(
+                    param,
+                    tensor,
+                    name_mapped,
+                    shard_id=mapped_shard_id,
+                    expert_id=expert_id,
+                    return_success=True,
+                )
+                if success:
+                    loaded_params.add(name_mapped)
+                break
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -815,8 +815,11 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         shared_expert_buf: dict[tuple[str, str], dict[str, torch.Tensor]] = {}
 
         for name, loaded_weight in weights:
-            layer_idx = extract_layer_index(name)
-            fuse_layer = fuse_by_layer.get(layer_idx, False)
+            # extract_layer_index asserts exactly one integer. embeddings /
+            # lm_head / norms have none (embed_tokens.weight crashed here).
+            fuse_layer = False
+            if ".shared_experts." in name:
+                fuse_layer = fuse_by_layer.get(extract_layer_index(name), False)
             # FP8 shared experts: re-quantize to MXFP4 and load into appended slot.
             if fuse_layer and ".shared_experts." in name and (
                 name.endswith(".weight_scale_inv")
@@ -920,7 +923,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
 
         return loaded_params
 
-    _SHARED_PROJ_TO_SHARD = {"w1": "w1", "w3": "w3", "down_proj": "w2"}
+    # Nightly's fuse_shared mapper leaves checkpoint `w2` unmapped
+    # (does not rename to down_proj). Accept both names.
+    _SHARED_PROJ_TO_SHARD = {"w1": "w1", "w3": "w3", "down_proj": "w2", "w2": "w2"}
 
     def _load_fused_shared_expert(
         self,


### PR DESCRIPTION
## Summary

DeepSeek-V4-Flash stores routed MoE experts as **MXFP4** but the always-on shared expert as **FP8** (E4M3 + 128x128 block scale). Today, fused shared-expert (FSE) execution via `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1` only supports checkpoints where shared-expert weights are already MXFP4-compatible -- the loader redirects shared-expert tensor names into appended routed-expert slot 256.

This PR adds a **load-time FP8->MXFP4 requant path** for FP8 shared experts: weights are dequantized to bf16, re-quantized with aiter's canonical `dynamic_mxfp4_quant`, and loaded into the appended expert slot through the existing routed-expert weight loader. The standalone shared-expert MLP is skipped when FSE is enabled (unchanged behavior).

**Scope:** DeepSeek-V4 AMD path, gfx942/gfx950 with AITER fused MoE, `n_shared_experts == 1`, FP8 shared + MXFP4 routed checkpoints (e.g. DeepSeek-V4-Flash). MXFP4-shared checkpoints continue to use the existing name-redirect loader.

**Precision note:** Requant is **lossy** (~12% weight RMS vs original FP8). Accuracy is validated against fusion-off on the same image/serve flags.

## What changed

- **New** `vllm/models/deepseek_v4/amd/fp8_to_mxfp4_shared.py` -- FP8 block-scale dequant -> MXFP4 quant helpers using aiter `dynamic_mxfp4_quant`
- `vllm/model_executor/layers/quantization/utils/config_utils.py`
  - treat `fp8` / `fp8_e4m3` shared-expert dtypes as FSE-compatible (in addition to `fp4`)
  - native DeepSeek `quant_method=fp8` checkpoints (DSv4-Flash) are FSE-compatible even though they are not AMD-Quark MXFP4-OCP exports
- `vllm/models/deepseek_v4/amd/model.py`
  - `_load_fused_shared_expert()` -- buffer FP8 weight + scale pairs, requant, load into appended slot via expert mapping
  - `load_weights()` -- intercept FP8 shared-expert tensors when FSE is enabled; preserve existing MXFP4 redirect for native MXFP4 shared weights
  - call `extract_layer_index` only on `.shared_experts.` names (embeddings / lm_head have no layer index)
  - accept both `w2` and `down_proj` shared-expert names (fuse-shared mapper may leave `w2` unmapped)

## Selection & gating

- **Enabled when:**
  - `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`
  - `VLLM_ROCM_USE_AITER_MOE=1`
  - Expert parallel disabled
  - Layer passes `is_shared_expert_quant_fse_compatible()` (now includes native FP8 shared experts)
  - Checkpoint shared-expert weights are FP8 (`float8_e4m3fn` / `float8_e4m3fnuz`) with block scales
- **Fallback:** FSE off -> standalone `shared_experts` MLP (unchanged). MXFP4 shared checkpoints -> existing name redirect (unchanged).
- **Not supported:** `n_shared_experts != 1` (existing guard)

Example serve flags:

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1
```

## Depends on

- aiter fused MoE with 257-expert grouped GEMM
- aiter `dynamic_mxfp4_quant` for load-time requant (existing utility; no new kernel port)

No FlyDSL or custom kernel packages required.

## Related work

- [#48728](https://github.com/vllm-project/vllm/pull/48728) (closed) -- heterogeneous FP8+MXFP4 fused shared expert for gfx950 (lossless kernel path). This PR targets **gfx942 requant-at-load**, validated on MI325X.
- [#46474](https://github.com/vllm-project/vllm/pull/46474) -- FSE for MiniMax M3 (same env flag pattern)
- Upstream already ships FSE env wiring, 257-expert mapping, and MXFP4 redirect; this PR completes DSv4-Flash FP8-shared checkpoint support.

## Not a duplicate

Searched open PRs for `fp8_to_mxfp4`, `shared expert`, `FSE`, and `257 expert`; no open PR implements load-time FP8->MXFP4 requant for DSv4 shared experts on gfx942.

- #48728 proposed a different (heterogeneous-kernel) design for gfx950 and was closed.
- Existing FSE loader redirect assumes shared weights are already MXFP4-formatted.

## Performance

**Environment:** 8× AMD Instinct MI325X (gfx942), TP8, `deepseek-ai/DeepSeek-V4-Flash`
**Image:** `vllm/vllm-openai-rocm:nightly-46638857f` (`v0.26.1rc1.dev1219+g46638857f`)
**Method:** matched A/B on that image. FSE off vs this PR with `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`. Stock FSE-on without this PR does **not** enable FSE (Quark MXFP4-OCP gate) and matches FSE-off.

`max_num_batched_tokens=32768`, `kv_cache_dtype=fp8_e4m3`, prefix caching off.

| Point | FSE off median TPOT | This PR | Δ |
|---|---:|---:|---:|
| 8k conc1 | 19.64 ms | 17.93 ms | **−8.7%** |
| 8k conc4 | 20.36 ms | 18.26 ms | **−10.3%** |
| 131k conc4 | 30.49 ms | 28.36 ms | **−7.0%** |
| 131k conc8 | 44.79 ms | 40.00 ms | **−10.7%** |

## Accuracy

`lm_eval` `gsm8k_cot_zeroshot`, n=500, `local-chat-completions`, `temperature=0`, `max_gen_toks=4096`, `apply_chat_template`, seed=4321. Same image and serve flags as the E2E table, **without** `--reasoning-parser` so `message.content` is the full generation (0 null-content responses).

| Task | Metric | FSE off | FSE on (this PR) | Δ |
|---|---|---:|---:|---:|
| GSM8K CoT zeroshot | flexible-extract exact_match | **0.930 ± 0.011** | **0.928 ± 0.012** | −0.2 pp |
| GSM8K CoT zeroshot | strict-match | 0.068 ± 0.011 | 0.080 ± 0.012 | +1.2 pp |

No accuracy regression vs matched FSE-off (Δ within 1 stderr).

## Test Plan

```text
Hardware: 8x MI325X (gfx942), TP8
Model:    deepseek-ai/DeepSeek-V4-Flash
Image:    vllm/vllm-openai-rocm:nightly-46638857f
Server:   VLLM_ROCM_USE_AITER=1, VLLM_ROCM_USE_AITER_MOE=1,
          VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1,
          kv_cache_dtype=fp8_e4m3, max_model_len=132096
          (no --reasoning-parser for GSM8K)
Baseline: FSE off (VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0)
Candidate: FSE on with this PR
```

- E2E bench:

  ```bash
  vllm bench serve --backend vllm --dataset-name random ...
  ```

- Accuracy:

  ```bash
  lm_eval --model local-chat-completions \
    --tasks gsm8k_cot_zeroshot --limit 500 \
    --gen_kwargs temperature=0,max_gen_toks=4096 --apply_chat_template
  ```

- Pre-commit:

  ```bash
  pre-commit run --files \
    vllm/models/deepseek_v4/amd/fp8_to_mxfp4_shared.py \
    vllm/models/deepseek_v4/amd/model.py \
    vllm/model_executor/layers/quantization/utils/config_utils.py
  ```

## Test Result

**E2E** (`nightly-46638857f`, TP8 DSv4-Flash, bt32k sweep): median TPOT −7% to −11% vs FSE-off (table above). Weight load ~30s. Stock FSE-on without this PR does not engage FSE.

**Accuracy:** GSM8K CoT zeroshot n=500, no reasoning parser: FSE-off **0.930 ± 0.011**, FSE-on **0.928 ± 0.012**.

**Load fixes needed on this tree:** `extract_layer_index` on non-layer tensors; Quark MXFP4-OCP gate blocking native `quant_method=fp8`; `w2` vs `down_proj` mapping.

## AI assistance

AI assistance was used to draft this PR description and the load/gate fixes. The submitter will review every changed line before marking the PR ready.
