### PR TITLE
[Bugfix][ROCm] Derive a8w4 SiTU MoE layout from AITER_SITUV2_A8W4 too

### DIFF
--- a/tests/kernels/moe/test_rocm_aiter_moe.py
+++ b/tests/kernels/moe/test_rocm_aiter_moe.py
@@ -565,6 +565,49 @@ def test_aiter_moe_shared_experts_enablement_follows_env(
         assert rocm_aiter_ops.is_fusion_moe_shared_experts_enabled() is expected
 
 
+@pytest.mark.parametrize(
+    ("vllm_flag", "aiter_flag", "expected"),
+    [
+        (True, True, True),
+        (True, False, True),
+        # aiter runs the interleaved a8w4 kernel off its own env var, so vLLM
+        # has to shuffle interleaved too. Before #52442 this combination left
+        # the kernel reading separated weights and silently produced garbage.
+        (False, True, True),
+        (False, False, False),
+    ],
+)
+def test_aiter_moe_situv2_a8w4_follows_both_env_vars(
+    vllm_flag: bool,
+    aiter_flag: bool,
+    expected: bool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The a8w4 SiTU gate must never disagree with aiter's own env var.
+
+    ``VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4`` drives the weight shuffle and
+    ``gate_mode`` on the vLLM side; ``AITER_SITUV2_A8W4`` drives the kernel
+    aiter picks. If either asks for the interleaved a8w4 path, both layouts
+    have to follow.
+    """
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    _assert_aiter_supported()
+
+    with monkeypatch.context() as mp:
+        mp.setenv("VLLM_ROCM_USE_AITER", "1")
+        mp.setenv("VLLM_ROCM_USE_AITER_MOE", "1")
+        mp.setenv("VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4", "1" if vllm_flag else "0")
+        if aiter_flag:
+            mp.setenv("AITER_SITUV2_A8W4", "1")
+        else:
+            mp.delenv("AITER_SITUV2_A8W4", raising=False)
+        _reload_envs()
+        rocm_aiter_ops.refresh_env_variables()
+
+        assert rocm_aiter_ops.is_fused_moe_situv2_a8w4_enabled() is expected
+
+
 @pytest.mark.parametrize("moe_padding", [True, False])
 def test_aiter_moe_padding_env_var(
     moe_padding: bool,

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1600,6 +1600,34 @@ def _rocm_aiter_fp8_attn_fake(
     )
 
 
+def _situv2_a8w4_enabled() -> bool:
+    """Whether the a8w4 SiTU MoE path is active, per vLLM *or* aiter.
+
+    Two separately named env vars have to agree here. aiter picks the
+    gate/up-interleaved afp8 (``_gui_``) FlyDSL SiTU kernel from its own
+    ``AITER_SITUV2_A8W4``, while vLLM picks the matching weight shuffle
+    (``guinterleave``) and ``gate_mode`` from
+    ``VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4``.
+
+    Setting only the aiter one left the interleave kernel reading
+    separated-layout weights, which produces degenerate output with no error
+    and no warning (https://github.com/vllm-project/vllm/issues/52442).
+    Deriving from both makes that mismatch unreachable.
+    """
+    if envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4:
+        return True
+    if os.getenv("AITER_SITUV2_A8W4", "0").lower() in ("true", "1"):
+        logger.warning_once(
+            "AITER_SITUV2_A8W4 is set but VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4 "
+            "is not. aiter will run the gate/up-interleaved a8w4 SiTU kernel, "
+            "so vLLM is enabling the matching interleaved weight layout. "
+            "Set VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1 explicitly to silence "
+            "this."
+        )
+        return True
+    return False
+
+
 # Global flag to ensure ops are registered only once
 _OPS_REGISTERED = False
 
@@ -1628,6 +1656,8 @@ class rocm_aiter_ops:
         VLLM_ROCM_USE_AITER_TRITON_ROPE: Controls Triton rotary embeddings.
         VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS: Controls shared expert fusion.
         VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4: Controls a8w4 SiTU fused MoE variant.
+            Also implied by aiter's own AITER_SITUV2_A8W4, which must not
+            disagree with it (see _situv2_a8w4_enabled).
         VLLM_ROCM_USE_AITER_TRITON_GEMM: Controls Triton unquantized GEMM.
 
     Note:
@@ -1696,7 +1726,7 @@ class rocm_aiter_ops:
     # TODO: Consolidate under VLLM_ROCM_USE_AITER_ROPE
     _TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
     _MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
-    _MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
+    _MOE_SITUV2_A8W4 = _situv2_a8w4_enabled()
     # TODO: Consolidate under _LINEAR_ENABLED
     _TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
     # Lazily probed: whether aiter.topk_softmax supports the
@@ -1726,7 +1756,7 @@ class rocm_aiter_ops:
         cls._FP4_GEMM_DYNAMIC_QUANT_ASM = envs.VLLM_ROCM_USE_AITER_FP4_ASM_GEMM
         cls._TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
         cls._MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
-        cls._MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
+        cls._MOE_SITUV2_A8W4 = _situv2_a8w4_enabled()
         cls._TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
 
     @staticmethod


### PR DESCRIPTION
## The bug

Kimi-K3 (2.8T mxfp4 compressed-tensors, SiTU MoE) on ROCm/gfx950 silently produces
degenerate output when `AITER_SITUV2_A8W4=1` is set without
`VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4=1`:

```
2 + 2 =                    ->  ' 0. 4. 0. 0. 4'
The capital of France is   ->  ' the 4. The (B. 1'
```

No error, no warning. Full report and root-cause confirmation in #52442.

Two separately named env vars have to agree here:

| env var | layer | effect |
|---|---|---|
| `AITER_SITUV2_A8W4` | aiter | `q_dtype_a=fp8` → selects the afp8 `_gui_` gate/up **interleave** FlyDSL SiTU kernel |
| `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4` | vLLM | `guinterleave=True` weight **shuffle** in `oracle/mxfp4.py` + `gate_mode=INTERLEAVE` in `rocm_aiter_moe.py` |

Set only the aiter one and the interleave kernel reads separated-layout weights.
Confirmed by instrumenting `aiter.fused_moe.fused_moe`: the call arrives with
`gate_mode=separated` while aiter has already picked the afp8 `_gui_` kernel.

The kernel itself is correct — an isolated harness on real K3 experts gives cos 0.9991
for afp8-gui vs abf16-separated vs torch reference. This is purely the layout mismatch.

## The fix

`is_fused_moe_situv2_a8w4_enabled()` now derives from **either** var, via a new
`_situv2_a8w4_enabled()` helper, so the shuffle can never disagree with the kernel aiter
picks. It warns once when it had to infer the layout from the aiter var.

| `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4` | `AITER_SITUV2_A8W4` | before | after |
|---|---|---|---|
| 1 | 1 | works | unchanged |
| 1 | unset | works (this is the [official recipe's](https://recipes.vllm.ai/moonshotai/Kimi-K3?hardware=mi355x) `amd.extra_env`) | unchanged |
| 0 | 1 | **silent garbage** | works, warns once |
| 0 | unset | a16w4 default | unchanged |

Only the row that was guaranteed garbage changes behaviour. Nothing that worked before
is touched.

Reading the env var stays out of the hot path: it is read once at import into
`_MOE_SITUV2_A8W4`, exactly like the other flags, and again in `refresh_env_variables()`.

## Why derive rather than error out

Both were offered in #52442. Deriving is the one that keeps existing working configs
working — and it is also what the recipe page suggests people will hit, since its prose
note for `AMD (MI355X / MI350X, CDNA4 gfx950)` mentions only `AITER_SITUV2_A8W4`, while
its `amd.extra_env` block sets only `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4`. Each half
names one of the two flags; following the prose alone lands exactly in the failure.

## Test

`test_aiter_moe_situv2_a8w4_follows_both_env_vars` covers all four flag combinations, in
the same style as the existing `test_aiter_moe_enablement_follows_env` /
`test_aiter_moe_shared_experts_enablement_follows_env`.

Verified the helper's decision table for all combinations including `"true"` and unknown
values. The correctness of the a8w4 path itself was verified on 8×MI350X: with the
interleaved layout matched, K3 is correct and reaches 2954 tok/s @ N=256 aggregate.

Env: `vllm/vllm-openai-rocm:nightly`, ROCm 7.2.3, 8×MI350X (gfx950), Kimi-K3 mxfp4,
`--tensor-parallel-size 8 --kv-cache-dtype fp8`.

Fixes #52442

cc @hongxiayang @tjtanaa @vllmellm
