### PR TITLE
[Bugfix] Restrict large batch defaults to CUDA GPUs

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -23,6 +23,7 @@ from vllm.engine.arg_utils import (
     optional_type,
     parse_type,
 )
+from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 
@@ -504,6 +505,34 @@ def test_prefix_cache_retention_interval_from_deprecated_env(
     args = parser.parse_args(["--prefix-cache-retention-interval", "32"])
     engine_args = EngineArgs.from_cli_args(args)
     assert engine_args.prefix_cache_retention_interval == 32
+
+
+@pytest.mark.parametrize(
+    ("is_cuda", "device_name", "expected_server_tokens"),
+    [
+        (True, "NVIDIA B200", 16384),
+        (False, "AMD MI300X", 8192),
+    ],
+)
+def test_large_memory_defaults_are_cuda_only(
+    is_cuda: bool, device_name: str, expected_server_tokens: int
+):
+    """Use the largest batch defaults only for CUDA GPUs."""
+    from unittest.mock import MagicMock, patch
+
+    from vllm.utils.mem_constants import GiB_bytes
+
+    mock_platform = MagicMock()
+    mock_platform.get_device_total_memory.return_value = 192 * GiB_bytes
+    mock_platform.get_device_name.return_value = device_name
+    mock_platform.is_cuda.return_value = is_cuda
+    mock_platform.is_tpu.return_value = False
+    mock_platform.is_cpu.return_value = False
+
+    with patch("vllm.engine.arg_utils.current_platform", mock_platform):
+        defaults, _ = EngineArgs.get_batch_defaults(world_size=1)
+
+    assert defaults[UsageContext.OPENAI_API_SERVER] == expected_server_tokens
 
 
 @pytest.mark.parametrize(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2614,8 +2614,9 @@ class EngineArgs:
         # NOTE(Kuntai): Setting large `max_num_batched_tokens` for A100 reduces
         # throughput, see PR #17885 for more details.
         # So here we do an extra device name check to prevent such regression.
-        if device_memory >= 160 * GiB_bytes:
-            # for GPUs like B200/B300 with >= 160GB memory, use the largest defaults
+        if current_platform.is_cuda() and device_memory >= 160 * GiB_bytes:
+            # For CUDA GPUs like B200/B300 with >= 160GB memory, use the
+            # largest defaults.
             default_max_num_batched_tokens = {
                 UsageContext.LLM_CLASS: 16384,
                 UsageContext.OPENAI_API_SERVER: 16384,


### PR DESCRIPTION
## Summary

- Restrict the 160 GiB batch-default tier to CUDA platforms.
- Keep ROCm devices such as MI300X on the existing non-160 GiB defaults.
- Add a CPU-only regression test covering the CUDA and MI300X behaviors.

Fixes #53961

## Why this is not duplicate work

I checked the issue timeline, searched open PR bodies for `53961`, and searched open PRs for `max_num_batched_tokens`. No open PR currently addresses this MI300X regression. An issue comment mentions interest in a focused fix, but no corresponding PR was found.

## Validation

- `VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/engine/test_arg_utils.py -v -k large_memory_defaults_are_cuda_only` — 2 passed.
- `.venv/bin/pre-commit run --files vllm/engine/arg_utils.py tests/engine/test_arg_utils.py` — passed.
- `git diff --check` — passed.
- The complete `tests/engine/test_arg_utils.py` suite was attempted; it stalled in an existing platform/socket-dependent test on this host and was interrupted after 53 tests passed. No test failure was reported.
- No model evaluation was run because this change only selects hardware-specific configuration defaults and does not change model outputs or accuracy.

AI assistance was used for issue investigation, implementation, and test setup. The human submitter must review every changed line and be able to explain and defend the change before merging.
