### PR TITLE
[Feature] Add request-static YaRN profiles for mRoPE

### DIFF
--- a/docs/features/context_extension.md
+++ b/docs/features/context_extension.md
@@ -68,3 +68,35 @@ The following parameters are specific to vLLM:
 
 - `max_model_len`: The new maximum sequence length after extension (original * factor).
   Used for KV cache pre‑allocation and request limit at serving time.
+
+## Request-static YaRN
+
+Static YaRN applies the configured factor to every request, including requests
+inside the model's native context window. For mRoPE models, vLLM can instead
+precompute several immutable YaRN tables and select one when each request is
+admitted:
+
+```bash
+vllm serve Qwen/Qwen3.8-27B \
+  --hf-overrides '{"text_config":{"rope_parameters":{"factor":4.0,"original_max_position_embeddings":262144,"rope_theta":10000000,"rope_type":"yarn","mrope_section":[11,11,10],"mrope_interleaved":true,"partial_rotary_factor":0.25}}}' \
+  --request-static-yarn-factors 1 2 4 \
+  --max-model-len 1000000
+```
+
+The selected factor is the smallest configured factor that covers
+`prompt_tokens + max_tokens`. It remains fixed for the request lifetime, so
+cached keys never require cross-factor conversion. Prefix-cache block hashes
+and LMCache request tags include the complete RoPE profile identity, preventing
+cross-profile cache reuse.
+
+Completed request counts are exposed as:
+
+```text
+vllm:request_static_yarn_factor_total{factor="1",...}
+vllm:request_static_yarn_factor_total{factor="2",...}
+vllm:request_static_yarn_factor_total{factor="4",...}
+```
+
+The factors must be sorted and unique, and the largest value must equal the
+`factor` in `rope_parameters`. Request-static YaRN currently requires mRoPE and
+does not support resumable requests.

--- a/tests/config/test_rope.py
+++ b/tests/config/test_rope.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config.rope import RequestStaticYarnConfig
+
+
+def make_hf_config(**overrides):
+    rope_parameters = {
+        "rope_type": "yarn",
+        "factor": 4.0,
+        "original_max_position_embeddings": 262_144,
+        "rope_theta": 10_000_000,
+        "partial_rotary_factor": 0.25,
+        "mrope_section": [11, 11, 10],
+        "mrope_interleaved": True,
+        **overrides,
+    }
+    return SimpleNamespace(rope_parameters=rope_parameters)
+
+
+def test_request_static_yarn_profiles_are_stable_and_cover_boundaries():
+    hf_config = make_hf_config()
+
+    config = RequestStaticYarnConfig.from_hf_config([1.0, 2.0, 4.0], hf_config)
+
+    assert config is not None
+    assert config.factor_offsets == (
+        (1.0, 0),
+        (2.0, 1_048_576),
+        (4.0, 3_145_728),
+    )
+    assert config.select_factor(262_144) == 1.0
+    assert config.select_factor(262_145) == 2.0
+    assert config.select_factor(524_289) == 4.0
+    assert len({profile_id for _, profile_id in config.factor_profile_ids}) == 3
+
+    config.apply_to_hf_config(hf_config)
+    assert hf_config.rope_parameters["request_static_factors"] == [1.0, 2.0, 4.0]
+
+
+def test_request_static_yarn_profile_ids_depend_on_rope_parameters():
+    first = RequestStaticYarnConfig.from_hf_config([1.0, 4.0], make_hf_config())
+    second = RequestStaticYarnConfig.from_hf_config(
+        [1.0, 4.0], make_hf_config(rope_theta=1_000_000)
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first.profile_id_for_factor(1.0) != second.profile_id_for_factor(1.0)
+
+
+@pytest.mark.parametrize(
+    ("factors", "overrides", "match"),
+    [
+        ([2.0, 1.0], {}, "unique, and sorted"),
+        ([0.5, 4.0], {}, "at least 1"),
+        ([1.0, 2.0], {}, "largest request-static factor"),
+        ([1.0, 4.0], {"rope_type": "linear"}, "rope_type='yarn'"),
+    ],
+)
+def test_request_static_yarn_rejects_invalid_profiles(factors, overrides, match):
+    with pytest.raises(ValueError, match=match):
+        RequestStaticYarnConfig.from_hf_config(factors, make_hf_config(**overrides))
+
+
+def test_request_static_yarn_rejects_uncovered_budget():
+    config = RequestStaticYarnConfig.from_hf_config([1.0, 4.0], make_hf_config())
+    assert config is not None
+
+    with pytest.raises(ValueError, match="largest request-static YaRN profile"):
+        config.select_factor(1_048_577)

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -524,6 +524,14 @@ def test_composite_arg_parser(arg, expected, option):
     assert getattr(args, option.replace("-", "_")) == expected
 
 
+def test_request_static_yarn_factors_cli():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--request-static-yarn-factors", "1", "2", "4"])
+    engine_args = EngineArgs.from_cli_args(args=args)
+
+    assert engine_args.request_static_yarn_factors == [1.0, 2.0, 4.0]
+
+
 def test_human_readable_model_len():
     # `exit_on_error` disabled to test invalid values below
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser(exit_on_error=False))

