### PR TITLE
[CPU] add CPU support for Voxtral

### DIFF
--- a/vllm/model_executor/models/whisper_causal.py
+++ b/vllm/model_executor/models/whisper_causal.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     subclass_attention_backend_with_overrides,
 )
+from vllm.v1.attention.backends.cpu_attn import CPUAttentionBackend
 from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
 
 try:
@@ -225,6 +226,7 @@ def create_whisper_attention_backend_with_block_pooling(
         b
         for b in (
             AiterFlashAttentionBackend,
+            CPUAttentionBackend,
             FlashAttentionBackend,
             RocmAttentionBackend,
             TritonAttentionBackend,
@@ -239,7 +241,9 @@ def create_whisper_attention_backend_with_block_pooling(
             "appreciated."
         )
 
-    if not issubclass(underlying_attn_backend, FlashAttentionBackend):
+    if not issubclass(
+        underlying_attn_backend, (CPUAttentionBackend, FlashAttentionBackend)
+    ):
         logger.info(
             "Using %s for Whisper causal attention with block pooling. "
             "This backend was recently enabled for this model. "


### PR DESCRIPTION
## Summary
co-developed with @NickCao.

- Adds `CPUAttentionBackend` to the supported backends list in `create_whisper_attention_backend_with_block_pooling` 

- [x] Verified Voxtral (`mistralai/Voxtral-Mini-4B-Realtime-2602`) on docker.io/vllm/vllm-openai-cpu:v0.28.0. 
```
vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602 --gpu-memory-utilization 0.5 --max-model-len 2048
```

with this test `python examples/speech_to_text/realtime/openai_realtime_client.py `
```
No audio path provided, using default: /root/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Session created: sess-a5704d3a3f60906e
Loading audio from: /root/.cache/vllm/assets/vllm_public_assets/mary_had_lamb.ogg
Sending 125 audio chunks...
Audio sent. Waiting for transcription...

Transcription:  First words I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, it squeaked with quite a flow, and everywhere that Mary went, thelamb was sure to go.

Final transcription:  First words I spoke in the original phonograph. A little piece of practical poetry. Mary had a little lamb, it squeaked with quite a flow, and everywhere that Mary went, the lamb was sure to go.
Usage: {'prompt_tokens': 39, 'total_tokens': 249, 'completion_tokens': 210, 'prompt_tokens_details': None, 'completion_tokens_details': None}
```
