### PR TITLE
[XPU][V2] Keep grammar-bitmask copies on the current stream under XPU graphs

### DIFF
--- a/tests/v1/worker/test_structured_outputs_xpu_stream.py
+++ b/tests/v1/worker/test_structured_outputs_xpu_stream.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Stream selection in StructuredOutputsWorker.apply_grammar_bitmask.
+
+SYCL command graphs reject cross-queue event dependencies, so under XPU
+graphs the grammar-bitmask H2D copies must stay on the current stream
+instead of joining a private copy stream via ``wait_stream`` (see
+``vllm/v1/worker/gpu/pp_utils.py`` for the same XPU limitation). These tests
+run on CPU tensors only, with ``torch.cuda.{Stream,stream,current_stream}``
+monkeypatched to lightweight fakes, so no accelerator is required or used.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.worker.gpu import structured_outputs as so_module
+from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
+
+
+class _FakeStream:
+    """Stand-in for ``torch.cuda.Stream``: records ``wait_stream`` calls."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.wait_stream_calls: list[_FakeStream] = []
+
+    def wait_stream(self, other: "_FakeStream") -> None:
+        self.wait_stream_calls.append(other)
+
+    def __repr__(self) -> str:
+        return f"_FakeStream({self.name!r})"
+
+
+class _FakeStreamContext:
+    """Stand-in for the context manager ``torch.cuda.stream(...)`` returns."""
+
+    def __init__(self, stream: _FakeStream) -> None:
+        self.stream = stream
+        self.enter_count = 0
+
+    def __enter__(self) -> _FakeStream:
+        self.enter_count += 1
+        return self.stream
+
+    def __exit__(self, *exc_info: Any) -> None:
+        return None
+
+
+class _FakeKernel:
+    """Stand-in for the ``@triton.jit`` kernel: records ``kernel[grid](...)``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, tuple, dict]] = []
+
+    def __getitem__(self, grid: Any) -> Any:
+        def _launch(*args: Any, **kwargs: Any) -> None:
+            self.calls.append((grid, args, kwargs))
+
+        return _launch
+
+
+def _install_fakes(monkeypatch: pytest.MonkeyPatch, is_xpu: bool) -> dict[str, Any]:
+    """Patch everything apply_grammar_bitmask touches with device-free fakes."""
+    monkeypatch.setattr(
+        so_module, "current_platform", SimpleNamespace(is_xpu=lambda: is_xpu)
+    )
+    # pin_memory() on a real tensor requires an initialized accelerator; keep
+    # this test's copies plain CPU-to-CPU regardless of the host's PIN_MEMORY.
+    monkeypatch.setattr(so_module, "PIN_MEMORY", False)
+
+    current_stream = _FakeStream("current")
+    stream_ctx_calls: list[_FakeStreamContext] = []
+
+    def fake_stream_ctor(*args: Any, **kwargs: Any) -> _FakeStream:
+        return _FakeStream("copy")
+
+    def fake_stream_ctx(stream: _FakeStream) -> _FakeStreamContext:
+        ctx = _FakeStreamContext(stream)
+        stream_ctx_calls.append(ctx)
+        return ctx
+
+    def fake_current_stream(*args: Any, **kwargs: Any) -> _FakeStream:
+        return current_stream
+
+    monkeypatch.setattr(torch.cuda, "Stream", fake_stream_ctor)
+    monkeypatch.setattr(torch.cuda, "stream", fake_stream_ctx)
+    monkeypatch.setattr(torch.cuda, "current_stream", fake_current_stream)
+
+    copy_calls: list[Any] = []
+
+    def fake_async_copy_to_gpu(
+        x: Any, out: torch.Tensor | None = None, device: Any = None
+    ) -> torch.Tensor:
+        copy_calls.append(x)
+        assert out is not None
+        return out
+
+    monkeypatch.setattr(so_module, "async_copy_to_gpu", fake_async_copy_to_gpu)
+
+    kernel = _FakeKernel()
+    monkeypatch.setattr(so_module, "_apply_grammar_bitmask_kernel", kernel)
+
+    return {
+        "current_stream": current_stream,
+        "stream_ctx_calls": stream_ctx_calls,
+        "copy_calls": copy_calls,
+        "kernel": kernel,
+    }
+
+
+def _run_apply_grammar_bitmask(
+    monkeypatch: pytest.MonkeyPatch, is_xpu: bool
+) -> tuple[StructuredOutputsWorker, dict[str, Any]]:
+    fakes = _install_fakes(monkeypatch, is_xpu)
+
+    worker = StructuredOutputsWorker(
+        max_num_logits=4,
+        vocab_size=32,
+        device=torch.device("cpu"),
+        mask_stride=4,
+        num_bonus_tokens=0,
+    )
+
+    # Two requests, one logit position each, both selected for grammar masking.
+    input_batch = SimpleNamespace(
+        req_ids=["a", "b"],
+        cu_num_logits_np=np.array([0, 1, 2], dtype=np.int64),
+        num_draft_tokens_per_req=None,
+        cu_num_logits=torch.tensor([0, 1, 2], dtype=torch.int32),
+    )
+    logits = torch.zeros(2, 32)
+    grammar_bitmask = np.zeros((2, 1), dtype=np.int32)
+
+    worker.apply_grammar_bitmask(logits, input_batch, ["a", "b"], grammar_bitmask)
+    return worker, fakes
+
+
+def test_non_xpu_uses_copy_stream_and_waits(monkeypatch: pytest.MonkeyPatch) -> None:
+    worker, fakes = _run_apply_grammar_bitmask(monkeypatch, is_xpu=False)
+
+    assert worker.use_copy_stream is True
+
+    # torch.cuda.stream(self.copy_stream) is constructed once and entered by
+    # both `with copy_ctx:` blocks (bitmask copy, then mapping copy).
+    assert len(fakes["stream_ctx_calls"]) == 1
+    ctx = fakes["stream_ctx_calls"][0]
+    assert ctx.stream is worker.copy_stream
+    assert ctx.enter_count == 2
+
+    # Both directions of the cross-stream join happen.
+    current_stream = fakes["current_stream"]
+    assert current_stream.wait_stream_calls == [worker.copy_stream]
+    assert worker.copy_stream.wait_stream_calls == [current_stream]
+
+    assert len(fakes["copy_calls"]) == 1
+    assert len(fakes["kernel"].calls) == 1
+
+
+def test_xpu_skips_copy_stream_and_waits(monkeypatch: pytest.MonkeyPatch) -> None:
+    worker, fakes = _run_apply_grammar_bitmask(monkeypatch, is_xpu=True)
+
+    assert worker.use_copy_stream is False
+
+    # No cross-queue context is ever opened on XPU.
+    assert fakes["stream_ctx_calls"] == []
+
+    # No cross-stream event dependency is created either.
+    current_stream = fakes["current_stream"]
+    assert current_stream.wait_stream_calls == []
+    assert worker.copy_stream.wait_stream_calls == []
+
+    # The copies and the kernel launch still happen, just on the current stream.
+    assert len(fakes["copy_calls"]) == 1
+    assert len(fakes["kernel"].calls) == 1

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
+
 import numpy as np
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import PIN_MEMORY
@@ -53,6 +56,9 @@ class StructuredOutputsWorker:
         )
         self.device = device
         self.copy_stream = torch.cuda.Stream()