--- a/tests/kernels/core/test_mrope.py
+++ b/tests/kernels/core/test_mrope.py
@@ -283,3 +283,81 @@ def test_mrope_torch_compile_tracing(
 
     except Exception as e:
         pytest.fail(f"forward_cuda failed to trace with torch.compile inductor: {e}")
+
+
+def test_request_static_yarn_mrope_profiles_match_static_references(
+    default_vllm_config,
+):
+    head_size = 64
+    original_max_position = 32
+    factors = [1.0, 2.0, 4.0]
+    common_parameters = {
+        "mrope_interleaved": True,
+        "mrope_section": [11, 11, 10],
+        "rope_type": "yarn",
+        "rope_theta": 10_000_000,
+        "partial_rotary_factor": 1.0,
+        "original_max_position_embeddings": original_max_position,
+    }
+    combined = get_rope(
+        head_size=head_size,
+        max_position=original_max_position * 4,
+        rope_parameters={
+            **common_parameters,
+            "factor": 4.0,
+            "request_static_factors": factors,
+        },
+        dtype=torch.float32,
+    )
+    assert combined.scaling_factor_to_offset == {
+        1.0: 0,
+        2.0: 128,
+        4.0: 384,
+    }
+
+    positions, query, key = generate_test_data(
+        num_tokens=7,
+        num_q_heads=2,
+        num_kv_heads=1,
+        head_size=head_size,
+        max_position_embeddings=original_max_position * 4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    native_parameters = dict(common_parameters)
+    native_parameters["rope_type"] = "default"
+    native_parameters.pop("original_max_position_embeddings")
+    native = get_rope(
+        head_size=head_size,
+        max_position=original_max_position,
+        rope_parameters=native_parameters,
+        dtype=torch.float32,
+    )
+    native_query, native_key = native.forward_native(
+        positions,
+        query.clone(),
+        key.clone(),
+    )
+    for factor in factors:
+        static = get_rope(
+            head_size=head_size,
+            max_position=int(original_max_position * factor),
+            rope_parameters={**common_parameters, "factor": factor},
+            dtype=torch.float32,
+        )
+        expected_query, expected_key = static.forward_native(
+            positions,
+            query.clone(),
+            key.clone(),
+        )
+        offset_positions = positions + combined.scaling_factor_to_offset[factor]
+        actual_query, actual_key = combined.forward_native(
+            offset_positions,
+            query.clone(),
+            key.clone(),
+        )
+        torch.testing.assert_close(actual_query, expected_query, rtol=0, atol=0)
+        torch.testing.assert_close(actual_key, expected_key, rtol=0, atol=0)
+        if factor == 1.0:
+            torch.testing.assert_close(expected_query, native_query, rtol=0, atol=0)
+            torch.testing.assert_close(expected_key, native_key, rtol=0, atol=0)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -88,6 +88,7 @@ def make_request(
     mm_positions: list[PlaceholderRange] | None = None,
     mm_hashes: list[str] | None = None,
     cache_salt: str | None = None,
+    rope_profile_id: str | None = None,
     prompt_embeds: torch.Tensor | None = None,
 ):
     mm_features = []
@@ -113,6 +114,7 @@ def make_request(
         pooling_params=None,
         lora_request=None,
         cache_salt=cache_salt,
+        rope_profile_id=rope_profile_id,
         block_hasher=get_request_block_hasher(block_size, hash_fn),
         prompt_embeds=prompt_embeds,
     )
@@ -652,6 +654,20 @@ def test_generate_block_hash_extra_keys_cache_salt():
     extra_keys, next_mm_idx = generate_block_hash_extra_keys(request_mm, 0, 5, 0)
     assert extra_keys == (("hash1", 0), "salt")
     assert next_mm_idx == 1
+
+
+def test_generate_block_hash_extra_keys_rope_profile():
+    request = make_request(
+        request_id="0",
+        prompt_token_ids=list(range(6)),
+        rope_profile_id="yarn:factor-2",
+    )
+
+    extra_keys, _ = generate_block_hash_extra_keys(request, 0, 3, 0)
+    assert extra_keys == (("rope_profile", "yarn:factor-2"),)
+
+    extra_keys, _ = generate_block_hash_extra_keys(request, 3, 6, 0)
+    assert extra_keys is None
 
 
 def test_generate_block_hash_extra_keys_prompt_embeds():

--- a/tests/v1/kv_connector/unit/test_lmcache_integration.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_integration.py
@@ -159,6 +159,7 @@ def test_request_interface():
     assumes(req, "sampling_params")
     assumes(req, "num_tokens")
     assumes(req, "kv_transfer_params", is_instance_of=(dict, NoneType))
+    assumes(req, "rope_profile_id", is_instance_of=(str, NoneType))
 
     from vllm.multimodal.inputs import MultiModalFeatureSpec
 
@@ -174,6 +175,7 @@ def test_new_request_interface():
     assumes(NewRequestData, "block_ids")
     assumes(NewRequestData, "prompt_token_ids")
     assumes(NewRequestData, "sampling_params")
+    assumes(NewRequestData, "rope_profile_id")
 
 
 def test_sampling_params_interface():
@@ -191,6 +193,20 @@ def test_sampling_params_interface():
         extra_args={"kv_transfer_params": kv_transfer_params}
     )
     assert sampling_params.extra_args["kv_transfer_params"] == kv_transfer_params
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_request_config import (
+        extract_request_configs,
+    )
+
+    assert extract_request_configs(None, "yarn:factor-2") == {
+        "lmcache.tag.rope_profile": "yarn:factor-2"
+    }
+    assert extract_request_configs(SamplingParams(), "yarn:factor-2") == {
+        "lmcache.tag.rope_profile": "yarn:factor-2"
+    }
+    assert extract_request_configs(sampling_params, "yarn:factor-2") == {
+        **kv_transfer_params,
+        "lmcache.tag.rope_profile": "yarn:factor-2",
+    }
 
 
 def test_tp_interface():

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -75,12 +75,14 @@ def test_prefill_kv_computed_with_cache():
         max_tokens_param=100,
         req_stats=req_stats,
         num_cached_tokens=1200,
+        rope_profile_factor=2.0,
     )
 
     finished_req = iteration_stats.finished_requests[0]
     assert finished_req.num_prompt_tokens == 10000
     assert finished_req.num_cached_tokens == 1200
     assert finished_req.request_id == "test-req-001"
+    assert finished_req.rope_profile_factor == 2.0
 
     # Verify calculation: prefill KV = prompt tokens - cached tokens
     prefill_kv_computed = finished_req.num_prompt_tokens - max(

--- a/tests/v1/worker/test_gpu_input_batch_v2.py
+++ b/tests/v1/worker/test_gpu_input_batch_v2.py
@@ -6,7 +6,12 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
-from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+from vllm.v1.worker.gpu.input_batch import (
+    InputBatch,
+    InputBuffers,
+    prepare_pos_seq_lens,
+)
+from vllm.v1.worker.gpu.mm.rope import RopeState
 
 DEVICE = current_platform.device_type
 
@@ -51,3 +56,69 @@ def test_make_dummy_distributes_remainder(num_reqs: int, num_tokens: int):
     assert torch.equal(
         batch.query_start_loc.cpu(), torch.from_numpy(batch.query_start_loc_np)
     )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="Requires a CUDA-like device"
+)
+def test_prepare_pos_seq_lens_separates_physical_and_rope_positions():
+    device = torch.device(DEVICE)
+    idx_mapping = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 3, 5], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.tensor([20, 10], dtype=torch.int32, device=device)
+    rope_offsets = torch.tensor([200, 100], dtype=torch.int64, device=device)
+    positions = torch.empty(5, dtype=torch.int64, device=device)
+    rope_positions = torch.empty_like(positions)
+    seq_lens = torch.empty(4, dtype=torch.int32, device=device)
+
+    prepare_pos_seq_lens(
+        idx_mapping,
+        query_start_loc,
+        num_computed_tokens,
+        positions,
+        seq_lens,
+        rope_positions,
+        rope_offsets,
+    )
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(positions.cpu(), torch.tensor([10, 11, 12, 20, 21]))
+    torch.testing.assert_close(
+        rope_positions.cpu(), torch.tensor([110, 111, 112, 220, 221])
+    )
+    torch.testing.assert_close(
+        seq_lens.cpu(), torch.tensor([13, 22, 0, 0], dtype=torch.int32)
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="Requires a CUDA-like device"
+)
+def test_rope_state_applies_request_static_offsets():
+    device = torch.device(DEVICE)
+    state = RopeState(
+        num_dims=3,
+        has_delta=True,
+        max_num_reqs=2,
+        max_num_tokens=5,
+        max_model_len=32,
+        device=device,
+    )
+    state.prefill_delta.gpu.zero_()
+    idx_mapping = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 3, 5], dtype=torch.int32, device=device)
+    prefill_lens = torch.zeros(2, dtype=torch.int32, device=device)
+    num_computed_tokens = torch.tensor([20, 10], dtype=torch.int32, device=device)
+    rope_offsets = torch.tensor([200, 100], dtype=torch.int64, device=device)
+
+    state.prepare_positions(
+        idx_mapping,
+        query_start_loc,
+        prefill_lens,
+        num_computed_tokens,
+        rope_offsets,
+    )
+    torch.accelerator.synchronize()
+
+    expected = torch.tensor([110, 111, 112, 220, 221]).expand(3, -1)
+    torch.testing.assert_close(state.get_positions(5).cpu(), expected)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -23,6 +23,7 @@ from vllm.config.multimodal import (
 )
 from vllm.config.pooler import POOLER_CONFIG_LOG_FIELDS, PoolerConfig
 from vllm.config.quantization import QuantizationConfigArgs
+from vllm.config.rope import RequestStaticYarnConfig
 from vllm.config.scheduler import RunnerType
 from vllm.config.utils import config, getattr_iter
 from vllm.logger import init_logger
