### PR TITLE
[Bugfix][Kernel] GDN readout: honor fp32 SSM state precision to avoid fp16 overflow → NaN

### DIFF
--- a/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
+++ b/tests/kernels/test_fused_sigmoid_gating_delta_rule.py
@@ -197,3 +197,53 @@ def test_fused_sigmoid_gating_delta_rule_update_spec(
     torch.testing.assert_close(
         last_recurrent_state, last_recurrent_state_ref, atol=1e-2, rtol=1e-2
     )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(), reason="requires a CUDA/ROCm GPU"
+)
+def test_fused_sigmoid_gating_readout_finite_under_large_fp32_state():
+    """Readout must stay finite when the fp32 SSM state is large.
+
+    The gated-delta-net recurrent state is an *unnormalized* accumulator that
+    grows over long, low-decay context (it is normalized only at the readout by
+    RMSNormGated). With an fp32 SSM state cache (``mamba_ssm_cache_dtype=float32``)
+    the readout ``o = state @ q`` can exceed fp16's ~65504 range. If the output
+    is materialized in the fp16 activation dtype it overflows to +/-inf and, after
+    normalization, becomes NaN -> the model degenerates to a single repeated
+    token. Regression for that overflow: fails when the output is downcast to
+    fp16, passes when it honors the fp32 state precision.
+    """
+    set_random_seed(0)
+    B, T, H, HV, K, V = 1, 1, 4, 4, 64, 128
+    dt = torch.float16
+    q = torch.randn(B, T, H, K, device=DEVICE, dtype=dt)
+    k = torch.randn(B, T, H, K, device=DEVICE, dtype=dt)
+    v = torch.randn(B, T, HV, V, device=DEVICE, dtype=dt)
+    a = torch.randn(B, T, HV, device=DEVICE, dtype=dt)
+    b = torch.randn(B, T, HV, device=DEVICE, dtype=dt)
+    A_log = torch.randn(HV, device=DEVICE, dtype=torch.float32)
+    dt_bias = torch.randn(HV, device=DEVICE, dtype=torch.float32)
+    # fp32 state at a magnitude reachable over long context; 1e6 > fp16 max.
+    state = torch.randn(B, HV, V, K, device=DEVICE, dtype=torch.float32) * 1e6
+
+    o, _ = fused_sigmoid_gating_delta_rule_update(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        initial_state=state.clone(),
+        inplace_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    n_bad = int((~torch.isfinite(o)).sum())
+    assert n_bad == 0, (
+        f"readout has {n_bad} non-finite (inf/NaN) entries under a large fp32 "
+        f"state -- fp16 overflow; max|o|={o.float().abs().max().item():.3e}"
+    )
+    # Carries the true large magnitude, not a saturated/clamped value.
+    assert o.float().abs().max().item() > 1e4

--- a/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_sigmoid_gating.py
@@ -222,7 +222,20 @@ def fused_sigmoid_gating_delta_rule_update(
     else:
         assert scale > 0, "scale must be positive"
 
-    o = q.new_empty(NK, *v.shape)
+    # The readout `o = state @ q` is accumulated in fp32 inside the kernel, but
+    # was materialized in the input (activation) dtype. The gated-delta-net
+    # recurrent state is an *unnormalized* accumulator that grows over long,
+    # low-decay context (it is normalized only at the readout by RMSNormGated),
+    # so with an fp32 SSM state cache the readout can exceed fp16's ~65504 range
+    # and overflow to +/-inf -> NaN after normalization. Materialize the output
+    # in the state's precision so an fp32 state is not silently downcast and
+    # overflowed; an fp16 state keeps the original (faster) dtype unchanged.
+    o_dtype = (
+        torch.float32
+        if initial_state is not None and initial_state.dtype == torch.float32
+        else q.dtype
+    )
+    o = q.new_empty(NK, *v.shape, dtype=o_dtype)
     if inplace_final_state:
         final_state = initial_state
     else:


### PR DESCRIPTION
## Purpose

Closes #54308.

On non-Blackwell GPUs, gated-delta-net (Qwen3-Next / GDN) decode degenerates to a single infinitely-repeated token when the SSM state cache is fp32 (`--mamba-ssm-cache-dtype float32`). Once the recurrent state grows large over long context, greedy/low-temperature decoding emits one token (e.g. `!!!!…`) forever.

## Root cause

`fused_sigmoid_gating_delta_rule_update` accumulates the readout `o = state @ q` in fp32 (`b_o` is `tl.float32`) but materialized the output tensor in the input/activation dtype:

```python
o = q.new_empty(NK, *v.shape)  # inherits q's dtype, e.g. fp16
```

The GDN recurrent state is an *unnormalized* accumulator: it grows over long, low-decay context and is normalized only at the readout by `RMSNormGated`. With an fp32 state cache the readout exceeds fp16's 65504 range and overflows to `±inf` at the store; `RMSNormGated` then produces `inf / inf = NaN`, and decode collapses to a single repeated token. Blackwell does not hit this because its `fi` / `cutedsl` GDN backends run the readout in fp32; the Triton path here is the one every non-Blackwell GPU takes.

## Fix

Materialize the output in the state's precision — fp32 when `initial_state` is fp32, unchanged otherwise. The fp16 path is byte-for-byte identical, so tensor-core / NVIDIA behavior is unaffected by construction.

The same materialize-in-activation-dtype pattern exists in the chunk/prefill kernels (`chunk_o`, `chunk_delta_h`, `wy_fast`) and the `core_attn_out` buffer. This PR fixes the decode-update kernel, which is the one that produces the observed decode degeneration; the chunk-path kernels are a straightforward follow-up.

## Test Plan

Adds `test_fused_sigmoid_gating_readout_finite_under_large_fp32_state` to `tests/kernels/test_fused_sigmoid_gating_delta_rule.py`: drives the decode kernel with fp16 activations and a large fp32 `initial_state` (`1e6`, past fp16 max) and asserts the readout is finite and preserves the true magnitude (not saturated to fp16 max).

## Test Result

- Before: 107 non-finite entries, `max|o| = inf`.
- After: finite, `max|o| > 1e4`.

Validated on AMD MI50 (gfx906). The change is gated on `initial_state.dtype`, so the fp16 path — and thus NVIDIA behavior — is unchanged.
