### PR TITLE
[Bugfix][DCP] Handle hybrid cache geometry in offload recovery

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,6 +129,108 @@ def test_pd_dcp_interleave_size_is_adjusted_to_block_size(caplog):
     assert "automatically adjusted from 3 to block_size 16" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "kv_transfer_config",
+    [
+        KVTransferConfig(
+            kv_connector="SimpleCPUOffloadConnector",
+            kv_role="kv_both",
+        ),
+        KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "SimpleCPUOffloadConnector",
+                        "kv_role": "kv_both",
+                    }
+                ]
+            },
+        ),
+    ],
+    ids=["direct", "multi"],
+)
+def test_simple_cpu_offload_keeps_dcp_interleave_size(
+    kv_transfer_config: KVTransferConfig,
+):
+    config = VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+            distributed_executor_backend="mp",
+        ),
+        kv_transfer_config=kv_transfer_config,
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=16))]
+    )
+
+    config.adjust_dcp_kv_cache_interleave_size(kv_cache_config)
+    config.validate_block_size()
+
+    assert config.parallel_config.cp_kv_cache_interleave_size == 1
+
+
+def test_simple_cpu_offload_rejects_invalid_dcp_interleave_size():
+    config = VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=3,
+            distributed_executor_backend="mp",
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="SimpleCPUOffloadConnector",
+            kv_role="kv_both",
+        ),
+    )
+
+    with pytest.raises(AssertionError, match="divisible"):
+        config.validate_block_size()
+
+
+def test_multi_connector_with_pd_uses_block_aligned_dcp_interleave():
+    config = VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+            distributed_executor_backend="mp",
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "SimpleCPUOffloadConnector",
+                        "kv_role": "kv_both",
+                    },
+                    {
+                        "kv_connector": "NixlConnector",
+                        "kv_role": "kv_both",
+                    },
+                ]
+            },
+        ),
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=16))]
+    )
+
+    config.adjust_dcp_kv_cache_interleave_size(kv_cache_config)
+
+    assert config.parallel_config.cp_kv_cache_interleave_size == 16
+
+
 def test_compile_config_repr_succeeds():
     # setup: VllmBackend mutates the config object
     config = VllmConfig()

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -656,7 +656,8 @@ def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
     assert moved[0].block_id == cow_copy.dst_block_id
 
 
-def test_boundary_state_offloads_returns_cow_target():
+@pytest.mark.parametrize("dcp_world_size", [1, 2])
+def test_boundary_state_offloads_returns_cow_target(dcp_world_size: int):
     """Boundary hand-offs expose aligned snapshots and the partial-tail CoW
     target, never the overwritten CoW source."""
     hash_block_size = 2
@@ -690,6 +691,8 @@ def test_boundary_state_offloads_returns_cow_target():
         kv_cache_config=kv_cache_config,
         max_model_len=8192,
         enable_caching=True,
+        dcp_world_size=dcp_world_size,
+        scheduler_block_size=block_size,
         hash_block_size=hash_block_size,
     )
 
@@ -697,10 +700,11 @@ def test_boundary_state_offloads_returns_cow_target():
     computed_blocks, num_computed, _ = manager.get_computed_blocks(req0)
     assert manager.allocate_slots(req0, 6, num_computed, computed_blocks) is not None
 
-    # Step A offers the materialized aligned checkpoint immediately.
-    ((group_id, block_id, boundary_tokens),) = drain_boundary_state_offloads(manager)[
-        "0"
-    ]
+    # Step A offers the materialized aligned Mamba checkpoint immediately. With
+    # DCP, full attention also offers its append-only prompt boundary block.
+    step_a_offloads = drain_boundary_state_offloads(manager)["0"]
+    mamba_offloads = [entry for entry in step_a_offloads if entry[0] == 1]
+    ((group_id, block_id, boundary_tokens),) = mamba_offloads
     assert group_id == 1
     assert boundary_tokens == 4
     aligned_hash = req0.block_hashes[4 // hash_block_size - 1]
@@ -709,6 +713,18 @@ def test_boundary_state_offloads_returns_cow_target():
     )
     assert aligned_block is not None
     assert block_id == aligned_block[0].block_id