@@ -224,6 +225,13 @@ class ModelConfig:
     - -1 or 'auto' -> Automatically choose the maximum model length that fits in
       GPU memory. This will use the model's maximum context length if it fits,
       otherwise it will find the largest length that can be accommodated."""
+    request_static_yarn_factors: list[float] | None = None
+    """Sorted YaRN factors to precompute and select per request from its
+    admitted prompt-plus-output token budget. Currently requires mRoPE."""
+    request_static_yarn_config: RequestStaticYarnConfig | None = field(
+        default=None, init=False
+    )
+    """Validated runtime state for request-static YaRN."""
     spec_target_max_model_len: int | None = None
     """Specify the maximum length for spec decoding draft models."""
     quantization: QuantizationMethods | str | None = None
@@ -446,6 +454,7 @@ class ModelConfig:
             "config_format",
             "hf_token",
             "hf_overrides",
+            "request_static_yarn_config",
             "logits_processors",
             "io_processor_plugin",
             "pooler_config",
@@ -635,6 +644,12 @@ class ModelConfig:
         if dict_overrides:
             self._apply_dict_overrides(hf_config, dict_overrides)
         self.hf_text_config = get_hf_text_config(self.hf_config)
+        self.request_static_yarn_config = RequestStaticYarnConfig.from_hf_config(
+            self.request_static_yarn_factors,
+            self.hf_text_config,
+        )
+        if self.request_static_yarn_config is not None:
+            self.request_static_yarn_config.apply_to_hf_config(self.hf_text_config)
         self.model_arch_config = self.get_model_arch_config()
         self.attention_chunk_size = getattr(
             self.hf_text_config, "attention_chunk_size", None

--- a/vllm/config/rope.py
+++ b/vllm/config/rope.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RequestStaticYarnConfig:
+    """Validated immutable YaRN profiles selected per request."""
+
+    factors: tuple[float, ...]
+    original_max_position: int
+    factor_offsets: tuple[tuple[float, int], ...]
+    factor_profile_ids: tuple[tuple[float, str], ...]
+
+    @classmethod
+    def from_hf_config(
+        cls,
+        factors: list[float] | tuple[float, ...] | None,
+        hf_text_config: Any,
+    ) -> "RequestStaticYarnConfig | None":
+        if factors is None:
+            return None
+
+        normalized = tuple(float(factor) for factor in factors)
+        if not normalized or normalized != tuple(sorted(set(normalized))):
+            raise ValueError(
+                "Request-static YaRN factors must be non-empty, unique, and sorted"
+            )
+        if any(factor < 1.0 for factor in normalized):
+            raise ValueError("Request-static YaRN factors must be at least 1")
+
+        rope_parameters = getattr(hf_text_config, "rope_parameters", None)
+        if not isinstance(rope_parameters, dict):
+            raise ValueError("Request-static YaRN requires one RoPE parameter mapping")
+        if rope_parameters.get("rope_type") != "yarn":
+            raise ValueError("Request-static YaRN requires rope_type='yarn'")
+        if "mrope_section" not in rope_parameters:
+            raise ValueError("Request-static YaRN currently requires mRoPE")
+
+        configured_factor = float(rope_parameters["factor"])
+        if configured_factor != normalized[-1]:
+            raise ValueError(
+                "The configured YaRN factor must equal the largest request-static "
+                f"factor ({normalized[-1]:g})"
+            )
+
+        original_max_position = int(rope_parameters["original_max_position_embeddings"])
+        offsets: list[tuple[float, int]] = []
+        profiles: list[tuple[float, str]] = []
+        offset = 0
+        for factor in normalized:
+            cache_rows = 4 * original_max_position * factor
+            if not cache_rows.is_integer():
+                raise ValueError(
+                    f"Request-static YaRN factor {factor:g} produces a fractional "
+                    "mRoPE cache size"
+                )
+            offsets.append((factor, offset))
+            offset += int(cache_rows)
+
+            profile_parameters = dict(rope_parameters)
+            profile_parameters["factor"] = factor
+            profile_parameters.pop("request_static_factors", None)
+            canonical = json.dumps(
+                profile_parameters,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            digest = hashlib.sha256(canonical.encode()).hexdigest()
+            profiles.append((factor, f"yarn:{digest}"))
+
+        return cls(
+            factors=normalized,
+            original_max_position=original_max_position,
+            factor_offsets=tuple(offsets),
+            factor_profile_ids=tuple(profiles),
+        )
+
+    def apply_to_hf_config(self, hf_text_config: Any) -> None:
+        hf_text_config.rope_parameters["request_static_factors"] = list(self.factors)
+
+    def select_factor(self, required_tokens: int) -> float:
+        for factor in self.factors:
+            if required_tokens <= self.original_max_position * factor:
+                return factor
+        raise ValueError(
+            f"Request needs {required_tokens} tokens, but the largest "
+            "request-static YaRN profile covers "
+            f"{self.original_max_position * self.factors[-1]:g}"
+        )
+
+    def offset_for_factor(self, factor: float) -> int:
+        for candidate, offset in self.factor_offsets:
+            if candidate == factor:
+                return offset
+        raise ValueError(f"Unknown request-static YaRN factor: {factor:g}")
+
+    def profile_id_for_factor(self, factor: float) -> str:
+        for candidate, profile_id in self.factor_profile_ids:
+            if candidate == factor:
+                return profile_id
+        raise ValueError(f"Unknown request-static YaRN factor: {factor:g}")

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -49,8 +49,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_integration.utils impo
     lmcache_get_or_create_config,
     mla_enabled,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_request_config import (
+    extract_request_configs,
+)
 from vllm.distributed.parallel_state import get_tensor_model_parallel_rank, get_tp_group
-from vllm.sampling_params import SamplingParams
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import get_kv_cache_torch_dtype
 from vllm.v1.attention.backend import AttentionMetadata
@@ -97,24 +99,6 @@ class DisaggSpec:
 
 
 tmp_disagg_tracker: dict[str, DisaggSpec] = {}
-
-
-def extract_request_configs(sampling_params: SamplingParams) -> dict | None:
-    request_configs = None
-    if (
-        sampling_params.extra_args is not None
-        and "kv_transfer_params" in sampling_params.extra_args
-    ):
-        kv_transfer_params = sampling_params.extra_args.get("kv_transfer_params")
-        if kv_transfer_params is None:
-            return None
-        assert isinstance(kv_transfer_params, dict)
-        for k, v in kv_transfer_params.items():
-            if k.startswith("lmcache."):
-                if request_configs is None:
-                    request_configs = {}
-                request_configs[k] = v
-    return request_configs
 
 
 @dataclass
@@ -190,10 +174,10 @@ class RequestTracker:
         # NOTE: Initialized in `update_state_after_alloc`
         disagg_spec = tmp_disagg_tracker.pop(new_request.req_id, None)
 
-        if new_request.sampling_params:
-            request_configs = extract_request_configs(new_request.sampling_params)
-        else:
-            request_configs = None
+        request_configs = extract_request_configs(
+            new_request.sampling_params,
+            new_request.rope_profile_id,
+        )
 
         mm_hashes, mm_positions = extract_mm_features(new_request, modify=True)
 
@@ -1179,10 +1163,10 @@ class LMCacheConnectorV1Impl:
             apply_mm_hashes_to_token_ids(token_ids_tensor, mm_hashes, mm_positions)
             token_ids = token_ids_tensor.tolist()
 
-        if request.sampling_params:
-            request_configs = extract_request_configs(request.sampling_params)
-        else:
-            request_configs = None
+        request_configs = extract_request_configs(
+            request.sampling_params,
+            request.rope_profile_id,
+        )
 
         if self.skip_last_n_tokens > 0:
             assert token_ids is not None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_request_config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_request_config.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.sampling_params import SamplingParams
+
+
+def extract_request_configs(
+    sampling_params: SamplingParams | None,
+    rope_profile_id: str | None = None,
+) -> dict | None:
+    request_configs = None
+    if (
+        sampling_params is not None
+        and sampling_params.extra_args is not None
+        and "kv_transfer_params" in sampling_params.extra_args
+    ):
+        kv_transfer_params = sampling_params.extra_args.get("kv_transfer_params")
+        if kv_transfer_params is not None:
+            assert isinstance(kv_transfer_params, dict)
+            for key, value in kv_transfer_params.items():
+                if key.startswith("lmcache."):
+                    if request_configs is None:
+                        request_configs = {}
+                    request_configs[key] = value
+    if rope_profile_id is not None:
+        if request_configs is None:
+            request_configs = {}
+        request_configs["lmcache.tag.rope_profile"] = rope_profile_id
+    return request_configs

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -452,6 +452,9 @@ class EngineArgs:
     kv_cache_dtype: CacheDType = CacheConfig.cache_dtype
     seed: int = ModelConfig.seed
     max_model_len: int = ModelConfig.max_model_len
+    request_static_yarn_factors: list[float] | None = (
+        ModelConfig.request_static_yarn_factors
+    )
     cudagraph_capture_sizes: list[int] | None = (
         CompilationConfig.cudagraph_capture_sizes
     )
@@ -876,6 +879,10 @@ class EngineArgs:
             "--tokenizer-revision", **model_kwargs["tokenizer_revision"]
         )
         model_group.add_argument("--max-model-len", **model_kwargs["max_model_len"])
+        model_group.add_argument(
+            "--request-static-yarn-factors",
+            **model_kwargs["request_static_yarn_factors"],
+        )
         model_group.add_argument("--quantization", "-q", **model_kwargs["quantization"])
         model_group.add_argument(
             "--quantization-config", **model_kwargs["quantization_config"]
@@ -1789,6 +1796,7 @@ class EngineArgs:
             model_class_overrides=self.model_class_overrides,
             tokenizer_revision=self.tokenizer_revision,
             max_model_len=self.max_model_len,
+            request_static_yarn_factors=self.request_static_yarn_factors,
             quantization=self.quantization,
             quantization_config=self.quantization_config,
             allow_deprecated_quantization=self.allow_deprecated_quantization,

--- a/vllm/model_executor/layers/rotary_embedding/__init__.py
+++ b/vllm/model_executor/layers/rotary_embedding/__init__.py
@@ -241,7 +241,8 @@ def get_rope(
             xdrope_section=rope_parameters["xdrope_section"],
         )
     elif scaling_type == "yarn":
-        scaling_factor = rope_parameters["factor"]
+        request_static_factors = rope_parameters.get("request_static_factors")
+        scaling_factor = request_static_factors or rope_parameters["factor"]
         original_max_position = rope_parameters["original_max_position_embeddings"]
         extra_kwargs = {
             k: v

--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -251,14 +251,28 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
         mrope_interleaved: bool = False,
         # YaRN parameters.
         *,
-        scaling_factor: float | None = None,
+        scaling_factor: float | list[float] | tuple[float, ...] | None = None,
         extrapolation_factor: float = 1,
         attn_factor: float = 1,
         beta_fast: int = 32,
         beta_slow: int = 1,
         truncate: bool = True,
     ) -> None:
-        self.scaling_factor = scaling_factor
+        self.scaling_factor: float | None
+
+        if isinstance(scaling_factor, (list, tuple)):
+            factors = tuple(float(factor) for factor in scaling_factor)
+            if not factors or factors != tuple(sorted(set(factors))):
+                raise ValueError(
+                    "Request-static YaRN factors must be non-empty, unique, and sorted"
+                )
+            if any(factor < 1.0 for factor in factors):
+                raise ValueError("Request-static YaRN factors must be at least 1")
+            self.scaling_factors: tuple[float, ...] | None = factors
+            self.scaling_factor = factors[-1]
+        else:
+            self.scaling_factors = None
+            self.scaling_factor = scaling_factor
         self.extrapolation_factor = extrapolation_factor
         self.attn_factor = attn_factor
         self.beta_fast = beta_fast
@@ -294,9 +308,31 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
         return YaRNScalingRotaryEmbedding._compute_inv_freq(self, base)
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
-        if self.scaling_factor is None:
-            return super()._compute_cos_sin_cache()
-        return YaRNScalingRotaryEmbedding._compute_cos_sin_cache(self)
+        if self.scaling_factors is None:
+            if self.scaling_factor is None:
+                return super()._compute_cos_sin_cache()
+            return YaRNScalingRotaryEmbedding._compute_cos_sin_cache(self)
+
+        caches = []
+        offsets: dict[float, int] = {}
+        offset = 0
+        for factor in self.scaling_factors:
+            self.scaling_factor = factor
+            self.mscale = float(yarn_get_mscale(factor) * self.attn_factor)
+            cache = YaRNScalingRotaryEmbedding._compute_cos_sin_cache(self)
+            offsets[factor] = offset
+            caches.append(cache)
+            offset += cache.shape[0]
+        self.scaling_factor = self.scaling_factors[-1]
+        self.mscale = float(yarn_get_mscale(self.scaling_factor) * self.attn_factor)
+        self._scaling_factor_to_offset = offsets
+        return torch.cat(caches, dim=0)
+
+    @property
+    def scaling_factor_to_offset(self) -> dict[float, int]:
+        if self.scaling_factors is None:
+            raise AttributeError("This mRoPE instance has one scaling factor")
+        return self._scaling_factor_to_offset
 
     def forward_native(
         self,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -604,12 +604,21 @@ def generate_block_hash_extra_keys(
     cache_salt_keys: list[str] = (
         [request.cache_salt] if (start_token_idx == 0 and request.cache_salt) else []
     )
+    rope_profile_keys: list[tuple[str, str]] = (
+        [("rope_profile", request.rope_profile_id)]
+        if start_token_idx == 0 and request.rope_profile_id is not None
+        else []
+    )
     prompt_embeds_keys = _gen_prompt_embeds_extra_hash_keys(
         request, start_token_idx, end_token_idx
     )
 
     extra_keys: list[Any] = (
-        lora_extra_keys + mm_extra_keys + cache_salt_keys + prompt_embeds_keys
+        lora_extra_keys
+        + mm_extra_keys
+        + cache_salt_keys
+        + rope_profile_keys
+        + prompt_embeds_keys
     )
 
     if not extra_keys:

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -44,6 +44,8 @@ class NewRequestData:
     lora_request: LoRARequest | None
     prompt_embeds: "torch.Tensor | None" = None
     prompt_is_token_ids: list[bool] | None = None
+    rope_profile_factor: float | None = None
+    rope_profile_id: str | None = None
 
     # Only used for v2 model runner.
     prefill_token_ids: list[int] | None = None
@@ -73,6 +75,8 @@ class NewRequestData:
             lora_request=request.lora_request,
             prompt_embeds=request.prompt_embeds,
             prompt_is_token_ids=request.prompt_is_token_ids,
+            rope_profile_factor=request.rope_profile_factor,
+            rope_profile_id=request.rope_profile_id,
             prefill_token_ids=prefill_token_ids,
         )
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -156,6 +156,8 @@ class EngineCoreRequest(
     abort_immediately: bool = False
 
     session_id: str | None = None
+    rope_profile_factor: float | None = None
+    rope_profile_id: str | None = None
 
     @property
     def params(self) -> SamplingParams | PoolingParams:

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -415,11 +415,38 @@ class InputProcessor:
                     )
                 )
 
+        rope_profile_factor = None
+        rope_profile_id = None
+        request_static_yarn = self.model_config.request_static_yarn_config
+        if request_static_yarn is not None:
+            if resumable:
+                raise VLLMValidationError(
+                    "Request-static YaRN does not yet support resumable requests"
+                )
+            prompt_len = length_from_prompt_token_ids_or_embeds(
+                prompt_token_ids, prompt_embeds
+            )
+            max_tokens = (
+                sampling_params.max_tokens if sampling_params is not None else 1
+            )
+            assert max_tokens is not None
+            try:
+                rope_profile_factor = request_static_yarn.select_factor(
+                    prompt_len + max_tokens
+                )
+            except ValueError as error:
+                raise VLLMValidationError(str(error)) from error
+            rope_profile_id = request_static_yarn.profile_id_for_factor(
+                rope_profile_factor
+            )
+
         return EngineCoreRequest(
             request_id=request_id,
             prompt_token_ids=prompt_token_ids,
             prompt_embeds=prompt_embeds,
             prompt_is_token_ids=prompt_is_token_ids,
+            rope_profile_factor=rope_profile_factor,
+            rope_profile_id=rope_profile_id,
             mm_features=mm_features,
             sampling_params=sampling_params,
             pooling_params=pooling_params,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -152,6 +152,7 @@ class RequestState:
         n: int | None = None,
         temperature: float | None = None,
         stream_input: bool = False,
+        rope_profile_factor: float | None = None,
     ):
         self.request_id = request_id
         self.external_req_id = external_req_id
@@ -172,6 +173,7 @@ class RequestState:
         self.top_p = top_p
         self.n = n
         self.temperature = temperature
+        self.rope_profile_factor = rope_profile_factor
         self.is_prefilling = True
         self.queue = queue
         self.num_cached_tokens = 0
@@ -278,6 +280,7 @@ class RequestState:
             log_stats=log_stats,
             stream_interval=stream_interval,
             stream_input=request.resumable,
+            rope_profile_factor=request.rope_profile_factor,
         )
 
     def make_request_output(
@@ -867,6 +870,7 @@ class OutputProcessor:
             max_tokens_param=req_state.max_tokens_param,
             req_stats=req_state.stats,
             num_cached_tokens=req_state.num_cached_tokens,
+            rope_profile_factor=req_state.rope_profile_factor,
         )
         self.lora_states.request_finished(req_state.request_id, req_state.lora_name)
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -724,6 +724,29 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 for idx in engine_indexes
             }
 
+        self.counter_request_static_yarn_factor: dict[float, dict[int, Counter]] = {}
+        request_static_yarn = vllm_config.model_config.request_static_yarn_config
+        if request_static_yarn is not None:
+            counter_request_static_yarn_factor = self._counter_cls(
+                name="vllm:request_static_yarn_factor",
+                documentation=(
+                    "Count of completed requests by selected request-static "
+                    "YaRN factor."
+                ),
+                labelnames=labelnames + ["factor"],
+            )
+            for factor in request_static_yarn.factors:
+                labelvalues_with_factor = {
+                    idx: labelvalues + [f"{factor:g}"]
+                    for idx, labelvalues in per_engine_labelvalues.items()
+                }
+                self.counter_request_static_yarn_factor[factor] = (
+                    create_metric_per_engine(
+                        counter_request_static_yarn_factor,
+                        labelvalues_with_factor,
+                    )
+                )
+
         #
         # Histograms of counts
         #
@@ -1232,6 +1255,10 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.counter_request_success[finished_request.finish_reason][
                 engine_idx
             ].inc()
+            if finished_request.rope_profile_factor is not None:
+                self.counter_request_static_yarn_factor[
+                    finished_request.rope_profile_factor
+                ][engine_idx].inc()
             self.histogram_e2e_time_request[engine_idx].observe(
                 finished_request.e2e_latency
             )

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -255,6 +255,7 @@ class FinishedRequestStats:
     mean_time_per_output_token: float = 0.0
     is_corrupted: bool = False
     num_cached_tokens: int = 0
+    rope_profile_factor: float | None = None
 
 
 @dataclass
@@ -536,6 +537,7 @@ class IterationStats:
         max_tokens_param: int | None,
         req_stats: RequestStateStats,
         num_cached_tokens: int = 0,
+        rope_profile_factor: float | None = None,
     ):
         e2e_latency = self._time_since(req_stats.arrival_time)
 
@@ -576,6 +578,7 @@ class IterationStats:
             mean_time_per_output_token=mean_time_per_output_token,
             is_corrupted=req_stats.is_corrupted,
             num_cached_tokens=num_cached_tokens,
+            rope_profile_factor=rope_profile_factor,
         )
         self.finished_requests.append(finished_req)
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -70,6 +70,8 @@ class Request:
         mm_features: list[MultiModalFeatureSpec] | None = None,
         lora_request: "LoRARequest | None" = None,
         cache_salt: str | None = None,
+        rope_profile_factor: float | None = None,
+        rope_profile_id: str | None = None,
         priority: int = 0,
         trace_headers: Mapping[str, str] | None = None,
         block_hasher: Callable[["Request"], list["BlockHash"]] | None = None,
@@ -181,6 +183,8 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
+        self.rope_profile_factor = rope_profile_factor
+        self.rope_profile_id = rope_profile_id
 
         # Multi-modal related
         self.mm_features = mm_features or []
@@ -252,6 +256,8 @@ class Request:
             arrival_time=request.arrival_time,
             lora_request=request.lora_request,
             cache_salt=request.cache_salt,
+            rope_profile_factor=request.rope_profile_factor,
+            rope_profile_id=request.rope_profile_id,
             priority=request.priority,
             trace_headers=request.trace_headers,
             block_hasher=block_hasher,

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -330,7 +330,10 @@ def _prepare_pos_seq_lens_kernel(
     idx_mapping_ptr,
     query_start_loc_ptr,
     num_computed_tokens_ptr,
+    rope_pos_ptr,
+    rope_position_offsets_ptr,
     max_num_reqs,
+    HAS_ROPE_POSITION_OFFSETS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     req_id = tl.program_id(0)
@@ -345,6 +348,9 @@ def _prepare_pos_seq_lens_kernel(
 
     req_state_idx = tl.load(idx_mapping_ptr + req_id)
     num_computed_tokens = tl.load(num_computed_tokens_ptr + req_state_idx)
+    rope_position_offset = 0
+    if HAS_ROPE_POSITION_OFFSETS:
+        rope_position_offset = tl.load(rope_position_offsets_ptr + req_state_idx)
 
     start = tl.load(query_start_loc_ptr + req_id)
     end = tl.load(query_start_loc_ptr + req_id + 1)
@@ -358,6 +364,12 @@ def _prepare_pos_seq_lens_kernel(
         mask = block < query_len
         pos = num_computed_tokens + block
         tl.store(pos_ptr + start + block, pos, mask=mask)
+        if HAS_ROPE_POSITION_OFFSETS:
+            tl.store(
+                rope_pos_ptr + start + block,
+                pos + rope_position_offset,
+                mask=mask,
+            )
 
 
 def prepare_pos_seq_lens(
@@ -366,7 +378,10 @@ def prepare_pos_seq_lens(
     num_computed_tokens: torch.Tensor,
     pos: torch.Tensor,
     seq_lens: torch.Tensor,
+    rope_pos: torch.Tensor | None = None,
+    rope_position_offsets: torch.Tensor | None = None,
 ) -> None:
+    assert (rope_pos is None) == (rope_position_offsets is None)
     num_reqs = idx_mapping.shape[0]
     # NOTE(woosuk): We do +1 because the last thread block is used
     # to pad unused seq_lens as 0 for full CUDA graphs.
@@ -376,8 +391,17 @@ def prepare_pos_seq_lens(
         idx_mapping,
         query_start_loc,
         num_computed_tokens,
+        rope_pos if rope_pos is not None else pos,
+        (
+            rope_position_offsets
+            if rope_position_offsets is not None
+            else num_computed_tokens
+        ),
         seq_lens.shape[0],
         BLOCK_SIZE=1024,
+        HAS_ROPE_POSITION_OFFSETS=(
+            rope_pos is not None and rope_position_offsets is not None
+        ),
     )
 
 

--- a/vllm/v1/worker/gpu/mm/rope.py
+++ b/vllm/v1/worker/gpu/mm/rope.py
@@ -113,6 +113,7 @@ class RopeState:
         query_start_loc: torch.Tensor,
         prefill_lens: torch.Tensor,
         num_computed_tokens: torch.Tensor,
+        rope_position_offsets: torch.Tensor | None = None,
     ) -> None:
         num_reqs = idx_mapping.shape[0]
         _prepare_rope_positions_kernel[(num_reqs,)](
@@ -126,8 +127,14 @@ class RopeState:
             query_start_loc,
             prefill_lens,
             num_computed_tokens,
+            (
+                rope_position_offsets
+                if rope_position_offsets is not None
+                else num_computed_tokens
+            ),
             BLOCK_SIZE=1024,
             NUM_DIMS=self.num_dims,
+            HAS_ROPE_POSITION_OFFSETS=rope_position_offsets is not None,
         )
 
 
@@ -175,11 +182,16 @@ def _prepare_rope_positions_kernel(
     query_start_loc_ptr,
     prefill_lens_ptr,
     num_computed_tokens_ptr,
+    rope_position_offsets_ptr,
     BLOCK_SIZE: tl.constexpr,
     NUM_DIMS: tl.constexpr,
+    HAS_ROPE_POSITION_OFFSETS: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + batch_idx)
+    rope_position_offset = 0
+    if HAS_ROPE_POSITION_OFFSETS:
+        rope_position_offset = tl.load(rope_position_offsets_ptr + req_state_idx)
 
     prefill_len = tl.load(prefill_lens_ptr + req_state_idx)
     num_computed = tl.load(num_computed_tokens_ptr + req_state_idx)
@@ -204,9 +216,10 @@ def _prepare_rope_positions_kernel(
                     + j * prefill_positions_stride1
                     + orig_pos,
                     mask=mask,
-                )
+                ).to(tl.int64)
             else:
-                pos = orig_pos + delta
+                pos = (orig_pos + delta).to(tl.int64)
+            pos += rope_position_offset
             tl.store(
                 positions_ptr + j * positions_stride + query_start + block,
                 pos,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -206,6 +206,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
         self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.is_encoder_decoder = self.model_config.is_encoder_decoder
+        self.request_static_yarn = self.model_config.request_static_yarn_config
 
         self.output_copy_stream = torch.cuda.Stream(self.device)
 
@@ -312,6 +313,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_num_tokens=self.max_num_tokens,
             device=self.device,
         )
+        self.request_static_yarn_model_positions: torch.Tensor | None = None
+        if self.request_static_yarn is not None:
+            self.request_static_yarn_model_positions = torch.zeros_like(
+                self.input_buffers.positions
+            )
         if self.use_pp:
             self.pp_handler = PPHandler(
                 max_num_reqs=self.max_num_reqs,
@@ -1034,12 +1040,30 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
             prompt_len = new_req_data.prompt_len
             sampling_params = new_req_data.sampling_params
+            max_tokens = sampling_params.max_tokens if sampling_params else 1
+            rope_position_offset = 0
+            assert max_tokens is not None
+
+            if self.request_static_yarn is not None:
+                factor = new_req_data.rope_profile_factor
+                assert factor is not None
+                rope_position_offset = self.request_static_yarn.offset_for_factor(
+                    factor
+                )
+                logger.debug(
+                    "Request %s selected request-static YaRN factor %g",
+                    req_id,
+                    factor,
+                )
+            else:
+                assert new_req_data.rope_profile_factor is None
             self.req_states.add_request(
                 req_id=req_id,
                 prompt_len=prompt_len,
                 all_token_ids=new_req_data.prefill_token_ids,
                 num_computed_tokens=new_req_data.num_computed_tokens,
-                max_tokens=sampling_params.max_tokens if sampling_params else 1,  # type: ignore[arg-type]
+                max_tokens=max_tokens,
+                rope_position_offset=rope_position_offset,
             )
             req_index = self.req_states.req_id_to_index[req_id]
             if self.adaptive_verification is not None:
@@ -1283,7 +1307,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.req_states.num_computed_tokens.gpu,
             self.input_buffers.positions,
             self.input_buffers.seq_lens,
+            self.request_static_yarn_model_positions,
+            (
+                self.req_states.rope_position_offset.gpu
+                if self.request_static_yarn is not None
+                else None
+            ),
         )
+        if (
+            self.request_static_yarn_model_positions is not None
+            and num_tokens_after_padding > num_tokens
+        ):
+            self.request_static_yarn_model_positions[
+                num_tokens:num_tokens_after_padding
+            ].zero_()
         seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
 
         dcp_local_seq_lens = None
@@ -1717,15 +1754,23 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if inputs_embeds is not None and not requires_raw_input_tokens(self.model):
                 input_ids = None
 
+        model_state_inputs = self.model_state.prepare_inputs(
+            input_batch, self.req_states
+        )
         model_inputs = {
             "input_ids": input_ids,
             "positions": input_batch.positions,
             "inputs_embeds": inputs_embeds,
             "intermediate_tensors": None,
-            # NOTE: Values returned by `prepare_inputs` will override the default
-            # values above.
-            **self.model_state.prepare_inputs(input_batch, self.req_states),
+            **model_state_inputs,
         }
+        if (
+            self.request_static_yarn_model_positions is not None
+            and "positions" not in model_state_inputs
+        ):
+            model_inputs["positions"] = self.request_static_yarn_model_positions[
+                : input_batch.num_tokens_after_padding
+            ]
         if not self.is_first_pp_rank:
             # Update for non-first PP ranks.
             model_inputs["input_ids"] = None

--- a/vllm/v1/worker/gpu/model_states/default.py
+++ b/vllm/v1/worker/gpu/model_states/default.py
@@ -151,6 +151,11 @@ class DefaultModelState(ModelState):
             input_batch.query_start_loc,
             req_states.prefill_len.gpu,
             req_states.num_computed_tokens.gpu,
+            (
+                req_states.rope_position_offset.gpu
+                if self.model_config.request_static_yarn_config is not None
+                else None
+            ),
         )
         positions = self.rope_state.get_positions(input_batch.num_tokens_after_padding)
         return {"positions": positions}

--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -68,6 +68,9 @@ class RequestState:
 
         # Max total seq length (prompt_len + max_tokens).
         self.max_seq_len = np.zeros(self.max_num_reqs, dtype=np.int32)
+        self.rope_position_offset = StagedWriteTensor(
+            self.max_num_reqs, dtype=torch.int64, device=device
+        )
 
         # Draft tokens.
         self.draft_tokens = torch.zeros(
@@ -95,6 +98,7 @@ class RequestState:
         all_token_ids: list[int],
         num_computed_tokens: int,
         max_tokens: int,
+        rope_position_offset: int = 0,
     ) -> None:
         assert len(self.free_indices) > 0, "No free indices"
         req_idx = self.free_indices.pop()
@@ -102,6 +106,7 @@ class RequestState:
         self.index_to_req_id[req_idx] = req_id
 
         self.max_seq_len[req_idx] = prompt_len + max_tokens
+        self.rope_position_offset.stage_write_elem(req_idx, rope_position_offset)
         self.prompt_len.np[req_idx] = prompt_len
         prefill_len = len(all_token_ids)
         assert prefill_len >= prompt_len, (
@@ -122,6 +127,7 @@ class RequestState:
         self.total_len.apply_write()
         self.all_token_ids.apply_write()
         self.num_computed_tokens.apply_write()
+        self.rope_position_offset.apply_write()
 
     def remove_request(self, req_id: str) -> int | None:
         """Return the freed slot index, or None if the request was not found."""

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -140,6 +140,11 @@ def run_mixed_prefill_decode_warmup(
         return block_ids
 
     sampling_params = SamplingParams(max_tokens=2, temperature=0.0)
+    rope_profile_factor = (
+        model_runner.request_static_yarn.factors[0]
+        if model_runner.request_static_yarn is not None
+        else None
+    )
 
     decode_prefill_output = SchedulerOutput.make_empty()
     decode_prefill_output.scheduled_new_reqs = [
@@ -153,6 +158,7 @@ def run_mixed_prefill_decode_warmup(
             num_computed_tokens=0,
             lora_request=None,
             prefill_token_ids=decode_token_ids,
+            rope_profile_factor=rope_profile_factor,
         ),
     ]
     decode_prefill_output.num_scheduled_tokens = {
@@ -183,6 +189,7 @@ def run_mixed_prefill_decode_warmup(
             num_computed_tokens=0,
             lora_request=None,
             prefill_token_ids=prefill_token_ids,
+            rope_profile_factor=rope_profile_factor,
         ),
     ]
     mixed_output.num_scheduled_tokens = {
@@ -290,6 +297,11 @@ def warmup_kernels(
     else:
         sampling_params = SamplingParams.for_sampler_warmup()
         pooling_params = None
+    rope_profile_factor = (
+        model_runner.request_static_yarn.factors[0]
+        if model_runner.request_static_yarn is not None
+        else None
+    )
 
     # Assign distinct block IDs per request per group. 0 null block, start from 1.
     next_block_id = 1
@@ -312,6 +324,7 @@ def warmup_kernels(
                 sampling_params,
                 pooling_params,
                 mm_features=warmup_mm_features,
+                rope_profile_factor=rope_profile_factor,
             ),
             block_ids=tuple(_alloc_blocks(n) for n in prefill_block_counts),
             prefill_token_ids=prompt_token_ids,

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -42,6 +42,7 @@ class CachedRequestState:
     block_ids: tuple[list[int], ...]
     num_computed_tokens: int
     output_token_ids: list[int]
+    rope_profile_factor: float | None = None
 
     mrope_positions: torch.Tensor | None = None
     mrope_position_delta: int | None = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -577,6 +577,7 @@ class GPUModelRunner(
         self.mm_registry = MULTIMODAL_REGISTRY
         self.uses_mrope = model_config.uses_mrope
         self.uses_xdrope_dim = model_config.uses_xdrope_dim
+        self.request_static_yarn = model_config.request_static_yarn_config
         self.supports_mm_inputs = self.mm_registry.supports_multimodal_inputs(
             model_config
         )
@@ -821,6 +822,9 @@ class GPUModelRunner(
         self.positions = torch.zeros(
             self.max_num_tokens, dtype=torch.int64, device=self.device
         )
+        self.request_static_yarn_model_positions: torch.Tensor | None = None
+        if self.request_static_yarn is not None:
+            self.request_static_yarn_model_positions = torch.zeros_like(self.positions)
         self.query_start_loc = self._make_buffer(
             self.max_num_reqs + 1, dtype=torch.int32
         )
@@ -879,6 +883,15 @@ class GPUModelRunner(
             # See page 5 of https://arxiv.org/abs/2409.12191
             self.mrope_positions = self._make_buffer(
                 (3, self.max_num_tokens + 1), dtype=torch.int64
+            )
+        self.request_static_yarn_token_offsets: CpuGpuBuffer | None = None
+        self.request_static_yarn_req_offsets_np: np.ndarray | None = None
+        if self.request_static_yarn is not None:
+            self.request_static_yarn_token_offsets = self._make_buffer(
+                self.max_num_tokens, dtype=torch.int64
+            )
+            self.request_static_yarn_req_offsets_np = np.zeros(
+                self.max_num_reqs, dtype=np.int64
             )
 
         # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
@@ -1038,12 +1051,16 @@ class GPUModelRunner(
                 return self.mrope_positions.gpu[:, :num_tokens]
             if self.uses_xdrope_dim > 0:
                 return self.xdrope_positions.gpu[:, :num_tokens]
+            if self.request_static_yarn_model_positions is not None:
+                return self.request_static_yarn_model_positions[:num_tokens]
             return self.positions[:num_tokens]
         else:
             if self.uses_mrope:
                 return self.mrope_positions.gpu[:, num_tokens]
             if self.uses_xdrope_dim > 0:
                 return self.xdrope_positions.gpu[:, num_tokens]
+            if self.request_static_yarn_model_positions is not None:
+                return self.request_static_yarn_model_positions[num_tokens]
             return self.positions[num_tokens]
 
     def _make_buffer(
@@ -1303,6 +1320,18 @@ class GPUModelRunner(
                 to_update = model.pooler.get_pooling_updates(task)
                 to_update.apply(pooling_params)
 
+            if self.request_static_yarn is not None:
+                assert new_req_data.rope_profile_factor is not None
+                self.request_static_yarn.offset_for_factor(
+                    new_req_data.rope_profile_factor
+                )
+                logger.debug(
+                    "Request %s selected request-static YaRN factor %g",
+                    req_id,
+                    new_req_data.rope_profile_factor,
+                )
+            else:
+                assert new_req_data.rope_profile_factor is None
             req_state = CachedRequestState(
                 req_id=req_id,
                 prompt_token_ids=new_req_data.prompt_token_ids,
@@ -1315,6 +1344,7 @@ class GPUModelRunner(
                 block_ids=new_req_data.block_ids,
                 num_computed_tokens=new_req_data.num_computed_tokens,
                 output_token_ids=[],
+                rope_profile_factor=new_req_data.rope_profile_factor,
                 lora_request=new_req_data.lora_request,
             )
             self.requests[req_id] = req_state
@@ -1647,6 +1677,7 @@ class GPUModelRunner(
         """
         self.input_batch.remove_request(req_id)
         req_state = self.requests[req_id]
