### PR TITLE
[Cleanup][MoE] Move FlashInfer MoE helpers under fused_moe

### DIFF
--- a/.buildkite/intel_jobs/lm_eval_intel.yaml
+++ b/.buildkite/intel_jobs/lm_eval_intel.yaml
@@ -20,6 +20,7 @@ steps:
     - csrc/
     - vllm/model_executor/layers/quantization
     - tests/evals/gpt_oss/
+    - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     - >-
       bash .buildkite/scripts/hardware_ci/run-intel-test.sh

--- a/.buildkite/intel_jobs/quantization.yaml
+++ b/.buildkite/intel_jobs/quantization.yaml
@@ -20,6 +20,7 @@ steps:
   - csrc/
   - vllm/model_executor/layers/quantization
   - tests/quantization
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
   # - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
   - >-

--- a/.buildkite/test_areas/compile.yaml
+++ b/.buildkite/test_areas/compile.yaml
@@ -56,6 +56,7 @@ steps:
   - tests/compile/passes/test_silu_mul_quant_fusion.py
   - tests/compile/passes/distributed/test_fusion_all_reduce.py
   - tests/compile/fullgraph/test_full_graph.py
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     # b200 runners are limited, so we limit the tests to the minimum set only supported on Blackwell
     - nvidia-smi

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -320,7 +320,7 @@ steps:
   - vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
   - vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
   - vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_two_sided.py
-  - vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/v1/attention/backends/flashinfer.py
   - vllm/v1/attention/backends/mla/cutlass_mla.py
   - vllm/v1/attention/backends/mla/flashinfer_mla.py

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -197,6 +197,7 @@ steps:
   - csrc/quantization/
   - vllm/model_executor/layers/quantization
   - tests/kernels/quantization
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     - pytest -v -s kernels/quantization --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
   parallelism: 6
@@ -219,6 +220,7 @@ steps:
       - vllm/kernels/aiter_ops.py
       - vllm/platforms/rocm.py
       - vllm/model_executor/kernels/
+      - vllm/model_executor/layers/fused_moe/flashinfer.py
       depends_on:
       - image-build-amd
 

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -8,6 +8,7 @@ steps:
   timeout_in_minutes: 45
   source_file_dependencies:
   - csrc/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   autorun_on_main: true
   commands:
@@ -51,6 +52,7 @@ steps:
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   source_file_dependencies:
   - csrc/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   commands:
     - export VLLM_USE_DEEP_GEMM=0  # We found Triton is faster than DeepGEMM for H100
@@ -63,6 +65,7 @@ steps:
   optional: true
   source_file_dependencies:
   - csrc/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell.txt
@@ -91,6 +94,7 @@ steps:
   - tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP2-PCP2-EP.yaml
   - tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-EP.yaml
   - tests/evals/gsm8k/configs/models-pcp.txt
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   - vllm/config/parallel.py
   - vllm/distributed/parallel_state.py
@@ -171,6 +175,7 @@ steps:
   num_devices: 2
   source_file_dependencies:
   - csrc/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell-ep.txt
@@ -356,6 +361,7 @@ steps:
   num_devices: 2
   source_file_dependencies:
   - csrc/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   - tests/evals/gpt_oss/
   commands:
@@ -370,6 +376,7 @@ steps:
   num_devices: 2
   source_file_dependencies:
   - csrc/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   - tests/evals/gpt_oss/
   commands:

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -30,6 +30,7 @@ steps:
       - vllm/v1/attention/selector.py
       - vllm/_aiter_ops.py
       - vllm/platforms/rocm.py
+      - vllm/model_executor/layers/fused_moe/flashinfer.py
 
 # - label: LM Eval Large Models (4xA100)
 #   key: lm-eval-large-models-4xa100
@@ -79,6 +80,7 @@ steps:
   source_file_dependencies:
   - csrc/
   - vllm/model_executor/layers/quantization
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   autorun_on_main: true
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small-tp.txt
@@ -431,6 +433,7 @@ steps:
   - csrc/
   - vllm/model_executor/layers/quantization
   - tests/evals/gpt_oss/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
     - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-spark.txt

--- a/.buildkite/test_areas/plugins.yaml
+++ b/.buildkite/test_areas/plugins.yaml
@@ -72,6 +72,7 @@ steps:
   source_file_dependencies:
   - vllm/model_executor/layers/quantization
   - tests/plugins_tests/test_gguf_plugin.py
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     - pip install "vllm-gguf-plugin >= 0.0.2"
     - pytest -v -s plugins_tests/gguf
@@ -86,6 +87,7 @@ steps:
   source_file_dependencies:
   - vllm/model_executor/layers/quantization
   - tests/plugins_tests/bitsandbytes
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     # bitsandbytes' int8 quant syncs internally, and it is out-of-tree, so
     # there is nothing to wrap on the vLLM side.
