### PR TITLE
[Kimi Perf] Tune hopper low latency gemm kernel, 4%~97% performance improvement

### DIFF
--- a/tests/kernels/test_bf16_skinny_gemm.py
+++ b/tests/kernels/test_bf16_skinny_gemm.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for BF16 skinny GEMMs and the Kimi-K3 SM103/SM100 selectors."""
+"""Tests for BF16 skinny GEMMs and the Kimi-K3 SM90/SM100/SM103 selectors."""
 
 from pathlib import Path
 from types import SimpleNamespace
@@ -52,9 +52,16 @@ EXPECTED_SELECTIONS = {
     (10240, 7168): (set(range(1, 5)), set()),
 }
 
+K3ProjectionTable = dict[tuple[int, int], k3_gemm.ProjectionSpec]
+K3_GPU_TABLES = (
+    ((10, 3), k3_gemm.KIMI_K3_PROJECTIONS),
+    ((9, 0), k3_gemm.KIMI_K3_PROJECTIONS_SM90),
+)
+
 CUTE_CASES = [
-    (spec.n, spec.k, num_tokens)
-    for spec in k3_gemm.KIMI_K3_PROJECTIONS.values()
+    (capability, spec.n, spec.k, num_tokens)
+    for capability, table in K3_GPU_TABLES
+    for spec in table.values()
     for num_tokens, _ in spec.cute_configs
 ]
 
@@ -186,6 +193,7 @@ def test_every_dsv3_routed_shape_is_instantiated() -> None:
     specs = [
         *KIMI_K3_PROJECTIONS.values(),
         *k3_gemm.KIMI_K3_PROJECTIONS_SM100.values(),
+        *k3_gemm.KIMI_K3_PROJECTIONS_SM90.values(),
         glm52_gemm.GLM52_QKV_A_PROJECTION,
         glm52_gemm.GLM52_Q_B_PROJECTION,
     ]
@@ -448,8 +456,12 @@ EXPECTED_SELECTIONS_SM100 = {
 }
 
 
-def test_sm100_table_is_keyed_by_shape() -> None:
-    for (n, k), spec in k3_gemm.KIMI_K3_PROJECTIONS_SM100.items():
+@pytest.mark.parametrize(
+    "table",
+    [k3_gemm.KIMI_K3_PROJECTIONS_SM100, k3_gemm.KIMI_K3_PROJECTIONS_SM90],
+)
+def test_device_table_is_keyed_by_shape(table: K3ProjectionTable) -> None:
+    for (n, k), spec in table.items():
         assert (spec.n, spec.k) == (n, k)
 
 
@@ -468,8 +480,12 @@ def test_sm100_selector_table(key: tuple[int, int]) -> None:
             assert backend is None
 
 
-def test_sm100_build_plan_matches_table() -> None:
-    for spec in k3_gemm.KIMI_K3_PROJECTIONS_SM100.values():
+@pytest.mark.parametrize(
+    "table",
+    [k3_gemm.KIMI_K3_PROJECTIONS_SM100, k3_gemm.KIMI_K3_PROJECTIONS_SM90],
+)
+def test_device_build_plan_matches_table(table: K3ProjectionTable) -> None:
+    for spec in table.values():
         plan = k3_gemm._build_plan(spec)
         for num_tokens in range(1, 17):
             backend = k3_gemm._backend_for(spec, num_tokens, has_residual=False)
@@ -477,6 +493,12 @@ def test_sm100_build_plan_matches_table() -> None:
                 assert num_tokens not in plan
             else:
                 assert plan[num_tokens][0] == backend
+
+
+def test_sm90_table_covers_measured_points() -> None:
+    specs = k3_gemm.KIMI_K3_PROJECTIONS_SM90.values()
+    assert len(k3_gemm.KIMI_K3_PROJECTIONS_SM90) == 18
+    assert sum(len(spec.cute_configs) + len(spec.dsv3_tokens) for spec in specs) == 90
 
 
 def test_low_latency_table_capability_routing(
@@ -492,6 +514,13 @@ def test_low_latency_table_capability_routing(
         lambda cc: cc == (10, 0),
     )
     assert k3_gemm._low_latency_table() is k3_gemm.KIMI_K3_PROJECTIONS_SM100
+
+    monkeypatch.setattr(
+        k3_gemm.current_platform,
+        "is_device_capability",
+        lambda cc: cc == (9, 0),
+    )
+    assert k3_gemm._low_latency_table() is k3_gemm.KIMI_K3_PROJECTIONS_SM90
 
     monkeypatch.setattr(
         k3_gemm.current_platform, "is_device_capability", lambda cc: False
@@ -599,18 +628,32 @@ def test_installation_requires_bf16_sm103(
     assert type(root.projection.quant_method) is k3_gemm.UnquantizedLinearMethod
 
 
-def _require_sm103_and_dsv3() -> None:
-    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 3):
-        pytest.skip("Kimi-K3 production selection requires SM103")
+def _require_capability_and_dsv3(capability: tuple[int, int]) -> None:
+    if (
+        not torch.cuda.is_available()
+        or torch.cuda.get_device_capability() != capability
+    ):
+        pytest.skip(f"Kimi-K3 selection requires SM{capability[0]}{capability[1]}")
     if not hasattr(torch.ops._C, "dsv3_fused_a_gemm"):
         pytest.skip("dsv3_fused_a_gemm was not built")
 
 
-def _require_sm103_and_cute() -> None:
-    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 3):
-        pytest.skip("Kimi-K3 production selection requires SM103")
+def _require_capability_and_cute(capability: tuple[int, int]) -> None:
+    if (
+        not torch.cuda.is_available()
+        or torch.cuda.get_device_capability() != capability
+    ):
+        pytest.skip(f"Kimi-K3 selection requires SM{capability[0]}{capability[1]}")
     if not k3_gemm.shape_dynamic_skinny_gemm.is_available():
         pytest.skip("CuTe DSL is not available")
+
+
+def _require_sm103_and_dsv3() -> None:
+    _require_capability_and_dsv3((10, 3))
+
+
+def _require_sm103_and_cute() -> None:
+    _require_capability_and_cute((10, 3))
 
 
 @pytest.mark.parametrize("spec,config", GLM_CUTE_CASES)
@@ -683,9 +726,11 @@ def test_glm_cute_selected_shapes_cuda_graph_capture(
     torch.testing.assert_close(output.float(), reference, rtol=2e-2, atol=2e-1)
 
 
-@pytest.mark.parametrize("n,k,num_tokens", CUTE_CASES)
-def test_cute_selected_shapes(n: int, k: int, num_tokens: int) -> None:
-    _require_sm103_and_cute()
+@pytest.mark.parametrize("capability,n,k,num_tokens", CUTE_CASES)
+def test_cute_selected_shapes(
+    capability: tuple[int, int], n: int, k: int, num_tokens: int
+) -> None:
+    _require_capability_and_cute(capability)
     torch.manual_seed(42)
     x = torch.randn(num_tokens, k, dtype=torch.bfloat16, device="cuda")
     weight = torch.randn(n, k, dtype=torch.bfloat16, device="cuda")
@@ -710,8 +755,9 @@ def _dsv3_probe_tokens(tokens: frozenset[int]) -> set[int]:
 # Derived from the table rather than hand-listed, so a shape routed to dsv3
 # cannot be added without being exercised here.
 DSV3_CASES = sorted(
-    (num_tokens, spec.n, spec.k)
-    for spec in KIMI_K3_PROJECTIONS.values()
+    (capability, num_tokens, spec.n, spec.k)
+    for capability, table in K3_GPU_TABLES
+    for spec in table.values()
     for num_tokens in _dsv3_probe_tokens(spec.dsv3_tokens)
 )
 
@@ -725,11 +771,11 @@ GLM_DSV3_CASES = [
 ]
 
 
-@pytest.mark.parametrize("num_tokens,n,k", DSV3_CASES)
-def test_dsv3_selected_shapes(num_tokens: int, n: int, k: int) -> None:
-    _require_sm103_and_dsv3()
-    spec = k3_gemm.KIMI_K3_PROJECTIONS[(n, k)]
-    assert num_tokens in spec.dsv3_tokens
+@pytest.mark.parametrize("capability,num_tokens,n,k", DSV3_CASES)
+def test_dsv3_selected_shapes(
+    capability: tuple[int, int], num_tokens: int, n: int, k: int
+) -> None:
+    _require_capability_and_dsv3(capability)
     torch.manual_seed(42)
     x = torch.randn(num_tokens, k, dtype=torch.bfloat16, device="cuda")
     weight = torch.randn(n, k, dtype=torch.bfloat16, device="cuda")
@@ -784,11 +830,14 @@ def test_nonpacked_single_token_dsv3_falls_back() -> None:
     torch.testing.assert_close(output, reference)
 
 
-def test_selected_kernels_cuda_graph_capture() -> None:
-    _require_sm103_and_cute()
-    _require_sm103_and_dsv3()
-    cute_spec = k3_gemm.KIMI_K3_PROJECTIONS[(6288, 7168)]
-    dsv3_spec = k3_gemm.KIMI_K3_PROJECTIONS[(1536, 128)]
+@pytest.mark.parametrize("capability,table", K3_GPU_TABLES)
+def test_selected_kernels_cuda_graph_capture(
+    capability: tuple[int, int], table: K3ProjectionTable
+) -> None:
+    _require_capability_and_cute(capability)
+    _require_capability_and_dsv3(capability)
+    cute_spec = table[(6288, 7168)]
+    dsv3_spec = table[(1536, 128)]
     cute_x = torch.randn(1, cute_spec.k, dtype=torch.bfloat16, device="cuda")
     cute_weight = torch.randn(
         cute_spec.n, cute_spec.k, dtype=torch.bfloat16, device="cuda"

--- a/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Kimi-K3 decode GEMM selection for unquantized BF16 on SM103 and SM100.
+"""Kimi-K3 decode GEMM selection for unquantized BF16 on SM90/SM100/SM103.
 
 Dispatch is purely by local ``(N, K)`` shape and token count ``M`` — the module
 name plays no role. Each measured shape maps to a :class:`ProjectionSpec`
