### PR TITLE
[Kernel][Qwen]Add qwen4 fuse op

### DIFF
--- a/tests/kernels/attention/test_qwen4_qsa_kernels.py
+++ b/tests/kernels/attention/test_qwen4_qsa_kernels.py
@@ -1,0 +1,272 @@
+# Copyright 2026, The FlagOS Contributors.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness coverage for the self-developed Qwen4 QSA kernels.
+
+Torch references live in this test module only. The production wrappers are
+required to fail closed instead of dispatching a Torch compute fallback.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytest.importorskip("triton")
+
+from vllm.model_executor.layers.qsa import (  # noqa: E402
+    qwen4_compress_norm_mrope_store_groups,
+    qwen4_qsa_mqa_paged_dot,
+    qwen4_store_qsa_kv_rows,
+)
+
+DEVICE = current_platform.device_type
+EPS = 1.0e-6
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Qwen4 QSA Triton kernels require CUDA/ROCm.",
+)
+
+
+def _qsa_mqa_reference(q, cache, table, token_to_req, positions, lengths, ratio):
+    columns = table.shape[1] * cache.shape[1]
+    req = token_to_req.to(torch.int64)
+    valid_req = (req >= 0) & (req < table.shape[0])
+    safe_req = req.clamp(0, table.shape[0] - 1)
+    seq = lengths.index_select(0, safe_req)
+    seq = torch.where(valid_req, seq, torch.zeros_like(seq))
+    visible = torch.minimum((positions.to(torch.int64) + 1) // ratio, seq // ratio)
+    col = torch.arange(columns, device=q.device, dtype=torch.int64)
+    logical_page = col // cache.shape[1]
+    offset = col % cache.shape[1]
+    safe_logical = logical_page.clamp(0, table.shape[1] - 1)
+    physical = table[safe_req[:, None], safe_logical[None, :]].to(torch.int64)
+    valid = (
+        valid_req[:, None]
+        & (col[None, :] < visible[:, None])
+        & (physical >= 0)
+        & (physical < cache.shape[0])
+    )
+    safe_physical = physical.clamp(0, cache.shape[0] - 1)
+    keys = cache[safe_physical, offset[None, :], 0].float()
+    dots = torch.matmul(q.float(), keys.transpose(1, 2))
+    logits = torch.relu(dots).sum(1) / math.sqrt(q.shape[-1])
+    logits = logits.masked_fill(~valid, -float("inf"))
+    return logits, visible.to(torch.int32)
+
+
+def test_qwen4_qsa_mqa_paged_dot_matches_torch_and_invalid_pages():
+    rows, page_size, pages, columns = 8, 16, 4, 48
+    torch.manual_seed(202)
+    q = torch.randn((rows, 4, 128), device=DEVICE, dtype=torch.bfloat16)
+    cache = torch.randn((pages, page_size, 1, 128), device=DEVICE, dtype=torch.bfloat16)
+    table = torch.tensor(
+        [[0, 1, 2], [1, 2, 3], [2, 3, 0], [3, 0, 1]],
+        device=DEVICE,
+        dtype=torch.int32,
+    )
+    table[2, 1] = -1
+    token_to_req = torch.tensor(
+        [0, 1, 2, 3, 0, 1, -1, 3], device=DEVICE, dtype=torch.int32
+    )
+    positions = torch.tensor(
+        [47, 39, 31, 23, 47, 35, 47, 15], device=DEVICE, dtype=torch.int64
+    )
+    lengths = torch.tensor([48, 40, 32, 24], device=DEVICE, dtype=torch.int64)
+
+    ref_logits, ref_visible = _qsa_mqa_reference(
+        q, cache, table, token_to_req, positions, lengths, 4
+    )
+    out_logits, out_visible = qwen4_qsa_mqa_paged_dot(
+        q,
+        cache,
+        table,
+        token_to_req,
+        positions,
+        lengths,
+        compress_ratio=4,
+        num_columns=columns,
+    )
+    torch.testing.assert_close(out_visible, ref_visible, atol=0, rtol=0)
+    torch.testing.assert_close(out_logits, ref_logits, atol=0.2, rtol=0.02)
+    assert torch.isneginf(out_logits[6]).all()
+    assert torch.isneginf(out_logits[2, 8:]).all()
+
+    snapshot = out_logits.clone()
+    for _ in range(10):
+        again, visible = qwen4_qsa_mqa_paged_dot(
+            q,
+            cache,
+            table,
+            token_to_req,
+            positions,
+            lengths,
+            compress_ratio=4,
+            num_columns=columns,
+        )
+        torch.testing.assert_close(again, snapshot, atol=0, rtol=0)
+        torch.testing.assert_close(visible, out_visible, atol=0, rtol=0)
+
+
+def test_qwen4_qsa_kv_store_matches_torch_and_skips_invalid_slots():
+    blocks, page_size, heads, dim, rows = 3, 4, 2, 17, 5
+    torch.manual_seed(303)
+    initial_k = torch.randn(
+        (blocks, page_size, heads, dim), device=DEVICE, dtype=torch.bfloat16
+    )
+    initial_v = torch.randn_like(initial_k)
+    key = torch.randn((rows, heads, dim), device=DEVICE, dtype=torch.bfloat16)
+    value = torch.randn_like(key)
+    slots = torch.tensor([0, 3, 4, 11, -1], device=DEVICE, dtype=torch.int64)
+
+    ref_k, ref_v = initial_k.clone(), initial_v.clone()
+    valid = (slots >= 0) & (slots < blocks * page_size)
+    safe = slots[valid]
+    ref_k.index_put_(
+        (safe // page_size, safe % page_size), key[valid], accumulate=False
+    )
+    ref_v.index_put_(
+        (safe // page_size, safe % page_size), value[valid], accumulate=False
+    )
+
+    out_k, out_v = initial_k.clone(), initial_v.clone()
+    qwen4_store_qsa_kv_rows(out_k, out_v, slots, key, value)
+    torch.testing.assert_close(out_k, ref_k, atol=0, rtol=0)
+    torch.testing.assert_close(out_v, ref_v, atol=0, rtol=0)
+
+
+def _compress_reference(
+    raw, rope, table, requests, positions, slots, weight, cos_sin, out
+):
+    ratio = 4
+    for row in range(requests.numel()):
+        request = int(requests[row].item())
+        end = int(positions[row].item())
+        slot = int(slots[row].item())
+        raw_rows = []
+        for offset in range(ratio):
+            pos = end - (ratio - 1 - offset)
+            page = int(table[request, pos // raw.shape[1]].item())
+            raw_rows.append(raw[page, pos % raw.shape[1], 0].float())
+        pooled = (torch.stack(raw_rows).sum(0) / ratio).to(torch.bfloat16)
+        pooled_fp32 = pooled.float()
+        variance = pooled_fp32.square().mean() / 1.0
+        normalized = (
+            pooled_fp32 * torch.rsqrt(variance + EPS) * (weight.float() + 1.0)
+        ).to(torch.bfloat16)
+        first_pos = end - ratio + 1
+        page = int(table[request, first_pos // raw.shape[1]].item())
+        axes = rope[page, first_pos % rope.shape[1], 0, :3]
+        freq = torch.arange(32, device=raw.device)
+        use_h = (freq % 3 == 1) & (freq < 3 * 11)
+        use_w = (freq % 3 == 2) & (freq < 3 * 10)
+        axis_pos = torch.where(
+            use_h,
+            axes[1],
+            torch.where(use_w, axes[2], axes[0]),
+        )
+        cos = cos_sin[axis_pos, freq].float()
+        sin = cos_sin[axis_pos, 32 + freq].float()
+        first = normalized[:32].float()
+        second = normalized[32:64].float()
+        rotated_first = (first * cos - second * sin).to(torch.bfloat16)
+        rotated_second = (second * cos + first * sin).to(torch.bfloat16)
+        stored = torch.cat((rotated_first, rotated_second, normalized[64:]), dim=0)
+        block, token = slot // out.shape[1], slot % out.shape[1]
+        out[block, token, 0].copy_(stored)
+
+
+def test_qwen4_qsa_fused_compress_norm_mrope_interleaved_matches_torch():
+    page_size, raw_blocks = 8, 2
+    torch.manual_seed(404)
+    raw = torch.randn(
+        (raw_blocks, page_size, 1, 128), device=DEVICE, dtype=torch.bfloat16
+    )
+    rope = torch.empty((raw_blocks, page_size, 1, 3), device=DEVICE, dtype=torch.int64)
+    rope[..., 0] = torch.arange(page_size, device=DEVICE).view(1, page_size, 1) % 16
+    rope[..., 1] = (
+        torch.arange(page_size, device=DEVICE).view(1, page_size, 1) + 1
+    ) % 16
+    rope[..., 2] = (
+        torch.arange(page_size, device=DEVICE).view(1, page_size, 1) + 2
+    ) % 16
+    table = torch.tensor([[0, 1]], device=DEVICE, dtype=torch.int32)
+    requests = torch.tensor([0, 0], device=DEVICE, dtype=torch.int32)
+    positions = torch.tensor([3, 7], device=DEVICE, dtype=torch.int64)
+    slots = torch.tensor([0, 1], device=DEVICE, dtype=torch.int64)
+    weight = torch.randn((128,), device=DEVICE, dtype=torch.bfloat16) * 0.01
+    t = torch.arange(16, device=DEVICE, dtype=torch.float32)
+    freq = torch.arange(32, device=DEVICE, dtype=torch.float32)
+    inv_freq = 1.0 / (10000.0 ** (freq / 32.0))
+    angles = t[:, None] * inv_freq[None, :]
+    cos_sin = torch.cat((angles.cos(), angles.sin()), dim=-1).to(torch.bfloat16)
+    initial = torch.full_like(raw, 7)
+    expected = initial.clone()
+    _compress_reference(
+        raw, rope, table, requests, positions, slots, weight, cos_sin, expected
+    )
+
+    actual = initial.clone()
+    qwen4_compress_norm_mrope_store_groups(
+        raw,
+        table,
+        requests,
+        positions,
+        slots,
+        actual,
+        weight,
+        cos_sin,
+        compress_ratio=4,
+        norm_eps=EPS,
+        rotary_dim=64,
+        mrope_section=(11, 11, 10),
+        mrope_interleaved=True,
+        rope_cache=rope,
+    )
+    torch.testing.assert_close(actual, expected, atol=0.03, rtol=0.02)
+
+    snapshot = actual.clone()
+    for _ in range(3):
+        repeated = initial.clone()
+        qwen4_compress_norm_mrope_store_groups(
+            raw,
+            table,
+            requests,
+            positions,
+            slots,
+            repeated,
+            weight,
+            cos_sin,
+            compress_ratio=4,
+            norm_eps=EPS,
+            rotary_dim=64,
+            mrope_section=(11, 11, 10),
+            mrope_interleaved=True,
+            rope_cache=rope,
+        )
+        torch.testing.assert_close(repeated, snapshot, atol=0, rtol=0)
+
+
+def test_qsa_exports_are_explicit():
+    from vllm.model_executor.layers import qsa as qsa_module
+
+    names = set(qsa_module.__all__)
+    assert {
+        "_qsa_mqa_paged_dot_kernel",
+        "_store_qsa_kv_rows_kernel",
+        "_compress_norm_mrope_store_qsa_groups_kernel",
+    } <= names
+
+
+def test_qwen4_qsa_cpu_guards_fail_closed():
+    cache = torch.empty((1, 16, 1, 128), dtype=torch.bfloat16)
+    q = torch.empty((1, 4, 128), dtype=torch.bfloat16)
+    table = torch.zeros((1, 1), dtype=torch.int32)
+    metadata = torch.zeros((1,), dtype=torch.int32)
+    with pytest.raises(RuntimeError):
+        qwen4_qsa_mqa_paged_dot(q, cache, table, metadata, metadata, metadata)

--- a/tests/kernels/test_qwen4_hyperconnection_kernels.py
+++ b/tests/kernels/test_qwen4_hyperconnection_kernels.py
@@ -1,0 +1,112 @@
+# Copyright 2026, The FlagOS Contributors.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness coverage for the self-developed Qwen4 hyperconnection kernels.
+
+Torch references live in this test module only. The production wrappers are
+required to fail closed instead of dispatching a Torch compute fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytest.importorskip("triton")
+
+from vllm.model_executor.layers.hyperconnection import (  # noqa: E402
+    qwen4_grouped_gemma_rmsnorm,
+    qwen4_hc_gate_reduce,
+    qwen4_hc_inject_combine,
+)
+
+DEVICE = current_platform.device_type
+HC = 4
+EPS = 1.0e-6
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Qwen4 hyperconnection Triton kernels require CUDA/ROCm.",
+)
+
+
+def _hc_refs(x, weight, logits, normed, injection, block, residual):
+    hidden = weight.numel() // HC
+    x3 = x.reshape(-1, HC, hidden).float()
+    w2 = weight.reshape(HC, hidden).float()
+    rms = torch.rsqrt(x3.square().mean(-1, keepdim=True) + EPS)
+    norm_ref = (x3 * rms * (1.0 + w2)).to(x.dtype).reshape_as(x)
+    gate_ref = (
+        (
+            torch.sigmoid(logits.float().reshape(-1, HC, hidden))
+            * normed.float().reshape(-1, HC, hidden)
+        )
+        .mean(-2)
+        .to(normed.dtype)
+    )
+    alpha = 2.0 * torch.sigmoid(injection.float() / HC)
+    inject_ref = (
+        (
+            residual.float().reshape(-1, HC, hidden)
+            + block.float().unsqueeze(-2) * alpha.unsqueeze(-1)
+        )
+        .to(residual.dtype)
+        .reshape_as(residual)
+    )
+    return norm_ref, gate_ref, inject_ref
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("rows,hidden", [(1, 257), (3, 513)])
+def test_qwen4_hyperconnection_matches_torch(dtype, rows, hidden):
+    torch.manual_seed(101 + rows + hidden)
+    x = torch.randn((rows, HC * hidden), device=DEVICE, dtype=dtype)
+    weight = torch.randn((HC * hidden,), device=DEVICE, dtype=dtype) * 0.01
+    logits = torch.randn_like(x)
+    normed = torch.randn_like(x)
+    injection = torch.randn((rows, HC), device=DEVICE, dtype=dtype)
+    block = torch.randn((rows, hidden), device=DEVICE, dtype=dtype)
+    residual = torch.randn_like(x)
+    norm_ref, gate_ref, inject_ref = _hc_refs(
+        x, weight, logits, normed, injection, block, residual
+    )
+
+    norm_out = qwen4_grouped_gemma_rmsnorm(x, weight, HC, EPS)
+    gate_out = qwen4_hc_gate_reduce(logits, normed, HC)
+    inject_out = qwen4_hc_inject_combine(injection, block, residual, HC)
+
+    atol = 3.0e-2 if dtype == torch.bfloat16 else 2.0e-2
+    rtol = 2.0e-2
+    torch.testing.assert_close(norm_out, norm_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(gate_out, gate_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(inject_out, inject_ref, atol=atol, rtol=rtol)
+
+    snapshots = (norm_out.clone(), gate_out.clone(), inject_out.clone())
+    for _ in range(10):
+        torch.testing.assert_close(
+            qwen4_grouped_gemma_rmsnorm(x, weight, HC, EPS),
+            snapshots[0],
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            qwen4_hc_gate_reduce(logits, normed, HC),
+            snapshots[1],
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            qwen4_hc_inject_combine(injection, block, residual, HC),
+            snapshots[2],
+            atol=0,
+            rtol=0,
+        )
+
+
+def test_qwen4_hc_cpu_guards_fail_closed():
+    x = torch.empty((1, 16), dtype=torch.bfloat16)
+    weight = torch.empty((16,), dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError):
+        qwen4_grouped_gemma_rmsnorm(x, weight, 4, EPS)

--- a/tests/kernels/test_qwen4_ple_state_kernels.py
+++ b/tests/kernels/test_qwen4_ple_state_kernels.py
@@ -1,0 +1,75 @@
+# Copyright 2026, The FlagOS Contributors.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness coverage for the self-developed Qwen4 PLE-state kernels.
+
+Torch references live in this test module only. The production wrappers are
+required to fail closed instead of dispatching a Torch compute fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytest.importorskip("triton")
+
+from vllm.model_executor.layers.ple_state import (  # noqa: E402
+    ple_state_gather,
+    ple_state_scatter_,
+)
+
+DEVICE = current_platform.device_type
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Qwen4 PLE-state Triton kernels require CUDA/ROCm.",
+)
+
+
+def _strided_state(cache_rows, hidden, width):
+    storage = torch.randn(
+        (cache_rows, width, hidden), device=DEVICE, dtype=torch.bfloat16
+    )
+    return storage.transpose(1, 2)
+
+
+def test_qwen4_ple_gather_preserves_strides_and_null_is_not_row_zero():
+    state = _strided_state(11, 3, 5)
+    indices = torch.tensor([1, -1, 1, 99, 2], device=DEVICE, dtype=torch.int64)
+    output = ple_state_gather(state, indices)
+    valid = (indices >= 0) & (indices < state.shape[0])
+    bounded = indices.clamp(0, state.shape[0] - 1)
+    expected = torch.ops.aten.index_select.default(state, 0, bounded)
+    expected = torch.where(valid.view(-1, 1, 1), expected, torch.zeros_like(expected))
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    assert output.stride(1) == 1
+    assert torch.equal(output[1], torch.zeros_like(output[1]))
+    assert not torch.equal(output[1], state[0])
+
+
+def test_qwen4_ple_scatter_masked_null_and_duplicate_is_exact():
+    state = _strided_state(11, 3, 5)
+    baseline = state.clone()
+    indices = torch.tensor([-1, 2, 2, 99, 4], device=DEVICE, dtype=torch.int64)
+    rows = torch.randn_like(state[: indices.numel()])
+    write_mask = torch.tensor(
+        [False, False, True, True, True], device=DEVICE, dtype=torch.bool
+    )
+    expected = baseline.clone()
+    for row, index in enumerate(indices.tolist()):
+        if bool(write_mask[row]) and 0 <= index < state.shape[0]:
+            expected[index].copy_(rows[row])
+    ple_state_scatter_(state, indices, rows, write_mask=write_mask)
+    torch.testing.assert_close(state, expected, atol=0, rtol=0)
+    torch.testing.assert_close(state[0], baseline[0], atol=0, rtol=0)
+    with pytest.raises(NotImplementedError):
+        ple_state_scatter_(baseline, indices, rows)
+
+
+def test_qwen4_ple_cpu_guards_fail_closed():
+    state = torch.empty((2, 3, 5), dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError):
+        ple_state_gather(state, torch.zeros((1,), dtype=torch.int64))

--- a/vllm/model_executor/layers/hyperconnection.py
+++ b/vllm/model_executor/layers/hyperconnection.py
@@ -1,0 +1,335 @@
+# Copyright 2026, The FlagOS Contributors.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Graph-safe Triton kernels for Qwen4 gated HyperConnection.
+
+This module contains only the three self-developed Qwen4 HC device kernels.
+The model wiring and vLLM custom-op registration stay in the model/plugin
+repository.  The wrappers below are standalone FlagGems-vllm entry points and
+fail closed when their accelerator/layout contract is not met.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+HAS_TRITON = True
+
+
+def can_use_hc_triton(*tensors: torch.Tensor) -> bool:
+    """Return whether the specialized contiguous inference path is usable."""
+
+    return bool(
+        HAS_TRITON
+        and tensors
+        and len({tensor.device for tensor in tensors}) == 1
+        and all(
+            tensor.device.type not in ("cpu", "meta")
+            and tensor.dtype in (torch.bfloat16, torch.float16)
+            and tensor.is_contiguous()
+            for tensor in tensors
+        )
+    )
+
+
+def _has_flat_row_layout(tensor: torch.Tensor) -> bool:
+    """Return whether leading dims can be flattened using ``stride(-2)``.
+
+    Packed HC projection output is split into ``[..., lowrank]`` and
+    ``[..., hc_count]`` views.  The latter is contiguous within each row but
+    retains the packed projection's wider row stride.  The injection kernel
+    accepts that layout explicitly, while still rejecting transposes and
+    layouts whose leading dimensions cannot be flattened into rows.
+    """
+
+    if tensor.ndim < 2 or tensor.stride(-1) != 1:
+        return False
+    if tensor.stride(-2) < tensor.shape[-1]:
+        return False
+    return all(
+        tensor.stride(dim) == tensor.shape[dim + 1] * tensor.stride(dim + 1)
+        for dim in range(tensor.ndim - 2)
+    )
+
+
+def can_use_hc_inject_triton(
+    injection_logits: torch.Tensor,
+    block_output: torch.Tensor,
+    residual: torch.Tensor,
+) -> bool:
+    """Allow packed-projection logits with a wider row stride.
+
+    ``_hc_inject_combine_kernel`` consumes ``stride_logits_row`` and only
+    requires the branch dimension to be contiguous.  The other two inputs
+    retain the stricter contiguous inference contract.
+    """
+
+    tensors = (injection_logits, block_output, residual)
+    return bool(
+        HAS_TRITON
+        and all(
+            tensor.device.type not in ("cpu", "meta")
+            and tensor.dtype in (torch.bfloat16, torch.float16)
+            for tensor in tensors
+        )
+        and len({tensor.device for tensor in tensors}) == 1
+        and _has_flat_row_layout(injection_logits)
+        and block_output.is_contiguous()
+        and residual.is_contiguous()
+    )
+
+
+@triton.jit
+def _grouped_gemma_rmsnorm_kernel(
+    input_ptr,
+    weight_ptr,
+    output_ptr,
+    hidden_size: tl.constexpr,
+    hc_count: tl.constexpr,
+    eps: tl.constexpr,
+    block_h: tl.constexpr,
+) -> None:
+    group_row = tl.program_id(0)
+    offsets = tl.arange(0, block_h)
+    mask = offsets < hidden_size
+    input_base = group_row * hidden_size
+    weight_base = (group_row % hc_count) * hidden_size
+    values = tl.load(input_ptr + input_base + offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    weight = tl.load(weight_ptr + weight_base + offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    inv_rms = tl.rsqrt(tl.sum(values * values, axis=0) / hidden_size + eps)
+    tl.store(
+        output_ptr + input_base + offsets,
+        values * inv_rms * (1.0 + weight),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _hc_gate_reduce_kernel(
+    logits_ptr,
+    normed_ptr,
+    output_ptr,
+    stride_logits_row,
+    stride_normed_row,
+    stride_output_row,
+    hidden_size: tl.constexpr,
+    hc_count: tl.constexpr,
+    block_h: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    offsets = tl.program_id(1) * block_h + tl.arange(0, block_h)
+    mask = offsets < hidden_size
+    accumulator = tl.zeros((block_h,), dtype=tl.float32)
+    for branch in tl.static_range(0, hc_count):
+        branch_offsets = branch * hidden_size + offsets
+        logits = tl.load(
+            logits_ptr + row * stride_logits_row + branch_offsets,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        normed = tl.load(
+            normed_ptr + row * stride_normed_row + branch_offsets,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.sigmoid(logits) * normed
+    tl.store(
+        output_ptr + row * stride_output_row + offsets,
+        accumulator / hc_count,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _hc_inject_combine_kernel(
+    injection_logits_ptr,
+    block_output_ptr,
+    residual_ptr,
+    output_ptr,
+    stride_logits_row,
+    stride_block_row,
+    stride_residual_row,
+    stride_output_row,
+    hidden_size: tl.constexpr,
+    hc_count: tl.constexpr,
+    block_h: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    branch = tl.program_id(1)
+    offsets = tl.program_id(2) * block_h + tl.arange(0, block_h)
+    mask = offsets < hidden_size
+    branch_offsets = branch * hidden_size + offsets
+    logits = tl.load(injection_logits_ptr + row * stride_logits_row + branch).to(
+        tl.float32
+    )
+    injection_weight = 2.0 * tl.sigmoid(logits / hc_count)
+    block_output = tl.load(
+        block_output_ptr + row * stride_block_row + offsets,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    residual = tl.load(
+        residual_ptr + row * stride_residual_row + branch_offsets,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(
+        output_ptr + row * stride_output_row + branch_offsets,
+        residual + block_output * injection_weight,
+        mask=mask,
+    )
+
+
+def qwen4_grouped_gemma_rmsnorm(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    hc_count: int,
+    eps: float,
+) -> torch.Tensor:
+    if hidden_states.ndim < 2 or hidden_states.shape[-1] != weight.numel():
+        raise ValueError("Qwen4 HC RMSNorm received incompatible input and weight")
+    if hc_count <= 0 or weight.numel() % hc_count or eps <= 0:
+        raise ValueError("Qwen4 HC RMSNorm requires a valid HC count")
+    if not can_use_hc_triton(hidden_states, weight):
+        raise RuntimeError("Qwen4 HC RMSNorm requires contiguous accelerator tensors")
+    output = torch.empty_like(hidden_states)
+    if not hidden_states.numel():
+        return output
+    hidden_size = weight.numel() // hc_count
+    block_h = triton.next_power_of_2(hidden_size)
+    rows = hidden_states.numel() // weight.numel()
+    _grouped_gemma_rmsnorm_kernel[(rows * hc_count,)](
+        hidden_states,
+        weight,
+        output,
+        hidden_size=hidden_size,
+        hc_count=hc_count,
+        eps=eps,
+        block_h=block_h,
+        num_warps=8 if block_h > 2048 else 4,
+    )
+    return output
+
+
+def qwen4_grouped_gemma_rmsnorm_fake(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    hc_count: int,
+    eps: float,
+) -> torch.Tensor:
+    del weight, hc_count, eps
+    return torch.empty_like(hidden_states)
+
+
+def qwen4_hc_gate_reduce(
+    logits: torch.Tensor,
+    normed: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    if logits.shape != normed.shape or logits.ndim < 2:
+        raise ValueError("Qwen4 HC gate logits and normalized input must match")
+    if hc_count <= 0 or logits.shape[-1] % hc_count:
+        raise ValueError("Qwen4 HC gate reduction requires a valid HC count")
+    if not can_use_hc_triton(logits, normed):
+        raise RuntimeError("Qwen4 HC gate reduction requires contiguous tensors")
+    hidden_size = logits.shape[-1] // hc_count
+    output = torch.empty(
+        (*logits.shape[:-1], hidden_size), dtype=normed.dtype, device=normed.device
+    )
+    if not logits.numel():
+        return output
+    rows = logits.numel() // logits.shape[-1]
+    block_h = 256
+    _hc_gate_reduce_kernel[(rows, triton.cdiv(hidden_size, block_h))](
+        logits,
+        normed,
+        output,
+        logits.stride(-2),
+        normed.stride(-2),
+        output.stride(-2),
+        hidden_size=hidden_size,
+        hc_count=hc_count,
+        block_h=block_h,
+        num_warps=4,
+    )
+    return output
+
+
+def qwen4_hc_gate_reduce_fake(
+    logits: torch.Tensor,
+    normed: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    del normed
+    return torch.empty(
+        (*logits.shape[:-1], logits.shape[-1] // hc_count),
+        dtype=logits.dtype,
+        device=logits.device,
+    )
+
+
+def qwen4_hc_inject_combine(
+    injection_logits: torch.Tensor,
+    block_output: torch.Tensor,
+    residual: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    if injection_logits.shape != (*block_output.shape[:-1], hc_count):
+        raise ValueError("Qwen4 HC injection logits have an invalid shape")
+    if hc_count <= 0:
+        raise ValueError("Qwen4 HC injection requires a positive HC count")
+    if residual.shape != (
+        *block_output.shape[:-1],
+        hc_count * block_output.shape[-1],
+    ):
+        raise ValueError("Qwen4 HC residual and block output shapes are incompatible")
+    if not can_use_hc_inject_triton(injection_logits, block_output, residual):
+        raise RuntimeError(
+            "Qwen4 HC injection received an unsupported accelerator layout"
+        )
+    output = torch.empty_like(residual)
+    if not residual.numel():
+        return output
+    hidden_size = block_output.shape[-1]
+    rows = block_output.numel() // hidden_size
+    block_h = 256
+    _hc_inject_combine_kernel[(rows, hc_count, triton.cdiv(hidden_size, block_h))](
+        injection_logits,
+        block_output,
+        residual,
+        output,
+        injection_logits.stride(-2),
+        block_output.stride(-2),
+        residual.stride(-2),
+        output.stride(-2),
+        hidden_size=hidden_size,
+        hc_count=hc_count,
+        block_h=block_h,
+        num_warps=4,
+    )
+    return output
+
+
+def qwen4_hc_inject_combine_fake(
+    injection_logits: torch.Tensor,
+    block_output: torch.Tensor,
+    residual: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    del injection_logits, block_output, hc_count
+    return torch.empty_like(residual)
+
+
+__all__ = [
+    "can_use_hc_inject_triton",
+    "can_use_hc_triton",
+    "qwen4_grouped_gemma_rmsnorm",
+    "qwen4_hc_gate_reduce",
+    "qwen4_hc_inject_combine",
+]

--- a/vllm/model_executor/layers/ple_state.py
+++ b/vllm/model_executor/layers/ple_state.py
@@ -1,0 +1,308 @@
+# Copyright 2026, The FlagOS Contributors.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Row I/O kernels for the Qwen4 PLE short-conv state.
+
+The short-conv cache is exposed as a non-contiguous logical
+``[rows, hidden, width]`` view of physical ``[rows, width, hidden]`` storage.
+FlagGems 5.3/5.4 materializes that whole multi-GiB view for ``index_select``.
+These public entries therefore use the compact stride-aware Triton kernel on
+an accelerator satisfying the guard and fail closed elsewhere. Only NVIDIA
+H100 has current correctness/performance evidence for this extraction.
+
+The scatter write mask supplied by PLE prevents NULL/padded rows from writing
+the reserved row zero; out-of-range rows are ignored.  The caller must supply
+that mask explicitly so the original ``-1`` index remains distinguishable from
+valid row zero.  Duplicate destinations are supported when the mask keeps only
+the desired (normally last) writer.  There is no Torch compute fallback.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+HAS_TRITON = True
+
+
+_BLOCK_SIZE = 1024
+_NUM_WARPS = 8
+
+
+def _is_triton_device(*tensors: torch.Tensor) -> bool:
+    return bool(
+        HAS_TRITON
+        and tensors
+        and len({tensor.device for tensor in tensors}) == 1
+        and all(tensor.device.type not in ("cpu", "meta") for tensor in tensors)
+    )
+
+
+if HAS_TRITON:
+
+    @triton.jit
+    def _ple_state_gather_kernel_3d(
+        state_ptr,
+        indices_ptr,
+        output_ptr,
+        indices_stride,
+        state_stride0,
+        state_stride1,
+        state_stride2,
+        output_stride0,
+        output_stride1,
+        output_stride2,
+        num_cache_rows,
+        hidden_size,
+        state_width,
+        HIDDEN_FASTEST: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        valid = offsets < hidden_size * state_width
+        index = tl.load(indices_ptr + row * indices_stride).to(tl.int64)
+        valid_index = (index >= 0) & (index < num_cache_rows)
+        safe_index = tl.minimum(tl.maximum(index, 0), num_cache_rows - 1)
+        if HIDDEN_FASTEST:
+            hidden = offsets % hidden_size
+            width = offsets // hidden_size
+        else:
+            hidden = offsets // state_width
+            width = offsets % state_width
+        source = (
+            state_ptr
+            + safe_index * state_stride0
+            + hidden * state_stride1
+            + width * state_stride2
+        )
+        destination = (
+            output_ptr
+            + row * output_stride0
+            + hidden * output_stride1
+            + width * output_stride2
+        )
+        values = tl.load(source, mask=valid & valid_index, other=0)
+        tl.store(destination, values, mask=valid)
+
+    @triton.jit
+    def _ple_state_scatter_kernel_3d(
+        state_ptr,
+        indices_ptr,
+        rows_ptr,
+        indices_stride,
+        write_mask_ptr,
+        write_mask_stride,
+        state_stride0,
+        state_stride1,
+        state_stride2,
+        rows_stride0,
+        rows_stride1,
+        rows_stride2,
+        num_cache_rows,
+        hidden_size,
+        state_width,
+        HIDDEN_FASTEST: tl.constexpr,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        row_elements = hidden_size * state_width
+        valid = offsets < row_elements
+        valid &= tl.load(write_mask_ptr + row * write_mask_stride)
+        index = tl.load(indices_ptr + row * indices_stride).to(tl.int64)
+        valid &= (index >= 0) & (index < num_cache_rows)
+        safe_index = tl.minimum(tl.maximum(index, 0), num_cache_rows - 1)
+        if HIDDEN_FASTEST:
+            hidden = offsets % hidden_size
+            width = offsets // hidden_size
+        else:
+            hidden = offsets // state_width
+            width = offsets % state_width
+        source = (
+            rows_ptr + row * rows_stride0 + hidden * rows_stride1 + width * rows_stride2
+        )
+        destination = (
+            state_ptr
+            + safe_index * state_stride0
+            + hidden * state_stride1
+            + width * state_stride2
+        )
+        values = tl.load(source, mask=valid, other=0)
+        tl.store(destination, values, mask=valid)
+
+else:  # pragma: no cover - exercised by import-only/CPU environments
+    _ple_state_gather_kernel_3d = None
+    _ple_state_scatter_kernel_3d = None
+
+
+def _validate_state_tensor(state: torch.Tensor, name: str) -> None:
+    if state.ndim != 3:
+        raise ValueError(f"PLE {name} must be a rank-3 [rows, hidden, width] tensor")
+    if state.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            f"PLE {name} must use float16, bfloat16, or float32; got {state.dtype}"
+        )
+
+
+def _empty_state_rows_like(state: torch.Tensor, num_rows: int) -> torch.Tensor:
+    """Allocate compact rows with the same dense inner layout as ``state``."""
+
+    if state.stride(1) <= state.stride(2):
+        return torch.empty(
+            (num_rows, state.shape[2], state.shape[1]),
+            dtype=state.dtype,
+            device=state.device,
+        ).transpose(1, 2)
+    return torch.empty(
+        (num_rows, state.shape[1], state.shape[2]),
+        dtype=state.dtype,
+        device=state.device,
+    )
+
+
+def ple_state_gather(
+    state: torch.Tensor,
+    indices: torch.Tensor,
+    output: torch.Tensor | None = None,
+    *,
+    indices_are_safe: bool = False,
+) -> torch.Tensor:
+    """Gather rows; original ``-1``/out-of-range indices produce zero rows.
+
+    ``indices_are_safe`` is retained for call-site compatibility; it never
+    bypasses the original-index validity check.
+    """
+
+    _validate_state_tensor(state, "state")
+    if not _is_triton_device(state, indices):
+        raise RuntimeError("Qwen4 PLE gather requires a Triton accelerator")
+    if indices.ndim != 1 or indices.device != state.device:
+        raise ValueError(
+            "PLE gather indices must be a one-dimensional same-device tensor"
+        )
+    if indices.dtype not in (torch.int32, torch.int64):
+        raise TypeError("PLE gather indices must be int32 or int64")
+    if state.shape[0] == 0:
+        raise ValueError("PLE gather requires at least one cache row")
+    expected_shape = (indices.numel(),) + tuple(state.shape[1:])
+    if output is not None:
+        _validate_state_tensor(output, "state output")
+        if output.shape != expected_shape:
+            raise ValueError(
+                "PLE state gather output has an invalid shape: "
+                f"got {tuple(output.shape)}, expected {expected_shape}"
+            )
+        if output.device != state.device or output.dtype != state.dtype:
+            raise ValueError(
+                "PLE state gather output must match state device and dtype"
+            )
+
+    if not indices.numel() or state.shape[1] == 0 or state.shape[2] == 0:
+        if output is None:
+            output = _empty_state_rows_like(state, indices.numel())
+        return output
+    if output is None:
+        output = _empty_state_rows_like(state, indices.numel())
+    row_elements = state.shape[1] * state.shape[2]
+    _ple_state_gather_kernel_3d[
+        (indices.numel(), triton.cdiv(row_elements, _BLOCK_SIZE))
+    ](
+        state,
+        indices,
+        output,
+        indices.stride(0),
+        state.stride(0),
+        state.stride(1),
+        state.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        state.shape[0],
+        state.shape[1],
+        state.shape[2],
+        HIDDEN_FASTEST=state.stride(1) <= state.stride(2),
+        BLOCK_SIZE=_BLOCK_SIZE,
+        num_warps=_NUM_WARPS,
+    )
+    return output
+
+
+def ple_state_scatter_(
+    state: torch.Tensor,
+    indices: torch.Tensor,
+    rows: torch.Tensor,
+    *,
+    write_mask: torch.Tensor | None = None,
+    indices_are_safe: bool = False,
+) -> torch.Tensor:
+    """Write rows through an explicit NULL/padding/duplicate write mask.
+
+    ``indices_are_safe`` is retained for call-site compatibility; it never
+    bypasses the original-index validity check.
+    """
+
+    _validate_state_tensor(state, "state")
+    _validate_state_tensor(rows, "state rows")
+    if not _is_triton_device(state, indices, rows):
+        raise RuntimeError("Qwen4 PLE scatter requires a Triton accelerator")
+    if indices.ndim != 1 or indices.device != state.device:
+        raise ValueError(
+            "PLE scatter indices must be a one-dimensional same-device tensor"
+        )
+    if indices.dtype not in (torch.int32, torch.int64):
+        raise TypeError("PLE scatter indices must be int32 or int64")
+    if state.shape[0] == 0:
+        raise ValueError("PLE scatter requires at least one cache row")
+    if rows.shape[0] != indices.numel() or tuple(rows.shape[1:]) != tuple(
+        state.shape[1:]
+    ):
+        raise ValueError(
+            "PLE state scatter rows and indices have incompatible shapes: "
+            f"rows={tuple(rows.shape)}, indices={indices.numel()}, "
+            f"state={tuple(state.shape)}"
+        )
+    if rows.device != state.device or rows.dtype != state.dtype:
+        raise ValueError("PLE state scatter rows must match state device and dtype")
+
+    if write_mask is None:
+        raise NotImplementedError(
+            "Qwen4 PLE scatter requires an explicit write_mask; "
+            "derive duplicate/null semantics in the caller"
+        )
+    if write_mask.ndim != 1 or write_mask.numel() != indices.numel():
+        raise ValueError("PLE state scatter write_mask must match indices")
+    if write_mask.device != state.device or write_mask.dtype != torch.bool:
+        raise ValueError("PLE state scatter write_mask must be same-device bool")
+
+    if not indices.numel() or state.shape[1] == 0 or state.shape[2] == 0:
+        return state
+
+    row_elements = state.shape[1] * state.shape[2]
+    _ple_state_scatter_kernel_3d[
+        (indices.numel(), triton.cdiv(row_elements, _BLOCK_SIZE))
+    ](
+        state,
+        indices,
+        rows,
+        indices.stride(0),
+        write_mask,
+        write_mask.stride(0),
+        state.stride(0),
+        state.stride(1),
+        state.stride(2),
+        rows.stride(0),
+        rows.stride(1),
+        rows.stride(2),
+        state.shape[0],
+        state.shape[1],
+        state.shape[2],
+        HIDDEN_FASTEST=state.stride(1) <= state.stride(2),
+        BLOCK_SIZE=_BLOCK_SIZE,
+        num_warps=_NUM_WARPS,
+    )
+    return state
+
+
+__all__ = ["ple_state_gather", "ple_state_scatter_"]

--- a/vllm/model_executor/layers/qsa.py
+++ b/vllm/model_executor/layers/qsa.py
@@ -1,0 +1,984 @@
+# Copyright 2026, The FlagOS Contributors.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4 QSA kernels for vLLM.
+
+Self-developed Triton kernels for Qwen4's QSA (Query-Sparse Attention) mechanism,
+including MQA paged attention with compressed key cache, KV cache storage, and
+group-wise compression with multiaxis RoPE.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+def _is_triton_device(*tensors: torch.Tensor) -> bool:
+    """Return true for same-device accelerator tensors accepted by Triton."""
+
+    return bool(
+        tensors
+        and len({tensor.device for tensor in tensors}) == 1
+        and all(tensor.device.type not in ("cpu", "meta") for tensor in tensors)
+    )
+
+
+@triton.jit
+def _qsa_mqa_paged_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    logical_page = columns // PAGE_SIZE
+    page_offset = columns % PAGE_SIZE
+    valid = (
+        (row < num_rows)
+        & (columns < num_columns)
+        & (columns < visible)
+        & (request >= 0)
+        & (request < num_requests)
+        & (logical_page < PAGE_TABLE_WIDTH)
+    )
+    safe_logical_page = tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1)
+    physical_page = tl.load(
+        page_table_ptr
+        + safe_request * stride_table_req
+        + safe_logical_page * stride_table_page,
+        mask=valid,
+        other=-1,
+    )
+    valid &= (physical_page >= 0) & (physical_page < num_pages)
+    safe_physical_page = tl.maximum(physical_page, 0).to(tl.int64)
+    score = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    for head in tl.static_range(0, NUM_HEADS):
+        query = tl.load(
+            q_ptr + row * stride_q_row + head * stride_q_head + dims * stride_q_dim,
+            mask=dims < HEAD_DIM,
+            other=0.0,
+        ).to(tl.float32)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_physical_page[:, None] * stride_cache_block
+            + page_offset[:, None] * stride_cache_token
+            + dims[None, :] * stride_cache_dim,
+            mask=valid[:, None] & (dims[None, :] < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        dot = tl.sum(keys * query[None, :], axis=1)
+        score += tl.maximum(dot, 0.0)
+
+    score /= score_divisor
+    tl.store(
+        logits_ptr + row * stride_logits_row + columns,
+        tl.where(valid, score, -float("inf")),
+        mask=(row < num_rows) & (columns < num_columns),
+    )
+
+
+@triton.jit
+def _qsa_mqa_paged_dot_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    """Tensor-core/MFMA QSA score path expressed with portable ``tl.dot``."""
+
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    dims = tl.arange(0, BLOCK_D)
+    heads = tl.arange(0, BLOCK_H)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    logical_page = columns // PAGE_SIZE
+    page_offset = columns % PAGE_SIZE
+    valid = (
+        (row < num_rows)
+        & (columns < num_columns)
+        & (columns < visible)
+        & (request >= 0)
+        & (request < num_requests)
+        & (logical_page < PAGE_TABLE_WIDTH)
+    )
+    physical_page = tl.load(
+        page_table_ptr
+        + safe_request * stride_table_req
+        + tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1) * stride_table_page,
+        mask=valid,
+        other=-1,
+    )
+    valid &= (physical_page >= 0) & (physical_page < num_pages)
+    safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+    query = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + heads[:, None] * stride_q_head
+        + dims[None, :] * stride_q_dim,
+        mask=(heads[:, None] < NUM_HEADS) & (dims[None, :] < HEAD_DIM),
+        other=0.0,
+    )
+    keys = tl.load(
+        k_cache_ptr
+        + safe_page[None, :] * stride_cache_block
+        + page_offset[None, :] * stride_cache_token
+        + dims[:, None] * stride_cache_dim,
+        mask=(dims[:, None] < HEAD_DIM) & valid[None, :],
+        other=0.0,
+    )
+    dots = tl.dot(query, keys)
+    score = tl.sum(tl.maximum(dots, 0.0), axis=0) / score_divisor
+    tl.store(
+        logits_ptr + row * stride_logits_row + columns,
+        tl.where(valid, score, -float("inf")),
+        mask=(row < num_rows) & (columns < num_columns),
+    )
+
+
+@triton.jit
+def _store_qsa_rows_kernel(
+    cache_ptr,
+    slots_ptr,
+    rows_ptr,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_rows_row,
+    stride_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    values = tl.load(
+        rows_ptr + row * stride_rows_row + dims * stride_rows_dim,
+        mask=valid & (dims < WIDTH),
+        other=0,
+    )
+    tl.store(
+        cache_ptr
+        + block * stride_cache_block
+        + token * stride_cache_token
+        + dims * stride_cache_dim,
+        values,
+        mask=valid & (dims < WIDTH),
+    )
+
+
+@triton.jit
+def _store_qsa_kv_rows_kernel(
+    k_cache_ptr,
+    v_cache_ptr,
+    slots_ptr,
+    k_rows_ptr,
+    v_rows_ptr,
+    stride_k_cache_block,
+    stride_k_cache_token,
+    stride_k_cache_head,
+    stride_k_cache_dim,
+    stride_v_cache_block,
+    stride_v_cache_token,
+    stride_v_cache_head,
+    stride_v_cache_dim,
+    stride_k_rows_row,
+    stride_k_rows_head,
+    stride_k_rows_dim,
+    stride_v_rows_row,
+    stride_v_rows_head,
+    stride_v_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    """Store K and V together while preserving arbitrary cache strides."""
+
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    k_values = tl.load(
+        k_rows_ptr
+        + row * stride_k_rows_row
+        + head * stride_k_rows_head
+        + dims * stride_k_rows_dim,
+        mask=valid & (head < NUM_HEADS) & (dims < HEAD_DIM),
+        other=0,
+    )
+    v_values = tl.load(
+        v_rows_ptr
+        + row * stride_v_rows_row
+        + head * stride_v_rows_head
+        + dims * stride_v_rows_dim,
+        mask=valid & (head < NUM_HEADS) & (dims < HEAD_DIM),
+        other=0,
+    )
+    tl.store(
+        k_cache_ptr
+        + block * stride_k_cache_block
+        + token * stride_k_cache_token
+        + head * stride_k_cache_head
+        + dims * stride_k_cache_dim,
+        k_values,
+        mask=valid & (head < NUM_HEADS) & (dims < HEAD_DIM),
+    )
+    tl.store(
+        v_cache_ptr
+        + block * stride_v_cache_block
+        + token * stride_v_cache_token
+        + head * stride_v_cache_head
+        + dims * stride_v_cache_dim,
+        v_values,
+        mask=valid & (head < NUM_HEADS) & (dims < HEAD_DIM),
+    )
+
+
+@triton.jit
+def _compress_qsa_groups_kernel(
+    raw_cache_ptr,
+    rope_cache_ptr,
+    raw_table_ptr,
+    rope_table_ptr,
+    token_to_req_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    pooled_ptr,
+    first_positions_ptr,
+    stride_raw_block,
+    stride_raw_token,
+    stride_raw_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_raw_table_req,
+    stride_raw_table_page,
+    stride_rope_table_req,
+    stride_rope_table_page,
+    stride_pooled_row,
+    stride_pooled_dim,
+    stride_positions_row,
+    stride_positions_dim,
+    num_rows,
+    num_raw_blocks,
+    num_rope_blocks,
+    num_raw_requests,
+    num_rope_requests,
+    RAW_PAGE_SIZE: tl.constexpr,
+    RAW_TABLE_WIDTH: tl.constexpr,
+    ROPE_PAGE_SIZE: tl.constexpr,
+    ROPE_TABLE_WIDTH: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    LOAD_ROPE_POSITIONS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_row = (
+        (row < num_rows)
+        & (request >= 0)
+        & (request < num_raw_requests)
+        & (request < num_rope_requests)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    if valid_row:
+        for group_offset in tl.range(0, COMPRESS_RATIO):
+            position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+            logical_page = position // RAW_PAGE_SIZE
+            page_offset = position % RAW_PAGE_SIZE
+            valid = logical_page < RAW_TABLE_WIDTH
+            physical_page = tl.load(
+                raw_table_ptr
+                + request * stride_raw_table_req
+                + tl.minimum(logical_page, RAW_TABLE_WIDTH - 1) * stride_raw_table_page,
+                mask=valid,
+                other=-1,
+            )
+            valid &= (physical_page >= 0) & (physical_page < num_raw_blocks)
+            values = tl.load(
+                raw_cache_ptr
+                + tl.maximum(physical_page, 0).to(tl.int64) * stride_raw_block
+                + page_offset * stride_raw_token
+                + dims * stride_raw_dim,
+                mask=valid & (dims < HEAD_DIM),
+                other=0.0,
+            ).to(tl.float32)
+            accumulator += values
+
+    tl.store(
+        pooled_ptr + row * stride_pooled_row + dims * stride_pooled_dim,
+        accumulator / COMPRESS_RATIO,
+        mask=(row < num_rows) & (dims < HEAD_DIM),
+    )
+
+    position_dims = tl.arange(0, 4)
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_ROPE_POSITIONS:
+        rope_logical_page = first_position // ROPE_PAGE_SIZE
+        rope_page_offset = first_position % ROPE_PAGE_SIZE
+        valid_rope = valid_row & (rope_logical_page < ROPE_TABLE_WIDTH)
+        rope_physical_page = tl.load(
+            rope_table_ptr
+            + tl.minimum(tl.maximum(request, 0), num_rope_requests - 1)
+            * stride_rope_table_req
+            + tl.minimum(rope_logical_page, ROPE_TABLE_WIDTH - 1)
+            * stride_rope_table_page,
+            mask=valid_rope,
+            other=-1,
+        )
+        valid_rope &= (rope_physical_page >= 0) & (rope_physical_page < num_rope_blocks)
+        rope_values = tl.load(
+            rope_cache_ptr
+            + tl.maximum(rope_physical_page, 0).to(tl.int64) * stride_rope_block
+            + rope_page_offset * stride_rope_token
+            + position_dims * stride_rope_dim,
+            mask=valid_rope & (position_dims < 3),
+            other=0,
+        )
+        tl.store(
+            first_positions_ptr
+            + row * stride_positions_row
+            + position_dims * stride_positions_dim,
+            rope_values,
+            mask=(row < num_rows) & (position_dims < 3),
+        )
+    else:
+        first_position = tl.where(valid_row, first_position, 0)
+        tl.store(
+            first_positions_ptr
+            + row * stride_positions_row
+            + position_dims * stride_positions_dim,
+            first_position,
+            mask=(row < num_rows) & (position_dims < 3),
+        )
+
+
+@triton.jit
+def _compress_norm_mrope_store_qsa_groups_kernel(
+    raw_cache_ptr,
+    rope_cache_ptr,
+    raw_table_ptr,
+    token_to_req_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    norm_weight_ptr,
+    cos_sin_cache_ptr,
+    compressed_cache_ptr,
+    stride_raw_block,
+    stride_raw_token,
+    stride_raw_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_cos_row,
+    stride_cos_dim,
+    stride_compressed_block,
+    stride_compressed_token,
+    stride_compressed_dim,
+    num_rows,
+    num_raw_blocks,
+    num_rope_blocks,
+    num_compressed_blocks,
+    num_requests,
+    num_cos_rows,
+    norm_eps,
+    RAW_PAGE_SIZE: tl.constexpr,
+    RAW_TABLE_WIDTH: tl.constexpr,
+    ROPE_PAGE_SIZE: tl.constexpr,
+    COMPRESSED_PAGE_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    ROTARY_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    MROPE_SECTION_T: tl.constexpr,
+    MROPE_SECTION_H: tl.constexpr,
+    MROPE_SECTION_W: tl.constexpr,
+    MROPE_INTERLEAVED: tl.constexpr,
+    LOAD_MROPE_POSITIONS: tl.constexpr,
+) -> None:
+    """Pool, Gemma-normalize, MRoPE, and store one compressed QSA key."""
+
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_row = (
+        (row < num_rows)
+        & (request >= 0)
+        & (request < num_requests)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+        & (compressed_slot < num_compressed_blocks * COMPRESSED_PAGE_SIZE)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+    if valid_row:
+        for group_offset in tl.range(0, COMPRESS_RATIO):
+            position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+            logical_page = position // RAW_PAGE_SIZE
+            page_offset = position % RAW_PAGE_SIZE
+            valid = logical_page < RAW_TABLE_WIDTH
+            physical_page = tl.load(
+                raw_table_ptr
+                + request * stride_table_req
+                + tl.minimum(logical_page, RAW_TABLE_WIDTH - 1) * stride_table_page,
+                mask=valid,
+                other=-1,
+            )
+            valid &= (physical_page >= 0) & (physical_page < num_raw_blocks)
+            accumulator += tl.load(
+                raw_cache_ptr
+                + tl.maximum(physical_page, 0).to(tl.int64) * stride_raw_block
+                + page_offset * stride_raw_token
+                + dims * stride_raw_dim,
+                mask=valid & (dims < HEAD_DIM),
+                other=0.0,
+            ).to(tl.float32)
+
+    # Match the unfused BF16 materialization before Gemma RMSNorm.
+    pooled = (accumulator / COMPRESS_RATIO).to(tl.bfloat16)
+    pooled_fp32 = pooled.to(tl.float32)
+    variance = tl.sum(pooled_fp32 * pooled_fp32, axis=0) / HEAD_DIM
+    weight = tl.load(
+        norm_weight_ptr + dims,
+        mask=dims < HEAD_DIM,
+        other=0.0,
+    ).to(tl.float32)
+    normalized = (pooled_fp32 * tl.rsqrt(variance + norm_eps) * (weight + 1.0)).to(
+        tl.bfloat16
+    )
+
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_MROPE_POSITIONS:
+        rope_page = first_position // ROPE_PAGE_SIZE
+        rope_offset = first_position % ROPE_PAGE_SIZE
+        valid_rope = valid_row & (rope_page < RAW_TABLE_WIDTH)
+        rope_physical_page = tl.load(
+            raw_table_ptr
+            + tl.minimum(tl.maximum(request, 0), num_requests - 1) * stride_table_req
+            + tl.minimum(rope_page, RAW_TABLE_WIDTH - 1) * stride_table_page,
+            mask=valid_rope,
+            other=-1,
+        )
+        valid_rope &= (rope_physical_page >= 0) & (rope_physical_page < num_rope_blocks)
+        axis_offsets = tl.arange(0, 4)
+        axis_positions = tl.load(
+            rope_cache_ptr
+            + tl.maximum(rope_physical_page, 0).to(tl.int64) * stride_rope_block
+            + rope_offset * stride_rope_token
+            + axis_offsets * stride_rope_dim,
+            mask=valid_rope & (axis_offsets < 3),
+            other=0,
+        )
+        time_position = tl.max(tl.where(axis_offsets == 0, axis_positions, 0))
+        height_position = tl.max(tl.where(axis_offsets == 1, axis_positions, 0))
+        width_position = tl.max(tl.where(axis_offsets == 2, axis_positions, 0))
+    else:
+        time_position = first_position
+        height_position = first_position
+        width_position = first_position
+
+    # HEAD_DIM=128 and ROTARY_DIM=64 in the production checkpoint.  Split the
+    # normalized vector without dynamic local indexing: first head half holds
+    # all rotary channels, second head half is the pass-through tail.
+    head_pairs = tl.permute(tl.reshape(normalized, (2, BLOCK_D // 2)), (1, 0))
+    rotary_values, pass_values = tl.split(head_pairs)
+    rotary_pairs = tl.permute(tl.reshape(rotary_values, (2, ROTARY_DIM // 2)), (1, 0))
+    first_half, second_half = tl.split(rotary_pairs)
+    frequencies = tl.arange(0, ROTARY_DIM // 2)
+    if MROPE_INTERLEAVED:
+        use_height = ((frequencies % 3) == 1) & (frequencies < 3 * MROPE_SECTION_H)
+        use_width = ((frequencies % 3) == 2) & (frequencies < 3 * MROPE_SECTION_W)
+    else:
+        height_start = MROPE_SECTION_T
+        width_start = height_start + MROPE_SECTION_H
+        use_height = (frequencies >= height_start) & (frequencies < width_start)
+        use_width = (frequencies >= width_start) & (
+            frequencies < width_start + MROPE_SECTION_W
+        )
+    rope_positions = tl.where(
+        use_height,
+        height_position,
+        tl.where(use_width, width_position, time_position),
+    )
+    valid_position = (rope_positions >= 0) & (rope_positions < num_cos_rows)
+    safe_positions = tl.minimum(tl.maximum(rope_positions, 0), num_cos_rows - 1)
+    cos = tl.load(
+        cos_sin_cache_ptr
+        + safe_positions * stride_cos_row
+        + frequencies * stride_cos_dim,
+        mask=valid_row & valid_position,
+        other=0.0,
+    )
+    sin = tl.load(
+        cos_sin_cache_ptr
+        + safe_positions * stride_cos_row
+        + (ROTARY_DIM // 2 + frequencies) * stride_cos_dim,
+        mask=valid_row & valid_position,
+        other=0.0,
+    )
+    rotated_first = (first_half * cos - second_half * sin).to(tl.bfloat16)
+    rotated_second = (second_half * cos + first_half * sin).to(tl.bfloat16)
+
+    compressed_block = tl.maximum(compressed_slot, 0) // COMPRESSED_PAGE_SIZE
+    compressed_token = tl.maximum(compressed_slot, 0) % COMPRESSED_PAGE_SIZE
+    compressed_base = (
+        compressed_cache_ptr
+        + compressed_block.to(tl.int64) * stride_compressed_block
+        + compressed_token * stride_compressed_token
+    )
+    tl.store(
+        compressed_base + frequencies * stride_compressed_dim,
+        rotated_first,
+        mask=valid_row & valid_position,
+    )
+    tl.store(
+        compressed_base + (ROTARY_DIM // 2 + frequencies) * stride_compressed_dim,
+        rotated_second,
+        mask=valid_row & valid_position,
+    )
+    pass_offsets = tl.arange(0, BLOCK_D // 2)
+    tl.store(
+        compressed_base + (ROTARY_DIM + pass_offsets) * stride_compressed_dim,
+        pass_values,
+        mask=valid_row & ((ROTARY_DIM + pass_offsets) < HEAD_DIM),
+    )
+
+
+def qwen4_qsa_mqa_paged_dot(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int = 4,
+    num_columns: int | None = None,
+    score_scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute QSA indexer scores directly from a paged compressed-key cache.
+
+    This entry point intentionally selects the self-developed ``tl.dot``
+    kernel.  The Qwen4 production contract is BF16, four query heads, and
+    head dimension 128; callers with another shape must use a different
+    implementation instead of silently falling back to Torch.
+    """
+
+    if not _is_triton_device(
+        q, k_cache, page_table, token_to_req, query_positions, sequence_lengths
+    ):
+        raise RuntimeError("Qwen4 QSA MQA dot requires a Triton accelerator")
+    if q.ndim != 3 or q.shape[1:] != (4, 128) or q.dtype != torch.bfloat16:
+        raise ValueError("Qwen4 QSA MQA dot requires BF16 q shaped [rows, 4, 128]")
+    if k_cache.ndim != 4 or k_cache.shape[2:] != (1, 128):
+        raise ValueError("Qwen4 QSA MQA cache must be [pages, page_size, 1, 128]")
+    if k_cache.dtype != q.dtype:
+        raise ValueError("Qwen4 QSA query and cache must have the same dtype")
+    if page_table.ndim != 2:
+        raise ValueError("Qwen4 QSA MQA page table must be rank-2")
+    if page_table.dtype not in (torch.int32, torch.int64):
+        raise TypeError("Qwen4 QSA page table must use int32 or int64")
+    rows = q.shape[0]
+    if rows and (not all(k_cache.shape[:2]) or not all(page_table.shape)):
+        raise ValueError(
+            "Qwen4 QSA MQA cache and page table must be nonempty for nonempty q"
+        )
+    if token_to_req.shape != (rows,) or query_positions.shape != (rows,):
+        raise ValueError("Qwen4 QSA request metadata must match query rows")
+    if token_to_req.dtype not in (
+        torch.int32,
+        torch.int64,
+    ) or query_positions.dtype not in (
+        torch.int32,
+        torch.int64,
+    ):
+        raise TypeError("Qwen4 QSA request metadata must use int32 or int64")
+    if sequence_lengths.shape != (page_table.shape[0],):
+        raise ValueError("Qwen4 QSA sequence lengths must match page-table requests")
+    if sequence_lengths.dtype not in (torch.int32, torch.int64):
+        raise TypeError("Qwen4 QSA sequence lengths must use int32 or int64")
+    if compress_ratio <= 0:
+        raise ValueError("Qwen4 QSA compression ratio must be positive")
+    divisor = math.sqrt(128) if score_scale is None else float(score_scale)
+    if divisor <= 0:
+        raise ValueError("Qwen4 QSA score scale must be positive")
+    capacity = page_table.shape[1] * k_cache.shape[1]
+    columns = capacity if num_columns is None else int(num_columns)
+    if columns < 0 or columns > capacity:
+        raise ValueError("Qwen4 QSA score width must be in [0, page-table capacity]")
+    logits = torch.empty((rows, columns), dtype=torch.float32, device=q.device)
+    visible_blocks = torch.empty((rows,), dtype=torch.int32, device=q.device)
+    if rows == 0 or columns == 0:
+        return logits, visible_blocks
+    block_n = 32
+    _qsa_mqa_paged_dot_kernel[(rows, triton.cdiv(columns, block_n))](
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(3),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        rows,
+        columns,
+        k_cache.shape[0],
+        page_table.shape[0],
+        divisor,
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_H=16,
+        BLOCK_N=block_n,
+        BLOCK_D=128,
+        COMPRESS_RATIO=compress_ratio,
+        num_warps=4,
+        num_stages=2,
+    )
+    return logits, visible_blocks
+
+
+
+def qwen4_store_qsa_kv_rows(
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+) -> None:
+    """Store paired QSA K/V rows in one stride-aware Triton launch.
+
+    The production fast-path precondition is that valid slots are unique.  An
+    invalid slot is safely ignored by the kernel; duplicate slots are outside
+    the parallel write contract and must be removed by the caller.
+    """
+
+    if not _is_triton_device(k_cache, v_cache, slot_mapping, key, value):
+        raise RuntimeError("Qwen4 QSA K/V store requires a Triton accelerator")
+    if k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+        raise ValueError("Qwen4 QSA K/V caches must be [blocks, page, heads, dim]")
+    if key.ndim != 3 or value.shape != key.shape:
+        raise ValueError("Qwen4 QSA K/V rows must be [rows, heads, dim]")
+    if key.shape != (slot_mapping.numel(), k_cache.shape[2], k_cache.shape[3]):
+        raise ValueError("Qwen4 QSA K/V rows and slot mapping have incompatible shapes")
+    if slot_mapping.dtype not in (torch.int32, torch.int64):
+        raise TypeError("Qwen4 QSA slot mapping must use int32 or int64")
+    if key.dtype != k_cache.dtype or value.dtype != v_cache.dtype:
+        raise ValueError("Qwen4 QSA K/V rows and caches must have matching dtypes")
+    if not all(k_cache.shape):
+        raise ValueError("Qwen4 QSA K/V caches must be nonempty")
+    if not key.shape[0]:
+        return
+    _store_qsa_kv_rows_kernel[(key.shape[0], key.shape[1])](
+        k_cache,
+        v_cache,
+        slot_mapping,
+        key,
+        value,
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        k_cache.stride(3),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        v_cache.stride(3),
+        key.stride(0),
+        key.stride(1),
+        key.stride(2),
+        value.stride(0),
+        value.stride(1),
+        value.stride(2),
+        key.shape[0],
+        k_cache.shape[0],
+        PAGE_SIZE=k_cache.shape[1],
+        NUM_HEADS=key.shape[1],
+        HEAD_DIM=key.shape[2],
+        BLOCK_D=triton.next_power_of_2(key.shape[2]),
+        num_warps=4,
+    )
+
+
+
+def qwen4_compress_norm_mrope_store_groups(
+    raw_cache: torch.Tensor,
+    raw_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compressed_cache: torch.Tensor,
+    norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    compress_ratio: int = 4,
+    norm_eps: float = 1.0e-6,
+    rotary_dim: int = 64,
+    mrope_section: tuple[int, int, int] = (11, 11, 10),
+    mrope_interleaved: bool = True,
+    rope_cache: torch.Tensor | None = None,
+) -> None:
+    """Fuse QSA group pooling, Gemma RMSNorm, interleaved MRoPE, and store.
+
+    For the Qwen4 cache, ``mrope_section=(11, 11, 10)`` describes counts of
+    frequency lanes.  With ``mrope_interleaved=True`` the actual lane selector
+    is ``frequency % 3`` (T/H/W), not three contiguous slices.
+    """
+
+    tensors = [
+        raw_cache,
+        raw_block_table,
+        token_to_req,
+        logical_positions,
+        compressed_slots,
+        compressed_cache,
+        norm_weight,
+        cos_sin_cache,
+    ]
+    if rope_cache is not None:
+        tensors.append(rope_cache)
+    if not _is_triton_device(*tensors):
+        raise RuntimeError("Qwen4 QSA compression requires a Triton accelerator")
+    if (
+        raw_cache.ndim != 4
+        or raw_cache.shape[2:] != (1, 128)
+        or not all(raw_cache.shape)
+    ):
+        raise ValueError("Qwen4 QSA raw cache must be nonempty [blocks, page, 1, 128]")
+    if (
+        compressed_cache.ndim != 4
+        or compressed_cache.shape[2:] != (1, 128)
+        or not all(compressed_cache.shape)
+    ):
+        raise ValueError("Qwen4 QSA compressed cache must be [blocks, page, 1, 128]")
+    if compressed_cache.dtype != raw_cache.dtype:
+        raise ValueError("Qwen4 QSA raw and compressed caches must match dtype")
+    if raw_block_table.ndim != 2:
+        raise ValueError("Qwen4 QSA raw block table must be rank-2")
+    if raw_block_table.dtype not in (torch.int32, torch.int64):
+        raise TypeError("Qwen4 QSA raw block table must use int32 or int64")
+    rows = token_to_req.numel()
+    if rows and not all(raw_block_table.shape):
+        raise ValueError("Qwen4 QSA raw block table must be nonempty for nonempty rows")
+    if logical_positions.shape != (rows,) or compressed_slots.shape != (rows,):
+        raise ValueError("Qwen4 QSA compression metadata must match token rows")
+    if (
+        token_to_req.dtype not in (torch.int32, torch.int64)
+        or logical_positions.dtype
+        not in (
+            torch.int32,
+            torch.int64,
+        )
+        or compressed_slots.dtype not in (torch.int32, torch.int64)
+    ):
+        raise TypeError("Qwen4 QSA compression metadata must use int32 or int64")
+    if norm_weight.shape != (128,) or norm_weight.dtype != raw_cache.dtype:
+        raise ValueError("Qwen4 QSA norm weight must be a same-dtype [128] vector")
+    if norm_weight.stride(0) != 1:
+        raise ValueError("Qwen4 QSA norm weight must be contiguous")
+    if cos_sin_cache.ndim != 2 or cos_sin_cache.shape[1] != rotary_dim:
+        raise ValueError("Qwen4 QSA cos/sin cache must be [positions, rotary_dim]")
+    if cos_sin_cache.dtype != raw_cache.dtype or not cos_sin_cache.shape[0]:
+        raise ValueError(
+            "Qwen4 QSA cos/sin cache must be nonempty and match cache dtype"
+        )
+    if (
+        len(mrope_section) != 3
+        or any(section < 0 for section in mrope_section)
+        or rotary_dim != 64
+        or sum(mrope_section) != rotary_dim // 2
+    ):
+        raise ValueError(
+            "Qwen4 QSA MRoPE requires rotary_dim=64 and sections summing to 32"
+        )
+    if compress_ratio <= 0 or norm_eps <= 0:
+        raise ValueError(
+            "Qwen4 QSA compression ratio and norm epsilon must be positive"
+        )
+    if rope_cache is not None and (
+        rope_cache.ndim != 4
+        or rope_cache.shape[:3] != raw_cache.shape[:3]
+        or rope_cache.shape[3] != 3
+        or rope_cache.dtype != torch.int64
+    ):
+        raise ValueError(
+            "Qwen4 QSA packed MRoPE cache must be [blocks, page, 1, 3] int64"
+        )
+    if rows == 0:
+        return
+    if rope_cache is None:
+        rope_cache = raw_cache
+        load_mrope_positions = False
+    else:
+        load_mrope_positions = True
+    _compress_norm_mrope_store_qsa_groups_kernel[(rows,)](
+        raw_cache,
+        rope_cache,
+        raw_block_table,
+        token_to_req,
+        logical_positions,
+        compressed_slots,
+        norm_weight,
+        cos_sin_cache,
+        compressed_cache,
+        raw_cache.stride(0),
+        raw_cache.stride(1),
+        raw_cache.stride(3),
+        rope_cache.stride(0),
+        rope_cache.stride(1),
+        rope_cache.stride(3),
+        raw_block_table.stride(0),
+        raw_block_table.stride(1),
+        cos_sin_cache.stride(0),
+        cos_sin_cache.stride(1),
+        compressed_cache.stride(0),
+        compressed_cache.stride(1),
+        compressed_cache.stride(3),
+        rows,
+        raw_cache.shape[0],
+        rope_cache.shape[0],
+        compressed_cache.shape[0],
+        raw_block_table.shape[0],
+        cos_sin_cache.shape[0],
+        float(norm_eps),
+        RAW_PAGE_SIZE=raw_cache.shape[1],
+        RAW_TABLE_WIDTH=raw_block_table.shape[1],
+        ROPE_PAGE_SIZE=rope_cache.shape[1],
+        COMPRESSED_PAGE_SIZE=compressed_cache.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=128,
+        ROTARY_DIM=rotary_dim,
+        BLOCK_D=128,
+        MROPE_SECTION_T=mrope_section[0],
+        MROPE_SECTION_H=mrope_section[1],
+        MROPE_SECTION_W=mrope_section[2],
+        MROPE_INTERLEAVED=mrope_interleaved,
+        LOAD_MROPE_POSITIONS=load_mrope_positions,
+        num_warps=4,
+    )
+
+
+__all__ = [
+    "_compress_qsa_groups_kernel",
+    "_compress_norm_mrope_store_qsa_groups_kernel",
+    "_qsa_mqa_paged_kernel",
+    "_qsa_mqa_paged_dot_kernel",
+    "_store_qsa_rows_kernel",
+    "_store_qsa_kv_rows_kernel",
+    "qwen4_compress_norm_mrope_store_groups",
+    "qwen4_qsa_mqa_paged_dot",
+    "qwen4_store_qsa_kv_rows",
+]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Add standalone Triton implementations for Qwen3.8-Flash-Next HyperConnection, QSA, and PLE state operations. The change exports the new operator family, adds fail-closed host guards without Torch compute fallbacks, and includes repository-native correctness tests and benchmarks.


This PR contains:

- three HyperConnection kernels: grouped Gemma RMSNorm, gate reduce, and injection combine;
- three self-developed QSA kernels plus three vendor baseline wrappers;
- PLE state gather and masked scatter kernels;
- correctness coverage for dtype/shape guards, invalid paging metadata, cache slots, MRoPE layout, strided state, null indices, duplicates, and deterministic execution;
- repository-native benchmark coverage for all added paths.

## Test Plan
Updated unit test tests/kernels/test_qwen4_qsa_kernels.py, test_qwen4_hyperconnection_kernels.py and test_qwen4_ple_state_kernels.py

## Test Result
```
======================================================================================================================================= test session starts ========================================================================================================================================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /tmp/qwen4_kernel_run
plugins: anyio-4.14.2
collected 13 items                                                                                                                                                                                                                                                                                 

test_qwen4_hyperconnection_kernels.py::test_qwen4_hyperconnection_matches_torch[1-257-dtype0] PASSED                                                                                                                                                                                         [  7%]
test_qwen4_hyperconnection_kernels.py::test_qwen4_hyperconnection_matches_torch[1-257-dtype1] PASSED                                                                                                                                                                                         [ 15%]
test_qwen4_hyperconnection_kernels.py::test_qwen4_hyperconnection_matches_torch[3-513-dtype0] PASSED                                                                                                                                                                                         [ 23%]
test_qwen4_hyperconnection_kernels.py::test_qwen4_hyperconnection_matches_torch[3-513-dtype1] PASSED                                                                                                                                                                                         [ 30%]
test_qwen4_hyperconnection_kernels.py::test_qwen4_hc_cpu_guards_fail_closed PASSED                                                                                                                                                                                                           [ 38%]
test_qwen4_ple_state_kernels.py::test_qwen4_ple_gather_preserves_strides_and_null_is_not_row_zero PASSED                                                                                                                                                                                     [ 46%]
test_qwen4_ple_state_kernels.py::test_qwen4_ple_scatter_masked_null_and_duplicate_is_exact PASSED                                                                                                                                                                                            [ 53%]
test_qwen4_ple_state_kernels.py::test_qwen4_ple_cpu_guards_fail_closed PASSED                                                                                                                                                                                                                [ 61%]
test_qwen4_qsa_kernels.py::test_qwen4_qsa_mqa_paged_dot_matches_torch_and_invalid_pages PASSED                                                                                                                                                                                               [ 69%]
test_qwen4_qsa_kernels.py::test_qwen4_qsa_kv_store_matches_torch_and_skips_invalid_slots PASSED                                                                                                                                                                                              [ 76%]
test_qwen4_qsa_kernels.py::test_qwen4_qsa_fused_compress_norm_mrope_interleaved_matches_torch PASSED                                                                                                                                                                                         [ 84%]
test_qwen4_qsa_kernels.py::test_qsa_exports_are_explicit PASSED                                                                                                                                                                                                                              [ 92%]
test_qwen4_qsa_kernels.py::test_qwen4_qsa_cpu_guards_fail_closed PASSED                                                                                                                                                                                                                      [100%]

======================================================================================================================================== 13 passed in 5.69s ========================================================================================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
