### PR TITLE
[Bugfix][Parser] Scope reasoning-end detection to the current turn via turn-boundary tokens

### DIFF
--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -27,6 +27,8 @@ _THINK_START_ID = 50
 _THINK_END_ID = 51
 _TOOL_CALL_ID = 60
 _TOOL_CALL_END_ID = 61
+_IM_START_ID = 70
+_IM_END_ID = 71
 _TEXT_ID = 100
 
 _QWEN3_VOCAB = {
@@ -34,6 +36,8 @@ _QWEN3_VOCAB = {
     "</think>": _THINK_END_ID,
     "<tool_call>": _TOOL_CALL_ID,
     "</tool_call>": _TOOL_CALL_END_ID,
+    "<|im_start|>": _IM_START_ID,
+    "<|im_end|>": _IM_END_ID,
 }
 
 
@@ -192,6 +196,72 @@ class TestIsReasoningEnd:
         assert not parser.is_reasoning_end([])
 
 
+class TestIsReasoningEndTurnBoundaries:
+    """Reasoning markers from earlier turns must not mark the new turn's
+    reasoning as finished (think-marker injection / interleaved-thinking
+    replay).
+    """
+
+    def test_injected_think_end_in_history_not_end(self, parser):
+        assert not parser.is_reasoning_end(
+            [_IM_START_ID, _TEXT_ID, _THINK_END_ID, _IM_END_ID, _IM_START_ID]
+        )
+
+    def test_replayed_reasoning_block_in_history_not_end(self, parser):
+        assert not parser.is_reasoning_end(
+            [
+                _IM_START_ID,
+                _THINK_START_ID,
+                _TEXT_ID,
+                _THINK_END_ID,
+                _TEXT_ID,
+                _IM_END_ID,
+                _IM_START_ID,
+            ]
+        )
+
+    def test_think_end_in_current_turn_is_end(self, parser):
+        assert parser.is_reasoning_end(
+            [_IM_START_ID, _TEXT_ID, _IM_END_ID, _IM_START_ID, _THINK_END_ID]
+        )
+
+    def test_unpaired_tool_call_in_history_not_end(self, parser):
+        assert not parser.is_reasoning_end(
+            [_TOOL_CALL_ID, _TEXT_ID, _IM_END_ID, _IM_START_ID]
+        )
+
+    def test_continued_turn_with_closed_thinking_is_end(self, parser):
+        assert parser.is_reasoning_end(
+            [_IM_START_ID, _THINK_START_ID, _TEXT_ID, _THINK_END_ID, _TEXT_ID]
+        )
+
+    def test_continued_turn_with_open_thinking_not_end(self, parser):
+        assert not parser.is_reasoning_end([_IM_START_ID, _THINK_START_ID, _TEXT_ID])
+
+    def test_empty_boundary_config_keeps_global_walk(self):
+        """Configs without turn_boundary_tokens keep the pre-existing
+        behavior: any </think> in the sequence ends reasoning."""
+        cfg = qwen3_config(turn_boundary_tokens=frozenset())
+        parser = Qwen3Parser(
+            make_mock_tokenizer(_QWEN3_VOCAB), parser_engine_config=cfg
+        )
+        assert parser.is_reasoning_end(
+            [_IM_START_ID, _TEXT_ID, _THINK_END_ID, _IM_END_ID, _IM_START_ID]
+        )
+
+    def test_boundary_tokens_missing_from_vocab_keep_global_walk(self):
+        """Boundary tokens absent from the vocabulary resolve to nothing,
+        so subclasses reusing the default on a non-ChatML vocab keep the
+        pre-existing behavior."""
+        vocab = {
+            token: token_id
+            for token, token_id in _QWEN3_VOCAB.items()
+            if not token.startswith("<|im_")
+        }
+        parser = Qwen3Parser(make_mock_tokenizer(vocab))
+        assert parser.is_reasoning_end([_TEXT_ID, _THINK_END_ID, _TEXT_ID])
+
+
 class TestDelegatingPromptDetection:
     def test_prompt_tool_example_does_not_skip_streaming_reasoning(
         self, mock_tokenizer, mock_request
@@ -210,6 +280,56 @@ class TestDelegatingPromptDetection:
         assert delta is not None
         assert delta.reasoning == "thinking"
         assert delta.content is None
+
+    def test_injected_think_end_in_history_keeps_streaming_reasoning(
+        self, mock_tokenizer, mock_request
+    ):
+        parser = _Qwen3DelegatingParser(mock_tokenizer)
+        prompt_ids = [
+            _IM_START_ID,
+            _TEXT_ID,
+            _THINK_END_ID,
+            _TEXT_ID,
+            _IM_END_ID,
+            _IM_START_ID,
+        ]
+
+        delta = parser.parse_delta(
+            "thinking",
+            [_TEXT_ID],
+            mock_request,
+            prompt_token_ids=prompt_ids,
+            finished=False,
+        )
+
+        assert delta is not None
+        assert delta.reasoning == "thinking"
+        assert delta.content is None
+
+    def test_think_end_in_generation_prompt_still_seeds_reasoning_ended(
+        self, mock_tokenizer, mock_request
+    ):
+        parser = _Qwen3DelegatingParser(mock_tokenizer)
+        prompt_ids = [
+            _IM_START_ID,
+            _TEXT_ID,
+            _IM_END_ID,
+            _IM_START_ID,
+            _THINK_START_ID,
+            _THINK_END_ID,
+        ]
+
+        delta = parser.parse_delta(
+            "answer",
+            [_TEXT_ID],
+            mock_request,
+            prompt_token_ids=prompt_ids,
+            finished=False,
+        )
+
+        assert delta is not None
+        assert delta.reasoning is None
+        assert delta.content == "answer"
 
 
 class TestStreaming:

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -147,6 +147,11 @@ class ParserEngine(Parser):
             self._reasoning_start_token_id = vocab.get(start_text)
         if end_text:
             self._reasoning_end_token_id = vocab.get(end_text)
+        self._turn_boundary_token_ids: frozenset[int] = frozenset(
+            token_id
+            for token in parser_engine_config.turn_boundary_tokens
+            if (token_id := vocab.get(token)) is not None
+        )
 
     @property
     def reasoning_start_str(self) -> str | None:
@@ -601,11 +606,17 @@ class ParserEngine(Parser):
         if end_id is not None:
             if not input_ids:
                 return self.parser_engine_config.initial_state != ParserState.REASONING
+            boundary_ids = self._turn_boundary_token_ids
             for i in range(len(input_ids) - 1, -1, -1):
-                if input_ids[i] == end_id:
+                token_id = input_ids[i]
+                if token_id == end_id:
                     return True
-                if start_id is not None and input_ids[i] == start_id:
+                if start_id is not None and token_id == start_id:
                     return False
+                if token_id in boundary_ids:
+                    return (
+                        self.parser_engine_config.initial_state != ParserState.REASONING
+                    )
             return False
         return self._reasoning_ended
 

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -84,6 +84,10 @@ class ParserEngineConfig:
     # Special tokens exempt from auto-drop but not state-machine terminals.
     preserve_tokens: frozenset[str] = field(default_factory=frozenset)
 
+    # Special tokens delimiting conversation turns in the prompt only
+    # considers reasoning markers after the last boundary token.
+    turn_boundary_tokens: frozenset[str] = field(default_factory=frozenset)
+
     # Prevents trailing-whitespace accumulation across multi-turn conversations.
     strip_trailing_reasoning_whitespace: bool = True
 

--- a/vllm/parser/nemotron_v3.py
+++ b/vllm/parser/nemotron_v3.py
@@ -16,7 +16,7 @@ import dataclasses
 import functools
 from typing import TYPE_CHECKING
 
-from vllm.parser.qwen3 import Qwen3Parser, qwen3_config
+from vllm.parser.qwen3 import CHATML_TURN_BOUNDARIES, Qwen3Parser, qwen3_config
 
 if TYPE_CHECKING:
     from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 @functools.cache
 def nemotron_v3_config(thinking: bool = True) -> ParserEngineConfig:
     return dataclasses.replace(
-        qwen3_config(thinking=thinking),
+        qwen3_config(thinking=thinking, turn_boundary_tokens=CHATML_TURN_BOUNDARIES),
         name="nemotron_v3",
         strip_trailing_reasoning_whitespace=True,
     )

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -42,6 +42,7 @@ THINK_START = "<think>"
 THINK_END = "</think>"
 TOOL_CALL_START = "<tool_call>"
 TOOL_CALL_END = "</tool_call>"
+CHATML_TURN_BOUNDARIES = frozenset(("<|im_start|>", "<|im_end|>"))
 FUNC_PREFIX = "<function="
 FUNC_END = "</function>"
 PARAM_START = "<parameter="
@@ -94,10 +95,12 @@ def qwen3_config(
     think_end: str = THINK_END,
     tool_start: str = TOOL_CALL_START,
     tool_end: str = TOOL_CALL_END,
+    turn_boundary_tokens: frozenset[str] = frozenset(),
 ) -> ParserEngineConfig:
     return ParserEngineConfig(
         name=name,
         initial_state=ParserState.REASONING if thinking else ParserState.CONTENT,
+        turn_boundary_tokens=turn_boundary_tokens,
         terminals={
             # Reasoning terminals
             "THINK_START": think_start,
@@ -215,6 +218,7 @@ class Qwen3Parser(ParserEngine):
     THINK_END = THINK_END
     TOOL_START = TOOL_CALL_START
     TOOL_END = TOOL_CALL_END
+    TURN_BOUNDARIES: frozenset[str] = CHATML_TURN_BOUNDARIES
 
     def __init__(
         self,
@@ -233,6 +237,7 @@ class Qwen3Parser(ParserEngine):
                 think_end=self.THINK_END,
                 tool_start=self.TOOL_START,
                 tool_end=self.TOOL_END,
+                turn_boundary_tokens=self.TURN_BOUNDARIES,
             ),
         )
         super().__init__(
@@ -259,12 +264,15 @@ class Qwen3Parser(ParserEngine):
         tool_call_id = self._tool_call_token_id
         tool_call_end_id = self._tool_call_end_token_id
         reasoning_start_id = self._reasoning_start_token_id
+        boundary_ids = self._turn_boundary_token_ids
         if tool_call_id is not None:
             for i in range(len(input_ids) - 1, -1, -1):
                 if (
                     reasoning_start_id is not None
                     and input_ids[i] == reasoning_start_id
                 ):
+                    return False
+                if input_ids[i] in boundary_ids:
                     return False
                 if input_ids[i] == tool_call_id:
                     if tool_call_end_id is not None and any(


### PR DESCRIPTION
## Purpose

`ParserEngine.is_reasoning_end()` walks the token sequence backwards and returns `True` on the first `</think>` it sees. It is called on the **full prompt** (the entire rendered conversation) from two places:

1. `DelegatingParser.parse_delta` (`vllm/parser/abstract_parser.py`) - seeds `reasoning_ended` at stream start. A stale `</think>` in history routes the new turn's entire `<think>…</think>` block into `content` instead of `reasoning` (and the answer is lost entirely under `include_reasoning=false`).
2. `StructuredOutputManager.should_fill_bitmask` (`vllm/v1/structured_output/__init__.py`) - seeds the scheduler's reasoning-end gate. A stale `</think>` applies the grammar bitmask from the first generated token, constraining the model's thinking.

#### Fix

Add `turn_boundary_tokens` to `ParserEngineConfig`; the backward walk now stops at the first turn boundary (`<|im_start|>`/`<|im_end|>` for the ChatML family), so markers from earlier turns are no longer visible. Hitting a
boundary falls back to `initial_state != REASONING` (the same semantics as an empty prompt) which keeps the "template closed the think block in the generation prompt" case working (covered by a test). This generalizes into the
engine what #44551 (Cohere) and `poolside_v1` ([here](https://github.com/vllm-project/vllm/pull/41129/changes#diff-4b2c2b20e84b6d2b6e8dd323843677442844cfd4506bc93385fe662a5edb7766)) already do per-parser, and follows the model-specific backward-scan direction maintainers requested when closing the generic serving-layer attempts (#46663 review).

Backward compatible: the default boundary set is empty, and boundary tokens missing from a tokenizer's vocab resolve to nothing, so parsers on non-ChatML vocabs (e.g. `SeedOssParser`) keep the previous behaviour. Both cases are covered by tests.

#### Why this is not a duplicate

- #44551 fixed this bug class for Cohere only
- #47775 does the same for Mistral
- #49728 / #41129 relate to poolside models
- #46042 / #50594 cover MiniMax-M3
- #25355 fixed GLM4
- #45891, #46663 and #50152 attempted a generic serving-layer "prompt tail" check and were closed; review feedback asked for a model-specific backward scan inside the parser
- #53302 complementary: it starts qwen3 in CONTENT when the generation prompt legitimately closes the think block, and relies on `is_reasoning_end(prompt)`, this PR makes that check robust against stale history markers
- #51238 is an orthogonal perf change to the decode-path `is_reasoning_end_streaming`

## Test Plan

```bash
pytest tests/parser/engine/test_qwen3_reasoning.py -v
pytest tests/parser -q
pre-commit run --files <changed files>
pre-commit run mypy-3.12 --all-files --hook-stage manual
```

E2E: serve `Qwen/Qwen3-1.7B` with `--reasoning-parser qwen3`, send streaming requests whose prompt contains a stale `</think>` (literal tag in user text), plus regression controls, at `temperature=0`; compare field routing before and after this change.

## Test Result

Tested on H100

- `tests/parser/engine/test_qwen3_reasoning.py`: **57 passed** (incl. 10 new turn-boundary tests)
- full `tests/parser` suite: **4086 passed, 0 failures**
- pre-commit on changed files: all hooks passed
- E2E (Qwen/Qwen3-1.7B, `--reasoning-parser qwen3`, streaming, temperature=0):

  | case | main | this PR |
  |---|---|---|
  | control single turn | reasoning 1227 ch / content 77 ch | identical |
  | replayed reasoning in history | reasoning 875 ch / content 16 ch | identical |
  | literal `</think>` in user text | **reasoning 0 ch, whole response incl. `<think>` tag leaked into content (602 ch)** | **reasoning 571 ch / content 16 ch, no leak** |

Control cases are byte-identical before/after.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>