### PR TITLE
[XPU] [SP] Support Sequence Parallelism for W8A8 Static FP8 on XPU

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -204,3 +204,30 @@ steps:
         python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP4-CT-AutoRound --max-model-len 4096'
       # Temporarily disabled (multi-GPU/MXFP8 not yet supported with XPU Graph):
       # python3 examples/basic/offline_inference/generate.py --model INCModel/Qwen3-30B-A3B-Instruct-2507-MXFP8-CT-AutoRound -tp 2 --max-model-len 4096
+  - label: "XPU compile distributed passes"
+    depends_on:
+      - image-build-xpu
+    timeout_in_minutes: 60
+    device: intel_gpu
+    agent_tags:
+      label: production
+      gpu: 2+
+      mem: 24+
+    no_plugin: true
+    env:
+      REGISTRY: "public.ecr.aws/q9t5s3a7"
+      REPO: "vllm-ci-test-repo"
+      VLLM_TEST_DEVICE: "xpu"
+    source_file_dependencies:
+      - vllm/compilation/
+      - vllm/model_executor/layers/quantization/
+      - tests/compile/passes/distributed/test_sequence_parallelism.py
+      - tests/compile/correctness_e2e/test_sequence_parallel.py
+      - tests/utils.py
+      - .buildkite/intel_jobs/test-intel.yaml
+    commands:
+      - >-
+        bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+        'cd tests &&
+        pytest -v -s compile/passes/distributed/test_sequence_parallelism.py &&
+        pytest -v -s compile/correctness_e2e/test_sequence_parallel.py'

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -16,6 +16,7 @@ from vllm.config import (
     CompilationConfig,
     CUDAGraphMode,
     DeviceConfig,
+    KernelConfig,
     ModelConfig,
     PassConfig,
     VllmConfig,
@@ -38,7 +39,10 @@ from vllm.utils.torch_utils import set_random_seed
 
 DEVICE_TYPE = current_platform.device_type
 
-pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Only test CUDA")
+pytestmark = pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_xpu()),
+    reason="Only test CUDA and XPU",
+)
 
 FP8_DTYPE = current_platform.fp8_dtype()
 prompts = [
@@ -179,7 +183,9 @@ class TestAllReduceRMSNormStaticQuantFP8Model(torch.nn.Module):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("fuse_norm_quant", [True, False])
 @pytest.mark.parametrize("dynamic", [False, True])
-@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
+@pytest.mark.skipif(
+    envs.VLLM_TARGET_DEVICE not in ["cuda", "xpu"], reason="Only test on CUDA and XPU"
+)
 def test_sequence_parallelism_pass(
     test_model_cls: type[torch.nn.Module],
     custom_ops: str,
@@ -262,7 +268,7 @@ def sequence_parallelism_pass_on_test_model(
     )
 
     # initialize distributed
-    init_distributed_environment()
+    init_distributed_environment(backend=current_platform.dist_backend)
 
     # configure vllm config for SequenceParallelismPass
     custom_ops_list = custom_ops.split(",") if custom_ops else []
@@ -285,10 +291,16 @@ def sequence_parallelism_pass_on_test_model(
         model=model_name, trust_remote_code=True, dtype=dtype, seed=42
     )
 
+    is_fp8_model = test_model_cls is TestAllReduceRMSNormStaticQuantFP8Model
+    kernel_config = KernelConfig(
+        linear_backend="xpu" if is_fp8_model and current_platform.is_xpu() else "auto"
+    )
+
     vllm_config = VllmConfig(
         model_config=model_config,
         device_config=device_config,
         compilation_config=compilation_config,
+        kernel_config=kernel_config,
     )
 
     with set_current_vllm_config(vllm_config):


### PR DESCRIPTION
## Summary

This PR enables Sequence Parallelism (SP) for **W8A8 static FP8** models on the XPU backend. SP improves Time‑to‑First‑Token (TTFT) for prefill‑heavy workloads by distributing long‑sequence computation across tensor parallel ranks via fused GEMM with reduce‑scatter/all‑gather patterns.

The implementation follows the same compilation‑based approach (`enable_sp: true`) and is validated on static FP8 quantization (per‑tensor scales).

## Performance Evaluation

**Model:** `RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8` (W8A8 static FP8), TP=4, `--linear-backend xpu`  
**Workload:** 10 prompts, input_len=4096, output_len=1024, max_concurrency=2, 2 runs per case (best reported).

### Accuracy (GSM8K, 5‑shot, 250 questions)

| Case                  | Accuracy | Invalid rate |
|-----------------------|----------|--------------|
| eager (baseline)      | 0.940    | 0.0          |
| sp_off (compile, no SP) | 0.932  | 0.0          |
| sp_on (compile + SP)  | 0.956    | 0.0          |

No accuracy regression is observed.

### Benchmark: sp_on vs sp_off (direct comparison)

Positive % = improvement (higher throughput / lower latency).

| Metric                    | sp_off  | sp_on   | Improvement |
|---------------------------|---------|---------|-------------|
| Output throughput (tok/s) | 7.48    | 7.04    | -5.88%      |
| Mean TTFT (ms)            | 20947   | 19486   | **+6.98%**  |
| Median TTFT (ms)          | 20953   | 19067   | **+9.00%**  |
| P99 TTFT (ms)             | 27948   | 26232   | **+6.14%**  |
| Mean TPOT (ms)            | 247.11  | 265.13  | -7.29%      |
| P99 TPOT (ms)             | 255.34  | 275.17  | -7.77%      |

SP reduces TTFT by **6–9%** on this prefill‑heavy workload – the primary goal of this feature.

### Benchmark: all configurations vs eager baseline

| Case                  | Throughput (tok/s) | Mean TTFT (ms) | Median TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) |
|-----------------------|--------------------|----------------|------------------|---------------|----------------|---------------|
| eager (baseline)      | 6.90               | 20545          | 20501            | 27613         | 269.83         | 279.85        |
| sp_off (compile, no SP)| 7.48 (+8.41%)     | 20947 (-1.96%) | 20953 (-2.21%)   | 27948 (-1.21%)| 247.11 (+8.42%)| 255.34 (+8.77%)|
| sp_on (compile + SP)  | 7.04 (+2.03%)     | 19486 (+5.15%) | 19067 (+6.99%)   | 26232 (+5.00%)| 265.13 (+1.74%)| 275.17 (+1.67%)|

`torch.compile` alone gives +8.4% throughput/TPOT over eager. Enabling SP trades some of that TPOT gain for a clear TTFT improvement – exactly the expected trade‑off for prefill‑oriented workloads.

### TPOT Regression

The ~7% TPOT regression is **expected** due to:
- SP collective overhead not being amortized at low concurrency (max_concurrency=2 < SP threshold).
- Decode steps fall back to the non‑SP path with extra bookkeeping, and `torch.compile` fusions are partially broken.

At higher concurrency (≥8), the decode batch size exceeds the SP threshold, and TPOT is expected to recover.

## Conclusion

- SP works correctly for **W8A8 static FP8** models on XPU.
- Accuracy is preserved.
- TTFT improves by **6–9%** vs `sp_off`.
- The moderate TPOT regression is within the anticipated trade‑off and acceptable for prefill‑heavy use cases.
 