### PR TITLE
[Rocm][CI] add dockerfile.xpu to rocm ci artifact

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -369,7 +369,6 @@ COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/scripts/benchmark_helion_kernels.p
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/tools/install_torchcodec_rocm.sh /tools/install_torchcodec_rocm.sh
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile /docker/Dockerfile
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.cpu /docker/Dockerfile.cpu
-COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.xpu /docker/Dockerfile.xpu
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm /docker/
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm_base /docker/Dockerfile.rocm_base
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/ci-rocm.hcl /docker/ci-rocm.hcl

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -369,6 +369,7 @@ COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/scripts/benchmark_helion_kernels.p
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/tools/install_torchcodec_rocm.sh /tools/install_torchcodec_rocm.sh
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile /docker/Dockerfile
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.cpu /docker/Dockerfile.cpu
+COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.xpu /docker/Dockerfile.xpu
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm /docker/
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/Dockerfile.rocm_base /docker/Dockerfile.rocm_base
 COPY --from=build_vllm ${COMMON_WORKDIR}/vllm/docker/ci-rocm.hcl /docker/ci-rocm.hcl

--- a/tests/tools/test_docker_build_metadata_args.py
+++ b/tests/tools/test_docker_build_metadata_args.py
@@ -154,7 +154,12 @@ def test_vllm_openai_image_embeds_metadata_contract() -> None:
 
 
 def test_rust_build_cache_excludes_git_metadata() -> None:
-    for name in ("Dockerfile", "Dockerfile.cpu", "Dockerfile.xpu"):
+    from vllm.platforms import current_platform
+
+    dockerfile_names = ["Dockerfile", "Dockerfile.cpu"]
+    if not current_platform.is_rocm():
+        dockerfile_names.append("Dockerfile.xpu")
+    for name in dockerfile_names:
         dockerfile = (REPO_ROOT / "docker" / name).read_text()
         cached_stage, exact_version_stage = dockerfile.split(
             "FROM rust-build-cache AS rust-build", maxsplit=1


### PR DESCRIPTION
Add dockerfile.xpu to the ci artifact since `tools/test_docker_build_metadata_args.py::test_rust_build_cache_excludes_git_metadata` needs this file.