### PR TITLE
Revert "[Feature][DSpark]: Logprobs adaptive verification" (#52242)

### DIFF
--- a/docs/features/speculative_decoding/adaptive_verification.md
+++ b/docs/features/speculative_decoding/adaptive_verification.md
@@ -36,7 +36,7 @@ Set `enable_adaptive_verification: false` to verify the full block for every req
 
 - The attention backend must tolerate device-decided query lengths, since the CPU lengths only bound them from above. Backends that plan off the CPU lengths are excluded by the attention selector, and rejected at startup for models that hard-wire their backend.
 - Full cudagraphs are required: step costs are profiled from captured graphs, so `--enforce-eager` is rejected at startup.
-- Not supported with LoRA (the per-token LoRA mapping is built from CPU-side boundaries) or pipeline parallelism (cost curves and confidences exist only on the last rank).
+- Not supported with LoRA (the per-token LoRA mapping is built from CPU-side boundaries), pipeline parallelism (cost curves and confidences exist only on the last rank), or output logprobs (to be fixed).
 
 ## Tuning the cost profile
 

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -411,7 +411,7 @@ def _validate_logprobs(
                 ref_prompt_logprob_toks,
                 ref_prompt_logprob_vals,
                 ref_prompt_token_ranks,
-                *_,
+                _,
             ) = ref_prompt_logprobs
             for idx, (prompt_token, pos_logprob_dict) in enumerate(
                 zip(prompt_token_ids[1:], prompt_logprobs[1:])

--- a/tests/v1/test_outputs.py
+++ b/tests/v1/test_outputs.py
@@ -42,25 +42,6 @@ def test_logprobs_tensors_cat():
     assert LogprobsTensors.cat([first]) is first
 
 
-def test_logprobs_tensors_tolists_with_tensor_boundaries():
-    """Adaptive verification hands over the request boundaries as a tensor
-    (they only exist on device); tolists() must materialize it as a plain
-    list so slice_request splits requests correctly."""
-    tensors = LogprobsTensors(
-        torch.tensor([[1, 2], [3, 4], [5, 6]]),
-        torch.tensor([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]),
-        torch.tensor([1, 2, 3]),
-        cu_num_generated_tokens_tensor=torch.tensor([0, 2, 3], dtype=torch.int32),
-    )
-
-    lists = tensors.to_cpu_nonblocking().tolists()
-
-    assert lists.cu_num_generated_tokens == [0, 2, 3]
-    sliced = lists.slice_request(1, 1)
-    assert sliced.logprob_token_ids.tolist() == [[5, 6]]
-    assert sliced.sampled_token_ranks.tolist() == [3]
-
-
 def test_sampling_mask_tensors_tolist():
     tensors = SamplingMaskTensors(
         packed_mask=torch.tensor(

--- a/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
@@ -51,7 +51,6 @@ def test_chunked_scores_match_full_batch(logprobs_mode: str):
     rejection_sampler = object.__new__(RejectionSampler)
     rejection_sampler.sampler = SimpleNamespace(logprobs_mode=logprobs_mode)
     rejection_sampler.num_speculative_steps = 3
-    rejection_sampler.enable_adaptive_verification = False
 
     def fake_verify(
         self,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -974,6 +974,20 @@ class SamplingParams(
         if speculative_config is None:
             return
 
+        # Adaptive verification compacts logits after the forward pass, while
+        # compute_topk_scores uses the scheduled layout in cu_num_logits_np.
+        # TODO(lucas): lift this restriction. The true boundaries exist on device as
+        # cu_num_logits; cu_num_generated_tokens is only read host-side after
+        # the logprobs D2H, so it could ride along on that copy.
+        if (
+            speculative_config.enable_adaptive_verification
+            and self.num_logprobs is not None
+        ):
+            raise ValueError(
+                "Output logprobs are not supported with DSpark confidence-based "
+                "verification."
+            )
+
         # Some sampling parameters are not yet compatible with spec decoding.
         if self.min_p > _SAMPLING_EPS or self.logit_bias:
             raise VLLMValidationError(

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -134,7 +134,7 @@ class LogprobsProcessor:
         assert self.num_prompt_logprobs is not None
         assert self.prompt_logprobs is not None
 
-        token_ids, logprobs, ranks, *_ = prompt_logprobs_tensors
+        token_ids, logprobs, ranks, _ = prompt_logprobs_tensors
 
         # Recover shapes.
         num_prompt_tokens, num_logprobs = logprobs.shape

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -98,47 +98,33 @@ class LogprobsTensors(NamedTuple):
     logprobs: torch.Tensor
     # [num_reqs x num_generated_tokens]
     selected_token_ranks: torch.Tensor
-    # [num_reqs + 1]
+    # [num_reqs]
     cu_num_generated_tokens: list[int] | None = None
-    # [num_reqs + 1]. Set instead of cu_num_generated_tokens when the
-    # boundaries only exist on device (adaptive verification); rides along on
-    # the async D2H copy.
-    cu_num_generated_tokens_tensor: torch.Tensor | None = None
 
     def tolists(self, cu_num_generated_tokens: list[int] | None = None):
-        if cu_num_generated_tokens is None:
-            if self.cu_num_generated_tokens_tensor is not None:
-                cu_num_generated_tokens = self.cu_num_generated_tokens_tensor.tolist()
-            else:
-                cu_num_generated_tokens = self.cu_num_generated_tokens
         return LogprobsLists(
             self.logprob_token_ids.cpu().numpy(),
             self.logprobs.cpu().numpy(),
             self.selected_token_ranks.cpu().numpy(),
-            cu_num_generated_tokens,
+            cu_num_generated_tokens
+            if cu_num_generated_tokens is not None
+            else self.cu_num_generated_tokens,
         )
 
     def to_cpu_nonblocking(self) -> "LogprobsTensors":
         if self.logprob_token_ids.device.type == "cpu":
             return self
-        cu_tensor = self.cu_num_generated_tokens_tensor
-        if cu_tensor is not None:
-            cu_tensor = cu_tensor.to("cpu", non_blocking=True)
         return LogprobsTensors(
             self.logprob_token_ids.to("cpu", non_blocking=True),
             self.logprobs.to("cpu", non_blocking=True),
             self.selected_token_ranks.to("cpu", non_blocking=True),
             self.cu_num_generated_tokens,
-            cu_tensor,
         )
 
     def filter(self, mask: torch.Tensor) -> "LogprobsTensors":
         """Filter the logprobs tensors with the given bool mask."""
         assert self.cu_num_generated_tokens is None, (
             "filter can't be used with cu_num_generated_tokens"
-        )
-        assert self.cu_num_generated_tokens_tensor is None, (
-            "filter can't be used with cu_num_generated_tokens_tensor"
         )
         return LogprobsTensors(
             self.logprob_token_ids[mask],
@@ -161,9 +147,6 @@ class LogprobsTensors(NamedTuple):
             if cu_num_generated_tokens is None:
                 return tensor
             return tensor._replace(cu_num_generated_tokens=cu_num_generated_tokens)
-        # The multi-chunk path rebuilds boundaries from the CPU layout, which
-        # the device-only boundaries of adaptive verification never use.
-        assert all(tensor.cu_num_generated_tokens_tensor is None for tensor in tensors)
         return LogprobsTensors(
             logprob_token_ids=torch.cat(
                 [tensor.logprob_token_ids for tensor in tensors]

--- a/vllm/v1/worker/gpu/sample/logprob.py
+++ b/vllm/v1/worker/gpu/sample/logprob.py
@@ -110,7 +110,7 @@ def compute_topk_scores(
     logits: torch.Tensor,
     num_logprobs: int,
     sampled_token_ids: torch.Tensor,
-    cu_num_logits: list[int] | torch.Tensor | None = None,
+    cu_num_logits: list[int] | None = None,
     logprob_token_ids_state: "LogprobTokenIdsState | None" = None,
     expanded_idx_mapping: torch.Tensor | None = None,
     max_per_req_token_ids: int = 0,
@@ -177,13 +177,11 @@ def compute_topk_scores(
         vocab_size,
         BLOCK_SIZE=8192,  # type: ignore
     )
-    is_tensor = isinstance(cu_num_logits, torch.Tensor)
     return LogprobsTensors(
         logprob_token_ids=logprob_token_ids,
         logprobs=scores,
         selected_token_ranks=token_ranks,
-        cu_num_generated_tokens=None if is_tensor else cu_num_logits,
-        cu_num_generated_tokens_tensor=cu_num_logits if is_tensor else None,
+        cu_num_generated_tokens=cu_num_logits,
     )
 
 

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -81,7 +81,6 @@ class RejectionSampler:
     ):
         self.sampler = sampler
         self.num_speculative_steps = spec_config.num_speculative_tokens
-        self.enable_adaptive_verification = spec_config.enable_adaptive_verification
         rejection_sample_method = spec_config.rejection_sample_method
         self.use_block_verification: bool = False
         self.synthetic_conditional_rates: torch.Tensor | None = None
@@ -123,20 +122,11 @@ class RejectionSampler:
             num_warps=1,
         )
         expanded_logits = num_logits != num_reqs
-        cu_num_generated_tokens: list[int] | torch.Tensor | None = None
-        if expanded_logits:
-            if self.enable_adaptive_verification:
-                # Adaptive verification keeps the true per-request boundaries
-                # on device only; cu_num_logits_np holds the pre-compacted
-                # layout.
-                cu_num_generated_tokens = cu_num_logits.clone()
-            else:
-                cu_num_generated_tokens = cu_num_logits_np.tolist()
         return compute_topk_scores(
             logits,
             max_num_logprobs,
             flat_sampled,
-            cu_num_generated_tokens,
+            cu_num_logits_np.tolist() if expanded_logits else None,
             logits_mode=self.sampler.logprobs_mode
             in ("raw_logits", "processed_logits"),
         )
@@ -201,7 +191,6 @@ class RejectionSampler:
             # guarantees the compacted batch always lands here.
             request_chunks: Iterable[tuple[int, int]] = ((0, num_reqs),)
         else:
-            assert not self.enable_adaptive_verification
             request_chunks = _iter_request_chunks(cu_num_logits_np, max_chunk_logits)
 
         sampled_chunks: list[torch.Tensor] = []

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5803,7 +5803,7 @@ class GPUModelRunner(
                 scores = logits.to(torch.float32)
             else:
                 scores = self.sampler.compute_logprobs(logits)
-            token_ids, logprobs, ranks, *_ = self.sampler.gather_logprobs(
+            token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
                 scores, num_prompt_logprobs, tgt_token_ids
             )
 


### PR DESCRIPTION
## Preferred fix: a 5-line Rust change, not this revert

This PR is filed to unblock nightly CI, but the **narrower fix is almost certainly better**: add the missing 5th field to `WireLogprobs` in `rust/src/engine-core-client/src/protocol/logprobs.rs` so the Rust deserializer matches the Python `NamedTuple`. Please prefer that if an author is available.

## Root cause

#52242 added a 5th field to the `LogprobsTensors` `NamedTuple` in `vllm/v1/outputs.py`:

```python
cu_num_generated_tokens_tensor: torch.Tensor | None = None
```

`NamedTuple`s serialize to msgpack as **fixed-length arrays**, and the Rust engine-core client still deserializes exactly 4 elements (`logprob_token_ids`, `logprobs`, `token_ranks`, `cu_num_generated_tokens`). The PR changed **no Rust files**, so every logprobs payload now fails to decode:

```
transport.rs:589 failed to decode output message
  error=messagepack decode failed for
  vllm_engine_core_client::protocol::output::EngineCoreOutputs:
  array had incorrect length, expected 4
```

The Rust frontend then returns **HTTP 500** for any request with `prompt_logprobs`.

## Evidence

- **Failing test:** `v1/sample/test_logprobs_e2e.py::test_prompt_logprobs_e2e_server` — `ClientResponseError: 500`, in job `:nvidia: (H200) Rust Frontend OpenAI Coverage`.
- **Bisect is airtight.** Green at builds 85493 (`ca29cd48`, pre-#52242) and 85562 (`c6e19b3b`, 153 commits *behind* the merge). Red at **85527, 85541, 85561, 85585, 85586, 85598, 85629** — every build containing `d5cadcee`.
- **Deterministic:** exactly **103** msgpack decode errors in every red log, across 7 builds and 7 different `h200-ci-5` agents.
- **No stacked dependents:** `d5cadcee` is the only commit touching `vllm/v1/outputs.py` since 2026-08-15, and `cu_num_generated_tokens_tensor` is referenced only by the 3 files this PR touched. The revert applied with no conflicts and is an exact inverse of the original diff.
- Red for ~2 days with no revert, fix-forward, or issue open against this signature.

Original PR: https://github.com/vllm-project/vllm/pull/52242
Failing build: https://buildkite.com/vllm/ci/builds/85598

Auto-generated by CI failure analyzer.
