### PR TITLE
[BUGFIX] Fix dflash batched token budget

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -905,3 +905,21 @@ class TestDpDeviceIdSharding:
             get_physical_gpu_ids_for_local_dp_rank(
                 evar, local_dp_rank=2, world_size=2, user_assigned_gpu_ids=[4, 5, 6, 7]
             )
+
+
+def test_parallel_drafting_batched_tokens_floor():
+    from types import SimpleNamespace
+
+    from vllm.engine.arg_utils import _parallel_drafting_batched_tokens_floor as floor
+
+    dflash = SimpleNamespace(parallel_drafting=True, num_speculative_tokens=12)
+    sequential = SimpleNamespace(parallel_drafting=False, num_speculative_tokens=5)
+    # The default 2048 cannot cover 256 seqs x 13 tokens/request -> raised to 3328.
+    assert floor(2048, 256, dflash) == 3328
+    # An explicit larger value is preserved.
+    assert floor(4096, 256, dflash) == 4096
+    # Small batches stay within the default.
+    assert floor(2048, 128, dflash) == 2048
+    # No speculative config or sequential drafting: unchanged.
+    assert floor(2048, 256, None) == 2048
+    assert floor(2048, 256, sequential) == 2048

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2343,6 +2343,31 @@ class EngineArgs:
         assert model_config.max_model_len is not None, (
             "max_model_len must be set by this point"
         )
+        # Parallel drafting (DFlash/DSpark) issues (1 + num_speculative_tokens)
+        # tokens per request in a single decode step, and that step cannot be
+        # chunked. The scheduler's max_num_batched_tokens therefore has a hard
+        # lower bound of max_num_seqs * (num_speculative_tokens + 1); below it
+        # the drafter's index arithmetic and the compiled forward ranges both
+        # overflow. Raise the default to that bound rather than letting users
+        # discover the failure as a CUDA out-of-bounds assert.
+        if (
+            speculative_config is not None
+            and speculative_config.parallel_drafting
+            and self.max_num_seqs is not None
+        ):
+            min_batched_tokens = self.max_num_seqs * (
+                speculative_config.num_speculative_tokens + 1
+            )
+            if self.max_num_batched_tokens < min_batched_tokens:
+                logger.info(
+                    "Raising max_num_batched_tokens from %s to %s to cover the "
+                    "parallel-drafting decode step (%s seqs x %s tokens/request).",
+                    self.max_num_batched_tokens,
+                    min_batched_tokens,
+                    self.max_num_seqs,
+                    speculative_config.num_speculative_tokens + 1,
+                )
+                self.max_num_batched_tokens = min_batched_tokens
         scheduler_config = SchedulerConfig(
             runner_type=model_config.runner_type,
             max_num_batched_tokens=self.max_num_batched_tokens,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -420,6 +420,30 @@ def get_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
     return copy.deepcopy(_compute_kwargs(cls))
 
 
+def _parallel_drafting_batched_tokens_floor(
+    max_num_batched_tokens: int,
+    max_num_seqs: int,
+    speculative_config: SpeculativeConfig | None,
+) -> int:
+    """Floor for ``max_num_batched_tokens`` under parallel drafting.
+
+    Parallel drafting (DFlash/DSpark) issues ``num_speculative_tokens + 1``
+    tokens per request in a single decode step that cannot be chunked, so the
+    scheduler's token capacity has a lower bound of
+    ``max_num_seqs * (num_speculative_tokens + 1)``. Below it, the drafter's
+    input-buffer index arithmetic and the torch.compile forward ranges both
+    overflow.
+    """
+    if (
+        speculative_config is None
+        or not speculative_config.parallel_drafting
+        or max_num_seqs <= 0
+    ):
+        return max_num_batched_tokens
+    floor = max_num_seqs * (speculative_config.num_speculative_tokens + 1)
+    return max(max_num_batched_tokens, floor)
+
+
 @dataclass
 class EngineArgs:
     """Arguments for vLLM engine."""
@@ -2355,19 +2379,21 @@ class EngineArgs:
             and speculative_config.parallel_drafting
             and self.max_num_seqs is not None
         ):
