### PR TITLE
[Distributed][MoonEP] Pin and build MoonEP in tools/ep_kernels

### DIFF
--- a/tools/ep_kernels/README.md
+++ b/tools/ep_kernels/README.md
@@ -4,10 +4,15 @@ Large-scale cluster-level expert parallel, as described in the [DeepSeek-V3 Tech
 
 Here we break down the requirements in 2 steps:
 
-1. Build and install the Python libraries ([DeepEP](https://github.com/deepseek-ai/DeepEP)), including necessary dependencies like NVSHMEM. This step does not require any privileged access. Any user can do this.
+1. Build and install the Python libraries ([DeepEP](https://github.com/deepseek-ai/DeepEP) and [MoonEP](https://github.com/MoonshotAI/MoonEP)), including necessary dependencies like NVSHMEM. This step does not require any privileged access. Any user can do this.
 2. Configure NVIDIA driver to enable IBGDA. This step requires root access, and must be done on the host machine.
 
 Step 2 is necessary for multi-node deployment.
+
+MoonEP has no releases or PyPI wheels yet, so it is built from source at a
+pinned commit (`MOONEP_COMMIT_HASH` / `--moonep-ref`), the same way DeepEP is
+handled. It has no NVSHMEM dependency; at runtime it requires NVSwitch
+multicast capable GPUs (single-node NVLink symmetric memory).
 
 All scripts accept a positional argument as workspace path for staging the build, defaulting to `$(pwd)/ep_kernels_workspace`.
 

--- a/tools/ep_kernels/install_python_libraries.sh
+++ b/tools/ep_kernels/install_python_libraries.sh
@@ -5,12 +5,14 @@ set -ex
 #   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace)
 #   --mode <mode>        "install" (default) or "wheel"
 #   --deepep-ref <commit> DeepEP commit hash
+#   --moonep-ref <commit> MoonEP commit hash
 #   --nvshmem-ver <ver>  NVSHMEM version 
 
 CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
 # Pinned in full: an abbreviated hash is not a ref, so a consumer that
 # fetches the pin directly ("git fetch origin <sha>") cannot resolve it.
 DEEPEP_COMMIT_HASH=${DEEPEP_COMMIT_HASH:-"d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"}
+MOONEP_COMMIT_HASH=${MOONEP_COMMIT_HASH:-"7745ffa00532d9086b49bab84a65b17f687ede14"}
 
 NVSHMEM_VER=${NVSHMEM_VER:-"3.3.24"}  # Default supports both CUDA 12 and 13
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
@@ -42,6 +44,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             DEEPEP_COMMIT_HASH="$2"
+            shift 2
+            ;;
+        --moonep-ref)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --moonep-ref requires an argument." >&2
+                exit 1
+            fi
+            MOONEP_COMMIT_HASH="$2"
             shift 2
             ;;
         --nvshmem-ver)
@@ -199,8 +209,9 @@ do_build() {
 #endif' csrc/kernels/backend/symmetric.hpp
     fi
 
-    if [[ "$name" == "DeepEP" ]]; then
-        # DeepEP links against the CUDA driver API in driverless build images.
+    if [[ "$name" == "DeepEP" || "$name" == "MoonEP" ]]; then
+        # DeepEP and MoonEP link against the CUDA driver API in driverless
+        # build images.
         local cuda_driver_stub
         local cuda_driver_stub_dir
         cuda_driver_stub=$(
@@ -231,6 +242,14 @@ do_build \
     "setup.py" \
     "$DEEPEP_COMMIT_HASH" \
     "export NVSHMEM_DIR=$WORKSPACE/nvshmem; "
+
+# build MoonEP (NVLink symmetric-memory EP; no NVSHMEM dependency)
+do_build \
+    "https://github.com/MoonshotAI/MoonEP" \
+    "MoonEP" \
+    "setup.py" \
+    "$MOONEP_COMMIT_HASH" \
+    ""
 
 if [ "$MODE" = "wheel" ]; then
     echo "All wheels written to $WHEEL_DIR"


### PR DESCRIPTION
## Purpose

Second item of the MoonEP integration roadmap RFC #52095, deferred out of #52101 at reviewer request: make MoonEP installable through the standard EP kernels tooling.

MoonEP (https://github.com/MoonshotAI/MoonEP) has no releases and no PyPI wheel, so this follows the exact pattern used for DeepEP in `tools/ep_kernels/install_python_libraries.sh`:

- `MOONEP_COMMIT_HASH` pinned to `7745ffa00532d9086b49bab84a65b17f687ede14` (the commit the #52101 integration and its GB300 validation were run against), overridable via `--moonep-ref <commit>` or the env var
- built via the existing `do_build` helper in both `install` and `wheel` modes; no NVSHMEM dependency
- the driverless-image `libcuda` stub handling is extended to MoonEP (its extension links the CUDA driver API, like DeepEP)
- README note covering the pin and MoonEP's runtime requirement (NVSwitch multicast / single-node NVLink symmetric memory)

Happy to gate the MoonEP build behind an opt-in flag instead of building it alongside DeepEP by default, if that is preferred for the container image pipeline — the build is one CUDA extension (~1 min) plus the `nvidia-cutlass-dsl` pip dependency.

## Test Plan

```bash
tools/ep_kernels/install_python_libraries.sh --workspace /tmp/epk_ws --mode wheel
bash -n tools/ep_kernels/install_python_libraries.sh
pre-commit run --files tools/ep_kernels/install_python_libraries.sh tools/ep_kernels/README.md
```

## Test Result

- Full script run in `wheel` mode on aarch64 + CUDA 13.1 (GB300 host), with the README's NCCL >= 2.30.4 `UV_OVERRIDE` in place: builds both DeepEP (at its existing pin) and MoonEP (at the new pin) and writes both wheels — `deep_ep-2.0.0+local-cp312-cp312-linux_aarch64.whl` and `moonep-0.0.1-cp312-cp312-linux_aarch64.whl` (the latter containing the compiled `moonep/_C` extension).
- The pinned MoonEP commit is the one already validated end-to-end in #52101 (kernel tests + OLMoE and Qwen3-30B-A3B serving on 4× GB300).
- shellcheck / markdownlint / all pre-commit hooks pass on the changed files.

## Notes

- Not a duplicate: no other PR touches MoonEP installation.
- AI assistance was used in developing this change; I have reviewed and tested every changed line.
