### PR TITLE
[Perf][Spec Decode] dflash/dspark: prefix-cache last-block-drop exemption + decode-path overhead reductions

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -8,7 +8,11 @@ import torch
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
-from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.attention.ops import triton_unified_attention
+from vllm.v1.attention.ops.triton_unified_attention import (
+    _should_use_3d,
+    unified_attention,
+)
 from vllm.v1.kv_cache_interface import KVQuantMode
 
 pytestmark = pytest.mark.skip_global_cleanup
@@ -42,6 +46,7 @@ def ref_paged_attn(
     scale: float,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
+    sinks: torch.Tensor | None = None,
 ) -> torch.Tensor:
     num_seqs = len(query_lens)
     block_tables = block_tables.cpu().numpy()
@@ -81,7 +86,14 @@ def ref_paged_attn(
         if soft_cap is not None and soft_cap > 0:
             attn = soft_cap * torch.tanh(attn / soft_cap)
         attn.masked_fill_(mask, float("-inf"))
-        attn = torch.softmax(attn, dim=-1).to(v.dtype)
+        if sinks is not None:
+            # A per-head sink is a virtual logit that joins the softmax
+            # denominator but contributes no value.
+            sink_col = sinks.float().view(-1, 1, 1).expand(attn.shape[0], query_len, 1)
+            attn = torch.cat([attn, sink_col], dim=-1)
+            attn = torch.softmax(attn, dim=-1)[..., :-1].to(v.dtype)
+        else:
+            attn = torch.softmax(attn, dim=-1).to(v.dtype)
         out = torch.einsum("hqk,khd->qhd", attn, v)
 
         outputs.append(out)
@@ -645,3 +657,300 @@ def test_triton_unified_attn_use_td_tile_clamp(
         soft_cap=None,
         seq_threshold_3D=0,
     )
+
+
+# Small uniform query lengths (spec-decode verify/draft shapes) admitted to
+# the 3D split-KV kernel. Mixes cover: the DSpark drafter geometry
+# (32 query / 2 KV heads, sliding_window=1024, sinks), non-pow2
+# num_queries_per_kv (5, 1) whose q-blocks overlap by construction, KV
+# lengths that straddle the sliding-window boundary, and non-divisible
+# segment tails.
+SEQ_LENS_SMALL_Q_3D = [
+    [(4, 8192)],
+    [(3, 1328), (4, 1025), (2, 35), (1, 523)],
+    [(4, 1024), (4, 16)],
+]
+
+
+def _run_unified_attention_3d_case(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    sliding_window: int | None,
+    use_sinks: bool,
+    seq_threshold_3D: int,
+    max_query_len_3d: int,
+    block_size: int = 16,
+    num_blocks: int = 2048,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run ``unified_attention`` once and return (output, ref, segm_max).
+
+    ``segm_max`` is NaN-poisoned before the launch so callers can assert
+    which kernel path (2D vs 3D) actually executed.
+    """
+    set_random_seed(0)
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    num_query_heads, num_kv_heads = num_heads
+    assert num_query_heads % num_kv_heads == 0
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    window_size = (sliding_window - 1, 0) if sliding_window is not None else (-1, -1)
+    scale = head_size**-0.5
+
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    )
+    value_cache = torch.randn_like(key_cache)
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
+
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+    sinks = torch.randn(num_query_heads, dtype=torch.float32) if use_sinks else None
+
+    output = torch.empty_like(query)
+
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+    # Sized per query TOKEN: the contract that admits q_len > 1 to 3D.
+    segm_buffer_tokens = seq_threshold_3D * max_query_len_3d
+    softmax_segm_output = torch.empty(
+        (
+            segm_buffer_tokens,
+            num_query_heads,
+            num_par_softmax_segments,
+            head_size_padded,
+        ),
+        dtype=torch.float32,
+    )
+    softmax_segm_max = torch.full(
+        (segm_buffer_tokens, num_query_heads, num_par_softmax_segments),
+        float("nan"),
+        dtype=torch.float32,
+    )
+    softmax_segm_expsum = torch.empty(
+        (segm_buffer_tokens, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+
+    unified_attention(
+        q=query,
+        k=key_cache,
+        v=value_cache,
+        out=output,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_tensor,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=scale,
+        causal=True,
+        window_size=window_size,
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+        max_query_len_3d=max_query_len_3d,
+        sinks=sinks,
+    )
+
+    ref_output = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=block_tables,
+        scale=scale,
+        sliding_window=sliding_window,
+        sinks=sinks,
+    )
+    return output, ref_output, softmax_segm_max
+
+
+@pytest.mark.parametrize("seq_lens", SEQ_LENS_SMALL_Q_3D)
+@pytest.mark.parametrize("num_heads", [(32, 2), (5, 1)])
+@pytest.mark.parametrize("sliding_window", [None, 1024])
+@pytest.mark.parametrize("use_sinks", [False, True])
+@torch.inference_mode()
+def test_triton_unified_attn_3d_small_q(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    sliding_window: int | None,
+    use_sinks: bool,
+) -> None:
+    """3D split-KV for small uniform spec-decode query lengths.
+
+    Guards the extension of the 3D kernel to ``max_seqlen_q <= 4`` and the
+    sliding-window segment layout: the 3D output must match both the
+    reference and the 2D kernel on identical inputs (the two paths are
+    numerically equivalent but not bitwise identical).
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    head_size = 128
+
+    output_3d, ref_output, segm_max = _run_unified_attention_3d_case(
+        seq_lens=seq_lens,
+        num_heads=num_heads,
+        head_size=head_size,
+        sliding_window=sliding_window,
+        use_sinks=use_sinks,
+        seq_threshold_3D=8,
+        max_query_len_3d=4,
+    )
+    # The 3D path (not a silent 2D fallback) must actually have run:
+    # token 0 / head 0 / segment 0 is written whenever it does.
+    assert torch.isfinite(segm_max[0, 0, 0]).item()
+
+    output_2d, _, segm_max_2d = _run_unified_attention_3d_case(
+        seq_lens=seq_lens,
+        num_heads=num_heads,
+        head_size=head_size,
+        sliding_window=sliding_window,
+        use_sinks=use_sinks,
+        seq_threshold_3D=0,
+        max_query_len_3d=4,
+    )
+    assert not torch.isfinite(segm_max_2d[:1, :1, :1]).any().item()
+
+    torch.testing.assert_close(output_3d, ref_output, atol=1.5e-2, rtol=1e-2)
+    torch.testing.assert_close(output_3d, output_2d, atol=1.5e-2, rtol=1e-2)
+
+
+def test_should_use_3d_gating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The 2D/3D dispatch: q_len > 1 shapes are admitted only when the
+    caller raised ``max_query_len_3d`` AND every query token fits in the
+    per-segment buffers; everything else preserves the previous
+    single-token-decode-only behavior."""
+    monkeypatch.setattr(triton_unified_attention, "is_batch_invariant", False)
+    common = dict(
+        seq_threshold_3D=8,
+        num_par_softmax_segments=16,
+        segm_buffers_allocated=True,
+    )
+    # Previous behavior: single-token decode within the threshold.
+    assert _should_use_3d(
+        num_tokens=4,
+        num_seqs=4,
+        max_seqlen_q=1,
+        max_query_len_3d=1,
+        segm_buffer_tokens=8,
+        **common,
+    )
+    # q_len > 1 needs the caller opt-in...
+    assert not _should_use_3d(
+        num_tokens=8,
+        num_seqs=2,
+        max_seqlen_q=4,
+        max_query_len_3d=1,
+        segm_buffer_tokens=32,
+        **common,
+    )
+    # ... and token-capacity buffers.
+    assert _should_use_3d(
+        num_tokens=8,
+        num_seqs=2,
+        max_seqlen_q=4,
+        max_query_len_3d=4,
+        segm_buffer_tokens=32,
+        **common,
+    )
+    assert not _should_use_3d(
+        num_tokens=32,
+        num_seqs=8,
+        max_seqlen_q=4,
+        max_query_len_3d=4,
+        segm_buffer_tokens=8,
+        **common,
+    )
+    # Sequence-count threshold and prefill shapes still route to 2D.
+    assert not _should_use_3d(
+        num_tokens=9,
+        num_seqs=9,
+        max_seqlen_q=1,
+        max_query_len_3d=4,
+        segm_buffer_tokens=32,
+        **common,
+    )
+    assert not _should_use_3d(
+        num_tokens=129,
+        num_seqs=1,
+        max_seqlen_q=129,
+        max_query_len_3d=4,
+        segm_buffer_tokens=32,
+        **common,
+    )
+    # Missing buffers fail closed.
+    assert not _should_use_3d(
+        num_tokens=4,
+        num_seqs=4,
+        max_seqlen_q=1,
+        max_query_len_3d=1,
+        seq_threshold_3D=8,
+        num_par_softmax_segments=16,
+        segm_buffers_allocated=False,
+        segm_buffer_tokens=8,
+    )
+    # Batch invariance disables 3D regardless of shape.
+    monkeypatch.setattr(triton_unified_attention, "is_batch_invariant", True)
+    assert not _should_use_3d(
+        num_tokens=4,
+        num_seqs=4,
+        max_seqlen_q=1,
+        max_query_len_3d=1,
+        segm_buffer_tokens=8,
+        **common,
+    )
+
+
+def test_spec_decode_3d_method_gate() -> None:
+    """Only dflash/dspark raise the small-q 3D admission; eagle/eagle3/mtp
+    and unknown speculative methods fail closed to the single-token-decode
+    behavior (their verify passes stay byte-identical on the 2D kernel)."""
+    from types import SimpleNamespace
+
+    from vllm.v1.attention.backends.triton_attn import (
+        MAX_QUERY_LEN_3D,
+        spec_decode_max_query_len_3d,
+    )
+
+    class _Spec:
+        def __init__(self, method: str):
+            self.method = method
+
+        def use_dflash(self) -> bool:
+            return self.method == "dflash"
+
+        def use_dspark(self) -> bool:
+            return self.method == "dspark"
+
+    def cfg(method: str | None, num_spec: int = 3) -> SimpleNamespace:
+        return SimpleNamespace(
+            speculative_config=None if method is None else _Spec(method),
+            num_speculative_tokens=num_spec,
+        )
+
+    # No speculative decoding: unchanged single-token behavior.
+    assert spec_decode_max_query_len_3d(cfg(None)) == 1
+    # Fail-closed for eagle-family and anything unaudited.
+    for method in ("eagle", "eagle3", "mtp", "draft_model", "future_method"):
+        assert spec_decode_max_query_len_3d(cfg(method)) == 1
+    # Opt-in methods size for 1 bonus + N draft tokens...
+    assert spec_decode_max_query_len_3d(cfg("dflash")) == 4
+    assert spec_decode_max_query_len_3d(cfg("dspark")) == 4
+    assert spec_decode_max_query_len_3d(cfg("dspark", num_spec=2)) == 3
+    # ... capped at the kernel admission limit.
+    assert spec_decode_max_query_len_3d(cfg("dspark", num_spec=16)) == MAX_QUERY_LEN_3D

--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -460,3 +460,105 @@ def test_build_attention_metadata_zeros_stale_is_prefilling():
     assert not captured_is_prefilling[2]  # decode  (200 >= 200)
     assert not captured_is_prefilling[3]  # stale data (10 < 100) zeroed
     assert not captured_is_prefilling[4]  # stale data (20 < 200) zeroed
+
+
+# --- uniform_decode_split (mamba builder fast path) -------------------------
+
+
+def _mamba_full_split(common_metadata, decode_threshold: int):
+    """The full path the mamba builder runs when the fast path declines:
+    single-token-prefill reclassification, then the split."""
+    is_prefilling = common_metadata.is_prefilling
+    assert is_prefilling is not None
+    query_lens_cpu = torch.diff(common_metadata.query_start_loc_cpu)
+    prefill_to_decode = (
+        is_prefilling
+        & (query_lens_cpu == 1)
+        & (common_metadata.seq_lens_cpu_upper_bound > 1)
+    )
+    if torch.any(prefill_to_decode).item():
+        is_prefilling = is_prefilling.clone()
+        is_prefilling[prefill_to_decode] = False
+        common_metadata = common_metadata.replace(is_prefilling=is_prefilling)
+    return split_decodes_and_prefills(
+        common_metadata,
+        decode_threshold=decode_threshold,
+        treat_short_extends_as_decodes=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "query_lens,is_prefilling,decode_threshold,expect_fast",
+    [
+        # Steady spec decode: uniform 4-token queries, nothing prefilling.
+        ([4, 4, 4], [False, False, False], 4, True),
+        # Plain decode.
+        ([1, 1, 1], [False, False, False], 1, True),
+        # Non-uniform but all within threshold, none prefilling.
+        ([1, 3, 4], [False, False, False], 4, True),
+        # A prefilling row declines the fast path.
+        ([4, 4, 129], [False, False, True], 4, False),
+        # A single-token prefill chunk (reclassification case) declines.
+        ([1, 1, 1], [False, False, True], 4, False),
+        # Query longer than the threshold declines.
+        ([1, 129], [False, True], 4, False),
+    ],
+)
+def test_uniform_decode_split_matches_full_path(
+    query_lens: list[int],
+    is_prefilling: list[bool],
+    decode_threshold: int,
+    expect_fast: bool,
+):
+    """The fast path must fire only when its result is value-identical to
+    the reclassification + split_decodes_and_prefills chain it skips."""
+    from vllm.v1.attention.backends.mamba_attn import uniform_decode_split
+
+    seq_lens = [max(q + 5, 10) for q in query_lens]
+    common_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=seq_lens, query_lens=query_lens),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_metadata.is_prefilling = torch.tensor(is_prefilling)
+
+    fast = uniform_decode_split(common_metadata, decode_threshold)
+    assert (fast is not None) == expect_fast
+    if fast is not None:
+        assert fast == _mamba_full_split(common_metadata, decode_threshold)
+
+
+def test_uniform_decode_split_requires_is_prefilling():
+    from vllm.v1.attention.backends.mamba_attn import uniform_decode_split
+
+    common_metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[10], query_lens=[1]),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_metadata.is_prefilling = None
+    assert uniform_decode_split(common_metadata, 1) is None
+
+
+def test_mamba_block_table_gather_offsets_identity():
+    """Passing the cached step-invariant offsets must not change the
+    gathered state block table."""
+    from vllm.v1.attention.backends.utils import mamba_get_block_table_tensor
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        num_speculative_blocks=3,
+    )
+    torch.manual_seed(0)
+    block_table = torch.randint(0, 100, (5, 32), dtype=torch.int32)
+    seq_lens = torch.tensor([0, 1, 16, 17, 400], dtype=torch.int32)
+    offsets = torch.arange(1 + spec.num_speculative_blocks, dtype=torch.int32)
+
+    ref = mamba_get_block_table_tensor(block_table, seq_lens.clone(), spec, "align")
+    got = mamba_get_block_table_tensor(
+        block_table, seq_lens.clone(), spec, "align", gather_offsets=offsets
+    )
+    assert torch.equal(ref, got)

--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -132,7 +132,7 @@ def test_mamba_align_split_partial_tail_schedule(dcp_world_size: int):
         cache_config=SimpleNamespace(block_size=block_size),
         max_num_scheduled_tokens=8192,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
-        use_eagle=False,
+        drop_prefix_cache_tail=False,
         hash_block_size=hash_block_size,
         dcp_world_size=dcp_world_size,
         scheduler_block_size=scheduler_block_size,
@@ -180,7 +180,7 @@ def test_mamba_align_split_when_block_exceeds_scheduling_budget():
         cache_config=SimpleNamespace(block_size=block_size),
         max_num_scheduled_tokens=token_budget,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
-        use_eagle=False,
+        drop_prefix_cache_tail=False,
         hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
@@ -219,7 +219,7 @@ def test_mamba_align_split_when_block_exceeds_long_prefill_threshold():
         scheduler_config=SimpleNamespace(
             long_prefill_token_threshold=long_prefill_threshold
         ),
-        use_eagle=False,
+        drop_prefix_cache_tail=False,
         hash_block_size=32,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -80,13 +80,20 @@ def _split(
     request: Request,
     num_new_tokens: int,
     use_eagle: bool = True,
+    drop_prefix_cache_tail: bool | None = None,
     partial_hit: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
 ) -> int:
-    """Call the real `Scheduler._mamba_block_aligned_split` on a stub self."""
+    """Call the real `Scheduler._mamba_block_aligned_split` on a stub self.
+
+    `drop_prefix_cache_tail` defaults to `use_eagle`, matching EAGLE-family
+    drafters; dflash/dspark set it to False (no last-block drop).
+    """
+    if drop_prefix_cache_tail is None:
+        drop_prefix_cache_tail = use_eagle
     stub = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=MAMBA_BLOCK_SIZE),
-        use_eagle=use_eagle,
+        drop_prefix_cache_tail=drop_prefix_cache_tail,
         max_num_scheduled_tokens=16384,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         # `prefix_match_unit` finer than the block size (#46384).
@@ -126,6 +133,19 @@ def test_internal_checkpoint_split(
         mamba_manager = manager.coordinator.single_type_managers[MAMBA_GROUP_ID]
         blocks = mamba_manager.req_to_blocks[request.request_id]
         assert all(not block.is_null for block in blocks)  # checkpoint + running state
+
+
+def test_dspark_split_keeps_last_cacheable_block() -> None:
+    """dflash/dspark hits keep the last matched block (no EAGLE drop), so the
+    split must not back `last_cache_position` off by one block either."""
+    prompt_len = 3602
+    (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
+    assert (
+        _split(request, prompt_len, use_eagle=True, drop_prefix_cache_tail=False)
+        == 2 * MAMBA_BLOCK_SIZE
+    )
+    # EAGLE-family drafters still back off one block.
+    assert _split(request, prompt_len, use_eagle=True) == MAMBA_BLOCK_SIZE
 
 
 def _run_chunked_prefill(

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -13,6 +13,7 @@ import torch
 
 import vllm.v1.core.kv_cache_manager as kv_cache_manager
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
+from vllm.config.speculative import SpeculativeConfig
 from vllm.distributed.kv_events import (
     MEDIUM_GPU,
     AllBlocksCleared,
@@ -1086,7 +1087,7 @@ def test_hybrid_cache_mamba_align_shared_prefix_detection():
         cache_config=SimpleNamespace(block_size=block_size),
         max_num_scheduled_tokens=3 * block_size,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
-        use_eagle=False,
+        drop_prefix_cache_tail=False,
         hash_block_size=block_size,
         mamba_partial_cache_hit=False,
         mamba_has_prefill_checkpoint_blocks=False,
@@ -2586,6 +2587,28 @@ def test_emit_cached_block_events_zero_cached():
     )
 
     assert pool.take_events() == []
+
+
+@pytest.mark.parametrize(
+    ("method", "needs_drop"),
+    [
+        ("eagle", True),
+        ("eagle3", True),
+        ("mtp", True),
+        ("dflash", False),
+        ("dspark", False),
+    ],
+)
+def test_last_block_drop_only_for_lookahead_polluted_kv(method: str, needs_drop: bool):
+    """EAGLE-family drafters cache chunk-boundary KV mixed with the prefill
+    lookahead token, so their hits must drop the last block. dflash/dspark
+    cache context KV derived from target hidden states and positions only, so
+    they keep it (the scheduler wires this predicate, not `use_eagle()`, into
+    the KV cache manager and the mamba align chunk-split backoff)."""
+    spec_config = object.__new__(SpeculativeConfig)
+    object.__setattr__(spec_config, "method", method)
+    assert spec_config.prefix_cache_needs_last_block_drop() is needs_drop
+    assert spec_config.use_eagle()
 
 
 def test_eagle_enabled_removes_last_block():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 from concurrent.futures import Future
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -27,6 +27,7 @@ from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
 from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
+from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -3805,6 +3806,7 @@ def test_mamba_align_eagle_schedules_encoder_at_boundary():
     )
     scheduler.need_mamba_block_aligned_split = True
     scheduler.use_eagle = True
+    scheduler.drop_prefix_cache_tail = True
     scheduler.num_prefill_lookahead = 1
     scheduler.max_num_encoder_input_tokens = 2048
     scheduler.encoder_cache_manager = EncoderCacheManager(cache_size=2048)
@@ -3823,6 +3825,47 @@ def test_mamba_align_eagle_schedules_encoder_at_boundary():
 
     assert output.num_scheduled_tokens[request.request_id] == block_size
     assert output.scheduled_encoder_inputs[request.request_id] == [0]
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_drop"),
+    [("dspark", False), ("dflash", False), ("eagle3", True)],
+)
+def test_kv_cache_manager_drop_wiring_for_drafter_method(
+    method: str, expected_drop: bool
+):
+    """The scheduler must wire `prefix_cache_needs_last_block_drop()` — not
+    `use_eagle`, which stays True for all of these drafters and keeps driving
+    the prefill lookahead — into the KV cache manager's last-block drop."""
+    # A real drafter-method SpeculativeConfig requires a drafter checkpoint,
+    # so build a skeleton with only the attributes Scheduler.__init__ reads.
+    spec_config = object.__new__(SpeculativeConfig)
+    object.__setattr__(spec_config, "method", method)
+    object.__setattr__(spec_config, "num_speculative_tokens", 3)
+    object.__setattr__(spec_config, "num_speculative_tokens_per_batch_size", None)
+
+    base = create_scheduler(num_speculative_tokens=3)
+    vllm_config = base.vllm_config
+    vllm_config.speculative_config = spec_config
+
+    with patch(
+        "vllm.v1.core.sched.scheduler.KVCacheManager", wraps=KVCacheManager
+    ) as spy:
+        scheduler = Scheduler(
+            vllm_config=vllm_config,
+            kv_cache_config=base.kv_cache_config,
+            structured_output_manager=base.structured_output_manager,
+            block_size=base.block_size,
+            log_stats=True,
+        )
+
+    # The manager's drop must come from the predicate, not from use_eagle.
+    assert spy.call_args.kwargs["use_eagle"] is expected_drop
+    assert scheduler.drop_prefix_cache_tail is expected_drop
+    # The prefill lookahead is the other half of use_eagle's old job and
+    # must survive for every drafter method here.
+    assert scheduler.use_eagle is True
+    assert scheduler.num_prefill_lookahead == 1
 
 
 @pytest.mark.parametrize("use_kv_connector", [False, True])

--- a/tests/v1/spec_decode/test_dflash_skip_rebuild.py
+++ b/tests/v1/spec_decode/test_dflash_skip_rebuild.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The DFlash FULL-replay metadata-rebuild skip must stay fail-closed.
+
+Under FULL cudagraph replay the freshly built draft attention metadata is
+discarded, so the rebuild exists only for its builder-state side effects;
+skipping it is legal exactly when every builder declares build() free of
+such side effects via ``supports_skip_draft_rebuild``.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.v1.attention.backend import AttentionMetadataBuilder
+from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadataBuilder
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
+    all_draft_builders_skip_safe,
+)
+
+
+def _group(*builders):
+    return SimpleNamespace(metadata_builders=list(builders))
+
+
+def _builder(skip_safe: bool):
+    return SimpleNamespace(supports_skip_draft_rebuild=skip_safe)
+
+
+def test_all_builders_skip_safe_requires_every_builder():
+    assert all_draft_builders_skip_safe([[_group(_builder(True))]])
+    assert all_draft_builders_skip_safe(
+        [[_group(_builder(True), _builder(True))], [_group(_builder(True))]]
+    )
+    # One unsafe builder anywhere blocks the skip.
+    assert not all_draft_builders_skip_safe(
+        [[_group(_builder(True))], [_group(_builder(False))]]
+    )
+
+
+def test_no_builders_fails_closed():
+    assert not all_draft_builders_skip_safe([])
+    assert not all_draft_builders_skip_safe([[], []])
+    assert not all_draft_builders_skip_safe([[_group()]])
+
+
+def test_base_builder_defaults_to_unsafe():
+    assert AttentionMetadataBuilder.supports_skip_draft_rebuild is False
+
+
+def _triton_builder(rswa_window: int | None) -> TritonAttentionMetadataBuilder:
+    """Real CPU construction with the smallest config __init__ reads."""
+    model_config = SimpleNamespace(
+        rswa_window=rswa_window,
+        get_num_attention_heads=lambda parallel_config: 2,
+        get_num_kv_heads=lambda parallel_config: 2,
+        get_head_size=lambda: 64,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(),
+        speculative_config=None,
+        scheduler_config=SimpleNamespace(max_num_seqs=4),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.NONE, static_forward_context={}
+        ),
+    )
+    return TritonAttentionMetadataBuilder(
+        kv_cache_spec=SimpleNamespace(block_size=16),
+        layer_names=[],
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+    )
+
+
+def test_triton_builder_skip_safe_iff_rswa_inactive():
+    # build() restages persistent state only on the R-SWA branch, so the
+    # constructed builder is skip-safe exactly when rswa_window is unset.
+    assert _triton_builder(rswa_window=None).supports_skip_draft_rebuild
+    assert not _triton_builder(rswa_window=1024).supports_skip_draft_rebuild

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1795,6 +1795,23 @@ class SpeculativeConfig:
         # TODO(ben): Refactor this so the naming is clearer
         return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
 
