### PR TITLE
[Bugfix] Return validation errors for malformed OpenAI request fields

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from vllm.config.multimodal import MultiModalConfig
 from vllm.entrypoints.openai.completion.protocol import CompletionRequest
@@ -561,6 +562,17 @@ def test_structured_outputs_structural_tag_invalid(structural_tag):
             prompt="Test prompt",
             max_tokens=10,
             structured_outputs={"structural_tag": structural_tag},
+        )
+
+
+def test_invalid_structured_outputs_type_rejected():
+    with pytest.raises(ValidationError, match="structured_outputs"):
+        CompletionRequest.model_validate(
+            {
+                "model": MODEL_NAME,
+                "prompt": "Test prompt",
+                "structured_outputs": 3,
+            }
         )
 
 

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+from pydantic import ValidationError
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.exceptions import VLLMValidationError
@@ -180,5 +181,16 @@ def test_multiple_structured_outputs_rejected():
                     "json": {"type": "object"},
                     "regex": ".*",
                 },
+            }
+        )
+
+
+def test_invalid_structured_outputs_type_rejected():
+    with pytest.raises(ValidationError, match="structured_outputs"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "structured_outputs": 3,
             }
         )

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -194,3 +194,33 @@ def test_invalid_structured_outputs_type_rejected():
                 "structured_outputs": 3,
             }
         )
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        3,
+        [{"role": "assistant", "content": "", "tool_calls": 3}],
+    ],
+)
+def test_invalid_messages_type_rejected(messages):
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest.model_validate(
+            {"messages": messages, "model": "facebook/opt-125m"}
+        )
+
+
+@pytest.mark.parametrize("tools", [3, [3], [{}]])
+def test_invalid_tools_type_rejected_with_named_tool_choice(tools):
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": tools,
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+            }
+        )

--- a/tests/tool_use/test_responses_request_validations.py
+++ b/tests/tool_use/test_responses_request_validations.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+from pydantic import ValidationError
 
 from vllm.entrypoints.openai.responses.protocol import (
     ResponsesRequest,
@@ -36,6 +37,13 @@ def test_responses_request_with_no_tools():
         {"input": "Hello", "model": "test-model", "tools": []}
     )
     assert request.tool_choice == "none"
+
+
+def test_responses_request_rejects_scalar_tools():
+    with pytest.raises(ValidationError, match="Input should be a valid list"):
+        ResponsesRequest.model_validate(
+            {"input": "Hello", "model": "test-model", "tools": 3}
+        )
 
 
 def test_responses_request_no_tools_tool_choice_none():

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -867,16 +867,18 @@ class ChatCompletionRequest(OpenAIBaseModel):
         structured_outputs_kwargs = data["structured_outputs"]
         # structured_outputs may arrive as a dict (from JSON/raw kwargs) or
         # as a StructuredOutputsParams dataclass instance.
