### PR TITLE
Bugfix: use PCP slot mappings for PIECEWISE capture

### DIFF
--- a/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-EP.yaml
+++ b/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-EP.yaml
@@ -4,7 +4,7 @@ num_questions: 1319
 num_fewshot: 5
 max_concurrency: 100
 server_args: >-
-  --enforce-eager
+  --compilation-config '{"cudagraph_mode":"PIECEWISE"}'
   --max-model-len 4096
   --max-num-batched-tokens 32768
   --safetensors-load-strategy prefetch

--- a/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP2-PCP2-EP.yaml
+++ b/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP2-PCP2-EP.yaml
@@ -4,7 +4,7 @@ num_questions: 1319
 num_fewshot: 5
 max_concurrency: 100
 server_args: >-
-  --enforce-eager
+  --compilation-config '{"cudagraph_mode":"PIECEWISE"}'
   --max-model-len 4096
   --max-num-batched-tokens 32768
   --safetensors-load-strategy prefetch

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -17,8 +17,11 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.distributed.device_communicators import pynccl_allocator
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.input_batch import InputBuffers
+from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
 pytestmark = pytest.mark.cpu_test
 
@@ -110,6 +113,56 @@ def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
         manager.capture(create_forward_fn)
 
     mock_cuda_graph.assert_called_once()
+
+
+def test_piecewise_capture_uses_pcp_dummy_slot_mappings():
+    num_reqs = 32
+    num_tokens = 56
+    pcp_world_size = 2
+    input_buffers = InputBuffers(num_reqs, num_tokens, torch.device("cpu"))
+
+    pcp_block_tables = SimpleNamespace(
+        num_kv_cache_groups=1,
+        input_block_tables=(torch.zeros(num_reqs * 2, 1, dtype=torch.int32),),
+    )
+    pcp_manager = PCPManager(
+        pcp_world_size=pcp_world_size,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        max_num_reqs=num_reqs,
+        max_num_tokens=num_tokens,
+        block_tables=pcp_block_tables,
+    )
+
+    block_tables = MagicMock()
+    block_tables.cp_size = 1
+    block_tables.get_dummy_block_tables.return_value = ()
+    block_tables.get_dummy_slot_mappings.return_value = torch.zeros(
+        1, num_tokens, dtype=torch.int64
+    )
+    model_state = MagicMock()
+    model_state.prepare_attn.return_value = {}
+    kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[],
+    )
+
+    gpu_cudagraph_utils.prepare_inputs_to_capture(
+        num_reqs,
+        num_tokens,
+        model_state,
+        input_buffers,
+        block_tables,
+        [],
+        kv_cache_config,
+        full_cudagraph=False,
+        pcp_manager=pcp_manager,
+    )
+
+    slot_mappings = model_state.prepare_attn.call_args.args[3]
+    assert slot_mappings.shape == (1, num_tokens * pcp_world_size)
+    block_tables.get_dummy_slot_mappings.assert_not_called()
 
 
 _DECODE_QUERY_LEN = 3

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -641,7 +641,7 @@ def prepare_inputs_to_capture(
         num_reqs, num_tokens, input_buffers, max_query_len=max_query_len
     )
     input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
-    slot_mapping_provider = block_tables
+    slot_mapping_provider: BlockTables | PCPManager = block_tables
     if pcp_manager is not None:
         slot_mapping_provider = pcp_manager
     slot_mappings = slot_mapping_provider.get_dummy_slot_mappings(num_tokens)

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -641,11 +641,10 @@ def prepare_inputs_to_capture(
         num_reqs, num_tokens, input_buffers, max_query_len=max_query_len
     )
     input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
-    slot_mappings = (
-        pcp_manager.get_dummy_slot_mappings(num_tokens)
-        if pcp_manager is not None and not full_cudagraph
-        else block_tables.get_dummy_slot_mappings(num_tokens)
-    )
+    slot_mapping_provider = block_tables
+    if pcp_manager is not None:
+        slot_mapping_provider = pcp_manager
+    slot_mappings = slot_mapping_provider.get_dummy_slot_mappings(num_tokens)
     slot_mappings_by_layer = build_slot_mappings_by_layer(
         slot_mappings, kv_cache_config
     )

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -41,6 +41,7 @@ from vllm.v1.worker.utils import AttentionGroup
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+    from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
 logger = init_logger(__name__)
 
@@ -75,10 +76,6 @@ class CreateForwardFn(Protocol):
         desc: BatchExecutionDescriptor,
         warmup: bool,
     ) -> Callable[[CUDAGraphMode], None]: ...
