### PR TITLE
[Bugfix][Spec Decode] DFlash2: mark SWA draft KV groups as eagle

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3,6 +3,7 @@
 import copy
 import hashlib
 import importlib
+import math
 from collections.abc import Callable
 from dataclasses import replace
 from types import SimpleNamespace
@@ -23,6 +24,7 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256, sha256_cbor, xxhash, xxhash_cbor
 from vllm.utils.mem_constants import GiB_bytes
+from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -172,6 +174,7 @@ def new_sliding_window_spec(
     dtype=torch.float32,
     page_size_padded=None,
     sliding_window=1,
+    non_causal_multi_token_decode=False,
 ):
     return SlidingWindowSpec(
         block_size=block_size,
@@ -180,6 +183,7 @@ def new_sliding_window_spec(
         dtype=dtype,
         page_size_padded=page_size_padded,
         sliding_window=sliding_window,
+        non_causal_multi_token_decode=non_causal_multi_token_decode,
     )
 
 
@@ -3419,3 +3423,91 @@ def test_deepseek_v4_annotation_requires_model_version():
     )
 
     assert not any(g.is_eagle_group for g in groups)
+
+
+def _qwen38_dflash2_specs(*, mark_draft: bool) -> dict[str, KVCacheSpec]:
+    full = new_kv_cache_spec(block_size=16)
+    mamba = new_mamba_spec(block_size=64, mamba_cache_mode="align")
+    draft = new_sliding_window_spec(
+        block_size=16,
+        sliding_window=2048,
+        non_causal_multi_token_decode=mark_draft,
+    )
+    specs: dict[str, KVCacheSpec] = {}
+    specs.update({f"model.layers.{i}.linear_attn": mamba for i in range(48)})
+    specs.update({f"model.layers.{i}.self_attn": full for i in range(48, 64)})
+    specs.update({f"draft.layers.{i}.self_attn": draft for i in range(5)})
+    return specs
+
+
+def _hybrid_coord(groups: list[KVCacheGroupSpec]):
+    block_sizes = [g.kv_cache_spec.block_size for g in groups]
+    scheduler_block_size = math.lcm(*block_sizes)
+    return get_kv_cache_coordinator(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=8,
+            kv_cache_tensors=[],
+            kv_cache_groups=groups,
+        ),
+        max_model_len=4096,
+        max_in_flight_tokens=256,
+        use_eagle=True,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        scheduler_block_size=scheduler_block_size,
+        hash_block_size=min(block_sizes),
+    )
+
+
+def test_dflash_swa_draft_marks_only_eagle_group():
+    """Qwen3.8 + DFlash2: 48 Mamba + 16 full + 5 draft SWA.
+
+    The general hybrid path must flag only the draft SWA group. Flag-all
+    would mark target full and (after #48375) Mamba groups as eagle.
+    """
+    groups = get_kv_cache_groups(
+        _spec_decode_grouping_config(method="dflash"),
+        _qwen38_dflash2_specs(mark_draft=True),
+    )
+
+    eagle = [g for g in groups if g.is_eagle_group]
+    assert len(eagle) == 1
+    eagle_group = eagle[0]
+    assert isinstance(eagle_group.kv_cache_spec, SlidingWindowSpec)
+    assert eagle_group.kv_cache_spec.non_causal_multi_token_decode
+    assert not getattr(eagle_group.kv_cache_spec, "non_causal", False)
+    assert all(name.startswith("draft.layers.") for name in eagle_group.layer_names)
+    assert all(
+        not g.is_eagle_group for g in groups if isinstance(g.kv_cache_spec, MambaSpec)
+    )
+
+
+def test_dflash_unmarked_swa_flag_all_hybrid_groups():
+    """Main-tree baseline: no draft marker → coordinator flags every group."""
+    groups = get_kv_cache_groups(
+        _spec_decode_grouping_config(method="dflash"),
+        _qwen38_dflash2_specs(mark_draft=False),
+    )
+    assert not any(g.is_eagle_group for g in groups)
+    coord = _hybrid_coord(groups)
+    assert coord.eagle_group_ids == set(range(len(groups)))
+
+
+def test_dflash_marked_swa_stops_hybrid_flag_all():
+    """Draft SWA marker must prevent flag-all on target full and Mamba groups."""
+    groups = get_kv_cache_groups(
+        _spec_decode_grouping_config(method="dflash"),
+        _qwen38_dflash2_specs(mark_draft=True),
+    )
+    coord = _hybrid_coord(groups)
+    eagle_idx = {i for i, g in enumerate(groups) if g.is_eagle_group}
+    assert eagle_idx == coord.eagle_group_ids
+    assert len(eagle_idx) == 1
+    assert isinstance(groups[next(iter(eagle_idx))].kv_cache_spec, SlidingWindowSpec)
+    assert all(
+        i not in coord.eagle_group_ids
+        for i, g in enumerate(groups)
+        if isinstance(g.kv_cache_spec, MambaSpec)
+    )

