### PR TITLE
[Doc] Correct the Mamba rationale on needs_kv_cache_zeroing

### DIFF
--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -1188,9 +1188,14 @@ class KVCacheConfig:
     def needs_kv_cache_zeroing(self) -> bool:
         """Whether newly allocated KV cache blocks must be zeroed before use.
 
-        Required for Mamba layers, whose state is read before it is fully written
-        (#35219), and for mixed-precision caches, where a block reused across
-        groups can be reinterpreted under a different precision and decode stale
-        bytes to NaN/Inf. Uniform-precision caches skip zeroing.
+        Required when Mamba layers are present. In a hybrid model they share a
+        block pool with attention, so a block holding fp32 Mamba state can be
+        reallocated to an attention layer with a smaller dtype, where the
+        leftover bytes decode as NaN/Inf (#35219). Only attention blocks are
+        zeroed; #35219 excludes Mamba blocks on the grounds that they overwrite
+        their state each step. Also required for mixed-precision
+        caches, where a block reused across groups can be reinterpreted under a
+        different precision and decode stale bytes to NaN/Inf. Uniform-precision
+        caches skip zeroing.
         """
         return self.has_mamba_layers or self.has_mixed_precision_kv_cache


### PR DESCRIPTION
## Purpose

The `needs_kv_cache_zeroing` docstring states the opposite of the PR it cites, and it is rendered
in the API reference at
https://docs.vllm.ai/en/latest/api/vllm/v1/kv_cache_interface/

Current text:

> Required for Mamba layers, whose state is read before it is fully written (#35219), and for
> mixed-precision caches, [...]

#35219 says Mamba blocks are deliberately *not* zeroed:

> **Only `FullAttentionSpec` blocks** — Mamba/SSM blocks are not zeroed (they overwrite their
> state fully each step); only attention blocks that may inherit stale Mamba fp32 data are
> cleared.

and gives the actual reason the flag exists:

> When a block previously used by Mamba (fp32 state) is reallocated to an attention layer with a
> smaller dtype, leftover fp32 bit patterns can appear as NaN/Inf in the new dtype.

So the direction is inverted. Mamba produces the stale bytes, and the attention blocks are the
ones zeroed.

The code follows #35219.
`single_type_kv_cache_manager.py` gates recording on `isinstance(kv_cache_spec, AttentionSpec)`,
and `KVBlockZeroer.__init__` says "Only AttentionSpec layers are processed; Mamba layers are
skipped." `MambaSpec` derives from `KVCacheSpec`, so a `MambaManager` never records a block and
none reach the zeroer.

This rewrites the Mamba clause to match, and adds that only attention blocks are zeroed. Both
implementations do that; the reference never said so. The mixed-precision clause is unchanged.

The wrong sentence is load-bearing: read literally it says the flag guarantees Mamba pages are
zeroed, and nothing in the reference contradicts that.

Provenance: #35219 added the property with no docstring. The docstring arrived four months
later in #47574, which is where the Mamba clause came from. #51749 later widened the gate from
`FullAttentionSpec` to `AttentionSpec` without touching the text.

## Not a duplicate

    gh pr list --repo vllm-project/vllm --state all --search "needs_kv_cache_zeroing"
    gh pr list --repo vllm-project/vllm --state all --search "kv_cache_zeroing docstring"
    gh pr list --repo vllm-project/vllm --state all --search "Mamba zeroing docstring"

The first returns 12 PRs, all concerning zeroing behaviour: #43741, #39283
and #37530 propose zeroing changes, #47574 and #51749 are the merged changes referenced above, and
the rest are unrelated. The other two searches return nothing. No open or merged PR corrects this
text.

## Test Plan

Docstring only, no behaviour change.

    ruff check vllm/v1/kv_cache_interface.py
    ruff format --check vllm/v1/kv_cache_interface.py

## Test Result

Both clean. There is no functional change to test.

## Tool assistance

Claude Code was used to investigate this and to draft this description. I reviewed every changed
line, and every quotation above is from #35219's description and the current tree.