@@ -104,6 +106,7 @@ steps:
   source_file_dependencies:
   - vllm/model_executor/layers/quantization
   - tests/plugins_tests/bitsandbytes
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     # bitsandbytes' int8 quant syncs internally, and it is out-of-tree, so
     # there is nothing to wrap on the vLLM side.

--- a/.buildkite/test_areas/quantization.yaml
+++ b/.buildkite/test_areas/quantization.yaml
@@ -11,6 +11,7 @@ steps:
     VLLM_USE_V2_MODEL_RUNNER: "0"
   source_file_dependencies:
   - csrc/
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   - vllm/model_executor/layers/quantization
   - tests/quantization
   commands:

--- a/.buildkite/test_areas/quantization.yaml
+++ b/.buildkite/test_areas/quantization.yaml
@@ -62,5 +62,6 @@ steps:
   source_file_dependencies:
   - vllm/model_executor/layers/quantization
   - tests/models/quantization
+  - vllm/model_executor/layers/fused_moe/flashinfer.py
   commands:
     - pytest -v -s models/quantization

--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -26,11 +26,11 @@ from vllm.model_executor.layers.fused_moe.experts.trtllm_fp8_moe import (
     TrtLlmFp8ExpertsModular,
     TrtLlmFp8ExpertsMonolithic,
 )
-from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+from vllm.model_executor.layers.fused_moe.flashinfer import (
     rotate_weights_for_fi_trtllm_fp8_per_tensor_moe,
     swap_w13_to_w31,
 )
+from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
 from vllm.model_executor.layers.quantization.utils.fp8_utils import input_to_float8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -404,7 +404,7 @@ def test_flashinfer_cutlass_moe_fp8_no_graph(
 def test_convert_moe_weights_to_flashinfer_trtllm_block_layout(
     num_experts, intermediate, hidden
 ):
-    from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    from vllm.model_executor.layers.fused_moe.flashinfer import (
         convert_moe_weights_to_flashinfer_trtllm_block_layout,
     )
 

--- a/tests/kernels/moe/test_routed_experts_capture_monolithic.py
+++ b/tests/kernels/moe/test_routed_experts_capture_monolithic.py
@@ -498,7 +498,7 @@ def _make_fp8_block_scale_monolithic_experts(
     Weights are shuffled into the BlockMajorK layout the kernel expects
     (same helper the vLLM weight loader uses for DeepSeek-FP8 models).
     """
-    from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    from vllm.model_executor.layers.fused_moe.flashinfer import (
         _shuffle_deepseek_fp8_moe_weights,
     )
 

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -30,6 +30,10 @@ from vllm.model_executor.layers.attention.attention import (
     set_default_quant_scales,
 )
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
+from vllm.model_executor.layers.fused_moe import flashinfer as flashinfer_utils
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    prepare_fp8_moe_layer_for_fi,
+)
 from vllm.model_executor.layers.quantization.fp8 import (
     Fp8Config,
     Fp8KVCacheMethod,
@@ -39,10 +43,6 @@ from vllm.model_executor.layers.quantization.fp8 import (
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.online.fp8 import (
     Fp8PerTensorOnlineLinearMethod,
-)
-from vllm.model_executor.layers.quantization.utils import flashinfer_utils
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    prepare_fp8_moe_layer_for_fi,
 )
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     process_fp8_input_tensor_strategy_moe,

--- a/tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py
+++ b/tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py
@@ -5,14 +5,14 @@ from types import SimpleNamespace
 
 import torch
 
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    align_fp4_moe_weights_for_fi,
+    align_trtllm_fp4_moe_hidden_dim_for_fi,
+)
 from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
 from vllm.model_executor.layers.quantization.utils import flashinfer_fp4_moe
 from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
     prepare_nvfp4_moe_layer_for_fi_or_cutlass,
-)
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    align_fp4_moe_weights_for_fi,
-    align_trtllm_fp4_moe_hidden_dim_for_fi,
 )
 
 

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
@@ -10,11 +10,11 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
 )
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    activation_to_flashinfer_int,
+)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
-)
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    activation_to_flashinfer_int,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -10,11 +10,11 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
 )
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    activation_to_flashinfer_type,
+)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
-)
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    activation_to_flashinfer_type,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
@@ -11,6 +11,9 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    activation_to_flashinfer_int,
+)
 from vllm.model_executor.layers.fused_moe.moe_output import (
     UnfinalizedMoEOutput,
     convert_flashinfer_moe_output,
@@ -20,9 +23,6 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 )
 from vllm.model_executor.layers.fused_moe.utils import (
     fi_moe_largest_bucket,
-)
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    activation_to_flashinfer_int,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -12,14 +12,14 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    activation_to_flashinfer_int,
+)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
 from vllm.model_executor.layers.fused_moe.utils import (
     fi_moe_largest_bucket,
-)
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    activation_to_flashinfer_int,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -11,6 +11,10 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    activation_to_flashinfer_int,
+    has_flashinfer_situ_activation,
+)
 from vllm.model_executor.layers.fused_moe.moe_output import (
     UnfinalizedMoEOutput,
     convert_flashinfer_moe_output,
@@ -20,10 +24,6 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 )
 from vllm.model_executor.layers.fused_moe.utils import (
     fi_moe_largest_bucket,
-)
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    activation_to_flashinfer_int,
-    has_flashinfer_situ_activation,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -13,6 +13,10 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.flashinfer import (
+    activation_to_flashinfer_int,
+    has_flashinfer_situ_activation,
+)
 from vllm.model_executor.layers.fused_moe.moe_output import (
     UnfinalizedMoEOutput,
     convert_flashinfer_moe_output,
@@ -21,10 +25,6 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
 from vllm.model_executor.layers.fused_moe.utils import fi_moe_largest_bucket
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    activation_to_flashinfer_int,
-    has_flashinfer_situ_activation,
-)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kNvfp4Dynamic,

--- a/vllm/model_executor/layers/fused_moe/flashinfer.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer helpers for fused MoE weight preparation and activation mapping."""
+
 from typing import TYPE_CHECKING
 
 import torch

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -20,10 +20,10 @@ from vllm.model_executor.layers.fused_moe.config import (
     fp8_w8a8_moe_quant_config,
     fp8_w8a16_moe_quant_config,
 )
-from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+from vllm.model_executor.layers.fused_moe.flashinfer import (
     prepare_fp8_moe_layer_for_fi,
 )
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     prepare_fp8_moe_layer_for_deepgemm,
 )

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -28,7 +28,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     mxfp4_w4a16_moe_quant_config,
     ocp_mx_moe_quant_config,
 )
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+from vllm.model_executor.layers.fused_moe.flashinfer import (
     swap_w13_to_w31,
 )
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import _swizzle_mxfp4

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -19,12 +19,12 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEQuantConfig,
 )
