### PR TITLE
[WIP]Support PCP with DP

### DIFF
--- a/tests/test_pcp_dp.py
+++ b/tests/test_pcp_dp.py
@@ -6,8 +6,12 @@ from types import SimpleNamespace
 import torch
 
 from vllm.config import ParallelConfig
+from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.device_communicators.all2all import AgRsAll2AllManager
 from vllm.forward_context import DPMetadata, _compute_sp_num_tokens
+from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.dp_utils import sync_cudagraph_and_dp_padding
 from vllm.v1.worker.gpu_worker import _dp_local_rank_offset
 
 
@@ -54,6 +58,95 @@ def test_ep_dispatch_sizes_preserve_dp_pcp_order_without_sp():
         num_dispatchers_per_dp_rank=2,
     ) as sizes:
         assert sizes == [10, 7, 5, 3]
+
+
+def test_batch_coordination_returns_dp_and_dp_pcp_token_counts(monkeypatch):
+    config = ParallelConfig(
+        prefill_context_parallel_size=2,
+        data_parallel_size=2,
+        enable_expert_parallel=True,
+    )
+    collective_calls = 0
+
+    monkeypatch.setattr(
+        "vllm.v1.worker.dp_utils._get_device_and_group",
+        lambda parallel_config: ("cpu", object(), 4, 0, 2, 0),
+    )
+
+    def fake_all_reduce(tensor, group):
+        nonlocal collective_calls
+        collective_calls += 1
+        tensor.copy_(
+            torch.tensor(
+                [
+                    [10, 7, 5, 3],
+                    [10, 7, 5, 3],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                ],
+                dtype=torch.int32,
+            )
+        )
+
+    monkeypatch.setattr("vllm.v1.worker.dp_utils.dist.all_reduce", fake_all_reduce)
+
+    _, num_tokens_across_dp, num_tokens_across_dp_pcp, _ = coordinate_batch_across_dp(
+        num_tokens_unpadded=10,
+        allow_microbatching=False,
+        parallel_config=config,
+    )
+
+    assert collective_calls == 1
+    assert num_tokens_across_dp.tolist() == [10, 5]
+    assert num_tokens_across_dp_pcp.tolist() == [10, 7, 5, 3]
+
+
+def test_v2_batch_coordination_returns_dp_and_dp_pcp_token_counts(monkeypatch):
+    collective_calls = 0
+    group = SimpleNamespace(world_size=4, rank_in_group=1, cpu_group=object())
+    monkeypatch.setattr("vllm.v1.worker.gpu.dp_utils.get_dp_group", lambda: group)
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.dp_utils.get_moe_dp_pcp_group", lambda: group
+    )
+
+    def fake_all_reduce(tensor, group):
+        nonlocal collective_calls
+        collective_calls += 1
+        tensor.copy_(
+            torch.tensor(
+                [
+                    [10, 7, 5, 3],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [-1, -1, -1, -1],
+                ],
+                dtype=torch.int32,
+            )
+        )
+
+    monkeypatch.setattr("vllm.v1.worker.gpu.dp_utils.dist.all_reduce", fake_all_reduce)
+
+    _, sync = sync_cudagraph_and_dp_padding(
+        cudagraph_manager=None,
+        desired_batch_desc=BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.NONE,
+            num_tokens=7,
+            num_reqs=1,
+        ),
+        num_tokens=7,
+        num_reqs=1,
+        uniform_token_count=None,
+        dp_size=2,
+        dp_rank=0,
+        pcp_size=2,
+        enable_expert_parallel=True,
+    )
+
+    assert collective_calls == 1
+    assert sync is not None
+    assert sync.num_tokens_across_dp.tolist() == [7, 3]
+    assert sync.num_tokens_across_dp_pcp is not None
+    assert sync.num_tokens_across_dp_pcp.tolist() == [10, 7, 5, 3]
 
 
 def test_ag_rs_selects_moe_dp_pcp_group_for_non_sp(monkeypatch):

--- a/tests/test_pcp_dp.py
+++ b/tests/test_pcp_dp.py
@@ -3,12 +3,10 @@
 
 from types import SimpleNamespace
 
-import pytest
 import torch
 
 from vllm.config import ParallelConfig
 from vllm.distributed.device_communicators.all2all import AgRsAll2AllManager
-from vllm.distributed.parallel_state import _get_moe_dp_pcp_group_ranks
 from vllm.forward_context import DPMetadata, _compute_sp_num_tokens
 from vllm.v1.worker.gpu_worker import _dp_local_rank_offset
 
@@ -58,27 +56,6 @@ def test_ep_dispatch_sizes_preserve_dp_pcp_order_without_sp():
         assert sizes == [10, 7, 5, 3]
 
 
-@pytest.mark.parametrize(
-    ("dp_size", "pcp_size", "expected"),
-    [
-        (2, 2, [[0, 2, 4, 6], [1, 3, 5, 7]]),
-        (2, 1, [[0, 2], [1, 3]]),
-        (1, 2, [[0, 2], [1, 3]]),
-        (1, 1, [[0], [1]]),
-    ],
-)
-def test_moe_dp_pcp_group_ranks_fix_tp_coordinate(dp_size, pcp_size, expected):
-    all_ranks = torch.arange(dp_size * pcp_size * 2).reshape(1, dp_size, 1, pcp_size, 2)
-
-    group_ranks = _get_moe_dp_pcp_group_ranks(
-        all_ranks,
-        data_parallel_size=dp_size,
-        prefill_context_parallel_size=pcp_size,
-    )
-
-    assert group_ranks == expected
-
-
 def test_ag_rs_selects_moe_dp_pcp_group_for_non_sp(monkeypatch):
     moe_dp_pcp_group = object()
     manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
@@ -86,12 +63,17 @@ def test_ag_rs_selects_moe_dp_pcp_group_for_non_sp(monkeypatch):
         "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
         lambda: moe_dp_pcp_group,
     )
-    monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.has_moe_dp_pcp_group",
-        lambda: True,
-    )
-    assert manager._uses_moe_dp_pcp_group(is_sequence_parallel=False)
     assert manager._get_comm_group(is_sequence_parallel=False) is moe_dp_pcp_group
+
+
+def test_ag_rs_selects_ep_group_for_sp(monkeypatch):
+    ep_group = object()
+    manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_ep_group",
+        lambda: ep_group,
+    )
+    assert manager._get_comm_group(is_sequence_parallel=True) is ep_group
 
 
 def test_ag_rs_moe_dp_pcp_uses_one_collective_for_each_direction(monkeypatch):
@@ -111,17 +93,14 @@ def test_ag_rs_moe_dp_pcp_uses_one_collective_for_each_direction(monkeypatch):
             assert tensor.tolist() == [10, 11, 12, 20, 21, 22]
             return tensor[3:5]
 
-    monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
-        lambda: FakeMoeDpPcpGroup(),
-    )
     manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
     sizes = [1, 2, 2, 1]
     group = FakeMoeDpPcpGroup()
-    manager._get_comm_group = lambda is_sequence_parallel: group
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
+        lambda: group,
+    )
     manager._get_sizes = lambda num_local_tokens, comm_group: sizes
-    manager._uses_staged_dp_pcp = lambda is_sequence_parallel: False
-
     hidden_states, _, _ = manager.dispatch(
         torch.tensor([20, 21]),
         torch.tensor([1, 1]),

--- a/tests/test_pcp_dp.py
+++ b/tests/test_pcp_dp.py
@@ -7,6 +7,7 @@ import torch
 
 from vllm.config import ParallelConfig
 from vllm.distributed.device_communicators.all2all import AgRsAll2AllManager
+from vllm.distributed.parallel_state import _get_moe_dp_pcp_group_ranks
 from vllm.forward_context import DPMetadata, _compute_sp_num_tokens
 from vllm.v1.worker.gpu_worker import _dp_local_rank_offset
 
@@ -56,82 +57,84 @@ def test_ep_dispatch_sizes_preserve_dp_pcp_order_without_sp():
         assert sizes == [10, 7, 5, 3]
 
 
-def test_ag_rs_detects_combined_pcp_dp_without_using_ep_group(monkeypatch):
-    dp_group = object()
+def test_moe_dp_pcp_group_ranks_fix_tp_coordinate():
+    all_ranks = torch.arange(8).reshape(1, 2, 1, 2, 2)
+
+    group_ranks = _get_moe_dp_pcp_group_ranks(
+        all_ranks,
+        data_parallel_size=2,
+        prefill_context_parallel_size=2,
+    )
+
+    assert group_ranks == [[0, 2, 4, 6], [1, 3, 5, 7]]
+
+
+def test_ag_rs_selects_moe_dp_pcp_group_for_non_sp(monkeypatch):
+    moe_dp_pcp_group = object()
     pcp_group = SimpleNamespace(world_size=2)
     dp_metadata = SimpleNamespace(num_tokens_across_dp_pcp_cpu=torch.tensor([1]))
     manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
     manager.dp_world_size = 2
 
     monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_dp_group",
-        lambda: dp_group,
-    )
-    monkeypatch.setattr(
         "vllm.distributed.device_communicators.all2all.get_pcp_group",
         lambda: pcp_group,
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
+        lambda: moe_dp_pcp_group,
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.has_moe_dp_pcp_group",
+        lambda: True,
     )
     monkeypatch.setattr(
         "vllm.distributed.device_communicators.all2all.get_forward_context",
         lambda: SimpleNamespace(dp_metadata=dp_metadata),
     )
 
-    assert manager._uses_combined_dp_pcp(is_sequence_parallel=False)
-    assert manager._get_comm_group(is_sequence_parallel=False) is dp_group
+    assert manager._uses_moe_dp_pcp_group(is_sequence_parallel=False)
+    assert manager._get_comm_group(is_sequence_parallel=False) is moe_dp_pcp_group
 
 
-def test_ag_rs_combined_pcp_dp_collective_order(monkeypatch):
+def test_ag_rs_moe_dp_pcp_uses_one_collective_for_each_direction(monkeypatch):
     calls = []
 
-    class FakePcpGroup:
-        world_size = 2
-        rank_in_group = 0
+    class FakeMoeDpPcpGroup:
+        world_size = 4
+        rank_in_group = 2
 
         def all_gatherv(self, tensors, dim, sizes):
-            calls.append(("pcp_ag", sizes))
+            calls.append(("moe_dp_pcp_ag", sizes))
             assert tensors[0].tolist() == [20, 21]
-            return [torch.tensor([20, 21, 22]) for _ in tensors]
-
-        def reduce_scatterv(self, tensor, dim, sizes):
-            calls.append(("pcp_rs", sizes))
-            assert tensor.tolist() == [20, 21, 22]
-            return tensor[:2]
-
-    class FakeDpGroup:
-        world_size = 2
-        rank_in_group = 1
-
-        def all_gatherv(self, tensors, dim, sizes):
-            calls.append(("dp_ag", sizes))
-            assert tensors[0].tolist() == [20, 21, 22]
             return [torch.tensor([10, 11, 12, 20, 21, 22]) for _ in tensors]
 
         def reduce_scatterv(self, tensor, dim, sizes):
-            calls.append(("dp_rs", sizes))
+            calls.append(("moe_dp_pcp_rs", sizes))
             assert tensor.tolist() == [10, 11, 12, 20, 21, 22]
-            return tensor[3:]
+            return tensor[3:5]
 
     monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_dp_group",
-        lambda: FakeDpGroup(),
-    )
-    monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_pcp_group",
-        lambda: FakePcpGroup(),
+        "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
+        lambda: FakeMoeDpPcpGroup(),
     )
     manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
     sizes = [1, 2, 2, 1]
+    group = FakeMoeDpPcpGroup()
+    manager._get_comm_group = lambda is_sequence_parallel: group
+    manager._get_sizes = lambda num_local_tokens, comm_group: sizes
+    manager._uses_staged_dp_pcp = lambda is_sequence_parallel: False
 
-    gathered = manager._dispatch_combined_dp_pcp(
-        [torch.tensor([20, 21])], sizes
+    hidden_states, _, _ = manager.dispatch(
+        torch.tensor([20, 21]),
+        torch.tensor([1, 1]),
+        torch.tensor([0, 0]),
     )
-    combined = manager._combine_combined_dp_pcp(gathered[0], sizes)
+    combined = manager.combine(hidden_states)
 
-    assert gathered[0].tolist() == [10, 11, 12, 20, 21, 22]
+    assert hidden_states.tolist() == [10, 11, 12, 20, 21, 22]
     assert combined.tolist() == [20, 21]
     assert calls == [
-        ("pcp_ag", [2, 1]),
-        ("dp_ag", [3, 3]),
-        ("dp_rs", [3, 3]),
-        ("pcp_rs", [2, 1]),
+        ("moe_dp_pcp_ag", [1, 2, 2, 1]),
+        ("moe_dp_pcp_rs", [1, 2, 2, 1]),
     ]

--- a/tests/test_pcp_dp.py
+++ b/tests/test_pcp_dp.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.config import ParallelConfig
@@ -57,29 +58,30 @@ def test_ep_dispatch_sizes_preserve_dp_pcp_order_without_sp():
         assert sizes == [10, 7, 5, 3]
 
 
-def test_moe_dp_pcp_group_ranks_fix_tp_coordinate():
-    all_ranks = torch.arange(8).reshape(1, 2, 1, 2, 2)
+@pytest.mark.parametrize(
+    ("dp_size", "pcp_size", "expected"),
+    [
+        (2, 2, [[0, 2, 4, 6], [1, 3, 5, 7]]),
+        (2, 1, [[0, 2], [1, 3]]),
+        (1, 2, [[0, 2], [1, 3]]),
+        (1, 1, [[0], [1]]),
+    ],
+)
+def test_moe_dp_pcp_group_ranks_fix_tp_coordinate(dp_size, pcp_size, expected):
+    all_ranks = torch.arange(dp_size * pcp_size * 2).reshape(1, dp_size, 1, pcp_size, 2)
 
     group_ranks = _get_moe_dp_pcp_group_ranks(
         all_ranks,
-        data_parallel_size=2,
-        prefill_context_parallel_size=2,
+        data_parallel_size=dp_size,
+        prefill_context_parallel_size=pcp_size,
     )
 
-    assert group_ranks == [[0, 2, 4, 6], [1, 3, 5, 7]]
+    assert group_ranks == expected
 
 
 def test_ag_rs_selects_moe_dp_pcp_group_for_non_sp(monkeypatch):
     moe_dp_pcp_group = object()
-    pcp_group = SimpleNamespace(world_size=2)
-    dp_metadata = SimpleNamespace(num_tokens_across_dp_pcp_cpu=torch.tensor([1]))
     manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
-    manager.dp_world_size = 2
-
-    monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_pcp_group",
-        lambda: pcp_group,
-    )
     monkeypatch.setattr(
         "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
         lambda: moe_dp_pcp_group,
@@ -88,11 +90,6 @@ def test_ag_rs_selects_moe_dp_pcp_group_for_non_sp(monkeypatch):
         "vllm.distributed.device_communicators.all2all.has_moe_dp_pcp_group",
         lambda: True,
     )
-    monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_forward_context",
-        lambda: SimpleNamespace(dp_metadata=dp_metadata),
-    )
-
     assert manager._uses_moe_dp_pcp_group(is_sequence_parallel=False)
     assert manager._get_comm_group(is_sequence_parallel=False) is moe_dp_pcp_group
 

