### PR TITLE
[MRV2] Add platform-provided runner component factory

### DIFF
--- a/tests/v1/worker/test_mrv2_component_factory.py
+++ b/tests/v1/worker/test_mrv2_component_factory.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for the RFC #51212 Layer 2 platform component factory.
+
+Architecture under test:
+    Platform.get_v2_runner_components() -> V2RunnerComponents -> GPUModelRunner
+
+The static/AST tests run without a GPU or a full vllm install.
+The remaining tests require the vllm package (all deps) but still no GPU.
+"""
+
+import ast
+import pathlib
+from dataclasses import fields
+
+import pytest
+
+from vllm.v1.worker.gpu.runner_components import V2RunnerComponents
+
+_SRC = pathlib.Path(__file__).parents[3] / "vllm/v1/worker/gpu/model_runner.py"
+_OWNED_CLS = {"RequestState", "InputBuffers", "InputBatch",
+               "ModelCudaGraphManager", "Sampler"}
+
+
+# ---------------------------------------------------------------------------
+# 1. V2RunnerComponents structure
+# ---------------------------------------------------------------------------
+
+def test_v2runner_components_fields():
+    """All six required class-fields must be present."""
+    expected = {
+        "request_state_cls", "input_buffers_cls", "input_batch_cls",
+        "cudagraph_manager_cls", "sampler_cls", "pcp_manager_cls",
+    }
+    assert {f.name for f in fields(V2RunnerComponents)} == expected
+
+
+def test_v2runner_components_is_frozen():
+    """Bundle must be immutable."""
+    from vllm.v1.worker.gpu.cudagraph_utils import ModelCudaGraphManager
+    from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+    from vllm.v1.worker.gpu.pcp_manager import PCPManager
+    from vllm.v1.worker.gpu.sample.sampler import Sampler
+    from vllm.v1.worker.gpu.states import RequestState
+
+    bundle = V2RunnerComponents(
+        request_state_cls=RequestState,
+        input_buffers_cls=InputBuffers,
+        input_batch_cls=InputBatch,
+        cudagraph_manager_cls=ModelCudaGraphManager,
+        sampler_cls=Sampler,
+        pcp_manager_cls=PCPManager,
+    )
+    with pytest.raises(Exception):
+        bundle.request_state_cls = RequestState  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. Default Platform factory
+# ---------------------------------------------------------------------------
+
+def test_default_factory_returns_v2runner_components():
+    """current_platform.get_v2_runner_components() must return V2RunnerComponents."""
+    from vllm.platforms import current_platform
+    assert isinstance(current_platform.get_v2_runner_components(), V2RunnerComponents)
+
+
+def test_default_factory_returns_canonical_classes():
+    """Default bundle must contain the canonical GPU implementation classes."""
+    from vllm.platforms import current_platform
+    from vllm.v1.worker.gpu.cudagraph_utils import ModelCudaGraphManager
+    from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+    from vllm.v1.worker.gpu.pcp_manager import PCPManager
+    from vllm.v1.worker.gpu.sample.sampler import Sampler
+    from vllm.v1.worker.gpu.states import RequestState
+
+    b = current_platform.get_v2_runner_components()
+    assert b.request_state_cls is RequestState
+    assert b.input_buffers_cls is InputBuffers
+    assert b.input_batch_cls is InputBatch
+    assert b.cudagraph_manager_cls is ModelCudaGraphManager
+    assert b.sampler_cls is Sampler
+    assert b.pcp_manager_cls is PCPManager
+
+
+# ---------------------------------------------------------------------------
+# 3. Custom Platform factory
+# ---------------------------------------------------------------------------
+
+def test_custom_factory_bundle_is_respected(monkeypatch):
+    """A platform-provided bundle with custom subclasses is stored by the runner."""
+    from vllm.v1.worker.gpu.cudagraph_utils import ModelCudaGraphManager
+    from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+    from vllm.v1.worker.gpu.pcp_manager import PCPManager
+    from vllm.v1.worker.gpu.sample.sampler import Sampler
+    from vllm.v1.worker.gpu.states import RequestState
+
+    class _RS(RequestState): pass
+    class _IB(InputBuffers): pass
+    class _Batch(InputBatch): pass
+    class _CG(ModelCudaGraphManager): pass
+    class _S(Sampler): pass
+    class _PCP(PCPManager): pass
+
+    custom = V2RunnerComponents(
+        request_state_cls=_RS, input_buffers_cls=_IB, input_batch_cls=_Batch,
+        cudagraph_manager_cls=_CG, sampler_cls=_S, pcp_manager_cls=_PCP,
+    )
+
+    import vllm.v1.worker.gpu.model_runner as mr_mod
+    monkeypatch.setattr(mr_mod, "current_platform",
+                        type("_P", (), {"get_v2_runner_components": staticmethod(lambda: custom)})())
+
+    from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner._components = mr_mod.current_platform.get_v2_runner_components()
+
+    assert runner._components is custom
+    assert runner._components.request_state_cls is _RS
+    assert runner._components.input_batch_cls is _Batch
+    assert runner._components.sampler_cls is _S
+
+
+# ---------------------------------------------------------------------------
+# 4 & 5. Static enforcement — no direct class construction bypasses the factory
+# ---------------------------------------------------------------------------
+
+def _bare_calls(tree: ast.AST, class_name: str, attr: str | None = None) -> list[int]:
+    """Return line numbers of bare ClassName(...) or ClassName.attr(...) calls."""
+    hits = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        f = node.func
+        if attr is None:
+            if isinstance(f, ast.Name) and f.id == class_name:
+                hits.append(node.lineno)
+        else:
+            if (isinstance(f, ast.Attribute)
+                    and isinstance(f.value, ast.Name)
+                    and f.value.id == class_name
+                    and f.attr == attr):
+                hits.append(node.lineno)
+    return hits
+
+
+@pytest.fixture(scope="module")
+def model_runner_ast() -> ast.AST:
+    return ast.parse(_SRC.read_text())
+
+
+@pytest.mark.parametrize("cls_name,attr", [
+    ("InputBatch", None),
+    ("InputBatch", "make_dummy"),
+    ("RequestState", None),
+    ("InputBuffers", None),
+])
+def test_no_bare_construction_in_model_runner(model_runner_ast, cls_name, attr):
+    """model_runner.py must use self._components for all owned-class construction."""
+    lines = _bare_calls(model_runner_ast, cls_name, attr)
+    label = f"{cls_name}.{attr}(" if attr else f"{cls_name}("
+    assert not lines, (
+        f"Bare {label} at line(s) {lines}; use self._components instead."
+    )

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from vllm.utils.argparse_utils import FlexibleArgumentParser
     from vllm.v1.attention.backend import AttentionBackend
     from vllm.v1.attention.selector import AttentionSelectorConfig
+    from vllm.v1.worker.gpu.runner_components import V2RunnerComponents
 else:
     FlexibleArgumentParser = object
 
@@ -378,6 +379,34 @@ class Platform:
     ) -> str:
         """Get the attention backend class of a device."""
         return ""
+
+    @classmethod
+    def get_v2_runner_components(cls) -> "V2RunnerComponents":
+        """Return the component bundle used by GPUModelRunner V2.
+
+        Out-of-tree platforms override this to supply custom subclasses of any
+        of the six bundled components.  The runner calls this exactly once
+        during ``__init__`` and stores the result, so this method never runs on
+        a hot path.
+
+        Lazy imports are used to avoid circular dependencies between
+        ``vllm.platforms`` and the worker implementation modules.
+        """
+        from vllm.v1.worker.gpu.cudagraph_utils import ModelCudaGraphManager
+        from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+        from vllm.v1.worker.gpu.pcp_manager import PCPManager
+        from vllm.v1.worker.gpu.runner_components import V2RunnerComponents
+        from vllm.v1.worker.gpu.sample.sampler import Sampler
+        from vllm.v1.worker.gpu.states import RequestState
+
+        return V2RunnerComponents(
+            request_state_cls=RequestState,
+            input_buffers_cls=InputBuffers,
+            input_batch_cls=InputBatch,
+            cudagraph_manager_cls=ModelCudaGraphManager,
+            sampler_cls=Sampler,
+            pcp_manager_cls=PCPManager,
+        )
 
     @classmethod
     def get_supported_vit_attn_backends(cls) -> list["AttentionBackendEnum"]:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -70,6 +70,7 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
     RoutedExpertsTensors,
 )
+from vllm.platforms import current_platform
 from vllm.v1.worker.block_table import get_block_table_width
 from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
 from vllm.v1.worker.gpu import pcp_manager as pcp
@@ -127,6 +128,7 @@ from vllm.v1.worker.gpu.mm.lora import set_active_mm_loras
 from vllm.v1.worker.gpu.model_states import init_model_state
 from vllm.v1.worker.gpu.pool.pooling_runner import PoolingRunner
 from vllm.v1.worker.gpu.pp_utils import PPHandler
+from vllm.v1.worker.gpu.runner_components import V2RunnerComponents
 from vllm.v1.worker.gpu.sample.batch_shard import (
     BatchSharder,
     all_to_all_logits,
@@ -165,6 +167,12 @@ logger = init_logger(__name__)
 
 class GPUModelRunner(LoRAModelRunnerMixin):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        # Resolve the platform-supplied component bundle once.  Subclasses and
+        # out-of-tree platforms customise this via Platform.get_v2_runner_components().
+        self._components: V2RunnerComponents = (
+            current_platform.get_v2_runner_components()
+        )
+
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
         self.cache_config = vllm_config.cache_config
@@ -289,7 +297,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.step_timing = StepTimingCollector()
 
         # General request states.
-        self.req_states = RequestState(
+        self.req_states = self._components.request_state_cls(
             max_num_reqs=self.max_num_reqs,
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
@@ -299,7 +307,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             num_prefill_lookahead=num_prefill_lookahead,
         )
         self.adaptive_verification: AdaptiveVerificationManager | None = None
-        self.input_buffers = InputBuffers(
+        self.input_buffers = self._components.input_buffers_cls(
             max_num_reqs=self.max_num_reqs,
             max_num_tokens=self.max_num_tokens,
             device=self.device,
@@ -427,7 +435,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Initialize samplers. Model states may override via custom_sampler().
         if self.is_last_pp_rank and not self.is_pooling_model:
-            self.sampler = Sampler(
+            self.sampler = self._components.sampler_cls(
                 max_num_reqs=self.max_num_reqs,
                 vocab_size=self.vocab_size,
                 device=self.device,
@@ -608,7 +616,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.supports_mm_inputs,
             self.req_states,
             self.block_tables,
-            cls=self.pcp_manager_cls,
+            cls=self._components.pcp_manager_cls,
         )
         initialize_mamba_ssu_backend(
             self.vllm_config.mamba_config, self.kv_cache_config
@@ -625,7 +633,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_reqs=self.max_num_reqs,
             is_profiling=is_profiling,
         )
-        self.cudagraph_manager = ModelCudaGraphManager(
+        self.cudagraph_manager = self._components.cudagraph_manager_cls(
             self.vllm_config,
             self.device,
             cudagraph_mode,
@@ -811,7 +819,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
         num_reqs = hidden_states.shape[0]
         logits = self.model.compute_logits(hidden_states)
-        dummy_input_batch = InputBatch.make_dummy(
+        dummy_input_batch = self._components.input_batch_cls.make_dummy(
             num_reqs, num_reqs, self.input_buffers
         )
 
@@ -1295,7 +1303,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # prompt_lens is only used in R-SWA case.
             prompt_lens = self.req_states.prompt_len.gpu[idx_mapping]
 
-        input_batch = InputBatch(
+        input_batch = self._components.input_batch_cls(
             req_ids=req_ids,
             num_reqs=num_reqs,
             num_reqs_after_padding=num_reqs_padded,
@@ -1579,7 +1587,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         else:
             # No actual tokens to run. A dummy run for DP or memory profiling.
             dummy_num_reqs = batch_desc.num_reqs or num_reqs
-            input_batch = InputBatch.make_dummy(
+            input_batch = self._components.input_batch_cls.make_dummy(
                 dummy_num_reqs,
                 batch_desc.num_tokens,
                 self.input_buffers,
@@ -2041,11 +2049,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
 
     ########### EPLB methods end ###########
-
-    # Out-of-tree hardware runners can select a PCP manager class.
-    @property
-    def pcp_manager_cls(self) -> type[pcp.PCPManager]:
-        return pcp.PCPManager
 
 
 class ExecuteModelState(NamedTuple):

--- a/vllm/v1/worker/gpu/runner_components.py
+++ b/vllm/v1/worker/gpu/runner_components.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+V2RunnerComponents — platform-supplied component bundle for GPUModelRunner V2.
+
+Out-of-tree platforms override Platform.get_v2_runner_components() to return a
+customised bundle.  The runner resolves the bundle exactly once during __init__
+and stores it, so no factory calls appear on hot paths.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu.cudagraph_utils import ModelCudaGraphManager
+    from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+    from vllm.v1.worker.gpu.pcp_manager import PCPManager
+    from vllm.v1.worker.gpu.sample.sampler import Sampler
+    from vllm.v1.worker.gpu.states import RequestState
+
+
+@dataclass(frozen=True)
+class V2RunnerComponents:
+    """Bundle of class objects used by GPUModelRunner V2.
+
+    Each field is a *class* (not an instance).  The runner instantiates them
+    using the arguments appropriate for each component.
+
+    Platforms that extend GPUModelRunner V2 override
+    ``Platform.get_v2_runner_components()`` to supply custom subclasses.  All
+    fields must remain compatible with the corresponding base-class constructor
+    signatures unless the platform also subclasses the runner itself.
+    """
+
+    request_state_cls: "type[RequestState]"
+    input_buffers_cls: "type[InputBuffers]"
+    input_batch_cls: "type[InputBatch]"
+    cudagraph_manager_cls: "type[ModelCudaGraphManager]"
+    sampler_cls: "type[Sampler]"
+    pcp_manager_cls: "type[PCPManager]"


### PR DESCRIPTION
## Summary

* Add a platform-provided component factory for Model Runner V2.
* Introduce `V2RunnerComponents` as a typed bundle of runner component classes.
* Route GPUModelRunner V2 component construction through the platform factory.
* Preserve the existing NVIDIA/CUDA implementations as the default behavior.
* Add focused tests for default/custom component wiring and direct-construction bypasses.

## Motivation

Model Runner V2 currently constructs several GPU-specific components directly inside `GPUModelRunner`. This makes it difficult for other platforms or out-of-tree implementations to customize individual runner components without modifying or duplicating the runner.

This change provides a single platform extension point through `Platform.get_v2_runner_components()`.

## Design

The component flow is:

`Platform.get_v2_runner_components()` → `V2RunnerComponents` → `GPUModelRunner`

The component bundle currently provides:

* `RequestState`
* `InputBuffers`
* `InputBatch`
* `ModelCudaGraphManager`
* `Sampler`
* `PCPManager`

The default platform factory returns the existing GPU implementations, preserving current behavior.

The component bundle is resolved once during `GPUModelRunner` initialization and reused for component construction, so the platform factory is not invoked on inference hot paths.

## Testing

* `git diff --check` passes.
* Static/AST tests for direct component-construction bypasses pass locally.
* Full pytest-based tests could not be executed locally because the development environment does not have the complete vLLM package dependencies installed (`cbor2` is unavailable).
* The remaining tests are designed to run without a GPU in a standard vLLM development environment.

## Related

Related to the Model Runner V2 pluggable-design work in RFC #51212.
