### PR TITLE
[Bugfix] Fail loudly when a piecewise cudagraph piece is replayed with a changed input address

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_input_address_check.py
+++ b/tests/v1/cudagraph/test_cudagraph_input_address_check.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Piecewise CUDA graph pieces are replayed reading their inputs from the
+addresses recorded at capture time; the wrapper does not copy inputs. If a
+producer feeding a piece (e.g. a custom op added to ``splitting_ops``) returns
+freshly-allocated outputs, those land at new addresses every step and replay
+reads stale memory -- silent output corruption. These tests pin that the
+address-stability check runs on the first replay (not only under DEBUG) so the
+failure is loud, and that a stable buffer still replays correctly.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.compilation.monitor import set_cudagraph_capturing_enabled
+from vllm.config import (
+    CompilationConfig,
+    CUDAGraphMode,
+    VllmConfig,
+    set_current_vllm_config,
+)
+from vllm.forward_context import BatchDescriptor, set_forward_context
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="CUDA graphs require a CUDA-like device",
+)
+
+D = 8
+
+
+class _Piece(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(D, D)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.lin(x)
+
+
+def _make_wrapper() -> tuple[CUDAGraphWrapper, VllmConfig]:
+    cc = CompilationConfig(cudagraph_mode=CUDAGraphMode.PIECEWISE)
+    vllm_config = VllmConfig(compilation_config=cc)
+    piece = _Piece().to(current_platform.device_type).eval()
+    with set_current_vllm_config(vllm_config):
+        set_cudagraph_capturing_enabled(True)
+        wrapper = CUDAGraphWrapper(
+            piece, vllm_config, runtime_mode=CUDAGraphMode.PIECEWISE
+        )
+    return wrapper, vllm_config
+
+
+def _run(wrapper, vllm_config, x, mode):
+    with (
+        set_current_vllm_config(vllm_config),
+        set_forward_context(
+            None,
+            vllm_config,
+            cudagraph_runtime_mode=mode,
+            batch_descriptor=BatchDescriptor(num_tokens=1),
+        ),
+    ):
+        return wrapper(x)
+
+
+@torch.no_grad()
+def test_stable_input_address_replays_ok():
+    """Reusing the capture-time buffer (stable address) replays without error
+    and reproduces the eager result -- the common, correct case must not
+    regress."""
+    dev = current_platform.device_type
+    wrapper, vllm_config = _make_wrapper()
+    buf = torch.zeros(1, D, device=dev)
+
+    # Warm up eagerly so cuBLAS workspaces exist before capture.
+    _run(wrapper, vllm_config, buf, CUDAGraphMode.NONE)
+    # Capture (records buf's address).
+    _run(wrapper, vllm_config, buf, CUDAGraphMode.PIECEWISE)
+
+    # Replay with new values written *into the same buffer* (address stable).
+    buf.copy_(torch.randn(1, D, device=dev))
+    out = _run(wrapper, vllm_config, buf, CUDAGraphMode.PIECEWISE).clone()
+    ref = wrapper.unwrap()(buf)
+    assert torch.equal(out, ref)
+
+
+@torch.no_grad()
+def test_unstable_input_address_raises_on_replay():
+    """A fresh input tensor (new address) on replay must fail loudly instead of
+    silently reading stale memory -- the ``splitting_ops`` fresh-output
+    footgun."""
+    dev = current_platform.device_type
+    wrapper, vllm_config = _make_wrapper()
+    captured = torch.zeros(1, D, device=dev)
+
+    _run(wrapper, vllm_config, captured, CUDAGraphMode.NONE)
+    _run(wrapper, vllm_config, captured, CUDAGraphMode.PIECEWISE)  # capture
+
+    # First replay with a *different* tensor. `captured` is kept alive so the
+    # allocator hands `fresh` a different address, mimicking a producer that
+    # returns a freshly-allocated output each step.
+    fresh = torch.randn(1, D, device=dev)
+    assert fresh.data_ptr() != captured.data_ptr()
+    with pytest.raises(RuntimeError, match="different input addresses"):
+        _run(wrapper, vllm_config, fresh, CUDAGraphMode.PIECEWISE)

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -130,9 +130,14 @@ class CUDAGraphEntry:
     cudagraph: torch.cuda.CUDAGraph | None = None
     output: Any | None = None
 
-    # for cudagraph debugging, track the input addresses
-    # during capture, and check if they are the same during replay
+    # track the input addresses during capture, and check they are the same
+    # during replay (see the check in CUDAGraphWrapper.__call__)
     input_addresses: list[int] | None = None
+
+    # whether the input-address stability check has run for this entry yet;
+    # the check runs on the first replay always, and on every replay in
+    # debug mode
+    replay_checked: bool = False
 
 
 @dataclasses.dataclass
@@ -343,16 +348,39 @@ class CUDAGraphWrapper:
             # manage the memory during cuda graph capture
             return output
 
-        if self.is_debugging_mode:
-            # check if the input addresses are the same
+        # Verify input-address stability before replay. A captured piece is
+        # replayed reading its inputs from the addresses recorded at capture
+        # time; the wrapper does not copy inputs (see the class docstring), so
+        # an input whose address changed means the graph reads stale memory and
+        # silently corrupts output. This is a footgun when a custom op is added
+        # to ``splitting_ops``: only ops that write into persistent buffers
+        # (e.g. the attention ops) are safe as piecewise splitting boundaries;
+        # an op that returns freshly-allocated outputs lands them at new
+        # addresses every step. Check on the first replay of every entry always
+        # (cheap, once per captured shape) so this fails loudly instead of
+        # silently corrupting, and on every replay in debug mode.
+        if self.is_debugging_mode or not entry.replay_checked:
+            entry.replay_checked = True
             new_input_addresses = [
                 x.data_ptr() for x in args if isinstance(x, torch.Tensor)
             ]
-            assert new_input_addresses == entry.input_addresses, (
-                f"Input addresses for cudagraphs are different "
-                f"during replay. Expected {entry.input_addresses}, "
-                f"got {new_input_addresses}"
-            )
+            if new_input_addresses != entry.input_addresses:
+                raise RuntimeError(
+                    "CUDA graph replay received different input addresses than "
+                    "were recorded at capture time for "
+                    f"{self.runtime_mode.name} graph {entry.batch_descriptor}. "
+                    "Captured pieces are replayed reading their inputs from "
+                    "the capture-time addresses (inputs are not copied), so a "
+                    "changed address makes replay read stale memory and "
+                    "silently corrupt output. This typically means an op "
+                    "feeding this piece returns freshly-allocated outputs "
+                    "instead of writing into persistent buffers -- e.g. a "
+                    "custom op added to `splitting_ops`; only ops that write "
+                    "persistent outputs (like the attention ops) are safe as "
+                    "piecewise splitting boundaries. "
+                    f"Expected {entry.input_addresses}, got "
+                    f"{new_input_addresses}."
+                )
 
         # Sync offloader before replay - ensures any external dependencies
         # from pre-capture prefetches are satisfied.


### PR DESCRIPTION
## Purpose

Fix silent output corruption when a piecewise CUDA graph piece is replayed with an input whose address changed since capture. This is the mechanism reported in #37363 (Bug 2, closed as stale).

Piecewise pieces are replayed reading their inputs from the addresses recorded at capture time; `CUDAGraphWrapper` deliberately does not copy inputs (per its docstring). If a producer feeding a piece returns **freshly-allocated** outputs — e.g. an op added to `splitting_ops` that doesn't write into persistent buffers, such as `vllm::moe_forward_shared` (its outputs are fresh `torch.empty_like` tensors; it declares no `mutates_args` and no out-variant, unlike the attention ops which write persistent buffers) — those outputs land at new addresses every step, so the downstream piece replays reading **stale memory** and silently corrupts output. The address-consistency check that would catch this only runs under `VLLM_LOGGING_LEVEL=DEBUG`, so a normal serve just emits garbage tokens with no error.

**This PR is detection-only** (fail-loud). It runs the existing address check on the **first replay of every captured entry** as well (cheap — one `data_ptr()` comparison per captured shape, once) and raises a descriptive `RuntimeError` instead of the DEBUG-only `assert`. It does **not** change what ops are allowed in `splitting_ops`; enabling fresh-output splitting ops is a separate design question (that's what #37361 attempted).

Key property: **no regression risk.** Any configuration that would trip the promoted check already hard-crashes today under `VLLM_LOGGING_LEVEL=DEBUG` (same comparison), so no config that runs cleanly can start failing — this only converts silent corruption in release into the same, now-actionable, error. The full every-replay check remains under DEBUG for late-onset address drift.

## Test Plan

- New unit test `tests/v1/cudagraph/test_cudagraph_input_address_check.py` (GPU):
  - `test_stable_input_address_replays_ok` — capturing a piece and replaying it while reusing the capture-time buffer (writing new values in-place) replays without error and reproduces the eager result (the common, correct path must not regress).
  - `test_unstable_input_address_raises_on_replay` — replaying with a freshly-allocated input tensor (new address, capture buffer kept alive) raises `RuntimeError`.
- End-to-end sanity on a real MoE that routes `vllm::moe_forward_shared`, serving `cudagraph_mode=PIECEWISE` with the MoE ops added to `splitting_ops` (the config that silently corrupts on `main`): confirm it now raises the clear error at first decode instead of returning garbage, in a normal (non-DEBUG) serve.

```
pytest tests/v1/cudagraph/test_cudagraph_input_address_check.py -v
```

## Test Result

Unit tests pass:

```
tests/v1/cudagraph/test_cudagraph_input_address_check.py::test_stable_input_address_replays_ok PASSED
tests/v1/cudagraph/test_cudagraph_input_address_check.py::test_unstable_input_address_raises_on_replay PASSED
```

End-to-end, the previously-silently-corrupting config now fails loudly at the first decode (non-DEBUG serve). Before this PR it returned garbage tokens (e.g. `"The capital of France is" -> "! 😀 😀 …"`); after:

```
RuntimeError: CUDA graph replay received different input addresses than were recorded
at capture time for PIECEWISE graph BatchDescriptor(num_tokens=8, ...). Captured pieces
are replayed reading their inputs from the capture-time addresses (inputs are not copied),
so a changed address makes replay read stale memory and silently corrupt output. This
typically means an op feeding this piece returns freshly-allocated outputs instead of
writing into persistent buffers -- e.g. a custom op added to `splitting_ops`; only ops that
write persistent outputs (like the attention ops) are safe as piecewise splitting boundaries.
Expected [...526144, ...913856, ...557312, ...249920, ...282880],
got      [...011904, ...193408, ...557312, ...249920, ...282880].
```

(Two of the five piece inputs — the MoE op's fresh tuple outputs — moved between capture and replay; the other three are persistent buffers. That address diff is the exact corruption source.)

---

Related: #37363 (original report of this mechanism, closed stale), #37361 (attempted enablement: copy inputs before replay), #37395 (attempted mitigation: eager fallback on mismatch). This PR is the minimal detection-only step and is independent of those design choices.
