### PR TITLE
[Misc] Let an explicit TORCHINDUCTOR_COMPILE_THREADS override the default of 1

### DIFF
--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -102,7 +102,8 @@ os.environ["PYTORCH_NVML_BASED_CUDA_CHECK"] = "1"
 
 # see https://github.com/vllm-project/vllm/issues/10480 and
 # https://github.com/vllm-project/vllm/issues/10619.
-os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
+# Default to 1 for the reasons above; an explicit environment setting wins.
+os.environ.setdefault("TORCHINDUCTOR_COMPILE_THREADS", "1")
 
 # Enable Triton autotuning result caching to disk by default.
 # Without this, Triton re-runs autotuning on every process restart,


### PR DESCRIPTION
FIX #53891

## Purpose

`env_override.py` sets `TORCHINDUCTOR_COMPILE_THREADS = "1"` with a plain assignment, so an explicit setting in the environment is silently overwritten — exporting the variable does nothing today. The `1` default exists for good reasons (#10480, #10619) and this PR does not change it: `setdefault` keeps the default while letting a deliberate override through.

Motivation for wanting the override at all: on an 8-core host, compiling a 128-expert fused-MoE graph (`gemma-4-26B-A4B`) takes 26 minutes at one Inductor thread, and a 12B dense graph 24 minutes, with every core but one idle. Users who accept the debugger/subprocess trade-offs documented in the linked issues currently have no way to opt in to parallel compile short of patching this file.

## Test Plan

On `rocm/vllm:rocm7.14.0_rdna_ubuntu24.04_py3.14_pytorch_2.11.0_vllm_0.23.0` with the one-line change applied to the installed module, import `vllm.env_override` twice: once with the variable exported to `8`, once with it unset.

## Test Result

```
external TORCHINDUCTOR_COMPILE_THREADS=8 -> preserved; torch._inductor.config.compile_threads == 8
unset                                    -> "1" as before; compile_threads == 1
```

Unpatched, the first case comes back clobbered to `"1"`.

## AI assistance

The investigation, the change and this description were produced with an AI agent; I reviewed the change and the reasoning behind it, the verification ran on my own hardware, and the commit carries a `Co-authored-by:` trailer.
