### PR TITLE
[Rust Frontend] Add pooling support to engine core client and LLM

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5867,6 +5867,7 @@ dependencies = [
  "futures",
  "parking_lot",
  "rmp-serde",
+ "rmpv",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/rust/src/engine-core-client/src/client.rs
+++ b/rust/src/engine-core-client/src/client.rs
@@ -9,7 +9,7 @@ use futures::future::join_all;
 use itertools::Itertools;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
-use tokio::sync::mpsc;
+use tokio::sync::{OnceCell, mpsc};
 use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, info, trace};
 
@@ -20,6 +20,7 @@ use crate::protocol::dtype::ModelDtype;
 use crate::protocol::handshake::EngineCoreReadyResponse;
 use crate::protocol::lora::LoraRequest;
 use crate::protocol::request::{EngineCoreRequest, EngineCoreRequestType};
+use crate::protocol::task::EngineTask;
 use crate::protocol::utility::{EngineCoreUtilityRequest, PauseMode};
 use crate::runtime::{BackgroundShutdownRuntime, build_zmq_runtime};
 use crate::transport::{self, ConnectedEngine};
@@ -268,6 +269,7 @@ pub struct EngineCoreClient {
     input_address: String,
     output_address: String,
     engines: Vec<ConnectedEngine>,
+    supported_tasks: OnceCell<Box<[EngineTask]>>,
     inner: Arc<ClientInner>,
     coordinator: Option<CoordinatorHandle>,
     abort_tx: mpsc::UnboundedSender<AbortRequest>,
@@ -415,6 +417,7 @@ impl EngineCoreClient {
             input_address: connected.input_address,
             output_address: connected.output_address,
             engines,
+            supported_tasks: OnceCell::new(),
             inner,
             coordinator,
             abort_tx,
@@ -448,6 +451,23 @@ impl EngineCoreClient {
     /// client.
     pub fn data_parallel_size(&self) -> usize {
         self.config.transport_mode.data_parallel_size()
+    }
+
+    /// Return the model tasks reported consistently by all connected engines.
+    ///
+    /// The first call discovers the capabilities through EngineCore's utility
+    /// API. Later calls reuse the cached result.
+    pub async fn get_supported_tasks(&self) -> Result<&[EngineTask]> {
+        Ok(self
+            .supported_tasks
+            .get_or_try_init(|| async {
+                Ok::<_, Error>(
+                    self.call_utility_consensus::<Vec<EngineTask>, _>("get_supported_tasks", ())
+                        .await?
+                        .into_boxed_slice(),
+                )
+            })
+            .await?)
     }
 
     #[cfg(test)]

--- a/rust/src/engine-core-client/src/protocol/mod.rs
+++ b/rust/src/engine-core-client/src/protocol/mod.rs
@@ -28,6 +28,7 @@ pub mod logprobs;
 pub mod lora;
 pub mod multimodal;
 pub mod output;
+pub mod pooling;
 pub mod request;
 pub mod sampling;
 pub mod stats;

--- a/rust/src/engine-core-client/src/protocol/mod.rs
+++ b/rust/src/engine-core-client/src/protocol/mod.rs
@@ -33,6 +33,7 @@ pub mod request;
 pub mod sampling;
 pub mod stats;
 pub mod structured_outputs;
+pub mod task;
 pub mod tensor;
 pub mod utility;
 

--- a/rust/src/engine-core-client/src/protocol/output.rs
+++ b/rust/src/engine-core-client/src/protocol/output.rs
@@ -14,6 +14,7 @@ use super::utility::UtilityOutput;
 use crate::error::{Error, Result, ext_value_decode};
 use crate::protocol::logprobs::MaybeWireLogprobs;
 use crate::protocol::stats::{PrefillStats, SchedulerStats};
+use crate::protocol::tensor::WireTensor;
 use crate::protocol::{OpaqueValue, decode_msgpack};
 
 /// The stop reason associated with a finished output.
@@ -91,7 +92,7 @@ pub struct EngineCoreOutput {
     #[serde(default)]
     pub new_prompt_logprobs_tensors: Option<MaybeWireLogprobs>,
     #[serde(default)]
-    pub pooling_output: Option<OpaqueValue>,
+    pub pooling_output: Option<WireTensor>,
     #[serde(default)]
     pub finish_reason: Option<EngineCoreFinishReason>,
     #[serde(default)]
@@ -148,6 +149,11 @@ impl EngineCoreOutput {
         self.new_prompt_logprobs_tensors = (self.new_prompt_logprobs_tensors.take())
             .map(|value| value.resolve(frames, "new_prompt_logprobs_tensors"))
             .transpose()?;
+        if let Some(pooling_output) = &mut self.pooling_output {
+            pooling_output
+                .resolve_aux_frame(frames)
+                .map_err(|message| ext_value_decode!("pooling_output: {message}"))?;
+        }
         Ok(())
     }
 }
@@ -374,6 +380,7 @@ mod tests {
 
     use super::*;
     use crate::protocol::output::EngineCoreOutput;
+    use crate::protocol::tensor::{WireArrayData, WireNdArray};
     use crate::protocol::{decode_msgpack, encode_msgpack};
 
     #[test]
@@ -401,6 +408,35 @@ mod tests {
         assert_eq!(
             decoded.finished_requests,
             Some(BTreeSet::from(["req-1".to_string()]))
+        );
+    }
+
+    #[test]
+    fn engine_core_outputs_resolve_multipart_pooling_tensor() {
+        let raw = [0.25_f32, -0.5].into_iter().flat_map(f32::to_ne_bytes).collect::<Vec<_>>();
+        let outputs: EngineCoreOutputs = RequestBatchOutputs {
+            outputs: vec![EngineCoreOutput {
+                request_id: "embed-1".to_string(),
+                pooling_output: Some(WireNdArray {
+                    dtype: "float32".to_string(),
+                    shape: vec![2],
+                    data: WireArrayData::AuxIndex(1),
+                }),
+                finish_reason: Some(EngineCoreFinishReason::Stop),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+        .into();
+        let first_frame = Bytes::from(encode_msgpack(&outputs).expect("encode outputs"));
+
+        let decoded =
+            decode_engine_core_outputs(&[first_frame, Bytes::from(raw)]).expect("decode outputs");
+        let output = &decoded.as_request_batch().expect("request batch").outputs[0];
+
+        assert_eq!(
+            output.pooling_output.as_ref().unwrap().to_f32_vec().unwrap(),
+            vec![0.25, -0.5]
         );
     }
 

--- a/rust/src/engine-core-client/src/protocol/pooling.rs
+++ b/rust/src/engine-core-client/src/protocol/pooling.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use serde::{Deserialize, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+/// Pooling task executed by the model.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/tasks.py#L10-L17>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolingTask {
+    /// Produce one embedding for each input sequence.
+    Embed,
+    /// Produce sequence-level classification outputs.
+    Classify,
+    /// Produce token-level embeddings.
+    TokenEmbed,
+    /// Produce token-level classification outputs.
+    TokenClassify,
+    /// Run a plugin-defined pooling task.
+    Plugin,
+    /// Produce sequence embeddings and token classifications together.
+    #[serde(rename = "embed&token_classify")]
+    EmbedAndTokenClassify,
+}
+
+/// API parameters for pooling models.
+///
+/// This is the supported positional prefix of Python's array-like
+/// `PoolingParams`. Python fills the omitted internal suffix with its declared
+/// defaults.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/pooling_params.py#L38-L73>
+///
+/// Original Python field documentation:
+/// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/config/pooler.py#L51-L115>
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct EngineCorePoolingParams {
+    /// Whether to apply activation function to the pooler outputs.
+    pub use_activation: bool,
+    /// Reduce the dimensions of embeddings if model support matryoshka
+    /// representation.
+    pub dimensions: Option<u32>,
+    /// If set, only the score corresponding to the `step_tag_id` in the
+    /// generated sentence should be returned. Otherwise, the scores for all
+    /// tokens are returned.
+    pub step_tag_id: Option<u32>,
+    /// A list of indices for the vocabulary dimensions to be extracted,
+    /// such as the token IDs of `good_token` and `bad_token` in the
+    /// `math-shepherd-mistral-7b-prm` model.
+    pub returned_token_ids: Option<Vec<u32>>,
+    /// The task used for pooling.
+    pub task: PoolingTask,
+}

--- a/rust/src/engine-core-client/src/protocol/pooling.rs
+++ b/rust/src/engine-core-client/src/protocol/pooling.rs
@@ -1,30 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-use serde::{Deserialize, Serialize};
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
-/// Pooling task executed by the model.
-///
-/// Original Python definition:
-/// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/tasks.py#L10-L17>
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PoolingTask {
-    /// Produce one embedding for each input sequence.
-    Embed,
-    /// Produce sequence-level classification outputs.
-    Classify,
-    /// Produce token-level embeddings.
-    TokenEmbed,
-    /// Produce token-level classification outputs.
-    TokenClassify,
-    /// Run a plugin-defined pooling task.
-    Plugin,
-    /// Produce sequence embeddings and token classifications together.
-    #[serde(rename = "embed&token_classify")]
-    EmbedAndTokenClassify,
-}
+use super::task::PoolingTask;
 
 /// API parameters for pooling models.
 ///

--- a/rust/src/engine-core-client/src/protocol/pooling.rs
+++ b/rust/src/engine-core-client/src/protocol/pooling.rs
@@ -16,12 +16,14 @@ use super::task::PoolingTask;
 ///
 /// Original Python field documentation:
 /// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/config/pooler.py#L51-L115>
-#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize_tuple, Deserialize_tuple)]
 pub struct EngineCorePoolingParams {
     /// Whether to apply activation function to the pooler outputs.
-    pub use_activation: bool,
+    /// `None` lets engine-core resolve the model's default.
+    pub use_activation: Option<bool>,
     /// Reduce the dimensions of embeddings if model support matryoshka
     /// representation.
+    /// `None` lets engine-core resolve the model's default.
     pub dimensions: Option<u32>,
     /// If set, only the score corresponding to the `step_tag_id` in the
     /// generated sentence should be returned. Otherwise, the scores for all

--- a/rust/src/engine-core-client/src/protocol/request.rs
+++ b/rust/src/engine-core-client/src/protocol/request.rs
@@ -9,6 +9,7 @@ use serde_default::DefaultFromSerde;
 use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use crate::protocol::multimodal::MmFeatures;
+use crate::protocol::pooling::EngineCorePoolingParams;
 use crate::protocol::sampling::EngineCoreSamplingParams;
 use crate::protocol::{OpaqueValue, lora};
 use crate::{Error, Result};
@@ -77,9 +78,7 @@ pub struct EngineCoreRequest {
     /// Multimodal features attached to the request.
     pub mm_features: Option<MmFeatures>,
     pub sampling_params: Option<EngineCoreSamplingParams>,
-    /// Pooling parameters are preserved in the schema but not yet strongly
-    /// typed.
-    pub pooling_params: Option<OpaqueValue>,
+    pub pooling_params: Option<EngineCorePoolingParams>,
     pub arrival_time: f64,
     #[serde(default)]
     pub lora_request: Option<lora::LoraRequest>,

--- a/rust/src/engine-core-client/src/protocol/task.rs
+++ b/rust/src/engine-core-client/src/protocol/task.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use serde::{Deserialize, Serialize};
+
+/// Generation task supported by the model runner.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/tasks.py#L7-L8>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GenerationTask {
+    /// Generate text from an input prompt.
+    Generate,
+    /// Transcribe audio input.
+    Transcription,
+    /// Run realtime audio inference.
+    Realtime,
+}
+
+/// Pooling task supported by the model runner.
+///
+/// Original Python definition:
+/// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/tasks.py#L10-L17>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolingTask {
+    /// Produce one embedding for each input sequence.
+    Embed,
+    /// Produce sequence-level classification outputs.
+    Classify,
+    /// Produce token-level embeddings.
+    TokenEmbed,
+    /// Produce token-level classification outputs.
+    TokenClassify,
+    /// Run a plugin-defined pooling task.
+    Plugin,
+    /// Produce sequence embeddings and token classifications together.
+    #[serde(rename = "embed&token_classify")]
+    EmbedAndTokenClassify,
+}
+
+/// Task supported by an EngineCore model runner.
+///
+/// EngineCore discovers generation and pooling capabilities from its workers.
+/// Frontend-only tasks such as `render` are resolved above the engine client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EngineTask {
+    /// A generation capability.
+    Generation(GenerationTask),
+    /// A pooling capability.
+    Pooling(PoolingTask),
+}
+
+impl From<GenerationTask> for EngineTask {
+    fn from(task: GenerationTask) -> Self {
+        Self::Generation(task)
+    }
+}
+
+impl From<PoolingTask> for EngineTask {
+    fn from(task: PoolingTask) -> Self {
+        Self::Pooling(task)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EngineTask, GenerationTask, PoolingTask};
+
+    #[test]
+    fn engine_tasks_use_python_wire_literals() {
+        let tasks = [
+            EngineTask::Generation(GenerationTask::Generate),
+            EngineTask::Generation(GenerationTask::Transcription),
+            EngineTask::Generation(GenerationTask::Realtime),
+            EngineTask::Pooling(PoolingTask::Embed),
+            EngineTask::Pooling(PoolingTask::EmbedAndTokenClassify),
+        ];
+
+        let encoded = rmp_serde::to_vec(&tasks).unwrap();
+        let literals: Vec<String> = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(
+            literals,
+            [
+                "generate",
+                "transcription",
+                "realtime",
+                "embed",
+                "embed&token_classify",
+            ]
+        );
+
+        let decoded: Vec<EngineTask> = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, tasks);
+    }
+
+    #[test]
+    fn unknown_engine_task_is_rejected() {
+        let encoded = rmp_serde::to_vec(&["render"]).unwrap();
+        assert!(rmp_serde::from_slice::<Vec<EngineTask>>(&encoded).is_err());
+    }
+
+    #[test]
+    fn engine_tasks_decode_from_python_style_rmpv_strings() {
+        let value = rmpv::Value::Array(vec!["generate".into(), "embed".into()]);
+        assert_eq!(
+            rmpv::ext::from_value::<Vec<EngineTask>>(value).unwrap(),
+            vec![
+                EngineTask::Generation(GenerationTask::Generate),
+                EngineTask::Pooling(PoolingTask::Embed),
+            ]
+        );
+    }
+}

--- a/rust/src/engine-core-client/src/protocol/task.rs
+++ b/rust/src/engine-core-client/src/protocol/task.rs
@@ -22,10 +22,11 @@ pub enum GenerationTask {
 ///
 /// Original Python definition:
 /// <https://github.com/vllm-project/vllm/blob/6ec92bcbc8/vllm/tasks.py#L10-L17>
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PoolingTask {
     /// Produce one embedding for each input sequence.
+    #[default]
     Embed,
     /// Produce sequence-level classification outputs.
     Classify,

--- a/rust/src/engine-core-client/src/protocol/tensor.rs
+++ b/rust/src/engine-core-client/src/protocol/tensor.rs
@@ -185,12 +185,8 @@ impl WireNdArray {
 
         match self.dtype.as_str() {
             "float32" => decode_chunks(data, numel, f32::from_ne_bytes),
-            "float16" => decode_chunks(data, numel, |bytes| {
-                f16::from_bits(u16::from_ne_bytes(bytes)).to_f32()
-            }),
-            "bfloat16" => decode_chunks(data, numel, |bytes| {
-                bf16::from_bits(u16::from_ne_bytes(bytes)).to_f32()
-            }),
+            "float16" => decode_chunks(data, numel, |bytes| f16::from_ne_bytes(bytes).to_f32()),
+            "bfloat16" => decode_chunks(data, numel, |bytes| bf16::from_ne_bytes(bytes).to_f32()),
             dtype => Err(format!("unsupported pooling output dtype {dtype:?}")),
         }
     }

--- a/rust/src/engine-core-client/src/protocol/tensor.rs
+++ b/rust/src/engine-core-client/src/protocol/tensor.rs
@@ -171,6 +171,49 @@ impl WireNdArray {
     pub(crate) fn resolve_aux_frame(&mut self, frames: &[Bytes]) -> Result<(), String> {
         self.data.resolve_aux_frame(frames)
     }
+
+    /// Decode a floating-point tensor into float32 values.
+    pub fn to_f32_vec(&self) -> Result<Vec<f32>, String> {
+        let data = self
+            .data
+            .as_raw_view()
+            .ok_or_else(|| "tensor auxiliary frame was not resolved".to_string())?;
+        let numel = self
+            .shape
+            .checked_numel()
+            .ok_or_else(|| format!("tensor shape product overflows usize: {:?}", self.shape))?;
+
+        match self.dtype.as_str() {
+            "float32" => decode_chunks(data, numel, f32::from_ne_bytes),
+            "float16" => decode_chunks(data, numel, |bytes| {
+                f16::from_bits(u16::from_ne_bytes(bytes)).to_f32()
+            }),
+            "bfloat16" => decode_chunks(data, numel, |bytes| {
+                bf16::from_bits(u16::from_ne_bytes(bytes)).to_f32()
+            }),
+            dtype => Err(format!("unsupported pooling output dtype {dtype:?}")),
+        }
+    }
+}
+
+fn decode_chunks<const N: usize, T>(
+    data: &[u8],
+    numel: usize,
+    decode: impl Fn([u8; N]) -> T,
+) -> Result<Vec<T>, String> {
+    let expected_len = numel
+        .checked_mul(N)
+        .ok_or_else(|| "tensor byte length overflows usize".to_string())?;
+    if data.len() != expected_len {
+        return Err(format!(
+            "tensor data length {} does not match expected byte length {expected_len}",
+            data.len()
+        ));
+    }
+    Ok(data
+        .chunks_exact(N)
+        .map(|chunk| decode(chunk.try_into().expect("chunks_exact ensures length")))
+        .collect())
 }
 
 /// Validate that the number of elements implied by the shape matches the length
@@ -364,6 +407,21 @@ mod tests {
     fn constructors_validate_shape_product() {
         let err = WireNdArray::from_f32(vec![2, 2], vec![1.0, 2.0]).unwrap_err();
         assert!(err.contains("does not match shape"));
+    }
+
+    #[test]
+    fn floating_point_tensors_decode_to_f32() {
+        let f32_tensor = WireNdArray::from_f32(vec![2], vec![1.0, -2.5]).unwrap();
+        assert_eq!(f32_tensor.to_f32_vec().unwrap(), vec![1.0, -2.5]);
+
+        let f16_tensor =
+            WireNdArray::from_f16(vec![2], vec![f16::from_f32(1.0), f16::from_f32(-2.5)]).unwrap();
+        assert_eq!(f16_tensor.to_f32_vec().unwrap(), vec![1.0, -2.5]);
+
+        let bf16_tensor =
+            WireNdArray::from_bf16(vec![2], vec![bf16::from_f32(1.0), bf16::from_f32(-2.5)])
+                .unwrap();
+        assert_eq!(bf16_tensor.to_f32_vec().unwrap(), vec![1.0, -2.5]);
     }
 
     #[test]

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -32,8 +32,9 @@ use crate::protocol::output::{
 use crate::protocol::request::{EngineCoreRequest, EngineCoreRequestType};
 use crate::protocol::sampling::EngineCoreSamplingParams;
 use crate::protocol::stats::{KvConnectorStats, MooncakeOperation, SchedulerStats};
+use crate::protocol::task::{EngineTask, GenerationTask, PoolingTask};
 use crate::protocol::tensor::{WireArrayData, WireTensor};
-use crate::protocol::utility::{UtilityOutput, UtilityResultEnvelope};
+use crate::protocol::utility::{EngineCoreUtilityRequest, UtilityOutput, UtilityResultEnvelope};
 use crate::test_utils::{
     IpcNamespace, setup_bootstrapped_mock_engine, setup_mock_engine_sockets,
     setup_mock_engine_with_init, spawn_mock_engine_task,
@@ -2426,6 +2427,66 @@ fn spawn_mock_utility_engine(
             .await;
         })
     })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn supported_tasks_are_typed_and_cached_lazily() {
+    init_tracing();
+    let ipc = IpcNamespace::new().unwrap();
+    let handshake_address = ipc.handshake_endpoint();
+
+    let (shutdown_tx, engine_task) = spawn_mock_engine_task(
+        handshake_address.clone(),
+        b"engine-tasks".to_vec(),
+        |dealer, push| {
+            Box::pin(async move {
+                let frames = recv_engine_message(dealer).await;
+                assert_eq!(frames[0].as_ref(), &[0x03]);
+                let request: EngineCoreUtilityRequest = rmp_serde::from_slice(&frames[1]).unwrap();
+                assert_eq!(request.method_name, "get_supported_tasks");
+
+                send_outputs(
+                    push,
+                    UtilityCallOutput {
+                        output: UtilityOutput {
+                            call_id: request.call_id,
+                            failure_message: None,
+                            result: Some(utility_result_value(vec!["generate", "embed"])),
+                        },
+                        ..Default::default()
+                    }
+                    .into(),
+                )
+                .await;
+
+                assert!(timeout(Duration::from_millis(200), dealer.recv()).await.is_err());
+            })
+        },
+    );
+
+    let client = connect_client_with_ipc(
+        handshake_test_config(
+            handshake_address,
+            1,
+            "test-model",
+            Duration::from_secs(2),
+            0,
+            None,
+        ),
+        &ipc,
+    )
+    .await;
+
+    let expected = [
+        EngineTask::Generation(GenerationTask::Generate),
+        EngineTask::Pooling(PoolingTask::Embed),
+    ];
+    assert_eq!(client.get_supported_tasks().await.unwrap(), expected);
+    assert_eq!(client.get_supported_tasks().await.unwrap(), expected);
+
+    let _ = shutdown_tx.send(());
+    engine_task.await.unwrap();
+    client.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/src/engine-core-client/src/tests/client.rs
+++ b/rust/src/engine-core-client/src/tests/client.rs
@@ -2639,6 +2639,8 @@ fn python_msgpack_fixtures_match_rust_encoding() {
     let mooncake_stats_hex = lines.next().expect("missing Mooncake stats fixture line");
     let multi_connector_stats_hex =
         lines.next().expect("missing MultiConnector stats fixture line");
+    let multipart_pooling_frames =
+        lines.next().expect("missing multipart pooling output fixture line");
     let ready_response_hex = lines.next().expect("missing ready response fixture line");
 
     let request_bytes = hex::decode(request_hex).unwrap();
@@ -2824,6 +2826,14 @@ fn python_msgpack_fixtures_match_rust_encoding() {
                 && stats.mooncake.is_some()
                 && stats.other.contains_key("UnsupportedConnector")
     ));
+    let multipart_pooling =
+        decode_engine_core_outputs(&decode_frames(multipart_pooling_frames)).unwrap();
+    let pooling_tensor = multipart_pooling.as_request_batch().unwrap().outputs[0]
+        .pooling_output
+        .as_ref()
+        .expect("multipart pooling output decoded");
+    assert_eq!(pooling_tensor.shape, vec![2]);
+    assert_eq!(pooling_tensor.to_f32_vec().unwrap(), vec![0.25, -0.5]);
 
     let map_keys = |bytes: &[u8]| -> BTreeSet<String> {
         match decode_value(bytes) {

--- a/rust/src/engine-core-client/src/tests/python_compat.py
+++ b/rust/src/engine-core-client/src/tests/python_compat.py
@@ -296,13 +296,14 @@ def engine_output_wire(
     *,
     new_logprobs=None,
     new_prompt_logprobs_tensors=None,
+    pooling_output=None,
 ):
     return [
         request_id,
         [7, 8],
         new_logprobs,
         new_prompt_logprobs_tensors,
-        None,
+        pooling_output,
         int(FinishReason.LENGTH),
     ]
 
@@ -331,6 +332,17 @@ multipart_logprobs = engine_outputs_wire(
             np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32),
             np.array([1, 2], dtype=np.int64),
             None,
+        ),
+    )
+)
+
+multipart_pooling_output = engine_outputs_wire(
+    engine_output_wire(
+        "embed-1",
+        pooling_output=(
+            "float32",
+            [2],
+            np.array([0.25, -0.5], dtype=np.float32).tobytes(),
         ),
     )
 )
@@ -504,4 +516,10 @@ print(
 print(msgspec.msgpack.encode(nixl_stats).hex())
 print(msgspec.msgpack.encode(mooncake_stats).hex())
 print(msgspec.msgpack.encode(multi_connector_stats).hex())
+print(
+    " ".join(
+        frame.hex()
+        for frame in encode_output_frames(multipart_pooling_output, size_threshold=1)
+    )
+)
 print(msgspec.msgpack.encode(ready_response).hex())

--- a/rust/src/llm/Cargo.toml
+++ b/rust/src/llm/Cargo.toml
@@ -28,6 +28,7 @@ bytes.workspace = true
 clap.workspace = true
 expect-test.workspace = true
 rmp-serde.workspace = true
+rmpv.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true

--- a/rust/src/llm/examples/README.md
+++ b/rust/src/llm/examples/README.md
@@ -27,3 +27,29 @@ cargo run -p vllm-llm --example external_engine_smoke -- \
 ```
 
 IMPORTANT: You must restart `vllm` each time you run the smoke test, as the vLLM engine cannot manage frontend closures and subsequent reconnects. In other words, do not reuse existing `vllm` instances, if any.
+
+## Embedding smoke test
+
+Start a fresh headless pooling engine:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m vllm.entrypoints.cli.main serve \
+  Qwen/Qwen3-Embedding-0.6B \
+  --headless \
+  --runner pooling \
+  --data-parallel-address 127.0.0.1 \
+  --data-parallel-rpc-port 62100 \
+  --data-parallel-size-local 1 \
+  --max-model-len 512 \
+  --dtype float16 \
+  --enforce-eager \
+  --kernel-config.enable_flashinfer_autotune=False \
+  --gpu-memory-utilization 0.1
+```
+
+Run one token-level embedding request through the Rust `Llm::encode()` interface:
+
+```bash
+cargo run -p vllm-llm --example external_engine_embedding -- \
+  --handshake-address tcp://127.0.0.1:62100
+```

--- a/rust/src/llm/examples/external_engine_embedding.rs
+++ b/rust/src/llm/examples/external_engine_embedding.rs
@@ -3,12 +3,12 @@
 
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use clap::Parser;
 use tokio::time::timeout;
 use tracing_subscriber::EnvFilter;
 use vllm_engine_core_client::{EngineCoreClient, EngineCoreClientConfig, TransportMode};
-use vllm_llm::{EncodeRequest, Llm, PoolingParams, PoolingTask};
+use vllm_llm::{EncodeRequest, EngineTask, Llm, PoolingParams, PoolingTask};
 
 const PROMPT: &str = "Represent this sentence for semantic search: a small cat sleeps on a sofa.";
 const PROMPT_TOKEN_IDS: &[u32] = &[
@@ -80,6 +80,15 @@ async fn main() -> Result<()> {
     })
     .await
     .context("failed to connect to external vLLM engine")?;
+    let supported_tasks = client
+        .get_supported_tasks()
+        .await
+        .context("failed to discover supported engine tasks")?
+        .to_vec();
+    ensure!(
+        supported_tasks.contains(&EngineTask::Pooling(PoolingTask::Embed)),
+        "model does not support the embedding task: {supported_tasks:?}"
+    );
     let llm = Llm::new(client);
 
     let output = timeout(
@@ -100,6 +109,7 @@ async fn main() -> Result<()> {
     let preview_len = output.output.data.len().min(8);
 
     println!("model={}", args.model);
+    println!("supported_tasks={supported_tasks:?}");
     println!("prompt={PROMPT:?}");
     println!("prompt_token_count={}", output.prompt_token_ids.len());
     println!("cached_token_count={}", output.cached_token_count);

--- a/rust/src/llm/examples/external_engine_embedding.rs
+++ b/rust/src/llm/examples/external_engine_embedding.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use tokio::time::timeout;
 use tracing_subscriber::EnvFilter;
 use vllm_engine_core_client::{EngineCoreClient, EngineCoreClientConfig, TransportMode};
-use vllm_llm::{EncodeRequest, EngineTask, Llm, PoolingParams, PoolingTask};
+use vllm_llm::{EncodeRequest, Llm, PoolingParams, PoolingTask};
 
 const PROMPT: &str = "Represent this sentence for semantic search: a small cat sleeps on a sofa.";
 const PROMPT_TOKEN_IDS: &[u32] = &[
@@ -45,12 +45,7 @@ fn build_request() -> EncodeRequest {
         request_id: format!("rust-embedding-{}", uuid::Uuid::new_v4()),
         prompt_token_ids: PROMPT_TOKEN_IDS.to_vec(),
         task: PoolingTask::Embed,
-        pooling_params: PoolingParams {
-            use_activation: true,
-            dimensions: None,
-            step_tag_id: None,
-            returned_token_ids: None,
-        },
+        pooling_params: PoolingParams::default(),
         arrival_time: None,
         cache_salt: None,
         trace_headers: None,
@@ -85,10 +80,6 @@ async fn main() -> Result<()> {
         .await
         .context("failed to discover supported engine tasks")?
         .to_vec();
-    ensure!(
-        supported_tasks.contains(&EngineTask::Pooling(PoolingTask::Embed)),
-        "model does not support the embedding task: {supported_tasks:?}"
-    );
     let llm = Llm::new(client);
 
     let output = timeout(
@@ -106,6 +97,10 @@ async fn main() -> Result<()> {
         .map(|&value| f64::from(value).powi(2))
         .sum::<f64>()
         .sqrt();
+    ensure!(
+        (l2_norm - 1.0).abs() < 1e-4,
+        "default embedding activation did not produce a unit vector: L2 norm={l2_norm}"
+    );
     let preview_len = output.output.data.len().min(8);
 
     println!("model={}", args.model);

--- a/rust/src/llm/examples/external_engine_embedding.rs
+++ b/rust/src/llm/examples/external_engine_embedding.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use tokio::time::timeout;
+use tracing_subscriber::EnvFilter;
+use vllm_engine_core_client::{EngineCoreClient, EngineCoreClientConfig, TransportMode};
+use vllm_llm::{EncodeRequest, Llm, PoolingParams, PoolingTask};
+
+const PROMPT: &str = "Represent this sentence for semantic search: a small cat sleeps on a sofa.";
+const PROMPT_TOKEN_IDS: &[u32] = &[
+    65743, 419, 11652, 369, 41733, 2711, 25, 264, 2613, 8251, 71390, 389, 264, 31069, 13, 151643,
+];
+
+#[derive(Debug, Parser)]
+#[command(about = "Run a Rust LLM embedding request against an external vLLM engine.")]
+struct Args {
+    #[arg(long)]
+    handshake_address: String,
+    #[arg(long, default_value_t = 1)]
+    engine_count: usize,
+    #[arg(long, default_value = "Qwen/Qwen3-Embedding-0.6B")]
+    model: String,
+    #[arg(long, default_value = "127.0.0.1")]
+    host: String,
+    #[arg(long, default_value_t = 0)]
+    client_index: u32,
+    #[arg(long, default_value_t = 120)]
+    ready_timeout_secs: u64,
+    #[arg(long, default_value_t = 120)]
+    output_timeout_secs: u64,
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("vllm_engine_core_client=info"));
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}
+
+fn build_request() -> EncodeRequest {
+    EncodeRequest {
+        request_id: format!("rust-embedding-{}", uuid::Uuid::new_v4()),
+        prompt_token_ids: PROMPT_TOKEN_IDS.to_vec(),
+        task: PoolingTask::Embed,
+        pooling_params: PoolingParams {
+            use_activation: true,
+            dimensions: None,
+            step_tag_id: None,
+            returned_token_ids: None,
+        },
+        arrival_time: None,
+        cache_salt: None,
+        trace_headers: None,
+        priority: 0,
+        data_parallel_rank: None,
+        session_id: None,
+        lora_request: None,
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<()> {
+    init_tracing();
+    let args = Args::parse();
+    let client = EngineCoreClient::connect(EngineCoreClientConfig {
+        transport_mode: TransportMode::HandshakeOwner {
+            handshake_address: args.handshake_address,
+            advertised_host: args.host,
+            engine_count: args.engine_count,
+            ready_timeout: Duration::from_secs(args.ready_timeout_secs),
+            local_input_address: None,
+            local_output_address: None,
+        },
+        coordinator_mode: None,
+        model_name: args.model.clone(),
+        client_index: args.client_index,
+    })
+    .await
+    .context("failed to connect to external vLLM engine")?;
+    let llm = Llm::new(client);
+
+    let output = timeout(
+        Duration::from_secs(args.output_timeout_secs),
+        llm.encode(build_request()),
+    )
+    .await
+    .context("timed out waiting for embedding output")??;
+    llm.shutdown().await.context("failed to shut down LLM client")?;
+
+    let l2_norm = output
+        .output
+        .data
+        .iter()
+        .map(|&value| f64::from(value).powi(2))
+        .sum::<f64>()
+        .sqrt();
+    let preview_len = output.output.data.len().min(8);
+
+    println!("model={}", args.model);
+    println!("prompt={PROMPT:?}");
+    println!("prompt_token_count={}", output.prompt_token_ids.len());
+    println!("cached_token_count={}", output.cached_token_count);
+    println!("embedding_shape={:?}", output.output.shape);
+    println!("embedding_l2_norm={l2_norm:.8}");
+    println!("embedding_preview={:?}", &output.output.data[..preview_len]);
+
+    Ok(())
+}

--- a/rust/src/llm/src/encode.rs
+++ b/rust/src/llm/src/encode.rs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::collections::BTreeMap;
+
+use futures::StreamExt as _;
+use vllm_engine_core_client::EngineCoreOutputStream;
+use vllm_engine_core_client::protocol::lora::LoraRequest;
+use vllm_engine_core_client::protocol::output::EngineCoreFinishReason;
+use vllm_engine_core_client::protocol::pooling::{EngineCorePoolingParams, PoolingTask};
+use vllm_engine_core_client::protocol::request::EngineCoreRequest;
+use vllm_engine_core_client::protocol::tensor::WireTensor;
+
+use crate::error::{Error, Result};
+use crate::output::FinishReason;
+use crate::request::prepare_request_id;
+use crate::request_metrics::{PoolingRequestMetricsTracker, current_unix_timestamp_secs};
+
+/// Normalized parameters for one token-level pooling request.
+///
+/// Model-aware defaults and validation are performed by the caller before
+/// reaching this token-level API.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoolingParams {
+    /// Whether to apply activation function to the pooler outputs.
+    pub use_activation: bool,
+    /// Reduce the dimensions of embeddings if model support matryoshka
+    /// representation.
+    pub dimensions: Option<u32>,
+    /// If set, only the score corresponding to the `step_tag_id` in the
+    /// generated sentence should be returned. Otherwise, the scores for all
+    /// tokens are returned.
+    pub step_tag_id: Option<u32>,
+    /// A list of indices for the vocabulary dimensions to be extracted,
+    /// such as the token IDs of `good_token` and `bad_token` in the
+    /// `math-shepherd-mistral-7b-prm` model.
+    pub returned_token_ids: Option<Vec<u32>>,
+}
+
+impl PoolingParams {
+    fn into_engine(self, task: PoolingTask) -> EngineCorePoolingParams {
+        EngineCorePoolingParams {
+            use_activation: self.use_activation,
+            dimensions: self.dimensions,
+            step_tag_id: self.step_tag_id,
+            returned_token_ids: self.returned_token_ids,
+            task,
+        }
+    }
+}
+
+/// Tokenized pooling request accepted by [`crate::Llm::encode`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct EncodeRequest {
+    /// Unique ID of the request.
+    pub request_id: String,
+    /// Token IDs of the prompt.
+    pub prompt_token_ids: Vec<u32>,
+    /// The task used for pooling.
+    pub task: PoolingTask,
+    /// Pooling parameters forwarded to engine-core.
+    pub pooling_params: PoolingParams,
+    /// Unix timestamp, in seconds, when this request arrived at the frontend.
+    pub arrival_time: Option<f64>,
+    /// Optional salt used to partition prefix-cache entries for this request.
+    pub cache_salt: Option<String>,
+    /// Optional tracing headers to forward to engine-core.
+    pub trace_headers: Option<BTreeMap<String, String>>,
+    /// Request scheduling priority. Lower values are scheduled earlier.
+    pub priority: i32,
+    /// Optional data-parallel rank override for routing this request.
+    pub data_parallel_rank: Option<u32>,
+    /// Stable session identity shared by related requests.
+    pub session_id: Option<String>,
+    /// Optional LoRA adapter request applied to this request.
+    pub lora_request: Option<LoraRequest>,
+}
+
+/// One owned pooling tensor returned by engine-core.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoolingOutput {
+    /// Tensor shape reported by the pooler.
+    pub shape: Vec<usize>,
+    /// Tensor values normalized to float32.
+    pub data: Vec<f32>,
+}
+
+impl TryFrom<WireTensor> for PoolingOutput {
+    type Error = String;
+
+    fn try_from(tensor: WireTensor) -> std::result::Result<Self, Self::Error> {
+        let data = tensor.to_f32_vec()?;
+        Ok(Self {
+            shape: tensor.shape,
+            data,
+        })
+    }
+}
+
+/// Final output of one token-level pooling request.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EncodeOutput {
+    /// Internal engine request ID that produced this output.
+    pub request_id: String,
+    /// Original prompt token IDs.
+    pub prompt_token_ids: Vec<u32>,
+    /// Final pooling tensor.
+    pub output: PoolingOutput,
+    /// Number of prompt tokens served from cache.
+    pub cached_token_count: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedEncodeRequest {
+    pub engine_request: EngineCoreRequest,
+}
+
+impl EncodeRequest {
+    pub(crate) fn prepare(self, randomize_request_id: bool) -> Result<PreparedEncodeRequest> {
+        if self.prompt_token_ids.is_empty() {
+            return Err(Error::EmptyPromptTokenIds {
+                request_id: self.request_id,
+            });
+        }
+        let Self {
+            request_id,
+            prompt_token_ids,
+            task,
+            pooling_params,
+            arrival_time,
+            cache_salt,
+            trace_headers,
+            priority,
+            data_parallel_rank,
+            session_id,
+            lora_request,
+        } = self;
+        let engine_request_id = prepare_request_id(&request_id, randomize_request_id);
+
+        Ok(PreparedEncodeRequest {
+            engine_request: EngineCoreRequest {
+                request_id: engine_request_id,
+                prompt_token_ids: Some(prompt_token_ids),
+                mm_features: None,
+                sampling_params: None,
+                pooling_params: Some(pooling_params.into_engine(task)),
+                arrival_time: arrival_time.unwrap_or_else(current_unix_timestamp_secs),
+                lora_request,
+                cache_salt,
+                data_parallel_rank,
+                prompt_embeds: None,
+                prompt_is_token_ids: None,
+                client_index: 0,
+                current_wave: 0,
+                priority,
+                trace_headers,
+                resumable: false,
+                external_req_id: Some(request_id),
+                reasoning_ended: None,
+                reasoning_parser_kwargs: None,
+                abort_immediately: false,
+                session_id,
+            },
+        })
+    }
+}
+
+impl PreparedEncodeRequest {
+    pub(crate) fn prompt_token_ids(&self) -> &[u32] {
+        self.engine_request
+            .prompt_token_ids
+            .as_deref()
+            .expect("prepared request must have prompt token ids")
+    }
+}
+
+pub(crate) async fn collect_encode_output(
+    prompt_token_ids: Vec<u32>,
+    mut stream: EngineCoreOutputStream,
+    mut request_metrics: PoolingRequestMetricsTracker,
+) -> Result<EncodeOutput> {
+    let mut pooling_output: Option<WireTensor> = None;
+    let mut cached_token_count = 0;
+
+    loop {
+        let raw = match stream.next().await {
+            Some(Ok(raw)) => raw,
+            Some(Err(error)) => {
+                request_metrics.record_finished(current_unix_timestamp_secs(), FinishReason::Error);
+                return Err(error.into());
+            }
+            None => {
+                unreachable!("engine-core stream closes only after a final output or an error")
+            }
+        };
+        request_metrics.observe_output(raw.timestamp, &raw.output);
+        let output = raw.output;
+        cached_token_count = cached_token_count.max(
+            output
+                .prefill_stats
+                .as_ref()
+                .map_or(0, |stats| stats.num_cached_tokens as usize),
+        );
+
+        if let Some(tensor) = output.pooling_output
+            && pooling_output.replace(tensor).is_some()
+        {
+            request_metrics.record_finished(current_unix_timestamp_secs(), FinishReason::Error);
+            return Err(Error::PoolingRequest {
+                request_id: output.request_id,
+                message: "received more than one pooling output".to_string(),
+            });
+        }
+
+        if let Some(finish_reason) = output.finish_reason {
+            let received_at = current_unix_timestamp_secs();
+            let semantic_finish_reason =
+                FinishReason::from_engine(finish_reason, output.stop_reason);
+            if finish_reason == EngineCoreFinishReason::Error {
+                request_metrics.record_finished(received_at, FinishReason::Error);
+                return Err(Error::PoolingRequest {
+                    request_id: output.request_id,
+                    message: "engine-core reported an error".to_string(),
+                });
+            }
+            let Some(tensor) = pooling_output else {
+                request_metrics.record_finished(received_at, semantic_finish_reason);
+                return Err(Error::PoolingRequest {
+                    request_id: output.request_id,
+                    message: "request finished without a pooling output".to_string(),
+                });
+            };
+            let pooling_output = match PoolingOutput::try_from(tensor) {
+                Ok(output) => output,
+                Err(message) => {
+                    request_metrics.record_finished(received_at, FinishReason::Error);
+                    return Err(Error::PoolingRequest {
+                        request_id: output.request_id,
+                        message: format!("failed to decode pooling output: {message}"),
+                    });
+                }
+            };
+            request_metrics.record_finished(received_at, semantic_finish_reason);
+            return Ok(EncodeOutput {
+                request_id: output.request_id,
+                prompt_token_ids,
+                output: pooling_output,
+                cached_token_count,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_request() -> EncodeRequest {
+        EncodeRequest {
+            request_id: "embed-1".to_string(),
+            prompt_token_ids: vec![11, 22],
+            task: PoolingTask::Embed,
+            pooling_params: PoolingParams {
+                use_activation: false,
+                dimensions: Some(128),
+                step_tag_id: None,
+                returned_token_ids: None,
+            },
+            arrival_time: Some(42.5),
+            cache_salt: Some("salt".to_string()),
+            trace_headers: Some(BTreeMap::from([(
+                "x-trace-id".to_string(),
+                "abc".to_string(),
+            )])),
+            priority: 3,
+            data_parallel_rank: Some(2),
+            session_id: Some("session-1".to_string()),
+            lora_request: None,
+        }
+    }
+
+    #[test]
+    fn prepare_lowers_normalized_pooling_request() {
+        let prepared = sample_request().prepare(false).unwrap();
+        let request = prepared.engine_request;
+
+        assert_eq!(request.request_id, "embed-1");
+        assert_eq!(request.external_req_id.as_deref(), Some("embed-1"));
+        assert!(request.sampling_params.is_none());
+        assert_eq!(
+            request.pooling_params,
+            Some(EngineCorePoolingParams {
+                use_activation: false,
+                dimensions: Some(128),
+                step_tag_id: None,
+                returned_token_ids: None,
+                task: PoolingTask::Embed,
+            })
+        );
+        assert_eq!(request.arrival_time, 42.5);
+        assert_eq!(request.cache_salt.as_deref(), Some("salt"));
+        assert_eq!(request.data_parallel_rank, Some(2));
+        assert_eq!(request.session_id.as_deref(), Some("session-1"));
+    }
+
+    #[test]
+    fn prepare_rejects_empty_prompt_tokens() {
+        let mut request = sample_request();
+        request.prompt_token_ids.clear();
+
+        assert!(matches!(
+            request.prepare(true).unwrap_err(),
+            Error::EmptyPromptTokenIds { request_id } if request_id == "embed-1"
+        ));
+    }
+}

--- a/rust/src/llm/src/encode.rs
+++ b/rust/src/llm/src/encode.rs
@@ -14,7 +14,7 @@ use vllm_engine_core_client::protocol::tensor::WireTensor;
 use crate::error::{Error, Result};
 use crate::output::FinishReason;
 use crate::request::prepare_request_id;
-use crate::request_metrics::{PoolingRequestMetricsTracker, current_unix_timestamp_secs};
+use crate::request_metrics::{RequestMetricsTracker, current_unix_timestamp_secs};
 
 /// Normalized parameters for one token-level pooling request.
 ///
@@ -89,6 +89,8 @@ impl TryFrom<WireTensor> for PoolingOutput {
     type Error = String;
 
     fn try_from(tensor: WireTensor) -> std::result::Result<Self, Self::Error> {
+        // TODO: Preserve the source dtype and resolved bytes here; perform
+        // float32 conversion at the text/API output boundary.
         let data = tensor.to_f32_vec()?;
         Ok(Self {
             shape: tensor.shape,
@@ -177,7 +179,7 @@ impl PreparedEncodeRequest {
 pub(crate) async fn collect_encode_output(
     prompt_token_ids: Vec<u32>,
     mut stream: EngineCoreOutputStream,
-    mut request_metrics: PoolingRequestMetricsTracker,
+    mut request_metrics: RequestMetricsTracker,
 ) -> Result<EncodeOutput> {
     let mut pooling_output: Option<WireTensor> = None;
     let mut cached_token_count = 0;
@@ -193,7 +195,8 @@ pub(crate) async fn collect_encode_output(
                 unreachable!("engine-core stream closes only after a final output or an error")
             }
         };
-        request_metrics.observe_output(raw.timestamp, &raw.output);
+        let received_at = current_unix_timestamp_secs();
+        request_metrics.observe_output(raw.timestamp, received_at, &raw.output);
         let output = raw.output;
         cached_token_count = cached_token_count.max(
             output
@@ -205,7 +208,7 @@ pub(crate) async fn collect_encode_output(
         if let Some(tensor) = output.pooling_output
             && pooling_output.replace(tensor).is_some()
         {
-            request_metrics.record_finished(current_unix_timestamp_secs(), FinishReason::Error);
+            request_metrics.record_finished(received_at, FinishReason::Error);
             return Err(Error::PoolingRequest {
                 request_id: output.request_id,
                 message: "received more than one pooling output".to_string(),
@@ -213,7 +216,6 @@ pub(crate) async fn collect_encode_output(
         }
 
         if let Some(finish_reason) = output.finish_reason {
-            let received_at = current_unix_timestamp_secs();
             let semantic_finish_reason =
                 FinishReason::from_engine(finish_reason, output.stop_reason);
             if finish_reason == EngineCoreFinishReason::Error {

--- a/rust/src/llm/src/encode.rs
+++ b/rust/src/llm/src/encode.rs
@@ -7,8 +7,9 @@ use futures::StreamExt as _;
 use vllm_engine_core_client::EngineCoreOutputStream;
 use vllm_engine_core_client::protocol::lora::LoraRequest;
 use vllm_engine_core_client::protocol::output::EngineCoreFinishReason;
-use vllm_engine_core_client::protocol::pooling::{EngineCorePoolingParams, PoolingTask};
+use vllm_engine_core_client::protocol::pooling::EngineCorePoolingParams;
 use vllm_engine_core_client::protocol::request::EngineCoreRequest;
+use vllm_engine_core_client::protocol::task::PoolingTask;
 use vllm_engine_core_client::protocol::tensor::WireTensor;
 
 use crate::error::{Error, Result};

--- a/rust/src/llm/src/encode.rs
+++ b/rust/src/llm/src/encode.rs
@@ -17,16 +17,18 @@ use crate::output::FinishReason;
 use crate::request::prepare_request_id;
 use crate::request_metrics::{RequestMetricsTracker, current_unix_timestamp_secs};
 
-/// Normalized parameters for one token-level pooling request.
+/// Parameters for one token-level pooling request.
 ///
-/// Model-aware defaults and validation are performed by the caller before
-/// reaching this token-level API.
-#[derive(Debug, Clone, PartialEq)]
+/// Engine-core resolves model-aware defaults and performs model-specific
+/// validation.
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct PoolingParams {
     /// Whether to apply activation function to the pooler outputs.
-    pub use_activation: bool,
+    /// `None` lets engine-core resolve the model's default.
+    pub use_activation: Option<bool>,
     /// Reduce the dimensions of embeddings if model support matryoshka
     /// representation.
+    /// `None` lets engine-core resolve the model's default.
     pub dimensions: Option<u32>,
     /// If set, only the score corresponding to the `step_tag_id` in the
     /// generated sentence should be returned. Otherwise, the scores for all
@@ -264,7 +266,7 @@ mod tests {
             prompt_token_ids: vec![11, 22],
             task: PoolingTask::Embed,
             pooling_params: PoolingParams {
-                use_activation: false,
+                use_activation: Some(false),
                 dimensions: Some(128),
                 step_tag_id: None,
                 returned_token_ids: None,
@@ -283,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_lowers_normalized_pooling_request() {
+    fn prepare_lowers_pooling_request() {
         let prepared = sample_request().prepare(false).unwrap();
         let request = prepared.engine_request;
 
@@ -293,7 +295,7 @@ mod tests {
         assert_eq!(
             request.pooling_params,
             Some(EngineCorePoolingParams {
-                use_activation: false,
+                use_activation: Some(false),
                 dimensions: Some(128),
                 step_tag_id: None,
                 returned_token_ids: None,

--- a/rust/src/llm/src/error.rs
+++ b/rust/src/llm/src/error.rs
@@ -8,8 +8,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Public error type for the Rust `llm` facade.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("generate request `{request_id}` has an empty prompt_token_ids")]
+    #[error("request `{request_id}` has an empty prompt_token_ids")]
     EmptyPromptTokenIds { request_id: String },
+    #[error("pooling request `{request_id}` failed: {message}")]
+    PoolingRequest { request_id: String, message: String },
     #[error("engine-core error")]
     EngineCoreClient(#[from] vllm_engine_core_client::Error),
 }

--- a/rust/src/llm/src/error.rs
+++ b/rust/src/llm/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 use thiserror::Error;
+use vllm_engine_core_client::protocol::task::EngineTask;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -12,6 +13,14 @@ pub enum Error {
     EmptyPromptTokenIds { request_id: String },
     #[error("pooling request `{request_id}` failed: {message}")]
     PoolingRequest { request_id: String, message: String },
+    #[error(
+        "model `{model_name}` does not support task {requested_task:?}; supported tasks: {supported_tasks:?}"
+    )]
+    UnsupportedTask {
+        model_name: String,
+        requested_task: EngineTask,
+        supported_tasks: Vec<EngineTask>,
+    },
     #[error("engine-core error")]
     EngineCoreClient(#[from] vllm_engine_core_client::Error),
 }

--- a/rust/src/llm/src/lib.rs
+++ b/rust/src/llm/src/lib.rs
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 use tracing::Span;
-use vllm_engine_core_client::EngineCoreClient;
+use vllm_engine_core_client::protocol::request::EngineCoreRequest;
+use vllm_engine_core_client::{EngineCoreClient, EngineCoreOutputStream};
 
+mod encode;
 mod error;
 mod inflight;
 mod log_stats;
@@ -11,6 +13,7 @@ mod output;
 mod request;
 mod request_metrics;
 
+pub use encode::{EncodeOutput, EncodeRequest, PoolingOutput, PoolingParams};
 pub use error::{Error, Result};
 pub use output::{
     CollectedGenerateOutput, FinishReason, GenerateOutput, GenerateOutputStream,
@@ -19,12 +22,13 @@ pub use output::{
 pub use request::GenerateRequest;
 pub use request_metrics::current_unix_timestamp_secs;
 pub use vllm_engine_core_client::protocol::logprobs::{Logprobs, PositionLogprobs, TokenLogprob};
+pub use vllm_engine_core_client::protocol::pooling::PoolingTask;
 
-use crate::inflight::InflightRequests;
+use crate::inflight::{InflightRequests, RequestGuard};
 use crate::log_stats::StatsLogger;
-use crate::request_metrics::RequestMetricsTracker;
+use crate::request_metrics::{PoolingRequestMetricsTracker, RequestMetricsTracker};
 
-/// Thin generate-and-abort facade over [`EngineCoreClient`].
+/// Token-level generation, pooling, and abort facade over [`EngineCoreClient`].
 ///
 /// This mirrors the narrow public shape of Python `AsyncLLM.generate()` and
 /// `abort()`, but keeps the boundary close to raw engine-core requests and
@@ -39,6 +43,22 @@ pub struct Llm {
 }
 
 impl Llm {
+    async fn submit(
+        &self,
+        engine_request: EngineCoreRequest,
+    ) -> Result<(EngineCoreOutputStream, RequestGuard)> {
+        let external_request_id = engine_request
+            .external_req_id
+            .clone()
+            .expect("prepared requests always set external_req_id");
+        let internal_request_id = engine_request.request_id.clone();
+        Span::current().record("engine_request_id", &internal_request_id);
+
+        let stream = self.client.call(engine_request).await?;
+        let guard = self.inflight.track(external_request_id, internal_request_id);
+        Ok((stream, guard))
+    }
+
     /// Create a new minimal LLM facade from an already connected engine-core
     /// client.
     pub fn new(client: EngineCoreClient) -> Self {
@@ -82,22 +102,12 @@ impl Llm {
     pub async fn generate(&self, req: GenerateRequest) -> Result<GenerateOutputStream> {
         let prepared = req.prepare(self.randomize_request_id)?;
         let prompt_token_ids = prepared.prompt_token_ids().into();
-        let external_request_id = prepared
-            .engine_request
-            .external_req_id
-            .clone()
-            .expect("prepare always sets external_req_id");
-        let internal_request_id = prepared.engine_request.request_id.clone();
-
-        // Record internal engine-core request ID in the current tracing span.
-        Span::current().record("engine_request_id", &internal_request_id);
-
         let arrival_time = prepared.engine_request.arrival_time;
         let max_tokens_param =
             (prepared.engine_request.sampling_params.as_ref()).map(|p| p.max_tokens);
         let prompt_len = prepared.prompt_token_ids().len() as u32;
 
-        let stream = self.client.call(prepared.engine_request).await?;
+        let (stream, guard) = self.submit(prepared.engine_request).await?;
 
         let request_metrics = RequestMetricsTracker::new(
             self.client.model_name().to_string(),
@@ -107,14 +117,29 @@ impl Llm {
             max_tokens_param,
             1,
         );
-        let guard = self.inflight.track(external_request_id, internal_request_id);
-
         Ok(GenerateOutputStream::new(
             prompt_token_ids,
             stream,
             request_metrics,
             guard,
         ))
+    }
+
+    /// Submit one tokenized pooling request and collect its final output.
+    pub async fn encode(&self, req: EncodeRequest) -> Result<EncodeOutput> {
+        let prepared = req.prepare(self.randomize_request_id)?;
+        let prompt_token_ids = prepared.prompt_token_ids().to_vec();
+        let arrival_time = prepared.engine_request.arrival_time;
+        let prompt_len = prepared.prompt_token_ids().len() as u32;
+
+        let (stream, _guard) = self.submit(prepared.engine_request).await?;
+        let request_metrics = PoolingRequestMetricsTracker::new(
+            self.client.model_name().to_string(),
+            stream.engine_index(),
+            arrival_time,
+            prompt_len,
+        );
+        encode::collect_encode_output(prompt_token_ids, stream, request_metrics).await
     }
 
     /// Abort in-flight requests by their external (user-supplied) request ids.

--- a/rust/src/llm/src/lib.rs
+++ b/rust/src/llm/src/lib.rs
@@ -26,7 +26,7 @@ pub use vllm_engine_core_client::protocol::pooling::PoolingTask;
 
 use crate::inflight::{InflightRequests, RequestGuard};
 use crate::log_stats::StatsLogger;
-use crate::request_metrics::{PoolingRequestMetricsTracker, RequestMetricsTracker};
+use crate::request_metrics::RequestMetricsTracker;
 
 /// Token-level generation, pooling, and abort facade over [`EngineCoreClient`].
 ///
@@ -133,11 +133,13 @@ impl Llm {
         let prompt_len = prepared.prompt_token_ids().len() as u32;
 
         let (stream, _guard) = self.submit(prepared.engine_request).await?;
-        let request_metrics = PoolingRequestMetricsTracker::new(
+        let request_metrics = RequestMetricsTracker::new(
             self.client.model_name().to_string(),
             stream.engine_index(),
             arrival_time,
             prompt_len,
+            None,
+            1,
         );
         encode::collect_encode_output(prompt_token_ids, stream, request_metrics).await
     }

--- a/rust/src/llm/src/lib.rs
+++ b/rust/src/llm/src/lib.rs
@@ -22,7 +22,7 @@ pub use output::{
 pub use request::GenerateRequest;
 pub use request_metrics::current_unix_timestamp_secs;
 pub use vllm_engine_core_client::protocol::logprobs::{Logprobs, PositionLogprobs, TokenLogprob};
-pub use vllm_engine_core_client::protocol::pooling::PoolingTask;
+pub use vllm_engine_core_client::protocol::task::{EngineTask, GenerationTask, PoolingTask};
 
 use crate::inflight::{InflightRequests, RequestGuard};
 use crate::log_stats::StatsLogger;

--- a/rust/src/llm/src/lib.rs
+++ b/rust/src/llm/src/lib.rs
@@ -43,6 +43,20 @@ pub struct Llm {
 }
 
 impl Llm {
+    async fn validate_task(&self, task: impl Into<EngineTask>) -> Result<()> {
+        let requested_task = task.into();
+        let supported_tasks = self.client.get_supported_tasks().await?;
+        if supported_tasks.contains(&requested_task) {
+            return Ok(());
+        }
+
+        Err(Error::UnsupportedTask {
+            model_name: self.client.model_name().to_string(),
+            requested_task,
+            supported_tasks: supported_tasks.to_vec(),
+        })
+    }
+
     async fn submit(
         &self,
         engine_request: EngineCoreRequest,
@@ -127,11 +141,13 @@ impl Llm {
 
     /// Submit one tokenized pooling request and collect its final output.
     pub async fn encode(&self, req: EncodeRequest) -> Result<EncodeOutput> {
+        let task = req.task;
         let prepared = req.prepare(self.randomize_request_id)?;
         let prompt_token_ids = prepared.prompt_token_ids().to_vec();
         let arrival_time = prepared.engine_request.arrival_time;
         let prompt_len = prepared.prompt_token_ids().len() as u32;
 
+        self.validate_task(task).await?;
         let (stream, _guard) = self.submit(prepared.engine_request).await?;
         let request_metrics = RequestMetricsTracker::new(
             self.client.model_name().to_string(),

--- a/rust/src/llm/src/output.rs
+++ b/rust/src/llm/src/output.rs
@@ -79,6 +79,19 @@ pub enum FinishReason {
 }
 
 impl FinishReason {
+    pub(crate) fn from_engine(
+        finish_reason: EngineCoreFinishReason,
+        stop_reason: Option<StopReason>,
+    ) -> Self {
+        match finish_reason {
+            EngineCoreFinishReason::Stop => Self::Stop(stop_reason),
+            EngineCoreFinishReason::Length => Self::Length,
+            EngineCoreFinishReason::Abort => Self::Abort,
+            EngineCoreFinishReason::Error => Self::Error,
+            EngineCoreFinishReason::Repetition => Self::Repetition(stop_reason),
+        }
+    }
+
     /// Construct a stop finish reason caused by EOS rather than an explicit
     /// stop string/token.
     pub fn stop_eos() -> Self {
@@ -116,19 +129,6 @@ impl FinishReason {
             _ => None,
         }
     }
-}
-
-fn finish_reason_from_engine(
-    finish_reason: Option<EngineCoreFinishReason>,
-    stop_reason: Option<StopReason>,
-) -> Option<FinishReason> {
-    finish_reason.map(|reason| match reason {
-        EngineCoreFinishReason::Stop => FinishReason::Stop(stop_reason),
-        EngineCoreFinishReason::Length => FinishReason::Length,
-        EngineCoreFinishReason::Abort => FinishReason::Abort,
-        EngineCoreFinishReason::Error => FinishReason::Error,
-        EngineCoreFinishReason::Repetition => FinishReason::Repetition(stop_reason),
-    })
 }
 
 /// Token and logprob output item returned by [`GenerateOutputStream`].
@@ -277,7 +277,9 @@ impl Stream for GenerateOutputStream {
             .map(|stats| stats.num_cached_tokens as usize)
             .unwrap_or(0);
 
-        let finish_reason = finish_reason_from_engine(raw.finish_reason, raw.stop_reason);
+        let finish_reason = raw
+            .finish_reason
+            .map(|reason| FinishReason::from_engine(reason, raw.stop_reason));
         if let Some(finish_reason) = finish_reason.as_ref() {
             self.request_metrics.record_finished(received_at, finish_reason.clone());
         }

--- a/rust/src/llm/src/request.rs
+++ b/rust/src/llm/src/request.rs
@@ -12,6 +12,16 @@ use vllm_engine_core_client::protocol::sampling::EngineCoreSamplingParams;
 use crate::error::{Error, Result};
 use crate::request_metrics::current_unix_timestamp_secs;
 
+/// Prepare a request ID for engine-core, randomizing it to avoid collisions if requested.
+pub(crate) fn prepare_request_id(external_request_id: &str, randomize_request_id: bool) -> String {
+    if randomize_request_id {
+        let random_suffix = Uuid::new_v4().simple().to_string();
+        format!("{external_request_id}-{}", &random_suffix[..8])
+    } else {
+        external_request_id.to_string()
+    }
+}
+
 /// Tokenized decoder-only generate request accepted by [`crate::Llm`].
 ///
 /// This is the first-stage Rust subset of the inputs that eventually flow into
@@ -83,13 +93,7 @@ impl GenerateRequest {
             lora_request,
         } = self;
 
-        let external_request_id = request_id;
-        let engine_request_id = if randomize_request_id {
-            let random_suffix = Uuid::new_v4().simple().to_string();
-            format!("{external_request_id}-{}", &random_suffix[..8])
-        } else {
-            external_request_id.clone()
-        };
+        let engine_request_id = prepare_request_id(&request_id, randomize_request_id);
         Ok(PreparedGenerateRequest {
             engine_request: EngineCoreRequest {
                 request_id: engine_request_id,
@@ -109,7 +113,7 @@ impl GenerateRequest {
                 trace_headers,
                 resumable: false,
                 session_id,
-                external_req_id: Some(external_request_id),
+                external_req_id: Some(request_id),
                 // Rust parser doesn't expose this information, leave it unset and let the
                 // reasoning logic in engine-sided structured output manager handle it.
                 reasoning_ended: None,

--- a/rust/src/llm/src/request_metrics.rs
+++ b/rust/src/llm/src/request_metrics.rs
@@ -48,6 +48,21 @@ pub(crate) struct RequestMetricsTracker {
     latest_num_cached_tokens: u32,
 }
 
+/// Request-scoped metrics for final-only pooling requests.
+pub(crate) struct PoolingRequestMetricsTracker {
+    /// Cached request metric handles for this request's model and engine index.
+    handles: RequestMetricHandles,
+
+    arrival_time: f64,
+    prompt_len: u32,
+    queued_ts: f64,
+    scheduled_ts: f64,
+    pooling_output_ts: f64,
+    latest_num_cached_tokens: u32,
+    prompt_tokens_recorded: bool,
+    finished: bool,
+}
+
 /// Cached request metric handles for one model and engine index.
 #[derive(Clone)]
 struct RequestMetricHandles {
@@ -78,6 +93,43 @@ struct RequestMetricHandles {
     request_decode_time_seconds: HistogramMetric,
     request_inference_time_seconds: HistogramMetric,
     request_time_per_output_token_seconds: HistogramMetric,
+}
+
+impl RequestMetricHandles {
+    fn record_prompt_tokens(&self, prefill_stats: &PrefillStats) {
+        self.prompt_tokens.inc_by(prefill_stats.num_prompt_tokens as u64);
+        self.prompt_tokens_local_compute
+            .inc_by(prefill_stats.num_computed_tokens as u64);
+        self.prompt_tokens_local_cache_hit
+            .inc_by(prefill_stats.num_local_cached_tokens as u64);
+        self.prompt_tokens_external_kv_transfer
+            .inc_by(prefill_stats.num_external_cached_tokens as u64);
+        self.prompt_tokens_cached.inc_by(prefill_stats.num_cached_tokens as u64);
+    }
+
+    fn observe_event(&self, event: &EngineCoreEvent, queued_ts: &mut f64, scheduled_ts: &mut f64) {
+        match event.r#type {
+            EngineCoreEventType::Queued => *queued_ts = event.timestamp,
+            EngineCoreEventType::Scheduled => {
+                if *scheduled_ts == 0.0 {
+                    *scheduled_ts = event.timestamp;
+                }
+            }
+            EngineCoreEventType::Preempted => {
+                self.num_preemptions.inc();
+            }
+        }
+    }
+
+    fn record_request_success(&self, finish_reason: FinishReason) {
+        self.request_success
+            .get_or_create(&FinishedReasonLabels {
+                model_name: self.labels.model_name.clone(),
+                engine: self.labels.engine,
+                finished_reason: finish_reason.as_str(),
+            })
+            .inc();
+    }
 }
 
 impl RequestMetricsTracker {
@@ -125,7 +177,9 @@ impl RequestMetricsTracker {
         self.handles.generation_tokens.inc_by(output.new_token_ids.len() as u64);
 
         if let Some(events) = &output.events {
-            self.observe_events(events);
+            for event in events {
+                self.handles.observe_event(event, &mut self.queued_ts, &mut self.scheduled_ts);
+            }
         }
 
         // Only outputs that actually carry tokens drive token-timing metrics.
@@ -135,7 +189,7 @@ impl RequestMetricsTracker {
         if !output.new_token_ids.is_empty() {
             if self.is_prefilling {
                 if let Some(prefill_stats) = &output.prefill_stats {
-                    self.record_prompt_tokens(prefill_stats);
+                    self.handles.record_prompt_tokens(prefill_stats);
                 }
                 self.first_token_latency = received_at - self.arrival_time;
                 self.handles.time_to_first_token_seconds.observe(self.first_token_latency);
@@ -171,7 +225,7 @@ impl RequestMetricsTracker {
             0.0
         };
 
-        self.record_request_success(finish_reason);
+        self.handles.record_request_success(finish_reason);
 
         self.handles.request_prompt_tokens.observe(self.prompt_len as f64);
         self.handles
@@ -196,49 +250,79 @@ impl RequestMetricsTracker {
             .request_time_per_output_token_seconds
             .observe(time_per_output_token_seconds);
     }
+}
 
-    /// Record prompt token counters through cached metric handles.
-    fn record_prompt_tokens(&self, prefill_stats: &PrefillStats) {
-        let computed = prefill_stats.num_computed_tokens as u64;
-        let local_cache_hit = prefill_stats.num_local_cached_tokens as u64;
-        let external_kv_transfer = prefill_stats.num_external_cached_tokens as u64;
-
-        self.handles.prompt_tokens.inc_by(prefill_stats.num_prompt_tokens as u64);
-        self.handles.prompt_tokens_local_compute.inc_by(computed);
-        self.handles.prompt_tokens_local_cache_hit.inc_by(local_cache_hit);
-        self.handles.prompt_tokens_external_kv_transfer.inc_by(external_kv_transfer);
-        self.handles.prompt_tokens_cached.inc_by(prefill_stats.num_cached_tokens as u64);
+impl PoolingRequestMetricsTracker {
+    pub(crate) fn new(
+        model_name: String,
+        engine_index: u32,
+        arrival_time: f64,
+        prompt_len: u32,
+    ) -> Self {
+        Self {
+            handles: resolve_request_metric_handles(&model_name, engine_index),
+            arrival_time,
+            prompt_len,
+            queued_ts: 0.0,
+            scheduled_ts: 0.0,
+            pooling_output_ts: 0.0,
+            latest_num_cached_tokens: 0,
+            prompt_tokens_recorded: false,
+            finished: false,
+        }
     }
 
-    /// Record request event counters through cached metric handles.
-    fn observe_events(&mut self, events: &[EngineCoreEvent]) {
-        for event in events {
-            match event.r#type {
-                EngineCoreEventType::Queued => {
-                    self.queued_ts = event.timestamp;
-                }
-                EngineCoreEventType::Scheduled => {
-                    if self.scheduled_ts == 0.0 {
-                        self.scheduled_ts = event.timestamp;
-                    }
-                }
-                EngineCoreEventType::Preempted => {
-                    self.handles.num_preemptions.inc();
-                }
+    pub(crate) fn observe_output(&mut self, batch_timestamp: f64, output: &EngineCoreOutput) {
+        if let Some(prefill_stats) = &output.prefill_stats {
+            self.latest_num_cached_tokens = prefill_stats.num_cached_tokens;
+            if !self.prompt_tokens_recorded {
+                self.handles.record_prompt_tokens(prefill_stats);
+                self.prompt_tokens_recorded = true;
+            }
+        }
+        if output.pooling_output.is_some() {
+            self.pooling_output_ts = batch_timestamp;
+        }
+        if let Some(events) = &output.events {
+            for event in events {
+                self.handles.observe_event(event, &mut self.queued_ts, &mut self.scheduled_ts);
             }
         }
     }
 
-    /// Increment the request-success counter for the terminal finish reason.
-    fn record_request_success(&self, finish_reason: FinishReason) {
+    pub(crate) fn record_finished(&mut self, received_at: f64, finish_reason: FinishReason) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+
+        let prefill_kv_computed_tokens =
+            self.prompt_len.saturating_sub(self.latest_num_cached_tokens);
+        self.handles.record_request_success(finish_reason);
+        self.handles.request_prompt_tokens.observe(self.prompt_len as f64);
         self.handles
-            .request_success
-            .get_or_create(&FinishedReasonLabels {
-                model_name: self.handles.labels.model_name.clone(),
-                engine: self.handles.labels.engine,
-                finished_reason: finish_reason.as_str(),
-            })
-            .inc();
+            .request_prefill_kv_computed_tokens
+            .observe(prefill_kv_computed_tokens as f64);
+        self.handles
+            .e2e_request_latency_seconds
+            .observe(received_at - self.arrival_time);
+        self.handles
+            .request_queue_time_seconds
+            .observe(diff_or_zero(self.scheduled_ts, self.queued_ts));
+        self.handles
+            .request_prefill_time_seconds
+            .observe(diff_or_zero(self.pooling_output_ts, self.scheduled_ts));
+        self.handles
+            .request_inference_time_seconds
+            .observe(diff_or_zero(self.pooling_output_ts, self.scheduled_ts));
+    }
+}
+
+impl Drop for PoolingRequestMetricsTracker {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.record_finished(current_unix_timestamp_secs(), FinishReason::Abort);
+        }
     }
 }
 

--- a/rust/src/llm/src/request_metrics.rs
+++ b/rust/src/llm/src/request_metrics.rs
@@ -48,21 +48,6 @@ pub(crate) struct RequestMetricsTracker {
     latest_num_cached_tokens: u32,
 }
 
-/// Request-scoped metrics for final-only pooling requests.
-pub(crate) struct PoolingRequestMetricsTracker {
-    /// Cached request metric handles for this request's model and engine index.
-    handles: RequestMetricHandles,
-
-    arrival_time: f64,
-    prompt_len: u32,
-    queued_ts: f64,
-    scheduled_ts: f64,
-    pooling_output_ts: f64,
-    latest_num_cached_tokens: u32,
-    prompt_tokens_recorded: bool,
-    finished: bool,
-}
-
 /// Cached request metric handles for one model and engine index.
 #[derive(Clone)]
 struct RequestMetricHandles {
@@ -182,11 +167,9 @@ impl RequestMetricsTracker {
             }
         }
 
-        // Only outputs that actually carry tokens drive token-timing metrics.
-        // A terminal output with no new tokens (e.g. the synthesized abort
-        // output) must not log a stray time-to-first-token or inter-token
-        // sample.
-        if !output.new_token_ids.is_empty() {
+        // Generation tokens and pooling tensors are both semantic outputs.
+        // Terminal control-only outputs do not drive output-timing metrics.
+        if !output.new_token_ids.is_empty() || output.pooling_output.is_some() {
             if self.is_prefilling {
                 if let Some(prefill_stats) = &output.prefill_stats {
                     self.handles.record_prompt_tokens(prefill_stats);
@@ -249,80 +232,6 @@ impl RequestMetricsTracker {
         self.handles
             .request_time_per_output_token_seconds
             .observe(time_per_output_token_seconds);
-    }
-}
-
-impl PoolingRequestMetricsTracker {
-    pub(crate) fn new(
-        model_name: String,
-        engine_index: u32,
-        arrival_time: f64,
-        prompt_len: u32,
-    ) -> Self {
-        Self {
-            handles: resolve_request_metric_handles(&model_name, engine_index),
-            arrival_time,
-            prompt_len,
-            queued_ts: 0.0,
-            scheduled_ts: 0.0,
-            pooling_output_ts: 0.0,
-            latest_num_cached_tokens: 0,
-            prompt_tokens_recorded: false,
-            finished: false,
-        }
-    }
-
-    pub(crate) fn observe_output(&mut self, batch_timestamp: f64, output: &EngineCoreOutput) {
-        if let Some(prefill_stats) = &output.prefill_stats {
-            self.latest_num_cached_tokens = prefill_stats.num_cached_tokens;
-            if !self.prompt_tokens_recorded {
-                self.handles.record_prompt_tokens(prefill_stats);
-                self.prompt_tokens_recorded = true;
-            }
-        }
-        if output.pooling_output.is_some() {
-            self.pooling_output_ts = batch_timestamp;
-        }
-        if let Some(events) = &output.events {
-            for event in events {
-                self.handles.observe_event(event, &mut self.queued_ts, &mut self.scheduled_ts);
-            }
-        }
-    }
-
-    pub(crate) fn record_finished(&mut self, received_at: f64, finish_reason: FinishReason) {
-        if self.finished {
-            return;
-        }
-        self.finished = true;
-
-        let prefill_kv_computed_tokens =
-            self.prompt_len.saturating_sub(self.latest_num_cached_tokens);
-        self.handles.record_request_success(finish_reason);
-        self.handles.request_prompt_tokens.observe(self.prompt_len as f64);
-        self.handles
-            .request_prefill_kv_computed_tokens
-            .observe(prefill_kv_computed_tokens as f64);
-        self.handles
-            .e2e_request_latency_seconds
-            .observe(received_at - self.arrival_time);
-        self.handles
-            .request_queue_time_seconds
-            .observe(diff_or_zero(self.scheduled_ts, self.queued_ts));
-        self.handles
-            .request_prefill_time_seconds
-            .observe(diff_or_zero(self.pooling_output_ts, self.scheduled_ts));
-        self.handles
-            .request_inference_time_seconds
-            .observe(diff_or_zero(self.pooling_output_ts, self.scheduled_ts));
-    }
-}
-
-impl Drop for PoolingRequestMetricsTracker {
-    fn drop(&mut self) {
-        if !self.finished {
-            self.record_finished(current_unix_timestamp_secs(), FinishReason::Abort);
-        }
     }
 }
 

--- a/rust/src/llm/src/request_metrics.rs
+++ b/rust/src/llm/src/request_metrics.rs
@@ -80,43 +80,6 @@ struct RequestMetricHandles {
     request_time_per_output_token_seconds: HistogramMetric,
 }
 
-impl RequestMetricHandles {
-    fn record_prompt_tokens(&self, prefill_stats: &PrefillStats) {
-        self.prompt_tokens.inc_by(prefill_stats.num_prompt_tokens as u64);
-        self.prompt_tokens_local_compute
-            .inc_by(prefill_stats.num_computed_tokens as u64);
-        self.prompt_tokens_local_cache_hit
-            .inc_by(prefill_stats.num_local_cached_tokens as u64);
-        self.prompt_tokens_external_kv_transfer
-            .inc_by(prefill_stats.num_external_cached_tokens as u64);
-        self.prompt_tokens_cached.inc_by(prefill_stats.num_cached_tokens as u64);
-    }
-
-    fn observe_event(&self, event: &EngineCoreEvent, queued_ts: &mut f64, scheduled_ts: &mut f64) {
-        match event.r#type {
-            EngineCoreEventType::Queued => *queued_ts = event.timestamp,
-            EngineCoreEventType::Scheduled => {
-                if *scheduled_ts == 0.0 {
-                    *scheduled_ts = event.timestamp;
-                }
-            }
-            EngineCoreEventType::Preempted => {
-                self.num_preemptions.inc();
-            }
-        }
-    }
-
-    fn record_request_success(&self, finish_reason: FinishReason) {
-        self.request_success
-            .get_or_create(&FinishedReasonLabels {
-                model_name: self.labels.model_name.clone(),
-                engine: self.labels.engine,
-                finished_reason: finish_reason.as_str(),
-            })
-            .inc();
-    }
-}
-
 impl RequestMetricsTracker {
     /// Create the per-request tracker from the normalized `llm`-layer request
     /// context.
@@ -162,17 +125,17 @@ impl RequestMetricsTracker {
         self.handles.generation_tokens.inc_by(output.new_token_ids.len() as u64);
 
         if let Some(events) = &output.events {
-            for event in events {
-                self.handles.observe_event(event, &mut self.queued_ts, &mut self.scheduled_ts);
-            }
+            self.observe_events(events);
         }
 
-        // Generation tokens and pooling tensors are both semantic outputs.
-        // Terminal control-only outputs do not drive output-timing metrics.
+        // Only outputs that carry tokens or a pooling tensor drive output-timing metrics.
+        // A terminal output with neither (e.g. the synthesized abort
+        // output) must not log a stray time-to-first-token or inter-token
+        // sample.
         if !output.new_token_ids.is_empty() || output.pooling_output.is_some() {
             if self.is_prefilling {
                 if let Some(prefill_stats) = &output.prefill_stats {
-                    self.handles.record_prompt_tokens(prefill_stats);
+                    self.record_prompt_tokens(prefill_stats);
                 }
                 self.first_token_latency = received_at - self.arrival_time;
                 self.handles.time_to_first_token_seconds.observe(self.first_token_latency);
@@ -208,7 +171,7 @@ impl RequestMetricsTracker {
             0.0
         };
 
-        self.handles.record_request_success(finish_reason);
+        self.record_request_success(finish_reason);
 
         self.handles.request_prompt_tokens.observe(self.prompt_len as f64);
         self.handles
@@ -232,6 +195,50 @@ impl RequestMetricsTracker {
         self.handles
             .request_time_per_output_token_seconds
             .observe(time_per_output_token_seconds);
+    }
+
+    /// Record prompt token counters through cached metric handles.
+    fn record_prompt_tokens(&self, prefill_stats: &PrefillStats) {
+        let computed = prefill_stats.num_computed_tokens as u64;
+        let local_cache_hit = prefill_stats.num_local_cached_tokens as u64;
+        let external_kv_transfer = prefill_stats.num_external_cached_tokens as u64;
+
+        self.handles.prompt_tokens.inc_by(prefill_stats.num_prompt_tokens as u64);
+        self.handles.prompt_tokens_local_compute.inc_by(computed);
+        self.handles.prompt_tokens_local_cache_hit.inc_by(local_cache_hit);
+        self.handles.prompt_tokens_external_kv_transfer.inc_by(external_kv_transfer);
+        self.handles.prompt_tokens_cached.inc_by(prefill_stats.num_cached_tokens as u64);
+    }
+
+    /// Record request event counters through cached metric handles.
+    fn observe_events(&mut self, events: &[EngineCoreEvent]) {
+        for event in events {
+            match event.r#type {
+                EngineCoreEventType::Queued => {
+                    self.queued_ts = event.timestamp;
+                }
+                EngineCoreEventType::Scheduled => {
+                    if self.scheduled_ts == 0.0 {
+                        self.scheduled_ts = event.timestamp;
+                    }
+                }
+                EngineCoreEventType::Preempted => {
+                    self.handles.num_preemptions.inc();
+                }
+            }
+        }
+    }
+
+    /// Increment the request-success counter for the terminal finish reason.
+    fn record_request_success(&self, finish_reason: FinishReason) {
+        self.handles
+            .request_success
+            .get_or_create(&FinishedReasonLabels {
+                model_name: self.handles.labels.model_name.clone(),
+                engine: self.handles.labels.engine,
+                finished_reason: finish_reason.as_str(),
+            })
+            .inc();
     }
 }
 

--- a/rust/src/llm/tests/encode.rs
+++ b/rust/src/llm/tests/encode.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+use uuid::Uuid;
+use vllm_engine_core_client::protocol::output::{
+    EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
+};
+use vllm_engine_core_client::protocol::pooling::PoolingTask;
+use vllm_engine_core_client::protocol::request::EngineCoreRequest;
+use vllm_engine_core_client::protocol::stats::PrefillStats;
+use vllm_engine_core_client::protocol::tensor::WireTensor;
+use vllm_engine_core_client::test_utils::{IpcNamespace, spawn_mock_engine_task};
+use vllm_engine_core_client::{EngineCoreClient, EngineCoreClientConfig};
+use vllm_llm::{EncodeRequest, Error, Llm, PoolingParams};
+use vllm_metrics::METRICS;
+use zeromq::prelude::{SocketRecv, SocketSend};
+use zeromq::{DealerSocket, PushSocket, ZmqMessage};
+
+fn sample_request() -> EncodeRequest {
+    EncodeRequest {
+        request_id: "embed-1".to_string(),
+        prompt_token_ids: vec![11, 22],
+        task: PoolingTask::Embed,
+        pooling_params: PoolingParams {
+            use_activation: false,
+            dimensions: Some(2),
+            step_tag_id: None,
+            returned_token_ids: None,
+        },
+        arrival_time: Some(42.5),
+        cache_salt: None,
+        trace_headers: None,
+        priority: 0,
+        data_parallel_rank: None,
+        session_id: None,
+        lora_request: None,
+    }
+}
+
+async fn recv_engine_request(dealer: &mut DealerSocket) -> EngineCoreRequest {
+    let frames = dealer.recv().await.unwrap().into_vec();
+    assert_eq!(frames[0].as_ref(), &[0x00]);
+    rmp_serde::from_slice(&frames[1]).unwrap()
+}
+
+async fn send_outputs(push: &mut PushSocket, outputs: EngineCoreOutputs) {
+    push.send(ZmqMessage::from(rmp_serde::to_vec_named(&outputs).unwrap()))
+        .await
+        .unwrap();
+}
+
+async fn connect_llm(handshake_address: String, model_name: &str, ipc: &IpcNamespace) -> Llm {
+    let client = EngineCoreClient::connect(
+        EngineCoreClientConfig::new_single(handshake_address)
+            .with_model_name(model_name)
+            .with_local_input_output_addresses(
+                Some(ipc.input_endpoint()),
+                Some(ipc.output_endpoint()),
+            ),
+    )
+    .await
+    .unwrap();
+    Llm::new(client).with_request_id_randomization(false)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn encode_lowers_request_and_collects_final_pooling_tensor() {
+    let ipc = IpcNamespace::new().unwrap();
+    let handshake_address = ipc.handshake_endpoint();
+    let model_name = format!("encode-metrics-{}", Uuid::new_v4().simple());
+
+    let (shutdown_tx, engine_task) = spawn_mock_engine_task(
+        handshake_address.clone(),
+        b"engine-encode".to_vec(),
+        |dealer, push| {
+            Box::pin(async move {
+                let request = recv_engine_request(dealer).await;
+                let params = request.pooling_params.as_ref().unwrap();
+                assert_eq!(request.external_req_id.as_deref(), Some("embed-1"));
+                assert_eq!(request.prompt_token_ids.as_deref(), Some(&[11, 22][..]));
+                assert_eq!(params.task, PoolingTask::Embed);
+                assert!(!params.use_activation);
+                assert_eq!(params.dimensions, Some(2));
+
+                send_outputs(
+                    push,
+                    RequestBatchOutputs {
+                        outputs: vec![EngineCoreOutput {
+                            request_id: request.request_id.clone(),
+                            pooling_output: Some(
+                                WireTensor::from_f32(vec![2], vec![0.25, -0.5]).unwrap(),
+                            ),
+                            finish_reason: Some(EngineCoreFinishReason::Stop),
+                            prefill_stats: Some(PrefillStats {
+                                num_prompt_tokens: 2,
+                                num_computed_tokens: 1,
+                                num_cached_tokens: 1,
+                                num_local_cached_tokens: 1,
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        }],
+                        finished_requests: Some(BTreeSet::from([request.request_id])),
+                        ..Default::default()
+                    }
+                    .into(),
+                )
+                .await;
+            })
+        },
+    );
+
+    let llm = connect_llm(handshake_address, &model_name, &ipc).await;
+    let mut request = sample_request();
+    request.arrival_time = None;
+    let output = llm.encode(request).await.unwrap();
+
+    assert_eq!(output.request_id, "embed-1");
+    assert_eq!(output.prompt_token_ids, vec![11, 22]);
+    assert_eq!(output.output.shape, vec![2]);
+    assert_eq!(output.output.data, vec![0.25, -0.5]);
+    assert_eq!(output.cached_token_count, 1);
+
+    let rendered = METRICS.render().unwrap();
+    assert!(rendered.contains(&format!(
+        "vllm:request_success_total{{model_name=\"{model_name}\",engine=\"0\",finished_reason=\"stop\"}} 1"
+    )));
+    assert!(rendered.contains(&format!(
+        "vllm:prompt_tokens_total{{model_name=\"{model_name}\",engine=\"0\"}} 2"
+    )));
+    assert!(rendered.contains(&format!(
+        "vllm:prompt_tokens_cached_total{{model_name=\"{model_name}\",engine=\"0\"}} 1"
+    )));
+    assert!(rendered.contains(&format!(
+        "vllm:time_to_first_token_seconds_count{{model_name=\"{model_name}\",engine=\"0\"}} 0"
+    )));
+
+    let _ = shutdown_tx.send(());
+    engine_task.await.unwrap();
+    llm.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn encode_reports_terminal_output_without_pooling_tensor() {
+    let ipc = IpcNamespace::new().unwrap();
+    let handshake_address = ipc.handshake_endpoint();
+
+    let (shutdown_tx, engine_task) = spawn_mock_engine_task(
+        handshake_address.clone(),
+        b"engine-missing-pooling".to_vec(),
+        |dealer, push| {
+            Box::pin(async move {
+                let request = recv_engine_request(dealer).await;
+                send_outputs(
+                    push,
+                    RequestBatchOutputs {
+                        outputs: vec![EngineCoreOutput {
+                            request_id: request.request_id.clone(),
+                            finish_reason: Some(EngineCoreFinishReason::Stop),
+                            ..Default::default()
+                        }],
+                        finished_requests: Some(BTreeSet::from([request.request_id])),
+                        ..Default::default()
+                    }
+                    .into(),
+                )
+                .await;
+            })
+        },
+    );
+
+    let llm = connect_llm(handshake_address, "test-model", &ipc).await;
+    let error = llm.encode(sample_request()).await.unwrap_err();
+    assert!(matches!(
+        error,
+        Error::PoolingRequest { request_id, message }
+            if request_id == "embed-1"
+                && message == "request finished without a pooling output"
+    ));
+
+    let _ = shutdown_tx.send(());
+    engine_task.await.unwrap();
+    llm.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelling_encode_future_aborts_engine_request() {
+    let ipc = IpcNamespace::new().unwrap();
+    let handshake_address = ipc.handshake_endpoint();
+    let (request_received_tx, request_received_rx) = oneshot::channel();
+
+    let (shutdown_tx, engine_task) = spawn_mock_engine_task(
+        handshake_address.clone(),
+        b"engine-cancel-encode".to_vec(),
+        move |dealer, _push| {
+            Box::pin(async move {
+                let request = recv_engine_request(dealer).await;
+                request_received_tx.send(()).unwrap();
+
+                let abort = timeout(Duration::from_secs(1), dealer.recv()).await.unwrap().unwrap();
+                let frames = abort.into_vec();
+                assert_eq!(frames[0].as_ref(), &[0x01]);
+                let aborted_ids: Vec<String> = rmp_serde::from_slice(&frames[1]).unwrap();
+                assert_eq!(aborted_ids, vec![request.request_id]);
+            })
+        },
+    );
+
+    let llm = Arc::new(connect_llm(handshake_address, "test-model", &ipc).await);
+    let encode_task = tokio::spawn({
+        let llm = Arc::clone(&llm);
+        async move { llm.encode(sample_request()).await }
+    });
+    request_received_rx.await.unwrap();
+    encode_task.abort();
+    assert!(encode_task.await.unwrap_err().is_cancelled());
+
+    let _ = shutdown_tx.send(());
+    engine_task.await.unwrap();
+    Arc::into_inner(llm)
+        .expect("encode task released its Llm handle")
+        .shutdown()
+        .await
+        .unwrap();
+}

--- a/rust/src/llm/tests/encode.rs
+++ b/rust/src/llm/tests/encode.rs
@@ -138,7 +138,10 @@ async fn encode_lowers_request_and_collects_final_pooling_tensor() {
         "vllm:prompt_tokens_cached_total{{model_name=\"{model_name}\",engine=\"0\"}} 1"
     )));
     assert!(rendered.contains(&format!(
-        "vllm:time_to_first_token_seconds_count{{model_name=\"{model_name}\",engine=\"0\"}} 0"
+        "vllm:time_to_first_token_seconds_count{{model_name=\"{model_name}\",engine=\"0\"}} 1"
+    )));
+    assert!(rendered.contains(&format!(
+        "vllm:request_generation_tokens_count{{model_name=\"{model_name}\",engine=\"0\"}} 1"
     )));
 
     let _ = shutdown_tx.send(());

--- a/rust/src/llm/tests/encode.rs
+++ b/rust/src/llm/tests/encode.rs
@@ -10,11 +10,15 @@ use tokio::time::timeout;
 use uuid::Uuid;
 use vllm_engine_core_client::protocol::output::{
     EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
+    UtilityCallOutput,
 };
 use vllm_engine_core_client::protocol::request::EngineCoreRequest;
 use vllm_engine_core_client::protocol::stats::PrefillStats;
-use vllm_engine_core_client::protocol::task::PoolingTask;
+use vllm_engine_core_client::protocol::task::{EngineTask, GenerationTask, PoolingTask};
 use vllm_engine_core_client::protocol::tensor::WireTensor;
+use vllm_engine_core_client::protocol::utility::{
+    EngineCoreUtilityRequest, UtilityOutput, UtilityResultEnvelope,
+};
 use vllm_engine_core_client::test_utils::{IpcNamespace, spawn_mock_engine_task};
 use vllm_engine_core_client::{EngineCoreClient, EngineCoreClientConfig};
 use vllm_llm::{EncodeRequest, Error, Llm, PoolingParams};
@@ -28,7 +32,7 @@ fn sample_request() -> EncodeRequest {
         prompt_token_ids: vec![11, 22],
         task: PoolingTask::Embed,
         pooling_params: PoolingParams {
-            use_activation: false,
+            use_activation: Some(false),
             dimensions: Some(2),
             step_tag_id: None,
             returned_token_ids: None,
@@ -55,6 +59,34 @@ async fn send_outputs(push: &mut PushSocket, outputs: EngineCoreOutputs) {
         .unwrap();
 }
 
+async fn answer_supported_tasks(
+    dealer: &mut DealerSocket,
+    push: &mut PushSocket,
+    tasks: Vec<&str>,
+) {
+    let frames = dealer.recv().await.unwrap().into_vec();
+    assert_eq!(frames[0].as_ref(), &[0x03]);
+    let request: EngineCoreUtilityRequest = rmp_serde::from_slice(&frames[1]).unwrap();
+    assert_eq!(request.method_name, "get_supported_tasks");
+
+    send_outputs(
+        push,
+        UtilityCallOutput {
+            engine_index: 0,
+            timestamp: 0.0,
+            output: UtilityOutput {
+                call_id: request.call_id,
+                failure_message: None,
+                result: Some(UtilityResultEnvelope::without_type_info(
+                    rmpv::ext::to_value(tasks).unwrap(),
+                )),
+            },
+        }
+        .into(),
+    )
+    .await;
+}
+
 async fn connect_llm(handshake_address: String, model_name: &str, ipc: &IpcNamespace) -> Llm {
     let client = EngineCoreClient::connect(
         EngineCoreClientConfig::new_single(handshake_address)
@@ -70,6 +102,37 @@ async fn connect_llm(handshake_address: String, model_name: &str, ipc: &IpcNames
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn encode_rejects_unsupported_task_before_submit() {
+    let ipc = IpcNamespace::new().unwrap();
+    let handshake_address = ipc.handshake_endpoint();
+    let (shutdown_tx, engine_task) = spawn_mock_engine_task(
+        handshake_address.clone(),
+        b"engine-task-validation".to_vec(),
+        |dealer, push| {
+            Box::pin(async move {
+                answer_supported_tasks(dealer, push, vec!["generate"]).await;
+            })
+        },
+    );
+
+    let llm = connect_llm(handshake_address, "test-model", &ipc).await;
+    let error = llm.encode(sample_request()).await.unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedTask {
+            model_name,
+            requested_task: EngineTask::Pooling(PoolingTask::Embed),
+            supported_tasks,
+        } if model_name == "test-model"
+            && supported_tasks == vec![EngineTask::Generation(GenerationTask::Generate)]
+    ));
+
+    let _ = shutdown_tx.send(());
+    engine_task.await.unwrap();
+    llm.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn encode_lowers_request_and_collects_final_pooling_tensor() {
     let ipc = IpcNamespace::new().unwrap();
     let handshake_address = ipc.handshake_endpoint();
@@ -80,12 +143,13 @@ async fn encode_lowers_request_and_collects_final_pooling_tensor() {
         b"engine-encode".to_vec(),
         |dealer, push| {
             Box::pin(async move {
+                answer_supported_tasks(dealer, push, vec!["embed"]).await;
                 let request = recv_engine_request(dealer).await;
                 let params = request.pooling_params.as_ref().unwrap();
                 assert_eq!(request.external_req_id.as_deref(), Some("embed-1"));
                 assert_eq!(request.prompt_token_ids.as_deref(), Some(&[11, 22][..]));
                 assert_eq!(params.task, PoolingTask::Embed);
-                assert!(!params.use_activation);
+                assert_eq!(params.use_activation, Some(false));
                 assert_eq!(params.dimensions, Some(2));
 
                 send_outputs(
@@ -159,6 +223,7 @@ async fn encode_reports_terminal_output_without_pooling_tensor() {
         b"engine-missing-pooling".to_vec(),
         |dealer, push| {
             Box::pin(async move {
+                answer_supported_tasks(dealer, push, vec!["embed"]).await;
                 let request = recv_engine_request(dealer).await;
                 send_outputs(
                     push,
@@ -201,8 +266,9 @@ async fn cancelling_encode_future_aborts_engine_request() {
     let (shutdown_tx, engine_task) = spawn_mock_engine_task(
         handshake_address.clone(),
         b"engine-cancel-encode".to_vec(),
-        move |dealer, _push| {
+        move |dealer, push| {
             Box::pin(async move {
+                answer_supported_tasks(dealer, push, vec!["embed"]).await;
                 let request = recv_engine_request(dealer).await;
                 request_received_tx.send(()).unwrap();
 

--- a/rust/src/llm/tests/encode.rs
+++ b/rust/src/llm/tests/encode.rs
@@ -11,9 +11,9 @@ use uuid::Uuid;
 use vllm_engine_core_client::protocol::output::{
     EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
 };
-use vllm_engine_core_client::protocol::pooling::PoolingTask;
 use vllm_engine_core_client::protocol::request::EngineCoreRequest;
 use vllm_engine_core_client::protocol::stats::PrefillStats;
+use vllm_engine_core_client::protocol::task::PoolingTask;
 use vllm_engine_core_client::protocol::tensor::WireTensor;
 use vllm_engine_core_client::test_utils::{IpcNamespace, spawn_mock_engine_task};
 use vllm_engine_core_client::{EngineCoreClient, EngineCoreClientConfig};

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -991,6 +991,11 @@ class EngineCore:
                 request.mm_features
             )
 
+        # Direct EngineCore clients may bypass frontend input processing, so
+        # resolve model-dependent pooling defaults at this shared boundary.
+        if request.pooling_params is not None:
+            request.pooling_params.verify(self.vllm_config.model_config)
+
         req = Request.from_engine_core_request(request, self.request_block_hasher)
         if req.use_structured_output:
             # Note on thread safety: no race condition.


### PR DESCRIPTION
## Purpose

Extract the `engine-core-client` and `llm` layers from #53736 following the architecture review. This PR adds typed pooling wire support and `Llm::encode`; text and API layers follow separately.

This is separate from #53736: it establishes the reusable lower-layer boundary first. AI assistance was used.

## Test Plan

- `cargo nextest run -p vllm-llm -p vllm-engine-core-client` (131 passed)
- `cargo clippy -p vllm-llm -p vllm-engine-core-client --all-targets -- -D warnings` (passed)
- `cargo fmt --all -- --check` and `git diff --check` (passed)

Model evaluation was omitted because model execution stays unchanged; coverage uses synthetic engine fixtures.