+    def prefix_cache_needs_last_block_drop(self) -> bool:
+        """Whether prefix-cache hits must exclude the last matched block.
+
+        EAGLE-family drafters combine the token one past a chunked-prefill
+        boundary (the prefill lookahead) with the chunk's final hidden state
+        and write the result into the drafter's KV cache, so the last block of
+        a hit may hold KV polluted by a continuation that a matching request
+        does not share. dflash/dspark drafters are exempt: their cached
+        context KV is a function of target hidden states and positions only;
+        the lookahead (anchor) token contributes KV only at positions past the
+        chunk end, in a block that is overwritten with clean context KV before
+        it can be completed and hashed. Expressed as an exemption from
+        use_eagle() so that new eagle-family methods keep the drop (fail
+        closed) until their drafter KV provenance is audited.
+        """
+        return self.use_eagle() and self.method not in ("dflash", "dspark")
+
     def use_dflash(self) -> bool:
         return self.method == "dflash"
 

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -597,6 +597,12 @@ class AttentionMetadataBuilder(ABC, Generic[M]):
     # Whether all step-dependent draft decode metadata can be updated in place,
     # allowing one metadata build to be reused across autoregressive draft steps.
     supports_draft_decode_metadata_update: bool = False
+    # Whether a draft-side build() may be skipped outright when the built
+    # metadata object would be discarded (FULL cudagraph replay of a
+    # single-pass drafter reads only persistent input buffers). True only
+    # when build() has no side effects a replayed graph depends on
+    # (persistent-buffer restaging, decode-plan updates, ...). Fail-closed.
+    supports_skip_draft_rebuild: bool = False
 
     @abstractmethod
     def __init__(

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -26,6 +26,39 @@ from vllm.v1.kv_cache_interface import MambaSpec
 M = TypeVar("M", bound="BaseMambaAttentionMetadata")
 
 
+def uniform_decode_split(
+    common_attn_metadata: CommonAttentionMetadata, decode_threshold: int
+) -> tuple[int, int, int, int] | None:
+    """Fast pure-decode replacement for the builder's batch split.
+
+    In steady decode (every step of a long generation) the batch has no
+    prefilling row and every query fits the decode threshold, so the
+    single-token-prefill reclassification and
+    ``split_decodes_and_prefills`` re-derive the same constants from CPU
+    tensors on every step. Under exactly those conditions both are
+    value-determined: no row reclassifies (nothing is prefilling) and the
+    split is all-decode by contract.
+
+    Returns:
+        ``(num_decodes, num_prefills, num_decode_tokens,
+        num_prefill_tokens)`` when the fast path applies, else ``None``
+        (callers must then run the full path).
+    """
+    is_prefilling = common_attn_metadata.is_prefilling
+    if (
+        common_attn_metadata.max_query_len > decode_threshold
+        or is_prefilling is None
+        or bool(is_prefilling.any())
+    ):
+        return None
+    return (
+        common_attn_metadata.num_reqs,
+        0,
+        common_attn_metadata.num_actual_tokens,
+        0,
+    )
+
+
 @dataclass
 class BaseMambaAttentionMetadata:
     num_prefills: int
@@ -196,6 +229,16 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             )
         else:
             self.decode_bc_pre_scratch = None