-        is_dataclass = isinstance(structured_outputs_kwargs, StructuredOutputsParams)
-        count = sum(
-            (
-                getattr(structured_outputs_kwargs, k, None)
-                if is_dataclass
-                else structured_outputs_kwargs.get(k)
+        if isinstance(structured_outputs_kwargs, StructuredOutputsParams):
+            count = sum(
+                getattr(structured_outputs_kwargs, k, None) is not None
+                for k in ("json", "regex", "choice")
             )
-            is not None
-            for k in ("json", "regex", "choice")
-        )
+        elif isinstance(structured_outputs_kwargs, dict):
+            count = sum(
+                structured_outputs_kwargs.get(k) is not None
+                for k in ("json", "regex", "choice")
+            )
+        else:
+            return data
         # you can only use one kind of constraints for structured outputs
         if count > 1:
             raise VLLMValidationError(

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -3,6 +3,7 @@
 
 # Adapted from
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/protocol/openai_api_protocol.py
+import contextlib
 import time
 from typing import Annotated, Any, ClassVar, Literal
 
@@ -540,7 +541,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 continue
             tool_calls = msg.get("tool_calls")
             if tool_calls is not None and not isinstance(tool_calls, list):
-                msg["tool_calls"] = list(tool_calls)
+                with contextlib.suppress(TypeError):
+                    msg["tool_calls"] = list(tool_calls)
             reasoning_content = msg.pop("reasoning_content", None)
             if reasoning_content is not None and msg.get("reasoning") is None:
                 msg["reasoning"] = reasoning_content
@@ -972,8 +974,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         f" in `tool_choice`! {correct_usage_message}",
                         parameter="tool_choice.function.name",
                     )
-                for tool in data["tools"]:
-                    if tool["function"]["name"] == function_name:
+                tools = data["tools"]
+                if not isinstance(tools, list):
+                    return data
+                for tool in tools:
+                    if not isinstance(tool, dict):
+                        return data
+                    tool_function = tool.get("function")
+                    if not isinstance(tool_function, dict):
+                        return data
+                    if tool_function.get("name") == function_name:
                         valid_tool = True
                         break
                 if not valid_tool:
@@ -1009,6 +1019,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if not isinstance(data, dict):
             return data
         messages = data.get("messages", [])
+        if not isinstance(messages, list):
+            return data
         for msg in messages:
             # Check if this is a system message
             if isinstance(msg, dict) and msg.get("role") == "system":

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -454,16 +454,18 @@ class CompletionRequest(OpenAIBaseModel):
         structured_outputs_kwargs = data["structured_outputs"]
         # structured_outputs may arrive as a dict (from JSON/raw kwargs) or
         # as a StructuredOutputsParams dataclass instance.
-        is_dataclass = isinstance(structured_outputs_kwargs, StructuredOutputsParams)
-        count = sum(
-            (
-                getattr(structured_outputs_kwargs, k, None)
-                if is_dataclass
-                else structured_outputs_kwargs.get(k)
+        if isinstance(structured_outputs_kwargs, StructuredOutputsParams):
+            count = sum(
+                getattr(structured_outputs_kwargs, k, None) is not None
+                for k in ("json", "regex", "choice")
             )
-            is not None
-            for k in ("json", "regex", "choice")
-        )
+        elif isinstance(structured_outputs_kwargs, dict):
+            count = sum(
+                structured_outputs_kwargs.get(k) is not None
+                for k in ("json", "regex", "choice")
+            )
+        else:
+            return data
         if count > 1:
             raise VLLMValidationError(
                 "You can only use one kind of constraints for structured "

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -597,7 +597,9 @@ class ResponsesRequest(OpenAIBaseModel):
 
         tools = data.get("tools")
         tool_choice = data.get("tool_choice", "auto")
-        has_tools = tools is not None and len(tools) > 0
+        if "tools" in data and not isinstance(tools, list):
+            return data
+        has_tools = bool(tools)
         is_named_tool_choice = (
             isinstance(tool_choice, dict) and tool_choice.get("type") == "function"
         )


### PR DESCRIPTION
## Purpose

Prevent malformed OpenAI-compatible requests from returning HTTP 500 when
`mode="before"` validators inspect raw JSON values before Pydantic validates
their field types.

The affected validators previously called `len()`, `.get()`, `list()`, iterated,
or indexed values that clients can supply with an invalid container type. This
could leak `TypeError`, `AttributeError`, or `KeyError` from invalid values such
as:

- scalar `tools` in the Responses API;
- scalar `structured_outputs` in Chat Completions and Completions;
- scalar `messages` or `messages[].tool_calls` in Chat Completions; and
- malformed `tools` used with a named Chat Completion tool choice.

The validators now leave structurally invalid values unchanged so Pydantic's
field validation returns the normal 4xx validation response. Existing semantic
validation remains unchanged for well-formed values.

I searched open vLLM issues and pull requests using combinations of malformed
request, HTTP 500, `structured_outputs`, `tools`, `messages`, and tool-choice
validation. While this PR was open, #53763 merged with an overlapping fix for
malformed Responses namespace tools. That code and its test were removed from
this PR during the rebase; the remaining cases are not covered by #53763.

This contribution was developed with assistance from OpenAI Codex. The human
contributor is responsible for reviewing every changed line and understanding
the change before requesting maintainer review.

## Test Plan

```bash
.venv/bin/python -m pytest -q --confcutdir=tests/tool_use \
  tests/tool_use/test_responses_request_validations.py \
  tests/tool_use/test_chat_completion_request_validations.py

.venv/bin/python -m pytest -q \
  --confcutdir=tests/entrypoints/openai/completion \
  tests/entrypoints/openai/completion/test_completion_error.py

.venv/bin/python -m pytest -q \
  --confcutdir=tests/entrypoints/openai/responses \
  tests/entrypoints/openai/responses/test_sampling_params.py

pre-commit run --files \
  vllm/entrypoints/openai/responses/protocol.py \
  vllm/entrypoints/openai/chat_completion/protocol.py \
  vllm/entrypoints/openai/completion/protocol.py \
  tests/tool_use/test_responses_request_validations.py \
  tests/tool_use/test_chat_completion_request_validations.py \
  tests/entrypoints/openai/completion/test_completion_error.py
```

## Test Result

```text
37 passed
32 passed
8 passed
77 passed total
```

All applicable pre-commit checks passed, including Ruff and mypy.

An initial run with the repository-level pytest teardown completed its first
test and then hit a macOS PyTorch 2.13.0 segmentation fault in
`torch.accelerator.empty_host_cache()`. The pure request-validation suites were
rerun with the scoped `--confcutdir` commands above to avoid that accelerator
cleanup; all tests passed.

Behavioral result:

```text
Before: malformed request field -> uncaught Python exception -> HTTP 500
After:  malformed request field -> Pydantic validation error -> HTTP 422
```

Model evaluation is not applicable because this change only affects request
validation and does not alter inference or generated output.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] The test plan is provided.
- [x] The test results and before/after behavior are provided.
- [x] Documentation updates are not required for this validation fix.

</details>
