### PR TITLE
[Bugfix] Route directly constructed embeddings through CPU offload

### DIFF
--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -141,3 +141,45 @@ def test_tower_weight_offloading(vllm_runner, monkeypatch, disable_uva):
     finally:
         set_offloader(original_offloader)
         envs.disable_envs_cache()
+
+
+def test_embedding_weight_offloading(vllm_runner, monkeypatch):
+    """`cpu_offload_params` must reach embeddings outside ``make_layers``."""
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    envs.disable_envs_cache()
+    original_offloader = get_offloader()
+
+    try:
+        with vllm_runner(
+            "Qwen/Qwen3.5-0.8B",
+            enforce_eager=True,
+            gpu_memory_utilization=0.3,
+            max_model_len=128,
+            max_num_seqs=1,
+            enable_prefix_caching=False,
+            cpu_offload_gb=1,
+            cpu_offload_params={"embed_tokens"},
+        ) as vllm_model:
+            engine_core = vllm_model.llm.llm_engine.engine_core.engine_core
+            model_runner = engine_core.model_executor.driver_worker.worker.model_runner
+
+            offloader = get_offloader()
+            assert isinstance(offloader, UVAOffloader)
+            assert offloader.cpu_offload_bytes > 0
+
+            model = model_runner.get_model()
+            embedding_params = [
+                p for name, p in model.named_parameters() if "embed_tokens" in name
+            ]
+            assert embedding_params
+            assert all(_is_offloaded(p) for p in embedding_params)
+
+            # An explicit embedding selector must not change layer residency.
+            assert not any(
+                _is_offloaded(p)
+                for name, p in model.named_parameters()
+                if ".layers." in name
+            )
+    finally:
+        set_offloader(original_offloader)
+        envs.disable_envs_cache()

--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Generator
 from operator import attrgetter
 from unittest.mock import Mock
 
 import pytest
+import torch
 import torch.nn as nn
 
 import vllm.envs as envs
@@ -14,31 +14,15 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.utils import maybe_offload_embeddings
 from vllm.model_executor.offloader import (
-    BaseOffloader,
     PrefetchOffloader,
     UVAOffloader,
     get_offloader,
     set_offloader,
 )
+from vllm.utils.platform_utils import is_uva_available
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 from ..utils import compare_two_settings
-
-
-class _RecordingOffloader(BaseOffloader):
-    supports_direct_module_offload = True
-
-    def __init__(self):
-        self.calls: list[tuple[list[nn.Module], str]] = []
-
-    def wrap_modules(
-        self,
-        modules_generator: Generator[nn.Module, None, None],
-        prefix: str = "",
-    ) -> list[nn.Module]:
-        modules = list(modules_generator)
-        self.calls.append((modules, prefix))
-        return modules
 
 
 def _model_with_direct_embedding() -> tuple[nn.Module, VocabParallelEmbedding]:
@@ -50,16 +34,29 @@ def _model_with_direct_embedding() -> tuple[nn.Module, VocabParallelEmbedding]:
     return model, embedding
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_uva_available(),
+    reason="UVA is not available.",
+)
 def test_direct_embedding_offload_preserves_prefix(monkeypatch, default_vllm_config):
     model, embedding = _model_with_direct_embedding()
-    offloader = _RecordingOffloader()
+    model.cuda()
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.should_pin_memory", lambda: False
+    )
+    offloader = UVAOffloader(
+        cpu_offload_max_bytes=embedding.weight.nbytes,
+        cpu_offload_params={"outer.language_model.model.embed_tokens"},
+    )
     monkeypatch.setattr(
         "vllm.model_executor.offloader.get_offloader", lambda: offloader
     )
 
     maybe_offload_embeddings(model, prefix="outer")
 
