### PR TITLE
[Core] Make optional module discovery side-effect-free

### DIFF
--- a/tests/utils_/test_import_utils.py
+++ b/tests/utils_/test_import_utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -49,7 +50,7 @@ def test_placeholder_module_error_handling():
 
 
 class TestHasModule:
-    """Tests for _has_module with trial import verification."""
+    """Tests for side-effect-free module discovery."""
 
     def setup_method(self):
         # Clear the @cache between tests so each test gets a fresh call
@@ -61,12 +62,7 @@ class TestHasModule:
     def test_returns_false_for_nonexistent_module(self):
         assert _has_module("nonexistent_module_xyz_12345") is False
 
-    def test_returns_false_when_find_spec_succeeds_but_import_fails(self):
-        """Simulate a native extension whose shared library is missing.
-
-        ``find_spec`` finds the package on disk, but the actual import
-        raises ``ImportError`` (e.g. missing ``libcudart.so``).
-        """
+    def test_does_not_import_module(self):
         fake_spec = MagicMock()
 
         with (
@@ -74,14 +70,21 @@ class TestHasModule:
                 "vllm.utils.import_utils.importlib.util.find_spec",
                 return_value=fake_spec,
             ),
-            patch(
-                "vllm.utils.import_utils.importlib.import_module",
-                side_effect=ImportError(
-                    "libcudart.so.12: cannot open shared object file"
-                ),
-            ),
+            patch("vllm.utils.import_utils.importlib.import_module") as import_module,
         ):
-            assert _has_module("fake_native_ext") is False
+            assert _has_module("fake_native_ext") is True
+            import_module.assert_not_called()
+
+    def test_discovery_does_not_execute_module(self, tmp_path, monkeypatch):
+        module_name = "module_with_import_side_effect"
+        (tmp_path / f"{module_name}.py").write_text(
+            "raise RuntimeError('module was imported')\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        assert module_name not in sys.modules
+        assert _has_module(module_name) is True
+        assert module_name not in sys.modules
 
     def test_returns_false_when_find_spec_raises(self):
         """``find_spec`` itself can raise for dotted names whose parent package
@@ -94,7 +97,7 @@ class TestHasModule:
             assert _has_module("fake_parent.child") is False
 
     def test_result_is_cached(self):
-        """Verify the @cache decorator prevents repeated imports."""
+        """Verify the @cache decorator prevents repeated spec lookups."""
         _has_module("json")  # prime the cache
 
         with patch("vllm.utils.import_utils.importlib.util.find_spec") as mock_spec:

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -392,34 +392,10 @@ class LazyLoader(ModuleType):
 # Optional dependency detection utilities
 @cache
 def _has_module(module_name: str) -> bool:
-    """Return True if *module_name* can be imported in the current environment.
-
-    Uses ``importlib.util.find_spec`` as a fast pre-check, then performs a
-    trial import to verify that native dependencies (shared libraries, etc.)
-    are also satisfied. Any failure during the trial import is treated as the
-    module being unavailable. The result is cached so that subsequent queries
-    for the same module incur no additional overhead.
-    """
-    try:
-        if importlib.util.find_spec(module_name) is None:
-            return False
-        importlib.import_module(module_name)
-    except Exception:
-        logger.warning(
-            "Module %s was found but failed to import", module_name, exc_info=True
-        )
-        return False
-    return True
-
-
-@cache
-def _has_module_spec(module_name: str) -> bool:
     """Return True if *module_name* is installed, without importing it.
 
-    Unlike [`_has_module`][vllm.utils.import_utils._has_module], this only
-    resolves the import spec. It therefore does not pay the import cost of
-    heavyweight modules, at the price of not verifying that native
-    dependencies (shared libraries, etc.) are satisfied. The result is cached.
+    This only resolves the import spec. Import errors from missing native
+    dependencies are raised when the module is actually used.
     """
     try:
         return importlib.util.find_spec(module_name) is not None
@@ -525,7 +501,7 @@ def has_tilelang() -> bool:
     callers must import it lazily at their point of use rather than relying
     on this function to have imported it already.
     """
-    if not _has_module_spec("tilelang"):
+    if not _has_module("tilelang"):
         return False
     # ROCm-only guard, imported lazily to avoid loading rocm on CUDA.
     from vllm.platforms import current_platform


### PR DESCRIPTION
## Purpose

Fixes #51162.

Optional module discovery was importing packages just to see whether they were available. This switches the shared check to find_spec, so discovery stays side-effect-free and an installed but broken package reports its real import error only when that package is actually used. It also removes the extra spec-only helper previously used by TileLang.

This is separate from #51159: that PR is already merged and explicitly left this shared cleanup as a follow-up.

Claude was used to help inspect the call sites and draft the regression tests. I reviewed every changed line.

## Test Plan

- Verify that discovering an available module does not call importlib.import_module.
- Verify that a real module whose top-level code raises is discoverable without executing it or adding it to sys.modules.
- Keep the existing coverage for missing modules, find_spec errors, and cached lookups.

## Test Result

- Isolated execution of the actual _has_module implementation with a side-effecting temporary module: passed.
- .venv/bin/python -m py_compile tests/utils_/test_import_utils.py vllm/utils/import_utils.py: passed.
- Pre-commit hooks for Ruff check, Ruff format, typos, and SPDX headers: passed.
- The focused pytest file could not be collected locally because the minimal environment does not include torch; the added regression tests are included for CI.