### PR TITLE
[ROCm] add AITER MLA prefill CI coverage

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2759,6 +2759,40 @@ steps:
   commands:
   - pytest -v -s v1/attention --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
+- label: ":amd: (MI300) ROCm AITER MLA Prefill" # Issue #53944
+  timeout_in_minutes: 45
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
+  dind: false
+  agent_pool: mi300_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  env:
+    VLLM_ROCM_USE_AITER: "1"
+  source_file_dependencies:
+  - vllm/v1/attention/backends/rocm_aiter_fa.py
+  - vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+  - vllm/v1/attention/selector.py
+  - tests/v1/attention/test_mla_backends.py
+  commands:
+  - pytest -v -s v1/attention/test_mla_backends.py -k 'test_backend_correctness or test_chunked_context_backend_correctness'
+
+- label: ":amd: (MI355) ROCm AITER MLA Prefill" # Issue #53944
+  timeout_in_minutes: 45
+  mirror_hardwares: [amdexperimental, amdproduction, amdgfx950nightly, amdmi355]
+  dind: false
+  agent_pool: mi355_1
+  optional: true
+  working_dir: "/vllm-workspace/tests"
+  env:
+    VLLM_ROCM_USE_AITER: "1"
+  source_file_dependencies:
+  - vllm/v1/attention/backends/rocm_aiter_fa.py
+  - vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+  - vllm/v1/attention/selector.py
+  - tests/v1/attention/test_mla_backends.py
+  commands:
+  - pytest -v -s v1/attention/test_mla_backends.py -k 'test_backend_correctness or test_chunked_context_backend_correctness'
+
 - label: ":amd: (MI300) V1 Core + KV + Metrics" # TBD
   timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]


### PR DESCRIPTION
## Purpose
Fix [#53944](https://github.com/vllm-project/vllm/issues/53944), where the ROCm AITER MLA prefill backend is not exercised by nightly CI.

This change adds separate optional Buildkite jobs for MI300 and MI355 environments. Each job sets `VLLM_ROCM_USE_AITER=1` before pytest collection and runs the two affected MLA prefill correctness tests, so backend selection and correctness are checked explicitly on both hardware tiers.

## Test Plan
- Parse `.buildkite/test-amd.yaml` with PyYAML.
- Verify that both new jobs select the expected MI300/MI355 queues or hardware constraints.
- Verify that each job exports `VLLM_ROCM_USE_AITER=1` before test collection.
- Verify that each job runs the two cited MLA prefill correctness tests.
- Execute the jobs in Buildkite on the corresponding ROCm hardware.

## Test Result
The Buildkite YAML parsed successfully. Both jobs were statically verified to contain the required environment variable and test selectors. MI300/MI355 ROCm hardware is not available in this sandbox, so the actual GPU correctness runs must be completed by upstream Buildkite CI.
