### PR TITLE
[Bugfix] Clamp TurboQuant value range to fp16 before quantizing

### DIFF
--- a/tests/kernels/turboquant/test_turboquant_store_value_range.py
+++ b/tests/kernels/turboquant/test_turboquant_store_value_range.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Value-path range handling in the TurboQuant store kernel.
+
+Regression coverage for gh-53334 observation 2: the per-vector value scale and
+zero point are stored as fp16. A bf16 value outlier whose magnitude exceeds the
+fp16 finite range (65504) used to cast to -inf at store time, so every element
+of that vector reconstructed as inf.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.ops.triton_turboquant_store import triton_turboquant_store
+
+DEVICE_TYPE = current_platform.device_type
+
+D = 128
+H = 1
+N = 1
+KEY_PACKED_SIZE = D
+BLOCK_SIZE = 16
+NUM_BLOCKS = 1
+
+
+def _store_and_reconstruct(outlier: float, value_quant_bits: int):
+    """Store one value vector containing `outlier`; reconstruct it from cache."""
+    val_data_bytes = D * value_quant_bits // 8
+    slot_bytes = KEY_PACKED_SIZE + val_data_bytes + 4
+
+    value = torch.zeros(N, H, D, dtype=torch.bfloat16, device=DEVICE_TYPE)
+    value[0, 0, 1:] = torch.linspace(-1.0, 4.0, D - 1, device=DEVICE_TYPE).to(
+        torch.bfloat16
+    )
+    value[0, 0, 0] = outlier
+    key = torch.zeros(N, H, D, dtype=torch.bfloat16, device=DEVICE_TYPE)
+
+    kv_cache = torch.zeros(
+        NUM_BLOCKS, BLOCK_SIZE, H, slot_bytes, dtype=torch.uint8, device=DEVICE_TYPE
+    )
+    triton_turboquant_store(
+        key,
+        value,
+        kv_cache,
+        torch.zeros(N, dtype=torch.int32, device=DEVICE_TYPE),
+        torch.eye(D, dtype=torch.float32, device=DEVICE_TYPE),
+        torch.zeros(1, dtype=torch.float32, device=DEVICE_TYPE),
+        mse_bits=1,
+        key_packed_size=KEY_PACKED_SIZE,
+        value_quant_bits=value_quant_bits,
+        key_fp8=True,
+    )
+    torch.cuda.synchronize()
+
+    slot = kv_cache[0, 0, 0].cpu()
+    meta = slot[KEY_PACKED_SIZE + val_data_bytes :][:4].numpy().tobytes()
+    scale = np.frombuffer(meta[0:2], dtype=np.float16)[0].astype(np.float32)
+    zero = np.frombuffer(meta[2:4], dtype=np.float16)[0].astype(np.float32)
+
+    packed = slot[KEY_PACKED_SIZE : KEY_PACKED_SIZE + val_data_bytes].numpy()
+    q = np.zeros(D, dtype=np.float32)
+    if value_quant_bits == 4:
+        q[0::2] = packed & 0x0F
+        q[1::2] = (packed >> 4) & 0x0F
+    else:  # 3-bit, 8 values packed into 3 bytes
+        bits = np.unpackbits(packed, bitorder="little").reshape(-1, 24)
+        for i in range(8):
+            grp = bits[:, i * 3 : (i + 1) * 3]
+            q[i::8] = (grp * (1 << np.arange(3))).sum(axis=1)[: D // 8]
+
+    return q * scale + zero, value[0, 0].float().cpu().numpy(), scale, zero
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("value_quant_bits", [4])
+@pytest.mark.parametrize(
+    "outlier",
+    [
+        -125000.0,  # beyond fp16 range; measured on a real 27B v-cache sink
+        -70000.0,  # just beyond fp16 range
+        -42000.0,  # within fp16 range (already worked before the fix)
+        -1.0,  # ordinary vector
+    ],
+)
+def test_value_outlier_reconstructs_finite(outlier, value_quant_bits):
+    """No value magnitude may reconstruct as inf.
+
+    Before the fix, |outlier| > 65504 stored a -inf zero point and every
+    element of the vector came back as inf.
+    """
+    recon, ref, scale, zero = _store_and_reconstruct(outlier, value_quant_bits)
+
+    assert np.isfinite(scale), f"stored scale is not finite: {scale}"
+    assert np.isfinite(zero), f"stored zero point is not finite: {zero}"
+    assert np.isfinite(recon).all(), (
+        f"outlier {outlier} poisoned the vector: "
+        f"{np.count_nonzero(~np.isfinite(recon))}/{D} elements non-finite"
+    )
+
+    # The elements that are not the outlier must stay usable. The bound is the
+    # inherent 4-bit per-vector quantization step for a vector with this range,
+    # which is what an in-range outlier of the same magnitude already produces.
+    step = (ref.clip(-65504.0).max() - max(ref.min(), -65504.0)) / 15.0
+    assert np.abs(recon[1:] - ref[1:]).max() <= step + 1e-3

--- a/vllm/v1/attention/ops/triton_turboquant_store.py
+++ b/vllm/v1/attention/ops/triton_turboquant_store.py
@@ -47,6 +47,15 @@ def _store_quantized_value(
         )
         val_min = tl.min(tl.where(d_mask, val_vec, float("inf")), axis=0)
         val_max = tl.max(tl.where(d_mask, val_vec, -float("inf")), axis=0)
+        # The per-vector scale and zero point are stored as fp16 further down.
+        # Clamp the observed range into fp16's finite limits *before* deriving
+        # the scale and quantizing, so the zero point used to quantize is the
+        # same one that is stored and later used to reconstruct. A bf16 value
+        # outlier (an attention sink of |min| > 65504 has been measured in real
+        # checkpoints) would otherwise cast to -inf at store time and poison
+        # every element of the vector on reconstruction.
+        val_min = tl.maximum(val_min, -65504.0)
+        val_max = tl.minimum(val_max, 65504.0)
         v_scale = (val_max - val_min) / 7.0
         v_scale = tl.where(v_scale > 1e-8, v_scale, 1e-8)
 
@@ -100,6 +109,15 @@ def _store_quantized_value(
         )
         val_min = tl.min(tl.where(d_mask, val_vec, float("inf")), axis=0)
         val_max = tl.max(tl.where(d_mask, val_vec, -float("inf")), axis=0)
+        # The per-vector scale and zero point are stored as fp16 further down.
+        # Clamp the observed range into fp16's finite limits *before* deriving
+        # the scale and quantizing, so the zero point used to quantize is the
+        # same one that is stored and later used to reconstruct. A bf16 value
+        # outlier (an attention sink of |min| > 65504 has been measured in real
+        # checkpoints) would otherwise cast to -inf at store time and poison
+        # every element of the vector on reconstruction.
+        val_min = tl.maximum(val_min, -65504.0)
+        val_max = tl.minimum(val_max, 65504.0)
         v_scale = (val_max - val_min) / 15.0
         v_scale = tl.where(v_scale > 1e-8, v_scale, 1e-8)
 


### PR DESCRIPTION
## Summary

`_store_quantized_value` derives the per-vector value scale and zero point from the observed min/max, quantizes against that min, and then stores both as fp16. A bf16 value outlier whose magnitude exceeds the fp16 finite range (65504) casts to `-inf` at store time, so reconstruction (`out = q*scale + zero`) returns `inf` for **every** element of that vector, not just the outlier.

Attention-sink magnitudes of this size occur in real checkpoints — the reporter measured v-cache sinks up to ~125k on a current 27B.

Fixes #53334 (observation 2).

## The fix

Clamp the observed range into the fp16 finite limits **before** deriving the scale and quantizing, so the zero point used to quantize is the same one that is stored and later used to reconstruct.

Clamping only at store time is not equivalent: quantization would still use the true `val_min` while reconstruction used the clamped one, skewing every element of the vector rather than just saturating the outlier. Measured on the same vector, that variant left the non-outlier elements with errors of ~59,500 — worse in practice than the `inf` it replaces, because it is silent.

## Verification

Measured on GB10 (sm_121), triton 3.7.0, by storing one vector through `triton_turboquant_store` whose remaining elements span `[-1, 4]` and reconstructing it from the packed cache:

| outlier | stored zero | reconstruction | max err on the rest | |
|---|---|---|---|---|
| -125000 | `-inf` | all `inf` | `inf` | before |
| -125000 | -65504 | finite | 17.00 | after |
| -42000 | -41984 | finite | 17.00 | unchanged |
| -1 | -1.0 | finite | 0.17 | unchanged |

The 17.00 bound is the inherent 4-bit per-vector step for a vector with that range — an in-range outlier of similar magnitude already produced it before this change. Vectors that fit in fp16 are unaffected.

## Test

Adds `tests/kernels/turboquant/test_turboquant_store_value_range.py`, which stores a vector through the real kernel and reconstructs it from the packed cache. Against `main` the two out-of-fp16-range cases fail (`2 failed, 2 passed`); with this change all four pass.
