### PR TITLE
[Core] KV cache: block-range eviction for live requests

### DIFF
--- a/tests/v1/core/test_kv_evict_for_request.py
+++ b/tests/v1/core/test_kv_evict_for_request.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for `KVCacheCoordinator.evict_blocks_for_request`.
+
+The primitive frees specific physical blocks from a still-alive request,
+compacting the request's block table on the scheduler side. It is the
+block-id-level free that `KVCacheManager.evict_token_range_for_request`
+builds on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import (
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+from vllm.v1.request import Request
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _make_kv_cache_config(block_size: int, num_blocks: int) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            )
+        ],
+    )
+
+
+def _make_request(
+    request_id: str,
+    prompt_token_ids: list[int],
+    block_size: int,
+    hash_fn: Callable = sha256,
+) -> Request:
+    sp = SamplingParams(max_tokens=1)
+    sp.update_from_generation_config({}, eos_token_id=100)
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=prompt_token_ids,
+        sampling_params=sp,
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(block_size, hash_fn),
+    )
+
+
+def _allocated_block_ids(manager: KVCacheManager, request_id: str) -> list[int]:
+    """First-group block IDs allocated for a request, in logical order,
+    excluding null_block sentinels."""
+    blocks = manager.coordinator.single_type_managers[0].req_to_blocks.get(
+        request_id, []
+    )
+    return [b.block_id for b in blocks if not b.is_null]
+
+
+def test_evict_blocks_compacts_block_list_no_caching():
+    """Caller frees a subset; surviving blocks shift down. Freed blocks
+    return to the free pool (their ref_cnt drops to 0)."""
+    block_size = 16
+    manager = KVCacheManager(
+        _make_kv_cache_config(block_size, num_blocks=8),
+        max_model_len=1024,
+        scheduler_block_size=block_size,
+        enable_caching=False,
+        hash_block_size=block_size,
+    )
+
+    # 4 full blocks worth of tokens (64 tokens).
+    req = _make_request("r0", [1] * 64, block_size)
+    computed, num_computed, _ = manager.get_computed_blocks(req)
+    assert num_computed == 0
+    blocks_owned = manager.allocate_slots(req, 64, 0, computed)
+    assert blocks_owned is not None
+
+    allocated = _allocated_block_ids(manager, "r0")
+    assert len(allocated) == 4, f"expected 4 allocated, got {allocated}"
+
+    # Free the middle two.
+    to_evict = [allocated[1], allocated[2]]
+    free_q = manager.block_pool.free_block_queue
+    free_before = free_q.num_free_blocks
+
+    n_freed = manager.coordinator.evict_blocks_for_request("r0", to_evict)
+    assert n_freed == 2
+
+    surviving = _allocated_block_ids(manager, "r0")
+    assert surviving == [allocated[0], allocated[3]], (
+        f"block list should be compacted to [{allocated[0]}, {allocated[3]}], "
+        f"got {surviving}"
+    )
+
+    # Freed blocks must be back in the free pool. With caching disabled
+    # each block's ref_cnt drops to 0 immediately.
+    assert free_q.num_free_blocks == free_before + 2
+
+    # Request must remain alive.
+    manager.free(req)
+
+
+def test_evict_blocks_idempotent_on_unknown_ids():
+    """Block IDs not in the request's table are silently skipped."""
+    block_size = 16
+    manager = KVCacheManager(
+        _make_kv_cache_config(block_size, num_blocks=8),
+        max_model_len=1024,
+        scheduler_block_size=block_size,
+        enable_caching=False,
+        hash_block_size=block_size,
+    )
+    req = _make_request("r1", [1] * 32, block_size)
+    computed, _, _ = manager.get_computed_blocks(req)
+    manager.allocate_slots(req, 32, 0, computed)
+    allocated = _allocated_block_ids(manager, "r1")
+
+    # Block ID 999 is not in this request's table.
+    n_freed = manager.coordinator.evict_blocks_for_request("r1", [999, 999, 999])
+    assert n_freed == 0
+    assert _allocated_block_ids(manager, "r1") == allocated
+    manager.free(req)
+
+
+def test_evict_blocks_empty_inputs_are_noop():
+    block_size = 16
+    manager = KVCacheManager(
+        _make_kv_cache_config(block_size, num_blocks=8),
+        max_model_len=1024,
+        scheduler_block_size=block_size,
+        enable_caching=False,
+        hash_block_size=block_size,
+    )
+    req = _make_request("r2", [1] * 32, block_size)
+    manager.allocate_slots(req, 32, 0, manager.get_computed_blocks(req)[0])
+    allocated = _allocated_block_ids(manager, "r2")
+
+    assert manager.coordinator.evict_blocks_for_request("r2", []) == 0
+    missing = manager.coordinator.evict_blocks_for_request("nonexistent-req", [1, 2, 3])
+    assert missing == 0
+    assert _allocated_block_ids(manager, "r2") == allocated
+    manager.free(req)
+
+
+def test_evict_blocks_with_caching_removes_from_prefix_cache():
+    """When caching is on, evicted blocks must be removed from the
+    prefix-cache hash map so future requests don't hit stale K/V."""
+    block_size = 16
+    manager = KVCacheManager(
+        _make_kv_cache_config(block_size, num_blocks=8),
+        max_model_len=1024,
+        scheduler_block_size=block_size,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    # Allocate 3 full blocks of identical tokens — guaranteed hashable.
+    req = _make_request("r3", [1] * 48, block_size)
+    computed, _, _ = manager.get_computed_blocks(req)
+    manager.allocate_slots(req, 48, 0, computed)
+    allocated = _allocated_block_ids(manager, "r3")
+    assert len(allocated) == 3
+
+    # Free the middle block. After eviction it must be neither in
+    # `cached_block_hash_to_block` nor have a block_hash.
+    middle_id = allocated[1]
+    pre_hash_count = len(manager.block_pool.cached_block_hash_to_block)
+
+    n_freed = manager.coordinator.evict_blocks_for_request("r3", [middle_id])
+    assert n_freed == 1
+    assert manager.block_pool.blocks[middle_id].block_hash is None
+    assert len(manager.block_pool.cached_block_hash_to_block) < pre_hash_count, (
+        "evicted block should have left the prefix-cache hash map"
+    )
+
+    # Surviving list is compacted.
+    assert _allocated_block_ids(manager, "r3") == [allocated[0], allocated[2]]
+    manager.free(req)
+
+
+def test_evict_blocks_then_continue_allocating():
+    """After eviction the request must still be allocatable (still alive)."""
+    block_size = 16
+    manager = KVCacheManager(
+        _make_kv_cache_config(block_size, num_blocks=8),
+        max_model_len=1024,
+        scheduler_block_size=block_size,
+        enable_caching=False,
+        hash_block_size=block_size,
+    )
+    req = _make_request("r4", [1] * 48, block_size)
+    manager.allocate_slots(req, 48, 0, manager.get_computed_blocks(req)[0])
+    allocated_before = _allocated_block_ids(manager, "r4")
+    assert len(allocated_before) == 3
+
+    # Drop the oldest.
+    manager.coordinator.evict_blocks_for_request("r4", [allocated_before[0]])
+    after_evict = _allocated_block_ids(manager, "r4")
+    assert len(after_evict) == 2
+
+    # Append more tokens; allocator should hand us a fresh block on top
+    # of the surviving two.
+    req.num_computed_tokens = 32  # 2 surviving blocks worth.
+    req._all_token_ids.extend([2] * 16)
+    req.prompt_token_ids = list(req._all_token_ids)
+    manager.allocate_slots(req, 16, 0)
+    after_grow = _allocated_block_ids(manager, "r4")
+    assert len(after_grow) == 3, f"expected 3 blocks after re-growth, got {after_grow}"
+    manager.free(req)

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -351,6 +351,16 @@ class KVCacheCoordinator(ABC):
             blocks.extend(manager.pop_blocks_for_free(request_id))
         return blocks
 
+    def evict_blocks_for_request(self, request_id: str, block_ids: list[int]) -> int:
+        """Free a subset of the request's blocks; request stays alive.
+
+        Used by streaming-video intra-session eviction.
+        """
+        total_freed = 0
+        for manager in self.single_type_managers:
+            total_freed += manager.evict_blocks_for_request(request_id, block_ids)
+        return total_freed
+
     def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
         """
         Get the number of common prefix blocks for all requests with allocated

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -627,6 +627,55 @@ class KVCacheManager:
         """
         self.block_pool.evict_blocks(block_ids)
 
+    def evict_token_range_for_request(
+        self, request_id: str, token_start: int, token_end: int
+    ) -> tuple[int, int, int]:
+        """Convenience wrapper: evict the block-aligned span overlapping
+        the token range `[token_start, token_end)` on the first kv-cache
+        group, then free those blocks via the coordinator.
+
+        Uses **inward** block alignment: only whole blocks fully within
+        `[token_start, token_end)` are freed. Block-aligned edges are
+        important so the caller can slice its per-token arrays
+        (`_all_token_ids`, and per-request position arrays if the model
+        tracks them explicitly) by the SAME range that was freed
+        from the block table — otherwise the two go out of sync and the
+        request's prompt grows past the worker's
+        `max_model_len`-sized buffers.
+
+        Returns `(aligned_start, aligned_end, num_blocks_freed)` where
+        `aligned_start` and `aligned_end` describe the token range that
+        was actually evicted (block-aligned, possibly narrower than
+        `[token_start, token_end)`). Callers MUST use this returned
+        range — not the original — when compacting their own per-token
+        arrays in lockstep with the KV cache.
+        """
+        assert len(self.coordinator.single_type_managers) == 1, (
+            "evict_token_range_for_request derives block ids from kv-cache "
+            "group 0 only; fanning them to multiple groups is unsound. "
+            "Callers must ensure a single-group (non-hybrid) config."
+        )
+        if token_end <= token_start:
+            return token_start, token_start, 0
+        first = self.coordinator.single_type_managers[0]
+        block_size = first.block_size
+        block_idx_start = (token_start + block_size - 1) // block_size
+        block_idx_end = token_end // block_size
+        if block_idx_end <= block_idx_start:
+            return token_start, token_start, 0
+        req_blocks = first.req_to_blocks.get(request_id)
+        if not req_blocks:
+            return token_start, token_start, 0
+        aligned_start = block_idx_start * block_size
+        aligned_end = block_idx_end * block_size
+        block_ids = [
+            req_blocks[i].block_id
+            for i in range(block_idx_start, min(block_idx_end, len(req_blocks)))
+            if not req_blocks[i].is_null
+        ]
+        num_freed = self.coordinator.evict_blocks_for_request(request_id, block_ids)
+        return aligned_start, aligned_end, num_freed
+
     def reset_prefix_cache(self) -> bool:
         """Reset prefix cache. This function may be used in RLHF
         flows to invalidate prefix caching after the weights are updated,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -523,6 +523,61 @@ class SingleTypeKVCacheManager(ABC):
         # Free blocks in reverse order so that the tail blocks are freed first.
         self.block_pool.free_blocks(reversed(self.pop_blocks_for_free(request_id)))
 
+    def evict_blocks_for_request(self, request_id: str, block_ids: list[int]) -> int:
+        """Free a subset of the request's blocks while the request stays alive.
+
+        Used for intra-session eviction in long-running streaming
+        sessions (StreamingLLM-style sink+window for text, sliding-window
+        video, or any policy that retires a token range of a live
+        request). The primitive is modality-agnostic: it operates on
+        blocks and token ranges only.
+
+        `num_cached_block` is decremented by the count of evicted blocks
+        that had a hash (i.e., were prefix-cacheable).
+
+        Args:
+            request_id: The request to evict from.
+            block_ids: Physical block IDs to free. Need not be in any
+                particular order; the function looks them up in
+                `req_to_blocks`. Caller is responsible for selecting a
+                contiguous range that corresponds to a session segment.
+
+        Returns:
+            Number of blocks whose memory was actually reclaimed, i.e.
+            blocks that reached `ref_cnt == 0` and were returned to the
+            free queue. Blocks still shared with another request
+            (`ref_cnt > 0` after the dereference) are dropped from this
+            request's table but NOT counted, since their memory is not
+            reclaimed.
+        """
+        req_blocks = self.req_to_blocks.get(request_id)
+        if not req_blocks or not block_ids:
+            return 0
+        block_id_set = set(block_ids)
+        surviving: list[KVCacheBlock] = []
+        blocks_to_free: list[KVCacheBlock] = []
+        for block in req_blocks:
+            if block.block_id in block_id_set and not block.is_null:
+                blocks_to_free.append(block)
+            else:
+                surviving.append(block)
+        if not blocks_to_free:
+            return 0
+        self.req_to_blocks[request_id] = surviving
+        # Free in reverse order so the tail blocks (most recently allocated)
+        # are evicted first — matches the LRU convention in `free`.
+        self.block_pool.free_blocks(reversed(blocks_to_free))
+        if self.enable_caching:
+            # Count cached blocks BEFORE evict_blocks clears their hashes.
+            cached_freed = sum(1 for b in blocks_to_free if b.block_hash is not None)
+            self.block_pool.evict_blocks({b.block_id for b in blocks_to_free})
+            if cached_freed and request_id in self.num_cached_block:
+                self.num_cached_block[request_id] = max(
+                    0, self.num_cached_block[request_id] - cached_freed
+                )
+
+        return sum(1 for b in blocks_to_free if b.ref_cnt == 0)
+
     @abstractmethod
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """


### PR DESCRIPTION
## Purpose

Add a primitive to free a block-aligned range of KV cache from a request that is
still running. Today blocks are only freed when a request finishes; a long-running
streaming-input session (#28973) therefore grows its KV without bound. This PR adds
the missing operation, with no policy attached and no consumer yet in-tree — the
retention policy that uses it follows in the next PR of this series (RFC #51948).
I split it out because it is the only part that touches the KV-cache managers, so it
can be reviewed on its own.

Three layers, matching the existing KV stack:

- `SingleTypeKVCacheManager.evict_blocks_for_request(request_id, block_ids) -> int`:
  removes the given blocks from a live request's block table, returns them to the
  free pool, and removes them from the prefix-cache index so their old content can
  never be matched by another request. Keeps `num_cached_block` consistent. Returns
  how many blocks were actually reclaimed — a block still shared with another
  request is dropped from this request's table but not counted, since its memory is
  not free.
- `KVCacheCoordinator.evict_blocks_for_request`: fan-out per group, same as the
  other coordinator methods.
- `KVCacheManager.evict_token_range_for_request(request_id, start, end)
  -> (aligned_start, aligned_end, num_freed)`: the caller-facing form. Callers think
  in tokens, memory lives in blocks, so the range is rounded INWARD to whole blocks
  and the function returns the range it actually freed. The contract is that the
  caller compacts its own per-token bookkeeping by exactly the returned range, so
  the block table and the token arrays cannot drift apart. Hybrid models (multiple
  KV groups with different block sizes) are rejected with an assert instead of
  fanning one token range to groups it cannot align to.

No behavior change for anything that does not call it. Besides streaming video
sessions, the same primitive works for StreamingLLM-style sink+window text sessions
or for pruning stale tool-call context out of a live request.

## Test Plan

pytest tests/v1/core/test_kv_evict_for_request.py

Five tests: block-list compaction without caching, freed-count vs. blocks shared
with a second request, removal from the prefix-cache index, no-op on unknown ids /
empty inputs, and continuing to allocate for the same request after an eviction.

## Test Result

- 5/5 new tests pass.
- `tests/v1/core/` failure set is identical to main on the same machine (the PR is
  purely additive).

---
Portions of this work were developed with AI assistance; all of it has been
reviewed and tested by me.
