### PR TITLE
[Mypy Fix] Mypy fix for "vllm/model_executor/models/[hH]"

### DIFF
--- a/tools/pre_commit/mypy.py
+++ b/tools/pre_commit/mypy.py
@@ -112,7 +112,6 @@ SEPARATE_GROUPS = [
 ]
 
 EXCLUDE = [
-    r"vllm/model_executor/models/[hH]",
     r"vllm/model_executor/models/[iI]",
     r"vllm/model_executor/models/[jJ]",
     r"vllm/model_executor/models/[kK]",

--- a/vllm/model_executor/models/h2ovl.py
+++ b/vllm/model_executor/models/h2ovl.py
@@ -114,6 +114,7 @@ class H2OVLMultiModalProcessor(BaseInternVLMultiModalProcessor[H2OVLProcessingIn
             if isinstance(images, ImageEmbeddingItems):
                 feature_size = images.get_feature_size(item_idx)
             else:
+                assert isinstance(images, ImageProcessorItems)
                 image_size = images.get_image_size(item_idx)
                 feature_size = self.info.get_num_image_tokens(
                     image_width=image_size.width,

--- a/vllm/model_executor/models/hrm_text.py
+++ b/vllm/model_executor/models/hrm_text.py
@@ -248,7 +248,7 @@ class HrmTextDecoderLayer(nn.Module):
         self,
         config: PretrainedConfig,
         layer_idx_in_stack: int,
-        stack_kind: str,
+        stack_kind: Literal["L", "H"],
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
@@ -312,7 +312,7 @@ class HrmTextStack(nn.Module):
     def __init__(
         self,
         config: PretrainedConfig,
-        stack_kind: str,
+        stack_kind: Literal["L", "H"],
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",

--- a/vllm/model_executor/models/hy_v3.py
+++ b/vllm/model_executor/models/hy_v3.py
@@ -161,6 +161,7 @@ class HYV3MoEFused(nn.Module):
             prefix=f"{prefix}.gate",
         )
 
+        self.shared_mlp: HYV3FeedForward | None
         if config.num_shared_experts > 0:
             self.shared_mlp = HYV3FeedForward(
                 hidden_size=config.hidden_size,
@@ -467,13 +468,14 @@ class HYV3Model(nn.Module, MixtureOfExperts):
         # Set MoE hyperparameters
         self.num_expert_groups = 1
         self.moe_layers = []
-        example_layer = None
+        example_layer: HYV3MoEFused | None = None
         for layer in self.layers:
             if isinstance(layer, PPMissingLayer):
                 continue
 
             assert isinstance(layer, HYV3DecoderLayer)
             if layer.block_type == "moe":
+                assert isinstance(layer.mlp, HYV3MoEFused)
                 example_layer = layer.mlp
                 self.moe_layers.append(layer.mlp.experts)
 
@@ -482,13 +484,11 @@ class HYV3Model(nn.Module, MixtureOfExperts):
             raise RuntimeError("No MoE layer found in model.layers.")
 
         self.num_moe_layers = len(self.moe_layers)
-        self.num_logical_experts = getattr(example_layer, "n_logical_experts", None)
-        self.num_physical_experts = getattr(example_layer, "n_physical_experts", None)
-        self.num_local_physical_experts = getattr(
-            example_layer, "n_local_physical_experts", None
-        )
-        self.num_routed_experts = getattr(example_layer, "n_routed_experts", None)
-        self.num_redundant_experts = getattr(example_layer, "n_redundant_experts", None)
+        self.num_logical_experts = example_layer.n_logical_experts
+        self.num_physical_experts = example_layer.n_physical_experts
+        self.num_local_physical_experts = example_layer.n_local_physical_experts
+        self.num_routed_experts = example_layer.n_routed_experts
+        self.num_redundant_experts = example_layer.n_redundant_experts
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -572,9 +572,10 @@ class HYV3Model(nn.Module, MixtureOfExperts):
                 continue
             if "scale" in name:
                 # Remapping the name of FP8 kv-scale.
-                name = maybe_remap_kv_scale_name(name, params_dict)
-                if name is None:
+                remapped_name = maybe_remap_kv_scale_name(name, params_dict)
+                if remapped_name is None:
                     continue
+                name = remapped_name
             is_found = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:

--- a/vllm/model_executor/models/hy_v3_mtp.py
+++ b/vllm/model_executor/models/hy_v3_mtp.py
@@ -24,7 +24,7 @@
 # limitations under the License.
 """Inference-only HY V3 MTP model compatible with HuggingFace weights."""
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 
 import regex as re
 import torch
@@ -288,7 +288,15 @@ class HYV3MTP(nn.Module):
         num_kv_heads = getattr(
             self.config, "num_key_value_heads", self.config.num_attention_heads
         )
-        split_params_mapping = [
+        split_params_mapping: list[
+            tuple[
+                str,
+                str,
+                int,
+                list[tuple[int | str, int]],
+                Callable[[torch.Tensor], torch.Tensor] | None,
+            ]
+        ] = [
             (".gate_up_proj", ".gate_and_up_proj", 2, [(1, 1), (0, 1)], None),
             (
                 ".qkv_proj",
@@ -299,6 +307,7 @@ class HYV3MTP(nn.Module):
             ),
         ]
 
+        expert_params_mapping: list[tuple[str, str, int, str]]
         if _is_moe(self.config):
             expert_params_mapping = fused_moe_make_expert_params_mapping(
                 self,
@@ -308,7 +317,7 @@ class HYV3MTP(nn.Module):
                 num_experts=self.config.num_experts,
             )
         else:
-            expert_params_mapping = {}
+            expert_params_mapping = []
 
         params_dict = dict(self.named_parameters())
 
@@ -354,9 +363,10 @@ class HYV3MTP(nn.Module):
             if name == "__skip__":
                 continue
             if "scale" in name:
-                name = maybe_remap_kv_scale_name(name, params_dict)
-                if name is None:
+                remapped_name = maybe_remap_kv_scale_name(name, params_dict)
+                if remapped_name is None:
                     continue
+                name = remapped_name
             is_found = False
 
             for param_name, weight_name, shard_id in stacked_params_mapping:

--- a/vllm/model_executor/models/hyperclovax_vision_v2.py
+++ b/vllm/model_executor/models/hyperclovax_vision_v2.py
@@ -329,6 +329,7 @@ class HCXVisionV2MultiModalProcessor(
                 if grid_thw_elem is not None:
                     # Access .data to get the actual tensor from MultiModalFieldElem
                     grid_thw = grid_thw_elem.data
+                    assert isinstance(grid_thw, torch.Tensor)
                     # Qwen2.5-VL style calculation
                     h, w = grid_thw[1].item(), grid_thw[2].item()
                     num_tokens = (h * w) // (merge_size**2)
@@ -340,6 +341,7 @@ class HCXVisionV2MultiModalProcessor(
                 if grid_thw_elem is not None:
                     # Access .data to get the actual tensor from MultiModalFieldElem
                     grid_thw = grid_thw_elem.data
+                    assert isinstance(grid_thw, torch.Tensor)
                     t, h, w = grid_thw[0].item(), grid_thw[1].item(), grid_thw[2].item()
                     num_tokens = (t * h * w) // (merge_size**2)
                 else:
@@ -607,7 +609,9 @@ class HCXVisionV2ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         return video_embeds.split(sizes)
 
     def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
-        modalities = {}
+        modalities: dict[
+            str, HCXVisionV2ImageInputs | HCXVisionV2VideoInputs | None
+        ] = {}
 
         for input_key in kwargs:
             if (


### PR DESCRIPTION
## Summary
- Enable mypy for `vllm/model_executor/models/[hH]` by removing that prefix from `EXCLUDE` (part of #26533).
- Fix the 20 mypy errors that appear once those files are checked (HY-V3, HyperCLOVAX V2, HRM-Text, H2OVL).

## Test plan
- [x] `pre-commit run --hook-stage manual mypy-3.13 -a`
- [x] `pre-commit run --hook-stage manual --from-ref origin/main --to-ref HEAD`
