### PR TITLE
[Bugfix] Restore portable all2all backend default

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -752,6 +752,10 @@ def test_data_parallel_rpc_port_has_fixed_default():
     assert ParallelConfig().data_parallel_rpc_port == 29550
 
 
+def test_all2all_backend_has_portable_default():
+    assert ParallelConfig().all2all_backend == "allgather_reducescatter"
+
+
 @pytest.mark.parametrize("port", [1, 29550, 65535])
 def test_data_parallel_rpc_port_accepts_valid_ports(port: int):
     assert ParallelConfig(data_parallel_rpc_port=port).data_parallel_rpc_port == port

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -192,7 +192,7 @@ class ParallelConfig:
       with 4 experts and 2 ranks, rank 0 will have experts [0, 2] and rank 1
       will have experts [1, 3]. This strategy can help improve load balancing
       for grouped expert models with no redundant experts."""
-    all2all_backend: All2AllBackend = "flashinfer_nvlink_one_sided"
+    all2all_backend: All2AllBackend = "allgather_reducescatter"
     """All2All backend for MoE expert parallel communication. Available options:
 
     - "allgather_reducescatter": All2all based on allgather and reducescatter


### PR DESCRIPTION
Fixes the post-merge regression introduced by #53311 by restoring `allgather_reducescatter` as the portable default. Users can still opt into `flashinfer_nvlink_one_sided` explicitly.

Post-merge evidence:
- [main #85642 L4 distributed](https://buildkite.com/vllm/ci/builds/85642#01a03df5-c395-4c24-83d2-cae35569ecb0): `No Unquantized MoE backend supports the deployment configuration`
- [main #85646 L4 LoRA TP](https://buildkite.com/vllm/ci/builds/85646#01a03e0a-5b76-4bb7-84e1-d4f65e6dbd0e): `Fused MoE LoRA with EP currently only supports allgather_reducescatter, got flashinfer_nvlink_one_sided`
- [main #85651 MI300 DP](https://buildkite.com/vllm/ci/builds/85651#01a03e5c-e4b3-40a6-9f75-4da44eb07211): repeated PowerMoE engine initialization failures because the one-sided backend is unavailable
- [main #85674 L4 PP+DP](https://buildkite.com/vllm/ci/builds/85674#01a03efc-8fe1-464f-91bb-faaf01de575b): the default one-sided manager does not implement the PP dispatch path

The source PR's selected CI covered four H200 jobs only; no L4 or MI300 job exercised the changed default.

A unit test now pins the portable default.

Testing:
- `python3 -m py_compile vllm/config/parallel.py tests/test_config.py`
- `git diff --check`
- Full pytest collection was unavailable locally because the checkout has no test dependencies (`numpy` missing).
