### PR TITLE
[Bugfix] Make Gemma4 MTP suppress_tokens masking CUDA-graph-safe

### DIFF
--- a/vllm/model_executor/models/gemma4_mtp.py
+++ b/vllm/model_executor/models/gemma4_mtp.py
@@ -524,6 +524,10 @@ class Gemma4MTP(nn.Module):
         draft_cfg = speculative_config.draft_model_config
         gen_cfg = draft_cfg.try_get_generation_config()
         self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
+        # Materialized on-device in load_weights: compute_logits runs under CUDA
+        # graph capture in the V2 speculator, where indexing with a Python list
+        # would issue an unpinned H2D copy (illegal during capture).
+        self._suppress_idx: torch.Tensor | None = None
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -576,8 +580,8 @@ class Gemma4MTP(nn.Module):
             )
         else:
             logits = self.logits_processor(self.lm_head, hidden_states)
-        if logits is not None and self._suppress_token_ids:
-            logits[:, self._suppress_token_ids] = -float("inf")
+        if logits is not None and self._suppress_idx is not None:
+            logits.index_fill_(1, self._suppress_idx, -float("inf"))
         return logits
 
     def get_top_tokens(
@@ -594,4 +598,11 @@ class Gemma4MTP(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         self._stable_full_lm_head_weight = None
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        if self._suppress_token_ids:
+            self._suppress_idx = torch.tensor(
+                self._suppress_token_ids,
+                dtype=torch.long,
+                device=next(self.parameters()).device,
+            )
+        return loaded


### PR DESCRIPTION
## Purpose

`Gemma4MTP.compute_logits` masks suppressed tokens by indexing logits with a
Python list taken from the draft's `generation_config` (`suppress_tokens`).
List indexing issues an unpinned host->device copy, which is illegal during
CUDA graph capture.

Since the V2 model runner became the default for non-MoE architectures, the
speculator captures the drafter prefill routine — including `compute_logits` —
into FULL CUDA graphs. Engine init then fails deterministically with:

    RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph
    capture unless the CPU tensor is pinned.

Trigger: any MTP draft whose `generation_config` has non-empty
`suppress_tokens` — currently `google/gemma-4-12B-it-assistant`
(`[258883, 258882]`). Other Gemma4 assistants ship no `suppress_tokens` and
are unaffected.

Fix:
- Materialize the suppress-index tensor once at the end of `load_weights`
  (post-load, so the device is real and never meta; pre-capture, so no H2D
  transfer ever occurs inside a graph).
- Mask via `logits.index_fill_`, mirroring the capture-safe pattern already
  used in `Gemma4ForConditionalGeneration.compute_logits` (`gemma4_mm.py`).
- Lazy per-call materialization is deliberately avoided: the drafter's first
  call happens under capture, and even a pinned copy there would bake a read
  of a transient staging buffer into the graph.

No behavior change for drafts without `suppress_tokens` (`_suppress_idx`
stays `None`; the branch is a no-op). On the V1 runner the masking result is
identical, just via `index_fill_`.

## Test Plan

Repro/verify (H100, gemma-4-12B-it + its MTP assistant, V2 runner default):

    python <a-python-test-file> \
      --model-path google/gemma-4-12B-it \
      --assistant-model google/gemma-4-12B-it-assistant \
      --spec-tokens 4

Regression (assistants without suppress_tokens, dense + MoE):

    same command with gemma-4-E4B-it / gemma-4-26B-A4B-it and their assistants

Lint: `ruff check` / `ruff format --check` clean; mypy introduces no new
findings (4 pre-existing `Tensor | Module` findings on untouched lines).

## Test Result

- Before: engine init crashes during `Capturing prefill CUDA graphs (FULL)`
  with the pinned-memory RuntimeError (traceback ends at
  `gemma4_mtp.py` `compute_logits`).
- After: init completes all graph captures; full unit suite passes
  (29/29, text + function-calling + image + multi-image) with MTP active.
- Regression runs on dense (E4B) and MoE (26B-A4B) assistants: no change.

---

**Duplicate-work check:** no open PR/issue found touching Gemma4 MTP
suppress-token masking or this capture crash.