### PR TITLE
[Bugfix][Frontend] Let the reasoning parser decide reasoning_ended when reasoning is hidden

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_reasoning_gate.py
+++ b/tests/entrypoints/openai/chat_completion/test_reasoning_gate.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The structured-output reasoning gate (``reasoning_ended`` passed to
+``engine.generate``) must be decided by the reasoning parser when one is
+configured — including engine-based parsers, which expose no
+``reasoning_parser`` attribute — even when the client hides reasoning
+(``include_reasoning=False``). Otherwise a grammar is enforced from the first
+token while an always-thinking model (GLM-5.3) is still inside ``<think>``."""
+
+from contextlib import suppress
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.entrypoints.openai.chat_completion.test_serving_chat import (
+    MODEL_NAME,
+    MockModelConfig,
+    _build_renderer,
+    _build_serving_chat,
+)
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.v1.engine.async_llm import AsyncLLM
+
+JSON_SCHEMA_RF = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "weather",
+        "schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+    },
+}
+
+
+class _EngineStyleParser:
+    """Mimics a parser-engine class returned by ParserManager.get_parser when
+    tool and reasoning parsing share one engine: no ``reasoning_parser``
+    attribute, but ``is_reasoning_end`` implemented on the object itself."""
+
+    reasoning_parser = None
+
+    def __init__(self, tokenizer, tools=None, **kwargs):
+        pass
+
+    def is_reasoning_end(self, input_ids):
+        return False  # prompt ends with <think>: reasoning has not ended
+
+    def adjust_request(self, request):
+        return request
+
+
+def _engine():
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    async def mock_generate(*args, **kwargs):
+        yield RequestOutput(
+            request_id="test-request",
+            prompt="test prompt",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text='{"city": "London"}',
+                    token_ids=[4, 5, 6],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason=None,
+                )
+            ],
+            finished=True,
+        )
+
+    mock_engine.generate = AsyncMock(side_effect=mock_generate)
+    return mock_engine
+
+
+async def _run(serving_chat, **request_fields):
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "Weather in London?"}],
+        response_format=JSON_SCHEMA_RF,
+        **request_fields,
+    )
+    raw = MagicMock()
+    raw.headers = {}
+    raw.state = MagicMock()
+    with suppress(Exception):
+        await serving_chat.create_chat_completion(req, raw)
+
+
+@pytest.mark.asyncio
+async def test_hidden_reasoning_defers_to_engine_parser():
+    engine = _engine()
+    serving_chat = _build_serving_chat(engine)
+    serving_chat.parser_cls = _EngineStyleParser
+    serving_chat._has_reasoning_parser = True
+
+    await _run(serving_chat, include_reasoning=False)
+    assert engine.generate.call_args.kwargs["reasoning_ended"] is False
+
+
+@pytest.mark.asyncio
+async def test_visible_reasoning_defers_to_engine_parser():
+    engine = _engine()
+    serving_chat = _build_serving_chat(engine)
+    serving_chat.parser_cls = _EngineStyleParser
+    serving_chat._has_reasoning_parser = True
+
+    await _run(serving_chat, include_reasoning=True)
+    assert engine.generate.call_args.kwargs["reasoning_ended"] is False
+
+
+@pytest.mark.asyncio
+async def test_hidden_reasoning_without_reasoning_parser_keeps_shortcut():
+    engine = _engine()
+    serving_chat = _build_serving_chat(engine)  # no reasoning parser configured
+
+    await _run(serving_chat, include_reasoning=False)
+    assert engine.generate.call_args.kwargs["reasoning_ended"] is True

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -155,6 +155,7 @@ class OpenAIServingChat(GenerateBaseServing):
 
         self.enable_auto_tools: bool = enable_auto_tools
         self._include_reasoning_tokens_details = bool(reasoning_parser)
+        self._has_reasoning_parser = bool(reasoning_parser)
         self.parser_cls = ParserManager.get_parser(
             tool_parser_name=tool_parser,
             reasoning_parser_name=reasoning_parser,
@@ -355,15 +356,15 @@ class OpenAIServingChat(GenerateBaseServing):
                     session_id=session_id,
                 )
             else:
-                if not request.include_reasoning:
-                    reasoning_ended = True
-                elif request._grammar_from_parser:
+                if request._grammar_from_parser:
                     # The Mistral grammar already includes an optional
                     # `think?` rule that handles both reasoning and
                     # non-reasoning outputs.
                     reasoning_ended = True
-                elif parser is not None and parser.reasoning_parser is not None:
+                elif parser is not None and self._has_reasoning_parser:
                     reasoning_ended = parser.is_reasoning_end(prompt_token_ids or [])
+                elif not request.include_reasoning:
+                    reasoning_ended = True
                 else:
                     reasoning_ended = None
 


### PR DESCRIPTION
Ask the configured reasoning parser instead, so structured outputs aren't enforced inside <think> for models that always reason.




## Purpose

`OpenAIServingChat` forces `reasoning_ended=True` for the structured-output gate whenever `include_reasoning=False`, treating "the client doesn't want to see reasoning" as "the model won't produce reasoning". For models whose chat template always opens the assistant turn with `<think>` (e.g. `zai-org/GLM-5.3-Flash`) the block is still generated, so a `json_schema` response format or strict-tool grammar is enforced from the first token, inside the reasoning. Result: ~30 completion tokens, empty `content`, `reasoning_tokens=0`. OpenRouter's `reasoning.exclude` maps to exactly this request shape, so it shows up as broken structured output there.

This PR lets the configured reasoning parser decide (`is_reasoning_end(prompt_token_ids)`) and keeps the `include_reasoning` shortcut only for servers with no reasoning parser. The check keys on the server-level reasoning-parser setting rather than `parser.reasoning_parser`, because when tool and reasoning parsing share one parser engine, `ParserManager.get_parser` returns the engine class itself and that attribute is `None`. Note: this change was developed with AI assistance (Claude); the code and tests were reviewed and validated end-to-end by the author.

## Test Plan

Unit test added: `tests/entrypoints/openai/chat_completion/test_reasoning_gate.py` — asserts the `reasoning_ended` value passed to `engine.generate` with an engine-style parser (no `reasoning_parser` attribute) for hidden and visible reasoning, and the legacy shortcut when no reasoning parser is configured.

## Test Result

Before: `finish_reason=stop`, `completion_tokens=25`, `content=null`, `reasoning_tokens=0`.
After: `completion_tokens=159`, `reasoning_tokens=129` (hidden), `content='{"location": "London", "temperature": 14, "conditions": "Partly cloudy"}'`.

Same request with `include_reasoning: true` is unchanged before/after. The three new unit tests pass; an internal endpoint eval suite (reasoning / structured output / tool calling / vision) went from 90/94 to 94/94 with this change on the model above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x] The test plan, such as providing test command.
- [x ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

