### PR TITLE
[Kimi-K3][Bugfix] Fix low-latency GEMM fallback initialization

### DIFF
--- a/tests/kernels/test_bf16_skinny_gemm.py
+++ b/tests/kernels/test_bf16_skinny_gemm.py
@@ -1031,19 +1031,12 @@ def test_residual_dispatch_falls_back_to_addmm(
     assert output is fallback
 
 
-def test_fallback_preserves_default_method(monkeypatch: pytest.MonkeyPatch) -> None:
-    fallback = torch.empty(2, 8)
-    monkeypatch.setattr(
-        k3_gemm.UnquantizedLinearMethod,
-        "apply",
-        lambda *args: fallback,
-    )
-    # 1-D input fails the runtime check, forcing the base-method fallback.
+def test_fallback_preserves_default_method() -> None:
+    x = torch.randn(2, 4)
+    weight = torch.randn(3, 4)
+    # CPU tensors fail the runtime check, forcing the base-method fallback.
     method = k3_gemm.KimiK3LowLatencyLinearMethod({}, {})
 
-    output = method.apply(
-        SimpleNamespace(weight=torch.empty(0)),
-        torch.empty(0),
-    )
+    output = method.apply(SimpleNamespace(weight=weight), x)
 
-    assert output is fallback
+    torch.testing.assert_close(output, torch.nn.functional.linear(x, weight))

--- a/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
@@ -725,6 +725,7 @@ class _KimiK3LowLatencyApply:
     """Mixin: try the precomputed plan, else defer to the base method."""
 
     def __init__(self, plan: dict[int, ResolvedCall]) -> None:
+        super().__init__()
         self._plan = plan
 
     def apply(


### PR DESCRIPTION
## Purpose

#50572 changed `UnquantizedLinearMethod` to select and store its GEMM implementation as `_gemm_impl` during initialization. Kimi-K3’s low-latency GEMM mixin did not call the inherited initializer, so unsupported shapes crashed when falling back to the default method.

This change adds the missing cooperative `super().__init__()` call.

The existing fallback test previously mocked `UnquantizedLinearMethod.apply`, which hid this initialization bug. It now exercises the real CPU fallback and catches the regression without loading a model.

No overlapping open PR was found for this failure.

## Testing

- Focused pytest: passed
- Pre-commit hooks: passed
- Full CUDA build: passed
- Kimi-K3 TP8 startup with real weights: passed; all endpoints healthy

Model evaluation was not run because this fixes startup initialization without changing output semantics.

AI assistance was used; all changes and test results were reviewed by the human submitter.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

