### PR TITLE
[Bugfix] Keep think tokens that appear after reasoning ends

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -415,6 +415,23 @@ class TestBaseThinkingReasoningParserEdgeCases:
         assert reasoning == "First"
         assert content == "Middle</test:think>Last"
 
+    def test_multiple_end_tokens_streaming(self, test_tokenizer):
+        """A think token after the block closed is content, not a delimiter."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+
+        deltas = [
+            "<test:think>",
+            "First",
+            "</test:think>",
+            "Middle",
+            "</test:think>",
+            "Last",
+        ]
+        reasoning, content = run_reasoning_extraction(parser, deltas, streaming=True)
+
+        assert reasoning == "First"
+        assert content == "Middle</test:think>Last"
+
     def test_nested_tokens(self, test_tokenizer):
         """Test behavior with nested-like token patterns."""
         parser = TestThinkingReasoningParser(test_tokenizer)

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -109,10 +109,13 @@ class BaseThinkingReasoningParser(ReasoningParser):
         Handles streaming output where previous + delta = current.
         Uses token IDs for faster processing.
         """
-        # Skip single special tokens
+        # Skip single special tokens, but only while they still delimit
+        # reasoning; afterwards they are content.
         if len(delta_token_ids) == 1 and (
             delta_token_ids[0] in [self.start_token_id, self.end_token_id]
         ):
+            if self.end_token_id in previous_token_ids:
+                return DeltaMessage(content=delta_text)
             return None
 
         # Check if start token is present in previous or delta.

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -47,7 +47,10 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
             and self.start_token_id not in previous_token_ids
             and self.start_token_id not in delta_token_ids
         ):
-            if self.end_token_id in delta_token_ids:
+            if self.end_token_id in previous_token_ids:
+                # end token in previous, thinking content ends
+                return DeltaMessage(content=delta_text)
+            elif self.end_token_id in delta_token_ids:
                 # end token in delta with more tokens,
                 # extract reasoning content and content
                 end_index = delta_text.find(self.end_token)
@@ -57,9 +60,6 @@ class DeepSeekR1ReasoningParser(BaseThinkingReasoningParser):
                     reasoning=reasoning,
                     content=content if content else None,
                 )
-            elif self.end_token_id in previous_token_ids:
-                # end token in previous, thinking content ends
-                return DeltaMessage(content=delta_text)
             else:
                 # no end token in previous or delta, reasoning content continues
                 return DeltaMessage(reasoning=delta_text)


### PR DESCRIPTION
## Purpose

a think token that shows up in the answer after the reasoning block already closed gets dropped from the streamed content, non streaming keeps it. so any model that mentions `</think>` in its reply, explaining the format or printing a prompt example, comes out mangled if you stream.

```
output: "figuring it out</think>you close the block with </think> when done"

non streaming content : 'you close the block with </think> when done'
streamed content      : 'you close the block with  when done'
```

`BaseThinkingReasoningParser` skips a delta thats a single start/end think token, which is right while that token is delimiting the block, but it kept skipping after the block closed so the text just vanished. now it only skips while reasoning is still open and emits the token as content after. `DeepSeekR1ReasoningParser` needed the same, its override checked `end in delta` before `end in previous` so it re-broke it, those two branches are swapped.

## Test Plan

added `test_multiple_end_tokens_streaming` in `tests/reasoning/test_base_thinking_reasoning_parser.py`, its the streaming mirror of the `test_multiple_end_tokens` thats already there. that one asserts the trailing token stays in the content but feeds the whole output as one chunk, which is why this never got caught.

```
pytest tests/reasoning -q --ignore=tests/reasoning/test_cohere_command_reasoning_parser.py
```

## Test Result

new test fails on main with `assert 'MiddleLast' == 'Middle</test:think>Last'` and passes with the change.

full `tests/reasoning` run: 418 passed before, 419 after, so just the one new test and nothing else moved. ruff format and check clean. ran on cpu so the per test cuda teardown errors show up either way, and `test_cohere_command_reasoning_parser.py` fails collection on a missing dep on main already, ignored it in both runs.

---

ai disclosure: i was checking the reasoning parsers streaming output against non streaming and they didnt line up, used claude to help track down the root cause and write the patch. ive gone through every line myself, understand it, and ran the tests above. commit is tagged with `Co-authored-by:` per the contributing guide.