--- a/tests/test_pcp_dp.py
+++ b/tests/test_pcp_dp.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.config import ParallelConfig
+from vllm.distributed.device_communicators.all2all import AgRsAll2AllManager
+from vllm.forward_context import DPMetadata, _compute_sp_num_tokens
+from vllm.v1.worker.gpu_worker import _dp_local_rank_offset
+
+
+def test_parallel_config_accepts_pcp_with_dp():
+    config = ParallelConfig(
+        tensor_parallel_size=2,
+        prefill_context_parallel_size=2,
+        data_parallel_size=2,
+    )
+
+    assert config.world_size_across_dp == 8
+
+
+def test_dp_local_rank_offset_includes_pcp():
+    config = SimpleNamespace(
+        data_parallel_rank_local=1,
+        data_parallel_index=3,
+        pipeline_parallel_size=1,
+        prefill_context_parallel_size=2,
+        tensor_parallel_size=2,
+    )
+
+    assert _dp_local_rank_offset(config) == 4
+
+
+def test_ep_dispatch_sizes_include_pcp_and_sequence_parallel_ranks():
+    sizes = _compute_sp_num_tokens(
+        torch.tensor([17, 8]),
+        sequence_parallel_size=2,
+        num_replicas_per_token_count=4,
+    )
+
+    assert sizes == [9, 9, 9, 9, 4, 4, 4, 4]
+
+
+def test_ep_dispatch_sizes_preserve_dp_pcp_order_without_sp():
+    metadata = DPMetadata(
+        num_tokens_across_dp_cpu=torch.tensor([17, 8]),
+        num_tokens_across_dp_pcp_cpu=torch.tensor([10, 7, 5, 3]),
+    )
+
+    with metadata.sp_local_sizes(
+        sequence_parallel_size=1,
+        num_dispatchers_per_dp_rank=2,
+    ) as sizes:
+        assert sizes == [10, 7, 5, 3]
+
+
+def test_ag_rs_detects_combined_pcp_dp_without_using_ep_group(monkeypatch):
+    dp_group = object()
+    pcp_group = SimpleNamespace(world_size=2)
+    dp_metadata = SimpleNamespace(num_tokens_across_dp_pcp_cpu=torch.tensor([1]))
+    manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
+    manager.dp_world_size = 2
+
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_dp_group",
+        lambda: dp_group,
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_pcp_group",
+        lambda: pcp_group,
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_forward_context",
+        lambda: SimpleNamespace(dp_metadata=dp_metadata),
+    )
+
+    assert manager._uses_combined_dp_pcp(is_sequence_parallel=False)
+    assert manager._get_comm_group(is_sequence_parallel=False) is dp_group
+
+
+def test_ag_rs_combined_pcp_dp_collective_order(monkeypatch):
+    calls = []
+
+    class FakePcpGroup:
+        world_size = 2
+        rank_in_group = 0
+
+        def all_gatherv(self, tensors, dim, sizes):
+            calls.append(("pcp_ag", sizes))
+            assert tensors[0].tolist() == [20, 21]
+            return [torch.tensor([20, 21, 22]) for _ in tensors]
+
+        def reduce_scatterv(self, tensor, dim, sizes):
+            calls.append(("pcp_rs", sizes))
+            assert tensor.tolist() == [20, 21, 22]
+            return tensor[:2]
+
+    class FakeDpGroup:
+        world_size = 2
+        rank_in_group = 1
+
+        def all_gatherv(self, tensors, dim, sizes):
+            calls.append(("dp_ag", sizes))
+            assert tensors[0].tolist() == [20, 21, 22]
+            return [torch.tensor([10, 11, 12, 20, 21, 22]) for _ in tensors]
+
+        def reduce_scatterv(self, tensor, dim, sizes):
+            calls.append(("dp_rs", sizes))
+            assert tensor.tolist() == [10, 11, 12, 20, 21, 22]
+            return tensor[3:]
+
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_dp_group",
+        lambda: FakeDpGroup(),
+    )
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.all2all.get_pcp_group",
+        lambda: FakePcpGroup(),
+    )
+    manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
+    sizes = [1, 2, 2, 1]
+
+    gathered = manager._dispatch_combined_dp_pcp(
+        [torch.tensor([20, 21])], sizes
+    )
+    combined = manager._combine_combined_dp_pcp(gathered[0], sizes)
+
+    assert gathered[0].tolist() == [10, 11, 12, 20, 21, 22]
+    assert combined.tolist() == [20, 21]
+    assert calls == [
+        ("pcp_ag", [2, 1]),
+        ("dp_ag", [3, 3]),
+        ("dp_rs", [3, 3]),
+        ("pcp_rs", [2, 1]),
+    ]

