### PR TITLE
[Bugfix][DSpark] Skip unregistered DeepSeek-V4 expert weights

### DIFF
--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -39,6 +39,53 @@ def test_deepseek_v4_mega_moe_expert_mapping():
     ]
 
 
+def test_dspark_skips_unregistered_expert_weight(monkeypatch):
+    dspark = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[SimpleNamespace(ffn=SimpleNamespace(use_mega_moe=True))],
+            confidence_head=None,
+        ),
+        config=SimpleNamespace(
+            n_routed_experts=1,
+            num_attention_heads=1,
+            expert_dtype="fp4",
+        ),
+        pad_shared_expert=False,
+        named_parameters=lambda: [],
+        _remap_dspark_name=lambda name: name,
+        process_weights_after_loading=lambda: None,
+    )
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.nvidia.dspark."
+        "make_deepseek_v4_expert_params_mapping",
+        lambda _: [
+            (
+                "experts.routed_experts.w13_",
+                "experts.0.w1.",
+                0,
+                "w1",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.nvidia.dspark."
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.nvidia.dspark."
+        "get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+
+    loaded = DSparkDeepseekV4ForCausalLM.load_weights(
+        dspark,
+        [("model.layers.0.ffn.experts.0.w1.scale", torch.ones(1))],
+    )
+
+    assert loaded == set()
+
+
 def test_deepseek_v4_mega_moe_ue8m0_uint8_to_float():
     raw = torch.tensor([0, 126, 127, 128], dtype=torch.uint8)
 

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -463,6 +463,8 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
                     if weight_name not in name:
                         continue
                     name_mapped = name.replace(weight_name, param_name)
+                    if name_mapped not in params_dict:
+                        continue
                     param = params_dict[name_mapped]
                     success = param.weight_loader(
                         param,


### PR DESCRIPTION
## Purpose

Fixes #51916.

The NVIDIA DeepSeek-V4 DSpark loader directly indexes mapped expert parameters. Some target-model expert scale weights are not registered by the DSpark draft model, causing a `KeyError` during startup. Skip mapped expert weights that are absent from the draft model, matching the existing XPU DSpark loader behavior.

This also adds a focused regression test for the reported `w13_weight_scale` case.

I searched open PRs for `51916`, `DSpark unregistered expert weight`, and `routed_experts.w13_weight_scale`. I did not find another PR addressing this issue. The related expert-scale representation PR does not add the missing-parameter guard.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/models/test_deepseek_v4_mega_moe.py::test_dspark_skips_unregistered_expert_weight \
  -vv
```

The issue reporter will additionally validate startup with the original 8xH20 DeepSeek-V4-Flash + DSpark configuration.

## Test Result

- `.venv/bin/python -m compileall -q vllm/models/deepseek_v4/nvidia/dspark.py tests/models/test_deepseek_v4_mega_moe.py` passed.
- `git diff --check` passed.
- The targeted regression test passed on an NVIDIA RTX A4000: `1 passed, 14 warnings in 1.69s`.
- Running the complete `test_deepseek_v4_mega_moe.py` file on the A4000 produced `11 passed, 7 failed`. All seven failures are existing MegaMoE kernel tests that require the unsupported `fp8e4nv` dtype on this Ampere GPU; none exercise the changed weight-loader path.
- End-to-end 8xH20 validation is pending with the issue reporter.

Model evaluation results are not yet available. This draft PR only skips checkpoint weights that the DSpark draft model does not register.
OpenAI Codex was used to inspect the loader paths, implement the guard, and draft the regression test and PR description. I reviewed each changed line.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The current test results and pending GPU validation are documented.
- [x] No documentation update is required.
</details>
