### PR TITLE
[ROCm][DeepSeek V4] Enable FHMoE with DP8 over RCCL

### DIFF
--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -452,6 +452,255 @@ def test_deepseek_v4_heterogeneous_fhmoe_keeps_native_intermediate_width() -> No
 
 
 @pytest.mark.parametrize(
+    ("tp_rank", "tp_size", "dp_size", "expected"),
+    [
+        (3, 8, 1, (0, 1)),
+        (3, 8, 8, (3, 8)),
+    ],
+)
+def test_deepseek_v4_heterogeneous_fhmoe_shared_expert_sharding(
+    tp_rank: int,
+    tp_size: int,
+    dp_size: int,
+    expected: tuple[int, int],
+) -> None:
+    from vllm.models.deepseek_v4.amd.model import (
+        _shared_expert_shard_rank_and_size,
+    )
+
+    assert _shared_expert_shard_rank_and_size(tp_rank, tp_size, dp_size) == expected
+
+
+def test_deepseek_v4_heterogeneous_fhmoe_shards_dp_shared_expert() -> None:
+    from vllm.model_executor.layers.fused_moe.config import FusedMoEParallelConfig
+    from vllm.models.deepseek_v4.amd.model import _prepare_native_fp8_shared_expert
+
+    hidden_size = 128
+    intermediate_size = 384
+    shard_size = 8
+    full_intermediate_size = intermediate_size * shard_size
+    w13 = (
+        torch.arange(2 * full_intermediate_size * hidden_size, dtype=torch.uint8)
+        .view(torch.float8_e4m3fn)
+        .reshape(2 * full_intermediate_size, hidden_size)
+    )
+    w2 = (
+        torch.arange(hidden_size * full_intermediate_size, dtype=torch.uint8)
+        .view(torch.float8_e4m3fn)
+        .reshape(hidden_size, full_intermediate_size)
+    )
+    w13_scale_bytes = (
+        torch.arange(2 * full_intermediate_size // 128, dtype=torch.uint8) + 0x60
+    ).reshape(-1, 1)
+    w2_scale_bytes = (
+        torch.arange(full_intermediate_size // 128, dtype=torch.uint8) + 0x70
+    ).reshape(1, -1)
+    w13_scale = w13_scale_bytes.view(torch.float8_e8m0fnu)
+    w2_scale = w2_scale_bytes.view(torch.float8_e8m0fnu)
+
+    shards = []
+    for dp_rank in range(shard_size):
+        flattened_size, flattened_rank = (
+            FusedMoEParallelConfig.flatten_tp_across_dp_and_pcp(
+                tp_size=1,
+                dp_size=shard_size,
+                dp_rank=dp_rank,
+                pcp_size=1,
+                pcp_rank=0,
+            )
+        )
+        assert flattened_size == shard_size
+        assert flattened_rank == dp_rank
+        shards.append(
+            _prepare_native_fp8_shared_expert(
+                w13,
+                w2,
+                w13_scale,
+                w2_scale,
+                intermediate_size,
+                flattened_rank,
+                flattened_size,
+            )
+        )
+
+    assert all(shard[0].shape == (1, 768, hidden_size) for shard in shards)
+    assert all(
+        shard[1].shape == (1, hidden_size, intermediate_size) for shard in shards
+    )
+    reconstructed_w1 = torch.cat(
+        [shard[0][0, :intermediate_size] for shard in shards], dim=0
+    )
+    reconstructed_w3 = torch.cat(
+        [shard[0][0, intermediate_size:] for shard in shards], dim=0
+    )
+    reconstructed_w2 = torch.cat([shard[1][0] for shard in shards], dim=1)
+    assert torch.equal(
+        reconstructed_w1.view(torch.uint8),
+        w13[:full_intermediate_size].view(torch.uint8),
+    )
+    assert torch.equal(
+        reconstructed_w3.view(torch.uint8),
+        w13[full_intermediate_size:].view(torch.uint8),
+    )
+    assert torch.equal(
+        reconstructed_w2.view(torch.uint8),
+        w2.view(torch.uint8),
+    )
+
+    scale_rows_per_shard = intermediate_size // 128
+    full_scale_rows = full_intermediate_size // 128
+    for rank, shard in enumerate(shards):
+        start = rank * scale_rows_per_shard
+        end = start + scale_rows_per_shard
+        expected_w13_scale = torch.cat(
+            (
+                w13_scale_bytes[start:end],
+                w13_scale_bytes[full_scale_rows + start : full_scale_rows + end],
+            ),
+            dim=0,
+        )
+        expected_w13_scale = expected_w13_scale.repeat_interleave(
+            128, dim=0
+        ).repeat_interleave(4, dim=1)
+        expected_w2_scale = (
+            w2_scale_bytes[:, start:end]
+            .repeat_interleave(128, dim=0)
+            .repeat_interleave(4, dim=1)
+        )
+        assert torch.equal(shard[2].view(torch.uint8), expected_w13_scale)
+        assert torch.equal(
+            shard[3].view(torch.uint8)[:, : expected_w2_scale.shape[1]],
+            expected_w2_scale,
+        )
+        assert torch.all(
+            shard[3].view(torch.uint8)[:, expected_w2_scale.shape[1] :] == 0x7F
+        )
+
+
+@pytest.mark.parametrize("use_fused", [False, True])
+def test_deepseek_v4_heterogeneous_fhmoe_uses_modular_kernel(
+    monkeypatch: pytest.MonkeyPatch, use_fused: bool
+) -> None:
+    from vllm.models.deepseek_v4.amd import model as deepseek_v4_model
+
+    class FakeSharedExpert(nn.Module):
+        def forward(self, x):
+            return x * 10
+
+    class FakeQuantMethod:
+        def __init__(self) -> None:
+            self.route_columns: list[int] = []
+
+        def apply(self, *, x, topk_ids, **kwargs):
+            self.route_columns.append(topk_ids.shape[1])
+            return 2 * x
+
+    shared_expert = FakeSharedExpert()
+    quant_method = FakeQuantMethod()
+    monkeypatch.setattr(
+        deepseek_v4_model,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            dp_metadata=SimpleNamespace(get_chunk_sizes_across_dp_rank=lambda: [2, 2])
+        ),
+    )
+    monkeypatch.setattr(
+        deepseek_v4_model,
+        "_use_heterogeneous_fhmoe",
+        lambda num_tokens: use_fused,
+    )
+
+    layer = deepseek_v4_model.DeepseekV4HeterogeneousSharedRoutedExperts.__new__(
+        deepseek_v4_model.DeepseekV4HeterogeneousSharedRoutedExperts
+    )
+    nn.Module.__init__(layer)
+    layer.moe_config = SimpleNamespace(dp_size=2, experts_per_token=1)
+    layer.shared_w1 = torch.ones(1)
+    layer.shared_w2 = torch.ones(1)
+    layer.shared_w1_scale = torch.ones(1)
+    layer.shared_w2_scale = torch.ones(1)
+    layer.shared_expert_id = 1
+    layer.quant_method = quant_method
+    layer._routed_quant_config = object()
+    layer._shared_expert_ref = lambda: shared_expert
+
+    x = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    topk_weights = torch.ones((2, 2), dtype=torch.float32)
+    topk_ids = torch.zeros((2, 2), dtype=torch.int32)
+    output = layer.forward_modular(x, topk_weights, topk_ids)
+
+    expected = 2 * x if use_fused else 12 * x
+    torch.testing.assert_close(output, expected)
+    assert quant_method.route_columns == [2 if use_fused else 1]
+
+
+@pytest.mark.parametrize("use_shared_route", [False, True])
+def test_deepseek_v4_heterogeneous_aiter_experts_selects_weights(
+    monkeypatch: pytest.MonkeyPatch, use_shared_route: bool
+) -> None:
+    from vllm.model_executor.layers.fused_moe.experts import rocm_aiter_moe
+
+    full_quant_config = object()
+    routed_quant_config = object()
+    experts = rocm_aiter_moe.DeepseekV4HeterogeneousAiterExperts.__new__(
+        rocm_aiter_moe.DeepseekV4HeterogeneousAiterExperts
+    )
+    experts.moe_config = SimpleNamespace(experts_per_token=1)
+    experts.quant_config = full_quant_config
+    experts.configure_shared_expert(
+        shared_w1=torch.ones(1),
+        shared_w2=torch.ones(1),
+        shared_w1_scale=torch.ones(1),
+        shared_w2_scale=torch.ones(1),
+        shared_expert_id=2,
+        routed_quant_config=routed_quant_config,
+    )
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_fused_experts(**kwargs):
+        calls.append(kwargs)
+        return 2 * kwargs["hidden_states"]
+
+    monkeypatch.setattr(rocm_aiter_moe, "rocm_aiter_fused_experts", fake_fused_experts)
+    monkeypatch.setattr(
+        rocm_aiter_moe.rocm_aiter_ops, "get_moe_dispatch_policy", lambda: None
+    )
+
+    hidden_states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    output = torch.empty_like(hidden_states)
+    route_columns = 2 if use_shared_route else 1
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=torch.ones((3, 2, 2)),
+        w2=torch.ones((3, 2, 2)),
+        topk_weights=torch.ones((2, route_columns)),
+        topk_ids=torch.zeros((2, route_columns), dtype=torch.int32),
+        activation=None,
+        global_num_experts=2,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=torch.empty(0),
+        workspace2=torch.empty(0),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    torch.testing.assert_close(output, 2 * hidden_states)
+    call = calls[0]
+    assert call["quant_config"] is (
+        full_quant_config if use_shared_route else routed_quant_config
+    )
+    assert call["w1"].shape[0] == (3 if use_shared_route else 2)
+    assert (call["shared_w1"] is not None) is use_shared_route
+    if not use_shared_route:
+        assert call["w1"].is_shuffled
+        assert call["w2"].is_shuffled
+
+
+@pytest.mark.parametrize(
     ("num_tokens", "supported_through", "expected"),
     [
         (0, 4096, False),
@@ -617,6 +866,8 @@ def test_deepseek_v4_heterogeneous_fhmoe_aiter_capability_catches_signature_erro
     [
         ("data_parallel_size", 1, True),
         ("data_parallel_size", 2, False),
+        ("tensor_parallel_size", 1, False),
+        ("dp8", True, True),
         ("prefill_context_parallel_size", 2, False),
         ("topk_method", "greedy", False),
         ("fhmoe_supported", False, False),
@@ -649,6 +900,9 @@ def test_deepseek_v4_heterogeneous_fhmoe_compatibility_gates(
     )
     if setting == "topk_method":
         hf_config.topk_method = value
+    elif setting == "dp8":
+        parallel_config.tensor_parallel_size = 1
+        parallel_config.data_parallel_size = 8
     elif setting != "fhmoe_supported":
         setattr(parallel_config, setting, value)
 

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -593,3 +593,137 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             output.set_(result)
         else:
             output.copy_(result)
+
+
+class DeepseekV4HeterogeneousAiterExperts(AiterExperts):
+    """AITER experts with DeepSeek V4's native-FP8 shared expert attached."""
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+        max_num_tokens: int | None = None,
+        num_dispatchers: int | None = None,
+    ):
+        super().__init__(
+            moe_config,
+            quant_config,
+            max_num_tokens=max_num_tokens,
+            num_dispatchers=num_dispatchers,
+        )
+        self.shared_w1: torch.Tensor | None = None
+        self.shared_w2: torch.Tensor | None = None
+        self.shared_w1_scale: torch.Tensor | None = None
+        self.shared_w2_scale: torch.Tensor | None = None
+        self.shared_expert_id = -1
+        self.routed_quant_config: FusedMoEQuantConfig | None = None
+
+    def configure_shared_expert(
+        self,
+        shared_w1: torch.Tensor,
+        shared_w2: torch.Tensor,
+        shared_w1_scale: torch.Tensor,
+        shared_w2_scale: torch.Tensor,
+        shared_expert_id: int,
+        routed_quant_config: FusedMoEQuantConfig,
+    ) -> None:
+        self.shared_w1 = shared_w1
+        self.shared_w2 = shared_w2
+        self.shared_w1_scale = shared_w1_scale
+        self.shared_w2_scale = shared_w2_scale
+        self.shared_expert_id = shared_expert_id
+        self.routed_quant_config = routed_quant_config
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ):
+        del global_num_experts, a2_scale, workspace13, workspace2
+        routed_columns = self.moe_config.experts_per_token
+        route_columns = topk_ids.shape[1]
+        if route_columns not in (routed_columns, routed_columns + 1):
+            raise ValueError(
+                "DeepSeek V4 heterogeneous routes must have either "
+                f"{routed_columns} or {routed_columns + 1} columns, "
+                f"got {route_columns}."
+            )
+
+        num_local_tokens = (
+            expert_tokens_meta.expert_num_tokens
+            if expert_tokens_meta is not None
+            else None
+        )
+        quant_config = self.routed_quant_config
+        shared_w1 = shared_w2 = shared_w1_scale = shared_w2_scale = None
+        shared_expert_id = -1
+        if route_columns == routed_columns + 1:
+            if any(
+                tensor is None
+                for tensor in (
+                    self.shared_w1,
+                    self.shared_w2,
+                    self.shared_w1_scale,
+                    self.shared_w2_scale,
+                )
+            ):
+                raise RuntimeError("Heterogeneous shared weights were not configured.")
+            quant_config = self.quant_config
+            shared_w1 = self.shared_w1
+            shared_w2 = self.shared_w2
+            shared_w1_scale = self.shared_w1_scale
+            shared_w2_scale = self.shared_w2_scale
+            shared_expert_id = self.shared_expert_id
+        else:
+            if quant_config is None or self.shared_expert_id < 0:
+                raise RuntimeError("Routed-only fallback was not configured.")
+            w1 = w1[: self.shared_expert_id]
+            w2 = w2[: self.shared_expert_id]
+            w1.is_shuffled = True
+            w2.is_shuffled = True
+
+        result = rocm_aiter_fused_experts(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            expert_mask=expert_map,
+            quant_config=quant_config,
+            moe_config=self.moe_config,
+            a1q_scale=a1q_scale,
+            num_local_tokens=num_local_tokens,
+            output_dtype=output.dtype,
+            moe_sorting_dispatch_policy=rocm_aiter_ops.get_moe_dispatch_policy(),
+            shared_w1=shared_w1,
+            shared_w2=shared_w2,
+            shared_w1_scale=shared_w1_scale,
+            shared_w2_scale=shared_w2_scale,
+            shared_expert_id=shared_expert_id,
+        )
+        if (
+            output.shape == result.shape
+            and output.dtype == result.dtype
+            and output.device == result.device
+            and output.is_contiguous()
+            and result.is_contiguous()
+            and output._base is None
+        ):
+            output.set_(result)
+        else:
+            output.copy_(result)

--- a/vllm/models/deepseek_v4/amd/model.py
+++ b/vllm/models/deepseek_v4/amd/model.py
@@ -18,6 +18,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import (
@@ -28,6 +29,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+    DeepseekV4HeterogeneousAiterExperts,
     rocm_aiter_fused_experts,
 )
 from vllm.model_executor.layers.fused_moe.utils import (
@@ -214,10 +216,13 @@ def _heterogeneous_shared_expert_enabled(vllm_config: VllmConfig) -> bool:
         reasons.append("expert parallelism is enabled")
     if parallel_config.enable_eplb:
         reasons.append("EPLB is enabled")
-    if parallel_config.tensor_parallel_size != 8:
-        reasons.append("tensor parallelism is not 8")
-    if parallel_config.data_parallel_size != 1:
-        reasons.append("data parallelism is enabled")
+    if parallel_config.tensor_parallel_size * parallel_config.data_parallel_size != 8:
+        reasons.append("tensor parallelism times data parallelism is not 8")
+    if (
+        parallel_config.tensor_parallel_size > 1
+        and parallel_config.data_parallel_size > 1
+    ):
+        reasons.append("combined tensor and data parallelism is unsupported")
     if parallel_config.prefill_context_parallel_size != 1:
         reasons.append("prefill context parallelism is enabled")
     if vllm_config.kernel_config.moe_backend != "aiter":
@@ -291,15 +296,42 @@ def _prepare_native_fp8_shared_expert(
     w13_scale: torch.Tensor,
     w2_scale: torch.Tensor,
     intermediate_size: int,
+    shard_rank: int = 0,
+    shard_size: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Expand native block-128 E8M0 scales to FHMoE's 1x32 layout."""
+    """Shard and expand native block-128 E8M0 scales for FHMoE's 1x32 layout."""
     if w13.dtype != torch.float8_e4m3fn or w2.dtype != torch.float8_e4m3fn:
         raise ValueError("Heterogeneous shared-expert weights must be FP8 E4M3.")
     hidden_size = w13.shape[1]
-    if w13.shape != (2 * intermediate_size, hidden_size):
+    full_intermediate_size = intermediate_size * shard_size
+    if w13.shape != (2 * full_intermediate_size, hidden_size):
         raise ValueError(f"Unexpected shared W13 shape {tuple(w13.shape)}.")
-    if w2.shape != (hidden_size, intermediate_size):
+    if w2.shape != (hidden_size, full_intermediate_size):
         raise ValueError(f"Unexpected shared W2 shape {tuple(w2.shape)}.")
+    if not 0 <= shard_rank < shard_size:
+        raise ValueError(f"Invalid shared expert shard {shard_rank}/{shard_size}.")
+    start = shard_rank * intermediate_size
+    end = start + intermediate_size
+    w13 = torch.cat(
+        (
+            w13[start:end],
+            w13[full_intermediate_size + start : full_intermediate_size + end],
+        ),
+        dim=0,
+    ).contiguous()
+    w2 = w2[:, start:end].contiguous()
+
+    scale_start = start // 128
+    scale_end = end // 128
+    full_scale_rows = full_intermediate_size // 128
+    w13_scale = torch.cat(
+        (
+            w13_scale[scale_start:scale_end],
+            w13_scale[full_scale_rows + scale_start : full_scale_rows + scale_end],
+        ),
+        dim=0,
+    ).contiguous()
+    w2_scale = w2_scale[:, scale_start:scale_end].contiguous()
 
     def scale_bytes(scale: torch.Tensor) -> torch.Tensor:
         if scale.dtype == torch.float8_e8m0fnu:
@@ -351,11 +383,45 @@ def _prepare_native_fp8_shared_expert(
     )
 
 
+def _shared_expert_shard_rank_and_size(
+    tp_rank: int, tp_size: int, dp_size: int
+) -> tuple[int, int]:
+    return (tp_rank, tp_size) if dp_size > 1 else (0, 1)
+
+
 class DeepseekV4HeterogeneousMxfp4MoEMethod(Mxfp4MoEMethod):
+    def __init__(self, moe):
+        super().__init__(moe)
+        if moe.dp_size > 1:
+            self.experts_cls = DeepseekV4HeterogeneousAiterExperts
+
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         super().process_weights_after_loading(layer)
         assert isinstance(layer, DeepseekV4HeterogeneousSharedRoutedExperts)
         layer.prepare_heterogeneous_shared_expert()
+        if self.moe.dp_size == 1:
+            return
+        if self.moe_kernel is None:
+            raise RuntimeError("The heterogeneous modular kernel is unavailable.")
+        experts = self.moe_kernel.fused_experts
+        if not isinstance(experts, DeepseekV4HeterogeneousAiterExperts):
+            raise RuntimeError("The heterogeneous AITER experts are unavailable.")
+        if (
+            layer.shared_w1 is None
+            or layer.shared_w2 is None
+            or layer.shared_w1_scale is None
+            or layer.shared_w2_scale is None
+            or layer._routed_quant_config is None
+        ):
+            raise RuntimeError("The heterogeneous shared weights are unavailable.")
+        experts.configure_shared_expert(
+            shared_w1=layer.shared_w1,
+            shared_w2=layer.shared_w2,
+            shared_w1_scale=layer.shared_w1_scale,
+            shared_w2_scale=layer.shared_w2_scale,
+            shared_expert_id=layer.shared_expert_id,
+            routed_quant_config=layer._routed_quant_config,
+        )
 
 
 class DeepseekV4HeterogeneousSharedRoutedExperts(RoutedExperts):
@@ -391,12 +457,20 @@ class DeepseekV4HeterogeneousSharedRoutedExperts(RoutedExperts):
         if shared_expert is None:
             raise RuntimeError("The native shared-expert module was released.")
 
+        moe_parallel_config = self.moe_config.moe_parallel_config
+        shard_rank, shard_size = _shared_expert_shard_rank_and_size(
+            moe_parallel_config.tp_rank,
+            moe_parallel_config.tp_size,
+            moe_parallel_config.dp_size,
+        )
         shared = _prepare_native_fp8_shared_expert(
             shared_expert.gate_up_proj.weight,
             shared_expert.down_proj.weight,
             shared_expert.gate_up_proj.weight_scale_inv,
             shared_expert.down_proj.weight_scale_inv,
             self.moe_config.intermediate_size_per_partition,
+            shard_rank=shard_rank,
+            shard_size=shard_size,
         )
         self.shared_w1 = rocm_aiter_ops.shuffle_weight_a16w4(shared[0], 16, True)
         self.shared_w2 = rocm_aiter_ops.shuffle_weight_a16w4(shared[1], 16, False)
@@ -454,7 +528,24 @@ class DeepseekV4HeterogeneousSharedRoutedExperts(RoutedExperts):
         ):
             raise RuntimeError("Heterogeneous shared weights were not prepared.")
 
-        if _use_heterogeneous_fhmoe(x.shape[0]):
+        num_fhmoe_tokens = x.shape[0]
+        if self.moe_config.dp_size > 1:
+            dp_metadata = get_forward_context().dp_metadata
+            assert dp_metadata is not None
+            sizes = dp_metadata.get_chunk_sizes_across_dp_rank()
+            assert sizes is not None
+            num_fhmoe_tokens = sum(sizes)
+
+        if _use_heterogeneous_fhmoe(num_fhmoe_tokens):
+            if self.moe_config.dp_size > 1:
+                return self.quant_method.apply(
+                    layer=self,
+                    x=x,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    shared_experts=None,
+                    shared_experts_input=None,
+                )
             self._ensure_moe_quant_config_init()
             quant_config = self.quant_method.moe_quant_config
             if quant_config is None:
@@ -470,7 +561,7 @@ class DeepseekV4HeterogeneousSharedRoutedExperts(RoutedExperts):
                 expert_mask=self.expert_map,
                 quant_config=quant_config,
                 output_dtype=x.dtype,
-                moe_sorting_dispatch_policy=(rocm_aiter_ops.get_moe_dispatch_policy()),
+                moe_sorting_dispatch_policy=rocm_aiter_ops.get_moe_dispatch_policy(),
                 shared_w1=self.shared_w1,
                 shared_w2=self.shared_w2,
                 shared_w1_scale=self.shared_w1_scale,
@@ -482,23 +573,33 @@ class DeepseekV4HeterogeneousSharedRoutedExperts(RoutedExperts):
         if shared_expert is None or self._routed_quant_config is None:
             raise RuntimeError("The separate shared-expert fallback is unavailable.")
         shared_out = shared_expert(x)
-        routed_w1 = self.w13_weight[: self.shared_expert_id]
-        routed_w2 = self.w2_weight[: self.shared_expert_id]
-        routed_w1.is_shuffled = True
-        routed_w2.is_shuffled = True
-        routed = rocm_aiter_fused_experts(
-            hidden_states=x,
-            w1=routed_w1,
-            w2=routed_w2,
-            topk_weights=topk_weights[:, :-1].contiguous(),
-            topk_ids=topk_ids[:, :-1].contiguous(),
-            moe_config=self.moe_config,
-            activation=self.activation,
-            expert_mask=self.expert_map,
-            quant_config=self._routed_quant_config,
-            output_dtype=x.dtype,
-            moe_sorting_dispatch_policy=rocm_aiter_ops.get_moe_dispatch_policy(),
-        )
+        if self.moe_config.dp_size > 1:
+            routed = self.quant_method.apply(
+                layer=self,
+                x=x,
+                topk_weights=topk_weights[:, :-1].contiguous(),
+                topk_ids=topk_ids[:, :-1].contiguous(),
+                shared_experts=None,
+                shared_experts_input=None,
+            )
+        else:
+            routed_w1 = self.w13_weight[: self.shared_expert_id]
+            routed_w2 = self.w2_weight[: self.shared_expert_id]
+            routed_w1.is_shuffled = True
+            routed_w2.is_shuffled = True
+            routed = rocm_aiter_fused_experts(
+                hidden_states=x,
+                w1=routed_w1,
+                w2=routed_w2,
+                topk_weights=topk_weights[:, :-1].contiguous(),
+                topk_ids=topk_ids[:, :-1].contiguous(),
+                moe_config=self.moe_config,
+                activation=self.activation,
+                expert_mask=self.expert_map,
+                quant_config=self._routed_quant_config,
+                output_dtype=x.dtype,
+                moe_sorting_dispatch_policy=rocm_aiter_ops.get_moe_dispatch_policy(),
+            )
         return routed + shared_out
 
 


### PR DESCRIPTION
## Summary

Extend the DeepSeek V4 heterogeneous fused MoE path from TP8/DP1 to TP1/DP8 on ROCm while preserving vLLM's existing distributed pipeline:

- shard the native FP8 shared-expert weights and E8M0 scales across the flattened DP ranks;
- run #53161's native-FP8-shared/MXFP4-routed heterogeneous kernel inside the existing modular expert boundary; and
- keep the standard PyNCCL/RCCL all-gather prepare and reduce-scatter finalize around the local heterogeneous kernel.

This draft preserves #53161's four original commits and metadata, followed by one DP8 commit authored and signed off by `Liuyinfeng01 <yinfeliu@amd.com>`.

## Design

The DP8 path follows the normal vLLM modular flow:

```text
RCCL all-gather prepare
  -> local AITER heterogeneous shared+routed expert kernel
  -> RCCL reduce-scatter finalize
```

For CSV-covered M, the modular AITER experts receive the appended shared-expert route and call `fhmoe_`. For unsupported M, the same modular kernel processes only the six routed routes while the native shared MLP remains separate.

TP8/DP1 retains #53161's original direct path. This change does not modify `CudaCommunicator`, AITER custom collectives, global graph capture, or NVIDIA model code. It does not depend on or duplicate #48247.

## Dependencies / merge blockers

- #53161 provides the underlying heterogeneous native-FP8-shared/MXFP4-routed kernel integration.
- [ROCm/aiter#4891](https://github.com/ROCm/aiter/pull/4891) provides the physical-I384 FHMoE configuration and capability contract.
- vLLM must consume an AITER revision or release containing that dependency before merge.

## Correctness

Full 5-shot GSM8K, greedy, 1319 questions, max output 2048, concurrency 64, 8 x MI355X TP1/DP8:

- FHMoE OFF reference: **1250/1319 = 94.77%**, invalid rate 0.
- RCCL modular FHMoE ON: **1247/1319 = 94.54%**, invalid rate 0.

The 0.23 percentage-point difference is within normal numeric variance. The earlier direct-kernel DP prototype was rejected because it omitted modular dispatch/combine and failed this check.

## Performance

### Decode-focused A/B

Configuration: 8 x MI355X, TP1/DP8, 240 requests (30/rank), cached 100K input / 1024 output, DSpark step 5 with synthetic AL 3.69, `max-num-batched-tokens=384`, and automatic `FULL_DECODE_ONLY` graph selection. Both arms use RCCL AG/RS; only the FHMoE flag changes.

| FHMoE | TPOT runs (ms) | Median TPOT | TPS runs | Median TPS |
|---|---:|---:|---:|---:|
| OFF | 18.813 / 20.253 / 20.048 | **20.048 ms** | 4,130.9 / 3,950.0 / 3,979.2 | **3,979.2 tok/s** |
| ON | 16.819 / 18.365 / 18.735 | **18.365 ms** | 4,232.6 / 4,348.4 / 4,299.9 | **4,299.9 tok/s** |

Median delta: **TPOT -8.39%**, **aggregate output throughput +8.06%**, and **TTFT -8.87%**. All six runs completed all 240 requests.

This gain removes the separate shared-expert execution; routed MoE and RCCL AG/RS remain.

### 8K/1K E2E smoke A/B

Actual random 8192-token prefill / 1024-token output, C240, auto graph, no fake KV connector, one run per arm:

- OFF: 1,644.35 output tok/s, 69.11 ms mean TPOT.
- ON: 1,656.53 output tok/s, 67.62 ms mean TPOT.
- Delta: output throughput **+0.74%**, mean TPOT **-2.16%**.

The E2E case is prefill-dominated and is reported as a smoke result, not a multi-run attribution claim.

## Trace evidence

Matched profiler artifacts are stored from the same RCCL/auto-graph configuration:

- OFF rank 0: `fhmoe_` count 0; `vllm::moe_forward_shared` present (5551 calls in the longer capture).
- ON rank 0: `aiter::fhmoe_` present (610 calls); `vllm::moe_forward_shared` count 0; `vllm::moe_forward` present.
- RCCL `ncclDevKernel_Generic_1` remains present in both arms.

The captures have different durations, so event counts are used only to prove path selection, not for direct aggregate-time comparison.

## Validation

- `git diff --check`: passed.
- Selected pre-commit hooks for all three changed files: passed, including Ruff and mypy.
- `tests/model_executor/layers/test_fused_shared_expert.py`: **71 passed**.
- Full TP1/DP8 server startup passed with RCCL/PyNCCL as the DP backend.
- Full GSM8K passed with zero invalid responses.
- Auto-graph decode A/B: six of six runs passed.
- Verified the PR contains the four unchanged #53161 commits plus one sole-author DP8 follow-on commit.

## AI assistance

Cursor assisted with implementation, testing, profiling analysis, and drafting. The human submitter reviewed the resulting change and is responsible for it.


---

# Re-measurement on the older `DeepSeek-V4-Pro` checkpoint

> **Scope note.** Everything **above** this heading is the original submission,
> measured on the checkpoint stated there. The section **below** re-runs
> correctness and ordinary 8K/1K serving on the older `DeepSeek-V4-Pro`
> snapshot, staged locally as `DeepSeek-V4-Pro-old`. The two checkpoints and
> workloads are not interchangeable; the results are reported separately.

## Setup

| Item | Value |
|---|---|
| Hardware | 8 x MI355X (gfx950), single node |
| Image | original FHMoE stack, image ID `sha256:7a47f7bfd883...` |
| vLLM / AITER / FlyDSL | `d9105ea8` + #54134 compatibility overlay / `a6d2b564` / `0.3.1` |
| Topology | TP1/DP8, RCCL all-gather prepare / reduce-scatter finalize |
| Model | `DeepSeek-V4-Pro` older snapshot, native FP8 shared experts + MXFP4 routed experts |
| Serving workload | random 8,192 input / 1,024 output tokens, greedy, real prefill |
| Graph / cache | `FULL_DECODE_ONLY`, FP8 KV cache, prefix caching disabled |
| A/B variable | `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0/1` only |

The image's compiled vLLM extensions and AITER installation were reused; only
the two #54134 Python runtime files were mounted. No fake KV connector,
speculative decoding, AgentX workload, or additional optimization overlay was
used for the serving matrix below.

## Path evidence

The ON startup log contains all three expected markers:

- `Using AITER DeepSeek V4 heterogeneous MoE...`
- `Using MoEPrepareAndFinalizeNaiveDPEPModular`
- `Using DeepseekV4HeterogeneousAiterExperts`

The OFF startup log contains none of the heterogeneous-FHMoE markers. Both
arms retain the standard DP all-gather / reduce-scatter path.

## Ordinary 8K/1K serving A/B

Each arm used one fresh server. Every concurrency point had one warmup request
and two measured runs. Values below are the raw run 1 / run 2 results; deltas
use the arithmetic mean of the two runs.

| Concurrency | OFF output tok/s | ON output tok/s | Throughput delta |
|---:|---:|---:|---:|
| 1 | 40.85 / 40.80 | 44.79 / 44.67 | **+9.57%** |
| 4 | 139.81 / 141.59 | 151.42 / 157.35 | **+9.72%** |
| 16 | 466.89 / 464.44 | 466.35 / 505.54 | **+4.35%** |
| 64 | 1,226.88 / 1,236.89 | 1,249.99 / 1,204.26 | -0.39% |
| 128 | 1,839.14 / 1,811.62 | 1,839.40 / 1,843.10 | +0.87% |
| 240 | 2,591.33 / 2,550.16 | 2,548.98 / 2,581.98 | -0.20% |

| Concurrency | OFF median TPOT (ms) | ON median TPOT (ms) | TPOT delta |
|---:|---:|---:|---:|
| 1 | 23.284 / 23.303 | 21.150 / 21.158 | **-9.18%** |
| 4 | 26.408 / 26.271 | 24.490 / 24.290 | **-7.40%** |
| 16 | 29.623 / 30.255 | 30.107 / 27.820 | **-3.26%** |
| 64 | 45.477 / 44.220 | 43.273 / 45.648 | -0.87% |
| 128 | 62.213 / 64.027 | 62.734 / 62.726 | -0.62% |
| 240 | 62.100 / 63.478 | 64.391 / 62.439 | +1.00% |

All 24 runs completed every request with zero failures. FHMoE gives a clear
low-concurrency benefit, narrows at C16, and is throughput-neutral once the
service is saturated at C64-C240. The C16 ON runs have visible run-to-run
variance, so the raw values are retained rather than presenting the mean as a
precise estimate.

## GSM8K (full 1,319, 5-shot, greedy)

| Arm | flexible-extract | strict-match |
|---|---:|---:|
| FHMoE OFF (baseline) | 0.9674 +/- 0.0049 | 0.9674 +/- 0.0049 |
| FHMoE ON (this PR) | 0.9666 +/- 0.0049 | 0.9666 +/- 0.0049 |

Both arms exited 0 and scored all 1,319 questions.

**Run-to-run variance.** The ON arm was run twice under an identical
configuration and scored **0.9629** and **0.9666** -- a 0.37 pp spread. The
ON-vs-OFF gap (0.08 pp) is therefore well inside the noise floor of a single
run, and the honest reading of this table is **accuracy parity**, not a
measurable regression. This matches the direction reported above on the other
checkpoint, where the two arms also land within a few tenths of a point.


