### PR TITLE
[Bugfix] Gracefully handle unsupported reasoning_effort in chat templates

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -844,6 +844,89 @@ SYSTEM_FIRST_TEMPLATE = (
 )
 
 
+EFFORT_VALIDATING_TEMPLATE = (
+    "{% if reasoning_effort is defined and "
+    "reasoning_effort not in ['xhigh', 'medium', 'low'] %}"
+    "{{ raise_exception('Unexpected reasoning effort ' + reasoning_effort + "
+    "'. Supported types are xhigh (default), medium, and low.') }}"
+    "{% endif %}"
+    "{% for message in messages %}"
+    "{{ message['role'] }}: {{ message['content'] }}\n"
+    "{% endfor %}"
+)
+
+EFFORT_BREAKING_TEMPLATE = (
+    "{% if reasoning_effort is defined %}"
+    "{{ raise_exception('Template broke for an unrelated reason') }}"
+    "{% endif %}"
+    "{% for message in messages %}"
+    "{{ message['role'] }}: {{ message['content'] }}\n"
+    "{% endfor %}"
+)
+
+
+class TestApplyChatTemplateEffortTolerant:
+    """Chat templates that reject unsupported reasoning_effort values should
+    surface a 400-style client error instead of crashing the request."""
+
+    @pytest.fixture
+    def model_config(self):
+        return ModelConfig(
+            "facebook/opt-125m",
+            tokenizer="facebook/opt-125m",
+            tokenizer_mode="auto",
+            trust_remote_code=False,
+            dtype="float16",
+        )
+
+    @pytest.fixture
+    def tokenizer(self):
+        return get_tokenizer("facebook/opt-125m")
+
+    def test_unsupported_effort_raises_bad_request(self, model_config, tokenizer):
+        conversation = [{"role": "user", "content": "Hello"}]
+        with pytest.raises(
+            VLLMValidationError,
+            match="Unexpected reasoning effort high",
+        ) as excinfo:
+            safe_apply_chat_template(
+                model_config,
+                tokenizer,
+                conversation,
+                chat_template=EFFORT_VALIDATING_TEMPLATE,
+                tokenize=False,
+                reasoning_effort="high",
+            )
+        # The template's own message tells the client which values are supported.
+        assert "Supported types are xhigh (default), medium, and low" in str(
+            excinfo.value
+        )
+
+    def test_supported_effort_accepted(self, model_config, tokenizer):
+        conversation = [{"role": "user", "content": "Hello"}]
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=EFFORT_VALIDATING_TEMPLATE,
+            tokenize=False,
+            reasoning_effort="medium",
+        )
+        assert result == "user: Hello\n"
+
+    def test_non_effort_template_error_is_bad_request(self, model_config, tokenizer):
+        conversation = [{"role": "user", "content": "Hello"}]
+        with pytest.raises(VLLMValidationError, match="unrelated reason"):
+            safe_apply_chat_template(
+                model_config,
+                tokenizer,
+                conversation,
+                chat_template=EFFORT_BREAKING_TEMPLATE,
+                tokenize=False,
+                reasoning_effort="high",
+            )
+
+
 class TestConsolidateSystemMessages:
     def test_no_system_messages_unchanged(self):
         conversation = [

--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import jinja2
 import pytest
 
 from vllm.config import ModelConfig
@@ -12,6 +13,7 @@ from vllm.renderers.hf import (
     _convert_developer_to_system,
     _detect_developer_role_support,
     _get_hf_base_chat_template_params,
+    _template_error_reason,
     _try_extract_ast,
     resolve_chat_template,
     resolve_chat_template_content_format,
@@ -897,9 +899,11 @@ class TestApplyChatTemplateEffortTolerant:
                 tokenize=False,
                 reasoning_effort="high",
             )
-        # The template's own message tells the client which values are supported.
-        assert "Supported types are xhigh (default), medium, and low" in str(
-            excinfo.value
+        # The client sees exactly the template's own reason, with no wrapper
+        # noise. It tells them which values are supported.
+        assert str(excinfo.value) == (
+            "Unexpected reasoning effort high. Supported types are xhigh "
+            "(default), medium, and low."
         )
 
     def test_supported_effort_accepted(self, model_config, tokenizer):
@@ -925,6 +929,20 @@ class TestApplyChatTemplateEffortTolerant:
                 tokenize=False,
                 reasoning_effort="high",
             )
+
+
+def test_template_error_reason_prefers_template_error():
+    # Upstream wrappers must not hide the template's own reason from clients.
+    reason = jinja2.TemplateError("Unexpected reasoning effort high")
+    wrapper = ValueError(f"An error occurred while rendering the template: {reason}")
+    wrapper.__cause__ = reason
+    assert _template_error_reason(wrapper) == str(reason)
+    assert _template_error_reason(reason) == str(reason)
+
+
+def test_template_error_reason_falls_back_to_message():
+    err = ValueError("plain failure")
+    assert _template_error_reason(err) == "plain failure"
 
 
 class TestConsolidateSystemMessages:

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -27,6 +27,7 @@ from vllm.entrypoints.chat_utils import (
     parse_chat_messages,
     parse_chat_messages_async,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EmbedsPrompt
 from vllm.inputs.engine import MultiModalInput
 from vllm.logger import init_logger
@@ -806,10 +807,12 @@ def safe_apply_chat_template(
             **resolved_kwargs,
         )
     except Exception as e:
-        logger.exception(
-            "An error occurred in `transformers` while applying chat template"
-        )
-        raise ValueError(str(e)) from e
+        # Chat templates reject invalid user input (e.g. an unsupported
+        # `reasoning_effort` value) by raising from within the template.
+        # Surface those as a 400 Bad Request carrying the template's own
+        # message (which typically lists the supported values) instead of a 500.
+        logger.warning("Chat template rejected the request: %s", e)
+        raise VLLMValidationError(str(e)) from e
 
     if return_assistant_tokens_mask:
         assert isinstance(plain, list), f"Expected list[int], got {type(plain)}"

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -685,6 +685,18 @@ def resolve_chat_template_kwargs(
     return {k: v for k, v in chat_template_kwargs.items() if k in accept_vars}
 
 
+def _template_error_reason(exc: BaseException) -> str:
+    # Extract the most specific reason from a chat template error chain.
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, jinja2.TemplateError):
+            return str(current)
+        current = current.__cause__ or current.__context__
+    return str(exc)
+
+
 @overload
 def safe_apply_chat_template(
     model_config: ModelConfig,
@@ -810,9 +822,10 @@ def safe_apply_chat_template(
         # Chat templates reject invalid user input (e.g. an unsupported
         # `reasoning_effort` value) by raising from within the template.
         # Surface those as a 400 Bad Request carrying the template's own
-        # message (which typically lists the supported values) instead of a 500.
+        # reason (which typically lists the supported values) instead of a
+        # 500 or any generic upstream wrapper message.
         logger.warning("Chat template rejected the request: %s", e)
-        raise VLLMValidationError(str(e)) from e
+        raise VLLMValidationError(_template_error_reason(e)) from e
 
     if return_assistant_tokens_mask:
         assert isinstance(plain, list), f"Expected list[int], got {type(plain)}"


### PR DESCRIPTION
## Summary
To fix #54017

Chat templates validate their input and reject invalid requests by raising
from inside the template. For example, the Qwen3.8 chat template only accepts
`xhigh` (default), `medium`, and `low` for `reasoning_effort`; sending the
standard `reasoning_effort: "high"` makes the template call
`raise_exception(...)`, which surfaces as a server-side error (500) instead
of a usable response.

This PR makes the generic HF renderer surface these template rejections as a
400 Bad Request carrying the template's own message, which typically lists
the supported values (e.g. for Qwen3.8: "Unexpected reasoning effort high.
Supported types are xhigh (default), medium, and low").

The handling is fully generic (no model-specific logic): any exception raised
by the template — an unsupported `reasoning_effort`, invalid
`chat_template_kwargs`, etc. — is re-raised as `VLLMValidationError`, which
the entrypoint error-handling layer already maps to 400. This covers all
entry points that go through the generic HF renderer
(`/v1/chat/completions`, `/v1/responses`, Anthropic `/v1/messages`, offline
chat, batch).

## Changes

- `vllm/renderers/hf.py`: in `safe_apply_chat_template`, re-raise template
  exceptions as `VLLMValidationError` (warning-level log) instead of wrapping
  them in a raw `ValueError`.
- `tests/renderers/test_hf.py`: unsupported effort → 400 with the template's
  message; supported effort passes through unchanged; unrelated template
  errors also surface as 400.
