### PR TITLE
[Bugfix][Spec Decode] Profile adaptive verification tails as mixed batches

### DIFF
--- a/tests/v1/spec_decode/test_adaptive_verification.py
+++ b/tests/v1/spec_decode/test_adaptive_verification.py
@@ -110,7 +110,9 @@ def test_budget_stops_where_marginal_drafts_stop_paying_for_themselves():
 
 def test_profiled_batches_seed_cost_curves_via_consumer():
     manager = AdaptiveVerificationManager.__new__(AdaptiveVerificationManager)
-    manager.req_states = SimpleNamespace(max_num_batched_tokens=4096, max_num_reqs=64)
+    manager.req_states = SimpleNamespace(
+        max_num_batched_tokens=4096, max_num_reqs=64, max_model_len=4096
+    )
     manager.num_speculative_steps = 7
     manager.num_bonus_tokens = 1
     curves: dict[str, list[tuple[int, float]]] = {}
@@ -143,6 +145,39 @@ def test_profiled_batches_seed_cost_curves_via_consumer():
     # count they would land inside the captured range and, once made monotonic,
     # smear that eager cost across every larger request count.
     assert curves["draft"] == [(1, 1.0), (128, 1.0)]
+
+
+def test_tail_profile_batches_mix_decode_and_prefill_shapes(monkeypatch):
+    monkeypatch.setattr(
+        adaptive_module.envs, "VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN", 8192
+    )
+    cases = [
+        (128, 16384, 1024, 126, [7688, 7688]),
+        # One chunk would be 8192 surplus + 8 freed decode tokens.
+        (128, 9216, 1024, 126, [4104, 4104]),
+        # A small request budget must become a schedulable prefill-only batch.
+        (2, 16384, 16, 0, [8192, 8192]),
+    ]
+    for max_reqs, max_tokens, capture_size, num_decode, prefill in cases:
+        manager = AdaptiveVerificationManager.__new__(AdaptiveVerificationManager)
+        manager.req_states = SimpleNamespace(
+            max_num_batched_tokens=max_tokens,
+            max_num_reqs=max_reqs,
+            max_model_len=8192,
+        )
+        manager.num_speculative_steps = 7
+        manager.num_bonus_tokens = 1
+        batches = {
+            batch["num_tokens"]: batch
+            for batch in manager.batches_to_profile([capture_size])
+        }
+
+        assert "num_scheduled_tokens_per_req" not in batches[capture_size]
+        batch = batches[max_tokens]
+        scheduled = batch["num_scheduled_tokens_per_req"]
+        assert batch["num_context_reqs"] == num_decode
+        assert scheduled == [8] * num_decode + prefill
+        assert sum(scheduled) == max_tokens
 
 
 def test_compact_batch_preserves_totals_and_bounds():

--- a/tests/v1/worker/test_gpu_input_batch_v2.py
+++ b/tests/v1/worker/test_gpu_input_batch_v2.py
@@ -2,11 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for the V2 model runner's InputBatch (vllm.v1.worker.gpu.input_batch)."""
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 import torch
 
 from vllm.platforms import current_platform
-from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+from vllm.v1.worker.gpu.input_batch import (
+    InputBatch,
+    InputBuffers,
+    set_dummy_context,
+)
 
 DEVICE = current_platform.device_type
 
@@ -51,3 +58,39 @@ def test_make_dummy_distributes_remainder(num_reqs: int, num_tokens: int):
     assert torch.equal(
         batch.query_start_loc.cpu(), torch.from_numpy(batch.query_start_loc_np)
     )
