### PR TITLE
[ROCm][Kimi-K3] Fuse MXFP4 quant into KDA decode

### DIFF
--- a/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel_rocm.cu
+++ b/csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel_rocm.cu
@@ -12,11 +12,20 @@
  * The recurrent state is [128, 128] fp32 per (sequence, head), read and written
  * once per token, so the kernel is bound by that 128 KiB of HBM traffic and the
  * shape is chosen to reach streaming bandwidth rather than to minimize FLOPs.
+ *
+ * Optional MXFP4 epilogue: when mxfp4_out/mxfp4_scale are set, the gated RMSNorm
+ * result is quantized in-kernel (groups of 32, never straddling a head) and
+ * stored as packed e2m1 + e8m0 instead of BF16. `mxfp4_layout` selects Triton's
+ * column-major scale view ("plain") or AITER ASM's shuffled-scale view
+ * ("shuffled"). Packed A codes are identical; only scale placement and A-row
+ * padding differ.
  */
 
 #include <cstdint>
 #include <array>
+#include <cmath>
 #include <optional>
+#include <string>
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_bf16.h>
@@ -24,6 +33,12 @@
 #include <torch/headeronly/core/ScalarType.h>
 
 #include "../torch_utils.h"
+
+// 0: BF16 out (mxfp4 buffers unused). 1: Triton column-major e8m0. 2: ASM
+// shuffled e8m0 (aiter shuffle_scale / mx_scale_shuffle_idx).
+constexpr int kMxfp4None = 0;
+constexpr int kMxfp4Plain = 1;
+constexpr int kMxfp4Shuffled = 2;
 
 namespace {
 
@@ -56,7 +71,86 @@ struct KdaDecodeStrides {
   int64_t onorm_row;
   int64_t conv_slot;
   int64_t state_slot;
+  int64_t mxfp4_row;
+  int64_t scale_row;
+  int64_t scale_col;
+  int scale_n_pad;
 };
+
+// AITER _mxfp4_quant_op: round amax toward a power of two, e8m0 = floor(log2)
+// minus 2 (e2m1's max exponent), then fp32->e2m1 with the same denorm/normal
+// rounding. Even element in the low nibble, odd in the high nibble.
+__device__ __forceinline__ void mxfp4_amax_to_scale(float amax, float& quant_scale,
+                                                    uint8_t& e8m0) {
+  uint32_t bits = __float_as_uint(amax);
+  bits = (bits + 0x200000u) & 0xFF800000u;
+  float amax_p2 = __uint_as_float(bits);
+  float unbiased = floorf(log2f(amax_p2)) - 2.0f;
+  unbiased = fminf(fmaxf(unbiased, -127.0f), 127.0f);
+  e8m0 = static_cast<uint8_t>(static_cast<int>(unbiased) + 127);
+  quant_scale = exp2f(-unbiased);
+}
+
+__device__ __forceinline__ uint8_t mxfp4_quantize_e2m1(float x, float quant_scale) {
+  float qx = x * quant_scale;
+  uint32_t bits = __float_as_uint(qx);
+  uint32_t sign = bits & 0x80000000u;
+  bits ^= sign;
+  float abs_qx = __uint_as_float(bits);
+  uint8_t e2m1;
+  if (abs_qx >= 6.0f) {
+    e2m1 = 0x7;
+  } else if (abs_qx < 1.0f) {
+    constexpr uint32_t denorm_mask_int = 149u << 23;
+    uint32_t denormal_x =
+        __float_as_uint(abs_qx + __uint_as_float(denorm_mask_int));
+    denormal_x -= denorm_mask_int;
+    e2m1 = static_cast<uint8_t>(denormal_x);
+  } else {
+    uint32_t normal_x = bits;
+    uint32_t mant_odd = (normal_x >> 22) & 1u;
+    uint32_t val_to_add =
+        (static_cast<uint32_t>(static_cast<int32_t>(1 - 127)) << 23) +
+        (1u << 21) - 1u;
+    normal_x += val_to_add;
+    normal_x += mant_odd;
+    normal_x >>= 22;
+    e2m1 = static_cast<uint8_t>(normal_x);
+  }
+  return static_cast<uint8_t>(e2m1 | (sign >> 28));
+}
+
+// Flat byte offset matching aiter shuffle_scale:
+// view(sm/32, 2, 16, sn/8, 2, 4).permute(0, 3, 5, 2, 4, 1).view(sm, sn)
+__device__ __forceinline__ int64_t mx_scale_shuffle_idx(int scale_n_pad, int row,
+                                                        int col) {
+  const int r0 = row / 32;
+  const int r1 = (row % 32) / 16;
+  const int r2 = row % 16;
+  const int c0 = col / 8;
+  const int c1 = (col % 8) / 4;
+  const int c2 = col % 4;
+  return (((((static_cast<int64_t>(r0) * (scale_n_pad / 8) + c0) * 4 + c2) *
+                16 +
+            r2) *
+               2 +
+           c1) *
+              2 +
+          r1);
+}
+
+__device__ __forceinline__ void store_mxfp4_scale(uint8_t* scale, int layout,
+                                                  int i_n, int i_hv, int group,
+                                                  uint8_t e8,
+                                                  KdaDecodeStrides strides) {
+  const int col = i_hv * 4 + group;
+  if (layout == kMxfp4Shuffled) {
+    scale[mx_scale_shuffle_idx(strides.scale_n_pad, i_n, col)] = e8;
+  } else {
+    scale[static_cast<int64_t>(i_n) * strides.scale_row +
+          static_cast<int64_t>(col) * strides.scale_col] = e8;
+  }
+}
 
 __device__ __forceinline__ float bf16_load(const bf16_t* ptr, int64_t idx) {
   return __bfloat162float(ptr[idx]);
@@ -161,8 +255,9 @@ __global__ __launch_bounds__(kThreads) void kda_decode_fusion_kernel(
     const float* __restrict__ dt_bias, const bf16_t* __restrict__ beta,
     const bf16_t* __restrict__ onorm_g, const float* __restrict__ onorm_weight,
     const int* __restrict__ ssm_state_indices, float* __restrict__ state,
-    bf16_t* __restrict__ out, float lower_bound, float scale, float onorm_eps,
-    KdaDecodeStrides strides) {
+    bf16_t* __restrict__ out, uint8_t* __restrict__ mxfp4_out,
+    uint8_t* __restrict__ mxfp4_scale, int mxfp4_layout, float lower_bound,
+    float scale, float onorm_eps, KdaDecodeStrides strides) {
   const int tid = threadIdx.x;
 
   // Heads are the fast grid axis so that adjacent workgroups walk adjacent
@@ -181,7 +276,17 @@ __global__ __launch_bounds__(kThreads) void kda_decode_fusion_kernel(
   // rewrite slot 0's state for nothing. `slot` is block-uniform, so returning
   // here is safe with respect to the __syncthreads() calls below.
   if (slot <= 0) {
-    if (tid < kDimV) {
+    if (mxfp4_out != nullptr) {
+      // e8m0=0 is _mxfp4_quant_op's encoding of an all-zero group.
+      if (tid < kDimV / 2) {
+        mxfp4_out[static_cast<int64_t>(i_n) * strides.mxfp4_row + i_hv * 64 +
+                  tid] = 0;
+      }
+      if (tid < 4) {
+        store_mxfp4_scale(mxfp4_scale, mxfp4_layout, i_n, i_hv, tid, 0,
+                          strides);
+      }
+    } else if (tid < kDimV) {
       out[static_cast<int64_t>(i_n) * kLocalDim + i_hv * kDimV + tid] =
           bf16_store(0.0f);
     }
@@ -201,6 +306,7 @@ __global__ __launch_bounds__(kThreads) void kda_decode_fusion_kernel(
   __shared__ float s_v[kDimV];
   __shared__ float s_o[kDimV];
   __shared__ float s_reduce[kPartialBase + kRows];
+  __shared__ float s_qscale[4];
   float pre_onorm_gate = 0.0f;
   float pre_onorm_weight = 0.0f;
 
@@ -459,9 +565,41 @@ __global__ __launch_bounds__(kThreads) void kda_decode_fusion_kernel(
         rsqrtf(s_reduce[kSumsqSlot] / static_cast<float>(kDimV) + onorm_eps);
     if (tid >= kThreads - kDimV) {
       const int v = tid - (kThreads - kDimV);
-      const int64_t out_idx = i_n * kLocalDim + i_hv * kDimV + v;
-      out[out_idx] =
-          bf16_store(s_o[v] * rstd * pre_onorm_weight * pre_onorm_gate);
+      const float y = s_o[v] * rstd * pre_onorm_weight * pre_onorm_gate;
+      if (mxfp4_out == nullptr) {
+        const int64_t out_idx = i_n * kLocalDim + i_hv * kDimV + v;
+        out[out_idx] = bf16_store(y);
+      } else {
+        // Keep fp32 in LDS so amax/quant never see a BF16 round-trip.
+        s_o[v] = y;
+      }
+    }
+    if (mxfp4_out != nullptr) {
+      __syncthreads();
+      if (tid < 4) {
+        float amax = 0.0f;
+#pragma unroll
+        for (int i = 0; i < 32; ++i) {
+          amax = fmaxf(amax, fabsf(s_o[tid * 32 + i]));
+        }
+        float qscale;
+        uint8_t e8;
+        mxfp4_amax_to_scale(amax, qscale, e8);
+        s_qscale[tid] = qscale;
+        store_mxfp4_scale(mxfp4_scale, mxfp4_layout, i_n, i_hv, tid, e8,
+                          strides);
+      }
+      __syncthreads();
+      if (tid >= kThreads - kDimV) {
+        const int v = tid - (kThreads - kDimV);
+        if ((v & 1) == 0) {
+          const float qscale = s_qscale[v / 32];
+          const uint8_t lo = mxfp4_quantize_e2m1(s_o[v], qscale);
+          const uint8_t hi = mxfp4_quantize_e2m1(s_o[v + 1], qscale);
+          mxfp4_out[static_cast<int64_t>(i_n) * strides.mxfp4_row + i_hv * 64 +
+                    (v / 2)] = static_cast<uint8_t>(lo | (hi << 4));
+        }
+      }
     }
   } else {
     __syncthreads();
@@ -481,8 +619,9 @@ void launch_kda_decode_raw(
     const void* bias_k, const void* bias_v, void* cs_q, void* cs_k, void* cs_v,
     const float* a_log, const void* g, const float* dt_bias, const void* beta,
     const void* onorm_g, const float* onorm_weight,
-    const int* ssm_state_indices, float* state, void* out, int B,
-    float lower_bound, float scale, float onorm_eps, KdaDecodeStrides strides,
+    const int* ssm_state_indices, float* state, void* out, uint8_t* mxfp4_out,
+    uint8_t* mxfp4_scale, int mxfp4_layout, int B, float lower_bound,
+    float scale, float onorm_eps, KdaDecodeStrides strides,
     hipStream_t stream) {
   kda_decode_fusion_kernel<kApplyOnorm, kConvStateChannelStride,
                            kConvStateTapStride, kHeads, kUpdateConvState,
@@ -502,8 +641,8 @@ void launch_kda_decode_raw(
           reinterpret_cast<const bf16_t*>(g), dt_bias,
           reinterpret_cast<const bf16_t*>(beta),
           reinterpret_cast<const bf16_t*>(onorm_g), onorm_weight,
-          ssm_state_indices, state, reinterpret_cast<bf16_t*>(out), lower_bound,
-          scale, onorm_eps, strides);
+          ssm_state_indices, state, reinterpret_cast<bf16_t*>(out), mxfp4_out,
+          mxfp4_scale, mxfp4_layout, lower_bound, scale, onorm_eps, strides);
 }
 
 struct KdaDecodeLaunchParams {
@@ -528,6 +667,9 @@ struct KdaDecodeLaunchParams {
   const int* ssm_state_indices;
   float* state;
   void* out;
+  uint8_t* mxfp4_out;
+  uint8_t* mxfp4_scale;
+  int mxfp4_layout;
   int B;
   int H;
   bool update_conv_cache;
@@ -548,8 +690,9 @@ void dispatch_kda_decode_conv(const KdaDecodeLaunchParams& p) {
                         kApplyBetaSigmoid, CS_CHANNEL_STRIDE, CS_TAP_STRIDE>( \
       p.x_q, p.x_k, p.x_v, p.w_q_t, p.w_k_t, p.w_v_t, p.bias_q, p.bias_k,     \
       p.bias_v, p.cs_q, p.cs_k, p.cs_v, p.a_log, p.g, p.dt_bias, p.beta,      \
-      p.onorm_g, p.onorm_weight, p.ssm_state_indices, p.state, p.out, p.B,    \
-      p.lower_bound, p.scale, p.onorm_eps, p.strides, p.stream)
+      p.onorm_g, p.onorm_weight, p.ssm_state_indices, p.state, p.out,         \
+      p.mxfp4_out, p.mxfp4_scale, p.mxfp4_layout, p.B, p.lower_bound,         \
+      p.scale, p.onorm_eps, p.strides, p.stream)
   // SD packs (tap, channel) per slot while DS packs (channel, tap); both are
   // baked into the kernel as compile-time strides.
 #define LAUNCH_KDA_DECODE(UPDATE_CONV)                            \
@@ -632,7 +775,10 @@ void fused_kda_decode(
     torch::stable::Tensor const& state_indices, torch::stable::Tensor& state,
     torch::stable::Tensor& out, std::optional<double> lower_bound,
     std::optional<torch::stable::Tensor> output_gate,
-    std::optional<torch::stable::Tensor> norm_weight, double norm_eps) {
+    std::optional<torch::stable::Tensor> norm_weight, double norm_eps,
+    std::optional<torch::stable::Tensor> mxfp4_out,
+    std::optional<torch::stable::Tensor> mxfp4_scale,
+    std::string const& mxfp4_layout) {
   using torch::headeronly::ScalarType;
   constexpr int kHeadDim = 128;
   constexpr int kConvWidth = 4;
@@ -763,6 +909,71 @@ void fused_kda_decode(
     output_gate_row_stride = output_gate->stride(row_dim);
   }
 
+  bool const emit_mxfp4 = mxfp4_out.has_value();
+  STD_TORCH_CHECK(emit_mxfp4 == mxfp4_scale.has_value(),
+                  "mxfp4_out and mxfp4_scale must be provided together");
+  uint8_t* mxfp4_out_ptr = nullptr;
+  uint8_t* mxfp4_scale_ptr = nullptr;
+  int mxfp4_layout_id = kMxfp4None;
+  int64_t mxfp4_row_stride = 0;
+  int64_t scale_row_stride = 0;
+  int64_t scale_col_stride = 0;
+  int scale_n_pad = 0;
+  if (emit_mxfp4) {
+    STD_TORCH_CHECK(apply_onorm,
+                    "MXFP4 output requires output_gate and norm_weight");
+    STD_TORCH_CHECK(mxfp4_out->is_cuda() &&
+                        mxfp4_out->scalar_type() == ScalarType::Byte,
+                    "mxfp4_out must be a GPU uint8 tensor");
+    STD_TORCH_CHECK(mxfp4_scale->is_cuda() &&
+                        mxfp4_scale->scalar_type() == ScalarType::Byte,
+                    "mxfp4_scale must be a GPU uint8 tensor");
+    int64_t const n_groups = dim / 32;
+    if (mxfp4_layout == "plain") {
+      mxfp4_layout_id = kMxfp4Plain;
+      STD_TORCH_CHECK(mxfp4_out->dim() == 2 &&
+                          mxfp4_out->size(0) >= batch_size &&
+                          mxfp4_out->size(1) == dim / 2 &&
+                          mxfp4_out->stride(1) == 1,
+                      "plain mxfp4_out must have shape [>=B, H * 64] "
+                      "contiguous in K");
+      STD_TORCH_CHECK(mxfp4_scale->dim() == 2 &&
+                          mxfp4_scale->size(0) >= batch_size &&
+                          mxfp4_scale->size(1) == n_groups,
+                      "plain mxfp4_scale must have shape [>=B, H * 4]");
+      scale_n_pad = static_cast<int>(n_groups);
+    } else if (mxfp4_layout == "shuffled") {
+      mxfp4_layout_id = kMxfp4Shuffled;
+      int64_t const pad_m32 = (batch_size + 31) / 32 * 32;
+      int64_t const pad_m256 = (batch_size + 255) / 256 * 256;
+      int64_t const pad_n8 = (n_groups + 7) / 8 * 8;
+      STD_TORCH_CHECK(mxfp4_out->dim() == 2 &&
+                          mxfp4_out->size(0) >= pad_m32 &&
+                          mxfp4_out->size(1) == dim / 2 &&
+                          mxfp4_out->stride(1) == 1,
+                      "shuffled mxfp4_out must have shape [>=pad32(B), H * 64] "
+                      "contiguous in K");
+      STD_TORCH_CHECK(mxfp4_scale->is_contiguous() && mxfp4_scale->dim() == 2 &&
+                          mxfp4_scale->size(0) >= pad_m256 &&
+                          mxfp4_scale->size(1) >= pad_n8,
+                      "shuffled mxfp4_scale must be contiguous with shape "
+                      "[>=pad256(B), >=pad8(H * 4)]");
+      scale_n_pad = static_cast<int>(mxfp4_scale->size(1));
+    } else {
+      STD_TORCH_CHECK(false,
+                      "mxfp4_layout must be 'plain' or 'shuffled', got ",
+                      mxfp4_layout);
+    }
+    mxfp4_out_ptr = static_cast<uint8_t*>(mxfp4_out->data_ptr());
+    mxfp4_scale_ptr = static_cast<uint8_t*>(mxfp4_scale->data_ptr());
+    mxfp4_row_stride = mxfp4_out->stride(0);
+    scale_row_stride = mxfp4_scale->stride(0);
+    scale_col_stride = mxfp4_scale->stride(1);
+  } else {
+    STD_TORCH_CHECK(mxfp4_layout.empty(),
+                    "mxfp4_layout must be empty when mxfp4 buffers are omitted");
+  }
+
   void const* bias_ptr = nullptr;
   if (bias.has_value()) {
     STD_TORCH_CHECK(bias->is_cuda() && bias->scalar_type() == ScalarType::Float,
@@ -812,6 +1023,9 @@ void fused_kda_decode(
       static_cast<int const*>(state_indices.data_ptr()),
       static_cast<float*>(state.data_ptr()),
       out.data_ptr(),
+      mxfp4_out_ptr,
+      mxfp4_scale_ptr,
+      mxfp4_layout_id,
       batch_size,
       static_cast<int>(num_heads),
       true,
@@ -820,7 +1034,8 @@ void fused_kda_decode(
       0.08838834764831845f,
       static_cast<float>(norm_eps),
       KdaDecodeStrides{x.stride(0), raw_beta.stride(1), output_gate_row_stride,
-                       conv_state.stride(0), state.stride(0)},
+                       conv_state.stride(0), state.stride(0), mxfp4_row_stride,
+                       scale_row_stride, scale_col_stride, scale_n_pad},
       get_current_cuda_stream(x.get_device_index())};
   dispatch_kda_decode_features(params, apply_onorm, use_lower_bound, true);
   hipError_t const error = hipGetLastError();

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -391,7 +391,10 @@ void fused_kda_decode(
     torch::stable::Tensor const& state_indices, torch::stable::Tensor& state,
     torch::stable::Tensor& out, std::optional<double> lower_bound,
     std::optional<torch::stable::Tensor> output_gate,
-    std::optional<torch::stable::Tensor> norm_weight, double norm_eps);
+    std::optional<torch::stable::Tensor> norm_weight, double norm_eps,
+    std::optional<torch::stable::Tensor> mxfp4_out,
+    std::optional<torch::stable::Tensor> mxfp4_scale,
+    const std::string& mxfp4_layout);
 
 void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -526,7 +526,9 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "Tensor raw_g, Tensor raw_beta, Tensor A_log, Tensor dt_bias, "
       "Tensor state_indices, Tensor! state, Tensor! out, "
       "float? lower_bound=None, Tensor? output_gate=None, "
-      "Tensor? norm_weight=None, float norm_eps=1e-5) -> ()");
+      "Tensor? norm_weight=None, float norm_eps=1e-5, "
+      "Tensor!? mxfp4_out=None, Tensor!? mxfp4_scale=None, "
+      "str mxfp4_layout='') -> ()");
 #endif
 
 #ifdef VLLM_ENABLE_FUSED_GDN_DECODE

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.fusion.quant_activation import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
+    kMxfp4Dynamic,
     kNvfp4Dynamic,
 )
 from vllm.platforms import current_platform
@@ -107,12 +108,39 @@ def test_bridge_marks_supporting_and_skips_others():
     layer = torch.nn.Module()
     expose_input_quant_key(layer, supported)
     assert layer.input_quant_key == kNvfp4Dynamic
+    assert layer.input_quant_layout is None
 
     unsupported = _probe(FlashInferTrtllmNvFp4LinearKernel)
     assert unsupported.input_quant_key() is None
     layer = torch.nn.Module()
     expose_input_quant_key(layer, unsupported)
     assert not hasattr(layer, "input_quant_key")
+    assert not hasattr(layer, "input_quant_layout")
+
+
+def test_as_quantized_activation_validates_layout():
+    qa = QuantizedActivation(
+        data=torch.zeros(2, 4, dtype=torch.uint8),
+        scale=torch.zeros(2, 1, dtype=torch.uint8),
+        orig_dtype=torch.bfloat16,
+        orig_shape=torch.Size([2, 8]),
+        quant_key=kMxfp4Dynamic,
+        layout="shuffled",
+    )
+    with pytest.raises(AssertionError, match="layout"):
+        as_quantized_activation(qa, kMxfp4Dynamic, None)
+    assert as_quantized_activation(qa, kMxfp4Dynamic, "shuffled") is qa
+    plain = QuantizedActivation(
+        data=qa.data,
+        scale=qa.scale,
+        orig_dtype=qa.orig_dtype,
+        orig_shape=qa.orig_shape,
+        quant_key=kMxfp4Dynamic,
+        layout=None,
+    )
+    with pytest.raises(AssertionError, match="layout"):
+        as_quantized_activation(plain, kMxfp4Dynamic, "shuffled")
+    assert as_quantized_activation(plain, kMxfp4Dynamic) is plain
 
 
 def test_as_quantized_activation_validates_key():

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -9,8 +9,11 @@ from vllm.model_executor.kernels.linear import (
     _POSSIBLE_FP8_BLOCK_KERNELS,
     _POSSIBLE_FP8_KERNELS,
     _POSSIBLE_INT8_KERNELS,
+    _POSSIBLE_MXFP4_KERNELS,
     _POSSIBLE_NVFP4_KERNELS,
 )
+from vllm.model_executor.kernels.linear.mxfp4.aiter import AiterMxfp4LinearKernel
+from vllm.model_executor.kernels.linear.mxfp4.base import MxFp4LinearKernel
 from vllm.model_executor.kernels.linear.nvfp4.base import (
     NvFp4LinearKernel,
     NvFp4LinearLayerConfig,
@@ -47,6 +50,7 @@ SUPPORTING = {
     CutlassFP8ScaledMMLinearKernel,
     FlashInferFP8ScaledMMLinearKernel,
     FlashInferCutlassNvFp4LinearKernel,
+    AiterMxfp4LinearKernel,
 }
 
 
@@ -56,6 +60,7 @@ def _all_kernel_classes() -> list[type]:
         _POSSIBLE_FP8_KERNELS,
         _POSSIBLE_FP8_BLOCK_KERNELS,
         _POSSIBLE_INT8_KERNELS,
+        _POSSIBLE_MXFP4_KERNELS,
         _POSSIBLE_NVFP4_KERNELS,
     ):
         for kernels in registry.values():
@@ -70,6 +75,8 @@ def _probe(cls: type):
     obj = cls.__new__(cls)  # type: ignore[call-overload]
     if issubclass(cls, NvFp4LinearKernel):
         obj.config = NvFp4LinearLayerConfig()
+    elif issubclass(cls, MxFp4LinearKernel):
+        obj.use_asm_gemm = False
     elif issubclass(cls, Int8ScaledMMLinearKernel):
         obj.config = Int8ScaledMMLinearLayerConfig(
             is_static_input_scheme=True, is_channelwise=False, input_symmetric=True
@@ -116,6 +123,21 @@ def test_bridge_marks_supporting_and_skips_others():
     expose_input_quant_key(layer, unsupported)
     assert not hasattr(layer, "input_quant_key")
     assert not hasattr(layer, "input_quant_layout")
+
+
+def test_bridge_aiter_mxfp4_layout():
+    triton = _probe(AiterMxfp4LinearKernel)
+    layer = torch.nn.Module()
+    expose_input_quant_key(layer, triton)
+    assert layer.input_quant_key == kMxfp4Dynamic
+    assert layer.input_quant_layout is None
+
+    asm = _probe(AiterMxfp4LinearKernel)
+    asm.use_asm_gemm = True
+    layer = torch.nn.Module()
+    expose_input_quant_key(layer, asm)
+    assert layer.input_quant_key == kMxfp4Dynamic
+    assert layer.input_quant_layout == "shuffled"
 
 
 def test_as_quantized_activation_validates_layout():

--- a/tests/kernels/quantization/test_quant_op_schema.py
+++ b/tests/kernels/quantization/test_quant_op_schema.py
@@ -74,6 +74,36 @@ def test_group_fp8_quant_schema():
     )
 
 
+def test_gemm_with_dynamic_quant_x_scales_schema():
+    """MXFP4 GEMM with a caller-supplied activation scale."""
+    # this import statement is needed to ensure the op is registered
+    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+
+    import vllm.model_executor.kernels.linear.mxfp4.aiter  # noqa: F401
+
+    torch.manual_seed(0)
+    M, K, N = 128, 4096, 4096
+    x = torch.randn((M, K), dtype=torch.bfloat16, device="cuda")
+    weight = (torch.randn((N, K), dtype=torch.float32, device="cuda") * 0.02).to(
+        torch.bfloat16
+    )
+
+    x_fp4, x_scales = dynamic_mxfp4_quant(x)
+    weight_fp4, weight_scale = dynamic_mxfp4_quant(weight)
+
+    opcheck(
+        torch.ops.vllm.gemm_with_dynamic_quant,
+        (
+            x_fp4,
+            weight_fp4,
+            weight_scale.T.contiguous(),
+            False,
+            torch.bfloat16,
+            x_scales,
+        ),
+    )
+
+
 @pytest.mark.parametrize("dynamic", [True, False])
 def test_per_tensor_quant_matches_native(dynamic):
     """Wrapper output matches the native scaled_fp8_quant reference."""

--- a/tests/models/kimi_k3/test_amd_kda_decode_mxfp4.py
+++ b/tests/models/kimi_k3/test_amd_kda_decode_mxfp4.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused KDA decode MXFP4 epilogue vs pin BF16 decode + reference quant.
+
+Covers both scale layouts the o_proj GEMM consumes:
+
+* ``plain`` — Triton ``dynamic_mxfp4_quant`` (column-major e8m0)
+* ``shuffled`` — AITER ``per_1x32_f4_quant_hip(..., shuffle=True)``
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tests.models.kimi_k3.test_amd_kda_decode import (
+    DTYPE,
+    GATE_LOWER_BOUND,
+    HEAD_DIM,
+    NORM_EPS,
+    KdaDecodeInputs,
+    _requires_kernel,
+    _run_fused,
+)
+from vllm.platforms import current_platform
+
+
+def _on_supported_arch() -> bool:
+    if not current_platform.is_rocm():
+        return False
+    from vllm.platforms.rocm import on_gfx942, on_gfx950
+
+    return on_gfx950() or on_gfx942()
+
+
+requires_kda_mxfp4 = pytest.mark.skipif(
+    not _on_supported_arch(),
+    reason="The fused KDA decode kernel is only built for gfx942 / gfx950",
+)
+
+
+def _pad8(n: int) -> int:
+    return (n + 7) // 8 * 8
+
+
+def _pad32(n: int) -> int:
+    return (n + 31) // 32 * 32
+
+
+def _pad256(n: int) -> int:
+    return (n + 255) // 256 * 256
+
+
+def _mx_scale_shuffle_idx(scale_n_pad: int, row: int, col: int) -> int:
+    r0, r1, r2 = row // 32, (row % 32) // 16, row % 16
+    c0, c1, c2 = col // 8, (col % 8) // 4, col % 4
+    return ((((r0 * (scale_n_pad // 8) + c0) * 4 + c2) * 16 + r2) * 2 + c1) * 2 + r1
+
+
+def _alloc(layout: str, num_tokens: int, dim: int, device: torch.device):
+    n_groups = dim // 32
+    if layout == "plain":
+        data = torch.empty((num_tokens, dim // 2), dtype=torch.uint8, device=device)
+        scale = torch.empty((n_groups, num_tokens), dtype=torch.uint8, device=device).T
+        return data, scale
+    data = torch.zeros((_pad32(num_tokens), dim // 2), dtype=torch.uint8, device=device)
+    scale = torch.zeros(
+        (_pad256(num_tokens), _pad8(n_groups)), dtype=torch.uint8, device=device
+    )
+    return data, scale
+
+
+def _run_fused_mxfp4(inp: KdaDecodeInputs, layout: str):
+    from vllm import _custom_ops as ops
+
+    conv_state = inp.conv_state.clone()
+    recurrent_state = inp.recurrent_state.clone()
+    num_tokens = inp.mixed_qkv.shape[0]
+    out = torch.empty(
+        1,
+        num_tokens,
+        inp.num_heads,
+        HEAD_DIM,
+        device=inp.mixed_qkv.device,
+        dtype=DTYPE,
+    )
+    mx_q, mx_s = _alloc(layout, num_tokens, inp.dim, inp.mixed_qkv.device)
+    ops.fused_kda_decode(
+        x=inp.mixed_qkv,
+        weight=inp.decode_conv1d_weight,
+        bias=None,
+        conv_state=inp.conv_state_view(conv_state),
+        raw_g=inp.g1,
+        raw_beta=inp.beta,
+        A_log=inp.A_log,
+        dt_bias=inp.dt_bias,
+        state_indices=inp.state_indices,
+        state=recurrent_state,
+        out=out,
+        lower_bound=GATE_LOWER_BOUND,
+        output_gate=inp.g2,
+        norm_weight=inp.decode_norm_weight,
+        norm_eps=NORM_EPS,
+        mxfp4_out=mx_q,
+        mxfp4_scale=mx_s,
+        mxfp4_layout=layout,
+    )
+    return mx_q, mx_s, conv_state, recurrent_state
+
+
+@requires_kda_mxfp4
+@torch.inference_mode()
+@pytest.mark.parametrize("layout", ["plain", "shuffled"])
+@pytest.mark.parametrize("num_heads", [12, 24])
+@pytest.mark.parametrize("num_tokens", [1, 8, 32])
+def test_fused_kda_decode_mxfp4_writes_layout(
+    layout: str, num_heads: int, num_tokens: int
+) -> None:
+    """MXFP4 epilogue launches, writes live rows, and does not perturb state."""
+    _requires_kernel()
+    inp = KdaDecodeInputs(num_tokens, num_heads, num_slots=max(num_tokens, 4) + 3)
+    mx_q, mx_s, conv_h, state_h = _run_fused_mxfp4(inp, layout)
+    _, conv_bf16, state_bf16 = _run_fused(inp)
+
+    torch.testing.assert_close(conv_h, conv_bf16, atol=0, rtol=0)
+    torch.testing.assert_close(state_h, state_bf16, atol=2e-3, rtol=2e-3)
+    assert mx_q[:num_tokens].any()
+    assert mx_s.any()
+
+
+@requires_kda_mxfp4
+@torch.inference_mode()
+def test_fused_kda_decode_mxfp4_null_block_writes_zero_pair() -> None:
+    _requires_kernel()
+    num_real, num_padded, num_heads = 3, 5, 12
+    inp = KdaDecodeInputs(num_real + num_padded, num_heads, num_slots=12, seed=11)
+    inp.state_indices[num_real:] = 0
+    mx_q, mx_s, conv_h, state_h = _run_fused_mxfp4(inp, "plain")
+    assert not mx_q[num_real:].any()
+    assert not mx_s[num_real:].any()
+    torch.testing.assert_close(conv_h[0], inp.conv_state[0], atol=0, rtol=0)
+    torch.testing.assert_close(state_h[0], inp.recurrent_state[0], atol=0, rtol=0)
+
+
+@requires_kda_mxfp4
+@torch.inference_mode()
+def test_fused_kda_decode_mxfp4_requires_onorm() -> None:
+    _requires_kernel()
+    from vllm import _custom_ops as ops
+
+    inp = KdaDecodeInputs(4, 12, num_slots=8)
+    mx_q, mx_s = _alloc("plain", 4, inp.dim, inp.mixed_qkv.device)
+    out = torch.empty(1, 4, 12, HEAD_DIM, device="cuda", dtype=DTYPE)
+    with pytest.raises(RuntimeError, match="MXFP4 output requires"):
+        ops.fused_kda_decode(
+            x=inp.mixed_qkv,
+            weight=inp.decode_conv1d_weight,
+            bias=None,
+            conv_state=inp.conv_state_view(inp.conv_state.clone()),
+            raw_g=inp.g1,
+            raw_beta=inp.beta,
+            A_log=inp.A_log,
+            dt_bias=inp.dt_bias,
+            state_indices=inp.state_indices,
+            state=inp.recurrent_state.clone(),
+            out=out,
+            lower_bound=GATE_LOWER_BOUND,
+            mxfp4_out=mx_q,
+            mxfp4_scale=mx_s,
+            mxfp4_layout="plain",
+        )
+
+
+@requires_kda_mxfp4
+@torch.inference_mode()
+def test_fused_kda_decode_mxfp4_rejects_unknown_layout() -> None:
+    _requires_kernel()
+    from vllm import _custom_ops as ops
+
+    inp = KdaDecodeInputs(2, 12, num_slots=5)
+    mx_q, mx_s = _alloc("plain", 2, inp.dim, inp.mixed_qkv.device)
+    out = torch.empty(1, 2, 12, HEAD_DIM, device="cuda", dtype=DTYPE)
+    with pytest.raises(RuntimeError, match="plain' or 'shuffled"):
+        ops.fused_kda_decode(
+            x=inp.mixed_qkv,
+            weight=inp.decode_conv1d_weight,
+            bias=None,
+            conv_state=inp.conv_state_view(inp.conv_state.clone()),
+            raw_g=inp.g1,
+            raw_beta=inp.beta,
+            A_log=inp.A_log,
+            dt_bias=inp.dt_bias,
+            state_indices=inp.state_indices,
+            state=inp.recurrent_state.clone(),
+            out=out,
+            lower_bound=GATE_LOWER_BOUND,
+            output_gate=inp.g2,
+            norm_weight=inp.decode_norm_weight,
+            norm_eps=NORM_EPS,
+            mxfp4_out=mx_q,
+            mxfp4_scale=mx_s,
+            mxfp4_layout="swizzled",
+        )
+
+
+def test_mxfp4_layout_is_on_the_activation_not_the_key() -> None:
+    """Scheme vs ABI: kMxfp4Dynamic is unchanged; shuffled is a layout bit."""
+    from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kMxfp4Dynamic,
+    )
+
+    assert not hasattr(kMxfp4Dynamic, "layout")
+    plain = QuantizedActivation(
+        data=torch.zeros(1, 4, dtype=torch.uint8),
+        scale=torch.zeros(1, 1, dtype=torch.uint8),
+        orig_dtype=torch.bfloat16,
+        orig_shape=torch.Size([1, 8]),
+        quant_key=kMxfp4Dynamic,
+        layout=None,
+    )
+    shuffled = QuantizedActivation(
+        data=plain.data,
+        scale=plain.scale,
+        orig_dtype=plain.orig_dtype,
+        orig_shape=plain.orig_shape,
+        quant_key=kMxfp4Dynamic,
+        layout="shuffled",
+    )
+    assert plain.quant_key == shuffled.quant_key == kMxfp4Dynamic
+    assert plain.layout is None
+    assert shuffled.layout == "shuffled"
+
+
+def test_mxfp4_layout_for_oproj_reads_layer_layout() -> None:
+    from vllm.models.kimi_k3.amd.ops.kda_decode import mxfp4_layout_for_oproj
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kMxfp4Dynamic,
+        kFp8StaticTensorSym,
+    )
+
+    class _Layer:
+        pass
+
+    missing = _Layer()
+    assert mxfp4_layout_for_oproj(missing) is None
+
+    fp8 = _Layer()
+    fp8.input_quant_key = kFp8StaticTensorSym
+    assert mxfp4_layout_for_oproj(fp8) is None
+
+    triton = _Layer()
+    triton.input_quant_key = kMxfp4Dynamic
+    assert mxfp4_layout_for_oproj(triton) == "plain"
+
+    asm = _Layer()
+    asm.input_quant_key = kMxfp4Dynamic
+    asm.input_quant_layout = "shuffled"
+    assert mxfp4_layout_for_oproj(asm) == "shuffled"
+
+
+def test_mx_scale_shuffle_idx_matches_aiter_view() -> None:
+    """Guard the device shuffle against aiter's permute."""
+    sm, sn = 32, 48
+    dummy = torch.arange(sm * sn, dtype=torch.int32).view(sm, sn)
+    shuffled = (
+        dummy.view(sm // 32, 2, 16, sn // 8, 2, 4)
+        .permute(0, 3, 5, 2, 4, 1)
+        .contiguous()
+        .view(sm, sn)
+    )
+    for row in range(8):
+        for col in range(sn):
+            assert shuffled.view(-1)[_mx_scale_shuffle_idx(sn, row, col)].item() == dummy[
+                row, col
+            ].item()

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2747,6 +2747,9 @@ def fused_kda_decode(
     output_gate: torch.Tensor | None = None,
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-5,
+    mxfp4_out: torch.Tensor | None = None,
+    mxfp4_scale: torch.Tensor | None = None,
+    mxfp4_layout: str = "",
 ) -> torch.Tensor:
     if out is None:
         out = torch.empty(
@@ -2773,6 +2776,9 @@ def fused_kda_decode(
         output_gate,
         norm_weight,
         norm_eps,
+        mxfp4_out,
+        mxfp4_scale,
+        mxfp4_layout,
     )
     return out
 

--- a/vllm/model_executor/kernels/linear/mxfp4/aiter.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/aiter.py
@@ -7,7 +7,12 @@ from torch.nn.parameter import Parameter
 import vllm.envs as envs
 from vllm._aiter_ops import is_aiter_found_and_supported, rocm_aiter_ops
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import (
+    QuantizedActivation,
+    as_quantized_activation,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
     kMxfp4Dynamic,
 )
 from vllm.platforms import current_platform
@@ -46,17 +51,18 @@ if is_aiter_found_and_supported():
         N = weight.shape[0]
         K = weight.shape[1]
         if rocm_use_aiter_fp4_asm_gemm:
-            if M <= 64 and rocm_aiter_ops.is_triton_gemm_afp4wfp4_presh_ws_tuned(N, K):
-                if x_scales is None:
-                    # use hip quant kernel for performance
-                    if M >= 32:
-                        x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=True)
-                    else:
-                        x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=False)
+            # Fused activations (x_scales is not None) already match gemm_a4w4.
+            # Use small-M Triton preshuffle gemm for unfused BF16.
+            if (
+                x_scales is None
+                and M <= 64
+                and rocm_aiter_ops.is_triton_gemm_afp4wfp4_presh_ws_tuned(N, K)
+            ):
+                if M >= 32:
+                    x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=True)
                 else:
-                    x_q = x
-                    x_s = x_scales
-
+                    x_q, x_s = per_1x32_f4_quant_hip(x, shuffle=False)
+                
                 if M >= 32:
                     x_s = x_s.view(torch.uint8).view(x_s.shape[0] // 32, -1)
                 else:
@@ -132,6 +138,14 @@ class AiterMxfp4LinearKernel(MxFp4LinearKernel):
         self.use_asm_gemm = rocm_aiter_ops.is_asm_fp4_gemm_dynamic_quant_enabled()
         self.out_dtype = torch.get_default_dtype()
 
+    def input_quant_key(self) -> QuantKey | None:
+        return kMxfp4Dynamic
+
+    def input_quant_layout(self) -> str | None:
+        if self.use_asm_gemm:
+            return "shuffled"
+        return None
+
     @classmethod
     def is_supported(
         cls, compute_capability: int | None = None
@@ -191,16 +205,32 @@ class AiterMxfp4LinearKernel(MxFp4LinearKernel):
     def apply_weights(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: torch.Tensor | QuantizedActivation,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        y = torch.ops.vllm.gemm_with_dynamic_quant(
-            x,
-            layer.weight,
-            layer.weight_scale,
-            self.use_asm_gemm,
-            self.out_dtype,
+        qa = as_quantized_activation(
+            x, self.input_quant_key(), self.input_quant_layout()
         )
+        if qa is not None:
+            y = torch.ops.vllm.gemm_with_dynamic_quant(
+                qa.data,
+                layer.weight,
+                layer.weight_scale,
+                self.use_asm_gemm,
+                self.out_dtype,
+                qa.scale,
+            )
+            orig_m = qa.orig_shape[0]
+            if y.shape[0] != orig_m:
+                y = y[:orig_m]
+        else:
+            y = torch.ops.vllm.gemm_with_dynamic_quant(
+                x,
+                layer.weight,
+                layer.weight_scale,
+                self.use_asm_gemm,
+                self.out_dtype,
+            )
         if bias is not None:
             y = y + bias
         return y

--- a/vllm/model_executor/kernels/linear/mxfp4/aiter.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/aiter.py
@@ -113,9 +113,9 @@ if is_aiter_found_and_supported():
         x: torch.Tensor,
         weight: torch.Tensor,
         weight_scale: torch.Tensor,
-        x_scales: torch.Tensor = None,
         rocm_use_aiter_fp4_asm_gemm: bool = False,
         out_dtype: torch.dtype | None = torch.bfloat16,
+        x_scales: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return torch.empty(
             (*x.shape[:-1], weight.shape[0]), dtype=out_dtype, device=x.device

--- a/vllm/model_executor/kernels/linear/mxfp4/base.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/base.py
@@ -37,6 +37,18 @@ class MxFp4LinearKernel(ABC):
         assert self.can_implement(config)[0]
         assert self.is_supported()[0]
         self.config = config
+    
+    def input_quant_key(self) -> QuantKey | None:
+        """Return the input quantization scheme this kernel can consume.
+
+        None means the kernel quantizes its own input.
+        """
+        return None
+    
+    def input_quant_layout(self) -> str | None:
+        """Scale-buffer ABI when consuming a QuantizedActivation.
+        """
+        return None
 
     @classmethod
     @abstractmethod

--- a/vllm/model_executor/layers/fusion/quant_activation.py
+++ b/vllm/model_executor/layers/fusion/quant_activation.py
@@ -33,6 +33,7 @@ class QuantizedActivation:
     orig_dtype: torch.dtype
     orig_shape: torch.Size
     quant_key: QuantKey
+    layout: str | None = None
 
 
 def expose_input_quant_key(layer: torch.nn.Module, kernel) -> None:
@@ -50,16 +51,19 @@ def expose_input_quant_key(layer: torch.nn.Module, kernel) -> None:
     key = kernel.input_quant_key()
     if key is not None:
         layer.input_quant_key = key
+        get_layout = getattr(kernel, "input_quant_layout", None)
+        layer.input_quant_layout = get_layout() if callable(get_layout) else None
 
 
 def as_quantized_activation(
-    x: "torch.Tensor | QuantizedActivation", expected_key: QuantKey | None
+    x: "torch.Tensor | QuantizedActivation", expected_key: QuantKey | None,
+    expected_layout: str | None = None
 ) -> "QuantizedActivation | None":
     """Validate and narrow a pre-quantized activation for a consumer kernel.
 
-    Returns the QuantizedActivation when x is one whose key matches the
-    kernel's declared expected_key, and None when x is a plain tensor (the
-    caller quantizes in-kernel). Raises on a key mismatch so a wrongly routed
+    Returns the QuantizedActivation when x is one whose key and layout matches the
+    kernel's declared expected_key and expected_layout, and None when x is a plain tensor (the
+    caller quantizes in-kernel). Raises on a mismatch so a wrongly routed
     activation fails loudly instead of being silently re-quantized.
     """
     if not isinstance(x, QuantizedActivation):
@@ -67,5 +71,9 @@ def as_quantized_activation(
     assert x.quant_key == expected_key, (
         f"QuantizedActivation key {x.quant_key} != consumer kernel "
         f"input_quant_key {expected_key}"
+    )
+    assert x.layout == expected_layout, (
+        f"QuantizedActivation layout {x.layout!r} != consumer kernel "
+        f"input_quant_layout {expected_layout!r}"
     )
     return x

--- a/vllm/model_executor/layers/quantization/online/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp4.py
@@ -32,6 +32,9 @@ from vllm.model_executor.layers.quantization.online.fp8 import (
 from vllm.model_executor.layers.quantization.online.moe_base import (
     OnlineMoEMethodBase,
 )
+from vllm.model_executor.layers.fusion.quant_activation import (
+    expose_input_quant_key,
+)
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
     mxfp4_quantize,
 )
@@ -125,6 +128,7 @@ class Mxfp4OnlineLinearMethod(_Fp8OnlineLinearBase):
         replace_parameter(layer, "weight_scale", weight_scale.data)
 
         self.kernel.process_weights_after_loading(layer)
+        expose_input_quant_key(layer, self.kernel)
 
         layer._already_called_process_weights_after_loading = True
 

--- a/vllm/models/kimi_k3/amd/kda.py
+++ b/vllm/models/kimi_k3/amd/kda.py
@@ -42,9 +42,12 @@ from vllm.model_executor.model_loader.weight_utils import sharded_weight_loader
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.models.kimi_k3.amd.kda_metadata import KimiK3ROCmKDABackend
 from vllm.models.kimi_k3.amd.ops.kda_decode import (
+    alloc_kda_mxfp4,
     is_fused_kda_decode_supported,
     make_decode_conv1d_weight_loader,
     make_decode_norm_weight_loader,
+    mxfp4_layout_for_oproj,
+    wrap_kda_mxfp4,
 )
 from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     chunk_kda_with_fused_gate,
@@ -287,15 +290,65 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             device=hidden_states.device,
         )
 
+        # Allocate the MXFP4 pair next to o_proj
+        mxfp4_layout = mxfp4_layout_for_oproj(self.o_proj)
+        mxfp4_data = mxfp4_scale = None
+        if mxfp4_layout is not None and self._kda_hip_decode_mxfp4_ready():
+            mxfp4_data, mxfp4_scale = alloc_kda_mxfp4(
+                num_tokens,
+                self.local_num_heads * self.head_dim,
+                mxfp4_layout,
+                hidden_states.device,
+            )
+
         self._forward(
             mixed_qkv=mixed_qkv,
             g1=g1,
             g2=g2,
             beta=beta,
             core_attn_out=core_attn_out,
+            mxfp4_data=mxfp4_data,
+            mxfp4_scale=mxfp4_scale,
+            mxfp4_layout=mxfp4_layout if mxfp4_data is not None else "",
         )
+        if mxfp4_data is not None:
+            attn_metadata_raw = get_forward_context().attn_metadata
+            m_meta = attn_metadata_raw.get(self.prefix)
+            written = (
+                m_meta.num_actual_tokens
+                if m_meta is not None
+                else num_tokens
+            )
+            orig_shape = torch.Size(
+                (written, self.local_num_heads * self.head_dim)
+            )
+            output[:] = self.o_proj(
+                wrap_kda_mxfp4(
+                    mxfp4_data,
+                    mxfp4_scale,
+                    orig_shape,
+                    hidden_states.dtype,
+                    self.o_proj,
+                )
+            )[0]
+            return
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
+
+    def _kda_hip_decode_mxfp4_ready(self) -> bool:
+        attn_metadata_raw = get_forward_context().attn_metadata
+        if attn_metadata_raw is None or not isinstance(attn_metadata_raw, dict):
+            return False
+        m = attn_metadata_raw.get(self.prefix)
+        if m is None:
+            return False
+        return (
+            self.decode_conv1d_weight is not None
+            and self.decode_norm_weight is not None
+            and m.spec_sequence_masks is None
+            and m.num_prefills == 0
+            and m.num_decodes > 0
+        )
 
     @eager_break_during_capture
     def _forward(
@@ -305,6 +358,9 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         g2: torch.Tensor,
         beta: torch.Tensor,
         core_attn_out: torch.Tensor,
+        mxfp4_data: torch.Tensor | None = None,
+        mxfp4_scale: torch.Tensor | None = None,
+        mxfp4_layout: str = "",
     ) -> None:
         forward_context = get_forward_context()
         attn_metadata_raw = forward_context.attn_metadata
@@ -364,6 +420,17 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                 output_gate=g2[:num_actual_tokens],
                 norm_weight=self.decode_norm_weight,
                 norm_eps=self.o_norm.eps,
+                mxfp4_out=(
+                    mxfp4_data[:num_actual_tokens]
+                    if mxfp4_data is not None and mxfp4_layout == "plain"
+                    else mxfp4_data
+                ),
+                mxfp4_scale=(
+                    mxfp4_scale[:num_actual_tokens]
+                    if mxfp4_scale is not None and mxfp4_layout == "plain"
+                    else mxfp4_scale
+                ),
+                mxfp4_layout=mxfp4_layout,
             )
             return
 

--- a/vllm/models/kimi_k3/amd/ops/kda_decode.py
+++ b/vllm/models/kimi_k3/amd/ops/kda_decode.py
@@ -16,7 +16,9 @@ from collections.abc import Callable
 import torch
 
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
+from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp4Dynamic
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 logger = init_logger(__name__)
@@ -25,6 +27,7 @@ logger = init_logger(__name__)
 # covers TP1/2/4/8).
 SUPPORTED_NUM_HEADS = (12, 24, 48, 96)
 
+_MXFP4_GROUP = 32
 
 def is_fused_kda_decode_supported(
     num_heads: int,
@@ -51,6 +54,59 @@ def is_fused_kda_decode_supported(
     # gfx950 (MI355X) and gfx942 (MI325X): both CDNA, sharing the wave64 / DPP /
     # bf16 primitives the kernel relies on.
     return on_gfx950() or on_gfx942()
+
+
+def mxfp4_layout_for_oproj(o_proj: torch.nn.Module) -> str | None:
+    """Return `plain` / `shuffled` when `o_proj` can consume that ABI.
+
+    Requires `input_quant_key is kMxfp4Dynamic`. `input_quant_layout` is `shuffled` and selects ASM.
+    """
+    if getattr(o_proj, "input_quant_key", None) != kMxfp4Dynamic:
+        return None
+    if getattr(o_proj, "input_quant_layout", None) == "shuffled":
+        return "shuffled"
+    return "plain"
+
+
+def alloc_kda_mxfp4(
+    num_tokens: int,
+    hidden: int,
+    layout: str,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Allocate the MXFP4 pair the fused decode kernel writes.
+    """
+    assert hidden % _MXFP4_GROUP == 0
+    n_groups = hidden // _MXFP4_GROUP
+    if layout == "plain":
+        data = torch.zeros((num_tokens, hidden // 2), dtype=torch.uint8, device=device)
+        scale = torch.zeros((n_groups, num_tokens), dtype=torch.uint8, device=device).T
+        return data, scale
+    if layout == "shuffled":
+        pad_m32 = (num_tokens + 31) // 32 * 32
+        pad_m256 = (num_tokens + 255) // 256 * 256
+        pad_n8 = (n_groups + 7) // 8 * 8
+        data = torch.zeros((pad_m32, hidden // 2), dtype=torch.uint8, device=device)
+        scale = torch.zeros((pad_m256, pad_n8), dtype=torch.uint8, device=device)
+        return data, scale
+    raise ValueError(f"Unknown MXFP4 layout: {layout!r}")
+
+
+def wrap_kda_mxfp4(
+    data: torch.Tensor,
+    scale: torch.Tensor,
+    orig_shape: torch.Size,
+    orig_dtype: torch.dtype,
+    o_proj: torch.nn.Module,
+) -> QuantizedActivation:
+    return QuantizedActivation(
+        data=data,
+        scale=scale,
+        orig_dtype=orig_dtype,
+        orig_shape=orig_shape,
+        quant_key=o_proj.input_quant_key,
+        layout=getattr(o_proj, "input_quant_layout", None)
+    )
 
 
 def make_decode_conv1d_weight_loader(

--- a/vllm/models/kimi_k3/amd/ops/kda_decode.py
+++ b/vllm/models/kimi_k3/amd/ops/kda_decode.py
@@ -79,8 +79,9 @@ def alloc_kda_mxfp4(
     assert hidden % _MXFP4_GROUP == 0
     n_groups = hidden // _MXFP4_GROUP
     if layout == "plain":
-        data = torch.zeros((num_tokens, hidden // 2), dtype=torch.uint8, device=device)
-        scale = torch.zeros((n_groups, num_tokens), dtype=torch.uint8, device=device).T
+        # Can use exact-size buffer since producer writes every element.
+        data = torch.empty((num_tokens, hidden // 2), dtype=torch.uint8, device=device)
+        scale = torch.empty((n_groups, num_tokens), dtype=torch.uint8, device=device).T
         return data, scale
     if layout == "shuffled":
         pad_m32 = (num_tokens + 31) // 32 * 32


### PR DESCRIPTION
Depends on #54063.

Kimi-K3 serve still needs #51392 so `o_proj` is `Mxfp4OnlineLinearMethod`. Until then `mxfp4_layout_for_oproj` returns `None`; serve behavior is unchanged.

Fuses MXFP4 quant into the ROCm KDA decode kernel, replacing a standalone quant launch, and writes the same `QuantizedActivation` ABI as PR A (`kMxfp4Dynamic`, layout from `o_proj.input_quant_layout`). Existing callers can omit the new kernel args and still store BF16.

Rebuild `_C_stable_libtorch` after the kernel commit.

## Test plan

- [ ] rebuild `_C_stable_libtorch` (gfx950 / gfx942)
- [ ] `pytest tests/models/kimi_k3/test_amd_kda_decode_mxfp4.py`
- [ ] `pytest tests/fusion/test_quant_activation_contract.py`
