### PR TITLE
[Bugfix][Processor] Replace bare asserts with ValueError in DeepseekVLV2/OCR processors

### DIFF
--- a/tests/models/multimodal/processing/test_deepseek_ocr.py
+++ b/tests/models/multimodal/processing/test_deepseek_ocr.py
@@ -132,3 +132,27 @@ class TestDeepseekOCREmptyImagesCrop:
                     "image_size": 1024,  # Wrong! Tensor has 640
                 },
             )
+
+
+class TestDeepseekOCRInputValidation:
+    """Bare ``assert`` used to validate user input here returned HTTP 500
+    (AssertionError) instead of HTTP 400 (ValueError) and disappeared under
+    ``python -O``, silently corrupting the tokenized sequence. See #53850.
+    """
+
+    def test_mismatched_image_count_raises_value_error(self, processor):
+        """Two ``<image>`` tokens with one image must raise ValueError, not
+        AssertionError (which would yield HTTP 500 and, under ``-O``, silently
+        drop the middle text segment)."""
+        image = Image.new("RGB", (100, 100), color="red")
+        with pytest.raises(ValueError, match="does not match number of images"):
+            processor(prompt="<image> and <image>", images=[image])
+
+    def test_missing_prompt_raises_value_error(self, processor):
+        image = Image.new("RGB", (100, 100), color="red")
+        with pytest.raises(ValueError, match="prompt and images"):
+            processor(prompt=None, images=[image])
+
+    def test_missing_images_raises_value_error(self, processor):
+        with pytest.raises(ValueError, match="prompt and images"):
+            processor(prompt="<image>\nDescribe this image.", images=None)

--- a/vllm/transformers_utils/processors/deepseek_ocr.py
+++ b/vllm/transformers_utils/processors/deepseek_ocr.py
@@ -250,9 +250,8 @@ class DeepseekOCRProcessor(ProcessorMixin):
                 - num_image_tokens (List[int]): the number of image tokens
         """
 
-        assert prompt is not None and images is not None, (
-            "prompt and images must be used at the same time."
-        )
+        if prompt is None or images is None:
+            raise ValueError("prompt and images must be used at the same time.")
 
         sft_format = prompt
 
@@ -311,7 +310,13 @@ class DeepseekOCRProcessor(ProcessorMixin):
     ):
         """Tokenize text with <image> tags."""
 
-        assert conversation.count(self.image_token) == len(images)
+        num_image_tags = conversation.count(self.image_token)
+        if num_image_tags != len(images):
+            raise ValueError(
+                f"Number of {self.image_token!r} tokens in prompt "
+                f"({num_image_tags}) does not match number of images "
+                f"({len(images)})."
+            )
         text_splits = conversation.split(self.image_token)
         images_list, images_crop_list, images_seq_mask, images_spatial_crop = (
             [],

--- a/vllm/transformers_utils/processors/deepseek_vl2.py
+++ b/vllm/transformers_utils/processors/deepseek_vl2.py
@@ -203,9 +203,8 @@ class DeepseekVLV2Processor(ProcessorMixin):
                 - num_image_tokens (list[int]): the number of image tokens
         """
 
-        assert prompt is not None and images is not None, (
-            "prompt and images must be used at the same time."
-        )
+        if prompt is None or images is None:
+            raise ValueError("prompt and images must be used at the same time.")
 
         sft_format = prompt
         (
@@ -310,7 +309,13 @@ class DeepseekVLV2Processor(ProcessorMixin):
         cropping: bool = True,
     ):
         """Tokenize text with <image> tags."""
-        assert conversation.count(self.image_token) == len(images)
+        num_image_tags = conversation.count(self.image_token)
+        if num_image_tags != len(images):
+            raise ValueError(
+                f"Number of {self.image_token!r} tokens in prompt "
+                f"({num_image_tags}) does not match number of images "
+                f"({len(images)})."
+            )
         text_splits = conversation.split(self.image_token)
         images_list, images_seq_mask, images_spatial_crop = [], [], []
         num_image_tokens = []


### PR DESCRIPTION
## Summary

`DeepseekVLV2Processor` and `DeepseekOCRProcessor` validated user-facing multimodal input with bare `assert` statements — the same class of bug fixed for the DeepSeek V3.2 encoder in #32884 and the V4 encoder in #53747, but still present in the multimodal processors.

Four sites changed:

- `vllm/transformers_utils/processors/deepseek_vl2.py:206` — `assert prompt is not None and images is not None`
- `vllm/transformers_utils/processors/deepseek_vl2.py:313` — `assert conversation.count(self.image_token) == len(images)`
- `vllm/transformers_utils/processors/deepseek_ocr.py:253` — `assert prompt is not None and images is not None`
- `vllm/transformers_utils/processors/deepseek_ocr.py:314` — `assert conversation.count(self.image_token) == len(images)`

Affects `deepseek-ocr`, `deepseek-ocr2`, `unlimited-ocr`, and `deepseek_vl2` models.

Closes #53850.

## Why this is not a duplicate

I searched open and closed issues/PRs for `deepseek_vl2 assert`, `deepseek_ocr bare assert`, `transformers_utils processors assert ValueError`, and every PR that has touched these two files. None convert these processor asserts to `ValueError`. The two related merged PRs (#32884, #53747) touched the DeepSeek **encoder/tokenizer** (`deepseek_v3_2_encoding.py`, `deepseek_v4_encoding.py`), not these multimodal **processors**.

## Why this matters

1. **Wrong HTTP status.** `AssertionError` is neither `ValueError` nor `VLLMError`, so `create_error_response` falls through to its `else` branch and returns HTTP 500 instead of HTTP 400 for malformed user input.

2. **Silent input corruption under `python -O`.** When CPython runs with `-O`, `assert` statements are removed. The image-count check in `tokenize_with_images` is the only guard for the `zip(text_splits, images)` + separate `text_splits[-1]` handling:
   - `text_splits = conversation.split(self.image_token)` yields `N+1` segments for `N` image tokens.
   - The loop pairs the first `N` segments with `N` images; `text_splits[-1]` (trailing text) is processed after the loop.
   - With the assert gone, mismatched counts silently drop or duplicate text segments and misalign images — corrupting the token sequence with no error.

## Test plan

```bash
ruff check vllm/transformers_utils/processors/deepseek_vl2.py \
          vllm/transformers_utils/processors/deepseek_ocr.py \
          tests/models/multimodal/processing/test_deepseek_ocr.py
ruff format --check <same files>
pytest tests/models/multimodal/processing/test_deepseek_ocr.py -v
```

Results:
- `ruff check`: All checks passed.
- `ruff format --check`: 3 files already formatted.
- New `TestDeepseekOCRInputValidation` class adds three regression tests covering: image-count mismatch, `prompt=None`, `images=None`. Each uses `pytest.raises(ValueError, match=...)` so an `AssertionError` (the old behavior) would fail the test.
- I also verified the changed paths in a standalone CPU harness (no GPU, no HF download): all four bad-input cases raise `ValueError` and not `AssertionError`, and the happy path still produces `input_ids`.

## AI assistance

This change was prepared with AI assistance (OpenAI opencode / glm-5.2). I reviewed every changed line, ran `ruff` and a standalone verification of the new error paths, and the human submitter (adisivaprasad) endorses and defends the change end-to-end.