### PR TITLE
sched: generalize has_requests() to use _push_connectors list

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4905,6 +4905,37 @@ def test_delayed_kv_connector_free_keeps_scheduler_active():
     assert not scheduler.has_finished_requests()
 
 
+
+
+def test_push_connectors_generalizes_has_requests():
+    """has_requests() must use _push_connectors generically.
+
+    Any object with has_pending_push_work() -> True added to
+    _push_connectors should keep the scheduler alive without
+    modifying has_requests() itself.  This validates the
+    generalisation introduced to resolve the hardcoded-connector TODO.
+    """
+    scheduler = create_scheduler()
+
+    # Baseline: no requests, no pending work.
+    assert not scheduler.has_unfinished_requests()
+    assert not scheduler.has_finished_requests()
+    assert not scheduler.has_requests()
+
+    # Inject a connector that reports pending push work.
+    mock_active = Mock()
+    mock_active.has_pending_push_work.return_value = True
+    scheduler._push_connectors = [mock_active]
+    assert scheduler.has_requests(), (
+        "has_requests() must return True when a connector has pending push work"
+    )
+
+    # Once push work drains, scheduler should be idle again.
+    mock_active.has_pending_push_work.return_value = False
+    assert not scheduler.has_requests(), (
+        "has_requests() must return False when all connectors report no pending work"
+    )
+
 def test_scheduler_kv_connector_stats():
     """Test worker-side, scheduler-side, and combined KV connector stats."""
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -175,6 +175,11 @@ class Scheduler(SchedulerInterface):
             self.ec_connector = ECConnectorFactory.create_connector(
                 config=self.vllm_config, role=ECConnectorRole.SCHEDULER
             )
+        # Build list of all connectors that can signal pending push work, so
+        # has_requests() stays general as new connector types are added.
+        self._push_connectors = [
+            c for c in [self.connector, self.ec_connector] if c is not None
+        ]
 
         num_gpu_blocks = self.cache_config.num_gpu_blocks
         assert num_gpu_blocks is not None and num_gpu_blocks > 0
@@ -2545,16 +2550,10 @@ class Scheduler(SchedulerInterface):
         # connector still has pending push work (e.g. push-mode WRITE transfers
         # in flight after all "live" requests have finished). Without this hook
         # the engine would quiesce before the connector can drain completions.
-        # TODO: replace with a more general mechanism for connectors to keep
-        # the scheduler alive.
         return (
             self.has_unfinished_requests()
             or self.has_finished_requests()
-            or (self.connector is not None and self.connector.has_pending_push_work())
-            or (
-                self.ec_connector is not None
-                and self.ec_connector.has_pending_push_work()
-            )
+            or any(c.has_pending_push_work() for c in self._push_connectors)
         )
 
     def reset_prefix_cache(


### PR DESCRIPTION
## Summary

Replace two hardcoded connector checks in `Scheduler.has_requests()` with a
generic `_push_connectors` list built once in `__init__`.

Previously, adding a new connector type required manually adding another `or`
clause to `has_requests()`. This is a maintenance trap — miss it and the engine
can quiesce before a connector drains its pending push work.

With this change, new connectors simply join `self._push_connectors` during
construction. `has_requests()` never needs to change again.

## Changes

- `vllm/v1/core/sched/scheduler.py`: build `_push_connectors` list in `__init__`
  after all connectors are assigned; replace hardcoded checks in `has_requests()`
  with `any(c.has_pending_push_work() for c in self._push_connectors)`
- `tests/v1/core/test_scheduler.py`: add `test_push_connectors_generalizes_has_requests`
  to verify the contract holds for arbitrary connector objects

## Testing