-    assert offloader.calls == [([embedding], "outer.language_model.model.embed_tokens")]
+    assert offloader.cpu_offload_bytes == embedding.weight.nbytes
+    assert getattr(embedding.weight, "_vllm_is_uva_offloaded", False)
+    assert embedding.weight.device.type == "cuda"
 
 
 def test_direct_embedding_offload_skips_unsupported_offloader(
@@ -82,23 +79,6 @@ def test_direct_embedding_offload_skips_unsupported_offloader(
     maybe_offload_embeddings(model)
 
     wrap_modules.assert_not_called()
-
-
-def test_uva_offloader_warns_for_unmatched_selectors(caplog, monkeypatch):
-    monkeypatch.setattr(
-        "vllm.model_executor.offloader.uva.is_uva_available", lambda: True
-    )
-    monkeypatch.setattr(
-        "vllm.model_executor.offloader.uva.should_pin_memory", lambda: False
-    )
-    offloader = UVAOffloader(
-        cpu_offload_max_bytes=1024,
-        cpu_offload_params={"missing"},
-    )
-
-    offloader.post_init()
-
-    assert "matched no parameters: missing" in caplog.text
 
 
 @pytest.mark.parametrize("disable_pin_memory", [False, True])
@@ -221,48 +201,6 @@ def test_tower_weight_offloading(vllm_runner, monkeypatch, disable_uva):
 
             # The language model must stay resident.
             assert not any(_is_offloaded(p) for p in model.language_model.parameters())
-    finally:
-        set_offloader(original_offloader)
-        envs.disable_envs_cache()
-
-
-def test_embedding_weight_offloading(vllm_runner, monkeypatch):
-    """`cpu_offload_params` must reach embeddings outside ``make_layers``."""
-    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
-    envs.disable_envs_cache()
-    original_offloader = get_offloader()
-
-    try:
-        with vllm_runner(
-            "Qwen/Qwen3.5-0.8B",
-            enforce_eager=True,
-            gpu_memory_utilization=0.3,
-            max_model_len=128,
-            max_num_seqs=1,
-            enable_prefix_caching=False,
-            cpu_offload_gb=1,
-            cpu_offload_params={"language_model.model.embed_tokens"},
-        ) as vllm_model:
-            engine_core = vllm_model.llm.llm_engine.engine_core.engine_core
-            model_runner = engine_core.model_executor.driver_worker.worker.model_runner
-
-            offloader = get_offloader()
-            assert isinstance(offloader, UVAOffloader)
-            assert offloader.cpu_offload_bytes > 0
-
-            model = model_runner.get_model()
-            embedding_params = [
-                p for name, p in model.named_parameters() if "embed_tokens" in name
-            ]
-            assert embedding_params
-            assert all(_is_offloaded(p) for p in embedding_params)
-
-            # An explicit embedding selector must not change layer residency.
-            assert not any(
-                _is_offloaded(p)
-                for name, p in model.named_parameters()
-                if ".layers." in name
-            )
     finally:
         set_offloader(original_offloader)
         envs.disable_envs_cache()

--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Generator
 from operator import attrgetter
+from unittest.mock import Mock
 
 import pytest
 import torch.nn as nn
 
 import vllm.envs as envs
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.utils import maybe_offload_embeddings
 from vllm.model_executor.offloader import (
+    BaseOffloader,
     PrefetchOffloader,
     UVAOffloader,
     get_offloader,
@@ -16,6 +23,82 @@ from vllm.model_executor.offloader import (
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 from ..utils import compare_two_settings
+
+
+class _RecordingOffloader(BaseOffloader):
+    supports_direct_module_offload = True
+
+    def __init__(self):
+        self.calls: list[tuple[list[nn.Module], str]] = []
+
+    def wrap_modules(
+        self,
+        modules_generator: Generator[nn.Module, None, None],
+        prefix: str = "",
+    ) -> list[nn.Module]:
+        modules = list(modules_generator)
+        self.calls.append((modules, prefix))
+        return modules
+
+
+def _model_with_direct_embedding() -> tuple[nn.Module, VocabParallelEmbedding]:
+    model = nn.Module()
+    model.language_model = nn.Module()
+    model.language_model.model = nn.Module()
+    embedding = VocabParallelEmbedding(16, 8, disable_tp=True)
+    model.language_model.model.embed_tokens = embedding
+    return model, embedding
+
+
+def test_direct_embedding_offload_preserves_prefix(monkeypatch, default_vllm_config):
+    model, embedding = _model_with_direct_embedding()
+    offloader = _RecordingOffloader()
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.get_offloader", lambda: offloader
+    )
+
+    maybe_offload_embeddings(model, prefix="outer")
+
+    assert offloader.calls == [([embedding], "outer.language_model.model.embed_tokens")]
+
+
+def test_direct_embedding_offload_skips_unsupported_offloader(
+    monkeypatch, default_vllm_config
+):
+    model, _ = _model_with_direct_embedding()
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.is_uva_available", lambda: False
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.should_pin_memory", lambda: False
+    )
+    offloader = UVAOffloader(cpu_offload_max_bytes=1024)
+    wrap_modules = Mock()
+    monkeypatch.setattr(offloader, "wrap_modules", wrap_modules)
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.get_offloader", lambda: offloader
+    )
+
+    maybe_offload_embeddings(model)
+
+    wrap_modules.assert_not_called()
+
+
+def test_uva_offloader_warns_for_unmatched_selectors(caplog, monkeypatch):
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.is_uva_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.should_pin_memory", lambda: False
+    )
+    offloader = UVAOffloader(
+        cpu_offload_max_bytes=1024,
+        cpu_offload_params={"missing"},
+    )
+
+    offloader.post_init()
+
+    assert "matched no parameters: missing" in caplog.text
 
 
 @pytest.mark.parametrize("disable_pin_memory", [False, True])
