### PR TITLE
[Log][Core] Clarify shm_broadcast long-wait diagnostics

### DIFF
--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import io
+import os
 import pickle
 import random
 import threading
@@ -658,10 +659,24 @@ def test_warning_logs(caplog_vllm):
         # "0 seconds" expected due to rounding of 1ms test interval
         with pytest.raises(TimeoutError):
             reader.dequeue(timeout=0.01, indefinite=False)
-        assert any(
-            "No available shared memory broadcast block found in 0 seconds"
-            in record.message
+        warning_messages = [
+            record.message
             for record in caplog_vllm.records
+            if "No available shared memory broadcast block found in 0 seconds"
+            in record.message
+        ]
+        assert warning_messages
+        assert any(
+            "role=local_reader" in message
+            and f"pid={os.getpid()}" in message
+            and "slot=0/10" in message
+            and "written_flag=0" in message
+            and "read_count=0/1" in message
+            and "reader_flags=[0]" in message
+            and "local_reader_index=0" in message
+            and "local_reader_flag=0" in message
+            and "waited_s=" in message
+            for message in warning_messages
         )
         caplog_vllm.clear()
 
@@ -677,6 +692,48 @@ def test_warning_logs(caplog_vllm):
         # Clean up when done
         writer.shutdown()
         reader.shutdown()
+
+
+def test_writer_warning_log_includes_wait_state(caplog_vllm):
+    with mock.patch(
+        "vllm.distributed.device_communicators.shm_broadcast.VLLM_RINGBUFFER_WARNING_INTERVAL",
+        new=0.001,
+    ):
+        writer = MessageQueue(
+            n_reader=1,
+            n_local_reader=1,
+            max_chunk_bytes=1024 * 1024,
+            max_chunks=1,
+        )
+        reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+        try:
+            writer.wait_until_ready()
+            reader.wait_until_ready()
+            writer.enqueue({"payload": "first"})
+
+            with pytest.raises(TimeoutError):
+                writer.enqueue({"payload": "second"}, timeout=0.01)
+
+            warning_messages = [
+                record.message
+                for record in caplog_vllm.records
+                if "No available shared memory broadcast block found in 0 seconds"
+                in record.message
+            ]
+            assert warning_messages
+            assert any(
+                "role=writer" in message
+                and f"pid={os.getpid()}" in message
+                and "slot=0/1" in message
+                and "written_flag=1" in message
+                and "read_count=0/1" in message
+                and "reader_flags=[0]" in message
+                and "waited_s=" in message
+                for message in warning_messages
+            )
+        finally:
+            writer.shutdown()
+            reader.shutdown()
 
 
 def _fake_disk_usage(free_bytes: int):

--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -703,16 +703,21 @@ def test_writer_warning_log_includes_wait_state(caplog_vllm):
         new=0.001,
     ):
         writer = MessageQueue(
-            n_reader=1,
-            n_local_reader=1,
+            n_reader=2,
+            n_local_reader=2,
+            local_reader_ranks=[4, 7],
             max_chunk_bytes=1024 * 1024,
             max_chunks=1,
         )
-        reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+        handle = writer.export_handle()
+        reader0 = MessageQueue.create_from_handle(handle, rank=4)
+        reader1 = MessageQueue.create_from_handle(handle, rank=7)
         try:
             writer.wait_until_ready()
-            reader.wait_until_ready()
+            reader0.wait_until_ready()
+            reader1.wait_until_ready()
             writer.enqueue({"payload": "first"})
+            assert reader0.dequeue() == {"payload": "first"}
 
             with pytest.raises(TimeoutError):
                 writer.enqueue({"payload": "second"}, timeout=0.01)
@@ -730,57 +735,11 @@ def test_writer_warning_log_includes_wait_state(caplog_vllm):
                 and f"pid={os.getpid()}" in message
                 and "slot=0/1" in message
                 and "written_flag=1" in message
-                and "read_count=0/1" in message
-                and "reader_flags=[0]" in message
-                and "local_reader_ranks=[0]" in message
+                and "read_count=1/2" in message
+                and "reader_flags=[1, 0]" in message
+                and "local_reader_ranks=[4, 7]" in message
                 and "wait_reason=awaiting_readers" in message
                 and "waited_s=" in message
