### PR TITLE
[Perf][GLM5.2] Fuse sparse MLA Q concatenation with head padding

### DIFF
--- a/tests/kernels/test_concat_mla_q.py
+++ b/tests/kernels/test_concat_mla_q.py
@@ -34,6 +34,17 @@ def test_concat_mla_q_contiguous(num_tokens, num_heads, nope_dim, rope_dim, dtyp
     torch.testing.assert_close(q_out, ref, atol=0, rtol=0)
 
 
+def test_concat_mla_q_padded_output_heads():
+    """The fused concat can write directly into a head-padded workspace."""
+    ql_nope = torch.randn(4, 8, 512, dtype=torch.bfloat16, device="cuda")
+    q_pe = torch.randn(4, 8, 64, dtype=torch.bfloat16, device="cuda")
+    q_out = torch.empty(4, 64, 576, dtype=torch.bfloat16, device="cuda")
+
+    ops.concat_mla_q(ql_nope, q_pe, q_out)
+
+    torch.testing.assert_close(q_out[:, :8], torch.cat((ql_nope, q_pe), dim=-1))
+
+
 @pytest.mark.parametrize("num_tokens", [t for t in NUM_TOKENS if t > 1])
 @pytest.mark.parametrize("num_heads", NUM_HEADS)
 @pytest.mark.parametrize("nope_dim", NOPE_DIM)

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -824,18 +824,20 @@ def test_flashmla_forward_bf16_kv_slices_req_id_to_mqa_tokens():
 
     captured = {}
 
-    def _stub_kernel(q, kv, indices, lengths):
+    def _stub_kernel(q, kv, indices, lengths, actual_num_heads):
         captured["indices"] = indices
+        captured["actual_num_heads"] = actual_num_heads
         return torch.zeros(q.shape[0], q.shape[1], 512, dtype=q.dtype, device=q.device)
 
     stub_impl = SimpleNamespace(_bf16_flash_mla_kernel=_stub_kernel)
 
     out = FlashMLASparseImpl._forward_bf16_kv(
-        stub_impl, q, kv_cache, topk_indices, attn_metadata
+        stub_impl, q, kv_cache, topk_indices, attn_metadata, q.shape[1]
     )
 
     assert out.shape[0] == num_mqa_tokens
     assert captured["indices"].shape[0] == num_mqa_tokens
+    assert captured["actual_num_heads"] == q.shape[1]
     reference = _triton_convert_reference_impl(
         attn_metadata.req_id_per_token[:num_mqa_tokens],
         attn_metadata.block_table,

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -587,7 +587,14 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
 
         vllm_config = get_current_vllm_config()
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        q_concat_shape = (max_tokens, num_heads, head_size)
+        q_concat_heads = num_heads
+        if not is_quantized_kv_cache(kv_cache_dtype):
+            q_concat_heads = (
+                (num_heads + self.prefill_padding - 1)
+                // self.prefill_padding
+                * self.prefill_padding
+            )
+        q_concat_shape = (max_tokens, q_concat_heads, head_size)
         if is_quantized_kv_cache(kv_cache_dtype):
             assert kv_cache_dtype == "fp8_ds_mla", (
                 "FlashMLA Sparse Attention backend fp8 only supports "
@@ -626,6 +633,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
+        actual_num_heads: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # Convert per-request indices to global slots (decode) or workspace
         # offsets (prefill). req_id_per_token covers the whole batch; slice it
@@ -648,6 +656,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
             kv_rows,
             topk_indices,
             topk_length,
+            actual_num_heads,
         )
 
     def _forward_fp8_kv_separate_prefill_decode(
@@ -880,6 +889,7 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         kv_c_and_k_pe_cache: torch.Tensor,
         topk_indices: torch.Tensor,
         topk_length: torch.Tensor | None = None,
+        actual_num_heads: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         num_tokens = q.shape[0]
         kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(
@@ -889,13 +899,14 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         # NOTE(Chen): kernel requires num_local_head to be a multiple of
         # 64 on hopper and 128 on blackwell. Pad from q's head count, not
         # self.num_heads: under DCP the heads are all-gathered before this.
-        actual_num_heads = q.shape[1]
+        if actual_num_heads is None:
+            actual_num_heads = q.shape[1]
         padded_num_heads = (
             (actual_num_heads + self.prefill_padding - 1)
             // self.prefill_padding
             * self.prefill_padding
         )
-        if actual_num_heads < padded_num_heads:
+        if q.shape[1] < padded_num_heads:
             logger.warning_once(
                 f"Padding num_heads from {actual_num_heads} to "
                 f"{padded_num_heads} for BF16 sparse prefill kernel"
@@ -928,10 +939,13 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         # MQA 576/512 approach for both prefill and decode
 
         # Concatenate q if it's a tuple (ql_nope, q_pe)
+        actual_num_heads = self.num_heads
         if isinstance(q, tuple):
             ql_nope, q_pe = q
             q = self.q_concat_buffer[: ql_nope.shape[0]]
             ops.concat_mla_q(ql_nope, q_pe, q)
+        else:
+            actual_num_heads = q.shape[1]
 
         num_actual_toks = q.shape[0]
 
@@ -945,7 +959,11 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
 
         if not use_fp8_cache:
             attn_out, bf16_lse = self._forward_bf16_kv(
-                q, kv_c_and_k_pe_cache, topk_indices, attn_metadata
+                q,
+                kv_c_and_k_pe_cache,
+                topk_indices,
+                attn_metadata,
+                actual_num_heads,
             )
             if self.need_to_return_lse_for_decode:
                 lse = bf16_lse


### PR DESCRIPTION



## Purpose
[Perf][GLM5.2] Fuse sparse MLA Q concatenation with head padding
## Test Plan
```
vllm serve zai-org/GLM-5.2-FP8 \
  --load-format instanttensor \
  --tensor-parallel-size 8 \
  --gpu-memory-utilization 0.9 \
  -ep \
  --trust-remote-code  --max-num-batched-tokens 16384 \
  --attention-backend FLASHMLA_SPARSE \
  --port 8000 --no-enable-prefix-caching --max-model-len 131072

```
## Test Result
```
vllm bench serve \
  --backend vllm --model zai-org/GLM-5.2-FP8 \
  --endpoint /v1/completions --dataset-name random \
  --random-input-len 1024 --random-output-len 128 \
  --num-prompts 32 --max-concurrency 32 --request-rate inf \
  --ignore-eos --temperature 0 --seed 12345
```

main:
```
Worker_TP0_EP0 pid=2347933) WARNING 08-26 20:03:35 [flashmla_sparse.py:899] Padding num_heads from 8 to 64 for BF16 sparse prefill kernel
```
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  9.92      
Total input tokens:                      32768     
Total generated tokens:                  4096      
Request throughput (req/s):              3.23      
Output token throughput (tok/s):         413.04    
Peak output token throughput (tok/s):    928.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          3717.33   
---------------Time to First Token----------------
Mean TTFT (ms):                          4229.27   
Median TTFT (ms):                        4307.78   
P99 TTFT (ms):                           5489.92   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          44.63     
Median TPOT (ms):                        44.03     
P99 TPOT (ms):                           66.48     
---------------Inter-token Latency----------------
Mean ITL (ms):                           44.63     
Median ITL (ms):                         35.15     
P99 ITL (ms):                            38.04     
==================================================

```

this pr
```
No WARNING
```
```
============ Serving Benchmark Result ============
Successful requests:                     32        
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  9.35      
Total input tokens:                      32768     
Total generated tokens:                  4096      
Request throughput (req/s):              3.42      
Output token throughput (tok/s):         437.95    
Peak output token throughput (tok/s):    960.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          3941.55   
---------------Time to First Token----------------
Mean TTFT (ms):                          3827.53   
Median TTFT (ms):                        3905.73   
P99 TTFT (ms):                           5063.13   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.36     
Median TPOT (ms):                        42.76     
P99 TPOT (ms):                           64.94     
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.36     
Median ITL (ms):                         34.07     
P99 ITL (ms):                            36.43     
==================================================

```
```
lm_eval run \
  --model local-completions \
  --model_args model=zai-org/GLM-5.2-FP8,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=64,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size 1 \
  --gen_kwargs temperature=0 \
  --output_path /home/chauncey/vllm/downloads/glm52_profile/gsm8k_lm_eval \
  --log_samples \
  --seed 12345

```
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9393|±  |0.0066|
|     |       |strict-match    |     5|exact_match|↑  |0.9386|±  |0.0066|
```


```
nvidia-smi \
  --query-gpu=timestamp,index,memory.used \
  --format=csv,noheader,nounits \                
  -lms 20 > memory_before.csv

```

main:
```

idle:

GPU  0 peak: 128397 MiB
GPU  1 peak: 128397 MiB
GPU  2 peak: 128397 MiB
GPU  3 peak: 128397 MiB
GPU  4 peak: 128397 MiB
GPU  5 peak: 128397 MiB
GPU  6 peak: 128397 MiB
GPU  7 peak: 128397 MiB

mem peak:

GPU  0 peak: 131753 MiB
GPU  1 peak: 131753 MiB
GPU  2 peak: 131753 MiB
GPU  3 peak: 131753 MiB
GPU  4 peak: 131753 MiB
GPU  5 peak: 131753 MiB
GPU  6 peak: 131753 MiB
GPU  7 peak: 131753 MiB

```


this pr


```
nvidia-smi \
  --query-gpu=timestamp,index,memory.used \
  --format=csv,noheader,nounits \                
  -lms 20 > memory_aftercsv
```
```
idle:
GPU  0 peak: 128397 MiB
GPU  1 peak: 128397 MiB
GPU  2 peak: 128397 MiB
GPU  3 peak: 128397 MiB
GPU  4 peak: 128397 MiB
GPU  5 peak: 128397 MiB
GPU  6 peak: 128397 MiB
GPU  7 peak: 128397 MiB

mem peak:
GPU  0 peak: 132785 MiB
GPU  1 peak: 132785 MiB
GPU  2 peak: 132785 MiB
GPU  3 peak: 132785 MiB
GPU  4 peak: 132785 MiB
GPU  5 peak: 132785 MiB
GPU  6 peak: 132785 MiB
GPU  7 peak: 132785 MiB


```

GPU memory profiling (20 ms nvidia-smi sampling, TP=8):

| Metric | main | this PR | delta |
|---|---:|---:|---:|
| Idle memory / GPU | 128397 MiB | 128397 MiB | 0 MiB |
| Peak memory / GPU | 131753 MiB | 132785 MiB | +1032 MiB |
| Peak - idle | 3356 MiB | 4388 MiB | +1032 MiB |



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

