### PR TITLE
[Bugfix][KV Connector] Avoid blocking on a full event queue

### DIFF
--- a/tests/distributed/test_events.py
+++ b/tests/distributed/test_events.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import threading
 import time
+from queue import Queue
 
 import msgspec
 import pytest
@@ -10,6 +11,7 @@ from vllm.distributed.kv_events import (
     EventBatch,
     EventPublisherFactory,
     NullEventPublisher,
+    ZmqEventPublisher,
 )
 
 DP_RANK = 0
@@ -72,6 +74,30 @@ def test_multiple_events(publisher, subscriber):
     assert len(received) == 10, "Number of messages mismatch"
     seqs = [seq for seq, _ in received]
     assert seqs == list(range(10)), "Sequence numbers mismatch"
+
+
+def test_publish_does_not_block_when_event_queue_is_full():
+    publisher = object.__new__(ZmqEventPublisher)
+    publisher._running = True
+    publisher._data_parallel_rank = DP_RANK
+    publisher._event_queue = Queue(maxsize=1)
+    queued_events = create_test_events(1)
+    publisher._event_queue.put_nowait(queued_events)
+
+    publish_thread = threading.Thread(
+        target=publisher.publish, args=(create_test_events(1),), daemon=True
+    )
+    publish_thread.start()
+    try:
+        publish_thread.join(timeout=1.0)
+        assert not publish_thread.is_alive(), (
+            "publish must not block inference when the event queue is full"
+        )
+        assert publisher._event_queue.get_nowait() is queued_events
+    finally:
+        if not publisher._event_queue.empty():
+            publisher._event_queue.get_nowait()
+        publish_thread.join(timeout=1.0)
 
 
 def test_replay_mechanism(publisher, subscriber):

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -264,8 +264,8 @@ class EventPublisher(ABC):
     def publish(self, events: EventBatch) -> None:
         """Emit events in order.
 
-        Implementations should guarantee at-least-once delivery and
-        monotonic ordering (e.g., via sequence numbers).
+        Implementations must not block inference indefinitely and should
+        preserve monotonic ordering for delivered events.
         """
 
     @abstractmethod
@@ -374,7 +374,14 @@ class ZmqEventPublisher(EventPublisher):
             raise RuntimeError("Publisher is closed")
         if events.data_parallel_rank is None:
             events.data_parallel_rank = self._data_parallel_rank
-        self._event_queue.put(events)
+        try:
+            self._event_queue.put_nowait(events)
+        except queue.Full:
+            logger.warning_once(
+                "KV event queue is full (%d items); dropping event batch "
+                "to avoid blocking inference",
+                self._event_queue.maxsize,
+            )
 
     def shutdown(self) -> None:
         """Stop the publisher thread and clean up resources."""


### PR DESCRIPTION
## Motivation

Fixes #53859.

`ZmqEventPublisher.publish()` currently uses blocking `Queue.put()`. If the
publisher thread stalls and the bounded queue fills, the EngineCore thread can
block indefinitely while publishing KV events. Because EngineCore stops making
progress, the frontend can later wedge in `shm_broadcast` as well.

## Modification

- Enqueue KV event batches with `put_nowait()`.
- When the queue is full, drop the new batch and emit a rate-limited warning.
- Update the publisher contract: delivered events remain ordered, but event
  delivery must not block inference indefinitely.
- Add a regression test that fills a one-item queue, calls `publish()` from a
  daemon thread, and verifies that it returns without replacing the already
  queued event.

Dropping the new batch preserves the order of batches that have already been
accepted by the queue. Consumers can recover missing state through the existing
replay/resynchronization mechanisms.

## Duplicate check

I searched issue comments and open/closed pull requests for `#53859`,
`ZmqEventPublisher queue full`, `event publisher backpressure`, and
`put_nowait Full kv events` before submitting.

#52857 touches the same publisher, but it only prevents `queue.Full` from
interrupting `shutdown()` while inserting the wake-up sentinel. It does not
change the blocking `publish()` path addressed here.

## Test results

Before the fix, the focused regression remains blocked after the one-second
join and fails the non-blocking assertion.

After the fix:

```text
.venv/bin/python -m pytest --confcutdir=tests/distributed \
  tests/distributed/test_events.py::test_publish_does_not_block_when_event_queue_is_full -vv
1 passed

.venv/bin/python -m pytest --confcutdir=tests/distributed \
  tests/distributed/test_events.py -vv
11 passed

pre-commit: all applicable hooks passed
git diff --check: passed
```

Model evaluation is not applicable because this changes publisher
backpressure behavior and does not touch model execution or output values.

## AI usage disclosure

AI assisted with implementation suggestions and test preparation. I reviewed
every changed line, understand the failure mode and implementation, and accept
responsibility for maintenance and reviewer follow-up.