@@ -8,12 +8,11 @@ holding the winning backend per token count. The static part of the decision is
 resolved once per module at install time into a small ``{M: call}`` plan, so the
 per-forward path is a single dict lookup.
 
-The two supported capabilities carry separate measured tables:
+The supported capabilities carry separate measured tables:
 :data:`KIMI_K3_PROJECTIONS` was tuned on B300 (SM103),
-:data:`KIMI_K3_PROJECTIONS_SM100` on B200 (SM100). The per-(shape, M) winners
-genuinely differ between the two parts (e.g. 3584x7168 favors dsv3 at M2..8 on
-B300 but only wins with CuTe at M1..3 on B200), so the tables must not be
-merged.
+:data:`KIMI_K3_PROJECTIONS_SM100` on B200 (SM100), and
+:data:`KIMI_K3_PROJECTIONS_SM90` on H200 (SM90). The per-(shape, M) winners
+genuinely differ between the parts, so the tables must not be merged.
 """
 
 from __future__ import annotations
@@ -493,6 +492,96 @@ KIMI_K3_PROJECTIONS_SM100: dict[tuple[int, int], ProjectionSpec] = {
     ),
 }
 
+_SM90CuteConfig = tuple[int, int, int, int]
+
+
+def _sm90_spec(
+    n: int,
+    k: int,
+    dsv3_tokens: frozenset[int] = frozenset(),
+    configs: tuple[_SM90CuteConfig, ...] = (),
+) -> ProjectionSpec:
+    cute_configs = tuple(
+        (m, _cute(m, *config)) for m, config in enumerate(configs, start=1)
+    )
+    return ProjectionSpec(n, k, dsv3_tokens, cute_configs)
+
+
+KIMI_K3_PROJECTIONS_SM90: dict[tuple[int, int], ProjectionSpec] = {
+    (1536, 128): _sm90_spec(1536, 128, frozenset(range(1, 9))),
+    (3072, 128): _sm90_spec(3072, 128, frozenset({1, 2, 5, 6, 7, 8, 9})),
+    (1536, 7168): _sm90_spec(
+        1536,
+        7168,
+        frozenset(range(7, 17)),
+        (
+            (224, 2, 4, 8),
+            (128, 3, 2, 8),
+            (128, 2, 1, 8),
+            (128, 2, 1, 8),
+            (128, 3, 1, 8),
+            (128, 3, 1, 8),
+        ),
+    ),
+    (3072, 7168): _sm90_spec(
+        3072,
+        7168,
+        configs=((224, 2, 4, 8), (128, 2, 2, 8), (64, 4, 1, 8), (128, 6, 1, 8)),
+    ),
+    (2112, 7168): _sm90_spec(
+        2112,
+        7168,
+        frozenset(range(5, 17)),
+        ((224, 2, 4, 8), (128, 4, 2, 8), (128, 2, 1, 8), (128, 2, 1, 8)),
+    ),
+    (2304, 1536): _sm90_spec(
+        2304,
+        1536,
+        frozenset(range(3, 9)),
+        ((96, 4, 2, 8), (96, 4, 1, 8)),
+    ),
+    (4608, 1536): _sm90_spec(
+        4608,
+        1536,
+        configs=((96, 4, 2, 4), (96, 4, 1, 8), (64, 4, 1, 8)),
+    ),
+    (3584, 7168): _sm90_spec(
+        3584,
+        7168,
+        configs=((224, 2, 4, 8), (128, 4, 2, 8), (128, 2, 1, 8)),
+    ),
+    (6288, 7168): _sm90_spec(
+        6288,
+        7168,
+        configs=((224, 2, 4, 8), (128, 4, 2, 8), (64, 4, 1, 8)),
+    ),
+    (12448, 7168): _sm90_spec(
+        12448,
+        7168,
+        configs=((224, 2, 4, 8), (224, 4, 2, 8), (128, 2, 1, 8)),
+    ),
+    (7168, 768): _sm90_spec(7168, 768, configs=((96, 4, 2, 4), (96, 4, 1, 8))),
+    (7168, 1536): _sm90_spec(7168, 1536, configs=((96, 4, 2, 8), (96, 4, 1, 8))),
+    (7168, 3072): _sm90_spec(
+        7168,
+        3072,
+        configs=((96, 2, 4, 8), (64, 4, 2, 8), (64, 2, 2, 8)),
+    ),
+    (7168, 3584): _sm90_spec(
+        7168,
+        3584,
+        configs=((224, 4, 2, 8), (64, 4, 2, 8), (64, 4, 2, 8)),
+    ),
+    (7168, 4224): _sm90_spec(7168, 4224, configs=((96, 4, 2, 4), (32, 4, 2, 4))),
+    (7168, 8448): _sm90_spec(7168, 8448, configs=((96, 2, 4, 8), (32, 4, 2, 8))),
+    (7168, 14336): _sm90_spec(7168, 14336, configs=((224, 2, 4, 8), (128, 2, 2, 8))),
+    (20480, 7168): _sm90_spec(
+        20480,
+        7168,
+        configs=((224, 4, 2, 8), (224, 4, 2, 8), (128, 2, 1, 8)),
+    ),
+}
+
 
 def _backend_for(
     spec: ProjectionSpec, num_tokens: int, has_residual: bool
@@ -543,6 +632,8 @@ def _low_latency_table() -> dict[tuple[int, int], ProjectionSpec] | None:
         return KIMI_K3_PROJECTIONS
     if current_platform.is_device_capability((10, 0)):
         return KIMI_K3_PROJECTIONS_SM100
+    if current_platform.is_device_capability((9, 0)):
+        return KIMI_K3_PROJECTIONS_SM90
     return None
 
 
@@ -694,7 +785,7 @@ def enable_kimi_k3_low_latency_gemm(
     Modules are matched purely by type, an exactly-unquantized method, and a
     local ``(N, K)`` present in the current device's measured table
     (:data:`KIMI_K3_PROJECTIONS` on SM103, :data:`KIMI_K3_PROJECTIONS_SM100`
-    on SM100).
+    on SM100, :data:`KIMI_K3_PROJECTIONS_SM90` on SM90).
     """
     if dtype != torch.bfloat16:
         return


