### PR TITLE
[MoE] Support out-of-tree fp8 MoE backends

### DIFF
--- a/docs/design/fused_moe_modular_kernel.md
+++ b/docs/design/fused_moe_modular_kernel.md
@@ -173,6 +173,13 @@ FusedMoEExpertsModular performs the core of the fused MoE operations. The variou
 `FusedMoEExpertsModular::finalize_weight_and_reduce_impl` /
 `FusedMoEExpertsModular::apply`: Refer to `FusedMoEExpertsModular` section above.
 
+An out-of-tree FP8 implementation can register its `FusedMoEExperts` class with
+`register_fp8_moe_backend()` from a `vllm.general_plugins` entry point. The
+registration selects only the experts component: vLLM continues to construct
+the router and the compatible `FusedMoEPrepareAndFinalize` implementation.
+Registered implementations receive canonical vLLM FP8 MoE weights and declare
+their deployment compatibility through `is_supported_config()`.
+
 ### FusedMoEModularKernel Initialization
 
 `FusedMoEMethodBase` class has 3 methods that are collectively responsible in creating the `FusedMoEModularKernel` object. They are,

--- a/docs/design/plugin_system.md
+++ b/docs/design/plugin_system.md
@@ -55,6 +55,51 @@ Every plugin has three parts:
 
 - **Endpoint plugins** (with group name `vllm.endpoint_plugins`): The primary use case for these plugins is to register custom, out-of-the-tree HTTP routes on the OpenAI compatible API server. Unlike the other plugin groups above, endpoint plugins are loaded only in the API server front end process and are **not loaded by default**. See [Endpoint Plugins](endpoint_plugins.md) for the interface and [Security](../usage/security.md#endpoint-plugins) for the opt-in and trust model.
 
+### FP8 MoE backend plugins
+
+General plugins can register out-of-tree FP8 MoE expert implementations. The
+implementation must subclass `FusedMoEExperts` and consume canonical vLLM FP8
+MoE weights.
+
+Add the plugin entry point to the external backend package's
+`pyproject.toml`. Users do not need to modify vLLM's `pyproject.toml` or a
+configuration file in their home directory:
+
+```toml
+[project.entry-points."vllm.general_plugins"]
+my_moe_backend = "my_moe_backend.plugin:register"
+```
+
+Install the external backend package into the same Python environment as
+vLLM. During startup, vLLM discovers the installed entry point and invokes its
+registration function in each worker process.
+
+The plugin function registers qualified class names so optional kernel
+dependencies are imported only when the backend is considered:
+
+```python
+def register():
+    from vllm.model_executor.layers.fused_moe import (
+        register_fp8_moe_backend,
+    )
+
+    register_fp8_moe_backend(
+        name="my_moe_backend",
+        expert_class_paths="my_moe_backend.experts.MyFp8Experts",
+    )
+```
+
+Select the backend explicitly with `--moe-backend my_moe_backend`. Registered
+backends do not affect automatic selection unless they pass
+`auto_select=True`; automatic registered backends are considered only after
+built-in backends. Explicit selection still calls the implementation's
+`is_supported_config()` method and fails during model initialization when the
+deployment is incompatible.
+
+Registration functions must be re-entrant because plugins are loaded in each
+vLLM process. Repeating an identical registration is supported, while a
+conflicting registration using the same name raises an error.
+
 ## Guidelines for Writing Plugins
 
 - **Being re-entrant**: The function specified in the entry point should be re-entrant, meaning it can be called multiple times without causing issues. This is necessary because the function might be called multiple times in some processes.

--- a/tests/kernels/moe/test_fp8_moe_backend_registry.py
+++ b/tests/kernels/moe/test_fp8_moe_backend_registry.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.config.kernel import KernelConfig
+from vllm.model_executor.layers.fused_moe.oracle import fp8 as fp8_oracle
+from vllm.model_executor.layers.fused_moe.oracle.fp8_registry import (
+    _REGISTERED_FP8_MOE_BACKENDS,
+    get_registered_fp8_moe_backend,
+    iter_auto_fp8_moe_backends,
+    register_fp8_moe_backend,
+    registered_fp8_moe_backend_names,
+    resolve_fp8_moe_experts,
+)
+
+
+class _SupportedExperts(mk.FusedMoEExpertsModular):
+    @staticmethod
+    def is_supported_config(cls, *args, **kwargs):
+        return True, None
+
+
+class _UnsupportedExperts(mk.FusedMoEExpertsModular):
+    @staticmethod
+    def is_supported_config(cls, *args, **kwargs):
+        return False, "test incompatibility"
+
+
+NOT_AN_EXPERT = object()
+
+
+@pytest.fixture(autouse=True)
+def reset_fp8_moe_backend_registry():
+    saved_registry = dict(_REGISTERED_FP8_MOE_BACKENDS)
+    _REGISTERED_FP8_MOE_BACKENDS.clear()
+    resolve_fp8_moe_experts.cache_clear()
+    yield
+    _REGISTERED_FP8_MOE_BACKENDS.clear()
+    _REGISTERED_FP8_MOE_BACKENDS.update(saved_registry)
+    resolve_fp8_moe_experts.cache_clear()
+
+
+def _class_path(cls: type) -> str:
+    return f"{__name__}.{cls.__name__}"
+
+
+def _moe_config(backend: str):
+    parallel_config = SimpleNamespace(use_batched_activation_format=False)
+    return SimpleNamespace(
+        moe_backend=backend,
+        moe_parallel_config=parallel_config,
+    )
+
+
+def test_register_and_resolve_backend():
+    register_fp8_moe_backend("My-Backend", _class_path(_SupportedExperts))
+
+    backend = get_registered_fp8_moe_backend("my_backend")
+    assert backend is not None
+    assert backend.name == "my_backend"
+    assert resolve_fp8_moe_experts(backend) == (_SupportedExperts,)
+    assert registered_fp8_moe_backend_names() == ("my_backend",)
+
+
+def test_register_multiple_expert_classes():
+    register_fp8_moe_backend(
+        "multiple",
+        [_class_path(_UnsupportedExperts), _class_path(_SupportedExperts)],
+    )
+
+    backend = get_registered_fp8_moe_backend("multiple")
+    assert backend is not None
+    assert resolve_fp8_moe_experts(backend) == (
+        _UnsupportedExperts,
+        _SupportedExperts,
+    )
+
+
+def test_registration_is_idempotent():
+    register_fp8_moe_backend("custom", _class_path(_SupportedExperts))
+    register_fp8_moe_backend("custom", _class_path(_SupportedExperts))
+
+    assert registered_fp8_moe_backend_names() == ("custom",)
+
+
+def test_conflicting_registration_fails():
+    register_fp8_moe_backend("custom", _class_path(_SupportedExperts))
+
+    with pytest.raises(ValueError, match="different configuration"):
+        register_fp8_moe_backend("custom", _class_path(_UnsupportedExperts))
+
+
+@pytest.mark.parametrize("name", ["auto", "triton", "flashinfer-cutlass"])
+def test_builtin_name_collision_fails(name: str):
+    with pytest.raises(ValueError, match="reserved"):
+        register_fp8_moe_backend(name, _class_path(_SupportedExperts))
+
+
+@pytest.mark.parametrize("paths", ["", [], [""]])
+def test_empty_class_paths_fail(paths):
+    with pytest.raises(
+        ValueError,
+        match="At least one expert class path is required",
+    ):
+        register_fp8_moe_backend("custom", paths)
+
+
+def test_invalid_expert_class_fails_during_resolution():
+    register_fp8_moe_backend("custom", f"{__name__}.NOT_AN_EXPERT")
+    backend = get_registered_fp8_moe_backend("custom")
+    assert backend is not None
+
+    with pytest.raises(TypeError, match="must be a subclass"):
+        resolve_fp8_moe_experts(backend)
+
+
+def test_auto_selection_is_opt_in():
+    register_fp8_moe_backend(
+        "manual",
+        _class_path(_SupportedExperts),
+        auto_select=False,
+    )
+    register_fp8_moe_backend(
+        "automatic",
+        _class_path(_SupportedExperts),
+        auto_select=True,
+    )
+
+    assert [backend.name for backend in iter_auto_fp8_moe_backends()] == ["automatic"]
+
+
+def test_kernel_config_accepts_registered_backend_name():
+    config = KernelConfig(moe_backend="My-Backend")
+    assert config.moe_backend == "my_backend"
+
+
+def test_explicit_registered_backend_selection():
+    register_fp8_moe_backend("custom", _class_path(_SupportedExperts))
+
+    backend, experts_cls = fp8_oracle.select_fp8_moe_backend(
+        _moe_config("custom"),
+        weight_key=None,
+        activation_key=None,
+    )
+
+    assert backend == get_registered_fp8_moe_backend("custom")
+    assert experts_cls is _SupportedExperts
+
+
+def test_explicit_unsupported_registered_backend_fails():
+    register_fp8_moe_backend("custom", _class_path(_UnsupportedExperts))
+
+    with pytest.raises(ValueError, match="test incompatibility"):
+        fp8_oracle.select_fp8_moe_backend(
+            _moe_config("custom"),
+            weight_key=None,
+            activation_key=None,
+        )
+
+
+def test_registered_backend_is_auto_fallback(monkeypatch):
+    register_fp8_moe_backend(
+        "custom",
+        _class_path(_SupportedExperts),
+        auto_select=True,
+    )
+    monkeypatch.setattr(fp8_oracle, "_get_priority_backends", lambda *args: [])
+
+    backend, experts_cls = fp8_oracle.select_fp8_moe_backend(
+        _moe_config("auto"),
+        weight_key=None,
+        activation_key=None,
+    )
+
+    assert backend == get_registered_fp8_moe_backend("custom")
+    assert experts_cls is _SupportedExperts
+
+
+def test_builtin_auto_selection_keeps_priority(monkeypatch):
+    register_fp8_moe_backend(
+        "custom",
+        _class_path(_SupportedExperts),
+        auto_select=True,
+    )
+    monkeypatch.setattr(
+        fp8_oracle,
+        "_get_priority_backends",
+        lambda *args: [fp8_oracle.Fp8MoeBackend.TRITON],
+    )
+    monkeypatch.setattr(
+        fp8_oracle,
+        "backend_to_kernel_cls",
+        lambda backend: [_SupportedExperts],
+    )
+
+    backend, experts_cls = fp8_oracle.select_fp8_moe_backend(
+        _moe_config("auto"),
+        weight_key=None,
+        activation_key=None,
+    )
+
+    assert backend == fp8_oracle.Fp8MoeBackend.TRITON
+    assert experts_cls is _SupportedExperts
+
+
+def test_registered_backend_uses_canonical_weights():
+    register_fp8_moe_backend("custom", _class_path(_SupportedExperts))
+    backend = get_registered_fp8_moe_backend("custom")
+    assert backend is not None
+
+    tensors = tuple(torch.empty(1) for _ in range(4))
+    converted = fp8_oracle.convert_to_fp8_moe_kernel_format(
+        backend,
+        SimpleNamespace(),
+        *tensors,
+        None,
+        None,
+    )
+
+    assert all(got is expected for got, expected in zip(converted, tensors))
+
+
+def test_unknown_backend_error_lists_registered_names():
+    register_fp8_moe_backend("custom", _class_path(_SupportedExperts))
+
+    with pytest.raises(ValueError, match=r"Registered backends: \['custom'\]"):
+        fp8_oracle.map_fp8_backend("missing")

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -3,7 +3,7 @@
 import contextlib
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, fields
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import Field, field_validator
 
@@ -119,7 +119,7 @@ class IrOpPriorityConfig:
         return cls(**kwargs)
 
 
-MoEBackend = Literal[
+BuiltinMoEBackend = Literal[
     "auto",
     "triton",
     "batched_triton",
@@ -181,6 +181,12 @@ def validate_flashinfer_moe_ep_model(
             f"model is {list(architectures)}."
         )
 
+
+# Including ``str`` allows registered backend names while retaining the
+# built-in names in generated CLI help.
+MoEBackend = BuiltinMoEBackend | str
+
+BUILTIN_MOE_BACKENDS: tuple[str, ...] = get_args(BuiltinMoEBackend)
 
 LinearBackend = Literal[
     "auto",

--- a/vllm/model_executor/layers/fused_moe/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/__init__.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.fused_moe.modular_kernel import (
     FusedMoEExpertsModular,
     FusedMoEPrepareAndFinalizeModular,
 )
+from vllm.model_executor.layers.fused_moe.oracle import register_fp8_moe_backend
 from vllm.model_executor.layers.fused_moe.routed_experts import (
     FusedMoeWeightScaleSupported,
     RoutedExperts,
@@ -85,6 +86,7 @@ __all__ = [
     "activation_without_mul",
     "apply_moe_activation",
     "fused_moe_make_expert_params_mapping",
+    "register_fp8_moe_backend",
     "override_config",
     "get_config",
 ]

--- a/vllm/model_executor/layers/fused_moe/oracle/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/__init__.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.fp8_registry import (
+    register_fp8_moe_backend,
+)
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoEKernelOracle,
 )
@@ -9,4 +12,5 @@ from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
 __all__ = [
     "MoEKernelOracle",
     "UnquantizedMoEKernelOracle",
+    "register_fp8_moe_backend",
 ]

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -19,6 +19,13 @@ from vllm.model_executor.layers.fused_moe.config import (
     fp8_w8a8_moe_quant_config,
     fp8_w8a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.fp8_registry import (
+    RegisteredFp8MoeBackend,
+    get_registered_fp8_moe_backend,
+    iter_auto_fp8_moe_backends,
+    registered_fp8_moe_backend_names,
+    resolve_fp8_moe_experts,
+)
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     prepare_fp8_moe_layer_for_fi,
@@ -64,6 +71,15 @@ class Fp8MoeBackend(Enum):
     TRITON_MXFP8 = "TRITON_MXFP8"
     # MXFP8 MoE via AITER (FlyDSL two-stage grouped GEMM) on gfx950.
     AITER_MXFP8 = "AITER_MXFP8"
+
+
+Fp8MoeBackendRef = Fp8MoeBackend | RegisteredFp8MoeBackend
+
+
+def _backend_name(backend: Fp8MoeBackendRef) -> str:
+    if isinstance(backend, RegisteredFp8MoeBackend):
+        return backend.name
+    return backend.value
 
 
 def _get_priority_backends(
@@ -134,9 +150,11 @@ def _get_priority_backends(
 
 
 def backend_to_kernel_cls(
-    backend: Fp8MoeBackend,
+    backend: Fp8MoeBackendRef,
 ) -> list[type[mk.FusedMoEExperts]]:
-    if backend == Fp8MoeBackend.FLASHINFER_TRTLLM:
+    if isinstance(backend, RegisteredFp8MoeBackend):
+        return list(resolve_fp8_moe_experts(backend))
+    elif backend == Fp8MoeBackend.FLASHINFER_TRTLLM:
         from vllm.model_executor.layers.fused_moe.experts.trtllm_fp8_moe import (  # noqa: E501
             TrtLlmFp8ExpertsModular,
             TrtLlmFp8ExpertsMonolithic,
@@ -247,8 +265,12 @@ def backend_to_kernel_cls(
         raise ValueError(f"Unknown FP8 MoE backend: {backend.value}")
 
 
-def map_fp8_backend(runner_backend: MoEBackend) -> Fp8MoeBackend:
+def map_fp8_backend(runner_backend: MoEBackend) -> Fp8MoeBackendRef:
     """Map user's MoEBackend to Fp8MoeBackend."""
+    registered_backend = get_registered_fp8_moe_backend(runner_backend)
+    if registered_backend is not None:
+        return registered_backend
+
     mapping = {
         "triton": Fp8MoeBackend.TRITON,
         "deep_gemm": Fp8MoeBackend.DEEPGEMM,
@@ -262,9 +284,11 @@ def map_fp8_backend(runner_backend: MoEBackend) -> Fp8MoeBackend:
     }
     if backend := mapping.get(runner_backend):
         return backend
+    registered_names = registered_fp8_moe_backend_names()
     raise ValueError(
         f"moe_backend='{runner_backend}' is not supported for FP8 MoE. "
-        f"Expected one of {list(mapping.keys())}."
+        f"Expected one of {list(mapping.keys())} or a registered backend. "
+        f"Registered backends: {list(registered_names)}."
     )
 
 
@@ -273,14 +297,17 @@ def select_fp8_moe_backend(
     weight_key: QuantKey | None,
     activation_key: QuantKey | None,
     allow_vllm_cutlass: bool = False,
-) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts] | None]:
+) -> tuple[Fp8MoeBackendRef, type[mk.FusedMoEExperts] | None]:
     """
     Select the primary FP8 MoE backend
     Note: Shape-specific fallbacks may still occur at runtime.
     """
 
     # NOTE: the kernels are selected in the following order.
-    AVAILABLE_BACKENDS = _get_priority_backends(config, weight_key, activation_key)
+    AVAILABLE_BACKENDS: list[Fp8MoeBackendRef] = [
+        *_get_priority_backends(config, weight_key, activation_key),
+        *iter_auto_fp8_moe_backends(),
+    ]
 
     # NOTE(rob): We need to peak into the P/F selection to determine
     # if we are using the batched or standard expert format, which
@@ -291,32 +318,34 @@ def select_fp8_moe_backend(
         else mk.FusedMoEActivationFormat.Standard
     )
 
-    def _make_log_backend(backend: Fp8MoeBackend):
-        available_backend_strs = [b.value for b in AVAILABLE_BACKENDS]
+    def _make_log_backend(backend: Fp8MoeBackendRef):
+        available_backend_strs = [_backend_name(b) for b in AVAILABLE_BACKENDS]
         return (
-            f"Using {backend.value} Fp8 MoE backend out "
+            f"Using {_backend_name(backend)} Fp8 MoE backend out "
             f"of potential backends: {available_backend_strs}."
         )
 
-    def _make_log_unsupported(backend: Fp8MoeBackend, reason: str | None) -> str:
+    def _make_log_unsupported(backend: Fp8MoeBackendRef, reason: str | None) -> str:
+        backend_name = _backend_name(backend)
         if reason:
             return (
-                f"FP8 MoE backend {backend.value} does not support the "
+                f"FP8 MoE backend {backend_name} does not support the "
                 f"deployment configuration since {reason}."
             )
         else:
             return (
-                f"FP8 MoE backend '{backend.value}' does not support the "
+                f"FP8 MoE backend '{backend_name}' does not support the "
                 "deployment configuration."
             )
 
     def _return_or_raise(
-        backend: Fp8MoeBackend,
+        backend: Fp8MoeBackendRef,
         config: FusedMoEConfig,
         weight_key: QuantKey | None,
         activation_key: QuantKey | None,
         activation_format: mk.FusedMoEActivationFormat,
-    ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts]]:
+    ) -> tuple[Fp8MoeBackendRef, type[mk.FusedMoEExperts]]:
+        reason = None
         for k_cls in backend_to_kernel_cls(backend):
             supported, reason = k_cls.is_supported_config(
                 k_cls, config, weight_key, activation_key, activation_format
@@ -331,7 +360,10 @@ def select_fp8_moe_backend(
     if runner_backend != "auto":
         requested_backend = map_fp8_backend(runner_backend)
         # For batched activation format, use batched variants if available.
-        if activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
+        if (
+            isinstance(requested_backend, Fp8MoeBackend)
+            and activation_format == mk.FusedMoEActivationFormat.BatchedExperts
+        ):
             if requested_backend == Fp8MoeBackend.DEEPGEMM:
                 requested_backend = Fp8MoeBackend.BATCHED_DEEPGEMM
             elif requested_backend == Fp8MoeBackend.TRITON:
@@ -358,8 +390,10 @@ def select_fp8_moe_backend(
     # Handle explicit DeepGEMM FP8 configuration.
     if envs.is_set("VLLM_USE_DEEP_GEMM") or envs.is_set("VLLM_MOE_USE_DEEP_GEMM"):
         if not envs.VLLM_USE_DEEP_GEMM or not envs.VLLM_MOE_USE_DEEP_GEMM:
-            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.DEEPGEMM)
-            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_DEEPGEMM)
+            if Fp8MoeBackend.DEEPGEMM in AVAILABLE_BACKENDS:
+                AVAILABLE_BACKENDS.remove(Fp8MoeBackend.DEEPGEMM)
+            if Fp8MoeBackend.BATCHED_DEEPGEMM in AVAILABLE_BACKENDS:
+                AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_DEEPGEMM)
         else:
             backend = (
                 Fp8MoeBackend.DEEPGEMM
@@ -387,12 +421,14 @@ def select_fp8_moe_backend(
             )
 
     if not allow_vllm_cutlass:
-        AVAILABLE_BACKENDS.remove(Fp8MoeBackend.VLLM_CUTLASS)
-        AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_VLLM_CUTLASS)
+        if Fp8MoeBackend.VLLM_CUTLASS in AVAILABLE_BACKENDS:
+            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.VLLM_CUTLASS)
+        if Fp8MoeBackend.BATCHED_VLLM_CUTLASS in AVAILABLE_BACKENDS:
+            AVAILABLE_BACKENDS.remove(Fp8MoeBackend.BATCHED_VLLM_CUTLASS)
 
     # Select kernels in order of backend.
-    for backend in AVAILABLE_BACKENDS:
-        for k_cls in backend_to_kernel_cls(backend):
+    for candidate_backend in AVAILABLE_BACKENDS:
+        for k_cls in backend_to_kernel_cls(candidate_backend):
             supported, reason = k_cls.is_supported_config(
                 k_cls,
                 config,
@@ -401,15 +437,11 @@ def select_fp8_moe_backend(
                 activation_format,
             )
             if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
+                logger.info_once(_make_log_backend(candidate_backend))
+                return candidate_backend, k_cls
             else:
-                logger.debug_once(_make_log_unsupported(backend, reason))
+                logger.debug_once(_make_log_unsupported(candidate_backend, reason))
 
-    # TODO(rob): per discussion with TPU team, we need a way to register
-    # MoE backends by OOT plugins, rather than having an explicit list
-    # of AVAILABLE_BACKENDS. Enabling returning `Fp8MoeBackend.NONE` is
-    # a temporary measure until these register APIs are complete.
     if current_platform.is_cuda() or current_platform.is_rocm():
         raise NotImplementedError(
             "No FP8 MoE backend supports the deployment configuration."
@@ -454,7 +486,7 @@ def _humming_fp8_weight_schema(
 
 
 def convert_to_fp8_moe_kernel_format(
-    fp8_backend: Fp8MoeBackend,
+    fp8_backend: Fp8MoeBackendRef,
     # TODO(bnell): replace layer with weight_block_size
     layer: RoutedExperts,
     w13: torch.Tensor,
@@ -546,6 +578,9 @@ def convert_to_fp8_moe_kernel_format(
         )
 
         w13, w2 = prepare_fp8_moe_layer_for_cpu(w13, w2)
+    elif isinstance(fp8_backend, RegisteredFp8MoeBackend):
+        # Registered backends consume canonical vLLM FP8 MoE weights.
+        pass
     else:
         if fp8_backend not in [
             Fp8MoeBackend.TRITON,
@@ -565,7 +600,7 @@ def convert_to_fp8_moe_kernel_format(
 
 
 def make_fp8_moe_quant_config(
-    fp8_backend: Fp8MoeBackend,
+    fp8_backend: Fp8MoeBackendRef,
     w1_scale: torch.Tensor,
     w2_scale: torch.Tensor,
     a1_scale: torch.Tensor | None,
@@ -690,7 +725,7 @@ def make_fp8_moe_kernel(
     moe_quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
-    fp8_backend: Fp8MoeBackend,
+    fp8_backend: Fp8MoeBackendRef,
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
 ) -> mk.FusedMoEKernel:
     # Create Prepare/Finalize.

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8_registry.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8_registry.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Registry for out-of-tree FP8 MoE expert implementations."""
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from functools import cache
+from typing import TYPE_CHECKING
+
+from vllm.config.kernel import BUILTIN_MOE_BACKENDS
+from vllm.utils.import_utils import resolve_obj_by_qualname
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEExperts
+
+
+@dataclass(frozen=True)
+class RegisteredFp8MoeBackend:
+    """Description of an out-of-tree FP8 MoE backend."""
+
+    name: str
+    expert_class_paths: tuple[str, ...]
+    auto_select: bool = False
+
+
+_REGISTERED_FP8_MOE_BACKENDS: dict[str, RegisteredFp8MoeBackend] = {}
+
+
+def _normalize_backend_name(name: str) -> str:
+    normalized = name.lower().replace("-", "_")
+    if not normalized:
+        raise ValueError("FP8 MoE backend name must not be empty.")
+    return normalized
+
+
+def register_fp8_moe_backend(
+    name: str,
+    expert_class_paths: str | Sequence[str],
+    *,
+    auto_select: bool = False,
+) -> None:
+    """Register an out-of-tree FP8 MoE backend.
+
+    Registration is idempotent when the normalized name, class paths, and
+    automatic-selection setting are identical. Registered implementations
+    consume canonical vLLM FP8 MoE weights.
+
+    Args:
+        name: User-facing backend name accepted by ``--moe-backend``.
+        expert_class_paths: One or more qualified ``FusedMoEExperts`` class
+            names. Classes are imported lazily when the oracle considers the
+            backend.
+        auto_select: Whether the backend may be considered after built-in
+            backends when ``--moe-backend auto`` is used.
+
+    Raises:
+        ValueError: If the registration is empty, conflicts with a built-in
+            backend, or conflicts with an existing registration.
+    """
+    normalized_name = _normalize_backend_name(name)
+    if normalized_name in BUILTIN_MOE_BACKENDS:
+        raise ValueError(
+            f"Cannot register FP8 MoE backend '{normalized_name}': "
+            "the name is reserved by a built-in MoE backend."
+        )
+
+    paths = (
+        (expert_class_paths,)
+        if isinstance(expert_class_paths, str)
+        else tuple(expert_class_paths)
+    )
+    if not paths or any(not isinstance(path, str) or not path for path in paths):
+        raise ValueError("At least one expert class path is required.")
+
+    registration = RegisteredFp8MoeBackend(
+        name=normalized_name,
+        expert_class_paths=paths,
+        auto_select=auto_select,
+    )
+    existing = _REGISTERED_FP8_MOE_BACKENDS.get(normalized_name)
+    if existing is not None and existing != registration:
+        raise ValueError(
+            f"FP8 MoE backend '{normalized_name}' is already registered "
+            "with a different configuration."
+        )
+    _REGISTERED_FP8_MOE_BACKENDS[normalized_name] = registration
+
+
+def get_registered_fp8_moe_backend(name: str) -> RegisteredFp8MoeBackend | None:
+    """Return a registered backend by normalized name."""
+    return _REGISTERED_FP8_MOE_BACKENDS.get(_normalize_backend_name(name))
+
+
+def iter_auto_fp8_moe_backends() -> Iterable[RegisteredFp8MoeBackend]:
+    """Iterate registered backends that opted into automatic selection."""
+    return (
+        backend
+        for backend in _REGISTERED_FP8_MOE_BACKENDS.values()
+        if backend.auto_select
+    )
+
+
+def registered_fp8_moe_backend_names() -> tuple[str, ...]:
+    """Return registered backend names in registration order."""
+    return tuple(_REGISTERED_FP8_MOE_BACKENDS)
+
+
+@cache
+def resolve_fp8_moe_experts(
+    backend: RegisteredFp8MoeBackend,
+) -> tuple[type["FusedMoEExperts"], ...]:
+    """Resolve and validate the expert classes for a registered backend."""
+    from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEExperts
+
+    classes: list[type[FusedMoEExperts]] = []
+    for class_path in backend.expert_class_paths:
+        obj = resolve_obj_by_qualname(class_path)
+        if not isinstance(obj, type) or not issubclass(obj, FusedMoEExperts):
+            raise TypeError(
+                f"Registered FP8 MoE expert '{class_path}' must be a subclass "
+                "of FusedMoEExperts."
+            )
+        classes.append(obj)
+    return tuple(classes)

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.config import (
         FusedMoEQuantConfig,
     )
-    from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+    from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+        Fp8MoeBackendRef,
+    )
     from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 
 import vllm.envs as envs
@@ -432,7 +434,7 @@ class _Fp8OnlineMoEBase(OnlineMoEMethodBase):
     weights onto meta device and materializes them just-in-time."""
 
     # Declared here for mypy; actual values are set in __init__.
-    fp8_backend: "Fp8MoeBackend"
+    fp8_backend: "Fp8MoeBackendRef"
     experts_cls: "type[mk.FusedMoEExperts] | None"
     weight_scale_name: str
     weight_block_size: list[int] | None


### PR DESCRIPTION



## Purpose

Resolve the existing TODO in FP8 MoE backend selection by allowing out-of-tree plugins to register custom `FusedMoEExperts` implementations.

Registered backends can be selected with `--moe-backend`, are imported lazily, and use vLLM's existing routing, weight loading, and prepare/finalize paths. Built-in backend selection remains unchanged.

## Test Plan

Run the included registry tests:

```bash
.venv/bin/python -m pytest  tests/kernels/moe/test_fp8_moe_backend_registry.py -v
```

I also tested an external CuTe DSL FP8 MoE backend on a single H100 (for correctness) then an end-to-end test with GLM-5.2-FP8 on an 8xH200 node using both TP-based expert parallelism and DP-based all-gather/reduce-scatter.

## Test Result

The registry test suite passed, and the external backend successfully served GLM-5.2-FP8 requests on an 8×H200 node across both mentioned parallelism strategies.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

