### PR TITLE
[Bugfix][Rust Frontend] Fix LogprobsTensors wire schema mismatch

### DIFF
--- a/rust/src/engine-core-client/src/protocol/logprobs.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs.rs
@@ -222,6 +222,7 @@ impl WireLogprobs {
                 data: WireArrayData::RawView(token_ranks.into()),
             },
             cu_num_generated_tokens: None,
+            cu_num_generated_tokens_tensor: None,
         })
     }
 
@@ -236,6 +237,15 @@ impl WireLogprobs {
             bail_ext_value_decode!(
                 "{field_prefix}.cu_num_generated_tokens: \
                  expected None for per-request engine-core logprobs payload, got {indices:?}"
+            );
+        }
+
+        // Unlike the sibling check above, don't Debug-print the payload:
+        // an opaque non-None value here may embed a full tensor blob.
+        if self.cu_num_generated_tokens_tensor.is_some() {
+            bail_ext_value_decode!(
+                "{field_prefix}.cu_num_generated_tokens_tensor: \
+                 expected None for per-request engine-core logprobs payload"
             );
         }
 

--- a/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
@@ -87,6 +87,7 @@ fn inline_prompt_logprobs_value() -> Value {
         ndarray_value("float32", &[2, 3], probs),
         ndarray_value("int64", &[2], ranks),
         Value::Nil,
+        Value::Nil,
     ])
 }
 
@@ -241,41 +242,11 @@ fn decodes_inline_prompt_logprobs() {
 }
 
 #[test]
