### PR TITLE
[ROCm][DSV4][Perf] Keep C4 decode metadata dense on gfx950

### DIFF
--- a/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
+++ b/tests/kernels/attention/test_rocm_triton_attn_dsv4.py
@@ -64,15 +64,40 @@ def _ref_global_topk_ragged(
     indptr = torch.zeros(lens.shape[0] + 1, dtype=torch.int32, device=topk.device)
     torch.cumsum(lens, dim=0, out=indptr[1:])
 
-    safe_topk = torch.clamp(topk, min=0)
+    safe_topk = torch.where(valid, torch.clamp(topk, min=0), 0)
     block_indices = safe_topk // block_size
     block_offsets = safe_topk % block_size
-    req_indices = token_to_req_indices[:, None].expand_as(topk)
+    safe_req_indices = torch.where(
+        is_valid_token, token_to_req_indices, torch.zeros_like(token_to_req_indices)
+    )
+    req_indices = safe_req_indices[:, None].expand_as(topk)
     slot_ids = block_table[req_indices, block_indices] * block_size + block_offsets
 
     offsets = torch.arange(topk.shape[1], dtype=torch.int32, device=topk.device)
     positions = indptr[:-1, None] + offsets[None, :]
     return slot_ids[valid], positions[valid].to(torch.long), indptr, lens
+
+
+def _ref_global_topk_dense(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    topk = topk_indices.reshape(topk_indices.shape[0], -1)
+    valid = (topk >= 0) & is_valid_token[:, None]
+    lens = valid.sum(dim=1, dtype=torch.int32)
+
+    safe_topk = torch.where(valid, torch.clamp(topk, min=0), 0)
+    block_indices = safe_topk // block_size
+    block_offsets = safe_topk % block_size
+    safe_req_indices = torch.where(
+        is_valid_token, token_to_req_indices, torch.zeros_like(token_to_req_indices)
+    )
+    req_indices = safe_req_indices[:, None].expand_as(topk)
+    slot_ids = block_table[req_indices, block_indices] * block_size + block_offsets
+    return torch.where(valid, slot_ids, -1).view_as(topk_indices), lens
 
 
 def _ref_sparse_prefill_ragged(
@@ -244,6 +269,18 @@ def _ragged_from_rows(
     )
 
 
+def _dense_from_rows(
+    rows: list[list[int]], width: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    indices = torch.full((len(rows), width), -1, dtype=torch.int32, device=device)
+    for row_idx, row in enumerate(rows):
+        indices[row_idx, : len(row)] = torch.tensor(
+            row, dtype=torch.int32, device=device
+        )
+    lengths = torch.tensor([len(row) for row in rows], dtype=torch.int32, device=device)
+    return indices, lengths
+
+
 def _launch_sparse_decode_reduce(
     part_m: torch.Tensor,
     part_l: torch.Tensor,
@@ -357,13 +394,13 @@ def test_compute_global_topk_ragged_indices_and_indptr() -> None:
     topk_indices = torch.tensor(
         [
             [0, 3, 4, -1],
-            [5, 8, -1, -1],
+            [torch.iinfo(torch.int32).max, 8, -1, -1],
             [2, 7, 9, -1],
         ],
         dtype=torch.int32,
         device=device,
     )
-    token_to_req_indices = torch.tensor([0, 1, 1], dtype=torch.int32, device=device)
+    token_to_req_indices = torch.tensor([0, -123, 1], dtype=torch.int32, device=device)
     block_table = torch.tensor(
         [
             [10, 11, 12],
@@ -395,6 +432,53 @@ def test_compute_global_topk_ragged_indices_and_indptr() -> None:
 
     torch.testing.assert_close(actual_ragged[expected_positions], expected_values)
     torch.testing.assert_close(actual_indptr, expected_indptr)
+    torch.testing.assert_close(actual_lens, expected_lens)
+
+
+@torch.inference_mode()
+def test_compute_global_topk_dense_indices_and_lens() -> None:
+    from vllm.models.deepseek_v4.common.ops import (
+        compute_global_topk_indices_and_lens,
+    )
+
+    device = torch.device("cuda")
+    block_size = 4
+    topk_indices = torch.tensor(
+        [
+            [0, 3, 4, -1],
+            [torch.iinfo(torch.int32).max, 8, -1, -1],
+            [2, 7, 9, -1],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    token_to_req_indices = torch.tensor([0, -123, 1], dtype=torch.int32, device=device)
+    block_table = torch.tensor(
+        [
+            [10, 11, 12],
+            [20, 21, 22],
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    is_valid_token = torch.tensor([True, False, True], dtype=torch.bool, device=device)
+
+    actual_indices, actual_lens = compute_global_topk_indices_and_lens(
+        topk_indices,
+        token_to_req_indices,
+        block_table,
+        block_size,
+        is_valid_token,
+    )
+    expected_indices, expected_lens = _ref_global_topk_dense(
+        topk_indices,
+        token_to_req_indices,
+        block_table,
+        block_size,
+        is_valid_token,
+    )
+
+    torch.testing.assert_close(actual_indices, expected_indices)
     torch.testing.assert_close(actual_lens, expected_lens)
 
 
@@ -727,6 +811,80 @@ def test_sparse_attn_decode_split_k_kernel(
 
 
 @requires_gfx950
+@pytest.mark.parametrize("num_heads", [8, 16, 32])
+@torch.inference_mode()
+def test_sparse_attn_decode_gfx950_dense_extra_skips_ragged_pack(
+    monkeypatch, num_heads: int
+) -> None:
+    from vllm.v1.attention.ops import rocm_aiter_mla_sparse as mod
+
+    device = torch.device("cuda")
+    torch.manual_seed(11)
+    block_size = 4
+    extra_lengths_list = [0, 1, 31, 32, 33, 63, 64, 65]
+    extra_rows = [list(range(length)) for length in extra_lengths_list]
+    stored_extra_rows = [*extra_rows, list(range(65)), list(range(65))]
+    expected_extra_rows = [*extra_rows, [], list(range(65))]
+    num_queries = len(stored_extra_rows)
+    q = (
+        torch.randn(
+            num_queries, num_heads, HEAD_DIM, dtype=torch.bfloat16, device=device
+        )
+        * 0.125
+    )
+    main_cache = torch.zeros(1, block_size, 584, dtype=torch.uint8, device=device)
+    main_ragged_indices = torch.empty(0, dtype=torch.int32, device=device)
+    main_ragged_indptr = torch.zeros(num_queries + 1, dtype=torch.int32, device=device)
+    extra_cache = _pack_fp8_ds_mla_cache(
+        torch.randn(65, HEAD_DIM, dtype=torch.bfloat16, device=device) * 0.125,
+        block_size,
+        use_fnuz=False,
+    )
+    extra_indices, extra_lengths = _dense_from_rows(stored_extra_rows, 1024, device)
+    extra_lengths[-2] = -7
+    extra_lengths[-1] = 2048
+    out = torch.empty_like(q)
+
+    monkeypatch.setattr(mod, "_decode_gfx950_num_splits", lambda *args: 4)
+    monkeypatch.setattr(
+        mod,
+        "build_ragged_indices_from_dense",
+        lambda *args, **kwargs: pytest.fail("dense extra metadata was repacked"),
+    )
+    actual = mod._rocm_sparse_attn_decode_triton(
+        q=q,
+        main_cache=main_cache,
+        main_indices=torch.empty(num_queries, 0, dtype=torch.int32, device=device),
+        main_lengths=torch.zeros(num_queries, dtype=torch.int32, device=device),
+        main_ragged_indices=main_ragged_indices,
+        main_ragged_indptr=main_ragged_indptr,
+        scale=HEAD_DIM**-0.5,
+        attn_sink=None,
+        nope_head_dim=NOPE_HEAD_DIM,
+        rope_head_dim=ROPE_HEAD_DIM,
+        extra_cache=extra_cache,
+        extra_indices=extra_indices,
+        extra_lengths=extra_lengths,
+        use_dense_extra_metadata=True,
+        out=out,
+        extra_cache_nan_free=True,
+    )
+    expected = _ref_sparse_decode_ragged(
+        q=q,
+        main_cache=main_cache,
+        main_rows=[[] for _ in range(num_queries)],
+        scale=HEAD_DIM**-0.5,
+        attn_sink=None,
+        block_size=block_size,
+        extra_cache=extra_cache,
+        extra_rows=expected_extra_rows,
+    )
+
+    assert actual.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
+@requires_gfx950
 @torch.inference_mode()
 def test_sparse_attn_decode_gfx950_adaptive_reduce_ignores_stale_scratch() -> None:
     device = torch.device("cuda")
@@ -821,8 +979,9 @@ def test_sparse_attn_decode_gfx950_outer64_boundaries(
 
 
 @requires_gfx950
+@pytest.mark.parametrize("extra_dense", [False, True])
 @torch.inference_mode()
-def test_sparse_attn_decode_gfx950_graph_replay(monkeypatch) -> None:
+def test_sparse_attn_decode_gfx950_graph_replay(monkeypatch, extra_dense: bool) -> None:
     from vllm.v1.attention.ops import rocm_aiter_mla_sparse as mod
 
     device = torch.device("cuda")
@@ -866,16 +1025,20 @@ def test_sparse_attn_decode_gfx950_graph_replay(monkeypatch) -> None:
     ]
     main_indices, main_indptr = _ragged_from_rows(main_rows, device)
     short_extra_rows = [row[:64] for row in extra_rows]
-    long_indices, long_indptr = _ragged_from_rows(extra_rows, device)
-    short_indices, short_indptr = _ragged_from_rows(short_extra_rows, device)
-    extra_indices = torch.full(
-        (num_queries * max_extra_per_query,),
-        -1,
-        dtype=torch.int32,
-        device=device,
-    )
-    extra_indices[: long_indices.numel()].copy_(long_indices)
-    extra_indptr = long_indptr.clone()
+    if extra_dense:
+        extra_indices, extra_offsets = _dense_from_rows(
+            extra_rows, max_extra_per_query, device
+        )
+    else:
+        long_indices, long_indptr = _ragged_from_rows(extra_rows, device)
+        extra_indices = torch.full(
+            (num_queries * max_extra_per_query,),
+            -1,
+            dtype=torch.int32,
+            device=device,
+        )
+        extra_indices[: long_indices.numel()].copy_(long_indices)
+        extra_offsets = long_indptr.clone()
     extra_indices_ptr = extra_indices.data_ptr()
     attn_sink = torch.linspace(-0.1, 0.1, num_heads, dtype=torch.float32, device=device)
     out = torch.empty_like(q)
@@ -894,7 +1057,8 @@ def test_sparse_attn_decode_gfx950_graph_replay(monkeypatch) -> None:
             rope_head_dim=ROPE_HEAD_DIM,
             extra_cache=extra_cache,
             extra_indices=extra_indices,
-            extra_indptr=extra_indptr,
+            extra_indptr=None if extra_dense else extra_offsets,
+            extra_dense_lengths=extra_offsets if extra_dense else None,
             out=out,
             extra_cache_nan_free=True,
             adaptive_splits=True,
@@ -919,8 +1083,18 @@ def test_sparse_attn_decode_gfx950_graph_replay(monkeypatch) -> None:
     )
     torch.testing.assert_close(captured_long, expected_long, atol=2e-2, rtol=2e-2)
 
-    extra_indices[: short_indices.numel()].copy_(short_indices)
-    extra_indptr.copy_(short_indptr)
+    if extra_dense:
+        extra_offsets.copy_(
+            torch.tensor(
+                [len(row) for row in short_extra_rows],
+                dtype=torch.int32,
+                device=device,
+            )
+        )
+    else:
+        short_indices, short_indptr = _ragged_from_rows(short_extra_rows, device)
+        extra_indices[: short_indices.numel()].copy_(short_indices)
+        extra_offsets.copy_(short_indptr)
     graph.replay()
     torch.accelerator.synchronize()
     short_out = out.clone()
@@ -941,8 +1115,17 @@ def test_sparse_attn_decode_gfx950_graph_replay(monkeypatch) -> None:
     assert not torch.equal(short_out, captured_long)
     torch.testing.assert_close(short_out, expected_short, atol=2e-2, rtol=2e-2)
 
-    extra_indices[: long_indices.numel()].copy_(long_indices)
-    extra_indptr.copy_(long_indptr)
+    if extra_dense:
+        extra_offsets.copy_(
+            torch.tensor(
+                [len(row) for row in extra_rows],
+                dtype=torch.int32,
+                device=device,
+            )
+        )
+    else:
+        extra_indices[: long_indices.numel()].copy_(long_indices)
+        extra_offsets.copy_(long_indptr)
     graph.replay()
     torch.accelerator.synchronize()
     torch.testing.assert_close(out, expected_long, atol=2e-2, rtol=2e-2)

--- a/vllm/models/deepseek_v4/amd/rocm.py
+++ b/vllm/models/deepseek_v4/amd/rocm.py
@@ -14,7 +14,10 @@ from vllm.distributed import (
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
-from vllm.models.deepseek_v4.common.ops import dequantize_and_gather_k_cache
+from vllm.models.deepseek_v4.common.ops import (
+    compute_global_topk_indices_and_lens,
+    dequantize_and_gather_k_cache,
+)
 from vllm.models.deepseek_v4.sparse_mla import (
     DeepseekV4FlashMLAMetadata,
     DeepseekV4SparseMLABackend,
@@ -831,6 +834,7 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
         topk_lens = None
         topk_ragged_indices = None
         topk_ragged_indptr = None
+        use_dense_topk_metadata = False
         if not swa_only:
             assert attn_metadata is not None
             assert swa_metadata.is_valid_token is not None
@@ -838,17 +842,27 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
             is_valid = swa_metadata.is_valid_token[:num_decode_tokens]
             if self.compress_ratio == 4:
                 assert self.topk_indices_buffer is not None
-                (
-                    topk_ragged_indices,
-                    topk_ragged_indptr,
-                    topk_lens,
-                ) = compute_global_topk_ragged_indices_and_indptr(
-                    self.topk_indices_buffer[:num_decode_tokens],
-                    swa_metadata.token_to_req_indices,
-                    attn_metadata.block_table[:num_decodes],
-                    block_size,
-                    is_valid,
-                )
+                if _ON_GFX950:
+                    topk_indices, topk_lens = compute_global_topk_indices_and_lens(
+                        self.topk_indices_buffer[:num_decode_tokens],
+                        swa_metadata.token_to_req_indices,
+                        attn_metadata.block_table[:num_decodes],
+                        block_size,
+                        is_valid,
+                    )
+                    use_dense_topk_metadata = True
+                else:
+                    (
+                        topk_ragged_indices,
+                        topk_ragged_indptr,
+                        topk_lens,
+                    ) = compute_global_topk_ragged_indices_and_indptr(
+                        self.topk_indices_buffer[:num_decode_tokens],
+                        swa_metadata.token_to_req_indices,
+                        attn_metadata.block_table[:num_decodes],
+                        block_size,
+                        is_valid,
+                    )
             else:
                 topk_indices = attn_metadata.c128a_global_decode_topk_indices
                 topk_lens = attn_metadata.c128a_decode_topk_lens
@@ -875,6 +889,7 @@ class DeepseekV4ROCMAiterMLAAttention(DeepseekV4Attention):
             rope_head_dim=self.rope_head_dim,
             output=output,
             adaptive_splits=adaptive_splits,
+            use_dense_topk_metadata=use_dense_topk_metadata,
             extra_cache_nan_free=_trust_dsv4_extra_cache_nan_free(
                 self.kv_cache_dtype,
                 self._has_kv_transfer,

--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -495,7 +495,7 @@ def _compute_global_topk_indices_and_lens_kernel(
             mask=mask,
             other=-1,
         )
-        is_valid = local_idx >= 0
+        is_valid = (local_idx >= 0) & is_valid_token
 
         block_indices = local_idx // block_size
         block_numbers = tl.load(
@@ -513,8 +513,7 @@ def _compute_global_topk_indices_and_lens_kernel(
         )
         count += tl.sum(is_valid.to(tl.int32), axis=0)
 
-    # Zero out length for padding tokens.
-    tl.store(topk_lens_ptr + token_idx, tl.where(is_valid_token, count, 0))
+    tl.store(topk_lens_ptr + token_idx, count)
 
 
 # FlashMLA sparse prefill asserts `params.topk % B_TOPK == 0` (see

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -2132,7 +2132,7 @@ def _sparse_attn_decode_gfx950_partial_kernel(
     main_indptr_ptr,
     extra_cache_ptr,
     extra_indices_ptr,
-    extra_indptr_ptr,
+    extra_offsets_ptr,
     part_m_ptr,
     part_l_ptr,
     part_acc_ptr,
@@ -2140,6 +2140,8 @@ def _sparse_attn_decode_gfx950_partial_kernel(
     q_stride1: tl.constexpr,
     main_cache_stride0: tl.constexpr,
     extra_cache_stride0: tl.constexpr,
+    extra_indices_stride: tl.constexpr,
+    extra_indices_width: tl.constexpr,
     main_num_rows,
     extra_num_rows,
     MAIN_BLOCK_SIZE: tl.constexpr,
@@ -2147,6 +2149,7 @@ def _sparse_attn_decode_gfx950_partial_kernel(
     scale: tl.constexpr,
     num_heads: tl.constexpr,
     HAS_EXTRA: tl.constexpr,
+    EXTRA_DENSE: tl.constexpr,
     NOPE_DIM: tl.constexpr,
     ROPE_DIM: tl.constexpr,
     IS_FNUZ_MAIN: tl.constexpr,
@@ -2178,9 +2181,14 @@ def _sparse_attn_decode_gfx950_partial_kernel(
         main_end = tl.load(main_indptr_ptr + query_idx + 1)
         main_len = main_end - main_start
         if HAS_EXTRA:
-            extra_start = tl.load(extra_indptr_ptr + query_idx)
-            extra_end = tl.load(extra_indptr_ptr + query_idx + 1)
-            extra_len = extra_end - extra_start
+            if EXTRA_DENSE:
+                extra_start = query_idx * extra_indices_stride
+                extra_len = tl.load(extra_offsets_ptr + query_idx)
+                extra_len = tl.maximum(0, tl.minimum(extra_len, extra_indices_width))
+            else:
+                extra_start = tl.load(extra_offsets_ptr + query_idx)
+                extra_end = tl.load(extra_offsets_ptr + query_idx + 1)
+                extra_len = extra_end - extra_start
         else:
             extra_start = 0
             extra_len = 0
@@ -2279,9 +2287,14 @@ def _sparse_attn_decode_gfx950_partial_kernel(
 
     if HAS_EXTRA:
         if not ADAPTIVE_SPLITS:
-            extra_start = tl.load(extra_indptr_ptr + query_idx)
-            extra_end = tl.load(extra_indptr_ptr + query_idx + 1)
-            extra_len = extra_end - extra_start
+            if EXTRA_DENSE:
+                extra_start = query_idx * extra_indices_stride
+                extra_len = tl.load(extra_offsets_ptr + query_idx)
+                extra_len = tl.maximum(0, tl.minimum(extra_len, extra_indices_width))
+            else:
+                extra_start = tl.load(extra_offsets_ptr + query_idx)
+                extra_end = tl.load(extra_offsets_ptr + query_idx + 1)
+                extra_len = extra_end - extra_start
         extra_chunk = (extra_len + work_splits - 1) // work_splits
         extra_lo = split_id * extra_chunk
         extra_hi = tl.minimum(extra_lo + extra_chunk, extra_len)
@@ -2792,6 +2805,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
     extra_cache: torch.Tensor | None = None,
     extra_indices: torch.Tensor | None = None,
     extra_indptr: torch.Tensor | None = None,
+    extra_dense_lengths: torch.Tensor | None = None,
     out: torch.Tensor | None = None,
     extra_cache_nan_free: bool = False,
     adaptive_splits: bool = False,
@@ -2830,10 +2844,23 @@ def _rocm_sparse_attn_decode_ragged_triton(
         "_rocm_sparse_attn_decode_ragged_triton",
     )
 
+    has_dense_extra_metadata = extra_dense_lengths is not None
+    if has_dense_extra_metadata:
+        assert _ON_GFX950, "dense extra metadata is only supported on gfx950"
+        assert extra_cache is not None and extra_indices is not None, (
+            "dense extra metadata requires extra_cache and extra_indices"
+        )
+        assert extra_indptr is None, (
+            "dense extra metadata cannot also provide a ragged indptr"
+        )
+    elif any(value is not None for value in (extra_cache, extra_indices, extra_indptr)):
+        assert all(
+            value is not None for value in (extra_cache, extra_indices, extra_indptr)
+        ), "ragged extra metadata requires cache, indices, and indptr"
     has_extra = (
         extra_cache is not None
         and extra_indices is not None
-        and extra_indptr is not None
+        and (has_dense_extra_metadata or extra_indptr is not None)
     )
     assert not extra_cache_nan_free or (_ON_GFX950 and has_extra), (
         "extra_cache_nan_free requires a gfx950 compressed cache with trusted "
@@ -2842,22 +2869,49 @@ def _rocm_sparse_attn_decode_ragged_triton(
     if has_extra:
         assert extra_cache is not None
         assert extra_indices is not None
-        assert extra_indptr is not None
-        assert extra_indices.ndim == 1, (
-            f"expected extra_indices=[nnz], got {extra_indices.shape}"
-        )
-        assert extra_indptr.ndim == 1, (
-            f"expected extra_indptr=[b+1], got {extra_indptr.shape}"
-        )
-        extra_indices = _as_int32_contiguous_1d(extra_indices)
-        extra_indptr = _as_int32_contiguous_1d(extra_indptr)
-        assert extra_indptr.numel() == num_queries + 1, (
-            f"expected extra_indptr shape [{num_queries + 1}], got {extra_indptr.shape}"
-        )
+        if has_dense_extra_metadata:
+            assert extra_dense_lengths is not None
+            assert extra_indices.ndim == 2 and extra_indices.shape[0] == num_queries, (
+                f"expected dense extra_indices=[b,width], got {extra_indices.shape}"
+            )
+            assert (
+                extra_indices.dtype == torch.int32 and extra_indices.is_contiguous()
+            ), "dense extra_indices must be contiguous int32 metadata"
+            assert (
+                extra_dense_lengths.dtype == torch.int32
+                and extra_dense_lengths.ndim == 1
+                and extra_dense_lengths.is_contiguous()
+                and extra_dense_lengths.numel() == num_queries
+            ), (
+                "dense extra lengths must be a contiguous int32 vector with "
+                f"{num_queries} entries, got {extra_dense_lengths.shape}"
+            )
+            extra_offsets = extra_dense_lengths
+            extra_indices_stride = extra_indices.stride(0)
+            extra_indices_width = extra_indices.shape[1]
+        else:
+            assert extra_indptr is not None
+            assert extra_indices.ndim == 1, (
+                f"expected extra_indices=[nnz], got {extra_indices.shape}"
+            )
+            assert extra_indptr.ndim == 1, (
+                f"expected extra_indptr=[b+1], got {extra_indptr.shape}"
+            )
+            extra_indices = _as_int32_contiguous_1d(extra_indices)
+            extra_indptr = _as_int32_contiguous_1d(extra_indptr)
+            assert extra_indptr.numel() == num_queries + 1, (
+                "expected extra_indptr shape "
+                f"[{num_queries + 1}], got {extra_indptr.shape}"
+            )
+            extra_offsets = extra_indptr
+            extra_indices_stride = 0
+            extra_indices_width = 0
     else:
         extra_cache = main_cache
         extra_indices = torch.empty(0, device=q.device, dtype=torch.int32)
-        extra_indptr = torch.zeros(num_queries + 1, device=q.device, dtype=torch.int32)
+        extra_offsets = torch.zeros(num_queries + 1, device=q.device, dtype=torch.int32)
+        extra_indices_stride = 0
+        extra_indices_width = 0
 
     block_h = 16
     if out is None:
@@ -2884,7 +2938,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
             main_indptr,
             extra_cache,
             extra_indices,
-            extra_indptr,
+            extra_offsets,
             attn_sink,
             out,
             q.stride(0),
@@ -2964,7 +3018,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
             main_indptr,
             extra_cache,
             extra_indices,
-            extra_indptr,
+            extra_offsets,
             part_m,
             part_l,
             part_acc,
@@ -2972,6 +3026,8 @@ def _rocm_sparse_attn_decode_ragged_triton(
             q.stride(1),
             main_cache.stride(0),
             extra_cache.stride(0),
+            extra_indices_stride,
+            extra_indices_width,
             main_cache.shape[0] * main_cache.shape[1],
             extra_cache.shape[0] * extra_cache.shape[1],
             main_cache.shape[1],
@@ -2979,6 +3035,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
             scale,
             num_heads,
             HAS_EXTRA=has_extra,
+            EXTRA_DENSE=has_dense_extra_metadata,
             NOPE_DIM=nope_head_dim,
             ROPE_DIM=rope_head_dim,
             IS_FNUZ_MAIN=is_fnuz,
@@ -3001,7 +3058,7 @@ def _rocm_sparse_attn_decode_ragged_triton(
             main_indptr,
             extra_cache,
             extra_indices,
-            extra_indptr,
+            extra_offsets,
             part_m,
             part_l,
             part_acc,
@@ -3081,6 +3138,7 @@ def _rocm_sparse_attn_decode_triton(
     out: torch.Tensor | None = None,
     extra_cache_nan_free: bool = False,
     adaptive_splits: bool = False,
+    use_dense_extra_metadata: bool = False,
 ) -> torch.Tensor:
     if main_ragged_indices is None or main_ragged_indptr is None:
         main_ragged_indices, main_ragged_indptr = build_ragged_indices_from_dense(
@@ -3091,7 +3149,12 @@ def _rocm_sparse_attn_decode_triton(
             num_rows=main_cache.shape[0] * main_cache.shape[1],
         )
 
-    if (
+    if use_dense_extra_metadata:
+        assert _ON_GFX950, "dense extra metadata is only supported on gfx950"
+        assert extra_cache is not None and extra_indices is not None
+        assert extra_lengths is not None
+        assert extra_ragged_indices is None and extra_ragged_indptr is None
+    elif (
         (extra_ragged_indices is None or extra_ragged_indptr is None)
         and extra_cache is not None
         and extra_indices is not None
@@ -3114,8 +3177,11 @@ def _rocm_sparse_attn_decode_triton(
         nope_head_dim=nope_head_dim,
         rope_head_dim=rope_head_dim,
         extra_cache=extra_cache,
-        extra_indices=extra_ragged_indices,
-        extra_indptr=extra_ragged_indptr,
+        extra_indices=(
+            extra_indices if use_dense_extra_metadata else extra_ragged_indices
+        ),
+        extra_indptr=None if use_dense_extra_metadata else extra_ragged_indptr,
+        extra_dense_lengths=extra_lengths if use_dense_extra_metadata else None,
         out=out,
         extra_cache_nan_free=extra_cache_nan_free,
         adaptive_splits=adaptive_splits,
@@ -3192,6 +3258,7 @@ def rocm_sparse_attn_decode(
     output: torch.Tensor,
     extra_cache_nan_free: bool = False,
     adaptive_splits: bool = False,
+    use_dense_topk_metadata: bool = False,
 ) -> None:
     assert swa_k_cache.dtype == torch.uint8, (
         "ROCm Triton sparse decode expects uint8 fp8_ds_mla SWA cache, "
@@ -3203,6 +3270,14 @@ def rocm_sparse_attn_decode(
         rope_head_dim,
         "rocm_sparse_attn_decode",
     )
+    if use_dense_topk_metadata:
+        assert not swa_only, "dense topk metadata requires the compressed cache"
+        assert topk_indices is not None and topk_lens is not None, (
+            "dense topk metadata requires indices and lengths"
+        )
+        assert topk_ragged_indices is None and topk_ragged_indptr is None, (
+            "dense topk metadata cannot also provide ragged metadata"
+        )
 
     main_indices = swa_indices.reshape(swa_indices.shape[0], -1)
 
@@ -3241,6 +3316,7 @@ def rocm_sparse_attn_decode(
         out=direct_out,
         extra_cache_nan_free=extra_cache_nan_free,
         adaptive_splits=adaptive_splits,
+        use_dense_extra_metadata=use_dense_topk_metadata,
     )
     if direct_out is None:
         output.copy_(attn_out.to(output.dtype))


### PR DESCRIPTION
## Summary

Keep DeepSeek-V4 C4 decode top-k metadata dense on gfx950 and let the native
Triton sparse-attention kernel consume the `[batch, topk]` indices plus per-row
lengths directly.

Previously the C4 path mapped local top-k indices to global cache slots, built a
ragged indptr, packed every dense row into a second flat buffer, and then read
that ragged representation in every C4 attention layer. The new gfx950 path
removes that repack. gfx942 and other architectures retain the existing ragged
path.

The shared global-index mapper also now masks padded rows before reading their
request or block-table metadata. This is required because FULL graph padding can
carry sentinel request IDs and top-k values; the safety change is shared by the
existing NVIDIA/XPU callers.

## Scope and C128

This PR intentionally changes C4 decode only. C128 metadata remains ragged.

C128 already exposes dense indices, but its active row width changes with
sequence length while FULL graphs capture fixed shapes and strides. Reusing the
C4 flag naively could capture width 128 and later clamp a longer C128 row during
replay. A safe C128 follow-up needs a graph-stable physical-capacity contract,
row-strided dense input support, and short-capture-to-long-replay coverage.
Also, C128 performs its conversion once per shared metadata build rather than
once per C128 layer, so its expected latency benefit is much smaller.

## Correctness and memory

- Dense and ragged decode outputs are bit-exact in eager and graph replay tests.
- Tests cover 8, 16, and 32 local heads, invalid padded rows, boundary lengths,
  stale dense tails, and long-to-short-to-long graph replay.
- The dense `[B, K]` output replaces the same-capacity flat ragged allocation
  and removes the small `[B + 1]` indptr. It does not increase GPU memory.
- Model serving validation used TP8. Other TP settings are structurally covered
  by the local-head-count unit matrix, but were not run end to end.

## Performance

MI355X/gfx950 graph-replay microbenchmark, 51 interleaved samples after warmup:

| Decode rows | Integrated speedup | Saved per C4 layer | Estimated 30-layer saving |
|---:|---:|---:|---:|
| 1 | 1.271x | 5.888 us | 0.177 ms |
| 4 | 1.261x | 5.800 us | 0.174 ms |
| 8 | 1.259x | 5.632 us | 0.169 ms |
| 16 | 1.269x | 6.196 us | 0.186 ms |

TP8 serving used 8k input / 1k output random requests. The comparator is the
arithmetic mean of two unchanged-code control runs with identical server and
prompt settings; the candidate was a third isolated run.

| Concurrency | Output throughput | Mean TPOT | Mean TTFT | Median TTFT |
|---:|---:|---:|---:|---:|
| 1 | +0.71% | -0.74% | +0.51% | -0.23% |
| 4 | +1.63% | -1.70% | -0.10% | -1.51% |
| 8 | +0.79% | -0.72% | -2.00% | -0.10% |

## Validation

```bash
HIP_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/kernels/attention/test_rocm_triton_attn_dsv4.py -q
# 62 passed

.venv/bin/pre-commit run --files \
  tests/kernels/attention/test_rocm_triton_attn_dsv4.py \
  vllm/models/deepseek_v4/amd/rocm.py \
  vllm/models/deepseek_v4/common/ops/cache_utils.py \
  vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
# passed

git diff --check upstream/main...HEAD
# passed
```

Full GSM8K, 5-shot, deterministic no-thinking generation completed all 1,319
examples:

| Filter | Exact match |
|---|---:|
| strict-match | 0.9553 |
| flexible-extract | 0.9545 |

Equivalent direct server command:

```bash
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_AITER_C4A_TOPK=aiter

vllm serve deepseek-ai/DeepSeek-V4-Pro \
  --port 8888 \
  --tensor-parallel-size 8 \
  --data-parallel-size 1 \
  --max-model-len 9472 \
  --max-num-seqs 512 \
  --max-num-batched-tokens 16384 \
  --async-scheduling \
  --no-enable-prefix-caching \
  --distributed-executor-backend mp \
  --gpu-memory-utilization 0.8 \
  --kv-cache-dtype fp8 \
  --trust-remote-code \
  --moe-backend aiter \
  --tokenizer-mode deepseek_v4 \
  --reasoning-parser deepseek_v4 \
  --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE"}'
```

Equivalent direct serving benchmark command:

```bash
for conc in 1 4 8; do
  vllm bench serve \
    --model deepseek-ai/DeepSeek-V4-Pro \
    --backend vllm \
    --base-url http://127.0.0.1:8888 \
    --endpoint /v1/completions \
    --dataset-name random \
    --random-input-len 8192 \
    --random-output-len 1024 \
    --random-range-ratio 0.8 \
    --num-prompts $((conc * 10)) \
    --max-concurrency "${conc}" \
    --num-warmups $((conc * 2)) \
    --request-rate inf \
    --ignore-eos \
    --percentile-metrics ttft,tpot,itl,e2el \
    --trust-remote-code \
    --save-result
done
```

## Duplicate-work check

No open PR duplicates this change. #41105 is the closest conceptual neighbor,
but it fuses CUDA top-k generation with the page-table transform; it does not
change the ROCm gfx950 sparse-decode consumer or eliminate its post-transform
repack. #51714 adds an optional external AITER/Gluon decode backend and still
expects ragged metadata. #50566, #46172, and #52628 optimize different decode or
metadata stages. #52212 is merged and is the native gfx950 Triton baseline for
this PR.

## AI assistance

OpenAI Codex assisted with investigation, implementation, testing, benchmarking,
review, and drafting. The human submitter directed and reviewed the work and is
responsible for understanding and defending every changed line and for rerunning
the relevant validation before merge.
