### PR TITLE
[Kimi-K3] AG-GEMM for Sequence Parallelism

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -279,16 +279,19 @@ steps:
     - pytest -v -s tests/v1/distributed/test_dbo.py
     - pytest -v -s tests/distributed/test_mnnvl_alltoall.py
 
-- label: ":nvidia: (B200) Kimi-K3 GEMM-RS/AR"
+- label: ":nvidia: (B200) Kimi-K3 GEMM-RS/AR + AG-GEMM"
   key: kimi-k3-gemm-rs-ar-2xb200
   timeout_in_minutes: 20
   device: b200-k8s
   working_dir: "/vllm-workspace/"
   num_devices: 2
   source_file_dependencies:
+    - vllm/models/kimi_k3/nvidia/ops/ag_gemm.py
     - vllm/models/kimi_k3/nvidia/ops/cute_dsl/gemm_rs_ar.py
+    - tests/kernels/test_kimi_k3_ag_gemm.py
     - tests/kernels/test_kimi_k3_gemm_rs_ar.py
   commands:
+    - pytest -v -s tests/kernels/test_kimi_k3_ag_gemm.py
     - pytest -v -s tests/kernels/test_kimi_k3_gemm_rs_ar.py
 
 - label: ":nvidia: (L4) Distributed 2-Node"

