### PR TITLE
[Perf][DSV4] Use broadcast mHC pre for DeepSeek V4 DSpark

### DIFF
--- a/tests/kernels/test_mhc_kernels.py
+++ b/tests/kernels/test_mhc_kernels.py
@@ -12,6 +12,7 @@ from vllm.model_executor.kernels.mhc.tilelang import (
     _torch_hc_prenorm_gemm,
 )
 from vllm.model_executor.layers.mhc import HAS_TILELANG_MHC
+from vllm.models.deepseek_v4.nvidia.dspark import DSparkDeepseekV4Model
 from vllm.models.deepseek_v4.nvidia.model import (
     DeepseekV4DecoderLayer,
     DeepseekV4Model,
@@ -416,3 +417,40 @@ def test_deepseek_v4_mhc_broadcast_refit_refreshes_in_place(monkeypatch):
     assert layer.hc_attn_fn_broadcast is buffer
     expected = layer.hc_attn_fn.detach().view(-1, 2, 8).sum(dim=1)
     assert torch.equal(layer.hc_attn_fn_broadcast, expected)
+
+
+def test_dspark_forwards_2d_embeddings_to_broadcast_mhc(monkeypatch):
+    inputs_embeds = torch.randn(3, 8, dtype=torch.bfloat16)
+
+    class RecordingLayer:
+        def __call__(self, hidden_states, *args):
+            assert hidden_states is inputs_embeds
+            assert hidden_states.ndim == 2
+            return hidden_states, None, None, None
+
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.nvidia.dspark.mhc_post_tilelang",
+        lambda hidden_states, *args: hidden_states,
+    )
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.nvidia.dspark.hc_head_fused_kernel_tilelang",
+        lambda hidden_states, *args: hidden_states,
+    )
+    model = SimpleNamespace(
+        use_sequence_parallel=False,
+        layers=[RecordingLayer()],
+        hc_head_fn=None,
+        hc_head_scale=None,
+        hc_head_base=None,
+        rms_norm_eps=1e-6,
+        hc_eps=1e-6,
+    )
+
+    output = DSparkDeepseekV4Model.forward(
+        model,
+        torch.arange(3),
+        torch.arange(3),
+        inputs_embeds,
+    )
+
+    assert output is inputs_embeds

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -495,18 +495,22 @@ def test_deepseek_v4_pwal_hook_finalizes_mega_moe_and_mhc_broadcast():
     assert calls == ["mega_moe", "mhc"]
 
 
-def test_deepseek_v4_drafter_pwal_hooks_finalize_mega_moe():
+def test_deepseek_v4_drafter_pwal_hooks_finalize_derived_weights():
     """MTP/DSpark drafters load as their own top-level models, so each needs
-    its own PWAL hook now that the megamoe forward no longer finalizes
-    weights lazily on first use."""
+    its own PWAL hook for derived MegaMoE and mHC broadcast weights."""
     calls = []
     mtp = SimpleNamespace(finalize_mega_moe_weights=lambda: calls.append("mtp"))
     DeepSeekV4MTP.process_weights_after_loading(mtp)
 
-    dspark = SimpleNamespace(_finalize_moe=lambda: calls.append("dspark"))
+    dspark = SimpleNamespace(
+        _finalize_moe=lambda: calls.append("dspark"),
+        model=SimpleNamespace(
+            finalize_mhc_broadcast_weights=lambda: calls.append("dspark_mhc")
+        ),
+    )
     DSparkDeepseekV4ForCausalLM.process_weights_after_loading(dspark)
 
-    assert calls == ["mtp", "dspark"]
+    assert calls == ["mtp", "dspark", "dspark_mhc"]
 
 
 @pytest.mark.skipif(

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -204,8 +204,7 @@ class DSparkDeepseekV4Model(nn.Module):
                 )
             inputs_embeds = sp_shard(inputs_embeds)
             input_ids = sp_shard(input_ids)
-        # Expand to hc_mult copies for hyper-connections ([T, H] -> [T, hc, H]).
-        hidden_states = inputs_embeds.unsqueeze(-2).repeat(1, self.hc_mult, 1)
+        hidden_states = inputs_embeds
 
         residual = post_mix = res_mix = None
         for layer in self.layers:
@@ -230,6 +229,9 @@ class DSparkDeepseekV4Model(nn.Module):
             self.hc_eps,
         )
         return hidden_states
+
+    def finalize_mhc_broadcast_weights(self) -> None:
+        self.layers[0].finalize_mhc_broadcast_weight()
 
 
 def _insert_context_kv(
@@ -516,6 +518,7 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
 
     def process_weights_after_loading(self) -> None:
         self._finalize_moe()
+        self.model.finalize_mhc_broadcast_weights()
 
     def _remap_dspark_name(self, name: str) -> str | None:
         """Map a checkpoint ``mtp.{i}.*`` name to this model's parameter path.

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1144,6 +1144,15 @@ class DeepseekV4DecoderLayer(nn.Module):
             requires_grad=False,
         )
 