+        assert new_req_data.rope_profile_factor == req_state.rope_profile_factor
 
         req_state.prompt_token_ids = new_req_data.prompt_token_ids
         req_state.mm_features = new_req_data.mm_features
@@ -2194,6 +2225,24 @@ class GPUModelRunner(
                 non_blocking=True,
             )
 
+        token_offsets = self.request_static_yarn_token_offsets
+        if self.request_static_yarn is not None:
+            req_offsets = self.request_static_yarn_req_offsets_np
+            assert req_offsets is not None
+            assert token_offsets is not None
+            for req_index, req_id in enumerate(self.input_batch.req_ids[:num_reqs]):
+                factor = self.requests[req_id].rope_profile_factor
+                assert factor is not None
+                req_offsets[req_index] = self.request_static_yarn.offset_for_factor(
+                    factor
+                )
+            np.take(
+                req_offsets,
+                req_indices,
+                out=token_offsets.np[:total_num_scheduled_tokens],
+            )
+            token_offsets.copy_to_gpu(total_num_scheduled_tokens)
+
         self.req_indices.np[:total_num_scheduled_tokens] = req_indices
         self.req_indices.copy_to_gpu(total_num_scheduled_tokens)
         req_indices_gpu = self.req_indices.gpu[:total_num_scheduled_tokens]