+
+        # Step-invariant gather offsets for mamba_get_block_table_tensor
+        # ("align" mode otherwise re-materializes this arange every build).
+        self._state_gather_offsets: torch.Tensor | None = None
+        if vllm_config.cache_config.mamba_cache_mode not in ("all", "none"):
+            self._state_gather_offsets = torch.arange(
+                1 + kv_cache_spec.num_speculative_blocks,
+                device=device,
+                dtype=torch.int32,
+            )
 
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
         if self.use_spec_decode:
@@ -450,37 +493,48 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             self.reorder_batch_threshold if num_accepted_tokens is not None else 1
         )
 
-        # FULL-CG dispatch is shape-based, so one-token prefills with
-        # prior Mamba state can replay a decode graph while `is_prefilling`
-        # is still true. Treat them as decode/update rows. This is required
-        # for NIXL disagg's h(N-1)->N recompute path and for sporadic
-        # final single-token prefill chunks that land in a `uniform` FULL-CG
-        # batch. Relies on `reorder` putting short extends before pure prefills.
-        is_prefilling = common_attn_metadata.is_prefilling
-        assert is_prefilling is not None
-        seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
-        assert seq_lens_cpu is not None
-        query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)
-        single_token_prefill_rows = is_prefilling & (query_lens_cpu == 1)
-        # First-token prefills have no prior Mamba state and must stay prefills.
-        has_prior_state = seq_lens_cpu > 1
-        prefill_to_decode = single_token_prefill_rows & has_prior_state
-        if torch.any(prefill_to_decode).item():
-            # ReplaySSM handles these rows as single-token flushes (see the
-            # write-position derivation below), same as the baseline decode path.
-            is_prefilling = is_prefilling.clone()
-            is_prefilling[prefill_to_decode] = False
-            common_attn_metadata = common_attn_metadata.replace(
-                is_prefilling=is_prefilling
+        fast_split = uniform_decode_split(common_attn_metadata, decode_threshold)
+        if fast_split is not None:
+            # Steady decode: skip the reclassification + split re-derivation
+            # (their results are value-determined, see uniform_decode_split).
+            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+                fast_split
             )
