### PR TITLE
[ROCm] Consume MXFP4 QuantizedActivation in AITER linear

### DIFF
--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.fusion.quant_activation import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
+    kMxfp4Dynamic,
     kNvfp4Dynamic,
 )
 from vllm.platforms import current_platform
@@ -107,12 +108,39 @@ def test_bridge_marks_supporting_and_skips_others():
     layer = torch.nn.Module()
     expose_input_quant_key(layer, supported)
     assert layer.input_quant_key == kNvfp4Dynamic
+    assert layer.input_quant_layout is None
 
     unsupported = _probe(FlashInferTrtllmNvFp4LinearKernel)
     assert unsupported.input_quant_key() is None
     layer = torch.nn.Module()
     expose_input_quant_key(layer, unsupported)
     assert not hasattr(layer, "input_quant_key")
+    assert not hasattr(layer, "input_quant_layout")
+
+
+def test_as_quantized_activation_validates_layout():
+    qa = QuantizedActivation(
+        data=torch.zeros(2, 4, dtype=torch.uint8),
+        scale=torch.zeros(2, 1, dtype=torch.uint8),
+        orig_dtype=torch.bfloat16,
+        orig_shape=torch.Size([2, 8]),
+        quant_key=kMxfp4Dynamic,
+        layout="shuffled",
+    )
+    with pytest.raises(AssertionError, match="layout"):
+        as_quantized_activation(qa, kMxfp4Dynamic, None)
+    assert as_quantized_activation(qa, kMxfp4Dynamic, "shuffled") is qa
+    plain = QuantizedActivation(
+        data=qa.data,
+        scale=qa.scale,
+        orig_dtype=qa.orig_dtype,
+        orig_shape=qa.orig_shape,
+        quant_key=kMxfp4Dynamic,
+        layout=None,
+    )
+    with pytest.raises(AssertionError, match="layout"):
+        as_quantized_activation(plain, kMxfp4Dynamic, "shuffled")
+    assert as_quantized_activation(plain, kMxfp4Dynamic) is plain
 
 
 def test_as_quantized_activation_validates_key():

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -9,8 +9,11 @@ from vllm.model_executor.kernels.linear import (
     _POSSIBLE_FP8_BLOCK_KERNELS,
     _POSSIBLE_FP8_KERNELS,
     _POSSIBLE_INT8_KERNELS,
+    _POSSIBLE_MXFP4_KERNELS,
     _POSSIBLE_NVFP4_KERNELS,
 )
+from vllm.model_executor.kernels.linear.mxfp4.aiter import AiterMxfp4LinearKernel
+from vllm.model_executor.kernels.linear.mxfp4.base import MxFp4LinearKernel
 from vllm.model_executor.kernels.linear.nvfp4.base import (
     NvFp4LinearKernel,
     NvFp4LinearLayerConfig,
@@ -47,6 +50,7 @@ SUPPORTING = {
     CutlassFP8ScaledMMLinearKernel,
     FlashInferFP8ScaledMMLinearKernel,
     FlashInferCutlassNvFp4LinearKernel,
+    AiterMxfp4LinearKernel,
 }
 
 
@@ -56,6 +60,7 @@ def _all_kernel_classes() -> list[type]:
         _POSSIBLE_FP8_KERNELS,
         _POSSIBLE_FP8_BLOCK_KERNELS,
         _POSSIBLE_INT8_KERNELS,
+        _POSSIBLE_MXFP4_KERNELS,
         _POSSIBLE_NVFP4_KERNELS,
     ):
         for kernels in registry.values():
@@ -70,6 +75,8 @@ def _probe(cls: type):
     obj = cls.__new__(cls)  # type: ignore[call-overload]
     if issubclass(cls, NvFp4LinearKernel):
         obj.config = NvFp4LinearLayerConfig()
+    elif issubclass(cls, MxFp4LinearKernel):
+        obj.use_asm_gemm = False
     elif issubclass(cls, Int8ScaledMMLinearKernel):
         obj.config = Int8ScaledMMLinearLayerConfig(
             is_static_input_scheme=True, is_channelwise=False, input_symmetric=True
@@ -116,6 +123,21 @@ def test_bridge_marks_supporting_and_skips_others():
     expose_input_quant_key(layer, unsupported)
     assert not hasattr(layer, "input_quant_key")
     assert not hasattr(layer, "input_quant_layout")
+
+
+def test_bridge_aiter_mxfp4_layout():
+    triton = _probe(AiterMxfp4LinearKernel)
+    layer = torch.nn.Module()
+    expose_input_quant_key(layer, triton)
+    assert layer.input_quant_key == kMxfp4Dynamic
+    assert layer.input_quant_layout is None
+
+    asm = _probe(AiterMxfp4LinearKernel)
+    asm.use_asm_gemm = True
+    layer = torch.nn.Module()
+    expose_input_quant_key(layer, asm)
+    assert layer.input_quant_key == kMxfp4Dynamic
+    assert layer.input_quant_layout == "shuffled"
 
 
 def test_as_quantized_activation_validates_layout():

--- a/tests/kernels/quantization/test_quant_op_schema.py
+++ b/tests/kernels/quantization/test_quant_op_schema.py
@@ -74,6 +74,36 @@ def test_group_fp8_quant_schema():
     )
 
 
