### PR TITLE
[Bugfix] Make Triton MoE reduction pad-aware under EP

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -26,6 +26,7 @@ from tests.kernels.utils import opcheck, stack_and_dev, torch_experts, torch_moe
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.fused_moe import (
     MoEActivation,
+    TritonExperts,
     fused_topk,
 )
 from vllm.model_executor.layers.fused_moe.activation import (
@@ -1640,6 +1641,30 @@ def test_moe_sum_pad_aware(topk: int, dtype: torch.dtype, topk_ids_dtype: torch.
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=0)
 
     opcheck(torch.ops._moe_C.moe_sum, (input, actual, topk_ids, expert_map))
+
+
+def test_triton_experts_moe_sum_ignores_unrouted_slots():
+    m, topk, k = 2, 4, 128
+    expert_output = torch.arange(m * topk * k, device="cuda", dtype=torch.float32).view(
+        m, topk, k
+    )
+    topk_ids = torch.tensor(
+        [[0, -1, 2, 1], [3, 1, -1, 0]], device="cuda", dtype=torch.int64
+    )
+    expert_map = torch.tensor([0, 1, -1, -1], device="cuda", dtype=torch.int32)
+    actual = torch.empty((m, k), device="cuda", dtype=expert_output.dtype)
+
+    experts = TritonExperts(
+        make_dummy_moe_config(),
+        FUSED_MOE_UNQUANTIZED_CONFIG,
+    )
+    experts.moe_sum(expert_output, actual, topk_ids, expert_map)
+
+    safe_topk_ids = topk_ids.clamp(min=0)
+    routed = (topk_ids >= 0) & (expert_map[safe_topk_ids] >= 0)
+    expected = torch.where(routed.unsqueeze(-1), expert_output, 0).sum(dim=1)
+
+    torch.testing.assert_close(actual, expected)
 
 
 def _batched_fused_marlin_moe_cases() -> list[Any]:

--- a/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
@@ -544,4 +544,4 @@ class Nvfp4QuantizationEmulationTritonExperts(TritonExperts):
             compute_type=compute_type,
         )
 
-        self.moe_sum(intermediate_cache3, output)
+        self.moe_sum(intermediate_cache3, output, topk_ids, expert_map)

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -560,10 +560,19 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
                 )
 
         # separate function is required for MoE + LoRA
-        self.moe_sum(intermediate_cache3, output)
+        self.moe_sum(intermediate_cache3, output, topk_ids, expert_map)
 
-    def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:
-        ops.moe_sum(input, output)
+    def moe_sum(
+        self,
+        input: torch.Tensor,
+        output: torch.Tensor,
+        topk_ids: torch.Tensor,
+        expert_map: torch.Tensor | None,
+    ) -> None:
+        if expert_map is not None:
+            ops.moe_sum(input, output, topk_ids, expert_map)
+        else:
+            ops.moe_sum(input, output)
 
 
 class TritonWNA16Experts(TritonExperts):
@@ -749,4 +758,4 @@ class TritonWNA16Experts(TritonExperts):
         )
 
         # separate function is required for MoE + LoRA
-        self.moe_sum(intermediate_cache3, output)
+        self.moe_sum(intermediate_cache3, output, topk_ids, expert_map)


### PR DESCRIPTION
## Purpose

Under expert parallelism, `topk_ids` can contain `-1` for invalid or non-local slots. Triton alignment correctly omits those slots, so the expert GEMMs leave the corresponding `intermediate_cache3` rows unwritten. Because that tensor is a view over reused workspace, those rows can contain stale values. The standard `TritonExperts` two-argument `moe_sum` then reduces every top-k slot and folds the stale rows into the output.

This PR passes `topk_ids` and `expert_map` to the existing pad-aware `moe_sum` path whenever expert mapping is active. The ordinary two-argument reduction remains unchanged outside expert parallelism. The inherited call sites in `TritonWNA16Experts` and `Nvfp4QuantizationEmulationTritonExperts` are updated as well.

### Duplicate-work check

I searched open PRs for `TritonExperts moe_sum expert_map`, `DeepEP V2 invalid slots`, `pad-aware reduction`, and `intermediate_cache3`. None wire the pad-aware reduction into standard `TritonExperts`.

- #48385 added the pad-aware operator and wired it into Marlin only.
- #46408 fixes the same unwritten-slot reduction class in the OAI Triton backend, not standard `TritonExperts`.
- #46432 and #47785 produce and align the `-1` sentinel safely but do not change final reduction.
- #51332 covers Humming. #50511 covers DeepEP V2 metadata and whole-tensor quantization padding.
- #43250 is a reduction performance change but does not consume routing metadata.

## Test Plan

```bash
.venv/bin/python -m pytest tests/kernels/moe/test_moe.py \
  -k 'test_moe_sum_pad_aware or test_triton_experts_moe_sum_ignores_unrouted_slots' -q

.venv/bin/pre-commit run --files \
  vllm/model_executor/layers/fused_moe/experts/triton_moe.py \
  vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py \
  tests/kernels/moe/test_moe.py
```

Model-level validation used `deepseek-ai/DeepSeek-V3-0324` with DeepEP V2, expert parallelism, CUDA graphs, and EFA on 4 `p6-b200.48xlarge` nodes with 32 B200 GPUs total in `ap-south-1`. It did not use `--enforce-eager`. The image pinned vLLM commit `185cada36bb25aa55f762d004d54c5ca1e3fc753` and applied a patch equivalent to this change.

## Test Result

Focused H100 CUDA tests:

```text
9 passed, 1102 deselected, 14 warnings in 8.54s
```

The new regression test fails before this change and passes after it. In a separate H100 isolation using the pinned `TritonExperts.apply`, real Triton GEMMs, reused workspace, and H100-compatible substitutes for assignment and reduction, 4 invalid slots produced 512 mismatched output elements and a maximum absolute error of 17.0625 activation units with ordinary reduction. Pad-aware reduction produced 0 mismatched output elements and a maximum absolute error of 0.0 activation units.

All applicable pre-commit hooks passed, including ruff, mypy, typos, and repository validation hooks.

B200 model correctness and transport smoke:

- 8 deterministic serving probes passed with 0 mismatches.
- NIXL with libfabric recorded 32 successful transfers, 0 failed transfers, and 2,302,672,896 transferred bytes.
- EFA counters recorded 2,302,676,640 RDMA-read bytes.

This validation is a correctness and transport smoke. It does not claim a throughput result.

AI assistance was used to investigate the root cause, implement the patch, draft the test, and draft this PR description. This PR remains a draft pending the human submitter's review of every changed line and the validation evidence.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is required for this internal correctness fix.
</details>

