### PR TITLE
[Quantization] Skip absent fused-layer shards in the GPTQ per-layer check (Gemma 4 k_eq_v)

### DIFF
--- a/tests/quantization/test_gptq_utils.py
+++ b/tests/quantization/test_gptq_utils.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for `is_layer_gptq_quantized`'s handling of fused layers.
+
+These exercise the fused-shard reconciliation logic directly (no GPU, no
+model loading), including the case where a fused layer's checkpoint is
+missing a shard entirely (e.g. Gemma 4's k_eq_v global-attention layers,
+which have no `v_proj` at all).
+"""
+
+import pytest
+
+from vllm.model_executor.layers.quantization.utils.gptq_utils import (
+    is_layer_gptq_quantized,
+)
+
+PREFIX = "model.layers.5.self_attn.qkv_proj"
+BASE = "model.layers.5.self_attn"
+Q_PROJ = f"{BASE}.q_proj"
+K_PROJ = f"{BASE}.k_proj"
+V_PROJ = f"{BASE}.v_proj"
+FUSED_MAPPING = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+
+
+def test_fused_layer_all_shards_quantized():
+    quantized_layers = [Q_PROJ, K_PROJ, V_PROJ]
+    assert is_layer_gptq_quantized(PREFIX, quantized_layers, FUSED_MAPPING)
+
+
+def test_fused_layer_all_shards_unquantized():
+    assert not is_layer_gptq_quantized(PREFIX, [], FUSED_MAPPING)
+
+
+def test_fused_layer_real_mismatch_raises():
+    # q_proj and k_proj are quantized, v_proj is present but unquantized.
+    quantized_layers = [Q_PROJ, K_PROJ]
+    with pytest.raises(ValueError):
+        is_layer_gptq_quantized(PREFIX, quantized_layers, FUSED_MAPPING)
+
+
+def test_fused_layer_real_mismatch_raises_with_modules_in_checkpoint():
+    # v_proj is genuinely present in the checkpoint, so a mismatch is
+    # still a real mismatch even when modules_in_checkpoint is provided.
+    quantized_layers = [Q_PROJ, K_PROJ]
+    modules_in_checkpoint = {Q_PROJ, K_PROJ, V_PROJ}
+    with pytest.raises(ValueError):
+        is_layer_gptq_quantized(
+            PREFIX,
+            quantized_layers,
+            FUSED_MAPPING,
+            modules_in_checkpoint=modules_in_checkpoint,
+        )
+
+
+def test_fused_layer_absent_shard_is_skipped():
+    # v_proj does not exist in the checkpoint at all (e.g. Gemma 4's
+    # k_eq_v layers), so it cannot disagree with q_proj/k_proj.
+    quantized_layers = [Q_PROJ, K_PROJ]
+    modules_in_checkpoint = {Q_PROJ, K_PROJ}
+    assert is_layer_gptq_quantized(
+        PREFIX,
+        quantized_layers,
+        FUSED_MAPPING,
+        modules_in_checkpoint=modules_in_checkpoint,
+    )
+
+
+def test_fused_layer_no_shard_in_checkpoint_returns_false():
+    quantized_layers = [Q_PROJ, K_PROJ, V_PROJ]
+    assert not is_layer_gptq_quantized(
+        PREFIX,
+        quantized_layers,
+        FUSED_MAPPING,
+        modules_in_checkpoint=set(),
+    )

--- a/vllm/model_executor/layers/quantization/auto_gptq.py
+++ b/vllm/model_executor/layers/quantization/auto_gptq.py
@@ -162,6 +162,7 @@ class AutoGPTQConfig(QuantizationConfig):
         self.quant_type = self.TYPE_MAP[(weight_bits, is_sym)]
 
         self.modules_in_block_to_quantize = modules_in_block_to_quantize or []
+        self.modules_in_checkpoint: set[str] | None = None
         # used to identify GPTQ model quantized by autoround
         self.autoround_version = full_config.get("autoround_version", "")
 
@@ -274,6 +275,10 @@ class AutoGPTQConfig(QuantizationConfig):
             self.modules_in_block_to_quantize = hf_to_vllm_mapper.apply_list(
                 self.modules_in_block_to_quantize
             )
+        if self.modules_in_checkpoint is not None:
+            self.modules_in_checkpoint = set(
+                hf_to_vllm_mapper.apply_list(list(self.modules_in_checkpoint))
+            )
 
     def maybe_update_config(
         self,
@@ -294,6 +299,9 @@ class AutoGPTQConfig(QuantizationConfig):
 
         unquant_dtypes = [torch.float16, torch.bfloat16, torch.float32]
         metadata = get_safetensors_params_metadata(model_name, revision=revision)
+        self.modules_in_checkpoint = {
+            param_name.rsplit(".", 1)[0] for param_name in metadata
+        }
         quant_layers: set[str] = {
             param_name.rsplit(".", 1)[0]
             for param_name, info in metadata.items()

--- a/vllm/model_executor/layers/quantization/utils/gptq_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/gptq_utils.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from copy import deepcopy
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -87,6 +87,7 @@ def is_layer_gptq_quantized(
     prefix: str,
     quantized_layers: list[str],
     fused_mapping: Mapping[str, list[str]] = MappingProxyType({}),
+    modules_in_checkpoint: Collection[str] | None = None,
 ) -> bool:
     # prefix: model.layers.0.self_attn.q_proj
     # proj_name: q_proj
@@ -111,6 +112,14 @@ def is_layer_gptq_quantized(
 
         is_quantized = None
         for shard_prefix in shard_prefixes:
+            if (
+                modules_in_checkpoint is not None
+                and shard_prefix not in modules_in_checkpoint
+            ):
+                # Shard does not exist in the checkpoint (e.g. Gemma 4's
+                # k_eq_v layers have no v_proj), so it cannot disagree.
+                continue
+
             is_shard_quantized = any(
                 layer in shard_prefix for layer in quantized_layers
             )
@@ -123,6 +132,10 @@ def is_layer_gptq_quantized(
                     "are quantized. All shards of fused layers "
                     "to have the same precision."
                 )
+
+        if is_quantized is None:
+            # None of the fused layer's shards exist in the checkpoint.
+            return False
     else:
         is_quantized = any(layer in prefix for layer in quantized_layers)
 
@@ -145,6 +158,7 @@ def get_linear_quant_method(
             prefix=prefix,
             quantized_layers=cloned_config.modules_in_block_to_quantize,
             fused_mapping=cloned_config.packed_modules_mapping,
+            modules_in_checkpoint=getattr(cloned_config, "modules_in_checkpoint", None),
         )
         # False = skip module, None = no override, else = Positive match
         if get_dynamic_override(  # noqa: E712


### PR DESCRIPTION
## Purpose

Fixes #53992.

`AutoGPTQConfig.maybe_update_config` derives `modules_in_block_to_quantize` by scanning the safetensors metadata for non-float parameters, which yields only the *quantized* module names. `is_layer_gptq_quantized` then expands a fused layer through `packed_modules_mapping` and requires every shard to agree — so a shard that is legitimately **absent** from the checkpoint (Gemma 4's global-attention layers have no `v_proj`; V is taken from K) is treated as "present but unquantized" and the model is rejected:

```
ValueError: Detected some but not all shards of language_model.model.layers.5.self_attn.qkv_proj are quantized. All shards of fused layers to have the same precision.
```

This PR records the set of module prefixes present in the checkpoint during the same scan (`AutoGPTQConfig.modules_in_checkpoint`, mapped through the HF→vLLM name mapper exactly like the existing list) and lets `is_layer_gptq_quantized` skip shards that do not exist in the checkpoint. A fused layer with none of its shards present returns `False`. Behaviour is unchanged when `modules_in_block_to_quantize` comes from the config (`modules_in_checkpoint` stays `None`), and a real present-but-unquantized mismatch still raises.

Related but different: #44072 handles a config that *lists* fused names (e.g. `mlp.gate_up_proj`) in `modules_in_block_to_quantize`; this PR handles the derived-from-checkpoint path where a fused layer's shard is genuinely absent. They are independent and compose.

Duplicate check: no open PR or issue for this (`gh pr list --search "gptq shards quantized gemma"`, issue search for the error text) before #53992 was filed.

## Test Plan

- New unit tests `tests/quantization/test_gptq_utils.py` (no GPU): all-quantized / all-unquantized fused layers unchanged; real mismatch still raises with and without a checkpoint set; absent shard → `True` without raising; no shard present → `False`.
- `pre-commit run --files ...` (ruff check/format, mypy).
- End-to-end on 2x Intel Arc Pro B70: `Intel/gemma-4-31B-it-int4-AutoRound` with a plain-GPTQ `quantization_config` (no `modules_in_block_to_quantize`, so the scan path runs), `--language-model-only`, XPU graphs on: model constructs, serves, and passes a 4-prompt coherence check.

## Test Result

- Unit tests: `6 passed`.
- pre-commit: all hooks pass.
- End-to-end (Arc Pro B70, TP=1, `--max-model-len 4096`, XPU graphs on): the same checkpoint/config that failed at construction with the shard error now loads, is healthy in ~100 s, passes the 4-prompt coherence check, and answers a `response_format: json_object` request with `{"city": "Paris", "country": "France"}`. (Run against this branch plus the pending `getMemoryInfo` fallback from #53990, which Arc needs to start at all; that change is not part of this PR.)

---

AI assistance: this change was developed with Claude Code (Claude Fable 5) — the implementation was produced by a coding agent from a written spec; the human submitter reviewed every line, ran the tests and the end-to-end check on the hardware, and defends the change.