-fn decodes_five_field_prompt_logprobs_payload() {
-    // vllm-project/vllm#52242 grew Python's `LogprobsTensors` to five
-    // positional fields; NamedTuple wire encoding always emits every slot,
-    // so prompt-logprobs payloads now arrive as 5-element arrays with a
-    // trailing `cu_num_generated_tokens_tensor` of `None`.
-    let Value::Array(mut fields) = inline_prompt_logprobs_value() else {
-        panic!("inline_prompt_logprobs_value must be an array");
-    };
-    fields.push(Value::Nil);
-
-    let frames = vec![Bytes::from(encode_value(&output_wire_with_custom_fields(
-        None,
-        Some(Value::Array(fields)),
-    )))];
-    let decoded = decode_engine_core_outputs(&frames).unwrap().into_request_batch().unwrap();
-
-    let logprobs = decoded.outputs[0]
-        .new_prompt_logprobs_tensors
-        .clone()
-        .unwrap()
-        .into_direct()
-        .unwrap();
-    assert_eq!(logprobs, expected_prompt_logprobs());
-}
-
-#[test]
 fn rejects_non_none_cu_num_generated_tokens_tensor() {
-    // Same base fixture as the accepting test above; the only difference is
-    // the trailing 5th slot: `Nil` decodes, any non-Nil value is rejected.
-    // A scalar sentinel is used because the slot is intentionally decoded
-    // opaquely.
     let Value::Array(mut fields) = inline_prompt_logprobs_value() else {
         panic!("inline_prompt_logprobs_value must be an array");
     };
-    fields.push(Value::from(42));
+    fields[4] = Value::from(42);
 
     let frames = vec![Bytes::from(encode_value(&output_wire_with_custom_fields(
         None,

--- a/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/tests.rs
@@ -241,6 +241,59 @@ fn decodes_inline_prompt_logprobs() {
 }
 
 #[test]
+fn decodes_five_field_prompt_logprobs_payload() {
+    // vllm-project/vllm#52242 grew Python's `LogprobsTensors` to five
+    // positional fields; NamedTuple wire encoding always emits every slot,
+    // so prompt-logprobs payloads now arrive as 5-element arrays with a
+    // trailing `cu_num_generated_tokens_tensor` of `None`.
+    let Value::Array(mut fields) = inline_prompt_logprobs_value() else {
+        panic!("inline_prompt_logprobs_value must be an array");
+    };
+    fields.push(Value::Nil);
+
+    let frames = vec![Bytes::from(encode_value(&output_wire_with_custom_fields(
+        None,
+        Some(Value::Array(fields)),
+    )))];
+    let decoded = decode_engine_core_outputs(&frames).unwrap().into_request_batch().unwrap();
+
+    let logprobs = decoded.outputs[0]
+        .new_prompt_logprobs_tensors
+        .clone()
+        .unwrap()
+        .into_direct()
+        .unwrap();
+    assert_eq!(logprobs, expected_prompt_logprobs());
+}
+
+#[test]
+fn rejects_non_none_cu_num_generated_tokens_tensor() {
+    // Same base fixture as the accepting test above; the only difference is
+    // the trailing 5th slot: `Nil` decodes, any non-Nil value is rejected.
+    // A scalar sentinel is used because the slot is intentionally decoded
+    // opaquely.
+    let Value::Array(mut fields) = inline_prompt_logprobs_value() else {
+        panic!("inline_prompt_logprobs_value must be an array");
+    };
+    fields.push(Value::from(42));
+
+    let frames = vec![Bytes::from(encode_value(&output_wire_with_custom_fields(
+        None,
+        Some(Value::Array(fields)),
+    )))];
+
+    let error = decode_engine_core_outputs(&frames).unwrap_err();
+    let crate::error::Error::ExtValueDecode { message } = &error else {
+        panic!("expected ValueDecodeExt");
+    };
+    assert_eq!(
+        message,
+        "new_prompt_logprobs_tensors.cu_num_generated_tokens_tensor: \
+         expected None for per-request engine-core logprobs payload"
+    );
+}
+
+#[test]
 fn decodes_big_endian_payloads() {
     let frames = vec![Bytes::from(encode_value(&output_wire_with_custom_fields(
         Some(Value::Array(vec![

--- a/rust/src/engine-core-client/src/protocol/logprobs/wire.rs
+++ b/rust/src/engine-core-client/src/protocol/logprobs/wire.rs
@@ -3,6 +3,7 @@
 
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
+use crate::protocol::OpaqueValue;
 use crate::protocol::tensor::WireNdArray;
 
 /// Python wire representation of `LogprobsLists` / `LogprobsTensors` before
@@ -13,7 +14,15 @@ use crate::protocol::tensor::WireNdArray;
 /// into semantic per-position logprobs records.
 ///
 /// Original Python definition:
-/// <https://github.com/vllm-project/vllm/blob/f22d6e026798a74e6542a52ef776c054f2de572a/vllm/v1/outputs.py#L23-L56>
+/// <https://github.com/vllm-project/vllm/blob/d5cadcee8641a9fcec15facb5a9157d157daa207/vllm/v1/outputs.py#L30-L106>
+///
+/// # Wire compatibility
+///
+/// Python's `LogprobsLists` / `LogprobsTensors` are `NamedTuple`s: every
+/// field is serialized positionally, and `Deserialize_tuple` here hard-fails
+/// on payloads longer than this struct. To preserve positional compatibility,
+/// append new Python fields and add matching trailing `#[serde(default)]`
+/// fields here in the same change.
 #[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct WireLogprobs {
     /// Wire array with shape `[num_positions, max_num_logprobs + 1]`.
@@ -31,4 +40,12 @@ pub struct WireLogprobs {
     /// the semantic Rust decoder rejects any other value.
     #[serde(default)]
     pub cu_num_generated_tokens: Option<Vec<usize>>,
+    /// Device-only generation boundaries added to `LogprobsTensors` in
+    /// vllm-project/vllm#52242. Preserved only for wire compatibility:
+    /// NamedTuple encoding always emits the slot even when it is `None`,
+    /// so this field must exist for the 5-element payload to decode.
+    /// Scheduler-sliced per-request outputs should emit `None` here, and
+    /// the semantic Rust decoder rejects any other value.
+    #[serde(default)]
+    pub cu_num_generated_tokens_tensor: Option<OpaqueValue>,
 }

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -353,7 +353,8 @@ inline_prompt_logprobs = engine_outputs_wire(
                 ).tobytes(),
             ),
             ("int64", [2], np.array([3, 4], dtype=np.int64).tobytes()),
-            None,
+            None,  # cu_num_generated_tokens
+            None,  # cu_num_generated_tokens_tensor
         ),
     )
 )
@@ -376,7 +377,8 @@ multipart_prompt_logprobs = engine_outputs_wire(
                 ).tobytes(),
             ),
             ("int64", [2], np.array([3, 4], dtype=np.int64).tobytes()),
-            None,
+            None,  # cu_num_generated_tokens
+            None,  # cu_num_generated_tokens_tensor
         ),
     )
 )


### PR DESCRIPTION
## Purpose

Fixes #53932.

#52242 added `cu_num_generated_tokens_tensor` as a fifth positional field to Python's `LogprobsTensors`. Because `NamedTuple` serialization includes every positional field even when it is `None`, serialized `LogprobsTensors` now have five elements, while Rust `WireLogprobs` still expected four under `Deserialize_tuple`.

This PR:

- adds a trailing `#[serde(default)] cu_num_generated_tokens_tensor: Option<OpaqueValue>` to `WireLogprobs`, preserving compatibility with existing 4-field payloads;
- rejects a non-`None` fifth value in `resolve()` rather than silently accepting data that the current decoder does not handle;
- documents the positional wire-compatibility requirement on `WireLogprobs`.

The rejected opaque value is not included in the error message because it may contain a full tensor payload.

I also checked the other Rust tuple types that decode Python output: `EngineCoreOutputs` 8/8, `EngineCoreOutput` 17/17, and `UtilityOutput` 3/3 already match. `WireLogprobs` was the only mismatch at 4/5 before this patch.

#53886 addresses the same regression by reverting #52242. This PR instead keeps #52242 and applies the narrower Rust-side fix that #53886 itself recommends: update `WireLogprobs` for the fifth positional field added to `LogprobsTensors`.

Dispatcher decode-error handling and CI dependency coverage are out of scope and tracked in #53932.

AI assistance (Claude and ChatGPT) was used during investigation and implementation. I reviewed the changes and ran the local validation below.

## Test Plan

Two regression tests cover the new field:

- `decodes_five_field_prompt_logprobs_payload`: verifies that a trailing `Nil` fifth field decodes successfully.
- `rejects_non_none_cu_num_generated_tokens_tensor`: verifies that a non-`Nil` fifth field is rejected.

Existing 4-field cases continue to pass.

```bash
cd rust
cargo fmt --check
cargo clippy -p vllm-engine-core-client --all-targets
cargo test -p vllm-engine-core-client
cd ..

git diff --check
```

Model evaluation was not run locally. This patch does not change model computation or logprob values; it only fixes Rust-side decoding of the wire payload.

I also did not run the H200 E2E test locally. The Rust regression tests reproduce the same wire decode failure seen in CI.

## Test Result

Before the fix:

```text
test protocol::logprobs::tests::decodes_five_field_prompt_logprobs_payload ... FAILED
test protocol::logprobs::tests::rejects_non_none_cu_num_generated_tokens_tensor ... FAILED

called `Result::unwrap()` on an `Err` value: Decode {
  target_type: "vllm_engine_core_client::protocol::output::EngineCoreOutputs",
  message: "array had incorrect length, expected 4; ..."
}
```

After the fix:

```text
test protocol::logprobs::tests::decodes_five_field_prompt_logprobs_payload ... ok
test protocol::logprobs::tests::rejects_non_none_cu_num_generated_tokens_tensor ... ok

test result: ok. 101 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.34s
```

`cargo fmt --check`, `cargo clippy -p vllm-engine-core-client --all-targets`, and `git diff --check` also pass.

---

Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.