### PR TITLE
[Bugfix][KV Offload] Handle padded GPU cache storage

### DIFF
--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -238,6 +238,28 @@ def test_register_shared_kv_cache_storage(monkeypatch, layout: KVCacheLayout):
     }
 
 
+def test_register_kv_cache_storage_with_trailing_padding(monkeypatch):
+    num_blocks = 4
+    block_bytes = 32
+    padding_bytes = 7
+    cache_bytes = num_blocks * block_bytes
+    raw = torch.zeros(cache_bytes + padding_bytes, dtype=torch.int8, device="cuda")
+    cache = raw[:cache_bytes].view(num_blocks, block_bytes)
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None,
+        kv_cache_config=MagicMock(num_blocks=num_blocks),
+        cpu_capacity_bytes=cache_bytes,
+    )
+    worker._backend = MagicMock()
+    monkeypatch.setattr("vllm.v1.simple_kv_offload.worker.PIN_MEMORY", False)
+
+    worker.register_kv_caches({"layer.0": cache})
+
+    assert worker.gpu_kv_caches is not None
+    assert list(worker.gpu_kv_caches) == ["layer.0"]
+    assert worker.gpu_kv_caches["layer.0"].shape == (num_blocks, block_bytes)
+
+
 def test_register_separate_kv_head_groups(monkeypatch):
     # LHBNC hoists the K/V head groups outside the block dim, so each layer's
     # blocks are registered as one region per group (K, V).

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -209,7 +209,10 @@ def test_register_shared_kv_cache_storage(monkeypatch, layout: KVCacheLayout):
         device="cuda",
     )
     caches = dense_kv_cache_views(raw, spec, num_blocks, num_layers, layout)
-    cache_config = MagicMock(num_blocks=num_blocks)
+    cache_config = MagicMock(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[MagicMock(size=raw.nbytes)],
+    )
     worker = SimpleCPUOffloadWorker(
         vllm_config=None,
         kv_cache_config=cache_config,
@@ -241,13 +244,15 @@ def test_register_shared_kv_cache_storage(monkeypatch, layout: KVCacheLayout):
 def test_register_kv_cache_storage_with_trailing_padding(monkeypatch):
     num_blocks = 4
     block_bytes = 32
-    padding_bytes = 7
     cache_bytes = num_blocks * block_bytes
-    raw = torch.zeros(cache_bytes + padding_bytes, dtype=torch.int8, device="cuda")
+    raw = torch.zeros(4096, dtype=torch.int8, device="cuda")
     cache = raw[:cache_bytes].view(num_blocks, block_bytes)
     worker = SimpleCPUOffloadWorker(
         vllm_config=None,
-        kv_cache_config=MagicMock(num_blocks=num_blocks),
+        kv_cache_config=MagicMock(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[MagicMock(size=cache_bytes)],
+        ),
         cpu_capacity_bytes=cache_bytes,
     )
     worker._backend = MagicMock()
@@ -282,7 +287,10 @@ def test_register_separate_kv_head_groups(monkeypatch):
     caches = dense_kv_cache_views(raw, spec, num_blocks, num_layers, layout)
     worker = SimpleCPUOffloadWorker(
         vllm_config=None,
-        kv_cache_config=MagicMock(num_blocks=num_blocks),
+        kv_cache_config=MagicMock(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[MagicMock(size=raw.nbytes)],
+        ),
         cpu_capacity_bytes=raw.nbytes,
     )
     worker._backend = MagicMock()

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -118,7 +118,15 @@ class SimpleCPUOffloadWorker:
             )
             block_bytes = tensor.stride(0) * tensor.element_size() * physical_per_block
             raw = torch.empty(0, dtype=torch.int8, device=tensor.device).set_(storage)
