### PR TITLE
[Bugfix][EPD] Preserve upstream status and error details in proxy responses

### DIFF
--- a/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
+++ b/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
@@ -579,7 +579,7 @@ async def forward_stream(
                     ((_first or _t3) - _t2) * 1e3,
                     (_t3 - _t2) * 1e3,
                 )
-                logger.info("[%s] Streaming completed", req_id)
+                logger.info("[%s] Streaming ended", req_id)
 
         return StreamingResponse(stream_response(), media_type="text/event-stream")
 

--- a/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
+++ b/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
@@ -316,9 +316,8 @@ async def maybe_prefill(
     if p_url:
         logger.info("[%s] Processing through prefill: %s", req_id, p_url)
 
-        prefill_response = await process_prefill_stage(req_data, p_url, req_id)
+        prefill_response_json = await process_prefill_stage(req_data, p_url, req_id)
         # for nixl connector to facilitate kv transfer...
-        prefill_response_json = await prefill_response.json()
         kv_transfer_params = prefill_response_json.get("kv_transfer_params", {})
         if kv_transfer_params:
             req_data["kv_transfer_params"] = kv_transfer_params
@@ -354,24 +353,25 @@ async def process_prefill_stage(
 
     headers = {"x-request-id": req_id}
     try:
-        prefill_response = await prefill_session.post(
+        async with prefill_session.post(
             f"{p_url}/v1/chat/completions", json=prefill_request, headers=headers
-        )
-        if prefill_response.status != 200:
-            error_text = await prefill_response.text()
-            logger.error(
-                "[%s] Prefill request failed with status %d: %s",
-                req_id,
-                prefill_response.status,
-                error_text,
-            )
-            raise HTTPException(
-                status_code=prefill_response.status,
-                detail={"error": "Prefill request failed", "message": error_text},
-            )
-        logger.info("[%s] Prefill request completed successfully", req_id)
+        ) as prefill_response:
+            if prefill_response.status != 200:
+                error_text = await prefill_response.text()
+                logger.error(
+                    "[%s] Prefill request failed with status %d: %s",
+                    req_id,
+                    prefill_response.status,
+                    error_text,
+                )
+                raise HTTPException(
+                    status_code=prefill_response.status,
+                    detail={"error": "Prefill request failed", "message": error_text},
+                )
+            prefill_response_json = await prefill_response.json()
+            logger.info("[%s] Prefill request completed successfully", req_id)
 
-        return prefill_response
+            return prefill_response_json
 
     except HTTPException:
         raise
@@ -484,7 +484,10 @@ async def forward_non_stream(
             f"{d_url}/v1/chat/completions", json=req_data, headers=headers
         ) as resp:
             if resp.status != 200:
-                error_text = await resp.text()
+                try:
+                    error_text = await resp.text()
+                except Exception:
+                    error_text = "<unable to read body>"
                 logger.error(
                     "[%s] Decode request failed with status %d: %s",
                     req_id,

--- a/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
+++ b/examples/disaggregated/disaggregated_encoder/disagg_epd_proxy.py
@@ -357,8 +357,6 @@ async def process_prefill_stage(
         prefill_response = await prefill_session.post(
             f"{p_url}/v1/chat/completions", json=prefill_request, headers=headers
         )
-        prefill_response.raise_for_status()
-
         if prefill_response.status != 200:
             error_text = await prefill_response.text()
             logger.error(
@@ -375,6 +373,8 @@ async def process_prefill_stage(
 
         return prefill_response
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Prefill processing failed: %s", str(e))
         raise HTTPException(
@@ -483,7 +483,18 @@ async def forward_non_stream(
         async with decode_session.post(
             f"{d_url}/v1/chat/completions", json=req_data, headers=headers
         ) as resp:
-            resp.raise_for_status()
+            if resp.status != 200:
+                error_text = await resp.text()
+                logger.error(
+                    "[%s] Decode request failed with status %d: %s",
+                    req_id,
+                    resp.status,
+                    error_text,
+                )
+                raise HTTPException(
+                    status_code=resp.status,
+                    detail={"error": "Decode request failed", "message": error_text},
+                )
             out = await resp.json()
             _t3 = time.perf_counter()
             logger.info(
@@ -505,7 +516,7 @@ async def forward_non_stream(
 
 async def forward_stream(
     req_data: dict, req_id: str, e_urls: list[str], p_url: str, d_url: str
-) -> AsyncIterator[str]:
+) -> StreamingResponse:
     try:
         # Step 1: Process through Encoder instance (if has MM input)
         _t0 = time.perf_counter()
@@ -521,33 +532,58 @@ async def forward_stream(
         logger.info("[%s] Starting streaming from decode: %s", req_id, d_url)
         headers = {"x-request-id": req_id}
 
-        # Streaming response
-        _first = None
-        async with decode_session.post(
+        # Open and validate the upstream response before returning a
+        # StreamingResponse. Otherwise FastAPI sends 200 before this generator
+        # runs, and an upstream 4xx/5xx can no longer reach the client.
+        resp = await decode_session.post(
             f"{d_url}/v1/chat/completions",
             json=req_data,
             headers=headers,
-        ) as resp:
-            resp.raise_for_status()
-            async for chunk in resp.content.iter_chunked(1024):
-                if chunk:
-                    if _first is None:
-                        _first = time.perf_counter()
-                    yield chunk.decode("utf-8", errors="ignore")
-        _t3 = time.perf_counter()
-
-        logger.info(
-            "STAGE %s encode=%.1f rewrite=%.2f decode_ttfb=%.1f decode_total=%.1f",
-            "no-rewrite" if NO_REWRITE else "rewrite",
-            (_t1 - _t0) * 1e3,
-            (_t2 - _t1) * 1e3,
-            ((_first or _t3) - _t2) * 1e3,
-            (_t3 - _t2) * 1e3,
         )
-        logger.info("[%s] Streaming completed", req_id)
+        if resp.status != 200:
+            try:
+                error_text = await resp.text()
+            finally:
+                resp.release()
+            logger.error(
+                "[%s] Decode stream request failed with status %d: %s",
+                req_id,
+                resp.status,
+                error_text,
+            )
+            raise HTTPException(
+                status_code=resp.status,
+                detail={"error": "Decode request failed", "message": error_text},
+            )
+
+        async def stream_response() -> AsyncIterator[str]:
+            _first = None
+            try:
+                async for chunk in resp.content.iter_chunked(1024):
+                    if chunk:
+                        if _first is None:
+                            _first = time.perf_counter()
+                        yield chunk.decode("utf-8", errors="ignore")
+            except Exception as e:
+                logger.exception("[%s] Error while streaming decode: %s", req_id, e)
+                raise
+            finally:
+                resp.release()
+                _t3 = time.perf_counter()
+                logger.info(
+                    "STAGE %s encode=%.1f rewrite=%.2f "
+                    "decode_ttfb=%.1f decode_total=%.1f",
+                    "no-rewrite" if NO_REWRITE else "rewrite",
+                    (_t1 - _t0) * 1e3,
+                    (_t2 - _t1) * 1e3,
+                    ((_first or _t3) - _t2) * 1e3,
+                    (_t3 - _t2) * 1e3,
+                )
+                logger.info("[%s] Streaming completed", req_id)
+
+        return StreamingResponse(stream_response(), media_type="text/event-stream")
 
     except HTTPException:
-        logger.exception("[%s] HTTPException in forward_stream", req_id)
         raise
     except Exception as e:
         logger.exception("[%s] Error in forward_stream: %s", req_id, str(e))
@@ -574,10 +610,7 @@ async def chat_completions(request: Request):
         is_streaming = req_data.get("stream", False)
 
         if is_streaming:
-            return StreamingResponse(
-                forward_stream(req_data, req_id, e_urls, p_url, d_url),
-                media_type="text/event-stream",
-            )
+            return await forward_stream(req_data, req_id, e_urls, p_url, d_url)
         result = await forward_non_stream(req_data, req_id, e_urls, p_url, d_url)
         return JSONResponse(content=result)
 


### PR DESCRIPTION

## Purpose

Fix error propagation in the disaggregated EPD proxy.

Previously, Prefill and Decode failures raised `aiohttp` exceptions and were
often converted into generic HTTP 500 responses, which discarded the upstream
status code and response body. For streaming requests, the proxy could also
send HTTP 200 before validating the Decode response, causing clients to see a
successful response followed by an unexplained stream failure.

This PR:

- preserves upstream Prefill and Decode status codes and error details;
- avoids rewrapping `HTTPException` from the Prefill stage as HTTP 500;
- validates streaming Decode responses before returning `StreamingResponse`;
- reliably releases upstream streaming responses after completion or failure.

## Changes

- Replaced `raise_for_status()` in the Prefill path with an explicit status
	check so the proxy can read and return the upstream error body.
- Added a dedicated `HTTPException` handler in `process_prefill_stage` to
	preserve the original Prefill status code instead of converting it to 500.
- Added explicit status checks for non-streaming Decode responses and included
	the upstream response body in proxy errors.
- Opened and validated streaming Decode responses before constructing the
	`StreamingResponse`, preventing an HTTP 200 response from being sent before
	an upstream failure is detected.
- Moved stream consumption into an inner async iterator and ensured the
	upstream response is released in its `finally` block.

## Test Plan

- Run the EPD example to cover successful streaming and non-streaming requests:

	```bash
	bash ./disagg_1e1p1d_example.sh
	```

	Verify that the streaming benchmark completes, the final non-streaming image
	request returns HTTP 200, and all EPD services shut down cleanly.

- Send an invalid-model request through the EPD proxy to exercise the Prefill
	error path:

	```bash
	curl -i http://127.0.0.1:10001/v1/chat/completions \
		-H "Content-Type: application/json" \
		-d '{
			"model": "invalid-model",
			"messages": [{"role": "user", "content": "hello"}],
			"stream": false
		}'
	```

	Verify that the proxy preserves the Prefill HTTP status code and that the
	response contains both `Prefill request failed` and the upstream error body,
	rather than returning a generic HTTP 500 error.

- Start a second proxy with Prefill disabled, reusing the running Encoder and
	Decode services, to isolate Decode error handling:

	```bash
	python disagg_epd_proxy.py \
		--host 127.0.0.1 \
		--port 10002 \
		--encode-servers-urls http://127.0.0.1:19534 \
		--prefill-servers-urls disable \
		--decode-servers-urls http://127.0.0.1:19536
	```

- Send the same invalid-model request to port 10002 with `"stream": false`.
	Verify that the response preserves the Decode status code and includes
	`Decode request failed` together with the upstream response body.

- Repeat the request to port 10002 with `"stream": true` and `curl -i -N`.
	Verify that the first response status is the upstream 4xx/5xx status—not HTTP
	200 followed by a disconnected stream—and that the Decode error body is
	returned.

- Run `git diff --check` and confirm that the modified Python file has no
	editor static diagnostics.

## Test Result

- `bash ./disagg_1e1p1d_example.sh` completed with exit
	code 0, covering the streaming benchmark and the non-streaming image request.
- The successful request paths continued to return normally after the proxy
	changes.
- `git diff --check` completed successfully with no whitespace errors.
- Editor static diagnostics reported no errors in
	`disagg_epd_proxy.py`.

## AI Assistance Disclosure

The changes in thie PR was drafted with GPT-5.6-sol. I've reviewed all suggested changes
, and the reported validation steps were performed manually.


