### PR TITLE
[Bugfix] Ignore non-dict JSON in model redirect file

### DIFF
--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+
+import vllm.envs as envs
 from vllm.transformers_utils.utils import (
     is_azure,
     is_cloud_storage,
     is_gcs,
     is_s3,
+    maybe_model_redirect,
 )
 
 
@@ -35,3 +39,23 @@ def test_is_cloud_storage():
     assert is_cloud_storage("az://model-container/path")
     assert not is_cloud_storage("/unix/local/path")
     assert not is_cloud_storage("nfs://nfs-fqdn.local")
+
+
+def test_maybe_model_redirect_ignores_non_dict_json(tmp_path, monkeypatch):
+    # A redirect file that is valid JSON but not an object (e.g. a list) must
+    # not crash; it should be treated as "no redirect".
+    redirect_file = tmp_path / "redirect.json"
+    redirect_file.write_text(json.dumps(["a", "b"]))
+    monkeypatch.setattr(envs, "VLLM_MODEL_REDIRECT_PATH", str(redirect_file))
+    maybe_model_redirect.cache_clear()
+
+    assert maybe_model_redirect("some/model") == "some/model"
+
+
+def test_maybe_model_redirect_uses_dict_json(tmp_path, monkeypatch):
+    redirect_file = tmp_path / "redirect.json"
+    redirect_file.write_text(json.dumps({"some/model": "/local/model"}))
+    monkeypatch.setattr(envs, "VLLM_MODEL_REDIRECT_PATH", str(redirect_file))
+    maybe_model_redirect.cache_clear()
+
+    assert maybe_model_redirect("some/model") == "/local/model"

--- a/vllm/transformers_utils/utils.py
+++ b/vllm/transformers_utils/utils.py
@@ -61,9 +61,10 @@ def modelscope_list_repo_files(
 def _maybe_json_dict(path: str | PathLike) -> dict[str, str]:
     with open(path) as f:
         try:
-            return json.loads(f.read())
+            parsed = json.loads(f.read())
         except Exception:
             return dict[str, str]()
+    return parsed if isinstance(parsed, dict) else dict[str, str]()
 
 
 def _maybe_space_split_dict(path: str | PathLike) -> dict[str, str]:


### PR DESCRIPTION
## Summary

`maybe_model_redirect` (used when `VLLM_MODEL_REDIRECT_PATH` is set) parses the
redirect file via `_maybe_json_dict`, which returned whatever `json.loads`
produced. If the file is valid JSON but not an object (e.g. a list or scalar),
the result was passed to `redirect_dict.get(...)` and raised `AttributeError`.

The fix only treats parsed JSON as a redirect map when it is a `dict`;
otherwise it falls back to the space-separated line format, and ultimately
leaves the model name unchanged.

## Reproduction

Before (with `VLLM_MODEL_REDIRECT_PATH` pointing at a file containing `[1, 2, 3]`):

```
>>> maybe_model_redirect("some/model")
AttributeError: 'list' object has no attribute 'get'
```

After: returns `"some/model"` unchanged.

## Test plan

Added to `tests/transformers_utils/test_utils.py`:

```
$ python -m pytest tests/transformers_utils/test_utils.py -q
6 passed
```

- `pre-commit` (ruff-check, ruff-format, mypy-3.12) pass on the changed files.

## Notes

Not a duplicate (searched open/all PRs for model redirect / json dict handling).
AI assistance was used; a human has reviewed every changed line.
