### PR TITLE
[Bugfix] Accept legacy comma-separated --collect-detailed-traces

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,6 +100,30 @@ def test_per_request_spec_decode_metrics_requires_spec_decode():
             )
 
 
+def test_collect_detailed_traces_accepts_legacy_comma_string():
+    # The CLI advertises comma-joined values (e.g. `model,worker`) in its
+    # choices, so `--collect-detailed-traces model,worker` arrives here as
+    # `["model,worker"]`. It must be split into individual modules instead of
+    # being rejected against the per-element Literal.
+    endpoint = "http://localhost:4317"
+    config = ObservabilityConfig(
+        collect_detailed_traces=["model,worker"],
+        otlp_traces_endpoint=endpoint,
+    )
+    assert config.collect_detailed_traces == ["model", "worker"]
+
+    # Already-split lists and invalid values keep their existing behaviour.
+    assert ObservabilityConfig(
+        collect_detailed_traces=["all"],
+        otlp_traces_endpoint=endpoint,
+    ).collect_detailed_traces == ["all"]
+    with pytest.raises(ValidationError):
+        ObservabilityConfig(
+            collect_detailed_traces=["bogus"],
+            otlp_traces_endpoint=endpoint,
+        )
+
+
 def test_compile_config_repr_succeeds():
     # setup: VllmBackend mutates the config object
     config = VllmConfig()

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from functools import cached_property
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from packaging.version import parse
 from pydantic import Field, field_validator, model_validator
@@ -151,15 +151,19 @@ class ObservabilityConfig:
                 )
         return value
 
-    @field_validator("collect_detailed_traces")
+    @field_validator("collect_detailed_traces", mode="before")
     @classmethod
-    def _validate_collect_detailed_traces(
-        cls, value: list[DetailedTraceModules] | None
-    ) -> list[DetailedTraceModules] | None:
+    def _validate_collect_detailed_traces(cls, value: Any) -> Any:
         """Handle the legacy case where users might provide a comma-separated
-        string instead of a list of strings."""
-        if value is not None and len(value) == 1 and "," in value[0]:
-            value = cast(list[DetailedTraceModules], value[0].split(","))
+        string instead of a list of strings.
+
+        Runs in ``before`` mode so the split happens prior to the
+        ``Literal`` validation of each element; otherwise a value such as
+        ``["model,worker"]`` (which the CLI advertises via ``choices``) is
+        rejected before this ever runs.
+        """
+        if isinstance(value, list) and len(value) == 1 and "," in value[0]:
+            value = value[0].split(",")
         return value
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary

`--collect-detailed-traces` advertises comma-joined values (e.g. `model,worker`)
in its argparse `choices`/`metavar`, but passing that documented form always
fails config validation.

`ObservabilityConfig._validate_collect_detailed_traces` was intended to split
the legacy comma-separated string, but it ran in the default `after` mode. In
`after` mode pydantic validates each list element against
`Literal["model", "worker", "all"]` **before** the validator runs, so
`["model,worker"]` (what argparse produces via `nargs="+"`) is rejected and the
comma-splitting is dead code.

The fix switches the validator to `mode="before"` so the split happens prior to
the `Literal` validation. Space-separated lists, single values, `None`, and
genuinely invalid values are unaffected.

## Reproduction

Before (on `main`):

```
$ python -c "from vllm.config.observability import ObservabilityConfig; \
ObservabilityConfig(collect_detailed_traces=['model,worker'], otlp_traces_endpoint='http://localhost:4317')"

1 validation error for ObservabilityConfig
collect_detailed_traces.0
  Input should be 'model', 'worker' or 'all' [type=literal_error, input_value='model,worker', input_type=str]
    For further information visit https://errors.pydantic.dev/2.13/v/literal_error
```

After (this PR):

```
$ python -c "from vllm.config.observability import ObservabilityConfig; \
print(ObservabilityConfig(collect_detailed_traces=['model,worker'], otlp_traces_endpoint='http://localhost:4317').collect_detailed_traces)"

['model', 'worker']
```

## Test plan

- Added `tests/test_config.py::test_collect_detailed_traces_accepts_legacy_comma_string`
  covering the comma form, the already-split list form, and rejection of invalid values.

```
$ python -m pytest tests/test_config.py::test_collect_detailed_traces_accepts_legacy_comma_string -q
1 passed
```

- `pre-commit` (ruff-check, ruff-format, mypy-3.12) pass on the changed files.

## Notes

Not a duplicate: no open PR addresses `collect_detailed_traces` legacy comma
parsing (searched open/all PRs for `collect_detailed_traces`).

AI assistance was used to help identify and fix this bug; a human has reviewed
every changed line.
