### PR TITLE
[Bugfix][Build] Fix GDN decode declaration guard

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -393,6 +393,9 @@ void fused_kda_decode(
     std::optional<torch::stable::Tensor> output_gate,
     std::optional<torch::stable::Tensor> norm_weight, double norm_eps);
 
+#endif
+
+#ifdef VLLM_ENABLE_FUSED_GDN_DECODE
 void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a,
     torch::stable::Tensor const& b, torch::stable::Tensor const& a_log,


### PR DESCRIPTION
The fused_gdn_decode_post_conv_mtp declaration was guarded by VLLM_ENABLE_FUSED_KDA_DECODE instead of VLLM_ENABLE_FUSED_GDN_DECODE.

On SM80 builds, GDN decode is enabled while KDA decode is disabled, causing _C_stable_libtorch compilation to fail with an undeclared identifier. Use the correct guard for the GDN declaration.




## Purpose

Fix a build failure on CUDA SM80 architectures.

The declaration of `fused_gdn_decode_post_conv_mtp` was incorrectly
guarded by `VLLM_ENABLE_FUSED_KDA_DECODE`. On SM80, GDN decode is enabled
but KDA decode is disabled, which caused `_C_stable_libtorch` compilation
to fail with an undeclared identifier.

Use `VLLM_ENABLE_FUSED_GDN_DECODE` for the GDN function declaration.

## Test Plan

Built vLLM from source with:

```bash
MAX_JOBS=16 uv pip install -e . --torch-backend=auto
```
Environment:
- GPU architecture: SM80
- CUDA: 13.0
- Python: 3.12.13
- PyTorch: 2.13.0
## Test Result
The editable build completed successfully after changing the declaration
guard.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

