### PR TITLE
[Bugfix] Match MiniCPM-V 4.5 version token instead of a bare substring

### DIFF
--- a/tests/transformers_utils/test_chat_template_fallback.py
+++ b/tests/transformers_utils/test_chat_template_fallback.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.transformers_utils.chat_templates.registry import (
+    get_chat_template_fallback_path,
+)
+
+
+@pytest.mark.parametrize(
+    ("name_or_path", "expected"),
+    [
+        ("openbmb/MiniCPM-V-4_5", "template_minicpmv45.jinja"),
+        ("openbmb/MiniCPM-V-4.5", "template_minicpmv45.jinja"),
+        ("openbmb/MiniCPM-V-4.5-int4", "template_minicpmv45.jinja"),
+        ("openbmb/MiniCPM-V-4.0", "template_chatml.jinja"),
+        ("openbmb/MiniCPM-V-2_6", "template_chatml.jinja"),
+        # "4.5" as a substring of a longer number must not select the 4.5
+        # template.
+        ("openbmb/MiniCPM-V-14.5", "template_chatml.jinja"),
+        ("/runs/2.4.5/MiniCPM-V-4.0", "template_chatml.jinja"),
+    ],
+)
+def test_minicpmv_chat_template_fallback_version_match(name_or_path, expected):
+    path = get_chat_template_fallback_path("minicpmv", name_or_path)
+    assert path is not None
+    assert path.name == expected

--- a/vllm/transformers_utils/chat_templates/registry.py
+++ b/vllm/transformers_utils/chat_templates/registry.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import TypeAlias
@@ -12,10 +13,14 @@ CHAT_TEMPLATES_DIR = Path(__file__).parent
 
 ChatTemplatePath: TypeAlias = Path | Callable[[str], Path | None]
 
+# Match a "4.5"/"4_5" version token, not a substring of a longer number such as
+# "14.5" or "2.4.5" (which would otherwise pick the wrong template).
+_MINICPMV_45_PATTERN = re.compile(r"(?<![\d.])4[._]5(?!\d)")
+
 
 def _get_minicpmv_chat_template_fallback(tokenizer_name_or_path: str) -> Path | None:
     # MiniCPM-V-4.5 version uses a dedicated template
-    if "4.5" in tokenizer_name_or_path or "4_5" in tokenizer_name_or_path:
+    if _MINICPMV_45_PATTERN.search(tokenizer_name_or_path):
         return CHAT_TEMPLATES_DIR / "template_minicpmv45.jinja"
 
     # Other versions use chatml template


### PR DESCRIPTION
## Summary

`_get_minicpmv_chat_template_fallback` selected the dedicated MiniCPM-V 4.5
chat template whenever the string `"4.5"` (or `"4_5"`) appeared *anywhere* in
the model name or path:

```python
if "4.5" in tokenizer_name_or_path or "4_5" in tokenizer_name_or_path:
    return CHAT_TEMPLATES_DIR / "template_minicpmv45.jinja"
```

That's a substring test, not a version check, so a name/path containing a
longer number that merely includes `4.5` — e.g. `MiniCPM-V-14.5`, or a local
checkpoint dir such as `/runs/2.4.5/MiniCPM-V-4.0` — wrongly gets the 4.5
template instead of the ChatML fallback.

## Reproduction

Old substring logic vs. the new version-token match:

```
path                                   | OLD substring -> template  | NEW token -> template
openbmb/MiniCPM-V-4_5                   | minicpmv45                 | minicpmv45
openbmb/MiniCPM-V-4.5                   | minicpmv45                 | minicpmv45
openbmb/MiniCPM-V-14.5                  | minicpmv45   (wrong)       | chatml
/runs/2.4.5/MiniCPM-V-4.0              | minicpmv45   (wrong)       | chatml
```

Real 4.5 checkpoints keep the 4.5 template; only the false-positive paths change.

## Fix

Match a `4.5`/`4_5` version token with digit boundaries so it is not a
substring of a longer number:

```python
_MINICPMV_45_PATTERN = re.compile(r"(?<![\d.])4[._]5(?!\d)")
...
if _MINICPMV_45_PATTERN.search(tokenizer_name_or_path):
    return CHAT_TEMPLATES_DIR / "template_minicpmv45.jinja"
```

## Test plan

- Added `tests/transformers_utils/test_chat_template_fallback.py` covering
  `4_5`/`4.5`/`4.5-int4` (→ 4.5 template) and `4.0`/`2_6`/`14.5`/`2.4.5` paths
  (→ ChatML).

```
$ python -m pytest tests/transformers_utils/test_chat_template_fallback.py -q
7 passed in 1.32s
```

## Not a duplicate

Searched open PRs — none touch the MiniCPM-V chat-template fallback:

```
$ gh pr list --repo vllm-project/vllm --state open --search "minicpmv chat template 4.5"
$ gh pr list --repo vllm-project/vllm --state open --search "get_chat_template_fallback_path"
(only this PR, #54159)
```

## Model evaluation

No eval needed for output/accuracy: template selection is unchanged for every
currently released MiniCPM-V version (4.0, 4.5, 2.x still map to the same
template as before). The fix only corrects selection for name/paths whose
number merely *contains* `4.5` (e.g. `14.5`, `2.4.5`), which previously loaded
the wrong template.

## Notes

AI assistance was used for this change; a human has reviewed every changed line.
