### PR TITLE
Fix: Prevent SageMaker logger standard from suppressing vLLM startup logs

### DIFF
--- a/vllm/entrypoints/launchers/app.py
+++ b/vllm/entrypoints/launchers/app.py
@@ -8,6 +8,8 @@ from fastapi import FastAPI
 from vllm.config import ModelConfig
 from vllm.entrypoints.serve.exception_handling.register import init_exception_handler
 from vllm.entrypoints.serve.middleware.register import init_entrypoints_middleware
+import logging
+
 from vllm.entrypoints.serve.sagemaker.api_router import sagemaker_standards_bootstrap
 from vllm.plugins.endpoint_plugins.interface import attach_endpoint_plugins
 from vllm.tasks import FALLBACK_SUPPORTED_TASKS, SupportedTask
@@ -52,5 +54,21 @@ def build_app(
 
     init_exception_handler(app)
     init_entrypoints_middleware(args, app, supported_tasks)
+    
+    # Save the original handlers on the vLLM logger so they can be restored.
+    # The SageMaker standards bootstrap function overwrites the root logger's
+    # handlers to ERROR level, which inadvertently silences the vLLM logger
+    # if it shares the same handlers (e.g. via VLLM_LOGGING_CONFIG_PATH).
+    vllm_logger = logging.getLogger("vllm")
+    original_handlers = [
+        (handler, handler.level) for handler in vllm_logger.handlers
+    ]
+    
     app = sagemaker_standards_bootstrap(app)
+    
+    # Restore the vllm logger handlers' levels if they were changed
+    for handler, original_level in original_handlers:
+        if handler.level != original_level:
+            handler.setLevel(original_level)
+            
     return app


### PR DESCRIPTION
### What does this PR do?
Fixes #53655

When vLLM is imported, the SageMaker integration transitively imports `model_hosting_container_standards.logging_config`, which forces the levels of existing root handlers to `ERROR`. 

If a user specifies a custom `VLLM_LOGGING_CONFIG_PATH` that maps the `vllm` logger to the same handler as the root logger, this mechanism silently suppresses all `INFO` and `WARNING` startup logs emitted by the vLLM engine, making debugging extremely difficult (e.g. chunked prefill configurations are not printed).

This PR fixes the issue by caching the original log levels of all handlers attached to the `vllm` namespace logger right before executing `sagemaker_standards_bootstrap`. After the bootstrap executes and potentially hijacks the shared handlers to `ERROR`, this patch safely restores the handlers to their intended log levels, ensuring vLLM logs propagate correctly without breaking SageMaker's integration requirements.

### Testing
Confirmed this fix locally by simulating the handler reference sharing and asserting that handler levels are preserved across the bootstrap boundary.

Signed-off-by: DresdenGman <213183438+DresdenGman@users.noreply.github.com>