@@ -2241,6 +2290,10 @@ class GPUModelRunner(
                     self.mrope_positions.cpu[row, :total_num_scheduled_tokens],
                     non_blocking=True,
                 )
+            if token_offsets is not None:
+                self.mrope_positions.gpu[:, :total_num_scheduled_tokens] += (
+                    token_offsets.gpu[:total_num_scheduled_tokens]
+                )
         elif self.uses_xdrope_dim > 0:
             # Only relevant for models using XD-RoPE (e.g, HunYuan-VL).
             # xdrope_positions is allocated as [uses_xdrope_dim, max_num_tokens
@@ -2254,6 +2307,14 @@ class GPUModelRunner(
                     self.xdrope_positions.cpu[row, :total_num_scheduled_tokens],
                     non_blocking=True,
                 )
+        elif token_offsets is not None:
+            model_positions = self.request_static_yarn_model_positions
+            assert model_positions is not None
+            torch.add(
+                self.positions[:total_num_scheduled_tokens],
+                token_offsets.gpu[:total_num_scheduled_tokens],
+                out=model_positions[:total_num_scheduled_tokens],
+            )
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):
             drift = self.num_computed_tokens[req_indices_gpu].to(
                 torch.int64
@@ -3687,6 +3748,10 @@ class GPUModelRunner(
             positions = self.mrope_positions.gpu[:, :num_input_tokens]
         elif self.uses_xdrope_dim > 0:
             positions = self.xdrope_positions.gpu[:, :num_input_tokens]
+        elif self.request_static_yarn_model_positions is not None:
+            positions = self.request_static_yarn_model_positions[:num_input_tokens]
+            if num_input_tokens > num_scheduled_tokens:
+                positions[num_scheduled_tokens:num_input_tokens].zero_()
         else:
             positions = self.positions[:num_input_tokens]
             if num_input_tokens > num_scheduled_tokens:
@@ -6180,6 +6245,8 @@ class GPUModelRunner(
                 positions = self.mrope_positions.gpu[:, :num_tokens_padded]
             elif self.uses_xdrope_dim > 0:
                 positions = self.xdrope_positions.gpu[:, :num_tokens_padded]
+            elif self.request_static_yarn_model_positions is not None:
+                positions = self.request_static_yarn_model_positions[:num_tokens_padded]
             else:
                 positions = self.positions[:num_tokens_padded]
 


### PR DESCRIPTION
## Summary

Add request-static YaRN profiles for mRoPE models.

A server precomputes a sorted set of YaRN tables (for example `1 2 4`), selects the smallest factor covering `prompt_tokens + max_tokens` at admission, and keeps that profile immutable for the request lifetime. This preserves native factor-1 behavior for short requests without converting keys already stored in the KV cache.

```bash
vllm serve Qwen/Qwen3.8-27B \
  --max-model-len 1000000 \
  --hf-overrides '{"text_config":{"rope_parameters":{"mrope_interleaved":true,"mrope_section":[11,11,10],"rope_type":"yarn","rope_theta":10000000,"partial_rotary_factor":0.25,"factor":4.0,"original_max_position_embeddings":262144}}}' \
  --request-static-yarn-factors 1 2 4
```

The change includes:

- validated public config and CLI admission policy;
- V1 and V2 physical/model-position separation;
- immutable profile propagation across scheduling, preemption, and MTP;
- profile-aware APC first-block hashes;
- automatic `lmcache.tag.rope_profile` identity;
- per-factor completed-request counters;
- usage documentation and CPU/GPU coverage.

Resumable requests are rejected because restoring one without its original profile would violate the immutable-profile invariant.

## Duplicate-work check

Related issue: #8793 (closed as stale on 2025-09-01; it asks for dynamic YaRN behavior but has no fixing PR).

Checks run immediately before opening this draft:

```text
gh issue view 8793 --repo vllm-project/vllm --comments
# GitHub GraphQL projectCards deprecation error; issue and 21 comments read through REST instead

gh pr list --repo vllm-project/vllm --state open --search '8793 in:body'
# []

gh pr list --repo vllm-project/vllm --state open --search '"request-static" YaRN'
# []
```

Broader keyword searches returned #41834 only; that PR is an unrelated DeepSeek V4 SM12x hardware enablement change. No equivalent open PR was found.

## Correctness and model evaluation

Pre-registered held-out gates used seed `71983` and were frozen before the upstream implementation.

RTX PRO 6000 Blackwell Server Edition, Qwen3.8-27B, FP8 KV:

| Gate | Result |
|---|---:|
| Short entity retrieval, 1K/16K/64K/131K | 24/24 native and 24/24 request-static; 0 correct→wrong; 0 margin-sign flips |
| Paired lm-eval (ARC Easy, BoolQ, PIQA, MMLU HS CS, MMLU ML) | 1,362 metric observations; exact aggregate parity; 0 correct→wrong |
| Long factor 2, ~300K | 3/3; same selected labels as isolated factor-2 references |
| Long factor 4, ~530K | 3/3; same selected labels as isolated factor-4 references |
| Gilded Gnosis backport, all long cases | 6/6 |

The factor-1, factor-2, and factor-4 combined CUDA mRoPE paths are bit-exact against isolated static tables (`rtol=0`, `atol=0`). End-to-end scalar logprobs are not restart-repeatable with FP8 KV: an unchanged static reference moved by up to `0.8124`, above the pre-registered `1e-4` threshold. This draft therefore reports exact kernel parity separately from runtime decision parity rather than claiming an unidentifiable scalar gate. Runtime selected labels and correctness had zero regressions.

Two alternatives were evaluated on the same gates:

| Method | Entity short | Academic zero-regression gate | Long |
|---|---:|---:|---:|
| Request-static YaRN 1/2/4 | pass | pass (0 correct→wrong) | pass |
| Dynamic NTK factor 4 | pass | fail (6 correct→wrong) | pass |
| Linear interpolation factor 4 | pass | fail (8 correct→wrong) | pass |

Request-static YaRN is selected because it is the only method satisfying every short and long gate.

## Serving compatibility

Observed on the RTX PRO 6000:

- V1 isolated/mixed: pass
- V2 isolated/mixed: pass
- chunked prefill through 530K tokens: pass
- CUDA graph capture/replay: pass
- APC cross-profile hits: 0; same-profile hits: 6,272 tokens
- LMCache profile tag unit/integration coverage: pass
- preemption/resume: one preemption forced with two 297,007-token factor-2 prompts; both completed
- same-checkpoint MTP: 117 draft tokens, 17 accepted tokens
- scrapeable factor counters for factors 1, 2, and 4: pass

The Gilded production backport also passed 24/24 short and 6/6 long cases. A separate Gilded Gnosis build served a correct smoke result on a GeForce RTX 5090.

## Performance

Matched Gilded servers, identical checkpoint/revision, FP8 KV, prompt lengths 1K/16K/131K, output length 128, concurrency 1/8, five waves per cell:

- added model memory: `805,306,368` bytes (768 MiB; gate ≤1 GiB);
- maximum prefill overhead: `0.2445%` (gate ≤2%);
- maximum decode overhead: `0.3944%` (gate ≤2%).

Concurrency-1 decode uses mean TPOT. Loaded concurrency-8 decode uses total service time per output token because per-request TPOT counts a shared scheduler stall once for every active request. At 131K/concurrency-8, two matched runs had `-0.018%` service-capacity overhead; the diagnostic mean per-request TPOT moved by `+3.81%` while the unchanged baseline itself varied substantially between runs. Both raw diagnostics are retained; the service-capacity metric is the observable loaded gate.

## Tests

```bash
.venv/bin/python -m pytest \
  tests/config/test_rope.py \
  tests/engine/test_arg_utils.py \
  tests/v1/core/test_kv_cache_utils.py \
  tests/v1/kv_connector/unit/test_lmcache_integration.py \
  tests/v1/metrics/test_stats.py \
  tests/kernels/core/test_mrope.py::test_request_static_yarn_mrope_profiles_match_static_references -q
# 213 passed

.venv/bin/pre-commit run --from-ref upstream/main --to-ref HEAD
# passed
```

Additional server/model gates are listed above. No checkpoint training was performed.

## AI assistance and draft status

OpenAI Codex assisted with research, implementation, tests, and this description. The commit includes a `Co-authored-by` trailer.

This is intentionally a **draft**. Before marking it ready, the human submitter must review every changed line, understand and be able to defend the cache/position invariants, and rerun the relevant tests and model evaluations. It must not be merged as a pure code-agent contribution.
