### PR TITLE
[Config] Delegate PCP compatibility checks to PCP manager

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2464,10 +2464,6 @@ class VllmConfig:
         model_config = self.model_config
         speculative_config = self.speculative_config
 
-        if self.parallel_config.prefill_context_parallel_size > 1 and not (
-            model_config is not None and model_config.use_mla
-        ):
-            unsupported.append("prefill context parallelism")
         if self.compilation_config.mode == CompilationMode.STOCK_TORCH_COMPILE:
             unsupported.append("stock torch.compile")
 


### PR DESCRIPTION
## Purpose

The generic Model Runner V2 feature check currently treats PCP as unsupported whenever the model does not use MLA. This duplicates an in-tree implementation restriction and makes it a global configuration restriction.

Some out-of-tree hardware plugins already support GQA with PCP, such as [vLLM Ascend support in vllm-project/vllm-ascend#14023](https://github.com/vllm-project/vllm-ascend/pull/14023). Because the generic validation runs before those plugins can apply their own capability checks, the global MLA requirement prevents otherwise supported plugin configurations from being used.

Remove the duplicated generic check and leave PCP model compatibility validation to the PCP manager, attention backend selection, or the owning hardware plugin. The in-tree CUDA implementation continues to reject unsupported PCP combinations through its own capability checks.

## Validation

Validated on NVIDIA H100 GPUs with `/home/weight/Qwen3-0.6B`, a GQA model configured with 16 attention heads and 8 key-value heads, using `--prefill-context-parallel-size 2 --tensor-parallel-size 1 --enforce-eager --max-model-len 1024 --gpu-memory-utilization 0.4`.

The generic configuration path accepted the combination and initialized the PCP topology with two ranks:

```text
non-default args: {'model': '/home/weight/Qwen3-0.6B', 'max_model_len': 1024, 'enforce_eager': True, 'prefill_context_parallel_size': 2, 'gpu_memory_utilization': 0.4}
DP group leader: node_rank=0, node_rank_within_dp=0, world_size=2, local_world_size=2
rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0
Using V2 Model Runner
```

The in-tree CUDA attention backend capability check then rejected this unsupported non-MLA PCP configuration:

```text
ValueError: No valid attention backend found for cuda with AttentionSelectorConfig(head_size=128, dtype=torch.bfloat16, kv_cache_dtype=auto, block_size=None, use_mla=False, has_sink=False, use_sparse=False, use_mm_prefix=False, use_per_head_quant_scales=False, attn_type=AttentionType.DECODER, has_sliding_window=False, use_non_causal=False, use_batch_invariant=False, use_kv_connector=False, use_adaptive_verification=False, use_pcp=True, use_dcp=False). Reasons: {FLASH_ATTN: [PCP not supported], FLASHINFER: [PCP not supported], TRITON_ATTN: [PCP not supported], FLEX_ATTENTION: [PCP not supported], TURBOQUANT: [kv_cache_dtype not supported, PCP not supported]}.
```
