### PR TITLE
[Kernel] Optimize the E=60 MoE Top-K fallback on A100

### DIFF
--- a/benchmarks/kernels/benchmark_fused_topk.py
+++ b/benchmarks/kernels/benchmark_fused_topk.py
@@ -2,9 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import itertools
+import statistics
 
 import torch
 
+import vllm._custom_ops as ops
 from vllm.model_executor.layers.fused_moe.router.fused_topk_router import fused_topk
 from vllm.triton_utils import triton
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -13,6 +15,8 @@ num_tokens_range = [2**i for i in range(0, 8, 2)]
 num_experts_range = [16, 32, 64, 128, 256, 512]
 topk_range = [3, 4]
 configs = list(itertools.product(num_tokens_range, num_experts_range, topk_range))
+
+A100_SMALL_TOPK_TOKENS = [1, 2, 4, 8, 16, 32, 64]
 
 
 def torch_topk(
@@ -87,11 +91,75 @@ def get_benchmark(scoring_func):
     return benchmark
 
 
+def benchmark_a100_small_topk():
+    """Compare the current fallback with the SM80 E=60 integrated path."""
+    if torch.cuda.get_device_capability() != (8, 0):
+        raise RuntimeError("--a100-small requires an SM80 GPU")
+
+    def measure(fn):
+        rounds = [
+            triton.testing.do_bench(
+                fn,
+                warmup=100,
+                rep=500,
+                quantiles=[0.5, 0.2, 0.8],
+            )
+            for _ in range(5)
+        ]
+        return tuple(
+            statistics.median(result[index] * 1000 for result in rounds)
+            for index in range(3)
+        )
+
+    torch.manual_seed(20260827)
+    for num_tokens in A100_SMALL_TOPK_TOKENS:
+        hidden_states = torch.empty(
+            (num_tokens, 1), dtype=torch.bfloat16, device="cuda"
+        )
+        gating_output = torch.randn(
+            (num_tokens, 60), dtype=torch.bfloat16, device="cuda"
+        )
+
+        def fallback(num_tokens=num_tokens, gating_output=gating_output):
+            weights = torch.empty((num_tokens, 4), dtype=torch.float32, device="cuda")
+            ids = torch.empty((num_tokens, 4), dtype=torch.int32, device="cuda")
+            source_rows = torch.empty_like(ids)
+            ops.topk_softmax(
+                weights,
+                ids,
+                source_rows,
+                gating_output,
+                False,
+            )
+            return weights, ids, source_rows
+
+        def integrated(hidden_states=hidden_states, gating_output=gating_output):
+            return fused_topk(hidden_states, gating_output, 4, False)
+
+        reference = fallback()
+        actual = integrated()
+        torch.accelerator.synchronize()
+        assert all(torch.equal(ref, out) for ref, out in zip(reference, actual))
+
+        baseline = measure(fallback)
+        optimized = measure(integrated)
+        gain = (1 - optimized[0] / baseline[0]) * 100
+        print(
+            f"M={num_tokens:2d} baseline={baseline[0]:.3f} us "
+            f"optimized={optimized[0]:.3f} us gain={gain:.2f}%"
+        )
+
+
 if __name__ == "__main__":
     parser = FlexibleArgumentParser(description="Benchmark the MoE topk kernel.")
     parser.add_argument("--scoring-func", type=str, default="softmax")
     parser.add_argument("--save-path", type=str, default="./configs/fused_topk/")
+    parser.add_argument("--a100-small", action="store_true")
     args = parser.parse_args()
+
+    if args.a100_small:
+        benchmark_a100_small_topk()
+        raise SystemExit
 
     # Get the benchmark function
     benchmark = get_benchmark(args.scoring_func)

--- a/csrc/libtorch_stable/moe/moe_ops.h
+++ b/csrc/libtorch_stable/moe/moe_ops.h
@@ -12,6 +12,14 @@ void topk_softmax(torch::stable::Tensor& topk_weights,
                   std::optional<torch::stable::Tensor> bias,
                   std::optional<torch::stable::Tensor> is_padding);
 
+#ifndef USE_ROCM
+void topk_softmax_a100(torch::stable::Tensor& topk_weights,
+                       torch::stable::Tensor& topk_indices,
+                       torch::stable::Tensor& token_expert_indices,
+                       torch::stable::Tensor& gating_output,
+                       std::optional<torch::stable::Tensor> is_padding);
+#endif
+
 void topk_sigmoid(torch::stable::Tensor& topk_weights,
                   torch::stable::Tensor& topk_indices,
                   torch::stable::Tensor& token_expert_indices,

--- a/csrc/libtorch_stable/moe/topk_softmax_kernels.cu
+++ b/csrc/libtorch_stable/moe/topk_softmax_kernels.cu
@@ -259,6 +259,71 @@ __launch_bounds__(TPB) __global__ void moeTopK(
     }
 }
 
+#ifndef USE_ROCM
+template <int TPB>
+__launch_bounds__(TPB) __global__ void topkSoftmaxA100(
+    const __nv_bfloat16* input, float* output, int* indices,
+    int* source_rows, const int num_rows, const bool* is_padding) {
+  using FloatReduce = cub::BlockReduce<float, TPB>;
+  using Kvp = cub::KeyValuePair<int, float>;
+  using KvpReduce = cub::BlockReduce<Kvp, TPB>;
+  __shared__ typename FloatReduce::TempStorage float_storage;
+  __shared__ typename KvpReduce::TempStorage kvp_storage;
+  __shared__ float row_max;
+  __shared__ float inverse_sum;
+  __shared__ float probabilities[60];
+
+  const int row = blockIdx.x;
+  const int row_offset = row * 60;
+  float thread_data = -FLT_MAX;
+  for (int expert = threadIdx.x; expert < 60; expert += TPB) {
+    thread_data = max(toFloat(input[row_offset + expert]), thread_data);
+  }
+  const float max_value =
+      FloatReduce(float_storage).Reduce(thread_data, CubMaxOp());
+  if (threadIdx.x == 0) row_max = max_value;
+  __syncthreads();
+
+  thread_data = 0.f;
+  for (int expert = threadIdx.x; expert < 60; expert += TPB) {
+    thread_data += expf(toFloat(input[row_offset + expert]) - row_max);
+  }
+  const float sum = FloatReduce(float_storage).Reduce(thread_data, CubAddOp());
+  if (threadIdx.x == 0) inverse_sum = 1.f / sum;
+  __syncthreads();
+
+  for (int expert = threadIdx.x; expert < 60; expert += TPB) {
+    float probability =
+        expf(toFloat(input[row_offset + expert]) - row_max) * inverse_sum;
+    if (isnan(probability) || isinf(probability)) probability = 0.f;
+    probabilities[expert] = probability;
+  }
+  __syncthreads();
+
+  cub::ArgMax arg_max;
+#pragma unroll
+  for (int rank = 0; rank < 4; ++rank) {
+    Kvp thread_kvp(0, -1.f);
+    for (int expert = threadIdx.x; expert < 60; expert += TPB) {
+      Kvp candidate(expert, probabilities[expert]);
+#pragma unroll
+      for (int prior = 0; prior < rank; ++prior) {
+        if (indices[row * 4 + prior] == expert) candidate = thread_kvp;
+      }
+      thread_kvp = arg_max(candidate, thread_kvp);
+    }
+    const Kvp result = KvpReduce(kvp_storage).Reduce(thread_kvp, arg_max);
+    if (threadIdx.x == 0) {
+      const int out = row * 4 + rank;
+      output[out] = probabilities[result.key];
+      indices[out] = is_padding != nullptr && is_padding[row] ? -1 : result.key;
+      source_rows[out] = rank * num_rows + row;
+    }
+    __syncthreads();
+  }
+}
+#endif
+
 // ====================== TopK softmax things ===============================
 
 /*
@@ -858,6 +923,82 @@ void topk_softmax(
         STD_TORCH_CHECK(false, "Unsupported gating_output data type: ", gating_output.scalar_type());
     }
 }
+
+#ifndef USE_ROCM
+void topk_softmax_a100(
+    torch::stable::Tensor& topk_weights,
+    torch::stable::Tensor& topk_indices,
+    torch::stable::Tensor& token_expert_indices,
+    torch::stable::Tensor& gating_output,
+    std::optional<torch::stable::Tensor> is_padding) {
+  const int num_tokens = gating_output.size(0);
+  STD_TORCH_CHECK(gating_output.is_cuda() && gating_output.is_contiguous() &&
+                      gating_output.scalar_type() ==
+                      torch::headeronly::ScalarType::BFloat16,
+                  "gating_output must be contiguous CUDA bfloat16");
+  STD_TORCH_CHECK(gating_output.dim() == 2 && gating_output.size(1) == 60 &&
+                      num_tokens > 0 && num_tokens <= 64,
+                  "expected gating_output shape [M, 60] with 0 < M <= 64");
+  STD_TORCH_CHECK(topk_weights.is_cuda() && topk_indices.is_cuda() &&
+                      token_expert_indices.is_cuda() &&
+                      topk_weights.is_contiguous() &&
+                      topk_indices.is_contiguous() &&
+                      token_expert_indices.is_contiguous() &&
+                      topk_weights.get_device_index() ==
+                          gating_output.get_device_index() &&
+                      topk_indices.get_device_index() ==
+                          gating_output.get_device_index() &&
+                      token_expert_indices.get_device_index() ==
+                          gating_output.get_device_index() &&
+                      topk_weights.scalar_type() ==
+                          torch::headeronly::ScalarType::Float &&
+                      topk_indices.scalar_type() ==
+                          torch::headeronly::ScalarType::Int &&
+                      token_expert_indices.scalar_type() ==
+                          torch::headeronly::ScalarType::Int,
+                  "expected float32 weights and int32 indices");
+  STD_TORCH_CHECK(topk_weights.dim() == 2 &&
+                      topk_weights.size(0) == num_tokens &&
+                      topk_weights.size(1) == 4 &&
+                      topk_indices.dim() == 2 &&
+                      topk_indices.size(0) == num_tokens &&
+                      topk_indices.size(1) == 4 &&
+                      token_expert_indices.dim() == 2 &&
+                      token_expert_indices.size(0) == num_tokens &&
+                      token_expert_indices.size(1) == 4,
+                  "expected output shape [M, 4]");
+
+  const bool* is_padding_ptr = nullptr;
+  if (is_padding.has_value()) {
+    const torch::stable::Tensor& is_padding_tensor = is_padding.value();
+    STD_TORCH_CHECK(is_padding_tensor.scalar_type() ==
+                            torch::headeronly::ScalarType::Bool &&
+                        is_padding_tensor.is_cuda() &&
+                        is_padding_tensor.get_device_index() ==
+                            gating_output.get_device_index() &&
+                        is_padding_tensor.dim() == 1 &&
+                        is_padding_tensor.size(0) == num_tokens &&
+                        is_padding_tensor.is_contiguous(),
+                    "is_padding must be a contiguous bool tensor of shape [M]");
+    is_padding_ptr = is_padding_tensor.const_data_ptr<bool>();
+  }
+
+  torch::stable::accelerator::DeviceGuard guard(
+      gating_output.get_device_index());
+  const cudaDeviceProp* device_prop = get_device_prop();
+  STD_TORCH_CHECK(device_prop->major == 8 && device_prop->minor == 0,
+                  "topk_softmax_a100 requires SM80");
+  const cudaStream_t stream =
+      get_current_cuda_stream(gating_output.get_device_index());
+  vllm::moe::topkSoftmaxA100<256><<<num_tokens, 256, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(
+          gating_output.const_data_ptr()),
+      topk_weights.mutable_data_ptr<float>(),
+      topk_indices.mutable_data_ptr<int>(),
+      token_expert_indices.mutable_data_ptr<int>(), num_tokens,
+      is_padding_ptr);
+}
+#endif
 
 void topk_sigmoid(
     torch::stable::Tensor& topk_weights,                // [num_tokens, topk]

--- a/csrc/libtorch_stable/moe/torch_bindings.cpp
+++ b/csrc/libtorch_stable/moe/torch_bindings.cpp
@@ -10,6 +10,12 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_moe_C, m) {
       "token_expert_indices, Tensor gating_output, bool renormalize, Tensor? "
       "bias, Tensor? is_padding) -> ()");
 
+#ifndef USE_ROCM
+  m.def(
+      "topk_softmax_a100(Tensor! topk_weights, Tensor! topk_indices, Tensor! "
+      "token_expert_indices, Tensor gating_output, Tensor? is_padding) -> ()");
+#endif
+
   // Apply topk sigmoid to the gating outputs.
   m.def(
       "topk_sigmoid(Tensor! topk_weights, Tensor! topk_indices, Tensor! "
@@ -135,6 +141,9 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_moe_C, m) {
 
 STABLE_TORCH_LIBRARY_IMPL(_moe_C, CUDA, m) {
   m.impl("topk_softmax", TORCH_BOX(&topk_softmax));
+#ifndef USE_ROCM
+  m.impl("topk_softmax_a100", TORCH_BOX(&topk_softmax_a100));
+#endif
   m.impl("topk_sigmoid", TORCH_BOX(&topk_sigmoid));
   m.impl("topk_softplus_sqrt", TORCH_BOX(&topk_softplus_sqrt));
   m.impl("moe_sum", TORCH_BOX(&moe_sum));

--- a/tests/kernels/moe/test_fused_topk.py
+++ b/tests/kernels/moe/test_fused_topk.py
@@ -8,10 +8,15 @@ Run `pytest tests/kernels/moe/test_fused_topk.py`.
 import pytest
 import torch
 
+import vllm._custom_ops as ops
+from tests.kernels.utils import opcheck
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     fused_topk_bias,
 )
-from vllm.model_executor.layers.fused_moe.router.fused_topk_router import fused_topk
+from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
+    _use_a100_small_topk,
+    fused_topk,
+)
 from vllm.platforms import current_platform
 
 
@@ -42,6 +47,111 @@ def torch_topk(
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
 
     return topk_weights, topk_ids
+
+
+def current_topk_reference(
+    gating_output: torch.Tensor,
+    is_padding: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_tokens = gating_output.shape[0]
+    weights = torch.empty((num_tokens, 4), dtype=torch.float32, device="cuda")
+    ids = torch.empty((num_tokens, 4), dtype=torch.int32, device="cuda")
+    source_rows = torch.empty_like(ids)
+    ops.topk_softmax(
+        weights,
+        ids,
+        source_rows,
+        gating_output,
+        False,
+        is_padding=is_padding,
+    )
+    return weights, ids, source_rows
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability((8, 0)),
+    reason="The specialized kernel is restricted to SM80.",
+)
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8, 16, 32, 64])
+@pytest.mark.parametrize("seed", [0, 17, 2026])
+def test_a100_small_topk_bitwise(num_tokens: int, seed: int):
+    torch.manual_seed(seed)
+    hidden_states = torch.empty((num_tokens, 1), dtype=torch.bfloat16, device="cuda")
+    gating_output = torch.randn((num_tokens, 60), dtype=torch.bfloat16, device="cuda")
+    reference = current_topk_reference(gating_output)
+    actual = fused_topk(hidden_states, gating_output, 4, False)
+    assert all(torch.equal(ref, out) for ref, out in zip(reference, actual))
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability((8, 0)),
+    reason="The specialized kernel is restricted to SM80.",
+)
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8, 16, 32, 64])
+def test_a100_small_topk_ties(num_tokens: int):
+    hidden_states = torch.empty((num_tokens, 1), dtype=torch.bfloat16, device="cuda")
+    gating_output = torch.zeros((num_tokens, 60), dtype=torch.bfloat16, device="cuda")
+    reference = current_topk_reference(gating_output)
+    actual = fused_topk(hidden_states, gating_output, 4, False)
+    assert all(torch.equal(ref, out) for ref, out in zip(reference, actual))
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability((8, 0)),
+    reason="The specialized kernel is restricted to SM80.",
+)
+def test_a100_small_topk_padding_and_opcheck():
+    gating_output = torch.randn((8, 60), dtype=torch.bfloat16, device="cuda")
+    is_padding = torch.tensor(
+        [False, True, False, False, True, False, False, True], device="cuda"
+    )
+    reference = current_topk_reference(gating_output, is_padding)
+    actual = tuple(torch.empty_like(tensor) for tensor in reference)
+    ops.topk_softmax_a100(*actual, gating_output, is_padding)
+    assert all(torch.equal(ref, out) for ref, out in zip(reference, actual))
+    opcheck(
+        torch.ops._moe_C.topk_softmax_a100,
+        (*actual, gating_output, is_padding),
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability((8, 0)),
+    reason="The specialized kernel is restricted to SM80.",
+)
+def test_a100_small_topk_dispatch_scope():
+    gating_output = torch.empty((8, 60), dtype=torch.bfloat16, device="cuda")
+    ids = torch.empty((8, 4), dtype=torch.int32, device="cuda")
+    assert _use_a100_small_topk(gating_output, ids, False)
+    assert not _use_a100_small_topk(gating_output.half(), ids, False)
+    assert not _use_a100_small_topk(gating_output.T.contiguous().T, ids, False)
+    assert not _use_a100_small_topk(gating_output[:, :59], ids, False)
+    assert not _use_a100_small_topk(gating_output.repeat(9, 1), ids.repeat(9, 1), False)
+    assert not _use_a100_small_topk(gating_output, ids[:, :3], False)
+    assert not _use_a100_small_topk(gating_output, ids, True)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability((8, 0)),
+    reason="The specialized kernel is restricted to SM80.",
+)
+def test_a100_small_topk_cuda_graph():
+    hidden_states = torch.empty((16, 1), dtype=torch.bfloat16, device="cuda")
+    gating_output = torch.randn((16, 60), dtype=torch.bfloat16, device="cuda")
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        for _ in range(3):
+            fused_topk(hidden_states, gating_output, 4, False)
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = fused_topk(hidden_states, gating_output, 4, False)
+    reference = current_topk_reference(gating_output)
+    graph.replay()
+    torch.accelerator.synchronize()
+    assert all(torch.equal(ref, out) for ref, out in zip(reference, captured))
 
 
 @pytest.mark.skipif(

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2419,6 +2419,22 @@ def topk_softmax(
     )
 
 
+def topk_softmax_a100(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    is_padding: torch.Tensor | None = None,
+) -> None:
+    torch.ops._moe_C.topk_softmax_a100(
+        topk_weights,
+        topk_ids,
+        token_expert_indices,
+        gating_output,
+        is_padding,
+    )
+
+
 def topk_sigmoid(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     get_routing_method_type,
 )
 from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
+from vllm.platforms import current_platform
 
 
 def _get_padding_mask(num_tokens: int) -> torch.Tensor | None:
@@ -30,16 +31,48 @@ def vllm_topk_softmax(
     gating_output: torch.Tensor,
     renormalize: bool = False,
 ) -> tuple[torch.Tensor, ...]:
-    ops.topk_softmax(
-        topk_weights,
-        topk_indices,
-        token_expert_indices,
-        gating_output,
-        renormalize,
-        is_padding=_get_padding_mask(topk_indices.shape[0]),
-    )
+    is_padding = _get_padding_mask(topk_indices.shape[0])
+    if _use_a100_small_topk(gating_output, topk_indices, renormalize):
+        ops.topk_softmax_a100(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            is_padding,
+        )
+    else:
+        ops.topk_softmax(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            is_padding=is_padding,
+        )
 
     return topk_weights, topk_indices
+
+
+def _use_a100_small_topk(
+    gating_output: torch.Tensor,
+    topk_indices: torch.Tensor,
+    renormalize: bool,
+) -> bool:
+    device_index = gating_output.device.index or 0
+    return (
+        gating_output.is_cuda
+        and current_platform.is_device_capability((8, 0), device_index)
+        and gating_output.dtype == torch.bfloat16
+        and gating_output.dim() == 2
+        and gating_output.is_contiguous()
+        and 0 < gating_output.shape[0] <= 64
+        and gating_output.shape[1] == 60
+        and topk_indices.dim() == 2
+        and topk_indices.is_contiguous()
+        and topk_indices.shape[1] == 4
+        and topk_indices.dtype == torch.int32
+        and not renormalize
+    )
 
 
 def vllm_topk_sigmoid(


### PR DESCRIPTION
## Purpose

This PR adds a specialized A100 path for the E=60 small-batch MoE
Top-K fallback in FusedTopKRouter.

For contiguous BF16 inputs with E=60, top_k=4,
renormalize=False, and 0 < M <= 64 on SM80, the current
fallback is dominated by fixed overhead.

The specialized path fuses Softmax, Top-4 selection, and output
writes into a single CUDA kernel. All unsupported configurations
continue to use the existing implementation.

## Test Plan

Tested on NVIDIA A100 PCIe 40GB (SM80), PyTorch 2.13.0+cu132,
Triton 3.7.1, vLLM main at fd57c4b7afebc0b43d25ed7f5848fc35786463d0.

- specialization correctness tests
- explicit tie cases
- targeted Full-MoE tests
- 100 deterministic generation requests
- CUDA Graph FULL / PIECEWISE
- C8 / C16 / C32 serving sanity tests
- applicable pre-commit hooks
- git diff --check

## Test Result

### Top-K

12.288 us -> 9.216 us (**-25.00%**)

### Full MoE

434.253 us -> 430.445 us (**-0.877%**)

### Correctness

- 29/29 specialization cases bitwise exact
- weights / IDs / source rows exact
- 100/100 deterministic generations identical

### CUDA Graph

- FULL: PASS
- PIECEWISE: PASS

### Serving

C8 / C16 / C32 remained within ±0.15% noise.
No end-to-end serving speedup is claimed.

## AI assistance disclosure

OpenAI Codex was used to assist with code navigation, implementation,
testing, benchmarking, and PR preparation.

I reviewed the complete submitted diff, validated the implementation
and benchmark results on NVIDIA A100, and take responsibility for
the submitted changes.