### PR TITLE
[Refactor] Move FlashInfer w13/w31 swap helper to global wrapper

### DIFF
--- a/tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py
+++ b/tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py
@@ -7,12 +7,16 @@ import torch
 
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
 from vllm.model_executor.layers.quantization.utils import flashinfer_fp4_moe
+from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    swap_w13_to_w31 as legacy_swap_w13_to_w31,
+)
 from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
     prepare_nvfp4_moe_layer_for_fi_or_cutlass,
 )
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     align_trtllm_fp4_moe_hidden_dim_for_fi,
 )
+from vllm.utils.flashinfer import swap_w13_to_w31
 
 
 def test_shared_nvfp4_input_scales_have_writable_storage(monkeypatch):
@@ -53,6 +57,14 @@ def test_shared_nvfp4_input_scales_have_writable_storage(monkeypatch):
     a2_scale.copy_(distinct_values)
     torch.testing.assert_close(a13_scale, distinct_values)
     torch.testing.assert_close(a2_scale, distinct_values)
+
+
+def test_swap_w13_to_w31_is_available_from_flashinfer_wrapper():
+    w13 = torch.arange(2 * 2 * 3 * 4, dtype=torch.float32).reshape(2, 6, 4)
+
+    expected = torch.cat([w13[:, 3:], w13[:, :3]], dim=1)
+    torch.testing.assert_close(swap_w13_to_w31(w13), expected)
+    torch.testing.assert_close(legacy_swap_w13_to_w31(w13), expected)
 
 
 def test_align_trtllm_fp4_moe_hidden_dim_noop():

--- a/vllm/model_executor/layers/quantization/utils/b12x_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/b12x_moe.py
@@ -5,12 +5,10 @@
 import torch
 import torch.nn.functional as F
 
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    swap_w13_to_w31,
-)
 from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
     swizzle_blockscale,
 )
+from vllm.utils.flashinfer import swap_w13_to_w31
 from vllm.utils.math_utils import round_up
 
 

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -6,6 +6,7 @@ import torch
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.utils.flashinfer import swap_w13_to_w31
 from vllm.utils.math_utils import round_up
 
 if TYPE_CHECKING:
@@ -48,12 +49,6 @@ def activation_to_flashinfer_type(activation: MoEActivation) -> "ActivationType"
         MoEActivation.RELU2_NO_MUL: ActivationType.Relu2,
     }
     return ACTIVATION_TO_FI_ACTIVATION[activation]
-
-
-def swap_w13_to_w31(x: torch.Tensor) -> torch.Tensor:
-    return (
-        x.reshape(-1, 2, x.shape[-2] // 2, x.shape[-1]).flip(dims=[1]).reshape(x.shape)
-    )
 
 
 def rotate_weights_for_fi_trtllm_fp8_per_tensor_moe(

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -109,6 +109,12 @@ def _lazy_import_wrapper(
     return wrapper
 
 
+def swap_w13_to_w31(x: torch.Tensor) -> torch.Tensor:
+    return (
+        x.reshape(-1, 2, x.shape[-2] // 2, x.shape[-1]).flip(dims=[1]).reshape(x.shape)
+    )
+
+
 # Create lazy wrappers for each function
 flashinfer_trtllm_bf16_moe = _lazy_import_wrapper(
     "flashinfer.fused_moe", "trtllm_bf16_moe"
@@ -1079,6 +1085,7 @@ def is_flashinfer_cudnn_fp8_prefill_attn_supported() -> bool:
 
 __all__ = [
     "has_flashinfer",
+    "swap_w13_to_w31",
     "flashinfer_trtllm_fp8_block_scale_moe",
     "flashinfer_cutlass_fused_moe",
     "flashinfer_cutedsl_grouped_gemm_nt_masked",


### PR DESCRIPTION
Fixes #31414

This PR starts consolidating FlashInfer utility helpers by moving the generic
`swap_w13_to_w31` tensor helper into `vllm.utils.flashinfer`, where other
FlashInfer compatibility wrappers live.

Changes:
- Add `swap_w13_to_w31` to `vllm.utils.flashinfer` and export it.
- Reuse that helper from `flashinfer_utils`.
- Update the B12x MoE utility to import the helper from the shared FlashInfer wrapper.
- Add a regression test that verifies the new public wrapper path and the legacy import path return identical results.

Validation:
- `python -m py_compile ...`
- `git diff --check`
- `pytest tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py -q`
  - Not completed locally because this sparse Windows test environment is still missing vLLM test dependencies, currently `transformers`.