### PR TITLE
[Bugfix][Kernel] Fix 32-bit index overflow in moe_wna16_gemm

### DIFF
--- a/csrc/libtorch_stable/moe/moe_wna16.cu
+++ b/csrc/libtorch_stable/moe/moe_wna16.cu
@@ -77,8 +77,12 @@ __global__ void moe_wna16_gemm_kernel(
             origin_k = BLOCK_SIZE_N * i + threadIdx.x / 4 * 4 + order;
           }
 
-          origin_k += token_index / top_k * size_k + blockIdx.z * BLOCK_SIZE_K;
-          block_input[m * BLOCK_SIZE_K + k] = input[origin_k];
+          // (token_index / top_k) * size_k reaches size_m * size_k, which
+          // exceeds 2 ** 31 for large prefills.
+          const int64_t input_offset =
+              static_cast<int64_t>(token_index / top_k) * size_k +
+              blockIdx.z * BLOCK_SIZE_K + origin_k;
+          block_input[m * BLOCK_SIZE_K + k] = input[input_offset];
         }
       }
     }
@@ -216,8 +220,11 @@ __global__ void moe_wna16_gemm_kernel(
       if (mul_topk_weight) {
         res[m] *= topk_weights[token_index];
       }
-      atomicAdd(&output[token_index * size_n + offset_n],
-                Dtype::float2num(res[m]));
+      // token_index reaches size_m * top_k, so token_index * size_n exceeds
+      // 2 ** 31 before any other index in this kernel does.
+      const int64_t output_offset =
+          static_cast<int64_t>(token_index) * size_n + offset_n;
+      atomicAdd(&output[output_offset], Dtype::float2num(res[m]));
     }
 
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800


### PR DESCRIPTION
## Purpose

Fixes #45884.

`moe_wna16.cu` already knows about this problem. At line 95 it says:

```cpp
// note that (size_n * size_k * expert_id) may greater than 2 ** 31
const uint64_t expert_offset = ((uint64_t)size_n) * size_k * expert_id;
```

But two other index computations in the same kernel have the same problem and were not covered.

**1. The output write (the one reported in #45884).** `token_index` comes from `sorted_token_ids` and reaches `size_m * top_k`, so `token_index * size_n` is the largest index in the whole kernel. `token_index` is `int32_t` and `size_n` is `uint32_t`, so the product is done in 32-bit unsigned and wraps.

**2. The input read.** `origin_k` is `int`, and `(token_index / top_k) * size_k` reaches `size_m * size_k`. Signed overflow here gives a negative index.

## Modifications

Both offsets are now computed in `int64_t`.

I did **not** widen the other three 32-bit index sites in this kernel (`expert_scales`, `expert_qzeros`, `expert_qweight`). They are bounded by `size_n * size_k` inside one expert, which is about 5.8e6 elements for normal MoE shapes, so they cannot reach 2 ** 31. Widening them would only add register pressure.

Smallest token count at which each site breaks, for `size_n=2816, size_k=2048, top_k=4, group_size=128`:

| site | line | kind | type | overflows at |
| --- | --- | --- | --- | --- |
| `output[token_index * size_n + offset_n]` | 219 | write | uint32 | 381,301 tokens |
| `input[origin_k]` | 80 | read | int32 | 1,048,576 tokens |
| `expert_scales[scales_offset_tmp]` | 112 | read | int32 | never |
| `expert_qzeros[qzeros_offset_tmp]` | 141 | read | int32 | never |
| `expert_qweight[weight_offset]` | 170 | read | int32 | never |

So the output write is the first thing to break, which matches the report.

## Accuracy Tests

I do not have an NVIDIA GPU, so I could not run the kernel. Triggering site 1 also needs an output tensor of about 8.6 GB, which is not something CI can do.

What I did instead: copied both expressions with their exact types into a host C++ program. Integer promotion is the same there as in device code for these scalar types.

```
site 1: output[token_index * size_n + offset_n]   (write)
  token_index  old (uint32)   new (int64)
  1525200      4294966015     4294966015     ok
  1525201      1535           4294968831     WRAPPED
  2000000      1337035519     5632002815     WRAPPED

site 2: input[origin_k]  (read)
  token_index  old (int32)    new (int64)
  4000000      2048000017     2048000017     ok
  4194304      -2147483631    2147483665     WRAPPED
  8388608      17             4294967313     WRAPPED
```

The middle row of site 1 is the exact example from #45884. The index becomes `1535` instead of `4294968831`, so the `atomicAdd` lands near the start of the output buffer and corrupts another token's row. It does not crash, it just returns wrong numbers.

Site 2 produces a negative index, which reads before the buffer.

Happy to attach the reproduction program if that is useful for review.

## Speed Tests and Profiling

Not measured, no GPU. The change is two 64-bit offset computations, one per output element and one per input load. I do not expect it to be visible, but I cannot show numbers, so please tell me if a benchmark is required before merge.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.vllm.ai/en/latest/contributing/index.html).
- [ ] Add unit tests — see Accuracy Tests above, the failing shape does not fit in CI.
- [ ] Update documentation.
- [ ] Provide accuracy and speed benchmark results.
