### PR TITLE
[Bugfix][Spec Decode] Restore hybrid mamba align cache hits under spec decode with a KV connector (related to #53505)

### DIFF
--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -79,28 +79,29 @@ def _make_hybrid_kv_cache_manager(
 def _split(
     request: Request,
     num_new_tokens: int,
-    use_eagle: bool = True,
+    drop_last_prefix_cache_block: bool = True,
     partial_hit: bool = False,
     num_prefill_checkpoint_blocks: int = 0,
 ) -> int:
     """Call the real `Scheduler._mamba_block_aligned_split` on a stub self."""
     stub = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=MAMBA_BLOCK_SIZE),
-        use_eagle=use_eagle,
+        drop_last_prefix_cache_block=drop_last_prefix_cache_block,
         max_num_scheduled_tokens=16384,
         scheduler_config=SimpleNamespace(long_prefill_token_threshold=0),
         # `prefix_match_unit` finer than the block size (#46384).
         mamba_partial_cache_hit=partial_hit,
         hash_block_size=ATTN_BLOCK_SIZE,
         mamba_has_prefill_checkpoint_blocks=(
-            num_prefill_checkpoint_blocks > 0 and not use_eagle
+            num_prefill_checkpoint_blocks > 0
+            and not drop_last_prefix_cache_block
         ),
     )
     return Scheduler._mamba_block_aligned_split(stub, request, num_new_tokens)
 
 
 @pytest.mark.parametrize(
-    ("prompt_len", "num_new_tokens", "use_eagle", "expected"),
+    ("prompt_len", "num_new_tokens", "drop_last_prefix_cache_block", "expected"),
     [
         (2002, 2002, False, 2002),
         (3602, 2000, False, 2000),
@@ -108,24 +109,47 @@ def _split(
     ],
 )
 def test_internal_checkpoint_split(
-    prompt_len: int, num_new_tokens: int, use_eagle: bool, expected: int
+    prompt_len: int,
+    num_new_tokens: int,
+    drop_last_prefix_cache_block: bool,
+    expected: int,
 ) -> None:
     (request,) = create_requests(1, num_tokens=prompt_len, block_size=ATTN_BLOCK_SIZE)
     assert (
         _split(
             request,
             num_new_tokens,
-            use_eagle=use_eagle,
+            drop_last_prefix_cache_block=drop_last_prefix_cache_block,
             num_prefill_checkpoint_blocks=1,
         )
         == expected
     )
-    if not use_eagle:
+    if not drop_last_prefix_cache_block:
         manager = _make_hybrid_kv_cache_manager(num_prefill_checkpoint_blocks=1)
         assert manager.allocate_slots(request, expected) is not None
         mamba_manager = manager.coordinator.single_type_managers[MAMBA_GROUP_ID]
         blocks = mamba_manager.req_to_blocks[request.request_id]
         assert all(not block.is_null for block in blocks)  # checkpoint + running state
+
+
+def test_dflash_does_not_back_off_last_cache_position() -> None:
+    """DFlash/DSpark never write target blocks, so the split must not back
+    off the last prefix-cache position by a mamba block.
+
+    Regression for #53477: the old `use_eagle` back-off made prompts shorter
+    than two mamba blocks skip the final block-aligned chunk, so the mamba
+    recurrent state was never materialized at a block boundary and the next
+    turn's prefix-cache lookup recomputed the whole context.
+    """
+    (request,) = create_requests(1, num_tokens=PROMPT_LEN, block_size=ATTN_BLOCK_SIZE)
+    assert (
+        _split(request, PROMPT_LEN, drop_last_prefix_cache_block=False)
+        == MAMBA_BLOCK_SIZE
+    )
+    assert (
+        _split(request, PROMPT_LEN, drop_last_prefix_cache_block=True)
+        == PROMPT_LEN
+    )
 
 
 def _run_chunked_prefill(
@@ -248,14 +272,14 @@ def test_poisoning_is_block_size_independent(
 @pytest.mark.parametrize("partial_hit", [False, True])
 @pytest.mark.parametrize("resume_at", [331, 1599, 1601, 2531, 3011])
 @pytest.mark.parametrize(
-    ("num_prefill_checkpoint_blocks", "use_eagle"),
+    ("num_prefill_checkpoint_blocks", "drop_last_prefix_cache_block"),
     [(0, True), (1, False)],
 )
 def test_unaligned_resume_never_runs_past_its_block(
     partial_hit: bool,
     resume_at: int,
     num_prefill_checkpoint_blocks: int,
-    use_eagle: bool,
+    drop_last_prefix_cache_block: bool,
 ) -> None:
     """A prefill resuming mid-block must re-align before crossing a boundary.
 
@@ -273,7 +297,7 @@ def test_unaligned_resume_never_runs_past_its_block(
         num_new = _split(
             request,
             prompt_len - pos,
-            use_eagle=use_eagle,
+            drop_last_prefix_cache_block=drop_last_prefix_cache_block,
             partial_hit=partial_hit,
             num_prefill_checkpoint_blocks=num_prefill_checkpoint_blocks,
         )

--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -14,13 +14,17 @@ import pytest
 import torch
 
 from vllm.utils.math_utils import cdiv
+from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     MambaSpec,
+    SlidingWindowSpec,
 )
 from vllm.v1.request import Request
 
@@ -150,6 +154,49 @@ def test_dflash_does_not_back_off_last_cache_position() -> None:
         _split(request, PROMPT_LEN, drop_last_prefix_cache_block=True)
         == PROMPT_LEN
     )
+
+
+def test_sliding_window_group_tolerates_finer_alignment() -> None:
+    """A coordinator alignment finer than a sliding-window group's block size
+    must fall back to block-aligned hits instead of crashing the EngineCore.
+
+    Regression for #53505: with a hybrid mamba target configured with a
+    `prefix_match_unit` finer than the draft model's sliding-window block,
+    `alignment_tokens % block_size != 0` used to hit an assert and kill all
+    in-flight requests.
+    """
+    block_size = 560
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=4 * block_size,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = SlidingWindowManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+        needs_kv_cache_zeroing=False,
+        max_admission_blocks_per_request=10**9,
+    )
+    block_hashes = [BlockHash(str(i).encode()) for i in range(4)]
+    computed_blocks, hit_length = manager.find_longest_cache_hit(
+        block_hashes=block_hashes,
+        max_length=4 * block_size,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=spec,
+        drop_eagle_block=False,
+        alignment_tokens=16,
+    )
+    assert computed_blocks == ([],)
+    assert hit_length == 0
 
 
 def _run_chunked_prefill(

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3805,6 +3805,7 @@ def test_mamba_align_eagle_schedules_encoder_at_boundary():
     )
     scheduler.need_mamba_block_aligned_split = True
     scheduler.use_eagle = True
+    scheduler.drop_last_prefix_cache_block = True
     scheduler.num_prefill_lookahead = 1
     scheduler.max_num_encoder_input_tokens = 2048
     scheduler.encoder_cache_manager = EncoderCacheManager(cache_size=2048)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1795,6 +1795,12 @@ class SpeculativeConfig:
         # TODO(ben): Refactor this so the naming is clearer
         return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
 
+    def use_eagle_preserves_target_kv_cache(self) -> bool:
+        # Only eagle-family drafters share (and pollute via lookahead KV
+        # write) the target's full-attention KV cache groups; DFlash/DSpark
+        # draft from their own KV cache and never write target blocks.
+        return self.method in ("eagle", "eagle3", "mtp")
+
     def use_dflash(self) -> bool:
         return self.method == "dflash"
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -225,7 +225,7 @@ class SchedulerOffloadConfig(NamedTuple):
 
         use_eagle = (
             vllm_config.speculative_config is not None
-            and vllm_config.speculative_config.use_eagle()
+            and vllm_config.speculative_config.use_eagle_preserves_target_kv_cache()
         )
         if use_eagle and not eagle_groups:
             eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -254,6 +254,7 @@ class Scheduler(SchedulerInterface):
         )
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
+        self.drop_last_prefix_cache_block = False
         self.num_spec_tokens = vllm_config.num_speculative_tokens
         self.num_lookahead_tokens = vllm_config.num_lookahead_tokens
         # Positions past the computed tokens that the drafter reads mid-prefill.
@@ -272,6 +273,9 @@ class Scheduler(SchedulerInterface):
                     vllm_num_speculative_tokens=self.num_spec_tokens,
                 )
             self.use_eagle = speculative_config.use_eagle()
+            self.drop_last_prefix_cache_block = (
+                speculative_config.use_eagle_preserves_target_kv_cache()
+            )
             if self.use_eagle:
                 self.num_prefill_lookahead = (
                     self.num_spec_tokens
@@ -288,7 +292,7 @@ class Scheduler(SchedulerInterface):
             max_model_len=self.max_model_len,
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
-            use_eagle=self.use_eagle,
+            use_eagle=self.drop_last_prefix_cache_block,
             num_prefill_lookahead=self.num_prefill_lookahead,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
@@ -409,11 +413,13 @@ class Scheduler(SchedulerInterface):
             return num_new_tokens
 
         block_size = self.cache_config.block_size
-        # The last block-aligned position whose state can be cached. With
-        # Eagle, FullAttn prunes the last matching block, so back off one
-        # block to avoid a Mamba cache miss.
+        # The last block-aligned position whose state can be cached.
+        # Eagle-family drafters pollute the target's last matching
+        # full-attention block with their lookahead KV write, so back off one
+        # block to avoid a Mamba cache miss. DFlash/DSpark draft from their own
+        # KV cache and never write target blocks.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle:
+        if self.drop_last_prefix_cache_block:
             last_cache_position = max(last_cache_position - block_size, 0)
 
         end = start + num_new_tokens

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -918,10 +918,12 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size == 1, "DCP not support sliding window attn now."
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        # Fine-grained partial hits are not supported for sliding window now
-        assert alignment_tokens % kv_cache_spec.block_size == 0, (
-            "SlidingWindowManager does not support fine-grained (partial) cache hits"
-        )
+        # Fine-grained partial hits are not supported for sliding window now.
+        # Fall back to block-aligned hits instead of crashing the engine when
+        # the coordinator alignment is finer than this group's block size
+        # (e.g. a hybrid mamba target with a finer `prefix_match_unit`).
+        if alignment_tokens % kv_cache_spec.block_size != 0:
+            alignment_tokens = kv_cache_spec.block_size
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,


### PR DESCRIPTION
# PR: [Bugfix][Spec Decode] Restore hybrid mamba align cache hits under spec decode with a KV connector (related to #53505)

**Related**: #53505 (scoped as related — see Scope below)

## Summary

Fix three deterministic defects on the spec-decode + hybrid-mamba + KV-connector
path. Two of them misclassify DFlash/DSpark as eagle-family drafters and corrupt
or degrade the mamba align prefix cache; the third hard-crashes the EngineCore
when a finer `prefix_match_unit` meets a sliding-window draft group.

Local reproduction uses the native `kv_offloading_size` OffloadingConnector (no
LMCacheMP server was available): output is clean before and after, and the
change restores the expected prefix-cache hits (`[0, 560, 560]`). It does not
reproduce the reporter's retrieve-ON LMCache corruption cell, so this PR is
declared **related to** #53505 rather than a full fix of that issue.

## Stack

This PR stacks on #54163 (commit `e1b29d5`). The shared capability-bit change
(`use_eagle_preserves_target_kv_cache()` and the scheduler/KV-cache-manager
wiring) is reviewed once in #54163; once that PR merges, the diff here shrinks
to the delta below (offloading fallback + sliding-window tolerance + regression
test).

## Root Causes

### 1. DFlash/DSpark get the EAGLE last-block drop (primary corruption source)

Same root cause as #53477: `use_eagle()` returns `True` for `dflash`/`dspark`,
so `_mamba_block_aligned_split()` backs `last_cache_position` off by one mamba
block. Prompts shorter than two mamba blocks never materialize a block-aligned
recurrent state; the next lookup converges to 0 and decode resumes from a wrong
boundary. With a connector attached, its `update_state_after_alloc` /
`build_connector_meta` bookkeeping and mamba partial-tail CoW paths amplify the
bad boundary into corrupted decode (the issue reporter's U+FFFD garbage /
runaway turns).

Fix: introduce `SpeculativeConfig.use_eagle_preserves_target_kv_cache()`
(`eagle/eagle3/mtp` only) and use it in the scheduler split + the KV cache
manager's `use_eagle` argument (see #53477 PR for the full chain).

### 2. Offloading connector marks every KV group as eagle under DFlash

`SchedulerOffloadConfig.from_spec()` fell back to

```python
use_eagle = (spec_config is not None and spec_config.use_eagle())
if use_eagle and not eagle_groups:
    eagle_groups = set(range(len(kv_cache_config.kv_cache_groups)))
```

Under DFlash/DSpark this flags **all 38 groups — including the target's mamba
group — as volatile eagle groups**, so `storable_chunks()` excludes the trailing
chunk of every decode step from offloading and the store/lookup windows drift.
This matches the reporter's H12 instrumentation showing off-by-window store
ranges even with retrieval disabled.

Fix: use the precise capability bit here too, so only eagle-family drafters get
the fallback.

### 3. SlidingWindowManager assert-crashes on a finer prefix_match_unit

With a hybrid mamba target configured with `prefix_match_unit` finer than the
mamba block size, the coordinator's `alignment_tokens` becomes finer than the
draft model's sliding-window group block size, and
`SlidingWindowManager.find_longest_cache_hit()` hit:

```python
assert alignment_tokens % kv_cache_spec.block_size == 0
# 16 % 560 -> EngineDeadError, killing all in-flight requests
```

Fix: fall back to block-aligned hits for that group instead of crashing.
(Verified crash before fix, clean hit after fix.)

Reachability note: on current main the core coordinator guard (#51843) already
disables fine-grained hits when an incompatible sliding-window manager is
present, so this assert is not reachable on the native path; the fallback is
kept as defense-in-depth. The Mooncake store-side
`partial_hash_hits_enabled()` mirror does not include the same
unsupported-manager exclusion — a coordinator-level regression with real
fine-grained hashes is left for a separate follow-up.

## Scope / not covered

The reporter's corruption repro needs a running LMCacheMP server with retrieval
enabled and long (40 min) agent sessions; this PR restores cache hits under the
native OffloadingConnector path but does **not** reproduce or claim to close
the retrieve-ON LMCache corruption cell. The remaining suspect is the `assert
RequestStatus.is_finished(req.status)` in `_update_from_kv_xfer_finished`
(crashes the engine on a retrieve that finished after the request was dropped) —
kept out of this PR for a separate fix.

## Changes

- `vllm/config/speculative.py` — add `use_eagle_preserves_target_kv_cache()`.
- `vllm/v1/core/sched/scheduler.py` — precise `drop_last_prefix_cache_block`;
  pass it as `KVCacheManager(use_eagle=...)`.
- `vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py` —
  eagle-group fallback uses the precise capability bit.
- `vllm/v1/core/single_type_kv_cache_manager.py` — SWA group falls back to
  block-aligned hits when the coordinator alignment is finer than its block size.
- `tests/v1/core/test_mamba_align_chunk_split.py` — two new regression tests
  (`test_dflash_does_not_back_off_last_cache_position`,
  `test_sliding_window_group_tolerates_finer_alignment`); stub updates.
- `tests/v1/core/test_scheduler.py` — attribute update for the eagle encoder test.

## Test commands and results

Local reproduction (2×L40S, vLLM 0.26.0 layout, Qwen3.5-4B hybrid +
Qwen3.5-4B-DFlash draft, native `kv_offloading_size` connector):

| Configuration | Before fix | After fix |
|---|---|---|
| DFlash + align + offload 0/1/4 GB | clean, but boundary wrong | clean, hits restored `[0,560,560]` |
| DFlash + align + `prefix_match_unit=16` | **EngineDeadError (assert)** | hits `[0,560,560]` |
| 4 concurrent interleaved sessions + offload | clean | clean, identical output |

```bash
# CPU unit tests
python -m pytest tests/v1/core/test_mamba_align_chunk_split.py -q
python -m pytest tests/v1/core/test_scheduler.py -q -k "mamba_align"
```

## Why this is not duplicating an existing PR

No open PR targets #53505. Overlapping/related work that touches the same files
or semantics and will need reconciliation:

- #54163 — this PR's stack base (the focused #53477 fix; same capability bit).
- #53479 — the same speculative back-off plus retained-boundary handling.
- #52771 — the same native-offloading fallback in `offloading/scheduler.py`
  under a different policy.
- #54076 — the splitter's mamba-group block-size source.
- #54041 — explicit DFlash draft-group annotation (closed).

Happy to reconcile or drop parts where the maintainer PRs cover the semantics.

## AI assistance disclosure

This fix was developed with AI assistance (static analysis, reproduction scripts,
test generation). All changes were reviewed and verified by a human.
