### PR TITLE
[Bugfix][Spec Decode] DFlash2: survive spec warmup with unfilled draft buffers (embed outside compile; clamp selector gathers)

### DIFF
--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -170,7 +170,21 @@ def _score_edges(
     anchor_token_ids: torch.Tensor,
     top_k: int,
 ) -> torch.Tensor:
-    successors = successor_table[candidate_ids]
+    # Clamp the gather indices into the codebooks' valid row range. candidate_ids
+    # (from the target LM head TopK) and anchor_token_ids (real prompt tokens) are
+    # always in [0, vocab) on the serving path, so clamp is an identity there. But
+    # during spec warmup / cudagraph capture the drafter's input_ids buffer carries
+    # uninitialized / -1 sentinel ids (never filled with valid tokens for the dummy
+    # step), and those reach anchor_token_ids -> predecessor_ids. These raw codebook
+    # gathers run INSIDE CandidateSelector's @support_torch_compile region, so an
+    # out-of-range id trips an inductor-lowered bounds assert
+    # (`index out of bounds: 0 <= tmp < vocab`) — the same -1-sentinel class as the
+    # VPE tp==1 / drafter-embed fixes, but on a distinct compiled gather that neither
+    # of those touches. Clamping keeps the index provably in-range so the compiled
+    # kernel is safe; warmup rows are discarded downstream by rejection sampling.
+    # See DESIGN-NOTES §18.
+    vocab_size = successor_table.shape[0]
+    successors = successor_table[candidate_ids.clamp(0, vocab_size - 1)]
     predecessor_ids = torch.cat(
         (
             anchor_token_ids[:, None, None].expand(-1, 1, top_k),
@@ -178,7 +192,7 @@ def _score_edges(
         ),
         dim=1,
     )
-    predecessors = predecessor_table[predecessor_ids]
+    predecessors = predecessor_table[predecessor_ids.clamp(0, vocab_size - 1)]
     return unary_logits[:, :, None] + torch.einsum(
         "blpr,blcr->blpc", predecessors * hidden[:, :, None], successors
     )

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -41,6 +41,17 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
         )
 
+        # Persistent, CUDA-graph-stable buffer for the draft ids' embeddings.
+        # The draft ids are embedded OUTSIDE the compiled drafter forward into
+        # this buffer (see _run_model): embedding in-compile trips a
+        # data-dependent local_scalar_dense in F.embedding -> orphan unbacked
+        # SymInt (PendingUnbackedSymbolNotFound {u0}) at the drafter's AOT
+        # compile, blocking graph mode. Mirrors SpecDecodeBaseProposer's buffer
+        # discipline. See DESIGN-NOTES §10.
+        self.inputs_embeds = torch.zeros(
+            self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device
+        )
+
         # Multimodal inputs not currently supported.
         self.supports_mm_inputs = False
 
@@ -236,10 +247,20 @@ class DFlashSpeculator(DraftModelSpeculator):
             slot_mapping=slot_mappings,
             batch_descriptor=batch_descriptor,
         ):
+            # Embed the draft ids outside the compiled forward into the
+            # CUDA-graph-stable buffer, then pass inputs_embeds (input_ids=None).
+            # Numerically identical to embedding in-compile: the model's forward
+            # would call the same embed_input_ids (incl. any input_embedding_scale
+            # override); only WHERE it runs changes. Keeps F.embedding out of the
+            # @support_torch_compile graph so the drafter AOT-compiles in graph
+            # mode. See DESIGN-NOTES §10.
+            self.inputs_embeds[:num_tokens] = self.model.embed_input_ids(
+                self.input_buffers.input_ids[:num_tokens]
+            )
             last_hidden_states = self.model(
-                input_ids=self.input_buffers.input_ids[:num_tokens],
+                input_ids=None,
                 positions=self.input_buffers.positions[:num_tokens],
-                inputs_embeds=None,
+                inputs_embeds=self.inputs_embeds[:num_tokens],
             )
         return last_hidden_states
 


### PR DESCRIPTION
## Purpose

Two warmup-time OOB crashes in the DFlash2 line (#52816) on single-GPU, graph-mode configs. Both share one root: at spec warmup the drafter's `input_ids` buffer is not yet filled with valid tokens, so `-1` / uninitialized sentinel ids flow into compiled gather sites.

1. **Embed draft ids outside the compiled forward.** The draft-id embedding sat inside the inductor-compiled region; during warmup this surfaces as an unbacked-SymInt / device-side assert inside the compiled graph. Moving the embed to a persistent, cudagraph-stable `inputs_embeds` buffer (`input_ids=None` into the compiled model) is numerically identical — it routes through the same `embed_input_ids` path including DFlash2's `input_embedding_scale` override.
2. **Clamp the candidate-selector codebook gathers.** `_score_edges` gathers straight into the `[vocab, rank]` codebooks (`successor_table[candidate_ids]`, `predecessor_table[predecessor_ids]`); warmup sentinel ids trip `index out of bounds: 0 <= tmpX < vocab` inside the compiled selector. Clamping into `[0, vocab-1]` is an identity on the serving path (TopK candidate ids and real anchor tokens are always in range), stays inside the compiled region (cudagraph-stable, no data-dependent shapes), and warmup rows are discarded by rejection sampling.

We diagnosed this by working through three distinct `-1`-sentinel gather sites; the third (the selector) is the one the first two fixes don't reach, which could explain why warmup crashes in this family have been hard to pin down. The third site is the target-side `VocabParallelEmbedding` at `tp_size==1`, filed separately as #53977 since it is independent of DFlash.

## Test Plan

E2E DFlash2 spec decode (draft length 7, graph mode, single GPU), Qwen3.8-27B target, on RTX 5090 (sm_120) and GB10 (sm_121): engine must complete DFlash2 speculator capture and serve; greedy determinism 2× temp-0/seed-0.

## Test Result

With #53977 plus these two fixes, on both cards: spec warmup completes (no device-side assert), speculator capture passes, `Application startup complete`; greedy determinism byte-identical (sha256-verified) on every arm; coherence pass. Without them, the engine dies in spec warmup — on sm_120 in the inductor-compiled selector with the vocab-bound assert, matching the analysis above.
