### PR TITLE
[Bugfix] Await the accepted-token copy before moving batch rows

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -499,6 +499,30 @@ def test_update_states_new_request(model_runner, dist_init):
     assert _is_req_state_block_table_match(model_runner, req_id)
 
 
+def test_update_states_syncs_accepted_counts_before_row_moves(model_runner, dist_init):
+    # add_request and condense permute the same pinned buffer the previous step's
+    # accepted-token D2H writes into, so the copy has to be awaited first.
+    calls = []
+    input_batch = model_runner.input_batch
+    model_runner.num_accepted_tokens_event = SimpleNamespace(
+        synchronize=lambda: calls.append("sync")
+    )
+
+    def record(name, func):
+        def wrapper(*args, **kwargs):
+            calls.append(name)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    for name in ("add_request", "condense"):
+        setattr(input_batch, name, record(name, getattr(input_batch, name)))
+
+    model_runner._update_states(_schedule_new_request("req_0"))
+
+    assert calls == ["sync", "add_request", "condense"]
+
+
 def test_update_states_request_finished(model_runner, dist_init):
     req_id = "req_0"
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1557,6 +1557,12 @@ class GPUModelRunner(
                 if orig != req_state.prev_num_draft_len:
                     req_state.prev_num_draft_len = orig
 
+        # The previous step's D2H fills num_accepted_tokens_cpu_tensor in that
+        # step's row order, and the row moves below permute the same pinned
+        # buffer. Wait here so the copy always lands first.
+        if self.num_accepted_tokens_event is not None:
+            self.num_accepted_tokens_event.synchronize()
+
         # Add the new or resumed requests to the persistent batch.
         # The smaller empty indices are filled first.
         for request in reqs_to_add:
@@ -2171,24 +2177,11 @@ class GPUModelRunner(
         if needs_cpu_accepted_counts:
             assert self.num_accepted_tokens_event is not None
             self.num_accepted_tokens_event.synchronize()
-            # Async mode: condense() reordered indices, use prev_positions mapping
-            if self.use_async_scheduling and prev_req_id_to_index:
-                prev_idx = self.prev_positions.np[:num_reqs]
-                new_mask = prev_idx < 0
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[
-                        np.where(new_mask, 0, prev_idx)
-                    ]
-                )
-                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
-                    self.num_accepted_tokens.np[:num_reqs]
-                )
-            else:
-                # Non-async mode: use values directly
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[:num_reqs]
-                )
+            # _update_states waits for the copy before moving rows, so the counts
+            # are already in current order; gathering again would permute twice.
+            self.num_accepted_tokens.np[:num_reqs] = (
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+            )
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
         else:


### PR DESCRIPTION
## Purpose

Fixes silent output corruption on hybrid (Mamba/GDN) models running speculative decoding with
`--enable-prefix-caching`, which forces `mamba_cache_mode="align"`, and async scheduling.

Step N copies the accepted-token counts D2H non-blocking into the pinned
`input_batch.num_accepted_tokens_cpu_tensor`, in step N's row order. Step N+1's `_update_states`
permutes that same buffer on the host - `add_request`, `swap_states`, `condense` - without waiting
on the event, and `_prepare_inputs` only syncs afterwards, then applies the `prev_positions` gather.

The gather is therefore correct only when the DMA lands after the row moves. Under host load the GPU
runs ahead, the copy lands early, `condense()` has already mapped the values into current order, and
the gather permutes them a second time. The request gets another request's count, which becomes its
conv-window shift and its GDN snapshot selector, and the wrongly gated state is written back into
the SSM cache, so it does not self-correct. Nothing is raised.

The non-align async path is already excluded from reading these counts for this reason, but align is
the one mode that needs them on the CPU.

Wait on the event in `_update_states` before the first row move, and drop the gather, which is
redundant once the copy has landed first. Both halves are needed: the wait alone is worse (7.6% vs
4.3% baseline), because it guarantees the early landing that triggers the double permute.


## Test Plan

Standalone repro, stdlib only: send one ~59k-token document repeatedly, each time asking for a
different labelled six-digit code inside it, so every request after the first hits the prefix cache
and reads the counts through the align path. A corrupted count degenerates the answer.

The race needs the GPU to run ahead of the host, so starve the server of CPU. Capping the container
is far more reliable than loading the box:

