### PR TITLE
metrics: expose vllm:model_config_info gauge (incl. auto-configured m…

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -362,13 +362,22 @@ used for information about an instance that does not change - so it
 only needs to be observed at startup - and allows comparing across
 instances in Prometheus.
 
-We use this concept for the `vllm:cache_config_info` metric:
+We use this concept for the `vllm:cache_config_info` and
+`vllm:model_config_info` metrics:
 
 ```text
 # HELP vllm:cache_config_info Information of the LLMEngine CacheConfig
 # TYPE vllm:cache_config_info gauge
 vllm:cache_config_info{block_size="16",cache_dtype="auto",cpu_offload_gb="0",enable_prefix_caching="False",gpu_memory_utilization="0.9",...} 1.0
+# HELP vllm:model_config_info Information of the LLMEngine ModelConfig
+# TYPE vllm:model_config_info gauge
+vllm:model_config_info{dtype="auto",enforce_eager="False",max_model_len="4096",model="meta-llama/Llama-3.1-8B-Instruct",quantization="None",served_model_name="meta-llama/Llama-3.1-8B-Instruct",tokenizer="meta-llama/Llama-3.1-8B-Instruct",tokenizer_mode="auto",...} 1.0
 ```
+
+`vllm:model_config_info` is particularly useful for observing the
+auto-configured `max_model_len` (and other model-level settings) without
+having to parse startup logs, since the value is resolved at engine
+initialization and exposed as a stable gauge.
 
 However, `prometheus_client` has
 [never supported Info metrics in multiprocessing mode](https://github.com/prometheus/client_python/pull/300) -

--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -191,6 +191,7 @@ EXPECTED_METRICS_V1 = [
     "vllm:generation_tokens_total",
     "vllm:iteration_tokens_total",
     "vllm:cache_config_info",
+    "vllm:model_config_info",
     "vllm:request_success_total",
     "vllm:request_prompt_tokens_sum",
     "vllm:request_prompt_tokens_bucket",
@@ -299,6 +300,20 @@ async def test_metrics_exist(
     for sample in cache_config_samples:
         assert sample.labels.get("kv_cache_size_tokens") not in (None, "None", "")
         assert sample.labels.get("kv_cache_max_concurrency") not in (None, "None", "")
+
+    model_config_samples = [
+        sample
+        for family in text_string_to_metric_families(response.text)
+        if family.name == "vllm:model_config_info"
+        for sample in family.samples
+    ]
+    assert model_config_samples
+    for sample in model_config_samples:
+        # max_model_len is resolved (possibly auto-configured) at engine init;
+        # it must be present and a positive integer once exposed.
+        assert sample.labels.get("max_model_len") not in (None, "None", "")
+        assert int(sample.labels["max_model_len"]) > 0
+        assert sample.labels.get("model") not in (None, "None", "")
 
 
 @pytest.mark.asyncio

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2021,6 +2021,25 @@ class ModelConfig:
         logger.info("Using max model len %s", max_model_len)
         return max_model_len
 
+    def metrics_info(self) -> dict[str, str]:
+        # Convert a curated subset of ModelConfig to dict(key: str, value: str)
+        # for the prometheus metrics info gauge. We intentionally expose only
+        # a stable, low-cardinality subset of fields (rather than the full
+        # __dict__) to avoid leaking large objects (e.g. hf_config) and to keep
+        # the metric label set predictable. This makes it possible to observe
+        # values such as the auto-configured max_model_len via /metrics instead
+        # of scraping startup logs.
+        return {
+            "model": str(self.model),
+            "served_model_name": str(self.served_model_name),
+            "tokenizer": str(self.tokenizer),
+            "tokenizer_mode": str(self.tokenizer_mode),
+            "dtype": str(self.dtype),
+            "max_model_len": str(self.max_model_len),
+            "quantization": str(self.quantization),
+            "enforce_eager": str(self.enforce_eager),
+        }
+
     @property
     def attn_type(self) -> AttnTypeStr:
         """Determine the attention type based on model configuration."""

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1081,6 +1081,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         if type == "cache_config":
             name = "vllm:cache_config_info"
             documentation = "Information of the LLMEngine CacheConfig"
+        elif type == "model_config":
+            name = "vllm:model_config_info"
+            documentation = "Information of the LLMEngine ModelConfig"
         assert name is not None, f"Unknown metrics info type {type}"
 
         # Info type metrics are syntactic sugar for a gauge permanently set to 1
@@ -1279,6 +1282,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
+        self.log_metrics_info("model_config", self.vllm_config.model_config)
 
 
 def build_buckets(mantissa_lst: list[int], max_value: int) -> list[int]:


### PR DESCRIPTION
## Motivation
Operators currently have to scrape startup logs to learn the (auto-configured)
`max_model_len`, which is fragile across pods/restarts. This adds a stable
Prometheus gauge so it (and other model-level settings) can be queried per-pod
via `/metrics`.

## Changes
- Add `ModelConfig.metrics_info()` returning a curated, stable label set
  including `max_model_len`, `model`, `served_model_name`, `tokenizer`,
  `tokenizer_mode`, `dtype`, `quantization`, and `enforce_eager`.
- Emit a new `vllm:model_config_info` Info-style gauge (value `1`, key/value
  labels) from `PrometheusStatLogger` at engine initialization, alongside the
  existing `vllm:cache_config_info`.
- Extend `log_metrics_info` to handle `model_config`.
- Doc + test updates: assert the gauge exists and that `max_model_len` is a
  positive integer.

## Example
```text
# TYPE vllm:model_config_info gauge
vllm:model_config_info{dtype="auto",enforce_eager="False",max_model_len="4096",model="...",quantization="None",served_model_name="...",tokenizer="...",tokenizer_mode="auto"} 1.0