### PR TITLE
[Bugfix][Spec Decode] Don't count skipped drafting as drafted tokens

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1519,6 +1519,134 @@ def test_per_request_spec_decode_acceptance_disabled_by_default():
     assert scheduler.requests[req.request_id].spec_decode_metrics is None
 
 
+def _prefill_one_request(scheduler):
+    """Add one request and run its prefill step. Returns (request, req_id)."""
+    [req] = create_requests(num_requests=1, num_tokens=1)
+    scheduler.add_request(req)
+    rid = req.request_id
+    scheduler.update_from_output(
+        scheduler.schedule(),
+        ModelRunnerOutput(
+            req_ids=[rid],
+            req_id_to_index={rid: 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    return req, rid
+
+
+def test_skipped_drafting_is_not_scheduled_as_spec_tokens():
+    """Padding from a skipped drafter must not be scheduled for verification.
+
+    When the input no longer fits in the drafter, the model runner keeps zero
+    padding in place of real proposals (needed for Mamba-based targets). Zero is
+    a valid token id, so the scheduler relies on ``drafting_skipped`` to tell the
+    padding apart from a genuine draft. Regression test for issue #34734.
+    """
+    scheduler = create_scheduler(num_speculative_tokens=3)
+    req, rid = _prefill_one_request(scheduler)
+
+    scheduler.update_draft_token_ids(
+        DraftTokenIds([rid], [[0, 0, 0]], drafting_skipped=True)
+    )
+
+    assert scheduler.requests[rid].spec_token_ids == []
+    output = scheduler.schedule()
+    assert rid not in output.scheduled_spec_decode_tokens
+    # Only the previously sampled token is scheduled, no speculative tokens.
+    assert output.num_scheduled_tokens[rid] == 1
+
+
+def test_skipped_drafting_reports_no_spec_decode_stats():
+    """A skipped drafter must not be reported as a draft with 0% acceptance."""
+    scheduler = create_scheduler(num_speculative_tokens=3)
+    req, rid = _prefill_one_request(scheduler)
+
+    scheduler.update_draft_token_ids(
+        DraftTokenIds([rid], [[0, 0, 0]], drafting_skipped=True)
+    )
+    engine_core_outputs = scheduler.update_from_output(
+        scheduler.schedule(),
+        ModelRunnerOutput(
+            req_ids=[rid],
+            req_id_to_index={rid: 0},
+            sampled_token_ids=[[42]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    outputs = engine_core_outputs.get(0) if engine_core_outputs else None
+    assert (
+        outputs is None
+        or outputs.scheduler_stats is None
+        or outputs.scheduler_stats.spec_decoding_stats is None
+    ), "skipped drafting must not report drafted tokens (issue #34734)"
+
+
+def test_real_drafts_are_still_scheduled_and_counted():
+    """Guard against over-correcting: a genuine draft is unaffected."""
+    scheduler = create_scheduler(num_speculative_tokens=3)
+    req, rid = _prefill_one_request(scheduler)
+
+    # Same token values as the padding case, but not flagged as skipped.
+    scheduler.update_draft_token_ids(DraftTokenIds([rid], [[0, 0, 0]]))
+
+    assert scheduler.requests[rid].spec_token_ids == [0, 0, 0]
+    output = scheduler.schedule()
+    assert output.scheduled_spec_decode_tokens[rid] == [0, 0, 0]
+    assert output.num_scheduled_tokens[rid] == 4  # 1 sampled + 3 spec
+
+    engine_core_outputs = scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[rid],
+            req_id_to_index={rid: 0},
+            sampled_token_ids=[[0, 0, 7]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    stats = engine_core_outputs[0].scheduler_stats.spec_decoding_stats
+    assert stats is not None
+    assert stats.num_drafts == 1
+    assert stats.num_draft_tokens == 3
+    assert stats.num_accepted_tokens == 2
+
+
+def test_skipped_drafting_in_output_marks_tokens_invalid():
+    """Async path: tokens already scheduled this step go down the invalid path.
+
+    Under async scheduling the speculative tokens are part of the in-flight
+    batch, so they cannot be un-scheduled. They are instead padded with -1 and
+    recorded in ``num_invalid_spec_tokens``, the existing channel for drafts
+    that must not count, which keeps them out of the drafted-token total.
+    """
+    scheduler = create_scheduler(num_speculative_tokens=3)
+    req, rid = _prefill_one_request(scheduler)
+
+    scheduler.update_draft_token_ids(DraftTokenIds([rid], [[1, 2, 3]]))
+    output = scheduler.schedule()
+    assert output.scheduled_spec_decode_tokens[rid] == [1, 2, 3]
+
+    scheduler.update_draft_token_ids_in_output(
+        DraftTokenIds([rid], [[0, 0, 0]], drafting_skipped=True), output
+    )
+
+    assert output.scheduled_spec_decode_tokens[rid] == [-1, -1, -1]
+    assert output.num_invalid_spec_tokens == {rid: 3}
+
+
+def test_drafting_skipped_defaults_to_false():
+    """Existing callers keep their behavior without passing the new flag."""
+    assert DraftTokenIds(["r0"], [[1, 2, 3]]).drafting_skipped is False
+
+
 def test_spec_decoding_stats_empty_output():
     """Test that spec decoding stats handle empty output tokens gracefully.
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2289,8 +2289,11 @@ class Scheduler(SchedulerInterface):
                 # The request may have been finished. Skip.
                 continue
 
-            if request.is_prefill_chunk:
-                # Ignore draft tokens for prefill chunks.
+            if request.is_prefill_chunk or draft_token_ids.drafting_skipped:
+                # Ignore draft tokens for prefill chunks, and the zero padding
+                # produced when the drafter was skipped: scheduling it would
+                # only spend verification on tokens that must be rejected, and
+                # would report them as drafted tokens (issue #34734).
                 if request.spec_token_ids:
                     request.spec_token_ids = []
                 continue
@@ -2324,8 +2327,13 @@ class Scheduler(SchedulerInterface):
             # Trim drafts to scheduled number of spec tokens
             # (needed for chunked prefill case for example).
             del spec_token_ids[orig_num_spec_tokens:]
+            if draft_token_ids.drafting_skipped:
+                # Zero padding, not a real draft. The tokens are already part of
+                # this step's batch, so drop them into the invalid path below to
+                # keep them out of the drafted-token stats (issue #34734).
+                spec_token_ids.clear()
             # Filter out spec tokens which do not adhere to the grammar.
-            if self.structured_output_manager.should_advance(request):
+            elif self.structured_output_manager.should_advance(request):
                 metadata = request.structured_output_request
                 spec_token_ids = metadata.grammar.validate_tokens(spec_token_ids)  # type: ignore[union-attr]
             # Pad to original number of spec tokens.

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -435,6 +435,12 @@ class DraftTokenIds:
     req_ids: list[str]
     # num_reqs x num_draft_tokens
     draft_token_ids: list[list[int]]
+    # True when the drafter was skipped for this step (e.g. the input no longer
+    # fits in the drafter) and ``draft_token_ids`` is therefore zero padding
+    # rather than real proposals. The padding is kept for compatibility, so the
+    # scheduler needs this flag to tell it apart from a genuine draft: zero is
+    # also a valid token id.
+    drafting_skipped: bool = False
 
 
 def make_empty_encoder_model_runner_output(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -931,6 +931,10 @@ class GPUModelRunner(
         self._draft_token_ids: list[list[int]] | torch.Tensor | None = None
         self._draft_probs: torch.Tensor | None = None
         self._draft_prob_req_ids: list[str] | None = None
+        # Set when the drafter was skipped and `_draft_token_ids` holds zero
+        # padding instead of real proposals, so the scheduler can avoid counting
+        # the padding as drafted tokens.
+        self._drafting_skipped: bool = False
         # N-gram GPU path: async D2H buffer/event for per-request valid draft counts.
         self._num_valid_draft_tokens: torch.Tensor | None = None
         self._num_valid_draft_tokens_cpu: torch.Tensor | None = None
@@ -4714,6 +4718,7 @@ class GPUModelRunner(
         self._draft_probs = None
         self._draft_prob_req_ids = None
         self._draft_token_req_ids = None
+        self._drafting_skipped = False
         self.valid_sampled_token_count_gpu = None
         self.input_batch.prev_sampled_token_ids = None
 
@@ -4820,6 +4825,10 @@ class GPUModelRunner(
                 ).expand(len(self.input_batch.req_ids), self.num_spec_tokens)
                 self._draft_probs = None
                 self._draft_prob_req_ids = None
+                # The padding above is indistinguishable from a real draft (zero
+                # is a valid token id), so record that drafting was skipped and
+                # let the scheduler decide what to do with it.
+                self._drafting_skipped = True
                 self._copy_draft_token_ids_to_cpu(scheduler_output, zeros_only=True)
 
         with record_function_or_nullcontext("gpu_model_runner: bookkeep"):
@@ -4995,7 +5004,9 @@ class GPUModelRunner(
         if not self.num_spec_tokens or not self._draft_token_req_ids:
             return None
         draft_token_ids, req_ids = self._get_draft_token_ids_cpu()
-        return DraftTokenIds(req_ids, draft_token_ids)
+        return DraftTokenIds(
+            req_ids, draft_token_ids, drafting_skipped=self._drafting_skipped
+        )
 
     def _copy_draft_token_ids_to_cpu(
         self, scheduler_output: "SchedulerOutput", zeros_only: bool = False


### PR DESCRIPTION
## Purpose

Fixes #34734.

When the input no longer fits in the drafter, `input_fits_in_drafter` is false and the model runner fills `_draft_token_ids` with zeros instead of running the drafter. That padding is deliberate — it is what keeps stale drafts from corrupting Mamba recurrent state and logprobs for sequences near `max_model_len`.

But zero is also a valid token id, so the scheduler cannot tell the padding apart from a real draft. It scheduled the padding for verification, where it is always rejected, and counted it in `num_drafts` / `num_draft_tokens`. With the default EAGLE3 checkpoints (`max_model_len: 2048`) any sequence beyond ~2000 tokens therefore reported an acceptance rate of 0.00%, in the log and in `vllm bench serve`.

@benchislett noted on #34751 that the padding has to stay on the runner side and that the condition needs to reach the scheduler some other way:

> For compatibility I think we'll need to keep the empty draft tokens on the model runner side, and find some more sophisticated way to communicate `input_fits_in_drafter` to the scheduler or compute it there.

This PR does that: the runner keeps zero-filling exactly as before and additionally sets an explicit flag.

## Modifications

**`vllm/v1/outputs.py`** — `DraftTokenIds` gains `drafting_skipped: bool = False`. Defaults to false, so existing construction sites are unchanged.

**`vllm/v1/worker/gpu_model_runner.py`** — `_drafting_skipped` is reset per step alongside the other cached draft outputs, set in the existing `if not input_fits_in_drafter:` branch, and propagated by `take_draft_token_ids`. The zero-fill itself is untouched.

**`vllm/v1/core/sched/scheduler.py`** — each path reuses the mechanism it already has for drafts that must not count:

- `update_draft_token_ids` (sync): clear `request.spec_token_ids`, mirroring the `is_prefill_chunk` branch immediately above. The padding is never scheduled, so nothing is reported — and verification is no longer spent on tokens that are guaranteed to be rejected.
- `update_draft_token_ids_in_output` (async): the tokens are already part of the in-flight batch and cannot be un-scheduled, so they fall through to the existing `num_invalid_spec_tokens` path — padded with `-1` and subtracted from the drafted-token total, exactly as grammar-invalidated drafts are today.

## Test Plan

Five tests added to `tests/v1/core/test_scheduler.py`, reusing the existing `create_scheduler` / `ModelRunnerOutput` harness (CPU-only, no model load):

| test | asserts |
|---|---|
| `test_skipped_drafting_is_not_scheduled_as_spec_tokens` | padding does not reach `scheduled_spec_decode_tokens`; only the sampled token is scheduled |
| `test_skipped_drafting_reports_no_spec_decode_stats` | `spec_decoding_stats` stays `None` |
| `test_skipped_drafting_in_output_marks_tokens_invalid` | async path yields `[-1, -1, -1]` and `num_invalid_spec_tokens == {rid: 3}` |
| `test_drafting_skipped_defaults_to_false` | existing callers keep current behavior |
| `test_real_drafts_are_still_scheduled_and_counted` | guard against over-correcting: a genuine draft with the *same* token values (`[0, 0, 0]`) is still scheduled and counted |

Run with `VLLM_TARGET_DEVICE=cpu`:

```
tests/v1/core/test_scheduler.py -k "skipped_drafting or real_drafts_are_still or drafting_skipped_defaults"
  -> 5 passed
```

Reverting only the `vllm/` changes and keeping the tests fails 4 of the 5 (the fifth covers unchanged behavior), confirming they exercise the bug.

**Regression check.** Full `tests/v1/core/test_scheduler.py` before vs after, comparing the set of failing tests: 40 → 36 failures, and the only difference is the 4 new tests flipping from fail to pass — no test newly broken. The remaining 36 are pre-existing failures in this sandbox from missing optional multimodal dependencies (`mistral_common` and friends), unrelated to spec decode.

Also green: `tests/v1/spec_decode/test_dflash_lookahead.py` (3 passed, covers `_input_fits_in_drafter` directly) and `tests/v1/core/test_priority_scheduler_random.py` (12 passed, exercises `update_draft_token_ids`).

`ruff check` and `ruff format --check` clean at the pinned v0.14.0.

## Note on scope

Under async scheduling `num_drafts` is still incremented for the step, because `make_spec_decoding_stats` tests `num_draft_tokens` before subtracting `num_invalid_spec_tokens`. The reported `num_draft_tokens` is 0, so the misleading 0.00% acceptance rate is gone either way, and this is the same behavior grammar-invalidated drafts already have today. Making `num_drafts` skip that case too would change the existing structured-output path as well, so I left it out — happy to fold it in if you would prefer that.

I do not have a spec-decode checkpoint or GPU to run this end to end, so the verification above is CPU scheduler-level only.

cc @benchislett