### PR TITLE
[Perf][PCP][DSpark] Shard context-KV precompute across PCP ranks

### DIFF
--- a/tests/distributed/oracle_pcp_direct_kv.py
+++ b/tests/distributed/oracle_pcp_direct_kv.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""PCP4 oracle: shipped fused_norm_rope gather+insert vs SymmMem peer stores."""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+from vllm.distributed.device_communicators.symm_mem import allocate_symm_mem_peer
+from vllm.model_executor.layers.attention.pcp_direct_kv import PCPPeerCacheFence
+from vllm.models.deepseek_v32.common.kernels import fused_norm_rope
+
+
+def run_oracle() -> None:
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    torch.cuda.set_device(rank)
+    device = torch.device(f"cuda:{rank}")
+    group = dist.group.WORLD
+
+    torch.manual_seed(0)
+    local = 13
+    q_dim, kv_dim, rope, idx_dim = 1536, 512, 64, 128
+    block_size, num_blocks = 64, 32
+    entry = kv_dim + rope
+
+    mla = allocate_symm_mem_peer(
+        (num_blocks, block_size, entry), torch.float8_e4m3fn, device, group
+    )
+    fence = PCPPeerCacheFence(group, device)
+
+    slots = torch.arange(local, device=device, dtype=torch.int64) + rank * local
+    positions = torch.arange(local, device=device)
+    q_c = torch.randn(local, q_dim, device=device, dtype=torch.bfloat16)
+    kv_c = torch.randn(local, kv_dim, device=device, dtype=torch.bfloat16)
+    k_pe = torch.randn(local, rope, device=device, dtype=torch.bfloat16)
+    index_k = torch.randn(local, idx_dim, device=device, dtype=torch.bfloat16)
+    q_w = torch.ones(q_dim, device=device, dtype=torch.bfloat16)
+    kv_w = torch.ones(kv_dim, device=device, dtype=torch.bfloat16)
+    idx_w = torch.ones(idx_dim, device=device, dtype=torch.float32)
+    idx_b = torch.zeros(idx_dim, device=device, dtype=torch.float32)
+    cos_sin = torch.randn(8192, rope, device=device, dtype=torch.float32)
+    topk = torch.empty(local, 64, device=device, dtype=torch.int32)
+    scale = torch.ones(1, device=device, dtype=torch.float32)
+
+    total = world * local
+    g_q = torch.empty(total, q_dim, device=device, dtype=q_c.dtype)
+    g_kv = torch.empty(total, kv_dim, device=device, dtype=kv_c.dtype)
+    g_pe = torch.empty(total, rope, device=device, dtype=k_pe.dtype)
+    g_ik = torch.empty(total, idx_dim, device=device, dtype=index_k.dtype)
+    g_pos = torch.empty(total, device=device, dtype=positions.dtype)
+    g_slots = torch.empty(total, device=device, dtype=slots.dtype)
+    dist.all_gather_into_tensor(g_q, q_c.contiguous())
+    dist.all_gather_into_tensor(g_kv, kv_c.contiguous())
+    dist.all_gather_into_tensor(g_pe, k_pe.contiguous())
+    dist.all_gather_into_tensor(g_ik, index_k.contiguous())
+    dist.all_gather_into_tensor(g_pos, positions.contiguous())
+    dist.all_gather_into_tensor(g_slots, slots.contiguous())
+
+    ref = torch.zeros_like(mla.storage)
+    fused_norm_rope(
+        g_pos,
+        g_q,
+        q_w,
+        1e-6,
+        g_kv,
+        kv_w,
+        1e-6,
+        g_pe,
+        cos_sin,
+        g_ik,
+        idx_w,
+        idx_b,
+        1e-6,
+        cos_sin,
+        torch.empty(total, 64, device=device, dtype=torch.int32),
+        slot_mapping=g_slots,
+        mla_kv_cache=ref,
+        mla_kv_cache_dtype="fp8",
+        mla_k_scale=scale,
+        has_indexer=False,
+    )
+    torch.cuda.synchronize()
+
+    mla.storage.zero_()
+    dist.barrier()
+    fused_norm_rope(
+        positions,
+        q_c,
+        q_w,
+        1e-6,
+        kv_c,
+        kv_w,
+        1e-6,
+        k_pe,
+        cos_sin,
+        index_k,
+        idx_w,
+        idx_b,
+        1e-6,
+        cos_sin,
+        topk,
+        slot_mapping=slots,
+        mla_kv_cache=mla.storage,
+        mla_kv_cache_dtype="fp8",
+        mla_k_scale=scale,
+        has_indexer=True,
+        index_rope_interleave=True,
+        mla_peer_ptrs=mla.peer_ptrs,
+        pcp_world_size=world,
+    )
+    fence()
+    torch.cuda.synchronize()
+    match = bool(torch.equal(mla.storage.view(torch.uint8), ref.view(torch.uint8)))
+    print(
+        f"rank{rank} mla_match={match} mcast={mla.multicast_ptr != 0}",
+        flush=True,
+    )
+    ok = torch.tensor(int(match), device=device)
+    dist.all_reduce(ok, op=dist.ReduceOp.MIN)
+    fence.close()
+    mla.close()
+    dist.destroy_process_group()
+    if int(ok.item()) != 1:
+        raise SystemExit("oracle mismatch")
+
+
+if __name__ == "__main__":
+    run_oracle()

--- a/tests/distributed/oracle_pcp_direct_kv.py
+++ b/tests/distributed/oracle_pcp_direct_kv.py
@@ -1,131 +1,28 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""PCP4 oracle: shipped fused_norm_rope gather+insert vs SymmMem peer stores."""
+"""PCP fused oracle entry: fp8_ds_mla + Indexer-K on a packed backing."""
 
 from __future__ import annotations
+
+import sys
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
 
-from vllm.distributed.device_communicators.symm_mem import allocate_symm_mem_peer
-from vllm.model_executor.layers.attention.pcp_direct_kv import PCPPeerCacheFence
-from vllm.models.deepseek_v32.common.kernels import fused_norm_rope
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tests.distributed.test_pcp_symm_kv import run_fp8_ds_mla_indexer_oracle
 
 
-def run_oracle() -> None:
+def main() -> None:
     dist.init_process_group(backend="nccl")
     rank = dist.get_rank()
-    world = dist.get_world_size()
     torch.cuda.set_device(rank)
-    device = torch.device(f"cuda:{rank}")
-    group = dist.group.WORLD
-
-    torch.manual_seed(0)
-    local = 13
-    q_dim, kv_dim, rope, idx_dim = 1536, 512, 64, 128
-    block_size, num_blocks = 64, 32
-    entry = kv_dim + rope
-
-    mla = allocate_symm_mem_peer(
-        (num_blocks, block_size, entry), torch.float8_e4m3fn, device, group
-    )
-    fence = PCPPeerCacheFence(group, device)
-
-    slots = torch.arange(local, device=device, dtype=torch.int64) + rank * local
-    positions = torch.arange(local, device=device)
-    q_c = torch.randn(local, q_dim, device=device, dtype=torch.bfloat16)
-    kv_c = torch.randn(local, kv_dim, device=device, dtype=torch.bfloat16)
-    k_pe = torch.randn(local, rope, device=device, dtype=torch.bfloat16)
-    index_k = torch.randn(local, idx_dim, device=device, dtype=torch.bfloat16)
-    q_w = torch.ones(q_dim, device=device, dtype=torch.bfloat16)
-    kv_w = torch.ones(kv_dim, device=device, dtype=torch.bfloat16)
-    idx_w = torch.ones(idx_dim, device=device, dtype=torch.float32)
-    idx_b = torch.zeros(idx_dim, device=device, dtype=torch.float32)
-    cos_sin = torch.randn(8192, rope, device=device, dtype=torch.float32)
-    topk = torch.empty(local, 64, device=device, dtype=torch.int32)
-    scale = torch.ones(1, device=device, dtype=torch.float32)
-
-    total = world * local
-    g_q = torch.empty(total, q_dim, device=device, dtype=q_c.dtype)
-    g_kv = torch.empty(total, kv_dim, device=device, dtype=kv_c.dtype)
-    g_pe = torch.empty(total, rope, device=device, dtype=k_pe.dtype)
-    g_ik = torch.empty(total, idx_dim, device=device, dtype=index_k.dtype)
-    g_pos = torch.empty(total, device=device, dtype=positions.dtype)
-    g_slots = torch.empty(total, device=device, dtype=slots.dtype)
-    dist.all_gather_into_tensor(g_q, q_c.contiguous())
-    dist.all_gather_into_tensor(g_kv, kv_c.contiguous())
-    dist.all_gather_into_tensor(g_pe, k_pe.contiguous())
-    dist.all_gather_into_tensor(g_ik, index_k.contiguous())
-    dist.all_gather_into_tensor(g_pos, positions.contiguous())
-    dist.all_gather_into_tensor(g_slots, slots.contiguous())
-
-    ref = torch.zeros_like(mla.storage)
-    fused_norm_rope(
-        g_pos,
-        g_q,
-        q_w,
-        1e-6,
-        g_kv,
-        kv_w,
-        1e-6,
-        g_pe,
-        cos_sin,
-        g_ik,
-        idx_w,
-        idx_b,
-        1e-6,
-        cos_sin,
-        torch.empty(total, 64, device=device, dtype=torch.int32),
-        slot_mapping=g_slots,
-        mla_kv_cache=ref,
-        mla_kv_cache_dtype="fp8",
-        mla_k_scale=scale,
-        has_indexer=False,
-    )
-    torch.cuda.synchronize()
-
-    mla.storage.zero_()
-    dist.barrier()
-    fused_norm_rope(
-        positions,
-        q_c,
-        q_w,
-        1e-6,
-        kv_c,
-        kv_w,
-        1e-6,
-        k_pe,
-        cos_sin,
-        index_k,
-        idx_w,
-        idx_b,
-        1e-6,
-        cos_sin,
-        topk,
-        slot_mapping=slots,
-        mla_kv_cache=mla.storage,
-        mla_kv_cache_dtype="fp8",
-        mla_k_scale=scale,
-        has_indexer=True,
-        index_rope_interleave=True,
-        mla_peer_ptrs=mla.peer_ptrs,
-        pcp_world_size=world,
-    )
-    fence()
-    torch.cuda.synchronize()
-    match = bool(torch.equal(mla.storage.view(torch.uint8), ref.view(torch.uint8)))
-    print(
-        f"rank{rank} mla_match={match} mcast={mla.multicast_ptr != 0}",
-        flush=True,
-    )
-    ok = torch.tensor(int(match), device=device)
-    dist.all_reduce(ok, op=dist.ReduceOp.MIN)
-    fence.close()
-    mla.close()
+    run_fp8_ds_mla_indexer_oracle()
+    print(f"rank{rank} fp8_ds_mla_indexer_match=True", flush=True)
     dist.destroy_process_group()
-    if int(ok.item()) != 1:
-        raise SystemExit("oracle mismatch")
 
 
 if __name__ == "__main__":
-    run_oracle()
+    main()

--- a/tests/distributed/test_pcp_symm_kv.py
+++ b/tests/distributed/test_pcp_symm_kv.py
@@ -298,6 +298,83 @@ def _worker_peer_fence_cudagraph(env: dict[str, str]) -> None:
     dist.destroy_process_group()
 
 
