### PR TITLE
[Bugfix] Bound client-supplied max_tokens on /inference/v1/generate

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
@@ -496,3 +496,72 @@ async def test_generate_with_lora_adapter(client, tokenizer, messages):
     completions_res = completions_data["choices"][0]["message"]["content"]
 
     assert generate_res == completions_res
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "max_tokens",
+    [
+        2147483647,  # INT32_MAX -- fits in int32 on its own, but the engine
+        # writes prompt_len + max_tokens, and it is the SUM that overflows
+        2147483648,  # INT32_MAX + 1
+        9223372036854775808,  # INT64_MAX + 1
+        1e18,  # float literal: pydantic coerces an integral float to int, so
+        # this reaches the same int32 write by a different parse path
+    ],
+)
+async def test_generate_rejects_unbounded_max_tokens(client, max_tokens: int):
+    """A client-supplied ``max_tokens`` must be bounded.
+
+    Unvalidated it reaches ``GpuModelRunnerStates.add_request``, which writes
+    ``prompt_len + max_tokens`` into an int32 numpy array and raises
+    OverflowError, killing EngineCore -- a single request was enough to take
+    the server down for every client.
+
+    The second assertion is the denial-of-service regression: the server must
+    still be serving afterwards.
+    """
+    payload = {
+        "model": MODEL_NAME,
+        "token_ids": [1, 2, 3],
+        "sampling_params": {"max_tokens": max_tokens, "temperature": 0.0},
+        "stream": False,
+    }
+    resp = await client.post(GEN_ENDPOINT, json=payload)
+    assert resp.status_code == 400, resp.text
+
+    followup = await client.post(
+        GEN_ENDPOINT,
+        json={
+            "model": MODEL_NAME,
+            "token_ids": [1, 2, 3],
+            "sampling_params": {"max_tokens": 5},
+            "stream": False,
+        },
+    )
+    assert followup.status_code == 200, (
+        f"engine did not survive max_tokens={max_tokens}: {followup.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_max_tokens_boundary(client):
+    """The bound is ``max_model_len - prompt_len``, inclusive.
+
+    Fixture serves with ``--max-model-len 1024``; the prompt is 3 tokens, so
+    1021 must be accepted and 1022 rejected.
+    """
+    for max_tokens, expected in ((1021, 200), (1022, 400)):
+        resp = await client.post(
+            GEN_ENDPOINT,
+            json={
+                "model": MODEL_NAME,
+                "token_ids": [1, 2, 3],
+                "sampling_params": {"max_tokens": max_tokens, "temperature": 0.0},
+                "stream": False,
+            },
+        )
+        assert resp.status_code == expected, (
+            f"max_tokens={max_tokens}: expected {expected}, "
+            f"got {resp.status_code} {resp.text}"
+        )

--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -71,3 +71,32 @@ def test_extra_args_preserves_custom_objects_and_shared_containers():
     params = SamplingParams(extra_args=extra_args)
     assert params.extra_args["first"][0] is custom
     assert params.extra_args["first"] is params.extra_args["second"]
+
+
+@pytest.mark.parametrize(
+    "max_tokens",
+    [
+        2147483648,  # INT32_MAX + 1
+        9223372036854775808,  # INT64_MAX + 1
+        int(1e18),  # what pydantic hands over for a JSON ``1e+18``
+    ],
+)
+def test_max_tokens_rejects_values_beyond_int32(max_tokens: int):
+    """The engine stores sequence lengths in int32 arrays.
+
+    An unrepresentable ``max_tokens`` must fail validation here rather than
+    raising OverflowError inside the worker, which kills EngineCore.
+    """
+    params = SamplingParams(max_tokens=max_tokens)
+    with pytest.raises(VLLMValidationError, match="max_tokens must be at most"):
+        params.verify(MockModelConfig(), None, None, None)
+
+
+def test_max_tokens_accepts_int32_max():
+    """The representability bound is inclusive of INT32_MAX.
+
+    Note this value is still rejected per-request by the endpoint, because the
+    engine writes ``prompt_len + max_tokens`` and it is the SUM that must fit.
+    That bound needs ``max_model_len``, so it lives at the endpoint, not here.
+    """
+    SamplingParams(max_tokens=2**31 - 1).verify(MockModelConfig(), None, None, None)

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -212,14 +212,33 @@ class ServingTokens(GenerateBaseServing):
         # not set it, matching the OpenAI-compat endpoints. ``SamplingParams``
         # defaults ``max_tokens`` to 16, which would otherwise silently cap
         # every generation that omits the field.
+        prompt_len = self._extract_prompt_len(engine_input)
         if not request.is_sampling_param_provided("max_tokens"):
             sampling_params.max_tokens = get_max_tokens(
                 max_model_len=self.model_config.max_model_len,
                 max_tokens=None,
-                input_length=self._extract_prompt_len(engine_input),
+                input_length=prompt_len,
                 default_sampling_params=self.default_sampling_params,
                 override_max_tokens=self.override_max_tokens,
             )
+        elif sampling_params.max_tokens is not None:
+            # A client-supplied value has to be bounded as well. The worker
+            # writes ``prompt_len + max_tokens`` into an int32 numpy array
+            # (``GpuModelRunnerStates.add_request``), so an unbounded value
+            # raises OverflowError there and kills EngineCore -- a single
+            # request is enough to terminate the server for every client.
+            # The bound is on the SUM, so max_tokens == INT32_MAX is already
+            # fatal for any non-empty prompt.
+            max_allowed = self.model_config.max_model_len - prompt_len
+            if sampling_params.max_tokens > max_allowed:
+                return self.create_error_response(
+                    f"max_tokens={sampling_params.max_tokens} cannot be greater "
+                    f"than max_model_len - prompt_len = {max_allowed} "
+                    f"(max_model_len={self.model_config.max_model_len}, "
+                    f"prompt_len={prompt_len}). "
+                    f"Please request fewer output tokens.",
+                    param="max_tokens",
+                )
 
         if self.force_no_detokenize:
             sampling_params.detokenize = False

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -212,6 +212,11 @@ def _get_llg_tokenizer(tokenizer: TokenizerLike) -> Any:
     return tokenizer.llg_tokenizer if is_mistral_tokenizer(tokenizer) else None
 
 
+# Upper bound for ``max_tokens``. The engine keeps per-request sequence lengths
+# in int32 numpy arrays, so anything beyond int32 range cannot be represented.
+_MAX_TOKENS_LIMIT = 2**31 - 1
+
+
 class SamplingParams(
     PydanticMsgspecMixin,
     msgspec.Struct,
@@ -606,6 +611,17 @@ class SamplingParams(
         if self.max_tokens is not None and self.max_tokens < 1:
             raise VLLMValidationError(
                 f"max_tokens must be at least 1, got {self.max_tokens}.",
+                parameter="max_tokens",
+                value=self.max_tokens,
+            )
+        # The engine stores per-request sequence lengths in int32 arrays, so a
+        # value that cannot be represented there must be rejected here rather
+        # than crashing a worker. This is a representability bound only; the
+        # per-request bound against max_model_len belongs at the endpoint.
+        if self.max_tokens is not None and self.max_tokens > _MAX_TOKENS_LIMIT:
+            raise VLLMValidationError(
+                f"max_tokens must be at most {_MAX_TOKENS_LIMIT}, "
+                f"got {self.max_tokens}.",
                 parameter="max_tokens",
                 value=self.max_tokens,
             )


### PR DESCRIPTION

## Purpose

A client-supplied `max_tokens` on `/inference/v1/generate` is never bounded and reaches `GpuModelRunnerStates.add_request`, which writes `prompt_len + max_tokens` into an `np.int32` array (`vllm/v1/worker/gpu/states.py`). That raises `OverflowError` in the worker, which is fatal to EngineCore: the request returns HTTP 500 and the server then shuts down, refusing everything afterwards including `GET /health`.

The handler does call `get_max_tokens`, but only inside `if not request.is_sampling_param_provided("max_tokens")` — it exists to *default* an omitted value, so a supplied one skips the clamp. Two details matter for review: the bound is on the **sum**, so `max_tokens=2147483647` (`INT32_MAX`, fine on its own) is already fatal for a non-empty prompt and a `> 2**31-1` check would not close this; and a JSON float reaches the same write via pydantic's integral-float coercion, so `1e+18` arrives as `10**18`. The endpoint is mounted whenever `"generate" in supported_tasks`, so a plain single instance exposes it. The OpenAI-compatible endpoints call `get_max_tokens` unconditionally and are unaffected.

## Fix

**1. Bound the client-supplied value at the endpoint** (`token_in_token_out/serving.py`). Adds the missing `else` branch, returning HTTP 400 through the same `create_error_response` path the handler already uses for its `sampling_params.n > max_num_seqs` check.

Rejecting rather than clamping is deliberate: silently capping would change behaviour for well-behaved clients and would not match the OpenAI endpoints, which reject.

**2. Add an int32 representability bound to `SamplingParams._verify_args`**, beside the existing `max_tokens < 1` lower bound, so consumers that never reach the endpoint check fail validation instead of crashing a worker.

Layer 2 alone does **not** fix this — `INT32_MAX` passes it and still overflows the sum — so both are needed. A bounds check at the `states.py` write alone was considered and rejected: it would stop the crash while silently accepting a nonsensical request.

## Test Plan

Added to `tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py`:

- `test_generate_rejects_unbounded_max_tokens` — parametrized over `2147483647`, `2147483648`, `9223372036854775808` and `1e18`; each must return HTTP 400, and a follow-up request must then succeed. That second assertion is the real regression guard: a 400-only check passes even if the engine dies immediately after answering.
- `test_generate_max_tokens_boundary` — `max_model_len - prompt_len` accepted, `+1` rejected.

Added to `tests/test_sampling_params.py`:

- `test_max_tokens_rejects_values_beyond_int32` — including `int(1e18)`, the value pydantic hands over for a JSON `1e+18`.
- `test_max_tokens_accepts_int32_max` — `INT32_MAX` is accepted by the representability bound; rejecting it is the endpoint's job, since it is the sum that must fit.

The pre-existing `test_generate_defaults_max_tokens_when_omitted` covers the defaulting path this patch restructures (it hoists `prompt_len` out of the `if`), and still passes.

## Test Result

Reproduced and fixed on aarch64 (GB10 and GB200), `--max-model-len 2048 --enforce-eager`. Each *before* result used a fresh server that received exactly one request in its life, since the crash kills the process; the *after* results all came from a single server that took every request below in sequence and stayed up.

Before, on released `vllm/vllm-openai:v0.28.0` (vLLM `0.28.0`):

```
POST /inference/v1/generate  {"max_tokens": 1e+18, ...}
-> HTTP 500, /health refused OverflowError: Python integer 1000000000000000003 out of bounds for int32
```

(`10**18` plus the 3-token prompt.) The integer payloads give the same crash at the same site, with the overflow value tracking the input — `2147483647 -> 2147483649`, `2147483648 -> 2147483650`.

After, on one server that received all of the following and stayed up:

| request | result |
|---|---|
| `max_tokens: 2147483647` | 400 — `cannot be greater than max_model_len - prompt_len` |
| `max_tokens: 2147483648` | 400 — `max_tokens must be at most 2147483647` |
| `max_tokens: 9223372036854775808` | 400 |
| `max_tokens: 1e+18` | 400 |
| `max_tokens: 1e+30`, `1e400`, `1.5` | 400 at request validation |
| `max_tokens: 16` | 200 |
| `max_tokens` omitted | 200 (server-side defaulting intact) |
| boundary: `max_model_len - prompt_len` / `+1` | 200 / 400 |
| `/v1/completions` with the same values | 400, unchanged |

No engine error in the log, and a follow-up inference returns 200.

Note the two layers catch different inputs: `2147483647` is rejected by the endpoint bound,
while `1e+18` is rejected earlier by the representability bound in `SamplingParams`.

## Essential Elements

- [x] Purpose
- [x] Test plan
- [x] Test results
- [ ] Documentation update — not applicable, no user-facing API change beyond rejecting
      previously-fatal input
