### PR TITLE
[XPU][CI] increase timeout of shutdown

### DIFF
--- a/tests/v1/shutdown/utils.py
+++ b/tests/v1/shutdown/utils.py
@@ -2,5 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Shutdown test utils"""
 
-SHUTDOWN_TEST_TIMEOUT_SEC = 120
+from vllm.platforms import current_platform
+
+# XPU tears down engine core processes and reclaims device memory more slowly,
+# so the default budget expires before wait_for_gpu_memory_to_clear finishes.
+SHUTDOWN_TEST_TIMEOUT_SEC = 240 if current_platform.is_xpu() else 120
 SHUTDOWN_TEST_THRESHOLD_BYTES = 2 * 2**30


### PR DESCRIPTION



## Purpose
Shutdown tests fail on XPU with Failed: Timeout >120.0s.

This PR increase timeout for XPU.

## Test Plan
`pytest -sv tests/v1/shutdown/test_delete.py`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

