### PR TITLE
[Bugfix] Support NoPE models on FLASHINFER_MLA_SPARSE_SM120 and validate effective topk buffer width

### DIFF
--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -199,10 +199,21 @@ class FlashInferMLASparseSM120Backend(_FlashInferMLASparseBackendBase):
                     "FLASHINFER_MLA_SPARSE_SM120 requires a model with "
                     "index_topk config"
                 )
-            if int(index_topk) != 2048:
+            # The kernel is instantiated for an index width of exactly 2048,
+            # but what reaches it is the topk BUFFER width: index_topk plus the
+            # kpool always-selected tail (kpool - 1), rounded up to a multiple
+            # of 128 by the indexer's buffer allocation. Validate that
+            # effective width, not the raw config value — e.g. GLM-5.3-Flash's
+            # index_topk=2044 with index_kpool=4 gives 2047 -> 2048, which the
+            # kernel accepts, but the raw value 2044 would be wrongly rejected.
+            kpool = getattr(hf_text_config, "index_kpool", 1) or 1
+            eff_width = int(index_topk) + (kpool - 1 if kpool > 1 else 0)
+            eff_width = ((eff_width + 127) // 128) * 128
+            if eff_width != 2048:
                 return (
-                    "FLASHINFER_MLA_SPARSE_SM120 requires index_topk=2048; "
-                    f"got {index_topk}"
+                    "FLASHINFER_MLA_SPARSE_SM120 requires an effective topk "
+                    f"buffer width of 2048; got {eff_width} "
+                    f"(index_topk={index_topk}, index_kpool={kpool})"
                 )
         return None
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``."""
+"""SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``.
+
+NoPE models (qk_rope_head_dim == 0, e.g. GLM-5.3-Flash) are supported by
+zero-padding the rope section: the fp8_ds_mla cache layout is a fixed 656-byte
+DeepSeek-shaped tile (512-dim fp8 latent + scales + 64-dim bf16 rope) and the
+compiled ``concat_and_cache_mla`` kernel asserts pe_dim == 64. The padding is
+applied symmetrically on both the KV-write and the query side; a zero rope
+vector contributes exactly 0 to the q_pe . k_pe dot product, so attention
+scores are bit-for-bit identical to true NoPE. This can be removed if the
+kernels grow native pe_dim == 0 support.
+"""
 
 from typing import TYPE_CHECKING, cast
 
@@ -21,6 +31,8 @@ from vllm.v1.attention.backends.mla.sparse_utils import (
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
+
+_DS_ROPE_DIM = 64  # rope section width of the fixed 656-byte fp8_ds_mla tile
 
 
 def _kv_scale_format_for_model(model_type: str | None) -> str:
@@ -74,6 +86,9 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
         self.kv_lora_rank: int = mla_args["kv_lora_rank"]
         self.qk_nope_head_dim: int = mla_args["qk_nope_head_dim"]
         self.qk_rope_head_dim: int = mla_args["qk_rope_head_dim"]
+        # NoPE models (GLM-5.3): pad the rope section with zeros to fit the
+        # DS-shaped tile. Exact: zero rope contributes nothing to scores.
+        self._nope_pad = self.qk_rope_head_dim == 0
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
@@ -103,6 +118,30 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
         self.supports_quant_query_input = False
         self._workspace_buffer: torch.Tensor | None = None
 
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        if kv_cache.numel() == 0:
+            return
+        if self._nope_pad and k_pe.size(-1) == 0:
+            k_pe = k_pe.new_zeros((*k_pe.shape[:-1], _DS_ROPE_DIM))
+        from vllm import _custom_ops as ops
+
+        ops.concat_and_cache_mla(
+            kv_c_normed,
+            k_pe.squeeze(1),
+            kv_cache,
+            slot_mapping.flatten(),
+            kv_cache_dtype=kv_cache_dtype,
+            scale=k_scale,
+        )
+
     def forward_mqa(
         self,
         q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
@@ -114,6 +153,11 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
             q = torch.cat(q, dim=-1)
 
         num_actual_toks = q.shape[0]
+
+        rope_dim = self.qk_rope_head_dim
+        if self._nope_pad:
+            q = torch.nn.functional.pad(q, (0, _DS_ROPE_DIM))
+            rope_dim = _DS_ROPE_DIM
 
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
@@ -141,20 +185,27 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
             flashinfer_trtllm_batch_decode_with_kv_cache_mla,
         )
 
+        # The indexer's kpool can widen the index buffer past the configured
+        # index_topk (always-selected tail slots, padded up by the buffer
+        # allocation). The kernel is generic over the width, but its shape
+        # check requires sparse_mla_top_k == the indices' actual width — pass
+        # the buffer width, not attn_metadata.topk_tokens.
+        eff_topk = topk_indices_physical.shape[-1]
+
         out = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
             query=q.unsqueeze(1),
             kv_cache=kv_c_and_k_pe_cache.view(torch.uint8).unsqueeze(1),
             workspace_buffer=self._workspace_buffer,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
+            qk_rope_head_dim=rope_dim,
             block_tables=topk_indices_physical.unsqueeze(1),
             seq_lens=None,
-            max_seq_len=attn_metadata.topk_tokens,
+            max_seq_len=eff_topk,
             out=output.unsqueeze(1),
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
-            sparse_mla_top_k=attn_metadata.topk_tokens,
+            sparse_mla_top_k=eff_topk,
             kv_scale_format=self.kv_scale_format,
         )
         return out.squeeze(1), None


### PR DESCRIPTION
## Purpose

Two fixes to the `FLASHINFER_MLA_SPARSE_SM120` backend that are prerequisites for serving NoPE sparse-MLA models (`qk_rope_head_dim=0`, e.g. GLM-5.3-Flash / `Glm5NextForConditionalGeneration`) with the `fp8_ds_mla` KV cache on SM120/SM121 devices such as the NVIDIA DGX Spark (GB10). Related to #45317 (DSA models unable to serve on GB10).

Note on scope: the GLM-5.3-Flash model architecture itself is not upstream yet, so no in-tree model exercises these paths today with `qk_rope_head_dim=0`. These are the attention-layer fixes we needed on top of a Glm5Next-enabled build; submitting them separately so the backend is ready when the model lands, and so other GB10 users patching locally have a reference. Happy to convert to draft or fold into a larger enablement PR if maintainers prefer.

**Fix 1: NoPE models crash in `concat_and_cache_mla` (fp8_ds_mla layout assumes a rope section)**

The `fp8_ds_mla` KV-cache tile is a fixed 656-byte DeepSeek-shaped layout (512-dim fp8 latent + scales + 64-dim bf16 rope), and the compiled `concat_and_cache_mla` kernel asserts `pe_dim == 64`. Models with `qk_rope_head_dim=0` crash on that assert. This PR zero-pads the missing rope section symmetrically on both the KV-write and the query side.

Bit-exactness argument: a zero rope vector contributes exactly 0 to the `q_pe · k_pe` dot product, so attention scores are bit-for-bit identical to true NoPE. This is a layout adaptation, not a numerical approximation.

**Fix 2: support check validates raw `index_topk` instead of the effective buffer width**

The SM120 support check requires `index_topk == 2048` (the only width the FlashInfer SM120 sparse-MLA kernel is instantiated for). However, what actually reaches the kernel is the topk *buffer* width: the indexer emits `index_topk` plus up to `index_kpool - 1` always-selected tail tokens, padded up to a multiple of 128. GLM-5.3-Flash ships `index_topk=2044, index_kpool=4` → effective width 2047 → padded to 2048, which the kernel accepts — but the raw-value check wrongly rejects it. This PR validates the effective padded width, and passes the indices' actual width as `sparse_mla_top_k`/`max_seq_len` in `forward_mqa` to satisfy the kernel's shape check when the buffer is wider than the configured topk.

## AI assistance disclosure (per AGENTS.md)

This PR was produced with AI assistance (Claude, credited via `Co-authored-by` trailer), directed and submitted by a human operator who runs the affected hardware in production. The fixes were developed and validated during a live GLM-5.3-Flash bring-up on 2× DGX Spark, not generated speculatively against the issue tracker.

## Why this is not duplicating an existing PR

Checked per the AGENTS.md duplicate-work procedure (`gh pr list --search "45317 in:body"`, `"sparse MLA sm120"`, `"NoPE fp8_ds_mla"`, plus #45317 comments):

- #46055 — backend *selection* for SM121 (capability gates in `flashmla*.py` / `sparse_mla.py`); no file overlap, complementary.
- #46840 — same `flashinfer_mla_sparse_sm120.py` file but a different concern: missing `topk_indices_buffer` error handling; no logic overlap with either fix here.
- #52815 / #51538 — DSpark SWA dispatch-width test coverage (`_required_sm120_sparse_topk`, widths 128/192/256), unrelated to the sparse index width 2048 validated here.
- #52499, #47527, #47779, #49059 — spec-decode shapes, packed decode, DCP, empty prefill chunks on SM120: same backend family, disjoint code paths.
- #41834 — large DSv4/SM12x enablement; does not add NoPE (`qk_rope_head_dim=0`) handling or effective-width validation.

No open PR addresses either NoPE zero-padding for `fp8_ds_mla` or effective-topk-width validation.

## Test Plan

- Hardware: 2× NVIDIA DGX Spark (GB10, sm_121), TP=2 across nodes
- Model: GLM-5.3-Flash-NVFP4 (`qk_rope_head_dim=0`, `kv_lora_rank=512`, `index_topk=2044`, `index_kpool=4`), `fp8_ds_mla` KV cache, 384k context (`--max-model-len 393216`), MTP speculative decode k=5
- These exact changes have been running in production serving (as bind-mounted patches on a Glm5Next-enabled vLLM build) since 2026-08-26
- Commands run against the live endpoint: OpenAI-compatible `chat/completions` smoke suite covering plain text generation, vision (image input), and tool calling; MTP acceptance read from the server's speculative-decode metrics
- Lint: `ruff check` on both changed files — passes

## Test Result

- Text generation, vision (multimodal), and tool-call smoke tests: passing
- Throughput: 21.0 tok/s decode (TP=2 across two GB10 nodes, Marlin NVFP4 backend)
- MTP speculative decode: healthy (~76% first-position acceptance, ~3 tokens/step mean)
- Correctness: outputs coherent at temperature 0; the zero-pad is bit-exact by construction (zero rope contributes zero to attention scores). Formal accuracy evals (e.g. `tests/evals/` / `vllm bench`) have not been run — the model is not in-tree yet; per the bit-exactness argument the change cannot alter attention scores for `qk_rope_head_dim=0` models beyond enabling them to run at all, and it is a no-op for every model with a real rope component (`_pad` path is gated on `qk_rope_head_dim == 0`).

Known uncertainties (flagging honestly for review):

- The "SM120 kernel only supports width 2048" premise is inferred from runtime behavior and the FlashInfer GLM_NSA instantiation; if other widths exist, the effective-width check should be relaxed rather than pinned to 2048.
- The `index_topk + (kpool - 1)` tail-token formula and multiple-of-128 padding follow the Glm5Next indexer's buffer allocation; if that lands differently upstream, the check needs to track it.
- No unit tests included yet — happy to add a minimal NoPE-config support-check test and a KV-write padding test (extending `tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`) if maintainers want this PR to carry them.

The same GB10 failure class was independently reported in #45317; the reporter there offered to validate fixes (validation not yet performed).