-            min_batched_tokens = self.max_num_seqs * (
-                speculative_config.num_speculative_tokens + 1
+            raised = _parallel_drafting_batched_tokens_floor(
+                self.max_num_batched_tokens,
+                self.max_num_seqs,
+                speculative_config,
             )
-            if self.max_num_batched_tokens < min_batched_tokens:
+            if raised > self.max_num_batched_tokens:
                 logger.info(
                     "Raising max_num_batched_tokens from %s to %s to cover the "
                     "parallel-drafting decode step (%s seqs x %s tokens/request).",
                     self.max_num_batched_tokens,
-                    min_batched_tokens,
+                    raised,
                     self.max_num_seqs,
                     speculative_config.num_speculative_tokens + 1,
                 )
-                self.max_num_batched_tokens = min_batched_tokens
+                self.max_num_batched_tokens = raised
         scheduler_config = SchedulerConfig(
             runner_type=model_config.runner_type,
             max_num_batched_tokens=self.max_num_batched_tokens,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -47,6 +47,19 @@ class DFlashSpeculator(DraftModelSpeculator):
         # Each request emits exactly (bonus + N mask) query tokens per step.
         self.num_query_per_req = 1 + self.num_speculative_steps
 
+        # The drafter forward carries only the (bonus + mask) query tokens; the
+        # context is handled via KV precomputation. At large L the per-step query
+        # budget max_num_reqs * (1 + L) can exceed the scheduler's
+        # max_num_batched_tokens, so the input buffers must be sized to the
+        # larger of the two or the query index arithmetic overflows.
+        self.max_query_tokens = self.max_num_reqs * self.num_query_per_req
+        if self.max_query_tokens > self.max_num_tokens:
+            self.input_buffers = InputBuffers(
+                max_num_reqs=self.max_num_reqs,
+                max_num_tokens=self.max_query_tokens,
+                device=device,
+            )
+
         self.parallel_drafting_token_id = get_parallel_drafting_token_id(
             self.draft_model_config.hf_config
         )
@@ -415,7 +428,7 @@ class DFlashSpeculator(DraftModelSpeculator):
                 self.num_query_per_req,
                 self.num_speculative_steps,
                 self.max_num_reqs,
-                self.max_num_tokens,
+                self.input_buffers.max_num_tokens,
                 self.max_model_len,
                 self.sample_from_anchor,
             )


### PR DESCRIPTION


## Summary
DFlash/DSpark drafters issue `max_num_seqs × (L + 1)` tokens in a single unchunkable decode step (a bonus query plus `L = num_speculative_tokens` mask queries per request), but two places still treat the drafter's token budget as `max_num_batched_tokens`:
1. `DFlashSpeculator` sizes its `InputBuffers` (input_ids/positions) to `max_num_batched_tokens`, so when `max_num_seqs × (L+1) > max_num_batched_tokens` (e.g. default 2048 with 256 seqs and L ≥ 8) the query index arithmetic overflows → CUDA `IndexKernel` out-of-bounds gather.
2. `create_engine_config` only validates `max_num_batched_tokens` against the drafting bound behind `lora_config is not None`, and never raises it — so the same config also trips torch.compile's piecewise-range check (`Shape: 3328 out of considered ranges: [(1, 2048)]`).

## Fix
- Size the DFlash drafter `InputBuffers` to `max(max_num_tokens, max_num_seqs × (L+1))`, and pass the grown buffer bounds into the triton kernel that pads query slot mappings.
- In `create_engine_config`, for `parallel_drafting` methods (DFlash/DSpark), raise the default `max_num_batched_tokens` to `max_num_seqs × (L+1)` so both the buffers and the compile ranges cover the decode step.

## Not a duplicate
- #51256 (merged) fixed the per-request *slot accounting* (`max_num_new_slots_for_drafting` = K, not K−1) feeding the scheduled-token budget validation, but deliberately does not raise the *capacity* — this PR is the complementary capacity floor (the default still OOBs at L≥8 even with #51256).
- #50065 (merged) only resizes the CPU-side `DFlashProposer` buffers for cudagraph padding; the GPU `DraftModelSpeculator` path here is separate.
- #53080 (open) proposes separating target/draft budgets — an alternative architecture; this PR is a minimal correctness floor and does not conflict if #53080 merges later.

## Test plan
- `python -m pytest tests/engine/test_arg_utils.py::test_parallel_drafting_batched_tokens_floor` — hermetic unit test for the token-budget floor (no GPU or model download).
- End-to-end on a 128 GB unified-memory NVIDIA host (GB10): serve a Qwen3.8-27B target with a DFlash2 drafter at `num_speculative_tokens: 12` (also 8 and 10) using the default `--max-num-batched-tokens`; previously these configs crashed with the CUDA out-of-bounds gather / `torch.compile` piecewise-range assert, and now the engine starts and spec-decodes correctly. L≤6 defaults are byte-for-byte unaffected.

## AI assistance
Prepared with assistance from an AI agent (Deepseek-v4-Flash-0731); human-reviewed end-to-end.
```
Co-authored-by: Deepseek-v4-Flash-0731 <noreply@deepseek.com>
```