--- a/benchmarks/kernels/benchmark_kimi_k3_ag_gemm.py
+++ b/benchmarks/kernels/benchmark_kimi_k3_ag_gemm.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark the Kimi-K3 AG-GEMM path against explicit AG followed by GEMM.
+
+The default shapes are the Kimi-K3 KDA and MLA input projections for the
+selected TP size. All ranks must belong to one NVLink domain. For example:
+
+    torchrun --nproc-per-node=8 \
+        benchmarks/kernels/benchmark_kimi_k3_ag_gemm.py
+"""
+
+import argparse
+import os
+import statistics
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pandas as pd
+import torch
+import torch.distributed as dist
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.distributed.parallel_state import (
+    get_tp_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.models.common.ops.sequence_parallel import sp_all_gather
+from vllm.models.kimi_k3.nvidia.ops.ag_gemm import AgGemm
+
+_KIMI_K3_HIDDEN_SIZE = 7168
+_KIMI_K3_NUM_HEADS = 96
+_KIMI_K3_HEAD_DIM = 128
+_KIMI_K3_Q_LORA_RANK = 1536
+_KIMI_K3_KV_LORA_RANK = 512
+_KIMI_K3_QK_ROPE_HEAD_DIM = 64
+_KIMI_K3_V_HEAD_DIM = 128
+_PROJECTIONS = ("kda", "mla")
+_LOCAL_M_SWEEP = [256, 384, 448, 512, 1024, 2048, 4096, 8192]
+_MAX_DEFAULT_M = 32768
+
+
+@dataclass
+class Candidate:
+    name: str
+    runs: list[Callable[[], torch.Tensor]]
+    check_correctness: bool = True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--m",
+        type=int,
+        nargs="+",
+        help=(
+            "Global token counts to benchmark. By default, sweep per-rank "
+            "counts densely around the crossover, up to 32768 global tokens."
+        ),
+    )
+    parser.add_argument(
+        "--projection",
+        choices=_PROJECTIONS,
+        nargs="+",
+        default=list(_PROJECTIONS),
+    )
+    parser.add_argument("--hidden-size", type=int, default=_KIMI_K3_HIDDEN_SIZE)
+    parser.add_argument(
+        "--num-workspaces",
+        type=int,
+        default=5,
+        help="Pointer-distinct inputs and CUDA graphs to rotate.",
+    )
+    parser.add_argument("--warmup-replays", type=int, default=5)
+    parser.add_argument("--samples", type=int, default=30)
+    return parser.parse_args()
+
+
+def projection_n(projection: str, world_size: int) -> int:
+    assert _KIMI_K3_NUM_HEADS % world_size == 0
+    if projection == "kda":
+        projection_size = _KIMI_K3_NUM_HEADS * _KIMI_K3_HEAD_DIM
+        local_projection_size = projection_size // world_size
+        local_num_heads = _KIMI_K3_NUM_HEADS // world_size
+        output_size = 4 * local_projection_size + _KIMI_K3_HEAD_DIM + local_num_heads
+        return output_size + (-output_size % 16)
+    assert projection == "mla"
+    return (
+        _KIMI_K3_Q_LORA_RANK
+        + _KIMI_K3_KV_LORA_RANK
+        + _KIMI_K3_QK_ROPE_HEAD_DIM
+        + _KIMI_K3_NUM_HEADS * _KIMI_K3_V_HEAD_DIM // world_size
+    )
+
+
+def capture_graph(
+    op: Callable[[], torch.Tensor],
+    stream: torch.cuda.Stream,
+    cpu_group: dist.ProcessGroup,
+    device_barrier: Callable[[], None],
+) -> tuple[torch.cuda.CUDAGraph, list[torch.Tensor | None]]:
+    result: list[torch.Tensor | None] = [None]
+    stream.wait_stream(torch.cuda.current_stream())
+    for _ in range(3):
+        device_barrier()
+        with torch.cuda.stream(stream):
+            result[0] = op()
+        stream.synchronize()
+    device_barrier()
+    dist.barrier(group=cpu_group)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        result[0] = op()
+    stream.synchronize()
+    device_barrier()
+    dist.barrier(group=cpu_group)
+    return graph, result
+
+
+def benchmark_graphs(
+    candidate_graphs: dict[str, list[torch.cuda.CUDAGraph]],
+    warmup_replays: int,
+    samples: int,
+    device_group: dist.ProcessGroup,
+    device_barrier: Callable[[], None],
+) -> dict[str, float]:
+    candidate_names = list(candidate_graphs)
+    for round_index in range(warmup_replays):
+        for candidate_index in range(len(candidate_names)):
+            candidate_id = (round_index + candidate_index) % len(candidate_names)
+            name = candidate_names[candidate_id]
+            graphs = candidate_graphs[name]
+            device_barrier()
+            graphs[round_index % len(graphs)].replay()
+    torch.accelerator.synchronize()
+
+    timings: dict[str, list[float]] = {name: [] for name in candidate_names}
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    for sample_index in range(samples):
+        for candidate_index in range(len(candidate_names)):
+            candidate_id = (sample_index + candidate_index) % len(candidate_names)
+            name = candidate_names[candidate_id]
+            graphs = candidate_graphs[name]
+            device_barrier()
+            start.record()
+            graphs[sample_index % len(graphs)].replay()
+            end.record()
+            end.synchronize()
+
+            elapsed = torch.tensor(
+                start.elapsed_time(end) * 1000,
+                dtype=torch.float64,
+                device=torch.accelerator.current_device_index(),
+            )
+            dist.all_reduce(elapsed, op=dist.ReduceOp.MAX, group=device_group)
+            timings[name].append(elapsed.item())
+    return {name: statistics.median(values) for name, values in timings.items()}
+
+
+def benchmark_shape(
+    ag_gemm: AgGemm,
+    projection: str,
+    M: int,
+    N: int,
+    K: int,
+    num_workspaces: int,
+    warmup_replays: int,
+    samples: int,
+    device_group: dist.ProcessGroup,
+    cpu_group: dist.ProcessGroup,
+    device_barrier: Callable[[], None],
+) -> dict[str, float | int | str]:
+    rank = dist.get_rank(device_group)
+    world_size = dist.get_world_size(device_group)
+    local_M = (M + world_size - 1) // world_size
+    padded_M = local_M * world_size
+    device = torch.device("cuda", torch.accelerator.current_device_index())
+    rng = torch.Generator(device=device)
+    rng.manual_seed(1000 + rank * 10 + local_M + N)
+    inputs = [
+        torch.randn(local_M, K, dtype=torch.bfloat16, device=device, generator=rng)
+        for _ in range(num_workspaces)
+    ]
+    gemm_inputs = [
+        torch.randn(M, K, dtype=torch.bfloat16, device=device, generator=rng)
+        for _ in range(num_workspaces)
+    ]
+    weight = torch.randn(N, K, dtype=torch.bfloat16, device=device, generator=rng)
+
+    def make_explicit(x: torch.Tensor) -> Callable[[], torch.Tensor]:
+        def run() -> torch.Tensor:
+            gathered = sp_all_gather(x)[:M]
+            return torch.mm(gathered, weight.T)
+
+        return run
+
+    def make_fused(x: torch.Tensor) -> Callable[[], torch.Tensor]:
+        def run() -> torch.Tensor:
+            return ag_gemm(x, weight)[:M]
+
+        return run
+
+    def make_torch_gemm(x: torch.Tensor) -> Callable[[], torch.Tensor]:
+        def run() -> torch.Tensor:
+            return torch.mm(x, weight.T)
+
+        return run
+
+    def make_all_gather(x: torch.Tensor) -> Callable[[], torch.Tensor]:
+        def run() -> torch.Tensor:
+            return sp_all_gather(x)[:M]
+
+        return run
+
+    candidates = (
+        Candidate("explicit_ag_gemm_us", [make_explicit(x) for x in inputs]),
+        Candidate("fused_ag_gemm_us", [make_fused(x) for x in inputs]),
+        Candidate(
+            "torch_gemm_us",
+            [make_torch_gemm(x) for x in gemm_inputs],
+            check_correctness=False,
+        ),
+        Candidate(
+            "all_gather_us",
+            [make_all_gather(x) for x in inputs],
+            check_correctness=False,
+        ),
+    )
+
+    expected = candidates[0].runs[0]()
+    for candidate in candidates[1:]:
+        if not candidate.check_correctness:
+            continue
+        torch.accelerator.synchronize()
+        device_barrier()
+        actual = candidate.runs[0]()
+        torch.accelerator.synchronize()
+        device_barrier()
+        torch.testing.assert_close(actual, expected, rtol=5e-2, atol=4.0)
+
+    candidate_graphs = {}
+    graph_keepalive: list[object] = []
+    for candidate in candidates:
+        stream = torch.cuda.Stream()
+        bundles = [
+            capture_graph(run, stream, cpu_group, device_barrier)
+            for run in candidate.runs
+        ]
+        candidate_graphs[candidate.name] = [graph for graph, _ in bundles]
+        graph_keepalive.extend(bundles)
+        graph_keepalive.append(stream)
+
+    times = benchmark_graphs(
+        candidate_graphs,
+        warmup_replays,
+        samples,
+        device_group,
+        device_barrier,
+    )
+    return {
+        "projection": projection,
+        "M": M,
+        "padded_M": padded_M,
+        "local_M": local_M,
+        "N": N,
+        "K": K,
+        **times,
+        "speedup": times["explicit_ag_gemm_us"] / times["fused_ag_gemm_us"],
+    }
+
+
+def print_results(results: list[dict[str, float | int | str]]) -> None:
+    results_df = pd.DataFrame(results)
+    end_to_end = results_df[
+        [
+            "projection",
+            "M",
+            "padded_M",
+            "local_M",
+            "N",
+            "K",
+            "explicit_ag_gemm_us",
+            "fused_ag_gemm_us",
+            "speedup",
+        ]
+    ].rename(
+        columns={
+            "explicit_ag_gemm_us": "Explicit AG + GEMM (us)",
+            "fused_ag_gemm_us": "Fused AG-GEMM (us)",
+            "speedup": "Fused speedup",
+        }
+    )
+    end_to_end = end_to_end.round(
+        {
+            "Explicit AG + GEMM (us)": 2,
+            "Fused AG-GEMM (us)": 2,
+            "Fused speedup": 3,
+        }
+    )
+
+    print("### End-to-end latency")
+    print(end_to_end.to_markdown(index=False))
+
+    components = results_df[
+        [
+            "projection",
+            "M",
+            "local_M",
+            "N",
+            "K",
+            "torch_gemm_us",
+            "all_gather_us",
+            "fused_ag_gemm_us",
+        ]
+    ].rename(
+        columns={
+            "torch_gemm_us": "Torch GEMM (us)",
+            "all_gather_us": "AG (us)",
+            "fused_ag_gemm_us": "AG-GEMM (us)",
+        }
+    )
+    components = components.round(2)
+
+    print("\n### Component latency")
+    print(components.to_markdown(index=False))
+
+
+def main() -> None:
+    args = parse_args()
+    assert args.m is None or (args.m and min(args.m) > 0)
+    assert args.hidden_size % 64 == 0
+    assert args.num_workspaces > 0
+    assert args.warmup_replays >= 0
+    assert args.samples > 0
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.accelerator.set_device_index(local_rank)
+    init_distributed_environment()
+    world_size = dist.get_world_size()
+    M_values = args.m or [
+        local_M * world_size
+        for local_M in _LOCAL_M_SWEEP
+        if local_M * world_size <= _MAX_DEFAULT_M
+    ]
+    with set_current_vllm_config(VllmConfig()):
+        initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    tp_group = get_tp_group()
+    group_warmup = torch.zeros(1, device=torch.accelerator.current_device_index())
+    dist.all_reduce(group_warmup, group=tp_group.device_group)
+    pynccl_comm = tp_group.device_communicator.pynccl_comm
+    assert pynccl_comm is not None
+    sync_input = torch.zeros(1, device=torch.accelerator.current_device_index())
+    sync_output = torch.empty_like(sync_input)
+
+    def device_barrier() -> None:
+        pynccl_comm.all_reduce(sync_input, sync_output)
+
+    ag_gemm = AgGemm(
+        max_global_tokens=max(M_values),
+        hidden_size=args.hidden_size,
+    )
+    results = [
+        benchmark_shape(
+            ag_gemm,
+            projection,
+            M,
+            projection_n(projection, world_size),
+            args.hidden_size,
+            args.num_workspaces,
+            args.warmup_replays,
+            args.samples,
+            tp_group.device_group,
+            tp_group.cpu_group,
+            device_barrier,
+        )
+        for projection in args.projection
+        for M in M_values
+    ]
+
+    if tp_group.rank_in_group == 0:
+        print_results(results)
+
+    dist.barrier(group=tp_group.cpu_group)
+    del ag_gemm
+    cleanup_dist_env_and_memory()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_kimi_k3_ag_gemm.py
+++ b/tests/kernels/test_kimi_k3_ag_gemm.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from tests.utils import ensure_current_vllm_config
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.distributed.parallel_state import (
+    get_tp_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.models.kimi_k3.nvidia.ops.ag_gemm import AgGemm
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import get_open_port
+from vllm.utils.system_utils import update_environment_variables
+
+_SHAPES = (
+    (129, 512),
+    (257, 768),
+    (1023, 511),
+    (1024, 512),
+    (8191, 512),
+)
+_K = 768
+
+
+def _reference(
+    local_input: torch.Tensor,
+    weight: torch.Tensor,
+    global_M: int,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    world_size = dist.get_world_size(group)
+    gathered = torch.empty(
+        (world_size * local_input.shape[0], local_input.shape[1]),
+        dtype=local_input.dtype,
+        device=local_input.device,
+    )
+    dist.all_gather_single(gathered, local_input, group=group)
+    return torch.mm(gathered[:global_M], weight.T)
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, global_M: int) -> None:
+    torch.testing.assert_close(
+        actual[:global_M],
+        expected,
+        rtol=5e-2,
+        atol=4.0,
+    )
+
+
+def _worker(local_rank: int, world_size: int, master_port: int) -> None:
+    device = torch.device("cuda", local_rank)
+    torch.accelerator.set_device_index(device)
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(master_port),
+        }
+    )
+
+    init_distributed_environment()
+    with ensure_current_vllm_config():
+        initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    tp_group = get_tp_group()
+    group = tp_group.device_group
+    ag_gemm = AgGemm(max_global_tokens=max(M for M, _ in _SHAPES), hidden_size=_K)
+
+    weight_generator = torch.Generator(device=device)
+    input_generator = torch.Generator(device=device)
+    weights = {}
+    for N in {N for _, N in _SHAPES}:
+        weight_generator.manual_seed(1000 + local_rank * 10 + N)
+        weights[N] = torch.randn(
+            N,
+            _K,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=weight_generator,
+        )
+
+    # Alternating shapes exercise workspace and signal reuse. Odd global token
+    # counts also verify that callers can discard sequence-parallel padding.
+    for global_M, N in (*_SHAPES, *_SHAPES[::-1]):
+        local_M = (global_M + world_size - 1) // world_size
+        input_generator.manual_seed(2000 + local_rank * 10 + global_M + N)
+        local_input = torch.randn(
+            local_M,
+            _K,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=input_generator,
+        )
+        expected = _reference(local_input, weights[N], global_M, group)
+        actual = ag_gemm(local_input, weights[N])
+        torch.accelerator.synchronize(device)
+        _assert_close(actual, expected, global_M)
+        dist.barrier(group=group)
+
+    # Exercise AG-GEMM under CUDA graph capture and repeated replay.
+    graph_M, graph_N = 1025, 512
+    local_M = (graph_M + world_size - 1) // world_size
+    input_generator.manual_seed(3000 + local_rank)
+    graph_input = torch.randn(
+        local_M,
+        _K,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=input_generator,
+    )
+    graph_expected = _reference(graph_input, weights[graph_N], graph_M, group)
+
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    for _ in range(3):
+        with torch.cuda.stream(capture_stream):
+            graph_output = ag_gemm(graph_input, weights[graph_N])
+        capture_stream.synchronize()
+        dist.barrier(group=group)
+    dist.barrier(group=tp_group.cpu_group)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        graph_output = ag_gemm(graph_input, weights[graph_N])
+    capture_stream.synchronize()
+    dist.barrier(group=group)
+
+    for _ in range(3):
+        graph.replay()
+        torch.accelerator.synchronize(device)
+        _assert_close(graph_output, graph_expected, graph_M)
+        dist.barrier(group=group)
+
+    dist.barrier(group=tp_group.cpu_group)
+    del ag_gemm
+    cleanup_dist_env_and_memory()
+
+
+@pytest.mark.distributed(num_gpus=2)
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="Kimi-K3 AG-GEMM requires SM100",
+)
+def test_kimi_k3_ag_gemm(monkeypatch: pytest.MonkeyPatch) -> None:
+    world_size = 2
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip("AG-GEMM requires two GPUs")
+
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+    monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+    try:
+        mp.spawn(
+            _worker,
+            args=(world_size, get_open_port()),
+            nprocs=world_size,
+        )
+    finally:
+        cleanup_dist_env_and_memory()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -209,8 +209,9 @@ if TYPE_CHECKING:
     VLLM_MOE_SKIP_PADDING: bool = True
     VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: bool = False
     VLLM_KIMI_K3_AUX_ATTN_RES_STREAM: bool = False
+    VLLM_KIMI_K3_AG_GEMM: bool = True
     VLLM_KIMI_K3_GEMM_AR: bool = True
-    VLLM_KIMI_K3_GEMM_RS: bool = False
+    VLLM_KIMI_K3_GEMM_RS: bool = True
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
@@ -1599,12 +1600,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_KIMI_K3_AUX_ATTN_RES_STREAM": lambda: bool(
         int(os.getenv("VLLM_KIMI_K3_AUX_ATTN_RES_STREAM", "0"))
     ),
+    # Use the Kimi-K3 sequence-parallel AG-GEMM path when eligible.
+    "VLLM_KIMI_K3_AG_GEMM": lambda: bool(int(os.getenv("VLLM_KIMI_K3_AG_GEMM", "1"))),
     # Use the SM100 BF16 GEMM-AR kernel for eligible Kimi-K3 row-parallel
     # attention projections. All TP ranks must belong to one NVLink domain.
     "VLLM_KIMI_K3_GEMM_AR": lambda: bool(int(os.getenv("VLLM_KIMI_K3_GEMM_AR", "1"))),
     # Use the SM100 BF16 GEMM-RS kernel for eligible Kimi-K3 sequence-parallel
     # row-parallel projections. All TP ranks must belong to one NVLink domain.
-    "VLLM_KIMI_K3_GEMM_RS": lambda: bool(int(os.getenv("VLLM_KIMI_K3_GEMM_RS", "0"))),
+    "VLLM_KIMI_K3_GEMM_RS": lambda: bool(int(os.getenv("VLLM_KIMI_K3_GEMM_RS", "1"))),
     # Allow use of FlashInfer FP8 block-scale GEMM for linear layers.
     # This uses TensorRT-LLM kernels and requires SM90+ (Hopper).
     "VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER": lambda: bool(

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -39,6 +39,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.parameter import BasevLLMParameter, BlockQuantScaleParameter
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.models.common.ops.sequence_parallel import sp_all_gather, sp_reduce_scatter
 from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
@@ -55,6 +56,7 @@ from vllm.v1.worker.workspace import current_workspace_manager
 logger = init_logger(__name__)
 
 _KDA_GATE_LOGBOUND_MIN = -5.0
+_KDA_AG_GEMM_MIN_LOCAL_M = 384
 
 
 def a_log_weight_loader(
@@ -399,9 +401,12 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         config: KimiLinearConfig,
         vllm_config: VllmConfig,
         prefix: str = "",
-        run_gemm_rs_ar: bool = False,
+        use_sequence_parallel: bool = False,
+        run_gemm_ar: bool = False,
     ) -> None:
         super().__init__(config, vllm_config, prefix)
+        assert not (use_sequence_parallel and run_gemm_ar)
+        self.use_sequence_parallel = use_sequence_parallel
         self.use_recoverssm = self.cache_config.use_kda_recoverssm
         if self.cache_config.use_replayssm and not self.use_recoverssm:
             raise ValueError(
@@ -572,20 +577,50 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             quant_config=self.quant_config,
             prefix=f"{prefix}.o_proj",
         )
-        self.gemm_rs_ar = None
-        if run_gemm_rs_ar:
-            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import (
-                get_gemm_rs_ar,
-            )
+        self.ag_gemm = None
+        self.gemm_rs = None
+        self.gemm_ar = None
 
-            gemm_rs_ar = get_gemm_rs_ar()
-            if gemm_rs_ar.can_run(self.o_proj):
-                self.gemm_rs_ar = gemm_rs_ar
-            else:
+        if self.use_sequence_parallel:
+            from vllm.models.kimi_k3.nvidia.ops.ag_gemm import get_ag_gemm
+            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import get_gemm_rs
+
+            ag_gemm = get_ag_gemm()
+            gemm_rs = get_gemm_rs()
+
+            # Fuse the input all-gather with the merged input projection.
+            if ag_gemm is not None and ag_gemm.can_run(self.in_proj_qkvgfab):
+                self.ag_gemm = ag_gemm
+            elif ag_gemm is not None:
                 logger.warning_once(
-                    "GEMM-RS/AR is disabled for %s due to an incompatible projection.",
+                    "Fused AG-GEMM is disabled for %s due to an "
+                    "incompatible projection.",
                     prefix,
                 )
+
+            # Fuse the output projection with the reduce-scatter.
+            if gemm_rs is not None and gemm_rs.can_run(self.o_proj):
+                self.gemm_rs = gemm_rs
+            elif gemm_rs is not None:
+                logger.warning_once(
+                    "Fused GEMM-RS is disabled for %s due to an "
+                    "incompatible projection.",
+                    prefix,
+                )
+        elif run_gemm_ar:
+            # Non-SP tokens require an all-reduce after the output projection.
+            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import get_gemm_ar
+
+            gemm_ar = get_gemm_ar()
+            if gemm_ar is not None and gemm_ar.can_run(self.o_proj):
+                self.gemm_ar = gemm_ar
+            elif gemm_ar is not None:
+                logger.warning_once(
+                    "Fused GEMM-AR is disabled for %s due to an "
+                    "incompatible projection.",
+                    prefix,
+                )
+
         compilation_config = vllm_config.compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
@@ -604,8 +639,18 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         hidden_states: torch.Tensor,
         positions: torch.Tensor,
     ) -> torch.Tensor:
-        num_tokens = hidden_states.size(0)
-        projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
+        if (
+            self.ag_gemm is not None
+            and hidden_states.shape[0] >= _KDA_AG_GEMM_MIN_LOCAL_M
+        ):
+            projected_qkvgfab = self.ag_gemm(hidden_states, self.in_proj_qkvgfab.weight)
+        else:
+            if self.use_sequence_parallel:
+                hidden_states = sp_all_gather(hidden_states)[: positions.shape[0]]
+            projected_qkvgfab = self.in_proj_qkvgfab(hidden_states)[0]
+
+        num_tokens = positions.size(0)
+        projected_qkvgfab = projected_qkvgfab[:num_tokens]
         split_sizes = [
             3 * self.local_projection_size,
             self.local_projection_size,
@@ -634,9 +679,19 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             core_attn_out=core_attn_out,
         )
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
-        if self.gemm_rs_ar is not None and self.gemm_rs_ar.should_run(core_attn_out):
-            return self.gemm_rs_ar(core_attn_out, self.o_proj.weight)
-        return self.o_proj(core_attn_out)[0]
+
+        # At most one fused reduction is active for a layer.
+        if self.gemm_rs is not None and self.gemm_rs.should_run(core_attn_out):
+            return self.gemm_rs(core_attn_out, self.o_proj.weight)
+
+        if self.gemm_ar is not None and self.gemm_ar.should_run(core_attn_out):
+            return self.gemm_ar(core_attn_out, self.o_proj.weight)
+
+        # Fall back to the standard projection and collective.
+        output = self.o_proj(core_attn_out)[0]
+        if self.use_sequence_parallel:
+            output = sp_reduce_scatter(output)
+        return output
 
     @eager_break_during_capture
     def _forward(

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -76,6 +76,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding, get_rope
 from vllm.model_executor.utils import replace_parameter
 from vllm.models.common.ops import fused_q_kv_rmsnorm
+from vllm.models.common.ops.sequence_parallel import sp_all_gather, sp_reduce_scatter
 from vllm.models.kimi_k3.nvidia.low_latency_gemm import try_low_latency_gemm
 from vllm.models.kimi_k3.nvidia.ops.fused_mla_key_concat_kv_cache import (
     fused_mla_decode_q_concat_kv_cache_insert,
@@ -111,6 +112,7 @@ logger = init_logger(__name__)
 # Below this conservative threshold, overlap the gate projection with attention
 # on the auxiliary stream.
 _GATE_MULTI_STREAM_TOKEN_THRESHOLD = 512
+_MLA_AG_GEMM_MIN_LOCAL_M = 512
 
 
 @torch.compile(backend=current_platform.simple_compile_backend)
@@ -139,9 +141,12 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         aux_stream: torch.cuda.Stream | None = None,
         use_rope: bool = False,
         non_causal_multi_token_decode: bool = False,
-        run_gemm_rs_ar: bool = False,
+        use_sequence_parallel: bool = False,
+        run_gemm_ar: bool = False,
     ) -> None:
         super().__init__()
+        assert not (use_sequence_parallel and run_gemm_ar)
+        self.use_sequence_parallel = use_sequence_parallel
         self.hidden_size = hidden_size
         self.qk_nope_head_dim = qk_nope_head_dim
         self.qk_rope_head_dim = qk_rope_head_dim
@@ -296,18 +301,52 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
-        self.gemm_rs_ar = None
-        if run_gemm_rs_ar:
-            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import (
-                get_gemm_rs_ar,
-            )
+        self.ag_gemm = None
+        self.gemm_rs = None
+        self.gemm_ar = None
 
-            gemm_rs_ar = get_gemm_rs_ar()
-            if gemm_rs_ar.can_run(self.o_proj):
-                self.gemm_rs_ar = gemm_rs_ar
-            else:
+        if self.use_sequence_parallel:
+            from vllm.models.kimi_k3.nvidia.ops.ag_gemm import get_ag_gemm
+            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import get_gemm_rs
+
+            ag_gemm = get_ag_gemm()
+            gemm_rs = get_gemm_rs()
+
+            # Only the merged q-LoRA qkv_a + gate projection uses AG-GEMM.
+            ag_projection = self.fused_qkv_a_g_proj
+            if (
+                ag_gemm is not None
+                and ag_projection is not None
+                and ag_gemm.can_run(ag_projection)
+            ):
+                self.ag_gemm = ag_gemm
+            elif ag_gemm is not None and ag_projection is not None:
                 logger.warning_once(
-                    "GEMM-RS/AR is disabled for %s due to an incompatible projection.",
+                    "Fused AG-GEMM is disabled for %s due to an "
+                    "incompatible projection.",
+                    prefix,
+                )
+
+            # Fuse the output projection with the reduce-scatter.
+            if gemm_rs is not None and gemm_rs.can_run(self.o_proj):
+                self.gemm_rs = gemm_rs
+            elif gemm_rs is not None:
+                logger.warning_once(
+                    "Fused GEMM-RS is disabled for %s due to an "
+                    "incompatible projection.",
+                    prefix,
+                )
+        elif run_gemm_ar:
+            # Non-SP tokens require an all-reduce after the output projection.
+            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import get_gemm_ar
+
+            gemm_ar = get_gemm_ar()
+            if gemm_ar is not None and gemm_ar.can_run(self.o_proj):
+                self.gemm_ar = gemm_ar
+            elif gemm_ar is not None:
+                logger.warning_once(
+                    "Fused GEMM-AR is disabled for %s due to an "
+                    "incompatible projection.",
                     prefix,
                 )
 
@@ -517,7 +556,6 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
     def _apply_q_lora_attention(
         self,
         positions: torch.Tensor,
-        hidden_states: torch.Tensor,
         qkv_lora: torch.Tensor,
     ) -> torch.Tensor:
         """Expand q-LoRA output and run attention."""
@@ -536,9 +574,9 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         q = self.q_b_proj(q_c)[0].view(-1, self.num_local_heads, self.qk_head_dim)
 
         attn_out = torch.empty(
-            (hidden_states.shape[0], self.num_local_heads * self.v_head_dim),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
+            (q.shape[0], self.num_local_heads * self.v_head_dim),
+            dtype=q.dtype,
+            device=q.device,
         )
         self._attention(positions, q, kv_c_normed, k_pe.unsqueeze(1), attn_out)
         return attn_out
@@ -556,8 +594,11 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         # run g_proj in aux_stream
         if (
             self._gate_events is not None
-            and hidden_states.shape[0] < _GATE_MULTI_STREAM_TOKEN_THRESHOLD
+            and positions.shape[0] < _GATE_MULTI_STREAM_TOKEN_THRESHOLD
         ):
+            if self.use_sequence_parallel:
+                hidden_states = sp_all_gather(hidden_states)[: positions.shape[0]]
+
             fused_qkv_a_g_proj = self.fused_qkv_a_g_proj
             assert fused_qkv_a_g_proj is not None
             qkv_a_weight = fused_qkv_a_g_proj.weight[:qkv_a_rows]
@@ -567,7 +608,6 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             return maybe_execute_in_parallel(
                 lambda: self._apply_q_lora_attention(
                     positions,
-                    hidden_states,
                     self._unquantized_gemm(hidden_states, qkv_a_weight),
                 ),
                 lambda: self._unquantized_gemm(hidden_states, gate_weight),
@@ -578,18 +618,33 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
 
         # run g_proj together with qkv_a
         if self.use_output_gate:
-            qkv_a_proj = self.fused_qkv_a_g_proj
-            assert qkv_a_proj is not None
-            qkv_lora, gate = qkv_a_proj(hidden_states)[0].split(
+            fused_qkv_a_g_proj = self.fused_qkv_a_g_proj
+            assert fused_qkv_a_g_proj is not None
+            # run AG-GEMM
+            if (
+                self.ag_gemm is not None
+                and hidden_states.shape[0] >= _MLA_AG_GEMM_MIN_LOCAL_M
+            ):
+                fused_projection = self.ag_gemm(
+                    hidden_states, fused_qkv_a_g_proj.weight
+                )
+            else:
+                if self.use_sequence_parallel:
+                    hidden_states = sp_all_gather(hidden_states)
+                fused_projection = fused_qkv_a_g_proj(hidden_states)[0]
+            fused_projection = fused_projection[: positions.shape[0]]
+            qkv_lora, gate = fused_projection.split(
                 [qkv_a_rows, self.num_local_heads * self.v_head_dim], dim=-1
             )
         else:
+            if self.use_sequence_parallel:
+                hidden_states = sp_all_gather(hidden_states)[: positions.shape[0]]
             qkv_a_proj = self.fused_qkv_a_proj
             assert qkv_a_proj is not None
             qkv_lora = qkv_a_proj(hidden_states)[0]
             gate = None
 
-        attn_out = self._apply_q_lora_attention(positions, hidden_states, qkv_lora)
+        attn_out = self._apply_q_lora_attention(positions, qkv_lora)
         return attn_out, gate
 
     def _forward_full_rank_q(
@@ -623,6 +678,8 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         if self.q_lora_rank is None:
+            if self.use_sequence_parallel:
+                hidden_states = sp_all_gather(hidden_states)[: positions.shape[0]]
             attn_out, gate = self._forward_full_rank_q(positions, hidden_states)
         else:
             attn_out, gate = self._forward_q_lora(positions, hidden_states)
@@ -630,10 +687,18 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         if gate is not None:
             attn_out = _gate_sigmoid_mul(attn_out, gate)
 
-        if self.gemm_rs_ar is not None and self.gemm_rs_ar.should_run(attn_out):
-            return self.gemm_rs_ar(attn_out, self.o_proj.weight)
+        # At most one fused reduction is active for a layer.
+        if self.gemm_rs is not None and self.gemm_rs.should_run(attn_out):
+            return self.gemm_rs(attn_out, self.o_proj.weight)
 
-        return self.o_proj(attn_out)[0]
+        if self.gemm_ar is not None and self.gemm_ar.should_run(attn_out):
+            return self.gemm_ar(attn_out, self.o_proj.weight)
+
+        # Fall back to the standard projection and collective.
+        output = self.o_proj(attn_out)[0]
+        if self.use_sequence_parallel:
+            output = sp_reduce_scatter(output)
+        return output
 
     @eager_break_during_capture
     def _attention(

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -132,6 +132,18 @@ logger = init_logger(__name__)
 # it the GEMMs saturate the device and the cross-stream sync is pure overhead,
 # so it falls back to sequential.
 _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD = 256
+_SHARED_EXPERT_AG_GEMM_MIN_LOCAL_M = 2048
+
+
+def kimi_sequence_parallel_enabled(vllm_config: VllmConfig) -> bool:
+    parallel_config = vllm_config.parallel_config
+    use_mega_moe = vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
+    return (
+        parallel_config.pipeline_parallel_size == 1
+        and parallel_config.enable_expert_parallel
+        and parallel_config.tensor_parallel_size > 1
+        and (use_mega_moe or parallel_config.data_parallel_size > 1)
+    )
 
 
 def shard_sequence_parallel_mlp(
@@ -154,13 +166,9 @@ def shard_sequence_parallel_mlp(
     )
 
 
-def maybe_init_gemm_rs_ar(vllm_config: VllmConfig, use_sequence_parallel: bool) -> bool:
-    # Both feature flags may be enabled; the worker's static SP topology binds
-    # its singleton to exactly one mode.
-    all_reduce = not use_sequence_parallel
-    mode = "GEMM-AR" if all_reduce else "GEMM-RS"
-    enabled = envs.VLLM_KIMI_K3_GEMM_AR if all_reduce else envs.VLLM_KIMI_K3_GEMM_RS
-    if not enabled:
+def maybe_init_gemm_rs(vllm_config: VllmConfig) -> bool:
+    """Initialize GEMM-RS when eligible and return whether it is available."""
+    if not envs.VLLM_KIMI_K3_GEMM_RS:
         return False
 
     parallel_config = vllm_config.parallel_config
@@ -181,32 +189,107 @@ def maybe_init_gemm_rs_ar(vllm_config: VllmConfig, use_sequence_parallel: bool) 
         reason = None
 
     if reason is not None:
-        logger.warning_once("%s is disabled because %s.", mode, reason)
+        logger.warning_once("GEMM-RS is disabled because %s.", reason)
         return False
 
-    from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import init_gemm_rs_ar
+    from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import init_gemm_rs
 
     config = vllm_config.model_config.hf_text_config
     try:
-        init_gemm_rs_ar(
-            max_M=vllm_config.scheduler_config.max_num_batched_tokens,
-            N=config.hidden_size,
-            all_reduce=all_reduce,
+        init_gemm_rs(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            config.hidden_size,
         )
     except RuntimeError as e:
         logger.warning_once(
-            "%s is disabled because initialization failed: %s. This may mean "
+            "GEMM-RS is disabled because initialization failed: %s. This may mean "
             "the TP ranks do not share one NVLink domain.",
-            mode,
             e,
         )
         return False
-    if all_reduce:
-        logger.info_once(
-            "GEMM-AR is enabled. To disable it, set VLLM_KIMI_K3_GEMM_AR=0."
-        )
+
+    logger.info_once("GEMM-RS is enabled.")
+    return True
+
+
+def maybe_init_gemm_ar(vllm_config: VllmConfig) -> bool:
+    """Initialize GEMM-AR when eligible and return whether it is available."""
+    if not envs.VLLM_KIMI_K3_GEMM_AR:
+        return False
+
+    parallel_config = vllm_config.parallel_config
+    tp_size = parallel_config.tensor_parallel_size
+    if parallel_config.use_ubatching:
+        reason = "ubatching is enabled"
+    elif vllm_config.model_config.dtype != torch.bfloat16:
+        reason = "the model dtype is not BF16"
+    elif not current_platform.is_cuda():
+        reason = "the device is not CUDA"
+    elif not current_platform.is_device_capability_family(100):
+        reason = "the device is not SM100-family"
+    elif not 1 < tp_size <= 16:
+        reason = "TP size is not in the supported range 2-16"
+    elif 128 % tp_size != 0:
+        reason = "TP size does not divide 128"
     else:
-        logger.info_once("GEMM-RS is enabled.")
+        reason = None
+
+    if reason is not None:
+        logger.warning_once("GEMM-AR is disabled because %s.", reason)
+        return False
+
+    from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import init_gemm_ar
+
+    config = vllm_config.model_config.hf_text_config
+    try:
+        init_gemm_ar(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            config.hidden_size,
+        )
+    except RuntimeError as e:
+        logger.warning_once(
+            "GEMM-AR is disabled because initialization failed: %s. This may mean "
+            "the TP ranks do not share one NVLink domain.",
+            e,
+        )
+        return False
+
+    logger.info_once("GEMM-AR is enabled. To disable it, set VLLM_KIMI_K3_GEMM_AR=0.")
+    return True
+
+
+def maybe_init_ag_gemm(vllm_config: VllmConfig) -> bool:
+    """Initialize AG-GEMM when eligible and return whether it is available."""
+    if not envs.VLLM_KIMI_K3_AG_GEMM:
+        return False
+
+    if vllm_config.parallel_config.use_ubatching:
+        reason = "ubatching is enabled"
+    elif vllm_config.model_config.dtype != torch.bfloat16:
+        reason = "the model dtype is not BF16"
+    else:
+        reason = None
+
+    if reason is not None:
+        logger.warning_once("AG-GEMM is disabled because %s.", reason)
+        return False
+
+    from vllm.models.kimi_k3.nvidia.ops.ag_gemm import init_ag_gemm
+
+    config = vllm_config.model_config.hf_text_config
+    try:
+        init_ag_gemm(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            config.hidden_size,
+        )
+    except RuntimeError as e:
+        logger.warning_once(
+            "AG-GEMM is disabled because initialization failed: %s.",
+            e,
+        )
+        return False
+
+    logger.info_once("AG-GEMM is enabled.")
     return True
 
 
@@ -235,12 +318,13 @@ class KimiMLP(nn.Module):
         reduce_results: bool = True,
         use_sequence_parallel: bool = False,
         can_shard_sequence_parallel: bool = False,
-        run_gemm_rs_ar: bool = False,
+        run_gemm_ar: bool = False,
         prefix: str = "",
         activation_situ_beta: float | None = None,
         activation_situ_linear_beta: float | None = None,
     ) -> None:
         super().__init__()
+        assert not (use_sequence_parallel and run_gemm_ar)
 
         self.shard_sequence_parallel = shard_sequence_parallel_mlp(
             hidden_size,
@@ -269,24 +353,50 @@ class KimiMLP(nn.Module):
             disable_tp=replicate,
             prefix=f"{prefix}.down_proj",
         )
-        self.gemm_rs_ar = None
-        # RS requires sequence sharding; AR operates on replicated tokens.
-        use_gemm_rs_ar = self.shard_sequence_parallel or (
-            not use_sequence_parallel and reduce_results
-        )
-        if use_gemm_rs_ar and run_gemm_rs_ar:
-            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import (
-                get_gemm_rs_ar,
-            )
+        self.ag_gemm = None
+        self.gemm_rs = None
+        self.gemm_ar = None
 
-            gemm_rs_ar = get_gemm_rs_ar()
-            if gemm_rs_ar.can_run(self.down_proj):
-                self.gemm_rs_ar = gemm_rs_ar
-            else:
+        if self.shard_sequence_parallel:
+            from vllm.models.kimi_k3.nvidia.ops.ag_gemm import get_ag_gemm
+            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import get_gemm_rs
+
+            ag_gemm = get_ag_gemm()
+            gemm_rs = get_gemm_rs()
+
+            # Fuse the input all-gather with the gate/up projection.
+            if ag_gemm is not None and ag_gemm.can_run(self.gate_up_proj):
+                self.ag_gemm = ag_gemm
+            elif ag_gemm is not None:
                 logger.warning_once(
-                    "GEMM-RS/AR is disabled for %s due to an incompatible projection.",
+                    "Fused AG-GEMM is disabled for %s due to an "
+                    "incompatible projection.",
                     prefix,
                 )
+
+            # Fuse the down projection with the reduce-scatter.
+            if gemm_rs is not None and gemm_rs.can_run(self.down_proj):
+                self.gemm_rs = gemm_rs
+            elif gemm_rs is not None:
+                logger.warning_once(
+                    "Fused GEMM-RS is disabled for %s due to an "
+                    "incompatible projection.",
+                    prefix,
+                )
+        elif run_gemm_ar and reduce_results:
+            # GEMM-AR applies only when this MLP owns the output reduction.
+            from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import get_gemm_ar
+
+            gemm_ar = get_gemm_ar()
+            if gemm_ar is not None and gemm_ar.can_run(self.down_proj):
+                self.gemm_ar = gemm_ar
+            elif gemm_ar is not None:
+                logger.warning_once(
+                    "Fused GEMM-AR is disabled for %s due to an "
+                    "incompatible projection.",
+                    prefix,
+                )
+
         if hidden_act == "silu":
             self.act_fn = SiluAndMul()
         elif hidden_act == "situ":
@@ -301,18 +411,29 @@ class KimiMLP(nn.Module):
             )
 
     def forward(self, x):
-        if self.shard_sequence_parallel:
-            # Each rank holds a weight shard but only its own tokens, so it
-            # cannot finish those tokens alone: gather the full token set,
-            # compute this rank's partial for all of them, then reduce-scatter,
-            # which sums across TP and restores the sequence sharding.
-            x = sp_all_gather(x)
-        gate_up, _ = self.gate_up_proj(x)
+        if (
+            self.ag_gemm is not None
+            and x.shape[0] >= _SHARED_EXPERT_AG_GEMM_MIN_LOCAL_M
+        ):
+            gate_up = self.ag_gemm(x, self.gate_up_proj.weight)
+        else:
+            if self.shard_sequence_parallel:
+                # Each rank holds a weight shard but only its own tokens, so it
+                # cannot finish those tokens alone: gather the full token set,
+                # compute this rank's partial for all of them, then reduce-scatter,
+                # which sums across TP and restores the sequence sharding.
+                x = sp_all_gather(x)
+            gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
 
-        if self.gemm_rs_ar is not None and self.gemm_rs_ar.should_run(x):
-            return self.gemm_rs_ar(x, self.down_proj.weight)
+        # At most one fused reduction is active for a layer.
+        if self.gemm_rs is not None and self.gemm_rs.should_run(x):
+            return self.gemm_rs(x, self.down_proj.weight)
 
+        if self.gemm_ar is not None and self.gemm_ar.should_run(x):
+            return self.gemm_ar(x, self.down_proj.weight)
+
+        # Fall back to the standard projection and collective.
         x, _ = self.down_proj(x)
         if self.shard_sequence_parallel:
             x = sp_reduce_scatter(x)
@@ -549,7 +670,6 @@ class KimiMoE(nn.Module):
         prefix: str = "",
         layer_idx: int = 0,
         use_sequence_parallel: bool = False,
-        run_gemm_rs_ar: bool = False,
     ):
         super().__init__()
         hidden_size = config.hidden_size
@@ -638,7 +758,6 @@ class KimiMoE(nn.Module):
                 # FusedMoE path below hands them to the runner, which fuses
                 # their reduction and assumes the replicated layout.
                 can_shard_sequence_parallel=self.use_mega_moe,
-                run_gemm_rs_ar=run_gemm_rs_ar,
                 prefix=f"{prefix}.shared_experts",
                 activation_situ_beta=activation_situ_beta,
                 activation_situ_linear_beta=activation_situ_linear_beta,
@@ -860,9 +979,12 @@ class KimiDecoderLayer(nn.Module):
         vllm_config: VllmConfig,
         prefix: str = "",
         aux_stream: torch.cuda.Stream | None = None,
-        run_gemm_rs_ar: bool = False,
+        *,
+        use_sequence_parallel: bool,
+        run_gemm_ar: bool,
     ) -> None:
         super().__init__()
+        assert not (use_sequence_parallel and run_gemm_ar)
         self.hidden_size = config.hidden_size
         self.layer_idx = int(prefix.rsplit(".", 1)[1])
 
@@ -870,7 +992,6 @@ class KimiDecoderLayer(nn.Module):
         layer_idx = self.layer_idx
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
-        parallel_config = vllm_config.parallel_config
         self.is_moe_layer = (
             self.is_moe
             and config.num_experts is not None
@@ -878,13 +999,7 @@ class KimiDecoderLayer(nn.Module):
             and layer_idx % config.moe_layer_freq == 0
         )
 
-        use_mega_moe = vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
-        self.use_sequence_parallel = (
-            parallel_config.pipeline_parallel_size == 1
-            and parallel_config.enable_expert_parallel
-            and parallel_config.tensor_parallel_size > 1
-            and (use_mega_moe or parallel_config.data_parallel_size > 1)
-        )
+        self.use_sequence_parallel = use_sequence_parallel
         if config.is_kda_layer(layer_idx):
             kda_config = config.linear_attn_config
             assert kda_config is not None
@@ -895,7 +1010,8 @@ class KimiDecoderLayer(nn.Module):
                     config,
                     vllm_config,
                     prefix=f"{prefix}.self_attn",
-                    run_gemm_rs_ar=run_gemm_rs_ar,
+                    use_sequence_parallel=self.use_sequence_parallel,
+                    run_gemm_ar=run_gemm_ar,
                 )
                 self._self_attn_writes_output = False
             else:
@@ -932,7 +1048,8 @@ class KimiDecoderLayer(nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.self_attn",
                 aux_stream=aux_stream,
-                run_gemm_rs_ar=run_gemm_rs_ar,
+                use_sequence_parallel=self.use_sequence_parallel,
+                run_gemm_ar=run_gemm_ar,
             )
             self._self_attn_writes_output = False
 
@@ -947,7 +1064,6 @@ class KimiDecoderLayer(nn.Module):
                 prefix=f"{prefix}.block_sparse_moe",
                 layer_idx=layer_idx,
                 use_sequence_parallel=self.use_sequence_parallel,
-                run_gemm_rs_ar=run_gemm_rs_ar,
             )
             self.mlp = self.block_sparse_moe
         else:
@@ -959,7 +1075,7 @@ class KimiDecoderLayer(nn.Module):
                 prefix=f"{prefix}.mlp",
                 use_sequence_parallel=self.use_sequence_parallel,
                 can_shard_sequence_parallel=True,
-                run_gemm_rs_ar=run_gemm_rs_ar,
+                run_gemm_ar=run_gemm_ar,
                 activation_situ_beta=config.activation_situ_beta,
                 activation_situ_linear_beta=config.activation_situ_linear_beta,
             )
@@ -1090,19 +1206,21 @@ class KimiDecoderLayer(nn.Module):
         )
         assert hidden_states is not None
 
-        M = None
-        if self.use_sequence_parallel:
-            hidden_states = sp_all_gather(hidden_states)
-            # Remove SP padding before attention.
-            hidden_states = hidden_states[: positions.shape[0]]
-            M = hidden_states.shape[0]
+        full_num_tokens = positions.shape[0]
+        self_attn = getattr(self, "self_attn", None)
+
+        # KDA and MLA own their SP input gather and output reduction. Other
+        # attention implementations still rely on the decoder layer to do so.
+        attention_owns_sp_collectives = isinstance(
+            self_attn, (KimiK3DeltaAttention, MultiHeadLatentAttention)
+        )
+        if self.use_sequence_parallel and not attention_owns_sp_collectives:
+            hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
 
         # Attention.
         hidden_states = self._run_self_attn(positions, hidden_states)
 
-        # GEMM-RS returns the local sequence shard; standard O-proj preserves M.
-        if self.use_sequence_parallel and hidden_states.shape[0] == M:
-            # Add SP padding if needed, and then perform reduce scatter.
+        if self.use_sequence_parallel and not attention_owns_sp_collectives:
             hidden_states = sp_reduce_scatter(hidden_states)
 
         hidden_states, prefix_sum, residual = self._post_attn_norm(
@@ -1130,22 +1248,18 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         self.config = config
         self.attn_res_block_size: int | None = config.attn_res_block_size
         self.use_attn_res = self.attn_res_block_size is not None
-        parallel_config = vllm_config.parallel_config
-        use_mega_moe = vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
-        self.use_sequence_parallel = (
-            parallel_config.pipeline_parallel_size == 1
-            and parallel_config.enable_expert_parallel
-            and parallel_config.tensor_parallel_size > 1
-            and (use_mega_moe or parallel_config.data_parallel_size > 1)
-        )
+        self.use_sequence_parallel = kimi_sequence_parallel_enabled(vllm_config)
+
+        if self.use_sequence_parallel:
+            # Initialize both SP fused collectives independently.
+            maybe_init_ag_gemm(vllm_config)
+            maybe_init_gemm_rs(vllm_config)
+            self.run_gemm_ar = False
+        else:
+            # Replicated-token layers may fuse their output all-reduce.
+            self.run_gemm_ar = maybe_init_gemm_ar(vllm_config)
 
         self.vocab_size = config.vocab_size
-
-        # GEMM-RS/AR uses NCCL symmetric-memory multicast, which requires all
-        # TP ranks to belong to one NVLink domain.
-        self.run_gemm_rs_ar = maybe_init_gemm_rs_ar(
-            vllm_config, self.use_sequence_parallel
-        )
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1167,7 +1281,8 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                 vllm_config,
                 prefix,
                 aux_stream=aux_stream,
-                run_gemm_rs_ar=self.run_gemm_rs_ar,
+                use_sequence_parallel=self.use_sequence_parallel,
+                run_gemm_ar=self.run_gemm_ar,
             )
 
         self.start_layer, self.end_layer, self.layers = make_layers(

--- a/vllm/models/kimi_k3/nvidia/mtp.py
+++ b/vllm/models/kimi_k3/nvidia/mtp.py
@@ -42,7 +42,11 @@ from .model import (
     KimiDecoderLayer,
     KimiMoE,
     get_spec_layer_idx_from_weight_name,
+    kimi_sequence_parallel_enabled,
     make_kimi_k3_mega_moe_expert_params_mapping,
+    maybe_init_ag_gemm,
+    maybe_init_gemm_ar,
+    maybe_init_gemm_rs,
 )
 
 logger = init_logger(__name__)
@@ -74,8 +78,12 @@ class KimiK3MultiTokenPredictorLayer(nn.Module):
         config: KimiLinearConfig,
         vllm_config: VllmConfig,
         prefix: str,
+        *,
+        use_sequence_parallel: bool,
+        run_gemm_ar: bool,
     ) -> None:
         super().__init__()
+        assert not (use_sequence_parallel and run_gemm_ar)
         self.config = config
         quant_config = vllm_config.quant_config
 
@@ -102,7 +110,12 @@ class KimiK3MultiTokenPredictorLayer(nn.Module):
         # convention: the MTP block creates its own stream).
         aux_stream = torch.cuda.Stream()
         self.mtp_block = KimiDecoderLayer(
-            block_config, vllm_config, prefix=prefix, aux_stream=aux_stream
+            block_config,
+            vllm_config,
+            prefix=prefix,
+            aux_stream=aux_stream,
+            use_sequence_parallel=use_sequence_parallel,
+            run_gemm_ar=run_gemm_ar,
         )
 
     def forward(
@@ -159,11 +172,25 @@ class KimiK3MultiTokenPredictor(nn.Module):
         self.config = config
         self.mtp_start_layer_idx = config.num_hidden_layers
         self.num_mtp_layers = config.num_nextn_predict_layers
+        use_sequence_parallel = kimi_sequence_parallel_enabled(vllm_config)
+
+        if use_sequence_parallel:
+            # Initialize both SP fused collectives independently.
+            maybe_init_ag_gemm(vllm_config)
+            maybe_init_gemm_rs(vllm_config)
+            run_gemm_ar = False
+        else:
+            # Replicated-token layers may fuse their output all-reduce.
+            run_gemm_ar = maybe_init_gemm_ar(vllm_config)
 
         self.layers = torch.nn.ModuleDict(
             {
                 str(idx): KimiK3MultiTokenPredictorLayer(
-                    config, vllm_config, f"{prefix}.layers.{idx}"
+                    config,
+                    vllm_config,
+                    f"{prefix}.layers.{idx}",
+                    use_sequence_parallel=use_sequence_parallel,
+                    run_gemm_ar=run_gemm_ar,
                 )
                 for idx in range(
                     self.mtp_start_layer_idx,

--- a/vllm/models/kimi_k3/nvidia/ops/ag_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/ops/ag_gemm.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.distributed import get_tp_group
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+
+
+class AgGemm:
+    """Overlap equal-shard all-gather with a BF16 GEMM.
+
+    All ranks must provide the same contiguous ``[local_M, K]`` input shape.
+    Outputs contain ``world_size * local_M`` rows concatenated in rank order.
+    The caller owns the logical unpadded token count and must slice outputs when
+    sequence-parallel inputs contain suffix padding.
+
+    The receive workspace has no cross-rank exit barrier. Before calling again,
+    callers must complete a collective or equivalent synchronization that
+    guarantees every rank has finished consuming its received shards.
+    """
+
+    def __init__(self, max_global_tokens: int, hidden_size: int) -> None:
+        import torch.distributed._symmetric_memory as symm_mem
+
+        tp_group = get_tp_group()
+        self.rank = tp_group.rank_in_group
+        self.world_size = tp_group.world_size
+        self.max_local_tokens = (
+            max_global_tokens + self.world_size - 1
+        ) // self.world_size
+        self.max_global_tokens = self.max_local_tokens * self.world_size
+        self.hidden_size = hidden_size
+        self.receive = symm_mem.empty(
+            (self.world_size, self.max_local_tokens, hidden_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        self.receive_handle = symm_mem.rendezvous(self.receive, tp_group.device_group)
+        self.comm_stream = torch.cuda.Stream(priority=-1)
+        self.wait_stream = torch.cuda.Stream(priority=-1)
+        self.ready_events = [torch.cuda.Event() for _ in range(self.world_size - 1)]
+
+    def can_run(self, linear: LinearBase) -> bool:
+        if not isinstance(linear.quant_method, UnquantizedLinearMethod):
+            return False
+        weight = linear.weight
+        return (
+            weight.ndim == 2
+            and weight.shape[1] == self.hidden_size
+            and weight.dtype == torch.bfloat16
+            and weight.device == self.receive.device
+            and weight.is_contiguous()
+        )
+
+    def __call__(self, local_input: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        from cuda.bindings import driver
+
+        assert local_input.ndim == 2
+        assert local_input.shape[0] <= self.max_local_tokens
+        assert local_input.shape[1] == self.hidden_size
+        assert local_input.dtype == torch.bfloat16
+        assert local_input.is_contiguous()
+
+        parent_stream = torch.cuda.current_stream()
+        self.comm_stream.wait_stream(parent_stream)
+        self.wait_stream.wait_stream(parent_stream)
+        shard_bytes = local_input.nbytes
+
+        # Each source owns a max-sized slot at every destination.
+        receive_rank_stride = (
+            self.max_local_tokens * self.hidden_size * local_input.element_size()
+        )
+        next_rank = (self.rank + 1) % self.world_size
+        previous_rank = (self.rank - 1) % self.world_size
+
+        def push_to_next_rank(
+            source_buffer: torch.Tensor,
+            source_rank: int,
+            channel: int,
+        ) -> None:
+            destination_ptr = (
+                self.receive_handle.buffer_ptrs[next_rank]
+                + source_rank * receive_rank_stride
+            )
+            result = driver.cuMemcpyDtoDAsync(
+                destination_ptr,
+                source_buffer.data_ptr(),
+                shard_bytes,
+                self.comm_stream.cuda_stream,
+            )
+            if result[0] != driver.CUresult.CUDA_SUCCESS:
+                raise RuntimeError(f"cuMemcpyDtoDAsync failed: {result[0]}")
+            self.receive_handle.put_signal(next_rank, channel=channel)
+
+        # Push shards clockwise around the ring and compute each one on arrival.
+        with torch.cuda.stream(self.comm_stream):
+            push_to_next_rank(local_input, self.rank, channel=1)
+
+        output = torch.empty(
+            (self.world_size, local_input.shape[0], weight.shape[0]),
+            dtype=local_input.dtype,
+            device=local_input.device,
+        )
+
+        # Compute the local shard while peer copies are in flight.
+        torch.mm(local_input, weight.T, out=output[self.rank])
+
+        for step, ready_event in enumerate(self.ready_events, start=1):
+            source_rank = (self.rank - step) % self.world_size
+            with torch.cuda.stream(self.wait_stream):
+                self.receive_handle.wait_signal(previous_rank, channel=step)
+                ready_event.record(self.wait_stream)
+
+            with torch.cuda.stream(self.comm_stream):
+                self.comm_stream.wait_event(ready_event)
+                # Do not send the final shard back to its owner.
+                if step < self.world_size - 1:
+                    push_to_next_rank(
+                        self.receive[source_rank, : local_input.shape[0]],
+                        source_rank,
+                        channel=step + 1,
+                    )
+
+            # Keep signal waits off the GEMM stream and release it via events.
+            parent_stream.wait_event(ready_event)
+            remote_input = self.receive[source_rank, : local_input.shape[0]]
+            torch.mm(remote_input, weight.T, out=output[source_rank])
+
+        # This only protects local source buffers; workspace reuse across ranks
+        # is governed by the class contract above.
+        parent_stream.wait_stream(self.comm_stream)
+        return output.flatten(0, 1)
+
+
+_ag_gemm: AgGemm | None = None
+
+
+def init_ag_gemm(max_global_tokens: int, hidden_size: int) -> None:
+    """Collectively initialize the process-wide AG-GEMM state."""
+    global _ag_gemm
+    if _ag_gemm is not None:
+        assert _ag_gemm.max_global_tokens >= max_global_tokens
+        assert _ag_gemm.hidden_size == hidden_size
+        return
+    _ag_gemm = AgGemm(max_global_tokens, hidden_size)
+
+
+def get_ag_gemm() -> AgGemm | None:
+    return _ag_gemm

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/gemm_rs_ar.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/gemm_rs_ar.py
@@ -698,12 +698,9 @@ class GemmRsAr:
 
     All TP ranks must belong to one NVLink domain for multimem instructions.
 
-    Each instance is bound to either RS or AR. A vLLM worker has one static
-    sequence-parallel topology, so the process-wide singleton only needs one
-    mode. Two independent mode-specific singletons would lift that restriction
-    but duplicate the large symmetric workspace. A future mixed-mode design
-    should instead use lightweight RS/AR frontends over one shared multicast
-    workspace; that is outside this integration's current scope.
+    Each instance is bound to either RS or AR. Separate process-wide handles
+    expose the two modes, while the worker's static sequence-parallel topology
+    guarantees that only one is initialized and allocates a workspace.
     """
 
     def __init__(self, *, max_M: int, N: int, all_reduce: bool = False) -> None:
@@ -842,43 +839,60 @@ class GemmRsAr:
         return output
 
 
-_gemm_rs_ar: GemmRsAr | None = None
+_gemm_rs: GemmRsAr | None = None
+_gemm_ar: GemmRsAr | None = None
 
 
-def init_gemm_rs_ar(max_M: int, N: int, *, all_reduce: bool = False) -> None:
-    """Collectively initialize the process-wide, mode-bound GEMM-RS/AR state."""
-    global _gemm_rs_ar
-    if _gemm_rs_ar is not None:
-        if _gemm_rs_ar.all_reduce != all_reduce:
-            current = "AR" if _gemm_rs_ar.all_reduce else "RS"
-            requested = "AR" if all_reduce else "RS"
-            raise RuntimeError(
-                f"GEMM-RS/AR is already initialized for {current}; "
-                f"a worker cannot reinitialize it for {requested}"
-            )
-        assert _gemm_rs_ar.max_M >= max_M and _gemm_rs_ar.N == N
+def init_gemm_rs(max_M: int, N: int) -> None:
+    """Initialize the process-wide GEMM reduce-scatter state."""
+    global _gemm_rs
+    if _gemm_ar is not None:
+        raise ValueError("GEMM-AR is already initialized")
+    if _gemm_rs is not None:
+        assert _gemm_rs.max_M >= max_M and _gemm_rs.N == N
         return