+def test_gemm_with_dynamic_quant_x_scales_schema():
+    """MXFP4 GEMM with a caller-supplied activation scale."""
+    # this import statement is needed to ensure the op is registered
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+    import vllm.model_executor.kernels.linear.mxfp4.aiter  # noqa: F401
+
+    torch.manual_seed(0)
+    M, K, N = 128, 4096, 4096
+    x = torch.randn((M, K), dtype=torch.bfloat16, device="cuda")
+    weight = (torch.randn((N, K), dtype=torch.float32, device="cuda") * 0.02).to(
+        torch.bfloat16
+    )
+
+    x_fp4, x_scales = dynamic_mxfp4_quant(x)
+    weight_fp4, weight_scale = dynamic_mxfp4_quant(weight)
+
+    opcheck(
+        torch.ops.vllm.gemm_with_dynamic_quant,
+        (
+            x_fp4,
+            weight_fp4,
+            weight_scale.T.contiguous(),
+            False,
+            torch.bfloat16,
+            x_scales,
+        ),
+    )
+
+
 @pytest.mark.parametrize("dynamic", [True, False])
 def test_per_tensor_quant_matches_native(dynamic):
     """Wrapper output matches the native scaled_fp8_quant reference."""

--- a/vllm/model_executor/kernels/linear/mxfp4/aiter.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/aiter.py
@@ -7,7 +7,12 @@ from torch.nn.parameter import Parameter
 import vllm.envs as envs
 from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    as_quantized_activation,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
     kMxfp4Dynamic,
 )
 from vllm.platforms import current_platform
@@ -46,17 +51,18 @@ if is_aiter_found_and_supported():
         N = weight.shape[0]
         K = weight.shape[1]
         if rocm_use_aiter_fp4_asm_gemm:
-            if M <= 64 and rocm_aiter_ops.is_triton_gemm_afp4wfp4_presh_ws_tuned(N, K):
-                if x_scales is None:
-                    # use hip quant kernel for performance
-                    if M >= 32:
-                        x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=True)
-                    else:
-                        x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=False)
+            # Fused activations (x_scales is not None) already match gemm_a4w4.
+            # Use small-M Triton preshuffle gemm for unfused BF16.
+            if (
+                x_scales is None
+                and M <= 64
+                and rocm_aiter_ops.is_triton_gemm_afp4wfp4_presh_ws_tuned(N, K)
+            ):
+                if M >= 32:
+                    x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=True)
                 else:
