### PR TITLE
[Bugfix] Drop num_stages for MLA decode with fp8 KV cache on small-smem GPUs

### DIFF
--- a/tests/kernels/attention/test_triton_decode_attention.py
+++ b/tests/kernels/attention/test_triton_decode_attention.py
@@ -325,3 +325,69 @@ def test_decode_attention_cross_layer_view(H_Q, H_KV, D_QK, D_V, is_mla, PAGE_SI
     # Same data and same compute order; only addressing differs.
     assert torch.equal(o_ref, o_xl)
     assert torch.equal(lse_ref, lse_xl)
+
+
+@pytest.mark.parametrize("PAGE_SIZE", [1, 16])
+def test_decode_attention_mla_fp8_kv_cache_smem(PAGE_SIZE):
+    """MLA decode with an fp8 KV cache must launch on small-shared-memory GPUs.
+
+    Regression test for the num_stages guard in _decode_grouped_att_m_fwd.
+    MLA with D_QK=576 pins BLOCK_DMODEL=512 and BLOCK_DPE=64, so the
+    ``BLOCK_DMODEL >= 1024`` branch never fired. With a bf16 KV cache the tile
+    still fits at num_stages=2, but an fp8 KV cache adds dequant staging and
+    needs 102400 bytes -- 1024 over the 101376-byte opt-in limit on consumer
+    and workstation Blackwell (GB10 / DGX Spark, RTX PRO 6000), so every decode
+    died with ``triton.runtime.errors.OutOfResources``.
+
+    The bf16 case is covered by test_decode_attention_cross_layer_view; this
+    test adds the fp8 variant of the same tile.
+    """
+    B, H_Q, H_KV, D_QK, D_V = 3, 16, 1, 576, 512
+    seq_len = 1027
+    CACHE_SIZE = 16384
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / (D_QK**0.5)
+    num_kv_splits = 8
+    num_pages = CACHE_SIZE // PAGE_SIZE
+
+    num_pages_per_batch = cdiv(seq_len, PAGE_SIZE)
+    req_to_page = torch.randint(
+        0, num_pages, (B, num_pages_per_batch), device=DEVICE_TYPE
+    )
+    q = torch.randn(B, H_Q, D_QK, dtype=dtype, device=DEVICE_TYPE)
+    b_seq_len = torch.full((B,), seq_len, device=DEVICE_TYPE)
+
+    k_bf16 = torch.randn(
+        num_pages, PAGE_SIZE, H_KV, D_QK, dtype=dtype, device=DEVICE_TYPE
+    )
+    k_fp8, k_scale = _quantize_to_fp8(k_bf16)
+    # MLA: the value cache is a prefix view of the key cache.
+    v_fp8 = k_fp8[..., :D_V]
+    v_scale = k_scale
+
+    o = torch.zeros(B, H_Q, D_V, dtype=dtype, device=DEVICE_TYPE)
+    lse = torch.zeros(B, H_Q, dtype=dtype, device=DEVICE_TYPE)
+    attn_logits = torch.empty(
+        (B, H_Q, num_kv_splits, D_V + 1), dtype=torch.float32, device=DEVICE_TYPE
+    )
+
+    # Before the fix this raised OutOfResources instead of running.
+    decode_attention_fwd(
+        q,
+        k_fp8,
+        v_fp8,
+        o,
+        lse,
+        req_to_page,
+        b_seq_len,
+        attn_logits,
+        num_kv_splits,
+        sm_scale,
+        PAGE_SIZE,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        is_mla=True,
+    )
+
+    assert torch.isfinite(o).all()
+    assert torch.isfinite(lse).all()

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -29,6 +29,7 @@ Memory-efficient attention for decoding.
 It supports page size >= 1.
 """
 
+import functools
 import logging
 
 import torch
@@ -38,6 +39,42 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 is_hip_ = current_platform.is_rocm()
+
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+
+# Shared memory the MLA grouped-decode tile (BLOCK_DMODEL=512 + BLOCK_DPE=64)
+# needs at num_stages=2 with an fp8 KV cache, measured with triton 3.7.0.
+# Devices whose opt-in per-block limit is below this cannot pipeline that
+# configuration; see _decode_grouped_att_m_fwd.
+_MLA_FP8_NUM_STAGES_2_SMEM_BYTES = 102400
+
+
+@functools.cache
+def _shared_memory_per_block_optin(device_index: int) -> int | None:
+    """Opt-in shared memory a single block may use, or None if unknown."""
+    try:
+        return torch.cuda.get_device_properties(
+            device_index
+        ).shared_memory_per_block_optin
+    except Exception:  # noqa: BLE001 - non-CUDA or property unavailable
+        return None
+
+
+def _mla_fp8_tile_overflows_smem(is_mla: bool, kv_dtype, device) -> bool:
+    """True when the MLA tile with an fp8 KV cache cannot fit at num_stages=2.
+
+    Returns False when the device's limit cannot be determined, preserving the
+    previous behaviour rather than pessimizing an unknown platform.
+    """
+    if not is_mla or kv_dtype not in _FP8_DTYPES:
+        return False
+    limit = _shared_memory_per_block_optin(
+        device.index if device.index is not None else torch.cuda.current_device()
+    )
+    if limit is None:
+        return False
+    return limit < _MLA_FP8_NUM_STAGES_2_SMEM_BYTES
+
 
 logger = logging.getLogger(__name__)
 
@@ -525,10 +562,23 @@ def _decode_grouped_att_m_fwd(
         # https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py
         extra_kargs = {"waves_per_eu": 1, "matrix_instr_nonkdim": 16, "kpack": 2}
         num_stages = 1
-    elif not is_hip_ and BLOCK_DMODEL >= 1024:
-        # Avoid shared memory overflow on NVIDIA when BLOCK_DMODEL is large
-        # like non-MLA D_QK=576, BLOCK_DMODEL=1024, BLOCK_H=16
-        # exceeds 101376 bytes limit
+    elif not is_hip_ and (
+        BLOCK_DMODEL >= 1024
+        or _mla_fp8_tile_overflows_smem(is_mla, k_buffer.dtype, q.device)
+    ):
+        # Avoid shared memory overflow on NVIDIA.
+        #
+        # BLOCK_DMODEL >= 1024: non-MLA D_QK=576 gives BLOCK_DMODEL=1024 with
+        # BLOCK_H=16, which exceeds the 101376 bytes limit.
+        #
+        # MLA pins BLOCK_DMODEL=512 + BLOCK_DPE=64 above. That tile fits at
+        # num_stages=2 with a bf16 KV cache, but an fp8 KV cache adds dequant
+        # staging and does not. Measured on GB10 (sm_121, 101376 bytes opt-in
+        # limit) with triton 3.7.0:
+        #     bf16 KV, num_stages=2 ->  63488 bytes (fits)
+        #     fp8  KV, num_stages=2 -> 102400 bytes (1024 over -> launch fails)
+        #     fp8  KV, num_stages=1 ->  83968 bytes (fits)
+        # Datacenter parts have a larger opt-in limit and keep the extra stage.
         num_stages = 1
 
     _fwd_grouped_kernel_stage1[grid](


### PR DESCRIPTION
## Summary

`_decode_grouped_att_m_fwd` already guards against shared-memory overflow by falling back to `num_stages=1`, but the condition only fires for `BLOCK_DMODEL >= 1024`. MLA with `D_QK=576` pins `BLOCK_DMODEL=512` and `BLOCK_DPE=64` earlier in the same function, so the guard never applied to it.

With a bf16 KV cache that tile still fits. With an fp8 KV cache the extra dequant staging pushes it past the 101,376-byte opt-in limit found on consumer and workstation Blackwell parts, and every MLA decode dies on the first generated token with `triton.runtime.errors.OutOfResources`.

Fixes #53748.

## Measurements

Shared memory required by the stage-1 grouped kernel, read from `JITFunction.warmup(...).metadata.shared` on GB10 (sm_121, `shared_memory_per_block_optin = 101,376`), triton 3.7.0, torch 2.12.0+cu130:

| KV dtype | `num_stages` | shared memory | vs limit |
|---|---|---|---|
| bf16 | 1 | 59,392 | fits, 41,984 spare |
| bf16 | 2 | 63,488 | fits, 37,888 spare |
| fp8 | 1 | 83,968 | fits, 17,408 spare |
| **fp8** | **2** | **102,400** | **1,024 over — launch fails** |

## Why not simply `or is_mla`

The issue suggests widening the guard to `BLOCK_DMODEL >= 1024 or is_mla`. The table above shows the bf16 MLA path has 37,888 bytes to spare at `num_stages=2`, so that condition would drop a pipeline stage it does not need to. It would also drop it on datacenter parts, whose opt-in limit accommodates the fp8 tile comfortably.

The condition here is therefore narrowed to three facts that must all hold: MLA tile, fp8 KV cache, and a device whose opt-in limit is below the measured requirement. When the device limit cannot be read the helper returns `False`, so any platform this cannot measure keeps its current behaviour rather than being pessimized.

I do not have a datacenter part on hand to confirm the no-regression claim there directly; the argument rests on the larger opt-in limit plus the explicit `limit < 102400` term in the condition.

## Verification

On GB10, intercepting the value the guard actually selects:

| KV dtype | before | after |
|---|---|---|
| bf16 | `num_stages=2`, launches | `num_stages=2`, launches |
| fp8 | `num_stages=2`, **OutOfResources** | `num_stages=1`, launches |

`tests/kernels/attention/test_triton_decode_attention.py`, same file, same GB10:

* against `main`: **2 failed, 115 passed** — the two failures are the new `test_decode_attention_mla_fp8_kv_cache_smem[1]` and `[16]`
* with this change: **117 passed**

## Test

The bf16 form of this exact tile is already covered by `test_decode_attention_cross_layer_view` with `(H_Q=16, H_KV=1, D_QK=576, D_V=512, is_mla=True)`, which is why CI never saw this. The added test is the fp8 variant of the same tile.