-    _gemm_rs_ar = GemmRsAr(max_M=max_M, N=N, all_reduce=all_reduce)
+    _gemm_rs = GemmRsAr(max_M=max_M, N=N, all_reduce=False)
+
+
+def init_gemm_ar(max_M: int, N: int) -> None:
+    """Initialize the process-wide GEMM all-reduce state."""
+    global _gemm_ar
+    if _gemm_rs is not None:
+        raise ValueError("GEMM-RS is already initialized")
+    if _gemm_ar is not None:
+        assert _gemm_ar.max_M >= max_M and _gemm_ar.N == N
+        return
+    _gemm_ar = GemmRsAr(max_M=max_M, N=N, all_reduce=True)
 
 
 def warmup_gemm_rs_ar() -> int:
-    """Compile every reachable dispatch for the initialized GEMM-RS/AR mode."""
-    # Initialization can be disabled or fail when multicast is unavailable.
-    if _gemm_rs_ar is None:
-        return 0
+    """Compile dispatch profiles for every initialized reduction mode."""
+    # The topology normally initializes only one mode. Iterate over both slots
+    # so warmup follows the mode-specific singleton lifecycle directly.
     # Keep these profiles in sync with the dispatch in GemmRsAr.__call__.
     profiles = ((128, 1), (128, 2), (256, 2))
