### PR TITLE
fix(rocm): add gfx1250 AITER_MXFP4_BF16 condition to GptOssMxfp4MoEMe…

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -742,6 +742,12 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
 ]:
     """Convert loaded weights into backend-specific kernel format."""
 
+    is_gfx1250 = False
+    if current_platform.is_rocm():
+        from vllm.platforms.rocm import on_gfx1250
+
+        is_gfx1250 = on_gfx1250()
+
     if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
         w13_weight_scale, w2_weight_scale = _pack_deepgemm_mxfp4_scales(
             w13_weight,
@@ -1060,7 +1066,7 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
+    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and not is_gfx1250:
         from vllm._aiter_ops import rocm_aiter_ops
 
         if w13_bias is not None:
@@ -1182,7 +1188,9 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
-    elif mxfp4_backend in TRITON_BACKENDS:
+    elif mxfp4_backend in TRITON_BACKENDS or (
+        mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16 and is_gfx1250
+    ):
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
         if w13_bias is not None:

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -348,9 +348,20 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             )
         )
 
-        # For TRITON backends, weights are wrapped tensors from triton_kernels
-        # that don't support .detach(). Manually assign parameters.
-        if self.mxfp4_backend not in TRITON_BACKENDS:
+        # For TRITON backends (and AITER_MXFP4_BF16 on gfx1250), weights
+        # are wrapped tensors from triton_kernels that don't support
+        # .detach(). Manually assign parameters.
+        is_gfx1250 = False
+        if current_platform.is_rocm():
+            from vllm.platforms.rocm import on_gfx1250
+
+            is_gfx1250 = on_gfx1250()
+
+        uses_triton_weight_format = self.mxfp4_backend in TRITON_BACKENDS or (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and is_gfx1250
+        )
+        if not uses_triton_weight_format:
             replace_parameter(layer, "w13_weight", w13)
             replace_parameter(layer, "w2_weight", w2)
             replace_parameter(layer, "w13_weight_scale", w13_scale)
@@ -398,7 +409,16 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         w1_bias = getattr(layer, "w13_bias", None)
         w2_bias = getattr(layer, "w2_bias", None)
 
-        if self.mxfp4_backend in TRITON_BACKENDS:
+        is_gfx1250 = False
+        if current_platform.is_rocm():
+            from vllm.platforms.rocm import on_gfx1250
+
+            is_gfx1250 = on_gfx1250()
+
+        if self.mxfp4_backend in TRITON_BACKENDS or (
+            self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16
+            and is_gfx1250
+        ):
             # TRITON backends free w13/w2_weight_scale after swizzling; the
             # swizzled scales live inside the precision configs instead.
             assert self.w13_precision_config is not None


### PR DESCRIPTION

GptOssMxfp4MoEMethod is missing the gfx1250 AITER_MXFP4_BF16 condition that already exists in the DeepSeek Mxfp4MoEMethod. On gfx1250, the AITER_MXFP4_BF16 backend is selected but is not in TRITON_BACKENDS, so the GPT-OSS path stores weight scales as raw torch.Tensor instead of PrecisionConfig. The AITER expert then accesses w1_precision which asserts isinstance(scale, PrecisionConfig) and crashes.

Three locations fixed to mirror the DeepSeek class:

1. oracle/mxfp4.py: convert_gpt_oss_weight_to_mxfp4_moe_kernel_format
   - Add is_gfx1250 detection
   - Gate AITER_MXFP4_BF16 branch with 'not is_gfx1250'
   - Extend TRITON_BACKENDS branch to handle AITER on gfx1250 (uses _swizzle_mxfp4 + PrecisionConfig, same as DeepSeek)

2. quantization/mxfp4.py: GptOssMxfp4MoEMethod._setup_kernel
   - Add uses_triton_weight_format with gfx1250 condition

3. quantization/mxfp4.py: GptOssMxfp4MoEMethod.get_fused_moe_quant_config
   - Add gfx1250 condition to scale retrieval

Non-gfx1250 AITER, NVIDIA, and all other backends are unchanged.

Fixes: ROCM-30016, AITIGER-9




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