-                for message in warning_messages
-            )
-        finally:
-            writer.shutdown()
-            reader.shutdown()
-
-
-def test_warning_log_includes_local_reader_rank_mapping(caplog_vllm):
-    with mock.patch(
-        "vllm.distributed.device_communicators.shm_broadcast."
-        "VLLM_RINGBUFFER_WARNING_INTERVAL",
-        new=0.001,
-    ):
-        writer = MessageQueue(
-            n_reader=2,
-            n_local_reader=2,
-            local_reader_ranks=[4, 7],
-            max_chunk_bytes=1024 * 1024,
-            max_chunks=1,
-        )
-        reader0 = MessageQueue.create_from_handle(writer.export_handle(), rank=4)
-        reader1 = MessageQueue.create_from_handle(writer.export_handle(), rank=7)
-        try:
-            writer.wait_until_ready()
-            reader0.wait_until_ready()
-            reader1.wait_until_ready()
-
-            with pytest.raises(TimeoutError):
-                reader1.dequeue(timeout=0.01)
-
-            warning_messages = [
-                record.message
-                for record in caplog_vllm.records
-                if "No available shared memory broadcast block found in 0 seconds"
-                in record.message
-            ]
-            assert warning_messages
-            assert any(
-                "role=local_reader" in message
-                and "rank=7" in message
-                and "read_count=0/2" in message
-                and "reader_flags=[0, 0]" in message
-                and "local_reader_ranks=[4, 7]" in message
-                and "local_reader_index=1" in message
-                and "local_reader_flag=0" in message
-                and "wait_reason=awaiting_write" in message
                 for message in warning_messages
             )
         finally:

--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -662,7 +662,7 @@ def test_warning_logs(caplog_vllm):
         warning_messages = [
             record.message
             for record in caplog_vllm.records
-            if "No available shared memory broadcast block found in 0 seconds"
+            if "Shared memory broadcast has not made progress in 0 seconds"
             in record.message
         ]
         assert warning_messages
@@ -687,7 +687,7 @@ def test_warning_logs(caplog_vllm):
         with pytest.raises(TimeoutError):
             reader.dequeue(timeout=0.01, indefinite=True)
         assert all(
-            "No available shared memory broadcast block found in 0 seconds"
+            "Shared memory broadcast has not made progress in 0 seconds"
             not in record.message
             for record in caplog_vllm.records
         )
@@ -725,7 +725,7 @@ def test_writer_warning_log_includes_wait_state(caplog_vllm):
             warning_messages = [
                 record.message
                 for record in caplog_vllm.records
-                if "No available shared memory broadcast block found in 0 seconds"
+                if "Shared memory broadcast has not made progress in 0 seconds"
                 in record.message
             ]
             assert warning_messages

--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -669,12 +669,15 @@ def test_warning_logs(caplog_vllm):
         assert any(
             "role=local_reader" in message
             and f"pid={os.getpid()}" in message
+            and "rank=0" in message
             and "slot=0/10" in message
             and "written_flag=0" in message
             and "read_count=0/1" in message
             and "reader_flags=[0]" in message
+            and "local_reader_ranks=[0]" in message
             and "local_reader_index=0" in message
             and "local_reader_flag=0" in message
+            and "wait_reason=awaiting_write" in message
             and "waited_s=" in message
             for message in warning_messages
         )
@@ -723,17 +726,67 @@ def test_writer_warning_log_includes_wait_state(caplog_vllm):
             assert warning_messages
             assert any(
                 "role=writer" in message
+                and "rank=unknown" in message
                 and f"pid={os.getpid()}" in message
                 and "slot=0/1" in message
                 and "written_flag=1" in message
                 and "read_count=0/1" in message
                 and "reader_flags=[0]" in message
+                and "local_reader_ranks=[0]" in message
+                and "wait_reason=awaiting_readers" in message
                 and "waited_s=" in message
                 for message in warning_messages
             )
         finally:
             writer.shutdown()
             reader.shutdown()
