### PR TITLE
[Quantization][Autoround][XPU] Add MXFP4 Hadamard rotation support

### DIFF
--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -987,6 +987,108 @@ def test_inc_mxfp4_linear_method_registers_and_processes_weights(
     assert captured["processed_layer"] is layer
 
 
+def test_inc_mxfp4_linear_rotation_rejects_tp_shard_crossing_block(
+    monkeypatch,
+) -> None:
+    """A rotation block spanning multiple TP shards is not supported.
+
+    E.g. a checkpoint-wide block_size=64 on a 64-wide layer is valid without
+    TP, but under tensor_parallel_size=2 each shard only sees 32 of the 64
+    input channels, so the block straddles two ranks. This must fail fast at
+    weight-creation time with a message that points at the TP mismatch, not
+    a generic "not divisible" error.
+    """
+
+    class DummyKernel:
+        pass
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_mxfp4_linear.init_mxfp4_linear_kernel",
+        lambda **kwargs: DummyKernel(),
+    )
+
+    from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
+        INCMxfp4LinearMethod,
+    )
+
+    method = INCMxfp4LinearMethod(
+        make_layer_config(group_size=32, data_type="mx_fp"),
+        rotation_block_size=64,
+    )
+
+    with pytest.raises(ValueError, match="tensor-parallel shard"):
+        method.create_weights(
+            torch.nn.Module(),
+            input_size_per_partition=32,
+            output_partition_sizes=[16],
+            input_size=64,
+            output_size=16,
+            params_dtype=torch.bfloat16,
+        )
+
+
+def test_inc_mxfp4_linear_rotation_validates_shard_alignment(monkeypatch) -> None:
+    """Divisibility is still enforced without TP, and an aligned TP shard is
+    accepted — covering the two codepaths the shard-aware check must not
+    regress.
+    """
+
+    class DummyKernel:
+        pass
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_mxfp4_linear.init_mxfp4_linear_kernel",
+        lambda **kwargs: DummyKernel(),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+    from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
+        INCMxfp4LinearMethod,
+    )
+
+    # No TP sharding (input_size_per_partition == input_size): a block_size
+    # that just does not fit the layer's width is a plain, generic error.
+    misaligned_method = INCMxfp4LinearMethod(
+        make_layer_config(group_size=32, data_type="mx_fp"),
+        rotation_block_size=48,
+    )
+    with pytest.raises(ValueError, match="not divisible by"):
+        misaligned_method.create_weights(
+            torch.nn.Module(),
+            input_size_per_partition=64,
+            output_partition_sizes=[16],
+            input_size=64,
+            output_size=16,
+            params_dtype=torch.bfloat16,
+        )
+
+    # TP shards the input, but the block_size still evenly divides the
+    # per-shard width, so this must be accepted.
+    aligned_method = INCMxfp4LinearMethod(
+        make_layer_config(group_size=32, data_type="mx_fp"),
+        rotation_block_size=32,
+    )
+    layer = torch.nn.Module()
+    aligned_method.create_weights(
+        layer,
+        input_size_per_partition=32,
+        output_partition_sizes=[16],
+        input_size=64,
+        output_size=16,
+        params_dtype=torch.bfloat16,
+    )
+    assert layer.input_size_per_partition == 32
+
+
 def test_inc_mxfp4_linear_applies_rotation_before_kernel(monkeypatch) -> None:
     captured = {}
 

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -1016,7 +1016,7 @@ def test_inc_mxfp4_linear_applies_rotation_before_kernel(monkeypatch) -> None:
     assert torch.equal(result, torch.ones_like(value))
 
 
-def test_inc_mxfp4_rotation_requires_cuda(monkeypatch) -> None:
+def test_inc_mxfp4_rotation_requires_cuda_or_xpu(monkeypatch) -> None:
     config = INCConfig.from_config(
         {
             "bits": 4,
@@ -1036,8 +1036,13 @@ def test_inc_mxfp4_rotation_requires_cuda(monkeypatch) -> None:
         "inc_mxfp4_scheme.current_platform.is_cuda",
         lambda: False,
     )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_mxfp4_scheme.current_platform.is_xpu",
+        lambda: False,
+    )
 
-    with pytest.raises(NotImplementedError, match="requires CUDA Hadacore"):
+    with pytest.raises(NotImplementedError, match="requires CUDA Hadacore or XPU ARK"):
         INCMxfp4Scheme().get_linear_method(
             config,
             object.__new__(LinearBase),

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -126,12 +126,23 @@ QWEN3_AUTOROUND_MODELS = [
         ),
         id="auto_round:mxfp8:qwen3-30b-a3b",
     ),
