### PR TITLE
[ROCm][Fix] Do not use `flashinfer_nvlink_one_sided` all2all backend by default on non-cuda platform

### DIFF
--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -14,7 +14,22 @@ import pytest
 import torch
 import torch.multiprocessing as mp
 
+from vllm.config import (
+    ParallelConfig,
+    VllmConfig,
+    get_current_vllm_config,
+    set_current_vllm_config,
+)
 from vllm.distributed import get_ep_group
+from vllm.distributed.device_communicators.all2all import (
+    AgRsAll2AllManager,
+    All2AllManagerBase,
+    FlashInferNVLinkOneSidedManager,
+)
+from vllm.distributed.device_communicators.base_device_communicator import (
+    DeviceCommunicatorBase,
+)
+from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
 from vllm.utils.flashinfer import (
     has_flashinfer_nvlink_one_sided,
     has_flashinfer_nvlink_two_sided,
@@ -23,6 +38,70 @@ from vllm.utils.import_utils import has_deep_ep_v2
 from vllm.utils.network_utils import get_open_port
 
 from ..utils import init_test_distributed_environment
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_backend"),
+    [
+        pytest.param(
+            "cuda",
+            "flashinfer_nvlink_one_sided",
+            marks=pytest.mark.skipif(
+                not has_flashinfer_nvlink_one_sided(),
+                reason="FlashInfer NVLink one-sided not available",
+            ),
+        ),
+        ("non_cuda", "allgather_reducescatter"),
+    ],
+)
+def test_default_ep_communicator_uses_platform_all2all_backend(
+    monkeypatch, platform, expected_backend
+):
+    def init_device_communicator(
+        self,
+        cpu_group,
+        device,
+        device_group,
+        unique_name,
+        global_ranks,
+        global_world_size,
+        *,
+        use_all2all,
+    ):
+        self.cpu_group = cpu_group
+        self.device = device
+        self.device_group = device_group
+        self.unique_name = unique_name
+        self.world_size = 1
+        self.use_all2all = unique_name.startswith("ep:") and use_all2all
+        self.all2all_backend = get_current_vllm_config().parallel_config.all2all_backend
+        self.all2all_manager = None
+
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform.is_cuda", lambda: platform == "cuda"
+    )
+    monkeypatch.setattr(DeviceCommunicatorBase, "__init__", init_device_communicator)
+    monkeypatch.setattr(All2AllManagerBase, "__init__", lambda self, *args: None)
+
+    vllm_config = VllmConfig(parallel_config=ParallelConfig())
+    with set_current_vllm_config(vllm_config):
+        device_comm_cls = CudaCommunicator
+        device_communicator = device_comm_cls(
+            cpu_group=object(),
+            device=torch.device("cuda:0"),
+            device_group=object(),
+            unique_name="ep:test",
+            use_all2all=True,
+        )
+
+    assert device_communicator.all2all_backend == expected_backend
+    if platform == "cuda":
+        assert isinstance(
+            device_communicator.all2all_manager, FlashInferNVLinkOneSidedManager
+        )
+    else:
+        assert isinstance(device_communicator.all2all_manager, AgRsAll2AllManager)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -192,7 +192,13 @@ class ParallelConfig:
       with 4 experts and 2 ranks, rank 0 will have experts [0, 2] and rank 1
       will have experts [1, 3]. This strategy can help improve load balancing
       for grouped expert models with no redundant experts."""
-    all2all_backend: All2AllBackend = "flashinfer_nvlink_one_sided"
+    all2all_backend: All2AllBackend = Field(
+        default_factory=lambda: (
+            "flashinfer_nvlink_one_sided"
+            if current_platform.is_cuda()
+            else "allgather_reducescatter"
+        )
+    )
     """All2All backend for MoE expert parallel communication. Available options:
 
     - "allgather_reducescatter": All2all based on allgather and reducescatter
@@ -492,6 +498,15 @@ class ParallelConfig:
                 self.all2all_backend,
             )
             self.all2all_backend = "allgather_reducescatter"
+
+        if (
+            self.all2all_backend == "flashinfer_nvlink_one_sided"
+            and not current_platform.is_cuda()
+        ):
+            raise ValueError(
+                "all2all_backend='flashinfer_nvlink_one_sided' is only "
+                "supported on CUDA. Use 'allgather_reducescatter' on ROCm."
+            )
 
         if self.data_parallel_size_local > self.data_parallel_size:
             raise ValueError(


### PR DESCRIPTION
## Disclosure

AI assistance was used. The changes were reviewed and tested manually.

## Purpose

Fix ROCm (non-CUDA) expert-parallel initialization after #53311 that made `flashinfer_nvlink_one_sided` the global all-to-all default.

FlashInfer's NVLink backend is CUDA-only.

e.g. `vllm serve amd/Qwen3.5-35B-A3B-MXFP4 --data-parallel-size 2` fails due to this:

```
[multiproc_executor.py:944]   File "/felmarty/repos/vllm/vllm/v1/worker/gpu_worker.py", line 1452, in init_worker_distributed_environment
[multiproc_executor.py:944]     ensure_model_parallel_initialized(
[multiproc_executor.py:944]   File "/felmarty/repos/vllm/vllm/distributed/parallel_state.py", line 2014, in ensure_model_parallel_initialized
[multiproc_executor.py:944]     initialize_model_parallel(
[multiproc_executor.py:944]   File "/felmarty/repos/vllm/vllm/distributed/parallel_state.py", line 1949, in initialize_model_parallel
[multiproc_executor.py:944]     _EP = init_model_parallel_group(
[multiproc_executor.py:944]           ^^^^^^^^^^^^^^^^^^^^^^^^^^
[multiproc_executor.py:944]   File "/felmarty/repos/vllm/vllm/distributed/parallel_state.py", line 1324, in init_model_parallel_group
[multiproc_executor.py:944]     return GroupCoordinator(
[multiproc_executor.py:944]            ^^^^^^^^^^^^^^^^^
[multiproc_executor.py:944]   File "/felmarty/repos/vllm/vllm/distributed/parallel_state.py", line 507, in __init__
[multiproc_executor.py:944]     self.device_communicator = device_comm_cls(
[multiproc_executor.py:944]                                ^^^^^^^^^^^^^^^^
[multiproc_executor.py:944]   File "/felmarty/repos/vllm/vllm/distributed/device_communicators/cuda_communicator.py", line 202, in __init__
[multiproc_executor.py:944]     self.all2all_manager = FlashInferNVLinkOneSidedManager(self.cpu_group)
[multiproc_executor.py:944]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[multiproc_executor.py:944]   File "/felmarty/repos/vllm/vllm/distributed/device_communicators/all2all.py", line 712, in __init__
[multiproc_executor.py:944]     assert has_flashinfer_nvlink_one_sided(), (
[multiproc_executor.py:944]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[multiproc_executor.py:944] AssertionError: flashinfer trtllm_moe_alltoall module not found. Please install/check flashinfer
```

## Test Plan

```bash
pytest tests/distributed/test_mnnvl_alltoall.py::test_default_ep_communicator_uses_platform_all2all_backend -v
```

and `vllm serve amd/Qwen3.5-35B-A3B-MXFP4 --data-parallel-size 2`

## Test Results

Passing on MI350