### PR TITLE
[Test] Fix mock_current_vllm_config missing kernel_config in test_dflash2

### DIFF
--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -160,6 +160,9 @@ def test_dflash2_model_decoder_layer_cls(monkeypatch):
             dtype=torch.float32,
             is_mm_prefix_lm=False,
         ),
+        kernel_config=SimpleNamespace(
+            linear_backend="auto",
+        ),
     )
     from vllm.platforms import current_platform
 


### PR DESCRIPTION
## Error:
https://buildkite.com/vllm/intel-ci/builds/9924/canvas?jid=01a04595-4bf3-4fca-9942-bd85cfa33652&tab=output
```
AttributeError: 'types.SimpleNamespace' object has no attribute 'kernel_config'. Did you mean: 'model_config'?
```

## Fix:
UnquantizedLinearMethod.__init__ now reads config.kernel_config.linear_backend, but the test's hand-crafted SimpleNamespace mock was not updated accordingly. Add kernel_config=SimpleNamespace(linear_backend="auto") to fix the AttributeError.