+
+
+def test_make_dummy_preserves_mixed_profile_shape_and_context():
+    split = np.array([8, 8, 8, 96], dtype=np.int32)
+    device = torch.device(DEVICE)
+    batch = InputBatch.make_dummy(
+        num_reqs=4,
+        num_tokens=120,
+        input_buffers=InputBuffers(4, 120, device),
+        num_scheduled_tokens=split,
+    )
+    input_block_table = torch.full((4, 8), -1, dtype=torch.int32, device=device)
+    block_tables = SimpleNamespace(
+        input_block_tables=[input_block_table],
+        kernel_block_sizes=[16],
+        blocks_per_kv_block=[1],
+    )
+
+    set_dummy_context(
+        batch,
+        block_tables,
+        context_len=64,
+        num_kv_blocks=32,
+        max_model_len=128,
+        num_context_reqs=3,
+    )
+
+    assert batch.num_scheduled_tokens.tolist() == split.tolist()
+    assert batch.seq_lens.tolist() == [72, 72, 72, 96]
+    assert batch.num_computed_tokens_np.tolist() == [64, 64, 64, 0]
+    assert batch.prefill_len_np.tolist() == [0, 0, 0, 96]
+    assert batch.is_prefilling_np.tolist() == [False, False, False, True]
+    assert batch.has_prefill
+    assert batch.positions.tolist() == list(range(64, 72)) * 3 + list(range(96))
+    assert (input_block_table[:, :6] >= 0).all()
+    assert (input_block_table[:, 6:] == -1).all()

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -119,6 +119,7 @@ class InputBatch:
         num_tokens: int,
         input_buffers: InputBuffers,
         max_query_len: int | None = None,
+        num_scheduled_tokens: np.ndarray | None = None,
     ) -> "InputBatch":
         assert 0 < num_reqs <= num_tokens
         device = input_buffers.device
@@ -129,21 +130,25 @@ class InputBatch:
         expanded_idx_mapping = idx_mapping
         expanded_local_pos = torch.zeros(num_reqs, dtype=torch.int32, device=device)
 
-        # Distribute the remainder evenly so that no dummy request exceeds
-        # ceil(num_tokens / num_reqs) <= max_model_len tokens. Varlen graphs
-        # accept any split with non-empty slots, so this shape works for them
-        # too; attention metadata is built from the promised max_query_len.
-        base_tokens = num_tokens // num_reqs
-        num_extra = num_tokens % num_reqs
-        assert max_query_len is None or base_tokens + (num_extra > 0) <= max_query_len
-        num_scheduled_tokens = np.full(num_reqs, base_tokens, dtype=np.int32)
-        if num_extra > 0:
-            num_scheduled_tokens[-num_extra:] += 1
+        if num_scheduled_tokens is None:
+            # Distribute the remainder evenly so that no dummy request exceeds
+            # ceil(num_tokens / num_reqs) <= max_model_len tokens. Varlen graphs
+            # accept any split with non-empty slots, so this shape works for them
+            # too; attention metadata is built from the promised max_query_len.
+            base_tokens = num_tokens // num_reqs
+            num_extra = num_tokens % num_reqs
+            num_scheduled_tokens = np.full(num_reqs, base_tokens, dtype=np.int32)
+            if num_extra > 0:
+                num_scheduled_tokens[-num_extra:] += 1
+        else:
+            num_scheduled_tokens = np.asarray(num_scheduled_tokens, dtype=np.int32)
+            assert num_scheduled_tokens.shape == (num_reqs,)
+            assert np.all(num_scheduled_tokens > 0)
         assert int(num_scheduled_tokens.sum()) == num_tokens
+        assert max_query_len is None or num_scheduled_tokens.max() <= max_query_len
 
         # seq_len equals to query_len
-        input_buffers.seq_lens[: num_reqs - num_extra] = base_tokens
-        input_buffers.seq_lens[num_reqs - num_extra : num_reqs] = base_tokens + 1
+        input_buffers.seq_lens[:num_reqs].copy_(torch.from_numpy(num_scheduled_tokens))
         # Pad for full CUDA graph mode.
         input_buffers.seq_lens[num_reqs:] = 0
         seq_lens = input_buffers.seq_lens[:num_reqs]
@@ -213,29 +218,61 @@ def set_dummy_context(
     context_len: int,
     num_kv_blocks: int,
     max_model_len: int,
+    num_context_reqs: int | None = None,
 ) -> None:
-    """Give each dummy request context_len of context, used when profiling step cost."""
-    if not block_tables.input_block_tables:
-        # Attention-free models have no KV context to fabricate.
-        return
+    """Give leading dummy requests context, used when profiling step cost."""
     num_reqs = input_batch.num_reqs
