### PR TITLE
[ROCm][Perf] Use the fused clamped SwiGLU kernel on ROCm

### DIFF
--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -226,9 +226,11 @@ class SiluAndMulWithClamp(CustomOp):
         self.swiglu_limit = float(swiglu_limit)
         self.alpha = float(alpha)
         self.beta = float(beta)
-        if current_platform.is_rocm() or current_platform.is_xpu():
+        if current_platform.is_xpu():
             self._forward_method = self.forward_native
         elif current_platform.is_cuda_alike():
+            # is_cuda_alike() includes ROCm, where this kernel is built and
+            # correct -- SiluAndMul above already takes the same path.
             self.op = torch.ops._C.silu_and_mul_with_clamp
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native


### PR DESCRIPTION
## Purpose

`SiluAndMulWithClamp` routes ROCm to `forward_native`, which evaluates the activation as six eager kernels — two clamps, a sigmoid, two multiplies and an add. The fused op it skips, `torch.ops._C.silu_and_mul_with_clamp`, carries no HIP-specific guard in `csrc/libtorch_stable/activation_kernels.cu` and is built and numerically correct on gfx950. `SiluAndMul`, a few classes up in the same file, already takes the `is_cuda_alike()` path on ROCm — this exclusion looks like an oversight rather than a guard.

```diff
- if current_platform.is_rocm() or current_platform.is_xpu():
+ if current_platform.is_xpu():
      self._forward_method = self.forward_native
  elif current_platform.is_cuda_alike():
      self.op = torch.ops._C.silu_and_mul_with_clamp
```

XPU keeps its existing native path.

## Test Plan

Measured on 8× MI355X (gfx950), ROCm 7.2.3, with GLM-5.3-Flash — a 320B/18B multimodal MoE that clamps the SwiGLU gate in both its dense and MoE MLPs (`swiglu_limit=10.0`). TP8, 1M context, bf16 KV cache.

1. **Numerical check** — fused output vs `forward_native` over the model's shapes.
2. **Isolated kernel timing** — both arms interleaved inside a single process, so the board's shared power budget (which drifts an unchanged kernel by up to ~13% between processes here) cannot bias one arm against the other.
3. **End to end** — `vllm bench serve`, each arm on a freshly started server so prefix-cache state matches.

## Test Result

Numerics: fused matches `forward_native` within bf16 rounding (max abs diff 3.1e-02 at values up to the clamp limit of 10).

Isolated kernel, interleaved:

| shape | tokens | native | fused | speedup |
|---|---|---|---|---|
| dense MLP d=1536 | 64 | 54.67 µs | 23.95 µs | 2.28× |
| MoE d=256 | 64 | 55.06 µs | 23.89 µs | 2.31× |
| dense MLP d=1536 | 512 | 57.75 µs | 24.58 µs | 2.35× |
| MoE d=256 | 512 | 54.01 µs | 23.55 µs | 2.29× |

A decode-phase torch profile attributed 1.94 ms per step to the six eager kernels across 45 layers — each sitting at the ~5.7 µs launch floor while moving very little data, so the chain is launch-bound rather than bandwidth-bound. Collapsing it to one kernel predicts ≈6.3% of a 24.11 ms step.

End to end:

| shape | before | after | Δ |
|---|---|---|---|
| in=1024 out=2048 conc=64 | 2652.99 tok/s, TPOT 22.87 ms | 2803.15 tok/s, TPOT 21.58 ms | **+5.7% / −5.6%** |
| in=8192 out=1024 conc=16 | 661.04 tok/s, TPOT 20.65 ms | 692.20 tok/s, TPOT 19.42 ms | **+4.7% / −6.0%** |

The three measurements agree, which is the reason for reporting all of them: the prediction from the profile (6.3%) and the end-to-end TPOT delta (5.6–6.0%) bracket the same number, and the isolated 2.3× is what produces it.

Not model-specific — any model using clamped SwiGLU on ROCm takes this path.
