### PR TITLE
[Build] Skip phantom outputs in strict editable installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -460,6 +460,20 @@ class cmake_build_ext(build_ext):
                     dirs_exist_ok=True,
                 )
 
+    def get_outputs(self):
+        # Some CMake extensions (e.g. _deep_gemm_C) compile into a vendored
+        # package instead of a top-level `.so`, so their nominal output path
+        # never exists. Filter those out so strict editable installs don't try
+        # to copy a phantom artifact.
+        return [f for f in super().get_outputs() if os.path.exists(f)]
+
+    def get_output_mapping(self):
+        return {
+            src: dst
+            for src, dst in super().get_output_mapping().items()
+            if os.path.exists(src)
+        }
+
 
 class precompiled_build_ext(build_ext):
     """Disables extension building when using precompiled binaries."""


### PR DESCRIPTION
## Summary

Optional CMake extensions (e.g. `_deep_gemm_C`, `_flashmla_C`,
`_flashmla_extension_C`, `_qutlass_C`) are declared in `ext_modules` but do not
always produce a top-level `.so`: some are skipped on unsupported architectures,
and others compile into a vendored package instead of a standalone shared object.

In a **strict editable install**:

```bash
pip install -e . --config-settings editable_mode=strict
```

setuptools iterates `build_ext.get_outputs()` and `build_ext.get_output_mapping()`
to construct the strict-mode mirror tree, and fails when a declared extension's
nominal output path does not exist (a "phantom" artifact).

This PR overrides both methods on `cmake_build_ext` to filter out entries whose
source path is missing, so strict editable installs succeed without attempting to
copy phantom artifacts. Non-strict (lax) editable installs and wheel builds are
unaffected, since they do not rely on this mapping.

## Why this is not a duplicate

- `gh pr list --repo vllm-project/vllm --search "strict editable"` and
  `--search "get_output_mapping"` returned no PR touching this code path.
- `git grep get_output_mapping / get_outputs -- setup.py` on the latest
  `vllm-project/vllm` `main` shows `cmake_build_ext` has no such override.

## Test commands run and results

- `python -c "import ast; ast.parse(open('setup.py').read())"` — parses OK.
- Line-length check on the edited region — no lines exceed 88 chars.
- Reviewed the change line-by-line; behavior is a no-op for lax editable and
  wheel builds (they do not consume `get_output_mapping`), and only filters
  non-existent paths for strict editable builds.

## Model evaluation

N/A — this is a build-system-only change; it does not affect model output,
accuracy, or serving.

## AI assistance

AI assistance (GitHub Copilot) was used to draft this change; the human submitter
reviewed every changed line and understands/defends it end-to-end.
