### PR TITLE
fix indexing for sparse MLA on AMD

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -1414,7 +1414,7 @@ def _sparse_attn_prefill_ragged_kernel(
 
         kv = tl.load(
             kv_ptr
-            + safe_slot[:, None] * kv_stride_n
+            + safe_slot[:, None].to(tl.int64) * kv_stride_n
             + dim_offsets[None, :] * kv_stride_d,
             mask=valid[:, None] & dim_mask[None, :],
             other=0.0,


### PR DESCRIPTION


## Purpose
sparse MLA indexing on int32, causing integer overflow and crash at high concurrency and high context length scenarios. Fix the crash by casting to int64.

## Test Plan
- Run GLM5.3-Flash at high conc and high context length

command:
```bash
vllm bench serve \
--backend openai-chat \
--model "zai-org/GLM-5.3-Flash" \
--base-url http://127.0.0.1:8000 \
--endpoint /v1/chat/completions \
--dataset-name random \
--random-input-len 8192 \
--random-output-len 1024 \
--random-range-ratio 0.0 \
--num-prompts 1000 \
--max-concurrency 100 \
--seed 15121545
```

## Test Result
- crashes with memory fault without this and passes with this fix

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