-    for BN, cta_group in profiles:
-        Sm100GemmRsArBF16.compile(
-            _gemm_rs_ar.rank,
-            _gemm_rs_ar.world_size,
-            BN,
-            cta_group,
-            _gemm_rs_ar.all_reduce,
-        )
-    return len(profiles)
+
+    num_compiled = 0
+    for gemm_reduction in (_gemm_rs, _gemm_ar):
+        if gemm_reduction is None:
+            continue
+
+        for BN, cta_group in profiles:
+            Sm100GemmRsArBF16.compile(
+                gemm_reduction.rank,
+                gemm_reduction.world_size,
+                BN,
+                cta_group,
+                gemm_reduction.all_reduce,
+            )
+        num_compiled += len(profiles)
+
+    return num_compiled
 
 
-def get_gemm_rs_ar() -> GemmRsAr:
-    assert _gemm_rs_ar is not None, "GEMM-RS/AR is not initialized"
-    return _gemm_rs_ar
+def get_gemm_rs() -> GemmRsAr | None:
+    return _gemm_rs
+
+
+def get_gemm_ar() -> GemmRsAr | None:
+    return _gemm_ar


### PR DESCRIPTION
## Purpose

This PR implements overlapping AG-GEMM with CUDA streams pipelining: compute local shard while sending the local activation shard to neighboring remote rank, and continue the rotation until all shards are computed. No custom kernel required, and technically we can adapt to any quantization kernels in the future.