@@ -158,7 +241,7 @@ def test_embedding_weight_offloading(vllm_runner, monkeypatch):
             max_num_seqs=1,
             enable_prefix_caching=False,
             cpu_offload_gb=1,
-            cpu_offload_params={"embed_tokens"},
+            cpu_offload_params={"language_model.model.embed_tokens"},
         ) as vllm_model:
             engine_core = vllm_model.llm.llm_engine.engine_core.engine_core
             model_runner = engine_core.model_executor.driver_worker.worker.model_runner

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -124,6 +124,9 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             the model weights. This virtually increases the GPU memory space
             you can use to hold the model weights, at the cost of CPU-GPU data
             transfer for every forward pass.
+        cpu_offload_params: UVA offloading: Set of parameter name segments to
+            selectively offload. If None or empty, parameters are offloaded
+            non-selectively until `cpu_offload_gb` is reached.
         offload_group_size: Prefetch offloading: Group every N layers
             together. Offload last `offload_num_in_group` layers of each group.
             Default is 0 (disabled).
@@ -197,6 +200,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
         seed: int = 0,
         gpu_memory_utilization: float = 0.92,
         cpu_offload_gb: float = 0,
+        cpu_offload_params: set[str] | None = None,
         offload_group_size: int = 0,
         offload_num_in_group: int = 1,
         offload_prefetch_step: int = 1,
@@ -314,6 +318,7 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             gpu_memory_utilization=gpu_memory_utilization,
             kv_cache_memory_bytes=kv_cache_memory_bytes,
             cpu_offload_gb=cpu_offload_gb,
