### PR TITLE
[Core][Perf] Pass shard index bounds as module buffers in VocabParallelEmbedding

### DIFF
--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -175,11 +175,11 @@ class VocabParallelEmbeddingShardIndices:
 @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
 def get_masked_input_and_mask(
     input_: torch.Tensor,
-    org_vocab_start_index: int,
-    org_vocab_end_index: int,
-    num_org_vocab_padding: int,
-    added_vocab_start_index: int,
-    added_vocab_end_index: int,
+    org_vocab_start_index: int | torch.Tensor,
+    org_vocab_end_index: int | torch.Tensor,
+    num_org_vocab_padding: int | torch.Tensor,
+    added_vocab_start_index: int | torch.Tensor,
+    added_vocab_end_index: int | torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # torch.compile will fuse all of the pointwise ops below
     # into a single kernel, making it very fast
@@ -355,6 +355,42 @@ class VocabParallelEmbedding(PluggableLayer):
             params_dtype=params_dtype,
             weight_loader=self.weight_loader,
         )
+        self.register_buffer(
+            "org_vocab_start_index",
+            torch.tensor(
+                self.shard_indices.org_vocab_start_index, dtype=torch.int64
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "org_vocab_end_index",
+            torch.tensor(
+                self.shard_indices.org_vocab_end_index, dtype=torch.int64
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "num_org_vocab_padding",
+            torch.tensor(
+                self.shard_indices.num_org_vocab_padding, dtype=torch.int64
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "added_vocab_start_index",
+            torch.tensor(
+                self.shard_indices.added_vocab_start_index,
+                dtype=torch.int64,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "added_vocab_end_index",
+            torch.tensor(
+                self.shard_indices.added_vocab_end_index, dtype=torch.int64
+            ),
+            persistent=False,
+        )
         self.update_param_tp_status()
 
     def update_param_tp_status(self):
@@ -528,11 +564,11 @@ class VocabParallelEmbedding(PluggableLayer):
         else:
             masked_input, input_mask = get_masked_input_and_mask(
                 input_,
-                self.shard_indices.org_vocab_start_index,
-                self.shard_indices.org_vocab_end_index,
-                self.shard_indices.num_org_vocab_padding,
-                self.shard_indices.added_vocab_start_index,
-                self.shard_indices.added_vocab_end_index,
+                self.org_vocab_start_index,
+                self.org_vocab_end_index,
+                self.num_org_vocab_padding,
+                self.added_vocab_start_index,
+                self.added_vocab_end_index,
             )
             output_parallel = self.quant_method.embedding(self, masked_input.long())
             if output_parallel.dtype in (


### PR DESCRIPTION



## Purpose

When `get_masked_input_and_mask` in `VocabParallelEmbedding` accepts Python int scalar bounds, graph compilers and torch.compile specialize on the rank-specific integer literals. This bakes rank-specific constants into the traced computation graph, causing:
1. Compilation cache misses across tensor parallel (TP) ranks.
2. Redundant per-rank Triton JIT compilation passes during startup / warmup.

This change registers the rank shard index boundaries as non-persistent tensor buffers on VocabParallelEmbedding, and passes them to get_masked_input_and_mask. This ensures the graph topology and compilation cache keys are rank-invariant across all TP ranks, allowing all ranks to share the same compiled kernel and compilation cache.

## Test Plan

Ran qwen3.5-397b with this path, and makes sure the generated `computation_graph.py` are consistent across ranks.

## Test Result

computation_graph.py` are identical across all 8 ranks.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

