### PR TITLE
[WIP][Model] Add upcoming XingChen4 model support

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -340,6 +340,7 @@ class SpeculativeConfig:
             "deepseek_v3",
             "deepseek_v32",
             "glm_moe_dsa",
+            "xingchen4",
         ):
             hf_config.model_type = "deepseek_mtp"
         if hf_config.model_type == "deepseek_mtp":

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -214,6 +214,7 @@ _TEXT_GENERATION_MODELS = {
     "TeleChat2ForCausalLM": ("telechat2", "TeleChat2ForCausalLM"),
     "TeleChat3ForCausalLM": ("llama", "LlamaForCausalLM"),
     "TeleFLMForCausalLM": ("teleflm", "TeleFLMForCausalLM"),
+    "XingChen4ForCausalLM": ("xingchen4", "XingChen4ForCausalLM"),
     "Zamba2ForCausalLM": ("zamba2", "Zamba2ForCausalLM"),
 }
 

--- a/vllm/model_executor/models/xingchen4.py
+++ b/vllm/model_executor/models/xingchen4.py
@@ -1,0 +1,750 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inference-only XingChen4 model.
+
+XingChen4 reuses the DeepSeek-V2/V3 backbone (MLA attention, MoE block,
+optional DSA indexer) and replaces the standard residual connection with
+Manifold-constrained Hyper-Connections (mHC): the residual stream is expanded
+into ``num_residual_streams`` parallel streams that are mixed by
+input-dependent, doubly-stochastic matrices produced by a Sinkhorn-Knopp
+projection.
+
+The mHC math is identical to DeepSeek-V4's, so instead of private kernels this
+implementation reuses the shared, platform-dispatched ops from
+``vllm.model_executor.layers.mhc`` (``mhc_pre`` / ``mhc_post``).
+A local custom op (``XingChen4_transpose_contiguous``) ensures the transposed
+``comb_mix`` is C-contiguous for the tilelang ``mhc_post`` kernel in a way that
+``torch.compile`` cannot elide.
+Checkpoint-to-op parameter mapping:
+
+    fn       <- {attn,ffn}_hc.mapping_weight  (fp32, (n^2 + 2n, n*C))
+    hc_scale <- [alpha_pre, alpha_post, alpha_res]  (fp32, (3,))
+    hc_base  <- {attn,ffn}_hc.bias            (fp32, (n^2 + 2n,))
+
+Both DSA (``model_type=deepseek_v32`` with ``index_topk`` and
+``index_n_heads``) and non-DSA (``model_type=deepseek_v3``) variants are
+supported. DSA detection requires both ``index_topk`` and ``index_n_heads``
+to be present in the config.
+"""
+
+from collections.abc import Iterable
+from itertools import islice
+from typing import Optional
+import os
+
+import torch
+from torch import nn
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.deepseek_v2 import (
+    DeepseekV2Attention,
+    DeepseekV2ForCausalLM,
+    DeepseekV2MLAAttention,
+    DeepseekV2MLP,
+    DeepseekV2Model,
+    DeepseekV2MoE,
+)
+from vllm.model_executor.models.utils import (
+    PPMissingLayer,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+)
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+
+from vllm.model_executor.layers.mhc import MHCPostOp, MHCPreOp
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.logger import init_logger
+logger = init_logger(__name__)
+
+
+if os.getenv("USE_FLAGOS") == "1":
+    import flag_gems
+    FLAG_GEMS_CONFIG = [
+        "arange_start",
+        "pow_scalar",
+        "rand_like",
+        "argmax",
+        "softmax",
+        "softmax_out",
+        "cumsum_out",
+        "moe_align_block_size",
+        "invoke_fused_moe_triton_kernel",
+        "topk_softmax",
+        "grouped_topk",
+        "moe_sum",
+    ]
+    flag_gems.only_enable(record=False, include=FLAG_GEMS_CONFIG)
+    logger.info("XingChen4: Flaggems is enabled.")
+
+# comb_mix must be transposed and C-contiguous for the mhc_post tilelang
+# kernel (requires strides[-1] == 1).  Wrapping transpose+contiguous in a
+# custom op prevents torch.compile from eliding the .contiguous() call,
+# which it would otherwise do since the downstream MHCPostOp is opaque.
+
+def _xingchen4_transpose_contiguous(x: torch.Tensor) -> torch.Tensor:
+    """Transpose last two dims and enforce C-contiguity."""
+    return x.transpose(-1, -2).contiguous()
+
+
+def _xingchen4_transpose_contiguous_fake(x: torch.Tensor) -> torch.Tensor:
+    """Abstract impl for torch.compile / meta tracing."""
+    shape = list(x.shape)
+    shape[-1], shape[-2] = shape[-2], shape[-1]
+    return torch.empty(shape, dtype=x.dtype, device=x.device)
+
+
+direct_register_custom_op(
+    op_name="xingchen4_transpose_contiguous",
+    op_func=_xingchen4_transpose_contiguous,
+    mutates_args=[],
+    fake_impl=_xingchen4_transpose_contiguous_fake,
+)
+
+
+def _xingchen4_ensure_contiguous(x: torch.Tensor) -> torch.Tensor:
+    """Dispatch to the registered custom op (opaque to torch.compile)."""
+    return torch.ops.vllm.xingchen4_transpose_contiguous(x)
+
+
+# ============================== mHC adapter ==============================
+
+
+class XingChen4MHC(nn.Module):
+    """mHC (Manifold-constrained Hyper-Connections) wrapper.
+
+    Delegates computation to MHCPreOp and MHCPostOp, which dispatch to
+    optimized TileLang/Triton/PyTorch kernels.
+
+    API:
+      - forward(hidden_states) -> (aggregated, h_res, h_post)
+      - fused_h_res_h_post_bda_inference(...) -> updated residual
+    """
+
+    def __init__(self, config) -> None:
+        super().__init__()
+        self.n = config.num_residual_streams
+        self.hidden_size = config.hidden_size
+        self.sinkhorn_iterations = getattr(
+            config, "mhc_sinkhorn_iterations", 20)
+        self.norm_eps = getattr(config, "mhc_norm_eps", 1e-6)
+        self.pre_eps = getattr(config, "mhc_pre_eps", 1e-6)
+        self.post_mult_value = getattr(config, "mhc_post_mult_value", 2.0)
+        self.h_res_clamp_min = getattr(
+            config, "mhc_h_res_clamp_min", None)
+        self.h_res_clamp_max = getattr(
+            config, "mhc_h_res_clamp_max", None)
+
+        hc_dim = self.n * self.hidden_size
+        mix_hc = self.n * self.n + 2 * self.n
+
+        # Weights stored as float32 to preserve full precision from
+        # checkpoint.  If these were created as the default dtype
+        # (bfloat16), vLLM would truncate float32 checkpoint weights to
+        # bfloat16 during loading, causing precision loss.
+        self.hc_fn = nn.Parameter(
+            torch.empty(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_scale = nn.Parameter(
+            torch.full((3,),
+                       getattr(config, "mhc_init_gating_factor", 0.01),
+                       dtype=torch.float32))
+        self.hc_base = nn.Parameter(
+            torch.zeros(mix_hc, dtype=torch.float32))
+
+        # MHC ops (stateless -- weights are passed as tensor args)
+        self.mhc_pre = MHCPreOp()
+        self.mhc_post = MHCPostOp()
+
+    def forward(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Compute mHC pre-mixing: aggregate n-stream -> 1-stream.
+
+        Args:
+            hidden_states: [nt, n*C] - n-stream hidden states (flattened)
+        Returns:
+            aggregated: [nt, C] - single-stream input for the sub-layer
+            h_res: [nt, n, n] - residual mixing matrix (comb_mix)
+            h_post: [nt, n, 1] - stream expansion weights (post_mix)
+        """
+        n = self.n
+        C = self.hidden_size
+
+        # Keep flattened: [nt, n*C] -> [nt, n, C]
+        residual = hidden_states.reshape(-1, n, C)
+
+        # MHCPreOp: compute mix weights and aggregated input.
+        post_mix, comb_mix, layer_input = self.mhc_pre(
+            residual=residual,
+            fn=self.hc_fn,
+            hc_scale=self.hc_scale,
+            hc_base=self.hc_base,
+            rms_eps=self.norm_eps,
+            hc_pre_eps=self.pre_eps,
+            hc_sinkhorn_eps=self.norm_eps,
+            hc_post_mult_value=self.post_mult_value,
+            sinkhorn_repeat=self.sinkhorn_iterations,
+            # clamp_min=self.h_res_clamp_min,
+            # clamp_max=self.h_res_clamp_max,
+        )
+        # Transpose and ensure C-contiguity via custom op (see comment above).
+        comb_mix = _xingchen4_ensure_contiguous(comb_mix)
+        # layer_input: [nt, C], comb_mix: [nt, n, n], post_mix: [nt, n, 1]
+        return layer_input, comb_mix, post_mix
+
+    def fused_h_res_h_post_bda_inference(
+        self,
+        h_res: torch.Tensor,
+        original_residual: torch.Tensor,
+        h_post: torch.Tensor,
+        layer_output_with_bias: tuple[torch.Tensor, torch.Tensor | None],
+    ) -> torch.Tensor:
+        """
+        Fused residual mixing + post expansion + bias-dropout-add.
+
+        Args:
+            h_res: [nt, n, n] - comb_mix from forward()
+            original_residual: [nt, n*C] - the n-stream input before aggregation
+            h_post: [nt, n, 1] - post_mix from forward()
+            layer_output_with_bias: (x [nt,C], bias None)
+        Returns:
+            output: [nt, n*C] - updated n-stream residual for next layer
+        """
+        x, _ = layer_output_with_bias
+
+        n = self.n
+        C = self.hidden_size
+
+        # All inputs are already flattened: reshape to [nt, n, C] for mhc_post
+        residual = original_residual.reshape(-1, n, C)
+
+        # h_res (comb_mix) is already C-contiguous from forward().
+        new_residual = self.mhc_post(x, residual, h_post, h_res)
+        # new_residual: [nt, n, C], flatten back to [nt, n*C]
+        return new_residual.reshape(-1, n * C)
+
+
+# ============================== Helpers ==============================
+
+
+def input_expand(x: torch.Tensor, n: int) -> torch.Tensor:
+    """(T, C) -> (T, n*C): replicate the single stream into n streams."""
+    T, C = x.shape
+    return x.unsqueeze(1).expand(T, n, C).reshape(T, n * C)
+
+
+def output_contract(x: torch.Tensor, n: int) -> torch.Tensor:
+    """(T, n*C) -> (T, C): average the n streams back into one."""
+    T, nC = x.shape
+    return x.view(T, n, nC // n).mean(dim=1)
+
+
+def _get_llama_4_scaling(
+    original_max_position_embeddings: int,
+    scaling_beta: float,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    scaling = 1 + scaling_beta * torch.log(
+        1 + torch.floor(positions / original_max_position_embeddings))
+    return scaling[..., None, None]
+
+
+# ============================ Decoder Layer ============================
+
+
+class XingChen4DecoderLayer(nn.Module):
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str,
+        config=None,
+        topk_indices_buffer: Optional[torch.Tensor] = None,
+    ) -> None:
+        super().__init__()
+        if config is None:
+            config = vllm_config.model_config.hf_config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        parallel_config = vllm_config.parallel_config
+
+        self.hidden_size = config.hidden_size
+        max_position_embeddings = getattr(config, "max_position_embeddings",
+                                          8192)
+        moe_layer_freq = getattr(config, "moe_layer_freq", 1)
+        layer_idx = int(prefix.split(sep=".")[-1])
+        self.layer_idx = layer_idx
+
+        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
+        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
+        v_head_dim = getattr(config, "v_head_dim", 0)
+        kv_lora_rank = getattr(config, "kv_lora_rank", 0)
+        use_mha = config.model_type == "deepseek" or all(
+            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim))
+        self.use_mha = use_mha
+
+        if use_mha:
+            attn_cls = DeepseekV2Attention
+        elif model_config.use_mla:
+            attn_cls = DeepseekV2MLAAttention
+        else:
+            attn_cls = DeepseekV2Attention
+
+        self.self_attn = attn_cls(
+            vllm_config=vllm_config,
+            config=config,
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            q_lora_rank=config.q_lora_rank if hasattr(config, "q_lora_rank")
+            else None,
+            kv_lora_rank=kv_lora_rank,
+            max_position_embeddings=max_position_embeddings,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+            topk_indices_buffer=topk_indices_buffer,
+        )
+
+        if (config.n_routed_experts is not None
+                and layer_idx >= config.first_k_dense_replace
+                and layer_idx % moe_layer_freq == 0):
+            self.mlp = DeepseekV2MoE(
+                config=config,
+                parallel_config=parallel_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+        else:
+            self.mlp = DeepseekV2MLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+
+        self.input_layernorm = RMSNorm(config.hidden_size,
+                                       eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size,
+                                                eps=config.rms_norm_eps)
+        self.routed_scaling_factor = getattr(config, "routed_scaling_factor",
+                                             1.0)
+
+        self.n = getattr(config, "num_residual_streams", 1)
+        self.enable_mhc = self.n > 1
+        if self.enable_mhc:
+            self.attn_hc = XingChen4MHC(config)
+            self.ffn_hc = XingChen4MHC(config)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        llama_4_scaling: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if self.enable_mhc:
+            # mHC mode: hidden_states carries the flattened streams
+            # (T, n*C); the `residual` argument is unused because the
+            # streams themselves play the residual role.
+            origin_hidden_states = hidden_states
+
+            # --- attention sub-block ---
+            aggregated, attn_h_res, attn_h_post = self.attn_hc(
+                origin_hidden_states)
+            attn_kwargs = {
+                "positions": positions,
+                "hidden_states": self.input_layernorm(aggregated),
+            }
+            if not self.use_mha:
+                attn_kwargs["llama_4_scaling"] = llama_4_scaling
+            attn_out = self.self_attn(**attn_kwargs)
+            if (not isinstance(self.self_attn, DeepseekV2Attention)
+                    and attn_out.dtype == torch.float16):
+                attn_out = attn_out * (1.0 / self.routed_scaling_factor)
+
+            # Fused residual mixing + post expansion for attention.
+            hidden_states = self.attn_hc.fused_h_res_h_post_bda_inference(
+                h_res=attn_h_res,
+                original_residual=origin_hidden_states,
+                h_post=attn_h_post,
+                layer_output_with_bias=(attn_out, None),
+            )
+
+            # --- MLP sub-block ---
+            aggregated, mlp_h_res, mlp_h_post = self.ffn_hc(
+                hidden_states)
+            mlp_out = self.mlp(self.post_attention_layernorm(aggregated))
+            if (isinstance(self.mlp, DeepseekV2MLP)
+                    and mlp_out.dtype == torch.float16):
+                mlp_out = mlp_out * (1.0 / self.routed_scaling_factor)
+
+            # Fused residual mixing + post expansion for MLP.
+            hidden_states = self.ffn_hc.fused_h_res_h_post_bda_inference(
+                h_res=mlp_h_res,
+                original_residual=hidden_states,
+                h_post=mlp_h_post,
+                layer_output_with_bias=(mlp_out, None),
+            )
+
+            return hidden_states, residual
+
+        # --- standard (non-mHC) path, same as DeepseekV2 ---
+        if residual is None:
+            residual = hidden_states.clone()
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(
+                hidden_states, residual)
+
+        attn_kwargs = {
+            "positions": positions,
+            "hidden_states": hidden_states,
+        }
+        if not self.use_mha:
+            attn_kwargs["llama_4_scaling"] = llama_4_scaling
+        hidden_states = self.self_attn(**attn_kwargs)
+
+        if (not isinstance(self.self_attn, DeepseekV2Attention)
+                and hidden_states.dtype == torch.float16):
+            hidden_states *= 1.0 / self.routed_scaling_factor
+            if self.layer_idx == 0:
+                residual *= 1.0 / self.routed_scaling_factor
+
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+
+        if (isinstance(self.mlp, DeepseekV2MLP)
+                and hidden_states.dtype == torch.float16):
+            hidden_states *= 1.0 / self.routed_scaling_factor
+
+        return hidden_states, residual
+
+
+# ============================== Model ==============================
+
+
+@support_torch_compile
+class XingChen4Model(nn.Module):
+    fall_back_to_pt_during_load = False
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+        self.device = current_platform.device_type
+
+        # Backward compatibility: older XingChen4 configs describe RoPE with
+        # `rope_scaling` while vLLM's DeepSeek attention expects
+        # `rope_parameters`. TODO: drop this once the released config.json
+        # natively provides `rope_parameters`.
+        if not hasattr(config, "rope_parameters") and hasattr(config,
+                                                              "rope_scaling"):
+            rs = config.rope_scaling or {}
+            rope_type = rs.get("type", "default")
+            if rope_type == "rope":
+                rope_type = "deepseek_yarn"
+            config.rope_parameters = {
+                "rope_type": rope_type,
+                "factor": rs.get("factor", 1.0),
+                "original_max_position_embeddings": rs.get(
+                    "original_max_position_embeddings", 4096),
+                "beta_fast": rs.get("beta_fast", 32),
+                "beta_slow": rs.get("beta_slow", 1),
+                "mscale": rs.get("mscale", 1.0),
+                "mscale_all_dim": rs.get("mscale_all_dim", 0),
+                "apply_yarn_scaling": rope_type in ("yarn", "deepseek_yarn"),
+            }
+
+        self.vocab_size = config.vocab_size
+        self.is_v32 = (
+            getattr(config, "index_topk", None) is not None
+            and getattr(config, "index_n_heads", None) is not None
+        )
+        if self.is_v32:
+            topk_tokens = config.index_topk
+            topk_indices_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                topk_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
+        else:
+            topk_indices_buffer = None
+            # Non-DSA checkpoints may carry DSA fields set to ``null`` in
+            # config.json (e.g. ``index_topk: null``).  ``hasattr`` returns
+            # True for attributes whose value is None, so the base class
+            # DeepseekV2MLAAttention — which checks
+            # ``hasattr(config, "index_topk")`` — would falsely detect a DSA
+            # model and crash inside Indexer with NoneType * NoneType.
+            # Delete all stale DSA attributes whose value is None so that
+            # downstream classes see a clean non-DSA config.
+            for _attr in ("index_topk", "index_n_heads", "index_head_dim"):
+                if hasattr(config, _attr) and getattr(config, _attr) is None:
+                    delattr(config, _attr)
+                    logger.info(
+                        "xingchen4: non-DSA checkpoint has stale '%s' "
+                        "set to None; deleted to prevent false DSA "
+                        "detection.", _attr)
+
+        if get_pp_group().is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            lambda prefix: XingChen4DecoderLayer(
+                vllm_config,
+                prefix,
+                topk_indices_buffer=topk_indices_buffer,
+            ),
+            prefix=f"{prefix}.layers",
+        )
+
+        if get_pp_group().is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+
+        self.make_empty_intermediate_tensors = (
+            make_empty_intermediate_tensors_factory(
+                ["hidden_states", "residual"], config.hidden_size))
+
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
+
+        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
+        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
+        self.is_fused_shared_expert_enabled = False
+        self.use_mha = config.model_type == "deepseek" or all(
+            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim))
+        self.num_redundant_experts = (
+            vllm_config.parallel_config.eplb_config.num_redundant_experts)
+        self.num_residual_streams = getattr(config, "num_residual_streams", 1)
+
+        if self.num_residual_streams > 1:
+            # The shared mHC ops assert bfloat16 inputs (they were built for
+            # DeepSeek-V4, which is bf16-only).
+            model_dtype = vllm_config.model_config.dtype
+            if model_dtype != torch.bfloat16:
+                raise ValueError(
+                    "XingChen4 mHC (num_residual_streams > 1) requires "
+                    f"bfloat16, got {model_dtype}. The shared mHC ops in "
+                    "vllm.model_executor.layers.mhc are bf16-only.")
+            # In mHC mode the inter-layer tensor is n*hidden_size wide and
+            # carries no separate `residual`, which the current PP
+            # intermediate-tensor plumbing does not support.
+            if vllm_config.parallel_config.pipeline_parallel_size > 1:
+                raise NotImplementedError(
+                    "XingChen4 mHC (num_residual_streams > 1) does not "
+                    "support pipeline parallelism yet.")
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor],
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors],
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                if input_ids is None:
+                    raise ValueError(
+                        "Either input_ids or inputs_embeds must be provided "
+                        "to XingChen4Model.forward")
+                hidden_states = self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        llama_4_scaling_config = getattr(self.config, "llama_4_scaling", None)
+        llama_4_scaling: Optional[torch.Tensor]
+        if llama_4_scaling_config is not None:
+            llama_4_scaling = _get_llama_4_scaling(
+                original_max_position_embeddings=llama_4_scaling_config[
+                    "original_max_position_embeddings"],
+                scaling_beta=llama_4_scaling_config["beta"],
+                positions=positions,
+            )
+        else:
+            llama_4_scaling = None
+
+        n_streams = self.num_residual_streams
+        if n_streams > 1:
+            hidden_states = input_expand(hidden_states, n_streams)
+
+        aux_hidden_states = []
+        for idx, layer in enumerate(
+                islice(self.layers, self.start_layer, self.end_layer),
+                start=self.start_layer,
+        ):
+            if idx in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states + residual)
+            hidden_states, residual = layer(positions, hidden_states, residual,
+                                            llama_4_scaling)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual})
+
+        if n_streams > 1:
+            hidden_states = output_contract(hidden_states, n_streams)
+            # mHC mode never populated `residual`; final RMSNorm is single-arg.
+            hidden_states = self.norm(hidden_states)
+        else:
+            hidden_states = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+        """Load XingChen4 weights.
+
+        1. Pre-process: merge alpha_{pre,post,res} into hc_scale (float32).
+        2. Name remapping: mapping_weight -> hc_fn, bias -> hc_base.
+        3. mHC weights ({attn,ffn}_hc.*) are loaded manually here so that
+           DeepseekV2Model.load_weights' stacked_params_mapping never sees
+           them.
+        4. Everything else is delegated to DeepseekV2Model.load_weights.
+        """
+        weights = list(weights)
+        params_dict = dict(self.named_parameters())
+
+        # 1. Pre-process: merge alpha_{pre,post,res} into hc_scale.
+        # Old checkpoints have separate alpha_pre/post/res (1,) per mHC
+        # module.  Merge them into a single hc_scale [3] tensor in float32
+        # to preserve full precision.
+        alpha_groups: dict[str, dict[int, torch.Tensor]] = {}
+        filtered_weights = []
+        for name, tensor in weights:
+            if name.endswith("alpha_pre"):
+                key = name[:-len("alpha_pre")]
+                alpha_groups.setdefault(key, {})[0] = tensor
+            elif name.endswith("alpha_post"):
+                key = name[:-len("alpha_post")]
+                alpha_groups.setdefault(key, {})[1] = tensor
+            elif name.endswith("alpha_res"):
+                key = name[:-len("alpha_res")]
+                alpha_groups.setdefault(key, {})[2] = tensor
+            else:
+                filtered_weights.append((name, tensor))
+        for prefix, alphas in alpha_groups.items():
+            hc_scale_key = f"{prefix}hc_scale"
+            if hc_scale_key not in params_dict:
+                continue
+            if 0 in alphas and 1 in alphas and 2 in alphas:
+                hc_scale = torch.stack(
+                    [alphas[0].view(()), alphas[1].view(()),
+                     alphas[2].view(())]).to(dtype=torch.float32)
+                filtered_weights.append((hc_scale_key, hc_scale))
+        weights = filtered_weights
+
+        # 2. split mHC weights from the rest, apply name remapping
+        processed_weights = []
+        hc_weights = []
+
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            # name remapping
+            if "indexer.k_norm_bias" in name:
+                name = name.replace("indexer.k_norm_bias",
+                                    "indexer.k_norm.bias")
+
+            # Legacy checkpoints may carry split pre/post/res biases; only
+            # the merged bias (remapped to hc_base) is used.
+            skip_patterns = (
+                "attn_hc.bias_pre", "attn_hc.bias_post", "attn_hc.bias_res",
+                "ffn_hc.bias_pre", "ffn_hc.bias_post", "ffn_hc.bias_res",
+            )
+            if any(p in name for p in skip_patterns):
+                continue
+
+            # Remap old parameter names to new float32 parameters.
+            # These are mutually exclusive: a name ending in mapping_weight
+            # is remapped to hc_fn; a name ending in _hc.bias is remapped
+            # to hc_base. Using elif avoids accidental double-remapping.
+            if name.endswith("mapping_weight"):
+                name = name.replace("mapping_weight", "hc_fn")
+            if name.endswith("_hc.bias"):
+                name = name.replace(".bias", ".hc_base")
+
+            # split mHC weights from the rest
+            if "attn_hc" in name or "ffn_hc" in name:
+                hc_weights.append((name, loaded_weight))
+            else:
+                processed_weights.append((name, loaded_weight))
+
+        # 3. manual mHC load
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in hc_weights:
+            if name not in params_dict:
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader",
+                                    default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        # 4. everything else via DeepseekV2Model
+        other_loaded = DeepseekV2Model.load_weights(self, processed_weights)
+        loaded_params.update(other_loaded)
+
+        return loaded_params
+
+
+# ============================ Causal LM ============================
+
+
+class XingChen4ForCausalLM(DeepseekV2ForCausalLM):
+    model_cls = XingChen4Model
+    packed_modules_mapping = {
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def set_moe_parameters(self):
+        """Override for XingChen4DecoderLayer (not a DeepseekV2DecoderLayer
+        instance)."""
+        self.expert_weights = []
+        self.num_expert_groups = getattr(self.config, "n_group", 1)
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            if hasattr(layer, "mlp") and isinstance(layer.mlp, DeepseekV2MoE):
+                example_moe = layer.mlp
+                self.moe_mlp_layers.append(layer.mlp)
+                self.moe_layers.append(layer.mlp.experts)
+        if example_moe is not None:
+            self.extract_moe_parameters(example_moe)

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -20,6 +20,10 @@ Example:
 
 
 _REASONING_PARSERS_TO_REGISTER = {
+    "xingchen4": (
+        "xingchen4_reasoning_parser",
+        "XingChen4ReasoningParser",
+    ),
     "deepseek_r1": (  # name
         "deepseek_r1_reasoning_parser",  # filename
         "DeepSeekR1ReasoningParser",  # class_name

--- a/vllm/reasoning/xingchen4_reasoning_parser.py
+++ b/vllm/reasoning/xingchen4_reasoning_parser.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright The XingChen Authors.
+#
+# Reasoning parser plugin for XingChen4 models.
+# Usage:
+#   vllm serve <model> \
+#       --reasoning-parser xingchen4 \
+#       --reasoning-parser-plugin xingchen4_reasoning_parser.py
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.reasoning.abs_reasoning_parsers import (
+    ReasoningParser,
+    ReasoningParserManager,
+)
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import (
+        ChatCompletionRequest,
+    )
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+    from vllm.tokenizers import TokenizerLike
+
+START_THINK = "<think>"
+END_THINK = "</think>"
+
+
+@ReasoningParserManager.register_module("xingchen4")
+class XingChen4ReasoningParser(ReasoningParser):
+    """Reasoning parser for xingchen4 models.
+
+    NOTE: the chat template injects the ``<think>`` / ``</think>`` markers into
+    the *prompt* via ``add_generation_prompt``; the model itself does not emit
+    the opening ``<think>``. As a result the generated text looks like:
+
+    * thinking enabled  → ``…reasoning…</think>content`` (contains ``</think>``)
+    * thinking disabled → ``content`` (NO marker at all — ``</think>`` already
+      lives at the tail of the prompt)
+
+    Therefore the only reliable signal in the generated output is whether
+    ``</think>`` is present. When it is absent the whole output is content.
+    """
+
+    def __init__(self, tokenizer: "TokenizerLike", *args, **kwargs):
+        super().__init__(tokenizer, *args, **kwargs)
+        if not self.model_tokenizer:
+            raise ValueError(
+                "XingChen4ReasoningParser requires a valid tokenizer."
+            )
+
+        # Per-request flag, refreshed in ``adjust_request``. When the caller
+        # explicitly disables thinking, the generated output is pure content
+        # and contains no ``</think>`` marker. Defaults to ``False`` (thinking
+        # on) so behaviour stays safe even if ``adjust_request`` is not called.
+        self._reasoning_disabled: bool = False
+
+        self.start_token = START_THINK
+        self.end_token = END_THINK
+
+        start_id = self.vocab.get(self.start_token)
+        end_id = self.vocab.get(self.end_token)
+
+        if start_id is None:
+            raise RuntimeError(
+                f"XingChen4ReasoningParser: '{self.start_token}' not found "
+                "in tokenizer vocabulary."
+            )
+        if end_id is None:
+            raise RuntimeError(
+                f"XingChen4ReasoningParser: '{self.end_token}' not found "
+                "in tokenizer vocabulary."
+            )
+
+        self.start_token_id: int = start_id
+        self.end_token_id: int = end_id
+
+    # ------------------------------------------------------------------
+    # Per-request setup
+    # ------------------------------------------------------------------
+
+    def adjust_request(self, request):
+        """Capture whether thinking is disabled for this request.
+
+        Clients toggle thinking via
+        ``extra_body={"chat_template_kwargs": {"enable_thinking": False}}``.
+        We refresh the flag on every request so a shared parser instance can
+        never leak state between requests.
+        """
+        request.skip_special_tokens = False
+        enabled = True
+        kwargs = getattr(request, "chat_template_kwargs", None)
+        if isinstance(kwargs, dict):
+            value = kwargs.get("enable_thinking", kwargs.get("thinking"))
+            if value is not None:
+                enabled = bool(value)
+        self._reasoning_disabled = not enabled
+        return request
+
+    # ------------------------------------------------------------------
+    # Properties used by structured-output engines (xgrammar, etc.)
+    # ------------------------------------------------------------------
+
+    @property
+    def reasoning_start_str(self) -> str:
+        return self.start_token
+
+    @property
+    def reasoning_end_str(self) -> str:
+        return self.end_token
+
+    # ------------------------------------------------------------------
+    # Token-level checks for structured output engines
+    # ------------------------------------------------------------------
+
+    def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
+        for i in range(len(input_ids) - 1, -1, -1):
+            if input_ids[i] == self.start_token_id:
+                return False
+            if input_ids[i] == self.end_token_id:
+                return True
+        return False
+
+    def is_reasoning_end_streaming(
+        self,
+        input_ids: Sequence[int],
+        delta_ids: Sequence[int],
+    ) -> bool:
+        return self.end_token_id in delta_ids
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        if self.end_token_id in input_ids[:-1]:
+            return input_ids[input_ids.index(self.end_token_id) + 1 :]
+        return []
+
+    # ------------------------------------------------------------------
+    # Non-streaming extraction
+    # ------------------------------------------------------------------
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: "ChatCompletionRequest | ResponsesRequest",
+    ) -> tuple[str | None, str | None]:
+        # ``<think>`` lives in the prompt, so strip it if it somehow appears.
+        before, sep, after = model_output.partition(self.start_token)
+        text = after if sep else before
+
+        # No ``</think>`` in the generated output means thinking was disabled
+        # (the marker already sits at the end of the prompt). The whole output
+        # is regular content, not reasoning.
+        if self.end_token not in text:
+            if self._reasoning_disabled:
+                return None, text or None    # → reasoning=None, content=text (thinking off)
+            return text or None, None
+
+        reasoning, _, content = text.partition(self.end_token)
+        return reasoning or None, content or None
+
+    # ------------------------------------------------------------------
+    # Streaming extraction
+    # ------------------------------------------------------------------
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        # Thinking disabled: the output is pure content, no markers appear.
+        if self._reasoning_disabled and self.end_token_id not in current_token_ids:
+            return DeltaMessage(content=delta_text) if delta_text else None
+
+        # Skip lone special tokens (start / end markers emitted solo).
+        if len(delta_token_ids) == 1 and delta_token_ids[0] in (
+            self.start_token_id,
+            self.end_token_id,
+        ):
+            return None
+
+        has_start_prev = self.start_token_id in previous_token_ids
+        has_start_delta = self.start_token_id in delta_token_ids
+        has_end_prev = self.end_token_id in previous_token_ids
+        has_end_delta = self.end_token_id in delta_token_ids
+
+        # ---- Case 1: <think> was already seen in previous tokens ----
+        if has_start_prev:
+            if has_end_delta:
+                end_idx = delta_text.find(self.end_token)
+                reasoning = delta_text[:end_idx]
+                content = delta_text[end_idx + len(self.end_token) :]
+                return DeltaMessage(
+                    reasoning=reasoning or None,
+                    content=content or None,
+                )
+            if has_end_prev:
+                return DeltaMessage(content=delta_text)
+            return DeltaMessage(reasoning=delta_text)
+
+        # ---- Case 2: <think> appears in the current delta ----
+        if has_start_delta:
+            start_idx = delta_text.find(self.start_token)
+            if has_end_delta:
+                end_idx = delta_text.find(self.end_token)
+                if start_idx == -1 or end_idx == -1:
+                    return DeltaMessage(reasoning=delta_text)
+                reasoning = delta_text[
+                    start_idx + len(self.start_token) : end_idx
+                ]
+                content = delta_text[end_idx + len(self.end_token) :]
+                return DeltaMessage(
+                    reasoning=reasoning or None,
+                    content=content or None,
+                )
+            reasoning = (
+                delta_text[start_idx + len(self.start_token) :]
+                if start_idx != -1
+                else delta_text
+            )
+            return DeltaMessage(reasoning=reasoning or None)
+
+        # ---- Case 3: no <think> at all (thinking-off / skip mode) ----
+        # The template generates </think> immediately; everything after
+        # that marker is regular content.
+        if has_end_delta:
+            end_idx = delta_text.find(self.end_token)
+            reasoning = delta_text[:end_idx]
+            content = delta_text[end_idx + len(self.end_token) :]
+            return DeltaMessage(
+                reasoning=reasoning or None,
+                content=content or None,
+            )
+        if has_end_prev:
+            return DeltaMessage(content=delta_text)
+
+        # Fallback: treat everything as reasoning (we haven't seen
+        # any marker yet — shouldn't happen in normal flow).
+        return DeltaMessage(reasoning=delta_text)
+
+    # ------------------------------------------------------------------
+    # Reasoning token counting
+    # ------------------------------------------------------------------
+
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        if (
+            self.end_token_id in token_ids
+            and self.start_token_id not in token_ids[: token_ids.index(self.end_token_id)]
+        ):
+            return token_ids.index(self.end_token_id)
+
+        count = 0
+        depth = 0
+        for tid in token_ids:
+            if tid == self.start_token_id:
+                depth += 1
+                continue
+            if tid == self.end_token_id:
+                if depth > 0:
+                    depth -= 1
+                continue
+            if depth > 0:
+                count += 1
+        return count

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -206,6 +206,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "apertus_tool_parser",
         "ApertusToolParser",
     ),
+    "xingchen4": (
+        "xingchen4_tool_parser",
+        "XingChen4ToolParser",
+    ),
 }
 
 

