### PR TITLE
[Bugfix] Reclaim offload regions left behind by a crashed engine

### DIFF
--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -840,3 +840,75 @@ def test_ftruncate_failure_cleans_up_creator(monkeypatch):
 
     mock_unlink.assert_called_once_with(mmap_path)
     mock_close.assert_called_once_with(9999)
+
+
+# ---------------------------------------------------------------------------
+# Orphan reclamation (gh-53987 / gh-54002)
+# ---------------------------------------------------------------------------
+
+
+def _write_orphan(engine_id: str, size: int = PAGE_SIZE) -> str:
+    """Leave behind a region file the way a hard-killed engine would."""
+    path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+    try:
+        os.ftruncate(fd, size)
+    finally:
+        os.close(fd)
+    return path
+
+
+def test_orphaned_region_is_reclaimed(iid):
+    """A region left by a crashed engine is removed when the next one starts.
+
+    cleanup() unlinks the file on a graceful shutdown, but a SIGKILL or an OOM
+    kill skips it. Where /dev/shm outlives the process the orphan keeps
+    consuming the tmpfs budget, so the next start must reclaim it.
+    """
+    orphan = _write_orphan(f"{iid}-orphan")
+    assert os.path.exists(orphan)
+
+    region = _make_region(iid)
+    try:
+        assert not os.path.exists(orphan)
+    finally:
+        region.cleanup()
+        _cleanup_file(orphan)
+
+
+def test_live_region_is_not_reclaimed(iid):
+    """A region another live engine is using must survive a new engine's start.
+
+    Reclaiming by filename alone would delete it, breaking a second vLLM
+    instance that shares this host's /dev/shm.
+    """
+    live = _make_region(f"{iid}-live")
+    live_path = live.mmap_path
+    try:
+        other = _make_region(f"{iid}-other")
+        try:
+            assert os.path.exists(live_path)
+        finally:
+            other.cleanup()
+    finally:
+        live.cleanup()
+        _cleanup_file(live_path)
+
+
+def test_empty_region_file_is_not_reclaimed(iid):
+    """A zero-length file is a region mid-creation, not an orphan.
+
+    The creator holds O_EXCL before it sizes the file, so an empty file may
+    belong to an engine that is starting right now.
+    """
+    path = f"/dev/shm/vllm_offload_{iid}-starting.mmap"
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+    os.close(fd)
+    try:
+        region = _make_region(iid)
+        try:
+            assert os.path.exists(path)
+        finally:
+            region.cleanup()
+    finally:
+        _cleanup_file(path)

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -912,3 +912,29 @@ def test_empty_region_file_is_not_reclaimed(iid):
             region.cleanup()
     finally:
         _cleanup_file(path)
+
+
+def test_symlink_in_shm_is_not_followed(iid, tmp_path):
+    """A planted symlink must not be opened or removed.
+
+    /dev/shm is world-writable, so a local user can create a name matching the
+    region glob that points somewhere else. Reclamation must refuse to follow
+    it rather than opening an arbitrary file for writing.
+    """
+    target = tmp_path / "victim"
+    target.write_bytes(b"untouched")
+    link = f"/dev/shm/vllm_offload_{iid}-evil.mmap"
+    os.symlink(target, link)
+    try:
+        region = _make_region(iid)
+        try:
+            assert target.exists(), "the symlink target must not be removed"
+            assert target.read_bytes() == b"untouched"
+            # Without O_NOFOLLOW the open() follows the link, the flock
+            # succeeds and the unlink below it removes the planted name --
+            # so a surviving symlink is what shows we never opened it.
+            assert os.path.islink(link), "the planted symlink must be left alone"
+        finally:
+            region.cleanup()
+    finally:
+        _cleanup_file(link)

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -109,7 +109,11 @@ def _reclaim_orphaned_regions(own_path: str) -> None:
         try:
             if os.path.getsize(path) == 0:
                 continue
-            with open(path, "r+b") as f:
+            # /dev/shm is world-writable, so refuse to follow a symlink a
+            # local user may have planted under our glob; O_NOFOLLOW makes
+            # os.open raise ELOOP, which the enclosing handler catches.
+            fd = os.open(path, os.O_RDWR | os.O_NOFOLLOW)
+            with os.fdopen(fd, "r+b") as f:
                 try:
                     fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 except OSError:

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import errno
+import fcntl
+import glob
 import mmap
 import os
 import time
