### PR TITLE
[Bugfix] Keep scanning ports after a stale PID in find_process_using_port

### DIFF
--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -249,3 +249,27 @@ def test_split_host_port():
 def test_join_host_port():
     assert join_host_port("127.0.0.1", 5555) == "127.0.0.1:5555"
     assert join_host_port("::1", 5555) == "[::1]:5555"
+
+
+def test_find_process_using_port_skips_stale_pid(monkeypatch):
+    """A stale PID on the first matching connection must not short-circuit the
+    scan; a later connection with a live PID should still be returned."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(network_utils.sys, "platform", "linux")
+
+    port = 65500
+    stale = SimpleNamespace(laddr=SimpleNamespace(port=port), pid=999999)
+    live = SimpleNamespace(laddr=SimpleNamespace(port=port), pid=424242)
+    monkeypatch.setattr(network_utils.psutil, "net_connections", lambda: [stale, live])
+
+    def fake_process(pid):
+        if pid == 999999:
+            raise network_utils.psutil.NoSuchProcess(pid)
+        return SimpleNamespace(pid=pid)
+
+    monkeypatch.setattr(network_utils.psutil, "Process", fake_process)
+
+    proc = network_utils.find_process_using_port(port)
+    assert proc is not None
+    assert proc.pid == 424242

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -261,7 +261,7 @@ def find_process_using_port(port: int) -> psutil.Process | None:
             try:
                 return psutil.Process(conn.pid)
             except psutil.NoSuchProcess:
-                return None
+                continue
     return None
 
 


### PR DESCRIPTION
## Summary

`find_process_using_port` scans `psutil.net_connections()` for the process
holding a port. When the first connection matching the port referenced a PID
that had already exited, `psutil.Process(pid)` raised `NoSuchProcess` and the
function returned `None` immediately — reporting "no process on this port" even
if a later connection on the same port had a live PID.

This is used during API-server shutdown
(`vllm/entrypoints/launchers/launcher.py`) to log which process still holds the
port, so a stale entry early in the list hid the real owner.

## Reproduction

The buggy path triggers when the first matching connection has a dead PID.
Simulated with `psutil` mocked (also what the regression test does):

```python
# net_connections() returns [stale_pid=999999, live_pid=424242] on the port
# Before fix: NoSuchProcess on 999999 -> returns None (wrong)
# After fix:  skips 999999, returns Process(424242)
```

Before this change the call returned `None`; after it returns the live process.

## Fix

`continue` scanning on `NoSuchProcess` instead of returning early:

```python
try:
    return psutil.Process(conn.pid)
except psutil.NoSuchProcess:
    continue
```

## Test plan

- Added `test_find_process_using_port_skips_stale_pid`, which mocks `psutil` so
  the first matching connection has a dead PID and a later one is live, and
  asserts the live process is returned.

```
$ python -m pytest tests/utils_/test_network_utils.py::test_find_process_using_port_skips_stale_pid -q
1 passed in 0.22s
```

## Not a duplicate

Searched open PRs before/after opening this one — no PR touches
`find_process_using_port`:

```
$ gh pr list --repo vllm-project/vllm --state open --search "find_process_using_port"
(only this PR, #54158)
```

## Model evaluation

Not applicable — this only affects shutdown-time diagnostic logging of which
process holds a port. It does not touch model loading, inference, tokenization,
or any request/response path, so model output, accuracy, and serving behavior
are unchanged.

## Notes

AI assistance was used for this change; a human has reviewed every changed line.
