### PR TITLE
[Bugfix] Remove race in fused groupwise RMSNorm quantization

### DIFF
--- a/csrc/libtorch_stable/quantization/fused_kernels/layernorm_utils.cuh
+++ b/csrc/libtorch_stable/quantization/fused_kernels/layernorm_utils.cuh
@@ -47,27 +47,13 @@ __device__ void compute_rms(float* rms, scalar_t const* __restrict__ input,
   *rms = s_rms;
 }
 
-__device__ float warpReduceMaxSpecialized(volatile float* val, int64_t tid,
-                                          int64_t thread_in_warp,
-                                          int64_t reduced_elems) {
+__device__ float warpReduceMax(float val) {
   static_assert(WARP_SIZE == 32 || WARP_SIZE == 64);
-  if constexpr (WARP_SIZE == 64) {
-    if (thread_in_warp + 64 < reduced_elems)
-      val[tid] = fmaxf(val[tid], val[tid + 64]);
+#pragma unroll
+  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+    val = fmaxf(val, VLLM_SHFL_DOWN_SYNC(val, offset));
   }
-  if (thread_in_warp + 32 < reduced_elems)
-    val[tid] = fmaxf(val[tid], val[tid + 32]);
-  if (thread_in_warp + 16 < reduced_elems)
-    val[tid] = fmaxf(val[tid], val[tid + 16]);
-  if (thread_in_warp + 8 < reduced_elems)
-    val[tid] = fmaxf(val[tid], val[tid + 8]);
-  if (thread_in_warp + 4 < reduced_elems)
-    val[tid] = fmaxf(val[tid], val[tid + 4]);
-  if (thread_in_warp + 2 < reduced_elems)
-    val[tid] = fmaxf(val[tid], val[tid + 2]);
-  if (thread_in_warp + 1 < reduced_elems)
-    val[tid] = fmaxf(val[tid], val[tid + 1]);
-  return val[tid];
+  return val;
 }
 
 template <typename scalar_t, typename scalar_out_t, bool has_residual = false,
@@ -115,16 +101,15 @@ __device__ void compute_dynamic_per_token_scales(
     for (auto i = 0; i < groups_per_warp; ++i) {
       int64_t const group_id = i * num_warps + warp_id;
       if (group_id < num_groups) {
-        int64_t warp_start = group_id * threads_per_group;
-        int64_t const start = warp_start + thread_in_warp;
-        int64_t const warp_end = min(warp_start + threads_per_group,
-                                     static_cast<int64_t>(hidden_size));
-        for (auto j = start; j + warp_size < warp_end; j += warp_size) {
-          s_max_vals[start] =
-              fmaxf(s_max_vals[start], s_max_vals[j + warp_size]);
+        int64_t const warp_start = group_id * threads_per_group;
+        float warp_max = 0.0f;
+        for (auto j = thread_in_warp; j < threads_per_group; j += warp_size) {
+          warp_max = fmaxf(warp_max, s_max_vals[warp_start + j]);
         }
-        warpReduceMaxSpecialized(s_max_vals, start, thread_in_warp,
-                                 min(warp_end - warp_start, warp_size));
+        warp_max = warpReduceMax(warp_max);
+        if (thread_in_warp == 0) {
+          s_max_vals[warp_start] = warp_max;
+        }
       }
     }
     __syncthreads();
@@ -375,16 +360,15 @@ __device__ void compute_dynamic_per_token_scales(
     for (auto i = 0; i < groups_per_warp; ++i) {
       int64_t const group_id = i * num_warps + warp_id;
       if (group_id < num_groups) {
-        int64_t warp_start = group_id * threads_per_group;
-        int64_t const start = warp_start + thread_in_warp;
-        int64_t const warp_end = min(warp_start + threads_per_group,
-                                     static_cast<int64_t>(hidden_size));
-        for (auto j = start; j + warp_size < warp_end; j += warp_size) {
-          s_max_vals[start] =
-              fmaxf(s_max_vals[start], s_max_vals[j + warp_size]);
+        int64_t const warp_start = group_id * threads_per_group;
+        float warp_max = 0.0f;
+        for (auto j = thread_in_warp; j < threads_per_group; j += warp_size) {
+          warp_max = fmaxf(warp_max, s_max_vals[warp_start + j]);
         }
-        warpReduceMaxSpecialized(s_max_vals, start, thread_in_warp,
-                                 min(warp_end - warp_start, warp_size));
+        warp_max = warpReduceMax(warp_max);
+        if (thread_in_warp == 0) {
+          s_max_vals[warp_start] = warp_max;
+        }
       }
     }
     __syncthreads();

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -330,6 +330,12 @@ def test_rms_norm(
         and dtype == torch.bfloat16
         and quant_dtype == current_platform.fp8_dtype()
     )
+    allow_cuda_fp8_rounding_outliers = (
+        current_platform.is_cuda()
+        and group_size is None
+        and dtype == torch.bfloat16
+        and quant_dtype == current_platform.fp8_dtype()
+    )
 
     def scales_close(rtol: float, atol: float) -> bool:
         if torch.allclose(ref_scales, ops_scales, rtol=rtol, atol=atol):
@@ -358,8 +364,15 @@ def test_rms_norm(
                 # Valid gfx950 reduction trees can straddle an E4M3 boundary.
                 ok = fp8_allclose(ops_out, ref_out, rtol=0.125, atol=2e-3)
                 ok = ok and int(fp8_ulp_distance(ops_out, ref_out).max()) <= 1
+            elif allow_cuda_fp8_rounding_outliers:
+                # A valid BF16 reduction can cross an E4M3 boundary for
+                # isolated values.
+                ulp = fp8_ulp_distance(ref_out, ops_out)
+                max_outliers = ulp.numel() // 100_000 + 8
+                ok = int(ulp.max()) <= 1
+                ok = ok and int((ulp > 0).sum().item()) <= max_outliers
             else:
-                # CUDA (& non-bf16): compare dequantized values with relaxed tolerance.
+                # Compare dequantized values with relaxed tolerance.
                 if group_size is None:
                     a_deq = a * ref_scales.view(-1, 1)
                     b_deq = b * ops_scales.view(-1, 1)


### PR DESCRIPTION
## Purpose

Fix three flaky fused quantized RMSNorm failures observed in the H200 kernel CI job:
https://buildkite.com/vllm/ci/builds/85850#01a04456-3602-4e62-b405-0c986c85cdc3

The two group-64 scale failures were caused by a real shared-memory race in `warpReduceMaxSpecialized`. Each reduction stage read values written by other lanes in the preceding stage without synchronization. CUDA racecheck reported thousands of hazards for the failing specialization.

Replace that reduction with a register-based warp shuffle and write only the final lane-0 result back to shared memory. This supports both CUDA warp-32 and ROCm wave-32/wave-64 paths and also handles groups with more or fewer contributors than the warp width.

The remaining CUDA BF16 per-token FP8 case had bit-identical scales and one isolated output differing by exactly one E4M3 ULP out of 2,103,296 values. Keep scale comparison strict, but permit a bounded number of isolated one-ULP output differences for this specific CUDA/BF16/per-token/FP8 configuration.

## Why this is not a duplicate

I searched open PRs for `fused quant layernorm`, `rms_norm_per_block_quant`, and `warpReduceMaxSpecialized`. No open PR addresses this reduction race or the per-token assertion.

The nearest open work is materially different:

- #45770 adds mixed input/weight dtype support.
- #49639 restores the scalar RMSNorm intermediate rounding boundary.
- #37196 refactors older static quantization kernels.

None changes `quantization/fused_kernels/layernorm_utils.cuh` or removes this shared-memory hazard.

## Performance

Direct H200 measurements timed the full fused op with preallocated outputs. Cold-L2 results used explicit L2 flushing; hot results used ten kernels per CUDA graph replay. Builds were alternated new/old/new or old/new/old to control for drift.

| BF16 + residual case | Cold L2, old -> new | Hot CUDA graph, old -> new |
|---|---:|---:|
| 2048x1024, group-64 INT8 | 22.82 -> 19.39 us (**15.0% faster**) | 17.81 -> 14.36 us (**19.3% faster**) |
| 2048x1024, group-64 FP8 | 24.48 -> 20.96 us (**14.4% faster**) | 19.68 -> 16.16 us (**17.9% faster**) |
| 2048x1024, group-128 FP8 | 22.50 -> 20.03 us (**11.0% faster**) | 17.67 -> 15.16 us (**14.2% faster**) |
| 1x1024, group-64 FP8 | 7.84 -> 7.84 us (no change) | 4.13 -> 4.01 us (**2.9% faster**) |
| 1x5120, group-64 FP8 | 12.45 -> 12.03 us (**3.3% faster**) | 7.77 -> 7.28 us (**6.3% faster**) |
| 1x5120, group-128 FP8 | 11.74 -> 11.52 us (**1.9% faster**) | 7.05 -> 6.77 us (**4.0% faster**) |

CUPTI Python was unavailable locally, so the FlashInfer benchmark helper used its CUDA-event/CUDA-graph fallback.

## Model evaluation

A seeded two-layer `Qwen2ForCausalLM` model-output equivalence check replaced all five RMSNorm outputs with FP8 group quantize/dequantize results and compared the unfused reference against this fused kernel over an 8x32 token batch:

| Group size | Token logits | Top-1 agreement | Max / mean abs logit diff | Mean cosine | Repeat deterministic |
|---|---:|---:|---:|---:|---:|
| 64 | 256 | 100% | 0 / 0 | 1.0 | yes, bitwise |
| 128 | 256 | 100% | 0 / 0 | 1.0 | yes, bitwise |

## Test plan and results

CUDA incremental build:

```bash
cmake --build --preset release --target install
```

Passed.

Original three failing cases:

```bash
.venv/bin/python -m pytest -q \
  'tests/kernels/core/test_fused_quant_layernorm.py::test_rms_norm[False-cuda:0-0-dtype0-True-2048x1024-int8-group-64-tma-0-scale-ub-False]' \
  'tests/kernels/core/test_fused_quant_layernorm.py::test_rms_norm[False-cuda:0-0-dtype0-True-2048x1024-float8_e4m3fn-group-64-tma-0-scale-ub-False]' \
  'tests/kernels/core/test_fused_quant_layernorm.py::test_rms_norm[True-cuda:0-0-dtype0-True-2048x1027-float8_e4m3fn-per-token-tma-0-scale-ub-False]'
```

Result: `3 passed, 14 warnings`.

Additional correctness coverage:

- FP8 group-64 at 1x5120: passed.
- INT8 group-128 at 1x5120: passed.
- 100 repeated 2048x1024 group-64 scale comparisons across INT8 and FP8: all bitwise deterministic.

CUDA racecheck covered both the original group-64 specialization and wider group-64/group-128 configurations:

```text
RACECHECK SUMMARY: 0 hazards displayed (0 errors, 0 warnings)
```

Before this change, the original specialization reported four warning classes and thousands of hazards.

Applicable repository hooks:

```bash
.venv/bin/pre-commit run --files \
  csrc/libtorch_stable/quantization/fused_kernels/layernorm_utils.cuh \
  tests/kernels/core/test_fused_quant_layernorm.py
```

All passed.

## AI assistance

OpenAI Codex assisted with diagnosis, implementation, racecheck analysis, benchmarking, model-output evaluation, test execution, and drafting this description. I reviewed every changed line and verified the commands and results above.