-            regions = raw.view(-1, num_blocks, block_bytes)
+            region_bytes = num_blocks * block_bytes
+            num_regions = raw.numel() // region_bytes
+            assert num_regions > 0, (
+                f"KV cache {name!r} storage has {raw.numel()} bytes, fewer than "
+                f"one {region_bytes}-byte cache region"
+            )
+            regions = raw[: num_regions * region_bytes].view(
+                num_regions, num_blocks, block_bytes
+            )
             for idx, region in enumerate(regions):
                 key_name = name if len(regions) == 1 else f"{name}.{idx}"
                 unique_gpu_caches[key_name] = region

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -99,6 +99,8 @@ class SimpleCPUOffloadWorker:
 
         assert self.kv_cache_config is not None
         num_blocks = self.kv_cache_config.num_blocks
+        assert self.kv_cache_config.kv_cache_tensors
+        logical_storage_bytes = self.kv_cache_config.kv_cache_tensors[0].size
 
         # The DMA backend copies whole blocks as base + block_id * stride(0),
         # so view each unique allocation as [num_blocks, block_bytes].
@@ -118,15 +120,11 @@ class SimpleCPUOffloadWorker:
             )
             block_bytes = tensor.stride(0) * tensor.element_size() * physical_per_block
             raw = torch.empty(0, dtype=torch.int8, device=tensor.device).set_(storage)
-            region_bytes = num_blocks * block_bytes
-            num_regions = raw.numel() // region_bytes
-            assert num_regions > 0, (
-                f"KV cache {name!r} storage has {raw.numel()} bytes, fewer than "
-                f"one {region_bytes}-byte cache region"
+            assert raw.numel() >= logical_storage_bytes, (
+                f"KV cache {name!r} storage has {raw.numel()} bytes, smaller "
+                f"than the configured {logical_storage_bytes}-byte allocation"
             )
-            regions = raw[: num_regions * region_bytes].view(
-                num_regions, num_blocks, block_bytes
-            )
+            regions = raw[:logical_storage_bytes].view(-1, num_blocks, block_bytes)
             for idx, region in enumerate(regions):
                 key_name = name if len(regions) == 1 else f"{name}.{idx}"
                 unique_gpu_caches[key_name] = region


### PR DESCRIPTION
## Purpose

Fix the `nvidia-h100-lm-eval-kv-offload-large` startup regression introduced by #51718. The failure reproduces on upstream `main` in [Build #85765](https://buildkite.com/vllm/ci/builds/85765) and [Build #85757](https://buildkite.com/vllm/ci/builds/85757).

`SimpleCPUOffloadWorker.register_kv_caches()` reshaped the entire 4-KiB-rounded backing storage into logical cache regions. DeepSeek-V4 has 2,816 trailing alignment bytes, so its 33,626,157,056-byte physical storage is not divisible by the configured 33,626,154,240-byte logical allocation and server startup fails.

Bound the storage view by `KVCacheTensor.size` before reshaping. This preserves the configured cache allocation while excluding all physical tail padding, including padding large enough to contain complete cache regions. A focused regression test covers a 128-byte logical cache backed by a 4-KiB allocation.

### Duplicate-work check

No open PR found for this `SimpleCPUOffloadConnector` storage-padding failure. #53607 concerns the separate `OffloadingConnector` transfer path, #52921 aligns pool sizing across workers, and #42992 fixes hybrid block sizing; none changes this reshape.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_worker.py -k trailing_padding -q
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_worker.py -q
.venv/bin/pre-commit run ruff-check --files vllm/v1/simple_kv_offload/worker.py tests/v1/simple_kv_offload/test_worker.py
.venv/bin/pre-commit run ruff-format --files vllm/v1/simple_kv_offload/worker.py tests/v1/simple_kv_offload/test_worker.py
```

The exact H100 DeepSeek-V4 evaluation also runs in PR CI.

## Test Result

Before the initial fix, the regression test failed during reshape with an invalid shape error. The strengthened 4-KiB-padding test then demonstrated the review finding against the initial fix: 32 regions were registered instead of one.

After bounding by the configured logical allocation:

```text
1 passed, 10 deselected
11 passed
ruff check: Passed
ruff format: Passed
```

All commit-time hooks, including mypy, SPDX, and forbidden-import checks, passed.

## AI assistance

AI assistance was used for investigation, implementation, and test execution. The submitting human must review every changed line and the reported results before merge.