### PR TITLE
[Bugfix] Breakable CG: intercept only PIECEWISE dispatches, default on

### DIFF
--- a/tests/compile/fullgraph/test_full_cudagraph.py
+++ b/tests/compile/fullgraph/test_full_cudagraph.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
 import os
-import weakref
 
 import pytest
 
@@ -10,6 +9,7 @@ from tests.utils import wait_for_gpu_memory_to_clear
 from tests.v1.attention.utils import full_cg_backend_configs as backend_configs
 from vllm import LLM, SamplingParams
 from vllm.config import CompilationConfig, CUDAGraphMode
+from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -51,6 +51,61 @@ for backend_config in other_backend_configs:
     model_backends_full_cudagraph.append(("Qwen/Qwen2-1.5B-Instruct", backend_config))
 
 
+BATCH_SIZE_MAX_TOKENS_CASES = [
+    (1, 10),
+    (7, 10),
+    (16, 10),
+    (25, 10),
+    (32, 10),
+    (45, 10),
+    (64, 10),
+    (123, 10),
+    (8, 5),
+    (8, 30),
+]
+
+
+def _generate_all_cases(llm: LLM) -> dict[tuple[int, int], list[str]]:
+    outputs = {}
+    for batch_size, max_tokens in BATCH_SIZE_MAX_TOKENS_CASES:
+        prompts = ["the quick brown fox"] * batch_size
+        # Use purely greedy decoding to avoid top-p truncation sensitivity
+        # that can amplify tiny numeric differences across runtimes.
+        sampling_params = SamplingParams(
+            temperature=0.0, max_tokens=max_tokens, top_p=1.0
+        )
+        responses = llm.generate(prompts, sampling_params)
+        outputs[(batch_size, max_tokens)] = [
+            response.outputs[0].text.lower() for response in responses
+        ]
+    return outputs
+
+
+def _run_all_cases(model: str, **llm_kwargs) -> dict[tuple[int, int], list[str]]:
+    """Build an LLM, generate outputs for every case, and tear it down.
+
+    Owns the LLM's lifetime so no reference outlives the shutdown: the engine
+    runs in-process (see env_vars in llm_pair), where GC alone does not
+    release its GPU memory.
+    """
+    llm = LLM(
+        model=model,
+        gpu_memory_utilization=0.43,
+        trust_remote_code=True,
+        max_model_len=1024,
+        max_num_seqs=128,
+        generation_config="vllm",
+        seed=42,
+        **llm_kwargs,
+    )
+    try:
+        return _generate_all_cases(llm)
+    finally:
+        llm.llm_engine.engine_core.shutdown()
+        del llm
+        cleanup_dist_env_and_memory()
+
+
 @pytest.fixture(scope="class")
 def llm_pair(request):
     model, backend_config, use_inductor_graph_partition = request.param
@@ -79,35 +134,32 @@ def llm_pair(request):
         # Force native sampler to avoid potential nondeterminism in FlashInfer
         # when per-request generators are not used in V1.
         "VLLM_USE_FLASHINFER_SAMPLER": "0",
+        # Run the engines in-process so each generate() batches all requests
+        # deterministically. With the multiprocess engine, the core busy loop
+        # starts prefilling while requests are still arriving over ZMQ, so
+        # requests land in timing-dependent prefill waves with different
+        # padded batch shapes. The resulting (legitimate) batch-shape numeric
+        # differences flip greedy near-ties, breaking the exact-match
+        # comparison between the two LLMs at larger batch sizes.
+        "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
     }
+    # Run the two engines one at a time, generating all cases' outputs up
+    # front: in-process engines share process-global state (e.g. the workspace
+    # manager singleton), so a second live engine would invalidate addresses
+    # baked into the first engine's CUDA graphs.
     with temporary_environ(env_vars):