@@ -63,6 +65,62 @@ def _get_populate_write_fn(
     return _madvise_populate_write
 
 
+_MMAP_GLOB = "/dev/shm/vllm_offload_*.mmap"
+
+
+def _hold_shared_lock(fd: int, path: str) -> None:
+    """Mark this region as in use for as long as the process lives.
+
+    The lock is advisory and shared, so every worker of the same engine can
+    hold it at once; the kernel releases it when the process exits, however
+    it exits. ``_reclaim_orphaned_regions`` reads it to tell a live region
+    from an orphan. A filesystem that does not support ``flock`` only costs
+    us that signal, so failure here is logged and ignored.
+    """
+    try:
+        fcntl.flock(fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
+    except OSError:
+        logger.debug("Could not flock %s; orphan reclaim disabled for it", path)
+
+
+def _reclaim_orphaned_regions(own_path: str) -> None:
+    """Remove offload regions left behind by an engine that died hard.
+
+    ``cleanup()`` unlinks the region on a graceful shutdown, but a SIGKILL,
+    an OOM kill or a segfault skips it. Where ``/dev/shm`` outlives the
+    process -- a container restart with a tmpfs-backed ``/dev/shm``, for
+    instance -- the orphan keeps consuming the tmpfs budget, and the next
+    start fails to allocate its own region.
+
+    Every participant holds a shared ``flock`` on its region for as long as
+    it lives, and the kernel drops that lock when the process dies. So an
+    orphan is exactly a region no one can be holding: if this process can
+    take the exclusive lock, nothing else is using the file and it is safe
+    to unlink. That keeps a second engine sharing this host's ``/dev/shm``
+    untouched, which unconditional name-based deletion would not.
+
+    Zero-length files are skipped: a region is empty only between its
+    creator's ``O_EXCL`` create and the ``ftruncate`` that sizes it, so
+    skipping them avoids racing a starting engine.
+    """
+    for path in glob.glob(_MMAP_GLOB):
+        if path == own_path:
+            continue
+        try:
+            if os.path.getsize(path) == 0:
+                continue
+            with open(path, "r+b") as f:
+                try:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError:
+                    continue  # still held: a live engine owns this region
+                os.unlink(path)
+        except OSError:
+            logger.debug("Skipped reclaiming %s", path, exc_info=True)
+        else:
+            logger.info("Reclaimed orphaned mmap file %s", path)
+
+
 class SharedOffloadRegion:
     """
     Single mmap-backed memory region shared across all workers for a
@@ -99,6 +157,8 @@ class SharedOffloadRegion:
             self._worker_offset = rank * cpu_page_size
             # exclusive upper bound for this worker's area within each row
             self._worker_area_end = (rank + 1) * cpu_page_size
+        _reclaim_orphaned_regions(self.mmap_path)
+
         try:
             self.fd: int | None = os.open(
                 self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
@@ -107,6 +167,7 @@ class SharedOffloadRegion:
             # Joiner path — another worker won O_EXCL. Reopen and wait
             # for the file to reach expected size.
             self.fd = os.open(self.mmap_path, os.O_RDWR)
+            _hold_shared_lock(self.fd, self.mmap_path)
             try:
                 _wait_for_file_size(self.fd, self.total_size_bytes)
             except (TimeoutError, OSError):
@@ -119,6 +180,7 @@ class SharedOffloadRegion:
             # land on a 0-byte stub and spin in _wait_for_file_size
             # for the full 30 s timeout.
             try:
+                _hold_shared_lock(self.fd, self.mmap_path)
                 check_shm_free_space(self.total_size_bytes)
                 os.ftruncate(self.fd, self.total_size_bytes)
             except (RuntimeError, OSError):


### PR DESCRIPTION
## Summary

`SharedOffloadRegion.cleanup()` unlinks `/dev/shm/vllm_offload_<engine_id>.mmap`, but only on a graceful shutdown. A SIGKILL, an OOM kill or a segfault skips it.

Where `/dev/shm` outlives the process — a Kubernetes container restart with a tmpfs-backed `emptyDir`, for instance — the orphan keeps consuming the tmpfs budget. If the mount was sized for one region, the restarted engine cannot allocate its own and dies at init, so a single crash turns into a CrashLoopBackOff that only deleting the pod clears.

Fixes #54002.

## Why not delete by filename

The issue suggests removing stale `vllm_offload_*.mmap` files at init. That is unsafe outside a container: a second engine sharing the host's `/dev/shm` would lose the region it is actively using.

Instead, every participant now holds a **shared `flock`** on its region for as long as it lives, and the kernel releases that lock however the process exits — including SIGKILL. An orphan is then exactly a file whose *exclusive* lock is available. That makes liveness something the kernel tracks for us, rather than bookkeeping that can itself go stale.

Zero-length files are skipped: a region is empty only between its creator's `O_EXCL` create and the `ftruncate` that sizes it, so reclamation cannot race an engine that is starting right now.

## Verification

On Linux, driving the real class: a child process creates a region and is SIGKILLed so `cleanup()` never runs, then a fresh engine starts.

| | before | after |
|---|---|---|
| crashed engine's 64 MiB region | still present | reclaimed |
| **live** engine's region, while a second engine starts | preserved | preserved |

The second row is the safety property — the reason for the lock rather than a filename match.

## Test

Three cases added to `tests/v1/kv_offload/cpu/test_shared_offload_region.py`:

* `test_orphaned_region_is_reclaimed` — fails on `main`, passes with this change
* `test_live_region_is_not_reclaimed` — guards against over-eager reclamation
* `test_empty_region_file_is_not_reclaimed` — guards the create/ftruncate window
