### PR TITLE
[CI] Run the 16 root-level tests that no step collects

### DIFF
--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -25,8 +25,42 @@ steps:
   - tests/test_vllm_port
   - tests/jit_monitor/test_hooks.py
   - tests/jit_monitor/test_hooks_gpu.py
+  - tests/test_access_log_filter.py
+  - tests/test_attention_backend_registry.py
+  - tests/test_audio_media_size_precheck.py
+  - tests/test_cmake_utils.py
+  - tests/test_connections.py
+  - tests/test_embedded_commit.py
+  - tests/test_force_first_config.py
+  - tests/test_fxgraphcache_pickle_patch.py
+  - tests/test_quantization_revision_pin.py
+  - tests/test_ray_env_utils.py
+  - tests/test_request_input_bounds.py
+  - tests/test_scalartype.py
+  - tests/test_tensorizer_revision_pin.py
+  - tests/test_triton_utils.py
+  - tests/test_version.py
+  - tests/test_zen_cpu_platform_detection.py
   commands:
   - pytest -v -s engine test_sequence.py test_config.py test_logger.py test_vllm_port.py jit_monitor/test_hooks.py jit_monitor/test_hooks_gpu.py
+  - >-
+    pytest -v -s
+    test_access_log_filter.py
+    test_attention_backend_registry.py
+    test_audio_media_size_precheck.py
+    test_cmake_utils.py
+    test_connections.py
+    test_embedded_commit.py
+    test_force_first_config.py
+    test_fxgraphcache_pickle_patch.py
+    test_quantization_revision_pin.py
+    test_ray_env_utils.py
+    test_request_input_bounds.py
+    test_scalartype.py
+    test_tensorizer_revision_pin.py
+    test_triton_utils.py
+    test_version.py
+    test_zen_cpu_platform_detection.py
   mirror:
     amd:
       label: ":amd: (MI300) Engine Core"


### PR DESCRIPTION
## Purpose

`tests/` has 27 root-level `test_*.py` files. 11 are named by a Buildkite step. The other 16 are not referenced anywhere under `.buildkite/` or `.github/`, and there is no catch-all — every `pytest` line in the CI config names explicit paths, so nothing sweeps the `tests/` root. Those 16 have never run in CI. The oldest landed in May 2025.

```
test_access_log_filter.py             test_quantization_revision_pin.py
test_attention_backend_registry.py    test_ray_env_utils.py
test_audio_media_size_precheck.py     test_request_input_bounds.py
test_cmake_utils.py                   test_scalartype.py
test_connections.py                   test_tensorizer_revision_pin.py
test_embedded_commit.py               test_triton_utils.py
test_force_first_config.py            test_version.py
test_fxgraphcache_pickle_patch.py     test_zen_cpu_platform_detection.py
```

This collects them in the Engine Core step, which is already where the root-level files live (`test_sequence.py`, `test_config.py`, `test_logger.py`, `test_vllm_port.py`). Happy to split them across areas instead if you'd prefer — a few would sit more precisely under attention/entrypoints/multimodal.

## Test Plan

I can't do a full CUDA build here, so I ran each file against a `VLLM_TARGET_DEVICE=empty` install with `--noconftest` (the root `conftest.py` pulls in fixtures that need a compiled vLLM):

```
pytest <file> -q --no-header --noconftest
```

## Test Result

13 files pass, 96 tests:

```
test_access_log_filter.py             19 passed
test_attention_backend_registry.py     4 passed
test_audio_media_size_precheck.py      6 passed
test_connections.py                    5 passed
test_embedded_commit.py                1 passed
test_fxgraphcache_pickle_patch.py      7 passed
test_quantization_revision_pin.py      1 passed
test_ray_env_utils.py                  7 passed
test_request_input_bounds.py          22 passed
test_scalartype.py                    12 passed
test_tensorizer_revision_pin.py        1 passed
test_triton_utils.py                  11 passed
test_zen_cpu_platform_detection.py     5 passed
```

The other 3 need a real build; each failure is environmental, not the test:

| file | local | cause |
| --- | --- | --- |
| `test_cmake_utils.py` | 3 failed | `FileNotFoundError: 'cmake'` — no cmake on the box |
| `test_version.py` | 6 failed | asserts `__version_tuple__[0] == 0`; my editable install has no real version metadata |
| `test_force_first_config.py` | skipped | module-level `pytest.skip` on `HAS_TRITON`, which is false without a device build. The body is all mocks (`SimpleNamespace` autotuner, monkeypatched installer), so it won't touch a GPU once it runs |

CI is the real check on those three. Runtime for all 16 was ~80s locally, against a 30 min step budget.
