### PR TITLE
[Model] Migrate Gemma4DSpark to AutoWeightsLoader

### DIFF
--- a/vllm/model_executor/models/gemma4_dspark.py
+++ b/vllm/model_executor/models/gemma4_dspark.py
@@ -19,13 +19,12 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.transformers_utils.configs.gemma4 import gemma4_layer_config
 
 from .gemma4_mtp import Gemma4MTPAttention, Gemma4MTPDecoderLayer
 from .qwen3_dflash import DFlashQwen3Model, _dflash_layer_causal
 from .qwen3_dspark import DSparkMarkovHead, Qwen3DSparkForCausalLM
-from .utils import extract_layer_index, maybe_prefix
+from .utils import AutoWeightsLoader, WeightsMapper, extract_layer_index, maybe_prefix
 
 
 class Gemma4DSparkAttention(Gemma4MTPAttention):
@@ -270,6 +269,12 @@ class Gemma4DSparkForCausalLM(Qwen3DSparkForCausalLM):
 
     dspark_shares_target_embeddings = False
     packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_stacked={
+            ".gate_proj": (".gate_up_proj", 0),
+            ".up_proj": (".gate_up_proj", 1),
+        }
+    )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         nn.Module.__init__(self)
@@ -290,25 +295,24 @@ class Gemma4DSparkForCausalLM(Qwen3DSparkForCausalLM):
         )
         self.draft_id_to_target_id = None
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        stacked = [("gate_up_proj", "gate_proj", 0), ("gate_up_proj", "up_proj", 1)]
-        params = dict(self.named_parameters())
-        params.update(dict(self.named_buffers()))
-        loaded: set[str] = set()
-        for name, w in weights:
+    def _prefix_checkpoint_names(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        # The checkpoint is flat (no "model." grouping) except for
+        # `lm_head`, which already matches this class's own submodule name.
+        # `confidence_head` is a Qwen3DSpark-only head; this draft model
+        # never has one, so any such weights in the checkpoint are unused.
+        for name, weight in weights:
             if "confidence_head" in name:
                 continue
             if "lm_head" not in name:
                 name = "model." + name
-            for pn, wn, shard in stacked:
-                if wn in name and (mapped := name.replace(wn, pn)) in params:
-                    params[mapped].weight_loader(params[mapped], w, shard)
-                    loaded.add(mapped)
-                    break
-            else:
-                if name in params:
-                    p = params[name]
-                    getattr(p, "weight_loader", default_weight_loader)(p, w)
-                    loaded.add(name)
+            yield name, weight
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        loaded = loader.load_weights(
+            self._prefix_checkpoint_names(weights), mapper=self.hf_to_vllm_mapper
+        )
         self.model._build_fused_kv_buffers()
         return loaded


### PR DESCRIPTION
Part of the ongoing effort tracked in #15697 to standardize weight loading
across all model backbones onto `AutoWeightsLoader`.

`Gemma4DSparkForCausalLM.load_weights` hand-rolled its own weight-name
matching and manually stacked `gate_proj`/`up_proj` into `gate_up_proj` by
iterating `named_parameters()` / `named_buffers()` directly. This replaces
that with the standard `AutoWeightsLoader` + `WeightsMapper` pattern already
used by the sibling `Gemma4MTP` model in `gemma4_mtp.py`:

- Added an `hf_to_vllm_mapper` class attribute using `orig_to_new_stacked`
  to declare the `gate_proj`/`up_proj` -> `gate_up_proj` stacking, instead
  of doing it by hand.
- Kept the existing flat-checkpoint-to-nested-module renaming (adding a
  `model.` prefix to everything except `lm_head`, and dropping unused
  `confidence_head` weights inherited from the `Qwen3DSparkForCausalLM`
  base class) as a small generator, `_prefix_checkpoint_names`, mirroring
  the same preprocessing step already used in
  `Qwen3DSparkForCausalLM.load_weights`.
- `load_weights` now delegates to `AutoWeightsLoader(self).load_weights(...)`
  and keeps the existing `self.model._build_fused_kv_buffers()` call
  afterward, unchanged.

No behavior change is intended: the same weight names are consumed, mapped,
and loaded, and the fused KV buffer precomputation still runs as the last
step. This also means `Gemma4DSparkForCausalLM` picks up
`AutoWeightsLoader`'s tied-weight handling and persistent-buffer loading,
which the hand-rolled loop did not have.

## Testing

- `pre-commit` passes on the changed file.
- I have not been able to run this against a real checkpoint on a GPU yet.
  Before merge it should be validated with
  `pytest tests/v1/e2e/spec_decode/acceptance_rates/dspark/test_dspark.py`
  (or the closest applicable Gemma4 DSpark acceptance-rate test) to confirm
  the migration doesn't change acceptance rates or fail weight loading.
  Happy to run this if someone can point me at a suitable checkpoint, or to
  defer to CI.

## AI assistance disclosure

Per CONTRIBUTING.md: Claude assisted in researching the
`AutoWeightsLoader` / `WeightsMapper` mechanism and drafting this diff. I
have reviewed every changed line and understand why it is equivalent to the
previous manual weight-loading logic, and I take responsibility for it.