--- a/tests/v1/spec_decode/test_dflash_causality.py
+++ b/tests/v1/spec_decode/test_dflash_causality.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import pytest
 
 from vllm.model_executor.models.qwen3_dflash import (
+    _dflash_all_layers_sliding,
     _dflash_layer_causal,
     _get_dflash_fc_input_size,
     dflash_has_any_non_causal,
@@ -21,12 +22,22 @@ from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
 )
 
 
-def _config(num_hidden_layers, layer_types=None, causal_override=None, is_causal=None):
-    dflash_config = None if causal_override is None else {"causal": causal_override}
+def _config(
+    num_hidden_layers,
+    layer_types=None,
+    causal_override=None,
+    is_causal=None,
+    use_swa=None,
+):
+    dflash_config = {}
+    if causal_override is not None:
+        dflash_config["causal"] = causal_override
+    if use_swa is not None:
+        dflash_config["use_swa"] = use_swa
     return SimpleNamespace(
         num_hidden_layers=num_hidden_layers,
         layer_types=layer_types,
-        dflash_config=dflash_config,
+        dflash_config=dflash_config or None,
         is_causal=is_causal,
     )
 
@@ -81,6 +92,24 @@ def test_dflash_layer_causal_honors_top_level_override():
     )
     assert _dflash_layer_causal(config, 0) is False
     assert _dflash_layer_causal(config, 1) is False
+
+
+@pytest.mark.parametrize(
+    "config,expected",
+    [
+        (_config(2, layer_types=None, use_swa=True), True),
+        (_config(2, layer_types=None, use_swa=False), False),
+        (_config(2, layer_types=["sliding_attention"] * 2), True),
+        (
+            _config(2, layer_types=["sliding_attention", "full_attention"]),
+            False,
+        ),
+        (_config(2, layer_types=["full_attention"] * 2, use_swa=True), True),
+        (_config(2, layer_types=["full_attention"] * 2, use_swa=False), False),
+    ],
+)
+def test_dflash_all_layers_sliding(config, expected):
+    assert _dflash_all_layers_sliding(config) is expected
 
 
 def _vllm_config(**draft_config):

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -245,6 +245,7 @@ class Attention(nn.Module, AttentionLayerBase):
         mm_prefix_clamp_sliding_window: bool = False,
         attn_backend: type[AttentionBackend] | None = None,
         head_size_v: int | None = None,
+        non_causal_multi_token_decode: bool = False,
         **extra_impl_args,
     ) -> None:
         """
@@ -327,6 +328,7 @@ class Attention(nn.Module, AttentionLayerBase):
         self.head_size_v = self.head_size if head_size_v is None else head_size_v
         self.num_kv_heads = num_kv_heads
         self.sliding_window = sliding_window
+        self.non_causal_multi_token_decode = non_causal_multi_token_decode
         self.has_sink = extra_impl_args.get("sinks") is not None
 
         # NOTE: model_config may be None during certain tests
@@ -629,6 +631,7 @@ class Attention(nn.Module, AttentionLayerBase):
                     dtype=self.kv_cache_torch_dtype,
                     kv_quant_mode=quant_mode,
                     sliding_window=self.sliding_window,
+                    non_causal_multi_token_decode=self.non_causal_multi_token_decode,
                 )
             ).real_page_size_bytes
             sw_block_size = _largest_kernel_block_within(
@@ -643,6 +646,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 kv_quant_mode=quant_mode,
                 sliding_window=self.sliding_window,
                 page_size_padded=shared_page,
+                non_causal_multi_token_decode=self.non_causal_multi_token_decode,
             )
         else:
             return FullAttentionSpec(

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -75,6 +75,17 @@ def dflash_has_any_non_causal(config: Qwen3Config) -> bool:
     )
 
 
+def _dflash_all_layers_sliding(config: Qwen3Config) -> bool:
+    """Whether every draft attention layer resolves to sliding window."""
+    dflash_config = getattr(config, "dflash_config", None) or {}
+    use_swa = dflash_config.get("use_swa", False)
+    layer_types = getattr(config, "layer_types", None)
+    if not layer_types:
+        return use_swa
+    num_sliding = sum(lt == _SLIDING_ATTENTION for lt in layer_types)
+    return num_sliding == len(layer_types) or (use_swa and num_sliding == 0)
+
+
 def dflash_target_rope_is_neox_style(target_model: nn.Module) -> bool | None:
     """The target's RoPE layout, from its first attention layer.
 
@@ -192,6 +203,7 @@ class DFlashQwen3Attention(nn.Module):
         is_neox_style: bool = True,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        non_causal_multi_token_decode: bool = False,
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
     ) -> None:
@@ -255,6 +267,9 @@ class DFlashQwen3Attention(nn.Module):
             prefix=f"{prefix}.attn",
             attn_type=attn_type,
             sinks=self.attention_sink_bias,
