### PR TITLE
fix: define math constants for FlashMLA MSVC builds

### DIFF
--- a/cmake/external_projects/flashmla.cmake
+++ b/cmake/external_projects/flashmla.cmake
@@ -163,7 +163,8 @@ if(FLASH_MLA_ARCHS)
 
     # _flashmla_C is now ABI-stable torch 2.11+
     target_compile_definitions(_flashmla_C PRIVATE
-        TORCH_TARGET_VERSION=0x020B000000000000ULL)
+        TORCH_TARGET_VERSION=0x020B000000000000ULL
+        _USE_MATH_DEFINES=1)
     if(VLLM_GPU_LANG STREQUAL "CUDA")
         target_compile_definitions(_flashmla_C PRIVATE USE_CUDA)
     endif()
@@ -181,7 +182,8 @@ if(FLASH_MLA_ARCHS)
 
     # _flashmla_extension_C is now ABI-stable w/ torch 2.11+
     target_compile_definitions(_flashmla_extension_C PRIVATE
-        TORCH_TARGET_VERSION=0x020B000000000000ULL)
+        TORCH_TARGET_VERSION=0x020B000000000000ULL
+        _USE_MATH_DEFINES=1)
     if(VLLM_GPU_LANG STREQUAL "CUDA")
         target_compile_definitions(_flashmla_extension_C PRIVATE USE_CUDA)
     endif()


### PR DESCRIPTION
## Purpose
Fix [#53935](https://github.com/vllm-project/vllm/issues/53935), where `M_LOG2E` availability in the FlashMLA extension depends on build configuration under MSVC.

The CMake configuration now passes `_USE_MATH_DEFINES=1` to both the `_flashmla_C` and `_flashmla_extension_C` targets. This makes the math constants exposed consistently by the Microsoft C runtime without changing the extension’s numerical implementation.

## Test Plan
- Inspect both FlashMLA extension targets and verify that the compile definition is applied to each target.
- Run `git diff --check` on the contribution branch.
- Build the FlashMLA extension with the affected MSVC/NVCC configuration in upstream CI.

## Test Result
The CMake target definitions and patch integrity were statically validated, and the diff contains no whitespace errors. CUDA, MSVC, and the FlashMLA toolchain are not available in this sandbox, so the platform-specific compilation must be completed by upstream CI.