+    def finalize_mhc_broadcast_weight(self) -> None:
+        broadcast = (
+            self.hc_attn_fn.detach().view(-1, self.hc_mult, self.hidden_size).sum(dim=1)
+        )
+        if self.hc_attn_fn_broadcast is None:
+            self.hc_attn_fn_broadcast = broadcast
+        else:
+            self.hc_attn_fn_broadcast.copy_(broadcast)
+
     def forward(
         self,
         x: torch.Tensor,
@@ -1614,15 +1623,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             return
         layer = self.layers[self.start_layer]
         if isinstance(layer, DeepseekV4DecoderLayer):
-            broadcast = (
-                layer.hc_attn_fn.detach()
-                .view(-1, layer.hc_mult, layer.hidden_size)
-                .sum(dim=1)
-            )
-            if layer.hc_attn_fn_broadcast is None:
-                layer.hc_attn_fn_broadcast = broadcast
-            else:
-                layer.hc_attn_fn_broadcast.copy_(broadcast)
+            layer.finalize_mhc_broadcast_weight()
 
 
 def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:


### PR DESCRIPTION
## Purpose

DeepSeek V4 DSpark currently expands the initial embeddings from `[T, H]` to
`[T, hc, H]` with an explicit `repeat` before its first decoder layer. The
target model already avoids this materialization through the broadcast mHC-pre
kernel, but the DSpark path did not use it.

This change:

- forwards the 2-D DSpark embeddings directly to the first decoder layer so it
  selects `mhc_pre_broadcast_tilelang`;
- derives the broadcast projection weight after checkpoint loading by summing
  `hc_attn_fn` over its replicated input-stream dimension;
- shares that derived-weight finalization between the target and DSpark paths,
  while preserving the tensor address during refits; and
- adds focused coverage for the 2-D DSpark forwarding contract and its
  post-weight-loading hook.

For DeepSeek-V4-Flash-0731 (`hidden_size=4096`, `hc_mult=4`), this removes the
explicit input replication and reduces the first mHC projection's input K
dimension from `4H` to `H`.

There is no linked issue. Before submission, open PRs were searched for
`DeepSeek V4 DSpark mHC broadcast`, `DSpark repeat optimization`,
`mhc_pre_broadcast`, `hc_attn_fn_broadcast`, and related DeepSeek V4/DSpark
performance terms. No PR implements this change. In particular, #51244 fuses
the end-of-model mHC post/head/norm path, #47807 changes mHC warmup, and #50737
optimizes the DSpark Markov head; none changes the initial DSpark mHC-pre path.

AI assistance was used to analyze, implement, test, benchmark, and draft this
change. The human submitter reviewed every changed line and the reported
test/evaluation results before requesting submission.

## Test Plan

1. Exercise the broadcast-weight derivation/refit and verify that DSpark keeps
   initial embeddings 2-D.
2. Run applicable Python formatting, lint, spelling, import, SPDX, and safety
   checks on all changed files.
3. Compare the original repeat path with the broadcast path in an isolated H20
   mHC-pre microbenchmark and a warmed 2xH20 TP2/EP DSpark serving benchmark.
4. Run the complete 1,319-question, 5-shot GSM8K evaluation with DSpark to
   check model quality and speculative acceptance.

## Test Result

Latest `upstream/main` unit test:

```text
.venv/bin/python -m pytest tests/kernels/test_mhc_kernels.py \
  -k 'deepseek_v4_mhc_broadcast or dspark_forwards' -v

3 passed, 51 deselected, 14 warnings in 3.88s
```

Applicable checks passed on all four changed files:

```text
ruff-check
ruff-format
typos 1.43.5
check_spdx_header.py
check_init_lazy_imports.py
check_forbidden_imports.py
check_torch_cuda.py
validate_config.py
check_boolean_context_manager.py
git diff --check
```

The top-level `pre-commit run` could not finish creating third-party hook
environments because the shared filesystem returned `Errno 524` while building
pre-commit's placeholder wheels. The applicable hooks above were therefore run
directly at their pinned versions or via the repository scripts.

H20 mHC-pre microbenchmark, using the model's real `H=4096`, `hc_mult=4`, token
counts 1 through 256, 100 ms warmup and 500 repetitions:

```text
median kernel speedup:       1.512x
median latency reduction:   33.88%
median time saved:          36.94 us
baseline range:             105.72-110.11 us
broadcast range:             68.18-73.23 us
```

The residual output was exact. Mixing intermediates differed by at most
`1.32e-4`; the maximum BF16 layer-input difference was `0.0625` at 256 tokens,
consistent with the changed summation order.

Warmed 2xH20 TP2 + expert-parallel DSpark A/B, 16 prompts x 128 output tokens,
8 measured repetitions per mode:

```text
                             repeat       broadcast      change
mean output throughput       751.73       769.06 tok/s   +2.30%
median output throughput     756.52       772.00 tok/s   +2.05%
median latency                 2.7071       2.6528 s      -2.01%
```

The final acceptance rate was 87.5% for the repeat run and 88.4% for the
broadcast run, so the end-to-end delta includes normal speculative/EP numerical
variance; the isolated microbenchmark is the directly attributable result.

Complete DeepSeek-V4-Flash-0731 GSM8K evaluation on 2xH20, TP2 + EP, eager,
FP8 KV cache, probabilistic DSpark with seven speculative tokens:

```text
questions:                  1319, 5-shot
measured accuracy:          0.9431
configured expectation:     0.9200 (tolerance 0.0800)
invalid rate:               0.001
evaluation latency:         303.7 s
QPS:                        4.3
mean acceptance length:     4.386
minimum acceptance length:  1.200

1 passed in 557.77s
```

An additional full H20 sweep of `tests/kernels/test_mhc_kernels.py` produced
46 passed, 8 skipped, and one unrelated numerical-tolerance failure in the
untouched `test_mhc_fused_post_pre[4-7168-128]` case: one of 917,504 elements
had absolute error 0.0151 versus `atol=0.01`. It reproduced on rerun and uses
`hidden_size=7168`; this model and optimization use `hidden_size=4096` and the
new broadcast path.

The GPU benchmark and GSM8K evaluation were collected before rebasing from
`48d7132962` to current `upstream/main`; none of the four affected files changed
upstream during that rebase. The focused unit test and code checks were rerun
after rebasing.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and non-duplication rationale are documented.
- [x] The test plan and commands are documented.
- [x] Unit, benchmark, and model-evaluation results are documented.
- [x] No documentation update is required for this internal optimization.

</details>
