### PR TITLE
[Bugfix][Frontend] Count reasoning tokens for the Muse-Glimmer parser

### DIFF
--- a/tests/reasoning/test_muse_glimmer_count_reasoning_tokens.py
+++ b/tests/reasoning/test_muse_glimmer_count_reasoning_tokens.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import string
+
+import pytest
+
+from vllm.reasoning.muse_glimmer_reasoning_parser import MuseGlimmerReasoningParser
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class CharTokenizer:
+    """Character-level tokenizer: MuseGlimmer's ATEM markers are multi-token,
+    matching the property the parser is written against."""
+
+    def __init__(self):
+        self._chars = {c: i for i, c in enumerate(string.printable)}
+        self._ids = {i: c for c, i in self._chars.items()}
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        return [self._chars[c] for c in text]
+
+    def decode(self, token_ids) -> str:
+        return "".join(self._ids[i] for i in token_ids)
+
+
+@pytest.fixture
+def parser_and_tokenizer():
+    tokenizer = CharTokenizer()
+    return MuseGlimmerReasoningParser(tokenizer), tokenizer
+
+
+def test_counts_closed_reasoning_span(parser_and_tokenizer):
+    parser, tok = parser_and_tokenizer
+    text = "to=self<|message|>think hard<|eom|>to=user<|message|>hi<|eot|>"
+    assert parser.count_reasoning_tokens(tok.encode(text)) == len("think hard")
+
+
+def test_counts_multiple_reasoning_spans(parser_and_tokenizer):
+    parser, tok = parser_and_tokenizer
+    text = (
+        "to=self<|message|>abc<|eom|>"
+        "to=user<|message|>answer<|eot|>"
+        "to=self<|message|>de<|eom|>"
+    )
+    assert parser.count_reasoning_tokens(tok.encode(text)) == len("abc") + len("de")
+
+
+def test_counts_open_reasoning_span_mid_stream(parser_and_tokenizer):
+    parser, tok = parser_and_tokenizer
+    text = "to=self<|message|>partial thought"
+    assert parser.count_reasoning_tokens(tok.encode(text)) == len("partial thought")
+
+
+def test_content_only_counts_zero(parser_and_tokenizer):
+    parser, tok = parser_and_tokenizer
+    text = "to=user<|message|>plain answer<|eot|>"
+    assert parser.count_reasoning_tokens(tok.encode(text)) == 0
+
+
+def test_empty_counts_zero(parser_and_tokenizer):
+    parser, _ = parser_and_tokenizer
+    assert parser.count_reasoning_tokens([]) == 0
+
+
+def test_mid_generation_turn_reopen(parser_and_tokenizer):
+    """Regression: real generations re-open the assistant turn before the
+    answer channel; the reasoning before it must still be counted."""
+    parser, tok = parser_and_tokenizer
+    text = (
+        " to=self<|message|>Simple. 2+2 = 4<|eom|>"
+        "<|start|>assistant to=user<|message|>2 + 2 = 4"
+    )
+    assert parser.count_reasoning_tokens(tok.encode(text)) == len("Simple. 2+2 = 4")
+
+
+def test_tool_channel_not_counted(parser_and_tokenizer):
+    parser, tok = parser_and_tokenizer
+    text = (
+        "to=self<|message|>pick a tool<|eom|>"
+        'to=functions.get_weather<|message|>{"city": "SF"}<|eom|>'
+    )
+    assert parser.count_reasoning_tokens(tok.encode(text)) == len("pick a tool")

--- a/vllm/reasoning/muse_glimmer_reasoning_parser.py
+++ b/vllm/reasoning/muse_glimmer_reasoning_parser.py
@@ -161,6 +161,34 @@ class MuseGlimmerReasoningParser(ReasoningParser):
         # path uses extract_reasoning() for the final split.
         return []
 
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        """Count generated tokens that belong to ``to=self`` reasoning bodies.
+
+        MuseGlimmer's framing markers are not guaranteed to be single vocab
+        tokens, so the marker-token counting used by ``BaseThinkingReasoningParser``
+        does not apply. Decode the generated ids, reuse the channel
+        classification that already drives extraction, and re-encode the
+        reasoning body. Re-encoding approximates the original token count at
+        span boundaries, which is acceptable for usage accounting.
+        """
+        if not token_ids:
+            return 0
+        try:
+            text = self.model_tokenizer.decode(token_ids)
+        except Exception:
+            return 0
+        # token_ids are generation-only, so no prompt anchoring is needed.
+        # Do NOT scope to _current_assistant_turn here: the model re-opens the
+        # turn mid-generation (``<|eom|><|start|>assistant to=user<|message|>``),
+        # and anchoring on the LAST turn-open would slice off the reasoning
+        # that precedes it.
+        reasoning_body, _ = self._classify_bodies(text)
+        if not reasoning_body:
+            return 0
+        return len(
+            self.model_tokenizer.encode(reasoning_body, add_special_tokens=False)
+        )
+
     @classmethod
     def _scoped_turn(cls, text: str) -> str:
         """Current assistant turn with reasoning spans removed."""


### PR DESCRIPTION
The muse_glimmer reasoning parser inherited the base count_reasoning_tokens() that returns 0, so usage.completion_tokens_details.reasoning_tokens was always 0. Classify the decoded output with the parser's own logic, including the turn re-open after tool calls, and count the reasoning text.




## Purpose

With `--reasoning-parser muse_glimmer`, chat completions always report `reasoning_tokens: 0` in `usage.completion_tokens_details`, because the parser inherits the base `count_reasoning_tokens()` that returns 0. Clients that rely on the count (OpenRouter's reasoning checks, billing) see no reasoning even when the model produced a long reasoning body.

This implements `count_reasoning_tokens()` for the Muse-Glimmer parser: decode the generated ids, classify the bodies with the parser's existing logic, and re-encode the reasoning text to count it. Classification is done without anchoring to the current assistant turn, because after a tool call the model re-opens the turn (`<|eom|><|start|>assistant to=user<|message|>`) and a turn-anchored scan would drop the reasoning emitted before it.

Note: developed with AI assistance (Claude); the code and tests were reviewed and validated end-to-end by the author.

## Test Plan

New unit tests in `tests/reasoning/test_muse_glimmer_count_reasoning_tokens.py` (reasoning only, reasoning + content, no reasoning, tool-call turn re-open, empty input).


## Test Result

Before: `reasoning_tokens: 0` for every request.
After: e.g. `reasoning_tokens: 43` for a request with an 83-character reasoning body, `0` when the model emits none; tool-call turns count the reasoning emitted before the re-open. Unit tests pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