-
-
-class PCPDummySlotMappingProvider(Protocol):
-    def get_dummy_slot_mappings(self, num_tokens: int) -> torch.Tensor: ...
 
 
 def _is_compatible(
@@ -495,7 +492,7 @@ class ModelCudaGraphManager(CudaGraphManager):
         block_tables: BlockTables,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
-        pcp_manager: PCPDummySlotMappingProvider | None = None,
+        pcp_manager: "PCPManager | None" = None,
         has_lora: bool = False,
         use_aux_hidden_state_outputs: bool = False,
         lora_capture_hook: Callable[[int, int, int], None] | None = None,
@@ -638,7 +635,7 @@ def prepare_inputs_to_capture(
     kv_cache_config: KVCacheConfig,
     full_cudagraph: bool,
     max_query_len: int | None = None,
-    pcp_manager: PCPDummySlotMappingProvider | None = None,
+    pcp_manager: "PCPManager | None" = None,
 ) -> AttentionState:
     input_batch = InputBatch.make_dummy(
         num_reqs, num_tokens, input_buffers, max_query_len=max_query_len

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -77,6 +77,10 @@ class CreateForwardFn(Protocol):
     ) -> Callable[[CUDAGraphMode], None]: ...
 
 
+class PCPDummySlotMappingProvider(Protocol):
+    def get_dummy_slot_mappings(self, num_tokens: int) -> torch.Tensor: ...
+
+
 def _is_compatible(
     desc: BatchExecutionDescriptor,
     num_reqs: int,
@@ -491,6 +495,7 @@ class ModelCudaGraphManager(CudaGraphManager):
         block_tables: BlockTables,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
+        pcp_manager: PCPDummySlotMappingProvider | None = None,
         has_lora: bool = False,
         use_aux_hidden_state_outputs: bool = False,
         lora_capture_hook: Callable[[int, int, int], None] | None = None,
@@ -540,6 +545,7 @@ class ModelCudaGraphManager(CudaGraphManager):
                 kv_cache_config,
                 full_cudagraph=desc.cg_mode == CUDAGraphMode.FULL,
                 max_query_len=desc.max_query_len,
+                pcp_manager=pcp_manager,
             )
 
             # Capture with dummy rows marked as padding.
@@ -632,12 +638,17 @@ def prepare_inputs_to_capture(
     kv_cache_config: KVCacheConfig,
     full_cudagraph: bool,
     max_query_len: int | None = None,
+    pcp_manager: PCPDummySlotMappingProvider | None = None,
 ) -> AttentionState:
     input_batch = InputBatch.make_dummy(
         num_reqs, num_tokens, input_buffers, max_query_len=max_query_len
     )
     input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
-    slot_mappings = block_tables.get_dummy_slot_mappings(num_tokens)
+    slot_mappings = (
+        pcp_manager.get_dummy_slot_mappings(num_tokens)
+        if pcp_manager is not None and not full_cudagraph
+        else block_tables.get_dummy_slot_mappings(num_tokens)
+    )
     slot_mappings_by_layer = build_slot_mappings_by_layer(
         slot_mappings, kv_cache_config
     )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -918,6 +918,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     self.block_tables,
                     self.attn_groups,
                     self.kv_cache_config,
+                    pcp_manager=self.pcp_manager,
                     has_lora=self.lora_config is not None,
                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),


### PR DESCRIPTION
## Summary

- build PIECEWISE capture slot mappings through `PCPManager` so dummy attention metadata follows the rank-major PCP layout
- cover the PCP2 mixed-batch capture shape with a focused regression test
- run both PCP GSM8K end-to-end configurations with PIECEWISE CUDA graphs

## Root cause

PIECEWISE capture created a global dummy slot mapping with `num_tokens` entries. **The PCP with `TRITON_MLA` preparation path consumes a rank-major mapping with `pcp_size * num_tokens` entries**, so mixed capture batches could fail while reshaping the mapping.

For example, the 56-token capture case with PCP2 enters `_gather_prefill_cache_inputs()` with only 56 slot-mapping entries and fails at:

```text
gathered_slot_mapping.view(pcp_size, local_num_tokens)
RuntimeError: shape '[2, 56]' is invalid for input of size 56
```

## Why the previous PCP PIECEWISE validation did not expose it

The regression coverage added by #53515 exercised PCP batch preparation and dispatch, but did not run the CUDA graph capture input preparation in `ModelCudaGraphManager.prepare_inputs_to_capture()`.

The end-to-end H20 validation also selected `FLASH_ATTN_MLA`. Its dummy capture batch was classified as pure decode, so the PCP cache-update path returned before the rank-major prefill reshape and masked the undersized mapping. Backends that classify the same dummy batch as mixed prefill/decode reach the reshape and expose the failure.

## Cross-GPU reproduction

H100 controlled A/B configuration: GLM-4.7-Flash, TP1 + PCP2 + EP, `max_num_seqs=32`, `max_num_batched_tokens=1024`, and PIECEWISE CUDA graphs.

| GPU | Attention backend | Result |
| --- | --- | --- |
| H100 | auto-selected `FLASH_ATTN_MLA` | all 11 capture sizes completed and the service became healthy |
| H100 | forced `TRITON_MLA` | reproduced `shape '[2, 56]' is invalid for input of size 56` during the first graph-memory profiling capture |
| RTX 5090 | auto-selected `TRITON_MLA` with DSV2LiteChat | reproduced the same 56-token reshape failure |

Both H100 runs used identical model, parallelism, graph, and kernel-warmup settings; only the attention backend changed. This isolates the trigger to attention-metadata dispatch rather than GPU architecture.

## Validation

GSM8K 5-shot accuracy with DSV2LiteChat, TP1 + PCP2, and `max_num_seqs=32`:

| Evaluation set | Eager | PIECEWISE | PIECEWISE vs. eager | Eager invalid | PIECEWISE invalid |
| --- | ---: | ---: | ---: | ---: | ---: |
| 32-question gate | 20/32 (62.50%) | 21/32 (65.63%) | +3.13 pp | 0 | 0 |
| Full 1,319 questions | 856/1,319 (64.90%) | 843/1,319 (63.91%) | -0.99 pp | 3 | 2 |
