### PR TITLE
[Kimi K3 Perf] Optimize `eh_proj` linear calculation, 12.9 ~ 25.2% kernel performance improvement

### DIFF
--- a/tests/kernels/test_bf16_skinny_gemm.py
+++ b/tests/kernels/test_bf16_skinny_gemm.py
@@ -39,6 +39,7 @@ EXPECTED_SELECTIONS = {
     (7168, 8448): (set(range(1, 4)), set()),
     (8448, 7168): ({1, 2}, set()),
     (16896, 7168): ({1, 2}, set()),
+    (7168, 14336): ({1, 2}, set()),
     (20480, 7168): (set(range(1, 5)), set()),
     (40960, 7168): (set(range(1, 5)), set()),
     # TP16.
@@ -96,6 +97,8 @@ EXPECTED_CUTE_CONFIGS = {
     (8448, 7168, 2): (32, 4, 4, 8),
     (16896, 7168, 1): (224, 6, 4, 8),
     (16896, 7168, 2): (32, 4, 4, 8),
+    (7168, 14336, 1): (256, 2, 1, 4),
+    (7168, 14336, 2): (224, 4, 2, 8),
     (20480, 7168, 1): (224, 4, 2, 8),
     (20480, 7168, 2): (64, 4, 2, 8),
     (20480, 7168, 3): (64, 2, 2, 8),
@@ -218,7 +221,12 @@ def test_cute_configs_match_measured_table() -> None:
         for n, k, num_tokens, config in configs
     }
     assert actual == EXPECTED_CUTE_CONFIGS
-    assert all(config.static_k is None for *_, config in configs)
+    static_k_configs = {
+        (n, k, num_tokens, config.static_k)
+        for n, k, num_tokens, config in configs
+        if config.static_k is not None
+    }
+    assert static_k_configs == {(7168, 14336, 1, 14336)}
 
 
 def test_residual_cute_configs_match_measured_table() -> None:

--- a/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
@@ -194,6 +194,14 @@ KIMI_K3_PROJECTIONS: dict[tuple[int, int], ProjectionSpec] = {
         ),
         name="dense_gate_up_proj",
     ),
+    (7168, 14336): ProjectionSpec(
+        7168,
+        14336,
+        cute_configs=(
+            (1, SkinnyGemmConfig(1, 256, 2, vector_width=4, static_k=14336)),
+            (2, _cute(2, 224, 4, 2)),
+        ),
+    ),
     (20480, 7168): ProjectionSpec(
         20480,
         7168,

--- a/vllm/models/kimi_k3/nvidia/mtp.py
+++ b/vllm/models/kimi_k3/nvidia/mtp.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
@@ -80,7 +81,14 @@ class KimiK3MultiTokenPredictorLayer(nn.Module):
 
         self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.eh_proj = ReplicatedLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "eh_proj"),