--- a/vllm/tool_parsers/xingchen4_tool_parser.py
+++ b/vllm/tool_parsers/xingchen4_tool_parser.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
+
+logger = init_logger(__name__)
+
+TOOL_START_TOKEN = "<tool_call>"
+TOOL_END_TOKEN = "</tool_call>"
+PARAM_KEY_START_TOKEN = "<param_key>"
+
+TOOL_CALL_REGEX = re.compile(
+    rf"{re.escape(TOOL_START_TOKEN)}(.*?){re.escape(TOOL_END_TOKEN)}",
+    re.DOTALL,
+)
+PARAM_REGEX = re.compile(
+    r"<param_key>(.*?)</param_key>\s*<param_value>(.*?)</param_value>",
+    re.DOTALL,
+)
+
+
+def _get_attr_or_item(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump(exclude_none=True)
+        if isinstance(dumped, Mapping):
+            return dumped
+    return {}
+
+
+def _tool_function(tool: ChatCompletionToolsParam | Mapping[str, Any]) -> Any:
+    return _get_attr_or_item(tool, "function")
+
+
+def _tool_name(tool: ChatCompletionToolsParam | Mapping[str, Any]) -> str | None:
+    function = _tool_function(tool)
+    name = _get_attr_or_item(function, "name")
+    return str(name) if name else None
+
+
+def _tool_parameters(
+    tool: ChatCompletionToolsParam | Mapping[str, Any]) -> Mapping[str, Any]:
+    function = _tool_function(tool)
+    return _as_mapping(_get_attr_or_item(function, "parameters"))
+
+
+def _iter_tool_names(
+    tools: Sequence[ChatCompletionToolsParam | Mapping[str, Any]] | None,
+) -> list[str]:
+    if tools is None:
+        return []
+    names = [_tool_name(tool) for tool in tools]
+    return sorted((name for name in names if name), key=len, reverse=True)
+
+
+def _is_string_type(
+    tool_name: str,
+    arg_name: str,
+    tools: Sequence[ChatCompletionToolsParam | Mapping[str, Any]] | None,
+) -> bool:
+    if tools is None:
+        return False
+
+    for tool in tools:
+        if _tool_name(tool) != tool_name:
+            continue
+
+        parameters = _tool_parameters(tool)
+        properties = _as_mapping(parameters.get("properties"))
+        arg_schema = _as_mapping(properties.get(arg_name))
+        arg_type = arg_schema.get("type")
+        if isinstance(arg_type, str):
+            return arg_type == "string"
+        if isinstance(arg_type, Sequence) and not isinstance(arg_type, str):
+            return "string" in arg_type
+        return False
+
+    logger.debug("No tool named '%s'.", tool_name)
+    return False
+
+
+def _deserialize(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except Exception:
+        pass
+
+    try:
+        return ast.literal_eval(value)
+    except Exception:
+        pass
+
+    return value
+
+
+def _json_arguments(value: str) -> dict[str, Any]:
+    parsed = _deserialize(value)
+    if not isinstance(parsed, Mapping):
+        return {}
+
+    arguments = parsed.get("arguments", parsed.get("parameters", parsed))
+    if isinstance(arguments, Mapping):
+        return dict(arguments)
+    return {}
+
+
+def _split_payload(
+    payload: str,
+    tools: Sequence[ChatCompletionToolsParam | Mapping[str, Any]] | None,
+) -> tuple[str, str, str]:
+    payload = payload.strip()
+    param_pos = payload.find(PARAM_KEY_START_TOKEN)
+    if param_pos != -1:
+        return payload[:param_pos].strip(), payload[param_pos:], ""
+
+    for tool_name in _iter_tool_names(tools):
+        if payload == tool_name:
+            return tool_name, "", ""
+        if payload.startswith(tool_name):
+            rest = payload[len(tool_name):].strip()
+            if rest.startswith("{"):
+                return tool_name, "", rest
+
+    return payload, "", ""
+
+
+def _parse_payload(
+    payload: str,
+    tools: Sequence[ChatCompletionToolsParam | Mapping[str, Any]] | None,
+) -> tuple[str, dict[str, Any]]:
+    tool_name, params_text, json_text = _split_payload(payload, tools)
+    arguments = _json_arguments(json_text) if json_text else {}
+
+    for key, value in PARAM_REGEX.findall(params_text):
+        arg_key = key.strip()
+        arg_val = value.strip()
+        if not _is_string_type(tool_name, arg_key, tools):
+            arg_val = _deserialize(arg_val)
+        arguments[arg_key] = arg_val
+
+    return tool_name, arguments
+
+
+def _partial_suffix_len(text: str, token: str) -> int:
+    max_len = min(len(text), len(token) - 1)
+    for size in range(max_len, 0, -1):
+        if token.startswith(text[-size:]):
+            return size
+    return 0
+
+
+class XingChen4ToolParser(ToolParser):
+    """Tool call parser for XingChen4 models.
+
+    Used when ``--enable-auto-tool-choice --tool-call-parser xingchen4``
+    is specified.
+
+    Supports two tool-call formats:
+      1. JSON: ``<tool_call>{"name": "func", "arguments": {...}}</tool_call>``
+      2. Tag-based:
+         ``<tool_call>func<param_key>k1</param_key><param_value>v1
+         </param_value>...</tool_call>``
+    """
+
+    def __init__(self, tokenizer: TokenizerLike,
+                 tools: list[Tool] | None = None):
+        super().__init__(tokenizer, tools)
+
+        self.current_tool_id: int = -1
+        self.tool_start_token = TOOL_START_TOKEN
+        self.tool_end_token = TOOL_END_TOKEN
+        self._buffer = ""
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        logger.debug("model_output: %s", model_output)
+
+        tool_calls: list[ToolCall] = []
+        try:
+            for match in TOOL_CALL_REGEX.finditer(model_output):
+                tool_name, arguments = _parse_payload(
+                    match.group(1), request.tools)
+                if not tool_name:
+                    continue
+
+                tool_calls.append(
+                    ToolCall(
+                        type="function",
+                        function=FunctionCall(
+                            name=tool_name,
+                            arguments=json.dumps(
+                                arguments, ensure_ascii=False),
+                        ),
+                    )
+                )
+        except Exception:
+            logger.exception("Failed to extract tool call spec")
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+        if tool_calls:
+            content = model_output[:model_output.find(self.tool_start_token)]
+            return ExtractedToolCallInformation(
+                tools_called=True,
+                tool_calls=tool_calls,
+                content=content,
+            )
+
+        return ExtractedToolCallInformation(
+            tools_called=False,
+            tool_calls=[],
+            content=model_output,
+        )
+
+    def _make_delta(
+        self,
+        content: str,
+        tool_calls: list[DeltaToolCall],
+    ) -> DeltaMessage | None:
+        if not content and not tool_calls:
+            return None
+        return DeltaMessage(
+            content=content or None,
+            tool_calls=tool_calls,
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        self._buffer += delta_text
+        content = ""
+        delta_tool_calls: list[DeltaToolCall] = []
+
+        while True:
+            start_idx = self._buffer.find(self.tool_start_token)
+            if start_idx == -1:
+                partial_len = _partial_suffix_len(
+                    self._buffer, self.tool_start_token)
+                if partial_len:
+                    content += self._buffer[:-partial_len]
+                    self._buffer = self._buffer[-partial_len:]
+                else:
+                    content += self._buffer
+                    self._buffer = ""
+                return self._make_delta(content, delta_tool_calls)
+
+            content += self._buffer[:start_idx]
+            self._buffer = self._buffer[start_idx:]
+            end_idx = self._buffer.find(self.tool_end_token)
+            if end_idx == -1:
+                return self._make_delta(content, delta_tool_calls)
+
+            end_pos = end_idx + len(self.tool_end_token)
+            tool_text = self._buffer[:end_pos]
+            extracted_tool_calls = self.extract_tool_calls(tool_text, request)
+
+            if not extracted_tool_calls.tool_calls:
+                logger.warning(
+                    "Failed to extract any tool calls from %r.", tool_text)
+                content += tool_text
+            else:
+                for tool_call in extracted_tool_calls.tool_calls:
+                    self.current_tool_id += 1
+                    delta_tool_calls.append(
+                        DeltaToolCall(
+                            index=self.current_tool_id,
+                            id=make_tool_call_id(),
+                            type=tool_call.type,
+                            function=DeltaFunctionCall(
+                                name=tool_call.function.name,
+                                arguments=tool_call.function.arguments,
+                            ),
+                        )
+                    )
+
+            self._buffer = self._buffer[end_pos:]

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -134,6 +134,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     **{"unlimited-ocr": "UnlimitedOCRConfig"},
     inkling_mm_model="InklingMMConfig",
     inkling_model="InklingModelConfig",
+    xingchen4="DeepseekV3Config",
 )
 
 _SPECULATIVE_DECODING_CONFIGS: set[str] = {"eagle", "speculators", "medusa"}

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -293,6 +293,7 @@ class ModelArchConfigConvertorBase:
             "bailing_hybrid",
             "bailing_hybrid_mtp",
             "bailing_hybrid_v3_mtp",
+            "xingchen4",
         ):
             # check is deepseek_v4 model
             if hasattr(self.hf_text_config, "compress_ratios"):


### PR DESCRIPTION
## Summary

This PR adds native vLLM support for the upcoming **XingChen4** MoE causal model.

XingChen4 reuses the DeepSeek-V2/V3 backbone (MLA attention, MoE block, optional DSA indexer) and replaces the standard residual connection with **Manifold-constrained Hyper-Connections (mHC)**: the residual stream is expanded into `num_residual_streams` parallel streams mixed by input-dependent, doubly-stochastic matrices produced via Sinkhorn-Knopp projection. The mHC math matches the shared ops in `vllm.model_executor.layers.mhc`, so no private kernels are introduced.
Additionally, this PR enables optional FlagOS/FlagGems acceleration for XingChen4: it enables the hot-path kernels (MoE, attention, softmax, topk, etc.) and brings measurable end-to-end inference speedups — up to 19.87% TTFT and 26.32% TPOT reduction on high-concurrency long-prompt workloads (H100 benchmark), opt-in and disabled by default.

> **Status: Draft.** Model weights are not yet public on Hugging Face Hub. This PR is opened for early code review. Once weights are released, I will:
> 1. add a test entry in `tests/models/registry.py`
> 2. update `docs/models/supported_models.md`
> 3. mark the PR ready for review.

## Changes

1. `vllm/model_executor/models/xingchen4.py`: full model implementation (`XingChen4ForCausalLM`), including forward pass, mHC adapter, and tensor-parallel `load_weights()`.
2. Register `XingChen4ForCausalLM` in `vllm/model_executor/models/registry.py` and related `__init__.py`.
3. Reasoning parser (`vllm/reasoning/xingchen4_reasoning_parser.py`) for reasoning-capable variants.
4. Tool parser (`vllm/tool_parsers/xingchen4_tool_parser.py`) for auto tool calling.
5. Register `xingchen4` in `vllm/config/speculative.py`, `vllm/transformers_utils/model_arch_config_convertor.py`, and `vllm/transformers_utils/config.py`.

## Optional FlagGems acceleration (opt-in)

An optional acceleration path is gated behind the env var `USE_FLAGOS=1` (disabled by default). When set, it enables a curated subset of FlagGems kernels via `flag_gems.only_enable(include=[...])`.

> **Scope note:** The acceleration is only enabled from the XingChen4 model path — the flag_gems.only_enable(...) call lives exclusively inside xingchen4.py and is gated behind the env var, so no other model load path triggers it. The whitelist is intentionally narrow (...), and with the env var unset the behavior is fully unchanged. 
 For completeness: only_enable substitutes operators at the PyTorch dispatch level, so once enabled the kernels apply to any op in the same process that matches the whitelist — we therefore consider this an acceleration prototype and welcome feedback on a more scoped kernel backend.

```bash
pip install flagtree==0.6.1 flag-gems==5.3.4 -i https://resource.flagos.net/repository/flagos-pypi-nvidia/simple            # see version constraints in the PR discussion
USE_FLAGOS=1 vllm serve ${model_path} \
    --chat-template ${model_path}/chat_template.jinja \
    --host 0.0.0.0 \
    --port 8000 \
    --served-model-name $mode_name \
    --trust-remote-code \
    --dtype bfloat16 \
    --nnodes 1 \
    --tensor-parallel-size 1 \
    --max-model-len 262144 \
    --gpu-memory-utilization 0.90 \
    --max-num-seqs 64 \
    --max-num-batched-tokens 2048 \
    --enable-prefix-caching \
    --reasoning-parser xingchen4 \
    --enable-auto-tool-choice \
    --tool-call-parser xingchen4 \
    --uvicorn-log-level info \
    --enable-log-requests \
    --disable-custom-all-reduce
```

All XingChen4 hot-path tests below run with FlagGems **disabled**.

## Benchmark method (H100 × 1)

- Framework: this branch vs. vanilla vLLM baseline (same branch, env var unset).
- Metric: **TTFT** (time to first token) and **TPOT** (time per output token).
- Workload: cold cache for each (input tokens + output tokens) pair.
- Each run: 5 repetitions, report the **median**; standard deviation in parentheses when ≥ 1%.
- No kernel warmup excluded; results reflect end-to-end served latency.

| input+output | concurrency | vanilla TTFT (ms) | flaggems TTFT (ms) | TTFT Δ | vanilla TPOT (ms) | flaggems TPOT (ms) | TPOT Δ |
|---|---|---|---|---|---|---|---|
| 50K+500 | 1 | 3965 | 3971 | ~0% | 10 | 10 | ~0% |
| 50K+500 | 10 | 23827 | 23050 | 3.26% | 60 | 62 | ~0% |
| 10K+500 | 1 | 486 | 483 | 0.62% | 8 | 8 | ~0% |
| 10K+500 | 10 | 1439 | 1153 | 19.87% | 38 | 28 | 26.32% |
| 1K+500 | 1 | 98 | 98 | ~0% | 8 | 7 | 12.50% |
| 1K+500 | 10 | 185 | 189 | ~0% | 17 | 17 | ~0% |

**Reading:** gains concentrate in the high-concurrency long-prompt case (10K+500, concurrency=10): ~19.87% TTFT / ~26.32% TPOT. Low-concurrency and short-prompt cases are neutral. The benefit is workload-specific, not universal.

## Test plan (internal non-public checkpoint)

1. Single-GPU: init, weight loading, text generation.
2. Tensor-parallel size=2: weight loading and inference.
3. Generation outputs and logits aligned with the Hugging Face transformers reference implementation (layer-wise comparison, reported in the accompanying notes).
4. FlagGems dual-path: default path (env unset) and accelerated path (env set) both produce consistent outputs/logits.

## Usage
```bash
vllm serve ${model_path} \
    --chat-template ${model_path}/chat_template.jinja \
    --host 0.0.0.0 \
    --port 8000 \
    --served-model-name $mode_name \
    --trust-remote-code \
    --dtype bfloat16 \
    --nnodes 1 \
    --tensor-parallel-size 1 \
    --max-model-len 262144 \
    --gpu-memory-utilization 0.90 \
    --max-num-seqs 64 \
    --max-num-batched-tokens 2048 \
    --enable-prefix-caching \
    --reasoning-parser xingchen4 \
    --enable-auto-tool-choice \
    --tool-call-parser xingchen4 \
    --uvicorn-log-level info \
    --enable-log-requests \
    --disable-custom-all-reduce
```

## Known limitations / open items for review

- **mHC checkpoint biases** (`bias_pre` / `bias_post` / `bias_res`) and the `h_res` clamp: currently merged/omitted to match the shared `MHCPreOp` signature. **Please review whether the folded formula is equivalent to the official checkpoint** — this is the main correctness item I need confirmed.
- `_xingchen4_transpose_contiguous` custom op exists to keep `comb_mix` C-contiguous for the TileLang `mhc_post` kernel that torch.compile cannot prove. Happy to simplify if reviewers prefer.
- Pipeline parallelism is not supported in mHC mode (n_streams > 1); tensor parallelism is.

## Checklist

- [x] Model registers and loads (single + TP=2)
- [x] Logit alignment vs HF reference (documented)
- [ ] Test entry in `tests/models/registry.py` (pending weights release)
- [ ] Docs entry in `docs/models/supported_models.md` (pending weights release)
- [ ] CI green