+        # SYCL command graphs reject cross-queue event dependencies, so XPU
+        # keeps the grammar-bitmask copies on the current stream instead.
+        self.use_copy_stream = not current_platform.is_xpu()
         self.mask_stride = mask_stride
         self.num_bonus_tokens = num_bonus_tokens
 
@@ -66,8 +72,14 @@ class StructuredOutputsWorker:
         if not grammar_req_ids:
             return
 
+        copy_ctx = (
+            torch.cuda.stream(self.copy_stream)
+            if self.use_copy_stream
+            else contextlib.nullcontext()
+        )
+
         # Asynchronously copy the bitmask to GPU.
-        with torch.cuda.stream(self.copy_stream):
+        with copy_ctx:
             bitmask = async_copy_to_gpu(
                 grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
             )
@@ -86,7 +98,7 @@ class StructuredOutputsWorker:
         )
 
         # Asynchronously copy the mapping to GPU.
-        with torch.cuda.stream(self.copy_stream):
+        with copy_ctx:
             logits_indices = torch.tensor(
                 mapping, dtype=torch.int32, device="cpu", pin_memory=PIN_MEMORY
             )
@@ -96,7 +108,8 @@ class StructuredOutputsWorker:
 
         # Ensure all async copies are complete before launching the kernel.
         current_stream = torch.cuda.current_stream()