+
+
+def test_warning_log_includes_local_reader_rank_mapping(caplog_vllm):
+    with mock.patch(
+        "vllm.distributed.device_communicators.shm_broadcast."
+        "VLLM_RINGBUFFER_WARNING_INTERVAL",
+        new=0.001,
+    ):
+        writer = MessageQueue(
+            n_reader=2,
+            n_local_reader=2,
+            local_reader_ranks=[4, 7],
+            max_chunk_bytes=1024 * 1024,
+            max_chunks=1,
+        )
+        reader0 = MessageQueue.create_from_handle(writer.export_handle(), rank=4)
+        reader1 = MessageQueue.create_from_handle(writer.export_handle(), rank=7)
+        try:
+            writer.wait_until_ready()
+            reader0.wait_until_ready()
+            reader1.wait_until_ready()
+
+            with pytest.raises(TimeoutError):
+                reader1.dequeue(timeout=0.01)
+
+            warning_messages = [
+                record.message
+                for record in caplog_vllm.records
+                if "No available shared memory broadcast block found in 0 seconds"
+                in record.message
+            ]
+            assert warning_messages
+            assert any(
+                "role=local_reader" in message
+                and "rank=7" in message
+                and "read_count=0/2" in message
+                and "reader_flags=[0, 0]" in message
+                and "local_reader_ranks=[4, 7]" in message
+                and "local_reader_index=1" in message
+                and "local_reader_flag=0" in message
+                and "wait_reason=awaiting_write" in message
+                for message in warning_messages
+            )
+        finally:
+            writer.shutdown()
+            reader0.shutdown()
+            reader1.shutdown()
 
 
 def _fake_disk_usage(free_bytes: int):

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -106,8 +106,9 @@ LONG_WAIT_TIME_LOG_MSG = (
     "when some processes are hanging or doing some "
     "time-consuming work (e.g. compilation, "
     "weight/kv cache quantization). "
-    "Wait state: role=%s pid=%d slot=%d/%d written_flag=%d "
-    "read_count=%d/%d reader_flags=%s%s waited_s=%.3f"
+    "Wait state: role=%s rank=%s pid=%d slot=%d/%d written_flag=%d "
+    "read_count=%d/%d reader_flags=%s local_reader_ranks=%s%s "
+    "wait_reason=%s waited_s=%.3f"
 )
 
 
@@ -541,6 +542,7 @@ class MessageQueue:
         self._is_writer = True
         self._is_local_reader = False
         self.local_reader_rank = -1
+        self.rank = None
         # rank does not matter for remote readers
         self._is_remote_reader = False
 
@@ -563,6 +565,7 @@ class MessageQueue:
         self = MessageQueue.__new__(MessageQueue)
         self.handle = handle
         self._is_writer = False
+        self.rank = rank
 
         context = Context()
 
@@ -649,6 +652,12 @@ class MessageQueue:
     def _long_wait_log_args(self, role: str, metadata_buffer, waited_s: float):
         memory_fence()
         reader_flags = list(metadata_buffer[1 : self.buffer.n_reader + 1])
+        written_flag = metadata_buffer[0]
+        read_count = sum(reader_flags)
+        if self._is_writer:
+            wait_reason = "awaiting_readers"
+        else:
+            wait_reason = "awaiting_write" if not written_flag else "already_read"
         reader_state = ""
         if self._is_local_reader:
             reader_state = (
@@ -658,14 +667,17 @@ class MessageQueue:
         return (
             VLLM_RINGBUFFER_WARNING_INTERVAL,
             role,
+            self.rank if self.rank is not None else "unknown",
             os.getpid(),
             self.current_idx,
             self.buffer.max_chunks,
-            metadata_buffer[0],
-            sum(reader_flags),
+            written_flag,
+            read_count,
             self.buffer.n_reader,
             reader_flags,
+            self.handle.local_reader_ranks,
             reader_state,
+            wait_reason,
             waited_s,
         )
 
@@ -999,6 +1011,7 @@ class MessageQueue:
             max_chunk_bytes=max_chunk_bytes,
             max_chunks=max_chunks,
         )
+        buffer_io.rank = rank
         handle = buffer_io.export_handle()
         handles = [None] * dist.get_world_size(pg) if rank == reader_rank else None
         dist.gather_object(handle, handles, dst=reader_rank, group=pg)
