### PR TITLE
[Bugfix][CPU] Allow dense attention fallback for GLM DSA

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -222,6 +222,43 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
 
 
 @pytest.mark.parametrize(
+    ("index_topk", "should_raise"),
+    [(0, False), (2048, True)],
+    ids=["dense-opt-out", "sparse-default"],
+)
+@pytest.mark.skip_global_cleanup
+def test_glm_moe_dsa_cpu_sparse_attention_config(monkeypatch, index_topk, should_raise):
+    from transformers import GlmMoeDsaConfig
+
+    from vllm.model_executor.models.config import (
+        GlmMoeDsaForCausalLM,
+        _is_sparse_mla_enabled,
+    )
+    from vllm.platforms import current_platform
+
+    hf_config = GlmMoeDsaConfig(index_topk=index_topk)
+    model_config = SimpleNamespace(hf_config=hf_config)
+    assert _is_sparse_mla_enabled(hf_config) is should_raise
+
+    dcp_defaults = []
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(
+            set_dcp_defaults=lambda **kwargs: dcp_defaults.append(kwargs)
+        ),
+    )
+    monkeypatch.setattr(current_platform, "is_cpu", lambda: True)
+
+    if should_raise:
+        with pytest.raises(ValueError, match=r"--hf-overrides.*index_topk"):
+            GlmMoeDsaForCausalLM.verify_and_update_config(vllm_config)
+        assert not dcp_defaults
+    else:
+        GlmMoeDsaForCausalLM.verify_and_update_config(vllm_config)
+        assert dcp_defaults == [{"comm_backend": "a2a", "q_replicate": True}]
+
+
+@pytest.mark.parametrize(
     ("architecture", "is_rocm", "expected"),
     [
         ("DeepseekV32ForCausalLM", False, True),

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _is_sparse_mla_enabled(hf_config: "PretrainedConfig") -> bool:
+    index_topk = getattr(hf_config, "index_topk", None)
+    return index_topk is not None and index_topk != 0
+
+
 class VerifyAndUpdateConfig:
     @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
@@ -31,7 +36,7 @@ class DeepseekV32ForCausalLM(VerifyAndUpdateConfig):
         hf_config = vllm_config.model_config.hf_config
 
         # Mirror the check in vllm/model_executor/models/deepseek_v2.py
-        is_v32 = hasattr(hf_config, "index_topk")
+        is_v32 = _is_sparse_mla_enabled(hf_config)
         assert is_v32
 
         cache_config = vllm_config.cache_config
@@ -43,6 +48,22 @@ class DeepseekV32ForCausalLM(VerifyAndUpdateConfig):
 class GlmMoeDsaForCausalLM(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        from vllm.platforms import current_platform
+
+        hf_config = vllm_config.model_config.hf_config
+        if current_platform.is_cpu():
+            if _is_sparse_mla_enabled(hf_config):
+                raise ValueError(
+                    "GLM-Moe-DSA sparse attention is not supported on CPU. "
+                    "To use dense MLA instead, pass "
+                    "--hf-overrides '{\"index_topk\": 0}'."
+                )
+            if getattr(hf_config, "index_topk", None) == 0:
+                logger.warning(
+                    "GLM-Moe-DSA sparse attention is disabled because index_topk "
+                    "is 0. Falling back to dense MLA."
+                )
+
         # For Glm-Moe-DSA, qrep + a2a is better than the default all-gather + ag-rs
         # in most cases.
         vllm_config.parallel_config.set_dcp_defaults(

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -108,6 +108,7 @@ from vllm.v1.attention.backends.mla.indexer import (
 )
 from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
+from .config import _is_sparse_mla_enabled
 from .interfaces import (
     MixtureOfExperts,
     SupportsEagle,
@@ -1117,7 +1118,7 @@ class DeepseekV2MLAAttention(nn.Module):
             mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))
             self.scaling = self.scaling * mscale * mscale
 
-        self.is_v32 = hasattr(config, "index_topk")
+        self.is_v32 = _is_sparse_mla_enabled(config)
 
         # IndexCache config
         # Refer: https://arxiv.org/abs/2603.12201 for more details.
@@ -1410,7 +1411,7 @@ class DeepseekV2Model(nn.Module):
         self.device = current_platform.device_type
         self.hidden_size = config.hidden_size
         self.vocab_size = config.vocab_size
-        self.is_v32 = hasattr(config, "index_topk")
+        self.is_v32 = _is_sparse_mla_enabled(config)
         if self.is_v32:
             topk_tokens = config.index_topk
             topk_indices_buffer = torch.empty(


### PR DESCRIPTION
## Purpose

Fixes #54018.

GLM-Moe-DSA currently treats the presence of `index_topk` as enabling sparse MLA, so its typed config provides no CPU-compatible opt-out. This PR:

- treats `index_topk=0` as an explicit dense-MLA opt-out on the generic GLM-Moe-DSA path;
- leaves the default positive `index_topk` sparse path unchanged;
- fails early on CPU with an actionable `--hf-overrides '{"index_topk": 0}'` message; and
- adds typed `GlmMoeDsaConfig` regression coverage for both cases.

### Duplicate check

I searched open PRs by issue number and by the GLM/CPU/`index_topk` terms immediately before submission. No open PR references #54018. #51471 enables the CPU MLA backend but does not provide a GLM DSA sparse-attention opt-out; #41834 concerns NVIDIA model support and does not address this CPU path.

### AI assistance

OpenAI Codex assisted with issue triage, implementation, and test preparation. I reviewed the final diff and understand and approve every changed line.

## Test Plan

- Exercise `GlmMoeDsaConfig(index_topk=0)` on a mocked CPU platform and verify configuration succeeds with dense MLA.
- Exercise the default positive `index_topk` on CPU and verify it fails early with the documented override.
- Run the DSA-focused config tests and lint/type-check all changed Python files.

## Test Result

Passed:

- `VLLM_TARGET_DEVICE=cpu pytest tests/test_config.py -k dsa -q`: `17 passed, 214 deselected` (run on Windows through the repository virtual environment with an in-memory `uvloop` compatibility shim).
- `pre-commit run ruff-check --files vllm/model_executor/models/config.py vllm/model_executor/models/deepseek_v2.py tests/test_config.py`.
- `pre-commit run ruff-format --files vllm/model_executor/models/config.py vllm/model_executor/models/deepseek_v2.py tests/test_config.py`.
- `pre-commit run typos --files vllm/model_executor/models/config.py vllm/model_executor/models/deepseek_v2.py tests/test_config.py`.
- `pre-commit run mypy-3.12 --hook-stage manual --files vllm/model_executor/models/config.py vllm/model_executor/models/deepseek_v2.py tests/test_config.py`.
- `git diff --check`.

Not run:

- A full GLM-5.2 Linux CPU model startup or output evaluation. This development host is Windows and its Linux Docker/WSL backend is unavailable. The default positive-`index_topk` behavior is unchanged; the explicit dense fallback still needs model-level validation in a Linux CPU environment.
- The complete repository-wide pre-commit suite, because the `actionlint` environment download failed with an unrelated TLS EOF. Every hook relevant to the changed Python files was run individually and passed.