### PR TITLE
Fix Humming MoE activation_output aliasing

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
@@ -533,18 +533,22 @@ class HummingExpertsBase(mk.FusedMoEExpertsModular):
         if num_bits == 16:
             required_buffers = ["gate_up_output", "activation_output", "down_output"]
         else:
+            required_buffers = [
+                "quanted_gate_up_input",
+                "gate_up_output",
+                "activation_output",
+                "quanted_down_input",
+                "down_output",
+            ]
+
             # Note: The fused SITU+FP8 quant goes gate_up_output ->
             #        quanted_down_input directly, never materializing
             #        activation_output. Dropping activation_output from the chain
             #        flips the even/odd workspace 2-coloring below so
             #        gate_up_output and quanted_down_input land
             #        on DIFFERENT workspaces.
-            required_buffers = [
-                "quanted_gate_up_input",
-                "gate_up_output",
-                "quanted_down_input",
-                "down_output",
-            ]
+            if self.fused_situ_quant_enabled(activation):
+                required_buffers.remove("activation_output")
 
         # batched moe use down_output as output
         if not self.is_batched():

--- a/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/fused_humming_moe.py
@@ -533,10 +533,15 @@ class HummingExpertsBase(mk.FusedMoEExpertsModular):
         if num_bits == 16:
             required_buffers = ["gate_up_output", "activation_output", "down_output"]
         else:
+            # Note: The fused SITU+FP8 quant goes gate_up_output ->
+            #        quanted_down_input directly, never materializing
+            #        activation_output. Dropping activation_output from the chain
+            #        flips the even/odd workspace 2-coloring below so
+            #        gate_up_output and quanted_down_input land
+            #        on DIFFERENT workspaces.
             required_buffers = [
                 "quanted_gate_up_input",
                 "gate_up_output",
-                "activation_output",
                 "quanted_down_input",
                 "down_output",
             ]


### PR DESCRIPTION
Signed-off-by: Elvir Crncevic <elvircrn@gmail.com>

Restores gsm8k accuracy for Kimi K3 at high lm_eval concurrencies:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9682|±  |0.0048|
|     |       |strict-match    |     5|exact_match|↑  |0.9689|±  |0.0048|
```

The drop in accuracy is caused by the activation kernel receiving aliased buffers.

On the humming fp8 path, we don't use the `activation_output` because activation and quantization is fused into the same kernel. The aliasing came from:

```
[quanted_gate_up_input, gate_up_output, activation_output, quanted_down_input, down_output]
              ↑               ↑                ↑                   ↑
            idx=4           idx=3            idx=2              idx=1
          (ws2)            (ws1)           (ws2)             (ws1) ← ALIASED
```

so removing the aliasing issue.


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

