### PR TITLE
[Bugfix][Spec Decode] Mask out-of-range input ids in VocabParallelEmbedding at tp_size==1

### DIFF
--- a/tests/model_executor/layers/test_vocab_parallel_embedding_oob.py
+++ b/tests/model_executor/layers/test_vocab_parallel_embedding_oob.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test: VocabParallelEmbedding must tolerate out-of-range ids at
+tp_size == 1.
+
+Speculative decoding feeds the target model a padded verification query block
+whose not-yet-filled / rejected draft slots carry the ``-1`` sentinel. The
+``tp_size > 1`` branch has always masked out-of-range ids before the gather;
+the single-GPU branch passed them straight into ``F.embedding``, tripping a
+device-side index assert (``indexSelectSmallIndex: srcIndex <
+srcSelectDimSize``) on the first spec step of every single-GPU spec-decode
+config, independent of KV-cache dtype.
+"""
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed.parallel_state import (
+    ensure_model_parallel_initialized,
+    init_distributed_environment,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_gpu_parallel_state():
+    with set_current_vllm_config(VllmConfig()):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            distributed_init_method="tcp://127.0.0.1:0",
+            local_rank=0,
+        )
+        ensure_model_parallel_initialized(1, 1)
+        yield
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_tp1_out_of_range_ids_are_masked(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    vocab_size, hidden = 128, 16
+    with set_current_vllm_config(VllmConfig()):
+        layer = VocabParallelEmbedding(vocab_size, hidden).to(device)
+
+    # Valid ids, the spec-decode -1 sentinel, and an over-range id.
+    input_ = torch.tensor([0, 5, -1, vocab_size, vocab_size - 1], device=device)
+    out = layer(input_)
+
+    # No device-side assert, and the out-of-range rows are zeroed --
+    # mirroring the tp > 1 semantics (those positions are discarded
+    # downstream by rejection sampling).
+    assert out.shape == (5, hidden)
+    assert torch.all(out[2] == 0)
+    assert torch.all(out[3] == 0)
+
+    # Valid-id rows are the plain embedding lookup, unchanged by the mask.
+    ref = layer.weight[input_[[0, 1, 4]]]
+    torch.testing.assert_close(out[[0, 1, 4]], ref)

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -498,7 +498,19 @@ class VocabParallelEmbedding(PluggableLayer):
 
     def forward(self, input_):
         if self.tp_size == 1:
-            return self.quant_method.embedding(self, input_.long())
+            # tp_size == 1 has no vocab sharding, but the input can still carry
+            # out-of-range placeholder ids: speculative decode feeds the target
+            # a padded query block whose not-yet-filled / rejected draft slots
+            # are the -1 sentinel. Without the tp>1 masking these reach the
+            # embedding gather and trip a device-side index assert
+            # (indexSelectSmallIndex: srcIndex < srcSelectDimSize). Mask them
+            # to index 0 and zero their output rows, mirroring the tp>1 path;
+            # such positions are discarded downstream by rejection sampling.
+            input_mask = (input_ < 0) | (input_ >= self.num_embeddings_per_partition)
+            masked_input = input_.masked_fill(input_mask, 0)
+            output = self.quant_method.embedding(self, masked_input.long())
+            output.masked_fill_(input_mask.unsqueeze(-1), 0)
+            return output
 
         if self.use_fused_embedding:
             output_parallel = ops.vocab_parallel_embedding(


### PR DESCRIPTION
## Purpose

Speculative decoding feeds the target model a padded verification query block whose not-yet-filled / rejected draft slots carry the `-1` sentinel. The `tp_size > 1` branch of `VocabParallelEmbedding.forward` has always masked out-of-range ids before the embedding gather; the single-GPU branch passes them straight into `F.embedding`, which trips a device-side index assert (`indexSelectSmallIndex: srcIndex < srcSelectDimSize`) on the first spec step. As far as we can tell this affects every single-GPU spec-decode configuration that routes padded draft ids through the target embedding, independent of KV-cache dtype — it seems to have gone unnoticed because multi-GPU setups mask, and single-GPU spec decode with the newer drafter families is still young.

The fix mirrors the `tp > 1` semantics at `tp == 1`: mask ids `< 0` or `>= num_embeddings_per_partition` to index 0 and zero their output rows. Those positions are discarded downstream by rejection sampling, so valid-id results are unchanged. The added comparisons are pointwise and appear negligible next to the gather itself; if maintainers would rather see this guarded at the spec-decode call sites instead of in the layer, we're happy to rework it that way.

## Test Plan

- New regression test `tests/model_executor/layers/test_vocab_parallel_embedding_oob.py` (CPU + CUDA): `-1` and over-range ids must not assert; their rows are zeroed; valid rows equal the plain lookup.
- E2E: DFlash2 draft-length-7 spec decoding, single GPU, on RTX 5090 (sm_120) and GB10 (sm_121).

## Test Result

- `python -m pytest tests/model_executor/layers/test_vocab_parallel_embedding_oob.py -q` → **2 passed** (RTX 5090, torch 2.13.0/cu130).
- E2E: previously died in spec warmup with the device-side assert; with this fix (plus two DFlash2-specific warmup fixes filed separately) the engine completes capture and serves, greedy-deterministic byte-identical across two temp-0/seed-0 runs on both cards.