### PR DESCRIPTION
## Purpose

Tune hopper low latency gemm kernel

## Test

Acc covered in current unit tests

Perf can be seen in this AI generated script

```py
from statistics import geometric_mean

import torch
import torch.nn.functional as F

from vllm.models.kimi_k3.nvidia import low_latency_gemm as gemm
from vllm.triton_utils import triton

COPIES = 8  # Distinct weights approximate different model layers.
WARMUP = 20
REPETITIONS = 100
TOKENS = range(1, 3)


def bench_graph(fn) -> float:
    """Return microseconds per GEMM, with graph launch cost amortized."""
    outputs = fn()
    torch.accelerator.synchronize()
    graph = torch.cuda.CUDAGraph()
    with torch.cuda.graph(graph):
        outputs = fn()
    latency_ms = triton.testing.do_bench(
        graph.replay,
        warmup=WARMUP,
        rep=REPETITIONS,
        return_mode="median",
    )
    del outputs
    return latency_ms * 1000 / COPIES


def run_plan(plan, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
    output = gemm._run_plan(plan, x, weight)
    return F.linear(x, weight) if output is None else output


def main() -> None:
    capability = torch.cuda.get_device_capability()
    if capability != (9, 0):
        raise RuntimeError(f"This benchmark requires Hopper (SM90), got {capability}")

    print(f"GPU: {torch.cuda.get_device_name()} {capability}")
    print("       N      K   M  backend          before_us   after_us  speedup")

    selected_speedups = []
    for (n, k), spec in gemm.KIMI_K3_PROJECTIONS_SM90.items():
        weights = [
            torch.empty((n, k), dtype=torch.bfloat16, device="cuda")
            for _ in range(COPIES)
        ]
        plan = gemm._build_plan(spec)

        for m in TOKENS:
            x = torch.empty((m, k), dtype=torch.bfloat16, device="cuda")
            backend = plan[m][0] if m in plan else "cuBLAS fallback"

            before_us = bench_graph(
                lambda x=x, weights=weights: [F.linear(x, w) for w in weights]
            )
            after_us = bench_graph(
                lambda plan=plan, x=x, weights=weights: [
                    run_plan(plan, x, w) for w in weights
                ]
            )
            speedup = before_us / after_us
            if m in plan:
                selected_speedups.append(speedup)

            print(
                f"{n:8d} {k:6d} {m:3d}  {backend:15s} "
                f"{before_us:10.2f} {after_us:10.2f} {speedup:8.2f}x"
            )

        weights.clear()
        torch.accelerator.empty_cache()

    print(
        f"Selected points: {len(selected_speedups)}, "
        f"geomean {geometric_mean(selected_speedups):.2f}x, "
        f"min {min(selected_speedups):.2f}x, max {max(selected_speedups):.2f}x"
    )


if __name__ == "__main__":
    main()
```

