### PR TITLE
[Bugfix] Name the real cause when a TurboQuant layer resolves to "auto"

### DIFF
--- a/tests/quantization/test_turboquant.py
+++ b/tests/quantization/test_turboquant.py
@@ -92,6 +92,20 @@ class TestTurboQuantConfig:
         with pytest.raises(ValueError, match="Unknown TurboQuant"):
             TurboQuantConfig.from_cache_dtype("turboquant_invalid", head_dim=128)
 
+    def test_auto_state_layer_dtype_raises_actionable(self):
+        # gh-53334 obs-1: a layer whose cache dtype resolves to "auto" (e.g. a
+        # linear-attention / state layer in a hybrid model) must fail with a
+        # clear, actionable message that names the real cause, instead of the
+        # generic, confusing "Unknown TurboQuant cache dtype: 'auto'.".
+        with pytest.raises(ValueError) as exc_info:
+            TurboQuantConfig.from_cache_dtype("auto", head_dim=128)
+        msg = str(exc_info.value)
+        assert "Unknown TurboQuant" not in msg, (
+            "'auto' must not be reported as an unknown preset; it means the "
+            "layer is not TurboQuant-compressible (state/auto-dtype)."
+        )
+        assert "auto" in msg and "layer" in msg
+
     # ---- Per-preset concrete value checks (table-driven) ----
 
     @pytest.mark.parametrize("preset", ALL_PRESETS)

--- a/vllm/model_executor/layers/quantization/turboquant/config.py
+++ b/vllm/model_executor/layers/quantization/turboquant/config.py
@@ -218,6 +218,18 @@ class TurboQuantConfig:
         Valid presets: turboquant_k8v4, turboquant_4bit_nc, etc.
         """
         if cache_dtype not in TQ_PRESETS:
+            if cache_dtype == "auto":
+                # A layer whose cache dtype resolved to "auto" (e.g. a
+                # linear-attention / state layer in a hybrid model, or a
+                # boundary skip) cannot be TurboQuant-compressed. Name the
+                # real cause instead of the generic "unknown dtype".
+                raise ValueError(
+                    "TurboQuant KV cache cannot represent a layer with cache "
+                    "dtype 'auto' (e.g. linear-attention / state layers of a "
+                    "hybrid model). --kv-cache-dtype turboquant_* applies only "
+                    "to full-attention layers; feed the state layer to its own "
+                    "backend (e.g. LinearAttentionBackend) instead."
+                )
             valid = ", ".join(TQ_PRESETS.keys())
             raise ValueError(
                 f"Unknown TurboQuant cache dtype: {cache_dtype!r}. "


### PR DESCRIPTION
## Summary

A hybrid model (linear-attention / state layers alongside full-attention ones) started with `--kv-cache-dtype turboquant_*` fails at engine init with:

```
ValueError: Unknown TurboQuant cache dtype: 'auto'.
Valid presets: turboquant_k8v4, turboquant_4bit_nc, turboquant_k3v4_nc, turboquant_3bit_nc
```

`auto` is not a preset the user typed, and it is not something they can fix by picking a different value from that list — it means a layer is not TurboQuant-compressible. The message sends them looking in the wrong place.

This reports that instead, and says what to do about it.

Fixes #53334 (observation 1).

## A question for maintainers

This assumes hybrid models are **intentionally** out of scope for the TurboQuant KV cache, and so treats the failure as a message problem.

The reporter framed it as a fork: *"If hybrids are intended to be unsupported, a clearer message would fail earlier and clearer; if support is intended, this is the blocker."*

I do not know which is the case. If hybrid support is planned, this is the wrong fix — please close it and treat #53334 observation 1 as a feature blocker rather than a UX issue.

## Test

`tests/quantization/test_turboquant.py::TestTurboQuantConfig::test_auto_state_layer_dtype_raises_actionable` asserts the message no longer reports `auto` as an unknown preset and names the real cause. Verified against `main` (old message) and with this change (new message).
