### PR TITLE
[Bugfix] Fix inverted text validation in FireRedASR2/FunASR processors

### DIFF
--- a/tests/transformers_utils/processors/test_asr_text_validation.py
+++ b/tests/transformers_utils/processors/test_asr_text_validation.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.transformers_utils.processors.fireredasr2 import FireRedASR2Processor
+from vllm.transformers_utils.processors.funasr import FunASRProcessor
+
+
+@pytest.mark.parametrize("cls", [FireRedASR2Processor, FunASRProcessor])
+@pytest.mark.parametrize("bad_text", [123, {"a": 1}, ["ok", 123]])
+def test_processor_rejects_invalid_text(cls, bad_text):
+    """`text` that is not a string or a list of strings must raise a clear
+    ``ValueError`` rather than a ``TypeError``/``KeyError`` (non-list) or be
+    silently accepted (list with non-string elements)."""
+    processor = object.__new__(cls)
+    processor._in_target_context_manager = False
+
+    with pytest.raises(ValueError, match="Invalid input text"):
+        processor(text=bad_text)

--- a/vllm/transformers_utils/processors/fireredasr2.py
+++ b/vllm/transformers_utils/processors/fireredasr2.py
@@ -291,7 +291,7 @@ class FireRedASR2Processor(ProcessorMixin):
             raise ValueError("You need to specify `text` input to process.")
         elif isinstance(text, str):
             text = [text]
-        elif not isinstance(text, list) and not isinstance(text[0], str):
+        elif not isinstance(text, list) or not all(isinstance(t, str) for t in text):
             raise ValueError(
                 "Invalid input text. Please provide a string, or a list of strings"
             )

--- a/vllm/transformers_utils/processors/funasr.py
+++ b/vllm/transformers_utils/processors/funasr.py
@@ -430,7 +430,7 @@ class FunASRProcessor(ProcessorMixin):
             raise ValueError("You need to specify `text` input to process.")
         elif isinstance(text, str):
             text = [text]
-        elif not isinstance(text, list) and not isinstance(text[0], str):
+        elif not isinstance(text, list) or not all(isinstance(t, str) for t in text):
             raise ValueError(
                 "Invalid input text. Please provide a string, or a list of strings"
             )


### PR DESCRIPTION
## Summary

Both ASR processors validated the `text` argument with:

```python
elif not isinstance(text, list) and not isinstance(text[0], str):
    raise ValueError("Invalid input text. ...")
```

Because of the `and`, this is inverted:

- A list containing non-string elements (e.g. `["ok", 123]`) passes validation
  and is used downstream.
- A non-list, non-subscriptable input (e.g. `123` or `{"a": 1}`) evaluates
  `text[0]` and raises `TypeError`/`KeyError` instead of the intended
  `ValueError`.

Fixed to `not isinstance(text, list) or not all(isinstance(t, str) for t in text)`.

## Reproduction

Before (bare processor instance):

```
>>> p(text=123)
TypeError: 'int' object is not subscriptable
>>> p(text={"a": 1})
KeyError: 0
>>> p(text=["ok", 123])   # accepted, no error
```

After: all three raise `ValueError: Invalid input text. Please provide a
string, or a list of strings`.

## Test plan

Added `tests/transformers_utils/processors/test_asr_text_validation.py`:

```
$ python -m pytest tests/transformers_utils/processors/test_asr_text_validation.py -q
6 passed
```

- `pre-commit` (ruff-check, ruff-format, mypy-3.12) pass on the changed files.

## Notes

Same one-line defect exists identically in `fireredasr2.py` and `funasr.py`, so
both are fixed together. Not a duplicate (searched open/all PRs). AI assistance
was used; a human has reviewed every changed line.