--- a/tests/test_pcp_dp.py
+++ b/tests/test_pcp_dp.py
@@ -50,7 +50,7 @@ def test_ep_dispatch_sizes_include_pcp_and_sequence_parallel_ranks():
 def test_ep_dispatch_sizes_preserve_dp_pcp_order_without_sp():
     metadata = DPMetadata(
         num_tokens_across_dp_cpu=torch.tensor([17, 8]),
-        num_tokens_across_dp_pcp_cpu=torch.tensor([10, 7, 5, 3]),
+        moe_non_sp_token_counts_cpu=torch.tensor([10, 7, 5, 3]),
     )
 
     with metadata.sp_local_sizes(
@@ -60,7 +60,7 @@ def test_ep_dispatch_sizes_preserve_dp_pcp_order_without_sp():
         assert sizes == [10, 7, 5, 3]
 
 
-def test_batch_coordination_returns_dp_and_dp_pcp_token_counts(monkeypatch):
+def test_batch_coordination_returns_dp_and_moe_non_sp_token_counts(monkeypatch):
     config = ParallelConfig(
         prefill_context_parallel_size=2,
         data_parallel_size=2,
@@ -90,7 +90,7 @@ def test_batch_coordination_returns_dp_and_dp_pcp_token_counts(monkeypatch):
 
     monkeypatch.setattr("vllm.v1.worker.dp_utils.dist.all_reduce", fake_all_reduce)
 
-    _, num_tokens_across_dp, num_tokens_across_dp_pcp, _ = coordinate_batch_across_dp(
+    _, num_tokens_across_dp, moe_non_sp_token_counts, _ = coordinate_batch_across_dp(
         num_tokens_unpadded=10,
         allow_microbatching=False,
         parallel_config=config,
@@ -98,15 +98,15 @@ def test_batch_coordination_returns_dp_and_dp_pcp_token_counts(monkeypatch):
 
     assert collective_calls == 1
     assert num_tokens_across_dp.tolist() == [10, 5]
-    assert num_tokens_across_dp_pcp.tolist() == [10, 7, 5, 3]
+    assert moe_non_sp_token_counts.tolist() == [10, 7, 5, 3]
 
 
-def test_v2_batch_coordination_returns_dp_and_dp_pcp_token_counts(monkeypatch):
+def test_v2_batch_coordination_returns_dp_and_moe_non_sp_token_counts(monkeypatch):
     collective_calls = 0
     group = SimpleNamespace(world_size=4, rank_in_group=1, cpu_group=object())
     monkeypatch.setattr("vllm.v1.worker.gpu.dp_utils.get_dp_group", lambda: group)
     monkeypatch.setattr(
-        "vllm.v1.worker.gpu.dp_utils.get_moe_dp_pcp_group", lambda: group
+        "vllm.v1.worker.gpu.dp_utils.get_moe_non_sp_group", lambda: group
     )
 
     def fake_all_reduce(tensor, group):
@@ -145,18 +145,18 @@ def test_v2_batch_coordination_returns_dp_and_dp_pcp_token_counts(monkeypatch):
     assert collective_calls == 1
     assert sync is not None
     assert sync.num_tokens_across_dp.tolist() == [7, 3]
-    assert sync.num_tokens_across_dp_pcp is not None
-    assert sync.num_tokens_across_dp_pcp.tolist() == [10, 7, 5, 3]
+    assert sync.moe_non_sp_token_counts is not None
+    assert sync.moe_non_sp_token_counts.tolist() == [10, 7, 5, 3]
 
 
-def test_ag_rs_selects_moe_dp_pcp_group_for_non_sp(monkeypatch):
-    moe_dp_pcp_group = object()
+def test_ag_rs_selects_moe_non_sp_group(monkeypatch):
+    moe_non_sp_group = object()
     manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
     monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
-        lambda: moe_dp_pcp_group,
+        "vllm.distributed.device_communicators.all2all.get_moe_non_sp_group",
+        lambda: moe_non_sp_group,
     )
-    assert manager._get_comm_group(is_sequence_parallel=False) is moe_dp_pcp_group
+    assert manager._get_comm_group(is_sequence_parallel=False) is moe_non_sp_group
 
 
 def test_ag_rs_selects_ep_group_for_sp(monkeypatch):
@@ -169,28 +169,28 @@ def test_ag_rs_selects_ep_group_for_sp(monkeypatch):
     assert manager._get_comm_group(is_sequence_parallel=True) is ep_group
 
 
-def test_ag_rs_moe_dp_pcp_uses_one_collective_for_each_direction(monkeypatch):
+def test_ag_rs_moe_non_sp_uses_one_collective_for_each_direction(monkeypatch):
     calls = []
 
-    class FakeMoeDpPcpGroup:
+    class FakeMoeNonSpGroup:
         world_size = 4
         rank_in_group = 2
 
         def all_gatherv(self, tensors, dim, sizes):
-            calls.append(("moe_dp_pcp_ag", sizes))
+            calls.append(("moe_non_sp_ag", sizes))
             assert tensors[0].tolist() == [20, 21]
             return [torch.tensor([10, 11, 12, 20, 21, 22]) for _ in tensors]
 
         def reduce_scatterv(self, tensor, dim, sizes):
-            calls.append(("moe_dp_pcp_rs", sizes))
+            calls.append(("moe_non_sp_rs", sizes))
             assert tensor.tolist() == [10, 11, 12, 20, 21, 22]
             return tensor[3:5]
 
     manager = AgRsAll2AllManager.__new__(AgRsAll2AllManager)
     sizes = [1, 2, 2, 1]
-    group = FakeMoeDpPcpGroup()
+    group = FakeMoeNonSpGroup()
     monkeypatch.setattr(
-        "vllm.distributed.device_communicators.all2all.get_moe_dp_pcp_group",
+        "vllm.distributed.device_communicators.all2all.get_moe_non_sp_group",
         lambda: group,
     )
     manager._get_sizes = lambda num_local_tokens, comm_group: sizes
@@ -204,6 +204,6 @@ def test_ag_rs_moe_dp_pcp_uses_one_collective_for_each_direction(monkeypatch):
     assert hidden_states.tolist() == [10, 11, 12, 20, 21, 22]
     assert combined.tolist() == [20, 21]
     assert calls == [
-        ("moe_dp_pcp_ag", [1, 2, 2, 1]),
-        ("moe_dp_pcp_rs", [1, 2, 2, 1]),
+        ("moe_non_sp_ag", [1, 2, 2, 1]),
+        ("moe_non_sp_rs", [1, 2, 2, 1]),
     ]

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -545,8 +545,6 @@ class ParallelConfig:
         tp = self.tensor_parallel_size
         pcp = self.prefill_context_parallel_size
         dcp = self.decode_context_parallel_size
-        if pcp > 1 and self.data_parallel_size > 1:
-            raise ValueError("PCP does not support data parallelism yet.")
         if pcp == 1:
             # DCP reuses the TP ranks when PCP is disabled.
             if tp % dcp != 0:

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -67,9 +67,7 @@ class AgRsAll2AllManager(All2AllManagerBase):
         )
 
     def _uses_moe_dp_pcp_group(self, is_sequence_parallel: bool) -> bool:
-        return has_moe_dp_pcp_group() and self._uses_dp_pcp_metadata(
-            is_sequence_parallel
-        )
+        return not is_sequence_parallel and has_moe_dp_pcp_group()
 
     def _uses_staged_dp_pcp(self, is_sequence_parallel: bool) -> bool:
         return not has_moe_dp_pcp_group() and self._uses_dp_pcp_metadata(

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -9,7 +9,11 @@ import torch.distributed as dist
 
 import vllm.envs as envs
 from vllm.config import get_current_vllm_config
-from vllm.distributed import get_dp_group, get_ep_group, get_pcp_group
+from vllm.distributed import (
+    get_dp_group,
+    get_ep_group,
+    get_pcp_group,
+)
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
@@ -50,12 +54,65 @@ class AgRsAll2AllManager(All2AllManagerBase):
     def __init__(self, cpu_group, tcp_store_group=None):
         super().__init__(cpu_group, tcp_store_group)
 
+    def _uses_combined_dp_pcp(self, is_sequence_parallel: bool) -> bool:
+        if is_sequence_parallel or self.dp_world_size == 1:
+            return False
+        dp_metadata = get_forward_context().dp_metadata
+        return (
+            get_pcp_group().world_size > 1
+            and dp_metadata is not None
+            and dp_metadata.num_tokens_across_dp_pcp_cpu is not None
+        )
+
     def _get_comm_group(self, is_sequence_parallel: bool) -> Any:
         if is_sequence_parallel:
             return get_ep_group()
         if self.dp_world_size > 1:
             return get_dp_group()
         return get_pcp_group()
+
+    def _dispatch_combined_dp_pcp(
+        self, tensors: list[torch.Tensor], sizes: list[int]
+    ) -> list[torch.Tensor]:
+        """All-gather in PCP-then-DP order to produce DP -> PCP layout."""
+        dp_group = get_dp_group()
+        pcp_group = get_pcp_group()
+        pcp_size = pcp_group.world_size
+        assert len(sizes) == dp_group.world_size * pcp_size
+
+        dp_rank = dp_group.rank_in_group
+        local_pcp_sizes = sizes[dp_rank * pcp_size : (dp_rank + 1) * pcp_size]
+        assert local_pcp_sizes[pcp_group.rank_in_group] == tensors[0].shape[0]
+        tensors = pcp_group.all_gatherv(tensors, dim=0, sizes=local_pcp_sizes)
+
+        sizes_per_dp = [
+            sum(sizes[i * pcp_size : (i + 1) * pcp_size])
+            for i in range(dp_group.world_size)
+        ]
+        return dp_group.all_gatherv(tensors, dim=0, sizes=sizes_per_dp)
+
+    def _combine_combined_dp_pcp(
+        self, hidden_states: torch.Tensor, sizes: list[int]
+    ) -> torch.Tensor:
+        """Undo combined dispatch: reduce-scatter DP, then PCP."""
+        dp_group = get_dp_group()
+        pcp_group = get_pcp_group()
+        pcp_size = pcp_group.world_size
+        assert len(sizes) == dp_group.world_size * pcp_size
+
+        sizes_per_dp = [
+            sum(sizes[i * pcp_size : (i + 1) * pcp_size])
+            for i in range(dp_group.world_size)
+        ]
+        hidden_states = dp_group.reduce_scatterv(
+            hidden_states, dim=0, sizes=sizes_per_dp
+        )
+
+        dp_rank = dp_group.rank_in_group
+        local_pcp_sizes = sizes[dp_rank * pcp_size : (dp_rank + 1) * pcp_size]
+        return pcp_group.reduce_scatterv(
+            hidden_states, dim=0, sizes=local_pcp_sizes
+        )
 
     def _get_sizes(self, num_local_tokens: int, comm_group: Any) -> list[int]:
         if self.dp_world_size == 1:
@@ -80,19 +137,24 @@ class AgRsAll2AllManager(All2AllManagerBase):
         """
         Gather hidden_states and router_logits from all dp ranks.
         """
-        dist_group = self._get_comm_group(is_sequence_parallel)
-        sizes = self._get_sizes(hidden_states.shape[0], dist_group)
-        assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
-
         tensors_to_gather = [hidden_states, router_logits]
         if extra_tensors is not None:
             tensors_to_gather.extend(extra_tensors)
 
-        gathered_tensors = dist_group.all_gatherv(
-            tensors_to_gather,
-            dim=0,
-            sizes=sizes,
-        )
+        dist_group = self._get_comm_group(is_sequence_parallel)
+        sizes = self._get_sizes(hidden_states.shape[0], dist_group)
+        if self._uses_combined_dp_pcp(is_sequence_parallel):
+            gathered_tensors = self._dispatch_combined_dp_pcp(
+                tensors_to_gather, sizes
+            )
+        else:
+            assert len(sizes) == dist_group.world_size
+            assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
+            gathered_tensors = dist_group.all_gatherv(
+                tensors_to_gather,
+                dim=0,
+                sizes=sizes,
+            )
 
         if extra_tensors is not None:
             return (gathered_tensors[0], gathered_tensors[1], gathered_tensors[2:])
@@ -112,19 +174,24 @@ class AgRsAll2AllManager(All2AllManagerBase):
         """
         Gather hidden_states and router_logits from all dp ranks.
         """
-        dist_group = self._get_comm_group(is_sequence_parallel)
-        sizes = self._get_sizes(hidden_states.shape[0], dist_group)
-        assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
-
         tensors_to_gather = [hidden_states, topk_weights, topk_ids]
         if extra_tensors is not None:
             tensors_to_gather.extend(extra_tensors)
 
-        gathered_tensors = dist_group.all_gatherv(
-            tensors_to_gather,
-            dim=0,
-            sizes=sizes,
-        )
+        dist_group = self._get_comm_group(is_sequence_parallel)
+        sizes = self._get_sizes(hidden_states.shape[0], dist_group)
+        if self._uses_combined_dp_pcp(is_sequence_parallel):
+            gathered_tensors = self._dispatch_combined_dp_pcp(
+                tensors_to_gather, sizes
+            )
+        else:
+            assert len(sizes) == dist_group.world_size
+            assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
+            gathered_tensors = dist_group.all_gatherv(
+                tensors_to_gather,
+                dim=0,
+                sizes=sizes,
+            )
 
         hidden_states = gathered_tensors[0]
         topk_weights = gathered_tensors[1]
@@ -145,6 +212,12 @@ class AgRsAll2AllManager(All2AllManagerBase):
         sizes = self._get_sizes(
             hidden_states.shape[0] // dist_group.world_size,
             dist_group,
+        )
+        if self._uses_combined_dp_pcp(is_sequence_parallel):
+            return self._combine_combined_dp_pcp(hidden_states, sizes)
+        assert len(sizes) == dist_group.world_size, (
+            f"Expected one token count per dispatch rank, got {len(sizes)} "
+            f"for world size {dist_group.world_size}."
         )
         hidden_states = dist_group.reduce_scatterv(hidden_states, dim=0, sizes=sizes)
         return hidden_states

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -12,7 +12,9 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed import (
     get_dp_group,
     get_ep_group,
+    get_moe_dp_pcp_group,
     get_pcp_group,
+    has_moe_dp_pcp_group,
 )
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.forward_context import get_forward_context
@@ -54,7 +56,7 @@ class AgRsAll2AllManager(All2AllManagerBase):
     def __init__(self, cpu_group, tcp_store_group=None):
         super().__init__(cpu_group, tcp_store_group)
 
-    def _uses_combined_dp_pcp(self, is_sequence_parallel: bool) -> bool:
+    def _uses_dp_pcp_metadata(self, is_sequence_parallel: bool) -> bool:
         if is_sequence_parallel or self.dp_world_size == 1:
             return False
         dp_metadata = get_forward_context().dp_metadata
@@ -64,17 +66,28 @@ class AgRsAll2AllManager(All2AllManagerBase):
             and dp_metadata.num_tokens_across_dp_pcp_cpu is not None
         )
 
+    def _uses_moe_dp_pcp_group(self, is_sequence_parallel: bool) -> bool:
+        return has_moe_dp_pcp_group() and self._uses_dp_pcp_metadata(
+            is_sequence_parallel
+        )
+
+    def _uses_staged_dp_pcp(self, is_sequence_parallel: bool) -> bool:
+        return not has_moe_dp_pcp_group() and self._uses_dp_pcp_metadata(
+            is_sequence_parallel
+        )
+
     def _get_comm_group(self, is_sequence_parallel: bool) -> Any:
         if is_sequence_parallel:
             return get_ep_group()
+        if self._uses_moe_dp_pcp_group(is_sequence_parallel):
+            return get_moe_dp_pcp_group()
         if self.dp_world_size > 1:
             return get_dp_group()
         return get_pcp_group()
 
-    def _dispatch_combined_dp_pcp(
+    def _dispatch_staged_dp_pcp(
         self, tensors: list[torch.Tensor], sizes: list[int]
     ) -> list[torch.Tensor]:
-        """All-gather in PCP-then-DP order to produce DP -> PCP layout."""
         dp_group = get_dp_group()
         pcp_group = get_pcp_group()
         pcp_size = pcp_group.world_size
@@ -91,10 +104,9 @@ class AgRsAll2AllManager(All2AllManagerBase):
         ]
         return dp_group.all_gatherv(tensors, dim=0, sizes=sizes_per_dp)
 
-    def _combine_combined_dp_pcp(
+    def _combine_staged_dp_pcp(
         self, hidden_states: torch.Tensor, sizes: list[int]
     ) -> torch.Tensor:
-        """Undo combined dispatch: reduce-scatter DP, then PCP."""
         dp_group = get_dp_group()
         pcp_group = get_pcp_group()
         pcp_size = pcp_group.world_size
@@ -110,9 +122,7 @@ class AgRsAll2AllManager(All2AllManagerBase):
 
         dp_rank = dp_group.rank_in_group
         local_pcp_sizes = sizes[dp_rank * pcp_size : (dp_rank + 1) * pcp_size]
-        return pcp_group.reduce_scatterv(
-            hidden_states, dim=0, sizes=local_pcp_sizes
-        )
+        return pcp_group.reduce_scatterv(hidden_states, dim=0, sizes=local_pcp_sizes)
 
     def _get_sizes(self, num_local_tokens: int, comm_group: Any) -> list[int]:
         if self.dp_world_size == 1:
@@ -143,18 +153,22 @@ class AgRsAll2AllManager(All2AllManagerBase):
 
         dist_group = self._get_comm_group(is_sequence_parallel)
         sizes = self._get_sizes(hidden_states.shape[0], dist_group)
-        if self._uses_combined_dp_pcp(is_sequence_parallel):
-            gathered_tensors = self._dispatch_combined_dp_pcp(
-                tensors_to_gather, sizes
-            )
-        else:
-            assert len(sizes) == dist_group.world_size
-            assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
-            gathered_tensors = dist_group.all_gatherv(
-                tensors_to_gather,
-                dim=0,
-                sizes=sizes,
-            )
+        if self._uses_staged_dp_pcp(is_sequence_parallel):
+            gathered_tensors = self._dispatch_staged_dp_pcp(tensors_to_gather, sizes)
+            if extra_tensors is not None:
+                return (
+                    gathered_tensors[0],
+                    gathered_tensors[1],
+                    gathered_tensors[2:],
+                )
+            return gathered_tensors[0], gathered_tensors[1]
+        assert len(sizes) == dist_group.world_size
+        assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
+        gathered_tensors = dist_group.all_gatherv(
+            tensors_to_gather,
+            dim=0,
+            sizes=sizes,
+        )
 
         if extra_tensors is not None:
             return (gathered_tensors[0], gathered_tensors[1], gathered_tensors[2:])
@@ -180,10 +194,8 @@ class AgRsAll2AllManager(All2AllManagerBase):
 
         dist_group = self._get_comm_group(is_sequence_parallel)
         sizes = self._get_sizes(hidden_states.shape[0], dist_group)
-        if self._uses_combined_dp_pcp(is_sequence_parallel):
-            gathered_tensors = self._dispatch_combined_dp_pcp(
-                tensors_to_gather, sizes
-            )
+        if self._uses_staged_dp_pcp(is_sequence_parallel):
+            gathered_tensors = self._dispatch_staged_dp_pcp(tensors_to_gather, sizes)
         else:
             assert len(sizes) == dist_group.world_size
             assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
@@ -213,8 +225,8 @@ class AgRsAll2AllManager(All2AllManagerBase):
             hidden_states.shape[0] // dist_group.world_size,
             dist_group,
         )
-        if self._uses_combined_dp_pcp(is_sequence_parallel):
-            return self._combine_combined_dp_pcp(hidden_states, sizes)
+        if self._uses_staged_dp_pcp(is_sequence_parallel):
+            return self._combine_staged_dp_pcp(hidden_states, sizes)
         assert len(sizes) == dist_group.world_size, (
             f"Expected one token count per dispatch rank, got {len(sizes)} "
             f"for world size {dist_group.world_size}."

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -11,7 +11,7 @@ import vllm.envs as envs
 from vllm.config import get_current_vllm_config
 from vllm.distributed import (
     get_ep_group,
-    get_moe_dp_pcp_group,
+    get_moe_non_sp_group,
 )
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.forward_context import get_forward_context
@@ -56,7 +56,7 @@ class AgRsAll2AllManager(All2AllManagerBase):
     def _get_comm_group(self, is_sequence_parallel: bool) -> Any:
         if is_sequence_parallel:
             return get_ep_group()
-        return get_moe_dp_pcp_group()
+        return get_moe_non_sp_group()
 
     def _get_sizes(self, num_local_tokens: int, comm_group: Any) -> list[int]:
         if self.dp_world_size == 1:

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -81,14 +81,15 @@ class AgRsAll2AllManager(All2AllManagerBase):
         """
         Gather hidden_states and router_logits from all dp ranks.
         """
-        tensors_to_gather = [hidden_states, router_logits]
-        if extra_tensors is not None:
-            tensors_to_gather.extend(extra_tensors)
-
         dist_group = self._get_comm_group(is_sequence_parallel)
         sizes = self._get_sizes(hidden_states.shape[0], dist_group)
         assert len(sizes) == dist_group.world_size
         assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
+
+        tensors_to_gather = [hidden_states, router_logits]
+        if extra_tensors is not None:
+            tensors_to_gather.extend(extra_tensors)
+
         gathered_tensors = dist_group.all_gatherv(
             tensors_to_gather,
             dim=0,
@@ -113,14 +114,15 @@ class AgRsAll2AllManager(All2AllManagerBase):
         """
         Gather hidden_states and router_logits from all dp ranks.
         """
-        tensors_to_gather = [hidden_states, topk_weights, topk_ids]
-        if extra_tensors is not None:
-            tensors_to_gather.extend(extra_tensors)
-
         dist_group = self._get_comm_group(is_sequence_parallel)
         sizes = self._get_sizes(hidden_states.shape[0], dist_group)
         assert len(sizes) == dist_group.world_size
         assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
+
+        tensors_to_gather = [hidden_states, topk_weights, topk_ids]
+        if extra_tensors is not None:
+            tensors_to_gather.extend(extra_tensors)
+
         gathered_tensors = dist_group.all_gatherv(
             tensors_to_gather,
             dim=0,

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -10,11 +10,8 @@ import torch.distributed as dist
 import vllm.envs as envs
 from vllm.config import get_current_vllm_config
 from vllm.distributed import (
-    get_dp_group,
     get_ep_group,
     get_moe_dp_pcp_group,
-    get_pcp_group,
-    has_moe_dp_pcp_group,
 )
 from vllm.distributed.utils import StatelessProcessGroup
 from vllm.forward_context import get_forward_context
@@ -56,71 +53,10 @@ class AgRsAll2AllManager(All2AllManagerBase):
     def __init__(self, cpu_group, tcp_store_group=None):
         super().__init__(cpu_group, tcp_store_group)
 
-    def _uses_dp_pcp_metadata(self, is_sequence_parallel: bool) -> bool:
-        if is_sequence_parallel or self.dp_world_size == 1:
-            return False
-        dp_metadata = get_forward_context().dp_metadata
-        return (
-            get_pcp_group().world_size > 1
-            and dp_metadata is not None
-            and dp_metadata.num_tokens_across_dp_pcp_cpu is not None
-        )
-
-    def _uses_moe_dp_pcp_group(self, is_sequence_parallel: bool) -> bool:
-        return not is_sequence_parallel and has_moe_dp_pcp_group()
-
-    def _uses_staged_dp_pcp(self, is_sequence_parallel: bool) -> bool:
-        return not has_moe_dp_pcp_group() and self._uses_dp_pcp_metadata(
-            is_sequence_parallel
-        )
-
     def _get_comm_group(self, is_sequence_parallel: bool) -> Any:
         if is_sequence_parallel:
             return get_ep_group()
-        if self._uses_moe_dp_pcp_group(is_sequence_parallel):
-            return get_moe_dp_pcp_group()
-        if self.dp_world_size > 1:
-            return get_dp_group()
-        return get_pcp_group()
-
-    def _dispatch_staged_dp_pcp(
-        self, tensors: list[torch.Tensor], sizes: list[int]
-    ) -> list[torch.Tensor]:
-        dp_group = get_dp_group()
-        pcp_group = get_pcp_group()
-        pcp_size = pcp_group.world_size
-        assert len(sizes) == dp_group.world_size * pcp_size
-
-        dp_rank = dp_group.rank_in_group
-        local_pcp_sizes = sizes[dp_rank * pcp_size : (dp_rank + 1) * pcp_size]
-        assert local_pcp_sizes[pcp_group.rank_in_group] == tensors[0].shape[0]
-        tensors = pcp_group.all_gatherv(tensors, dim=0, sizes=local_pcp_sizes)
-
-        sizes_per_dp = [
-            sum(sizes[i * pcp_size : (i + 1) * pcp_size])
-            for i in range(dp_group.world_size)
-        ]
-        return dp_group.all_gatherv(tensors, dim=0, sizes=sizes_per_dp)
-
-    def _combine_staged_dp_pcp(
-        self, hidden_states: torch.Tensor, sizes: list[int]
-    ) -> torch.Tensor:
-        dp_group = get_dp_group()
-        pcp_group = get_pcp_group()
-        pcp_size = pcp_group.world_size
-        assert len(sizes) == dp_group.world_size * pcp_size
-
-        sizes_per_dp = [
-            sum(sizes[i * pcp_size : (i + 1) * pcp_size])
-            for i in range(dp_group.world_size)
-        ]
-        hidden_states = dp_group.reduce_scatterv(
-            hidden_states, dim=0, sizes=sizes_per_dp
-        )
-
-        dp_rank = dp_group.rank_in_group
-        local_pcp_sizes = sizes[dp_rank * pcp_size : (dp_rank + 1) * pcp_size]
-        return pcp_group.reduce_scatterv(hidden_states, dim=0, sizes=local_pcp_sizes)
+        return get_moe_dp_pcp_group()
 
     def _get_sizes(self, num_local_tokens: int, comm_group: Any) -> list[int]:
         if self.dp_world_size == 1:
@@ -151,15 +87,6 @@ class AgRsAll2AllManager(All2AllManagerBase):
 
         dist_group = self._get_comm_group(is_sequence_parallel)
         sizes = self._get_sizes(hidden_states.shape[0], dist_group)
-        if self._uses_staged_dp_pcp(is_sequence_parallel):
-            gathered_tensors = self._dispatch_staged_dp_pcp(tensors_to_gather, sizes)
-            if extra_tensors is not None:
-                return (
-                    gathered_tensors[0],
-                    gathered_tensors[1],
-                    gathered_tensors[2:],
-                )
-            return gathered_tensors[0], gathered_tensors[1]
         assert len(sizes) == dist_group.world_size
         assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
         gathered_tensors = dist_group.all_gatherv(
@@ -192,16 +119,13 @@ class AgRsAll2AllManager(All2AllManagerBase):
 
         dist_group = self._get_comm_group(is_sequence_parallel)
         sizes = self._get_sizes(hidden_states.shape[0], dist_group)
-        if self._uses_staged_dp_pcp(is_sequence_parallel):
-            gathered_tensors = self._dispatch_staged_dp_pcp(tensors_to_gather, sizes)
-        else:
-            assert len(sizes) == dist_group.world_size
-            assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
-            gathered_tensors = dist_group.all_gatherv(
-                tensors_to_gather,
-                dim=0,
-                sizes=sizes,
-            )
+        assert len(sizes) == dist_group.world_size
+        assert sizes[dist_group.rank_in_group] == hidden_states.shape[0]
+        gathered_tensors = dist_group.all_gatherv(
+            tensors_to_gather,
+            dim=0,
+            sizes=sizes,
+        )
 
         hidden_states = gathered_tensors[0]
         topk_weights = gathered_tensors[1]
@@ -223,8 +147,6 @@ class AgRsAll2AllManager(All2AllManagerBase):
             hidden_states.shape[0] // dist_group.world_size,
             dist_group,
         )
-        if self._uses_staged_dp_pcp(is_sequence_parallel):
-            return self._combine_staged_dp_pcp(hidden_states, sizes)
         assert len(sizes) == dist_group.world_size, (
             f"Expected one token count per dispatch rank, got {len(sizes)} "
             f"for world size {dist_group.world_size}."

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -420,7 +420,12 @@ class ElasticEPScalingExecutor:
         self._wait_for_group_cleanup()
         self._release_cuda_graphs()
         retired_groups = _replace_active_groups(
-            world=None, dp=None, ep=None, eplb=None, node_count=None
+            world=None,
+            dp=None,
+            moe_dp_pcp=None,
+            ep=None,
+            eplb=None,
+            node_count=None,
         )
         self._start_group_cleanup(retired_groups)
         # Finish collective cleanup before this worker is shut down.

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -422,7 +422,7 @@ class ElasticEPScalingExecutor:
         retired_groups = _replace_active_groups(
             world=None,
             dp=None,
-            moe_dp_pcp=None,
+            moe_non_sp=None,
             ep=None,
             eplb=None,
             node_count=None,

--- a/vllm/distributed/elastic_ep/standby_state.py
+++ b/vllm/distributed/elastic_ep/standby_state.py
@@ -5,6 +5,7 @@ import torch
 from vllm.distributed.parallel_state import (
     _init_stateless_group,
     _node_count,
+    get_pcp_group,
     get_pp_group,
     get_tp_group,
     get_world_group,
@@ -14,6 +15,7 @@ from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
 _STANDBY_WORLD: StatelessGroupCoordinator | None = None
 _STANDBY_WORLD_NODE_COUNT: int | None = None
 _STANDBY_DP: StatelessGroupCoordinator | None = None
+_STANDBY_MOE_DP_PCP: StatelessGroupCoordinator | None = None
 _STANDBY_EP: StatelessGroupCoordinator | None = None
 _STANDBY_EPLB: StatelessGroupCoordinator | None = None
 
@@ -47,6 +49,7 @@ def create_standby_groups(
         _STANDBY_WORLD, \
         _STANDBY_WORLD_NODE_COUNT, \
         _STANDBY_DP, \
+        _STANDBY_MOE_DP_PCP, \
         _STANDBY_EP, \
         _STANDBY_EPLB
 
@@ -71,19 +74,34 @@ def create_standby_groups(
     _STANDBY_WORLD_NODE_COUNT = _node_count(_STANDBY_WORLD.tcp_store_group)
 
     tp_size = get_tp_group().world_size
+    pcp_size = get_pcp_group().world_size
     pp_size = get_pp_group().world_size
 
     all_ranks = torch.arange(new_world_size_across_dp).reshape(
-        -1, new_dp_size, pp_size, tp_size
+        -1, new_dp_size, pp_size, pcp_size, tp_size
     )
-    standby_dp_ranks = all_ranks.transpose(1, 3).reshape(-1, new_dp_size).unbind(0)
+    standby_dp_ranks = all_ranks.transpose(1, 4).reshape(-1, new_dp_size).unbind(0)
     standby_dp_ranks = [x.tolist() for x in standby_dp_ranks]
     _STANDBY_DP = _init_stateless_group(
         standby_dp_ranks, "dp", master_ip, backend, coord_store=coord_store
     )
 
+    standby_moe_dp_pcp_ranks = (
+        all_ranks.permute(0, 2, 4, 1, 3).reshape(-1, new_dp_size * pcp_size).unbind(0)
+    )
+    standby_moe_dp_pcp_ranks = [x.tolist() for x in standby_moe_dp_pcp_ranks]
+    _STANDBY_MOE_DP_PCP = _init_stateless_group(
+        standby_moe_dp_pcp_ranks,
+        "moe_dp_pcp_group",
+        master_ip,
+        backend,
+        coord_store=coord_store,
+    )
+
     standby_ep_ranks = (
-        all_ranks.transpose(1, 2).reshape(-1, new_dp_size * tp_size).unbind(0)
+        all_ranks.transpose(1, 2)
+        .reshape(-1, new_dp_size * pcp_size * tp_size)
+        .unbind(0)
     )
     standby_ep_ranks = [x.tolist() for x in standby_ep_ranks]
     _STANDBY_EP = _init_stateless_group(
@@ -106,12 +124,14 @@ def pop_standby_groups() -> dict:
         _STANDBY_WORLD, \
         _STANDBY_WORLD_NODE_COUNT, \
         _STANDBY_DP, \
+        _STANDBY_MOE_DP_PCP, \
         _STANDBY_EP, \
         _STANDBY_EPLB
 
     result = dict(
         world=_STANDBY_WORLD,
         dp=_STANDBY_DP,
+        moe_dp_pcp=_STANDBY_MOE_DP_PCP,
         ep=_STANDBY_EP,
         eplb=_STANDBY_EPLB,
         node_count=_STANDBY_WORLD_NODE_COUNT,
@@ -119,6 +139,7 @@ def pop_standby_groups() -> dict:
     _STANDBY_WORLD = None
     _STANDBY_WORLD_NODE_COUNT = None
     _STANDBY_DP = None
+    _STANDBY_MOE_DP_PCP = None
     _STANDBY_EP = None
     _STANDBY_EPLB = None
     return result

--- a/vllm/distributed/elastic_ep/standby_state.py
+++ b/vllm/distributed/elastic_ep/standby_state.py
@@ -15,7 +15,7 @@ from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
 _STANDBY_WORLD: StatelessGroupCoordinator | None = None
 _STANDBY_WORLD_NODE_COUNT: int | None = None
 _STANDBY_DP: StatelessGroupCoordinator | None = None
-_STANDBY_MOE_DP_PCP: StatelessGroupCoordinator | None = None
+_STANDBY_MOE_NON_SP: StatelessGroupCoordinator | None = None
 _STANDBY_EP: StatelessGroupCoordinator | None = None
 _STANDBY_EPLB: StatelessGroupCoordinator | None = None
 
@@ -49,7 +49,7 @@ def create_standby_groups(
         _STANDBY_WORLD, \
         _STANDBY_WORLD_NODE_COUNT, \
         _STANDBY_DP, \
-        _STANDBY_MOE_DP_PCP, \
+        _STANDBY_MOE_NON_SP, \
         _STANDBY_EP, \
         _STANDBY_EPLB
 
@@ -86,13 +86,13 @@ def create_standby_groups(
         standby_dp_ranks, "dp", master_ip, backend, coord_store=coord_store
     )
 
-    standby_moe_dp_pcp_ranks = (
+    standby_moe_non_sp_ranks = (
         all_ranks.permute(0, 2, 4, 1, 3).reshape(-1, new_dp_size * pcp_size).unbind(0)
     )
-    standby_moe_dp_pcp_ranks = [x.tolist() for x in standby_moe_dp_pcp_ranks]
-    _STANDBY_MOE_DP_PCP = _init_stateless_group(
-        standby_moe_dp_pcp_ranks,
-        "moe_dp_pcp_group",
+    standby_moe_non_sp_ranks = [x.tolist() for x in standby_moe_non_sp_ranks]
+    _STANDBY_MOE_NON_SP = _init_stateless_group(
+        standby_moe_non_sp_ranks,
+        "moe_non_sp_group",
         master_ip,
         backend,
         coord_store=coord_store,
@@ -124,14 +124,14 @@ def pop_standby_groups() -> dict:
         _STANDBY_WORLD, \
         _STANDBY_WORLD_NODE_COUNT, \
         _STANDBY_DP, \
-        _STANDBY_MOE_DP_PCP, \
+        _STANDBY_MOE_NON_SP, \
         _STANDBY_EP, \
         _STANDBY_EPLB
 
     result = dict(
         world=_STANDBY_WORLD,
         dp=_STANDBY_DP,
-        moe_dp_pcp=_STANDBY_MOE_DP_PCP,
+        moe_non_sp=_STANDBY_MOE_NON_SP,
         ep=_STANDBY_EP,
         eplb=_STANDBY_EPLB,
         node_count=_STANDBY_WORLD_NODE_COUNT,
@@ -139,7 +139,7 @@ def pop_standby_groups() -> dict:
     _STANDBY_WORLD = None
     _STANDBY_WORLD_NODE_COUNT = None
     _STANDBY_DP = None
-    _STANDBY_MOE_DP_PCP = None
+    _STANDBY_MOE_NON_SP = None
     _STANDBY_EP = None
     _STANDBY_EPLB = None
     return result

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1415,6 +1415,35 @@ def get_dp_group() -> GroupCoordinator:
     return _DP
 
 
+# The MoE DP-PCP group is used for activation dispatch and combine when DP and
+# PCP are enabled without sequence parallelism. Each group fixes ExternalDP,
+# PP, and TP while spanning DP x PCP ranks in DP -> PCP order, allowing one
+# variable-sized collective to cover both parallel axes.
+_MOE_DP_PCP_GROUP: GroupCoordinator | None = None
+
+
+def get_moe_dp_pcp_group() -> GroupCoordinator:
+    assert _MOE_DP_PCP_GROUP is not None, "MoE DP-PCP group is not initialized"
+    return _MOE_DP_PCP_GROUP
+
+
+def has_moe_dp_pcp_group() -> bool:
+    return _MOE_DP_PCP_GROUP is not None
+
+
+def _get_moe_dp_pcp_group_ranks(
+    all_ranks: torch.Tensor,
+    data_parallel_size: int,
+    prefill_context_parallel_size: int,
+) -> list[list[int]]:
+    # Fix ExternalDP, PP, and TP; flatten DP then PCP into each group.
+    ranks = all_ranks.permute(0, 2, 4, 1, 3).reshape(
+        -1,
+        data_parallel_size * prefill_context_parallel_size,
+    )
+    return [x.tolist() for x in ranks.unbind(0)]
+
+
 _EP: GroupCoordinator | None = None
 
 
@@ -1924,6 +1953,24 @@ def initialize_model_parallel(
     assert _EP is None, "expert parallel group is already initialized"
     # Don't create EP group for dense models.
     if config.model_config is None or config.model_config.is_moe:
+        global _MOE_DP_PCP_GROUP
+        assert _MOE_DP_PCP_GROUP is None, "MoE DP-PCP group is already initialized"
+        if (
+            not enable_elastic_ep
+            and data_parallel_size > 1
+            and prefill_context_model_parallel_size > 1
+        ):
+            _MOE_DP_PCP_GROUP = init_model_parallel_group(
+                _get_moe_dp_pcp_group_ranks(
+                    all_ranks,
+                    data_parallel_size,
+                    prefill_context_model_parallel_size,
+                ),
+                get_world_group().local_rank,
+                backend,
+                group_name="moe_dp_pcp_group",
+            )
+
         group_ranks = (
             all_ranks.transpose(1, 2)
             .reshape(
@@ -2108,6 +2155,11 @@ def destroy_model_parallel():
     if _DP:
         _DP.destroy()
     _DP = None
+
+    global _MOE_DP_PCP_GROUP
+    if _MOE_DP_PCP_GROUP:
+        _MOE_DP_PCP_GROUP.destroy()
+    _MOE_DP_PCP_GROUP = None
 
     global _EP
     if _EP:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1363,22 +1363,22 @@ def _replace_active_groups(
     *,
     world: GroupCoordinator | None,
     dp: GroupCoordinator | None,
-    moe_dp_pcp: GroupCoordinator | None,
+    moe_non_sp: GroupCoordinator | None,
     ep: GroupCoordinator | None,
     eplb: GroupCoordinator | None,
     node_count: int | None,
 ) -> tuple[GroupCoordinator | None, ...]:
     """Replace the active groups and return the groups they replaced.
 
-    The caller must destroy the returned DP, MoE DP-PCP, EP, WORLD, and EPLB
+    The caller must destroy the returned DP, MoE non-SP, EP, WORLD, and EPLB
     groups collectively and in that order. Pass all-``None`` to remove the
     active groups without replacement.
     """
-    global _WORLD, _DP, _MOE_DP_PCP_GROUP, _EP, _EPLB, _NODE_COUNT
-    old_groups = _DP, _MOE_DP_PCP_GROUP, _EP, _WORLD, _EPLB
+    global _WORLD, _DP, _MOE_NON_SP_GROUP, _EP, _EPLB, _NODE_COUNT
+    old_groups = _DP, _MOE_NON_SP_GROUP, _EP, _WORLD, _EPLB
     _WORLD = world
     _DP = dp
-    _MOE_DP_PCP_GROUP = moe_dp_pcp
+    _MOE_NON_SP_GROUP = moe_non_sp
     _EP = ep
     _EPLB = eplb
     _NODE_COUNT = node_count
@@ -1417,16 +1417,17 @@ def get_dp_group() -> GroupCoordinator:
     return _DP
 
 
-# The MoE DP-PCP group is the activation dispatch and combine group for MoE
-# execution without sequence parallelism. Each group fixes ExternalDP, PP, and
-# TP while spanning DP x PCP ranks in DP -> PCP order. A size-one DP or PCP
-# dimension naturally yields the group for the remaining parallel dimension.
-_MOE_DP_PCP_GROUP: GroupCoordinator | None = None
+# Communication group for MoE execution without sequence parallelism. It is
+# used for activation dispatch/combine and the corresponding token-count
+# synchronization. Each group fixes ExternalDP, PP, and TP while spanning
+# DP x PCP ranks in DP -> PCP order. A size-one DP or PCP dimension naturally
+# yields the group for the remaining parallel dimension.
+_MOE_NON_SP_GROUP: GroupCoordinator | None = None
 
 
-def get_moe_dp_pcp_group() -> GroupCoordinator:
-    assert _MOE_DP_PCP_GROUP is not None, "MoE DP-PCP group is not initialized"
-    return _MOE_DP_PCP_GROUP
+def get_moe_non_sp_group() -> GroupCoordinator:
+    assert _MOE_NON_SP_GROUP is not None, "MoE non-SP group is not initialized"
+    return _MOE_NON_SP_GROUP
 
 
 _EP: GroupCoordinator | None = None
@@ -1938,8 +1939,8 @@ def initialize_model_parallel(
     assert _EP is None, "expert parallel group is already initialized"
     # Don't create EP group for dense models.
     if config.model_config is None or config.model_config.is_moe:
-        global _MOE_DP_PCP_GROUP
-        assert _MOE_DP_PCP_GROUP is None, "MoE DP-PCP group is already initialized"
+        global _MOE_NON_SP_GROUP
+        assert _MOE_NON_SP_GROUP is None, "MoE non-SP group is already initialized"
         # Fix ExternalDP, PP, and TP; flatten DP then PCP into each group.
         group_ranks = all_ranks.permute(0, 2, 4, 1, 3).reshape(
             -1,
@@ -1947,19 +1948,19 @@ def initialize_model_parallel(
         )
         group_ranks = [x.tolist() for x in group_ranks.unbind(0)]
         if enable_elastic_ep:
-            _MOE_DP_PCP_GROUP = _init_stateless_group(
+            _MOE_NON_SP_GROUP = _init_stateless_group(
                 group_ranks,
-                "moe_dp_pcp_group",
+                "moe_non_sp_group",
                 parallel_config.data_parallel_master_ip,
                 backend,
                 coord_store=coord_store,
             )
         else:
-            _MOE_DP_PCP_GROUP = init_model_parallel_group(
+            _MOE_NON_SP_GROUP = init_model_parallel_group(
                 group_ranks,
                 get_world_group().local_rank,
                 backend,
-                group_name="moe_dp_pcp_group",
+                group_name="moe_non_sp_group",
             )
 
         group_ranks = (
@@ -2147,10 +2148,10 @@ def destroy_model_parallel():
         _DP.destroy()
     _DP = None
 
-    global _MOE_DP_PCP_GROUP
-    if _MOE_DP_PCP_GROUP:
-        _MOE_DP_PCP_GROUP.destroy()
-    _MOE_DP_PCP_GROUP = None
+    global _MOE_NON_SP_GROUP
+    if _MOE_NON_SP_GROUP:
+        _MOE_NON_SP_GROUP.destroy()
+    _MOE_NON_SP_GROUP = None
 
     global _EP
     if _EP:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1363,20 +1363,22 @@ def _replace_active_groups(
     *,
     world: GroupCoordinator | None,
     dp: GroupCoordinator | None,
+    moe_dp_pcp: GroupCoordinator | None,
     ep: GroupCoordinator | None,
     eplb: GroupCoordinator | None,
     node_count: int | None,
 ) -> tuple[GroupCoordinator | None, ...]:
     """Replace the active groups and return the groups they replaced.
 
-    The caller must destroy the returned DP, EP, WORLD, and EPLB groups
-    collectively and in that order. Pass all-``None`` to remove the active
-    groups without replacement.
+    The caller must destroy the returned DP, MoE DP-PCP, EP, WORLD, and EPLB
+    groups collectively and in that order. Pass all-``None`` to remove the
+    active groups without replacement.
     """
-    global _WORLD, _DP, _EP, _EPLB, _NODE_COUNT
-    old_groups = _DP, _EP, _WORLD, _EPLB
+    global _WORLD, _DP, _MOE_DP_PCP_GROUP, _EP, _EPLB, _NODE_COUNT
+    old_groups = _DP, _MOE_DP_PCP_GROUP, _EP, _WORLD, _EPLB
     _WORLD = world
     _DP = dp
+    _MOE_DP_PCP_GROUP = moe_dp_pcp
     _EP = ep
     _EPLB = eplb
     _NODE_COUNT = node_count
@@ -1415,34 +1417,16 @@ def get_dp_group() -> GroupCoordinator:
     return _DP
 
 
-# The MoE DP-PCP group is the activation dispatch and combine group for static
-# MoE execution without sequence parallelism. Each group fixes ExternalDP, PP,
-# and TP while spanning DP x PCP ranks in DP -> PCP order. A size-one DP or PCP
-# dimension naturally degenerates to the remaining dimension, so this group is
-# used uniformly for every non-SP MoE topology.
+# The MoE DP-PCP group is the activation dispatch and combine group for MoE
+# execution without sequence parallelism. Each group fixes ExternalDP, PP, and
+# TP while spanning DP x PCP ranks in DP -> PCP order. A size-one DP or PCP
+# dimension naturally yields the group for the remaining parallel dimension.
 _MOE_DP_PCP_GROUP: GroupCoordinator | None = None
 
 
 def get_moe_dp_pcp_group() -> GroupCoordinator:
     assert _MOE_DP_PCP_GROUP is not None, "MoE DP-PCP group is not initialized"
     return _MOE_DP_PCP_GROUP
-
-
-def has_moe_dp_pcp_group() -> bool:
-    return _MOE_DP_PCP_GROUP is not None
-
-
-def _get_moe_dp_pcp_group_ranks(
-    all_ranks: torch.Tensor,
-    data_parallel_size: int,
-    prefill_context_parallel_size: int,
-) -> list[list[int]]:
-    # Fix ExternalDP, PP, and TP; flatten DP then PCP into each group.
-    ranks = all_ranks.permute(0, 2, 4, 1, 3).reshape(
-        -1,
-        data_parallel_size * prefill_context_parallel_size,
-    )
-    return [x.tolist() for x in ranks.unbind(0)]
 
 
 _EP: GroupCoordinator | None = None
@@ -1956,13 +1940,23 @@ def initialize_model_parallel(
     if config.model_config is None or config.model_config.is_moe:
         global _MOE_DP_PCP_GROUP
         assert _MOE_DP_PCP_GROUP is None, "MoE DP-PCP group is already initialized"
-        if not enable_elastic_ep:
+        # Fix ExternalDP, PP, and TP; flatten DP then PCP into each group.
+        group_ranks = all_ranks.permute(0, 2, 4, 1, 3).reshape(
+            -1,
+            data_parallel_size * prefill_context_model_parallel_size,
+        )
+        group_ranks = [x.tolist() for x in group_ranks.unbind(0)]
+        if enable_elastic_ep:
+            _MOE_DP_PCP_GROUP = _init_stateless_group(
+                group_ranks,
+                "moe_dp_pcp_group",
+                parallel_config.data_parallel_master_ip,
+                backend,
+                coord_store=coord_store,
+            )
+        else:
             _MOE_DP_PCP_GROUP = init_model_parallel_group(
-                _get_moe_dp_pcp_group_ranks(
-                    all_ranks,
-                    data_parallel_size,
-                    prefill_context_model_parallel_size,
-                ),
+                group_ranks,
                 get_world_group().local_rank,
                 backend,
                 group_name="moe_dp_pcp_group",

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1415,10 +1415,11 @@ def get_dp_group() -> GroupCoordinator:
     return _DP
 
 
-# The MoE DP-PCP group is used for activation dispatch and combine when DP and
-# PCP are enabled without sequence parallelism. Each group fixes ExternalDP,
-# PP, and TP while spanning DP x PCP ranks in DP -> PCP order, allowing one
-# variable-sized collective to cover both parallel axes.
+# The MoE DP-PCP group is the activation dispatch and combine group for static
+# MoE execution without sequence parallelism. Each group fixes ExternalDP, PP,
+# and TP while spanning DP x PCP ranks in DP -> PCP order. A size-one DP or PCP
+# dimension naturally degenerates to the remaining dimension, so this group is
+# used uniformly for every non-SP MoE topology.
 _MOE_DP_PCP_GROUP: GroupCoordinator | None = None
 
 
@@ -1955,11 +1956,7 @@ def initialize_model_parallel(
     if config.model_config is None or config.model_config.is_moe:
         global _MOE_DP_PCP_GROUP
         assert _MOE_DP_PCP_GROUP is None, "MoE DP-PCP group is already initialized"
-        if (
-            not enable_elastic_ep
-            and data_parallel_size > 1
-            and prefill_context_model_parallel_size > 1
-        ):
+        if not enable_elastic_ep:
             _MOE_DP_PCP_GROUP = init_model_parallel_group(
                 _get_moe_dp_pcp_group_ranks(
                     all_ranks,

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -95,6 +95,7 @@ class DPMetadata:
         parallel_config: ParallelConfig,
         num_tokens: int,
         num_tokens_across_dp_cpu: torch.Tensor,
+        num_tokens_across_dp_pcp_cpu: torch.Tensor | None = None,
     ) -> "DPMetadata":
         assert num_tokens_across_dp_cpu is not None
         assert (
@@ -110,28 +111,14 @@ class DPMetadata:
         assert num_tokens_across_dp_cpu[dp_rank] == batchsize, (
             f"{num_tokens_across_dp_cpu[dp_rank]} {batchsize}"
         )
-        num_tokens_across_dp_pcp_cpu = None
         if (
             parallel_config.data_parallel_size > 1
             and parallel_config.prefill_context_parallel_size > 1
             and parallel_config.enable_expert_parallel
         ):
-            from vllm.distributed import get_pcp_group
-
-            pcp_group = get_pcp_group()
-            counts_by_pcp = [
-                torch.empty_like(num_tokens_across_dp_cpu)
-                for _ in range(pcp_group.world_size)
-            ]
-            torch.distributed.all_gather(
-                counts_by_pcp,
-                num_tokens_across_dp_cpu,
-                group=pcp_group.cpu_group,
+            assert num_tokens_across_dp_pcp_cpu is not None, (
+                "DP-PCP token counts must be supplied by batch coordination"
             )
-            # all_gather produces PCP -> DP. EP ranks are DP -> PCP -> TP.
-            num_tokens_across_dp_pcp_cpu = torch.stack(
-                counts_by_pcp, dim=1
-            ).flatten()
 
         return DPMetadata(
             num_tokens_across_dp_cpu,
@@ -324,6 +311,7 @@ def set_forward_context(
     vllm_config: VllmConfig,
     num_tokens: int | None = None,
     num_tokens_across_dp: torch.Tensor | None = None,
+    num_tokens_across_dp_pcp: torch.Tensor | None = None,
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
@@ -358,7 +346,12 @@ def set_forward_context(
         ):
             assert ubatch_slices is None
             assert num_tokens is not None
-            _, num_tokens_across_dp, _ = coordinate_batch_across_dp(
+            (
+                _,
+                num_tokens_across_dp,
+                num_tokens_across_dp_pcp,
+                _,
+            ) = coordinate_batch_across_dp(
                 num_tokens_unpadded=num_tokens,
                 parallel_config=vllm_config.parallel_config,
                 allow_microbatching=False,
@@ -368,7 +361,10 @@ def set_forward_context(
             assert num_tokens is not None
             num_tokens_across_dp = torch.tensor([num_tokens], dtype=torch.int32)
         dp_metadata = DPMetadata.make(
-            vllm_config.parallel_config, num_tokens or 0, num_tokens_across_dp
+            vllm_config.parallel_config,
+            num_tokens or 0,
+            num_tokens_across_dp,
+            num_tokens_across_dp_pcp,
         )
 
     # Convenience: if cudagraph is used and num_tokens is given, we can just

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -83,9 +83,10 @@ def _compute_sp_num_tokens(
 @dataclass
 class DPMetadata:
     num_tokens_across_dp_cpu: torch.Tensor
-    # Flattened in DP -> PCP order. Each entry is the token count local to one
-    # PCP coordinate before any TP sequence-parallel sharding.
-    num_tokens_across_dp_pcp_cpu: torch.Tensor | None = None
+    # Token counts indexed by rank_in_group of get_moe_non_sp_group().
+    # Each entry is local to one PCP coordinate before TP sequence-parallel
+    # sharding.
+    moe_non_sp_token_counts_cpu: torch.Tensor | None = None
 
     # NOTE: local_sizes should only be set by the chunked_sizes context manager
     local_sizes: list[int] | None = None
@@ -95,7 +96,7 @@ class DPMetadata:
         parallel_config: ParallelConfig,
         num_tokens: int,
         num_tokens_across_dp_cpu: torch.Tensor,
-        num_tokens_across_dp_pcp_cpu: torch.Tensor | None = None,
+        moe_non_sp_token_counts_cpu: torch.Tensor | None = None,
     ) -> "DPMetadata":
         assert num_tokens_across_dp_cpu is not None
         assert (
@@ -116,13 +117,13 @@ class DPMetadata:
             and parallel_config.prefill_context_parallel_size > 1
             and parallel_config.enable_expert_parallel
         ):
-            assert num_tokens_across_dp_pcp_cpu is not None, (
-                "DP-PCP token counts must be supplied by batch coordination"
+            assert moe_non_sp_token_counts_cpu is not None, (
+                "MoE non-SP token counts must be supplied by batch coordination"
             )
 
         return DPMetadata(
             num_tokens_across_dp_cpu,
-            num_tokens_across_dp_pcp_cpu,
+            moe_non_sp_token_counts_cpu,
         )
 
     @contextmanager
@@ -137,8 +138,8 @@ class DPMetadata:
         """
         token_counts = self.num_tokens_across_dp_cpu
         count_groups_per_dp_rank = 1
-        if self.num_tokens_across_dp_pcp_cpu is not None:
-            token_counts = self.num_tokens_across_dp_pcp_cpu
+        if self.moe_non_sp_token_counts_cpu is not None:
+            token_counts = self.moe_non_sp_token_counts_cpu
             count_groups_per_dp_rank = (
                 token_counts.numel() // self.num_tokens_across_dp_cpu.numel()
             )
@@ -311,7 +312,7 @@ def set_forward_context(
     vllm_config: VllmConfig,
     num_tokens: int | None = None,
     num_tokens_across_dp: torch.Tensor | None = None,
-    num_tokens_across_dp_pcp: torch.Tensor | None = None,
+    moe_non_sp_token_counts: torch.Tensor | None = None,
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
@@ -349,7 +350,7 @@ def set_forward_context(
             (
                 _,
                 num_tokens_across_dp,
-                num_tokens_across_dp_pcp,
+                moe_non_sp_token_counts,
                 _,
             ) = coordinate_batch_across_dp(
                 num_tokens_unpadded=num_tokens,
@@ -364,7 +365,7 @@ def set_forward_context(
             vllm_config.parallel_config,
             num_tokens or 0,
             num_tokens_across_dp,
-            num_tokens_across_dp_pcp,
+            moe_non_sp_token_counts,
         )
 
     # Convenience: if cudagraph is used and num_tokens is given, we can just

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -59,19 +59,33 @@ class BatchDescriptor:
 
 
 def _compute_sp_num_tokens(
-    num_tokens_across_dp_cpu: torch.Tensor, sequence_parallel_size: int
+    num_tokens_across_dp_cpu: torch.Tensor,
+    sequence_parallel_size: int,
+    num_replicas_per_token_count: int | None = None,
 ) -> list[int]:
+    """Expand token counts into EP-dispatcher order.
+
+    Sequence parallelism first shards each token count across TP. Remaining
+    dispatcher axes replicate that resulting local count.
+    """
+    if num_replicas_per_token_count is None:
+        num_replicas_per_token_count = sequence_parallel_size
+    assert num_replicas_per_token_count >= sequence_parallel_size
+
     sp_tokens = (
         num_tokens_across_dp_cpu + sequence_parallel_size - 1
     ) // sequence_parallel_size
 
-    sp_tokens = sp_tokens.repeat_interleave(sequence_parallel_size)
+    sp_tokens = sp_tokens.repeat_interleave(num_replicas_per_token_count)
     return sp_tokens.tolist()
 
 
 @dataclass
 class DPMetadata:
     num_tokens_across_dp_cpu: torch.Tensor
+    # Flattened in DP -> PCP order. Each entry is the token count local to one
+    # PCP coordinate before any TP sequence-parallel sharding.
+    num_tokens_across_dp_pcp_cpu: torch.Tensor | None = None
 
     # NOTE: local_sizes should only be set by the chunked_sizes context manager
     local_sizes: list[int] | None = None
@@ -96,16 +110,64 @@ class DPMetadata:
         assert num_tokens_across_dp_cpu[dp_rank] == batchsize, (
             f"{num_tokens_across_dp_cpu[dp_rank]} {batchsize}"
         )
-        return DPMetadata(num_tokens_across_dp_cpu)
+        num_tokens_across_dp_pcp_cpu = None
+        if (
+            parallel_config.data_parallel_size > 1
+            and parallel_config.prefill_context_parallel_size > 1
+            and parallel_config.enable_expert_parallel
+        ):
+            from vllm.distributed import get_pcp_group
+
+            pcp_group = get_pcp_group()
+            counts_by_pcp = [
+                torch.empty_like(num_tokens_across_dp_cpu)
+                for _ in range(pcp_group.world_size)
+            ]
+            torch.distributed.all_gather(
+                counts_by_pcp,
+                num_tokens_across_dp_cpu,
+                group=pcp_group.cpu_group,
+            )
+            # all_gather produces PCP -> DP. EP ranks are DP -> PCP -> TP.
+            num_tokens_across_dp_pcp_cpu = torch.stack(
+                counts_by_pcp, dim=1
+            ).flatten()
+
+        return DPMetadata(
+            num_tokens_across_dp_cpu,
+            num_tokens_across_dp_pcp_cpu,
+        )
 
     @contextmanager
-    def sp_local_sizes(self, sequence_parallel_size: int):
+    def sp_local_sizes(
+        self,
+        sequence_parallel_size: int,
+        num_dispatchers_per_dp_rank: int | None = None,
+    ):
         """
         Context manager for setting self.local_sizes. Same as self.chunked_sizes
         but without any chunking.
         """
+        token_counts = self.num_tokens_across_dp_cpu
+        count_groups_per_dp_rank = 1
+        if self.num_tokens_across_dp_pcp_cpu is not None:
+            token_counts = self.num_tokens_across_dp_pcp_cpu
+            count_groups_per_dp_rank = (
+                token_counts.numel() // self.num_tokens_across_dp_cpu.numel()
+            )
+
+        if num_dispatchers_per_dp_rank is None:
+            num_dispatchers_per_dp_rank = (
+                sequence_parallel_size * count_groups_per_dp_rank
+            )
+        assert num_dispatchers_per_dp_rank % count_groups_per_dp_rank == 0
+        num_replicas_per_token_count = (
+            num_dispatchers_per_dp_rank // count_groups_per_dp_rank
+        )
         self.local_sizes = _compute_sp_num_tokens(
-            self.num_tokens_across_dp_cpu, sequence_parallel_size
+            token_counts,
+            sequence_parallel_size,
+            num_replicas_per_token_count,
         )
         try:
             yield self.local_sizes

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -636,8 +636,23 @@ class MoERunner(MoERunnerInterface):
         returns a no-op context.
         """
         ctx = get_forward_context()
+        parallel_config = self.moe_config.moe_parallel_config
+        num_dispatchers_per_dp_rank = self.moe_config.sp_size
+        if parallel_config.use_all2all_kernels:
+            if parallel_config.is_sequence_parallel:
+                assert parallel_config.ep_size % parallel_config.dp_size == 0
+                num_dispatchers_per_dp_rank = (
+                    parallel_config.ep_size // parallel_config.dp_size
+                )
+            else:
+                # TP is an expert-sharding axis in non-SP MoE and is reduced
+                # separately. Only PCP contributes another token dispatcher.
+                num_dispatchers_per_dp_rank = parallel_config.pcp_size
         return (
-            ctx.dp_metadata.sp_local_sizes(self.moe_config.sp_size)
+            ctx.dp_metadata.sp_local_sizes(
+                self.moe_config.sp_size,
+                num_dispatchers_per_dp_rank,
+            )
             if ctx.dp_metadata
             else nullcontext()
         )

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -208,14 +208,17 @@ class ExtractHiddenStatesProposer:
         # TODO(Flechman): support DBO ubatching
         should_ubatch, num_tokens_across_dp = False, None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
-            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
-                coordinate_batch_across_dp(
-                    num_tokens_unpadded=num_tokens,
-                    parallel_config=self.vllm_config.parallel_config,
-                    allow_microbatching=False,
-                    num_tokens_padded=num_tokens_padded,
-                    cudagraph_mode=cudagraph_mode.value,
-                )
+            (
+                should_ubatch,
+                num_tokens_across_dp,
+                _,
+                synced_cudagraph_mode,
+            ) = coordinate_batch_across_dp(
+                num_tokens_unpadded=num_tokens,
+                parallel_config=self.vllm_config.parallel_config,
+                allow_microbatching=False,
+                num_tokens_padded=num_tokens_padded,
+                cudagraph_mode=cudagraph_mode.value,
             )
             assert not should_ubatch, (
                 "DBO ubatching not implemented for extract_hidden_states"

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1824,14 +1824,17 @@ class SpecDecodeBaseProposer:
         # TODO(Flechman): support DBO ubatching
         should_ubatch, num_tokens_across_dp = False, None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
-            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
-                coordinate_batch_across_dp(
-                    num_tokens_unpadded=num_tokens,
-                    parallel_config=self.vllm_config.parallel_config,
-                    allow_microbatching=False,
-                    num_tokens_padded=num_tokens_padded,
-                    cudagraph_mode=cudagraph_mode.value,
-                )
+            (
+                should_ubatch,
+                num_tokens_across_dp,
+                _,
+                synced_cudagraph_mode,
+            ) = coordinate_batch_across_dp(
+                num_tokens_unpadded=num_tokens,
+                parallel_config=self.vllm_config.parallel_config,
+                allow_microbatching=False,
+                num_tokens_padded=num_tokens_padded,
+                cudagraph_mode=cudagraph_mode.value,
             )
             assert not should_ubatch, "DBO ubatching not implemented for EAGLE"
 

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -9,7 +9,7 @@ import torch.distributed as dist
 from vllm.config import ParallelConfig
 from vllm.distributed.parallel_state import (
     get_dp_group,
-    get_moe_dp_pcp_group,
+    get_moe_non_sp_group,
     get_pcp_group,
 )
 from vllm.logger import init_logger
@@ -30,7 +30,7 @@ def _get_device_and_group(parallel_config: ParallelConfig):
         parallel_config.enable_expert_parallel
         and parallel_config.prefill_context_parallel_size > 1
     ):
-        group_coordinator = get_moe_dp_pcp_group()
+        group_coordinator = get_moe_non_sp_group()
         pcp_size = parallel_config.prefill_context_parallel_size
         pcp_rank = get_pcp_group().rank_in_group
 
@@ -151,8 +151,8 @@ def _synchronize_dp_ranks(
     """
     assert num_tokens_padded >= num_tokens_unpadded
 
-    # Coordinate the batch with one all-reduce. MoE with PCP uses the combined
-    # DP-PCP group so the result can also drive expert dispatch metadata.
+    # Coordinate the batch with one all-reduce. MoE with PCP uses the non-SP
+    # group so the result can also drive expert dispatch metadata.
     tensor, pcp_size, pcp_rank = _run_ar(
         should_ubatch=should_attempt_ubatching,
         orig_num_tokens_per_ubatch=num_tokens_unpadded,
@@ -189,17 +189,17 @@ def _synchronize_dp_ranks(
         # should_dp_pad is True
         synchronized_token_counts = _post_process_dp_padding(tensor, should_dp_pad)
 
-        num_tokens_across_dp_pcp = None
+        moe_non_sp_token_counts = None
         num_tokens_after_padding = synchronized_token_counts
         if pcp_size > 1:
-            num_tokens_across_dp_pcp = synchronized_token_counts
+            moe_non_sp_token_counts = synchronized_token_counts
             num_tokens_after_padding = synchronized_token_counts[pcp_rank::pcp_size]
             assert len(num_tokens_after_padding) == parallel_config.data_parallel_size
 
     return (
         should_ubatch,
         num_tokens_after_padding,
-        num_tokens_across_dp_pcp,
+        moe_non_sp_token_counts,
         synced_cudagraph_mode,
     )
 
@@ -233,9 +233,9 @@ def coordinate_batch_across_dp(
         num_tokens_after_padding: A tensor containing the total number of
         tokens per-microbatch for each DP rank including padding. Will be
         padded up to the max value across all DP ranks when cudagraph is enabled.
-        num_tokens_across_dp_pcp: A DP -> PCP ordered tensor containing token
-            counts when MoE PCP participates in batch coordination. The DP
-            result contains the ranks at this rank's PCP coordinate.
+        moe_non_sp_token_counts: Token counts indexed by rank_in_group of
+            get_moe_non_sp_group() when PCP participates in batch coordination.
+            The DP result contains the ranks at this rank's PCP coordinate.
         synced_cudagraph_mode: The synchronized cudagraph mode (min across ranks)
     ]
 
@@ -261,7 +261,7 @@ def coordinate_batch_across_dp(
     (
         should_ubatch,
         num_tokens_after_padding,
-        num_tokens_across_dp_pcp,
+        moe_non_sp_token_counts,
         synced_cudagraph_mode,
     ) = _synchronize_dp_ranks(
         num_tokens_unpadded,
@@ -274,6 +274,6 @@ def coordinate_batch_across_dp(
     return (
         should_ubatch,
         num_tokens_after_padding,
-        num_tokens_across_dp_pcp,
+        moe_non_sp_token_counts,
         synced_cudagraph_mode,
     )

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -7,7 +7,11 @@ import torch
 import torch.distributed as dist
 
 from vllm.config import ParallelConfig
-from vllm.distributed.parallel_state import get_dp_group
+from vllm.distributed.parallel_state import (
+    get_dp_group,
+    get_moe_dp_pcp_group,
+    get_pcp_group,
+)
 from vllm.logger import init_logger
 from vllm.utils.gpu_sync_debug import gpu_sync_allowed
 from vllm.v1.worker.ubatch_utils import (
@@ -19,9 +23,21 @@ logger = init_logger(__name__)
 
 
 def _get_device_and_group(parallel_config: ParallelConfig):
-    # Use the actual device assigned to the DP group, not just the device type
-    device = get_dp_group().device
-    group = get_dp_group().device_group
+    group_coordinator = get_dp_group()
+    pcp_size = 1
+    pcp_rank = 0
+    if (
+        parallel_config.enable_expert_parallel
+        and parallel_config.prefill_context_parallel_size > 1
+    ):
+        group_coordinator = get_moe_dp_pcp_group()
+        pcp_size = parallel_config.prefill_context_parallel_size
+        pcp_rank = get_pcp_group().rank_in_group
+
+    # Use the actual device assigned to the synchronization group, not just
+    # the device type.
+    device = group_coordinator.device
+    group = group_coordinator.device_group
 
     # Transferring this tensor from GPU to CPU will introduce a GPU sync
     # point that could adversely affect performance of vllm with asynch
@@ -29,11 +45,18 @@ def _get_device_and_group(parallel_config: ParallelConfig):
     # this optimization if we run into this case.
     if parallel_config.disable_nccl_for_dp_synchronization:
         logger.info_once(
-            "Using CPU all reduce to synchronize DP padding between ranks.",
+            "Using CPU all reduce to synchronize parallel padding between ranks.",
         )
         device = "cpu"
-        group = get_dp_group().cpu_group
-    return device, group
+        group = group_coordinator.cpu_group
+    return (
+        device,
+        group,
+        group_coordinator.world_size,
+        group_coordinator.rank_in_group,
+        pcp_size,
+        pcp_rank,
+    )
 
 
 def _run_ar(
@@ -42,19 +65,19 @@ def _run_ar(
     padded_num_tokens_per_ubatch: int,
     cudagraph_mode: int,
     parallel_config: ParallelConfig,
-) -> torch.Tensor:
-    dp_size = parallel_config.data_parallel_size
-    dp_rank = parallel_config.data_parallel_rank
-    device, group = _get_device_and_group(parallel_config)
+) -> tuple[torch.Tensor, int, int]:
+    device, group, sync_size, sync_rank, pcp_size, pcp_rank = _get_device_and_group(
+        parallel_config
+    )
     # Populate this rank's contribution on CPU to reduce GPU syncs.
-    tensor_cpu = torch.zeros(4, dp_size, dtype=torch.int32)
-    tensor_cpu[0][dp_rank] = orig_num_tokens_per_ubatch
-    tensor_cpu[1][dp_rank] = padded_num_tokens_per_ubatch
-    tensor_cpu[2][dp_rank] = 1 if should_ubatch else 0
-    tensor_cpu[3][dp_rank] = cudagraph_mode
+    tensor_cpu = torch.zeros(4, sync_size, dtype=torch.int32)
+    tensor_cpu[0][sync_rank] = orig_num_tokens_per_ubatch
+    tensor_cpu[1][sync_rank] = padded_num_tokens_per_ubatch
+    tensor_cpu[2][sync_rank] = 1 if should_ubatch else 0
+    tensor_cpu[3][sync_rank] = cudagraph_mode
     tensor = tensor_cpu.to(device, non_blocking=True)
     dist.all_reduce(tensor, group=group)
-    return tensor
+    return tensor, pcp_size, pcp_rank
 
 
 def _post_process_ubatch(tensor: torch.Tensor, num_ubatches: int) -> bool:
@@ -107,7 +130,7 @@ def _synchronize_dp_ranks(
     should_attempt_ubatching: bool,
     cudagraph_mode: int,
     parallel_config: ParallelConfig,
-) -> tuple[bool, torch.Tensor | None, int]:
+) -> tuple[bool, torch.Tensor | None, torch.Tensor | None, int]:
     """
     1. Decides if each DP rank is going to microbatch. Either all ranks
     run with microbatching or none of them do.
@@ -128,10 +151,9 @@ def _synchronize_dp_ranks(
     """
     assert num_tokens_padded >= num_tokens_unpadded
 
-    # Coordinate between the DP ranks via an All Reduce
-    # to determine the total number of tokens that each rank
-    # will run and if we are using ubatching or not.
-    tensor = _run_ar(
+    # Coordinate the batch with one all-reduce. MoE with PCP uses the combined
+    # DP-PCP group so the result can also drive expert dispatch metadata.
+    tensor, pcp_size, pcp_rank = _run_ar(
         should_ubatch=should_attempt_ubatching,
         orig_num_tokens_per_ubatch=num_tokens_unpadded,
         padded_num_tokens_per_ubatch=num_tokens_padded,
@@ -165,9 +187,21 @@ def _synchronize_dp_ranks(
 
         # Pad all DP ranks up to the maximum token count across ranks if
         # should_dp_pad is True
-        num_tokens_after_padding = _post_process_dp_padding(tensor, should_dp_pad)
+        synchronized_token_counts = _post_process_dp_padding(tensor, should_dp_pad)
 
-    return should_ubatch, num_tokens_after_padding, synced_cudagraph_mode
+        num_tokens_across_dp_pcp = None
+        num_tokens_after_padding = synchronized_token_counts
+        if pcp_size > 1:
+            num_tokens_across_dp_pcp = synchronized_token_counts
+            num_tokens_after_padding = synchronized_token_counts[pcp_rank::pcp_size]
+            assert len(num_tokens_after_padding) == parallel_config.data_parallel_size
+
+    return (
+        should_ubatch,
+        num_tokens_after_padding,
+        num_tokens_across_dp_pcp,
+        synced_cudagraph_mode,
+    )
 
 
 def coordinate_batch_across_dp(
@@ -177,7 +211,7 @@ def coordinate_batch_across_dp(
     num_tokens_padded: int | None = None,
     uniform_decode: bool | None = None,
     cudagraph_mode: int = 0,
-) -> tuple[bool, torch.Tensor | None, int]:
+) -> tuple[bool, torch.Tensor | None, torch.Tensor | None, int]:
     """
     Coordinates amongst all DP ranks to determine if and how the full batch
     should be split into microbatches.
@@ -199,13 +233,16 @@ def coordinate_batch_across_dp(
         num_tokens_after_padding: A tensor containing the total number of
         tokens per-microbatch for each DP rank including padding. Will be
         padded up to the max value across all DP ranks when cudagraph is enabled.
+        num_tokens_across_dp_pcp: A DP -> PCP ordered tensor containing token
+            counts when MoE PCP participates in batch coordination. The DP
+            result contains the ranks at this rank's PCP coordinate.
         synced_cudagraph_mode: The synchronized cudagraph mode (min across ranks)
     ]
 
     """
     if parallel_config.data_parallel_size == 1:
         # Early exit.
-        return False, None, cudagraph_mode
+        return False, None, None, cudagraph_mode
 
     # If the caller has explicitly enabled microbatching.
     should_attempt_ubatching = False
@@ -221,14 +258,22 @@ def coordinate_batch_across_dp(
     if num_tokens_padded is None:
         num_tokens_padded = num_tokens_unpadded
 
-    (should_ubatch, num_tokens_after_padding, synced_cudagraph_mode) = (
-        _synchronize_dp_ranks(
-            num_tokens_unpadded,
-            num_tokens_padded,
-            should_attempt_ubatching,
-            cudagraph_mode,
-            parallel_config,
-        )
+    (
+        should_ubatch,
+        num_tokens_after_padding,
+        num_tokens_across_dp_pcp,
+        synced_cudagraph_mode,
+    ) = _synchronize_dp_ranks(
+        num_tokens_unpadded,
+        num_tokens_padded,
+        should_attempt_ubatching,
+        cudagraph_mode,
+        parallel_config,
     )
 
-    return (should_ubatch, num_tokens_after_padding, synced_cudagraph_mode)
+    return (
+        should_ubatch,
+        num_tokens_after_padding,
+        num_tokens_across_dp_pcp,
+        synced_cudagraph_mode,
+    )

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -523,13 +523,13 @@ class ModelCudaGraphManager(CudaGraphManager):
                 else None
             )
             parallel_config = self.vllm_config.parallel_config
-            num_tokens_across_dp_pcp = None
+            moe_non_sp_token_counts = None
             if (
                 self.dp_size > 1
                 and parallel_config.enable_expert_parallel
                 and parallel_config.prefill_context_parallel_size > 1
             ):
-                num_tokens_across_dp_pcp = torch.full(
+                moe_non_sp_token_counts = torch.full(
                     (self.dp_size * parallel_config.prefill_context_parallel_size,),
                     num_tokens,
                     dtype=torch.int32,
@@ -578,7 +578,7 @@ class ModelCudaGraphManager(CudaGraphManager):
                     num_tokens=num_tokens,
                     cudagraph_runtime_mode=cg_mode,
                     num_tokens_across_dp=num_tokens_across_dp,
-                    num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
+                    moe_non_sp_token_counts=moe_non_sp_token_counts,
                     slot_mapping=slot_mappings,
                     batch_descriptor=batch_descriptor,
                     is_padding=input_buffers.is_padding[:num_tokens],

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -522,6 +522,19 @@ class ModelCudaGraphManager(CudaGraphManager):
                 if self.dp_size > 1
                 else None
             )
+            parallel_config = self.vllm_config.parallel_config
+            num_tokens_across_dp_pcp = None
+            if (
+                self.dp_size > 1
+                and parallel_config.enable_expert_parallel
+                and parallel_config.prefill_context_parallel_size > 1
+            ):
+                num_tokens_across_dp_pcp = torch.full(
+                    (self.dp_size * parallel_config.prefill_context_parallel_size,),
+                    num_tokens,
+                    dtype=torch.int32,
+                    device="cpu",
+                )
 
             model_inputs = {
                 "input_ids": input_buffers.input_ids[:num_tokens],
@@ -565,6 +578,7 @@ class ModelCudaGraphManager(CudaGraphManager):
                     num_tokens=num_tokens,
                     cudagraph_runtime_mode=cg_mode,
                     num_tokens_across_dp=num_tokens_across_dp,
+                    num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
                     slot_mapping=slot_mappings,
                     batch_descriptor=batch_descriptor,
                     is_padding=input_buffers.is_padding[:num_tokens],

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -8,7 +8,7 @@ import torch
 import torch.distributed as dist
 
 from vllm.config.compilation import CUDAGraphMode
-from vllm.distributed.parallel_state import get_dp_group, get_moe_dp_pcp_group
+from vllm.distributed.parallel_state import get_dp_group, get_moe_non_sp_group
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     CudaGraphManager,
@@ -27,9 +27,9 @@ class DPSyncState:
     # Token counts for the DP ranks at this rank's PCP coordinate. All entries
     # hold the agreed padded count, unless `eager`, where nothing was padded.
     num_tokens_across_dp: torch.Tensor
-    # DP -> PCP ordered token counts when PCP participates in batch
-    # coordination.
-    num_tokens_across_dp_pcp: torch.Tensor | None
+    # Token counts indexed by rank_in_group of get_moe_non_sp_group() when PCP
+    # participates in batch coordination.
+    moe_non_sp_token_counts: torch.Tensor | None
     # Agreed uniform decode length. None means the ranks disagreed, which is an
     # answer, not "unknown".
     uniform_token_count: int | None
@@ -59,7 +59,7 @@ def sync_cudagraph_and_dp_padding(
     assert dp_size > 1, "DP size must be greater than 1"
     group_coordinator = get_dp_group()
     if enable_expert_parallel and pcp_size > 1:
-        group_coordinator = get_moe_dp_pcp_group()
+        group_coordinator = get_moe_non_sp_group()
     sync_size = group_coordinator.world_size
     sync_rank = group_coordinator.rank_in_group
     group = group_coordinator.cpu_group
@@ -71,10 +71,10 @@ def sync_cudagraph_and_dp_padding(
     dist.all_reduce(tensor, group=group)
 
     synchronized_token_counts = tensor[0]
-    num_tokens_across_dp_pcp = None
+    moe_non_sp_token_counts = None
     num_tokens_across_dp = synchronized_token_counts
     if enable_expert_parallel and pcp_size > 1:
-        num_tokens_across_dp_pcp = synchronized_token_counts
+        moe_non_sp_token_counts = synchronized_token_counts
         pcp_rank = sync_rank % pcp_size
         num_tokens_across_dp = synchronized_token_counts[pcp_rank::pcp_size]
         assert len(num_tokens_across_dp) == dp_size
@@ -108,7 +108,7 @@ def sync_cudagraph_and_dp_padding(
             ),
             DPSyncState(
                 num_tokens_across_dp=num_tokens_across_dp,
-                num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
+                moe_non_sp_token_counts=moe_non_sp_token_counts,
                 uniform_token_count=synced_uniform_token_count,
                 eager=True,
             ),
@@ -142,7 +142,7 @@ def sync_cudagraph_and_dp_padding(
 
     return synced_desc, DPSyncState(
         num_tokens_across_dp=num_tokens_across_dp,
-        num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
+        moe_non_sp_token_counts=moe_non_sp_token_counts,
         uniform_token_count=synced_uniform_token_count,
         eager=False,
     )
@@ -237,12 +237,12 @@ def dispatch_cg_and_sync_dp(
                 num_tokens_across_dp=torch.full_like(
                     dp_sync.num_tokens_across_dp, batch_desc.num_tokens
                 ),
-                num_tokens_across_dp_pcp=(
+                moe_non_sp_token_counts=(
                     torch.full_like(
-                        dp_sync.num_tokens_across_dp_pcp,
+                        dp_sync.moe_non_sp_token_counts,
                         batch_desc.num_tokens,
                     )
-                    if dp_sync.num_tokens_across_dp_pcp is not None
+                    if dp_sync.moe_non_sp_token_counts is not None
                     else None
                 ),
             )

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -8,7 +8,7 @@ import torch
 import torch.distributed as dist
 
 from vllm.config.compilation import CUDAGraphMode
-from vllm.distributed.parallel_state import get_dp_group
+from vllm.distributed.parallel_state import get_dp_group, get_moe_dp_pcp_group
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     CudaGraphManager,
@@ -24,9 +24,12 @@ class DPSyncState:
     value here.
     """
 
-    # Per-rank token counts, for the forward context. All entries hold the
-    # agreed padded count, unless `eager`, where nothing was padded.
+    # Token counts for the DP ranks at this rank's PCP coordinate. All entries
+    # hold the agreed padded count, unless `eager`, where nothing was padded.
     num_tokens_across_dp: torch.Tensor
+    # DP -> PCP ordered token counts when PCP participates in batch
+    # coordination.
+    num_tokens_across_dp_pcp: torch.Tensor | None
     # Agreed uniform decode length. None means the ranks disagreed, which is an
     # answer, not "unknown".
     uniform_token_count: int | None
@@ -43,6 +46,8 @@ def sync_cudagraph_and_dp_padding(
     uniform_token_count: int | None,
     dp_size: int,
     dp_rank: int,
+    pcp_size: int = 1,
+    enable_expert_parallel: bool = False,
     max_query_len: int | None = None,
     num_active_loras: int = 0,
 ) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
@@ -52,15 +57,27 @@ def sync_cudagraph_and_dp_padding(
     Returns (synced_batch_desc, sync). `sync` is None when no rank has work.
     """
     assert dp_size > 1, "DP size must be greater than 1"
-    group = get_dp_group().cpu_group
-    tensor = torch.zeros(4, dp_size, dtype=torch.int32, device="cpu")
-    tensor[0][dp_rank] = num_tokens
-    tensor[1][dp_rank] = desired_batch_desc.cg_mode.value
-    tensor[2][dp_rank] = uniform_token_count or 0  # (0 means None)
-    tensor[3][dp_rank] = max_query_len or -1  # (-1 means None)
+    group_coordinator = get_dp_group()
+    if enable_expert_parallel and pcp_size > 1:
+        group_coordinator = get_moe_dp_pcp_group()
+    sync_size = group_coordinator.world_size
+    sync_rank = group_coordinator.rank_in_group
+    group = group_coordinator.cpu_group
+    tensor = torch.zeros(4, sync_size, dtype=torch.int32, device="cpu")
+    tensor[0][sync_rank] = num_tokens
+    tensor[1][sync_rank] = desired_batch_desc.cg_mode.value
+    tensor[2][sync_rank] = uniform_token_count or 0  # (0 means None)
+    tensor[3][sync_rank] = max_query_len or -1  # (-1 means None)
     dist.all_reduce(tensor, group=group)
 
-    num_tokens_across_dp = tensor[0]
+    synchronized_token_counts = tensor[0]
+    num_tokens_across_dp_pcp = None
+    num_tokens_across_dp = synchronized_token_counts
+    if enable_expert_parallel and pcp_size > 1:
+        num_tokens_across_dp_pcp = synchronized_token_counts
+        pcp_rank = sync_rank % pcp_size
+        num_tokens_across_dp = synchronized_token_counts[pcp_rank::pcp_size]
+        assert len(num_tokens_across_dp) == dp_size
     cg_mode_across_dp = tensor[1]
     uniform_token_counts_across_dp = tensor[2]
     max_query_lens_across_dp = tensor[3]
@@ -72,7 +89,7 @@ def sync_cudagraph_and_dp_padding(
     ):
         synced_uniform_token_count = None
 
-    if torch.all(num_tokens_across_dp == 0).item():
+    if torch.all(synchronized_token_counts == 0).item():
         synced_desc = BatchExecutionDescriptor(
             cg_mode=CUDAGraphMode.NONE, num_tokens=0, num_reqs=0
         )
@@ -91,6 +108,7 @@ def sync_cudagraph_and_dp_padding(
             ),
             DPSyncState(
                 num_tokens_across_dp=num_tokens_across_dp,
+                num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
                 uniform_token_count=synced_uniform_token_count,
                 eager=True,
             ),
@@ -100,7 +118,7 @@ def sync_cudagraph_and_dp_padding(
         "cudagraph_manager should only be None during profile run, "
         "where synced_cg_mode must be NONE across all DP ranks"
     )
-    synced_num_tokens = int(num_tokens_across_dp.max().item())
+    synced_num_tokens = int(synchronized_token_counts.max().item())
 
     # Varlen decode graphs are selected by the query-length bound, so ranks must agree
     # on it or they pad to different token counts below.
@@ -120,10 +138,11 @@ def sync_cudagraph_and_dp_padding(
     )
 
     # Update num_tokens_across_dp to reflect padded size.
-    num_tokens_across_dp[:] = synced_desc.num_tokens
+    synchronized_token_counts[:] = synced_desc.num_tokens
 
     return synced_desc, DPSyncState(
         num_tokens_across_dp=num_tokens_across_dp,
+        num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
         uniform_token_count=synced_uniform_token_count,
         eager=False,
     )
@@ -136,6 +155,8 @@ def dispatch_cg_and_sync_dp(
     uniform_token_count: int | None,
     dp_size: int,
     dp_rank: int,
+    pcp_size: int = 1,
+    enable_expert_parallel: bool = False,
     max_query_len: int | None = None,
     need_eager: bool = False,
     num_active_loras: int = 0,
@@ -158,6 +179,8 @@ def dispatch_cg_and_sync_dp(
             place when a sync is reused, since that one is agreed across ranks.
         dp_size: Data-parallel world size. 1 skips all cross-rank work.
         dp_rank: This rank's index in the DP group.
+        pcp_size: Prefill-context-parallel world size.
+        enable_expert_parallel: Whether MoE expert parallelism is enabled.
         max_query_len: Upper bound on per-request query length, for selecting
             varlen decode graphs. None means the graph must not constrain it.
         need_eager: Force `CUDAGraphMode.NONE` instead of dispatching.
@@ -214,6 +237,14 @@ def dispatch_cg_and_sync_dp(
                 num_tokens_across_dp=torch.full_like(
                     dp_sync.num_tokens_across_dp, batch_desc.num_tokens
                 ),
+                num_tokens_across_dp_pcp=(
+                    torch.full_like(
+                        dp_sync.num_tokens_across_dp_pcp,
+                        batch_desc.num_tokens,
+                    )
+                    if dp_sync.num_tokens_across_dp_pcp is not None
+                    else None
+                ),
             )
         return batch_desc, dp_sync
 
@@ -225,6 +256,8 @@ def dispatch_cg_and_sync_dp(
         uniform_token_count,
         dp_size,
         dp_rank,
+        pcp_size,
+        enable_expert_parallel,
         max_query_len=max_query_len,
         num_active_loras=num_active_loras,
     )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1556,6 +1556,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             uniform_tok_count,
             self.dp_size,
             self.dp_rank,
+            pcp_size=self.parallel_config.prefill_context_parallel_size,
+            enable_expert_parallel=self.parallel_config.enable_expert_parallel,
             max_query_len=max_query_len,
             need_eager=is_profile or skip_compiled,
             num_active_loras=num_active_loras,
@@ -1738,6 +1740,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 cudagraph_runtime_mode=batch_desc.cg_mode,
                 num_tokens_across_dp=(
                     dp_sync.num_tokens_across_dp if dp_sync is not None else None
+                ),
+                num_tokens_across_dp_pcp=(
+                    dp_sync.num_tokens_across_dp_pcp if dp_sync is not None else None
                 ),
                 batch_descriptor=batch_descriptor,
                 slot_mapping=slot_mappings_by_layer,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1741,8 +1741,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 num_tokens_across_dp=(
                     dp_sync.num_tokens_across_dp if dp_sync is not None else None
                 ),
-                num_tokens_across_dp_pcp=(
-                    dp_sync.num_tokens_across_dp_pcp if dp_sync is not None else None
+                moe_non_sp_token_counts=(
+                    dp_sync.moe_non_sp_token_counts if dp_sync is not None else None
                 ),
                 batch_descriptor=batch_descriptor,
                 slot_mapping=slot_mappings_by_layer,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4065,12 +4065,12 @@ class GPUModelRunner(
         # across ranks
         should_ubatch = False
         num_tokens_across_dp = None
-        num_tokens_across_dp_pcp = None
+        moe_non_sp_token_counts = None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
             (
                 should_ubatch,
                 num_tokens_across_dp,
-                num_tokens_across_dp_pcp,
+                moe_non_sp_token_counts,
                 synced_cudagraph_mode,
             ) = coordinate_batch_across_dp(
                 num_tokens_unpadded=num_tokens,
@@ -4108,7 +4108,7 @@ class GPUModelRunner(
             batch_descriptor,
             should_ubatch,
             num_tokens_across_dp,
-            num_tokens_across_dp_pcp,
+            moe_non_sp_token_counts,
             cudagraph_stats,
         )
 
@@ -4332,7 +4332,7 @@ class GPUModelRunner(
                 batch_desc,
                 should_ubatch,
                 num_tokens_across_dp,
-                num_tokens_across_dp_pcp,
+                moe_non_sp_token_counts,
                 cudagraph_stats,
             ) = self._determine_batch_execution_and_padding(
                 num_tokens=num_tokens_unpadded,
@@ -4497,7 +4497,7 @@ class GPUModelRunner(
                 self.vllm_config,
                 num_tokens=num_tokens_padded,
                 num_tokens_across_dp=num_tokens_across_dp,
-                num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
+                moe_non_sp_token_counts=moe_non_sp_token_counts,
                 cudagraph_runtime_mode=cudagraph_mode,
                 batch_descriptor=batch_desc,
                 ubatch_slices=ubatch_slices_padded,
@@ -5991,7 +5991,7 @@ class GPUModelRunner(
             batch_desc,
             should_ubatch,
             num_tokens_across_dp,
-            num_tokens_across_dp_pcp,
+            moe_non_sp_token_counts,
             _,
         ) = self._determine_batch_execution_and_padding(
             num_tokens=num_tokens_unpadded,
@@ -6195,8 +6195,8 @@ class GPUModelRunner(
                 num_tokens_padded = ubatch_slices_padded[0].num_tokens
                 if num_tokens_across_dp is not None:
                     num_tokens_across_dp[:] = num_tokens_padded
-                if num_tokens_across_dp_pcp is not None:
-                    num_tokens_across_dp_pcp[:] = num_tokens_padded
+                if moe_non_sp_token_counts is not None:
+                    moe_non_sp_token_counts[:] = num_tokens_padded
 
             with (
                 self.maybe_randomize_inputs(
@@ -6207,7 +6207,7 @@ class GPUModelRunner(
                     self.vllm_config,
                     num_tokens=num_tokens_padded,
                     num_tokens_across_dp=num_tokens_across_dp,
-                    num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
+                    moe_non_sp_token_counts=moe_non_sp_token_counts,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,
                     ubatch_slices=ubatch_slices_padded,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4011,6 +4011,7 @@ class GPUModelRunner(
         BatchDescriptor,
         bool,
         torch.Tensor | None,
+        torch.Tensor | None,
         CUDAGraphStat | None,
     ]:
         uniform_decode = self._is_uniform_decode(
@@ -4062,17 +4063,22 @@ class GPUModelRunner(
 
         # Extra coordination when running data-parallel since we need to coordinate
         # across ranks
-        should_ubatch, num_tokens_across_dp = False, None
+        should_ubatch = False
+        num_tokens_across_dp = None
+        num_tokens_across_dp_pcp = None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
-            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
-                coordinate_batch_across_dp(
-                    num_tokens_unpadded=num_tokens,
-                    parallel_config=self.parallel_config,
-                    allow_microbatching=allow_microbatching,
-                    num_tokens_padded=num_tokens_padded,
-                    uniform_decode=uniform_decode,
-                    cudagraph_mode=cudagraph_mode.value,
-                )
+            (
+                should_ubatch,
+                num_tokens_across_dp,
+                num_tokens_across_dp_pcp,
+                synced_cudagraph_mode,
+            ) = coordinate_batch_across_dp(
+                num_tokens_unpadded=num_tokens,
+                parallel_config=self.parallel_config,
+                allow_microbatching=allow_microbatching,
+                num_tokens_padded=num_tokens_padded,
+                uniform_decode=uniform_decode,
+                cudagraph_mode=cudagraph_mode.value,
             )
 
             # Extract DP-synced values
@@ -4102,6 +4108,7 @@ class GPUModelRunner(
             batch_descriptor,
             should_ubatch,
             num_tokens_across_dp,
+            num_tokens_across_dp_pcp,
             cudagraph_stats,
         )
 
@@ -4325,6 +4332,7 @@ class GPUModelRunner(
                 batch_desc,
                 should_ubatch,
                 num_tokens_across_dp,
+                num_tokens_across_dp_pcp,
                 cudagraph_stats,
             ) = self._determine_batch_execution_and_padding(
                 num_tokens=num_tokens_unpadded,
@@ -4489,6 +4497,7 @@ class GPUModelRunner(
                 self.vllm_config,
                 num_tokens=num_tokens_padded,
                 num_tokens_across_dp=num_tokens_across_dp,
+                num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
                 cudagraph_runtime_mode=cudagraph_mode,
                 batch_descriptor=batch_desc,
                 ubatch_slices=ubatch_slices_padded,
@@ -5977,29 +5986,33 @@ class GPUModelRunner(
 
         num_sampled_tokens = np.ones(num_reqs, dtype=np.int32)
 
-        _cudagraph_mode, batch_desc, should_ubatch, num_tokens_across_dp, _ = (
-            self._determine_batch_execution_and_padding(
-                num_tokens=num_tokens_unpadded,
-                num_reqs=num_reqs,
-                num_scheduled_tokens_np=num_scheduled_tokens,
-                max_num_scheduled_tokens=max_query_len,
-                use_cascade_attn=False,
-                allow_microbatching=allow_microbatching,
-                force_eager=is_profile
-                or (cudagraph_runtime_mode == CUDAGraphMode.NONE),
-                # `force_uniform_decode` is used for cudagraph capture; because for
-                # capturing mixed prefill-decode batches, we sometimes use
-                # num_tokens == num_reqs which looks like a uniform decode batch to the
-                # dispatcher; but we actually want to capture a piecewise cudagraph
-                force_uniform_decode=uniform_decode,
-                # `force_has_lora` is used for cudagraph capture; because LoRA is
-                # activated later in the context manager, but we need to know the
-                # LoRA state when determining the batch descriptor for capture
-                force_has_lora=num_active_loras > 0,
-                # `force_num_active_loras` is used for cudagraph capture; because we
-                # need to capture graphs for specific num_active_loras counts
-                force_num_active_loras=num_active_loras,
-            )
+        (
+            _cudagraph_mode,
+            batch_desc,
+            should_ubatch,
+            num_tokens_across_dp,
+            num_tokens_across_dp_pcp,
+            _,
+        ) = self._determine_batch_execution_and_padding(
+            num_tokens=num_tokens_unpadded,
+            num_reqs=num_reqs,
+            num_scheduled_tokens_np=num_scheduled_tokens,
+            max_num_scheduled_tokens=max_query_len,
+            use_cascade_attn=False,
+            allow_microbatching=allow_microbatching,
+            force_eager=is_profile or (cudagraph_runtime_mode == CUDAGraphMode.NONE),
+            # `force_uniform_decode` is used for cudagraph capture; because for
+            # capturing mixed prefill-decode batches, we sometimes use
+            # num_tokens == num_reqs which looks like a uniform decode batch to the
+            # dispatcher; but we actually want to capture a piecewise cudagraph
+            force_uniform_decode=uniform_decode,
+            # `force_has_lora` is used for cudagraph capture; because LoRA is
+            # activated later in the context manager, but we need to know the
+            # LoRA state when determining the batch descriptor for capture
+            force_has_lora=num_active_loras > 0,
+            # `force_num_active_loras` is used for cudagraph capture; because we
+            # need to capture graphs for specific num_active_loras counts
+            force_num_active_loras=num_active_loras,
         )
 
         if cudagraph_runtime_mode is None:
@@ -6182,6 +6195,8 @@ class GPUModelRunner(
                 num_tokens_padded = ubatch_slices_padded[0].num_tokens
                 if num_tokens_across_dp is not None:
                     num_tokens_across_dp[:] = num_tokens_padded
+                if num_tokens_across_dp_pcp is not None:
+                    num_tokens_across_dp_pcp[:] = num_tokens_padded
 
             with (
                 self.maybe_randomize_inputs(
@@ -6192,6 +6207,7 @@ class GPUModelRunner(
                     self.vllm_config,
                     num_tokens=num_tokens_padded,
                     num_tokens_across_dp=num_tokens_across_dp,
+                    num_tokens_across_dp_pcp=num_tokens_across_dp_pcp,
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,
                     ubatch_slices=ubatch_slices_padded,

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -478,15 +478,29 @@ class UBatchWrapper:
         assert dp_metadata is not None
         ubatch_dp_metadata = []
         for ubatch_slice in ubatch_slices:
-            dp_size = self.vllm_config.parallel_config.data_parallel_size
+            parallel_config = self.vllm_config.parallel_config
+            dp_size = parallel_config.data_parallel_size
             ubatch_num_tokens_across_dp = torch.tensor(
                 [ubatch_slice.num_tokens] * dp_size, device="cpu", dtype=torch.int32
             )
+            ubatch_num_tokens_across_dp_pcp = None
+            if (
+                parallel_config.enable_expert_parallel
+                and parallel_config.prefill_context_parallel_size > 1
+            ):
+                ubatch_num_tokens_across_dp_pcp = torch.tensor(
+                    [ubatch_slice.num_tokens]
+                    * dp_size
+                    * parallel_config.prefill_context_parallel_size,
+                    device="cpu",
+                    dtype=torch.int32,
+                )
             ubatch_dp_metadata.append(
                 DPMetadata.make(
-                    self.vllm_config.parallel_config,
+                    parallel_config,
                     ubatch_slice.num_tokens,
                     ubatch_num_tokens_across_dp,
+                    ubatch_num_tokens_across_dp_pcp,
                 )
             )
 

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -483,12 +483,12 @@ class UBatchWrapper:
             ubatch_num_tokens_across_dp = torch.tensor(
                 [ubatch_slice.num_tokens] * dp_size, device="cpu", dtype=torch.int32
             )
-            ubatch_num_tokens_across_dp_pcp = None
+            ubatch_moe_non_sp_token_counts = None
             if (
                 parallel_config.enable_expert_parallel
                 and parallel_config.prefill_context_parallel_size > 1
             ):
-                ubatch_num_tokens_across_dp_pcp = torch.tensor(
+                ubatch_moe_non_sp_token_counts = torch.tensor(
                     [ubatch_slice.num_tokens]
                     * dp_size
                     * parallel_config.prefill_context_parallel_size,
@@ -500,7 +500,7 @@ class UBatchWrapper:
                     parallel_config,
                     ubatch_slice.num_tokens,
                     ubatch_num_tokens_across_dp,
-                    ubatch_num_tokens_across_dp_pcp,
+                    ubatch_moe_non_sp_token_counts,
                 )
             )
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -93,6 +93,19 @@ from .utils import request_memory
 logger = init_logger(__name__)
 
 
+def _dp_local_rank_offset(parallel_config) -> int:
+    """Return the local device offset of a data-parallel replica."""
+    dp_local_rank = parallel_config.data_parallel_rank_local
+    if dp_local_rank is None:
+        dp_local_rank = parallel_config.data_parallel_index
+    model_parallel_world_size = (
+        parallel_config.pipeline_parallel_size
+        * parallel_config.prefill_context_parallel_size
+        * parallel_config.tensor_parallel_size
+    )
+    return dp_local_rank * model_parallel_world_size
+
+
 def _num_workspace_lanes(vllm_config: VllmConfig, use_v2_model_runner: bool) -> int:
     spec_config = vllm_config.speculative_config
     return (
@@ -323,18 +336,8 @@ class Worker(WorkerBase):
                 and parallel_config.data_parallel_backend != "ray"
                 and parallel_config.nnodes_within_dp == 1
             ):
-                # Use local DP rank if available, otherwise use global DP rank.
-                dp_local_rank = self.parallel_config.data_parallel_rank_local
-                if dp_local_rank is None:
-                    dp_local_rank = self.parallel_config.data_parallel_index
-
-                tp_pp_world_size = (
-                    self.parallel_config.pipeline_parallel_size
-                    * self.parallel_config.tensor_parallel_size
-                )
-
-                # DP_LOCAL_RANK * TP_PP_WORLD_SIZE + TP_LOCAL_RANK
-                self.local_rank += dp_local_rank * tp_pp_world_size
+                # DP_LOCAL_RANK * TP_PP_PCP_WORLD_SIZE + MODEL_LOCAL_RANK
+                self.local_rank += _dp_local_rank_offset(self.parallel_config)
 
             # Publish the logical-to-physical mapping for topology queries
             # such as NIC affinity and P2P checks.


### PR DESCRIPTION
## Purpose

Support prefill context parallelism (PCP) together with data parallelism (DP) on GPU, including expert-parallel MoE execution. The change:

- includes the PCP axis in DP-local device placement;
- coordinates batch token counts once on `moe_dp_pcp_group` before the
  forward context, retaining both the current PCP coordinate's DP view and
  the DP-to-PCP ordered MoE dispatcher view;
- creates a TP-free `moe_dp_pcp_group` for every MoE topology, carries it
  through elastic group transitions, and uses it directly for
  non-sequence-parallel dispatch and combine;
- sizes dispatcher metadata for sequence-parallel and non-sequence-parallel all-to-all backends.

## Test Plan

- Run the focused PCP+DP unit tests, including the legacy and V2 ModelRunner
  batch-coordination paths.
- Run the full GSM8K dataset with the default all-gather/reduce-scatter backend and piecewise CUDA graphs.
- Run 32-question GSM8K piecewise-graph smokes for non-sequence-parallel
  DP2/PCP2, DP2/PCP1, and DP1/PCP2 topologies.
- Run 32-question GSM8K smoke tests in eager mode for the default, DeepEP high-throughput, DeepEP low-latency, and NIXL-EP paths.

The full and backend-matrix runs use GLM-4.7-Flash with TP=2, PCP=2, DP=2,
and EP enabled. The non-sequence-parallel topology smokes use TP=1 and EP.

## Test Result

- Focused communication-group and single-collective batch-coordination checks:
  9 passed on H20.
- Default backend, piecewise CUDA graphs, 32 questions: 26/32 correct, 0 invalid.
- Default backend, piecewise CUDA graphs, full GSM8K: 1103/1319 correct (83.62%), 0 invalid.
- Default backend, non-SP V2 ModelRunner TP1/DP2/PCP2, piecewise CUDA graphs,
  32 questions: 24/32 correct, 0 invalid on H20.
- Default backend, non-SP TP1/DP2/PCP1, piecewise CUDA graphs, 32 questions:
  25/32 correct, 0 invalid.
- Default backend, non-SP TP1/DP1/PCP2, piecewise CUDA graphs, 32 questions:
  23/32 correct, 0 invalid.
- Default backend, eager, 32 questions: 23/32 correct, 0 invalid.
- DeepEP high-throughput, eager, 32 questions: 26/32 correct, 0 invalid.
- DeepEP low-latency, eager, 32 questions: 23/32 correct, 0 invalid (`max_num_batched_tokens=500`).
- NIXL-EP, eager, 32 questions: 23/32 correct, 0 invalid.

Additional backend coverage requires runtime capabilities that were not present on the validation host: NCCL GIN/IBGDA for DeepEP v2, MNNVL process-sharing permissions for FlashInfer NVLink one/two-sided, and an installed MoRI backend.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