+            cpu_offload_params=cpu_offload_params or set(),
             offload_group_size=offload_group_size,
             offload_num_in_group=offload_num_in_group,
             offload_prefetch_step=offload_prefetch_step,

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -58,6 +58,7 @@ def initialize_model(
         # new-style model class
         with set_current_vllm_config(vllm_config, check_compile=True, prefix=prefix):
             model = model_class(vllm_config=vllm_config, prefix=prefix)
+            maybe_offload_embeddings(model, prefix=prefix)
             record_metadata_for_reloading(model)
             return model
 
@@ -90,9 +91,35 @@ def initialize_model(
         kwargs["scheduler_config"] = vllm_config.scheduler_config
     with set_current_vllm_config(vllm_config, check_compile=True, prefix=prefix):
         model = model_class(**kwargs)
+        maybe_offload_embeddings(model, prefix=prefix)
         record_metadata_for_reloading(model)
 
     return model
+
+
+def maybe_offload_embeddings(model: nn.Module, prefix: str = "") -> None:
+    """Route directly-constructed embeddings through compatible offloaders.
+
+    ``make_layers`` is the normal offloader entry point, but embeddings are
+    commonly created directly by model constructors. Do this before checkpoint
+    loading so offloaded parameters never need a full device-resident copy.
+    """
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+    from vllm.model_executor.offloader import get_offloader
+
+    offloader = get_offloader()
+    if not offloader.supports_direct_module_offload:
+        return
+
+    for name, module in model.named_modules():
+        if isinstance(module, VocabParallelEmbedding):
+            module_prefix = f"{prefix}.{name}" if prefix and name else prefix or name
+            offloader.wrap_modules(
+                (direct_module for direct_module in [module]),
+                prefix=module_prefix,
+            )
 
 
 def process_weights_after_loading(

--- a/vllm/model_executor/offloader/base.py
+++ b/vllm/model_executor/offloader/base.py
@@ -60,6 +60,14 @@ class BaseOffloader(ABC):
     circular layer stack) must keep this `False`.
     """
 
+    supports_direct_module_offload: bool = False
+    """Whether ``wrap_modules`` accepts non-layer modules.
+
+    Some model components, such as token embeddings, are constructed directly
+    instead of through ``make_layers``. Offloaders that depend on a sequential
+    decoder-layer layout must keep this ``False``.
+    """
+
     @abstractmethod
     def wrap_modules(
         self,

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -44,6 +44,7 @@ class UVAOffloader(BaseOffloader):
         self.cpu_offload_max_bytes = cpu_offload_max_bytes
         self.cpu_offload_bytes = 0
         self.cpu_offload_params = cpu_offload_params or set()
+        self._matched_cpu_offload_params: set[str] = set()
 
         self.pin_memory = should_pin_memory()
         self.uva_offloading = (
@@ -82,17 +83,22 @@ class UVAOffloader(BaseOffloader):
         if device == torch.device("cpu"):
             return module
 
-        if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
+        if (
+            self.cpu_offload_bytes >= self.cpu_offload_max_bytes
+            and not self.cpu_offload_params
+        ):
             return module
 
         # offload parameters to CPU
         # use pin_memory if possible, which helps cudagraph capture speed
         offloaded_parameters = False
         for name, p in module.named_parameters():
-            if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
-                # we use per-parameter offloading
-                # one module might have some parameters offloaded and some not
-                break
+            matched_params = {
+                param
+                for param in self.cpu_offload_params
+                if f".{param}." in f".{prefix}{name}."
+            }
+            self._matched_cpu_offload_params.update(matched_params)
 
             # Skip parameters an earlier wrap_modules call already offloaded.
             # The UVA path leaves p.device as the accelerator (a view of CPU
@@ -100,17 +106,13 @@ class UVAOffloader(BaseOffloader):
             if p.device.type == "cpu" or getattr(p, "_vllm_is_uva_offloaded", False):
                 continue
 
-            if self.cpu_offload_params:
-                # Check if parameter belongs to the offloading set
-                # Add dots here to ensure we match full segments only
-                # e.g., "experts.w2_weight" matches "mlp.experts.w2_weight"
-                # but not "mlp.experts.w2_weight_scale"
-                should_offload = any(
-                    f".{param}." in f".{prefix}{name}."
-                    for param in self.cpu_offload_params
-                )
-                if not should_offload:
-                    continue
+            if self.cpu_offload_params and not matched_params:
+                continue
+
+            if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
+                # We offload whole parameters, so one parameter may exceed the
+                # remaining budget. Continue scanning to validate selectors.
+                continue
 
             cpu_data = p.data.to(device="cpu")
             if self.pin_memory:
@@ -153,3 +155,11 @@ class UVAOffloader(BaseOffloader):
             module.forward = forward
 
         return module
+
+    def post_init(self):
+        unmatched_params = self.cpu_offload_params - self._matched_cpu_offload_params
+        if unmatched_params:
+            logger.warning(
+                "CPU offload parameter selector(s) matched no parameters: %s",
+                ", ".join(sorted(unmatched_params)),
+            )

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -49,6 +49,10 @@ class UVAOffloader(BaseOffloader):
         self.uva_offloading = (
             is_uva_available() and not envs.VLLM_WEIGHT_OFFLOADING_DISABLE_UVA
         )
+        # Directly-constructed embeddings are only safe to offload through
+        # UVA. The functional_call fallback does not support all embedding
+        # users (for example, tied input/output embeddings).
+        self.supports_direct_module_offload = self.uva_offloading
 
     def wrap_modules(
         self,

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -44,7 +44,6 @@ class UVAOffloader(BaseOffloader):
         self.cpu_offload_max_bytes = cpu_offload_max_bytes
         self.cpu_offload_bytes = 0
         self.cpu_offload_params = cpu_offload_params or set()
-        self._matched_cpu_offload_params: set[str] = set()
 
         self.pin_memory = should_pin_memory()
         self.uva_offloading = (
@@ -83,22 +82,17 @@ class UVAOffloader(BaseOffloader):
         if device == torch.device("cpu"):
             return module
 
-        if (
-            self.cpu_offload_bytes >= self.cpu_offload_max_bytes
-            and not self.cpu_offload_params
-        ):
+        if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
             return module
 
         # offload parameters to CPU
         # use pin_memory if possible, which helps cudagraph capture speed
         offloaded_parameters = False
         for name, p in module.named_parameters():
-            matched_params = {
-                param
-                for param in self.cpu_offload_params
-                if f".{param}." in f".{prefix}{name}."
-            }
-            self._matched_cpu_offload_params.update(matched_params)
+            if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
+                # we use per-parameter offloading
+                # one module might have some parameters offloaded and some not
+                break
 
             # Skip parameters an earlier wrap_modules call already offloaded.
             # The UVA path leaves p.device as the accelerator (a view of CPU
@@ -106,13 +100,17 @@ class UVAOffloader(BaseOffloader):
             if p.device.type == "cpu" or getattr(p, "_vllm_is_uva_offloaded", False):
                 continue
 
-            if self.cpu_offload_params and not matched_params:
-                continue
-
-            if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
-                # We offload whole parameters, so one parameter may exceed the
-                # remaining budget. Continue scanning to validate selectors.
-                continue
+            if self.cpu_offload_params:
+                # Check if parameter belongs to the offloading set
+                # Add dots here to ensure we match full segments only
+                # e.g., "experts.w2_weight" matches "mlp.experts.w2_weight"
+                # but not "mlp.experts.w2_weight_scale"
+                should_offload = any(
+                    f".{param}." in f".{prefix}{name}."
+                    for param in self.cpu_offload_params
+                )
+                if not should_offload:
+                    continue
 
             cpu_data = p.data.to(device="cpu")
             if self.pin_memory:
@@ -155,11 +153,3 @@ class UVAOffloader(BaseOffloader):
             module.forward = forward
 
         return module
-
-    def post_init(self):
-        unmatched_params = self.cpu_offload_params - self._matched_cpu_offload_params
-        if unmatched_params:
-            logger.warning(
-                "CPU offload parameter selector(s) matched no parameters: %s",
-                ", ".join(sorted(unmatched_params)),
-            )


### PR DESCRIPTION
## Purpose

`--cpu-offload-params embed_tokens` currently offloads nothing for models whose
token embeddings are constructed directly instead of through `make_layers`.
Those embeddings remain on the GPU, reducing the memory available for the KV
cache.

The normal offloader entry point is called from `make_layers`, which only sees
the decoder layer stack. This change routes directly constructed
`VocabParallelEmbedding` modules through the compatible offloader after model
construction and before checkpoint loading.

The change:

- preserves fully qualified module prefixes for exact-segment selector
  matching;
- enables direct-module routing only for UVA when UVA is available and enabled;
- exposes `cpu_offload_params` explicitly in the high-level `LLM` API while
  keeping Prefetch's `offload_params` separate;
- leaves Prefetch and the non-UVA fallback unchanged; and
- adds a Qwen3.5 regression test for embedding offloading.

Fixes #53931.

## Test Plan

```bash
ruff check vllm/model_executor/model_loader/utils.py \
  vllm/entrypoints/llm.py \
  vllm/model_executor/offloader/base.py \
  vllm/model_executor/offloader/uva.py \
  tests/basic_correctness/test_cpu_offload.py

ruff format --check vllm/model_executor/model_loader/utils.py \
  vllm/entrypoints/llm.py \
  vllm/model_executor/offloader/base.py \
  vllm/model_executor/offloader/uva.py \
  tests/basic_correctness/test_cpu_offload.py

pre-commit run --files \
  vllm/model_executor/model_loader/utils.py \
  vllm/entrypoints/llm.py \
  vllm/model_executor/offloader/base.py \
  vllm/model_executor/offloader/uva.py \
  tests/basic_correctness/test_cpu_offload.py

.venv/bin/python -m pytest -q --collect-only \
  tests/basic_correctness/test_cpu_offload.py \
  -k embedding_weight_offloading

git diff --check
```

The behavior was also validated on real GPUs with untied and tied embeddings,
TP1 and TP2, fully qualified and unmatched selectors, UVA disabled, and the
Prefetch backend. The high-level `LLM` argument mapping was also checked to
confirm that UVA's `cpu_offload_params` and Prefetch's `offload_params` remain
independent.

## Test Result

All lint, formatting, pre-commit, type-checking, collection, and diff checks
passed. The new regression test was collected successfully, and the explicit
`LLM(cpu_offload_params=...)` argument was forwarded to `EngineArgs` correctly.

### Memory and KV-cache capacity

Qwen3-8B was tested with `cpu_offload_gb=2`, selector `embed_tokens`, and
`max_model_len=4096`:

| GPU memory utilization | Before | After | Change |
|---:|---:|---:|---:|
| 0.40 | Initialization failed: no available KV-cache blocks | 522 blocks / 8,352 tokens | Usable after the fix |
| 0.45 | 895 blocks / 14,320 tokens | 1,421 blocks / 22,736 tokens | +8,416 tokens (+58.8%) |
| 0.50 | 1,794 blocks / 28,704 tokens | 2,320 blocks / 37,120 tokens | +8,416 tokens (+29.3%) |
| 0.55 | 2,692 blocks / 43,072 tokens | 3,219 blocks / 51,504 tokens | +8,432 tokens (+19.6%) |

The selected embedding changed from `0 B` to `1,244,659,712 B` offloaded. At
GPU memory utilization 0.45, the model-memory metric decreased from
`15.268 GiB` to `14.108 GiB`.

Qwen3.5-0.8B, including its tied input/output embedding path, produced:

| Model/profile | Before | After | Change |
|---|---:|---:|---:|
| Qwen3.5-0.8B, block size 512, utilization 0.30 | 113 blocks / 14,464 tokens | 189 blocks / 24,192 tokens | +9,728 tokens (+67.3%) |

### Correctness and compatibility

| Case | Result |
|---|---|
| Qwen3-8B, TP1 | Embedding output was bitwise equal (`max_abs_diff=0`); generation was unchanged |
| Qwen3.5-0.8B, tied embeddings | Embedding output was bitwise equal (`max_abs_diff=0`); generation was unchanged |
| Qwen3-30B-A3B-Instruct-2507, TP2 | Both ranks offloaded `311,164,928 B`; generation succeeded unchanged |
| Full selector `model.embed_tokens` | Matched the fully qualified parameter path |
| Unmatched selector | Offload remained `0 B`; parameters stayed resident |
| Selector `lm_head` | Reached the directly constructed `ParallelLMHead` |
| `VLLM_WEIGHT_OFFLOADING_DISABLE_UVA=1` | Direct-module routing was disabled; existing behavior was preserved |
| Prefetch backend | No second `wrap_modules` call; existing behavior was preserved |

### Throughput sanity check

Qwen3-8B was tested with identical prompts, 32 generated tokens, and three
repeats per batch:

| Batch size | Before runs / mean tok/s | After runs / mean tok/s |
|---:|---|---|
| 1 | 44.78 / 49.97 / 49.41 / **48.05** | 51.12 / 52.12 / 51.71 / **51.65** |
| 4 | 191.88 / 196.51 / 160.46 / **182.95** | 199.06 / 203.54 / 202.86 / **201.82** |
| 8 | 358.95 / 386.85 / 395.93 / **380.58** | 404.00 / 402.46 / 402.35 / **402.94** |

These throughput measurements are a regression sanity check, not a general
performance claim. The primary benefit is lower model residency and increased
KV-cache capacity.

## Why this is not a duplicate

Issue #53931 reports this reachability bug and has no assignee, development
branch, linked pull request, or comment indicating that another contributor is
preparing a fix. Searches for open pull requests referencing #53931 or combining
embedding selectors with weight offloading found no matching implementation.

Merged PR #53120 established the common offloader-path pattern for modules that
`make_layers` cannot reach. This change applies that pattern to directly
constructed embeddings while preserving Prefetch and non-UVA behavior.

## Documentation

No new option or syntax is introduced. This fixes the existing documented
segment-matching behavior of `cpu_offload_params`; its configuration docstring
remains the source of truth.

## AI assistance

AI tools were used for duplicate-work checks, code
changes, test design, and organizing the validation results.