-    query_len = input_batch.max_query_len or int(input_batch.num_scheduled_tokens.max())
+    explicit_context_reqs = num_context_reqs is not None
+    if not explicit_context_reqs and not block_tables.input_block_tables:
+        # Preserve the existing attention-free dummy path.
+        return
+    if num_context_reqs is None:
+        num_context_reqs = num_reqs
+    assert 0 <= num_context_reqs <= num_reqs
+    query_len = 0
+    if num_context_reqs:
+        query_len = (
+            input_batch.max_query_len
+            if num_context_reqs == num_reqs and input_batch.max_query_len is not None
+            else int(input_batch.num_scheduled_tokens[:num_context_reqs].max())
+        )
     context_len = max(min(context_len, max_model_len - query_len), 0)
-    if not context_len:
+    if not context_len and not explicit_context_reqs:
         return
 
-    # Decode-like shape: each request continues after context_len
+    # Decode-like rows continue after context_len
     # already-computed tokens.
-    input_batch.seq_lens += context_len
-    input_batch.seq_lens_cpu_upper_bound += context_len
-    input_batch.num_computed_tokens_np.fill(context_len)
-    input_batch.num_computed_prefill_tokens_np.fill(context_len)
+    input_batch.seq_lens[:num_context_reqs] += context_len
+    input_batch.seq_lens_cpu_upper_bound[:num_context_reqs] += context_len
+    input_batch.num_computed_tokens_np[:num_context_reqs].fill(context_len)
+    input_batch.num_computed_prefill_tokens_np[:num_context_reqs].fill(context_len)
+
+    if num_context_reqs < num_reqs:
+        input_batch.prefill_len_np[num_context_reqs:] = (
+            input_batch.num_scheduled_tokens[num_context_reqs:]
+        )
+        input_batch.is_prefilling_np[num_context_reqs:] = True
+        input_batch.has_prefill = True
+
     local_pos = np.arange(input_batch.num_tokens, dtype=np.int64) - np.repeat(
         input_batch.query_start_loc_np[:-1], input_batch.num_scheduled_tokens
     )
-    input_batch.positions.copy_(torch.from_numpy(local_pos + context_len))
+    context_offsets = np.zeros(num_reqs, dtype=np.int64)
+    context_offsets[:num_context_reqs] = context_len
+    input_batch.positions.copy_(
+        torch.from_numpy(
+            local_pos + np.repeat(context_offsets, input_batch.num_scheduled_tokens)
+        )
+    )
 
-    seq_len = context_len + query_len
+    if not block_tables.input_block_tables:
+        # Attention-free models have no KV context to fabricate.
+        return
+
+    seq_len = max(
+        context_len + query_len,
+        int(input_batch.seq_lens_cpu_upper_bound.max()),
+    )
     for block_table, block_size, bpk in zip(
         block_tables.input_block_tables,
         block_tables.kernel_block_sizes,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -680,6 +680,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         skip_attn: bool = False,
         uniform_decode: bool = False,
         context_len: int = 0,
+        num_scheduled_tokens_per_req: list[int] | None = None,
+        num_context_reqs: int | None = None,
         skip_eplb: bool = False,
         is_profile: bool = False,
         **kwargs,
@@ -692,6 +694,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Create a dummy scheduler output.
         num_reqs = min(num_tokens, self.max_num_reqs)
         if uniform_decode:
+            assert num_scheduled_tokens_per_req is None
             # HACK(lucas): for now since the worker is shared between MRV1 and MRV2,
             # and for spec-decode with MTP we want to make sure the dummy runs use
             # 1+num_speculative_tokens we use max here, this will likely be eventually
@@ -699,12 +702,19 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             num_tokens = max(num_tokens, self.decode_query_len)
             num_reqs = num_tokens // self.decode_query_len
             assert num_tokens % self.decode_query_len == 0
-        # Distribute the remainder evenly so no dummy request exceeds
-        # ceil(num_tokens / num_reqs) <= max_model_len tokens.
-        num_tokens_per_request = [
-            num_tokens // num_reqs + (i >= num_reqs - num_tokens % num_reqs)
-            for i in range(num_reqs)
-        ]
+        if num_scheduled_tokens_per_req is None:
+            # Distribute the remainder evenly so no dummy request exceeds
+            # ceil(num_tokens / num_reqs) <= max_model_len tokens.
+            num_tokens_per_request = [
+                num_tokens // num_reqs + (i >= num_reqs - num_tokens % num_reqs)
+                for i in range(num_reqs)
+            ]
+        else:
+            assert num_context_reqs is not None
+            num_tokens_per_request = num_scheduled_tokens_per_req
+            num_reqs = len(num_tokens_per_request)
+            assert 0 < num_reqs <= self.max_num_reqs
+            assert all(n > 0 for n in num_tokens_per_request)
 
         assert sum(num_tokens_per_request) == num_tokens
         num_scheduled_tokens = {
@@ -739,6 +749,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 skip_attn_for_dummy_run=skip_attn,
                 is_profile=is_profile,
                 context_len=context_len,
+                num_context_reqs=num_context_reqs,
             )
         self.kv_connector.set_disabled(False)
 
@@ -1502,6 +1513,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         skip_attn_for_dummy_run: bool = False,
         is_profile: bool = False,
         context_len: int = 0,
+        num_context_reqs: int | None = None,
     ) -> ModelRunnerOutput | IntermediateTensors | None:
         if not dummy_run:
             # Update the request states.