-                    x_q = x
-                    x_s = x_scales
-
+                    x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=False)
+                
                 if M >= 32:
                     x_s = x_s.view(torch.uint8).view(x_s.shape[0] // 32, -1)
                 else:
@@ -132,6 +138,14 @@ class AiterMxfp4LinearKernel(MxFp4LinearKernel):
         self.use_asm_gemm = rocm_aiter_ops.is_asm_fp4_gemm_dynamic_quant_enabled()
         self.out_dtype = torch.get_default_dtype()
 
+    def input_quant_key(self) -> QuantKey | None:
+        return kMxfp4Dynamic
+
+    def input_quant_layout(self) -> str | None:
+        if self.use_asm_gemm:
+            return "shuffled"
+        return None
+
     @classmethod
     def is_supported(
         cls, compute_capability: int | None = None
@@ -191,16 +205,32 @@ class AiterMxfp4LinearKernel(MxFp4LinearKernel):
     def apply_weights(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: torch.Tensor | QuantizedActivation,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        y = torch.ops.vllm.gemm_with_dynamic_quant(
-            x,
-            layer.weight,
-            layer.weight_scale,
-            self.use_asm_gemm,
-            self.out_dtype,
+        qa = as_quantized_activation(
+            x, self.input_quant_key(), self.input_quant_layout()
         )
+        if qa is not None:
+            y = torch.ops.vllm.gemm_with_dynamic_quant(
+                qa.data,
+                layer.weight,
+                layer.weight_scale,
+                self.use_asm_gemm,
+                self.out_dtype,
+                qa.scale,
+            )
+            orig_m = qa.orig_shape[0]
+            if y.shape[0] != orig_m:
+                y = y[:orig_m]
+        else:
+            y = torch.ops.vllm.gemm_with_dynamic_quant(
+                x,
+                layer.weight,
+                layer.weight_scale,
+                self.use_asm_gemm,
+                self.out_dtype,
+            )
         if bias is not None:
             y = y + bias
         return y

--- a/vllm/model_executor/kernels/linear/mxfp4/aiter.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/aiter.py
@@ -113,9 +113,9 @@ if is_aiter_found_and_supported():
         x: torch.Tensor,
         weight: torch.Tensor,
         weight_scale: torch.Tensor,
-        x_scales: torch.Tensor = None,
         rocm_use_aiter_fp4_asm_gemm: bool = False,
         out_dtype: torch.dtype | None = torch.bfloat16,
+        x_scales: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return torch.empty(
             (*x.shape[:-1], weight.shape[0]), dtype=out_dtype, device=x.device

--- a/vllm/model_executor/kernels/linear/mxfp4/base.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/base.py
@@ -37,6 +37,18 @@ class MxFp4LinearKernel(ABC):
         assert self.can_implement(config)[0]
         assert self.is_supported()[0]
         self.config = config
+    
+    def input_quant_key(self) -> QuantKey | None:
+        """Return the input quantization scheme this kernel can consume.
+
+        None means the kernel quantizes its own input.
+        """
+        return None
+    
+    def input_quant_layout(self) -> str | None:
+        """Scale-buffer ABI when consuming a QuantizedActivation.
+        """
+        return None
 
     @classmethod
     @abstractmethod

--- a/vllm/model_executor/layers/fusion/quant_activation.py
+++ b/vllm/model_executor/layers/fusion/quant_activation.py
@@ -33,6 +33,7 @@ class QuantizedActivation:
     orig_dtype: torch.dtype
     orig_shape: torch.Size
     quant_key: QuantKey
+    layout: str | None = None
 
 
 def expose_input_quant_key(layer: torch.nn.Module, kernel) -> None:
@@ -50,16 +51,19 @@ def expose_input_quant_key(layer: torch.nn.Module, kernel) -> None:
     key = kernel.input_quant_key()
     if key is not None:
         layer.input_quant_key = key
+        get_layout = getattr(kernel, "input_quant_layout", None)
+        layer.input_quant_layout = get_layout() if callable(get_layout) else None
 
 
 def as_quantized_activation(
-    x: "torch.Tensor | QuantizedActivation", expected_key: QuantKey | None
+    x: "torch.Tensor | QuantizedActivation", expected_key: QuantKey | None,
+    expected_layout: str | None = None
 ) -> "QuantizedActivation | None":
     """Validate and narrow a pre-quantized activation for a consumer kernel.
 
-    Returns the QuantizedActivation when x is one whose key matches the
-    kernel's declared expected_key, and None when x is a plain tensor (the
-    caller quantizes in-kernel). Raises on a key mismatch so a wrongly routed
+    Returns the QuantizedActivation when x is one whose key and layout matches the
+    kernel's declared expected_key and expected_layout, and None when x is a plain tensor (the
+    caller quantizes in-kernel). Raises on a mismatch so a wrongly routed
     activation fails loudly instead of being silently re-quantized.
     """
     if not isinstance(x, QuantizedActivation):
@@ -67,5 +71,9 @@ def as_quantized_activation(
     assert x.quant_key == expected_key, (
         f"QuantizedActivation key {x.quant_key} != consumer kernel "
         f"input_quant_key {expected_key}"
+    )
+    assert x.layout == expected_layout, (
+        f"QuantizedActivation layout {x.layout!r} != consumer kernel "
+        f"input_quant_layout {expected_layout!r}"
     )
     return x

--- a/vllm/model_executor/layers/quantization/online/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp4.py
@@ -32,6 +32,9 @@ from vllm.model_executor.layers.quantization.online.fp8 import (
 from vllm.model_executor.layers.quantization.online.moe_base import (
     OnlineMoEMethodBase,
 )
+from vllm.model_executor.layers.fusion.quant_activation import (
+    expose_input_quant_key,
+)
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
     mxfp4_quantize,
 )
@@ -125,6 +128,7 @@ class Mxfp4OnlineLinearMethod(_Fp8OnlineLinearBase):
         replace_parameter(layer, "weight_scale", weight_scale.data)
 
         self.kernel.process_weights_after_loading(layer)
+        expose_input_quant_key(layer, self.kernel)
 
         layer._already_called_process_weights_after_loading = True
 


### PR DESCRIPTION
Kimi-K3 serve still needs #51392 before `o_proj` is `Mxfp4OnlineLinearMethod`. This PR does not wire serve; tests stub `input_quant_key` / `input_quant_layout`.

Triton `gemm_afp4wfp4` and ASM `gemm_a4w4` are both `kMxfp4Dynamic` but use different scale layouts. Put layout on `QuantizedActivation` / `input_quant_layout` (`shuffled` when ASM is on). AITER linear unwraps a prequantized activation and skips in-op requant; unfused BF16 still quantizes inside the op. Also matches `gemm_with_dynamic_quant_fake` argument order to the real op (supersedes #52811).

## Test plan

- [ ] `pytest tests/fusion/test_quant_activation_contract.py`
- [ ] `pytest tests/kernels/quantization/test_quant_op_schema.py` (ROCm + AITER)