+def _worker_copy_strided_cache_rows(env: dict[str, str]) -> None:
+    update_environment_variables(env)
+    rank = int(env["RANK"])
+    world_size = int(env["WORLD_SIZE"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+
+    from vllm.distributed.device_communicators.symm_mem import allocate_symm_mem_peer
+    from vllm.model_executor.layers.attention.pcp_direct_kv import (
+        PCPPeerCacheFence,
+        copy_pcp_cache_rows_to_peers,
+    )
+
+    device = torch.device(f"cuda:{rank}")
+    block_size = 4
+    num_blocks = 4
+    num_heads = 3
+    head_nbytes = 17
+    token_stride = head_nbytes
+    head_stride = block_size * token_stride + 7
+    block_stride = num_heads * head_stride + 11
+    prefix = 37
+    suffix = 31
+    cache_span = (
+        (num_blocks - 1) * block_stride
+        + (num_heads - 1) * head_stride
+        + (block_size - 1) * token_stride
+        + head_nbytes
+    )
+    allocation = allocate_symm_mem_peer(
+        (prefix + cache_span + suffix,), torch.uint8, device, dist.group.WORLD
+    )
+    guard = 0xA5
+    allocation.storage.fill_(guard)
+    cache = torch.as_strided(
+        allocation.storage[prefix:],
+        (num_blocks, num_heads, block_size, head_nbytes),
+        (block_stride, head_stride, token_stride, 1),
+    )
+
+    local_slots = torch.tensor(
+        [rank * 2, rank * 2 + 1, -1, num_blocks * block_size],
+        dtype=torch.int64,
+        device=device,
+    )
+    for local_slot in (rank * 2, rank * 2 + 1):
+        cache[local_slot // block_size, :, local_slot % block_size].fill_(rank + 1)
+    fence = PCPPeerCacheFence(dist.group.WORLD, device)
+    copy_pcp_cache_rows_to_peers(
+        cache,
+        local_slots,
+        allocation.peer_ptrs_for_view(cache),
+        rank,
+        token_dim=2,
+        segment_dim=1,
+    )
+    fence()
+    torch.cuda.synchronize()
+
+    expected = torch.full_like(allocation.storage, guard)
+    expected_cache = torch.as_strided(
+        expected[prefix:],
+        cache.shape,
+        cache.stride(),
+    )
+    for source_rank in range(world_size):
+        for source_slot in (source_rank * 2, source_rank * 2 + 1):
+            expected_cache[
+                source_slot // block_size, :, source_slot % block_size
+            ].fill_(source_rank + 1)
+    assert torch.equal(allocation.storage, expected)
+
+    fence.close()
+    allocation.close()
+    dist.destroy_process_group()
+
+
 def _worker_fused_direct_tp2_pcp2(env: dict[str, str]) -> None:
     update_environment_variables(env)
     global_rank = int(env["RANK"])
@@ -345,6 +422,11 @@ def _worker_fused_direct_tp2_pcp2(env: dict[str, str]) -> None:
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")
 def test_pcp_peer_cache_fence_cudagraph_replay():
     _distributed_run(_worker_peer_fence_cudagraph, world_size=2)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")
+def test_copy_strided_cache_rows_to_pcp_peers():
+    _distributed_run(_worker_copy_strided_cache_rows, world_size=2)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")

--- a/tests/distributed/test_pcp_symm_kv.py
+++ b/tests/distributed/test_pcp_symm_kv.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Focused tests for PCP symmetric-memory peer allocation and direct-final writes."""
 
-import multiprocess as mp
+import multiprocessing as mp
 import pytest
 import torch
 import torch.distributed as dist
@@ -66,6 +66,7 @@ def _worker_peer_allocation(env: dict[str, str]) -> None:
             allocation.storage[source_offset : source_offset + 16], expected
         )
     allocation.close()
+    assert allocation._peer_views == []
     dist.destroy_process_group()
 
 
@@ -117,47 +118,69 @@ def test_select_pcp_direct_slot_row_rejects_global_token_count():
     assert unpadded.shape == (2, 512)
 
 
-def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
-    """Shipped fused_norm_rope: peer-store replicas == gather+local-insert."""
-    update_environment_variables(env)
-    rank = int(env["RANK"])
-    torch.cuda.set_device(rank)
-    dist.init_process_group(backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"]))
+def run_fp8_ds_mla_indexer_oracle() -> None:
+    """Byte-exact fused peer stores vs gather+insert for production GLM layout.
+
+    Packed uint8 backing with a nonzero layer offset. MLA is fp8_ds_mla (656 B)
+    plus Indexer-K (128 fp8 + 4-byte scale).
+    """
     from vllm.distributed.device_communicators.symm_mem import allocate_symm_mem_peer
     from vllm.model_executor.layers.attention.pcp_direct_kv import PCPPeerCacheFence
     from vllm.models.deepseek_v32.common.kernels import fused_norm_rope
 
+    rank = dist.get_rank()
     world = dist.get_world_size()
     device = torch.device(f"cuda:{rank}")
     group = dist.group.WORLD
     torch.manual_seed(0)
     local = 13
-    q_dim, kv_dim, rope = 1536, 512, 64
-    mla = allocate_symm_mem_peer(
-        (32, 64, kv_dim + rope), torch.float8_e4m3fn, device, group
+    q_dim, kv_dim, rope, idx_dim = 1536, 512, 64, 128
+    mla_entry, idx_entry = 656, 132
+    block_size, num_blocks = 64, 32
+    layer_offset = 4096
+    mla_nbytes = num_blocks * block_size * mla_entry
+    idx_nbytes = num_blocks * block_size * idx_entry
+    backing = allocate_symm_mem_peer(
+        (layer_offset + mla_nbytes + idx_nbytes,), torch.uint8, device, group
     )
+    guard = 0xA5
+    backing.storage.fill_(guard)
+    mla_view = backing.storage[layer_offset : layer_offset + mla_nbytes].view(
+        num_blocks, block_size, mla_entry
+    )
+    idx_view = backing.storage[
+        layer_offset + mla_nbytes : layer_offset + mla_nbytes + idx_nbytes
+    ].view(num_blocks, block_size, idx_entry)
+    mla_view.zero_()
+    idx_view.zero_()
     fence = PCPPeerCacheFence(group, device)
+    q_w = torch.ones(q_dim, device=device, dtype=torch.bfloat16)
+    kv_w = torch.ones(kv_dim, device=device, dtype=torch.bfloat16)
+    idx_w = torch.ones(idx_dim, device=device, dtype=torch.float32)
+    idx_b = torch.zeros(idx_dim, device=device, dtype=torch.float32)
+    cos_sin = torch.randn(8192, rope, device=device, dtype=torch.float32)
+    torch.manual_seed(rank + 1)
     slots = torch.arange(local, device=device, dtype=torch.int64) + rank * local
     positions = torch.arange(local, device=device)
     q_c = torch.randn(local, q_dim, device=device, dtype=torch.bfloat16)
     kv_c = torch.randn(local, kv_dim, device=device, dtype=torch.bfloat16)
     k_pe = torch.randn(local, rope, device=device, dtype=torch.bfloat16)
-    q_w = torch.ones(q_dim, device=device, dtype=torch.bfloat16)
-    kv_w = torch.ones(kv_dim, device=device, dtype=torch.bfloat16)
-    cos_sin = torch.randn(8192, rope, device=device, dtype=torch.float32)
-    scale = torch.ones(1, device=device, dtype=torch.float32)
+    index_k = torch.randn(local, idx_dim, device=device, dtype=torch.bfloat16)
     total = world * local
     g_q = torch.empty(total, q_dim, device=device, dtype=q_c.dtype)
     g_kv = torch.empty(total, kv_dim, device=device, dtype=kv_c.dtype)
     g_pe = torch.empty(total, rope, device=device, dtype=k_pe.dtype)
+    g_ik = torch.empty(total, idx_dim, device=device, dtype=index_k.dtype)
     g_pos = torch.empty(total, device=device, dtype=positions.dtype)
     g_slots = torch.empty(total, device=device, dtype=slots.dtype)
     dist.all_gather_into_tensor(g_q, q_c.contiguous())
     dist.all_gather_into_tensor(g_kv, kv_c.contiguous())
     dist.all_gather_into_tensor(g_pe, k_pe.contiguous())
+    dist.all_gather_into_tensor(g_ik, index_k.contiguous())
     dist.all_gather_into_tensor(g_pos, positions.contiguous())
     dist.all_gather_into_tensor(g_slots, slots.contiguous())
-    ref = torch.zeros_like(mla.storage)
+    ref_mla = torch.zeros_like(mla_view)
+    ref_idx = torch.zeros_like(idx_view)
     fused_norm_rope(
         g_pos,
         g_q,
@@ -168,19 +191,21 @@ def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
         1e-6,
         g_pe,
         cos_sin,
-        None,
-        None,
-        None,
+        g_ik,
+        idx_w,
+        idx_b,
         1e-6,
-        None,
+        cos_sin,
         torch.empty(total, 64, device=device, dtype=torch.int32),
         slot_mapping=g_slots,
-        mla_kv_cache=ref,
-        mla_kv_cache_dtype="fp8",
-        mla_k_scale=scale,
-        has_indexer=False,
+        indexer_k_cache=ref_idx,
+        mla_kv_cache=ref_mla,
+        mla_kv_cache_dtype="fp8_ds_mla",
+        has_indexer=True,
+        index_rope_interleave=True,
     )
-    mla.storage.zero_()
+    mla_view.zero_()
+    idx_view.zero_()
     dist.barrier()
     fused_norm_rope(
         positions,
@@ -192,28 +217,47 @@ def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
         1e-6,
         k_pe,
         cos_sin,
-        None,
-        None,
-        None,
+        index_k,
+        idx_w,
+        idx_b,
         1e-6,
-        None,
+        cos_sin,
         torch.empty(local, 64, device=device, dtype=torch.int32),
         slot_mapping=slots,
-        mla_kv_cache=mla.storage,
-        mla_kv_cache_dtype="fp8",
-        mla_k_scale=scale,
-        has_indexer=False,
-        mla_peer_ptrs=mla.peer_ptrs,
+        indexer_k_cache=idx_view,
+        mla_kv_cache=mla_view,
+        mla_kv_cache_dtype="fp8_ds_mla",
+        has_indexer=True,
+        index_rope_interleave=True,
+        mla_peer_ptrs=backing.peer_ptrs_for_view(mla_view),
+        indexer_peer_ptrs=backing.peer_ptrs_for_view(idx_view),
         pcp_world_size=world,
     )
     fence()
     torch.cuda.synchronize()
-    assert torch.equal(mla.storage.view(torch.uint8), ref.view(torch.uint8))
+    assert torch.equal(mla_view, ref_mla)
+    assert torch.equal(idx_view, ref_idx)
+    expected_guard = torch.full((layer_offset,), guard, dtype=torch.uint8, device=device)
+    assert torch.equal(backing.storage[:layer_offset], expected_guard)
     fence.close()
-    mla.close()
+    backing.close()
+    assert backing._peer_views == []
+
+
+def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
+    update_environment_variables(env)
+    rank = int(env["RANK"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"]))
+    run_fp8_ds_mla_indexer_oracle()
     dist.destroy_process_group()
 
 
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")
+def test_fused_direct_fp8_ds_mla_indexer_pcp2():
+    _distributed_run(_worker_fused_direct_matches_gather_insert, world_size=2)
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 4, reason="needs 4 GPUs")
-def test_fused_direct_peer_stores_match_gather_insert():
+def test_fused_direct_fp8_ds_mla_indexer_pcp4():
     _distributed_run(_worker_fused_direct_matches_gather_insert, world_size=4)

--- a/tests/distributed/test_pcp_symm_kv.py
+++ b/tests/distributed/test_pcp_symm_kv.py
@@ -3,6 +3,7 @@
 """Focused tests for PCP symmetric-memory peer allocation and direct-final writes."""
 
 import multiprocessing as mp
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -41,7 +42,9 @@ def _worker_peer_allocation(env: dict[str, str]) -> None:
     update_environment_variables(env)
     rank = int(env["RANK"])
     torch.cuda.set_device(rank)
-    dist.init_process_group(backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"]))
+    dist.init_process_group(
+        backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"])
+    )
     from vllm.distributed.device_communicators.symm_mem import allocate_symm_mem_peer
 
     device = torch.device(f"cuda:{rank}")
@@ -92,9 +95,13 @@ def test_select_pcp_direct_slot_row_uses_this_rank_not_rank0():
         ],
         dtype=torch.int64,
     )
-    rank2 = select_pcp_direct_slot_row(gathered, pcp_world_size=4, pcp_rank=2, local_tokens=2)
+    rank2 = select_pcp_direct_slot_row(
+        gathered, pcp_world_size=4, pcp_rank=2, local_tokens=2
+    )
     assert rank2.tolist() == [[10, 11], [110, 111]]
-    rank0 = select_pcp_direct_slot_row(gathered, pcp_world_size=4, pcp_rank=0, local_tokens=3)
+    rank0 = select_pcp_direct_slot_row(
+        gathered, pcp_world_size=4, pcp_rank=0, local_tokens=3
+    )
     assert rank0.tolist() == [[0, 1, 2], [100, 101, 102]]
 
 
@@ -237,7 +244,9 @@ def run_fp8_ds_mla_indexer_oracle() -> None:
     torch.cuda.synchronize()
     assert torch.equal(mla_view, ref_mla)
     assert torch.equal(idx_view, ref_idx)
-    expected_guard = torch.full((layer_offset,), guard, dtype=torch.uint8, device=device)
+    expected_guard = torch.full(
+        (layer_offset,), guard, dtype=torch.uint8, device=device
+    )
     assert torch.equal(backing.storage[:layer_offset], expected_guard)
     fence.close()
     backing.close()
@@ -248,7 +257,9 @@ def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
     update_environment_variables(env)
     rank = int(env["RANK"])
     torch.cuda.set_device(rank)
-    dist.init_process_group(backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"]))
+    dist.init_process_group(
+        backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"])
+    )
     run_fp8_ds_mla_indexer_oracle()
     dist.destroy_process_group()
 

--- a/tests/distributed/test_pcp_symm_kv.py
+++ b/tests/distributed/test_pcp_symm_kv.py
@@ -125,7 +125,10 @@ def test_select_pcp_direct_slot_row_rejects_global_token_count():
     assert unpadded.shape == (2, 512)
 
 
-def run_fp8_ds_mla_indexer_oracle() -> None:
+def run_fp8_ds_mla_indexer_oracle(
+    group: dist.ProcessGroup | None = None,
+    seed_offset: int = 0,
+) -> None:
     """Byte-exact fused peer stores vs gather+insert for production GLM layout.
 
     Packed uint8 backing with a nonzero layer offset. MLA is fp8_ds_mla (656 B)
@@ -135,11 +138,11 @@ def run_fp8_ds_mla_indexer_oracle() -> None:
     from vllm.model_executor.layers.attention.pcp_direct_kv import PCPPeerCacheFence
     from vllm.models.deepseek_v32.common.kernels import fused_norm_rope
 
-    rank = dist.get_rank()
-    world = dist.get_world_size()
-    device = torch.device(f"cuda:{rank}")
-    group = dist.group.WORLD
-    torch.manual_seed(0)
+    group = group or dist.group.WORLD
+    rank = dist.get_rank(group)
+    world = dist.get_world_size(group)
+    device = torch.device(f"cuda:{dist.get_rank()}")
+    torch.manual_seed(seed_offset)
     local = 13
     q_dim, kv_dim, rope, idx_dim = 1536, 512, 64, 128
     mla_entry, idx_entry = 656, 132
@@ -150,6 +153,7 @@ def run_fp8_ds_mla_indexer_oracle() -> None:
     backing = allocate_symm_mem_peer(
         (layer_offset + mla_nbytes + idx_nbytes,), torch.uint8, device, group
     )
+    assert backing.peer_ptrs.numel() == world
     guard = 0xA5
     backing.storage.fill_(guard)
     mla_view = backing.storage[layer_offset : layer_offset + mla_nbytes].view(
@@ -166,7 +170,7 @@ def run_fp8_ds_mla_indexer_oracle() -> None:
     idx_w = torch.ones(idx_dim, device=device, dtype=torch.float32)
     idx_b = torch.zeros(idx_dim, device=device, dtype=torch.float32)
     cos_sin = torch.randn(8192, rope, device=device, dtype=torch.float32)
-    torch.manual_seed(rank + 1)
+    torch.manual_seed(seed_offset + rank + 1)
     slots = torch.arange(local, device=device, dtype=torch.int64) + rank * local
     positions = torch.arange(local, device=device)
     q_c = torch.randn(local, q_dim, device=device, dtype=torch.bfloat16)
@@ -180,12 +184,12 @@ def run_fp8_ds_mla_indexer_oracle() -> None:
     g_ik = torch.empty(total, idx_dim, device=device, dtype=index_k.dtype)
     g_pos = torch.empty(total, device=device, dtype=positions.dtype)
     g_slots = torch.empty(total, device=device, dtype=slots.dtype)
-    dist.all_gather_into_tensor(g_q, q_c.contiguous())
-    dist.all_gather_into_tensor(g_kv, kv_c.contiguous())
-    dist.all_gather_into_tensor(g_pe, k_pe.contiguous())
-    dist.all_gather_into_tensor(g_ik, index_k.contiguous())
-    dist.all_gather_into_tensor(g_pos, positions.contiguous())
-    dist.all_gather_into_tensor(g_slots, slots.contiguous())
+    dist.all_gather_into_tensor(g_q, q_c.contiguous(), group=group)
+    dist.all_gather_into_tensor(g_kv, kv_c.contiguous(), group=group)
+    dist.all_gather_into_tensor(g_pe, k_pe.contiguous(), group=group)
+    dist.all_gather_into_tensor(g_ik, index_k.contiguous(), group=group)
+    dist.all_gather_into_tensor(g_pos, positions.contiguous(), group=group)
+    dist.all_gather_into_tensor(g_slots, slots.contiguous(), group=group)
     ref_mla = torch.zeros_like(mla_view)
     ref_idx = torch.zeros_like(idx_view)
     fused_norm_rope(
@@ -213,7 +217,7 @@ def run_fp8_ds_mla_indexer_oracle() -> None:
     )
     mla_view.zero_()
     idx_view.zero_()
-    dist.barrier()
+    dist.barrier(group=group)
     fused_norm_rope(
         positions,
         q_c,
@@ -264,6 +268,50 @@ def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
     dist.destroy_process_group()
 
 
+def _worker_fused_direct_tp2_pcp2(env: dict[str, str]) -> None:
+    update_environment_variables(env)
+    global_rank = int(env["RANK"])
+    world_size = int(env["WORLD_SIZE"])
+    torch.cuda.set_device(global_rank)
+    from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+    from vllm.distributed.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+        get_pcp_group,
+        get_tp_group,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    config = VllmConfig()
+    config.parallel_config = ParallelConfig(
+        tensor_parallel_size=2,
+        prefill_context_parallel_size=2,
+    )
+    with set_current_vllm_config(config):
+        init_distributed_environment(
+            world_size=world_size,
+            rank=global_rank,
+            local_rank=global_rank,
+            backend="nccl",
+        )
+        initialize_model_parallel(
+            tensor_model_parallel_size=2,
+            prefill_context_model_parallel_size=2,
+        )
+        pcp_group = get_pcp_group()
+        tp_rank = get_tp_group().rank_in_group
+        gathered_tp_ranks = [None] * pcp_group.world_size
+        dist.all_gather_object(gathered_tp_ranks, tp_rank, group=pcp_group.cpu_group)
+        assert gathered_tp_ranks == [tp_rank] * pcp_group.world_size
+        run_fp8_ds_mla_indexer_oracle(
+            group=pcp_group.device_group,
+            seed_offset=1000 * (tp_rank + 1),
+        )
+        destroy_model_parallel()
+        destroy_distributed_environment()
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")
 def test_fused_direct_fp8_ds_mla_indexer_pcp2():
     _distributed_run(_worker_fused_direct_matches_gather_insert, world_size=2)
@@ -272,3 +320,8 @@ def test_fused_direct_fp8_ds_mla_indexer_pcp2():
 @pytest.mark.skipif(torch.cuda.device_count() < 4, reason="needs 4 GPUs")
 def test_fused_direct_fp8_ds_mla_indexer_pcp4():
     _distributed_run(_worker_fused_direct_matches_gather_insert, world_size=4)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="needs 4 GPUs")
+def test_fused_direct_fp8_ds_mla_indexer_tp2_pcp2_subgroups():
+    _distributed_run(_worker_fused_direct_tp2_pcp2, world_size=4)

--- a/tests/distributed/test_pcp_symm_kv.py
+++ b/tests/distributed/test_pcp_symm_kv.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Focused tests for PCP symmetric-memory peer allocation and direct-final writes."""
+
+import multiprocess as mp
+import pytest
+import torch
+import torch.distributed as dist
+
+from vllm.utils.network_utils import get_open_port
+from vllm.utils.system_utils import update_environment_variables
+
+mp.set_start_method("spawn", force=True)
+
+
+def _distributed_run(fn, world_size: int) -> None:
+    port = str(get_open_port())
+    processes: list[mp.Process] = []
+    for rank in range(world_size):
+        env = {
+            "RANK": str(rank),
+            "LOCAL_RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "LOCAL_WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": port,
+        }
+        process = mp.Process(target=fn, args=(env,))
+        processes.append(process)
+        process.start()
+    for process in processes:
+        process.join(timeout=180)
+    for process in processes:
+        if process.is_alive():
+            process.kill()
+            process.join()
+        assert process.exitcode == 0
+
+
+def _worker_peer_allocation(env: dict[str, str]) -> None:
+    update_environment_variables(env)
+    rank = int(env["RANK"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"]))
+    from vllm.distributed.device_communicators.symm_mem import allocate_symm_mem_peer
+
+    device = torch.device(f"cuda:{rank}")
+    allocation = allocate_symm_mem_peer((4096,), torch.int8, device, dist.group.WORLD)
+    assert allocation.peer_ptrs.numel() == dist.get_world_size()
+    assert int(allocation.peer_ptrs[rank].item()) == int(allocation.storage.data_ptr())
+    assert not bool((allocation.peer_ptrs == 0).any().item())
+
+    view = allocation.storage.view(torch.int32)[16:32]
+    view_ptrs = allocation.peer_ptrs_for_view(view)
+    assert int(view_ptrs[rank].item()) == int(view.data_ptr())
+
+    offset = 64 + rank * 16
+    sentinel = torch.full((16,), rank + 7, dtype=torch.int8, device=device)
+    for peer_view in allocation._peer_views:
+        peer_view[offset : offset + 16].copy_(sentinel)
+    dist.barrier()
+    for source in range(dist.get_world_size()):
+        source_offset = 64 + source * 16
+        expected = torch.full((16,), source + 7, dtype=torch.int8, device=device)
+        assert torch.equal(
+            allocation.storage[source_offset : source_offset + 16], expected
+        )
+    allocation.close()
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")
+def test_symm_mem_peer_allocation_two_gpu():
+    _distributed_run(_worker_peer_allocation, world_size=2)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="needs 4 GPUs")
+def test_symm_mem_peer_allocation_four_gpu():
+    _distributed_run(_worker_peer_allocation, world_size=4)
+
+
+def test_select_pcp_direct_slot_row_uses_this_rank_not_rank0():
+    from vllm.v1.worker.gpu.pcp_manager import select_pcp_direct_slot_row
+
+    # Rank-major gathered slots: two groups, PCP=4, padded=3.
+    # Rank 2's local tokens are 10,11 then PAD.
+    gathered = torch.tensor(
+        [
+            [0, 1, 2, 3, 4, 5, 10, 11, -1, 20, 21, 22],
+            [100, 101, 102, 103, 104, 105, 110, 111, -1, 120, 121, 122],
+        ],
+        dtype=torch.int64,
+    )
+    rank2 = select_pcp_direct_slot_row(gathered, pcp_world_size=4, pcp_rank=2, local_tokens=2)
+    assert rank2.tolist() == [[10, 11], [110, 111]]
+    rank0 = select_pcp_direct_slot_row(gathered, pcp_world_size=4, pcp_rank=0, local_tokens=3)
+    assert rank0.tolist() == [[0, 1, 2], [100, 101, 102]]
+
+
+def test_select_pcp_direct_slot_row_world_size_one_is_identity():
+    from vllm.v1.worker.gpu.pcp_manager import select_pcp_direct_slot_row
+
+    slots = torch.arange(6, dtype=torch.int64).view(2, 3)
+    assert torch.equal(select_pcp_direct_slot_row(slots, 1, 0, 3), slots)
+
+
+def test_select_pcp_direct_slot_row_rejects_global_token_count():
+    from vllm.v1.worker.gpu.pcp_manager import select_pcp_direct_slot_row
+
+    gathered = torch.zeros(2, 4 * 1024, dtype=torch.int64)
+    with pytest.raises(ValueError, match="exceeds padded PCP row"):
+        select_pcp_direct_slot_row(gathered, 4, 0, 2048)
+    row = select_pcp_direct_slot_row(gathered, 4, 0, 1024)
+    assert row.shape == (2, 1024)
+    # Padded local row is the producer length; unpadded is a prefix of it.
+    unpadded = select_pcp_direct_slot_row(gathered, 4, 1, 512)
+    assert unpadded.shape == (2, 512)
+
+
+def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
+    """Shipped fused_norm_rope: peer-store replicas == gather+local-insert."""
+    update_environment_variables(env)
+    rank = int(env["RANK"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"]))
+    from vllm.distributed.device_communicators.symm_mem import allocate_symm_mem_peer
+    from vllm.model_executor.layers.attention.pcp_direct_kv import PCPPeerCacheFence
+    from vllm.models.deepseek_v32.common.kernels import fused_norm_rope
+
+    world = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    group = dist.group.WORLD
+    torch.manual_seed(0)
+    local = 13
+    q_dim, kv_dim, rope = 1536, 512, 64
+    mla = allocate_symm_mem_peer(
+        (32, 64, kv_dim + rope), torch.float8_e4m3fn, device, group
+    )
+    fence = PCPPeerCacheFence(group, device)
+    slots = torch.arange(local, device=device, dtype=torch.int64) + rank * local
+    positions = torch.arange(local, device=device)
+    q_c = torch.randn(local, q_dim, device=device, dtype=torch.bfloat16)
+    kv_c = torch.randn(local, kv_dim, device=device, dtype=torch.bfloat16)
+    k_pe = torch.randn(local, rope, device=device, dtype=torch.bfloat16)
+    q_w = torch.ones(q_dim, device=device, dtype=torch.bfloat16)
+    kv_w = torch.ones(kv_dim, device=device, dtype=torch.bfloat16)
+    cos_sin = torch.randn(8192, rope, device=device, dtype=torch.float32)
+    scale = torch.ones(1, device=device, dtype=torch.float32)
+    total = world * local
+    g_q = torch.empty(total, q_dim, device=device, dtype=q_c.dtype)
+    g_kv = torch.empty(total, kv_dim, device=device, dtype=kv_c.dtype)
+    g_pe = torch.empty(total, rope, device=device, dtype=k_pe.dtype)
+    g_pos = torch.empty(total, device=device, dtype=positions.dtype)
+    g_slots = torch.empty(total, device=device, dtype=slots.dtype)
+    dist.all_gather_into_tensor(g_q, q_c.contiguous())
+    dist.all_gather_into_tensor(g_kv, kv_c.contiguous())
+    dist.all_gather_into_tensor(g_pe, k_pe.contiguous())
+    dist.all_gather_into_tensor(g_pos, positions.contiguous())
+    dist.all_gather_into_tensor(g_slots, slots.contiguous())
+    ref = torch.zeros_like(mla.storage)
+    fused_norm_rope(
+        g_pos,
+        g_q,
+        q_w,
+        1e-6,
+        g_kv,
+        kv_w,
+        1e-6,
+        g_pe,
+        cos_sin,
+        None,
+        None,
+        None,
+        1e-6,
+        None,
+        torch.empty(total, 64, device=device, dtype=torch.int32),
+        slot_mapping=g_slots,
+        mla_kv_cache=ref,
+        mla_kv_cache_dtype="fp8",
+        mla_k_scale=scale,
+        has_indexer=False,
+    )
+    mla.storage.zero_()
+    dist.barrier()
+    fused_norm_rope(
+        positions,
+        q_c,
+        q_w,
+        1e-6,
+        kv_c,
+        kv_w,
+        1e-6,
+        k_pe,
+        cos_sin,
+        None,
+        None,
+        None,
+        1e-6,
+        None,
+        torch.empty(local, 64, device=device, dtype=torch.int32),
+        slot_mapping=slots,
+        mla_kv_cache=mla.storage,
+        mla_kv_cache_dtype="fp8",
+        mla_k_scale=scale,
+        has_indexer=False,
+        mla_peer_ptrs=mla.peer_ptrs,
+        pcp_world_size=world,
+    )
+    fence()
+    torch.cuda.synchronize()
+    assert torch.equal(mla.storage.view(torch.uint8), ref.view(torch.uint8))
+    fence.close()
+    mla.close()
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="needs 4 GPUs")
+def test_fused_direct_peer_stores_match_gather_insert():
+    _distributed_run(_worker_fused_direct_matches_gather_insert, world_size=4)

--- a/tests/distributed/test_pcp_symm_kv.py
+++ b/tests/distributed/test_pcp_symm_kv.py
@@ -268,6 +268,36 @@ def _worker_fused_direct_matches_gather_insert(env: dict[str, str]) -> None:
     dist.destroy_process_group()
 
 
+def _worker_peer_fence_cudagraph(env: dict[str, str]) -> None:
+    update_environment_variables(env)
+    rank = int(env["RANK"])
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl", rank=rank, world_size=int(env["WORLD_SIZE"])
+    )
+    from vllm.model_executor.layers.attention.pcp_direct_kv import PCPPeerCacheFence
+
+    device = torch.device(f"cuda:{rank}")
+    fence = PCPPeerCacheFence(dist.group.WORLD, device)
+    fence()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fence()
+    dist.barrier()
+    for _ in range(4):
+        graph.replay()
+    torch.cuda.synchronize()
+    # Capture records but does not execute the increment. Four replays follow
+    # the eager warmup, so the device-resident epoch must now be five.
+    assert int(fence._epoch.item()) == 5
+
+    del graph
+    fence.close()
+    dist.destroy_process_group()
+
+
 def _worker_fused_direct_tp2_pcp2(env: dict[str, str]) -> None:
     update_environment_variables(env)
     global_rank = int(env["RANK"])
@@ -310,6 +340,11 @@ def _worker_fused_direct_tp2_pcp2(env: dict[str, str]) -> None:
         )
         destroy_model_parallel()
         destroy_distributed_environment()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")
+def test_pcp_peer_cache_fence_cudagraph_replay():
+    _distributed_run(_worker_peer_fence_cudagraph, world_size=2)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs 2+ GPUs")

--- a/tests/v1/spec_decode/test_dspark_pcp_prefill.py
+++ b/tests/v1/spec_decode/test_dspark_pcp_prefill.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+
+
+def _make_speculator() -> tuple[DSparkSpeculator, Mock]:
+    speculator = object.__new__(DSparkSpeculator)
+    model = Mock()
+    model.get_draft_kv_cache_layer_names.return_value = ["draft.0", "draft.1"]
+    model.combine_hidden_states.side_effect = lambda states: states[:, :2] + 1
+    speculator.model = model
+    speculator._pcp_context_kv_precomputed = False
+    return speculator, model
+
+
+def test_precompute_pcp_context_kv_uses_only_local_rows():
+    speculator, model = _make_speculator()
+    input_batch = SimpleNamespace(
+        num_tokens=2,
+        positions=torch.tensor([10, 11, 99]),
+    )
+    aux_hidden_states = [
+        torch.tensor([[1.0], [2.0], [90.0]]),
+        torch.tensor([[3.0], [4.0], [91.0]]),
+    ]
+    slot_mappings = {
+        "draft.0": torch.tensor([4, 5, 40]),
+        "draft.1": torch.tensor([8, 9, 80]),
+    }
+
+    speculator.precompute_pcp_context_kv(input_batch, aux_hidden_states, slot_mappings)
+
+    model.combine_hidden_states.assert_called_once()
+    args, kwargs = model.precompute_and_store_context_kv.call_args
+    assert torch.equal(args[0], torch.tensor([[2.0, 4.0], [3.0, 5.0]]))
+    assert torch.equal(args[1], torch.tensor([10, 11]))
+    assert len(args[2]) == 2
+    assert torch.equal(args[2][0], torch.tensor([4, 5]))
+    assert torch.equal(args[2][1], torch.tensor([8, 9]))
+    assert kwargs == {"publish_to_pcp": True}
+    assert speculator._pcp_context_kv_precomputed
+
+    with pytest.raises(RuntimeError, match="already precomputed"):
+        speculator.precompute_pcp_context_kv(
+            input_batch, aux_hidden_states, slot_mappings
+        )
+
+
+def test_precompute_pcp_context_kv_rejects_missing_layer_mapping():
+    speculator, _ = _make_speculator()
+    input_batch = SimpleNamespace(num_tokens=1, positions=torch.tensor([0]))
+
+    with pytest.raises(RuntimeError, match="draft.1"):
+        speculator.precompute_pcp_context_kv(
+            input_batch,
+            [torch.ones(1, 1), torch.ones(1, 1)],
+            {"draft.0": torch.tensor([0])},
+        )

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -284,6 +284,63 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
     assert actual_feedback_hidden is hidden
 
 
+def test_replicated_pcp_rebuilds_global_draft_attention(monkeypatch):
+    speculator = object.__new__(_TestSpeculator)
+    speculator.block_tables = Mock()
+    speculator.block_tables.input_block_tables = [torch.empty(0)]
+    speculator.kv_cache_config = object()
+    speculator.input_buffers = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
+        positions=torch.arange(5),
+    )
+    rebuilt_metadata = object()
+    speculator._build_draft_attn_metadata = Mock(return_value=rebuilt_metadata)
+    slot_mappings_tensor = torch.arange(5).reshape(1, 5)
+    speculator.block_tables.compute_slot_mappings.return_value = slot_mappings_tensor
+    monkeypatch.setattr(
+        spec_module,
+        "build_slot_mappings_by_layer",
+        lambda slot_mappings, kv_cache_config: {"attention_layer": slot_mappings},
+    )
+
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        idx_mapping=torch.tensor([3, 7], dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([9, 11], dtype=torch.int32),
+        query_start_loc_np=torch.tensor([0, 2, 5], dtype=torch.int32).numpy(),
+    )
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.NONE,
+        num_tokens=5,
+        num_reqs=2,
+    )
+
+    metadata, slot_mappings = speculator._prepare_replicated_pcp_attn(
+        input_batch, batch_desc
+    )
+
+    assert metadata is rebuilt_metadata
+    speculator.block_tables.gather_block_tables.assert_called_once_with(
+        input_batch.idx_mapping,
+        num_reqs_padded=2,
+    )
+    speculator.block_tables.compute_slot_mappings.assert_called_once_with(
+        input_batch.idx_mapping,
+        speculator.input_buffers.query_start_loc,
+        speculator.input_buffers.positions,
+        num_tokens_padded=5,
+    )
+    speculator._build_draft_attn_metadata.assert_called_once_with(
+        num_reqs=2,
+        num_reqs_padded=2,
+        num_tokens_padded=5,
+        seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+        step=0,
+        query_start_loc_np=input_batch.query_start_loc_np,
+    )
+    assert set(slot_mappings) == {"attention_layer"}
+
+
 @pytest.mark.parametrize(
     (
         "method_name",

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -284,63 +284,6 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
     assert actual_feedback_hidden is hidden
 
 
-def test_replicated_pcp_rebuilds_global_draft_attention(monkeypatch):
-    speculator = object.__new__(_TestSpeculator)
-    speculator.block_tables = Mock()
-    speculator.block_tables.input_block_tables = [torch.empty(0)]
-    speculator.kv_cache_config = object()
-    speculator.input_buffers = SimpleNamespace(
-        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
-        positions=torch.arange(5),
-    )
-    rebuilt_metadata = object()
-    speculator._build_draft_attn_metadata = Mock(return_value=rebuilt_metadata)
-    slot_mappings_tensor = torch.arange(5).reshape(1, 5)
-    speculator.block_tables.compute_slot_mappings.return_value = slot_mappings_tensor
-    monkeypatch.setattr(
-        spec_module,
-        "build_slot_mappings_by_layer",
-        lambda slot_mappings, kv_cache_config: {"attention_layer": slot_mappings},
-    )
-
-    input_batch = SimpleNamespace(
-        num_reqs=2,
-        idx_mapping=torch.tensor([3, 7], dtype=torch.int32),
-        seq_lens_cpu_upper_bound=torch.tensor([9, 11], dtype=torch.int32),
-        query_start_loc_np=torch.tensor([0, 2, 5], dtype=torch.int32).numpy(),
-    )
-    batch_desc = BatchExecutionDescriptor(
-        cg_mode=CUDAGraphMode.NONE,
-        num_tokens=5,
-        num_reqs=2,
-    )
-
-    metadata, slot_mappings = speculator._prepare_replicated_pcp_attn(
-        input_batch, batch_desc
-    )
-
-    assert metadata is rebuilt_metadata
-    speculator.block_tables.gather_block_tables.assert_called_once_with(
-        input_batch.idx_mapping,
-        num_reqs_padded=2,
-    )
-    speculator.block_tables.compute_slot_mappings.assert_called_once_with(
-        input_batch.idx_mapping,
-        speculator.input_buffers.query_start_loc,
-        speculator.input_buffers.positions,
-        num_tokens_padded=5,
-    )
-    speculator._build_draft_attn_metadata.assert_called_once_with(
-        num_reqs=2,
-        num_reqs_padded=2,
-        num_tokens_padded=5,
-        seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
-        step=0,
-        query_start_loc_np=input_batch.query_start_loc_np,
-    )
-    assert set(slot_mappings) == {"attention_layer"}
-
-
 @pytest.mark.parametrize(
     (
         "method_name",

--- a/tests/v1/worker/test_gpu_pcp_manager.py
+++ b/tests/v1/worker/test_gpu_pcp_manager.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from types import SimpleNamespace
-from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -11,7 +10,6 @@ import vllm.v1.worker.gpu.pcp_manager as pcp_module
 from vllm.v1.worker.gpu import pcp_manager as pcp_manager_module
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 
 
 def _copy_to_cpu(value, out=None, device=None):
@@ -113,6 +111,9 @@ def test_graph_padding_cannot_be_smaller_than_largest_pcp_rank(monkeypatch):
             query_start_loc_np=np.arange(4, dtype=np.int32),
             padded_num_tokens=2,
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_partition_reuses_gpu_cursor_for_replicated_spec_decode():
     device = torch.device("cuda")
     global_buffers = InputBuffers(max_num_reqs=1, max_num_tokens=4, device=device)
@@ -179,108 +180,5 @@ def test_restore_hidden_states_appends_zero_graph_padding(monkeypatch):
     actual = manager.restore_hidden_states(torch.empty(0))
 
     assert actual.shape == (8, 2)
-    torch.testing.assert_close(
-        actual[:5],
-        restored,
-    )
+    torch.testing.assert_close(actual[:5], restored)
     torch.testing.assert_close(actual[5:], torch.zeros(3, 2))
-
-
-def test_maybe_prepare_replicated_pcp_attn_uses_global_gpu_metadata(monkeypatch):
-    speculator = Mock(spec=DraftModelSpeculator)
-    speculator.block_tables = Mock()
-    speculator.kv_cache_config = object()
-    speculator._build_draft_attn_metadata = Mock(return_value=object())
-    slot_mappings_tensor = torch.arange(5).reshape(1, 5)
-    speculator.block_tables.compute_slot_mappings.return_value = slot_mappings_tensor
-    monkeypatch.setattr(
-        pcp_module,
-        "build_slot_mappings_by_layer",
-        lambda slot_mappings, kv_cache_config: {"attention_layer": slot_mappings},
-    )
-
-    input_batch = SimpleNamespace(
-        num_reqs=2,
-        num_reqs_after_padding=2,
-        num_tokens_after_padding=5,
-        idx_mapping=torch.tensor([3, 7], dtype=torch.int32),
-        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
-        query_start_loc_np=np.array([0, 2, 5], dtype=np.int32),
-        positions=torch.arange(5),
-        seq_lens=torch.tensor([9, 11], dtype=torch.int32),
-        seq_lens_cpu_upper_bound=torch.tensor([20, 22], dtype=torch.int32),
-    )
-
-    attn_metadata, slot_mappings = pcp_module._maybe_prepare_replicated_pcp_attn(
-        Mock(spec=PCPManager),
-        speculator,
-        input_batch,
-        None,
-        None,
-    )
-
-    assert attn_metadata is speculator._build_draft_attn_metadata.return_value
-    assert set(slot_mappings) == {"attention_layer"}
-    speculator.block_tables.gather_block_tables.assert_called_once_with(
-        input_batch.idx_mapping,
-        num_reqs_padded=2,
-    )
-    speculator.block_tables.compute_slot_mappings.assert_called_once_with(
-        input_batch.idx_mapping,
-        input_batch.query_start_loc,
-        input_batch.positions,
-        num_tokens_padded=5,
-    )
-    speculator._build_draft_attn_metadata.assert_called_once_with(
-        num_reqs=2,
-        num_reqs_padded=2,
-        num_tokens_padded=5,
-        seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
-        step=0,
-        query_start_loc_np=input_batch.query_start_loc_np,
-        query_start_loc_gpu=input_batch.query_start_loc,
-        seq_lens=input_batch.seq_lens,
-    )
-
-
-def test_maybe_prepare_replicated_pcp_attn_preserves_inputs_when_disabled():
-    speculator = Mock(spec=DraftModelSpeculator)
-    speculator.block_tables = Mock()
-    attn_metadata = object()
-    slot_mappings = {"attention_layer": torch.arange(2)}
-
-    actual_metadata, actual_slot_mappings = (
-        pcp_module._maybe_prepare_replicated_pcp_attn(
-            None,
-            speculator,
-            SimpleNamespace(),
-            attn_metadata,
-            slot_mappings,
-        )
-    )
-
-    assert actual_metadata is attn_metadata
-    assert actual_slot_mappings is slot_mappings
-    speculator.block_tables.gather_block_tables.assert_not_called()
-
-
-def test_maybe_prepare_replicated_pcp_attn_preserves_inputs_when_skipping_attn():
-    speculator = Mock(spec=DraftModelSpeculator)
-    speculator.block_tables = Mock()
-    attn_metadata = object()
-    slot_mappings = {"attention_layer": torch.arange(2)}
-
-    actual_metadata, actual_slot_mappings = (
-        pcp_module._maybe_prepare_replicated_pcp_attn(
-            Mock(spec=PCPManager),
-            speculator,
-            SimpleNamespace(),
-            attn_metadata,
-            slot_mappings,
-            skip_attn=True,
-        )
-    )
-
-    assert actual_metadata is attn_metadata
-    assert actual_slot_mappings is slot_mappings
-    speculator.block_tables.gather_block_tables.assert_not_called()

--- a/tests/v1/worker/test_gpu_pcp_manager.py
+++ b/tests/v1/worker/test_gpu_pcp_manager.py
@@ -158,6 +158,34 @@ def test_partition_reuses_gpu_cursor_for_replicated_spec_decode():
     assert local_batch.num_computed_tokens_np.tolist() == [20]
 
 
+def test_restore_hidden_states_appends_zero_graph_padding(monkeypatch):
+    manager = PCPManager(
+        pcp_world_size=4,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+    )
+    manager._global_batch = SimpleNamespace(
+        num_tokens=5,
+        num_tokens_after_padding=8,
+    )
+    restored = torch.arange(10, dtype=torch.float32).reshape(5, 2)
+    manager._hidden_restore_idx = torch.arange(5)
+    monkeypatch.setattr(
+        pcp_module,
+        "get_pcp_group",
+        lambda: SimpleNamespace(all_gather=lambda *_args, **_kwargs: restored),
+    )
+
+    actual = manager.restore_hidden_states(torch.empty(0))
+
+    assert actual.shape == (8, 2)
+    torch.testing.assert_close(
+        actual[:5],
+        restored,
+    )
+    torch.testing.assert_close(actual[5:], torch.zeros(3, 2))
+
+
 def test_maybe_prepare_replicated_pcp_attn_uses_global_gpu_metadata(monkeypatch):
     speculator = Mock(spec=DraftModelSpeculator)
     speculator.block_tables = Mock()

--- a/tests/v1/worker/test_gpu_pcp_manager.py
+++ b/tests/v1/worker/test_gpu_pcp_manager.py
@@ -1,11 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import numpy as np
 import pytest
 import torch
 
+import vllm.v1.worker.gpu.pcp_manager as pcp_module
 from vllm.v1.worker.gpu import pcp_manager as pcp_manager_module
+from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
+from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 
 
 def _copy_to_cpu(value, out=None, device=None):
@@ -107,3 +113,146 @@ def test_graph_padding_cannot_be_smaller_than_largest_pcp_rank(monkeypatch):
             query_start_loc_np=np.arange(4, dtype=np.int32),
             padded_num_tokens=2,
         )
+def test_partition_reuses_gpu_cursor_for_replicated_spec_decode():
+    device = torch.device("cuda")
+    global_buffers = InputBuffers(max_num_reqs=1, max_num_tokens=4, device=device)
+    global_batch = InputBatch.make_dummy(
+        num_reqs=1,
+        num_tokens=4,
+        input_buffers=global_buffers,
+    )
+
+    # Model an async step after rejection: the CPU scheduler cursor is still
+    # optimistic, while the GPU cursor used to build positions/seq_lens has
+    # already rolled back to the accepted prefix.
+    global_batch.num_draft_tokens = 3
+    global_batch.num_draft_tokens_per_req = np.array([3], dtype=np.int32)
+    global_batch.num_computed_tokens_np[:] = 20
+    global_batch.prefill_len_np[:] = 8
+    global_batch.num_computed_prefill_tokens_np[:] = 8
+    global_batch.positions.copy_(torch.arange(10, 14, device=device))
+    global_batch.seq_lens.fill_(14)
+
+    manager = PCPManager(
+        pcp_world_size=4,
+        pcp_rank=0,
+        device=device,
+        req_states=SimpleNamespace(),
+        max_num_reqs=1,
+        max_num_tokens=4,
+    )
+    local_batch = manager.partition_batch(global_batch)
+
+    # q_len > 1 remains one replicated decode row. Its actual device metadata
+    # follows the corrected GPU cursor, not the stale CPU upper bound.
+    assert local_batch.num_reqs == 1
+    assert local_batch.num_scheduled_tokens.tolist() == [4]
+    torch.testing.assert_close(
+        local_batch.positions,
+        torch.arange(10, 14, device=device),
+    )
+    torch.testing.assert_close(
+        local_batch.seq_lens,
+        torch.tensor([14], dtype=torch.int32, device=device),
+    )
+    assert local_batch.num_computed_tokens_np.tolist() == [20]
+
+
+def test_maybe_prepare_replicated_pcp_attn_uses_global_gpu_metadata(monkeypatch):
+    speculator = Mock(spec=DraftModelSpeculator)
+    speculator.block_tables = Mock()
+    speculator.kv_cache_config = object()
+    speculator._build_draft_attn_metadata = Mock(return_value=object())
+    slot_mappings_tensor = torch.arange(5).reshape(1, 5)
+    speculator.block_tables.compute_slot_mappings.return_value = slot_mappings_tensor
+    monkeypatch.setattr(
+        pcp_module,
+        "build_slot_mappings_by_layer",
+        lambda slot_mappings, kv_cache_config: {"attention_layer": slot_mappings},
+    )
+
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        num_reqs_after_padding=2,
+        num_tokens_after_padding=5,
+        idx_mapping=torch.tensor([3, 7], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
+        query_start_loc_np=np.array([0, 2, 5], dtype=np.int32),
+        positions=torch.arange(5),
+        seq_lens=torch.tensor([9, 11], dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([20, 22], dtype=torch.int32),
+    )
+
+    attn_metadata, slot_mappings = pcp_module._maybe_prepare_replicated_pcp_attn(
+        Mock(spec=PCPManager),
+        speculator,
+        input_batch,
+        None,
+        None,
+    )
+
+    assert attn_metadata is speculator._build_draft_attn_metadata.return_value
+    assert set(slot_mappings) == {"attention_layer"}
+    speculator.block_tables.gather_block_tables.assert_called_once_with(
+        input_batch.idx_mapping,
+        num_reqs_padded=2,
+    )
+    speculator.block_tables.compute_slot_mappings.assert_called_once_with(
+        input_batch.idx_mapping,
+        input_batch.query_start_loc,
+        input_batch.positions,
+        num_tokens_padded=5,
+    )
+    speculator._build_draft_attn_metadata.assert_called_once_with(
+        num_reqs=2,
+        num_reqs_padded=2,
+        num_tokens_padded=5,
+        seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+        step=0,
+        query_start_loc_np=input_batch.query_start_loc_np,
+        query_start_loc_gpu=input_batch.query_start_loc,
+        seq_lens=input_batch.seq_lens,
+    )
+
+
+def test_maybe_prepare_replicated_pcp_attn_preserves_inputs_when_disabled():
+    speculator = Mock(spec=DraftModelSpeculator)
+    speculator.block_tables = Mock()
+    attn_metadata = object()
+    slot_mappings = {"attention_layer": torch.arange(2)}
+
+    actual_metadata, actual_slot_mappings = (
+        pcp_module._maybe_prepare_replicated_pcp_attn(
+            None,
+            speculator,
+            SimpleNamespace(),
+            attn_metadata,
+            slot_mappings,
+        )
+    )
+
+    assert actual_metadata is attn_metadata
+    assert actual_slot_mappings is slot_mappings
+    speculator.block_tables.gather_block_tables.assert_not_called()
+
+
+def test_maybe_prepare_replicated_pcp_attn_preserves_inputs_when_skipping_attn():
+    speculator = Mock(spec=DraftModelSpeculator)
+    speculator.block_tables = Mock()
+    attn_metadata = object()
+    slot_mappings = {"attention_layer": torch.arange(2)}
+
+    actual_metadata, actual_slot_mappings = (
+        pcp_module._maybe_prepare_replicated_pcp_attn(
+            Mock(spec=PCPManager),
+            speculator,
+            SimpleNamespace(),
+            attn_metadata,
+            slot_mappings,
+            skip_attn=True,
+        )
+    )
+
+    assert actual_metadata is attn_metadata
+    assert actual_slot_mappings is slot_mappings
+    speculator.block_tables.gather_block_tables.assert_not_called()

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -57,9 +57,12 @@ class SymmMemPeerAllocation:
         return self.multicast_ptr + (local_view.data_ptr() - self.storage.data_ptr())
 
     def close(self) -> None:
-        self.peer_ptrs = torch.empty(0, dtype=torch.int64, device=self.storage.device)
+        device = self.peer_ptrs.device
+        self._peer_views.clear()
+        self.peer_ptrs = torch.empty(0, dtype=torch.int64, device=device)
         self.handle = None
-        self.storage = torch.empty(0, dtype=self.storage.dtype, device="cpu")
+        self.multicast_ptr = 0
+        self.storage = torch.empty(0, dtype=torch.int8, device="cpu")
 
 
 def allocate_symm_mem_peer(

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -12,14 +12,101 @@ from vllm.distributed.device_communicators.all_reduce_utils import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
+from dataclasses import dataclass
+from typing import Any
+
 try:
     import torch.distributed._symmetric_memory as torch_symm_mem
 
     symm_mem_available = True
 except ImportError:
+    torch_symm_mem = None  # type: ignore[assignment]
     symm_mem_available = False
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class SymmMemPeerAllocation:
+    """Rendezvoused symmetric buffer plus per-rank peer pointers."""
+
+    storage: torch.Tensor
+    handle: Any
+    peer_ptrs: torch.Tensor
+    world_size: int
+    rank: int
+    multicast_ptr: int
+    buffer_size: int
+    _peer_views: list[torch.Tensor]
+
+    def peer_ptrs_for_view(self, local_view: torch.Tensor) -> torch.Tensor:
+        offset_bytes = local_view.data_ptr() - self.storage.data_ptr()
+        if offset_bytes < 0 or offset_bytes >= self.buffer_size:
+            raise ValueError(
+                "Symmetric-memory view offset "
+                f"{offset_bytes} is outside buffer size {self.buffer_size}"
+            )
+        view_ptrs = self.peer_ptrs + offset_bytes
+        if bool((view_ptrs == 0).any().item()):
+            raise RuntimeError("Symmetric-memory view produced a null peer pointer")
+        return view_ptrs
+
+    def multicast_ptr_for_view(self, local_view: torch.Tensor) -> int:
+        if self.multicast_ptr == 0:
+            return 0
+        return self.multicast_ptr + (local_view.data_ptr() - self.storage.data_ptr())
+
+    def close(self) -> None:
+        self.peer_ptrs = torch.empty(0, dtype=torch.int64, device=self.storage.device)
+        self.handle = None
+        self.storage = torch.empty(0, dtype=self.storage.dtype, device="cpu")
+
+
+def allocate_symm_mem_peer(
+    shape: tuple[int, ...] | int,
+    dtype: torch.dtype,
+    device: torch.device,
+    group: ProcessGroup,
+) -> SymmMemPeerAllocation:
+    if not symm_mem_available or torch_symm_mem is None:
+        raise RuntimeError("torch.distributed._symmetric_memory is unavailable")
+    storage = torch_symm_mem.empty(shape, dtype=dtype, device=device)
+    storage.zero_()
+    torch.accelerator.synchronize()
+    handle = torch_symm_mem.rendezvous(storage, group.group_name)
+    if handle is None:
+        raise RuntimeError("symmetric-memory rendezvous returned None")
+    handle.barrier()
+    view_shape = (shape,) if isinstance(shape, int) else tuple(shape)
+    peer_views = [
+        handle.get_buffer(peer, list(view_shape), dtype, 0)
+        for peer in range(group.size())
+    ]
+    peer_ptrs = torch.tensor(
+        [int(view.data_ptr()) for view in peer_views],
+        dtype=torch.int64,
+        device=storage.device,
+    )
+    if bool((peer_ptrs == 0).any().item()):
+        raise RuntimeError("symmetric-memory rendezvous produced a null peer pointer")
+    if int(peer_ptrs[group.rank()].item()) != int(storage.data_ptr()):
+        raise RuntimeError("Local symmetric-memory pointer does not match storage")
+    multicast_ptr = 0
+    try:
+        multicast_ptr = int(handle.multicast_ptr or 0)
+    except Exception:
+        multicast_ptr = 0
+    buffer_size = int(getattr(handle, "buffer_size", storage.nbytes))
+    return SymmMemPeerAllocation(
+        storage=storage,
+        handle=handle,
+        peer_ptrs=peer_ptrs,
+        world_size=group.size(),
+        rank=group.rank(),
+        multicast_ptr=multicast_ptr,
+        buffer_size=buffer_size,
+        _peer_views=peer_views,
+    )
 
 
 class SymmMemCommunicator:

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass
+from typing import Any
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -11,9 +14,6 @@ from vllm.distributed.device_communicators.all_reduce_utils import (
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-
-from dataclasses import dataclass
-from typing import Any
 
 try:
     import torch.distributed._symmetric_memory as torch_symm_mem

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -202,7 +202,6 @@ if TYPE_CHECKING:
     VLLM_USE_DIRECT_DCP_Q_GATHER: bool | None = None
     VLLM_USE_DIRECT_DCP_KV_GATHER: bool | None = None
     VLLM_USE_PCP_DIRECT_KV: bool = False
-    VLLM_PCP_DIRECT_KV_MULTIMEM: bool = True
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -2156,9 +2155,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, use Python spinloop extension to poll in a more efficient
     # way when using the mp backend.
     "VLLM_USE_SPINLOOP_EXT": lambda: bool(int(os.getenv("VLLM_USE_SPINLOOP_EXT", "0"))),
-    "VLLM_USE_PCP_DIRECT_KV": lambda: bool(int(os.getenv("VLLM_USE_PCP_DIRECT_KV", "0"))),
-    "VLLM_PCP_DIRECT_KV_MULTIMEM": lambda: bool(
-        int(os.getenv("VLLM_PCP_DIRECT_KV_MULTIMEM", "0"))
+    "VLLM_USE_PCP_DIRECT_KV": lambda: bool(
+        int(os.getenv("VLLM_USE_PCP_DIRECT_KV", "0"))
     ),
     # Comma-separated GPU_BDF=NIC_BDF pairs for RDMA NIC selection.
     # Must be set together with VLLM_NIC_SELECTION_VARS.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -201,6 +201,7 @@ if TYPE_CHECKING:
     VLLM_USE_DIRECT_DCP_A2A: bool | None = None
     VLLM_USE_DIRECT_DCP_Q_GATHER: bool | None = None
     VLLM_USE_DIRECT_DCP_KV_GATHER: bool | None = None
+    VLLM_USE_PCP_DIRECT_KV: bool = False
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -2154,6 +2155,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, use Python spinloop extension to poll in a more efficient
     # way when using the mp backend.
     "VLLM_USE_SPINLOOP_EXT": lambda: bool(int(os.getenv("VLLM_USE_SPINLOOP_EXT", "0"))),
+    "VLLM_USE_PCP_DIRECT_KV": lambda: bool(int(os.getenv("VLLM_USE_PCP_DIRECT_KV", "0"))),
     # Comma-separated GPU_BDF=NIC_BDF pairs for RDMA NIC selection.
     # Must be set together with VLLM_NIC_SELECTION_VARS.
     "VLLM_GPU_NIC_PCIE_MAPPING": lambda: os.getenv("VLLM_GPU_NIC_PCIE_MAPPING", ""),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -202,6 +202,7 @@ if TYPE_CHECKING:
     VLLM_USE_DIRECT_DCP_Q_GATHER: bool | None = None
     VLLM_USE_DIRECT_DCP_KV_GATHER: bool | None = None
     VLLM_USE_PCP_DIRECT_KV: bool = False
+    VLLM_PCP_DIRECT_KV_MULTIMEM: bool = True
     VLLM_DEEP_GEMM_WARMUP: Literal[
         "skip",
         "full",
@@ -2156,6 +2157,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # way when using the mp backend.
     "VLLM_USE_SPINLOOP_EXT": lambda: bool(int(os.getenv("VLLM_USE_SPINLOOP_EXT", "0"))),
     "VLLM_USE_PCP_DIRECT_KV": lambda: bool(int(os.getenv("VLLM_USE_PCP_DIRECT_KV", "0"))),
+    "VLLM_PCP_DIRECT_KV_MULTIMEM": lambda: bool(
+        int(os.getenv("VLLM_PCP_DIRECT_KV_MULTIMEM", "0"))
+    ),
     # Comma-separated GPU_BDF=NIC_BDF pairs for RDMA NIC selection.
     # Must be set together with VLLM_NIC_SELECTION_VARS.
     "VLLM_GPU_NIC_PCIE_MAPPING": lambda: os.getenv("VLLM_GPU_NIC_PCIE_MAPPING", ""),

--- a/vllm/model_executor/layers/attention/pcp_direct_kv.py
+++ b/vllm/model_executor/layers/attention/pcp_direct_kv.py
@@ -29,8 +29,21 @@ _MAX_FENCE_SPINS = 100_000_000
 
 @triton.jit
 def _trap_if_nonzero(value):
-    if value != 0:
-        tl.device_assert(False, "PCP direct-KV fence timed out")
+    # Unconditional PTX trap. tl.device_assert is a no-op unless TRITON_DEBUG=1.
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .pred %p0;
+            setp.ne.s32 %p0, $1, 0;
+            @%p0 trap;
+        }
+        """,
+        "=r, r",
+        [value.to(tl.int32)],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
 
 
 @triton.jit
@@ -161,7 +174,7 @@ def get_layer_peer_ptrs(layer_name: str) -> torch.Tensor | None:
 
 
 def get_layer_mcast_ptr(layer_name: str) -> int:
-    if not _STATE.enabled:
+    if not _STATE.enabled or not bool(envs.VLLM_PCP_DIRECT_KV_MULTIMEM):
         return 0
     return int(_STATE.layer_mcast_ptrs.get(layer_name, 0))
 
@@ -175,13 +188,14 @@ def should_allocate_pcp_direct_kv(vllm_config) -> bool:
     if not pcp_direct_kv_requested():
         return False
     if not current_platform.is_cuda() or not symm_mem_available:
-        logger.warning(
-            "VLLM_USE_PCP_DIRECT_KV=1 ignored: CUDA symmetric memory is unavailable"
+        raise RuntimeError(
+            "VLLM_USE_PCP_DIRECT_KV=1 requires CUDA torch.distributed._symmetric_memory"
         )
-        return False
     parallel_config = vllm_config.parallel_config
     if parallel_config.prefill_context_parallel_size <= 1:
-        return False
+        raise RuntimeError(
+            "VLLM_USE_PCP_DIRECT_KV=1 requires prefill_context_parallel_size > 1"
+        )
     if parallel_config.tensor_parallel_size != 1:
         raise RuntimeError("VLLM_USE_PCP_DIRECT_KV requires tensor_parallel_size=1")
     if parallel_config.decode_context_parallel_size != 1:
@@ -193,17 +207,10 @@ def should_allocate_pcp_direct_kv(vllm_config) -> bool:
     return True
 
 
-def try_allocate_pcp_direct_backing(
+def allocate_pcp_direct_backing(
     nbytes: int, device: torch.device, group: ProcessGroup
-) -> SymmMemPeerAllocation | None:
-    try:
-        allocation = allocate_symm_mem_peer((nbytes,), torch.int8, device, group)
-    except Exception as error:
-        logger.warning(
-            "PCP direct-KV symmetric allocation failed (%s); using ordinary allocation",
-            error,
-        )
-        return None
+) -> SymmMemPeerAllocation:
+    allocation = allocate_symm_mem_peer((nbytes,), torch.int8, device, group)
     _STATE.allocations.append(allocation)
     return allocation
 
@@ -214,22 +221,32 @@ def bind_pcp_direct_layer_views(
     device: torch.device,
 ) -> None:
     if not _STATE.allocations:
-        _STATE.enabled = False
-        return
+        raise RuntimeError(
+            "VLLM_USE_PCP_DIRECT_KV=1 requires every KV buffer to be allocated "
+            "with PyTorch symmetric memory"
+        )
     layer_peer_ptrs: dict[str, torch.Tensor] = {}
     layer_mcast_ptrs: dict[str, int] = {}
+    missing: list[str] = []
     for layer_name, cache in kv_caches.items():
         tensor = _as_cache_tensor(cache)
         if tensor is None:
             continue
         allocation = _allocation_for_tensor(tensor)
         if allocation is None:
+            missing.append(layer_name)
             continue
         layer_peer_ptrs[layer_name] = allocation.peer_ptrs_for_view(tensor)
         layer_mcast_ptrs[layer_name] = allocation.multicast_ptr_for_view(tensor)
+    if missing:
+        raise RuntimeError(
+            "VLLM_USE_PCP_DIRECT_KV=1: cache layers not on symmetric-memory "
+            f"backing: {', '.join(missing)}"
+        )
     if not layer_peer_ptrs:
-        _STATE.enabled = False
-        return
+        raise RuntimeError(
+            "VLLM_USE_PCP_DIRECT_KV=1: no bindable KV cache tensors"
+        )
     _STATE.layer_peer_ptrs = layer_peer_ptrs
     _STATE.layer_mcast_ptrs = layer_mcast_ptrs
     _STATE.world_size = group.size()

--- a/vllm/model_executor/layers/attention/pcp_direct_kv.py
+++ b/vllm/model_executor/layers/attention/pcp_direct_kv.py
@@ -188,8 +188,6 @@ def should_allocate_pcp_direct_kv(vllm_config) -> bool:
         raise RuntimeError(
             "VLLM_USE_PCP_DIRECT_KV=1 requires prefill_context_parallel_size > 1"
         )
-    if parallel_config.tensor_parallel_size != 1:
-        raise RuntimeError("VLLM_USE_PCP_DIRECT_KV requires tensor_parallel_size=1")
     if parallel_config.decode_context_parallel_size != 1:
         raise RuntimeError(
             "VLLM_USE_PCP_DIRECT_KV requires decode_context_parallel_size=1"

--- a/vllm/model_executor/layers/attention/pcp_direct_kv.py
+++ b/vllm/model_executor/layers/attention/pcp_direct_kv.py
@@ -137,7 +137,6 @@ class PCPDirectKVState:
     rank: int = 0
     allocations: list[SymmMemPeerAllocation] = field(default_factory=list)
     layer_peer_ptrs: dict[str, torch.Tensor] = field(default_factory=dict)
-    layer_mcast_ptrs: dict[str, int] = field(default_factory=dict)
     fence: PCPPeerCacheFence | None = None
 
     def close(self) -> None:
@@ -148,7 +147,6 @@ class PCPDirectKVState:
             allocation.close()
         self.allocations.clear()
         self.layer_peer_ptrs.clear()
-        self.layer_mcast_ptrs.clear()
         self.enabled = False
 
 
@@ -171,12 +169,6 @@ def get_layer_peer_ptrs(layer_name: str) -> torch.Tensor | None:
     if not _STATE.enabled:
         return None
     return _STATE.layer_peer_ptrs.get(layer_name)
-
-
-def get_layer_mcast_ptr(layer_name: str) -> int:
-    if not _STATE.enabled or not bool(envs.VLLM_PCP_DIRECT_KV_MULTIMEM):
-        return 0
-    return int(_STATE.layer_mcast_ptrs.get(layer_name, 0))
 
 
 def publish_pcp_direct_kv() -> None:
@@ -226,7 +218,6 @@ def bind_pcp_direct_layer_views(
             "with PyTorch symmetric memory"
         )
     layer_peer_ptrs: dict[str, torch.Tensor] = {}
-    layer_mcast_ptrs: dict[str, int] = {}
     missing: list[str] = []
     for layer_name, cache in kv_caches.items():
         tensor = _as_cache_tensor(cache)
@@ -237,28 +228,23 @@ def bind_pcp_direct_layer_views(
             missing.append(layer_name)
             continue
         layer_peer_ptrs[layer_name] = allocation.peer_ptrs_for_view(tensor)
-        layer_mcast_ptrs[layer_name] = allocation.multicast_ptr_for_view(tensor)
     if missing:
         raise RuntimeError(
             "VLLM_USE_PCP_DIRECT_KV=1: cache layers not on symmetric-memory "
             f"backing: {', '.join(missing)}"
         )
     if not layer_peer_ptrs:
-        raise RuntimeError(
-            "VLLM_USE_PCP_DIRECT_KV=1: no bindable KV cache tensors"
-        )
+        raise RuntimeError("VLLM_USE_PCP_DIRECT_KV=1: no bindable KV cache tensors")
     _STATE.layer_peer_ptrs = layer_peer_ptrs
-    _STATE.layer_mcast_ptrs = layer_mcast_ptrs
     _STATE.world_size = group.size()
     _STATE.rank = group.rank()
     _STATE.fence = PCPPeerCacheFence(group, device)
     _STATE.enabled = True
     logger.info(
-        "PCP direct-KV enabled: world_size=%d layers=%d allocations=%d multicast=%s",
+        "PCP direct-KV enabled: world_size=%d layers=%d allocations=%d",
         _STATE.world_size,
         len(layer_peer_ptrs),
         len(_STATE.allocations),
-        any(ptr != 0 for ptr in layer_mcast_ptrs.values()),
     )
 
 

--- a/vllm/model_executor/layers/attention/pcp_direct_kv.py
+++ b/vllm/model_executor/layers/attention/pcp_direct_kv.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PCP direct-final KV publication through PyTorch symmetric memory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+from torch.distributed import ProcessGroup
+
+import vllm.envs as envs
+from vllm.distributed.device_communicators.symm_mem import (
+    SymmMemPeerAllocation,
+    allocate_symm_mem_peer,
+    symm_mem_available,
+)
+from vllm.distributed.parallel_state import in_the_same_node_as
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+_MAX_FENCE_SPINS = 100_000_000
+
+
+@triton.jit
+def _trap_if_nonzero(value):
+    if value != 0:
+        tl.device_assert(False, "PCP direct-KV fence timed out")
+
+
+@triton.jit
+def _publish_fence_kernel(
+    peer_ptrs,
+    epoch,
+    parity,
+    source_rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    destination_rank = tl.program_id(0)
+    if destination_rank < world_size:
+        dest_base = tl.load(peer_ptrs + destination_rank).to(tl.pointer_type(tl.int32))
+        tl.atomic_xchg(
+            dest_base + parity * world_size + source_rank,
+            epoch,
+            sem="release",
+            scope="sys",
+        )
+
+
+@triton.jit
+def _wait_fence_kernel(
+    local_signal_ptr,
+    epoch,
+    parity,
+    world_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_SPINS: tl.constexpr,
+):
+    source_rank = tl.arange(0, BLOCK_SIZE)
+    mask = source_rank < world_size
+    signal_ptr = local_signal_ptr + parity * world_size + source_rank
+    observed = tl.atomic_add(signal_ptr, 0, mask=mask, sem="acquire", scope="sys")
+    pending = tl.max(tl.where(mask & (observed != epoch), 1, 0))
+    spins = 0
+    while (pending != 0) & (spins < MAX_SPINS):
+        observed = tl.atomic_add(signal_ptr, 0, mask=mask, sem="acquire", scope="sys")
+        pending = tl.max(tl.where(mask & (observed != epoch), 1, 0))
+        spins += 1
+    _trap_if_nonzero(pending)
+
+
+class PCPPeerCacheFence:
+    """Two-kernel release/acquire publication for one PCP group."""
+
+    def __init__(self, group: ProcessGroup, device: torch.device) -> None:
+        self._group = group
+        self._world_size = group.size()
+        self._rank = group.rank()
+        self._epoch = 0
+        self._allocation = allocate_symm_mem_peer(
+            (2, self._world_size),
+            dtype=torch.int32,
+            device=device,
+            group=group,
+        )
+        self._allocation.storage.zero_()
+        torch.accelerator.synchronize()
+        dist.barrier(group=group)
+
+    def __call__(self) -> None:
+        self._epoch = self._epoch % 0x7FFFFFFE + 1
+        parity = self._epoch & 1
+        _publish_fence_kernel[(self._world_size,)](
+            self._allocation.peer_ptrs,
+            self._epoch,
+            parity,
+            source_rank=self._rank,
+            world_size=self._world_size,
+        )
+        _wait_fence_kernel[(1,)](
+            self._allocation.storage,
+            self._epoch,
+            parity,
+            world_size=self._world_size,
+            BLOCK_SIZE=triton.next_power_of_2(self._world_size),
+            MAX_SPINS=_MAX_FENCE_SPINS,
+        )
+
+    def close(self) -> None:
+        torch.accelerator.synchronize(self._allocation.storage.device)
+        dist.barrier(group=self._group)
+        self._allocation.close()
+
+
+@dataclass
+class PCPDirectKVState:
+    enabled: bool = False
+    world_size: int = 1
+    rank: int = 0
+    allocations: list[SymmMemPeerAllocation] = field(default_factory=list)
+    layer_peer_ptrs: dict[str, torch.Tensor] = field(default_factory=dict)
+    layer_mcast_ptrs: dict[str, int] = field(default_factory=dict)
+    fence: PCPPeerCacheFence | None = None
+
+    def close(self) -> None:
+        if self.fence is not None:
+            self.fence.close()
+            self.fence = None
+        for allocation in self.allocations:
+            allocation.close()
+        self.allocations.clear()
+        self.layer_peer_ptrs.clear()
+        self.layer_mcast_ptrs.clear()
+        self.enabled = False
+
+
+_STATE = PCPDirectKVState()
+
+
+def pcp_direct_kv_requested() -> bool:
+    return bool(envs.VLLM_USE_PCP_DIRECT_KV)
+
+
+def pcp_direct_kv_active() -> bool:
+    return _STATE.enabled
+
+
+def get_pcp_direct_kv_state() -> PCPDirectKVState:
+    return _STATE
+
+
+def get_layer_peer_ptrs(layer_name: str) -> torch.Tensor | None:
+    if not _STATE.enabled:
+        return None
+    return _STATE.layer_peer_ptrs.get(layer_name)
+
+
+def get_layer_mcast_ptr(layer_name: str) -> int:
+    if not _STATE.enabled:
+        return 0
+    return int(_STATE.layer_mcast_ptrs.get(layer_name, 0))
+
+
+def publish_pcp_direct_kv() -> None:
+    if _STATE.enabled and _STATE.fence is not None:
+        _STATE.fence()
+
+
+def should_allocate_pcp_direct_kv(vllm_config) -> bool:
+    if not pcp_direct_kv_requested():
+        return False
+    if not current_platform.is_cuda() or not symm_mem_available:
+        logger.warning(
+            "VLLM_USE_PCP_DIRECT_KV=1 ignored: CUDA symmetric memory is unavailable"
+        )
+        return False
+    parallel_config = vllm_config.parallel_config
+    if parallel_config.prefill_context_parallel_size <= 1:
+        return False
+    if parallel_config.tensor_parallel_size != 1:
+        raise RuntimeError("VLLM_USE_PCP_DIRECT_KV requires tensor_parallel_size=1")
+    if parallel_config.decode_context_parallel_size != 1:
+        raise RuntimeError(
+            "VLLM_USE_PCP_DIRECT_KV requires decode_context_parallel_size=1"
+        )
+    if parallel_config.data_parallel_size != 1:
+        raise RuntimeError("VLLM_USE_PCP_DIRECT_KV requires data_parallel_size=1")
+    return True
+
+
+def try_allocate_pcp_direct_backing(
+    nbytes: int, device: torch.device, group: ProcessGroup
+) -> SymmMemPeerAllocation | None:
+    try:
+        allocation = allocate_symm_mem_peer((nbytes,), torch.int8, device, group)
+    except Exception as error:
+        logger.warning(
+            "PCP direct-KV symmetric allocation failed (%s); using ordinary allocation",
+            error,
+        )
+        return None
+    _STATE.allocations.append(allocation)
+    return allocation
+
+
+def bind_pcp_direct_layer_views(
+    kv_caches: dict[str, object],
+    group: ProcessGroup,
+    device: torch.device,
+) -> None:
+    if not _STATE.allocations:
+        _STATE.enabled = False
+        return
+    layer_peer_ptrs: dict[str, torch.Tensor] = {}
+    layer_mcast_ptrs: dict[str, int] = {}
+    for layer_name, cache in kv_caches.items():
+        tensor = _as_cache_tensor(cache)
+        if tensor is None:
+            continue
+        allocation = _allocation_for_tensor(tensor)
+        if allocation is None:
+            continue
+        layer_peer_ptrs[layer_name] = allocation.peer_ptrs_for_view(tensor)
+        layer_mcast_ptrs[layer_name] = allocation.multicast_ptr_for_view(tensor)
+    if not layer_peer_ptrs:
+        _STATE.enabled = False
+        return
+    _STATE.layer_peer_ptrs = layer_peer_ptrs
+    _STATE.layer_mcast_ptrs = layer_mcast_ptrs
+    _STATE.world_size = group.size()
+    _STATE.rank = group.rank()
+    _STATE.fence = PCPPeerCacheFence(group, device)
+    _STATE.enabled = True
+    logger.info(
+        "PCP direct-KV enabled: world_size=%d layers=%d allocations=%d multicast=%s",
+        _STATE.world_size,
+        len(layer_peer_ptrs),
+        len(_STATE.allocations),
+        any(ptr != 0 for ptr in layer_mcast_ptrs.values()),
+    )
+
+
+def close_pcp_direct_kv() -> None:
+    _STATE.close()
+
+
+def _as_cache_tensor(cache: object) -> torch.Tensor | None:
+    if isinstance(cache, torch.Tensor):
+        return cache
+    kv_cache = getattr(cache, "kv_cache", None)
+    if isinstance(kv_cache, torch.Tensor):
+        return kv_cache
+    return None
+
+
+def _allocation_for_tensor(tensor: torch.Tensor) -> SymmMemPeerAllocation | None:
+    storage_ptr = tensor.untyped_storage().data_ptr()
+    for allocation in _STATE.allocations:
+        if allocation.storage.untyped_storage().data_ptr() == storage_ptr:
+            return allocation
+    return None
+
+
+def pcp_group_is_single_node(group) -> bool:
+    try:
+        return all(in_the_same_node_as(group.cpu_group, source_rank=0))
+    except Exception:
+        return False

--- a/vllm/model_executor/layers/attention/pcp_direct_kv.py
+++ b/vllm/model_executor/layers/attention/pcp_direct_kv.py
@@ -47,15 +47,21 @@ def _trap_if_nonzero(value):
 
 
 @triton.jit
-def _publish_fence_kernel(
+def _peer_cache_fence_kernel(
     peer_ptrs,
-    epoch,
-    parity,
+    local_signal_ptr,
+    epoch_ptr,
     source_rank: tl.constexpr,
     world_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_SPINS: tl.constexpr,
 ):
-    destination_rank = tl.program_id(0)
-    if destination_rank < world_size:
+    # Keep the epoch on device so CUDA graph replay advances it on every launch.
+    epoch = tl.atomic_add(epoch_ptr, 1, sem="relaxed", scope="gpu") + 1
+    parity = epoch & 1
+
+    # System-scope release publishes this rank's preceding peer-cache writes.
+    for destination_rank in tl.static_range(0, world_size):
         dest_base = tl.load(peer_ptrs + destination_rank).to(tl.pointer_type(tl.int32))
         tl.atomic_xchg(
             dest_base + parity * world_size + source_rank,
@@ -63,20 +69,10 @@ def _publish_fence_kernel(
             sem="release",
             scope="sys",
         )
-
-
-@triton.jit
-def _wait_fence_kernel(
-    local_signal_ptr,
-    epoch,
-    parity,
-    world_size: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-    MAX_SPINS: tl.constexpr,
-):
-    source_rank = tl.arange(0, BLOCK_SIZE)
-    mask = source_rank < world_size
-    signal_ptr = local_signal_ptr + parity * world_size + source_rank
+    # System-scope acquire waits until every peer has published the same epoch.
+    peer_rank = tl.arange(0, BLOCK_SIZE)
+    mask = peer_rank < world_size
+    signal_ptr = local_signal_ptr + parity * world_size + peer_rank
     observed = tl.atomic_add(signal_ptr, 0, mask=mask, sem="acquire", scope="sys")
     pending = tl.max(tl.where(mask & (observed != epoch), 1, 0))
     spins = 0
@@ -88,13 +84,13 @@ def _wait_fence_kernel(
 
 
 class PCPPeerCacheFence:
-    """Two-kernel release/acquire publication for one PCP group."""
+    """Device-epoch release/acquire publication for one PCP group."""
 
     def __init__(self, group: ProcessGroup, device: torch.device) -> None:
         self._group = group
         self._world_size = group.size()
         self._rank = group.rank()
-        self._epoch = 0
+        self._epoch = torch.zeros((1,), dtype=torch.int32, device=device)
         self._allocation = allocate_symm_mem_peer(
             (2, self._world_size),
             dtype=torch.int32,
@@ -106,19 +102,11 @@ class PCPPeerCacheFence:
         dist.barrier(group=group)
 
     def __call__(self) -> None:
-        self._epoch = self._epoch % 0x7FFFFFFE + 1
-        parity = self._epoch & 1
-        _publish_fence_kernel[(self._world_size,)](
+        _peer_cache_fence_kernel[(1,)](
             self._allocation.peer_ptrs,
-            self._epoch,
-            parity,
-            source_rank=self._rank,
-            world_size=self._world_size,
-        )
-        _wait_fence_kernel[(1,)](
             self._allocation.storage,
             self._epoch,
-            parity,
+            source_rank=self._rank,
             world_size=self._world_size,
             BLOCK_SIZE=triton.next_power_of_2(self._world_size),
             MAX_SPINS=_MAX_FENCE_SPINS,

--- a/vllm/model_executor/layers/attention/pcp_direct_kv.py
+++ b/vllm/model_executor/layers/attention/pcp_direct_kv.py
@@ -83,6 +83,45 @@ def _peer_cache_fence_kernel(
     _trap_if_nonzero(pending)
 
 
+@triton.jit
+def _copy_cache_rows_to_peers_kernel(
+    peer_ptrs,
+    slot_mapping,
+    source_rank: tl.constexpr,
+    world_size: tl.constexpr,
+    num_physical_rows: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    cache_block_stride_bytes: tl.constexpr,
+    cache_token_stride_bytes: tl.constexpr,
+    segment_stride_bytes: tl.constexpr,
+    segment_nbytes: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    segment_idx = tl.program_id(1)
+    byte_offset = tl.program_id(2) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    slot = tl.load(slot_mapping + token_idx)
+    valid_slot = (slot >= 0) & (slot < num_physical_rows)
+    block_idx = slot // cache_block_size
+    block_offset = slot % cache_block_size
+    row_offset = (
+        block_idx * cache_block_stride_bytes
+        + block_offset * cache_token_stride_bytes
+        + segment_idx * segment_stride_bytes
+        + byte_offset
+    )
+    mask = valid_slot & (byte_offset < segment_nbytes)
+
+    source_base = tl.load(peer_ptrs + source_rank).to(tl.pointer_type(tl.uint8))
+    value = tl.load(source_base + row_offset, mask=mask, other=0)
+    for peer_rank in tl.static_range(0, world_size):
+        if peer_rank != source_rank:
+            destination_base = tl.load(peer_ptrs + peer_rank).to(
+                tl.pointer_type(tl.uint8)
+            )
+            tl.store(destination_base + row_offset, value, mask=mask)
+
+
 class PCPPeerCacheFence:
     """Device-epoch release/acquire publication for one PCP group."""
 
@@ -157,6 +196,106 @@ def get_layer_peer_ptrs(layer_name: str) -> torch.Tensor | None:
     if not _STATE.enabled:
         return None
     return _STATE.layer_peer_ptrs.get(layer_name)
+
+
+def copy_pcp_cache_rows_to_peers(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    peer_ptrs: torch.Tensor,
+    source_rank: int,
+    token_dim: int,
+    segment_dim: int | None = None,
+) -> None:
+    """Copy locally produced physical cache rows to every PCP replica."""
+    if not cache.is_cuda or not slot_mapping.is_cuda or not peer_ptrs.is_cuda:
+        raise ValueError("PCP cache-row publication requires CUDA tensors")
+    if not 0 < token_dim < cache.ndim:
+        raise ValueError(
+            f"Invalid token dimension {token_dim} for {tuple(cache.shape)}"
+        )
+    if segment_dim is not None and (
+        not 0 < segment_dim < cache.ndim or segment_dim == token_dim
+    ):
+        raise ValueError(
+            f"Invalid segment dimension {segment_dim} for {tuple(cache.shape)}"
+        )
+    if slot_mapping.ndim != 1:
+        raise ValueError("PCP cache-row slot mapping must be one-dimensional")
+
+    # Packed caches use one contiguous segment per token. Head-major attention
+    # caches use one contiguous content segment per head and token.
+    payload_dims = [
+        dim for dim in range(1, cache.ndim) if dim != token_dim and dim != segment_dim
+    ]
+    segment_elements = 1
+    for dim in sorted(payload_dims, key=cache.stride):
+        size = cache.shape[dim]
+        if size != 1 and cache.stride(dim) != segment_elements:
+            raise ValueError("PCP cache-row segments must be contiguous")
+        segment_elements *= size
+    if cache.stride(token_dim) < segment_elements:
+        raise ValueError("PCP cache token segments overlap")
+    if segment_dim is None:
+        segment_count = 1
+        segment_stride = 0
+    else:
+        segment_count = cache.shape[segment_dim]
+        segment_stride = cache.stride(segment_dim)
+        if segment_stride < segment_elements:
+            raise ValueError("PCP cache row segments overlap")
+
+    world_size = peer_ptrs.numel()
+    if world_size <= 1 or slot_mapping.numel() == 0:
+        return
+    if not 0 <= source_rank < world_size:
+        raise ValueError(
+            f"PCP source rank {source_rank} is outside world size {world_size}"
+        )
+
+    block = 256
+    cache_block_size = cache.shape[token_dim]
+    segment_nbytes = segment_elements * cache.element_size()
+    _copy_cache_rows_to_peers_kernel[
+        (
+            slot_mapping.numel(),
+            segment_count,
+            triton.cdiv(segment_nbytes, block),
+        )
+    ](
+        peer_ptrs,
+        slot_mapping,
+        source_rank=source_rank,
+        world_size=world_size,
+        num_physical_rows=cache.shape[0] * cache_block_size,
+        cache_block_size=cache_block_size,
+        cache_block_stride_bytes=cache.stride(0) * cache.element_size(),
+        cache_token_stride_bytes=cache.stride(token_dim) * cache.element_size(),
+        segment_stride_bytes=segment_stride * cache.element_size(),
+        segment_nbytes=segment_nbytes,
+        BLOCK_SIZE=block,
+    )
+
+
+def publish_pcp_cache_rows(
+    layer_name: str,
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    token_dim: int,
+    segment_dim: int | None = None,
+) -> None:
+    if not _STATE.enabled:
+        raise RuntimeError("PCP direct-KV is not active")
+    peer_ptrs = _STATE.layer_peer_ptrs.get(layer_name)
+    if peer_ptrs is None:
+        raise RuntimeError(f"No PCP peer cache pointers registered for {layer_name}")
+    copy_pcp_cache_rows_to_peers(
+        cache,
+        slot_mapping,
+        peer_ptrs,
+        _STATE.rank,
+        token_dim,
+        segment_dim,
+    )
 
 
 def publish_pcp_direct_kv() -> None:

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -594,6 +594,8 @@ class DFlashQwen3Model(nn.Module):
         context_states: torch.Tensor,
         context_positions: torch.Tensor,
         context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None = None,
+        *,
+        publish_to_pcp: bool = False,
     ) -> None:
         """Precompute K/V for context states write them into each layer's KV cache.
 
@@ -643,9 +645,16 @@ class DFlashQwen3Model(nn.Module):
         if context_slot_mapping is None:
             return
 
+        if publish_to_pcp:
+            from vllm.model_executor.layers.attention.pcp_direct_kv import (
+                publish_pcp_cache_rows,
+                publish_pcp_direct_kv,
+            )
+
         # --- Per-layer cache insert ---
         all_k_final = all_k_flat.view(L, num_ctx, nkv, hd)
         per_layer = isinstance(context_slot_mapping, (list, tuple))
+        published_rows = False
         for i in range(L):
             slot_mapping = (
                 context_slot_mapping[i] if per_layer else context_slot_mapping
@@ -661,6 +670,19 @@ class DFlashQwen3Model(nn.Module):
                 kv_cache,
                 slot_mapping,
             )
+            if publish_to_pcp:
+                publish_pcp_cache_rows(
+                    attn.layer_name,
+                    kv_cache,
+                    slot_mapping,
+                    token_dim=2,
+                    segment_dim=1,
+                )
+                published_rows = True
+        if publish_to_pcp:
+            if not published_rows:
+                raise RuntimeError("DSpark PCP precompute published no cache rows")
+            publish_pcp_direct_kv()
 
     def forward(
         self,
@@ -787,10 +809,15 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         context_states: torch.Tensor,
         context_positions: torch.Tensor,
         context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None = None,
+        *,
+        publish_to_pcp: bool = False,
     ) -> None:
         """Precompute projected + RoPE'd K/V and write to cache."""
         self.model.precompute_and_store_context_kv(
-            context_states, context_positions, context_slot_mapping
+            context_states,
+            context_positions,
+            context_slot_mapping,
+            publish_to_pcp=publish_to_pcp,
         )
 
     def combine_hidden_states(

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -13,6 +13,11 @@ from vllm.distributed.parallel_state import get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.attention.attention import get_attention_context
+from vllm.model_executor.layers.attention.pcp_direct_kv import (
+    get_layer_peer_ptrs,
+    pcp_direct_kv_active,
+    publish_pcp_direct_kv,
+)
 from vllm.model_executor.layers.layernorm import LayerNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -315,6 +320,8 @@ class DeepseekV32Attention(MLAAttention):
         slot_mapping = forward_context.slot_mapping
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
+        direct_kv = pcp_direct_kv_active()
+        collect_pcp = self.use_pcp and not direct_kv
 
         if self.indexer is not None and not self.skip_topk:
             has_indexer = True
@@ -322,8 +329,8 @@ class DeepseekV32Attention(MLAAttention):
             indexer_k_norm_bias = self.indexer.k_norm.bias
             indexer_k_norm_eps = self.indexer.k_norm.eps
             indexer_k_rope_cos_sin_cache = self.indexer_rope_emb.cos_sin_cache
-            indexer_k_cache = None if self.use_pcp else self.indexer.k_cache.kv_cache
-            index_k_out = torch.empty_like(index_k) if self.use_pcp else None
+            indexer_k_cache = None if collect_pcp else self.indexer.k_cache.kv_cache
+            index_k_out = torch.empty_like(index_k) if collect_pcp else None
             indexer_softmax_scale = self.indexer.softmax_scale
             indexer_n_head_scale = self.indexer.n_head**-0.5
         else:
@@ -337,7 +344,7 @@ class DeepseekV32Attention(MLAAttention):
             indexer_softmax_scale = 0.0
             indexer_n_head_scale = 0.0
 
-        if attn_metadata is None or self.use_pcp:
+        if attn_metadata is None or collect_pcp:
             mla_kv_cache = None
             mla_k_scale = None
             indexer_k_cache = None
@@ -346,8 +353,17 @@ class DeepseekV32Attention(MLAAttention):
             mla_kv_cache = self.kv_cache
             mla_k_scale = self._k_scale
 
-        kv_c_out = torch.empty_like(kv_c) if self.use_pcp else None
-        k_pe_out = torch.empty_like(k_pe) if self.use_pcp else None
+        kv_c_out = torch.empty_like(kv_c) if collect_pcp else None
+        k_pe_out = torch.empty_like(k_pe) if collect_pcp else None
+        mla_peer_ptrs = None
+        indexer_peer_ptrs = None
+        pcp_world_size = 1
+        if direct_kv and mla_kv_cache is not None:
+            mla_peer_ptrs = get_layer_peer_ptrs(self.layer_name)
+            if has_indexer and self.indexer is not None:
+                indexer_peer_ptrs = get_layer_peer_ptrs(self.indexer.k_cache.prefix)
+            if mla_peer_ptrs is not None:
+                pcp_world_size = int(mla_peer_ptrs.numel())
         q_c = fused_norm_rope(
             positions,
             q_c,
@@ -374,7 +390,12 @@ class DeepseekV32Attention(MLAAttention):
             kv_c_out=kv_c_out,
             k_pe_out=k_pe_out,
             index_k_out=index_k_out,
+            mla_peer_ptrs=mla_peer_ptrs,
+            indexer_peer_ptrs=indexer_peer_ptrs,
+            pcp_world_size=pcp_world_size,
         )
+        if pcp_world_size > 1:
+            publish_pcp_direct_kv()
 
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
@@ -431,7 +452,8 @@ class DeepseekV32Attention(MLAAttention):
         if self.indexer is not None and not self.skip_topk:
             assert index_q_fp8 is not None
             assert index_weights_out is not None
-            if self.use_pcp:
+            collect_pcp = self.use_pcp and not pcp_direct_kv_active()
+            if collect_pcp:
                 assert index_k is not None
             sparse_attn_indexer(
                 q_c,
@@ -448,8 +470,8 @@ class DeepseekV32Attention(MLAAttention):
                 self.indexer.max_model_len,
                 self.indexer.max_total_seq_len,
                 self.topk_indices_buffer,
-                skip_k_cache_insert=not self.use_pcp,
-                use_pcp=self.use_pcp,
+                skip_k_cache_insert=not collect_pcp,
+                use_pcp=collect_pcp,
                 dense_mha_metadata_layer_name=self._dense_mha_metadata_layer_name,
                 dcp_rank=(
                     self.dcp_manager.group.rank_in_group
@@ -473,7 +495,7 @@ class DeepseekV32Attention(MLAAttention):
             return
         attn_metadata = cast("MLACommonMetadata", attn_metadata)
 
-        if self.use_pcp:
+        if self.use_pcp and not pcp_direct_kv_active():
             assert kv_c is not None and k_pe is not None
             kv_for_cache, kpe_for_cache, cache_slot_mapping = (
                 maybe_gather_mla_latent_cache_inputs(

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -561,9 +561,14 @@ def fused_norm_rope(
     if pcp_world_size > 1:
         if mla_peer_ptrs is None or mla_peer_ptrs.numel() != pcp_world_size:
             raise ValueError("mla_peer_ptrs must have one pointer per PCP rank")
-        if has_indexer and indexer_k_cache is not None:
-            if indexer_peer_ptrs is None or indexer_peer_ptrs.numel() != pcp_world_size:
-                raise ValueError("indexer_peer_ptrs must have one pointer per PCP rank")
+        if (
+            has_indexer
+            and indexer_k_cache is not None
+            and (
+                indexer_peer_ptrs is None or indexer_peer_ptrs.numel() != pcp_world_size
+            )
+        ):
+            raise ValueError("indexer_peer_ptrs must have one pointer per PCP rank")
     if mla_peer_ptrs is None:
         mla_peer_ptrs = torch.zeros(1, dtype=torch.int64, device=device)
     if indexer_peer_ptrs is None:

--- a/vllm/models/deepseek_v32/common/kernels.py
+++ b/vllm/models/deepseek_v32/common/kernels.py
@@ -71,20 +71,25 @@ def _fp8_quant_and_cache_write(
     cache_stride,
     offsets,
     HEAD_DIM: tl.constexpr,
+    peer_ptrs,
+    PCP_WORLD_SIZE: tl.constexpr,
 ):
     k_fp8, scale = _fp8_ue8m0_quantize(vals)
 
     block_idx = slot_idx // cache_block_size
     block_offset = slot_idx % cache_block_size
     block_start = block_idx * cache_block_size * cache_stride
+    data_off = block_start + block_offset * HEAD_DIM + offsets
+    scale_elem_off = (block_start + cache_block_size * HEAD_DIM + block_offset * 4) // 4
 
-    tl.store(
-        kv_cache_ptr + block_start + block_offset * HEAD_DIM + offsets,
-        k_fp8,
-        mask=mask,
-    )
-    scale_byte_off = block_start + cache_block_size * HEAD_DIM + block_offset * 4
-    tl.store(kv_cache_scale_ptr + scale_byte_off // 4, scale)
+    if PCP_WORLD_SIZE == 1:
+        tl.store(kv_cache_ptr + data_off, k_fp8, mask=mask)
+        tl.store(kv_cache_scale_ptr + scale_elem_off, scale)
+        return
+    for peer in tl.static_range(0, PCP_WORLD_SIZE):
+        base = tl.load(peer_ptrs + peer)
+        tl.store(base.to(tl.pointer_type(tl.float8e4nv)) + data_off, k_fp8, mask=mask)
+        tl.store(base.to(tl.pointer_type(tl.float32)) + scale_elem_off, scale)
 
 
 @triton.jit
@@ -158,6 +163,9 @@ def _fused_norm_rope_kernel(
     HAS_INDEXER: tl.constexpr,
     INDEX_ROPE_INTERLEAVE: tl.constexpr,
     USE_PDL: tl.constexpr,
+    mla_peer_ptrs,
+    indexer_peer_ptrs,
+    PCP_WORLD_SIZE: tl.constexpr,
 ):
     tok_idx = tl.program_id(0).to(tl.int64)
     pid = tl.program_id(1)
@@ -265,39 +273,75 @@ def _fused_norm_rope_kernel(
                 # concat_and_cache_ds_mla kernel; floored to FLT_MIN.
                 tile_scale = tl.maximum(tile_amax * (1.0 / 448.0), 1.1754944e-38)
                 kv_c_fp8 = tl.reshape((kv_2d / tile_scale).to(tl.float8e4nv), (KV_DIM,))
-                tl.store(mla_cache_ptr + byte_base + kv_block, kv_c_fp8)
                 tile_off = tl.arange(0, MLA_NUM_TILES)
-                tl.store(
-                    mla_cache_ds_scale_ptr + byte_base // 4 + KV_DIM // 4 + tile_off,
-                    tl.reshape(tile_scale, (MLA_NUM_TILES,)),
-                )
-                rope_dst = mla_cache_ds_rope_ptr + byte_base // 2 + (KV_DIM // 2 + 8)
-                tl.store(rope_dst + dim_off * 2, r1.to(tl.bfloat16))
-                tl.store(rope_dst + dim_off * 2 + 1, r2.to(tl.bfloat16))
+                tile_scales = tl.reshape(tile_scale, (MLA_NUM_TILES,))
+                if PCP_WORLD_SIZE == 1:
+                    tl.store(mla_cache_ptr + byte_base + kv_block, kv_c_fp8)
+                    tl.store(
+                        mla_cache_ds_scale_ptr
+                        + byte_base // 4
+                        + KV_DIM // 4
+                        + tile_off,
+                        tile_scales,
+                    )
+                    rope_dst = (
+                        mla_cache_ds_rope_ptr + byte_base // 2 + (KV_DIM // 2 + 8)
+                    )
+                    tl.store(rope_dst + dim_off * 2, r1.to(tl.bfloat16))
+                    tl.store(rope_dst + dim_off * 2 + 1, r2.to(tl.bfloat16))
+                else:
+                    for peer in tl.static_range(0, PCP_WORLD_SIZE):
+                        base = tl.load(mla_peer_ptrs + peer)
+                        tl.store(
+                            base.to(tl.pointer_type(tl.float8e4nv))
+                            + byte_base
+                            + kv_block,
+                            kv_c_fp8,
+                        )
+                        tl.store(
+                            base.to(tl.pointer_type(tl.float32))
+                            + byte_base // 4
+                            + KV_DIM // 4
+                            + tile_off,
+                            tile_scales,
+                        )
+                        rope_dst = (
+                            base.to(tl.pointer_type(tl.bfloat16))
+                            + byte_base // 2
+                            + (KV_DIM // 2 + 8)
+                        )
+                        tl.store(rope_dst + dim_off * 2, r1.to(tl.bfloat16))
+                        tl.store(rope_dst + dim_off * 2 + 1, r2.to(tl.bfloat16))
                 return
 
-            dst = (
-                mla_cache_ptr
-                + mla_block_idx * mla_cache_block_stride
+            dst_off = (
+                mla_block_idx * mla_cache_block_stride
                 + mla_block_off * mla_cache_entry_stride
             )
-            # kv_c_normed (KV_DIM elements)
             if MLA_CACHE_FP8:
                 scale = tl.load(mla_cache_scale_ptr)
-                kv_c_fp8 = (kv_c.to(tl.float32) / scale).to(tl.float8e4nv)
-                tl.store(dst + kv_block, kv_c_fp8)
+                kv_c_store = (kv_c.to(tl.float32) / scale).to(tl.float8e4nv)
+                r1_store = (r1 / scale).to(tl.float8e4nv)
+                r2_store = (r2 / scale).to(tl.float8e4nv)
             else:
-                tl.store(dst + kv_block, kv_c)
-            # k_pe_roped (from registers, interleaved layout)
-            if MLA_CACHE_FP8:
-                tl.store(dst + KV_DIM + dim_off * 2, (r1 / scale).to(tl.float8e4nv))
-                tl.store(
-                    dst + KV_DIM + dim_off * 2 + 1,
-                    (r2 / scale).to(tl.float8e4nv),
-                )
+                kv_c_store = kv_c
+                r1_store = r1
+                r2_store = r2
+            if PCP_WORLD_SIZE == 1:
+                dst = mla_cache_ptr + dst_off
+                tl.store(dst + kv_block, kv_c_store)
+                tl.store(dst + KV_DIM + dim_off * 2, r1_store)
+                tl.store(dst + KV_DIM + dim_off * 2 + 1, r2_store)
             else:
-                tl.store(dst + KV_DIM + dim_off * 2, r1)
-                tl.store(dst + KV_DIM + dim_off * 2 + 1, r2)
+                for peer in tl.static_range(0, PCP_WORLD_SIZE):
+                    base = tl.load(mla_peer_ptrs + peer)
+                    if MLA_CACHE_FP8:
+                        dst = base.to(tl.pointer_type(tl.float8e4nv)) + dst_off
+                    else:
+                        dst = base.to(tl.pointer_type(tl.bfloat16)) + dst_off
+                    tl.store(dst + kv_block, kv_c_store)
+                    tl.store(dst + KV_DIM + dim_off * 2, r1_store)
+                    tl.store(dst + KV_DIM + dim_off * 2 + 1, r2_store)
     elif pid == 0:
         if not HAS_INDEXER:
             # Shared layer: no indexer K to process.
@@ -398,6 +442,8 @@ def _fused_norm_rope_kernel(
                 indexer_cache_stride,
                 index_k_block,
                 INDEX_K_DIM,
+                indexer_peer_ptrs,
+                PCP_WORLD_SIZE,
             )
 
 
@@ -429,6 +475,9 @@ def fused_norm_rope(
     kv_c_out: torch.Tensor | None = None,
     k_pe_out: torch.Tensor | None = None,
     index_k_out: torch.Tensor | None = None,
+    mla_peer_ptrs: torch.Tensor | None = None,
+    indexer_peer_ptrs: torch.Tensor | None = None,
+    pcp_world_size: int = 1,
 ) -> torch.Tensor:
     assert positions.ndim == 1
     assert q_c.ndim == 2
@@ -507,6 +556,18 @@ def fused_norm_rope(
 
     if q_c_out is None:
         q_c_out = torch.empty_like(q_c)
+    if pcp_world_size < 1:
+        raise ValueError(f"pcp_world_size must be >= 1, got {pcp_world_size}")
+    if pcp_world_size > 1:
+        if mla_peer_ptrs is None or mla_peer_ptrs.numel() != pcp_world_size:
+            raise ValueError("mla_peer_ptrs must have one pointer per PCP rank")
+        if has_indexer and indexer_k_cache is not None:
+            if indexer_peer_ptrs is None or indexer_peer_ptrs.numel() != pcp_world_size:
+                raise ValueError("indexer_peer_ptrs must have one pointer per PCP rank")
+    if mla_peer_ptrs is None:
+        mla_peer_ptrs = torch.zeros(1, dtype=torch.int64, device=device)
+    if indexer_peer_ptrs is None:
+        indexer_peer_ptrs = torch.zeros(1, dtype=torch.int64, device=device)
     kv_c_out_stride = 0
     k_pe_out_stride = 0
     index_k_out_stride = 0
@@ -585,6 +646,9 @@ def fused_norm_rope(
         HAS_INDEXER=has_indexer,
         INDEX_ROPE_INTERLEAVE=index_rope_interleave,
         USE_PDL=use_pdl,
+        mla_peer_ptrs=mla_peer_ptrs,
+        indexer_peer_ptrs=indexer_peer_ptrs,
+        PCP_WORLD_SIZE=pcp_world_size,
         launch_pdl=use_pdl,
     )
     return q_c_out

--- a/vllm/v1/attention/ops/pcp.py
+++ b/vllm/v1/attention/ops/pcp.py
@@ -52,7 +52,9 @@ def maybe_gather_mla_latent_cache_inputs(
     num_decode_tokens: int | None,
     use_pcp: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-    if not use_pcp or num_decode_tokens is None:
+    from vllm.model_executor.layers.attention.pcp_direct_kv import pcp_direct_kv_active
+
+    if pcp_direct_kv_active() or not use_pcp or num_decode_tokens is None:
         return kv_c_normed, k_pe, slot_mapping
     assert slot_mapping is not None
     num_tokens = kv_c_normed.shape[0]
@@ -72,7 +74,9 @@ def maybe_gather_indexer_k(
     num_decode_tokens: int,
     use_pcp: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    if not use_pcp:
+    from vllm.model_executor.layers.attention.pcp_direct_kv import pcp_direct_kv_active
+
+    if pcp_direct_kv_active() or not use_pcp:
         return k, slot_mapping
     (cache_k,), cache_slot_mapping = _gather_prefill_cache_inputs(
         (k,), slot_mapping, num_decode_tokens

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -19,14 +19,21 @@ else:
 logger = init_logger(__name__)
 
 
-def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
+def check_attention_cp_compatibility(
+    vllm_config: VllmConfig,
+    exclude_layer_names: set[str] | None = None,
+) -> None:
     pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
     dcp_size = vllm_config.parallel_config.decode_context_parallel_size
     interleave_size = vllm_config.parallel_config.cp_kv_cache_interleave_size
     if pcp_size * dcp_size > 1:
         layer_type = cast(type[Any], AttentionLayerBase)
         layers = get_layers_from_vllm_config(vllm_config, layer_type)
-        for layer in layers.values():
+        for name, layer in layers.items():
+            # A replicated drafter's layers never run CP-sharded attention,
+            # so they are exempt from the PCP/DCP backend checks.
+            if exclude_layer_names is not None and name in exclude_layer_names:
+                continue
             get_attn_backend = getattr(layer, "get_attn_backend", None)
             if pcp_size > 1 and get_attn_backend is not None:
                 backend = get_attn_backend()

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -210,27 +210,23 @@ def init_kv_cache(
     vllm_config: VllmConfig,
 ) -> dict[str, Any]:
     buffer_allocator = None
-    try:
-        from vllm.distributed.parallel_state import get_pcp_group
-        from vllm.model_executor.layers.attention.pcp_direct_kv import (
-            pcp_direct_kv_requested,
-            try_allocate_pcp_direct_backing,
-        )
+    from vllm.distributed.parallel_state import get_pcp_group
+    from vllm.model_executor.layers.attention.pcp_direct_kv import (
+        allocate_pcp_direct_backing,
+        pcp_direct_kv_requested,
+    )
 
-        if pcp_direct_kv_requested():
-            pcp_group = get_pcp_group()
-            if pcp_group.world_size > 1:
+    if pcp_direct_kv_requested():
+        pcp_group = get_pcp_group()
+        if pcp_group.world_size <= 1:
+            raise RuntimeError(
+                "VLLM_USE_PCP_DIRECT_KV=1 requires PCP world size greater than 1"
+            )
 
-                def buffer_allocator(nbytes: int, device: torch.device) -> torch.Tensor:
-                    allocation = try_allocate_pcp_direct_backing(
-                        nbytes, device, pcp_group.device_group
-                    )
-                    if allocation is not None:
-                        return allocation.storage
-                    return torch.zeros(nbytes, dtype=torch.int8, device=device)
-
-    except Exception:
-        buffer_allocator = None
+        def buffer_allocator(nbytes: int, device: torch.device) -> torch.Tensor:
+            return allocate_pcp_direct_backing(
+                nbytes, device, pcp_group.device_group
+            ).storage
     kv_caches = allocate_kv_cache(
         kv_cache_config,
         device,
@@ -249,18 +245,23 @@ def init_kv_cache(
         else 1
     )
     bind_kv_cache(kv_caches, forward_context, runner_kv_caches, num_attn_module)
-    try:
-        from vllm.distributed.parallel_state import get_pcp_group
-        from vllm.model_executor.layers.attention.pcp_direct_kv import (
-            bind_pcp_direct_layer_views,
-            should_allocate_pcp_direct_kv,
-        )
+    from vllm.model_executor.layers.attention.pcp_direct_kv import (
+        bind_pcp_direct_layer_views,
+        close_pcp_direct_kv,
+        pcp_direct_kv_active,
+        should_allocate_pcp_direct_kv,
+    )
 
-        if should_allocate_pcp_direct_kv(vllm_config):
-            pcp_group = get_pcp_group()
+    if should_allocate_pcp_direct_kv(vllm_config):
+        pcp_group = get_pcp_group()
+        try:
             bind_pcp_direct_layer_views(kv_caches, pcp_group.device_group, device)
-    except RuntimeError:
-        raise
+        except Exception:
+            close_pcp_direct_kv()
+            raise
+        if not pcp_direct_kv_active():
+            close_pcp_direct_kv()
+            raise RuntimeError("VLLM_USE_PCP_DIRECT_KV=1 failed to enable after bind")
     return kv_caches
 
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -209,11 +209,34 @@ def init_kv_cache(
     kernel_block_sizes: list[int],
     vllm_config: VllmConfig,
 ) -> dict[str, Any]:
+    buffer_allocator = None
+    try:
+        from vllm.distributed.parallel_state import get_pcp_group
+        from vllm.model_executor.layers.attention.pcp_direct_kv import (
+            pcp_direct_kv_requested,
+            try_allocate_pcp_direct_backing,
+        )
+
+        if pcp_direct_kv_requested():
+            pcp_group = get_pcp_group()
+            if pcp_group.world_size > 1:
+
+                def buffer_allocator(nbytes: int, device: torch.device) -> torch.Tensor:
+                    allocation = try_allocate_pcp_direct_backing(
+                        nbytes, device, pcp_group.device_group
+                    )
+                    if allocation is not None:
+                        return allocation.storage
+                    return torch.zeros(nbytes, dtype=torch.int8, device=device)
+
+    except Exception:
+        buffer_allocator = None
     kv_caches = allocate_kv_cache(
         kv_cache_config,
         device,
         vllm_config.cache_config.get_resolved_kv_cache_layout(),
         kernel_block_sizes,
+        buffer_allocator,
     )
     for layer_name, target in get_shared_kv_cache_layers(vllm_config).items():
         kv_caches[layer_name] = kv_caches[target]
@@ -226,6 +249,18 @@ def init_kv_cache(
         else 1
     )
     bind_kv_cache(kv_caches, forward_context, runner_kv_caches, num_attn_module)
+    try:
+        from vllm.distributed.parallel_state import get_pcp_group
+        from vllm.model_executor.layers.attention.pcp_direct_kv import (
+            bind_pcp_direct_layer_views,
+            should_allocate_pcp_direct_kv,
+        )
+
+        if should_allocate_pcp_direct_kv(vllm_config):
+            pcp_group = get_pcp_group()
+            bind_pcp_direct_layer_views(kv_caches, pcp_group.device_group, device)
+    except RuntimeError:
+        raise
     return kv_caches
 
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -227,12 +227,13 @@ def init_kv_cache(
             return allocate_pcp_direct_backing(
                 nbytes, device, pcp_group.device_group
             ).storage
+
     kv_caches = allocate_kv_cache(
         kv_cache_config,
         device,
         vllm_config.cache_config.get_resolved_kv_cache_layout(),
         kernel_block_sizes,
-        buffer_allocator,
+        buffer_allocator=buffer_allocator,
     )
     for layer_name, target in get_shared_kv_cache_layers(vllm_config).items():
         kv_caches[layer_name] = kv_caches[target]

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -633,7 +633,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             lora_capture_cases=self.lora_capture_cases,
             varlen_decode=self.adaptive_verification is not None,
         )
-        check_attention_cp_compatibility(self.vllm_config)
+        check_attention_cp_compatibility(
+            self.vllm_config,
+            exclude_layer_names=(
+                self.speculator.draft_attn_layer_names
+                if isinstance(self.speculator, DraftModelSpeculator)
+                else None
+            ),
+        )
         if isinstance(self.speculator, DraftModelSpeculator):
             # HACK(woosuk)
             self.speculator.set_attn(
@@ -780,16 +787,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            attn_metadata, slot_mappings_by_layer = (
-                pcp._maybe_prepare_replicated_pcp_attn(
-                    self.pcp_manager,
-                    self.speculator,
-                    input_batch,
-                    attn_metadata,
-                    slot_mappings_by_layer,
-                    skip_attn=skip_attn,
-                )
-            )
             with use_workspace_lane(self._draft_workspace_lane):
                 self.speculator.propose(
                     input_batch=input_batch,
@@ -1847,9 +1844,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         hidden_states, input_batch = pcp.maybe_restore_pcp_for_sampling(
             self.pcp_manager, hidden_states, input_batch
         )
-        aux_hidden_states = pcp.maybe_restore_pcp_for_speculator(
-            self.pcp_manager, aux_hidden_states
-        )
+        # Aux hidden states feed the replicated drafter (e.g. DSpark), so
+        # like the main hidden states they are restored from the rank-local
+        # shard to the global batch layout.
+        if self.pcp_manager is not None and aux_hidden_states is not None:
+            aux_hidden_states = [
+                self.pcp_manager.restore_hidden_states(h) for h in aux_hidden_states
+            ]
 
         sampler_output, num_sampled, num_rejected = self.sample(
             hidden_states, input_batch, grammar_output
@@ -1928,20 +1929,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             spec_hidden_states = hidden_states
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
-                spec_hidden_states = pcp.maybe_restore_pcp_hidden_state_buffer(
-                    self.pcp_manager,
-                    pre_hc_hidden_states,
-                )
-                spec_hidden_states = spec_hidden_states[: hidden_states.shape[0]]
-            attn_metadata, slot_mappings_by_layer = (
-                pcp._maybe_prepare_replicated_pcp_attn(
-                    self.pcp_manager,
-                    self.speculator,
-                    input_batch,
-                    attn_metadata,
-                    slot_mappings_by_layer,
-                )
-            )
+                if self.pcp_manager is not None:
+                    pre_hc_hidden_states = self.pcp_manager.restore_hidden_state_buffer(
+                        pre_hc_hidden_states
+                    )
+                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]
             with use_workspace_lane(self._draft_workspace_lane):
                 draft_tokens = self.speculator.propose(
                     input_batch,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -780,6 +780,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
+            attn_metadata, slot_mappings_by_layer = (
+                pcp._maybe_prepare_replicated_pcp_attn(
+                    self.pcp_manager,
+                    self.speculator,
+                    input_batch,
+                    attn_metadata,
+                    slot_mappings_by_layer,
+                    skip_attn=skip_attn,
+                )
+            )
             with use_workspace_lane(self._draft_workspace_lane):
                 self.speculator.propose(
                     input_batch=input_batch,
@@ -1923,6 +1933,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     pre_hc_hidden_states,
                 )
                 spec_hidden_states = spec_hidden_states[: hidden_states.shape[0]]
+            attn_metadata, slot_mappings_by_layer = (
+                pcp._maybe_prepare_replicated_pcp_attn(
+                    self.pcp_manager,
+                    self.speculator,
+                    input_batch,
+                    attn_metadata,
+                    slot_mappings_by_layer,
+                )
+            )
             with use_workspace_lane(self._draft_workspace_lane):
                 draft_tokens = self.speculator.propose(
                     input_batch,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -141,6 +141,7 @@ from vllm.v1.worker.gpu.spec_decode.adaptive_verification import (
     AdaptiveVerificationManager,
     maybe_create_adaptive_verification_manager,
 )
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     set_eagle3_aux_hidden_state_layers,
 )
@@ -1839,6 +1840,28 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # The first PP rank holds the encoder cache, so pass its EC output on.
             output = ModelRunnerOutput.with_kv_conn_output_only(kv_connector_output)
             return ModelRunnerOutput.with_ec_conn_output(output, ec_connector_output)
+
+        # Pure prefill still has PCP-local target auxiliary states and slot
+        # mappings here. Project only this rank's DSpark context shard, then
+        # publish those physical draft-cache rows to every PCP replica.
+        if (
+            self.pcp_manager is not None
+            and self.pcp_manager.direct_kv_enabled
+            and isinstance(self.speculator, DSparkSpeculator)
+            and self.speculative_config is not None
+            and self.speculative_config.method == "dspark"
+            and aux_hidden_states is not None
+            and slot_mappings_by_layer is not None
+            and input_batch.has_prefill
+            and input_batch.is_prefilling_np.all()
+        ):
+            with use_workspace_lane(self._draft_workspace_lane):
+                self.speculator.precompute_pcp_context_kv(
+                    input_batch,
+                    aux_hidden_states,
+                    slot_mappings_by_layer,
+                )
+            aux_hidden_states = None
 
         # Last rank: sample tokens
         hidden_states, input_batch = pcp.maybe_restore_pcp_for_sampling(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1837,6 +1837,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         hidden_states, input_batch = pcp.maybe_restore_pcp_for_sampling(
             self.pcp_manager, hidden_states, input_batch
         )
+        aux_hidden_states = pcp.maybe_restore_pcp_for_speculator(
+            self.pcp_manager, aux_hidden_states
+        )
 
         sampler_output, num_sampled, num_rejected = self.sample(
             hidden_states, input_batch, grammar_output
@@ -1915,7 +1918,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             spec_hidden_states = hidden_states
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
-                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
+                spec_hidden_states = pcp.maybe_restore_pcp_hidden_state_buffer(
+                    self.pcp_manager,
+                    pre_hc_hidden_states,
+                )
+                spec_hidden_states = spec_hidden_states[: hidden_states.shape[0]]
             with use_workspace_lane(self._draft_workspace_lane):
                 draft_tokens = self.speculator.propose(
                     input_batch,

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -70,7 +70,7 @@ class PCPManager:
         self.dcp_world_size = dcp_world_size
         self.dcp_rank = dcp_rank
         self.cp_interleave = cp_interleave
-        self.direct_kv_enabled = direct_kv_enabled
+        self._direct_kv_requested = direct_kv_enabled
 
         self._global_batch: InputBatch | None = None
         self._req_states = req_states
@@ -79,6 +79,14 @@ class PCPManager:
         self._padded_gather_idx: torch.Tensor | None = None
         self._gathered_kv_write_mask: torch.Tensor | None = None
         self._pad_slot_id = torch.tensor(PAD_SLOT_ID, dtype=torch.int64, device=device)
+
+    @property
+    def direct_kv_enabled(self) -> bool:
+        from vllm.model_executor.layers.attention.pcp_direct_kv import (
+            pcp_direct_kv_active,
+        )
+
+        return self._direct_kv_requested and pcp_direct_kv_active()
 
         max_num_local_reqs = 2 * max_num_reqs if max_num_reqs is not None else None
         self._input_buffers = (

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -782,8 +782,6 @@ def _validate_pcp_direct_kv_config(vllm_config: VllmConfig) -> None:
         raise NotImplementedError(
             "Direct PCP KV requires the specialized NVIDIA deepseek_v32 attention path."
         )
-    if parallel_config.tensor_parallel_size != 1:
-        raise NotImplementedError("Direct PCP KV currently requires TP=1.")
     if parallel_config.decode_context_parallel_size != 1:
         raise NotImplementedError("Direct PCP KV currently requires DCP=1.")
     if parallel_config.data_parallel_size != 1:

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -7,7 +7,13 @@ import numpy as np
 import torch
 
 from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.distributed.parallel_state import get_dcp_group, get_pcp_group
+from vllm.distributed.parallel_state import (
+    get_dcp_group,
+    get_pcp_group,
+    in_the_same_node_as,
+)
+import vllm.envs as envs
+from vllm.platforms import current_platform
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
@@ -56,6 +62,7 @@ class PCPManager:
         dcp_world_size: int = 1,
         dcp_rank: int = 0,
         cp_interleave: int = 1,
+        direct_kv_enabled: bool = False,
     ) -> None:
         self.pcp_world_size = pcp_world_size
         self.pcp_rank = pcp_rank
@@ -63,6 +70,7 @@ class PCPManager:
         self.dcp_world_size = dcp_world_size
         self.dcp_rank = dcp_rank
         self.cp_interleave = cp_interleave
+        self.direct_kv_enabled = direct_kv_enabled
 
         self._global_batch: InputBatch | None = None
         self._req_states = req_states
@@ -160,6 +168,10 @@ class PCPManager:
             )
         if vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs():
             raise NotImplementedError("MRV2 PCP supports PIECEWISE CUDA graphs only.")
+
+        if not envs.VLLM_USE_PCP_DIRECT_KV:
+            return
+        _validate_pcp_direct_kv_config(vllm_config)
 
     @staticmethod
     def _reorder_segments(
@@ -600,6 +612,13 @@ class PCPManager:
             out_ptrs=self._local_block_table_ptrs,
         )
         slot_mappings = self.prepare_slot_mappings()
+        if self.direct_kv_enabled:
+            slot_mappings = select_pcp_direct_slot_row(
+                slot_mappings,
+                self.pcp_world_size,
+                self.pcp_rank,
+                input_batch.num_tokens_after_padding,
+            )
         return block_tables, slot_mappings
 
     def prepare_slot_mappings(self) -> torch.Tensor:
@@ -619,6 +638,8 @@ class PCPManager:
     def get_dummy_slot_mappings(self, num_tokens: int) -> torch.Tensor:
         assert self._gathered_kv_slot_mappings is not None
         self._gathered_kv_slot_mappings.fill_(PAD_SLOT_ID)
+        if self.direct_kv_enabled:
+            return self._gathered_kv_slot_mappings[:, :num_tokens]
         return self._gathered_kv_slot_mappings[:, : num_tokens * self.pcp_world_size]
 
     def _convert_to_gathered_slot_mappings(
@@ -698,6 +719,95 @@ def maybe_restore_pcp_for_sampling(
     return manager.restore_for_sampling(hidden_states)
 
 
+def select_pcp_direct_slot_row(
+    gathered_slot_mappings: torch.Tensor,
+    pcp_world_size: int,
+    pcp_rank: int,
+    local_tokens: int,
+) -> torch.Tensor:
+    """Select this producer's destination slots from rank-major gathered slots."""
+    if pcp_world_size <= 1:
+        return gathered_slot_mappings
+    if gathered_slot_mappings.ndim != 2:
+        raise ValueError(
+            "Expected gathered slot mappings with shape "
+            f"[num_groups, pcp_world_size * padded_tokens], got {tuple(gathered_slot_mappings.shape)}"
+        )
+    _, expanded = gathered_slot_mappings.shape
+    if expanded % pcp_world_size != 0:
+        raise ValueError(
+            f"Gathered slot width {expanded} is not divisible by PCP={pcp_world_size}"
+        )
+    padded = expanded // pcp_world_size
+    if local_tokens > padded:
+        raise ValueError(
+            f"Local token count {local_tokens} exceeds padded PCP row {padded}"
+        )
+    return gathered_slot_mappings.view(-1, pcp_world_size, padded)[
+        :, pcp_rank, :local_tokens
+    ]
+
+
+def _is_deepseek_v32_attention(layer: object) -> bool:
+    cls = type(layer)
+    return cls.__name__ == "DeepseekV32Attention" and cls.__module__.startswith(
+        "vllm.models.deepseek_v32"
+    )
+
+
+def _validate_pcp_direct_kv_config(vllm_config: VllmConfig) -> None:
+    parallel_config = vllm_config.parallel_config
+    model_config = vllm_config.model_config
+    if not current_platform.is_cuda():
+        raise NotImplementedError("Direct PCP KV requires CUDA.")
+    model_type = getattr(model_config.hf_text_config, "model_type", None)
+    if model_type not in ("glm_moe_dsa", "deepseek_v32"):
+        raise NotImplementedError(
+            "Direct PCP KV currently supports GLM-5.2 / DeepSeek-V3.2 only "
+            f"(got model_type={model_type!r})."
+        )
+    forward_layers = vllm_config.compilation_config.static_forward_context
+    if forward_layers and not any(
+        _is_deepseek_v32_attention(layer) for layer in forward_layers.values()
+    ):
+        raise NotImplementedError(
+            "Direct PCP KV requires the specialized NVIDIA deepseek_v32 attention path."
+        )
+    if parallel_config.tensor_parallel_size != 1:
+        raise NotImplementedError("Direct PCP KV currently requires TP=1.")
+    if parallel_config.decode_context_parallel_size != 1:
+        raise NotImplementedError("Direct PCP KV currently requires DCP=1.")
+    if parallel_config.data_parallel_size != 1:
+        raise NotImplementedError("Direct PCP KV currently requires DP=1.")
+    if parallel_config.use_ubatching:
+        raise NotImplementedError(
+            "Direct PCP KV does not support dual batch overlap or ubatching."
+        )
+    if vllm_config.scheduler_config.async_scheduling:
+        raise NotImplementedError("Direct PCP KV does not support async scheduling.")
+    if vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+        raise NotImplementedError(
+            "Direct PCP KV currently requires eager execution. Set --enforce-eager."
+        )
+    cache_config = vllm_config.cache_config
+    if cache_config is None or cache_config.cache_dtype not in ("fp8", "fp8_ds_mla"):
+        raise NotImplementedError(
+            "Direct PCP KV requires --kv-cache-dtype fp8 or fp8_ds_mla."
+        )
+    if cache_config.enable_prefix_caching:
+        raise NotImplementedError(
+            "Direct PCP KV does not support prefix caching or copy-on-write. "
+            "Set --no-enable-prefix-caching."
+        )
+    kv_transfer_config = vllm_config.kv_transfer_config
+    if kv_transfer_config is not None and kv_transfer_config.kv_connector is not None:
+        raise NotImplementedError(
+            "Direct PCP KV does not support KV connectors or offloading."
+        )
+    if getattr(model_config, "enable_sleep_mode", False):
+        raise NotImplementedError("Direct PCP KV does not support sleep mode.")
+
+
 def maybe_build_pcp_manager(
     vllm_config: VllmConfig,
     device: torch.device,
@@ -709,9 +819,22 @@ def maybe_build_pcp_manager(
     parallel_config = vllm_config.parallel_config
     pcp_size = parallel_config.prefill_context_parallel_size
     if pcp_size <= 1:
+        if envs.VLLM_USE_PCP_DIRECT_KV:
+            raise ValueError(
+                "VLLM_USE_PCP_DIRECT_KV=1 requires "
+                "--prefill-context-parallel-size greater than 1."
+            )
         return None
 
     cls.validate_config(vllm_config, supports_mm_inputs)
+
+    direct_kv_enabled = bool(envs.VLLM_USE_PCP_DIRECT_KV)
+    if direct_kv_enabled and not all(
+        in_the_same_node_as(get_pcp_group().cpu_group, source_rank=0)
+    ):
+        raise NotImplementedError(
+            "Direct PCP KV currently requires every PCP rank on one host."
+        )
 
     pcp_rank = get_pcp_group().rank_in_group
     dcp_size = parallel_config.decode_context_parallel_size
@@ -728,4 +851,5 @@ def maybe_build_pcp_manager(
         dcp_world_size=dcp_size,
         dcp_rank=dcp_rank,
         cp_interleave=parallel_config.cp_kv_cache_interleave_size,
+        direct_kv_enabled=direct_kv_enabled,
     )

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -6,15 +6,15 @@ from dataclasses import dataclass, replace
 import numpy as np
 import torch
 
+import vllm.envs as envs
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed.parallel_state import (
     get_dcp_group,
     get_pcp_group,
     in_the_same_node_as,
 )
-import vllm.envs as envs
-from vllm.platforms import current_platform
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
@@ -80,14 +80,6 @@ class PCPManager:
         self._gathered_kv_write_mask: torch.Tensor | None = None
         self._pad_slot_id = torch.tensor(PAD_SLOT_ID, dtype=torch.int64, device=device)
 
-    @property
-    def direct_kv_enabled(self) -> bool:
-        from vllm.model_executor.layers.attention.pcp_direct_kv import (
-            pcp_direct_kv_active,
-        )
-
-        return self._direct_kv_requested and pcp_direct_kv_active()
-
         max_num_local_reqs = 2 * max_num_reqs if max_num_reqs is not None else None
         self._input_buffers = (
             InputBuffers(max_num_local_reqs, max_num_tokens, device)
@@ -137,6 +129,14 @@ class PCPManager:
             if max_num_tokens is not None and num_kv_cache_groups > 0
             else None
         )
+
+    @property
+    def direct_kv_enabled(self) -> bool:
+        from vllm.model_executor.layers.attention.pcp_direct_kv import (
+            pcp_direct_kv_active,
+        )
+
+        return self._direct_kv_requested and pcp_direct_kv_active()
 
     @staticmethod
     def validate_config(
@@ -739,7 +739,8 @@ def select_pcp_direct_slot_row(
     if gathered_slot_mappings.ndim != 2:
         raise ValueError(
             "Expected gathered slot mappings with shape "
-            f"[num_groups, pcp_world_size * padded_tokens], got {tuple(gathered_slot_mappings.shape)}"
+            f"[num_groups, pcp_world_size * padded_tokens], "
+            f"got {tuple(gathered_slot_mappings.shape)}"
         )
     _, expanded = gathered_slot_mappings.shape
     if expanded % pcp_world_size != 0:

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -174,20 +174,10 @@ class PCPManager:
                 raise NotImplementedError(
                     "MRV2 PCP speculative decoding does not support DCP yet."
                 )
-            if speculative_config.draft_sample_method != "greedy":
-                raise NotImplementedError(
-                    "MRV2 PCP speculative decoding currently requires greedy "
-                    "draft sampling."
-                )
             if speculative_config.enable_adaptive_verification:
                 raise NotImplementedError(
                     "MRV2 PCP speculative decoding does not support adaptive "
                     "verification yet."
-                )
-            if speculative_config.num_speculative_tokens_per_batch_size:
-                raise NotImplementedError(
-                    "MRV2 PCP speculative decoding does not support dynamic "
-                    "draft lengths yet."
                 )
             if vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
                 raise NotImplementedError(
@@ -706,10 +696,25 @@ class PCPManager:
         return gathered_kv_slot_mappings
 
     def restore_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self._global_batch is not None
         if self._hidden_restore_idx is None:
             return hidden_states
         gathered = get_pcp_group().all_gather(hidden_states, dim=0)
-        return gathered[self._hidden_restore_idx]
+        restored = gathered[self._hidden_restore_idx]
+        num_tokens = self._global_batch.num_tokens
+        num_tokens_padded = self._global_batch.num_tokens_after_padding
+        assert restored.shape[0] == num_tokens
+        if num_tokens == num_tokens_padded:
+            return restored
+
+        # PCP restore reconstructs only active global tokens, whereas
+        # PIECEWISE graphs keep the target batch padded to a capture size. The
+        # drafter follows that padded shape contract, so append explicit zero
+        # rows rather than aliasing a real token through an arbitrary index.
+        padded_shape = (num_tokens_padded, *restored.shape[1:])
+        padded = restored.new_zeros(padded_shape)
+        padded[:num_tokens].copy_(restored)
+        return padded
 
     def restore_hidden_state_buffer(self, hidden_states: torch.Tensor) -> torch.Tensor:
         assert self._padded_gather_idx is not None

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -16,16 +17,18 @@ from vllm.distributed.parallel_state import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import (
     InputBatch,
     InputBuffers,
-    combine_sampled_and_draft_tokens,
-    prepare_pos_seq_lens,
 )
 from vllm.v1.worker.gpu.states import RequestState
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu.spec_decode.speculator import BaseSpeculator
 
 logger = init_logger(__name__)
 
@@ -84,11 +87,6 @@ class PCPManager:
         self._input_buffers = (
             InputBuffers(max_num_local_reqs, max_num_tokens, device)
             if max_num_local_reqs is not None and max_num_tokens is not None
-            else None
-        )
-        self._local_req_idx = (
-            torch.arange(max_num_local_reqs, dtype=torch.int32, device=device)
-            if max_num_local_reqs is not None
             else None
         )
         self._local_block_tables: tuple[torch.Tensor, ...] | None
@@ -411,7 +409,6 @@ class PCPManager:
     ) -> InputBatch:
         assert self._req_states is not None
         assert self._input_buffers is not None
-        req_states = self._req_states
         input_buffers = self._input_buffers
         global_batch = input_batch
         self._global_batch = global_batch
@@ -419,7 +416,6 @@ class PCPManager:
         num_scheduled_tokens = global_batch.num_scheduled_tokens
         num_computed_tokens = global_batch.num_computed_tokens_np
         is_prefilling = global_batch.is_prefilling_np
-
         segments_by_rank, per_rank_num_tokens = self._build_batch_layout(
             num_scheduled_tokens,
             num_computed_tokens,
@@ -512,6 +508,17 @@ class PCPManager:
             local_gather_idx,
             out=input_buffers.input_ids[:num_local_tokens_padded],
         )
+        # Positions are derived from the GPU request-state cursor in
+        # prepare_inputs(). Reuse them verbatim so RoPE positions, attention
+        # sequence lengths, and slot mappings all observe the same cursor after
+        # speculative rejection. The CPU num_computed_tokens value below is
+        # only an asynchronous upper bound for metadata construction.
+        torch.index_select(
+            global_batch.positions,
+            0,
+            local_gather_idx,
+            out=input_buffers.positions[:num_local_tokens_padded],
+        )
 
         local_query_start_loc_np = np.empty(
             input_buffers.max_num_reqs + 1, dtype=np.int32
@@ -526,17 +533,16 @@ class PCPManager:
         local_to_global_req_idx = async_copy_to_gpu(
             local_to_global_req_idx_np, device=self.device
         )
-        local_start_pos = async_copy_to_gpu(local_start_pos_np, device=self.device)
-
-        assert self._local_req_idx is not None
-        prepare_pos_seq_lens(
-            self._local_req_idx[:num_local_reqs],
-            local_query_start_loc,
-            local_start_pos,
-            input_buffers.positions,
-            input_buffers.seq_lens[:num_local_reqs],
-        )
         seq_lens = input_buffers.seq_lens[:num_local_reqs]
+        if num_local_tokens > 0:
+            local_end_positions = torch.index_select(
+                input_buffers.positions,
+                0,
+                local_query_start_loc[1:] - 1,
+            )
+            seq_lens.copy_(local_end_positions + 1)
+        else:
+            seq_lens.zero_()
         is_padding = input_buffers.is_padding[:num_local_tokens_padded]
         is_padding[:num_local_tokens].fill_(False)
         is_padding[num_local_tokens:].fill_(True)
@@ -559,18 +565,11 @@ class PCPManager:
             cu_num_logits = torch.zeros(
                 num_local_reqs + 1, device=self.device, dtype=torch.int32
             )
-        logits_indices = combine_sampled_and_draft_tokens(
-            input_buffers.input_ids,
-            local_to_global_req_idx,
-            req_states.last_sampled_tokens,
-            local_query_start_loc,
-            seq_lens,
-            req_states.prefill_len.gpu,
-            req_states.draft_tokens,
-            cu_num_logits,
-            total_num_logits,
-            1,
-        )
+        # The global batch has already materialized sampled and draft tokens.
+        # Recombining the rank-local view as a one-logit batch would overwrite
+        # the final draft token with the last sampled token. Local logits are
+        # never sampled directly; they are restored to the global layout first.
+        logits_indices = local_query_start_loc[1:] - 1
 
         local_prefill_len_np = global_batch.prefill_len_np[
             local_to_global_batch_req_idx_np
@@ -725,6 +724,49 @@ class PCPManager:
     ) -> tuple[torch.Tensor, InputBatch]:
         assert self._global_batch is not None
         return self.restore_hidden_states(hidden_states), self._global_batch
+
+
+def _maybe_prepare_replicated_pcp_attn(
+    manager: PCPManager | None,
+    speculator: "BaseSpeculator",
+    input_batch: InputBatch,
+    attn_metadata: dict[str, Any] | None,
+    slot_mappings: dict[str, torch.Tensor] | None,
+    *,
+    skip_attn: bool = False,
+) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor] | None]:
+    from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+
+    if manager is None or not isinstance(speculator, DraftModelSpeculator) or skip_attn:
+        return attn_metadata, slot_mappings
+
+    num_reqs = input_batch.num_reqs
+    num_reqs_padded = input_batch.num_reqs_after_padding
+    num_tokens_padded = input_batch.num_tokens_after_padding
+    speculator.block_tables.gather_block_tables(
+        input_batch.idx_mapping,
+        num_reqs_padded=num_reqs_padded,
+    )
+    slot_mappings_tensor = speculator.block_tables.compute_slot_mappings(
+        input_batch.idx_mapping,
+        input_batch.query_start_loc,
+        input_batch.positions,
+        num_tokens_padded=num_tokens_padded,
+    )
+    slot_mappings = build_slot_mappings_by_layer(
+        slot_mappings_tensor, speculator.kv_cache_config
+    )
+    attn_metadata = speculator._build_draft_attn_metadata(
+        num_reqs=num_reqs,
+        num_reqs_padded=num_reqs_padded,
+        num_tokens_padded=num_tokens_padded,
+        seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+        step=0,
+        query_start_loc_np=input_batch.query_start_loc_np,
+        query_start_loc_gpu=input_batch.query_start_loc,
+        seq_lens=input_batch.seq_lens,
+    )
+    return attn_metadata, slot_mappings
 
 
 def maybe_partition_pcp_batch(
@@ -901,7 +943,6 @@ def maybe_build_pcp_manager(
     pcp_rank = get_pcp_group().rank_in_group
     dcp_size = parallel_config.decode_context_parallel_size
     dcp_rank = get_dcp_group().rank_in_group if dcp_size > 1 else 0
-
     return cls(
         pcp_world_size=pcp_size,
         pcp_rank=pcp_rank,

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -161,11 +161,41 @@ class PCPManager:
             raise NotImplementedError("MRV2 PCP does not support MM inputs yet.")
         if vllm_config.lora_config is not None:
             raise NotImplementedError("MRV2 PCP does not support LoRA yet.")
-        if vllm_config.speculative_config is not None:
-            raise NotImplementedError(
-                "MRV2 PCP does not support speculative decoding yet."
-            )
         is_sparse_mla = hasattr(model_config.hf_text_config, "index_topk")
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None:
+            if speculative_config.method != "mtp":
+                raise NotImplementedError(
+                    "MRV2 PCP speculative decoding currently supports MTP only."
+                )
+            if is_sparse_mla:
+                raise NotImplementedError(
+                    "MRV2 PCP speculative decoding currently supports dense MLA only."
+                )
+            if parallel_config.decode_context_parallel_size != 1:
+                raise NotImplementedError(
+                    "MRV2 PCP speculative decoding does not support DCP yet."
+                )
+            if speculative_config.draft_sample_method != "greedy":
+                raise NotImplementedError(
+                    "MRV2 PCP speculative decoding currently requires greedy "
+                    "draft sampling."
+                )
+            if speculative_config.enable_adaptive_verification:
+                raise NotImplementedError(
+                    "MRV2 PCP speculative decoding does not support adaptive "
+                    "verification yet."
+                )
+            if speculative_config.num_speculative_tokens_per_batch_size:
+                raise NotImplementedError(
+                    "MRV2 PCP speculative decoding does not support dynamic "
+                    "draft lengths yet."
+                )
+            if vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+                raise NotImplementedError(
+                    "MRV2 PCP speculative decoding currently requires "
+                    "cudagraph_mode=NONE."
+                )
         if (
             is_sparse_mla
             and vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
@@ -383,9 +413,6 @@ class PCPManager:
         assert self._input_buffers is not None
         req_states = self._req_states
         input_buffers = self._input_buffers
-        if input_batch.num_draft_tokens > 0:
-            raise NotImplementedError("MRV2 PCP does not support spec decode yet.")
-
         global_batch = input_batch
         self._global_batch = global_batch
 
@@ -685,6 +712,13 @@ class PCPManager:
         gathered = get_pcp_group().all_gather(hidden_states, dim=0)
         return gathered[self._hidden_restore_idx]
 
+    def restore_hidden_state_buffer(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self._padded_gather_idx is not None
+        local_num_tokens_padded = (
+            self._padded_gather_idx.shape[0] // self.pcp_world_size
+        )
+        return self.restore_hidden_states(hidden_states[:local_num_tokens_padded])
+
     def restore_for_sampling(
         self,
         hidden_states: torch.Tensor,
@@ -814,6 +848,27 @@ def _validate_pcp_direct_kv_config(vllm_config: VllmConfig) -> None:
     if getattr(model_config, "enable_sleep_mode", False):
         raise NotImplementedError("Direct PCP KV does not support sleep mode.")
 
+
+def maybe_restore_pcp_hidden_state_buffer(
+    manager: PCPManager | None,
+    hidden_states: torch.Tensor | None,
+) -> torch.Tensor:
+    assert hidden_states is not None
+    if manager is None:
+        return hidden_states
+    return manager.restore_hidden_state_buffer(hidden_states)
+
+
+def maybe_restore_pcp_for_speculator(
+    manager: PCPManager | None,
+    aux_hidden_states: list[torch.Tensor] | None,
+) -> list[torch.Tensor] | None:
+    if manager is None or aux_hidden_states is None:
+        return aux_hidden_states
+    return [
+        manager.restore_hidden_states(aux_hidden_state)
+        for aux_hidden_state in aux_hidden_states
+    ]
 
 def maybe_build_pcp_manager(
     vllm_config: VllmConfig,

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -179,11 +179,6 @@ class PCPManager:
                     "MRV2 PCP speculative decoding does not support adaptive "
                     "verification yet."
                 )
-            if vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
-                raise NotImplementedError(
-                    "MRV2 PCP speculative decoding currently requires "
-                    "cudagraph_mode=NONE."
-                )
         if (
             is_sparse_mla
             and vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE

--- a/vllm/v1/worker/gpu/pcp_manager.py
+++ b/vllm/v1/worker/gpu/pcp_manager.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -17,7 +16,6 @@ from vllm.distributed.parallel_state import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
@@ -26,9 +24,6 @@ from vllm.v1.worker.gpu.input_batch import (
     InputBuffers,
 )
 from vllm.v1.worker.gpu.states import RequestState
-
-if TYPE_CHECKING:
-    from vllm.v1.worker.gpu.spec_decode.speculator import BaseSpeculator
 
 logger = init_logger(__name__)
 
@@ -162,13 +157,15 @@ class PCPManager:
         is_sparse_mla = hasattr(model_config.hf_text_config, "index_topk")
         speculative_config = vllm_config.speculative_config
         if speculative_config is not None:
-            if speculative_config.method != "mtp":
+            if speculative_config.method not in ("mtp", "dspark"):
                 raise NotImplementedError(
-                    "MRV2 PCP speculative decoding currently supports MTP only."
+                    "MRV2 PCP speculative decoding currently supports MTP "
+                    "and DSpark only."
                 )
-            if is_sparse_mla:
+            if is_sparse_mla and speculative_config.method == "mtp":
                 raise NotImplementedError(
-                    "MRV2 PCP speculative decoding currently supports dense MLA only."
+                    "MRV2 PCP MTP speculative decoding currently supports "
+                    "dense MLA only."
                 )
             if parallel_config.decode_context_parallel_size != 1:
                 raise NotImplementedError(
@@ -401,6 +398,7 @@ class PCPManager:
         num_scheduled_tokens = global_batch.num_scheduled_tokens
         num_computed_tokens = global_batch.num_computed_tokens_np
         is_prefilling = global_batch.is_prefilling_np
+
         segments_by_rank, per_rank_num_tokens = self._build_batch_layout(
             num_scheduled_tokens,
             num_computed_tokens,
@@ -712,6 +710,9 @@ class PCPManager:
         return padded
 
     def restore_hidden_state_buffer(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Restore a persistent max-token-sized buffer (e.g. the target's
+        pre-hc_head residual) by slicing it to the rank-local padded token
+        count before the all-gather."""
         assert self._padded_gather_idx is not None
         local_num_tokens_padded = (
             self._padded_gather_idx.shape[0] // self.pcp_world_size
@@ -724,49 +725,6 @@ class PCPManager:
     ) -> tuple[torch.Tensor, InputBatch]:
         assert self._global_batch is not None
         return self.restore_hidden_states(hidden_states), self._global_batch
-
-
-def _maybe_prepare_replicated_pcp_attn(
-    manager: PCPManager | None,
-    speculator: "BaseSpeculator",
-    input_batch: InputBatch,
-    attn_metadata: dict[str, Any] | None,
-    slot_mappings: dict[str, torch.Tensor] | None,
-    *,
-    skip_attn: bool = False,
-) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor] | None]:
-    from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
-
-    if manager is None or not isinstance(speculator, DraftModelSpeculator) or skip_attn:
-        return attn_metadata, slot_mappings
-
-    num_reqs = input_batch.num_reqs
-    num_reqs_padded = input_batch.num_reqs_after_padding
-    num_tokens_padded = input_batch.num_tokens_after_padding
-    speculator.block_tables.gather_block_tables(
-        input_batch.idx_mapping,
-        num_reqs_padded=num_reqs_padded,
-    )
-    slot_mappings_tensor = speculator.block_tables.compute_slot_mappings(
-        input_batch.idx_mapping,
-        input_batch.query_start_loc,
-        input_batch.positions,
-        num_tokens_padded=num_tokens_padded,
-    )
-    slot_mappings = build_slot_mappings_by_layer(
-        slot_mappings_tensor, speculator.kv_cache_config
-    )
-    attn_metadata = speculator._build_draft_attn_metadata(
-        num_reqs=num_reqs,
-        num_reqs_padded=num_reqs_padded,
-        num_tokens_padded=num_tokens_padded,
-        seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
-        step=0,
-        query_start_loc_np=input_batch.query_start_loc_np,
-        query_start_loc_gpu=input_batch.query_start_loc,
-        seq_lens=input_batch.seq_lens,
-    )
-    return attn_metadata, slot_mappings
 
 
 def maybe_partition_pcp_batch(
@@ -891,27 +849,6 @@ def _validate_pcp_direct_kv_config(vllm_config: VllmConfig) -> None:
         raise NotImplementedError("Direct PCP KV does not support sleep mode.")
 
 
-def maybe_restore_pcp_hidden_state_buffer(
-    manager: PCPManager | None,
-    hidden_states: torch.Tensor | None,
-) -> torch.Tensor:
-    assert hidden_states is not None
-    if manager is None:
-        return hidden_states
-    return manager.restore_hidden_state_buffer(hidden_states)
-
-
-def maybe_restore_pcp_for_speculator(
-    manager: PCPManager | None,
-    aux_hidden_states: list[torch.Tensor] | None,
-) -> list[torch.Tensor] | None:
-    if manager is None or aux_hidden_states is None:
-        return aux_hidden_states
-    return [
-        manager.restore_hidden_states(aux_hidden_state)
-        for aux_hidden_state in aux_hidden_states
-    ]
-
 def maybe_build_pcp_manager(
     vllm_config: VllmConfig,
     device: torch.device,
@@ -943,6 +880,7 @@ def maybe_build_pcp_manager(
     pcp_rank = get_pcp_group().rank_in_group
     dcp_size = parallel_config.decode_context_parallel_size
     dcp_rank = get_dcp_group().rank_in_group if dcp_size > 1 else 0
+
     return cls(
         pcp_world_size=pcp_size,
         pcp_rank=pcp_rank,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -68,6 +68,36 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
     def on_multi_step_decode_end(self, num_reqs: int) -> None: ...
 
+    def _prepare_replicated_pcp_attn(
+        self,
+        input_batch: InputBatch,
+        batch_desc: BatchExecutionDescriptor,
+    ) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor]]:
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = batch_desc.num_reqs or num_reqs
+        self.block_tables.gather_block_tables(
+            input_batch.idx_mapping,
+            num_reqs_padded=num_reqs_padded,
+        )
+        slot_mappings_tensor = self.block_tables.compute_slot_mappings(
+            input_batch.idx_mapping,
+            self.input_buffers.query_start_loc,
+            self.input_buffers.positions,
+            num_tokens_padded=batch_desc.num_tokens,
+        )
+        slot_mappings = build_slot_mappings_by_layer(
+            slot_mappings_tensor, self.kv_cache_config
+        )
+        attn_metadata = self._build_draft_attn_metadata(
+            num_reqs=num_reqs,
+            num_reqs_padded=num_reqs_padded,
+            num_tokens_padded=batch_desc.num_tokens,
+            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+            step=0,
+            query_start_loc_np=input_batch.query_start_loc_np,
+        )
+        return attn_metadata, slot_mappings
+
     @property
     def advance_draft_positions(self) -> bool:
         """
@@ -294,6 +324,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             if prefill_batch_sync is not None
             else None
         )
+
+        if self.replicated_pcp and not (dummy_run and skip_attn_for_dummy_run):
+            attn_metadata, slot_mappings = self._prepare_replicated_pcp_attn(
+                input_batch, prefill_batch_desc
+            )
 
         self._prepare_eplb_forward(num_tokens)
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -78,6 +78,42 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
         """
         return True
 
+    def _prepare_prefill_attn(
+        self,
+        input_batch: InputBatch,
+        batch_desc: BatchExecutionDescriptor,
+    ) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor]]:
+        """Build draft prefill attention metadata and slot mappings from the
+        input batch, for when the target model's metadata cannot be reused
+        (e.g. a PCP-sharded target with a replicated drafter)."""
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = batch_desc.num_reqs or num_reqs
+        self.block_tables.gather_block_tables(
+            input_batch.idx_mapping,
+            num_reqs_padded=num_reqs_padded,
+        )
+        # Use input_batch.positions: the drafter's own positions buffer is
+        # stale at rejected token slots and would emit KV writes into live
+        # cache slots.
+        slot_mappings_tensor = self.block_tables.compute_slot_mappings(
+            input_batch.idx_mapping,
+            input_batch.query_start_loc,
+            input_batch.positions,
+            batch_desc.num_tokens,
+        )
+        slot_mappings = build_slot_mappings_by_layer(
+            slot_mappings_tensor, self.kv_cache_config
+        )
+        attn_metadata = self._build_draft_attn_metadata(
+            num_reqs=num_reqs,
+            num_reqs_padded=num_reqs_padded,
+            num_tokens_padded=batch_desc.num_tokens,
+            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+            step=0,
+            query_start_loc_np=input_batch.query_start_loc_np,
+        )
+        return attn_metadata, slot_mappings
+
     def set_attn(
         self,
         model_state: ModelState,
@@ -295,6 +331,20 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             else None
         )
 
+        # The target model's attention metadata and slot mappings can be
+        # reused for draft prefill (identical batch shape and KV cache
+        # layout) — except under PCP, where they describe the rank-local
+        # sharded batch while the replicated drafter runs the global batch.
+        prefill_attn_metadata: dict[str, Any] | None = attn_metadata
+        prefill_slot_mappings: dict[str, torch.Tensor] | None = slot_mappings
+        if self.replicated_pcp:
+            if dummy_run and skip_attn_for_dummy_run:
+                prefill_attn_metadata, prefill_slot_mappings = None, None
+            else:
+                prefill_attn_metadata, prefill_slot_mappings = (
+                    self._prepare_prefill_attn(input_batch, prefill_batch_desc)
+                )
+
         self._prepare_eplb_forward(num_tokens)
 
         self.on_prefill_begin(num_reqs)
@@ -303,14 +353,11 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             assert self.prefill_cudagraph_manager is not None
             self.prefill_cudagraph_manager.run_fullgraph(prefill_batch_desc)
         else:
-            # The target model's attention metadata and slot mappings
-            # can directly be used for draft prefill, because of the
-            # identical batch shape and KV cache layout.
             self._prefill(
                 num_reqs,
                 prefill_batch_desc.num_tokens,
-                attn_metadata,
-                slot_mappings,
+                prefill_attn_metadata,
+                prefill_slot_mappings,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=prefill_batch_desc.cg_mode,
                 mm_inputs=mm_inputs,

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -68,36 +68,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
     def on_multi_step_decode_end(self, num_reqs: int) -> None: ...
 
-    def _prepare_replicated_pcp_attn(
-        self,
-        input_batch: InputBatch,
-        batch_desc: BatchExecutionDescriptor,
-    ) -> tuple[dict[str, Any] | None, dict[str, torch.Tensor]]:
-        num_reqs = input_batch.num_reqs
-        num_reqs_padded = batch_desc.num_reqs or num_reqs
-        self.block_tables.gather_block_tables(
-            input_batch.idx_mapping,
-            num_reqs_padded=num_reqs_padded,
-        )
-        slot_mappings_tensor = self.block_tables.compute_slot_mappings(
-            input_batch.idx_mapping,
-            self.input_buffers.query_start_loc,
-            self.input_buffers.positions,
-            num_tokens_padded=batch_desc.num_tokens,
-        )
-        slot_mappings = build_slot_mappings_by_layer(
-            slot_mappings_tensor, self.kv_cache_config
-        )
-        attn_metadata = self._build_draft_attn_metadata(
-            num_reqs=num_reqs,
-            num_reqs_padded=num_reqs_padded,
-            num_tokens_padded=batch_desc.num_tokens,
-            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
-            step=0,
-            query_start_loc_np=input_batch.query_start_loc_np,
-        )
-        return attn_metadata, slot_mappings
-
     @property
     def advance_draft_positions(self) -> bool:
         """
@@ -324,11 +294,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             if prefill_batch_sync is not None
             else None
         )
-
-        if self.replicated_pcp and not (dummy_run and skip_attn_for_dummy_run):
-            attn_metadata, slot_mappings = self._prepare_replicated_pcp_attn(
-                input_batch, prefill_batch_desc
-            )
 
         self._prepare_eplb_forward(num_tokens)
 

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -283,14 +283,15 @@ class DFlashSpeculator(DraftModelSpeculator):
         num_tokens_padded: int,
         seq_lens_cpu_upper_bound: torch.Tensor,
         step: int,
-        num_query_per_req: int | None = None,
+        num_query_per_req: int = 1,
         causal: bool | Mapping[int, bool] = False,
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
+        query_start_loc_gpu: torch.Tensor | None = None,
+        seq_lens: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
         if not self.draft_attn_layer_names:
             return None
-        assert num_query_per_req is None  # Omitted for DFlash, read from self instead
         if dcp_local_seq_lens is None and self.block_tables.cp_size > 1:
             prepare_dcp_local_seq_lens(
                 self.input_buffers.dcp_local_seq_lens,
@@ -311,6 +312,8 @@ class DFlashSpeculator(DraftModelSpeculator):
             causal=causal,
             query_start_loc_np=query_start_loc_np,
             dcp_local_seq_lens=dcp_local_seq_lens,
+            query_start_loc_gpu=query_start_loc_gpu,
+            seq_lens=seq_lens,
         )
 
     @torch.inference_mode()

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -100,6 +100,7 @@ class DFlashSpeculator(DraftModelSpeculator):
 
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
+        self._pcp_context_kv_precomputed = False
 
     @property
     def attn_vllm_config(self) -> VllmConfig:
@@ -341,6 +342,8 @@ class DFlashSpeculator(DraftModelSpeculator):
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
         is_profile: bool = False,
     ) -> torch.Tensor:
+        context_kv_precomputed = self._pcp_context_kv_precomputed
+        self._pcp_context_kv_precomputed = False
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens
         num_query_tokens = num_reqs * self.num_query_per_req
@@ -353,13 +356,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         # number of rejected tokens, we maintain the size of input_ids and
         # hidden_states the same as the target model's. This means, we pad each
         # request's query length to include any rejected positions.
-        if aux_hidden_states:
-            hidden_states = self.model.combine_hidden_states(
-                torch.cat(aux_hidden_states, dim=-1)
+        if not context_kv_precomputed:
+            if aux_hidden_states:
+                hidden_states = self.model.combine_hidden_states(
+                    torch.cat(aux_hidden_states, dim=-1)
+                )
+            else:
+                hidden_states = last_hidden_states
+            self.hidden_states[:num_target_tokens].copy_(
+                hidden_states[:num_target_tokens]
             )
-        else:
-            hidden_states = last_hidden_states
-        self.hidden_states[:num_target_tokens].copy_(hidden_states[:num_target_tokens])
 
         if dummy_run and skip_attn_for_dummy_run:
             # Memory profiling path: block_tables / kv_cache_config are not initialized.
@@ -441,11 +447,12 @@ class DFlashSpeculator(DraftModelSpeculator):
             ]
         else:
             context_slots = self._context_slot_mappings[0][:num_target_tokens]
-        self.model.precompute_and_store_context_kv(
-            self.hidden_states[:num_target_tokens],
-            self.context_positions[:num_target_tokens],
-            context_slots,
-        )
+        if not context_kv_precomputed:
+            self.model.precompute_and_store_context_kv(
+                self.hidden_states[:num_target_tokens],
+                self.context_positions[:num_target_tokens],
+                context_slots,
+            )
 
         # Every DFlash step has exactly num_query_per_req tokens, so we can use FULL CGs
         batch_desc, batch_sync = dispatch_cg_and_sync_dp(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -283,15 +283,14 @@ class DFlashSpeculator(DraftModelSpeculator):
         num_tokens_padded: int,
         seq_lens_cpu_upper_bound: torch.Tensor,
         step: int,
-        num_query_per_req: int = 1,
+        num_query_per_req: int | None = None,
         causal: bool | Mapping[int, bool] = False,
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
-        query_start_loc_gpu: torch.Tensor | None = None,
-        seq_lens: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
         if not self.draft_attn_layer_names:
             return None
+        assert num_query_per_req is None  # Omitted for DFlash, read from self instead
         if dcp_local_seq_lens is None and self.block_tables.cp_size > 1:
             prepare_dcp_local_seq_lens(
                 self.input_buffers.dcp_local_seq_lens,
@@ -312,8 +311,6 @@ class DFlashSpeculator(DraftModelSpeculator):
             causal=causal,
             query_start_loc_np=query_start_loc_np,
             dcp_local_seq_lens=dcp_local_seq_lens,
-            query_start_loc_gpu=query_start_loc_gpu,
-            seq_lens=seq_lens,
         )
 
     @torch.inference_mode()
@@ -386,6 +383,14 @@ class DFlashSpeculator(DraftModelSpeculator):
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
             )
             return self.draft_tokens[:num_reqs]
+
+        # Under PCP the runner gathered block tables for the rank-local
+        # sharded batch; the replicated drafter needs them gathered for the
+        # global batch (its context-KV slot mappings are derived from them).
+        if self.replicated_pcp:
+            self.block_tables.gather_block_tables(
+                input_batch.idx_mapping, num_reqs_padded=num_reqs
+            )
 
         # The query slot mapping is written into the shared BlockTables slot_mappings.
         # That buffer's address is what the captured CUDA graph reads from at replay.

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -30,6 +30,7 @@ import torch
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.logger import init_logger
+from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
@@ -116,6 +117,40 @@ class DSparkSpeculator(DFlashSpeculator):
                 " a fixed number of drafts instead."
             )
         return model
+
+    @torch.inference_mode()
+    def precompute_pcp_context_kv(
+        self,
+        input_batch: InputBatch,
+        aux_hidden_states: list[torch.Tensor],
+        slot_mappings: dict[str, torch.Tensor],
+    ) -> None:
+        """Build rank-local context KV and publish it to every PCP peer."""
+        if self._pcp_context_kv_precomputed:
+            raise RuntimeError("DSpark PCP context KV was already precomputed")
+        if not aux_hidden_states:
+            raise RuntimeError("DSpark PCP precompute requires auxiliary hidden states")
+
+        num_tokens = input_batch.num_tokens
+        layer_names = self.model.get_draft_kv_cache_layer_names()
+        missing = [name for name in layer_names if name not in slot_mappings]
+        if missing:
+            raise RuntimeError(
+                "Missing DSpark PCP slot mappings for: " + ", ".join(missing)
+            )
+        context_slot_mappings = [
+            slot_mappings[name][:num_tokens] for name in layer_names
+        ]
+        context_states = self.model.combine_hidden_states(
+            torch.cat(aux_hidden_states, dim=-1)
+        )
+        self.model.precompute_and_store_context_kv(
+            context_states[:num_tokens],
+            input_batch.positions[:num_tokens],
+            context_slot_mappings,
+            publish_to_pcp=True,
+        )
+        self._pcp_context_kv_precomputed = True
 
     def _sample_logits(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -250,6 +250,8 @@ class DraftModelSpeculator(BaseSpeculator):
         causal: bool | Mapping[int, bool] = True,
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
+        query_start_loc_gpu: torch.Tensor | None = None,
+        seq_lens: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
         if query_start_loc_np is not None:
             # Non-uniform query layout (e.g. multi-module MTP's mixed
@@ -284,16 +286,18 @@ class DraftModelSpeculator(BaseSpeculator):
             out=draft_seq_lens_cpu_upper_bound[:num_reqs],
         )
         draft_seq_lens_cpu_upper_bound[:num_reqs].clamp_(max=self.max_model_len)
+        if query_start_loc_gpu is None:
+            query_start_loc_gpu = self.input_buffers.query_start_loc
+        if seq_lens is None:
+            seq_lens = self.input_buffers.seq_lens
         attn_metadata = build_attn_metadata(
             attn_groups=self.attn_groups,
             num_reqs=num_reqs_padded,
             num_tokens=num_tokens_padded,
-            query_start_loc_gpu=self.input_buffers.query_start_loc[
-                : num_reqs_padded + 1
-            ],
+            query_start_loc_gpu=query_start_loc_gpu[: num_reqs_padded + 1],
             query_start_loc_cpu=query_start_loc_cpu,
             max_query_len=max_query_len,
-            seq_lens=self.input_buffers.seq_lens[:num_reqs_padded],
+            seq_lens=seq_lens[:num_reqs_padded],
             dcp_local_seq_lens=(
                 None
                 if dcp_local_seq_lens is None

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config import VllmConfig, get_layers_from_vllm_config, replace
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
@@ -72,6 +72,16 @@ class BaseSpeculator(ABC):
 
 class DraftModelSpeculator(BaseSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        target_parallel_config = vllm_config.parallel_config
+        self.replicated_pcp = target_parallel_config.prefill_context_parallel_size > 1
+        if self.replicated_pcp:
+            vllm_config = replace(
+                vllm_config,
+                parallel_config=replace(
+                    target_parallel_config,
+                    prefill_context_parallel_size=1,
+                ),
+            )
         self.vllm_config = vllm_config
         self.device = device
 

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -72,6 +72,9 @@ class BaseSpeculator(ABC):
 
 class DraftModelSpeculator(BaseSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        # Under PCP the drafter runs replicated over the global batch on
+        # every rank, so its attention groups, forward context, and
+        # cudagraphs must not see PCP.
         target_parallel_config = vllm_config.parallel_config
         self.replicated_pcp = target_parallel_config.prefill_context_parallel_size > 1
         if self.replicated_pcp:
@@ -250,8 +253,6 @@ class DraftModelSpeculator(BaseSpeculator):
         causal: bool | Mapping[int, bool] = True,
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
-        query_start_loc_gpu: torch.Tensor | None = None,
-        seq_lens: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
         if query_start_loc_np is not None:
             # Non-uniform query layout (e.g. multi-module MTP's mixed
@@ -286,18 +287,16 @@ class DraftModelSpeculator(BaseSpeculator):
             out=draft_seq_lens_cpu_upper_bound[:num_reqs],
         )
         draft_seq_lens_cpu_upper_bound[:num_reqs].clamp_(max=self.max_model_len)
-        if query_start_loc_gpu is None:
-            query_start_loc_gpu = self.input_buffers.query_start_loc
-        if seq_lens is None:
-            seq_lens = self.input_buffers.seq_lens
         attn_metadata = build_attn_metadata(
             attn_groups=self.attn_groups,
             num_reqs=num_reqs_padded,
             num_tokens=num_tokens_padded,
-            query_start_loc_gpu=query_start_loc_gpu[: num_reqs_padded + 1],
+            query_start_loc_gpu=self.input_buffers.query_start_loc[
+                : num_reqs_padded + 1
+            ],
             query_start_loc_cpu=query_start_loc_cpu,
             max_query_len=max_query_len,
-            seq_lens=seq_lens[:num_reqs_padded],
+            seq_lens=self.input_buffers.seq_lens[:num_reqs_padded],
             dcp_local_seq_lens=(
                 None
                 if dcp_local_seq_lens is None

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1400,6 +1400,13 @@ class Worker(WorkerBase):
 
         self.elastic_ep_executor.shutdown()
 
+        # Drop SymmMem peer views before the runner releases KV tensors.
+        from vllm.model_executor.layers.attention.pcp_direct_kv import (
+            close_pcp_direct_kv,
+        )
+
+        close_pcp_direct_kv()
+
         # Release GPU resources held by the model runner so that memory
         # can be reclaimed when running in-process
         if model_runner := getattr(self, "model_runner", None):

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -386,7 +386,8 @@ def allocate_kv_cache(
 
     Every KVCacheTensor places its layers in the same backing allocation: layer ``l`` of
     block ``b`` starts at ``offset + l * layer_stride + b * block_stride``. Cache
-    groups overlay each other, so tensors may address the same bytes.
+    groups overlay each other, so tensors may address the same bytes. Callers may
+    provide a custom allocator for the single backing buffer.
     """
     if not kv_cache_config.kv_cache_tensors:
         return {}

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import math
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import product as iprod
 from typing import Any
@@ -380,6 +380,7 @@ def allocate_kv_cache(
     device: torch.device,
     layout: KVCacheLayout,
     kernel_block_sizes: list[int] | None = None,
+    buffer_allocator: Callable[[int, torch.device], torch.Tensor] | None = None,
 ) -> dict[str, torch.Tensor]:
     """Allocate the KV cache and view it as ``[B, H, N, C]`` per layer.
 
@@ -394,10 +395,11 @@ def allocate_kv_cache(
     assert len(sizes) == 1, "KV cache tensors must share one backing allocation."
     raw_size = sizes.pop()
     page_size = 4096
-    buf = torch.zeros(
-        ((raw_size + page_size - 1) // page_size) * page_size,
-        dtype=torch.int8,
-        device=device,
+    size = ((raw_size + page_size - 1) // page_size) * page_size
+    buf = (
+        torch.zeros(size, dtype=torch.int8, device=device)
+        if buffer_allocator is None
+        else buffer_allocator(size, device)
     )
 
     kv_caches: dict[str, torch.Tensor] = {}


### PR DESCRIPTION
## Summary

Optimize DSpark prefill under PCP by computing context KV from only each rank’s local target auxiliary states.

For pure-prefill batches, this PR:

- Projects rank-local auxiliary states instead of restoring and projecting the full context on every PCP rank.
- Writes the local DSpark KV rows into the symmetric cache.
- Publishes those physical rows directly to PCP peers.
- Uses stride-aware copies for head-major paged-cache layouts.
- Issues one direct-KV fence after all draft layers.
- Skips the redundant context-KV projection during `propose()`.

Mixed batches, decode batches, and configurations without direct-KV retain the existing replicated fallback.

## Motivation

The current PCP+DSpark path restores the global auxiliary states and redundantly performs the complete context-KV projection on every PCP rank.

This removes that duplicated computation and communication while preserving the replicated DSpark cache expected after prefill.

## Dependencies

- Depends on #52863
- Depends on #54030
- Depends on #53427
- Related: #54016 is required when using FlashInfer one-sided EP with `DP=1`

The new feature is contained in commit `618242fe0c`. Dependency changes will disappear from the PR diff as the prerequisite PRs merge and this branch is rebased.