### PR TITLE
[Core] Make parallel sampling (n>1) reqs admission atomic

### DIFF
--- a/tests/v1/engine/test_admission_control.py
+++ b/tests/v1/engine/test_admission_control.py
@@ -14,6 +14,7 @@ These tests cover:
 
 import argparse
 import asyncio
+from collections.abc import Awaitable, Callable
 from http import HTTPStatus
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -34,6 +35,7 @@ from vllm.exceptions import (
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.utils.argparse_utils import human_readable_int
+from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.output_processor import OutputProcessor
 
@@ -73,6 +75,45 @@ def _make_output_processor(**request_states) -> OutputProcessor:
     op = OutputProcessor.__new__(OutputProcessor)
     op.request_states = request_states
     return op
+
+
+def _make_engine_request(request_id: str, n: int) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=request_id,
+        prompt_token_ids=[1],
+        mm_features=None,
+        sampling_params=SamplingParams(n=n),
+        pooling_params=None,
+        arrival_time=0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def _make_request_test_llm(
+    max_num_queued_reqs: int,
+    add_request_async: Callable[[EngineCoreRequest], Awaitable[None]],
+) -> AsyncLLM:
+    llm = _make_async_llm(max_num_queued_reqs=max_num_queued_reqs)
+    llm.output_processor = OutputProcessor(None, log_stats=False)
+    llm.engine_core = SimpleNamespace(
+        resources=SimpleNamespace(engine_dead=False),
+        add_request_async=AsyncMock(side_effect=add_request_async),
+        abort_requests_async=AsyncMock(),
+        shutdown=MagicMock(),
+    )
+    llm.vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(kv_sharing_fast_prefill=False)
+    )
+    llm.output_handler = None
+    llm.log_requests = False
+    llm._run_output_handler = MagicMock()
+    llm.input_processor = MagicMock()
+    llm.input_processor.assign_request_id.side_effect = lambda request: setattr(
+        request, "external_req_id", request.request_id
+    )
+    return llm
 
 
 def _make_scheduler_config(**kwargs) -> SchedulerConfig:
@@ -299,6 +340,55 @@ async def test_concurrent_single_request_admission_respects_limit():
     assert sum(result is None for result in results) == 1
     assert sum(isinstance(result, QueueOverflowError) for result in results) == 1
     assert len(request_states) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("first_n", [1, 3])
+async def test_parallel_admission_is_all_or_nothing(first_n: int):
+    """An n>1 request reserves either all its capacity or none of it."""
+
+    async def add_request_async(_request):
+        await asyncio.sleep(0)
+
+    llm = _make_request_test_llm(3, add_request_async)
+    second_n = 3 if first_n == 1 else 1
+    first = _make_engine_request("first", first_n)
+    second = _make_engine_request("second", second_n)
+    results = await asyncio.gather(
+        llm.add_request("first", first, first.params),
+        llm.add_request("second", second, second.params),
+        return_exceptions=True,
+    )
+
+    assert not isinstance(results[0], Exception)
+    assert isinstance(results[1], QueueOverflowError)
+    assert llm.output_processor.get_num_unfinished_requests() == first_n
+    assert llm.engine_core.add_request_async.await_count == first_n
+
+
+@pytest.mark.asyncio
+async def test_parallel_admission_cancellation_cleans_up_all_children():
+    """Cancellation during core submission must release every reserved slot."""
+    first_submission_started = asyncio.Event()
+
+    async def add_request_async(_request):
+        first_submission_started.set()
+        await asyncio.Event().wait()
+
+    llm = _make_request_test_llm(3, add_request_async)
+    request = _make_engine_request("parallel", 3)
+    output = llm.generate(request, request.params, request.request_id)
+    generate_task = asyncio.create_task(anext(output))
+
+    await first_submission_started.wait()
+    generate_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await generate_task
+
+    assert llm.engine_core.add_request_async.await_count == 1
+    assert llm.output_processor.get_num_unfinished_requests() == 0
+    aborted_ids = llm.engine_core.abort_requests_async.await_args.args[0]
+    assert set(aborted_ids) == {"0_parallel", "1_parallel", "2_parallel"}
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -382,10 +382,6 @@ class AsyncLLM(EngineClient):
                 "prompt logprobs"
             )
 
-        if isinstance(params, SamplingParams) and params.n > 1:
-            # TODO (NickLucche) Batch check admission check for all n requests
-            self.check_admission(params.n, request_id)
-
         if isinstance(prompt, AsyncGenerator):
             if reasoning_ended is not None or reasoning_parser_kwargs is not None:
                 raise NotImplementedError
@@ -481,14 +477,28 @@ class AsyncLLM(EngineClient):
 
         # Fan out child requests (for n>1).
         parent_request = ParentRequest(request)
+        child_requests: list[EngineCoreRequest] = []
         for idx in range(parent_params.n):
             request_id, child_params = parent_request.get_child_info(idx)
             child_request = request if idx == parent_params.n - 1 else copy(request)
             child_request.request_id = request_id
             child_request.sampling_params = child_params
-            await self._add_request(
-                child_request, prompt_text, parent_request, idx, queue
-            )
+            child_requests.append(child_request)
+
+        self.check_admission(parent_params.n, parent_request.request_id)
+        try:
+            for idx, child_request in enumerate(child_requests):
+                self.output_processor.add_request(
+                    child_request, prompt_text, parent_request, idx, queue
+                )
+
+            for child_request in child_requests:
+                await self.engine_core.add_request_async(child_request)
+                if self.log_requests:
+                    logger.info("Added request %s.", child_request.request_id)
+        except BaseException:
+            await self.abort(parent_request.request_id, internal=True)
+            raise
         return queue
 
     async def _add_request(


### PR DESCRIPTION
Follow-up to #49445 that resolves its documented `n > 1` admission-race TODO.

## Summary

Parallel sampling currently checks capacity for all `n` children, then registers and submits each child around a separate `await`. Another request can therefore consume capacity after only part of the admitted batch has been registered.

This change separates local registration from EngineCore submission:

1. Build all child requests.
2. Check admission once for all `n` slots.
3. Register all children synchronously, without yielding.
4. Submit the registered children to EngineCore.
5. Abort all children if registration or submission is interrupted.

Within one frontend event loop, **admission is therefore all-or-nothing**: all `n` child slots are reserved, or none are. Cancellation during EngineCore submission also releases every reserved slot.

## Relationship to existing work

This is a focused correctness follow-up to #49445, not another queue-control implementation. #27064, #39492, and #49330 propose broader or alternative admission mechanisms; none addresses the `n > 1` interleaving in #49445's parallel-sampling fan-out.

## Tests

```text
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest -q tests/v1/engine/test_admission_control.py
48 passed in 3.62s

.venv/bin/pre-commit run --files vllm/v1/engine/async_llm.py tests/v1/engine/test_admission_control.py
Passed
```

Model evaluation: not applicable. This changes admission bookkeeping only and does not affect model outputs or accuracy.

cc @panpan0000

AI assistance was used to develop this change. The human submitter must review every changed line and understand the implementation before marking the PR ready for review.
