### PR TITLE
[Bugfix] Resolve callable hf_overrides in get_quant_config

### DIFF
--- a/tests/model_executor/test_resolve_hf_overrides_for_quant.py
+++ b/tests/model_executor/test_resolve_hf_overrides_for_quant.py
@@ -1,0 +1,31 @@
+import pytest
+
+from vllm.model_executor.model_loader.weight_utils import (
+    resolve_hf_overrides_for_quant,
+)
+
+
+def test_dict_passthrough():
+    assert resolve_hf_overrides_for_quant({"a": 1}) == {"a": 1}
+
+
+def test_none_becomes_empty():
+    assert resolve_hf_overrides_for_quant(None) == {}
+
+
+def test_callable_with_hf_config():
+    def compose(cfg):
+        return {"quantization_config_dict_json": cfg}
+
+    assert resolve_hf_overrides_for_quant(compose, hf_config="draft") == {
+        "quantization_config_dict_json": "draft"
+    }
+
+
+def test_callable_zero_arg():
+    assert resolve_hf_overrides_for_quant(lambda: {"k": 1}) == {"k": 1}
+
+
+def test_invalid_type_still_raises():
+    with pytest.raises(ValueError, match="must be a dict"):
+        resolve_hf_overrides_for_quant(["not-a-dict"])

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -236,6 +236,34 @@ def convert_bin_to_safetensor_file(
             raise RuntimeError(f"The output tensors do not match for key {k}")
 
 
+def resolve_hf_overrides_for_quant(
+    hf_overrides: Any,
+    hf_config: Any = None,
+) -> dict[str, Any]:
+    """Materialize ModelConfig.hf_overrides for get_quant_config.
+
+    Speculative draft configs may store a callable (compose_draft_hf_overrides)
+    instead of a dict. Invoke it; keep raising for other non-dict types.
+    """
+    if callable(hf_overrides):
+        try:
+            hf_overrides = hf_overrides(hf_config)
+        except TypeError:
+            try:
+                hf_overrides = hf_overrides()
+            except TypeError:
+                hf_overrides = {}
+    if hf_overrides is None:
+        return {}
+    if not isinstance(hf_overrides, dict):
+        raise ValueError(
+            "hf_overrides must be a dict (or callable returning a dict) "
+            "for get_quant_config to get the quantization config from it; "
+            f"got {type(hf_overrides).__name__}"
+        )
+    return hf_overrides
+
+
 # TODO(woosuk): Move this to other place.
 def get_quant_config(
     model_config: ModelConfig, load_config: LoadConfig
@@ -288,12 +316,10 @@ def get_quant_config(
 
     # if hf_quant_config is None, we will try to get config from
     # hf_overrides
-    hf_overrides = model_config.hf_overrides
-    if not isinstance(hf_overrides, dict):
-        raise ValueError(
-            "hf_overrides must be a dict for get_quant_config "
-            "to get the quantization config from it."
-        )
+    hf_overrides = resolve_hf_overrides_for_quant(
+        model_config.hf_overrides,
+        getattr(model_config, "hf_config", None),
+    )
     quantization_config_file = hf_overrides.get("quantization_config_file", None)
     if quantization_config_file is not None:
         if hasattr(quant_cls, "from_config_file"):


### PR DESCRIPTION
## Purpose

`get_quant_config` required `ModelConfig.hf_overrides` to be a dict. Speculative draft configs store `compose_draft_hf_overrides` (a **callable**), so `--speculative-config '{"method":"dflash","quantization":"fp8",...}'` died with:

```
ValueError: hf_overrides must be a dict for get_quant_config to get the quantization config from it.
```

That blocked online FP8/W8 of a BF16 DFlash draft on Ampere (2×3090, vLLM 0.27.1, Qwen3.8-27B AWQ + DFlash2).

## Test Plan

- [x] Unit: `resolve_hf_overrides_for_quant` — dict passthrough, `None`→`{}`, callable with config, zero-arg callable, invalid type still raises.
- [ ] CI: `tests/model_executor/test_resolve_hf_overrides_for_quant.py`
- Repro (GPU, optional): DFlash + `quantization=fp8` no longer hits this ValueError (Marlin pack `K=0` on DFlash grouped-conv is a **separate** issue).

Fixes part of https://github.com/vllm-project/vllm/issues/53873

## (Optional) Documentation Update
N/A — bugfix only.