<img width="701" height="427" alt="image" src="https://github.com/user-attachments/assets/cc59f6a7-e456-44e8-833a-11476177eb04" />

Implementation details
- Inter-GPU transfer is done in push mode using `cuMemcpyDtoDAsync` -> CopyEngine-based, no SM usage. Hence, this only requires P2P, no multicast is needed.
- Synchronization is done via PyTorch's built-in `handle.put_signal(next_rank, channel=channel)` and `handle.wait_signal(previous_rank, channel=step)`.
- We purposely **don't** have a cross-rank exit barrier, which is meant to prevent next invocation overrides recv buffers that previous GEMM might not have finished. Instead, we rely on the fact that there will be another collective between 2 consecutive AG-GEMM invocations acting as an implicit barrier.
- For data push, we don't issue all push at once in the beginning. Instead, we only push to the receiver of the current round, and wait for the expected incoming data to arrive before pushing to the next receiver. In microbenchmarks, this design seems to be a bit faster, likely because we avoid transport contention.

### vLLM integration

The AG-GEMM logic alone is very straight forward: `ag_gemm.py` only has 150 LOC. The rest of the changes target some refactoring of SP collective ownership and initialization logic.
- KDA/MLA/MLP now owns SP collectives, regardless of whether the fused AG-GEMM/GEMM-RS are activated. This is more natural as the fusion boundary is within the same module, not leaking outside to `DecoderLayer`. When fused AG-GEMM and GEMM-RS are not used (either because it's not supported or disabled), KDA/MLA/MLP modules are now responsible to invoke the unfused AG/RS collectives.
  - For Kimi-Linear, DecoderLayer still executes SP collectives
- GEMM-RS is also enabled by default now. Previously I left it off by default in #52079 because I don't know a reliable way to determine whether multicast memory is available. However, the check is actually quite simple: see if `multicast_ptr` is not None #53053 (thanks @wzhao18)
- This PR also separate GEMM-RS and GEMM-AR. Previously #53053 combines them together since they share the same kernel code. However, separating them (i.e. initialization logic, dispatch logic) improves readability and logical flow: `use_sequence_parallel` now implies AG-GEMM and GEMM-RS, while `run_gemm_ar` controls GEMM-AR only
  - In the future, we may want to integrate GEMM-AR directly into `RowParallelLinear` so all models can benefit from it, and we don't need manual dispatch for each model. 

## Microbenchmark results

Using `benchmarks/kernels/benchmark_kimi_k3_ag_gemm.py`, TP8, GB300

Projection | Global M | Local M | N | K | AG + GEMM | AG-GEMM | Speedup
-- | -- | -- | -- | -- | -- | -- | --
KDA | 2,048 | 256 | 6,288 | 7,168 | 178.30 µs | 202.21 µs | 0.882×
KDA | 3,072 | 384 | 6,288 | 7,168 | 290.51 µs | 231.57 µs | 1.255×
KDA | 3,584 | 448 | 6,288 | 7,168 | 318.24 µs | 246.77 µs | 1.290×
KDA | 4,096 | 512 | 6,288 | 7,168 | 351.97 µs | 259.68 µs | 1.355×
KDA | 8,192 | 1,024 | 6,288 | 7,168 | 592.56 µs | 469.36 µs | 1.262×
KDA | 16,384 | 2,048 | 6,288 | 7,168 | 1,154.70 µs | 866.64 µs | 1.332×
KDA | 32,768 | 4,096 | 6,288 | 7,168 | 2,261.60 µs | 1,747.81 µs | 1.294×
MLA | 2,048 | 256 | 3,648 | 7,168 | 142.30 µs | 194.10 µs | 0.733×
MLA | 3,072 | 384 | 3,648 | 7,168 | 236.96 µs | 220.64 µs | 1.074×
MLA | 3,584 | 448 | 3,648 | 7,168 | 245.15 µs | 258.02 µs | 0.950×
MLA | 4,096 | 512 | 3,648 | 7,168 | 267.52 µs | 244.05 µs | 1.096×
MLA | 8,192 | 1,024 | 3,648 | 7,168 | 476.66 µs | 401.82 µs | 1.186×
MLA | 16,384 | 2,048 | 3,648 | 7,168 | 832.72 µs | 684.16 µs | 1.217×
MLA | 32,768 | 4,096 | 3,648 | 7,168 | 1,628.88 µs | 1,055.84 µs | 1.543×

Component breakdown

Projection | Global M | Local M | N | K | GEMM only | AG only | AG-GEMM
-- | -- | -- | -- | -- | -- | -- | --
KDA | 2,048 | 256 | 6,288 | 7,168 | 111.31 µs | 76.80 µs | 202.21 µs
KDA | 3,072 | 384 | 6,288 | 7,168 | 161.15 µs | 142.32 µs | 231.57 µs
KDA | 3,584 | 448 | 6,288 | 7,168 | 185.33 µs | 145.26 µs | 246.77 µs
KDA | 4,096 | 512 | 6,288 | 7,168 | 215.02 µs | 147.26 µs | 259.68 µs
KDA | 8,192 | 1,024 | 6,288 | 7,168 | 399.31 µs | 203.81 µs | 469.36 µs
KDA | 16,384 | 2,048 | 6,288 | 7,168 | 801.20 µs | 362.53 µs | 866.64 µs
KDA | 32,768 | 4,096 | 6,288 | 7,168 | 1,576.83 µs | 695.84 µs | 1,747.81 µs
MLA | 2,048 | 256 | 3,648 | 7,168 | 76.56 µs | 76.18 µs | 194.10 µs
MLA | 3,072 | 384 | 3,648 | 7,168 | 106.78 µs | 141.90 µs | 220.64 µs
MLA | 3,584 | 448 | 3,648 | 7,168 | 112.91 µs | 144.18 µs | 258.02 µs
MLA | 4,096 | 512 | 3,648 | 7,168 | 130.48 µs | 149.70 µs | 244.05 µs
MLA | 8,192 | 1,024 | 3,648 | 7,168 | 276.61 µs | 205.82 µs | 401.82 µs
MLA | 16,384 | 2,048 | 3,648 | 7,168 | 478.93 µs | 363.95 µs | 684.16 µs
MLA | 32,768 | 4,096 | 3,648 | 7,168 | 950.88 µs | 692.45 µs | 1,055.84 µs

At very large bs, the overlap is ideal, which makes sense because our GEMM efficiency is determined by local GEMM shape (M/8). Future work can improve performance for medium M by having a single GEMM kernel that perform in-kernel waiting.

## E2E perf

```
VLLM_ALLREDUCE_USE_FLASHINFER: "1"
VLLM_USE_RUST_FRONTEND: "1"
VLLM_ENGINE_READY_TIMEOUT_S: "3600"

vllm serve {model}
--port {port}
-tp 8 -ep --moe-backend deep_gemm_mega_moe
--nnodes {nnodes}
--node-rank {node_rank}
--master-addr {master_addr}
--trust-remote-code
--load-format fastsafetensors
--no-enable-prefix-caching
--kv-cache-dtype fp8
--attention-config '{"mla_prefill_backend":"flashinfer","use_prefill_query_quantization":true}'
--reasoning-parser kimi_k3
--tool-call-parser kimi_k3
--enable-auto-tool-choice
```

```
VLLM_USE_RUST_BENCH: "1"

vllm bench serve
--backend openai-chat
--base-url http://{head_addr}:8000
--model {model}
--dataset-name speed-bench
--speed-bench-config throughput_8k
--speed-bench-max-input-len 8192
--speed-bench-output-len 1024
--ignore-eos
--num-warmups 5
--sweep-max-concurrency 1,4,16
--sweep-num-prompts-factor 10
--percentile-metrics "ttft,tpot,itl,e2el"
--metric-percentiles 50,90,99
--result-dir "{log_dir}/results"
--save-result
```

Baseline is 3bb19cd8a32f9cd25f04883028ab3dc719f3edab

### Mixed prefill-decode (aggregated serving)

8k-1k

### Prefill-only (PD serving)

8k-1

## Test Plan

TP8
- GSM8K: 0.9651
- OCRBench: 89.6

TEP8+SP (MegaMoE)
- GSM8K: 0.9651
- OCRBench: 89.5

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