+        else:
+            # FULL-CG dispatch is shape-based, so one-token prefills with
+            # prior Mamba state can replay a decode graph while `is_prefilling`
+            # is still true. Treat them as decode/update rows. This is required
+            # for NIXL disagg's h(N-1)->N recompute path and for sporadic
+            # final single-token prefill chunks that land in a `uniform` FULL-CG
+            # batch. Relies on `reorder` putting short extends before pure
+            # prefills.
+            is_prefilling = common_attn_metadata.is_prefilling
+            assert is_prefilling is not None
+            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+            assert seq_lens_cpu is not None
+            query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)
+            single_token_prefill_rows = is_prefilling & (query_lens_cpu == 1)
+            # First-token prefills have no prior Mamba state and must stay
+            # prefills.
+            has_prior_state = seq_lens_cpu > 1
+            prefill_to_decode = single_token_prefill_rows & has_prior_state
+            if torch.any(prefill_to_decode).item():
+                # ReplaySSM handles these rows as single-token flushes (see the
+                # write-position derivation below), same as the baseline decode
+                # path.
+                is_prefilling = is_prefilling.clone()
+                is_prefilling[prefill_to_decode] = False
+                common_attn_metadata = common_attn_metadata.replace(
+                    is_prefilling=is_prefilling
+                )
 
-        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-            split_decodes_and_prefills(
-                common_attn_metadata,
-                decode_threshold=decode_threshold,
-                treat_short_extends_as_decodes=False,
+            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+                split_decodes_and_prefills(
+                    common_attn_metadata,
+                    decode_threshold=decode_threshold,
+                    treat_short_extends_as_decodes=False,
+                )
             )
-        )
 
         # Need flags to indicate if there are initial states
         has_initial_states_p = None
@@ -529,6 +583,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
                 common_attn_metadata.seq_lens,
                 self.kv_cache_spec,
                 self.vllm_config.cache_config.mamba_cache_mode,
+                gather_offsets=self._state_gather_offsets,
             )
 
         if state_indices_tensor.dim() == 1:
@@ -815,6 +870,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             metadata.seq_lens,
             self.kv_cache_spec,
             self.vllm_config.cache_config.mamba_cache_mode,
+            gather_offsets=self._state_gather_offsets,
         )
         if state_indices_tensor.dim() == 1:
             state_indices_tensor = state_indices_tensor.unsqueeze(-1)

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -205,6 +205,11 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             device=device,
         )
         self.rswa_window = model_config.rswa_window
+        # build() touches persistent builder state only in the R-SWA branch
+        # (persistent_rswa_prefix_lens is restaged for captured graphs to
+        # read), so skipping a to-be-discarded draft build() is safe exactly
+        # when R-SWA is inactive.
+        self.supports_skip_draft_rebuild = self.rswa_window is None
         self.persistent_rswa_prefix_lens: torch.Tensor | None = None
         if self.rswa_window is not None:
             self.persistent_rswa_prefix_lens = torch.empty(

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -39,7 +39,10 @@ from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
     triton_reshape_and_cache_flash_per_token_head_quant,
 )
-from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.attention.ops.triton_unified_attention import (
+    MAX_QUERY_LEN_3D,
+    unified_attention,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVQuantMode,
@@ -52,6 +55,23 @@ logger = init_logger(__name__)
 # constants
 MIN_LAUNCH_GRID_SIZE_2D = 128  # Minimum launch grid size of 2D kernel
 NUM_PAR_SOFTMAX_SEGMENTS = 16  # Number of parallel tiled softmax segments
+
+
+def spec_decode_max_query_len_3d(vllm_config: VllmConfig) -> int:
+    """Largest query length the 3D (split-KV) kernel may serve.
+
+    Method-gated fail-closed: only dflash/dspark drafters opt in to
+    ``q > 1`` (their draft/verify passes are the measured target of the
+    small-q 3D path). eagle/eagle3/mtp and any unaudited speculative
+    method return 1, which keeps their verify passes on the exact
+    pre-existing 2D launch byte-identical.
+    """
+    spec_config = vllm_config.speculative_config
+    if spec_config is None or not (
+        spec_config.use_dflash() or spec_config.use_dspark()
+    ):
+        return 1
+    return min(1 + vllm_config.num_speculative_tokens, MAX_QUERY_LEN_3D)
 
 
 @dataclass
@@ -94,6 +114,9 @@ class TritonAttentionMetadata:
     mm_prefix_range_tensor: torch.Tensor | None = None
     rswa_prefix_lens: torch.Tensor | None = None
     rswa_window: int | None = None
+    # Largest query length the 3D kernel may serve; >1 only when the
+    # softmax_segm_* buffers above are sized per query token (spec decode).
+    max_query_len_3d: int = 1
 
 
 class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMetadata]):
@@ -153,9 +176,17 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
 
         self.num_par_softmax_segments = NUM_PAR_SOFTMAX_SEGMENTS
         headdim_padded = next_power_of_2(self.headdim)