@@ -1069,6 +1082,7 @@ class MessageQueue:
                     max_chunk_bytes=max_chunk_bytes,
                     max_chunks=max_chunks,
                 )
+            buffer_io.rank = group_rank
             handle = buffer_io.export_handle()
             if isinstance(pg, ProcessGroup):
                 dist.broadcast_object_list(

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -105,7 +105,9 @@ LONG_WAIT_TIME_LOG_MSG = (
     "in %d seconds. This typically happens "
     "when some processes are hanging or doing some "
     "time-consuming work (e.g. compilation, "
-    "weight/kv cache quantization)."
+    "weight/kv cache quantization). "
+    "Wait state: role=%s pid=%d slot=%d/%d written_flag=%d "
+    "read_count=%d/%d reader_flags=%s%s waited_s=%.3f"
 )
 
 
@@ -644,6 +646,29 @@ class MessageQueue:
         if self._spin_condition is not None:
             self._spin_condition.cancel()
 
+    def _long_wait_log_args(self, role: str, metadata_buffer, waited_s: float):
+        memory_fence()
+        reader_flags = list(metadata_buffer[1 : self.buffer.n_reader + 1])
+        reader_state = ""
+        if self._is_local_reader:
+            reader_state = (
+                f" local_reader_index={self.local_reader_rank}"
+                f" local_reader_flag={reader_flags[self.local_reader_rank]}"
+            )
+        return (
+            VLLM_RINGBUFFER_WARNING_INTERVAL,
+            role,
+            os.getpid(),
+            self.current_idx,
+            self.buffer.max_chunks,
+            metadata_buffer[0],
+            sum(reader_flags),
+            self.buffer.n_reader,
+            reader_flags,
+            reader_state,
+            waited_s,
+        )
+
     @contextmanager
     def acquire_write(self, timeout: float | None = None):
         assert self._is_writer, "Only writers can acquire write"
@@ -678,7 +703,10 @@ class MessageQueue:
                     # if we wait for a long time, log a message
                     if elapsed > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning:
                         logger.info(
-                            LONG_WAIT_TIME_LOG_MSG, VLLM_RINGBUFFER_WARNING_INTERVAL
+                            LONG_WAIT_TIME_LOG_MSG,
+                            *self._long_wait_log_args(
+                                "writer", metadata_buffer, elapsed
+                            ),
                         )
                         n_warning += 1
 
@@ -799,7 +827,12 @@ class MessageQueue:
                     # if we wait for a long time, log a message
                     if read_timeout.should_warn():
                         logger.info(
-                            LONG_WAIT_TIME_LOG_MSG, VLLM_RINGBUFFER_WARNING_INTERVAL
+                            LONG_WAIT_TIME_LOG_MSG,
+                            *self._long_wait_log_args(
+                                "local_reader",
+                                metadata_buffer,
+                                time.monotonic() - read_timeout.started,
+                            ),
                         )
 
                     continue

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -101,7 +101,7 @@ def to_bytes_big(value: int, size: int) -> bytes:
 
 
 LONG_WAIT_TIME_LOG_MSG = (
-    "No available shared memory broadcast block found "
+    "Shared memory broadcast has not made progress "
     "in %d seconds. This typically happens "
     "when some processes are hanging or doing some "
     "time-consuming work (e.g. compilation, "

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -651,8 +651,9 @@ class MessageQueue:
 
     def _long_wait_log_args(self, role: str, metadata_buffer, waited_s: float):
         memory_fence()
-        reader_flags = list(metadata_buffer[1 : self.buffer.n_reader + 1])
-        written_flag = metadata_buffer[0]
+        metadata_snapshot = list(metadata_buffer[: self.buffer.n_reader + 1])
+        written_flag = metadata_snapshot[0]
+        reader_flags = metadata_snapshot[1:]
         read_count = sum(reader_flags)
         if self._is_writer:
             wait_reason = "awaiting_readers"


### PR DESCRIPTION
## Summary

This PR fixes the ambiguous long-wait diagnostic for the `shm_broadcast` ring buffer and turns it into an actionable state snapshot.

- Identify whether the blocked process is a writer or local reader.
- Report rank (when known), PID, ring-buffer slot, and elapsed wait time.
- Report the written flag, per-reader flags, and read progress.
- Map local reader flags back to process-group ranks.
- Classify the wait as `awaiting_readers`, `awaiting_write`, or `already_read`.
- Describe the condition as a lack of broadcast progress instead of implying shared-memory exhaustion.

The metadata is captured as a best-effort snapshot after a memory fence. This is instrumentation only: it does not change queue scheduling, synchronization, warning cadence, timeout, retry, or termination behavior.

## Production value

Previously, reader and writer stalls emitted the same message:

```text
No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
```

This wording could incorrectly suggest that the shared-memory capacity was exhausted, while the actual condition may be that a producer has not published a slot or a reader has not consumed one.

A reader waiting for a writer now reports:

```text
Shared memory broadcast has not made progress in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization). Wait state: role=local_reader rank=0 pid=12345 slot=0/10 written_flag=0 read_count=0/1 reader_flags=[0] local_reader_ranks=[0] local_reader_index=0 local_reader_flag=0 wait_reason=awaiting_write waited_s=60.001
```

`written_flag=0` and `wait_reason=awaiting_write` direct investigation to the producer or worker expected to publish the slot.

A writer blocked by one reader now reports:

```text
Shared memory broadcast has not made progress in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization). Wait state: role=writer rank=unknown pid=12340 slot=0/1 written_flag=1 read_count=1/2 reader_flags=[1, 0] local_reader_ranks=[4, 7] wait_reason=awaiting_readers waited_s=60.001
```

The flag-to-rank mapping identifies rank 7 as the reader that has not consumed the slot. A directly constructed writer may not have a process-group rank; in that case the writer rank is reported as `unknown` rather than guessed.

## Diagnostic guide

| Log state | Interpretation | Next investigation |
| --- | --- | --- |
| `role=local_reader`, `written_flag=0`, `wait_reason=awaiting_write` | The current slot has not been published. | Inspect the producer/worker expected to write this slot. |
| `role=writer`, `written_flag=1`, `wait_reason=awaiting_readers` | The slot is published but at least one local reader has not consumed it. | Use `reader_flags` with `local_reader_ranks` to identify the reader to inspect. |
| `role=local_reader`, `written_flag=1`, `wait_reason=already_read` | This reader has already consumed the current slot and is waiting for the writer to advance or recycle it. | Compare all reader flags and inspect the writer or readers with an unset flag. |
| The same `slot` and flags remain unchanged across repeated logs | The shared-memory state is not making progress. | Correlate the identified process with its Python stack, GPU activity, and collective diagnostics. |
| The slot or flags change between logs | The system is making progress, but a producer or reader may be slow. | Investigate the slow process and workload before treating it as a deadlock. |

The message is emitted at info level. Emitting it does not terminate the process; existing caller timeout behavior remains unchanged. This information supports investigations such as #51921 by collecting the shared-memory state that otherwise requires a custom instrumentation build. It does not diagnose the underlying GPU, kernel, or collective failure by itself.

## Why this is not a duplicate

The related open PRs have different scopes:

- #52917 changes adaptive spin and architecture-specific waiting behavior.
- #53217 fixes an out-of-band buffer send race.

This PR does not change waiting behavior or fix either race. It only fixes the diagnostic wording and provides the state needed to distinguish a reader waiting for a writer from a writer waiting for specific readers.

## Testing

- `.venv/bin/python -m pytest tests/distributed/test_shm_broadcast.py -q -k warning` — 2 passed, 28 deselected.
- `.venv/bin/python -m pytest tests/distributed/test_shm_broadcast.py -v` — 23 passed, 1 skipped, 6 failed on macOS arm64 because existing forked distributed tests abort during MPSGraph Objective-C initialization. The modified warning tests passed.
- `pre-commit run --files vllm/distributed/device_communicators/shm_broadcast.py tests/distributed/test_shm_broadcast.py` — passed.
- `git diff --check` — passed.

## Model evaluation

Not applicable. This change only affects diagnostic logging and tests; it does not affect model output, accuracy, or serving behavior.

## AI assistance

AI assistance was used for implementation and analysis. The submitting human remains responsible for reviewing and defending every changed line and the reported test results.