+            # Draft-layer marker for HybridKVCacheCoordinator last-block drop.
+            # Not AttentionSpec.non_causal (that disables prefix cache).
+            non_causal_multi_token_decode=non_causal_multi_token_decode,
         )
         self.causal = causal
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
@@ -337,6 +352,10 @@ class DFlashQwen3DecoderLayer(nn.Module):
             head_dim=getattr(config, "head_dim", None),
             cache_config=cache_config,
             quant_config=quant_config,
+            # In a mixed SWA/full drafter, marking only the SWA subset would
+            # suppress the conservative flag-all fallback while leaving full
+            # draft groups unmarked.
+            non_causal_multi_token_decode=_dflash_all_layers_sliding(config),
             rope_parameters=config.rope_parameters,
             prefix=f"{prefix}.self_attn",
             attn_type=attn_type,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -696,6 +696,10 @@ class SlidingWindowSpec(AttentionSpec):
     # re-prefill the last num_spec_prefill_tokens - 1 tokens from the end
     # of the sequence, and thus needs to delay freeing/caching of blocks.
     extra_retained_tokens: int = 0
+    # Same name as MLAAttentionSpec: marks a speculative draft SWA group so
+    # the general hybrid grouping path can set KVCacheGroupSpec.is_eagle_group.
+    # Does not set AttentionSpec.non_causal (that disables prefix cache).
+    non_causal_multi_token_decode: bool = False
 
     def max_admission_blocks_per_request(
         self, max_in_flight_tokens: int, max_model_len: int


### PR DESCRIPTION
## Purpose

#52047 established the generic spec-driven annotation path for draft KV cache
groups, but only `MLAAttentionSpec` publishes its draft marker. An all-sliding
DFlash2 drafter produces `SlidingWindowSpec` groups, so no group is identified
and `HybridKVCacheCoordinator` falls back to treating every target and draft KV
group as eagle.

For Qwen3.8-27B + DFlash2 this means all 15 hybrid groups take eagle handling,
including target full-attention and Mamba groups. The target full-attention
groups then take the last-block drop even though only the draft group contains
draft KV.

This PR:

- adds `non_causal_multi_token_decode` to `SlidingWindowSpec`;
- propagates the marker through `Attention.get_kv_cache_spec()`;
- publishes it from Qwen3 DFlash only when every draft attention layer resolves
  to sliding-window attention.

The all-SWA guard is intentional. On a mixed SWA/full-attention drafter, marking
only the SWA subset would suppress the conservative flag-all fallback while
leaving full-attention draft groups unmarked. Mixed and all-full drafters
therefore retain the existing fallback behavior.

After rebasing onto #52047, this PR does not change `kv_cache_utils.py`; it uses
the merged generic annotator.

## Before / after

Qwen3.8-27B + DFlash2 (48 Mamba + 16 full + 5 draft SWA -> 15 groups):

| | `is_eagle_group` | coordinator `eagle_group_ids` |
|---|---|---|
| before | 0 / 15 | all 15 |
| after | 1 / 15 (draft SWA) | that group only |

## Why this is not a duplicate

- #52047 implements the generic annotator and covers MLA/DSpark; it does not
  expose the marker on `SlidingWindowSpec` or wire Qwen3 DFlash.
- #54163/#54165 change broader DFlash/DSpark cache capability and Mamba/offload
  behavior; this PR only identifies the all-SWA draft group precisely.
- #50457 changes all-sliding DFlash KV allocation to full attention as part of a
  broader coordinator series. It is a different approach and should be
  re-evaluated for composition if it lands first.

No other open PR found by searches for `DFlash SWA draft KV groups eagle` or
`SlidingWindowSpec non_causal_multi_token_decode` implements this wiring.

## Test plan and result

Supported-environment command:

```bash
.venv/bin/python -m pytest \
  tests/v1/core/test_kv_cache_utils.py \
  tests/v1/spec_decode/test_dflash_causality.py \
  -k dflash -v
```

Local Windows run used an import-only `uvloop` stub because `uvloop` is not
available on Windows. Result:

```text
22 passed, 95 deselected
```

The three focused grouping/coordinator regressions passed, along with the DFlash
configuration matrix, including the new all-SWA/mixed/all-full guard cases.
Commit hooks passed Ruff check/format, mypy, SPDX, forbidden-import, CUDA API,
and configuration validation. Unrelated `actionlint` and Docker graph hooks
were skipped because no workflow/Dockerfile files changed and their local
Windows dependencies were unavailable.

## Model / serving evaluation

A real-model GPU A/B has not yet been run after the rebase. The next validation
is repeated-prefix DFlash serving on L20/L40, checking cache-hit counters, draft
acceptance, and output consistency before requesting merge.

## AI assistance disclosure

AI assistance was used for code investigation, rebase/conflict resolution,
review, test design.