### PR TITLE
[Bugfix][Frontend] Align image_embeds handling across the sync and async parsers

### DIFF
--- a/tests/renderers/test_chat_utils_prompt_embeds.py
+++ b/tests/renderers/test_chat_utils_prompt_embeds.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import inspect
 import io
+from collections import defaultdict
 from typing import Final
 from unittest import mock
 
@@ -23,6 +24,8 @@ from vllm.entrypoints.chat_utils import (
     MM_PARSER_MAP,
     MODALITY_PLACEHOLDERS_MAP,
     PROMPT_EMBEDS_PLACEHOLDER_TOKEN,
+    AsyncMultiModalContentParser,
+    MultiModalContentParser,
     parse_chat_messages,
     parse_chat_messages_async,
 )
@@ -575,3 +578,64 @@ async def test_end_to_end_multi_message_conversation(tokenizer, parse_fn):
     assert mask.count(False) == LEN_SYS + LEN_USR
     assert torch.equal(embeds[positions[0][0] : positions[0][0] + LEN_SYS], t_sys)
     assert torch.equal(embeds[positions[1][0] : positions[1][0] + LEN_USR], t_usr)
+
+
+def _image_embeds_parsers():
+    mm_config = mock.MagicMock()
+    mm_config.enable_mm_embeds = True
+    model_config = mock.MagicMock()
+    model_config.get_multimodal_config.return_value = mm_config
+
+    sync_conn = mock.MagicMock()
+    sync_conn.fetch_image_embedding.return_value = "embedding"
+
+    async def _fetch(_):
+        return "embedding"
+
+    async_conn = mock.MagicMock()
+    async_conn.fetch_image_embedding_async = _fetch
+
+    class _Sync(MultiModalContentParser):
+        def __init__(self):
+            self._placeholder_storage = defaultdict(list)
+            self._tracker = mock.MagicMock()
+            self._tracker.add.return_value = "<ph>"
+
+        @property
+        def model_config(self):
+            return model_config
+
+        @property
+        def _connector(self):
+            return sync_conn
+
+    class _Async(AsyncMultiModalContentParser):
+        def __init__(self):
+            self._placeholder_storage = defaultdict(list)
+            self._tracker = mock.MagicMock()
+            self._tracker.add.return_value = "<ph>"
+
+        @property
+        def model_config(self):
+            return model_config
+
+        @property
+        def _connector(self):
+            return async_conn
+
+    return _Sync(), _Async()
+
+
+@pytest.mark.parametrize(
+    "image_embeds",
+    ["ZW1iZWQ=", {"a": "ZW1iZWQ="}, None, 123, ["ZW1iZWQ="]],
+    ids=["str", "dict", "none", "int", "list"],
+)
+@pytest.mark.asyncio
+async def test_image_embeds_sync_and_async_parsers_agree(image_embeds):
+    sync_parser, async_parser = _image_embeds_parsers()
+
+    sync_parser.parse_image_embeds(image_embeds)
+    await async_parser._image_embeds_with_uuid_async(image_embeds, None)
+
+    assert sync_parser._tracker.add.call_count == 1

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1003,20 +1003,18 @@ class MultiModalContentParser(BaseMultiModalContentParser):
                 parameter="image_embeds",
             )
 
+        embeds: torch.Tensor | dict[str, torch.Tensor] | None
         if isinstance(image_embeds, dict):
             embeds = {
                 k: self._connector.fetch_image_embedding(v)
                 for k, v in image_embeds.items()
             }
-            placeholder = self._tracker.add("image_embeds", (embeds, uuid))
+        elif isinstance(image_embeds, str):
+            embeds = self._connector.fetch_image_embedding(image_embeds)
+        else:
+            embeds = None
 
-        if isinstance(image_embeds, str):
-            embedding = self._connector.fetch_image_embedding(image_embeds)
-            placeholder = self._tracker.add("image_embeds", (embedding, uuid))
-
-        if image_embeds is None:
-            placeholder = self._tracker.add("image_embeds", (None, uuid))
-
+        placeholder = self._tracker.add("image_embeds", (embeds, uuid))
         self._add_placeholder("image", placeholder)
 
     def parse_audio_embeds(


### PR DESCRIPTION
## Purpose

`MultiModalContentParser.parse_image_embeds` and its async counterpart disagree on what to do with an `image_embeds` value that is neither a string, a dict, nor `None`.

The sync path runs three independent `if` statements:

```python
if isinstance(image_embeds, dict):
    placeholder = ...
if isinstance(image_embeds, str):
    placeholder = ...
if image_embeds is None:
    placeholder = ...
self._add_placeholder("image", placeholder)
```

Any other type matches none of them, `placeholder` stays unbound, and the next line raises `UnboundLocalError`. `_image_embeds_with_uuid_async` already uses `if / elif / else` and treats the same value as absent embeds.

| `image_embeds` | sync | async |
| --- | --- | --- |
| `str`, `dict`, `None` | ok | ok |
| anything else | `UnboundLocalError` | treated as `None` |

This gives the sync path the same `if / elif / else` shape, so both agree and one `self._tracker.add` call covers all three cases.

### Reach

`ChatCompletionRequest` rejects the offending types with a `TypeError` before the parser runs, so the OpenAI server is not returning 500s over this today. `LLM.chat` takes `ChatCompletionMessageParam`, a `TypedDict` with no runtime validation, so an offline caller reaches the sync path and sees `UnboundLocalError` with no indication of which field was wrong.

`mypy --enable-error-code possibly-undefined` reports this as the only possibly-undefined name in `vllm/entrypoints/`, `vllm/renderers/` and `vllm/tokenizers/`. The other 17 hits are guarded by conditions mypy cannot follow, for example `mm_updates` in `renderers/hf.py`, which is written and read under the same `prompt_embeds_info is not None` check.

## Test Plan

```
pytest tests/renderers/test_chat_utils_prompt_embeds.py
ruff check <changed files>
ruff format --check <changed files>
mypy --python-version 3.13 vllm/entrypoints/chat_utils.py
```

`test_image_embeds_sync_and_async_parsers_agree` drives both parsers over five input shapes and expects neither to raise. The file already parametrises other cases across sync and async, so this follows that pattern.

## Test Result

With the fix:

```
85 passed
```

With `chat_utils.py` reverted and the test kept:

```
2 failed, 3 passed
```

The two failures are the `int` and `list` cases.

`mypy` reports 30 errors in this file before and after the change. All 30 are pre-existing annotation findings that the CI configuration does not enable. The explicit `embeds` annotation keeps the count from rising, since mypy otherwise infers the type from the first branch and rejects the second.

`ruff check` and `ruff format --check` pass with the version pinned in `.pre-commit-config.yaml`.

No accuracy or performance testing. This changes control flow inside one parser method.

## Note

AI assistance was used for this change. I reviewed every changed line, ran the tests above, and can explain the change.