```bash
docker run -d --name arm --gpus '"device=6"' -p 8000:8000 --cpus=4 \
    vllm/vllm-openai:v0.27.1 --model Qwen/Qwen3.8-27B-FP8 \
    --enable-prefix-caching --max-num-seqs 64 --max-num-batched-tokens 32768 \
    --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
python3 repro_mamba_align_race.py --base-url http://localhost:8000 --model qwen \
    --rounds 12 --concurrency 24
```

Script: https://gist.github.com/johny-jose/2cc21af3b78604c97712b1dc183d7328. Without `--cpus`, an idle box reads 0-1/192 and the bug looks absent.

## Test Result

1xH200, Qwen3.8-27B-FP8, `--cpus=4`, concurrency 24, arms driven concurrently.

On `main` (nightly `a9a17e709`, whose `gpu_model_runner.py` is identical to `main`), 52 rounds x 24
per arm:

| arm | wrong / 1248 |
|---|---|
| `--enable-prefix-caching` + MTP=3 | **29 (2.32%)** |
| + this patch | **0** |

Fisher exact p = 1.6e-9.

Wider matrix on v0.27.1, 12 rounds x 24, isolating the trigger:

| arm | wrong / 288 |
|---|---|
| `--enable-prefix-caching`, no MTP | 0 |
| `--enable-prefix-caching` + MTP=3 | **16 (5.56%)** |
| + `--no-async-scheduling` | 0 |
| + this patch | 0 |

The no-MTP arm rules out the prompt and the context length; corruption needs align + spec decode +
async scheduling together.

Failures are a duplicated digit run spliced into the answer, and repeat per topic because the repro
replays the same batch composition each round:

```
trellis:  want 996580  got '996586580'
cobalt:   want 573780  got '573788269'
citadel:  want 198695  got '198698695'
```

Under heavier starvation the same arm degenerates further - a truncated fragment then a run of one
token (`'**\n</think>!!!!!!!!!!!!!!!!!'`). Longer run at that severity, v0.26.0, concurrency 100:
186/5400 corrupted on baseline, 0/5400 patched, 0/1800 with `--no-async-scheduling`.

Throughput, same GPU, no CPU cap, RAG-shaped prompts, servers benchmarked sequentially:

| concurrency | baseline | patch | `--no-async-scheduling` |
|---|---|---|---|
| 1 | 58.6 | 56.6 | 55.5 |
| 8 | 220.3 | 221.5 | 221.4 |
| 32 | 347.4 | 354.6 | 330.7 |
| 64 | 436.8 | 413.4 | 423.7 |
| 128 | 487.8 | 482.1 | 466.3 |

1.2% at the knee, against 4.4% for `--no-async-scheduling`, and it keeps async scheduling, prefix
caching and MTP all on.

`synchronize()` on an unrecorded event returns immediately, so the new wait is a no-op for
non-hybrid spec-decode models: `_update_states_after_model_execute` returns early when
`not is_hybrid`, above both `.record()` sites, so the event is created but never recorded.

### Test suite

New: `test_update_states_syncs_accepted_counts_before_row_moves` pins the ordering contract by
recording the order of `synchronize()`, `add_request()` and `condense()`. It fails on an unpatched
tree (the sync lands last) and passes with the fix, so it guards against the sync being moved or
dropped later.

`tests/v1/worker/test_gpu_model_runner.py`, `test_gpu_input_batch.py`, `test_mamba_utils.py`,
`test_gpu_batch_ordering.py`: 105 passed (104 pre-existing plus the new one), no other change from
baseline.

`tests/v1/e2e/general/test_mamba_prefix_cache.py` (`mrv1`, `mrv1_async`, `mrv2`, `mrv2_async`):
4 passed with and without the patch.

`tests/v1/e2e/general/test_async_scheduling.py::test_with_eagle3_spec_decoding`: passes 3/3 with and
without.

`tests/v1/spec_decode/test_acceptance_length.py -k gpt-oss-20b-eagle3` (FLASH_ATTN and TRITON_ATTN)
fails 3/3 with *and* without the patch on this nightly, so it is pre-existing and unrelated.

One note in case others hit it: in `vllm/vllm-openai:nightly`,
`flashinfer/gdn_kernels/gdn_decode_bf16_state.py:2701` runs
`torch.cuda.get_device_properties(0)` at module scope, so importing `tests/utils.py` initializes
CUDA in the pytest parent and every `fork_new_process_for_each_test` test dies with
"Cannot re-initialize CUDA in forked subprocess". I ran the tests above one per pytest invocation
with the fork decorator disabled.