+    full_offloads = [entry for entry in step_a_offloads if entry[0] == 0]
+    if dcp_world_size > 1:
+        ((_, full_block_id, full_boundary_tokens),) = full_offloads
+        assert full_boundary_tokens == 6
+        partial_full_hash = req0.block_hashes[6 // hash_block_size - 1]
+        partial_full_block = manager.block_pool.get_cached_block(
+            partial_full_hash, kv_cache_group_ids=[0]
+        )
+        assert partial_full_block is not None
+        assert full_block_id == partial_full_block[0].block_id
+    else:
+        assert full_offloads == []
 
     partial_mamba_hash = req0.block_hashes[6 // hash_block_size - 1]
     source_block = manager.block_pool.get_cached_block(

--- a/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
+++ b/tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py
@@ -337,3 +337,43 @@ def test_async_progressive_load_failure(
         assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
         assert scheduler.failed_recving_kv_req_ids == {request.request_id}
         assert scheduler.connector.get_num_new_matched_tokens.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "invalid_group,invalid_idx,expected_computed_tokens",
+    [
+        (0, 4, 0),
+        (1, 1, 24_576),
+    ],
+)
+def test_hybrid_load_failure_uses_runtime_manager_block_sizes(
+    scheduler: Scheduler,
+    invalid_group: int,
+    invalid_idx: int,
+    expected_computed_tokens: int,
+):
+    """Hybrid recovery must use DCP-scaled manager block sizes and align the
+    shared computed-token boundary for every cache group."""
+    managers = [Mock(block_size=1_536), Mock(block_size=24_576)]
+    scheduler.kv_cache_manager.coordinator.single_type_managers = managers
+    scheduler.block_size = 24_576
+
+    block_ids_by_group = (
+        list(range(100, 141)),
+        list(range(200, 203)),
+    )
+    scheduler.kv_cache_manager.get_block_ids = Mock(return_value=block_ids_by_group)
+    request = Mock(request_id="hybrid-request", num_computed_tokens=62_976)
+    invalid_block_ids = {
+        block_ids_by_group[invalid_group][invalid_idx],
+    }
+
+    affected, _, _ = scheduler._update_requests_with_invalid_blocks(
+        [request],
+        invalid_block_ids,
+        num_scheduled_tokens={},
+        evict_blocks=False,
+    )
+
+    assert affected == {"hybrid-request"}
+    assert request.num_computed_tokens == expected_computed_tokens

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import pytest
@@ -288,6 +289,34 @@ def simulate_store_completion(
         ),
     )
     scheduler.update_connector_output(output)
+
+
+def test_exact_boundary_handoff_is_stored_on_final_step() -> None:
+    fix = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16)
+    sched = fix.scheduler
+    req = make_request(num_blocks=1)
+    blocks = fix.gpu_block_pool.get_new_blocks(1)
+    fix.gpu_block_pool.cache_full_blocks(
+        request=req,
+        blocks=blocks,
+        num_cached_blocks=0,
+        num_full_blocks=1,
+        block_size=BLOCK_SIZE,
+        kv_cache_group_id=0,
+    )
+    sched.update_state_after_alloc(
+        req, KVCacheBlocks(blocks=(blocks,)), num_external_tokens=0
+    )
+    output = make_scheduler_output({req.request_id: 0})
+    output.kv_connector_block_state = KVConnectorBlockState(
+        block_ids={},
+        boundary_state_offloads={req.request_id: [(0, blocks[0].block_id, BLOCK_SIZE)]},
+    )
+
+    meta = sched.build_connector_meta(output)
+
+    assert meta.store_gpu_blocks == [blocks[0].block_id]
+    assert len(meta.store_cpu_blocks) == 1
 
 
 def simulate_load_completion(
@@ -1954,7 +1983,7 @@ def test_dcp_mixed_attention_mamba_store_and_load_geometry() -> None:
         scheduler_block_size=scheduler_block_size,
         hash_block_size=hash_block_size,
     )
-    assert not sched.cpu_coordinator.enable_partial_hash_hits
+    assert sched.cpu_coordinator.enable_partial_hash_hits
     gpu_pool = BlockPool(
         num_gpu_blocks=num_gpu_blocks,
         enable_caching=True,
@@ -2031,8 +2060,156 @@ def test_dcp_mixed_attention_mamba_store_and_load_geometry() -> None:
     assert len(load_meta.load_cpu_blocks) == 3
 
 
-def test_eager_store_uses_aligned_handoff_for_mamba() -> None:
-    """Mamba stores use exact handoffs, not historical block positions."""
+def test_dcp_mixed_cache_loads_fine_grained_external_hit() -> None:
+    """Map a fine-grained external suffix after a nonzero local prefix."""
+    hash_block_size = BLOCK_SIZE
+    mamba_block_size = 4 * BLOCK_SIZE
+    local_tokens = 4 * BLOCK_SIZE
+    external_tokens = 6 * BLOCK_SIZE
+    total_cached_tokens = local_tokens + external_tokens
+    fix = _make_hybrid_attention_mamba_scheduler(
+        num_cpu_blocks=32,
+        num_gpu_blocks=32,
+        block_size=mamba_block_size,
+        hash_block_size=hash_block_size,
+        dcp_world_size=2,
+    )
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+
+    assert external_tokens % mamba_block_size != 0
+    assert sched.cpu_coordinator.enable_partial_hash_hits
+
+    producer = _make_cp_request(num_blocks=10, virtual_block_size=hash_block_size)
+    attention_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool,
+        producer,
+        num_blocks=5,
+        virtual_block_size=2 * BLOCK_SIZE,
+        group_id=0,
+    )
+    mamba_blocks = gpu_pool.get_new_blocks(3)
+    gpu_pool.cache_full_blocks(
+        request=producer,
+        blocks=mamba_blocks,
+        num_cached_blocks=0,
+        num_full_blocks=2,
+        block_size=mamba_block_size,
+        kv_cache_group_id=1,
+    )
+    gpu_pool.cache_partial_block(
+        request=producer,
+        block=mamba_blocks[2],
+        num_tokens=total_cached_tokens,
+        kv_cache_group_id=1,
+        block_size=mamba_block_size,
+    )
+    producer_blocks = KVCacheBlocks(blocks=(attention_blocks, mamba_blocks))
+    sched.update_state_after_alloc(producer, producer_blocks, num_external_tokens=0)
+
+    # Positional scanning stores append-only FA blocks. Mamba align blocks use
+    # exact handoffs for every retained boundary, including the partial tail.
+    store_output = make_scheduler_output(
+        {producer.request_id: total_cached_tokens},
+        new_reqs={producer.request_id: producer_blocks.get_block_ids()},
+    )
+    store_output.kv_connector_block_state = KVConnectorBlockState(
+        block_ids={},
+        boundary_state_offloads={
+            producer.request_id: [
+                (0, attention_blocks[4].block_id, total_cached_tokens),
+                (1, mamba_blocks[0].block_id, mamba_block_size),
+                (1, mamba_blocks[1].block_id, 2 * mamba_block_size),
+                (1, mamba_blocks[2].block_id, total_cached_tokens),
+            ]
+        },
+    )
+    store_meta = sched.build_connector_meta(store_output)
+    assert set(store_meta.store_gpu_blocks) == {
+        *(block.block_id for block in attention_blocks),
+        *(block.block_id for block in mamba_blocks),
+    }
+    simulate_store_completion(sched, store_meta.store_event)
+
+    consumer = Request(
+        request_id="req-dcp-mixed-fine-load",
+        prompt_token_ids=producer.prompt_token_ids,
+        sampling_params=producer.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=producer._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(
+        consumer, num_computed_tokens=local_tokens
+    )
+    assert hit_tokens == external_tokens
+    assert is_async is True
+    pending_blocks, pending_tokens = sched._pending_cpu_hits[consumer.request_id]
+    assert pending_tokens == external_tokens
+    assert len(pending_blocks[1]) == 2
+    assert pending_blocks[1][0].is_null
+    assert not pending_blocks[1][1].is_null
+
+    local_attention = attention_blocks[:2]
+    local_mamba = mamba_blocks[:1]
+    load_blocks = KVCacheBlocks(
+        blocks=(
+            local_attention + gpu_pool.get_new_blocks(3),
+            local_mamba + gpu_pool.get_new_blocks(2),
+        )
+    )
+    sched.update_state_after_alloc(
+        consumer,
+        load_blocks,
+        num_external_tokens=hit_tokens,
+    )
+    load_meta = sched.build_connector_meta(
+        make_scheduler_output(
+            {consumer.request_id: 1},
+            new_reqs={consumer.request_id: load_blocks.get_block_ids()},
+        )
+    )
+    assert load_meta.load_gpu_blocks == [
+        *(block.block_id for block in load_blocks.blocks[0][2:5]),
+        load_blocks.blocks[1][2].block_id,
+    ]
+    assert len(load_meta.load_cpu_blocks) == 4
+
+
+def test_external_lookup_rejects_misaligned_local_prefix(caplog) -> None:
+    scheduler_block_size = 4 * BLOCK_SIZE
+    fix = _make_hybrid_attention_mamba_scheduler(block_size=scheduler_block_size)
+
+    request = _make_cp_request(num_blocks=2, virtual_block_size=scheduler_block_size)
+    with caplog.at_level(logging.WARNING):
+        hit_tokens, is_async = fix.scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens=BLOCK_SIZE
+        )
+
+    assert (hit_tokens, is_async) == (0, False)
+    assert "requires scheduler-block-aligned local tokens" in caplog.text
+
+
+def test_fine_grained_external_hits_require_eager_offload() -> None:
+    hash_block_size = BLOCK_SIZE
+    scheduler_block_size = 4 * BLOCK_SIZE
+
+    eager = _make_hybrid_attention_mamba_scheduler(
+        block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+    )
+    lazy = _make_hybrid_attention_mamba_scheduler(
+        block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+        lazy=True,
+    )
+
+    assert eager.scheduler.cpu_coordinator.enable_partial_hash_hits
+    assert not lazy.scheduler.cpu_coordinator.enable_partial_hash_hits
+
+
+def test_eager_store_does_not_scan_mamba_blocks_positionally() -> None:
+    """Mamba stores must use exact handoffs, not historical block positions."""
     block_size = 4 * BLOCK_SIZE
     fix = _make_hybrid_attention_mamba_scheduler(
         num_cpu_blocks=16, num_gpu_blocks=24, block_size=block_size
@@ -2069,21 +2246,16 @@ def test_eager_store_uses_aligned_handoff_for_mamba() -> None:
     assert sched._reqs_to_store[req.request_id].num_stored_blocks == [2, 0]
     simulate_store_completion(sched, meta1.store_event)
 
-    # Making another historical Mamba position hashable does not make it a safe
-    # positional source. The coarse path also rejects a non-LCM handoff.
+    # A later hash update still must not make the positional snapshot a valid
+    # source. The explicit boundary-handoff tests cover the supported path.
     gpu_blocks[0]._block_hash = make_block_hash_with_group_id(req.block_hashes[0], 1)
     req.num_computed_tokens = 2 * block_size
-    output2 = make_scheduler_output(
-        {req.request_id: 1},
-        cached_req_new_blocks={req.request_id: None},
+    meta2 = sched.build_connector_meta(
+        make_scheduler_output(
+            {req.request_id: 1},
+            cached_req_new_blocks={req.request_id: None},
+        )
     )
-    output2.kv_connector_block_state = KVConnectorBlockState(
-        block_ids={},
-        boundary_state_offloads={
-            req.request_id: [(1, gpu_blocks[0].block_id, block_size + BLOCK_SIZE)]
-        },
-    )
-    meta2 = sched.build_connector_meta(output2)
     assert meta2.store_event == -1
     assert meta2.store_gpu_blocks == []
     assert sched._reqs_to_store[req.request_id].num_stored_blocks == [2, 0]

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -28,6 +28,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.sched.output import (
     CachedRequestData,
+    KVConnectorBlockState,
     NewRequestData,
     SchedulerOutput,
 )
@@ -1635,6 +1636,73 @@ def _allocate_cp_gpu_blocks(
     return blocks
 
 
+def _make_hybrid_attention_mamba_scheduler(
+    *,
+    num_cpu_blocks: int = 8,
+    num_gpu_blocks: int = 16,
+    attention_block_size: int = BLOCK_SIZE,
+    block_size: int = 4 * BLOCK_SIZE,
+    hash_block_size: int | None = None,
+    dcp_world_size: int = 4,
+    lazy: bool = False,
+) -> SchedulerFixture:
+    """Build a scheduler for one attention group plus one Mamba-align group."""
+    hash_block_size = hash_block_size or block_size
+    attention_spec = FullAttentionSpec(
+        block_size=attention_block_size,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    groups = [
+        KVCacheGroupSpec(["attention"], attention_spec),
+        KVCacheGroupSpec(["mamba"], mamba_spec),
+    ]
+    tensors = [
+        KVCacheTensor(
+            size=spec.page_size_bytes * num_gpu_blocks,
+            layers=group.layer_names,
+            layer_stride=spec.page_size_bytes * num_gpu_blocks,
+            block_stride=spec.page_size_bytes,
+        )
+        for group, spec in zip(groups, (attention_spec, mamba_spec))
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_gpu_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=groups,
+    )
+    vllm_config = _make_cp_vllm_config(dcp_world_size=dcp_world_size)
+    vllm_config.cache_config.prefix_cache_retention_interval = 0
+    cpu_capacity_bytes = sum(tensor.size for tensor in tensors)
+    sched = SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=cpu_capacity_bytes,
+        scheduler_block_size=block_size,
+        hash_block_size=hash_block_size,
+        lazy_offload=lazy,
+    )
+    gpu_block_pool = BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    sched.bind_gpu_block_pool(gpu_block_pool)
+    return SchedulerFixture(
+        scheduler=sched,
+        gpu_block_pool=gpu_block_pool,
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test 15: CP block size scaling is correct
 # ---------------------------------------------------------------------------
@@ -1760,7 +1828,9 @@ def test_cp_effective_block_size_store_and_load(
     req = _make_cp_request(num_blocks=2, virtual_block_size=vbs)
     gpu_blocks = _allocate_cp_gpu_blocks(gpu_pool, req, 2, vbs)
     kv = KVCacheBlocks(blocks=(gpu_blocks,))
-    req.num_computed_tokens = vbs
+    # build_connector_meta runs before the scheduled tokens are committed to
+    # the request, so only num_scheduled_tokens contributes on this step.
+    req.num_computed_tokens = 0
     sched.update_state_after_alloc(req, kv, num_external_tokens=0)
     m1 = sched.build_connector_meta(
         make_scheduler_output(
@@ -1775,7 +1845,7 @@ def test_cp_effective_block_size_store_and_load(
     # Load one DCP-scaled logical block from a two-block CPU hit.
     req2 = _make_cp_request(num_blocks=2, virtual_block_size=vbs)
     kv2 = KVCacheBlocks(blocks=(_allocate_cp_gpu_blocks(gpu_pool, req2, 2, vbs),))
-    req2.num_computed_tokens = 2 * vbs
+    req2.num_computed_tokens = 0
     sched.update_state_after_alloc(req2, kv2, num_external_tokens=0)
     m2 = sched.build_connector_meta(
         make_scheduler_output(
@@ -1911,13 +1981,21 @@ def test_dcp_mixed_attention_mamba_store_and_load_geometry() -> None:
     req.num_computed_tokens = scheduler_block_size
     sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
 
-    store_meta = sched.build_connector_meta(
-        make_scheduler_output(
-            {req.request_id: scheduler_block_size},
-            new_reqs={req.request_id: kv_blocks.get_block_ids()},
-        )
+    store_output = make_scheduler_output(
+        {req.request_id: scheduler_block_size},
+        new_reqs={req.request_id: kv_blocks.get_block_ids()},
     )
-    assert len(store_meta.store_gpu_blocks) == 3
+    store_output.kv_connector_block_state = KVConnectorBlockState(
+        block_ids={},
+        boundary_state_offloads={
+            req.request_id: [(1, mamba_blocks[0].block_id, scheduler_block_size)]
+        },
+    )
+    store_meta = sched.build_connector_meta(store_output)
+    assert set(store_meta.store_gpu_blocks) == {
+        *(block.block_id for block in attention_blocks),
+        mamba_blocks[0].block_id,
+    }
     simulate_store_completion(sched, store_meta.store_event)
 
     req2 = Request(
@@ -1951,3 +2029,61 @@ def test_dcp_mixed_attention_mamba_store_and_load_geometry() -> None:
     )
     assert len(load_meta.load_gpu_blocks) == 3
     assert len(load_meta.load_cpu_blocks) == 3
+
+
+def test_eager_store_uses_aligned_handoff_for_mamba() -> None:
+    """Mamba stores use exact handoffs, not historical block positions."""
+    block_size = 4 * BLOCK_SIZE
+    fix = _make_hybrid_attention_mamba_scheduler(
+        num_cpu_blocks=16, num_gpu_blocks=24, block_size=block_size
+    )
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+
+    req = _make_cp_request(num_blocks=2, virtual_block_size=block_size)
+    attn_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool, req, 2, virtual_block_size=block_size, group_id=0
+    )
+    gpu_blocks = gpu_pool.get_new_blocks(2)
+    gpu_blocks[1]._block_hash = make_block_hash_with_group_id(req.block_hashes[1], 1)
+    kv_blocks = KVCacheBlocks(blocks=(attn_blocks, gpu_blocks))
+    req.num_computed_tokens = 0
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+
+    output = make_scheduler_output(
+        {req.request_id: 2 * block_size},
+        new_reqs={req.request_id: kv_blocks.get_block_ids()},
+    )
+    output.kv_connector_block_state = KVConnectorBlockState(
+        block_ids={},
+        boundary_state_offloads={
+            req.request_id: [(1, gpu_blocks[1].block_id, 2 * block_size)]
+        },
+    )
+    meta1 = sched.build_connector_meta(output)
+    assert meta1.store_event >= 0
+    assert set(meta1.store_gpu_blocks) == {
+        *(block.block_id for block in attn_blocks),
+        gpu_blocks[1].block_id,
+    }
+    assert sched._reqs_to_store[req.request_id].num_stored_blocks == [2, 0]
+    simulate_store_completion(sched, meta1.store_event)
+
+    # Making another historical Mamba position hashable does not make it a safe
+    # positional source. The coarse path also rejects a non-LCM handoff.
+    gpu_blocks[0]._block_hash = make_block_hash_with_group_id(req.block_hashes[0], 1)
+    req.num_computed_tokens = 2 * block_size
+    output2 = make_scheduler_output(
+        {req.request_id: 1},
+        cached_req_new_blocks={req.request_id: None},
+    )
+    output2.kv_connector_block_state = KVConnectorBlockState(
+        block_ids={},
+        boundary_state_offloads={
+            req.request_id: [(1, gpu_blocks[0].block_id, block_size + BLOCK_SIZE)]
+        },
+    )
+    meta2 = sched.build_connector_meta(output2)
+    assert meta2.store_event == -1
+    assert meta2.store_gpu_blocks == []
+    assert sched._reqs_to_store[req.request_id].num_stored_blocks == [2, 0]

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -39,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
@@ -1833,3 +1834,120 @@ def test_cp_lazy_target_blocks_scaling(cp_world_size: int) -> None:
             f"cp_world_size={cp_world_size}: target_cp={target_cp} should be "
             f"less than target_base={target_base}"
         )
+
+
+def test_dcp_mixed_attention_mamba_store_and_load_geometry() -> None:
+    """DCP scales attention blocks but keeps replicated Mamba blocks unscaled."""
+    dcp_world_size = 2
+    attention_block_size = BLOCK_SIZE
+    mamba_block_size = 4 * BLOCK_SIZE
+    hash_block_size = attention_block_size * dcp_world_size
+    scheduler_block_size = mamba_block_size
+    num_gpu_blocks = 16
+
+    attention_spec = FullAttentionSpec(
+        block_size=attention_block_size,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+    )
+    mamba_spec = MambaSpec(
+        block_size=mamba_block_size,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    groups = [
+        KVCacheGroupSpec(["attention"], attention_spec),
+        KVCacheGroupSpec(["mamba"], mamba_spec),
+    ]
+    tensors = [
+        KVCacheTensor(
+            size=spec.page_size_bytes * num_gpu_blocks,
+            layers=group.layer_names,
+            layer_stride=spec.page_size_bytes * num_gpu_blocks,
+            block_stride=spec.page_size_bytes,
+        )
+        for group, spec in zip(groups, (attention_spec, mamba_spec))
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_gpu_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=groups,
+    )
+    vllm_config = _make_cp_vllm_config(dcp_world_size=dcp_world_size)
+    cpu_capacity_bytes = sum(tensor.size for tensor in tensors)
+    sched = SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=cpu_capacity_bytes,
+        scheduler_block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+    )
+    assert not sched.cpu_coordinator.enable_partial_hash_hits
+    gpu_pool = BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    sched.bind_gpu_block_pool(gpu_pool)
+
+    req = _make_cp_request(num_blocks=2, virtual_block_size=hash_block_size)
+    attention_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool,
+        req,
+        num_blocks=2,
+        virtual_block_size=hash_block_size,
+        group_id=0,
+    )
+    mamba_blocks = _allocate_cp_gpu_blocks(
+        gpu_pool,
+        req,
+        num_blocks=1,
+        virtual_block_size=mamba_block_size,
+        group_id=1,
+    )
+    kv_blocks = KVCacheBlocks(blocks=(attention_blocks, mamba_blocks))
+    req.num_computed_tokens = scheduler_block_size
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+
+    store_meta = sched.build_connector_meta(
+        make_scheduler_output(
+            {req.request_id: scheduler_block_size},
+            new_reqs={req.request_id: kv_blocks.get_block_ids()},
+        )
+    )
+    assert len(store_meta.store_gpu_blocks) == 3
+    simulate_store_completion(sched, store_meta.store_event)
+
+    req2 = Request(
+        request_id="req-dcp-mixed-load",
+        prompt_token_ids=req.prompt_token_ids,
+        sampling_params=req.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(req2, num_computed_tokens=0)
+    assert hit_tokens == scheduler_block_size
+    assert is_async is True
+
+    load_blocks = KVCacheBlocks(
+        blocks=(
+            gpu_pool.get_new_blocks(2),
+            gpu_pool.get_new_blocks(1),
+        )
+    )
+    sched.update_state_after_alloc(
+        req2,
+        load_blocks,
+        num_external_tokens=scheduler_block_size,
+    )
+    load_meta = sched.build_connector_meta(
+        make_scheduler_output(
+            {req2.request_id: 1},
+            new_reqs={req2.request_id: load_blocks.get_block_ids()},
+        )
+    )
+    assert len(load_meta.load_gpu_blocks) == 3
+    assert len(load_meta.load_cpu_blocks) == 3

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2773,17 +2773,25 @@ class VllmConfig:
             and self.kv_transfer_config.kv_connector is not None
             and self.parallel_config.cp_kv_cache_interleave_size != local_block_size
         ):
-            interleave = self.parallel_config.cp_kv_cache_interleave_size
-            self.parallel_config.cp_kv_cache_interleave_size = local_block_size
-            logger.info_once(
-                "When using PD disaggregation with DCP "
-                "(decode_context_parallel_size=%d), "
-                "cp_kv_cache_interleave_size is automatically adjusted "
-                "from %d to block_size %d for block-level alignment.",
-                dcp_size,
-                interleave,
-                local_block_size,
+            from vllm.distributed.kv_transfer.kv_connector.factory import (
+                KVConnectorFactory,
             )
+
+            connector_cls = KVConnectorFactory.get_connector_class(
+                self.kv_transfer_config
+            )
+            if connector_cls.requires_dcp_block_aligned_interleave:
+                interleave = self.parallel_config.cp_kv_cache_interleave_size
+                self.parallel_config.cp_kv_cache_interleave_size = local_block_size
+                logger.info_once(
+                    "When using PD disaggregation with DCP "
+                    "(decode_context_parallel_size=%d), "
+                    "cp_kv_cache_interleave_size is automatically adjusted "
+                    "from %d to block_size %d for block-level alignment.",
+                    dcp_size,
+                    interleave,
+                    local_block_size,
+                )
 
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2769,29 +2769,20 @@ class VllmConfig:
             )
 
         if (
-            self.kv_transfer_config is not None
-            and self.kv_transfer_config.kv_connector is not None
+            self._requires_dcp_block_aligned_interleave()
             and self.parallel_config.cp_kv_cache_interleave_size != local_block_size
         ):
-            from vllm.distributed.kv_transfer.kv_connector.factory import (
-                KVConnectorFactory,
+            interleave = self.parallel_config.cp_kv_cache_interleave_size
+            self.parallel_config.cp_kv_cache_interleave_size = local_block_size
+            logger.info_once(
+                "When using PD disaggregation with DCP "
+                "(decode_context_parallel_size=%d), "
+                "cp_kv_cache_interleave_size is automatically adjusted "
+                "from %d to block_size %d for block-level alignment.",
+                dcp_size,
+                interleave,
+                local_block_size,
             )
-
-            connector_cls = KVConnectorFactory.get_connector_class(
-                self.kv_transfer_config
-            )
-            if connector_cls.requires_dcp_block_aligned_interleave:
-                interleave = self.parallel_config.cp_kv_cache_interleave_size
-                self.parallel_config.cp_kv_cache_interleave_size = local_block_size
-                logger.info_once(
-                    "When using PD disaggregation with DCP "
-                    "(decode_context_parallel_size=%d), "
-                    "cp_kv_cache_interleave_size is automatically adjusted "
-                    "from %d to block_size %d for block-level alignment.",
-                    dcp_size,
-                    interleave,
-                    local_block_size,
-                )
 
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.
@@ -2801,14 +2792,10 @@ class VllmConfig:
         """
         block_size = self.cache_config.block_size
 
-        # Skip DCP interleave-size compatibility when a KV connector is configured:
-        # cp_kv_cache_interleave_size is pinned to block_size for PD by each worker
-        pd_active = (
-            self.kv_transfer_config is not None
-            and self.kv_transfer_config.kv_connector is not None
-            and self.kv_transfer_config.is_kv_transfer_instance
-        )
-        if self.parallel_config.decode_context_parallel_size > 1 and not pd_active:
+        if (
+            self.parallel_config.decode_context_parallel_size > 1
+            and not self._requires_dcp_block_aligned_interleave()
+        ):
             assert (
                 self.parallel_config.cp_kv_cache_interleave_size <= block_size
                 and block_size % self.parallel_config.cp_kv_cache_interleave_size == 0
@@ -2824,6 +2811,18 @@ class VllmConfig:
                 "to schedule a multiple of block_size tokens even if they are "
                 "in the middle of a mm input"
             )
+
+    def _requires_dcp_block_aligned_interleave(self) -> bool:
+        """Whether the configured connector composition needs block alignment."""
+        config = self.kv_transfer_config
+        if config is None or not config.is_kv_transfer_instance:
+            return False
+
+        from vllm.distributed.kv_transfer.kv_connector.factory import (
+            KVConnectorFactory,
+        )
+
+        return KVConnectorFactory.requires_dcp_block_aligned_interleave(config)
 
     @model_validator(mode="after")
     def validate_nvfp4_kv_cache_with_mla(self) -> "VllmConfig":

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -144,6 +144,25 @@ class KVConnectorFactory:
 
         return MultiConnector.all_children_support_hma(kv_transfer_config)
 
+    @classmethod
+    def requires_dcp_block_aligned_interleave(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        """Return whether this connector composition requires block alignment."""
+        if kv_transfer_config.kv_connector != "MultiConnector":
+            connector_cls = cls.get_connector_class(kv_transfer_config)
+            return connector_cls.requires_dcp_block_aligned_interleave
+
+        connectors = kv_transfer_config.kv_connector_extra_config.get("connectors", [])
+        if not connectors:
+            return True
+        return any(
+            cls.requires_dcp_block_aligned_interleave(
+                KVTransferConfig(**{"engine_id": kv_transfer_config.engine_id, **child})
+            )
+            for child in connectors
+        )
+
 
 # Register various connectors here.
 # The registration should not be done in each individual file, as we want to

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -173,6 +173,14 @@ class KVConnectorBase_V1(ABC):
     Base class for KV connectors.
     """
 
+    requires_dcp_block_aligned_interleave: bool = True
+    """Whether this connector needs cp_kv_cache_interleave_size pinned to block_size
+    when decode_context_parallel_size > 1.
+
+    Connectors that only move KV within the same DCP rank (e.g. CPU offloading) should
+    set this to False.
+    """
+
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:
         """Whether external hits can complete divergent local hybrid hits.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -47,6 +47,8 @@ from vllm.v1.request import Request
 
 
 class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
+    requires_dcp_block_aligned_interleave = False
+
     @property
     def requires_kv_delivery(self) -> bool:
         # Runs as kv_both, but is a best-effort cache: a dropped save is just a

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -54,6 +54,8 @@ _DISK_ONLY_KEYS = (
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
     """CPU KV cache offloading with custom kernel transfers and BlockPool LRU."""
 
+    requires_dcp_block_aligned_interleave = False
+
     @property
     def requires_kv_delivery(self) -> bool:
         # Runs as kv_both, but is a best-effort cache: a dropped save is just a

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -578,6 +578,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         hash_block_size: int,
         metrics_collector: KVCacheMetricsCollector | None = None,
         num_prefill_lookahead: int = 0,
+        allow_partial_hash_hits: bool = True,
     ):
         super().__init__(
             kv_cache_config,
@@ -639,7 +640,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             )
             for g in kv_cache_config.kv_cache_groups
         )
-        self.enable_partial_hash_hits = has_partial_mamba_group
+        self.enable_partial_hash_hits = (
+            allow_partial_hash_hits and has_partial_mamba_group
+        )
         if self.enable_partial_hash_hits:
             unsupported_partial_hit_managers = {
                 type(manager).__name__
@@ -950,6 +953,7 @@ def get_kv_cache_coordinator(
     hash_block_size: int,
     metrics_collector: KVCacheMetricsCollector | None = None,
     num_prefill_lookahead: int = 0,
+    allow_partial_hash_hits: bool = True,
 ) -> KVCacheCoordinator:
     if not enable_caching:
         return KVCacheCoordinatorNoPrefixCache(
@@ -993,4 +997,5 @@ def get_kv_cache_coordinator(
         hash_block_size=hash_block_size,
         metrics_collector=metrics_collector,
         num_prefill_lookahead=num_prefill_lookahead,
+        allow_partial_hash_hits=allow_partial_hash_hits,
     )

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -854,12 +854,16 @@ class KVCacheManager:
         """Drain this step's boundary-state hand-offs for a KV connector.
 
         Returns ``{request_id: [(group_id, block_id, boundary_tokens), ...]}``
-        for mamba "align" boundary states: the
-        request's committed boundary-state snapshots and, on a sub-block partial
-        hit, the CoW copy of its last-prompt-boundary state. Only mamba "align"
-        groups contribute; empty otherwise. A connector reads the referenced
-        blocks — never resolving them positionally — and offloads them so a
-        later request can hit that prefix.
+        for the durable boundary blocks of producers' last-prompt-boundary
+        partial tails. Mamba "align" groups contribute exact boundary-state
+        snapshots (including CoW targets for sub-block partial hits); DCP
+        full-attention groups contribute the request's own boundary block,
+        which is a durable source because KV below that boundary is
+        append-only. Empty otherwise.
+
+        A connector reads the referenced block IDs (without positional
+        resolution) and offloads them so a later request can hit that
+        sub-block prefix.
         """
         offloads: dict[str, list[tuple[int, int, int]]] = {}
         for mgr in self.coordinator.single_type_managers:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2959,68 +2959,91 @@ class Scheduler(SchedulerInterface):
         # these requests must be rescheduled, but only the first will recompute
         # it. This set tracks blocks already marked for recomputation.
         marked_invalid_block_ids: set[int] = set()
+        managers = self.kv_cache_manager.coordinator.single_type_managers
+        # num_computed_tokens is a single cross-group value, so it can only be
+        # truncated to an alignment every group agrees on. Groups whose own
+        # block is finer than the scheduler block lose a little already-computed
+        # work; a per-group boundary would leave the other groups misaligned.
+        common_block_alignment = self.block_size
         for request in requests:
-            is_affected = False
-            marked_invalid_block = False
             req_id = request.request_id
-            # TODO (davidb): add support for hybrid memory allocator
-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
             # tokens
             req_num_computed_tokens = (
                 request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
             )
 
-            req_num_computed_blocks = (
-                req_num_computed_tokens + self.block_size - 1
-            ) // self.block_size
-            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
-                if block_id not in invalid_block_ids:
-                    continue
+            invalid_positions: list[tuple[int, int]] = []
+            for manager, req_block_ids in zip(
+                managers,
+                req_block_ids_by_group,
+                strict=True,
+            ):
+                group_block_size = manager.block_size
+                req_num_computed_blocks = (
+                    req_num_computed_tokens + group_block_size - 1
+                ) // group_block_size
+                invalid_positions.extend(
+                    (idx * group_block_size, block_id)
+                    for idx, block_id in enumerate(
+                        req_block_ids[:req_num_computed_blocks]
+                    )
+                    if block_id in invalid_block_ids
+                )
 
-                is_affected = True
+            if not invalid_positions:
+                continue
 
-                if block_id in marked_invalid_block_ids:
-                    # This invalid block is shared with a previous request
-                    # and was already marked for recomputation.
-                    # This means this request can still consider this block
-                    # as computed when rescheduled.
-                    # Currently this only applies to sync loading; Async
-                    # loading does not yet support block sharing
-                    continue
+            unmarked_positions = [
+                (token_idx, block_id)
+                for token_idx, block_id in invalid_positions
+                if block_id not in marked_invalid_block_ids
+            ]
+            marked_invalid_block_ids.update(
+                block_id for _, block_id in invalid_positions
+            )
 
-                marked_invalid_block_ids.add(block_id)
-
-                if marked_invalid_block:
-                    # This request has already marked an invalid block for
-                    # recomputation and updated its num_computed_tokens.
-                    continue
-
-                marked_invalid_block = True
-                # Truncate the computed tokens at the first failed block
-                request.num_computed_tokens = idx * self.block_size
-                num_affected_tokens = (
+            if unmarked_positions:
+                # Truncate at the earliest failed token boundary across all
+                # hybrid KV-cache groups.
+                earliest_invalid_token = min(
+                    token_idx for token_idx, _ in unmarked_positions
+                )
+                request.num_computed_tokens = (
+                    earliest_invalid_token
+                    - earliest_invalid_token % common_block_alignment
+                )
+                total_affected_tokens += (
                     req_num_computed_tokens - request.num_computed_tokens
                 )
-                total_affected_tokens += num_affected_tokens
 
-                # collect invalid block and all downstream dependent blocks
                 if evict_blocks:
-                    blocks_to_evict.update(req_block_ids[idx:])
+                    # Every group can depend on tokens after the failed
+                    # boundary, so evict each group's downstream blocks.
+                    for manager, req_block_ids in zip(
+                        managers,
+                        req_block_ids_by_group,
+                        strict=True,
+                    ):
+                        first_invalid_idx = (
+                            request.num_computed_tokens // manager.block_size
+                        )
+                        blocks_to_evict.update(req_block_ids[first_invalid_idx:])
+            else:
+                # All invalid blocks are shared with previous requests and
+                # will be recomputed by them. Revert to considering only
+                # cached tokens as computed.
+                aligned_computed_tokens = (
+                    req_num_computed_tokens
+                    - req_num_computed_tokens % common_block_alignment
+                )
+                total_affected_tokens += (
+                    request.num_computed_tokens - aligned_computed_tokens
+                )
+                request.num_computed_tokens = aligned_computed_tokens
 
-            if is_affected:
-                if not marked_invalid_block:
-                    # All invalid blocks of this request are shared with
-                    # previous requests and will be recomputed by them.
-                    # Revert to considering only cached tokens as computed.
-                    # Currently this only applies to sync loading; Async
-                    # loading does not yet support block sharing
-                    total_affected_tokens += (
-                        request.num_computed_tokens - req_num_computed_tokens
-                    )
-                    request.num_computed_tokens = req_num_computed_tokens
-
-                affected_req_ids.add(request.request_id)
+            affected_req_ids.add(request.request_id)
 
         return affected_req_ids, total_affected_tokens, blocks_to_evict
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import ClassVar
 
+from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
@@ -32,6 +33,8 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
+
+logger = init_logger(__name__)
 
 
 class SingleTypeKVCacheManager(ABC):
@@ -118,16 +121,20 @@ class SingleTypeKVCacheManager(ABC):
         # managers (full attention, mamba "align"); harmlessly empty elsewhere.
         self._partial_hit_reqs: dict[str, tuple[int, KVCacheBlock]] = {}
         self._pending_cow_copies: list[tuple[KVCacheBlock, KVCacheBlock]] = []
-        # Boundary-state offload hand-off for external KV connectors. A mamba
-        # "align" block table is not append-only (interior states are
-        # nulled/freed and speculative blocks relocate in place), so a
-        # connector cannot resolve its state blocks positionally. Record
-        # (request, group, block, exact token boundary) for each committed
-        # boundary state so a connector can offload the right block under the
-        # right hash. Populated only by mamba "align".
+        # Boundary-state offload hand-off for external KV connectors.
+        # For mamba "align", the block table is not append-only (interior
+        # states are nulled/freed and speculative blocks relocate in place), so
+        # connectors must use exact offered block IDs. For full attention under
+        # DCP, producers can also hand off exact boundary blocks because KV
+        # below each offered boundary is append-only.
         self._pending_boundary_state_offloads: list[
             tuple[str, int, KVCacheBlock, int]
         ] = []
+        # DCP full-attention tails do not need CoW, but still need a one-shot
+        # hand-off to an external connector after the prompt boundary is filled.
+        # The queue above is drained every step, so dedup needs its own record
+        # that survives until the request is freed.
+        self._external_partial_tail_boundaries: set[tuple[str, int]] = set()
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -399,9 +406,10 @@ class SingleTypeKVCacheManager(ABC):
 
         Entries are ``(req_id, group_id, block, boundary_tokens)``.
 
-        Only mamba "align" populates this. The blocks are not kept alive by
-        the request block table for the whole request, so a caller that reads
-        them asynchronously must pin them first.
+        Mamba "align" and DCP full-attention producers can populate this.
+        The blocks are not guaranteed to stay reachable via request block
+        tables for the whole request lifetime, so asynchronous callers must pin
+        before reading.
         """
         pending = self._pending_boundary_state_offloads
         self._pending_boundary_state_offloads = []
@@ -519,6 +527,16 @@ class SingleTypeKVCacheManager(ABC):
         req_blocks = self.req_to_blocks.pop(request_id, [])
         self.num_cached_block.pop(request_id, None)
         self._partial_hit_reqs.pop(request_id, None)
+        self._external_partial_tail_boundaries = {
+            entry
+            for entry in self._external_partial_tail_boundaries
+            if entry[0] != request_id
+        }
+        self._pending_boundary_state_offloads = [
+            entry
+            for entry in self._pending_boundary_state_offloads
+            if entry[0] != request_id
+        ]
         return req_blocks
 
     def free(self, request_id: str) -> None:
@@ -820,13 +838,30 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_idx = boundary_tokens // self.block_size
         if block_idx >= len(blocks):
             return
-        self.block_pool.cache_partial_block(
+        partial_hash = self.block_pool.cache_partial_block(
             request=request,
             block=blocks[block_idx],
             num_tokens=boundary_tokens,
             kv_cache_group_id=self.kv_cache_group_id,
             block_size=self.block_size,
         )
+        boundary_key = (request.request_id, boundary_tokens)
+        if (
+            partial_hash is not None
+            and self.dcp_world_size > 1
+            and boundary_key not in self._external_partial_tail_boundaries
+        ):
+            # Unlike Mamba align mode, full-attention KV is append-only inside
+            # the block, so the request block itself is a durable DMA source.
+            self._external_partial_tail_boundaries.add(boundary_key)
+            self._pending_boundary_state_offloads.append(
+                (
+                    request.request_id,
+                    self.kv_cache_group_id,
+                    blocks[block_idx],
+                    boundary_tokens,
+                )
+            )
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -137,6 +137,7 @@ class SimpleCPUOffloadScheduler:
             pcp_world_size=1,
             scheduler_block_size=self.block_size,
             hash_block_size=self.hash_block_size,
+            allow_partial_hash_hits=False,
         )
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
         # GPU block pool reference - bound after scheduler builds kv_cache_manager
@@ -342,7 +343,6 @@ class SimpleCPUOffloadScheduler:
 
         # Build transfer pairs across all groups.
         total_computed_tokens = num_computed_tokens + num_external_tokens
-        kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
 
         # The scheduler may have accepted fewer blocks than
         # get_num_new_matched_tokens() reported.
@@ -351,9 +351,7 @@ class SimpleCPUOffloadScheduler:
         # the rest will be released along with the temp pin below.
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-            )
+            g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
             assert num_external_tokens % g_block_size == 0, (
                 f"num_external_tokens={num_external_tokens} not aligned to "
                 f"group {g} block_size={g_block_size}"
@@ -372,9 +370,7 @@ class SimpleCPUOffloadScheduler:
                 continue
 
             # Number of blocks in the computed range for this group.
-            g_block_size = (
-                kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-            )
+            g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
             n_computed_g = cdiv(total_computed_tokens, g_block_size)
 
             # Back-trace: ext blocks sit at the tail of the computed range.
@@ -591,9 +587,7 @@ class SimpleCPUOffloadScheduler:
                 already_stored_g = state.num_stored_blocks[g]
                 group_gpu_ids = block_ids_by_group[g]
 
-                g_block_size = (
-                    kv_cache_groups[g].kv_cache_spec.block_size * self.cp_world_size
-                )
+                g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
                 ready_blocks_g = aligned_tokens // g_block_size
                 scannable = group_gpu_ids[already_stored_g:ready_blocks_g]
 

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -137,7 +137,7 @@ class SimpleCPUOffloadScheduler:
             pcp_world_size=1,
             scheduler_block_size=self.block_size,
             hash_block_size=self.hash_block_size,
-            allow_partial_hash_hits=False,
+            allow_partial_hash_hits=not lazy_offload,
         )
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
         # GPU block pool reference - bound after scheduler builds kv_cache_manager
@@ -255,6 +255,15 @@ class SimpleCPUOffloadScheduler:
         if stale := self._pending_cpu_hits.pop(request.request_id, None):
             self._free_pending_cpu_hit(stale)
 
+        if num_computed_tokens % self.block_size != 0:
+            logger.warning_once(
+                "SimpleCPU external lookup requires scheduler-block-aligned "
+                "local tokens, got %d tokens with scheduler block size %d.",
+                num_computed_tokens,
+                self.block_size,
+            )
+            return 0, False
+
         num_skipped_hashes = num_computed_tokens // self.hash_block_size
         remaining_hashes = request.block_hashes[num_skipped_hashes:]
 
@@ -332,17 +341,13 @@ class SimpleCPUOffloadScheduler:
 
         cpu_hit_blocks_full, _ = pending
 
-        # ``num_external_tokens`` is LCM-aligned (checked per-group below),
-        # so this counts whole scheduler-aligned chunks of incoming tokens.
-        num_blocks_to_load = num_external_tokens // self.block_size
-        assert num_blocks_to_load > 0
         num_cached_fa_blocks = sum(
             blk.block_hash is not None for blk in blocks.blocks[self.fa_gidx]
         )
         num_computed_tokens = num_cached_fa_blocks * self.fa_block_size
-
-        # Build transfer pairs across all groups.
-        total_computed_tokens = num_computed_tokens + num_external_tokens
+        assert num_computed_tokens % self.block_size == 0, (
+            "SimpleCPU external loads must start at a scheduler-block boundary"
+        )
 
         # The scheduler may have accepted fewer blocks than
         # get_num_new_matched_tokens() reported.
@@ -352,11 +357,7 @@ class SimpleCPUOffloadScheduler:
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
             g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
-            assert num_external_tokens % g_block_size == 0, (
-                f"num_external_tokens={num_external_tokens} not aligned to "
-                f"group {g} block_size={g_block_size}"
-            )
-            n_take_g = num_external_tokens // g_block_size
+            n_take_g = cdiv(num_external_tokens, g_block_size)
             cpu_hit_blocks.append(cpu_hit_blocks_full[g][:n_take_g])
 
         gpu_block_ids: list[int] = []
@@ -369,12 +370,10 @@ class SimpleCPUOffloadScheduler:
             if n_ext_g == 0:
                 continue
 
-            # Number of blocks in the computed range for this group.
             g_block_size = self.cpu_coordinator.single_type_managers[g].block_size
-            n_computed_g = cdiv(total_computed_tokens, g_block_size)
-
-            # Back-trace: ext blocks sit at the tail of the computed range.
-            gpu_ext_start = n_computed_g - n_ext_g
+            # The local prefix starts on the scheduler LCM, which is also a
+            # physical block boundary for every group.
+            gpu_ext_start = num_computed_tokens // g_block_size
             group_gpu_ids = block_ids_by_group[g]
 
             for i, cpu_blk in enumerate(cpu_blocks_g):
@@ -546,17 +545,17 @@ class SimpleCPUOffloadScheduler:
         # Dedup against blocks already scheduled.
         in_flight = self._in_flight_store_gpu_blocks
 
-        # Mamba align state blocks are not positionally stable. Consume exact
-        # same-step handoffs, but keep the coarse baseline scheduler-aligned.
+        # Exact recurrent/partial-tail states are published after their hashes
+        # become valid. Store them before request teardown. Mamba align groups
+        # use this as their only safe source because their block tables are not
+        # positionally stable.
         block_state = scheduler_output.kv_connector_block_state
         boundary_offloads = (
             block_state.boundary_state_offloads if block_state is not None else {}
         )
         for req_id, entries in boundary_offloads.items():
             scheduled_for_req = False
-            for _, gpu_block_id, boundary_tokens in entries:
-                if boundary_tokens % self.block_size != 0:
-                    continue
+            for _, gpu_block_id, _ in entries:
                 gpu_block = gpu_block_pool.blocks[gpu_block_id]
                 block_hash = gpu_block.block_hash
                 if (

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -525,9 +525,8 @@ class SimpleCPUOffloadScheduler:
         """Identify newly computed blocks to offload from scheduler requests.
 
         Only considers blocks whose KV data has been **confirmed computed** by
-        the GPU. This means blocks from the current step are NOT stored until the
-        next step. If a request finishes in the same step as its last full block,
-        that block may be missed. (TODO: flush on finish.)
+        the GPU. Blocks scheduled in the current step can be stored here because
+        the worker orders the DMA read after the compute-done event.
 
         Returns:
             (gpu_block_ids, cpu_block_ids, req_ids) for the store event.
@@ -546,6 +545,40 @@ class SimpleCPUOffloadScheduler:
         num_groups = len(kv_cache_groups)
         # Dedup against blocks already scheduled.
         in_flight = self._in_flight_store_gpu_blocks
+
+        # Mamba align state blocks are not positionally stable. Consume exact
+        # same-step handoffs, but keep the coarse baseline scheduler-aligned.
+        block_state = scheduler_output.kv_connector_block_state
+        boundary_offloads = (
+            block_state.boundary_state_offloads if block_state is not None else {}
+        )
+        for req_id, entries in boundary_offloads.items():
+            scheduled_for_req = False
+            for _, gpu_block_id, boundary_tokens in entries:
+                if boundary_tokens % self.block_size != 0:
+                    continue
+                gpu_block = gpu_block_pool.blocks[gpu_block_id]
+                block_hash = gpu_block.block_hash
+                if (
+                    block_hash is None
+                    or gpu_block_id in in_flight
+                    or cpu_block_pool.cached_block_hash_to_block.get_one_block(
+                        block_hash
+                    )
+                    is not None
+                    or num_free <= 0
+                ):
+                    continue
+                cpu_block = cpu_block_pool.get_new_blocks(1)[0]
+                cpu_block._block_hash = block_hash
+                merged_gpu_block_ids.append(gpu_block_id)
+                merged_cpu_block_ids.append(cpu_block.block_id)
+                in_flight.add(gpu_block_id)
+                gpu_block_pool.touch([gpu_block])
+                num_free -= 1
+                scheduled_for_req = True
+            if scheduled_for_req:
+                req_ids.append(req_id)
 
         for req_id, new_block_id_groups, preempted in yield_req_data(scheduler_output):
             state = self._reqs_to_store.get(req_id)
@@ -574,13 +607,25 @@ class SimpleCPUOffloadScheduler:
             block_hashes_to_store: list[bytes] = []
             advanced_per_group: list[int] = [0] * num_groups
             out_of_space = False
-            # Confirmed tokens: KV data written and visible to all streams.
+            # Confirmed tokens: include tokens already computed in prior steps
+            # and tokens scheduled in the current step. Current-step stores are
+            # ordered after a compute-done event in the worker, so their KV is
+            # visible before DMA reads begin.
             req = state.request
-            confirmed_tokens = req.num_computed_tokens - req.num_output_placeholders
+            confirmed_tokens = (
+                req.num_computed_tokens + num_new_tokens - req.num_output_placeholders
+            )
+            confirmed_tokens = max(0, min(confirmed_tokens, req.num_tokens))
             # Cap to blocks with confirmed KV data.
             aligned_tokens = confirmed_tokens // self.block_size * self.block_size
 
             for g in range(num_groups):
+                # Mamba align block tables relocate state blocks in place, so a
+                # connector's historical block IDs are not safe DMA sources.
+                # These groups are stored only from exact handoffs above.
+                if isinstance(kv_cache_groups[g].kv_cache_spec, MambaSpec):
+                    continue
+
                 # FIXME (yifan): handle CPU cache eviction, where
                 # num_stored_blocks can be stale and omit evicted blocks in
                 # the middle of the request.


### PR DESCRIPTION
# Summary

This PR makes `SimpleCPUOffloadConnector` work correctly for hybrid attention/recurrent models under DCP.

The implementation is split into a conservative coarse baseline and an eager-only fine-grained extension:

- Derive SimpleCPU offload geometry from the resolved per-group KV cache config.
- Recover failed hybrid KV loads per cache group at a common scheduler boundary.
- Use connector capability metadata for DCP interleave adjustment and validation.
- Store Mamba align states only from explicit boundary handoffs, avoiding stale positional GPU block IDs.
- Load eager fine-grained external hits using per-group absolute token ranges.

PR #54457 is treated as a dependency for the connector capability flag. This PR adds the follow-up validation path needed by `SimpleCPUOffloadConnector`.

# Validation

Runtime configuration:

```text
Kimi-K3
TP8 / DCP8 / A2A
DSpark, rejection_sample_method=block
FP8 KV cache
prefix cache enabled
SimpleCPU eager offload
AITER MLA backend
eager / no graph
GPU blocks override = 512
CPU offload pool = 187.5 GB per rank
prefix_cache_retention_interval = 0
```

AgentX / AIPerf, 15 minutes:

```text
theoretical prefix cache hit:   71.77%
aiperf prompt cache read:       1001472 / 3498796 = 28.62%
server local counter delta:     0 / 4140621 = 0.00%
server external counter delta:  1161216 / 4140621 = 28.04%
request errors:                 0
```

The AIPerf command exited non-zero because its profiling metric coverage check reported TTFT coverage at 95.8% versus the required 98.0%. The request stream completed without request errors, and the server metric deltas above are from the run's before/after snapshots rather than server-lifetime counters.

GSM8K, `lm_eval`, 5-shot, `local-completions`, concurrency 64:

```text
strict exact_match:    0.9636 +/- 0.0052
flexible exact_match:  0.9629 +/- 0.0052
```

Deterministic cold/hot/evict/replay:

```text
hot local hit:                     58368 / 60950
post-pressure replay external hit: 58368 / 60950
content_equal:                     true
```

# Notes

The coarse path intentionally does not use Mamba positional scanning. Mamba align block tables are not append-only, so retained Mamba states are consumed from exact handoff events emitted by the KV cache manager. Full-attention groups remain eligible for positional stores because their block tables are append-only.

Lazy SimpleCPU offload remains coarse. Fine-grained external hits are enabled only for eager offload, where same-step store ordering is explicitly synchronized with the compute-complete event.