### PR TITLE
[Bugfix][MLA] Declare masked_mha_available on SM120 sparse MLA impl (GB10 startup crash)

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -41,6 +41,15 @@ def test_sm120_backend_uses_sparse_mqa_for_prefill() -> None:
     assert not impl_cls.supports_dense_mha_prefill
 
 
+def test_sm120_backend_exposes_masked_mha_available_false() -> None:
+    # The prefill dispatcher reads ``impl.masked_mha_available`` for any sparse
+    # impl; SM120 has no masked-MHA prefill kernel, so the attribute must exist
+    # and be False rather than AttributeError at startup. See #51920.
+    impl_cls = FlashInferMLASparseSM120Backend.get_impl_cls()
+
+    assert impl_cls.masked_mha_available is False
+
+
 def test_v32_glm_sm120_backend_accepts_glm_block_size(
     monkeypatch,
 ) -> None:

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -34,6 +34,13 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
 
     is_sparse = True
     supports_dense_mha_prefill = False
+    # SM120 sparse MLA implements only the sparse-MQA path and has no
+    # masked-MHA prefill kernel. The prefill dispatcher in mla_attention reads
+    # ``self.impl.masked_mha_available`` unconditionally for any sparse impl, so
+    # it must exist here (the generic impl only sets it in __init__, which this
+    # subclass does not inherit) and be False to keep the masked-MHA branch off.
+    # See #51920.
+    masked_mha_available = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Purpose

Fixes #51920. On sm_120 / sm_121 (GB10 / DGX Spark) the engine crashes at startup profiling with:

```
AttributeError: 'FlashInferMLASparseSM120Impl' object has no attribute 'masked_mha_available'
```

`FlashInferMLASparseSM120Impl` sets `is_sparse = True`, and the prefill dispatcher in `mla_attention.py` reads `self.impl.masked_mha_available` for **any** sparse impl once `num_mha_tokens > 0` (behind a `# type: ignore[attr-defined]`). The generic sparse impl sets that attribute in `__init__` via `_is_masked_mha_available(...)`; the SM120 subclass inherits from `MLAAttentionImpl` directly and never runs that path, so the read `AttributeError`s whenever a masked-MHA-eligible prefill backend is present.

#51395 corrected the related `supports_dense_mha_prefill` capability, but that doesn't gate this read, so the crash persists on current main.

## Fix

SM120 sparse MLA implements only the sparse-MQA path and has no masked-MHA prefill kernel, so declare `masked_mha_available = False` as a class attribute next to `is_sparse` / `supports_dense_mha_prefill`. The masked-MHA branch (`... and self.impl.masked_mha_available and ...`) then short-circuits off, exactly as the reporter verified boots and serves.

## Verified on a GB10 (sm_121)

`FLASHINFER_MLA_SPARSE_SM120` is the auto-selected sparse-MLA backend on family-120, so this path is GB10/consumer-Blackwell only. On the GB10:

```
FlashInferMLASparseSM120Backend.get_impl_cls() -> FlashInferMLASparseSM120Impl
is_sparse                = True
masked_mha_available     = False   # was AttributeError (attr absent) on main
```

## Tests

Adds a class-level assertion in `tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py` (device-free) that the impl exposes `masked_mha_available is False`, alongside the existing `is_sparse` / `supports_dense_mha_prefill` checks.

Thanks @joesinvestments for the report + verified workaround and @SyaOtiLan for pinning the sparse-MQA-only mechanism.
