### PR TITLE
[Attention] Warn once when speculative decoding forces the Triton unified-attention 2D decode path

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -173,6 +173,17 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             dtype=torch.float32,
             device=device,
         )
+        if vllm_config.speculative_config is not None:
+            logger.warning_once(
+                "Speculative decoding is enabled: decode steps carry "
+                "max_seqlen_q > 1, which excludes them from the segmented 3D "
+                "flash-decoding path of the Triton unified attention kernel. "
+                "Decode runs on the 2D path, whose throughput degrades as "
+                "context grows (see "
+                "https://github.com/vllm-project/vllm/issues/48076). Consider "
+                "disabling speculation for long-context serving, or an "
+                "attention backend that supports speculation as decode."
+            )
         self.rswa_window = model_config.rswa_window
         self.persistent_rswa_prefix_lens: torch.Tensor | None = None
         if self.rswa_window is not None:


### PR DESCRIPTION
## Purpose

The unified-attention launcher takes the segmented 3D flash-decoding path only when `max_seqlen_q == 1`. Speculative decoding makes every verify step carry `query_len = 1 + num_speculative_tokens`, so enabling MTP/EAGLE silently moves decode onto the 2D path. The slowdown grows with context length and keeps being rediscovered the hard way: #48076 and #52049, where it presented as "MTP is 3x slower at 50K+". Measured on the default TRITON_ATTN routing: -61% at 50K context on an A100, -71% at 32K on 2x RX 7900 XT (numbers and method: https://github.com/cadamcat/dual-radeon-vllm/tree/main/benchmarks/cuda-a100).

#45450 and #46724 admit multi-query decode into the 3D path and would remove the cliff itself; both are currently stalled with merge conflicts. Until one lands, nothing in the log explains the collapse. This adds one `warning_once` at metadata-builder init when a speculative config is active: the mechanism becomes visible in the startup log, at zero hot-path cost and with no behavior change. On ROCm the warning is the whole story — FlashInfer is not available there as an alternative backend.

## Test Plan

The touched builder `__init__` is structurally identical on main, v0.28.0 and a 0.23-era tree, so the line was verified by injecting it into installed builds on both vendors: gemma-4-31B w4a16 + the official MTP assistant (its config path forces TRITON_ATTN, so the builder under test is the one that runs), engine init with and without `speculative_config`.

## Test Result

- CUDA, A100-SXM4-80GB, vLLM 0.28.0, TP=1: with speculation the warning prints exactly once (`WARNING ... [triton_attn.py:179] Speculative decoding is enabled: ...`); without, zero occurrences. Engine init completes in both runs.
- ROCm, 2x Radeon RX 7900 XT (gfx1100), 0.23-era container, TP=2: same — exactly once with speculation (deduped across both TP workers and the target+drafter builder inits), zero without, init completes in both runs.

## AI assistance

The investigation, the change and this description were produced with an AI agent; I reviewed the change and the reasoning behind it, the two-vendor verification ran on hardware I own and on a rented A100, and the commit carries a `Co-authored-by:` trailer.