And we can get

```bash
GPU: NVIDIA H200 (9, 0)
       N      K   M  backend          before_us   after_us  speedup
    1536    128   1  dsv3_fused_a          3.18       1.61     1.97x
    1536    128   2  dsv3_fused_a          3.15       1.62     1.94x
    3072    128   1  dsv3_fused_a          3.26       1.72     1.89x
    3072    128   2  dsv3_fused_a          3.27       1.72     1.90x
    1536   7168   1  cute                 11.29       7.63     1.48x
    1536   7168   2  cute                 11.32       7.94     1.43x
    3072   7168   1  cute                 16.38      12.86     1.27x
    3072   7168   2  cute                 17.26      13.48     1.28x
    2112   7168   1  cute                 13.38       9.62     1.39x
    2112   7168   2  cute                 13.72       9.98     1.37x
    2304   1536   1  cute                  6.18       3.98     1.55x
    2304   1536   2  cute                  6.19       4.10     1.51x
    4608   1536   1  cute                  7.58       5.77     1.31x
    4608   1536   2  cute                  7.56       5.92     1.28x
    3584   7168   1  cute                 17.78      14.61     1.22x
    3584   7168   2  cute                 17.85      15.46     1.15x
    6288   7168   1  cute                 26.98      23.56     1.15x
    6288   7168   2  cute                 26.82      24.65     1.09x
   12448   7168   1  cute                 49.24      44.27     1.11x
   12448   7168   2  cute                 49.74      45.74     1.09x
    7168    768   1  cute                  6.60       4.90     1.35x
    7168    768   2  cute                  6.60       5.15     1.28x
    7168   1536   1  cute                  9.39       7.54     1.25x
    7168   1536   2  cute                  9.39       8.10     1.16x
    7168   3072   1  cute                 16.20      12.84     1.26x
    7168   3072   2  cute                 16.13      13.54     1.19x
    7168   3584   1  cute                 18.05      15.25     1.18x
    7168   3584   2  cute                 18.08      15.56     1.16x
    7168   4224   1  cute                 20.26      17.82     1.14x
    7168   4224   2  cute                 20.14      18.64     1.08x
    7168   8448   1  cute                 34.52      32.59     1.06x
    7168   8448   2  cute                 34.35      32.95     1.04x
    7168  14336   1  cute                 54.46      50.78     1.07x
    7168  14336   2  cute                 54.73      52.04     1.05x
   20480   7168   1  cute                 80.22      70.42     1.14x
   20480   7168   2  cute                 78.52      71.68     1.10x
Selected points: 36, geomean 1.28x, min 1.04x, max 1.97x
```