+    pytest.param(
+        "INCModel/Qwen3.6-27B-MXFP4-RTN-Hadamard-12L-test",
+        marks=pytest.mark.skipif(
+            not (current_platform.is_cuda() or current_platform.is_xpu()),
+            reason="Qwen3.6-27B MXFP4 AutoRound model requires CUDA/XPU.",
+        ),
+        id="auto_round:mxfp4:qwen3-6-27b-hadamard",
+    ),
 ]
 
 MODEL_RUNNER_KWARGS: dict[str, dict[str, Any]] = {
     "INCModel/Qwen3-1.7B-AutoRound-MXFP4-W4A4": {"enforce_eager": True},
     "INCModel/Qwen3-30B-A3B-12L-MXFP4-test": {"enforce_eager": True},
     "INCModel/Qwen3-30B-A3B-12L-MXFP8-test": {"enforce_eager": True},
+    "INCModel/Qwen3.6-27B-MXFP4-RTN-Hadamard-12L-test": {
+        "enable_chunked_prefill": True
+    },
     "Intel/Qwen3-8B-w2g64-for-ut": {
         "block_size": 64,
         "gpu_memory_utilization": 0.8,

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -8,11 +8,13 @@ Validating the configuration and printing results for manual checking.
 Run `pytest tests/quantization/test_auto_round.py`.
 """
 
+import math
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 import torch
+from compressed_tensors.transform import deterministic_hadamard_matrix
 
 from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
@@ -600,6 +602,101 @@ def test_inc_config_accepts_mxfp_family_llm_compressor() -> None:
     assert isinstance(resolve_scheme(layer_config), INCMxfp4Scheme)
 
 
+def test_inc_config_accepts_mxfp4_hadamard_rotation() -> None:
+    config = INCConfig.from_config(
+        {
+            "bits": 4,
+            "group_size": 32,
+            "sym": True,
+            "packing_format": "auto_round:llm_compressor",
+            "data_type": "mx_fp",
+            "rotation_config": {
+                "backend": "transform",
+                "block_size": 32,
+                "hadamard_type": "hadamard",
+            },
+        }
+    )
+
+    assert config.rotation_config == {
+        "backend": "transform",
+        "block_size": 32,
+        "hadamard_type": "hadamard",
+    }
+
+
+def test_inc_config_accepts_maximum_rotation_block_size() -> None:
+    config = INCConfig.from_config(
+        {
+            "bits": 4,
+            "group_size": 32,
+            "sym": True,
+            "packing_format": "auto_round:llm_compressor",
+            "data_type": "mx_fp",
+            "rotation_config": {
+                "backend": "transform",
+                "block_size": 32768,
+                "hadamard_type": "hadamard",
+            },
+        }
+    )
+
+    assert config.rotation_config is not None
+    assert config.rotation_config["block_size"] == 32768
+
+
+@pytest.mark.parametrize(
+    ("rotation_config", "error"),
+    [
+        (
+            {"backend": "inplace", "hadamard_type": "hadamard"},
+            "backend='transform'",
+        ),
+        (
+            {"backend": "transform", "hadamard_type": "random_hadamard"},
+            "deterministic",
+        ),
+        (
+            {
+                "backend": "transform",
+                "block_size": 24,
+                "hadamard_type": "hadamard",
+            },
+            "positive power of two",
+        ),
+        (
+            {
+                "backend": "transform",
+                "block_size": 65536,
+                "hadamard_type": "hadamard",
+            },
+            "no greater than 32768",
+        ),
+        (
+            {
+                "backend": "transform",
+                "block_size": True,
+                "hadamard_type": "hadamard",
+            },
+            "positive power of two",
+        ),
+        (True, "rotation_config must be an object"),
+    ],
+)
+def test_inc_config_rejects_unsupported_rotation(rotation_config, error) -> None:
+    with pytest.raises(ValueError, match=error):
+        INCConfig.from_config(
+            {
+                "bits": 4,
+                "group_size": 32,
+                "sym": True,
+                "packing_format": "auto_round:llm_compressor",
+                "data_type": "mx_fp",
+                "rotation_config": rotation_config,
+            }
+        )
+
+
 def test_qwen3_1p7b_mxfp4_autoround_uses_mxfp4_linear_scheme(
     monkeypatch,
 ) -> None:
@@ -877,6 +974,113 @@ def test_inc_mxfp4_linear_method_registers_and_processes_weights(
     assert layer.weight.data.data_ptr() == packed_data.data_ptr()
     assert not hasattr(layer, "weight_packed")
     assert captured["processed_layer"] is layer
+
+
+def test_inc_mxfp4_linear_applies_rotation_before_kernel(monkeypatch) -> None:
+    captured = {}
+
+    class DummyKernel:
+        def apply_weights(self, layer, x, bias):
+            captured["kernel_input"] = x
+            return x
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_mxfp4_linear.init_mxfp4_linear_kernel",
+        lambda **kwargs: DummyKernel(),
+    )
+
+    def fake_hadamard(x):
+        captured["hadamard_shape"] = x.shape
+        return x + 1
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_mxfp4_linear.ops.hadacore_transform",
+        fake_hadamard,
+    )
+
+    from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
+        INCMxfp4LinearMethod,
+    )
+
+    method = INCMxfp4LinearMethod(
+        make_layer_config(group_size=32, data_type="mx_fp"),
+        rotation_block_size=32,
+    )
+    value = torch.zeros(2, 64)
+    result = method.apply_weights(torch.nn.Module(), value)
+
+    assert captured["hadamard_shape"] == (2, 2, 32)
+    assert torch.equal(captured["kernel_input"], torch.ones_like(value))
+    assert torch.equal(result, torch.ones_like(value))
+
+
+def test_inc_mxfp4_rotation_requires_cuda(monkeypatch) -> None:
+    config = INCConfig.from_config(
+        {
+            "bits": 4,
+            "group_size": 32,
+            "sym": True,
+            "packing_format": "auto_round:llm_compressor",
+            "data_type": "mx_fp",
+            "rotation_config": {
+                "backend": "transform",
+                "block_size": 32,
+                "hadamard_type": "hadamard",
+            },
+        }
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_mxfp4_scheme.current_platform.is_cuda",
+        lambda: False,
+    )
+
+    with pytest.raises(NotImplementedError, match="requires CUDA Hadacore"):
+        INCMxfp4Scheme().get_linear_method(
+            config,
+            object.__new__(LinearBase),
+            "model.layers.0.mlp.gate_proj",
+            make_layer_config(group_size=32, data_type="mx_fp"),
+        )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA Hadacore only")
+def test_inc_mxfp4_linear_rotation_matches_hadamard(monkeypatch) -> None:
+    class DummyKernel:
+        def apply_weights(self, layer, x, bias):
+            return x
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes."
+        "inc_mxfp4_linear.init_mxfp4_linear_kernel",
+        lambda **kwargs: DummyKernel(),
+    )
+
+    from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
+        INCMxfp4LinearMethod,
+    )
+
+    block_size = 32
+    method = INCMxfp4LinearMethod(
+        make_layer_config(group_size=32, data_type="mx_fp"),
+        rotation_block_size=block_size,
+    )
+    identity = torch.eye(block_size, dtype=torch.bfloat16, device="cuda")
+    value = torch.cat((identity, identity), dim=-1)
+    original = value.clone()
+    hadamard = deterministic_hadamard_matrix(
+        block_size, dtype=torch.float64, device="cuda"
+    ) / math.sqrt(block_size)
+    expected = (
+        value.unflatten(-1, (-1, block_size)).to(hadamard.dtype) @ hadamard.T
+    ).to(value.dtype)
+
+    result = method.apply_weights(torch.nn.Module(), value)
+
+    torch.testing.assert_close(result.unflatten(-1, (-1, block_size)), expected)
+    torch.testing.assert_close(value, original)
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -18,7 +18,11 @@ from compressed_tensors.transform import deterministic_hadamard_matrix
 
 from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
-from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
 from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQConfig
 from vllm.model_executor.layers.quantization.inc import INCConfig
 from vllm.model_executor.layers.quantization.inc.config_parser import INCLayerConfig
@@ -636,6 +640,29 @@ def test_inc_config_accepts_mxfp4_hadamard_rotation() -> None:
     }
 
 
+@pytest.mark.parametrize("backend", [None, "auto"])
+def test_inc_config_accepts_auto_rotation_backend(backend) -> None:
+    rotation_config = {
+        "block_size": 32,
+        "hadamard_type": "hadamard",
+    }
+    if backend is not None:
+        rotation_config["backend"] = backend
+
+    config = INCConfig.from_config(
+        {
+            "bits": 4,
+            "group_size": 32,
+            "sym": True,
+            "packing_format": "auto_round:llm_compressor",
+            "data_type": "mx_fp",
+            "rotation_config": rotation_config,
+        }
+    )
+
+    assert config.rotation_config == rotation_config
+
+
 def test_inc_config_accepts_maximum_rotation_block_size() -> None:
     config = INCConfig.from_config(
         {
@@ -661,7 +688,7 @@ def test_inc_config_accepts_maximum_rotation_block_size() -> None:
     [
         (
             {"backend": "inplace", "hadamard_type": "hadamard"},
-            "backend='transform'",
+            "backends 'auto' and 'transform'",
         ),
         (
             {"backend": "transform", "hadamard_type": "random_hadamard"},
@@ -987,9 +1014,7 @@ def test_inc_mxfp4_linear_method_registers_and_processes_weights(
     assert captured["processed_layer"] is layer
 
 
-def test_inc_mxfp4_linear_rotation_rejects_tp_shard_crossing_block(
-    monkeypatch,
-) -> None:
+def test_inc_mxfp4_linear_rotation_rejects_tp_shard_crossing_block() -> None:
     """A rotation block spanning multiple TP shards is not supported.
 
     E.g. a checkpoint-wide block_size=64 on a 64-wide layer is valid without
@@ -999,23 +1024,18 @@ def test_inc_mxfp4_linear_rotation_rejects_tp_shard_crossing_block(
     a generic "not divisible" error.
     """
 
-    class DummyKernel:
-        pass
+    class FailingQuantMethod(LinearMethodBase):
+        def create_weights(self, *args, **kwargs) -> None:
+            pytest.fail("quant_method.create_weights should not be reached")
 
-    monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.inc.schemes."
-        "inc_mxfp4_linear.init_mxfp4_linear_kernel",
-        lambda **kwargs: DummyKernel(),
+        def apply(self, layer, x, bias=None):
+            raise NotImplementedError
+
+    from vllm.model_executor.layers.quantization.inc.transform.linear import (
+        INCLinearTransformMethod,
     )
 
-    from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
-        INCMxfp4LinearMethod,
-    )
-
-    method = INCMxfp4LinearMethod(
-        make_layer_config(group_size=32, data_type="mx_fp"),
-        rotation_block_size=64,
-    )
+    method = INCLinearTransformMethod(FailingQuantMethod(), block_size=64)
 
     with pytest.raises(ValueError, match="tensor-parallel shard"):
         method.create_weights(
@@ -1054,13 +1074,18 @@ def test_inc_mxfp4_linear_rotation_validates_shard_alignment(monkeypatch) -> Non
     from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
         INCMxfp4LinearMethod,
     )
+    from vllm.model_executor.layers.quantization.inc.transform.linear import (
+        INCLinearTransformMethod,
+    )
+
+    def make_quant_method() -> INCLinearMethod:
+        return INCLinearMethod(
+            INCMxfp4LinearMethod(make_layer_config(group_size=32, data_type="mx_fp"))
+        )
 
     # No TP sharding (input_size_per_partition == input_size): a block_size
     # that just does not fit the layer's width is a plain, generic error.
-    misaligned_method = INCMxfp4LinearMethod(
-        make_layer_config(group_size=32, data_type="mx_fp"),
-        rotation_block_size=48,
-    )
+    misaligned_method = INCLinearTransformMethod(make_quant_method(), block_size=48)
     with pytest.raises(ValueError, match="not divisible by"):
         misaligned_method.create_weights(
             torch.nn.Module(),
@@ -1073,10 +1098,7 @@ def test_inc_mxfp4_linear_rotation_validates_shard_alignment(monkeypatch) -> Non
 
     # TP shards the input, but the block_size still evenly divides the
     # per-shard width, so this must be accepted.
-    aligned_method = INCMxfp4LinearMethod(
-        make_layer_config(group_size=32, data_type="mx_fp"),
-        rotation_block_size=32,
-    )
+    aligned_method = INCLinearTransformMethod(make_quant_method(), block_size=32)
     layer = torch.nn.Module()
     aligned_method.create_weights(
         layer,
@@ -1108,21 +1130,31 @@ def test_inc_mxfp4_linear_applies_rotation_before_kernel(monkeypatch) -> None:
         return x + 1
 
     monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.inc.schemes."
-        "inc_mxfp4_linear.ops.hadacore_transform",
+        "vllm.model_executor.layers.quantization.inc.transform.hadamard.ops."
+        "hadacore_transform",
         fake_hadamard,
     )
 
     from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
         INCMxfp4LinearMethod,
     )
+    from vllm.model_executor.layers.quantization.inc.transform.hadamard import (
+        HadamardTransform,
+    )
+    from vllm.model_executor.layers.quantization.inc.transform.linear import (
+        INCLinearTransformMethod,
+    )
 
-    method = INCMxfp4LinearMethod(
-        make_layer_config(group_size=32, data_type="mx_fp"),
-        rotation_block_size=32,
+    block_size = 32
+    method = INCLinearTransformMethod(
+        INCLinearMethod(
+            INCMxfp4LinearMethod(make_layer_config(group_size=32, data_type="mx_fp"))
+        ),
+        block_size=block_size,
+        rotation=HadamardTransform(block_size),
     )
     value = torch.zeros(2, 64)
-    result = method.apply_weights(torch.nn.Module(), value)
+    result = method.apply(torch.nn.Module(), value)
 
     assert captured["hadamard_shape"] == (2, 2, 32)
     assert torch.equal(captured["kernel_input"], torch.ones_like(value))
@@ -1145,13 +1177,13 @@ def test_inc_mxfp4_rotation_requires_cuda_or_xpu(monkeypatch) -> None:
         }
     )
     monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.inc.schemes."
-        "inc_mxfp4_scheme.current_platform.is_cuda",
+        "vllm.model_executor.layers.quantization.inc.transform."
+        "linear.current_platform.is_cuda",
         lambda: False,
     )
     monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.inc.schemes."
-        "inc_mxfp4_scheme.current_platform.is_xpu",
+        "vllm.model_executor.layers.quantization.inc.transform."
+        "linear.current_platform.is_xpu",
         lambda: False,
     )
 
@@ -1179,11 +1211,20 @@ def test_inc_mxfp4_linear_rotation_matches_hadamard(monkeypatch) -> None:
     from vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_linear import (  # noqa: E501
         INCMxfp4LinearMethod,
     )
+    from vllm.model_executor.layers.quantization.inc.transform.hadamard import (
+        HadamardTransform,
+    )
+    from vllm.model_executor.layers.quantization.inc.transform.linear import (
+        INCLinearTransformMethod,
+    )
 
     block_size = 32
-    method = INCMxfp4LinearMethod(
-        make_layer_config(group_size=32, data_type="mx_fp"),
-        rotation_block_size=block_size,
+    method = INCLinearTransformMethod(
+        INCLinearMethod(
+            INCMxfp4LinearMethod(make_layer_config(group_size=32, data_type="mx_fp"))
+        ),
+        block_size=block_size,
+        rotation=HadamardTransform(block_size),
     )
     identity = torch.eye(block_size, dtype=torch.bfloat16, device="cuda")
     value = torch.cat((identity, identity), dim=-1)
@@ -1195,7 +1236,7 @@ def test_inc_mxfp4_linear_rotation_matches_hadamard(monkeypatch) -> None:
         value.unflatten(-1, (-1, block_size)).to(hadamard.dtype) @ hadamard.T
     ).to(value.dtype)
 
-    result = method.apply_weights(torch.nn.Module(), value)
+    result = method.apply(torch.nn.Module(), value)
 
     torch.testing.assert_close(result.unflatten(-1, (-1, block_size)), expected)
     torch.testing.assert_close(value, original)

--- a/vllm/model_executor/layers/quantization/inc/inc.py
+++ b/vllm/model_executor/layers/quantization/inc/inc.py
@@ -79,6 +79,7 @@ class INCConfig(QuantizationConfig):
         extra_config: dict[str, Any] | None = None,
         data_type: str = "int",
         backend: str = "auto",
+        rotation_config: dict[str, Any] | None = None,
     ) -> None:
         super().__init__()
 
@@ -121,6 +122,7 @@ class INCConfig(QuantizationConfig):
         self.extra_config = extra_config
         self.data_type = data_type
         self.backend = backend
+        self.rotation_config = rotation_config
         self.pack_factor = Fraction(32, weight_bits)
         self.config_parser = INCConfigParser(self)
 
@@ -157,6 +159,36 @@ class INCConfig(QuantizationConfig):
                 f"{field_name}={expected_value!r}, "
                 f"but found {field_name}={actual_value!r}."
             )
+
+    def _validate_rotation_config(self) -> None:
+        if self.rotation_config is not None:
+            if not isinstance(self.rotation_config, dict):
+                raise ValueError("rotation_config must be an object")
+            if not (self.is_mxfp and self.weight_bits == 4):
+                raise ValueError(
+                    "AutoRound Hadamard rotation is only supported with INC MXFP4"
+                )
+            if self.rotation_config.get("backend") != "transform":
+                raise ValueError(
+                    "INC only supports AutoRound rotation backend='transform'"
+                )
+            if self.rotation_config.get("hadamard_type") != "hadamard":
+                raise ValueError(
+                    "INC only supports deterministic hadamard_type='hadamard'"
+                )
+            block_size = self.rotation_config.get("block_size", 32)
+            if (
+                not isinstance(block_size, int)
+                or isinstance(block_size, bool)
+                or block_size <= 0
+                or block_size & (block_size - 1)
+                or block_size > (1 << 15)
+            ):
+                raise ValueError(
+                    "AutoRound rotation block_size must be a positive power of two "
+                    "no greater than 32768"
+                )
+            self.rotation_config = {**self.rotation_config, "block_size": block_size}
 
     def _validate_int_quantization(self) -> None:
         int_packing_formats = {
@@ -214,6 +246,7 @@ class INCConfig(QuantizationConfig):
         )
 
     def _validate_supported_quantization(self) -> None:
+        self._validate_rotation_config()
         if self.data_type == "int":
             self._validate_int_quantization()
         elif self.data_type == self.FP8_BLOCK_DATA_TYPE:
@@ -305,6 +338,7 @@ class INCConfig(QuantizationConfig):
             extra_config=cls.get_from_keys_or(config, ["extra_config"], None),
             data_type=data_type,
             backend=cls.get_from_keys_or(config, ["backend", "vllm_backend"], "auto"),
+            rotation_config=cls.get_from_keys_or(config, ["rotation_config"], None),
         )
         quant_config._validate_raw_config(config)
         return quant_config

--- a/vllm/model_executor/layers/quantization/inc/inc.py
+++ b/vllm/model_executor/layers/quantization/inc/inc.py
@@ -168,9 +168,11 @@ class INCConfig(QuantizationConfig):
                 raise ValueError(
                     "AutoRound Hadamard rotation is only supported with INC MXFP4"
                 )
-            if self.rotation_config.get("backend") != "transform":
+            rotation_backend = self.rotation_config.get("backend", "auto")
+            if rotation_backend not in {"auto", "transform"}:
                 raise ValueError(
-                    "INC only supports AutoRound rotation backend='transform'"
+                    "INC only supports AutoRound rotation backends "
+                    f"'auto' and 'transform', but found {rotation_backend!r}"
                 )
             if self.rotation_config.get("hadamard_type") != "hadamard":
                 raise ValueError(

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_ark_ops.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_ark_ops.py
@@ -94,6 +94,27 @@ def _inc_ark_woq_linear_fake(
     )
 
 
+def _inc_ark_mxfp4_hadamard_quant_impl(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from auto_round_kernel.mxfp4_hadamard import mxfp4_hadamard_quant
+
+    return mxfp4_hadamard_quant(x)
+
+
+def _inc_ark_mxfp4_hadamard_quant_fake(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        torch.empty(
+            (*x.shape[:-1], x.shape[-1] // 2), dtype=torch.uint8, device=x.device
+        ),
+        torch.empty(
+            (*x.shape[:-1], x.shape[-1] // 32), dtype=torch.uint8, device=x.device
+        ),
+    )
+
+
 class ark_ops:
     @staticmethod
     def register_ops_once() -> None:
@@ -113,6 +134,12 @@ class ark_ops:
             op_name="inc_ark_woq_linear",
             op_func=_inc_ark_woq_linear_impl,
             fake_impl=_inc_ark_woq_linear_fake,
+            dispatch_key=current_platform.dispatch_key,
+        )
+        direct_register_custom_op(
+            op_name="inc_ark_mxfp4_hadamard_quant",
+            op_func=_inc_ark_mxfp4_hadamard_quant_impl,
+            fake_impl=_inc_ark_mxfp4_hadamard_quant_fake,
             dispatch_key=current_platform.dispatch_key,
         )
         _OPS_REGISTERED = True

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_ark_ops.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_ark_ops.py
@@ -94,27 +94,6 @@ def _inc_ark_woq_linear_fake(
     )
 
 
-def _inc_ark_mxfp4_hadamard_quant_impl(
-    x: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    from auto_round_kernel.mxfp4_hadamard import mxfp4_hadamard_quant
-
-    return mxfp4_hadamard_quant(x)
-
-
-def _inc_ark_mxfp4_hadamard_quant_fake(
-    x: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    return (
-        torch.empty(
-            (*x.shape[:-1], x.shape[-1] // 2), dtype=torch.uint8, device=x.device
-        ),
-        torch.empty(
-            (*x.shape[:-1], x.shape[-1] // 32), dtype=torch.uint8, device=x.device
-        ),
-    )
-
-
 class ark_ops:
     @staticmethod
     def register_ops_once() -> None:
@@ -134,12 +113,6 @@ class ark_ops:
             op_name="inc_ark_woq_linear",
             op_func=_inc_ark_woq_linear_impl,
             fake_impl=_inc_ark_woq_linear_fake,
-            dispatch_key=current_platform.dispatch_key,
-        )
-        direct_register_custom_op(
-            op_name="inc_ark_mxfp4_hadamard_quant",
-            op_func=_inc_ark_mxfp4_hadamard_quant_impl,
-            fake_impl=_inc_ark_mxfp4_hadamard_quant_fake,
             dispatch_key=current_platform.dispatch_key,
         )
         _OPS_REGISTERED = True

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
@@ -108,7 +108,7 @@ class INCMxfp4LinearMethod(INCLinearScheme):
                     f"Linear input width {x.shape[-1]} is not divisible by "
                     f"AutoRound rotation block_size={self.rotation_block_size}"
                 )
-            if current_platform.is_xpu():
+            if current_platform.is_xpu() and x.is_xpu:
                 return self._apply_xpu_rotation(layer, x, bias)
             original_shape = x.shape
             x = x.unflatten(-1, (-1, self.rotation_block_size)).contiguous().clone()

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
@@ -59,7 +59,26 @@ class INCMxfp4LinearMethod(INCLinearScheme):
         params_dtype: torch.dtype,
         **extra_weight_attrs: Any,
     ) -> None:
-        del input_size, output_size
+        del output_size
+        if self.rotation_block_size is not None and (
+            input_size_per_partition % self.rotation_block_size
+        ):
+            if input_size_per_partition != input_size:
+                raise ValueError(
+                    f"AutoRound rotation block_size={self.rotation_block_size} "
+                    "does not evenly divide this layer's tensor-parallel shard "
+                    f"width={input_size_per_partition} (full input_size="
+                    f"{input_size}). Hadamard rotation blocks that span "
+                    "multiple tensor-parallel shards are not supported; "
+                    "either use tensor_parallel_size=1 for this checkpoint, "
+                    "or re-quantize with a rotation block_size that evenly "
+                    "divides the per-shard width."
+                )
+            raise ValueError(
+                f"Linear input width {input_size_per_partition} is not "
+                "divisible by AutoRound rotation "
+                f"block_size={self.rotation_block_size}"
+            )
         output_size_per_partition = sum(output_partition_sizes)
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
@@ -103,11 +122,6 @@ class INCMxfp4LinearMethod(INCLinearScheme):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.rotation_block_size is not None:
-            if x.shape[-1] % self.rotation_block_size:
-                raise ValueError(
-                    f"Linear input width {x.shape[-1]} is not divisible by "
-                    f"AutoRound rotation block_size={self.rotation_block_size}"
-                )
             if current_platform.is_xpu() and x.is_xpu:
                 return self._apply_xpu_rotation(layer, x, bias)
             original_shape = x.shape

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
@@ -13,7 +13,9 @@ from vllm.model_executor.parameter import (
     GroupQuantScaleParameter,
     ModelWeightParameter,
 )
+from vllm.platforms import current_platform
 
+from . import inc_ark_ops  # noqa: F401
 from .inc_scheme import INCLinearScheme
 
 if TYPE_CHECKING:
@@ -26,7 +28,7 @@ class INCMxfp4LinearMethod(INCLinearScheme):
     E2M1 weights packed two per byte with per-group E8M0 scales
     (group_size=32, no global scale). The platform kernel is selected by
     ``init_mxfp4_linear_kernel`` (FlashInfer / Marlin on CUDA, ``fp4_gemm``
-    on XPU). Hadamard rotation currently requires CUDA.
+    on XPU). XPU rotation uses ARK's fused XMX Hadamard and MXFP4 kernel.
     """
 
     def __init__(
@@ -106,8 +108,27 @@ class INCMxfp4LinearMethod(INCLinearScheme):
                     f"Linear input width {x.shape[-1]} is not divisible by "
                     f"AutoRound rotation block_size={self.rotation_block_size}"
                 )
+            if current_platform.is_xpu():
+                return self._apply_xpu_rotation(layer, x, bias)
             original_shape = x.shape
             x = x.unflatten(-1, (-1, self.rotation_block_size)).contiguous().clone()
             x = ops.hadacore_transform(x)
             x = x.flatten(-2, -1).reshape(original_shape)
         return self.kernel.apply_weights(layer, x, bias)
+
+    def _apply_xpu_rotation(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        x_fp4, x_blockscale = torch.ops.vllm.inc_ark_mxfp4_hadamard_quant(x)
+        output = torch.ops._xpu_C.fp4_gemm(
+            x_fp4.view(torch.float4_e2m1fn_x2),
+            layer.weight,
+            x_blockscale.view(torch.float8_e8m0fnu),
+            layer.weight_scale,
+            x.dtype,
+            bias,
+        )
+        return output.reshape(*x.shape[:-1], layer.output_size_per_partition)

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch.nn.parameter import Parameter
 
+import vllm._custom_ops as ops
 from vllm.model_executor.kernels.linear import init_mxfp4_linear_kernel
 from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp4Dynamic
 from vllm.model_executor.parameter import (
@@ -25,16 +26,21 @@ class INCMxfp4LinearMethod(INCLinearScheme):
     E2M1 weights packed two per byte with per-group E8M0 scales
     (group_size=32, no global scale). The platform kernel is selected by
     ``init_mxfp4_linear_kernel`` (FlashInfer / Marlin on CUDA, ``fp4_gemm``
-    on XPU).
+    on XPU). Hadamard rotation currently requires CUDA.
     """
 
-    def __init__(self, layer_config: "INCLayerConfig") -> None:
+    def __init__(
+        self,
+        layer_config: "INCLayerConfig",
+        rotation_block_size: int | None = None,
+    ) -> None:
         if not isinstance(layer_config.group_size, int):
             raise ValueError(
                 "INC MXFP4 requires scalar group_size, "
                 f"but found group_size={layer_config.group_size!r}."
             )
         self.group_size = layer_config.group_size or 32
+        self.rotation_block_size = rotation_block_size
         self.kernel = init_mxfp4_linear_kernel(activation_quant_key=kMxfp4Dynamic)
 
     @classmethod
@@ -94,4 +100,14 @@ class INCMxfp4LinearMethod(INCLinearScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if self.rotation_block_size is not None:
+            if x.shape[-1] % self.rotation_block_size:
+                raise ValueError(
+                    f"Linear input width {x.shape[-1]} is not divisible by "
+                    f"AutoRound rotation block_size={self.rotation_block_size}"
+                )
+            original_shape = x.shape
+            x = x.unflatten(-1, (-1, self.rotation_block_size)).contiguous().clone()
+            x = ops.hadacore_transform(x)
+            x = x.flatten(-2, -1).reshape(original_shape)
         return self.kernel.apply_weights(layer, x, bias)

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_linear.py
@@ -6,16 +6,13 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch.nn.parameter import Parameter
 
-import vllm._custom_ops as ops
 from vllm.model_executor.kernels.linear import init_mxfp4_linear_kernel
 from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp4Dynamic
 from vllm.model_executor.parameter import (
     GroupQuantScaleParameter,
     ModelWeightParameter,
 )
-from vllm.platforms import current_platform
 
-from . import inc_ark_ops  # noqa: F401
 from .inc_scheme import INCLinearScheme
 
 if TYPE_CHECKING:
@@ -28,21 +25,16 @@ class INCMxfp4LinearMethod(INCLinearScheme):
     E2M1 weights packed two per byte with per-group E8M0 scales
     (group_size=32, no global scale). The platform kernel is selected by
     ``init_mxfp4_linear_kernel`` (FlashInfer / Marlin on CUDA, ``fp4_gemm``
-    on XPU). XPU rotation uses ARK's fused XMX Hadamard and MXFP4 kernel.
+    on XPU).
     """
 
-    def __init__(
-        self,
-        layer_config: "INCLayerConfig",
-        rotation_block_size: int | None = None,
-    ) -> None:
+    def __init__(self, layer_config: "INCLayerConfig") -> None:
         if not isinstance(layer_config.group_size, int):
             raise ValueError(
                 "INC MXFP4 requires scalar group_size, "
                 f"but found group_size={layer_config.group_size!r}."
             )
         self.group_size = layer_config.group_size or 32
-        self.rotation_block_size = rotation_block_size
         self.kernel = init_mxfp4_linear_kernel(activation_quant_key=kMxfp4Dynamic)
 
     @classmethod
@@ -60,25 +52,6 @@ class INCMxfp4LinearMethod(INCLinearScheme):
         **extra_weight_attrs: Any,
     ) -> None:
         del output_size
-        if self.rotation_block_size is not None and (
-            input_size_per_partition % self.rotation_block_size
-        ):
-            if input_size_per_partition != input_size:
-                raise ValueError(
-                    f"AutoRound rotation block_size={self.rotation_block_size} "
-                    "does not evenly divide this layer's tensor-parallel shard "
-                    f"width={input_size_per_partition} (full input_size="
-                    f"{input_size}). Hadamard rotation blocks that span "
-                    "multiple tensor-parallel shards are not supported; "
-                    "either use tensor_parallel_size=1 for this checkpoint, "
-                    "or re-quantize with a rotation block_size that evenly "
-                    "divides the per-shard width."
-                )
-            raise ValueError(
-                f"Linear input width {input_size_per_partition} is not "
-                "divisible by AutoRound rotation "
-                f"block_size={self.rotation_block_size}"
-            )
         output_size_per_partition = sum(output_partition_sizes)
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
@@ -121,28 +94,4 @@ class INCMxfp4LinearMethod(INCLinearScheme):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        if self.rotation_block_size is not None:
-            if current_platform.is_xpu() and x.is_xpu:
-                return self._apply_xpu_rotation(layer, x, bias)
-            original_shape = x.shape
-            x = x.unflatten(-1, (-1, self.rotation_block_size)).contiguous().clone()
-            x = ops.hadacore_transform(x)
-            x = x.flatten(-2, -1).reshape(original_shape)
         return self.kernel.apply_weights(layer, x, bias)
-
-    def _apply_xpu_rotation(
-        self,
-        layer: torch.nn.Module,
-        x: torch.Tensor,
-        bias: torch.Tensor | None,
-    ) -> torch.Tensor:
-        x_fp4, x_blockscale = torch.ops.vllm.inc_ark_mxfp4_hadamard_quant(x)
-        output = torch.ops._xpu_C.fp4_gemm(
-            x_fp4.view(torch.float4_e2m1fn_x2),
-            layer.weight,
-            x_blockscale.view(torch.float8_e8m0fnu),
-            layer.weight_scale,
-            x.dtype,
-            bias,
-        )
-        return output.reshape(*x.shape[:-1], layer.output_size_per_partition)

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_scheme.py
@@ -40,18 +40,20 @@ class INCMxfp4Scheme(INCScheme):
         del layer, prefix
         from .inc_mxfp4_linear import INCMxfp4LinearMethod
 
-        if config.rotation_config is not None and not current_platform.is_cuda():
+        if (
+            config.rotation_config is not None
+            and not current_platform.is_cuda()
+            and not current_platform.is_xpu()
+        ):
             raise NotImplementedError(
-                "AutoRound Hadamard rotation currently requires CUDA Hadacore"
+                "AutoRound Hadamard rotation requires CUDA Hadacore or XPU ARK"
             )
         rotation_block_size = (
             config.rotation_config["block_size"]
             if config.rotation_config is not None
             else None
         )
-        return INCLinearMethod(
-            INCMxfp4LinearMethod(layer_config, rotation_block_size)
-        )
+        return INCLinearMethod(INCMxfp4LinearMethod(layer_config, rotation_block_size))
 
     def get_moe_method(
         self,

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_scheme.py
@@ -4,6 +4,7 @@
 from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 from ..inc_linear import INCLinearMethod
 from .inc_scheme import INCScheme
@@ -36,10 +37,21 @@ class INCMxfp4Scheme(INCScheme):
         prefix: str,
         layer_config: "INCLayerConfig",
     ):
-        del config, layer, prefix
+        del layer, prefix
         from .inc_mxfp4_linear import INCMxfp4LinearMethod
 
-        return INCLinearMethod(INCMxfp4LinearMethod(layer_config))
+        if config.rotation_config is not None and not current_platform.is_cuda():
+            raise NotImplementedError(
+                "AutoRound Hadamard rotation currently requires CUDA Hadacore"
+            )
+        rotation_block_size = (
+            config.rotation_config["block_size"]
+            if config.rotation_config is not None
+            else None
+        )
+        return INCLinearMethod(
+            INCMxfp4LinearMethod(layer_config, rotation_block_size)
+        )
 
     def get_moe_method(
         self,
@@ -48,7 +60,11 @@ class INCMxfp4Scheme(INCScheme):
         prefix: str,
         layer_config: "INCLayerConfig",
     ):
-        del config, prefix, layer_config
+        del prefix, layer_config
+        if config.rotation_config is not None:
+            raise NotImplementedError(
+                "AutoRound Hadamard rotation is not supported for fused MoE"
+            )
         from .inc_mxfp4_moe import INCMxfp4MoEMethod
 
         return INCMxfp4MoEMethod(layer.moe_config)

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_scheme.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_scheme.py
@@ -4,7 +4,6 @@
 from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 
 from ..inc_linear import INCLinearMethod
 from .inc_scheme import INCScheme
@@ -23,7 +22,11 @@ class INCMxfp4Scheme(INCScheme):
 
     Dispatches to :class:`INCMxfp4LinearMethod` for linear layers and
     :class:`INCMxfp4MoEMethod` for fused MoE layers; see those classes for the
-    per-module weight layout and kernel-selection details.
+    per-module weight layout and kernel-selection details. When the
+    checkpoint requests an AutoRound Hadamard rotation
+    (``config.rotation_config``), the linear method is additionally wrapped
+    with an HMT transform method from ``..transform.linear``, keeping the
+    rotation decoupled from the quantization scheme itself.
     """
 
     @staticmethod
@@ -40,20 +43,23 @@ class INCMxfp4Scheme(INCScheme):
         del layer, prefix
         from .inc_mxfp4_linear import INCMxfp4LinearMethod
 
-        if (
-            config.rotation_config is not None
-            and not current_platform.is_cuda()
-            and not current_platform.is_xpu()
-        ):
-            raise NotImplementedError(
-                "AutoRound Hadamard rotation requires CUDA Hadacore or XPU ARK"
+        if config.rotation_config is not None:
+            from ..transform.linear import require_supported_platform
+
+            # Fail fast, before constructing a platform-specific MXFP4
+            # kernel, if this platform cannot run the rotation at all.
+            require_supported_platform()
+
+        linear_method = INCLinearMethod(INCMxfp4LinearMethod(layer_config))
+
+        if config.rotation_config is not None:
+            from ..transform.linear import build_linear_transform_method
+
+            return build_linear_transform_method(
+                linear_method, config.rotation_config["block_size"]
             )
-        rotation_block_size = (
-            config.rotation_config["block_size"]
-            if config.rotation_config is not None
-            else None
-        )
-        return INCLinearMethod(INCMxfp4LinearMethod(layer_config, rotation_block_size))
+
+        return linear_method
 
     def get_moe_method(
         self,

--- a/vllm/model_executor/layers/quantization/inc/transform/__init__.py
+++ b/vllm/model_executor/layers/quantization/inc/transform/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/model_executor/layers/quantization/inc/transform/ark_ops.py
+++ b/vllm/model_executor/layers/quantization/inc/transform/ark_ops.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from ..schemes.inc_ark_ops import get_ark_state
+
+logger = init_logger(__name__)
+
+_OPS_REGISTERED = False
+
+
+def _inc_ark_mxfp4_hadamard_quant_impl(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from auto_round_kernel.mxfp4_hadamard import mxfp4_hadamard_quant
+
+    return mxfp4_hadamard_quant(x)
+
+
+def _inc_ark_mxfp4_hadamard_quant_fake(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        torch.empty(
+            (*x.shape[:-1], x.shape[-1] // 2), dtype=torch.uint8, device=x.device
+        ),
+        torch.empty(
+            (*x.shape[:-1], x.shape[-1] // 32), dtype=torch.uint8, device=x.device
+        ),
+    )
+
+
+def register_ops_once() -> None:
+    global _OPS_REGISTERED
+    if _OPS_REGISTERED:
+        return
+
+    is_available, error_str, _, _ = get_ark_state()
+    if not is_available:
+        logger.debug(
+            "Skip registering inc_ark_mxfp4_hadamard_quant because ARK is "
+            "unavailable: %s",
+            error_str or "unknown error",
+        )
+        return
+
+    direct_register_custom_op(
+        op_name="inc_ark_mxfp4_hadamard_quant",
+        op_func=_inc_ark_mxfp4_hadamard_quant_impl,
+        fake_impl=_inc_ark_mxfp4_hadamard_quant_fake,
+        dispatch_key=current_platform.dispatch_key,
+    )
+    _OPS_REGISTERED = True
+
+
+register_ops_once()
+
+__all__ = ["register_ops_once"]

--- a/vllm/model_executor/layers/quantization/inc/transform/hadamard.py
+++ b/vllm/model_executor/layers/quantization/inc/transform/hadamard.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm._custom_ops as ops
+
+__all__ = ["HadamardTransform"]
+
+
+class HadamardTransform(torch.nn.Module):
+    """Apply a block-wise Hadamard transform to the last dimension."""
+
+    def __init__(self, block_size: int) -> None:
+        super().__init__()
+        self.block_size = block_size
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        original_shape = x.shape
+        x = x.unflatten(-1, (-1, self.block_size)).contiguous().clone()
+        x = ops.hadacore_transform(x)
+        return x.flatten(-2, -1).reshape(original_shape)

--- a/vllm/model_executor/layers/quantization/inc/transform/linear.py
+++ b/vllm/model_executor/layers/quantization/inc/transform/linear.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.platforms import current_platform
+
+from . import ark_ops  # noqa: F401  (registers the ARK fused rotation+quant op)
+from .hadamard import HadamardTransform
+
+__all__ = [
+    "INCLinearTransformMethod",
+    "ArkFusedMxfp4TransformMethod",
+    "require_supported_platform",
+    "build_linear_transform_method",
+]
+
+
+class INCLinearTransformMethod(LinearMethodBase):
+    """Apply an input transform before a wrapped linear method."""
+
+    def __init__(
+        self,
+        quant_method: LinearMethodBase,
+        block_size: int,
+        rotation: HadamardTransform | None = None,
+    ) -> None:
+        self.quant_method = quant_method
+        self.block_size = block_size
+        self.rotation = rotation
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        self._validate_block_size(input_size_per_partition, input_size)
+        self.quant_method.create_weights(
+            layer=layer,
+            input_size_per_partition=input_size_per_partition,
+            output_partition_sizes=output_partition_sizes,
+            input_size=input_size,
+            output_size=output_size,
+            params_dtype=params_dtype,
+            **extra_weight_attrs,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.quant_method.process_weights_after_loading(layer)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert self.rotation is not None
+        x = self.rotation(x)
+        return self.quant_method.apply(layer, x, bias)
+
+    def _validate_block_size(
+        self, input_size_per_partition: int, input_size: int
+    ) -> None:
+        if input_size_per_partition % self.block_size == 0:
+            return
+        if input_size_per_partition != input_size:
+            raise ValueError(
+                f"AutoRound rotation block_size={self.block_size} "
+                "does not evenly divide this layer's tensor-parallel shard "
+                f"width={input_size_per_partition} (full input_size="
+                f"{input_size}). Hadamard rotation blocks that span "
+                "multiple tensor-parallel shards are not supported; "
+                "either use tensor_parallel_size=1 for this checkpoint, "
+                "or re-quantize with a rotation block_size that evenly "
+                "divides the per-shard width."
+            )
+        raise ValueError(
+            f"Linear input width {input_size_per_partition} is not "
+            f"divisible by AutoRound rotation block_size={self.block_size}"
+        )
+
+
+class ArkFusedMxfp4TransformMethod(INCLinearTransformMethod):
+    """Apply fused ARK Hadamard, MXFP4 quantization, and FP4 GEMM."""
+
+    def __init__(self, quant_method: LinearMethodBase, block_size: int) -> None:
+        super().__init__(quant_method, block_size, rotation=None)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        x_fp4, x_blockscale = torch.ops.vllm.inc_ark_mxfp4_hadamard_quant(x)
+        output = torch.ops._xpu_C.fp4_gemm(
+            x_fp4.view(torch.float4_e2m1fn_x2),
+            layer.weight,
+            x_blockscale.view(torch.float8_e8m0fnu),
+            layer.weight_scale,
+            x.dtype,
+            bias,
+        )
+        return output.reshape(*x.shape[:-1], layer.output_size_per_partition)
+
+
+def require_supported_platform() -> None:
+    """Raise if the platform does not support Hadamard transforms."""
+    if not (current_platform.is_xpu() or current_platform.is_cuda()):
+        raise NotImplementedError(
+            "AutoRound Hadamard rotation requires CUDA Hadacore or XPU ARK"
+        )
+
+
+def build_linear_transform_method(
+    quant_method: LinearMethodBase,
+    block_size: int,
+) -> LinearMethodBase:
+    """Wrap a linear method with the platform-specific Hadamard transform."""
+    require_supported_platform()
+    if current_platform.is_xpu():
+        return ArkFusedMxfp4TransformMethod(quant_method, block_size)
+    return INCLinearTransformMethod(
+        quant_method, block_size, HadamardTransform(block_size)
+    )


### PR DESCRIPTION
## Dependency status

This PR depends on a new upstream ARK release containing the XPU HMT+MXFP4 kernel.

The kernel implementation is available in upstream development, but no compatible `auto-round-lib` wheel has been officially released yet. The currently `auto_round_lib==0.15.0` does not contain `auto_round_kernel.mxfp4_hadamard`.

## Accuracy Evaluation on A100

### auto-round
vllm ({'pretrained': 'Qwen3.6-27B-AutoRound-MXFP4-RTN-Hadamard', 'tensor_parallel_size': 1, 'max_model_len': 8192, 'max_num_batched_tokens': 32768, 'max_num_seqs': 128, 'add_bos_token': True, 'gpu_memory_utilization': 0.85, 'dtype': 'bfloat16', 'max_gen_toks': 2048, 'enable_prefix_caching': False, 'reasoning_parser': 'qwen3', 'language_model_only': True, 'enable_thinking': False, 'enforce_eager': False}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: auto

|Tasks|Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-----|------:|------|-----:|--------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9689|±  |0.0048|
|     |       |strict-match    |     5|exact_match|↑  |0.9697|±  |0.0047|
|hellaswag                              |      1|none            |     0|acc        |↑  |0.6267|±  |0.0048|
|                                       |       |none            |     0|acc_norm   |↑  |0.8226|±  |0.0038|
|piqa                                   |      1|none            |     0|acc        |↑  |0.8139|±  |0.0091|
|                                       |       |none            |     0|acc_norm   |↑  |0.8281|±  |0.0088|
|mmlu                                      |       |none            |     0|acc   |↑  |0.8376|±  |0.0030|

---

### llm-compressor
vllm ({'pretrained': 'Qwen3.6-27B-MXFP4-QuIP-v-Hadamard', 'tensor_parallel_size': 1, 'max_model_len': 8192, 'max_num_batched_tokens': 32768, 'max_num_seqs': 128, 'add_bos_token': True, 'gpu_memory_utilization': 0.85, 'dtype': 'bfloat16', 'max_gen_toks': 2048, 'enable_prefix_caching': False, 'reasoning_parser': 'qwen3', 'language_model_only': True, 'enable_thinking': False, 'enforce_eager': False}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: auto

|Tasks|Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|-----|------:|------|-----:|--------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9719|±  |0.0045|
|     |       |strict-match    |     5|exact_match|↑  |0.9727|±  |0.0045|
|hellaswag                              |      1|none            |     0|acc        |↑  |0.6304|±  |0.0048|
|                                       |       |none            |     0|acc_norm   |↑  |0.8331|±  |0.0037|
|piqa                                   |      1|none            |     0|acc        |↑  |0.8123|±  |0.0092|
|                                       |       |none            |     0|acc_norm   |↑  |0.8270|±  |0.0089|
|mmlu                                      |       |none            |     0|acc   |↑  |0.8218|±  |0.0031|


