### PR TITLE
[UX][DeepEPv2] Make --cc.cudagraph-mode=None select the "normal" DeepEPv2 layout

### DIFF
--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -6,7 +6,10 @@ from typing import Any
 
 import torch
 
-from vllm.config import get_current_vllm_config
+from vllm.config import (
+    CUDAGraphMode,
+    get_current_vllm_config,
+)
 from vllm.distributed import (
     get_ep_group,
 )
@@ -266,7 +269,9 @@ def maybe_make_prepare_finalize(
         )
         handle = all2all_manager.get_handle(all_to_all_args)
         vllm_config = get_current_vllm_config()
-        use_cudagraph = not vllm_config.model_config.enforce_eager
+        use_cudagraph = (
+            vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
+        )
 
         prepare_finalize = DeepEPV2PrepareAndFinalize(
             buffer=handle,


### PR DESCRIPTION



## Purpose
- deepepV2 has two modes (do_expand=True and do_expand=False), do_expand=True is intended for prefill (no CUDAGraph)
- with do_expand=False, the kernel needs to support skipping padding / useless tokens
- DeepGEMM Grouped layout does not do this
- it is a footgun to key off --enforce-eager rather than the cudagraph mode for selecting this

## Test Plan / Result
lmeval

performance

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

