### PR TITLE
[Bugfix][Model] Detect FP8_DYNAMIC quantization from llmcompressor recipe.yaml

### DIFF
--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,6 +6,7 @@ only get the `eos_token_id` from the tokenizer as defined by
 `BaseRenderer.get_eos_token_id`.
 """
 
+import json
 import math
 from types import SimpleNamespace
 from typing import cast
@@ -250,3 +251,107 @@ def test_mrope_num_dims_from_nested_rope_parameters():
 
 def test_mrope_num_dims_without_mrope():
     assert mrope_num_dims(PretrainedConfig()) == 0
+
+
+def _write_granite_config(tmp_path, quantization_config=None):
+    payload = {
+        "architectures": ["GraniteForCausalLM"],
+        "model_type": "granite",
+        "hidden_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "vocab_size": 128,
+        "intermediate_size": 32,
+        "max_position_embeddings": 128,
+    }
+    if quantization_config is not None:
+        payload["quantization_config"] = quantization_config
+    (tmp_path / "config.json").write_text(json.dumps(payload))
+
+def test_recipe_yaml_fp8_dynamic_maps_to_compressed_tensors():
+    recipe = {
+        "default_stage": {
+            "default_modifiers": {
+                "QuantizationModifier": {
+                    "targets": ["Linear"],
+                    "ignore": ["lm_head"],
+                    "scheme": "FP8_DYNAMIC",
+                }
+            }
+        }
+    }
+    mapped = config_module._recipe_to_quantization_config(recipe)
+    assert mapped is not None
+    assert mapped["quant_method"] == "compressed-tensors"
+    assert mapped["format"] == "naive-quantized"
+    assert mapped["ignore"] == ["lm_head"]
+    group = mapped["config_groups"]["group_0"]
+    assert group["targets"] == ["Linear"]
+    assert group["weights"]["strategy"] == "channel"
+    assert group["weights"]["type"] == "float"
+    assert group["weights"]["num_bits"] == 8
+    assert group["input_activations"]["strategy"] == "token"
+    assert group["input_activations"]["dynamic"] is True
+
+
+def test_recipe_yaml_unknown_or_shapeless_input_returns_none():
+    assert config_module._recipe_to_quantization_config(None) is None
+    assert config_module._recipe_to_quantization_config({}) is None
+    assert (
+        config_module._recipe_to_quantization_config(
+            {
+                "default_stage": {
+                    "default_modifiers": {
+                        "QuantizationModifier": {
+                            "scheme": "W8A8",
+                            "targets": ["Linear"],
+                        }
+                    }
+                }
+            }
+        )
+        is None
+    )
+    assert (
+        config_module._recipe_to_quantization_config(
+            {
+                "default_stage": {
+                    "default_modifiers": {
+                        "QuantizationModifier": {"scheme": "FP8_DYNAMIC"}
+                    }
+                }
+            }
+        )
+        is None
+    )
+
+
+def test_config_loads_quantization_from_recipe_yaml(tmp_path):
+    _write_granite_config(tmp_path)
+    (tmp_path / "recipe.yaml").write_text(
+        "default_stage:\n"
+        "  default_modifiers:\n"
+        "    QuantizationModifier:\n"
+        "      targets: [Linear]\n"
+        "      ignore: [lm_head]\n"
+        "      scheme: FP8_DYNAMIC\n"
+    )
+
+    config = config_module.get_config(tmp_path, trust_remote_code=False)
+    assert config.quantization_config is not None
+    assert config.quantization_config["quant_method"] == "compressed-tensors"
+
+
+def test_config_json_quantization_wins_over_recipe_yaml(tmp_path):
+    _write_granite_config(tmp_path, quantization_config={"quant_method": "awq"})
+    (tmp_path / "recipe.yaml").write_text(
+        "default_stage:\n"
+        "  default_modifiers:\n"
+        "    QuantizationModifier:\n"
+        "      targets: [Linear]\n"
+        "      scheme: FP8_DYNAMIC\n"
+    )
+
+    config = config_module.get_config(tmp_path, trust_remote_code=False)
+    assert config.quantization_config == {"quant_method": "awq"}

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -269,6 +269,7 @@ def _write_granite_config(tmp_path, quantization_config=None):
         payload["quantization_config"] = quantization_config
     (tmp_path / "config.json").write_text(json.dumps(payload))
 
+
 def test_recipe_yaml_fp8_dynamic_maps_to_compressed_tensors():
     recipe = {
         "default_stage": {

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
 import huggingface_hub
-import yaml
 import torch
+import yaml
 from huggingface_hub import constants
 from packaging.version import Version
 from safetensors.torch import _TYPES as _SAFETENSORS_TO_TORCH_DTYPE
@@ -907,7 +907,7 @@ def get_config(
     if quantization_config is None and file_or_path_exists(
         model, "recipe.yaml", revision
     ):
-        recipe = _get_hf_yaml_file_to_dict("recipe.yaml", model, revision)
+        recipe = _get_hf_yaml_file_to_dict("recipe.yaml", str(model), revision)
         quantization_config = _recipe_to_quantization_config(recipe)
 
     if quantization_config is not None:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Literal, TypeAlias
 
 import huggingface_hub
+import yaml
 import torch
 from huggingface_hub import constants
 from packaging.version import Version
@@ -754,6 +755,67 @@ def maybe_override_with_speculators(
     return model, tokenizer, speculative_config
 
 
+def _get_hf_yaml_file_to_dict(
+    file_name: str, model: str, revision: str | None
+) -> dict[str, Any] | None:
+    file_path = try_get_local_file(model=model, file_name=file_name, revision=revision)
+    if file_path is None:
+        file_path = huggingface_hub.hf_hub_download(model, file_name, revision=revision)
+    if isinstance(file_path, Path) and file_path.is_file():
+        with open(file_path) as f:
+            return yaml.safe_load(f)
+    return None
+
+
+def _recipe_to_quantization_config(
+    recipe: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Map an llmcompressor recipe.yaml to a compressed-tensors config dict.
+
+    Only the schemes vLLM can serve are mapped; anything else returns None so
+    the loader falls back to its previous behavior rather than guessing.
+    """
+    if not isinstance(recipe, dict):
+        return None
+    stage = recipe.get("default_stage")
+    if not isinstance(stage, dict):
+        return None
+    modifiers = stage.get("default_modifiers")
+    if not isinstance(modifiers, dict):
+        return None
+    quant = modifiers.get("QuantizationModifier")
+    if not isinstance(quant, dict):
+        return None
+    targets = quant.get("targets") or []
+    ignore = quant.get("ignore") or []
+    if quant.get("scheme") != "FP8_DYNAMIC" or not targets:
+        return None
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "naive-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": targets,
+                "weights": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "strategy": "channel",
+                    "symmetric": True,
+                    "dynamic": False,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "strategy": "token",
+                    "symmetric": True,
+                    "dynamic": True,
+                },
+            }
+        },
+        "ignore": ignore,
+    }
+
+
 def get_config(
     model: str | Path,
     trust_remote_code: bool,
@@ -838,6 +900,15 @@ def get_config(
         quantization_config = get_hf_file_to_dict(
             "hf_quant_config.json", model, revision
         )
+
+    # llmcompressor keeps the recipe in recipe.yaml instead of config.json
+    # (e.g. granite-4.2 FP8); a checkpoint with weight_scale tensors and no
+    # quantization_config otherwise loads unquantized and dies on the scale.
+    if quantization_config is None and file_or_path_exists(
+        model, "recipe.yaml", revision
+    ):
+        recipe = _get_hf_yaml_file_to_dict("recipe.yaml", model, revision)
+        quantization_config = _recipe_to_quantization_config(recipe)
 
     if quantization_config is not None:
         config.quantization_config = quantization_config


### PR DESCRIPTION
## Purpose

Fixes #53950.

Granite 4.2 FP8 checkpoints (`ibm-granite/granite-4.2-30b-fp8`, also `granite-4.2-30b-nvfp4`) ship their quantization recipe in `recipe.yaml` (`default_modifiers.QuantizationModifier.scheme: FP8_DYNAMIC`) and carry no `quantization_config` in `config.json` and no `hf_quant_config.json`. The loader therefore never detects quantization, instantiates plain `RowParallelLinear` layers, and dies on the checkpoint's `weight_scale` parameters: `ValueError: There is no module or parameter named 'layers.0.mlp.down_proj.weight_scale' in GraniteModel`.

`vllm/transformers_utils/config.py` now falls back to `recipe.yaml` after the two existing config paths and maps the llmcompressor `FP8_DYNAMIC` scheme onto the compressed-tensors config dict the loader already understands (`naive-quantized`, `channel` weight strategy, `token` dynamic input activations, schema verified against a working `neuralmagic/...-FP8-dynamic` checkpoint). Unknown or shapeless recipes return `None`, so every other checkpoint keeps the exact previous behavior.

Not a duplicate: nothing open references #53950, and the loader had no recipe.yaml path at all (`recipe` only appears under `tools/recipes/`, a different runtime-tuning concept).

## Test Plan

New tests in `tests/transformers_utils/test_config.py`: the FP8_DYNAMIC mapping shape, unknown/shapeless recipes returning `None`, a local repo dir with `config.json` + `recipe.yaml` resolving to the compressed-tensors config, and `config.json`'s own `quantization_config` winning over the recipe fallback.

```
.venv/bin/python -m pytest tests/transformers_utils/test_config.py -q -k recipe
```

## Test Result

4/4 new tests pass. `tests/transformers_utils/` otherwise matches upstream/main (the three failures there are pre-existing environment issues: HF 401 on the llama3 tokenizer download and two dspark config failures, identical on a clean main checkout). `ruff check` and `ruff format` clean on both touched files. Not run: a full model load with the real 30B checkpoint (no GPU here); the config resolution is covered by the new tests.

AI assistance: this PR was prepared with help from Kimi K3 (investigation, patch, tests); I reviewed the diff and ran the tests above.