@@ -1594,21 +1606,33 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         else:
             # No actual tokens to run. A dummy run for DP or memory profiling.
             dummy_num_reqs = batch_desc.num_reqs or num_reqs
+            dummy_num_scheduled_tokens = None
+            if num_context_reqs is not None:
+                if batch_desc.num_tokens == num_toks and dummy_num_reqs == num_reqs:
+                    dummy_num_scheduled_tokens = np.fromiter(
+                        scheduler_output.num_scheduled_tokens.values(),
+                        dtype=np.int32,
+                        count=num_reqs,
+                    )
+                else:
+                    num_context_reqs = None
             input_batch = InputBatch.make_dummy(
                 dummy_num_reqs,
                 batch_desc.num_tokens,
                 self.input_buffers,
                 max_query_len=batch_desc.max_query_len,
+                num_scheduled_tokens=dummy_num_scheduled_tokens,
             )
             if not skip_attn_for_dummy_run:
                 block_tables, slot_mappings = self.prepare_dummy_attn(input_batch)
-                if context_len:
+                if context_len or num_context_reqs is not None:
                     set_dummy_context(
                         input_batch,
                         self.block_tables,
                         context_len,
                         self.kv_cache_config.num_blocks,
                         self.max_model_len,
+                        num_context_reqs=num_context_reqs,
                     )
             else:
                 assert batch_desc.cg_mode != CUDAGraphMode.FULL, (

--- a/vllm/v1/worker/gpu/spec_decode/adaptive_verification.py
+++ b/vllm/v1/worker/gpu/spec_decode/adaptive_verification.py
@@ -13,6 +13,7 @@ import vllm.envs as envs
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import init_logger
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.gpu.async_utils import StepTimingSample, stream
@@ -170,7 +171,9 @@ class AdaptiveVerificationManager:
         self._pending_resets.append(req_idx)
         self._confidence_probs[req_idx].fill_(1.0)
 
-    def batches_to_profile(self, capture_sizes: list[int]) -> Iterator[dict[str, int]]:
+    def batches_to_profile(
+        self, capture_sizes: list[int]
+    ) -> Iterator[dict[str, int | list[int]]]:
         """Dummy-run kwargs whose step timings seed the cost tables.
 
         Run these inside StepTimingCollector.collect(), then hand the block's
@@ -187,12 +190,39 @@ class AdaptiveVerificationManager:
                 size = min(size * 2, max_num_tokens)
                 tail_sizes.add(size)
             tail_sizes -= set(capture_sizes)
+        max_num_reqs = self.req_states.max_num_reqs
+        decode_query_len = self.num_speculative_steps + self.num_bonus_tokens
+        max_decode_tokens = max_num_reqs * decode_query_len
+        profile_context_len = envs.VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN
+        max_prefill_tokens = min(
+            profile_context_len or self.req_states.max_model_len,
+            self.req_states.max_model_len,
+        )
         for num_tokens in capture_sizes + sorted(tail_sizes):
+            batch: dict[str, int | list[int]] = {
+                "num_tokens": num_tokens,
+                "context_len": profile_context_len,
+            }
+            surplus = num_tokens - max_decode_tokens
+            prefill_capacity = max_prefill_tokens - decode_query_len
+            if num_tokens in tail_sizes and surplus > 0:
+                if prefill_capacity <= 0:
+                    continue
+                num_prefill_reqs = min(cdiv(surplus, prefill_capacity), max_num_reqs)
+                num_decode_reqs = max_num_reqs - num_prefill_reqs
+                prefill_tokens = num_tokens - num_decode_reqs * decode_query_len
+                base_tokens, num_extra = divmod(prefill_tokens, num_prefill_reqs)
+                if base_tokens + (num_extra > 0) > max_prefill_tokens:
+                    continue
+                batch["num_scheduled_tokens_per_req"] = [
+                    decode_query_len
+                ] * num_decode_reqs + [
+                    base_tokens + (i >= num_prefill_reqs - num_extra)
+                    for i in range(num_prefill_reqs)
+                ]
+                batch["num_context_reqs"] = num_decode_reqs
             for _ in range(_PROFILE_REPLAYS):
-                yield {
-                    "num_tokens": num_tokens,
-                    "context_len": envs.VLLM_ADAPTIVE_VERIFICATION_PROFILE_CONTEXT_LEN,
-                }
+                yield batch
 
     def set_initial_cost_curves(self, samples: list[StepTimingSample]) -> None:
         def median_curve(


### PR DESCRIPTION
## Summary

Fixes #54046.

Adaptive verification profiles token counts beyond the cudagraph capture limit by distributing them across dummy requests. With `max_num_seqs=128` and seven speculative tokens, a real decode request contributes eight query tokens, so a fully occupied decode step contains at most:

```text
128 * (1 + 7) = 1024 tokens
```

Tail samples above 1024 tokens cannot be uniform decode batches. Previously, however, a 16384-token sample was profiled as 128 requests with 128 query tokens each, producing a shape the scheduler cannot generate for speculative decoding.

This change profiles tail samples as schedulable mixed decode/prefill batches.

For the configuration reported in the issue:

```text
max_num_batched_tokens = 16384
max_num_seqs           = 128
num_speculative_tokens = 7
profile_context_len    = 8192
```

the 16384-token profile becomes:

```text
126 decode requests * 8 tokens
2 fresh-prefill requests * 7688 tokens
```

## Changes

- Keep captured token sizes unchanged so their dummy runs continue to match their cudagraph descriptors.
- Convert only tail sizes above the decode ceiling into mixed decode/prefill batches.
- Account for the decode tokens freed when a request slot becomes prefill.
- Allow small request budgets to produce a schedulable prefill-only tail instead of falling back to an invalid uniform shape.
- Carry the explicit per-request split through the existing scheduler output.
- Give context only to decode rows.
- Mark trailing rows as fresh prefill and construct their positions accordingly.
- Size dummy block tables for the longest decode or prefill sequence.
- Preserve the existing even split when no explicit profile shape is supplied.
- Fall back to the existing dummy shape if cudagraph dispatch pads or reshapes the batch.

## Tests

Hardware:

```text
NVIDIA GeForce RTX 5090
CUDA-enabled PyTorch environment
```

Regression command:

```bash
CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest -q \
  tests/v1/spec_decode/test_adaptive_verification.py \
  tests/v1/worker/test_gpu_input_batch_v2.py \
  tests/v1/worker/test_gpu_model_runner_v2.py \
  tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py \
  tests/v1/cudagraph/test_cudagraph_dispatch.py \
  tests/v1/cudagraph/test_cudagraph_manager.py
```

Result:

```text
54 passed, 14 warnings
```

Additional checks:

```text
py_compile: passed
ruff check 0.14.0: passed
ruff format --check 0.14.0: passed
```

The CUDA regression test verifies the explicit split, decode-only context, fresh-prefill metadata, positions, sequence lengths, and KV block-table coverage.

A full DSpark model-serving evaluation was not run because the corresponding large-model environment was not available on this single-GPU host. This change affects startup profiling shapes and does not modify sampling or verification kernels.

## Related work

#54065 addresses the same reported issue. This implementation additionally:

- keeps the prefill rows context-free instead of applying dummy decode context to every row;
- accounts for freed decode tokens when sizing prefill chunks;
- covers small request budgets that require a prefill-only tail.

## AI assistance

AI assistance was used during investigation, implementation and test. Every changed line and the reported test results were reviewed.