-from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+from vllm.model_executor.layers.fused_moe.flashinfer import (
     align_moe_weights_for_fi,
     convert_moe_weights_to_flashinfer_trtllm_block_layout,
     swap_w13_to_w31,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.platforms import current_platform
 
 if TYPE_CHECKING:

--- a/vllm/model_executor/layers/quantization/utils/b12x_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/b12x_moe.py
@@ -5,7 +5,7 @@
 import torch
 import torch.nn.functional as F
 
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+from vllm.model_executor.layers.fused_moe.flashinfer import (
     swap_w13_to_w31,
 )
 from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -8,7 +8,7 @@ import torch
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+from vllm.model_executor.layers.fused_moe.flashinfer import (
     align_fp4_moe_weights_for_fi,
     align_trtllm_fp4_moe_hidden_dim_for_fi,
 )


### PR DESCRIPTION
## Purpose

Fixes #31414.

`flashinfer_utils.py` currently lives under quantization utilities, but its helpers are MoE-specific and are also used by BF16 and unquantized MoE code. This PR moves it to `fused_moe/flashinfer.py` and updates the code, tests, and Buildkite dependencies that reference it. Runtime behavior is unchanged.

There are other open approaches to #31414. Some keep the file under quantization, while others move it into the global `vllm.utils` package. This PR keeps the general `vllm.utils.flashinfer` wrappers where they are and places the MoE helpers under `fused_moe`, alongside most of their callers.

## Test Plan

```bash
PYTHONPATH="$PWD" .venv/bin/python -m pytest \
  tests/quantization/test_fp8.py \
  tests/quantization/test_trtllm_nvfp4_hidden_dim_padding.py \
  tests/kernels/moe/test_flashinfer.py \
  tests/kernels/moe/test_routed_experts_capture_monolithic.py \
  tests/kernels/moe/test_trtllm_bf16_moe.py -q \
  -k "test_prepare_gated_trtllm_fp8_moe_weights_pads_each_projection or test_shared_nvfp4_input_scales_have_writable_storage or test_align_trtllm_fp4_moe or test_convert_moe_weights_to_flashinfer_trtllm_block_layout"
```

## Test Result

Local results recorded before the latest rebase:

- Targeted tests: **7 passed, 2 skipped, 48 deselected**.
- `test_trtllm_nvfp4_hidden_dim_padding.py`: **4 passed**.
- All 12 affected production modules imported successfully in separate Python processes.
- The CI dependency matcher was run over 58 Buildkite YAML files. All 129 dependency lists that matched the old path still matched the relocated file.

See the checks tab for CI results on the current head.

## AI assistance

ChatGPT assisted with the code changes, conflict resolution, and test analysis. I reviewed the full diff and ran the tests above.
