### PR TITLE
[Kernel] Fix UB type-punning in vectorized_process

### DIFF
--- a/csrc/libtorch_stable/sampler.cu
+++ b/csrc/libtorch_stable/sampler.cu
@@ -107,11 +107,6 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads,
   } else {
     static_assert(sizeof(WideT) % sizeof(T) == 0);
     constexpr int items_per_scalar = sizeof(WideT) / sizeof(T);
-    // TODO: it's UB
-    union {
-      WideT scalar;
-      T array[items_per_scalar];
-    } wide;
 
     int skip_cnt =
         (reinterpret_cast<size_t>(in) % sizeof(WideT))
@@ -125,11 +120,23 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads,
     const idxT len_cast = (len - skip_cnt) / items_per_scalar;
 
     for (idxT i = thread_rank; i < len_cast; i += num_threads) {
-      wide.scalar = in_cast[i];
+      WideT wide_val = in_cast[i];
+
+      T tmp[items_per_scalar];
+
+      const unsigned char* src =
+          reinterpret_cast<const unsigned char*>(&wide_val);
+      unsigned char* dst = reinterpret_cast<unsigned char*>(tmp);
+
+#pragma unroll
+      for (size_t b = 0; b < sizeof(WideT); ++b) {
+        dst[b] = src[b];
+      }
+
       const idxT real_i = skip_cnt + i * items_per_scalar;
 #pragma unroll
       for (int j = 0; j < items_per_scalar; ++j) {
-        f(wide.array[j], real_i + j);
+        f(tmp[j], real_i + j);
       }
     }
 


### PR DESCRIPTION
Replace UB union punning with memcpy-safe copy. All relevant tests in test_top_k_per_row.py and test_indexer_dcp_localize.py passed


## Purpose
Currently, the `vectorized_process` device function utilizes a `union` to type-pun a 128-bit vector load (e.g., `float4`) into an array of scalars (`T array[...]`). While commonly used in C, this is technically Undefined Behavior (UB) in C++. Since we are constrained to C++17 (meaning `std::bit_cast` is unavailable), this PR replaces the union with a strictly standard-compliant approach.

We fix the UB by:
1. Emitting an explicit vector load (`WideT wide_val = in_cast[i];`).
2. Leveraging the C++ standard `unsigned char*` aliasing exception to copy the bytes into a local scalar array. 

Because `sizeof(WideT)` is a compile-time constant, modern compilers (NVCC/LLVM) completely unroll the byte-copy loop and apply SROA (Scalar Replacement of Aggregates). **This results in zero overhead and identical hardware behavior.**

## Test Plan
- Run kernel-specific tests targeting `top_k_per_row_decode`:
  - `pytest tests/kernels/test_top_k_per_row.py`
  - `pytest tests/v1/attention/test_indexer_dcp_localize.py`
- Inspect generated PTX to ensure the `ld.global.v4.f32` (128-bit load) is still successfully emitted and that no local memory spilling occurs.
- Run a custom microbenchmark testing aligned and unaligned memory accesses to ensure no bandwidth regressions.
(Tested on sm_86 1x3070ti 8gb vram)

## Test Result
**1. Pytest:**
All relevant tests passed successfully.
- `tests/kernels/test_top_k_per_row.py`: 119 passed, 54 skipped.
- `tests/v1/attention/test_indexer_dcp_localize.py`: 36 passed.

**2. PTX Verification:**
The generated PTX for both the original UB kernel and this new C++17 SAFE kernel are **100% identical**. Both successfully emit the 128-bit vector load, use the exact same number of registers, and neither kernel spills to thread-local memory.
```
ptx
        // Both kernels generate the exact same core loop memory load
        ld.global.v4.f32        {%f1, %f2, %f3, %f4}, [%rd19];
```

Starting benchmark (100 iterations per test)...
----------------------------------------------------------------------
UB     | Offset: 0 | Len: 100000000 | Time: 2.041 ms | B/W: 392.03 GB/s
SAFE   | Offset: 0 | Len: 100000000 | Time: 2.051 ms | B/W: 390.00 GB/s
----------------------------------------------------------------------
UB     | Offset: 1 | Len: 100000000 | Time: 2.113 ms | B/W: 378.60 GB/s
SAFE   | Offset: 1 | Len: 100000000 | Time: 2.111 ms | B/W: 379.01 GB/s
----------------------------------------------------------------------
UB     | Offset: 2 | Len: 100000007 | Time: 2.116 ms | B/W: 378.12 GB/s
SAFE   | Offset: 2 | Len: 100000007 | Time: 2.113 ms | B/W: 378.63 GB/s
----------------------------------------------------------------------
---
Detailed benchmark code and results are in the attached benchmarkTPunAndSafe.txt
Detailed PTX analysis is in the godboltPTX.txt file.
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

