### PR TITLE
[Bugfix] Add compilation timeout for JSON schema and grammar in xgrammar

### DIFF
--- a/tests/v1/structured_output/test_grammar_compilation_timeout.py
+++ b/tests/v1/structured_output/test_grammar_compilation_timeout.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for grammar and JSON schema compilation timeout guard.
+
+Verifies that deeply-nested schemas or complex grammars that would cause
+exponential state-space explosion are rejected with a timeout rather than
+hanging worker threads indefinitely (#54003).
+"""
+
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+
+from vllm.v1.structured_output.utils import compile_grammar_with_timeout
+
+
+class TestCompileGrammarWithTimeout:
+    """Unit tests for the compile_grammar_with_timeout utility."""
+
+    def test_normal_json_schema_compiles_successfully(self):
+        schema = '{"type": "object", "properties": {"name": {"type": "string"}}}'
+        result = compile_grammar_with_timeout(
+            lambda s: "compiled",
+            schema,
+            grammar_spec=schema,
+            grammar_type="JSON schema",
+        )
+        assert result == "compiled"
+
+    def test_normal_grammar_compiles_successfully(self):
+        grammar = 'root ::= "hello" | "world"'
+        result = compile_grammar_with_timeout(
+            lambda g: "compiled",
+            grammar,
+            grammar_spec=grammar,
+            grammar_type="Grammar",
+        )
+        assert result == "compiled"
+
+    def test_timeout_raises_value_error(self):
+        def slow_compile(spec: str):
+            time.sleep(10)
+            return "never"
+
+        with (
+            patch("vllm.envs.VLLM_GRAMMAR_COMPILATION_TIMEOUT_S", 1),
+            pytest.raises(ValueError, match="JSON schema compilation timed out"),
+        ):
+            compile_grammar_with_timeout(
+                slow_compile,
+                '{"type": "slow"}',
+                grammar_spec='{"type": "slow"}',
+                grammar_type="JSON schema",
+            )
+
+    def test_timeout_disabled_when_zero(self):
+        result = None
+        with patch("vllm.envs.VLLM_GRAMMAR_COMPILATION_TIMEOUT_S", 0):
+            result = compile_grammar_with_timeout(
+                lambda s: "no_timeout",
+                '{"type": "test"}',
+                grammar_spec='{"type": "test"}',
+                grammar_type="JSON schema",
+            )
+        assert result == "no_timeout"
+
+    def test_compilation_error_propagates(self):
+        def failing_compile(spec: str):
+            raise RuntimeError("compilation failed")
+
+        with pytest.raises(RuntimeError, match="compilation failed"):
+            compile_grammar_with_timeout(
+                failing_compile,
+                "bad",
+                grammar_spec="bad",
+                grammar_type="JSON schema",
+            )
+
+    def test_spec_included_in_error_message(self):
+        def slow_compile(spec: str):
+            time.sleep(10)
+            return "never"
+
+        schema = '{"oneOf": [{"type": "string"}]}'
+        with (
+            patch("vllm.envs.VLLM_GRAMMAR_COMPILATION_TIMEOUT_S", 1),
+            pytest.raises(ValueError, match=r'Spec: \{"oneOf"'),
+        ):
+            compile_grammar_with_timeout(
+                slow_compile,
+                schema,
+                grammar_spec=schema,
+                grammar_type="JSON schema",
+            )
+
+
+def generate_nested_schema(depth: int) -> dict:
+    """Generate a nested oneOf schema that causes exponential branching."""
+    schema: dict = {"type": "string"}
+    for _ in range(depth):
+        schema = {
+            "oneOf": [
+                {"type": "object", "properties": {"x": schema}, "required": ["x"]},
+                {"type": "object", "properties": {"y": schema}, "required": ["y"]},
+            ]
+        }
+    return schema
+
+
+def test_real_xgrammar_compilation_timeout():
+    """Real E2E test verifying that actual xgrammar compilation aborts on timeout."""
+    import xgrammar as xgr
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+    tok_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+    compiler = xgr.GrammarCompiler(tok_info)
+
+    # 1. Normal shallow schema compiles quickly (<0.5s)
+    shallow_schema = json.dumps(generate_nested_schema(4))
+    t0 = time.time()
+    result = compile_grammar_with_timeout(
+        compiler.compile_json_schema,
+        shallow_schema,
+        grammar_spec=shallow_schema,
+        grammar_type="JSON schema",
+        timeout=5,
+    )
+    assert result is not None
+    assert (time.time() - t0) < 1.0
+
+    # 2. Deep schema taking >3s to compile must abort at 1s timeout
+    deep_schema = json.dumps(generate_nested_schema(13))
+    t0 = time.time()
+    with pytest.raises(ValueError, match="JSON schema compilation timed out after 1s"):
+        compile_grammar_with_timeout(
+            compiler.compile_json_schema,
+            deep_schema,
+            grammar_spec=deep_schema,
+            grammar_type="JSON schema",
+            timeout=1,
+        )
+    elapsed = time.time() - t0
+    assert 0.9 <= elapsed <= 2.5, f"Expected ~1s timeout, took {elapsed:.2f}s"

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -220,6 +220,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
+    VLLM_GRAMMAR_COMPILATION_TIMEOUT_S: int = 10
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
     VLLM_DISABLE_REQUEST_ID_RANDOMIZATION: bool = False
@@ -1633,6 +1634,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Set to 0 to disable the timeout (not recommended in production).
     "VLLM_REGEX_COMPILATION_TIMEOUT_S": lambda: int(
         os.getenv("VLLM_REGEX_COMPILATION_TIMEOUT_S", "5")
+    ),
+    # Maximum time in seconds allowed for JSON schema, CFG grammar, and structural
+    # tag compilation in structured output backends (xgrammar). Prevents unbounded
+    # worker stalls on deeply-nested or pathological schemas.
+    # Set to 0 to disable the timeout (not recommended in production).
+    "VLLM_GRAMMAR_COMPILATION_TIMEOUT_S": lambda: int(
+        os.getenv("VLLM_GRAMMAR_COMPILATION_TIMEOUT_S", "10")
     ),
     # Control the threshold for msgspec to use 'zero copy' for
     # serialization/deserialization of tensors. Tensors below

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -20,6 +20,7 @@ from vllm.v1.structured_output.backend_types import (
 )
 from vllm.v1.structured_output.utils import (
     choice_as_grammar,
+    compile_grammar_with_timeout,
     compile_regex_with_timeout,
     convert_lark_to_ebnf,
     grammar_is_likely_lark,
@@ -83,15 +84,28 @@ class XgrammarBackend(StructuredOutputBackend):
         stop_token_ids: set[int] | None = None,
     ) -> StructuredOutputGrammar:
         if request_type == StructuredOutputOptions.JSON:
-            ctx = self.compiler.compile_json_schema(
-                grammar_spec, any_whitespace=not self.disable_any_whitespace
+            ctx = compile_grammar_with_timeout(
+                self.compiler.compile_json_schema,
+                grammar_spec,
+                grammar_spec=grammar_spec,
+                grammar_type="JSON schema",
+                any_whitespace=not self.disable_any_whitespace,
             )
         elif request_type == StructuredOutputOptions.JSON_OBJECT:
-            ctx = self.compiler.compile_json_schema(
-                '{"type": "object"}', any_whitespace=not self.disable_any_whitespace
+            ctx = compile_grammar_with_timeout(
+                self.compiler.compile_json_schema,
+                '{"type": "object"}',
+                grammar_spec='{"type": "object"}',
+                grammar_type="JSON object schema",
+                any_whitespace=not self.disable_any_whitespace,
             )
         elif request_type == StructuredOutputOptions.GRAMMAR:
-            ctx = self.compiler.compile_grammar(grammar_spec)
+            ctx = compile_grammar_with_timeout(
+                self.compiler.compile_grammar,
+                grammar_spec,
+                grammar_spec=grammar_spec,
+                grammar_type="Grammar",
+            )
         elif request_type == StructuredOutputOptions.REGEX:
             ctx = compile_regex_with_timeout(
                 self.compiler.compile_regex,
@@ -109,9 +123,20 @@ class XgrammarBackend(StructuredOutputBackend):
                     )
                     for s in s_tag["structures"]
                 ]
-                ctx = self.compiler.compile_structural_tag(tags, s_tag["triggers"])
+                ctx = compile_grammar_with_timeout(
+                    self.compiler.compile_structural_tag,
+                    tags,
+                    s_tag["triggers"],
+                    grammar_spec=grammar_spec,
+                    grammar_type="Structural tag",
+                )
             else:
-                ctx = self.compiler.compile_structural_tag(grammar_spec)
+                ctx = compile_grammar_with_timeout(
+                    self.compiler.compile_structural_tag,
+                    grammar_spec,
+                    grammar_spec=grammar_spec,
+                    grammar_type="Structural tag",
+                )
         else:
             logger.error(
                 "Validation should have already occurred. Please file an issue."
@@ -329,7 +354,12 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
     if so_params.choice:
         choice_grammar = choice_as_grammar(so_params.choice)
         try:
-            xgr.Grammar.from_ebnf(choice_grammar)
+            compile_grammar_with_timeout(
+                xgr.Grammar.from_ebnf,
+                choice_grammar,
+                grammar_spec=choice_grammar,
+                grammar_type="Choice grammar",
+            )
         except Exception as err:
             raise VLLMValidationError(
                 f"Failed to transform choices into a grammar: {err}"
@@ -353,7 +383,12 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
             )
 
         try:
-            xgr.Grammar.from_json_schema(schema)
+            compile_grammar_with_timeout(
+                xgr.Grammar.from_json_schema,
+                schema,
+                grammar_spec=str(schema),
+                grammar_type="JSON schema",
+            )
         except Exception as err:
             raise VLLMValidationError(
                 f"Failed to transform json schema into a grammar: {err}"
@@ -373,7 +408,12 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
         # Test parsing EBNF grammar, possibly already converted from Lark
         try:
             # parse the grammar, but we aren't compiling it.
-            xgr.Grammar.from_ebnf(so_params.grammar)
+            compile_grammar_with_timeout(
+                xgr.Grammar.from_ebnf,
+                so_params.grammar,
+                grammar_spec=so_params.grammar,
+                grammar_type="Grammar",
+            )
         except Exception as e:
             raise VLLMValidationError("Invalid grammar specification.") from e
         return
@@ -392,8 +432,19 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
                     )
                     for s in s_tag["structures"]
                 ]
-                xgr.Grammar.from_structural_tag(tags, s_tag["triggers"])
+                compile_grammar_with_timeout(
+                    xgr.Grammar.from_structural_tag,
+                    tags,
+                    s_tag["triggers"],
+                    grammar_spec=so_params.structural_tag,
+                    grammar_type="Structural tag",
+                )
             else:
-                xgr.Grammar.from_structural_tag(so_params.structural_tag)
+                compile_grammar_with_timeout(
+                    xgr.Grammar.from_structural_tag,
+                    so_params.structural_tag,
+                    grammar_spec=so_params.structural_tag,
+                    grammar_type="Structural tag",
+                )
         except Exception as e:
             raise VLLMValidationError("Invalid structural tag specification.") from e

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -46,6 +46,60 @@ _T = TypeVar("_T")
 CACHE = None
 
 
+def compile_with_timeout(
+    fn: Callable[..., _T],
+    *args,
+    spec: str = "",
+    spec_type: str = "Grammar",
+    timeout: int = 0,
+    **kwargs,
+) -> _T:
+    """Run a grammar/regex compilation callable with a timeout.
+
+    Prevents worker stalls where complex grammars, nested schemas, or
+    adversarial patterns cause exponential DFA state-space explosion,
+    hanging the inference worker indefinitely.
+
+    Args:
+        fn: Callable that performs the compilation.
+        *args: Positional arguments to pass to *fn*.
+        spec: The specification string (regex, schema, or grammar), included
+            in timeout error messages.
+        spec_type: Human-readable type of grammar being compiled (e.g. 'Regex',
+            'JSON schema', 'Grammar', 'Structural tag').
+        timeout: Timeout in seconds. If <= 0, timeout is disabled.
+        **kwargs: Keyword arguments to pass to *fn*.
+
+    Raises:
+        ValueError: If compilation exceeds the configured timeout.
+    """
+    if timeout <= 0:
+        return fn(*args, **kwargs)
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(fn, *args, **kwargs)
+    try:
+        result = future.result(timeout=timeout)
+    except TimeoutError:
+        future.cancel()
+        executor.shutdown(wait=False, cancel_futures=True)
+        if spec_type == "Regex":
+            cause = "nested quantifiers"
+            preview = f" Pattern: {spec[:200]}" if spec else ""
+        else:
+            cause = "nested oneOf/anyOf"
+            preview = f" Spec: {spec[:200]}" if spec else ""
+        raise ValueError(
+            f"{spec_type} compilation timed out after {timeout}s. "
+            f"The pattern or schema may be too complex or contain constructs "
+            f"that cause exponential state-space explosion (e.g. "
+            f"{cause}).{preview}"
+        ) from None
+    else:
+        executor.shutdown(wait=False)
+        return result
+
+
 def compile_regex_with_timeout(fn: Callable[[str], _T], pattern: str) -> _T:
     """Run a regex compilation callable with a timeout.
 
@@ -62,26 +116,50 @@ def compile_regex_with_timeout(fn: Callable[[str], _T], pattern: str) -> _T:
     Raises:
         ValueError: If compilation exceeds the configured timeout.
     """
-    timeout = envs.VLLM_REGEX_COMPILATION_TIMEOUT_S
-    if timeout <= 0:
-        return fn(pattern)
+    return compile_with_timeout(
+        fn,
+        pattern,
+        spec=pattern,
+        spec_type="Regex",
+        timeout=envs.VLLM_REGEX_COMPILATION_TIMEOUT_S,
+    )
 
-    executor = ThreadPoolExecutor(max_workers=1)
-    future = executor.submit(fn, pattern)
-    try:
-        result = future.result(timeout=timeout)
-    except TimeoutError:
-        future.cancel()
-        executor.shutdown(wait=False, cancel_futures=True)
-        raise ValueError(
-            f"Regex compilation timed out after {timeout}s. "
-            "The pattern may be too complex or contain constructs that "
-            "cause exponential state-space explosion (e.g. nested "
-            f"quantifiers). Pattern: {pattern[:200]}"
-        ) from None
-    else:
-        executor.shutdown(wait=False)
-        return result
+
+def compile_grammar_with_timeout(
+    fn: Callable[..., _T],
+    *args,
+    grammar_spec: str = "",
+    grammar_type: str = "Grammar",
+    timeout: int | None = None,
+    **kwargs,
+) -> _T:
+    """Run a grammar/schema compilation callable with a timeout.
+
+    Prevents worker stalls on deeply nested or pathological schemas (e.g.
+    exponential oneOf branching).
+
+    Args:
+        fn: Callable performing the compilation.
+        *args: Positional arguments to pass to *fn*.
+        grammar_spec: The raw spec string for preview in error messages.
+        grammar_type: Human-readable type (e.g. 'JSON schema', 'Grammar').
+        timeout: Timeout in seconds (defaults to
+            VLLM_GRAMMAR_COMPILATION_TIMEOUT_S).
+        **kwargs: Keyword arguments to pass to *fn*.
+
+    Raises:
+        ValueError: If compilation exceeds the configured timeout.
+    """
+    if timeout is None:
+        timeout = envs.VLLM_GRAMMAR_COMPILATION_TIMEOUT_S
+    return compile_with_timeout(
+        fn,
+        *args,
+        spec=grammar_spec,
+        spec_type=grammar_type,
+        timeout=timeout,
+        **kwargs,
+    )
 
 
 def apply_grammar_bitmask(


### PR DESCRIPTION
    ## Purpose
    
    Fixes #54003: Adds a compilation timeout guard (`VLLM_GRAMMAR_COMPILATION_TIMEOUT_S`,
  defaulting to 10s) for JSON schema, CFG grammar, and structural tags in the `xgrammar`
  backend.
    
    Previously, `compile_regex_with_timeout` protected regex patterns against exponential DFA
  state-space explosion, but JSON schema compilation (`compiler.compile_json_schema`) and CFG
  compilation (`compiler.compile_grammar`) had no timeout protection. Complex schemas with
  recursive or deep combinatorial branching (e.g. nested `oneOf`/`anyOf`) could stall
  inference workers indefinitely and exhaust worker memory.
    
    This PR brings JSON schema, grammar, and structural tag compilation to parity with regex
  timeout handling:
    1. Adds `VLLM_GRAMMAR_COMPILATION_TIMEOUT_S` (default 10s, 0 to disable) in `vllm/envs.
  py`.
    2. Refactors `compile_with_timeout` and introduces `compile_grammar_with_timeout` in
  `vllm/v1/structured_output/utils.py`.
    3. Wraps JSON schema, JSON object, grammar, and structural tag compilation and validation
  calls in `vllm/v1/structured_output/backend_xgrammar.py`.
    4. Adds dedicated unit and real compiler integration tests in
  `tests/v1/structured_output/test_grammar_compilation_timeout.py`.
    
    ## Test Plan
    
    - Unit & regression test suite:
      ```bash
      VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest
  tests/v1/structured_output/test_grammar_compilation_timeout.py
  tests/v1/structured_output/test_regex_compilation_timeout.py
  tests/v1/structured_output/test_validation.py -v

  • Pre-commit linting and type-checking:
    .venv/bin/python -m pre_commit run --files vllm/envs.py
  vllm/v1/structured_output/backend_xgrammar.py vllm/v1/structured_output/utils.py
  tests/v1/structured_output/test_grammar_compilation_timeout.py


  ## Test Result

  1. Pytest Results (30 passed in 14.63s):
      • test_normal_json_schema_compiles_successfully: PASSED
      • test_normal_grammar_compiles_successfully: PASSED
      • test_timeout_raises_value_error: PASSED
      • test_timeout_disabled_when_zero: PASSED
      • test_compilation_error_propagates: PASSED
      • test_spec_included_in_error_message: PASSED
      • test_real_xgrammar_compilation_timeout: PASSED (verifies real compiler.
      compile_json_schema with HuggingFace tokenizer aborts after timeout)
      • All 18 existing validation tests in tests/v1/structured_output/test_validation.py:
      PASSED
  2. Pre-commit Checks:
      • ruff check: Passed
      • ruff format: Passed
      • typos: Passed
      • Run mypy for Python 3.10: Passed
      • Check SPDX headers: Passed
      • Validate configuration has default values and docstrings: Passed
      • Sign-off Commit: Passed


  ## Duplicate-Work Check (AGENTS.md)

  • gh issue view 54003: Issue filed on 2026-08-27 with 0 PRs linked.
  • gh pr list --search "54003 in:body": 0 open PRs.
  • gh pr list --search "grammar compilation timeout": Confirmed no active PRs. PR #45172
  attempted a broad cross-backend scheduler rewrite but has been inactive with merge
  conflicts since June 2026. This PR is a minimal, targeted, and non-conflicting fix rebased
  on current origin/main.

  ## AI Assistance Statement (AGENTS.md)

  This contribution was authored with AI assistance (Antigravity). Every changed line,
  docstring, typing annotation, and test has been reviewed, inspected, and verified end-to-
  end by the human author.