-        full = LLM(
-            model=model,
-            gpu_memory_utilization=0.43,
-            trust_remote_code=True,
-            max_model_len=1024,
-            max_num_seqs=128,
+        full_outputs = _run_all_cases(
+            model,
             compilation_config=CompilationConfig(**backend_config.comp_config),
-            generation_config="vllm",
-            seed=42,
         )
-        piecewise = LLM(
-            model=model,
-            gpu_memory_utilization=0.43,
-            trust_remote_code=True,
-            max_model_len=1024,
-            max_num_seqs=128,
+        piecewise_outputs = _run_all_cases(
+            model,
             compilation_config=CompilationConfig(
                 cudagraph_mode=CUDAGraphMode.PIECEWISE
             ),
-            generation_config="vllm",
-            seed=42,
         )
 
-    # PyTest caches the fixture values so we use weakref.proxy to enable GC
-    yield weakref.proxy(full), weakref.proxy(piecewise)
-    del full
-    del piecewise
+    yield full_outputs, piecewise_outputs
 
     wait_for_gpu_memory_to_clear(
         devices=[0],
@@ -124,51 +176,29 @@ def llm_pair(request):
     ],
     indirect=True,
 )
+# The llm_pair fixture already cleans up after its engines; the autouse
+# cleanup_fixture's per-test cleanup_dist_env_and_memory() is redundant here.
+@pytest.mark.skip_global_cleanup
 class TestFullCUDAGraph:
     """
-    Use a class such that an llm pair is constructed once for all
+    Use a class such that the llm_pair outputs are computed once for all
     batch_size/max_tokens combinations and released immediately after.
-
-    Module-scope fixtures would stick around the whole time,
-    meaning there would be multiple LLM instances hogging memory simultaneously.
     """
 
     @pytest.mark.parametrize(
         ("batch_size", "max_tokens"),
-        [
-            (1, 10),
-            (7, 10),
-            (16, 10),
-            (25, 10),
-            (32, 10),
-            (45, 10),
-            (64, 10),
-            (123, 10),
-            (8, 5),
-            (8, 30),
-        ],
+        BATCH_SIZE_MAX_TOKENS_CASES,
     )
-    def test_full_cudagraph(self, batch_size, max_tokens, llm_pair: tuple[LLM, LLM]):
+    def test_full_cudagraph(self, batch_size, max_tokens, llm_pair):
         """
         Test various batch sizes and max_tokens to ensure that the
         full cudagraph compilation works for padded cases too.
         """
-
-        full_cudagraph_llm, piecewise_llm = llm_pair
-
-        prompts = ["the quick brown fox"] * batch_size
-        # Use purely greedy decoding to avoid top-p truncation sensitivity
-        # that can amplify tiny numeric differences across runtimes.
-        sampling_params = SamplingParams(
-            temperature=0.0, max_tokens=max_tokens, top_p=1.0
-        )
-
-        piecewise_responses = piecewise_llm.generate(prompts, sampling_params)
-        full_responses = full_cudagraph_llm.generate(prompts, sampling_params)
+        full_outputs, piecewise_outputs = llm_pair
+        case = (batch_size, max_tokens)
 
         # Check that all responses are the same
-        for piecewise_res, full_res in zip(piecewise_responses, full_responses):
-            assert (
-                piecewise_res.outputs[0].text.lower()
-                == full_res.outputs[0].text.lower()
-            )
+        for piecewise_text, full_text in zip(
+            piecewise_outputs[case], full_outputs[case]
+        ):
+            assert piecewise_text == full_text

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -160,6 +160,9 @@ def test_use_cudagraphs(
 ):
     # Disable multiprocessing so that the counter is in the same process
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    # This test pins the torch.compile path; breakable cudagraphs
+    # (default-on) replace compilation when no mode is explicitly set.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     compilation_config = {
         "cudagraph_capture_sizes": [100],
@@ -249,7 +252,10 @@ def test_torch_compile_disable(vllm_runner, monkeypatch):
         pass
 
 
-def test_splitting_ops_dynamic():
+def test_splitting_ops_dynamic(monkeypatch):
+    # Splitting ops are only populated on the torch.compile path; pin
+    # breakable cudagraphs (default-on) off so the default config compiles.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
     # Default config
     config = VllmConfig()
     # Default V1 config leaves cudagraph mode unset; splitting ops are only

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,11 +252,16 @@ def dist_init():
 
 
 @pytest.fixture
-def default_vllm_config():
+def default_vllm_config(monkeypatch):
     """Set a default VllmConfig for tests that directly test CustomOps or pathways
     that use get_current_vllm_config() outside of a full engine context.
     """
     from vllm.config import VllmConfig, set_current_vllm_config
+
+    # Pin breakable cudagraphs (default-on) off: it forces
+    # CompilationMode.NONE, which flips the custom-op base default to "all"
+    # and breaks direct CustomOp use on CPU tensors.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     config = VllmConfig()
     with set_current_vllm_config(config):

--- a/tests/models/language/generation/test_hybrid.py
+++ b/tests/models/language/generation/test_hybrid.py
@@ -489,6 +489,13 @@ def test_apc_single_prompt(
     except ValueError:
         pass
 
+    # Compare on the compiled path: an APC hit legitimately computes from
+    # restored state instead of a full prefill, and under uncompiled kernel
+    # numerics the tiny test models' resulting divergence can exceed the
+    # top-N logprob tolerance. These tests target APC semantics, not kernel
+    # numerics.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
+
     compare_operator: Callable = (
         check_logprobs_close if num_logprobs > 0 else check_outputs_equal  # type: ignore
     )
@@ -552,6 +559,13 @@ def test_apc_single_prompt_block_align_alignment(
         model_info.check_transformers_version(on_fail="skip")
     except ValueError:
         pass
+
+    # Compare on the compiled path: an APC hit legitimately computes from
+    # restored state instead of a full prefill, and under uncompiled kernel
+    # numerics the tiny test models' resulting divergence can exceed the
+    # top-N logprob tolerance. These tests target APC semantics, not kernel
+    # numerics.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     compare_operator: Callable = (
         check_logprobs_close if num_logprobs > 0 else check_outputs_equal  # type: ignore
@@ -634,6 +648,13 @@ def test_apc_multiple_prompts_all_cached_outputs(
     except ValueError:
         pass
 
+    # Compare on the compiled path: an APC hit legitimately computes from
+    # restored state instead of a full prefill, and under uncompiled kernel
+    # numerics the tiny test models' resulting divergence can exceed the
+    # top-N logprob tolerance. These tests target APC semantics, not kernel
+    # numerics.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
+
     compare_operator: Callable = (
         check_logprobs_close if num_logprobs > 0 else check_outputs_equal  # type: ignore
     )
@@ -702,6 +723,13 @@ def test_apc_multiple_prompts_block_align_alignment(
         model_info.check_transformers_version(on_fail="skip")
     except ValueError:
         pass
+
+    # Compare on the compiled path: an APC hit legitimately computes from
+    # restored state instead of a full prefill, and under uncompiled kernel
+    # numerics the tiny test models' resulting divergence can exceed the
+    # top-N logprob tolerance. These tests target APC semantics, not kernel
+    # numerics.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     compare_operator: Callable = (
         check_logprobs_close if num_logprobs > 0 else check_outputs_equal  # type: ignore
@@ -787,6 +815,13 @@ def test_apc_multiple_prompts_partial_cached_outputs(
         model_info.check_transformers_version(on_fail="skip")
     except ValueError:
         pass
+
+    # Compare on the compiled path: an APC hit legitimately computes from
+    # restored state instead of a full prefill, and under uncompiled kernel
+    # numerics the tiny test models' resulting divergence can exceed the
+    # top-N logprob tolerance. These tests target APC semantics, not kernel
+    # numerics.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     compare_operator: Callable = (
         check_logprobs_close if num_logprobs > 0 else check_outputs_equal  # type: ignore

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,37 +239,22 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
 
 
 def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
-    """ROCm keeps the DSA models (DeepSeek V3.2/V4, GLM-5.2) on their compiled
-    MRV1 paths and off breakable cudagraphs by default."""
-    from vllm.config.vllm import (
-        ROCM_DEFAULT_MRV1_ARCHITECTURES,
-        default_breakable_cudagraph_architectures,
-    )
+    """ROCm keeps the DSA models (DeepSeek V3.2/V4, GLM-5.2) on their compiled MRV1 paths."""
+    from vllm.config.vllm import ROCM_DEFAULT_MRV1_ARCHITECTURES
     from vllm.platforms import current_platform
 
     monkeypatch.setattr(current_platform, "is_rocm", lambda: True)
-    # The lookup is lru_cached against a fixed platform.
-    default_breakable_cudagraph_architectures.cache_clear()
-    try:
-        assert "DeepseekV32ForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
-        assert "DeepseekV4ForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
-        assert "GlmMoeDsaForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
+    assert "DeepseekV32ForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
+    assert "DeepseekV4ForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
+    assert "GlmMoeDsaForCausalLM" in ROCM_DEFAULT_MRV1_ARCHITECTURES
 
-        breakable_architectures = default_breakable_cudagraph_architectures()
-        assert "DeepseekV32ForCausalLM" not in breakable_architectures
-        assert "DeepseekV32MTPModel" not in breakable_architectures
-        assert "GlmMoeDsaForCausalLM" not in breakable_architectures
-
-        # The carve-out takes effect via the runner-selection property
-        # (warning_once args must be hashable for its lru_cache).
-        monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
-        config = SimpleNamespace(
-            model_config=SimpleNamespace(architectures=["DeepseekV32ForCausalLM"])
-        )
-        assert VllmConfig.use_v2_model_runner.fget(config) is False
-    finally:
-        default_breakable_cudagraph_architectures.cache_clear()
-
+    # The carve-out takes effect via the runner-selection property
+    # (warning_once args must be hashable for its lru_cache).
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(architectures=["DeepseekV32ForCausalLM"])
+    )
+    assert VllmConfig.use_v2_model_runner.fget(config) is False
 
 @pytest.mark.parametrize(
     ("model", "architecture"),
@@ -286,14 +271,12 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
     from vllm.compilation.breakable_cudagraph import (
         is_breakable_cudagraph_enabled,
     )
-    from vllm.config.vllm import default_breakable_cudagraph_architectures
     from vllm.platforms import current_platform
 
     monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
     monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
     monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
     monkeypatch.setattr(current_platform, "is_rocm", lambda: False)
-    default_breakable_cudagraph_architectures.cache_clear()
 
     model_config = SimpleNamespace(
         model=model,
@@ -314,9 +297,6 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
     )
     config._dflash_needs_multi_kv_group = lambda: False
     config._get_v2_model_runner_unsupported_features = lambda: []
-    config._uses_breakable_cudagraph_by_default = lambda: (
-        VllmConfig._uses_breakable_cudagraph_by_default(config)
-    )
 
     try:
         assert VllmConfig.use_v2_model_runner.fget(config)
@@ -326,7 +306,6 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
         assert config.compilation_config.cudagraph_mode.has_piecewise_cudagraphs()
     finally:
         os.environ.pop("VLLM_USE_BREAKABLE_CUDAGRAPH", None)
-        default_breakable_cudagraph_architectures.cache_clear()
 
 
 @pytest.mark.parametrize("is_rocm", [False, True])
@@ -340,14 +319,10 @@ def test_breakable_cudagraph_default_on_opt_out(monkeypatch, is_rocm):
     monkeypatch.setattr(current_platform, "is_rocm", lambda: is_rocm)
 
     def make_config():
-        config = SimpleNamespace(
+        return SimpleNamespace(
             model_config=SimpleNamespace(architectures=["DeepseekV32ForCausalLM"]),
             compilation_config=CompilationConfig(),
         )
-        config._uses_breakable_cudagraph_by_default = lambda: (
-            VllmConfig._uses_breakable_cudagraph_by_default(config)
-        )
-        return config
 
     monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
     config = make_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -329,41 +329,35 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
         default_breakable_cudagraph_architectures.cache_clear()
 
 
-@pytest.mark.parametrize(
-    ("architecture", "is_rocm", "expected"),
-    [
-        ("DeepseekV32ForCausalLM", False, True),
-        ("DeepseekV32ForCausalLM", True, False),
-        ("DeepseekV32MTPModel", False, True),
-        ("DeepseekV32MTPModel", True, False),
-        ("GlmMoeDsaForCausalLM", False, True),
-        ("GlmMoeDsaForCausalLM", True, False),
-    ],
-)
-def test_dsa_breakable_cudagraph_platform_default(
-    monkeypatch, architecture, is_rocm, expected
-):
-    from vllm.config.vllm import default_breakable_cudagraph_architectures
+@pytest.mark.parametrize("is_rocm", [False, True])
+def test_breakable_cudagraph_default_on_opt_out(monkeypatch, is_rocm):
+    """VLLM_USE_BREAKABLE_CUDAGRAPH defaults to on (all platforms and
+    architectures); setting it to 0 opts out."""
+    import vllm.envs as envs
     from vllm.platforms import current_platform
 
-    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    envs.disable_envs_cache()
     monkeypatch.setattr(current_platform, "is_rocm", lambda: is_rocm)
-    default_breakable_cudagraph_architectures.cache_clear()
-    config = SimpleNamespace(
-        model_config=SimpleNamespace(architectures=[architecture]),
-        compilation_config=CompilationConfig(),
-    )
-    config._uses_breakable_cudagraph_by_default = lambda: (
-        VllmConfig._uses_breakable_cudagraph_by_default(config)
-    )
 
-    try:
-        assert VllmConfig._maybe_enable_breakable_cudagraph(config) is expected
-        if expected:
-            assert config.compilation_config.mode == CompilationMode.NONE
-    finally:
-        os.environ.pop("VLLM_USE_BREAKABLE_CUDAGRAPH", None)
-        default_breakable_cudagraph_architectures.cache_clear()
+    def make_config():
+        config = SimpleNamespace(
+            model_config=SimpleNamespace(architectures=["DeepseekV32ForCausalLM"]),
+            compilation_config=CompilationConfig(),
+        )
+        config._uses_breakable_cudagraph_by_default = lambda: (
+            VllmConfig._uses_breakable_cudagraph_by_default(config)
+        )
+        return config
+
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    config = make_config()
+    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is True
+    assert config.compilation_config.mode == CompilationMode.NONE
+
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
+    config = make_config()
+    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is False
+    assert config.compilation_config.mode is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,7 +239,8 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
 
 
 def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
-    """ROCm keeps the DSA models (DeepSeek V3.2/V4, GLM-5.2) on their compiled MRV1 paths."""
+    """ROCm keeps the DSA models (DeepSeek V3.2/V4, GLM-5.2) on their
+    compiled MRV1 paths."""
     from vllm.config.vllm import ROCM_DEFAULT_MRV1_ARCHITECTURES
     from vllm.platforms import current_platform
 
@@ -255,6 +256,7 @@ def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
         model_config=SimpleNamespace(architectures=["DeepseekV32ForCausalLM"])
     )
     assert VllmConfig.use_v2_model_runner.fget(config) is False
+
 
 @pytest.mark.parametrize(
     ("model", "architecture"),
@@ -277,6 +279,7 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
     monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
     monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
     monkeypatch.setattr(current_platform, "is_rocm", lambda: False)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
 
     model_config = SimpleNamespace(
         model=model,
@@ -308,15 +311,14 @@ def test_dsa_models_default_to_mrv2_and_breakable_cudagraph(
         os.environ.pop("VLLM_USE_BREAKABLE_CUDAGRAPH", None)
 
 
-@pytest.mark.parametrize("is_rocm", [False, True])
-def test_breakable_cudagraph_default_on_opt_out(monkeypatch, is_rocm):
-    """VLLM_USE_BREAKABLE_CUDAGRAPH defaults to on (all platforms and
+def test_breakable_cudagraph_default_on_opt_out(monkeypatch):
+    """VLLM_USE_BREAKABLE_CUDAGRAPH defaults to on for CUDA (all
     architectures); setting it to 0 opts out."""
     import vllm.envs as envs
     from vllm.platforms import current_platform
 
     envs.disable_envs_cache()
-    monkeypatch.setattr(current_platform, "is_rocm", lambda: is_rocm)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
 
     def make_config():
         return SimpleNamespace(
@@ -333,6 +335,34 @@ def test_breakable_cudagraph_default_on_opt_out(monkeypatch, is_rocm):
     config = make_config()
     assert VllmConfig._maybe_enable_breakable_cudagraph(config) is False
     assert config.compilation_config.mode is None
+
+
+def test_breakable_cudagraph_default_off_on_other_platforms(monkeypatch):
+    """Off CUDA, breakable does not default on: on platforms without CUDA
+    graph support (e.g. CPU) it would only disable torch.compile, and on ROCm
+    it currently regresses performance. An explicit env opt-in is still
+    honored."""
+    import vllm.envs as envs
+    from vllm.platforms import current_platform
+
+    envs.disable_envs_cache()
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: False)
+
+    def make_config():
+        return SimpleNamespace(
+            model_config=None,
+            compilation_config=CompilationConfig(),
+        )
+
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    config = make_config()
+    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is False
+    assert config.compilation_config.mode is None
+
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "1")
+    config = make_config()
+    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is True
+    assert config.compilation_config.mode == CompilationMode.NONE
 
 
 def test_breakable_cudagraph_yields_to_explicit_compilation(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -360,6 +360,32 @@ def test_breakable_cudagraph_default_on_opt_out(monkeypatch, is_rocm):
     assert config.compilation_config.mode is None
 
 
+def test_breakable_cudagraph_yields_to_explicit_compilation(monkeypatch):
+    """Breakable cudagraphs (default-on) yield when a compilation mode is
+    explicitly set, unless the env var explicitly enables breakable."""
+    import vllm.envs as envs
+
+    envs.disable_envs_cache()
+
+    def make_config():
+        return SimpleNamespace(
+            model_config=None,
+            compilation_config=CompilationConfig(mode=CompilationMode.VLLM_COMPILE),
+        )
+
+    # Default-on, but an explicitly requested compilation mode wins.
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    config = make_config()
+    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is False
+    assert config.compilation_config.mode == CompilationMode.VLLM_COMPILE
+
+    # Explicitly enabling breakable wins over the compilation mode.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "1")
+    config = make_config()
+    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is True
+    assert config.compilation_config.mode == CompilationMode.NONE
+
+
 @pytest.mark.parametrize(
     ("model_type", "expected_architecture"),
     [
@@ -1888,8 +1914,14 @@ def test_is_prefix_caching_supported(
         ("inductor", ["none", "-fused_layernorm"], False),
     ],
 )
-def test_is_custom_op_enabled(backend: str, custom_ops: list[str], expected: bool):
+def test_is_custom_op_enabled(
+    backend: str, custom_ops: list[str], expected: bool, monkeypatch
+):
     """Test that is_custom_op_enabled works correctly."""
+    # Pin breakable cudagraphs (default-on) off: with no explicit
+    # compilation mode it forces CompilationMode.NONE, which flips the
+    # custom-op base default this test pins for the compiled path.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
     config = VllmConfig(
         compilation_config=CompilationConfig(backend=backend, custom_ops=custom_ops)
     )
@@ -1982,8 +2014,13 @@ def test_validate_mamba_align_subblock_prefill():
         ("RedHatAI/DeepSeek-V2.5-1210-FP8", CompilationConfig(), OptimizationLevel.O3),
     ],
 )
-def test_vllm_config_defaults(model_id, compilation_config, optimization_level):
+def test_vllm_config_defaults(
+    model_id, compilation_config, optimization_level, monkeypatch
+):
     """Test that optimization-level defaults are correctly applied."""
+    # These cases exercise the torch.compile-based default path; pin
+    # breakable cudagraphs (default-on) off, as it changes the defaults.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     model_config = None
     if model_id is not None:
@@ -2065,7 +2102,7 @@ def test_vllm_config_callable_defaults():
     not current_platform.support_static_graph_mode(),
     reason="Explicit overrides may be force-overwritten without static graph support.",
 )
-def test_vllm_config_explicit_overrides():
+def test_vllm_config_explicit_overrides(monkeypatch):
     """Test that explicit property overrides work correctly with callable defaults.
 
     When users explicitly set configuration properties, those values
@@ -2073,6 +2110,10 @@ def test_vllm_config_explicit_overrides():
     optimization levels.
     """
     from vllm.config.compilation import PassConfig
+
+    # Pin breakable cudagraphs (default-on) off: it changes the default
+    # compilation mode this test asserts on.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     quantized_model = ModelConfig("RedHatAI/Llama-3.2-1B-FP8")
     moe_model = ModelConfig("deepseek-ai/DeepSeek-V2-Lite")
@@ -2166,9 +2207,13 @@ def test_vllm_config_explicit_overrides():
     assert config.compilation_config.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
 
 
-def test_fusion_pass_op_priority():
+def test_fusion_pass_op_priority(monkeypatch):
     """This test checks that custom op enablement & IR op priority
     correctly control default fusions"""
+    # Pin breakable cudagraphs (default-on) off: it forces
+    # CompilationMode.NONE when no compilation mode is explicitly set,
+    # which skips the inductor fusion defaults this test pins.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
 
     # Default config, O2, rms_norm+quant fusion disabled
     cfg1 = VllmConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -362,7 +362,7 @@ def test_breakable_cudagraph_default_on_opt_out(monkeypatch, is_rocm):
 
 def test_breakable_cudagraph_yields_to_explicit_compilation(monkeypatch):
     """Breakable cudagraphs (default-on) yield when a compilation mode is
-    explicitly set, unless the env var explicitly enables breakable."""
+    explicitly set; setting both explicitly is a startup error."""
     import vllm.envs as envs
 
     envs.disable_envs_cache()
@@ -379,11 +379,10 @@ def test_breakable_cudagraph_yields_to_explicit_compilation(monkeypatch):
     assert VllmConfig._maybe_enable_breakable_cudagraph(config) is False
     assert config.compilation_config.mode == CompilationMode.VLLM_COMPILE
 
-    # Explicitly enabling breakable wins over the compilation mode.
+    # Explicitly enabling both is contradictory: rejected at config time.
     monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "1")
-    config = make_config()
-    assert VllmConfig._maybe_enable_breakable_cudagraph(config) is True
-    assert config.compilation_config.mode == CompilationMode.NONE
+    with pytest.raises(ValueError, match="conflicts with the explicitly"):
+        VllmConfig._maybe_enable_breakable_cudagraph(make_config())
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -92,7 +92,12 @@ class TestCudagraphDispatcher:
             ("PIECEWISE", CompilationMode.VLLM_COMPILE, True),
         ],
     )
-    def test_dispatcher(self, cudagraph_mode_str, compilation_mode, lora_config):
+    def test_dispatcher(
+        self, cudagraph_mode_str, compilation_mode, lora_config, monkeypatch
+    ):
+        # These cases exercise the compiled-piecewise dispatcher paths;
+        # pin breakable cudagraphs (now default-on) off.
+        monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "0")
         # Setup dispatcher
         comp_config = CompilationConfig(
             cudagraph_mode=cudagraph_mode_str,

--- a/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
@@ -62,7 +62,7 @@ def _make_profiling_runner(
     runner.cudagraph_manager = _FakeCudaGraphManager(
         needs_capture, num_full_descs, piecewise_only
     )
-    runner.vllm_config = SimpleNamespace()
+    runner.vllm_config = SimpleNamespace(compilation_config=runner.compilation_config)
 
     events: list[str] = []
     runner.events = events
@@ -250,12 +250,12 @@ def test_profile_cudagraph_memory_clears_captured_graphs(monkeypatch):
     monkeypatch.setattr(
         cgu.CUDAGraphWrapper,
         "clear_all_graphs",
-        classmethod(lambda cls: cleared.append("piecewise")),
+        classmethod(lambda cls, vllm_config=None: cleared.append("piecewise")),
     )
     monkeypatch.setattr(
         cgu.BreakableCUDAGraphWrapper,
         "clear_all_graphs",
-        classmethod(lambda cls: cleared.append("breakable")),
+        classmethod(lambda cls, vllm_config=None: cleared.append("breakable")),
     )
 
     cgu.profile_cudagraph_memory(runner)
@@ -276,20 +276,25 @@ def test_profile_cudagraph_memory_redirects_wrapper_pools(monkeypatch):
     runner = _make_profiling_runner(CUDAGraphMode.FULL_AND_PIECEWISE)
 
     class _FakeWrapper:
-        def __init__(self) -> None:
+        def __init__(self, compilation_config: Any) -> None:
+            self.compilation_config = compilation_config
             self.graph_pool: Any = GLOBAL_POOL
             self.pool_during_capture: Any = None
 
         def clear_graphs(self) -> None:
             pass
 
-    wrapper = _FakeWrapper()
+    wrapper = _FakeWrapper(runner.vllm_config.compilation_config)
+    # A wrapper from another engine in the same process must be left alone.
+    other_wrapper = _FakeWrapper(SimpleNamespace())
     cgu.CUDAGraphWrapper._all_instances.add(wrapper)
+    cgu.CUDAGraphWrapper._all_instances.add(other_wrapper)
     try:
         capture_model = runner.capture_model
 
         def _capture_model() -> int:
             wrapper.pool_during_capture = wrapper.graph_pool
+            other_wrapper.pool_during_capture = other_wrapper.graph_pool
             return capture_model()
 
         runner.capture_model = _capture_model
@@ -298,8 +303,11 @@ def test_profile_cudagraph_memory_redirects_wrapper_pools(monkeypatch):
 
         assert wrapper.pool_during_capture == THROWAWAY_POOL
         assert wrapper.graph_pool == GLOBAL_POOL
+        assert other_wrapper.pool_during_capture == GLOBAL_POOL
+        assert other_wrapper.graph_pool == GLOBAL_POOL
     finally:
         cgu.CUDAGraphWrapper._all_instances.discard(wrapper)
+        cgu.CUDAGraphWrapper._all_instances.discard(other_wrapper)
 
 
 def test_profile_cudagraph_memory_swaps_and_drops_speculator_managers(monkeypatch):

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -244,14 +244,15 @@ class _BreakableEntry:
 
 
 class BreakableCUDAGraphWrapper:
-    """Drop-in replacement for :class:`CUDAGraphWrapper` that uses
+    """PIECEWISE-mode replacement for :class:`CUDAGraphWrapper` that uses
     :class:`BreakableCUDAGraphCapture` instead of a single monolithic
     ``torch.cuda.graph()`` capture.
 
-    Same dispatch contract as ``CUDAGraphWrapper``:
+    Dispatch contract:
         * If no ``forward_context`` is available, run the underlying
           callable eagerly.
-        * If runtime mode mismatch / NONE, run eagerly.
+        * If the runtime mode is not PIECEWISE, run eagerly -- FULL
+          dispatches are left to an enclosing ``CUDAGraphWrapper``.
         * Otherwise, lazily capture per ``batch_descriptor`` and replay
           on subsequent invocations with the same descriptor.
     """
@@ -270,12 +271,9 @@ class BreakableCUDAGraphWrapper:
         runnable: Callable[..., Any],
         vllm_config: VllmConfig,
     ) -> None:
-        # Unlike the original CUDAGraphWrapper which strictly matches a
-        # single runtime_mode, this wrapper captures whatever the
-        # dispatcher emits (any non-NONE runtime_mode) -- breakable's
-        # capture is identical for prefill and decode, so there's nothing
-        # to dispatch on at the runtime_mode level. Entries are keyed by
-        # BatchDescriptor which already encodes batch shape / uniformity.
+        # Entries are keyed by BatchDescriptor which already encodes
+        # batch shape / uniformity; only PIECEWISE dispatches are
+        # intercepted (see __call__).
         self.runnable = runnable
         self.vllm_config = vllm_config
         self.compilation_config = vllm_config.compilation_config
@@ -315,11 +313,11 @@ class BreakableCUDAGraphWrapper:
         batch_descriptor = forward_context.batch_descriptor
         cudagraph_runtime_mode = forward_context.cudagraph_runtime_mode
 
-        # Capture whenever the dispatcher says "some cudagraph mode" --
-        # breakable produces the same artifact regardless of PIECEWISE
-        # vs FULL, so we match either. Entries are keyed by batch
-        # descriptor, which already encodes prefill/decode distinctions.
-        if cudagraph_runtime_mode == CUDAGraphMode.NONE:
+        # Only intercept PIECEWISE dispatches; FULL dispatches are handled
+        # by an enclosing CUDAGraphWrapper (or run eagerly when there is
+        # none). Entries are keyed by batch descriptor, which already
+        # encodes prefill/decode distinctions.
+        if cudagraph_runtime_mode != CUDAGraphMode.PIECEWISE:
             return self.runnable(*args, **kwargs)
 
         assert batch_descriptor is not None

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -34,7 +34,7 @@ import torch
 
 import vllm.envs as envs
 from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
-from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.config import CompilationConfig, CompilationMode, CUDAGraphMode, VllmConfig
 from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
 from vllm.forward_context import (
     BatchDescriptor,
@@ -54,6 +54,17 @@ def is_breakable_cudagraph_enabled() -> bool:
     # Per-config yielding to an explicit compilation mode is resolved in
     # VllmConfig._maybe_enable_breakable_cudagraph.
     return envs.VLLM_USE_BREAKABLE_CUDAGRAPH is not False
+
+
+def uses_breakable_cudagraph(compilation_config: CompilationConfig) -> bool:
+    """Whether breakable cudagraphs are active for this engine's config: the
+    env flag is not disabled and compilation resolved to mode NONE (breakable
+    yields to an explicitly requested compilation mode; see
+    VllmConfig._maybe_enable_breakable_cudagraph)."""
+    return (
+        is_breakable_cudagraph_enabled()
+        and compilation_config.mode == CompilationMode.NONE
+    )
 
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -271,10 +271,17 @@ class BreakableCUDAGraphWrapper:
         """Clear captured graphs, optionally scoped to one engine's config.
 
         Multiple engines may coexist in one process; clearing across engines
-        invalidates another engine's already-captured graphs.
+        invalidates another engine's already-captured graphs. Engine identity
+        is the ``compilation_config`` object: derived configs (e.g. from
+        ``VllmConfig.with_hf_config`` for a multimodal model's language
+        backbone) are distinct VllmConfig instances that share the engine's
+        compilation_config.
         """
         for instance in list(cls._all_instances):
-            if vllm_config is None or instance.vllm_config is vllm_config:
+            if (
+                vllm_config is None
+                or instance.compilation_config is vllm_config.compilation_config
+            ):
                 instance.clear_graphs()
 
     def __init__(

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -163,8 +163,10 @@ class BreakableCUDAGraphCapture:
     def __enter__(self) -> BreakableCUDAGraphCapture:
         if getattr(BreakableCUDAGraphCapture._tls, "active", None) is not None:
             raise RuntimeError("Nested BreakableCUDAGraphCapture is not supported.")
-        BreakableCUDAGraphCapture._tls.active = self
+        # Begin the first segment before publishing to the thread-local so a
+        # capture_begin failure does not leave a dangling "active" capture.
         self._begin_segment()
+        BreakableCUDAGraphCapture._tls.active = self
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
@@ -265,9 +267,15 @@ class BreakableCUDAGraphWrapper:
     )
 
     @classmethod
-    def clear_all_graphs(cls) -> None:
+    def clear_all_graphs(cls, vllm_config: VllmConfig | None = None) -> None:
+        """Clear captured graphs, optionally scoped to one engine's config.
+
+        Multiple engines may coexist in one process; clearing across engines
+        invalidates another engine's already-captured graphs.
+        """
         for instance in list(cls._all_instances):
-            instance.clear_graphs()
+            if vllm_config is None or instance.vllm_config is vllm_config:
+                instance.clear_graphs()
 
     def __init__(
         self,

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -272,10 +272,7 @@ class BreakableCUDAGraphWrapper:
 
         Multiple engines may coexist in one process; clearing across engines
         invalidates another engine's already-captured graphs. Engine identity
-        is the ``compilation_config`` object: derived configs (e.g. from
-        ``VllmConfig.with_hf_config`` for a multimodal model's language
-        backbone) are distinct VllmConfig instances that share the engine's
-        compilation_config.
+        is the ``compilation_config`` object.
         """
         for instance in list(cls._all_instances):
             if (

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -50,7 +50,10 @@ logger = init_logger(__name__)
 
 
 def is_breakable_cudagraph_enabled() -> bool:
-    return bool(envs.VLLM_USE_BREAKABLE_CUDAGRAPH)
+    # None (unset) means default-on; only an explicit "0" disables.
+    # Per-config yielding to an explicit compilation mode is resolved in
+    # VllmConfig._maybe_enable_breakable_cudagraph.
+    return envs.VLLM_USE_BREAKABLE_CUDAGRAPH is not False
 
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -170,10 +170,17 @@ class CUDAGraphWrapper:
     _all_instances: ClassVar[weakref.WeakSet["CUDAGraphWrapper"]] = weakref.WeakSet()
 
     @classmethod
-    def clear_all_graphs(cls) -> None:
-        """Clear captured graphs from all CUDAGraphWrapper instances."""
+    def clear_all_graphs(cls, vllm_config: VllmConfig | None = None) -> None:
+        """Clear captured graphs from all CUDAGraphWrapper instances.
+
+        When ``vllm_config`` is given, only instances belonging to that engine
+        are cleared -- multiple engines may coexist in one process (e.g.
+        in-process engines in tests), and clearing across engines invalidates
+        another engine's already-captured graphs.
+        """
         for instance in list(cls._all_instances):
-            instance.clear_graphs()
+            if vllm_config is None or instance.vllm_config is vllm_config:
+                instance.clear_graphs()
 
     def __init__(
         self,

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -176,11 +176,7 @@ class CUDAGraphWrapper:
         When ``vllm_config`` is given, only instances belonging to that engine
         are cleared -- multiple engines may coexist in one process (e.g.
         in-process engines in tests), and clearing across engines invalidates
-        another engine's already-captured graphs. Engine identity is the
-        ``compilation_config`` object: derived configs (e.g. from
-        ``VllmConfig.with_hf_config`` for a multimodal model's language
-        backbone) are distinct VllmConfig instances that share the engine's
-        compilation_config.
+        another engine's already-captured graphs.
         """
         for instance in list(cls._all_instances):
             if (

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -176,10 +176,17 @@ class CUDAGraphWrapper:
         When ``vllm_config`` is given, only instances belonging to that engine
         are cleared -- multiple engines may coexist in one process (e.g.
         in-process engines in tests), and clearing across engines invalidates
-        another engine's already-captured graphs.
+        another engine's already-captured graphs. Engine identity is the
+        ``compilation_config`` object: derived configs (e.g. from
+        ``VllmConfig.with_hf_config`` for a multimodal model's language
+        backbone) are distinct VllmConfig instances that share the engine's
+        compilation_config.
         """
         for instance in list(cls._all_instances):
-            if vllm_config is None or instance.vllm_config is vllm_config:
+            if (
+                vllm_config is None
+                or instance.compilation_config is vllm_config.compilation_config
+            ):
                 instance.clear_graphs()
 
     def __init__(

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -78,7 +78,10 @@ class TorchCompileWithNoGuardsWrapper:
         self._compile_prefix = compile_prefix
         self._is_encoder = is_encoder
 
-        vllm_config = get_current_vllm_config()
+        # Prefer the instance's own config (set by the support_torch_compile
+        # __init__ before this call); a component with an explicit
+        # compilation config must not silently use the global current one.
+        vllm_config = getattr(self, "vllm_config", None) or get_current_vllm_config()
         self.vllm_config = vllm_config
         mode = vllm_config.compilation_config.mode
         self.layerwise_nvtx_tracing_enabled = (
@@ -90,10 +93,11 @@ class TorchCompileWithNoGuardsWrapper:
         backend = vllm_config.compilation_config.init_backend(
             vllm_config, prefix=compile_prefix, is_encoder=is_encoder
         )
-        options = {}
 
         if isinstance(backend, str) and backend == "inductor":
             options = vllm_config.compilation_config.inductor_compile_config
+        else:
+            options = {}
 
         self.first_compile = True
         self.evaluate_guards = (

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1002,10 +1002,14 @@ class ModelConfig:
         # If 'hf_config is not hf_text_config' it's a nested config, i.e. multimodal
         cls += "MultiModal" if self.hf_config is not self.hf_text_config else ""
         cls += "MoE" if self.is_moe else ""
-        # Check if the architecture we're wrapping has defaults
+        # Check if the architecture we're wrapping has defaults. Derived
+        # sub-model configs (VllmConfig.with_hf_config on e.g. a multimodal
+        # model's text config) can have no architectures.
         runner = None
         task = None
-        if defaults := try_match_architecture_defaults(self.architectures[0]):
+        if self.architectures and (
+            defaults := try_match_architecture_defaults(self.architectures[0])
+        ):
             _, (runner, task) = defaults
         # User specified value take precedence
         if self.runner != "auto":

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -712,10 +712,6 @@ class VllmConfig:
         return bool(architectures & default_breakable_cudagraph_architectures())
 
     def _maybe_enable_breakable_cudagraph(self) -> bool:
-        from vllm.compilation.breakable_cudagraph import (
-            is_breakable_cudagraph_enabled,
-        )
-
         # Breakable cudagraphs are on by default, but yield when
         # compilation was explicitly enabled: an explicitly-set compilation
         # mode implies the torch.compile-based piecewise path instead.
@@ -723,8 +719,8 @@ class VllmConfig:
             self.compilation_config.mode is not None
             and self.compilation_config.mode != CompilationMode.NONE
         )
-        env_set = "VLLM_USE_BREAKABLE_CUDAGRAPH" in os.environ
-        if env_set and explicitly_compiled and is_breakable_cudagraph_enabled():
+        enabled_env = envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+        if enabled_env and explicitly_compiled:
             raise ValueError(
                 "VLLM_USE_BREAKABLE_CUDAGRAPH=1 conflicts with the explicitly "
                 f"set compilation mode {self.compilation_config.mode}: "
@@ -732,9 +728,8 @@ class VllmConfig:
                 "compilation. Either set VLLM_USE_BREAKABLE_CUDAGRAPH=0 or "
                 "drop the explicit compilation mode."
             )
-        enabled = is_breakable_cudagraph_enabled() and not (
-            not env_set and explicitly_compiled
-        )
+        # None (unset) means default-on unless compilation is explicit.
+        enabled = enabled_env if enabled_env is not None else not explicitly_compiled
         if enabled:
             self.compilation_config.mode = CompilationMode.NONE
         return enabled

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -723,8 +723,17 @@ class VllmConfig:
             self.compilation_config.mode is not None
             and self.compilation_config.mode != CompilationMode.NONE
         )
+        env_set = "VLLM_USE_BREAKABLE_CUDAGRAPH" in os.environ
+        if env_set and explicitly_compiled and is_breakable_cudagraph_enabled():
+            raise ValueError(
+                "VLLM_USE_BREAKABLE_CUDAGRAPH=1 conflicts with the explicitly "
+                f"set compilation mode {self.compilation_config.mode}: "
+                "breakable cudagraphs replace torch.compile-based "
+                "compilation. Either set VLLM_USE_BREAKABLE_CUDAGRAPH=0 or "
+                "drop the explicit compilation mode."
+            )
         enabled = is_breakable_cudagraph_enabled() and not (
-            "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ and explicitly_compiled
+            not env_set and explicitly_compiled
         )
         if enabled:
             self.compilation_config.mode = CompilationMode.NONE

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -712,21 +712,20 @@ class VllmConfig:
         return bool(architectures & default_breakable_cudagraph_architectures())
 
     def _maybe_enable_breakable_cudagraph(self) -> bool:
-        if (
-            "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ
-            and self._uses_breakable_cudagraph_by_default()
-        ):
-            os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
-            logger.info_once(
-                "Auto-enabling VLLM_USE_BREAKABLE_CUDAGRAPH=1. "
-                "Set VLLM_USE_BREAKABLE_CUDAGRAPH=0 to opt out."
-            )
-
         from vllm.compilation.breakable_cudagraph import (
             is_breakable_cudagraph_enabled,
         )
 
-        enabled = is_breakable_cudagraph_enabled()
+        # Breakable cudagraphs are on by default, but yield when
+        # compilation was explicitly enabled: an explicitly-set compilation
+        # mode implies the torch.compile-based piecewise path instead.
+        explicitly_compiled = (
+            self.compilation_config.mode is not None
+            and self.compilation_config.mode != CompilationMode.NONE
+        )
+        enabled = is_breakable_cudagraph_enabled() and not (
+            "VLLM_USE_BREAKABLE_CUDAGRAPH" not in os.environ and explicitly_compiled
+        )
         if enabled:
             self.compilation_config.mode = CompilationMode.NONE
         return enabled
@@ -1473,7 +1472,7 @@ class VllmConfig:
         if (
             self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-            and not envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+            and not breakable_cudagraph_enabled
         ):
             logger.info_once(
                 "Cudagraph mode %s is not compatible with compilation mode %s."
@@ -1718,7 +1717,7 @@ class VllmConfig:
             if self.compilation_config.cudagraph_mode.requires_piecewise_compilation():
                 assert (
                     self.compilation_config.mode == CompilationMode.VLLM_COMPILE
-                    or envs.VLLM_USE_BREAKABLE_CUDAGRAPH
+                    or breakable_cudagraph_enabled
                 ), (
                     "Compilation mode should be CompilationMode.VLLM_COMPILE "
                     "when cudagraph_mode piecewise cudagraphs is used, "

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -72,40 +72,6 @@ ROCM_DEFAULT_MRV1_ARCHITECTURES = frozenset(
     {"DeepseekV32ForCausalLM", "DeepseekV4ForCausalLM", "GlmMoeDsaForCausalLM"}
 )
 
-DEFAULT_BREAKABLE_CUDAGRAPH_ARCHITECTURES = frozenset(
-    {
-        "DeepseekV32MTPModel",
-        "DeepseekV32ForCausalLM",
-        "DeepseekV4ForCausalLM",
-        "DeepSeekV4MTPModel",
-        "Dots3NoteForCausalLM",
-        "Dots3NoteMTPModel",
-        "GlmMoeDsaForCausalLM",
-        "HYV4ForCausalLM",
-        "HYV4MTPModel",
-        "InklingForCausalLM",
-        "InklingForConditionalGeneration",
-        "KimiK3ForConditionalGeneration",
-        "KimiK3MTPModel",
-        "KimiLinearForCausalLM",
-        "MiniMaxM3SparseForCausalLM",
-        "MiniMaxM3SparseForConditionalGeneration",
-    }
-)
-
-
-@lru_cache
-def default_breakable_cudagraph_architectures() -> frozenset[str]:
-    """Architectures defaulting to breakable CUDA graphs on this platform."""
-    from vllm.platforms import current_platform
-
-    if current_platform.is_rocm():
-        # Breakable CUDA graphs currently regress performance on ROCm, so no
-        # architecture opts in by default here. Users can still force it with
-        # VLLM_USE_BREAKABLE_CUDAGRAPH=1.
-        return frozenset()
-    return DEFAULT_BREAKABLE_CUDAGRAPH_ARCHITECTURES
-
 
 class OptimizationLevel(IntEnum):
     """Optimization level enum."""
@@ -702,14 +668,6 @@ class VllmConfig:
         layer_types = getattr(draft_config.hf_config, "layer_types", None) or []
         num_sliding = sum(lt == "sliding_attention" for lt in layer_types)
         return 0 < num_sliding < len(layer_types)
-
-    def _uses_breakable_cudagraph_by_default(self) -> bool:
-        model_config = self.model_config
-        if model_config is None:
-            return False
-
-        architectures = set(model_config.architectures)
-        return bool(architectures & default_breakable_cudagraph_architectures())
 
     def _maybe_enable_breakable_cudagraph(self) -> bool:
         # Breakable cudagraphs are on by default, but yield when

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -686,8 +686,15 @@ class VllmConfig:
                 "compilation. Either set VLLM_USE_BREAKABLE_CUDAGRAPH=0 or "
                 "drop the explicit compilation mode."
             )
-        # None (unset) means default-on unless compilation is explicit.
-        enabled = enabled_env if enabled_env is not None else not explicitly_compiled
+        if enabled_env is not None:
+            enabled = enabled_env
+        else:
+            # None (unset) means default-on unless compilation is explicit,
+            # and only on CUDA.
+            # On ROCm, breakable cudagraphs currently regress performance.
+            from vllm.platforms import current_platform
+
+            enabled = not explicitly_compiled and current_platform.is_cuda()
         if enabled:
             self.compilation_config.mode = CompilationMode.NONE
         return enabled

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -5,13 +5,14 @@ import weakref
 from collections.abc import Iterable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed import P2POp
 
+from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphWrapper
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphWrapper
 from vllm.compilation.wrapper import reset_compile_wrapper
@@ -400,12 +401,30 @@ class ElasticEPScalingExecutor:
         self._staged_moe_quant_methods.clear()
 
     def _release_cuda_graphs(self) -> None:
-        if isinstance(self.worker.model_runner.model, CUDAGraphWrapper):
-            wrapper = self.worker.model_runner.model
-            wrapper.concrete_cudagraph_entries = {}
-
-        elif isinstance(self.worker.model_runner.model, UBatchWrapper):
+        if isinstance(self.worker.model_runner.model, UBatchWrapper):
             raise RuntimeError("DBO is not yet supported in elastic EP")
+
+        # Drop all of this engine's captured graphs, including the breakable
+        # piecewise graphs nested inside the FULL wrapper and any drafter
+        # wrappers. A stale graph replayed after scale-up reads the old
+        # (freed) workspace and pre-reshuffle expert weights.
+        CUDAGraphWrapper.clear_all_graphs(self.worker.vllm_config)
+        BreakableCUDAGraphWrapper.clear_all_graphs(self.worker.vllm_config)
+
+        # With every graph released, the shared graph pool's use_count drops
+        # to 0 and the allocators destroy it; re-capturing into the stale
+        # handle trips c10's create_or_incref_pool assert. Swap in a fresh
+        # global pool and rebind this engine's wrappers to it.
+        from vllm.platforms import current_platform
+
+        new_pool = current_platform.graph_pool_handle()
+        type(current_platform)._global_graph_pool = new_pool
+        compilation_config = self.worker.vllm_config.compilation_config
+        wrappers: list[Any] = list(CUDAGraphWrapper._all_instances)
+        wrappers.extend(BreakableCUDAGraphWrapper._all_instances)
+        for wrapper in wrappers:
+            if wrapper.compilation_config is compilation_config:
+                wrapper.graph_pool = new_pool
 
         torch.compiler.reset()
         with set_current_vllm_config(self.worker.vllm_config):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -175,7 +175,7 @@ if TYPE_CHECKING:
     VLLM_DP_SIZE: int = 1
     VLLM_USE_STANDALONE_COMPILE: bool = True
     VLLM_ENABLE_PREGRAD_PASSES: bool = True
-    VLLM_USE_BREAKABLE_CUDAGRAPH: bool = True
+    VLLM_USE_BREAKABLE_CUDAGRAPH: bool | None = None
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
@@ -765,9 +765,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ENABLE_PREGRAD_PASSES": lambda: (
         os.environ.get("VLLM_ENABLE_PREGRAD_PASSES", "1") == "1"
     ),
-    # Breakable cudagraph does not rely on torch.compile
-    "VLLM_USE_BREAKABLE_CUDAGRAPH": lambda: (
-        os.environ.get("VLLM_USE_BREAKABLE_CUDAGRAPH", "1") == "1"
+    # Breakable cudagraph does not rely on torch.compile.
+    # None (unset) means default-on: enabled unless an explicit compilation
+    # mode makes it yield (see VllmConfig._maybe_enable_breakable_cudagraph).
+    "VLLM_USE_BREAKABLE_CUDAGRAPH": lambda: maybe_convert_bool(
+        os.getenv("VLLM_USE_BREAKABLE_CUDAGRAPH", None)
     ),
     # Debug pattern matching inside custom passes.
     # Should be set to the fx.Node name (e.g. 'getitem_34' or 'scaled_mm_3').

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -175,7 +175,7 @@ if TYPE_CHECKING:
     VLLM_DP_SIZE: int = 1
     VLLM_USE_STANDALONE_COMPILE: bool = True
     VLLM_ENABLE_PREGRAD_PASSES: bool = True
-    VLLM_USE_BREAKABLE_CUDAGRAPH: bool = False
+    VLLM_USE_BREAKABLE_CUDAGRAPH: bool = True
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
@@ -765,9 +765,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ENABLE_PREGRAD_PASSES": lambda: (
         os.environ.get("VLLM_ENABLE_PREGRAD_PASSES", "1") == "1"
     ),
-    # Experimental: breakable cudagraph does not rely on torch.compile
+    # Breakable cudagraph does not rely on torch.compile
     "VLLM_USE_BREAKABLE_CUDAGRAPH": lambda: (
-        os.environ.get("VLLM_USE_BREAKABLE_CUDAGRAPH", "0") == "1"
+        os.environ.get("VLLM_USE_BREAKABLE_CUDAGRAPH", "1") == "1"
     ),
     # Debug pattern matching inside custom passes.
     # Should be set to the fx.Node name (e.g. 'getitem_34' or 'scaled_mm_3').

--- a/vllm/lora/ops/triton_ops/lora_shrink_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_op.py
@@ -179,8 +179,8 @@ def _lora_shrink(
         assert weight.dtype in [torch.float16, torch.bfloat16]
 
     assert inputs.size(1) == lora_a_weights[0].size(-1)
-    assert inputs.is_contiguous()
     assert output_tensor.is_contiguous()
+    inputs = inputs.contiguous()
 
     # metadata sanity check
     M = inputs.size(0)

--- a/vllm/model_executor/layers/hpc/rope_norm.py
+++ b/vllm/model_executor/layers/hpc/rope_norm.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import torch
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import get_current_vllm_config_or_none
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
@@ -43,6 +44,7 @@ class QkNormPolicy(IntEnum):
     NORM_THEN_ROPE = 2
 
 
+@eager_break_during_capture
 def hpc_rope_norm_forward(
     qkv: torch.Tensor,
     output: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/gdn/olmo_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/olmo_gdn_linear_attn.py
@@ -4,6 +4,7 @@ import torch
 from einops import rearrange
 from torch import nn
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
@@ -527,6 +528,7 @@ def _make_fused_conv1d_weight_loader(dims, tp_size, tp_rank):
     return weight_loader
 
 
+@eager_break_during_capture
 def olmo_hybrid_gdn_full_forward(
     hidden_states: torch.Tensor,
     output: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -12,6 +12,7 @@ from torch import nn
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
@@ -1909,6 +1910,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         )
 
 
+@eager_break_during_capture
 def qwen_gdn_attention_core(
     qkv_or_qkvz: torch.Tensor,
     b_or_ba: torch.Tensor,
@@ -1969,6 +1971,7 @@ direct_register_custom_op(
 )
 
 
+@eager_break_during_capture
 def qwen_gdn_attention_core_fused_norm_packed(
     mixed_qkvz: torch.Tensor,
     ba: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/linear/minimax_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/linear/minimax_linear_attn.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn.functional as F
 from einops import rearrange
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import get_current_vllm_config
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.model_executor.custom_op import PluggableLayer
@@ -325,6 +326,7 @@ class MiniMaxText01LinearAttention(LinearAttention):
         output[:num_actual_tokens], _ = self.out_proj(hidden)
 
 
+@eager_break_during_capture
 def linear_attention(
     hidden_states: torch.Tensor,
     output: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/mamba_mixer.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn
 from torch.nn.parameter import Parameter
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, ModelConfig, get_current_vllm_config
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
@@ -521,6 +522,7 @@ def split_batch_to_prefill_and_decode(
     )
 
 
+@eager_break_during_capture
 def mamba_mixer(
     hidden_states: torch.Tensor,
     output: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import torch
 from torch import nn
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, ModelConfig, get_current_vllm_config
 from vllm.config.mamba import MambaBackendEnum
 from vllm.distributed import (
@@ -1260,6 +1261,7 @@ def share_replayssm_ring_trackers(
             mixer._updates_replayssm_trackers = layer_name == last_layer_name
 
 
+@eager_break_during_capture
 def mamba_mixer2(
     projected_states: torch.Tensor,
     output: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/short_conv.py
+++ b/vllm/model_executor/layers/mamba/short_conv.py
@@ -4,6 +4,7 @@
 
 import torch
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, ModelConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import ForwardContext, get_forward_context
@@ -360,6 +361,7 @@ class ShortConv(MambaBase, PluggableLayer):
         return MambaAttentionBackendEnum.SHORT_CONV
 
 
+@eager_break_during_capture
 def short_conv(
     hidden_states: torch.Tensor,
     output: torch.Tensor,

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -42,14 +42,12 @@ class CudagraphDispatcher:
             CUDAGraphMode.FULL: set(),
         }
 
-        from vllm.compilation.breakable_cudagraph import (
-            is_breakable_cudagraph_enabled,
-        )
+        from vllm.compilation.breakable_cudagraph import uses_breakable_cudagraph
 
         assert (
             not self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
             or self.compilation_config.is_attention_compiled_piecewise()
-            or is_breakable_cudagraph_enabled()
+            or uses_breakable_cudagraph(self.compilation_config)
         ), (
             "Compilation mode should be CompilationMode.VLLM_COMPILE when "
             "cudagraph_mode piecewise cudagraphs is used, "

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 
 from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphWrapper
+from vllm.compilation.cuda_graph import CUDAGraphWrapper
 from vllm.config import (
     CUDAGraphMode,
     VllmConfig,
@@ -533,7 +534,7 @@ class SpecDecodeBaseProposer:
 
         if self.method in ("eagle3", "dflash"):
             model = self.model
-            if isinstance(model, BreakableCUDAGraphWrapper):
+            while isinstance(model, (BreakableCUDAGraphWrapper, CUDAGraphWrapper)):
                 model = model.unwrap()
             assert isinstance(
                 model,

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -14,13 +14,13 @@ from tqdm import tqdm
 
 from vllm.compilation.breakable_cudagraph import (
     BreakableCUDAGraphWrapper,
-    is_breakable_cudagraph_enabled,
+    uses_breakable_cudagraph,
 )
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphWrapper
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.config import VllmConfig, set_current_vllm_config
-from vllm.config.compilation import CompilationMode, CUDAGraphMode
+from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
 from vllm.distributed.parallel_state import (
     get_pp_group,
@@ -161,12 +161,8 @@ class CudaGraphManager:
         self._capture_descs: dict[CUDAGraphMode, list[BatchExecutionDescriptor]] = {}
 
         # Breakable CUDA graph (PW CUDA graph without torch.compile).
-        # Only when the config resolved to no compilation -- breakable
-        # yields to an explicitly requested compilation mode (see
-        # VllmConfig._maybe_enable_breakable_cudagraph).
         self.use_breakable_cg = (
-            is_breakable_cudagraph_enabled()
-            and self.compilation_config.mode == CompilationMode.NONE
+            uses_breakable_cudagraph(self.compilation_config)
             and self.cudagraph_mode.has_piecewise_cudagraphs()
         )
         self.breakable_cg_runner: BreakableCUDAGraphWrapper | None = None

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -797,9 +797,11 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
                 # Create the breakable runner before the wrapper pool swap so
                 # its pool is covered as well.
                 manager.init_breakable_cg_runner(runner.model)
-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-                BreakableCUDAGraphWrapper._all_instances
-            )
+            # Only touch wrappers belonging to this engine; other engines may
+            # coexist in the same process (e.g. in-process engines in tests).
+            wrappers: list[Any] = list(CUDAGraphWrapper._all_instances)
+            wrappers.extend(BreakableCUDAGraphWrapper._all_instances)
+            all_wrappers = [w for w in wrappers if w.vllm_config is runner.vllm_config]
             for wrapper in all_wrappers:
                 original_pools[id(wrapper)] = wrapper.graph_pool
                 wrapper.graph_pool = throwaway_pool
@@ -826,8 +828,8 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
         finally:
             compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
             compilation_counter.num_gpu_runner_capture_triggers = saved_capture_triggers
-            CUDAGraphWrapper.clear_all_graphs()
-            BreakableCUDAGraphWrapper.clear_all_graphs()
+            CUDAGraphWrapper.clear_all_graphs(runner.vllm_config)
+            BreakableCUDAGraphWrapper.clear_all_graphs(runner.vllm_config)
             for wrapper in all_wrappers:
                 if id(wrapper) in original_pools:
                     wrapper.graph_pool = original_pools[id(wrapper)]

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -20,7 +20,7 @@ from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphWrapper
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.config import VllmConfig, set_current_vllm_config
-from vllm.config.compilation import CUDAGraphMode
+from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.distributed.device_communicators.pynccl_allocator import set_graph_pool_id
 from vllm.distributed.parallel_state import (
     get_pp_group,
@@ -160,9 +160,13 @@ class CudaGraphManager:
         self._candidates: dict[tuple[int, int], list[BatchExecutionDescriptor]] = {}
         self._capture_descs: dict[CUDAGraphMode, list[BatchExecutionDescriptor]] = {}
 
-        # Breakable CUDA graph (PW CUDA graph without torch.compile)
+        # Breakable CUDA graph (PW CUDA graph without torch.compile).
+        # Only when the config resolved to no compilation -- breakable
+        # yields to an explicitly requested compilation mode (see
+        # VllmConfig._maybe_enable_breakable_cudagraph).
         self.use_breakable_cg = (
             is_breakable_cudagraph_enabled()
+            and self.compilation_config.mode == CompilationMode.NONE
             and self.cudagraph_mode.has_piecewise_cudagraphs()
         )
         self.breakable_cg_runner: BreakableCUDAGraphWrapper | None = None

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -799,9 +799,16 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
                 manager.init_breakable_cg_runner(runner.model)
             # Only touch wrappers belonging to this engine; other engines may
             # coexist in the same process (e.g. in-process engines in tests).
-            wrappers: list[Any] = list(CUDAGraphWrapper._all_instances)
-            wrappers.extend(BreakableCUDAGraphWrapper._all_instances)
-            all_wrappers = [w for w in wrappers if w.vllm_config is runner.vllm_config]
+            # compilation_config identity is the engine tag: derived configs
+            # (VllmConfig.with_hf_config) are distinct VllmConfig instances
+            # that share the engine's compilation_config.
+            wrapper_instances: list[Any] = list(CUDAGraphWrapper._all_instances)
+            wrapper_instances.extend(BreakableCUDAGraphWrapper._all_instances)
+            all_wrappers = [
+                wrapper
+                for wrapper in wrapper_instances
+                if wrapper.compilation_config is runner.vllm_config.compilation_config
+            ]
             for wrapper in all_wrappers:
                 original_pools[id(wrapper)] = wrapper.graph_pool
                 wrapper.graph_pool = throwaway_pool

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -799,9 +799,6 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
                 manager.init_breakable_cg_runner(runner.model)
             # Only touch wrappers belonging to this engine; other engines may
             # coexist in the same process (e.g. in-process engines in tests).
-            # compilation_config identity is the engine tag: derived configs
-            # (VllmConfig.with_hf_config) are distinct VllmConfig instances
-            # that share the engine's compilation_config.
             wrapper_instances: list[Any] = list(CUDAGraphWrapper._all_instances)
             wrapper_instances.extend(BreakableCUDAGraphWrapper._all_instances)
             all_wrappers = [

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5516,9 +5516,12 @@ class GPUModelRunner(
         assert cudagraph_mode is not None
         # Breakable cudagraphs replace only the torch.compile-based
         # PIECEWISE path; FULL cudagraphs (if any) are still applied on top
-        # via CUDAGraphWrapper below.
+        # via CUDAGraphWrapper below. Breakable applies only when the
+        # config resolved to no compilation -- it yields to an explicitly
+        # requested compilation mode (see _maybe_enable_breakable_cudagraph).
         use_breakable = (
             is_breakable_cudagraph_enabled()
+            and self.compilation_config.mode == CompilationMode.NONE
             and cudagraph_mode.has_piecewise_cudagraphs()
             and not self.parallel_config.use_ubatching
         )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3381,22 +3381,23 @@ class GPUModelRunner(
     def get_model(self) -> nn.Module:
         if not hasattr(self, "model"):
             raise ValueError("Cannot get model before model has been initialized")
-        if isinstance(
-            self.model, (CUDAGraphWrapper, UBatchWrapper, BreakableCUDAGraphWrapper)
+        model = self.model
+        # get raw model out of (possibly nested) cudagraph wrappers.
+        while isinstance(
+            model, (CUDAGraphWrapper, UBatchWrapper, BreakableCUDAGraphWrapper)
         ):
-            # get raw model out of the cudagraph wrapper.
-            return self.model.unwrap()
-        return self.model
+            model = model.unwrap()
+        return model
 
     def get_draft_model(self) -> nn.Module | None:
         drafter = getattr(self, "drafter", None)
         if drafter is None:
             return None
         model = getattr(drafter, "model", None)
-        if isinstance(
+        while isinstance(
             model, (CUDAGraphWrapper, UBatchWrapper, BreakableCUDAGraphWrapper)
         ):
-            return cast(nn.Module, model.unwrap())
+            model = model.unwrap()
         return cast(nn.Module | None, model)
 
     def get_supported_generation_tasks(self) -> list[GenerationTask]:
@@ -5510,27 +5511,41 @@ class GPUModelRunner(
         # for other compilation modes, cudagraph behavior is controlled by
         # CudagraphWrapper and CudagraphDispatcher of vllm.
 
-        # wrap the model with full cudagraph wrapper if needed.
+        # wrap the model with cudagraph wrappers if needed.
         cudagraph_mode = self.compilation_config.cudagraph_mode
         assert cudagraph_mode is not None
-        if (
+        # Breakable cudagraphs replace only the torch.compile-based
+        # PIECEWISE path; FULL cudagraphs (if any) are still applied on top
+        # via CUDAGraphWrapper below.
+        use_breakable = (
             is_breakable_cudagraph_enabled()
-            and cudagraph_mode != CUDAGraphMode.NONE
+            and cudagraph_mode.has_piecewise_cudagraphs()
             and not self.parallel_config.use_ubatching
-        ):
+        )
+        if use_breakable:
             self.model = BreakableCUDAGraphWrapper(self.model, self.vllm_config)
             drafter = getattr(self, "drafter", None)
             if drafter is not None and hasattr(drafter, "model"):
                 drafter.model = BreakableCUDAGraphWrapper(
                     drafter.model, self.vllm_config
                 )
-        elif (
+        if (
             cudagraph_mode.has_full_cudagraphs()
             and not self.parallel_config.use_ubatching
         ):
             self.model = CUDAGraphWrapper(
                 self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
             )
+            if use_breakable:
+                # Keep the drafter graphed for FULL dispatches; it has no
+                # torch.compile piecewise graphs when breakable is used.
+                drafter = getattr(self, "drafter", None)
+                if drafter is not None and hasattr(drafter, "model"):
+                    drafter.model = CUDAGraphWrapper(
+                        drafter.model,
+                        self.vllm_config,
+                        runtime_mode=CUDAGraphMode.FULL,
+                    )
         elif self.parallel_config.use_ubatching:
             if cudagraph_mode.has_full_cudagraphs():
                 self.model = UBatchWrapper(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -23,7 +23,7 @@ from tqdm import tqdm
 import vllm.envs as envs
 from vllm.compilation.breakable_cudagraph import (
     BreakableCUDAGraphWrapper,
-    is_breakable_cudagraph_enabled,
+    uses_breakable_cudagraph,
 )
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphStat, CUDAGraphWrapper
@@ -5516,12 +5516,9 @@ class GPUModelRunner(
         assert cudagraph_mode is not None
         # Breakable cudagraphs replace only the torch.compile-based
         # PIECEWISE path; FULL cudagraphs (if any) are still applied on top
-        # via CUDAGraphWrapper below. Breakable applies only when the
-        # config resolved to no compilation -- it yields to an explicitly
-        # requested compilation mode (see _maybe_enable_breakable_cudagraph).
+        # via CUDAGraphWrapper below.
         use_breakable = (
-            is_breakable_cudagraph_enabled()
-            and self.compilation_config.mode == CompilationMode.NONE
+            uses_breakable_cudagraph(self.compilation_config)
             and cudagraph_mode.has_piecewise_cudagraphs()
             and not self.parallel_config.use_ubatching
         )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6648,8 +6648,8 @@ class GPUModelRunner(
         if current_platform.is_rocm():
             # Drop captured graphs before distributed teardown. On ROCm, delayed
             # graph destruction can surface HSA faults in the next engine startup.
-            CUDAGraphWrapper.clear_all_graphs()
-            BreakableCUDAGraphWrapper.clear_all_graphs()
+            CUDAGraphWrapper.clear_all_graphs(self.vllm_config)
+            BreakableCUDAGraphWrapper.clear_all_graphs(self.vllm_config)
             self.encoder_cudagraph_manager = None
         self.compilation_config.static_forward_context.clear()
         self.model = None  # type: ignore[assignment]
@@ -6771,9 +6771,15 @@ class GPUModelRunner(
         profiling_pool = current_platform.graph_pool_handle()
         encoder_profiling_pool = current_platform.graph_pool_handle()
         original_pools: dict[int, Any] = {}
-        all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-            BreakableCUDAGraphWrapper._all_instances
-        )
+        # Only touch wrappers belonging to this engine; other engines may
+        # coexist in the same process (e.g. in-process engines in tests).
+        wrapper_instances: list[Any] = list(CUDAGraphWrapper._all_instances)
+        wrapper_instances.extend(BreakableCUDAGraphWrapper._all_instances)
+        all_wrappers = [
+            instance
+            for instance in wrapper_instances
+            if instance.vllm_config is self.vllm_config
+        ]
         for instance in all_wrappers:
             original_pools[id(instance)] = instance.graph_pool
             instance.graph_pool = profiling_pool
@@ -6864,13 +6870,10 @@ class GPUModelRunner(
                     )
         finally:
             set_cudagraph_capturing_enabled(False)
-            CUDAGraphWrapper.clear_all_graphs()
-            BreakableCUDAGraphWrapper.clear_all_graphs()
+            CUDAGraphWrapper.clear_all_graphs(self.vllm_config)
+            BreakableCUDAGraphWrapper.clear_all_graphs(self.vllm_config)
             if encoder_cudagraph_manager is not None:
                 encoder_cudagraph_manager.clear()
-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-                BreakableCUDAGraphWrapper._all_instances
-            )
             for instance in all_wrappers:
                 if id(instance) in original_pools:
                     instance.graph_pool = original_pools[id(instance)]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6773,12 +6773,15 @@ class GPUModelRunner(
         original_pools: dict[int, Any] = {}
         # Only touch wrappers belonging to this engine; other engines may
         # coexist in the same process (e.g. in-process engines in tests).
+        # compilation_config identity is the engine tag: derived configs
+        # (VllmConfig.with_hf_config) are distinct VllmConfig instances that
+        # share the engine's compilation_config.
         wrapper_instances: list[Any] = list(CUDAGraphWrapper._all_instances)
         wrapper_instances.extend(BreakableCUDAGraphWrapper._all_instances)
         all_wrappers = [
             instance
             for instance in wrapper_instances
-            if instance.vllm_config is self.vllm_config
+            if instance.compilation_config is self.compilation_config
         ]
         for instance in all_wrappers:
             original_pools[id(instance)] = instance.graph_pool


### PR DESCRIPTION
`BreakableCUDAGraphWrapper` previously captured/replayed for any non-`NONE` runtime mode, so with `VLLM_USE_BREAKABLE_CUDAGRAPH=1` it also swallowed FULL dispatches and the full-cudagraph wrapper was never applied in the V1 model runner. Now breakable only handles `PIECEWISE` dispatches, and `CUDAGraphWrapper(FULL)` is composed on top (model and drafter) whenever `FULL` cudagraphs are used.

Also make `VLLM_USE_BREAKABLE_CUDAGRAPH` default to on for cuda (continuing to exclude ROCm for now where there may be performance regressions).

Kimi K3 used to help with this.