### PR TITLE
[Spec Decode] Enable adaptive DSpark verification for Qwen GDN

### DIFF
--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -196,6 +196,73 @@ def test_causal_conv1d_update(dim, width, seqlen, has_bias, silu_activation, ity
     assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
 
 
+@torch.inference_mode()
+def test_causal_conv1d_update_spec_varlen_matches_per_request() -> None:
+    """Speculative varlen batching must match independent request updates."""
+    set_random_seed(0)
+    device = DEVICE
+    query_lens = [4, 2, 0]
+    num_reqs, dim, width = len(query_lens), 64, 4
+    max_query_len = max(query_lens)
+    num_tokens = sum(query_lens)
+    state_len = width - 1 + max_query_len - 1
+
+    x = torch.randn(num_tokens, dim, dtype=torch.bfloat16, device=device)
+    weight = torch.randn(dim, width, dtype=torch.bfloat16, device=device)
+    bias = torch.randn(dim, dtype=torch.bfloat16, device=device)
+    state_seed = torch.randn(
+        num_reqs + 1,
+        dim,
+        state_len,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    state_indices = torch.tensor([1, 2, 0], dtype=torch.int32, device=device)
+    num_accepted_tokens = torch.ones(num_reqs, dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 4, 6, 6], dtype=torch.int32, device=device)
+
+    actual_state = state_seed.clone()
+    actual = causal_conv1d_update(
+        x,
+        actual_state,
+        weight,
+        bias,
+        activation="silu",
+        conv_state_indices=state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        query_start_loc=query_start_loc,
+        max_query_len=max_query_len,
+        out=torch.empty_like(x),
+    )
+
+    expected_state = state_seed.clone()
+    expected_parts = []
+    for req_idx, request_x in enumerate(torch.split(x, query_lens)):
+        if request_x.shape[0] == 0:
+            continue
+        request_out = causal_conv1d_update(
+            request_x.T.unsqueeze(0),
+            expected_state,
+            weight,
+            bias,
+            activation="silu",
+            conv_state_indices=state_indices[req_idx : req_idx + 1],
+            num_accepted_tokens=num_accepted_tokens[req_idx : req_idx + 1],
+            out=torch.empty(
+                1,
+                dim,
+                request_x.shape[0],
+                dtype=request_x.dtype,
+                device=device,
+            ),
+        )
+        expected_parts.append(request_out.squeeze(0).T)
+    expected = torch.cat(expected_parts)
+
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=1e-2)
+    torch.testing.assert_close(actual_state, expected_state, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("itype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("silu_activation", [False, True])
 @pytest.mark.parametrize("has_bias", [False, True])

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -236,16 +236,38 @@ def test_fused_forward_uses_packed_entrypoint() -> None:
 
 
 @pytest.mark.parametrize(
-    "seq_lens,query_lens,draft_tokens,expected_fused_calls,cpu_query_lens",
+    (
+        "seq_lens,query_lens,draft_tokens,expected_fused_calls,"
+        "cpu_query_lens,num_accepted_tokens"
+    ),
     [
-        pytest.param([128], [SPEC_TOKENS], [NUM_SPEC], 1, None, id="pure-mtp"),
+        pytest.param([128], [SPEC_TOKENS], [NUM_SPEC], 1, None, [1], id="pure-mtp"),
         pytest.param(
             [128, 96, 80],
             [4, 2, 1],
             [NUM_SPEC, NUM_SPEC, NUM_SPEC],
             1,
             [3, 2, 2],
-            id="ragged-mtp-cpu-device-mismatch",
+            [1, 1, 1],
+            id="ragged-mtp-full-rejection",
+        ),
+        pytest.param(
+            [128, 96, 80],
+            [4, 2, 1],
+            [NUM_SPEC, NUM_SPEC, NUM_SPEC],
+            1,
+            [3, 2, 2],
+            [2, 1, 1],
+            id="ragged-mtp-partial-acceptance",
+        ),
+        pytest.param(
+            [128, 96, 80],
+            [4, 2, 1],
+            [NUM_SPEC, NUM_SPEC, NUM_SPEC],
+            1,
+            [3, 2, 2],
+            [4, 2, 1],
+            id="ragged-mtp-full-acceptance",
         ),
         pytest.param(
             [128, 96],
@@ -253,10 +275,11 @@ def test_fused_forward_uses_packed_entrypoint() -> None:
             [NUM_SPEC, -1],
             0,
             None,
+            [1, 1],
             id="mixed-mtp-falls-back",
         ),
-        pytest.param([96], [64], [-1], 0, None, id="pure-prefill"),
-        pytest.param([128], [1], [-1], 0, None, id="pure-decode"),
+        pytest.param([96], [64], [-1], 0, None, [1], id="pure-prefill"),
+        pytest.param([128], [1], [-1], 0, None, [1], id="pure-decode"),
     ],
 )
 @torch.inference_mode()
@@ -266,6 +289,7 @@ def test_fused_model_path_matches_reference(
     draft_tokens: list[int],
     expected_fused_calls: int,
     cpu_query_lens: list[int] | None,
+    num_accepted_tokens: list[int],
 ) -> None:
     """Fused MTP and its mixed/prefill/decode fallbacks match the reference."""
     torch.manual_seed(1)
@@ -299,8 +323,8 @@ def test_fused_model_path_matches_reference(
         metadata = builder.build(
             common_prefix_len=0,
             common_attn_metadata=common,
-            num_accepted_tokens=torch.ones(
-                batch.batch_size, dtype=torch.int32, device=device
+            num_accepted_tokens=torch.tensor(
+                num_accepted_tokens, dtype=torch.int32, device=device
             ),
             num_decode_draft_tokens_cpu=torch.tensor(draft_tokens, dtype=torch.int32),
         )

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -236,18 +236,27 @@ def test_fused_forward_uses_packed_entrypoint() -> None:
 
 
 @pytest.mark.parametrize(
-    "seq_lens,query_lens,draft_tokens,expected_fused_calls",
+    "seq_lens,query_lens,draft_tokens,expected_fused_calls,cpu_query_lens",
     [
-        pytest.param([128], [SPEC_TOKENS], [NUM_SPEC], 1, id="pure-mtp"),
+        pytest.param([128], [SPEC_TOKENS], [NUM_SPEC], 1, None, id="pure-mtp"),
+        pytest.param(
+            [128, 96, 80],
+            [4, 2, 1],
+            [NUM_SPEC, NUM_SPEC, NUM_SPEC],
+            1,
+            [3, 2, 2],
+            id="ragged-mtp-cpu-device-mismatch",
+        ),
         pytest.param(
             [128, 96],
             [SPEC_TOKENS, 64],
             [NUM_SPEC, -1],
             0,
+            None,
             id="mixed-mtp-falls-back",
         ),
-        pytest.param([96], [64], [-1], 0, id="pure-prefill"),
-        pytest.param([128], [1], [-1], 0, id="pure-decode"),
+        pytest.param([96], [64], [-1], 0, None, id="pure-prefill"),
+        pytest.param([128], [1], [-1], 0, None, id="pure-decode"),
     ],
 )
 @torch.inference_mode()
@@ -256,6 +265,7 @@ def test_fused_model_path_matches_reference(
     query_lens: list[int],
     draft_tokens: list[int],
     expected_fused_calls: int,
+    cpu_query_lens: list[int] | None,
 ) -> None:
     """Fused MTP and its mixed/prefill/decode fallbacks match the reference."""
     torch.manual_seed(1)
@@ -276,6 +286,14 @@ def test_fused_model_path_matches_reference(
     common = create_common_attn_metadata(
         batch, BLOCK_SIZE, device, arange_block_indices=True
     )
+    if cpu_query_lens is not None:
+        query_start_loc_cpu = torch.zeros(len(cpu_query_lens) + 1, dtype=torch.int32)
+        torch.cumsum(
+            torch.tensor(cpu_query_lens, dtype=torch.int32),
+            dim=0,
+            out=query_start_loc_cpu[1:],
+        )
+        common = common.replace(query_start_loc_cpu=query_start_loc_cpu)
     common.block_table_tensor.add_(1)
     with set_current_vllm_config(vllm_config):
         metadata = builder.build(

--- a/tests/kernels/test_fused_gdn_post_conv.py
+++ b/tests/kernels/test_fused_gdn_post_conv.py
@@ -384,3 +384,88 @@ def test_fused_gdn_decode_post_conv_mtp_head_ratios(
         )
 
     torch.testing.assert_close(state_actual, state_ref, atol=3e-2, rtol=3e-2)
+
+
+@torch.inference_mode()
+def test_fused_gdn_decode_post_conv_mtp_cudagraph_replays_ragged_layout() -> None:
+    """A captured uniform batch must consume new ragged device boundaries."""
+    if torch.cuda.get_device_capability() < (8, 0):
+        pytest.skip("fused GDN decode MTP requires compute capability 8.0+")
+    if not hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp"):
+        pytest.skip("fused GDN decode MTP op is not built")
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    num_reqs, num_tokens, state_width = 3, 6, 4
+    H, HV, K, V = 1, 2, 128, 128
+    scale = K**-0.5
+    norm_eps = 1e-6
+
+    mixed_qkv = torch.randn(
+        num_tokens,
+        2 * H * K + HV * V,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    ba = torch.randn(num_tokens, 2 * HV, dtype=torch.bfloat16, device=device)
+    b, a = ba.chunk(2, dim=-1)
+    A_log = 0.5 * torch.randn(HV, dtype=torch.float32, device=device)
+    dt_bias = 0.1 * torch.randn(HV, dtype=torch.float32, device=device)
+    output_gate = torch.randn(num_tokens, HV, V, dtype=torch.bfloat16, device=device)
+    norm_weight = torch.randn(V, dtype=torch.float32, device=device)
+    state_seed = 0.01 * torch.randn(
+        num_reqs * state_width + 1,
+        HV,
+        V,
+        K,
+        dtype=torch.float32,
+        device=device,
+    )
+    state_indices = torch.arange(
+        1,
+        num_reqs * state_width + 1,
+        dtype=torch.int32,
+        device=device,
+    ).view(num_reqs, state_width)
+    num_accepted_tokens = torch.ones(num_reqs, dtype=torch.int32, device=device)
+    cu_seqlens = torch.tensor([0, 2, 4, 6], dtype=torch.int32, device=device)
+
+    def run(state: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+        return ops.fused_gdn_decode_post_conv_mtp(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            state_indices=state_indices,
+            cu_seqlens=cu_seqlens,
+            num_accepted_tokens=num_accepted_tokens,
+            state=state,
+            output_gate=output_gate,
+            norm_weight=norm_weight,
+            out=out,
+            scale=scale,
+            norm_eps=norm_eps,
+        )
+
+    warmup_state = state_seed.clone()
+    run(warmup_state, torch.empty_like(output_gate))
+    torch.accelerator.synchronize()
+
+    graph_state = state_seed.clone()
+    graph_out = torch.empty_like(output_gate)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run(graph_state, graph_out)
+
+    ragged_cu_seqlens = torch.tensor([0, 4, 5, 6], dtype=torch.int32, device=device)
+    eager_state = state_seed.clone()
+    cu_seqlens.copy_(ragged_cu_seqlens)
+    eager_out = run(eager_state, torch.empty_like(output_gate))
+
+    graph_state.copy_(state_seed)
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(graph_out, eager_out, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(graph_state, eager_state, atol=3e-2, rtol=3e-2)

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -592,6 +592,97 @@ def test_kda_spec_decode_correctness(
     assert torch.isnan(output_storage[..., H * D :]).all()
 
 
+@torch.inference_mode()
+def test_kda_spec_decode_ragged_matches_per_request():
+    """The KDA path inheriting GDN varlen support must consume device cu_seqlens."""
+    query_lens = [4, 2, 1]
+    num_seqs, max_query_len, H, D = len(query_lens), max(query_lens), 12, 128
+    total_tokens = sum(query_lens)
+    torch.manual_seed(5678)
+
+    q, k, v, raw_g = [
+        torch.randn(
+            1,
+            total_tokens,
+            H,
+            D,
+            dtype=torch.bfloat16,
+            device=DEVICE,
+        )
+        for _ in range(4)
+    ]
+    raw_beta = torch.randn(
+        1,
+        total_tokens,
+        H,
+        dtype=torch.bfloat16,
+        device=DEVICE,
+    )
+    A_log = 0.5 * torch.randn(H, dtype=torch.float32, device=DEVICE)
+    dt_bias = 0.1 * torch.randn(H, D, dtype=torch.float32, device=DEVICE)
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(query_lens).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    state_indices = torch.arange(
+        1,
+        num_seqs * max_query_len + 1,
+        dtype=torch.int32,
+        device=DEVICE,
+    ).view(num_seqs, max_query_len)
+    num_accepted_tokens = torch.tensor([1, 2, 1], dtype=torch.int32, device=DEVICE)
+    initial_state = 0.01 * torch.randn(
+        num_seqs * max_query_len + 1,
+        H,
+        D,
+        D,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+
+    ragged_state = initial_state.clone()
+    ragged_output, _ = fused_recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=-5.0,
+        initial_state=ragged_state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+    )
+
+    reference_state = initial_state.clone()
+    reference_outputs = []
+    for request_idx, (start, end) in enumerate(
+        zip(cu_seqlens[:-1].tolist(), cu_seqlens[1:].tolist())
+    ):
+        request_output, _ = fused_recurrent_kda(
+            q=q[:, start:end],
+            k=k[:, start:end],
+            v=v[:, start:end],
+            raw_g=raw_g[:, start:end],
+            raw_beta=raw_beta[:, start:end],
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=-5.0,
+            initial_state=reference_state,
+            cu_seqlens=torch.tensor([0, end - start], dtype=torch.int32, device=DEVICE),
+            ssm_state_indices=state_indices[request_idx : request_idx + 1],
+            num_accepted_tokens=num_accepted_tokens[request_idx : request_idx + 1],
+        )
+        reference_outputs.append(request_output)
+
+    reference_output = torch.cat(reference_outputs, dim=1)
+    assert_close("ragged output", reference_output, ragged_output, 1e-3, err_atol=1e-3)
+    assert_close("ragged state", reference_state, ragged_state, 3e-3, err_atol=3e-3)
+
+
 @pytest.mark.parametrize(
     (
         "conv_state_dim_first",

--- a/tests/models/test_qwen3_5_mtp_config.py
+++ b/tests/models/test_qwen3_5_mtp_config.py
@@ -31,3 +31,17 @@ def test_mtp_override_recognizes_text_only_types(model_type, expected_arch):
     assert cfg.model_type == "qwen3_5_mtp"
     assert cfg.architectures == [expected_arch]
     assert cfg.n_predict == 1
+
+
+def test_mtp_override_preserves_explicit_qwen35_dspark_architecture():
+    cfg = PretrainedConfig(
+        model_type="qwen3_5_text",
+        architectures=["Qwen3DSparkModel"],
+        mtp_num_hidden_layers=1,
+    )
+
+    overridden = SpeculativeConfig.hf_config_override(cfg)
+
+    assert overridden.model_type == "qwen3_5_text"
+    assert overridden.architectures == ["Qwen3DSparkModel"]
+    assert not hasattr(overridden, "n_predict")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -347,6 +347,42 @@ def test_resolve_cudagraph_mode_adjusts_spec_decode_sizes_only_for_v1(
     assert compilation_config.cudagraph_capture_sizes == expected_capture_sizes
 
 
+@pytest.mark.parametrize(
+    ("support", "piecewise_available", "expected_mode"),
+    [
+        (
+            AttentionCGSupport.VARLEN_DECODE,
+            False,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+        (
+            AttentionCGSupport.VARLEN_DECODE,
+            True,
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+        ),
+        (AttentionCGSupport.ALWAYS, False, CUDAGraphMode.FULL),
+    ],
+)
+def test_varlen_decode_support_does_not_enable_mixed_full_graphs(
+    support, piecewise_available, expected_mode
+):
+    compilation_config = CompilationConfig(
+        cudagraph_mode=CUDAGraphMode.FULL,
+        mode=(CompilationMode.VLLM_COMPILE if piecewise_available else None),
+    )
+    if piecewise_available:
+        compilation_config.set_splitting_ops_for_v1("", 1)
+
+    resolved_mode = compilation_config.resolve_cudagraph_mode_and_sizes(
+        support,
+        "FakeAttentionBackend",
+        uniform_decode_query_len=8,
+        use_v2_model_runner=True,
+    )
+
+    assert resolved_mode == expected_mode
+
+
 def test_resolve_cudagraph_mode_skips_mamba_block_check_while_profiling():
     """Cudagraph memory profiling uses a minimal KV cache, so the Mamba
     block-count guard must only fire for the real cache sizing."""

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -17,7 +17,9 @@ from tests.v1.attention.utils import (
 )
 from vllm.config import SpeculativeConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionBackend,
     GDNAttentionMetadata,
     GDNAttentionMetadataBuilder,
 )
@@ -167,6 +169,14 @@ def _build(
             batch_spec.batch_size, dtype=torch.int32, device=DEVICE
         )
     return builder.build(common_prefix_len=0, common_attn_metadata=common, **kwargs)
+
+
+def test_gdn_advertises_varlen_decode_cudagraph_support():
+    assert GDNAttentionBackend.supports_device_cpu_query_lens_mismatch()
+    assert (
+        GDNAttentionMetadataBuilder.get_cudagraph_support(None, None)
+        == AttentionCGSupport.VARLEN_DECODE
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -221,3 +221,26 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
     assert meta.spec_query_start_loc.shape == (batch.batch_size + 1,)
     assert meta.num_accepted_tokens is not None
     assert meta.num_accepted_tokens.shape == (batch.batch_size,)
+
+
+def test_adaptive_varlen_uses_device_query_start_loc():
+    """Spec-decode boundaries must come from the device-side ragged layout."""
+    builder = _create_gdn_builder(num_speculative_tokens=3)
+    batch = BatchSpec(seq_lens=[64, 64, 64, 0], query_lens=[4, 1, 1, 0])
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
+
+    query_start_loc_cpu = torch.tensor([0, 2, 4, 6, 6], dtype=torch.int32)
+    common = common.replace(query_start_loc_cpu=query_start_loc_cpu)
+    meta = builder.build(
+        common_prefix_len=0,
+        common_attn_metadata=common,
+        num_accepted_tokens=torch.ones(batch.batch_size, dtype=torch.int32),
+        num_decode_draft_tokens_cpu=torch.tensor([3, 3, 3, -1], dtype=torch.int32),
+    )
+
+    expected_query_start_loc = torch.tensor([0, 4, 5, 6, 6], dtype=torch.int32)
+    assert meta.num_spec_decodes == 3
+    assert meta.num_spec_decode_tokens == 6
+    assert meta.spec_query_start_loc is not None
+    torch.testing.assert_close(meta.spec_query_start_loc, expected_query_start_loc)
+    assert not torch.equal(meta.spec_query_start_loc, query_start_loc_cpu)

--- a/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
+++ b/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end adaptive DSpark verification on a hybrid-GDN target."""
+
+import math
+from itertools import accumulate
+
+import pytest
+import torch
+
+from tests.utils import large_gpu_mark
+from vllm import SamplingParams
+from vllm.platforms import current_platform
+from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backends.gdn_attn import (
+    GDNAttentionBackend,
+    GDNAttentionMetadataBuilder,
+)
+from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
+    AdaptiveVerificationManager,
+)
+
+TARGET_MODEL = "Qwen/Qwen3.5-0.8B"
+DRAFT_MODEL = "satgeze/Qwen3.5-0.8B-DSpark"
+NUM_SPECULATIVE_TOKENS = 7
+
+pytestmark = [
+    pytest.mark.hybrid_model,
+    pytest.mark.skipif(
+        not current_platform.is_cuda(),
+        reason="adaptive GDN CUDA-graph coverage requires CUDA",
+    ),
+]
+
+
+@large_gpu_mark(min_gb=16)
+def test_adaptive_dspark_replays_ragged_gdn_decode(
+    monkeypatch: pytest.MonkeyPatch,
+    vllm_runner,
+) -> None:
+    """Ragged device query lengths must produce valid target outputs.
+
+    The capability overrides let this test audit the execution path before GDN
+    advertises adaptive-verification support globally. Remove them when the
+    production capability gates are enabled.
+    """
+
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "0")
+    monkeypatch.setenv("VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN", "64")
+
+    def supports_device_query_lens(_cls) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        GDNAttentionBackend,
+        "supports_device_cpu_query_lens_mismatch",
+        classmethod(supports_device_query_lens),
+    )
+    monkeypatch.setattr(
+        GDNAttentionMetadataBuilder,
+        "_cudagraph_support",
+        AttentionCGSupport.ALWAYS,
+    )
+
+    trace_step = {"value": 0}
+    pending_layouts: dict[int, tuple[tuple[str, ...], tuple[int, ...], int]] = {}
+    observed_layouts: list[
+        tuple[tuple[str, ...], tuple[int, ...], torch.Tensor, int]
+    ] = []
+
+    original_get_num_tokens = AdaptiveVerificationManager.get_num_tokens
+    original_reallocate_drafts = AdaptiveVerificationManager.reallocate_drafts
+
+    def controlled_get_num_tokens(
+        manager: AdaptiveVerificationManager,
+        num_tokens_per_req: dict[str, int],
+        draft_tokens: dict[str, list[int]],
+    ) -> int:
+        original_num_tokens = original_get_num_tokens(
+            manager, num_tokens_per_req, draft_tokens
+        )
+        batch_budget = manager._batch_budget
+        assert batch_budget is not None
+        drafts_per_req, non_draft_per_req, _ = batch_budget
+        req_ids = tuple(num_tokens_per_req)
+        num_verification_reqs = sum(drafts_per_req[req_id] > 0 for req_id in req_ids)
+        total_drafts = sum(drafts_per_req.values())
+
+        if num_verification_reqs < 2:
+            return original_num_tokens
+
+        drafts_per_high_confidence_req = (4, 3)[trace_step["value"] % 2]
+        draft_budget = min(
+            drafts_per_high_confidence_req * num_verification_reqs,
+            total_drafts - 1,
+        )
+        trace_step["value"] += 1
+
+        manager._batch_budget = (
+            drafts_per_req,
+            non_draft_per_req,
+            draft_budget,
+        )
+
+        if draft_budget == total_drafts:
+            cpu_draft_lens = [drafts_per_req[req_id] for req_id in req_ids]
+        else:
+            cpu_draft_lens = [0] * len(req_ids)
+            even_drafts, remainder = divmod(draft_budget, num_verification_reqs)
+            for req_idx in range(num_verification_reqs):
+                cpu_draft_lens[req_idx] = even_drafts + (req_idx < remainder)
+        cpu_query_lens = tuple(
+            non_draft_per_req[req_id] + cpu_draft_lens[req_idx]
+            for req_idx, req_id in enumerate(req_ids)
+        )
+        pending_layouts[id(manager)] = (req_ids, cpu_query_lens, draft_budget)
+        return sum(non_draft_per_req.values()) + draft_budget
+
+    def record_reallocated_drafts(
+        manager: AdaptiveVerificationManager,
+        req_ids: list[str],
+        idx_mapping: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, int]:
+        pending = pending_layouts.pop(id(manager), None)
+        if pending is not None:
+            # Duplicate prompts are adjacent. Make the first request in every
+            # pair win the GPU ranking and the second lose it. The CPU splits
+            # the same total budget evenly, guaranteeing a CPU/device mismatch
+            # without changing draft tokens or target verification semantics.
+            confidences = torch.full(
+                (len(req_ids), manager.num_speculative_steps),
+                0.01,
+                dtype=torch.float32,
+                device=idx_mapping.device,
+            )
+            confidences[::2].fill_(0.99)
+            manager._confidence_probs[idx_mapping] = confidences
+
+        result = original_reallocate_drafts(manager, req_ids, idx_mapping)
+        if pending is not None:
+            pending_req_ids, cpu_query_lens, draft_budget = pending
+            observed_layouts.append(
+                (
+                    pending_req_ids,
+                    cpu_query_lens,
+                    result[1][: len(req_ids) + 1].clone(),
+                    draft_budget,
+                )
+            )
+        return result
+
+    monkeypatch.setattr(
+        AdaptiveVerificationManager,
+        "get_num_tokens",
+        controlled_get_num_tokens,
+    )
+    monkeypatch.setattr(
+        AdaptiveVerificationManager,
+        "reallocate_drafts",
+        record_reallocated_drafts,
+    )
+
+    runner_config = {
+        "language_model_only": True,
+        "dtype": "bfloat16",
+        "max_model_len": 512,
+        "max_num_seqs": 6,
+        "max_num_batched_tokens": 512,
+        "kv_cache_memory_bytes": 2 << 30,
+        "block_size": None,
+        "enable_chunked_prefill": True,
+        "enable_prefix_caching": False,
+        "gdn_prefill_backend": "triton",
+        "ignore_patterns": [
+            "model_v02.safetensors",
+            "model_v03.safetensors",
+        ],
+        "compilation_config": {
+            "cudagraph_capture_sizes": [8, 16, 32, 48],
+        },
+        "speculative_config": {
+            "method": "dspark",
+            "model": DRAFT_MODEL,
+            "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
+            "enable_adaptive_verification": True,
+            "rejection_sample_method": "synthetic",
+            "synthetic_acceptance_rates": [0.0] * NUM_SPECULATIVE_TOKENS,
+        },
+    }
+    unique_prompts = [
+        "The capital of France is",
+        "One plus one equals",
+        "The color of grass is",
+    ]
+    prompts = [prompt for prompt in unique_prompts for _ in range(2)]
+    sampling_params = SamplingParams(
+        temperature=0,
+        max_tokens=12,
+        ignore_eos=True,
+        logprobs=1,
+        seed=0,
+    )
+
+    with vllm_runner(TARGET_MODEL, **runner_config) as runner:
+        llm = runner.get_llm()
+        cudagraph_mode = llm.llm_engine.vllm_config.compilation_config.cudagraph_mode
+        assert cudagraph_mode.has_full_cudagraphs()
+
+        outputs = llm.generate(prompts, sampling_params)
+        torch.accelerator.synchronize()
+
+        assert len(outputs) == len(prompts)
+        for output in outputs:
+            completion = output.outputs[0]
+            token_ids = list(completion.token_ids)
+            assert len(token_ids) == sampling_params.max_tokens
+            assert completion.logprobs is not None
+            assert len(completion.logprobs) == len(token_ids)
+            for token_id, step_logprobs in zip(
+                token_ids, completion.logprobs, strict=True
+            ):
+                assert token_id in step_logprobs
+                assert math.isfinite(step_logprobs[token_id].logprob)
+
+        ragged_layouts: list[tuple[tuple[int, ...], tuple[int, ...], int]] = []
+        for (
+            req_ids,
+            cpu_query_lens,
+            device_query_start_loc,
+            draft_budget,
+        ) in observed_layouts:
+            if len(req_ids) < 2:
+                continue
+            device_starts = device_query_start_loc.cpu().tolist()
+            device_query_lens = tuple(
+                end - start for start, end in zip(device_starts, device_starts[1:])
+            )
+            if len(set(device_query_lens)) > 1:
+                ragged_layouts.append((cpu_query_lens, device_query_lens, draft_budget))
+
+        assert ragged_layouts, "adaptive verification never produced a ragged batch"
+        assert any(cpu != device for cpu, device, _ in ragged_layouts), (
+            "device query lengths never differed from the CPU placeholder"
+        )
+        assert len({device for _, device, _ in ragged_layouts}) >= 2, (
+            f"device query lengths did not change across decode steps: {ragged_layouts}"
+        )
+        for cpu_query_lens, device_query_lens, draft_budget in ragged_layouts:
+            expected_total = len(device_query_lens) + draft_budget
+            assert sum(cpu_query_lens) == expected_total
+            assert sum(device_query_lens) == expected_total
+            assert tuple(accumulate(device_query_lens, initial=0)) != tuple(
+                accumulate(cpu_query_lens, initial=0)
+            )

--- a/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
+++ b/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
@@ -2,8 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """End-to-end adaptive DSpark verification on a hybrid-GDN target."""
 
+import asyncio
 import math
+from contextlib import AsyncExitStack
 from itertools import accumulate
+from typing import TypedDict
 
 import pytest
 import torch
@@ -11,8 +14,12 @@ import torch
 from tests.utils import large_gpu_mark
 from vllm import SamplingParams
 from vllm.config.compilation import CUDAGraphMode
+from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.platforms import current_platform
+from vllm.sampling_params import RequestOutputKind
+from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
     AdaptiveVerificationManager,
 )
@@ -20,6 +27,22 @@ from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
 TARGET_MODEL = "Qwen/Qwen3.5-0.8B"
 DRAFT_MODEL = "satgeze/Qwen3.5-0.8B-DSpark"
 NUM_SPECULATIVE_TOKENS = 7
+DP_TARGET_MODEL = "Qwen/Qwen3.6-35B-A3B"
+DP_DRAFT_MODEL = "RedHatAI/Qwen3.6-35B-A3B-speculator.dspark"
+DP_NUM_SPECULATIVE_TOKENS = 8
+
+
+class _BatchObservation(TypedDict):
+    request_rows: tuple[tuple[str, bool, bool], ...]
+    has_prefill: bool
+    has_spec_decode: bool
+
+
+class _DispatchObservation(_BatchObservation):
+    uniform_token_count: int | None
+    cg_mode: CUDAGraphMode
+    decode_only: bool
+
 
 pytestmark = [
     pytest.mark.hybrid_model,
@@ -281,3 +304,318 @@ def test_adaptive_dspark_replays_ragged_gdn_decode(
             assert tuple(accumulate(device_query_lens, initial=0)) != tuple(
                 accumulate(cpu_query_lens, initial=0)
             )
+
+
+@large_gpu_mark(min_gb=16)
+def test_adaptive_dspark_mixed_prefill_uses_piecewise(
+    monkeypatch: pytest.MonkeyPatch,
+    vllm_runner,
+) -> None:
+    """A real prefill+adaptive-decode batch must not use decode-only FULL."""
+
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "0")
+    monkeypatch.setenv("VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN", "64")
+    monkeypatch.setenv("VLLM_GDN_DECODE_KERNEL", "cuda")
+
+    current_batch: _BatchObservation | None = None
+    observed_dispatches: list[_DispatchObservation] = []
+    original_gather = GPUModelRunner.gather_batch_req_state
+    original_dispatch = CudaGraphManager.dispatch
+
+    def record_gather(
+        runner: GPUModelRunner,
+        scheduler_output,
+        dummy_run: bool,
+    ):
+        nonlocal current_batch
+        result = original_gather(runner, scheduler_output, dummy_run)
+        batch_state, _ = result
+        current_batch = None
+        if not dummy_run and batch_state is not None:
+            spec_decode_tokens = scheduler_output.scheduled_spec_decode_tokens
+            draft_req_ids = {
+                req_id for req_id, tokens in spec_decode_tokens.items() if tokens
+            }
+            request_rows = tuple(
+                (req_id, bool(is_prefilling), req_id in draft_req_ids)
+                for req_id, is_prefilling in zip(
+                    batch_state.req_ids,
+                    batch_state.is_prefilling_np,
+                    strict=True,
+                )
+            )
+            current_batch = _BatchObservation(
+                request_rows=request_rows,
+                has_prefill=batch_state.has_prefill,
+                has_spec_decode=any(
+                    not is_prefilling and has_drafts
+                    for _, is_prefilling, has_drafts in request_rows
+                ),
+            )
+        return result
+
+    def record_dispatch(
+        manager: CudaGraphManager,
+        num_reqs: int,
+        num_tokens: int,
+        uniform_token_count: int | None,
+        num_active_loras: int,
+        max_query_len: int | None = None,
+        has_prefill: bool = False,
+    ):
+        descriptor = original_dispatch(
+            manager,
+            num_reqs,
+            num_tokens,
+            uniform_token_count,
+            num_active_loras,
+            max_query_len=max_query_len,
+            has_prefill=has_prefill,
+        )
+        if manager.varlen_decode and current_batch is not None:
+            observed_dispatches.append(
+                _DispatchObservation(
+                    **current_batch,
+                    uniform_token_count=uniform_token_count,
+                    cg_mode=descriptor.cg_mode,
+                    decode_only=descriptor.decode_only,
+                )
+            )
+        return descriptor
+
+    monkeypatch.setattr(GPUModelRunner, "gather_batch_req_state", record_gather)
+    monkeypatch.setattr(CudaGraphManager, "dispatch", record_dispatch)
+
+    runner_config = {
+        "language_model_only": True,
+        "dtype": "bfloat16",
+        "max_model_len": 256,
+        "max_num_seqs": 4,
+        "max_num_batched_tokens": 256,
+        "kv_cache_memory_bytes": 2 << 30,
+        "enable_chunked_prefill": True,
+        "enable_prefix_caching": False,
+        "gdn_prefill_backend": "triton",
+        "ignore_patterns": ["model_v02.safetensors", "model_v03.safetensors"],
+        "compilation_config": {"cudagraph_capture_sizes": [8, 16, 24, 32]},
+        "speculative_config": {
+            "method": "dspark",
+            "model": DRAFT_MODEL,
+            "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
+            "enable_adaptive_verification": True,
+            "rejection_sample_method": "synthetic",
+            "synthetic_acceptance_rates": [0.0] * NUM_SPECULATIVE_TOKENS,
+        },
+    }
+    decode_params = SamplingParams(
+        temperature=0,
+        max_tokens=16,
+        ignore_eos=True,
+        logprobs=1,
+        seed=0,
+    )
+    prefill_params = SamplingParams(
+        temperature=0,
+        max_tokens=4,
+        ignore_eos=True,
+        logprobs=1,
+        seed=1,
+    )
+
+    with vllm_runner(TARGET_MODEL, **runner_config) as runner:
+        llm = runner.get_llm()
+        engine = llm.llm_engine
+        for request_idx, prompt in enumerate(
+            ["The capital of France is", "One plus one equals"]
+        ):
+            engine.add_request(f"decode-{request_idx}", prompt, decode_params)
+
+        finished_outputs = {}
+        for _ in range(32):
+            for output in engine.step():
+                if output.finished:
+                    finished_outputs[output.request_id] = output
+            if any(
+                not dispatch["has_prefill"] and dispatch["has_spec_decode"]
+                for dispatch in observed_dispatches
+            ):
+                break
+        else:
+            pytest.fail("initial requests never reached adaptive decode")
+
+        engine.add_request("late-prefill", "Hello", prefill_params)
+        for _ in range(64):
+            for output in engine.step():
+                if output.finished:
+                    finished_outputs[output.request_id] = output
+            if not engine.has_unfinished_requests():
+                break
+        else:
+            pytest.fail("generation did not finish")
+
+        torch.accelerator.synchronize()
+
+    mixed_dispatches = [
+        dispatch
+        for dispatch in observed_dispatches
+        if dispatch["has_prefill"]
+        and dispatch["has_spec_decode"]
+        and any(
+            req_id.startswith("late-prefill-") and is_prefilling
+            for req_id, is_prefilling, _ in dispatch["request_rows"]
+        )
+    ]
+    assert mixed_dispatches, (
+        "the late request was never scheduled with an adaptive decode request"
+    )
+    assert all(
+        dispatch["cg_mode"] == CUDAGraphMode.PIECEWISE and not dispatch["decode_only"]
+        for dispatch in mixed_dispatches
+    ), mixed_dispatches
+
+    assert len(finished_outputs) == 3
+    assert set(finished_outputs) == {"decode-0", "decode-1", "late-prefill"}
+    for output in finished_outputs.values():
+        completion = output.outputs[0]
+        expected_tokens = (
+            prefill_params.max_tokens
+            if output.request_id == "late-prefill"
+            else decode_params.max_tokens
+        )
+        assert len(completion.token_ids) == expected_tokens
+        assert completion.logprobs is not None
+        assert len(completion.logprobs) == expected_tokens
+
+
+@large_gpu_mark(min_gb=40)
+@pytest.mark.distributed(num_gpus=2)
+@pytest.mark.asyncio
+async def test_adaptive_dspark_gdn_dp2_mixed_prefill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DP=2/EP must finish when one rank adds prefill during GDN decode."""
+    if torch.accelerator.device_count() < 2:
+        pytest.skip("adaptive GDN DP=2 coverage requires two GPUs")
+
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "0")
+    monkeypatch.setenv("VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN", "64")
+    monkeypatch.setenv("VLLM_GDN_DECODE_KERNEL", "cuda")
+
+    engine_args = AsyncEngineArgs(
+        model=DP_TARGET_MODEL,
+        language_model_only=True,
+        max_model_len=512,
+        max_num_seqs=8,
+        max_num_batched_tokens=512,
+        gpu_memory_utilization=0.8,
+        enable_chunked_prefill=True,
+        enable_prefix_caching=False,
+        gdn_prefill_backend="triton",
+        data_parallel_size=2,
+        data_parallel_backend="mp",
+        enable_expert_parallel=True,
+        compilation_config={"cudagraph_capture_sizes": [8, 16, 32, 64]},
+        speculative_config={
+            "method": "dspark",
+            "model": DP_DRAFT_MODEL,
+            "num_speculative_tokens": DP_NUM_SPECULATIVE_TOKENS,
+            "enable_adaptive_verification": True,
+            "rejection_sample_method": "synthetic",
+            "synthetic_acceptance_rates": [0.0] * DP_NUM_SPECULATIVE_TOKENS,
+        },
+        trust_remote_code=True,
+        disable_log_stats=True,
+    )
+
+    async def generate(
+        engine: AsyncLLM,
+        request_id: str,
+        prompt: str,
+        dp_rank: int,
+        max_tokens: int,
+        first_output: asyncio.Event,
+    ) -> tuple[int, bool]:
+        params = SamplingParams(
+            temperature=0,
+            max_tokens=max_tokens,
+            ignore_eos=True,
+            logprobs=1,
+            seed=0,
+            output_kind=RequestOutputKind.DELTA,
+        )
+        num_tokens = 0
+        valid_logprobs = True
+        async for output in engine.generate(
+            request_id=request_id,
+            prompt=prompt,
+            sampling_params=params,
+            data_parallel_rank=dp_rank,
+        ):
+            completion = output.outputs[0]
+            num_tokens += len(completion.token_ids)
+            assert completion.logprobs is not None
+            for token_id, step_logprobs in zip(
+                completion.token_ids, completion.logprobs, strict=True
+            ):
+                valid_logprobs &= math.isfinite(step_logprobs[token_id].logprob)
+            if num_tokens:
+                first_output.set()
+            await asyncio.sleep(0)
+        return num_tokens, valid_logprobs
+
+    async with AsyncExitStack() as stack:
+        engine = AsyncLLM.from_engine_args(engine_args)
+        stack.callback(engine.shutdown)
+
+        first_rank0 = asyncio.Event()
+        first_rank1 = asyncio.Event()
+        rank0_task = asyncio.create_task(
+            generate(
+                engine,
+                "rank0-decode",
+                "Explain why GPU synchronization can reduce throughput.",
+                0,
+                96,
+                first_rank0,
+            )
+        )
+        rank1_task = asyncio.create_task(
+            generate(
+                engine,
+                "rank1-decode",
+                "Explain why GPU synchronization can reduce throughput.",
+                1,
+                96,
+                first_rank1,
+            )
+        )
+        await asyncio.wait_for(
+            asyncio.gather(first_rank0.wait(), first_rank1.wait()), timeout=300
+        )
+        assert not (rank0_task.done() and rank1_task.done())
+
+        late_first_output = asyncio.Event()
+        late_prefill_task = asyncio.create_task(
+            generate(
+                engine,
+                "rank1-late-prefill",
+                (
+                    "Adaptive verification keeps request-specific query lengths "
+                    "on the GPU while the CPU keeps fixed-size bookkeeping. "
+                )
+                * 24,
+                1,
+                16,
+                late_first_output,
+            )
+        )
+        await asyncio.wait_for(late_first_output.wait(), timeout=300)
+        assert not (rank0_task.done() and rank1_task.done())
+
+        results = await asyncio.wait_for(
+            asyncio.gather(rank0_task, rank1_task, late_prefill_task), timeout=900
+        )
+
+    assert [num_tokens for num_tokens, _ in results] == [96, 96, 16]
+    assert all(valid_logprobs for _, valid_logprobs in results)

--- a/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
+++ b/tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
@@ -10,12 +10,9 @@ import torch
 
 from tests.utils import large_gpu_mark
 from vllm import SamplingParams
+from vllm.config.compilation import CUDAGraphMode
 from vllm.platforms import current_platform
-from vllm.v1.attention.backend import AttentionCGSupport
-from vllm.v1.attention.backends.gdn_attn import (
-    GDNAttentionBackend,
-    GDNAttentionMetadataBuilder,
-)
+from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
     AdaptiveVerificationManager,
 )
@@ -34,43 +31,53 @@ pytestmark = [
 
 
 @large_gpu_mark(min_gb=16)
+@pytest.mark.parametrize("gdn_decode_kernel", ["cuda", "triton"])
 def test_adaptive_dspark_replays_ragged_gdn_decode(
     monkeypatch: pytest.MonkeyPatch,
     vllm_runner,
+    gdn_decode_kernel: str,
 ) -> None:
-    """Ragged device query lengths must produce valid target outputs.
-
-    The capability overrides let this test audit the execution path before GDN
-    advertises adaptive-verification support globally. Remove them when the
-    production capability gates are enabled.
-    """
+    """Ragged device query lengths must produce valid target outputs."""
 
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
     monkeypatch.setenv("VLLM_USE_FLASHINFER_SAMPLER", "0")
     monkeypatch.setenv("VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN", "64")
-
-    def supports_device_query_lens(_cls) -> bool:
-        return True
-
-    monkeypatch.setattr(
-        GDNAttentionBackend,
-        "supports_device_cpu_query_lens_mismatch",
-        classmethod(supports_device_query_lens),
-    )
-    monkeypatch.setattr(
-        GDNAttentionMetadataBuilder,
-        "_cudagraph_support",
-        AttentionCGSupport.ALWAYS,
-    )
+    monkeypatch.setenv("VLLM_GDN_DECODE_KERNEL", gdn_decode_kernel)
 
     trace_step = {"value": 0}
     pending_layouts: dict[int, tuple[tuple[str, ...], tuple[int, ...], int]] = {}
     observed_layouts: list[
         tuple[tuple[str, ...], tuple[int, ...], torch.Tensor, int]
     ] = []
+    observed_dispatches: list[tuple[int | None, bool, CUDAGraphMode, bool]] = []
 
     original_get_num_tokens = AdaptiveVerificationManager.get_num_tokens
     original_reallocate_drafts = AdaptiveVerificationManager.reallocate_drafts
+    original_dispatch = CudaGraphManager.dispatch
+
+    def record_dispatch(
+        manager: CudaGraphManager,
+        num_reqs: int,
+        num_tokens: int,
+        uniform_token_count: int | None,
+        num_active_loras: int,
+        max_query_len: int | None = None,
+        has_prefill: bool = False,
+    ):
+        desc = original_dispatch(
+            manager,
+            num_reqs,
+            num_tokens,
+            uniform_token_count,
+            num_active_loras,
+            max_query_len=max_query_len,
+            has_prefill=has_prefill,
+        )
+        if manager.varlen_decode:
+            observed_dispatches.append(
+                (uniform_token_count, has_prefill, desc.cg_mode, desc.decode_only)
+            )
+        return desc
 
     def controlled_get_num_tokens(
         manager: AdaptiveVerificationManager,
@@ -160,6 +167,7 @@ def test_adaptive_dspark_replays_ragged_gdn_decode(
         "reallocate_drafts",
         record_reallocated_drafts,
     )
+    monkeypatch.setattr(CudaGraphManager, "dispatch", record_dispatch)
 
     runner_config = {
         "language_model_only": True,
@@ -205,7 +213,7 @@ def test_adaptive_dspark_replays_ragged_gdn_decode(
     with vllm_runner(TARGET_MODEL, **runner_config) as runner:
         llm = runner.get_llm()
         cudagraph_mode = llm.llm_engine.vllm_config.compilation_config.cudagraph_mode
-        assert cudagraph_mode.has_full_cudagraphs()
+        assert cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
 
         outputs = llm.generate(prompts, sampling_params)
         torch.accelerator.synchronize()
@@ -246,10 +254,30 @@ def test_adaptive_dspark_replays_ragged_gdn_decode(
         assert len({device for _, device, _ in ragged_layouts}) >= 2, (
             f"device query lengths did not change across decode steps: {ragged_layouts}"
         )
+        assert any(
+            uniform_token_count is None
+            and not has_prefill
+            and cg_mode == CUDAGraphMode.FULL
+            and decode_only
+            for (
+                uniform_token_count,
+                has_prefill,
+                cg_mode,
+                decode_only,
+            ) in observed_dispatches
+        ), "ragged decode never used a decode-only FULL graph"
+        assert not any(
+            has_prefill and decode_only
+            for _, has_prefill, _, decode_only in observed_dispatches
+        ), "a prefill batch used a decode-only FULL graph"
         for cpu_query_lens, device_query_lens, draft_budget in ragged_layouts:
             expected_total = len(device_query_lens) + draft_budget
             assert sum(cpu_query_lens) == expected_total
             assert sum(device_query_lens) == expected_total
+            assert all(
+                1 <= query_len <= NUM_SPECULATIVE_TOKENS + 1
+                for query_len in device_query_lens
+            )
             assert tuple(accumulate(device_query_lens, initial=0)) != tuple(
                 accumulate(cpu_query_lens, initial=0)
             )

--- a/tests/v1/spec_decode/test_adaptive_verification.py
+++ b/tests/v1/spec_decode/test_adaptive_verification.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.worker.gpu.async_utils import StepTimingSample
@@ -35,7 +36,13 @@ def make_manager(
     return manager
 
 
-def test_manager_scopes_varlen_check_without_weakening_runner_cg_mode(monkeypatch):
+@pytest.mark.parametrize(
+    "target_support",
+    [AttentionCGSupport.VARLEN_DECODE, AttentionCGSupport.ALWAYS],
+)
+def test_manager_scopes_varlen_check_without_weakening_runner_cg_mode(
+    monkeypatch, target_support
+):
     class Backend:
         @classmethod
         def supports_device_cpu_query_lens_mismatch(cls):
@@ -59,7 +66,7 @@ def test_manager_scopes_varlen_check_without_weakening_runner_cg_mode(monkeypatc
 
     groups = [
         [
-            group("target", AttentionCGSupport.ALWAYS),
+            group("target", target_support),
             group("draft", AttentionCGSupport.UNIFORM_BATCH),
         ]
     ]
@@ -87,6 +94,37 @@ def test_manager_scopes_varlen_check_without_weakening_runner_cg_mode(monkeypatc
 
     assert manager is created
     assert runner_support.min_cg_support == AttentionCGSupport.UNIFORM_BATCH
+
+
+def test_manager_rejects_backend_without_varlen_decode_cudagraphs():
+    class Backend:
+        @classmethod
+        def supports_device_cpu_query_lens_mismatch(cls):
+            return True
+
+    builder = SimpleNamespace(
+        get_cudagraph_support=lambda *_args: AttentionCGSupport.UNIFORM_BATCH
+    )
+    group = SimpleNamespace(
+        layer_names=["target"],
+        backend=Backend,
+        kv_cache_spec=None,
+        get_metadata_builder=lambda _index: builder,
+    )
+    support = AttentionCGSupportInfo(AttentionCGSupport.UNIFORM_BATCH, "TargetBackend")
+
+    with pytest.raises(ValueError, match="VARLEN_DECODE or AttentionCGSupport.ALWAYS"):
+        maybe_create_adaptive_verification_manager(
+            enable_adaptive_verification=True,
+            attn_groups=[[group]],
+            attn_cg_support=support,
+            req_states=object(),
+            query_start_loc=object(),
+            num_bonus_tokens=1,
+            max_total_logits=1,
+            vllm_config=None,
+            target_layer_names={"target"},
+        )
 
 
 def test_budget_stops_where_marginal_drafts_stop_paying_for_themselves():

--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -16,6 +16,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
+from vllm.v1.worker.gpu import dp_utils
 from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 pytestmark = pytest.mark.cpu_test
@@ -196,6 +197,141 @@ def test_dynamic_sd_non_uniform_batch_falls_back_to_piecewise(monkeypatch):
     assert desc.num_reqs is None
     assert desc.num_tokens == 3
     assert desc.num_active_loras == 0
+
+
+def test_varlen_decode_full_graph_rejects_mixed_prefill(monkeypatch):
+    """The same ragged shape uses FULL for decode and PIECEWISE for mixed."""
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=8,
+        max_spec_tokens=7,
+        use_dynamic_sd=False,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=8,
+        varlen_decode=True,
+    )
+    manager._graphs_captured = True
+
+    ragged_decode = manager.dispatch(
+        num_reqs=3,
+        num_tokens=6,
+        uniform_token_count=None,
+        num_active_loras=0,
+        max_query_len=4,
+        has_prefill=False,
+    )
+    assert ragged_decode.cg_mode == CUDAGraphMode.FULL
+    assert ragged_decode.decode_only
+
+    mixed_batch = manager.dispatch(
+        num_reqs=3,
+        num_tokens=6,
+        uniform_token_count=None,
+        num_active_loras=0,
+        max_query_len=4,
+        has_prefill=True,
+    )
+    assert mixed_batch.cg_mode == CUDAGraphMode.PIECEWISE
+    assert not mixed_batch.decode_only
+
+
+def test_has_prefill_does_not_disable_mixed_full_graph(monkeypatch):
+    """ALWAYS-capable backends can still use their mixed FULL graph."""
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=8,
+        max_spec_tokens=7,
+        cudagraph_mode="FULL",
+        use_dynamic_sd=False,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL,
+        decode_query_len=8,
+    )
+    manager._graphs_captured = True
+
+    desc = manager.dispatch(
+        num_reqs=3,
+        num_tokens=6,
+        uniform_token_count=None,
+        num_active_loras=0,
+        max_query_len=4,
+        has_prefill=True,
+    )
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert not desc.decode_only
+
+
+def test_dp_sync_keeps_prefill_rank_out_of_varlen_decode_graph(monkeypatch):
+    """A prefill on any DP rank makes the synchronized graph mixed."""
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        dp_utils,
+        "get_dp_group",
+        lambda: SimpleNamespace(cpu_group=object()),
+    )
+
+    def fake_all_reduce(tensor, group):
+        assert group is not None
+        tensor[0, 1] = 6
+        tensor[1, 1] = CUDAGraphMode.PIECEWISE.value
+        tensor[2, 1] = 0
+        tensor[3, 1] = 4
+        tensor[4, 1] = 1
+
+    monkeypatch.setattr(dp_utils.dist, "all_reduce", fake_all_reduce)
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=8,
+        max_spec_tokens=7,
+        use_dynamic_sd=False,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=8,
+        varlen_decode=True,
+    )
+    manager._graphs_captured = True
+    local_desc = manager.dispatch(
+        num_reqs=3,
+        num_tokens=6,
+        uniform_token_count=None,
+        num_active_loras=0,
+        max_query_len=4,
+    )
+    assert local_desc.cg_mode == CUDAGraphMode.FULL
+
+    synced_desc, _ = dp_utils.sync_cudagraph_and_dp_padding(
+        manager,
+        local_desc,
+        num_tokens=6,
+        num_reqs=3,
+        uniform_token_count=None,
+        dp_size=2,
+        dp_rank=0,
+        max_query_len=4,
+        has_prefill=False,
+    )
+    assert synced_desc.cg_mode == CUDAGraphMode.PIECEWISE
 
 
 def test_prompt_chunks_shaped_like_spec_decode_miss_the_full_graph(monkeypatch):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -844,11 +844,15 @@ class SpeculativeConfig:
             hf_config.update(
                 {"n_predict": n_predict, "architectures": ["Exaone4_5_MTP"]}
             )
-        if hf_config.model_type in (
-            "qwen3_5",
-            "qwen3_5_moe",
-            "qwen3_5_text",
-            "qwen3_5_moe_text",
+        if (
+            hf_config.model_type
+            in (
+                "qwen3_5",
+                "qwen3_5_moe",
+                "qwen3_5_text",
+                "qwen3_5_moe_text",
+            )
+            and initial_architecture != "Qwen3DSparkModel"
         ):
             # Checkpoints that ship only the text config resolve to the
             # `qwen3_5_text` / `qwen3_5_moe_text` model types and carry the

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -569,8 +569,11 @@ class AttentionCGSupport(Enum):
     Here we do not consider the cascade attention, as currently
     it is never cudagraph supported."""
 
-    ALWAYS = 3
+    ALWAYS = 4
     """Cudagraph always supported; supports mixed-prefill-decode"""
+    VARLEN_DECODE = 3
+    """Cudagraph supported for decode batches with per-request query lengths
+    that may differ. Mixed prefill-decode batches are not supported."""
     UNIFORM_BATCH = 2
     """Cudagraph supported for batches the only contain query lengths that are
     the same, this can be used for spec-decode

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -37,6 +37,13 @@ class GDNAttentionBackend(AttentionBackend):
     def is_ssm(cls) -> bool:
         return True
 
+    @classmethod
+    def supports_device_cpu_query_lens_mismatch(cls) -> bool:
+        # GDN state planning and decode kernels use the device-side
+        # query_start_loc. CPU query lengths are only used for batch
+        # classification and fixed-size bookkeeping.
+        return True
+
 
 @dataclass
 class GDNAttentionMetadata:
@@ -81,7 +88,7 @@ class GDNAttentionMetadata:
 
 class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]):
     kv_cache_spec: MambaSpec
-    _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
+    _cudagraph_support = AttentionCGSupport.VARLEN_DECODE
 
     reorder_batch_threshold: int = 1
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -62,9 +62,10 @@ class BatchExecutionDescriptor:
     num_reqs: int | None  # None means no request padding is needed (PIECEWISE graphs)
     uniform_token_count: int | None = None
     # Upper bound on per-request query length. Varlen decode graphs leave
-    # uniform_token_count unset, so this is what keeps a prefill batch out of one.
+    # uniform_token_count unset and use this bound for compatible decode batches.
     max_query_len: int | None = None
     num_active_loras: int = 0
+    decode_only: bool = False
 
 
 class CreateForwardFn(Protocol):
@@ -86,6 +87,7 @@ def _is_compatible(
     uniform_token_count: int | None,
     num_active_loras: int,
     max_query_len: int | None,
+    has_prefill: bool,
 ) -> bool:
     # desc.uniform_token_count=None (PIECEWISE) can handle any uniform_token_count
     # desc.num_reqs=None means no request padding needed (PIECEWISE)
@@ -103,6 +105,7 @@ def _is_compatible(
         and (desc.num_reqs is None or desc.num_reqs >= num_reqs)
         and desc.num_tokens >= num_tokens
         and desc.num_active_loras == num_active_loras
+        and not (desc.decode_only and has_prefill)
     )
 
 
@@ -241,6 +244,7 @@ class CudaGraphManager:
                     num_reqs=min(num_tokens, self.max_num_reqs),
                     max_query_len=self.decode_query_len,
                     num_active_loras=num_active_loras,
+                    decode_only=True,
                 )
                 descs_by_mode[decode_mode].append(desc)
             # Capture uniform decode specfifc graphs if required
@@ -263,6 +267,7 @@ class CudaGraphManager:
                         num_reqs=rounded_num_reqs,
                         uniform_token_count=decode_query_len,
                         num_active_loras=num_active_loras,
+                        decode_only=True,
                     )
 
                     # avoid duplicate graphs
@@ -409,6 +414,7 @@ class CudaGraphManager:
         uniform_token_count: int | None,
         num_active_loras: int,
         max_query_len: int | None = None,
+        has_prefill: bool = False,
     ) -> BatchExecutionDescriptor:
         """Find matching cudagraph descriptor from priority-ordered candidates."""
 
@@ -423,6 +429,7 @@ class CudaGraphManager:
                     uniform_token_count,
                     effective_loras,
                     max_query_len,
+                    has_prefill,
                 ):
                     return desc
         return BatchExecutionDescriptor(

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -33,6 +33,9 @@ class DPSyncState:
     # Whether the ranks agreed to run eager. A dispatch reusing this must run
     # eager too; no shape was agreed, so picking a graph per rank would diverge.
     eager: bool
+    # Whether any rank has prefill work. Decode-only graphs must not be selected
+    # when this is true.
+    has_prefill: bool
 
 
 def sync_cudagraph_and_dp_padding(
@@ -45,6 +48,7 @@ def sync_cudagraph_and_dp_padding(
     dp_rank: int,
     max_query_len: int | None = None,
     num_active_loras: int = 0,
+    has_prefill: bool = False,
 ) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
     """
     Coordinates the batch descriptor and DP padding across all ranks.
@@ -53,17 +57,20 @@ def sync_cudagraph_and_dp_padding(
     """
     assert dp_size > 1, "DP size must be greater than 1"
     group = get_dp_group().cpu_group
-    tensor = torch.zeros(4, dp_size, dtype=torch.int32, device="cpu")
+    tensor = torch.zeros(5, dp_size, dtype=torch.int32, device="cpu")
     tensor[0][dp_rank] = num_tokens
     tensor[1][dp_rank] = desired_batch_desc.cg_mode.value
     tensor[2][dp_rank] = uniform_token_count or 0  # (0 means None)
     tensor[3][dp_rank] = max_query_len or -1  # (-1 means None)
+    tensor[4][dp_rank] = has_prefill
     dist.all_reduce(tensor, group=group)
 
     num_tokens_across_dp = tensor[0]
     cg_mode_across_dp = tensor[1]
     uniform_token_counts_across_dp = tensor[2]
     max_query_lens_across_dp = tensor[3]
+    has_prefill_across_dp = tensor[4]
+    synced_has_prefill = bool(has_prefill_across_dp.any().item())
 
     # If ranks disagree on the uniform token count, or its 0 (means None) set to None
     synced_uniform_token_count: int | None = int(uniform_token_counts_across_dp[0])
@@ -93,6 +100,7 @@ def sync_cudagraph_and_dp_padding(
                 num_tokens_across_dp=num_tokens_across_dp,
                 uniform_token_count=synced_uniform_token_count,
                 eager=True,
+                has_prefill=synced_has_prefill,
             ),
         )
 
@@ -107,7 +115,6 @@ def sync_cudagraph_and_dp_padding(
     synced_max_query_len: int | None = None
     if bool(torch.all(max_query_lens_across_dp != -1).item()):
         synced_max_query_len = int(max_query_lens_across_dp.max().item())
-
     # Dispatch for the final synced values, use num_reqs instead of synced_num_reqs
     # so we don't perform request padding for PIECEWISE graphs.
     # num_active_loras is per-rank and doesn't need cross-rank agreement.
@@ -117,6 +124,7 @@ def sync_cudagraph_and_dp_padding(
         synced_uniform_token_count,
         num_active_loras=num_active_loras,
         max_query_len=synced_max_query_len,
+        has_prefill=synced_has_prefill,
     )
 
     # Update num_tokens_across_dp to reflect padded size.
@@ -126,6 +134,7 @@ def sync_cudagraph_and_dp_padding(
         num_tokens_across_dp=num_tokens_across_dp,
         uniform_token_count=synced_uniform_token_count,
         eager=False,
+        has_prefill=synced_has_prefill,
     )
 
 
@@ -139,6 +148,7 @@ def dispatch_cg_and_sync_dp(
     max_query_len: int | None = None,
     need_eager: bool = False,
     num_active_loras: int = 0,
+    has_prefill: bool = False,
     dp_sync: DPSyncState | None = None,
 ) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
     """Pick a cudagraph descriptor for this batch, agreeing it across DP ranks.
@@ -163,6 +173,8 @@ def dispatch_cg_and_sync_dp(
         need_eager: Force `CUDAGraphMode.NONE` instead of dispatching.
         num_active_loras: Active LoRA count for this rank. Does not need
             cross-rank agreement; it never changes a bucket's token count.
+        has_prefill: Whether this rank has prefill work. It is synchronized
+            across ranks before the final graph is selected.
         dp_sync: Agreement from a prior dispatch over this same batch, to reuse.
             Must come from a batch with this same padded `num_tokens` and the
             same `uniform_token_count`; `num_reqs` may differ, as neither
@@ -193,6 +205,7 @@ def dispatch_cg_and_sync_dp(
             dp_sync.uniform_token_count if dp_sync is not None else uniform_token_count,
             num_active_loras=num_active_loras,
             max_query_len=max_query_len,
+            has_prefill=dp_sync.has_prefill if dp_sync is not None else has_prefill,
         )
 
     if dp_size == 1:
@@ -227,4 +240,5 @@ def dispatch_cg_and_sync_dp(
         dp_rank,
         max_query_len=max_query_len,
         num_active_loras=num_active_loras,
+        has_prefill=has_prefill,
     )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1557,6 +1557,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_query_len=max_query_len,
             need_eager=is_profile or skip_compiled,
             num_active_loras=num_active_loras,
+            has_prefill=(
+                batch_req_state.has_prefill if batch_req_state is not None else False
+            ),
         )
 
         if batch_desc.num_tokens == 0:

--- a/vllm/v1/worker/gpu/spec_decode/adaptive_verification.py
+++ b/vllm/v1/worker/gpu/spec_decode/adaptive_verification.py
@@ -478,10 +478,14 @@ def maybe_create_adaptive_verification_manager(
             target_attn_cg_support = target_attn_cg_support.narrow(
                 *additional_attn_cg_support
             )
-    if target_attn_cg_support.min_cg_support != AttentionCGSupport.ALWAYS:
+    if target_attn_cg_support.min_cg_support not in (
+        AttentionCGSupport.VARLEN_DECODE,
+        AttentionCGSupport.ALWAYS,
+    ):
         raise ValueError(
             "Adaptive verification captures varlen decode cudagraphs, so every"
-            " target attention builder must report AttentionCGSupport.ALWAYS, but "
+            " target attention builder must report "
+            "AttentionCGSupport.VARLEN_DECODE or AttentionCGSupport.ALWAYS, but "
             f"{target_attn_cg_support.min_cg_attn_backend} reports "
             f"{target_attn_cg_support.min_cg_support}. Pass "
             "enable_adaptive_verification=false in the speculative config, or "


### PR DESCRIPTION
## Summary

This change adds layered coverage for ragged GDN speculative-decode batches whose per-request query lengths are assigned on the GPU.

It also keeps the explicit `Qwen3DSparkModel` architecture intact for the small Qwen3.5 DSpark checkpoint used by the end-to-end test.

The tests cover:

- device `query_start_loc` taking precedence over a different CPU placeholder layout;
- packed varlen causal-convolution output and cache state against independent per-request execution;
- the fused Qwen3.5 GDN model path with ragged query lengths and CPU/device disagreement;
- fused CUDA GDN MTP decode under CUDAGraph replay when the captured uniform layout is replaced by a ragged layout;
- end-to-end adaptive DSpark generation on `Qwen/Qwen3.5-0.8B` with `satgeze/Qwen3.5-0.8B-DSpark`, including multiple ragged layouts across decode steps and valid output logprobs.

Related to #51869.

## Why this is not duplicate work

The open runtime-K metadata PR changes the exposed state-index width for uniform runtime-K batches; it does not cover ragged device query boundaries, CPU/device query-length disagreement, decode-kernel correctness, or end-to-end adaptive GDN execution.

Searches for `GDN varlen` and `adaptive GDN` found no open PR covering this combination.

## Tests

```bash
.venv/bin/python -m pytest -q \
  tests/models/test_qwen3_5_mtp_config.py \
  tests/v1/attention/test_gdn_metadata_builder.py::test_adaptive_varlen_uses_device_query_start_loc \
  tests/kernels/mamba/test_causal_conv1d.py::test_causal_conv1d_update_spec_varlen_matches_per_request \
  'tests/kernels/mamba/test_gdn_fused_mtp.py::test_fused_model_path_matches_reference[ragged-mtp-cpu-device-mismatch]' \
  tests/kernels/test_fused_gdn_post_conv.py::test_fused_gdn_decode_post_conv_mtp_cudagraph_replays_ragged_layout \
  tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
# 10 passed

PIP_INDEX_URL=https://pypi.org/simple .venv/bin/pre-commit run --files \
  vllm/config/speculative.py \
  tests/models/test_qwen3_5_mtp_config.py \
  tests/v1/attention/test_gdn_metadata_builder.py \
  tests/kernels/mamba/test_causal_conv1d.py \
  tests/kernels/mamba/test_gdn_fused_mtp.py \
  tests/kernels/test_fused_gdn_post_conv.py \
  tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_adaptive_gdn.py
# passed
```

## Model evaluation

The end-to-end test ran the Qwen3.5 0.8B target and DSpark draft with six concurrent requests. It forced confidence-based GPU assignment to produce different ragged layouts across decode steps, verified that GPU query lengths differed from the CPU placeholder while preserving the same total token budget, and checked completion lengths and finite token logprobs.

## AI assistance

AI assistance was used for code-path inspection, implementation, testing, and documentation. The human submitter reviewed every changed line, ran the tests above, and is responsible for the contribution.
