### PR TITLE
[Fix] Fix sm8x build failure: move fused_gdn_decode_post_conv_mtp to correct ifdef guard

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -392,7 +392,9 @@ void fused_kda_decode(
     torch::stable::Tensor& out, std::optional<double> lower_bound,
     std::optional<torch::stable::Tensor> output_gate,
     std::optional<torch::stable::Tensor> norm_weight, double norm_eps);
+#endif
 
+#ifdef VLLM_ENABLE_FUSED_GDN_DECODE
 void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a,
     torch::stable::Tensor const& b, torch::stable::Tensor const& a_log,
@@ -403,7 +405,6 @@ void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor& state, torch::stable::Tensor const& output_gate,
     torch::stable::Tensor const& norm_weight, torch::stable::Tensor& out,
     double scale, double norm_eps);
-
 #endif
 
 #ifdef VLLM_ENABLE_KIMI_K3_ATTN_RES


### PR DESCRIPTION
## Summary
Fixes a compilation regression introduced in #51674 for sm8x architectures (Ampere/Ada: A100, A10, L20, RTX 4090, etc.).
## Root Cause
In #51674, fused_gdn_decode_post_conv_mtp was added to ops.h inside the existing #ifdef VLLM_ENABLE_FUSED_KDA_DECODE block (after fused_kda_decode) instead of a new #ifdef VLLM_ENABLE_FUSED_GDN_DECODE block. Since VLLM_ENABLE_FUSED_KDA_DECODE only applies to sm9.0a+, sm8x builds get VLLM_ENABLE_FUSED_GDN_DECODE=1 without the declaration being visible, causing:

`error: 'fused_gdn_decode_post_conv_mtp' was not declared in this scope`

## Fix
Move the declaration to its own `#ifdef VLLM_ENABLE_FUSED_GDN_DECODE` block.
CI was unaffected because it runs on Hopper/Blackwell where both macros are defined simultaneously.

## How to reproduce:
docker build -f docker/Dockerfile --target vllm-openai \
  --build-arg torch_cuda_arch_list="8.9" .