### PR TITLE
[Spec Decode] Support sample_from_anchor for DFlash draft models

### DIFF
--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -119,7 +119,16 @@ def test_selector_asks_for_fp32_proposal_logits():
 
 
 @pytest.mark.skip_global_cleanup
-def test_dflash2_model_decoder_layer_cls(monkeypatch):
+@pytest.mark.parametrize(
+    ("num_dflash_query_tokens", "expected_conv_block_size"),
+    [
+        pytest.param(5, 5, id="bonus-anchor"),
+        pytest.param(4, 4, id="sample-anchor"),
+    ],
+)
+def test_dflash2_model_decoder_layer_cls(
+    monkeypatch, num_dflash_query_tokens, expected_conv_block_size
+):
     from types import SimpleNamespace
 
     from vllm.config import set_current_vllm_config
@@ -207,6 +216,7 @@ def test_dflash2_model_decoder_layer_cls(monkeypatch):
                 quantization=None,
             ),
             num_speculative_tokens=4,
+            num_dflash_query_tokens=num_dflash_query_tokens,
             enable_adaptive_verification=False,
         ),
         model_config=SimpleNamespace(
@@ -228,3 +238,9 @@ def test_dflash2_model_decoder_layer_cls(monkeypatch):
     # 4. Assert that the layers are DFlash2Qwen3DecoderLayer (the subclass)
     assert len(model.layers) == 2
     assert isinstance(model.layers[0], DFlash2Qwen3DecoderLayer)
+
+    # 5. The convolutions span one draft block, whose width is the query layout
+    # the checkpoint asks for, not a fixed 1 + num_speculative_tokens.
+    for layer in model.layers:
+        assert layer.attention_conv.block_size == expected_conv_block_size
+        assert layer.mlp_conv.block_size == expected_conv_block_size

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1744,7 +1744,8 @@ class SpeculativeConfig:
         ==================== ============= ======== ================
         EAGLE3               eagle3        No       0
         P-EAGLE              eagle3        Yes      K - 1
-        DFlash               dflash        Yes      K
+        DFlash (bonus)       dflash        Yes      K
+        DFlash (anchor)      dflash        Yes      K - 1
         DSpark               dspark        Yes      K - 1
         MTP                  mtp           No       0
         N-gram               ngram         No       0
@@ -1755,8 +1756,8 @@ class SpeculativeConfig:
         num_draft_tokens = self.num_speculative_tokens
 
         if self.use_dflash():
-            # DFlash uses one bonus query followed by K mask queries.
-            return num_draft_tokens
+            # The scheduler already budgets one query slot per request.
+            return self.num_dflash_query_tokens - 1
 
         if self.parallel_drafting:
             if self.uses_draft_model():
@@ -1797,6 +1798,20 @@ class SpeculativeConfig:
 
     def use_dflash(self) -> bool:
         return self.method == "dflash"
+
+    def dflash_samples_from_anchor(self) -> bool:
+        if not self.use_dflash() or self.draft_model_config is None:
+            return False
+        hf_config = self.draft_model_config.hf_config
+        dflash_config = getattr(hf_config, "dflash_config", None) or {}
+        if isinstance(dflash_config, Mapping):
+            return bool(dflash_config.get("sample_from_anchor", False))
+        return bool(getattr(dflash_config, "sample_from_anchor", False))
+
+    @property
+    def num_dflash_query_tokens(self) -> int:
+        """Number of DFlash query positions that produce one draft block."""
+        return self.num_speculative_tokens + int(not self.dflash_samples_from_anchor())
 
     def use_dspark(self) -> bool:
         return self.method == "dspark"

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -604,10 +604,7 @@ class VllmConfig:
         if speculative_config is None:
             return 0
         if speculative_config.use_dflash():
-            # DFlash requires an extra lookahead slot since it uses in-fill-style
-            # decoding instead of standard next-token sampling, so it has a query
-            # for the last sampled token plus queries for each draft token.
-            return self.num_speculative_tokens + 1
+            return speculative_config.num_dflash_query_tokens
         if speculative_config.use_eagle() or speculative_config.uses_draft_model():
             # DSpark (covered by use_eagle) drafts a block of num_speculative_tokens
             # query tokens in which the anchor itself is the first prediction
@@ -2479,6 +2476,13 @@ class VllmConfig:
         if self.speculative_config:
             if self.speculative_config.method == "dspark":
                 unsupported.append("dspark speculative decoding")
+            # The V1 runner hardcodes the 1 + K DFlash query layout, so an
+            # anchor-sampling checkpoint would silently draft one token too many.
+            if (
+                self.speculative_config.use_dflash()
+                and self.speculative_config.dflash_samples_from_anchor()
+            ):
+                unsupported.append("dflash sample_from_anchor")
             if self.speculative_config.enable_adaptive_verification:
                 unsupported.append("adaptive draft verification")
 

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -127,8 +127,7 @@ class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
             hidden_size=config.hidden_size,
             taps=int(draft_config["conv_kernel_size"]),
             group_size=int(draft_config["conv_group_size"]),
-            # Query tokens per request: the bonus token plus the mask tokens.
-            block_size=1 + speculative_config.num_speculative_tokens,
+            block_size=speculative_config.num_dflash_query_tokens,
             params_dtype=vllm_config.model_config.dtype,
         )
         self.attention_conv = DFlashGroupedConv(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -44,8 +44,8 @@ class DFlashSpeculator(DraftModelSpeculator):
         # Multimodal inputs not currently supported.
         self.supports_mm_inputs = False
 
-        # Each request emits exactly (bonus + N mask) query tokens per step.
-        self.num_query_per_req = 1 + self.num_speculative_steps
+        self.num_query_per_req = self.speculative_config.num_dflash_query_tokens
+        self.sample_from_anchor = self.speculative_config.dflash_samples_from_anchor()
 
         self.parallel_drafting_token_id = get_parallel_drafting_token_id(
             self.draft_model_config.hf_config
@@ -56,20 +56,6 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.requires_non_causal = dflash_has_any_non_causal(
             self.draft_model_config.hf_config
         )
-
-        # Whether the anchor query position is itself a prediction. DFlash default uses
-        # the anchor as the bonus token (only mask tokens predict); DSpark samples from
-        # the anchor and the N-1 mask token positions. See _prepare_dflash_inputs_kernel
-        dflash_config = (
-            getattr(self.draft_model_config.hf_config, "dflash_config", None) or {}
-        )
-        if dflash_config.get("sample_from_anchor", False):
-            raise ValueError(
-                "sample_from_anchor=True is not supported for DFlash. "
-                "DFlash uses a fixed 1+N query layout where the anchor "
-                "is the bonus token."
-            )
-        self.sample_from_anchor = False
 
         # Context positions for the K/V precompute. Populated by
         # prepare_dflash_inputs, and processed by the model's
@@ -631,8 +617,9 @@ def _prepare_dflash_inputs_kernel(
     tl.store(out_query_slot_mapping_ptr + query_idx, q_slot, mask=is_query)
 
     # --- Sample indices / positions / idx_mapping ---
-    # When SAMPLE_FROM_ANCHOR (DSpark), so we sample at EVERY query position
-    # and each position k predicts the NEXT token (sampled position = query_pos + 1).
+    # When SAMPLE_FROM_ANCHOR (DSpark, or DFlash with sample_from_anchor=True),
+    # we sample at EVERY query position and each position k predicts the NEXT
+    # token (sampled position = query_pos + 1).
     # Otherwise (DFlash default) the anchor is the bonus token and only the mask tokens
     # at offsets > 0 are sampled from, each AT its own position.
     sample_off = 0 if SAMPLE_FROM_ANCHOR else 1


### PR DESCRIPTION


## Purpose

Support DFlash/DFlash2 checkpoints with `sample_from_anchor=True` on the V2 GPU model runner.

With anchor sampling, `K` draft tokens use `K` query positions instead of the default `K + 1`. This PR applies that query geometry consistently to scheduler slots, KV lookahead, DFlash2 convolution block size, and the DFlash speculator.

This complements [vllm-project/speculators#1006](https://github.com/vllm-project/speculators/pull/1006), which added DFlash2 training and checkpoint support.

## Test Plan

```bash
pytest -q tests/v1/spec_decode/test_dflash2.py
pytest -q tests/v1/spec_decode/test_dflash_prepare_inputs.py
```

Also run end-to-end generation for both layouts:

```
sample_from_anchor=False: 8 queries -> 7 draft tokens
sample_from_anchor=True:  7 queries -> 7 draft tokens
```

## Test Result

```bash
pytest -q tests/v1/spec_decode/test_dflash2.py
# 7 passed

pytest -q tests/v1/spec_decode/test_dflash_prepare_inputs.py
# 3 passed
```

End-to-end on NVIDIA H200 with a patched stock vLLM nightly (`0.26.1rc1.dev1261+gf25c580af`):

```bash
CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3.8-27B \
  --speculative-config '{
    "method": "dflash",
    "model": "DaoCloud/Qwen3.8-27B-DFlash2-Exp",
    "num_speculative_tokens": 7
  }'
```

```bash
CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3.8-27B \
  --speculative-config '{
    "method": "dflash",
    "model": "z-lab/Qwen3.8-27B-DFlash2",
    "num_speculative_tokens": 7
  }'
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