+            return_bias=False,
+        )
 
         self.shared_head = SharedHead(
             config=config, prefix=prefix, quant_config=quant_config


### PR DESCRIPTION
## Purpose

Enabling m=1 and m=2 for low latency gemm

Originally we use `nn.Linear`, it is not `LinearBase`, so won't work in `enable_kimi_k3_low_latency_gemm`

Now we enable it

## Test

Acc covered in current unit tests

Perf can be seen in this AI generated script

```bash
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""Sweep cuBLAS vs CuTe for the Kimi-K3 MTP eh_proj."""

import statistics

import torch

from vllm.model_executor.kernels.linear.cute_dsl.skinny_gemm import (
    SkinnyGemmConfig,
    shape_dynamic_skinny_gemm,
)

N = 7168
K = 14336
MS = range(1, 17)
REPEATS = 9
REPLAYS = 200

# block_size, outputs_per_block, k_unroll, vector_width
CANDIDATES = (
    (32, 4, 4, 8),
    (32, 8, 4, 8),
    (64, 2, 1, 8),
    (64, 4, 1, 8),
    (64, 4, 2, 8),
    (64, 8, 2, 8),
    (128, 2, 1, 8),
    (128, 4, 1, 8),
    (128, 4, 2, 8),
    (224, 2, 2, 8),
    (224, 4, 2, 8),
    (224, 7, 2, 8),
    (224, 4, 4, 8),
    (256, 2, 2, 8),
    (256, 4, 2, 8),
    (256, 7, 2, 8),
    (448, 2, 2, 8),
    (448, 4, 2, 8),
)


def configs(m: int) -> list[SkinnyGemmConfig]:
    result = [SkinnyGemmConfig(m, *candidate) for candidate in CANDIDATES]
    if m == 1:
        result.append(SkinnyGemmConfig(1, 256, 2, vector_width=4, static_k=K))
    return result


def benchmark(call, weights: list[torch.Tensor]) -> float:
    for weight in weights:
        call(weight)
    torch.accelerator.synchronize()

    graph = torch.cuda.CUDAGraph()
    with torch.cuda.graph(graph):
        for weight in weights:
            call(weight)
    for _ in range(10):
        graph.replay()
    torch.accelerator.synchronize()

    samples = []
    for _ in range(REPEATS):
        start = torch.cuda.Event(enable_timing=True)
        end = torch.cuda.Event(enable_timing=True)
        start.record()
        for _ in range(REPLAYS):
            graph.replay()
        end.record()
        end.synchronize()
        samples.append(start.elapsed_time(end) * 1000 / (REPLAYS * len(weights)))
    return statistics.median(samples)


@torch.inference_mode()
def main() -> None:
    torch.accelerator.set_device_index(0)
    print(torch.cuda.get_device_name(), torch.cuda.get_device_capability())
    print(" M | cuBLAS(us) | CuTe(us) | gain(%) | best config")
    print("---|------------|----------|---------|------------")

    for m in MS:
        torch.manual_seed(m)
        x = torch.randn(m, K, device="cuda", dtype=torch.bfloat16)
        weights = [
            torch.randn(N, K, device="cuda", dtype=torch.bfloat16) for _ in range(2)
        ]
        reference = torch.nn.functional.linear(x, weights[0])
        cublas_us = benchmark(
            lambda weight, x=x: torch.nn.functional.linear(x, weight), weights
        )

        best_us = float("inf")
        best_config = None
        for config in configs(m):
            output = shape_dynamic_skinny_gemm(x, weights[0], config)
            torch.testing.assert_close(
                output.float(), reference.float(), rtol=2e-2, atol=2e-1
            )
            latency = benchmark(
                lambda weight, config=config, x=x: shape_dynamic_skinny_gemm(
                    x, weight, config
                ),
                weights,
            )
            if latency < best_us:
                best_us, best_config = latency, config

        gain = (cublas_us - best_us) / cublas_us * 100
        print(
            f"{m:2d} | {cublas_us:10.3f} | {best_us:8.3f} | {gain:7.1f} | {best_config}"
        )


if __name__ == "__main__":
    main()

```

And we can get 

```bash
 M | cuBLAS(us) | CuTe(us) | gain(%) | best config
---|------------|----------|---------|------------
 1 |     36.984 |   27.653 |    25.2 | SkinnyGemmConfig(num_rows=1, block_size=256, outputs_per_block=2, k_unroll=1, vector_width=4, static_k=14336)
 2 |     37.105 |   32.304 |    12.9 | SkinnyGemmConfig(num_rows=2, block_size=32, outputs_per_block=4, k_unroll=4, vector_width=8, static_k=None)
 3 |     37.200 |   35.510 |     4.5 | SkinnyGemmConfig(num_rows=3, block_size=64, outputs_per_block=8, k_unroll=2, vector_width=8, static_k=None)
 4 |     37.541 |   37.212 |     0.9 | SkinnyGemmConfig(num_rows=4, block_size=64, outputs_per_block=4, k_unroll=1, vector_width=8, static_k=None)
 ...
```

(Note that we only choose M=1 and M=2 now)