-        current_stream.wait_stream(self.copy_stream)
+        if self.use_copy_stream:
+            current_stream.wait_stream(self.copy_stream)
 
         num_masks = bitmask.shape[0]
         assert num_masks == len(mapping)
@@ -117,7 +130,8 @@ class StructuredOutputsWorker:
 
         # Ensure the copy stream waits for the device tensors to finish being used
         # before it re-uses or deallocates them
-        self.copy_stream.wait_stream(current_stream)
+        if self.use_copy_stream:
+            self.copy_stream.wait_stream(current_stream)
 
 
 # Adapted from


### PR DESCRIPTION
## Purpose

Fixes #53993.

On XPU with graphs enabled, the V2 model runner fails in the post-capture kernel warmup (and on any real structured-output request) because `StructuredOutputsWorker.apply_grammar_bitmask` forks a private `copy_stream` for the bitmask / mapping H2D copies and joins it with `current_stream.wait_stream(copy_stream)`; the current SYCL queue is in command-graph recording mode and rejects the cross-queue event dependency:

```
  File "vllm/v1/worker/gpu/structured_outputs.py", line 99, in apply_grammar_bitmask
    current_stream.wait_stream(self.copy_stream)
RuntimeError: Event dependency from handler::depends_on does not correspond to a node within the graph
```

followed by `RuntimeError: wait cannot be called for a queue which is recording to a command graph` at shutdown. `vllm/v1/worker/gpu/pp_utils.py` already special-cases the same XPU limitation.

This PR keeps the two small copies on the current stream on XPU (`use_copy_stream = not current_platform.is_xpu()`) and skips both cross-stream waits there; the CUDA/ROCm path is byte-for-byte unchanged (same stream object, same two `wait_stream` calls).

Duplicate check: no open PR or issue for this before #53993 was filed (issue search for both error strings).

## Test Plan

- New unit test `tests/v1/worker/test_structured_outputs_xpu_stream.py` (no GPU; streams and copies are faked): non-XPU enters the copy-stream context and issues both `wait_stream` calls; XPU enters no stream context and issues no `wait_stream`, while the copies and the kernel launch still happen.
- `pre-commit run --files ...` (ruff check/format, mypy).
- End-to-end on Intel Arc Pro B70: `Intel/gemma-4-31B-it-int4-AutoRound` (selects the V2 runner) with `VLLM_XPU_ENABLE_XPU_GRAPH=1` (FULL_AND_PIECEWISE): engine warmup completes, server healthy, 4-prompt coherence check, and a `response_format: json_object` chat request (exercises the bitmask path at runtime).

## Test Result

- Unit tests: `2 passed`.
- pre-commit: all hooks pass.
- End-to-end (Arc Pro B70, TP=1, `VLLM_USE_V2_MODEL_RUNNER=1`, `VLLM_XPU_ENABLE_XPU_GRAPH=1` FULL_AND_PIECEWISE, Gemma 4 31B INT4): warmup completes, server healthy in ~155 s, 4-prompt coherence check passes, and a `response_format: json_object` chat request (runtime grammar-bitmask path) returns `{"city": "Paris", "country": "France"}`. Without this change the identical configuration fails in warmup as described in #53993. (Run with the pending `getMemoryInfo` fallback from #53990 applied locally so vLLM can start on Arc; not part of this PR.)


**Scope note (TP=2):** with this fix, the V2 runner + XPU graphs passes end-to-end at TP=1. At TP=2 the grammar-bitmask error is gone but the sampled warmup then hits a *different* cross-stream wait under graph recording, in `vllm/v1/sample/ops/topk_topp_triton.py:924` (`apply_top_k_top_p_triton`): `RuntimeError: wait method cannot be used for an event associated with a command graph`. That is a separate site (the Triton top-k/top-p sampler path taken with tensor parallelism) and is not addressed here; I'll report it separately once characterized. This PR is still required for either configuration.

---

AI assistance: this change was developed with Claude Code (Claude Fable 5) — the implementation was produced by a coding agent from a written spec; the human submitter reviewed every line, ran the tests and the end-to-end check on the hardware, and defends the change.