+        # Spec-decode drafts/verifies run small uniform query lengths
+        # (1 bonus + N draft tokens) that are still decode-shaped; admit
+        # them to the 3D kernel by sizing the per-segment buffers per
+        # query TOKEN instead of per sequence. Fail-closed method gate:
+        # only dflash/dspark opt in; eagle/eagle3/mtp and unknown methods
+        # keep the single-token-only 3D admission (byte-identical verify).
+        self.max_query_len_3d = spec_decode_max_query_len_3d(vllm_config)
+        segm_buffer_tokens = self.seq_threshold_3D * self.max_query_len_3d
         self.softmax_segm_output = torch.empty(
             (
-                self.seq_threshold_3D,
+                segm_buffer_tokens,
                 self.num_heads_q,
                 self.num_par_softmax_segments,
                 headdim_padded,
@@ -164,12 +195,12 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             device=device,
         )
         self.softmax_segm_max = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (segm_buffer_tokens, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
         self.softmax_segm_expsum = torch.empty(
-            (self.seq_threshold_3D, self.num_heads_q, self.num_par_softmax_segments),
+            (segm_buffer_tokens, self.num_heads_q, self.num_par_softmax_segments),
             dtype=torch.float32,
             device=device,
         )
@@ -245,6 +276,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             softmax_segm_output=self.softmax_segm_output,
             softmax_segm_max=self.softmax_segm_max,
             softmax_segm_expsum=self.softmax_segm_expsum,
+            max_query_len_3d=self.max_query_len_3d,
         )
 
         mm_ranges = common_attn_metadata.mm_req_doc_ranges
@@ -673,6 +705,7 @@ class TritonAttentionImpl(AttentionImpl):
             softmax_segm_output=softmax_segm_output,
             softmax_segm_max=softmax_segm_max,
             softmax_segm_expsum=softmax_segm_expsum,
+            max_query_len_3d=attn_metadata.max_query_len_3d,
             sinks=self.sinks,
             output_scale=output_scale,
             mm_prefix_range=mm_prefix_range_tensor,

--- a/vllm/v1/attention/backends/triton_attn_diffkv.py
+++ b/vllm/v1/attention/backends/triton_attn_diffkv.py
@@ -56,7 +56,7 @@ class TritonAttentionDiffKVMetadataBuilder(TritonAttentionMetadataBuilder):
         head_size_v_padded = next_power_of_2(head_size_v)
         self.softmax_segm_output = torch.empty(
             (
-                self.seq_threshold_3D,
+                self.seq_threshold_3D * self.max_query_len_3d,
                 self.num_heads_q,
                 self.num_par_softmax_segments,
                 head_size_v_padded,

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -1130,6 +1130,7 @@ def mamba_get_block_table_tensor(
     seq_lens: torch.Tensor,
     kv_cache_spec: KVCacheSpec,
     mamba_cache_mode: str,
+    gather_offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Get the block table tensor for mamba kernels from the input
@@ -1146,6 +1147,10 @@ def mamba_get_block_table_tensor(
     - "align": input  (#requests, cdiv(max_model_len, block_size));
                output (#requests, 1 + num_speculative_blocks), which are the last
                1 + num_speculative_blocks of each request.
+
+    ``gather_offsets`` optionally supplies the step-invariant
+    ``arange(1 + num_speculative_blocks)`` int32 tensor so per-step callers
+    avoid re-materializing it.
     """
     if mamba_cache_mode in ("all", "none"):
         return block_table
@@ -1157,10 +1162,13 @@ def mamba_get_block_table_tensor(
         start_indices.clamp_(min=0)
         # Use int32 for arithmetic to avoid dtype promotion overhead,
         # then convert to int64 for gather (which requires Long indices)
-        offsets = torch.arange(
-            1 + kv_cache_spec.num_speculative_blocks,
-            device=block_table.device,
-            dtype=torch.int32,
+        if gather_offsets is None:
+            gather_offsets = torch.arange(
+                1 + kv_cache_spec.num_speculative_blocks,
+                device=block_table.device,
+                dtype=torch.int32,
+            )
+        indices_to_gather = (start_indices.unsqueeze(1) + gather_offsets).to(
+            torch.int64
         )
-        indices_to_gather = (start_indices.unsqueeze(1) + offsets).to(torch.int64)
         return torch.gather(block_table, 1, indices_to_gather)

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -139,6 +139,42 @@ def init_softmax_M(
 
 
 @triton.jit
+def compute_window_segment_layout(
+    seq_len,
+    context_len,
+    TILE_SIZE: tl.constexpr,
+    NUM_SEGMENTS: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+):
+    """Per-sequence 3D segment layout scoped to the sliding-window range.
+
+    The default 3D layout splits ``[0, seq_len)`` into ``NUM_SEGMENTS``
+    equal tile slices. Under sliding-window attention only the last
+    ``SLIDING_WINDOW`` keys (plus the query span) are visible, so that
+    layout lights up just one or two segments and serializes the KV read.
+    This layout re-bases the split on the window range instead: tiles
+    ``[seg_tile_base, num_tiles)`` where ``seg_tile_base`` is derived from
+    the window lower bound of the sequence's FIRST query token, which
+    lower-bounds the allowed keys of every query row (causal or not).
+
+    Must be computed identically by ``kernel_unified_attention`` (which
+    decides the tile range each segment covers) and ``reduce_segments``
+    (which masks the segments it combines), so it is shared here.
+
+    Returns ``(seg_tile_base, tiles_per_segment, segment_span)`` where
+    ``segment_span = num_tiles - seg_tile_base`` and segment ``s`` covers
+    tiles ``[seg_tile_base + s * tiles_per_segment, seg_tile_base +
+    (s + 1) * tiles_per_segment)``.
+    """
+    num_tiles = cdiv_fn(seq_len, TILE_SIZE)
+    first_allowed_key = tl.maximum(context_len - SLIDING_WINDOW + 1, 0)
+    seg_tile_base = first_allowed_key // TILE_SIZE
+    segment_span = num_tiles - seg_tile_base
+    tiles_per_segment = cdiv_fn(segment_span, NUM_SEGMENTS)
+    return seg_tile_base, tiles_per_segment, segment_span
+
+
+@triton.jit
 def compute_tile_loop_bounds(
     context_len,
     seq_len,
@@ -157,6 +193,7 @@ def compute_tile_loop_bounds(
     USE_PER_SEQ_CAUSAL: tl.constexpr = False,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
+    seg_tile_base_or_0=0,
 ):
     """Compute the tile-loop bounds ``(loop_lo, loop_hi)`` and the
     derived ``max_seq_prefix_len`` used for per-tile masking.
@@ -171,8 +208,11 @@ def compute_tile_loop_bounds(
        only tiles that can contain an allowed key under SWA.
        For non-causal sequences, the window extends in both directions.
     3. 3D scoping: when ``IS_3D`` is True, further narrows to the
-       segment's slice via ``(segm_idx * tiles_per_segment,
-       (segm_idx + 1) * tiles_per_segment)``.
+       segment's slice via ``(seg_tile_base + segm_idx * tiles_per_segment,
+       seg_tile_base + (segm_idx + 1) * tiles_per_segment)``.
+       ``seg_tile_base_or_0`` is non-zero only for the sliding-window
+       segment layout (``compute_window_segment_layout``); the default 0
+       keeps the original full-sequence layout.
     """
     # compute the length of the longest sequence prefix spanned by any
     # query token in the current q_block (q_block_local_idx)
@@ -229,8 +269,9 @@ def compute_tile_loop_bounds(
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
 
     if IS_3D:
-        loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)
-        loop_hi = min((segm_idx_or_0 + 1) * tiles_per_segment_or_0, tile_end)
+        segm_tile_lo = seg_tile_base_or_0 + segm_idx_or_0 * tiles_per_segment_or_0
+        loop_lo = max(segm_tile_lo, tile_start)
+        loop_hi = min(segm_tile_lo + tiles_per_segment_or_0, tile_end)
     else:
         loop_lo = tile_start
         loop_hi = tile_end

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -21,6 +21,7 @@ from vllm.v1.attention.ops.triton_attention_helpers import (
     cdiv_fn,
     compute_kv_seq_mask,
     compute_tile_loop_bounds,
+    compute_window_segment_layout,
     find_seq_idx,
     init_softmax_M,
     load_qq_bias_tile,
@@ -289,6 +290,10 @@ def kernel_unified_attention(
     # instead of letting them override it. Default False preserves the
     # original (causal AND SW) OR mm_prefix behavior for all other models.
     MM_PREFIX_CLAMP_SW: tl.constexpr = False,
+    # 3D only: re-base the segment layout on the sliding-window tile range
+    # (see compute_window_segment_layout). Set by the wrapper only when a
+    # sliding window is active without mm_prefix / R-SWA / chunked masking.
+    USE_SW_SEGMENTATION: tl.constexpr = False,
 ):
     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
@@ -319,11 +324,28 @@ def kernel_unified_attention(
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
 
+    context_len = seq_len - cur_batch_query_len
+
     if IS_3D:
-        tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
-        if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
-            return
+        if USE_SW_SEGMENTATION:
+            seg_tile_base, tiles_per_segment, segment_span = (
+                compute_window_segment_layout(
+                    seq_len,
+                    context_len,
+                    TILE_SIZE,
+                    NUM_SEGMENTS_PER_SEQ,
+                    SLIDING_WINDOW,
+                )
+            )
+            if segm_idx * tiles_per_segment >= segment_span:
+                return
+        else:
+            seg_tile_base = 0
+            tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
+            if segm_idx * tiles_per_segment * TILE_SIZE >= seq_len:
+                return
     else:
+        seg_tile_base = 0
         tiles_per_segment = 0
 
     # Number of valid query rows in this block (used by TD descriptor
@@ -386,8 +408,6 @@ def kernel_unified_attention(
         score_scale = scale * tl.load(q_scale) * tl.load(k_scale)
         value_scale = tl.load(v_scale)
 
-    context_len = seq_len - cur_batch_query_len
-
     if USE_ALIBI_SLOPES:
         alibi_slope = tl.load(
             alibi_slopes_ptr + query_offset_1, mask=query_mask_1, other=0.0
@@ -414,6 +434,7 @@ def kernel_unified_attention(
         USE_PER_SEQ_CAUSAL,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
+        seg_tile_base_or_0=seg_tile_base,
     )
 
     # iterate through tiles (now limited to the sliding window range)
@@ -704,6 +725,11 @@ def reduce_segments(
     USE_FP8: tl.constexpr,  # bool
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
+    # Must mirror the segment layout used by kernel_unified_attention:
+    # the wrapper passes the same SLIDING_WINDOW / USE_SW_SEGMENTATION pair
+    # to both kernels.
+    SLIDING_WINDOW: tl.constexpr = 0,
+    USE_SW_SEGMENTATION: tl.constexpr = False,
 ):
     query_token_idx = tl.program_id(0)
     query_head_idx = tl.program_id(1)
@@ -715,12 +741,22 @@ def reduce_segments(
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
 
-    # number of segments for this particular sequence
-    num_segments = NUM_SEGMENTS_PER_SEQ
-    tiles_per_segment = cdiv_fn(seq_len, num_segments * TILE_SIZE)
-
-    # create masks for subsequent loads
-    act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
+    # number of segments actually populated for this particular sequence
+    if USE_SW_SEGMENTATION:
+        cur_batch_query_len = tl.load(query_start_len_ptr + seq_idx + 1) - tl.load(
+            query_start_len_ptr + seq_idx
+        )
+        _, tiles_per_segment, segment_span = compute_window_segment_layout(
+            seq_len,
+            seq_len - cur_batch_query_len,
+            TILE_SIZE,
+            NUM_SEGMENTS_PER_SEQ,
+            SLIDING_WINDOW,
+        )
+        act_num_segments = cdiv_fn(segment_span, tiles_per_segment)
+    else:
+        tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
+        act_num_segments = cdiv_fn(seq_len, tiles_per_segment * TILE_SIZE)
     segm_mask = tl.arange(0, NUM_SEGMENTS_PER_SEQ) < tl.full(
         [NUM_SEGMENTS_PER_SEQ], act_num_segments, dtype=tl.int32
     )
@@ -781,6 +817,52 @@ def _is_gemma3_attention(head_size: int, sliding_window: int) -> bool:
     return sliding_window == 1024 and head_size in (128, 256)
 
 
+# Largest max_seqlen_q admitted to the 3D (split-KV) kernel. Spec-decode
+# verify/draft batches run small uniform query lengths (1 bonus + N draft
+# tokens) that leave the 2D grid latency-bound exactly like plain decode;
+# larger (prefill-shaped) queries keep the 2D kernel.
+MAX_QUERY_LEN_3D = 4
+
+
+def _should_use_3d(
+    *,
+    num_tokens: int,
+    num_seqs: int,
+    max_seqlen_q: int,
+    max_query_len_3d: int,
+    seq_threshold_3D: int | None,
+    num_par_softmax_segments: int | None,
+    segm_buffers_allocated: bool,
+    segm_buffer_tokens: int,
+) -> bool:
+    """Decide between the 2D and 3D (split-KV) kernel launch.
+
+    Launch the 2D kernel if any of the following holds:
+
+    1. No intermediate tiled softmax buffers for the 3D kernel have been
+       allocated, or
+    2. ``max_seqlen_q`` exceeds the caller-admitted 3D query length
+       (1 unless the caller opts small uniform spec-decode shapes in via
+       ``max_query_len_3d``), or
+    3. the per-segment buffers cannot hold one row per query token
+       (callers sized for single-token decode admit only q_len == 1), or
+    4. the number of sequences exceeds the configured threshold, or
+    5. batch invariance is enabled.
+    """
+    if (
+        seq_threshold_3D is None
+        or num_par_softmax_segments is None
+        or not segm_buffers_allocated
+        or is_batch_invariant
+    ):
+        return False
+    if max_seqlen_q > max(max_query_len_3d, 1):
+        return False
+    if max_seqlen_q > 1 and num_tokens > segm_buffer_tokens:
+        return False
+    return num_seqs <= seq_threshold_3D
+
+
 def _get_tile_size(
     head_size: int,
     sliding_window: int,
@@ -821,6 +903,11 @@ def unified_attention(
     softmax_segm_output=None,
     softmax_segm_max=None,
     softmax_segm_expsum=None,
+    # Largest query length admitted to the 3D kernel. Callers that size the
+    # softmax_segm_* buffers per query TOKEN (not per sequence) may raise
+    # this to small uniform spec-decode shapes; ``None`` keeps the previous
+    # single-token-decode-only behavior.
+    max_query_len_3d: int | None = None,
     alibi_slopes=None,
     output_scale=None,
     qq_bias=None,
@@ -929,6 +1016,23 @@ def unified_attention(
     num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = q.shape[2]
 
+    use_3d = _should_use_3d(
+        num_tokens=q.shape[0],
+        num_seqs=num_seqs,
+        max_seqlen_q=max_seqlen_q,
+        max_query_len_3d=max_query_len_3d if max_query_len_3d is not None else 1,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        segm_buffers_allocated=(
+            softmax_segm_output is not None
+            and softmax_segm_max is not None
+            and softmax_segm_expsum is not None
+        ),
+        segm_buffer_tokens=(
+            softmax_segm_max.shape[0] if softmax_segm_max is not None else 0
+        ),
+    )
+
     BLOCK_M = (
         16 if num_queries_per_kv <= 16 else triton.next_power_of_2(num_queries_per_kv)
     )
@@ -945,6 +1049,7 @@ def unified_attention(
     tuned_large_head = (
         head_size == 256
         and max_seqlen_q > 1
+        and not use_3d
         and num_queries_per_kv <= 16
         and current_platform.is_device_capability_family(100)
     )
@@ -1033,20 +1138,23 @@ def unified_attention(
             f"(out.stride(1) = {out.stride(1)} != head_size = {head_size})."
         )
 
-    # Launch the 2D kernel if
-    # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
-    # 2. The batch includes at least one prefill request, or
-    # 3. The number of sequences exceeds the configured threshold, or
-    # 4. Batch invariance is enabled
-    use_3d = not (
-        seq_threshold_3D is None
-        or num_par_softmax_segments is None
-        or softmax_segm_output is None
-        or softmax_segm_max is None
-        or softmax_segm_expsum is None
-        or max_seqlen_q > 1
-        or num_seqs > seq_threshold_3D
-        or is_batch_invariant
+    # Under sliding-window attention the default full-sequence 3D segment
+    # layout leaves most segments empty (only the window range has visible
+    # keys), so re-base the segments on the window tile range. Gated on the
+    # caller's ``max_query_len_3d`` opt-in (> 1) so that every non-opted
+    # launch (all pre-existing q = 1 decode) keeps the exact previous
+    # full-sequence layout. Excluded whenever another masking mode can
+    # widen the visible range past the window lower bound (mm_prefix
+    # bidirectional ranges, R-SWA global prefixes) or redefine it (chunked
+    # attention).
+    use_sw_segmentation = (
+        use_3d
+        and max_query_len_3d is not None
+        and max_query_len_3d > 1
+        and sliding_window_val > 0
+        and not use_mm_prefix
+        and not use_rswa
+        and chunk_lookback == -1
     )
 
     # The kernel signature is the same for 2D and 3D — only the launch
@@ -1163,6 +1271,7 @@ def unified_attention(
         USE_TD=use_td,
         USE_TD_QO=use_td_qo,
         MM_PREFIX_CLAMP_SW=mm_prefix_clamp_sliding_window,
+        USE_SW_SEGMENTATION=use_sw_segmentation,
         **launch_kwargs,
     )
 
@@ -1186,4 +1295,6 @@ def unified_attention(
             BLOCK_Q=BLOCK_Q,
             NUM_SEGMENTS_PER_SEQ=num_par_softmax_segments,
             USE_FP8=output_scale is not None,
+            SLIDING_WINDOW=sliding_window_val,
+            USE_SW_SEGMENTATION=use_sw_segmentation,
         )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -254,6 +254,10 @@ class Scheduler(SchedulerInterface):
         )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
+        # Prefill lookahead and the prefix-cache last-block drop are distinct:
+        # dflash/dspark read one token ahead mid-prefill but never cache
+        # lookahead-polluted KV, so they keep the lookahead without the drop.
+        self.drop_prefix_cache_tail = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
         self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
         # Positions past the computed tokens that the drafter reads mid-prefill.
@@ -272,6 +276,9 @@ class Scheduler(SchedulerInterface):
                     vllm_num_speculative_tokens=self.num_spec_tokens,
                 )
             self.use_eagle = speculative_config.use_eagle()
+            self.drop_prefix_cache_tail = (
+                speculative_config.prefix_cache_needs_last_block_drop()
+            )
             if self.use_eagle:
                 self.num_prefill_lookahead = (
                     self.num_spec_tokens
@@ -288,7 +295,7 @@ class Scheduler(SchedulerInterface):
             max_model_len=self.max_model_len,
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
-            use_eagle=self.use_eagle,
+            use_eagle=self.drop_prefix_cache_tail,
             num_prefill_lookahead=self.num_prefill_lookahead,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
@@ -409,11 +416,11 @@ class Scheduler(SchedulerInterface):
             return num_new_tokens
 
         block_size = self.cache_config.block_size
-        # The last block-aligned position whose state can be cached. With
-        # Eagle, FullAttn prunes the last matching block, so back off one
-        # block to avoid a Mamba cache miss.
+        # The last block-aligned position whose state can be cached. When the
+        # EAGLE last-block drop applies, FullAttn prunes the last matching
+        # block, so back off one block to avoid a Mamba cache miss.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle:
+        if self.drop_prefix_cache_tail:
             last_cache_position = max(last_cache_position - block_size, 0)
 
         end = start + num_new_tokens

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -31,6 +31,24 @@ from vllm.v1.worker.utils import AttentionGroup
 logger = init_logger(__name__)
 
 
+def all_draft_builders_skip_safe(attn_groups: list[list[AttentionGroup]]) -> bool:
+    """Whether every draft attention metadata builder allows skipping a
+    build whose result would be discarded (FULL cudagraph replay).
+
+    Fail-closed: False when there are no builders or any builder does not
+    declare ``supports_skip_draft_rebuild``.
+    """
+    builders = [
+        builder
+        for groups in attn_groups
+        for group in groups
+        for builder in group.metadata_builders
+    ]
+    return bool(builders) and all(
+        builder.supports_skip_draft_rebuild for builder in builders
+    )
+
+
 class DFlashSpeculator(DraftModelSpeculator):
     _speculator_name = "DFlash"  # For logging, so we can share methods with subclasses
 
@@ -183,6 +201,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         ]
         assert self.draft_kv_cache_group_ids, "No draft attention groups found."
         self.draft_kv_cache_group_id = self.draft_kv_cache_group_ids[0]
+
+        # Under FULL replay the freshly built draft metadata / slot-mapping
+        # dict is discarded (run_fullgraph reads only persistent input
+        # buffers), so the rebuild may be skipped when no builder restages
+        # persistent state in build() and DCP does not need
+        # dcp_local_seq_lens refreshed on the way in. Fail-closed.
+        self._skip_draft_rebuild_on_full_replay = (
+            all_draft_builders_skip_safe(self.attn_groups)
+            and self.block_tables.cp_size == 1
+        )
 
         # Per-group context slot buffers for the precompute (one row per group).
         self._context_slot_mappings = torch.zeros(
@@ -456,29 +484,39 @@ class DFlashSpeculator(DraftModelSpeculator):
             batch_sync.num_tokens_across_dp if batch_sync is not None else None
         )
 
-        # Rebuild the draft attention metadata even when replaying the FULL
-        # graph so that any attention metadata builder state is updated.
-        draft_attn_metadata = self._build_draft_attn_metadata(
-            num_reqs=num_reqs,
-            num_reqs_padded=num_reqs_padded,
-            num_tokens_padded=num_tokens_padded,
-            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
-            step=self.num_query_per_req,
-            causal=self._group_causal,
-        )
-        draft_slot_mappings_by_layer = build_slot_mappings_by_layer(
-            self.block_tables.slot_mappings[:, :num_tokens_padded],
-            self.kv_cache_config,
-        )
-
         # DFlash processes all speculative tokens in one forward pass,
         # so the real token count is num_query_tokens.
         self._prepare_eplb_forward(num_query_tokens)
 
         if batch_desc.cg_mode == CUDAGraphMode.FULL:
+            # The built metadata / slot-mapping dict would be discarded here
+            # (the captured graph reads only persistent input buffers), so
+            # skip the rebuild when every builder declared it side-effect
+            # free; otherwise rebuild purely for its builder-state updates.
+            if not self._skip_draft_rebuild_on_full_replay:
+                self._build_draft_attn_metadata(
+                    num_reqs=num_reqs,
+                    num_reqs_padded=num_reqs_padded,
+                    num_tokens_padded=num_tokens_padded,
+                    seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+                    step=self.num_query_per_req,
+                    causal=self._group_causal,
+                )
             assert self.query_cudagraph_manager is not None
             self.query_cudagraph_manager.run_fullgraph(batch_desc)
         else:
+            draft_attn_metadata = self._build_draft_attn_metadata(
+                num_reqs=num_reqs,
+                num_reqs_padded=num_reqs_padded,
+                num_tokens_padded=num_tokens_padded,
+                seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+                step=self.num_query_per_req,
+                causal=self._group_causal,
+            )
+            draft_slot_mappings_by_layer = build_slot_mappings_by_layer(
+                self.block_tables.slot_mappings[:, :num_tokens_padded],
+                self.kv_cache_config,
+            )
             self._generate_draft(
                 num_reqs,
                 num_tokens_padded,


### PR DESCRIPTION
## Purpose

Batch-1 speculative decode with the dflash/dspark drafter family loses throughput in three independent places, each measured with per-span instrumentation over 1000 steady decode cycles on GB200 (Nemotron-3.5-Lightning-30B-A3B-NVFP4 + DSpark, production recipe). The worker host and the GPU are co-saturated on this path (~4.0 ms host vs ~4.1 ms GPU per cycle), so both GPU-side and host-side dead weight convert directly to inter-token latency:

1. **Prefix caching drops a clean block on every hit.** `use_eagle()` gates the EAGLE last-block drop, but dflash/dspark never cache lookahead-polluted KV (context KV is projected from target hidden states and positions only; the anchor token writes past the chunk end and is overwritten before its block can be hashed). The drop protects nothing for them and costs one full scheduler block (2,192 tokens, ~50 ms TTFT) per cache hit — on the mamba side too, since the align chunk-split backoff shares the predicate and the KV coordinator min()-reconciles.
2. **The drafter's attention runs the serialized 2D kernel.** The triton unified-attention 3D split-KV launch was gated to `max_seqlen_q == 1`; drafter/verify passes run small uniform q (1 bonus + N draft) that is still decode-shaped. On the drafter geometry (hq=32, hkv=2, hd=128, SW 1024 + sinks), the q=3 2D full-range pass takes 1011 us; the microbenchmark's q=1 3D full-range control on the same KV read measures 113.4 us at the shipped default segment count (`NUM_PAR_SOFTMAX_SEGMENTS` = 16, ~8.9x) and 61.9 us at the sweep's 32-segment point (~16.3x) — and a sliding window lights only ~1-2 of the equal-slice segments, so the segment layout is re-based on the visible window.
3. **Dead host work every cycle.** Under FULL cudagraph replay the propose path rebuilds draft attention metadata and slot mappings, then discards both (`run_fullgraph` reads only persistent input buffers) — 0.125 ms/cycle. The hybrid-mamba builder re-derives the single-token-prefill reclassification chain and the decode/prefill split from scratch each step, though both are value-determined constants in steady uniform decode.

## Changes (four self-contained, independently revertable commits)

1. `[Perf][Spec Decode]` Exempt dflash/dspark from the EAGLE prefix-cache last-block drop — new `SpeculativeConfig.prefix_cache_needs_last_block_drop()` (True for eagle/eagle3/mtp, fail-closed for unknown eagle-family methods) wired into the KV-cache manager drop and the mamba-align backoff; `num_prefill_lookahead` unchanged.
2. `[Perf][Kernel]` Extend 3D split-KV to `q <= 4`, opt-in via a new `max_query_len_3d` argument (default None = exact previous behavior, batch-invariance still forces 2D), with per-query-token segm buffers and a window-based segment layout shared by main kernel and reduce. The window layout is gated on the same opt-in (`max_query_len_3d > 1`): every non-opted launch — including all existing q=1 sliding-window 3D decode (e.g. Gemma3 on TRITON_ATTN) — keeps the exact previous full-sequence segment layout (the `USE_SW_SEGMENTATION=False` branches are the unchanged upstream layout computation); extending the window layout to that default population is deferred to a follow-up with its own model eval. Method-gated fail-closed: only dflash/dspark raise the admission above q=1; eagle/eagle3/mtp and unknown speculative methods keep their verify passes byte-identical on the 2D launch and their q=1 3D decode on the previous segment layout.
3. `[Perf][Spec Decode]` Skip the dead rebuild on FULL replay behind a new fail-closed builder flag `supports_skip_draft_rebuild` (base False; Triton builder True iff R-SWA is inactive) AND `cp_size == 1`; any other builder/config keeps the rebuild for its side effects.
4. `[Perf][Mamba]` Fast uniform-decode metadata build: an all-decode shortcut that fires only when no row is prefilling and `max_query_len <= decode_threshold` (provably value-identical to the full reclassification + split chain), plus caching of the step-invariant gather-offset arange. No metadata value changes on any path.

## Test Plan

Commands run (from the repo root, `.venv` per AGENTS.md; GPU suites inside the GB200 container):

```bash
# Commit 1 (CPU): 318 passed
pytest tests/v1/core/test_scheduler.py tests/v1/core/test_prefix_caching.py \
  tests/v1/core/test_mamba_align_chunk_split.py \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
# Commit 2 (GPU, GB200): 24 new kernel-matrix tests + 1 gating test passed
# (25 in the selection; of 1609 passing overall; the 290 use_td-family
# failures reproduce identically on the unpatched container)
pytest tests/kernels/attention/test_triton_unified_attention.py
# Commit 2 (CPU): 2 passed (3D-admission gating + fail-closed method gate)
pytest tests/kernels/attention/test_triton_unified_attention.py -k "should_use_3d or method_gate"
# Commit 3 (CPU): 4 passed
pytest tests/v1/spec_decode/test_dflash_skip_rebuild.py
# Commit 4 (CPU): 31 passed (8 new + 23 pre-existing)
pytest tests/v1/attention/test_attention_splitting.py
```

- Commit 1: 318 passed (scheduler 153, prefix caching 96, mamba align chunk split 34, partial hits 35) incl. 3 new tests (predicate, ctor-spy wiring, align-split behavior).
- Commit 2: 26 new tests — 24 kernel-matrix tests on GB200 in-container (3D vs reference AND vs 2D, q 1-4 x SW {off,1024} x sinks x pow2/non-pow2 `num_queries_per_kv`, non-divisible segment tails, NaN-poison liveness; asserted via `torch.testing.assert_close` at atol 1.5e-2 / rtol 1e-2 against both references — the tighter maxdiff 8e-6 is from the standalone GB200 microbenchmark's q=1 3D-vs-2D full-range control, not from these tests) + 2 CPU gating tests (admission predicate; dflash/dspark-only method gate, fail-closed for eagle/eagle3/mtp/unknown). The GB200 GPU selection collected the 24 matrix tests plus the admission gating test: 25 passed.
- Commit 3: 4 new CPU tests (fail-closed gating: no builders, any unsafe builder, base default, R-SWA branch).
- Commit 4: 8 new CPU tests (fast path fires iff value-identical to the full chain; gather-offsets identity) alongside the 23 pre-existing.
- Series `git am`-clean on current main (re-verified 2026-08-27 on freshly-fetched origin/main `fd57c4b7`, after rebasing over #53694; `git am --keep-non-patch` of the whole 4-patch series in a throwaway worktree, all 17 resulting files byte-identical to branch HEAD, author/DCO preserved; no upstream commit in `f25c580a..fd57c4b7` touches any changed file); ruff check/format clean; pre-existing GPU-test failures in our areas reproduce identically on the unpatched container (era drift, not introduced).

## Test Result

A/B on GB200 and GB300, interleaved stock/patched arms on the same node with sha-verified overlays, aiperf 32K shared prefix / 2K in / 256 out, concurrency 1, temp 0, synthetic acceptance length 3. Two campaigns, labeled by code state: the **validation jobs** (GB200 + GB300) measured the pre-final code; because three post-validation changes touched functional lines (a mypy-driven attribute-form change, the rebase over #53694, and the split-KV opt-in gate in the hot kernel file), a **shipped-HEAD recheck** (GB200 job 1962848, interleaved stock/series 2v2, overlay regenerated in-job from the final patches and sha-verified = HEAD, failed_arms=0) re-ran the full A/B on exactly this branch HEAD. All pre-registered per-commit gates PASS on the recheck; it is the primary column below.

| metric (attribution) | stock | this PR (shipped-HEAD recheck, GB200) | Δ | validation-phase value (pre-final code) |
|---|---|---|---|---|
| cache-hit TTFT (commit 1) | 257.8 ms | 203.4 ms | **−54.4 ms** (hit `cached_tokens` 28,496 → 30,688, +2,192 = exactly the block; bands exact in every arm) | −36.0 ms (252.1 → 216.1) |
| drafter FULL-graph GPU span (commit 2) | 0.7986 ms/cycle | 0.5923 ms/cycle | −0.206 ms | 0.584 (0.582–0.584 across patched arms); standalone ITL −0.033 ms/tok |
| dead-rebuild host span (commit 3) | 0.1249 ms/cycle | 0.0071 ms/cycle | −0.118 ms | 0.0073 |
| target-side input-prep host span (commit 4) | 1.7455 ms/cycle (instrumented baseline arm) | 1.5766 ms/cycle | −0.17 ms (gate ≤ 1.60) | 1.48–1.53 (−0.22..−0.29 within-arm vs 1.7455/1.7701 pre-commit-4 arms); ITL −0.030 ms/tok, no regression |
| decode tok/s, GB200 (series) | 743.3 (ITL 1.3454) | **776.6 (ITL 1.2877)** | **+4.5%**, every patched rep > every stock rep (min separation 28.8 t/s; ITL fully separated) | 732.4 → 801.4 (+9.4%, ITL 1.3655 → 1.2483; series n=3 vs interleaved stock n=2) |
| decode tok/s, GB300 (series, 2 reps — validation phase; the recheck was GB200-only) | 716.3-724.3 (both clean stock arms; a third stock arm at 366.6 is excluded as a documented node-contention outlier) | **765.7 / 763.5** | +5.4-6.9% (vs the stock band) | (same — no GB300 recheck arm) |
| end-to-end request latency, GB200 | 600.9 ms | 531.8 ms | −11.5% | 600.3 → 534.5 (−11.0%) |

Rows 2-4 are within-job attribution cells (per-span instrumentation) measured against the commit-1-instrumented baseline arm — commit 1 does not touch the decode path, so it stands in for stock on these spans; their stock column is that validation-phase baseline arm, their PR column the shipped-HEAD recheck cell.

Across the two GB200 campaigns the joint decode gain envelope is **+33.3..+69.0 t/s** (stock draw range across jobs 727–763 t/s, series 776–814): the recheck landed at the low end — reproducing an earlier same-day stock-vs-series cell (+36.6 t/s) — and the validation job at the high end. Three of six pre-registered *aggregate* recheck gates missed, each dispositioned in the artifact set, none implicating a commit: (a) joint decode +33.3 vs the ≥ +35 t/s gate and ITL −0.0577 vs ≤ −0.06 — missed by 1.7 t/s / 0.0023 ms under a uniform +1-6% host / +0.7-1.4% GPU drift measured on series-touched AND series-untouched spans alike (an environment signature; no series-specific span regressed); (b) a miscalibrated real-rejection acceptance gate — series 37.2% vs same-job stock control 52.0%, but the stock control's own run-to-run intervals span 28.4-52.0%, wider than the gate itself, and the series intervals (28.4-45.7%) sit inside the pooled stock envelope; (c) one greedy-argmax flip at a documented near-tie (details in the numerics paragraph below).

Memory: commit 2 sizes the three persistent split-KV softmax workspaces per admitted query token, so they grow only when a dflash/dspark drafter is configured, capped at 4x (`MAX_QUERY_LEN_3D`) on top of a base set by `seq_threshold_3D`. With decode cudagraphs disabled the threshold keeps its grid-derived value — at the production drafter geometry (hq=32, hkv=2, hd=128 → `seq_threshold_3D`=64) that is +48 MiB per builder instance (`softmax_segm_output` 16 MiB → 64 MiB; `segm_max`/`expsum` 0.125 → 0.5 MiB each). With decode cudagraphs enabled the threshold first snaps to the closest capture size, so the validated production recipe (`cudagraph_mode` FULL, capture sizes [1,2,4] → threshold 4) pays ~+3 MiB per builder (`softmax_segm_output` 1 → 4 MiB; `segm_max`/`expsum` +24 KiB each). Without a dflash/dspark drafter, sizes are unchanged.

Numerics gates, every production arm on both platforms and both campaigns: acceptance length pinned at 3.00 with per-position acceptance 1.000/1.000/0.000; with real rejection, acceptance parity within the measured small-sample floor (the series does not touch the sampler). Temp-0 stability: the patched hit-vs-miss top-20 logprob gap sits at/below each arm's own within-arm noise in **every** series arm — 0.25-0.32 in the three argmax-stable arms, matching the unpatched stock controls (0.24-0.30, one per EQ2 campaign). Greedy argmax was stable across all requests in those three arms; the fourth series EQ2 arm (shipped-HEAD recheck, job 1962848) flipped greedy argmax once, at the same documented 0.125-margin pos-0 near-tie the prior arm recorded — a flip at the greedy floor, not a numerics regression: that arm's gap (0.661) still sits below its own within-hit noise (0.666 = 5.3× the margin), and the unpatched stock controls themselves fail temp-0 self-consistency on the same probe (`gen_text_a_eq_b = false` in both stock runs). 2D-vs-3D is the same numerically-equivalent policy surface upstream already applies to all q=1 decode. Sub-fixes that did not reproduce their predicted span on hardware were dropped from the series before submission; every line above ships only what measured.

## Related issues/PRs

Commit-1 area (searches dated 2026-08-26T09:42Z): not a duplicate. #53388 (draft) adds an opt-in family-wide `disable_eagle_block_drop` knob over the same scheduler sites; commit 1 changes the default by drafter-KV provenance, no knob, and the two compose. #47926 fixes the complementary dflash/dspark restored-region draft-KV defect (zero file overlap; acceptance-parity arms bound the interaction at nil). #53479, #50897 orthogonal; #53614/#53598 touch adjacent lines, mechanical rebase either order. Issues #51771, #47930. Re-swept 2026-08-27T08:56Z (the one area not refreshed alongside the 08-27 sweeps below), plus a 2026-08-27 audit pass that caught a miss of both sweeps — two additional hits in total, one from each. From the re-sweep, created after the original sweep: **#53945** (OPEN, non-draft, created 2026-08-26T19:36Z) caches the Mamba state at the block-grid position of EAGLE resume and overlaps 4 of commit 1's 6 files (`vllm/v1/core/sched/scheduler.py` + all three shared test files); both of its scheduler hunks land inside `Scheduler._mamba_block_aligned_split`, the same function as commit 1's backoff hunk. Not a duplicate, but the composition is semantically non-trivial: its new `tail_boundary`/`junction_stop` logic is keyed on `self.use_eagle` with a rationale that only holds while the last-block drop applies — post-commit-1, `use_eagle` stays True for dflash/dspark while the drop no longer applies, so whichever lands second should re-key that logic on `self.drop_prefix_cache_tail` (commit 1's predicate); the shared test-file hunks are disjoint/adjacent, mechanical either order. From the audit, an original-sweep miss (created before that sweep) which the re-sweep also failed to surface: **#51295** (OPEN, draft, created 2026-08-06T18:15:36Z) fixes a hybrid-attention cache miss caused by the EAGLE drop and overlaps the same 4 of commit 1's 6 files (`vllm/v1/core/sched/scheduler.py` + all three shared test files). Its single scheduler hunk (@@ -404) adds a `self.use_eagle`-keyed hash-unit backoff (`tail_boundary = max(tail_boundary - self.hash_block_size, 0)`) inside `Scheduler._mamba_block_aligned_split` — the same function as commit 1's backoff hunk (@@ -409), adjacent sub-blocks with no direct textual conflict, but the composition hazard is identical to #53945's: post-commit-1, `use_eagle` stays True for dflash/dspark while the drop no longer applies, so its `tail_boundary` backoff would fire for a drop that never happens; whichever lands second should re-key on `self.drop_prefix_cache_tail`. Not a duplicate (its mechanism is the hybrid-KV lookup alignment, not the drop exemption); the shared test-file hunks are mechanical either order.

Commit-2 area (searches dated 2026-08-27T02:41Z): **#45450** (OPEN, non-draft, updated 2026-08-26) implements both of commit 2's mechanisms on the same three files — spec-decode 3D admission via a `speculative_config`-derived query length with per-query-token segment buffers, and window-relative 3D segmentation via a shared `@triton.jit` helper used by mainloop and reduce — measured on B300/NVFP4 with MTP over a v0.22.1 base (its body: not re-validated on main). Material differences here: (a) fail-closed method gate — only dflash/dspark opt in, eagle/eagle3/mtp verify numerics stay byte-identical, whereas #45450 admits MTP/EAGLE; (b) R-SWA and chunked-masking exclusions; (c) validated on current main-era containers with per-commit attribution cells. (Scope note: this PR's window layout is gated on the same opt-in, so existing q=1 sliding-window 3D decode is byte-unchanged here — matching #45450's q=1 exclusion rather than differing on it.) Also adjacent: #52879 (OPEN draft, same files, references #48076), #44652 (OPEN, relaxes the same 3D-launch gate for multi-query verify + non-causal support), and issue #48076 (batch>=12 3D->2D fallback — different trigger: the `num_seqs` threshold, which this series does not change). Re-sweep 2026-08-27T08:56Z surfaced a miss of the original sweep: **#53930** (OPEN, non-draft, created 2026-08-26T17:51Z — about 9 h before the sweep above) adds a `logger.warning_once` in `TritonAttentionMetadataBuilder.__init__` anchored exactly between the segm-buffer allocations commit 2 re-shapes and the `rswa_window` line commit 3 appends after, so it conflicts textually with this series whichever lands second (mechanical to resolve); more materially, its warning fires unconditionally whenever `speculative_config is not None` and asserts "Decode runs on the 2D path" (citing #48076) — factually wrong for dflash/dspark once commit 2 lands, so if it merges the warning needs scoping to speculative methods the 3D admission does not cover (`spec_decode_max_query_len_3d() == 1`).

Commit-3 area (searches dated 2026-08-27T04:10Z): not a duplicate. **#53426** (OPEN, updated 2026-08-24) is the nearest neighbor — it also removes dead drafter-side work and touches the same `dflash/speculator.py` (plus commit 1's `speculative.py`; hunks disjoint from ours in both files), but skips a different thing under a different policy: an explicit opt-in, default-off knob to drop the K=0 draft *sync forward* when dynamic spec decode resolves K=0 (accepted for mtp/dflash only; dspark is refused), whereas commit 3 is a no-knob, fail-closed builder-flag skip of the draft *metadata rebuild* whose result FULL cudagraph replay discards — the draft forward still runs (as a replay) and the skip fires on ordinary K>0 steady decode for dflash AND dspark. Orthogonal dead work; the two compose, worst case a mechanical rebase in `propose()` (adjacent, non-overlapping hunks). #52782 (OPEN, NVTX/torch-profiler annotations to the model runner + DFlash speculator) and #53096 (OPEN, capture-log guard on `needs_capture()`) touch the same file with no semantic overlap — mechanical rebase either order; same class, added on the 2026-08-27T08:56Z re-sweep (a miss of the sweeps above, which it predates): **#53978** (OPEN, non-draft, created 2026-08-27T02:32Z) hardens DFlash2 spec warmup against unfilled draft buffers in `dflash/speculator.py` hunks (`__init__`, `_run_model`) disjoint from commit 3's — no semantic overlap, mechanical rebase either order. Two more same-file opens the 08:56Z re-sweep missed (both added by a 2026-08-27 audit): **#53970** (OPEN, non-draft, created 2026-08-27T01:12Z — inside the window that re-sweep demonstrably scanned) fixes the dflash batched token budget in `dflash/speculator.py` hunks (`__init__` @@ -47, `propose` @@ -415) disjoint from commit 3's (@@ -31 / -184 / -456; its `propose` hunk sits ~35-40 lines above ours) — no semantic overlap, mechanical rebase either order; **#53929** (OPEN, non-draft, created 2026-08-26T17:38Z) validates ragged GDN decode with Qwen3.5 DSpark and touches two series files — commit 1's `vllm/config/speculative.py` (@@ -844 vs c1's @@ -1795, disjoint) and commit 3's `vllm/v1/attention/backend.py` (@@ -569, in `AttentionCGSupport`, vs commit 3's @@ -597 in `AttentionMetadataBuilder` — disjoint, different classes) — no semantic overlap with either commit's mechanism, mechanical rebase either order. **#53694** (MERGED 2026-08-27; re-swept 2026-08-27T04:56Z) landed in the same `propose()` lines commit 3 rewrites — it hoists the DP-sync `num_tokens_across_dp` read out of the dispatch call's return; orthogonal mechanism (DP-sync plumbing, not a metadata-rebuild skip), inert at DP=1 (`dispatch_cg_and_sync_dp` returns no sync state when `dp_size == 1`, the measured recipe), and this series is rebased over it (commit 3's only conflict, context-only). No open PR implements a replay-time metadata-rebuild skip (dflash-speculator and draft-metadata sweeps).

Commit-4 area (searches dated 2026-08-27T04:10Z): not a duplicate. **#39936** (OPEN, last updated 2026-06-04) cheapens `split_decodes_and_prefills` itself (env-gated CPU-launch-overhead reduction inside the function, plus `block_table.py` slot-mapping changes, Blackwell-targeted); commit 4 instead avoids re-running the reclassification chain + split at all on provably all-decode steady steps, and its `utils.py` change is confined to `mamba_get_block_table_tensor` — zero hunk overlap with #39936's `split_decodes_and_prefills` hunks, and #39936 does not touch `mamba_attn.py`. Different mechanism, composes: #39936 speeds the general path, commit 4 removes it from the steady-decode loop while keeping it as the fail-closed fallback. Also in the area, an enumeration miss of the 04:10Z sweep (added by a 2026-08-27 audit): **#48188** (OPEN, non-draft, created 2026-07-09) speeds up `_compute_chunk_metadata` internals by ~6x in the same `mamba_attn.py` — its single hunk (@@ -281,43, spanning lines 281-323) is disjoint from all of commit 4's hunks (26 / 197 / 450 / 529 / 815), and its mechanism (cheapening the chunk-metadata computation itself) is different from commit 4's (skipping the reclassification chain + split entirely on provably all-decode steady steps); the two compose — commit 4's fallback path would simply run #48188's faster computation — mechanical rebase either order. The `split_decodes_and_prefills` / mamba-metadata-builder sweeps surfaced no open PR with commit 4's shortcut (that statement stands; #48188 is the nearest same-file neighbor, not a duplicate).

## AI assistance disclosure

Developed with AI assistance (Claude Code): profiling, root-cause tracing, the fixes, and the hardware A/Bs. I have reviewed every changed line and can defend the series end-to-end.

Signed-off-by: Rishi Puri <riship@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
