### PR TITLE
[Kernel][GDN] Tune packed decode launch on SM120

### DIFF
--- a/benchmarks/kernels/benchmark_qwen_gdn_packed_decode.py
+++ b/benchmarks/kernels/benchmark_qwen_gdn_packed_decode.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from dataclasses import dataclass
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.third_party.flash_linear_attention.ops.fused_recurrent import (
+    _get_packed_decode_launch_config,
+    fused_recurrent_gated_delta_rule_packed_decode,
+    fused_recurrent_gated_delta_rule_packed_decode_kernel,
+)
+from vllm.triton_utils import triton
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+@dataclass
+class Inputs:
+    mixed_qkv: torch.Tensor
+    a: torch.Tensor
+    b: torch.Tensor
+    A_log: torch.Tensor
+    dt_bias: torch.Tensor
+    state: torch.Tensor
+    out: torch.Tensor
+    state_indices: torch.Tensor
+
+
+def make_inputs(
+    batch_size: int,
+    dtype: torch.dtype,
+    state_dtype: torch.dtype,
+) -> Inputs:
+    torch.manual_seed(0)
+    h = hv = 16
+    k = v = 128
+    qkv_dim = 2 * h * k + hv * v
+    num_states = batch_size + 1
+
+    return Inputs(
+        mixed_qkv=torch.randn(batch_size, qkv_dim, device="cuda", dtype=dtype).mul_(
+            0.1
+        ),
+        a=torch.randn(batch_size, hv, device="cuda", dtype=dtype).mul_(0.1),
+        b=torch.randn(batch_size, hv, device="cuda", dtype=dtype).mul_(0.1),
+        A_log=torch.zeros(hv, device="cuda", dtype=torch.float32),
+        dt_bias=torch.zeros(hv, device="cuda", dtype=torch.float32),
+        state=torch.randn(num_states, hv, v, k, device="cuda", dtype=state_dtype).mul_(
+            0.1
+        ),
+        out=torch.empty(batch_size, 1, hv, v, device="cuda", dtype=dtype),
+        state_indices=torch.arange(1, batch_size + 1, device="cuda", dtype=torch.int32),
+    )
+
+
+def launch(inputs: Inputs, bv: int, num_warps: int, num_stages: int) -> None:
+    batch_size = inputs.mixed_qkv.shape[0]
+    h = hv = 16
+    k = v = bk = 128
+    split_batch_head_grid = batch_size * hv > 65535
+    grid = (
+        (triton.cdiv(v, bv), hv, batch_size)
+        if split_batch_head_grid
+        else (triton.cdiv(v, bv), batch_size * hv)
+    )
+
+    fused_recurrent_gated_delta_rule_packed_decode_kernel[grid](
+        mixed_qkv=inputs.mixed_qkv,
+        a=inputs.a,
+        b=inputs.b,
+        A_log=inputs.A_log,
+        dt_bias=inputs.dt_bias,
+        o=inputs.out,
+        h0=inputs.state,
+        ht=inputs.state,
+        ssm_state_indices=inputs.state_indices,
+        scale=k**-0.5,
+        stride_mixed_qkv_tok=inputs.mixed_qkv.stride(0),
+        stride_a_tok=inputs.a.stride(0),
+        stride_b_tok=inputs.b.stride(0),
+        stride_init_state_token=inputs.state.stride(0),
+        stride_final_state_token=inputs.state.stride(0),
+        stride_indices_seq=inputs.state_indices.stride(0),
+        H=h,
+        HV=hv,
+        K=k,
+        V=v,
+        BK=bk,
+        BV=bv,
+        SOFTPLUS_THRESHOLD=20.0,
+        USE_QK_L2NORM_IN_KERNEL=True,
+        SPLIT_BATCH_HEAD_GRID=split_batch_head_grid,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+def clone_inputs(inputs: Inputs) -> Inputs:
+    return Inputs(
+        mixed_qkv=inputs.mixed_qkv,
+        a=inputs.a,
+        b=inputs.b,
+        A_log=inputs.A_log,
+        dt_bias=inputs.dt_bias,
+        state=inputs.state.clone(),
+        out=torch.empty_like(inputs.out),
+        state_indices=inputs.state_indices,
+    )
+
+
+def benchmark(
+    batch_size: int,
+    dtype: torch.dtype,
+    state_dtype: torch.dtype,
+    bv: int,
+    num_warps: int,
+    num_stages: int,
+    rep_ms: int,
+) -> dict[str, float | int]:
+    source = make_inputs(batch_size, dtype, state_dtype)
+    reference = clone_inputs(source)
+    candidate = clone_inputs(source)
+
+    launch(reference, bv=32, num_warps=1, num_stages=3)
+    launch(
+        candidate,
+        bv=bv,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    torch.accelerator.synchronize()
+
+    out_diff = (candidate.out.float() - reference.out.float()).abs().max().item()
+    state_diff = (candidate.state.float() - reference.state.float()).abs().max().item()
+
+    bench_inputs = make_inputs(batch_size, dtype, state_dtype)
+
+    def run() -> None:
+        launch(
+            bench_inputs,
+            bv=bv,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+
+    latency = triton.testing.do_bench_cudagraph(
+        run,
+        rep=rep_ms,
+        quantiles=[0.5, 0.2, 0.8],
+    )
+    if isinstance(latency, float):
+        median_ms = low_ms = high_ms = latency
+    else:
+        median_ms, low_ms, high_ms = latency
+
+    return {
+        "batch_size": batch_size,
+        "bv": bv,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "median_us": median_ms * 1000,
+        "p20_us": low_ms * 1000,
+        "p80_us": high_ms * 1000,
+        "max_out_abs_diff": out_diff,
+        "max_state_abs_diff": state_diff,
+    }
+
+
+def validate_wrapper(
+    batch_size: int,
+    dtype: torch.dtype,
+    state_dtype: torch.dtype,
+) -> dict[str, float | int]:
+    source = make_inputs(batch_size, dtype, state_dtype)
+    reference = clone_inputs(source)
+    candidate = clone_inputs(source)
+
+    launch(reference, bv=32, num_warps=1, num_stages=3)
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=candidate.mixed_qkv,
+        a=candidate.a,
+        b=candidate.b,
+        A_log=candidate.A_log,
+        dt_bias=candidate.dt_bias,
+        scale=128**-0.5,
+        initial_state=candidate.state,
+        out=candidate.out,
+        ssm_state_indices=candidate.state_indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(candidate.out, reference.out, rtol=0, atol=0)
+    torch.testing.assert_close(candidate.state, reference.state, rtol=0, atol=0)
+
+    bv, num_warps, num_stages = _get_packed_decode_launch_config(
+        batch_size,
+        16,
+        16,
+        128,
+        128,
+        torch.accelerator.current_device_index(),
+    )
+    return {
+        "batch_size": batch_size,
+        "bv": bv,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "max_out_abs_diff": (candidate.out.float() - reference.out.float())
+        .abs()
+        .max()
+        .item(),
+        "max_state_abs_diff": (candidate.state.float() - reference.state.float())
+        .abs()
+        .max()
+        .item(),
+    }
+
+
+def metadata(
+    dtype: torch.dtype,
+    state_dtype: torch.dtype,
+    rep_ms: int,
+) -> dict[str, object]:
+    device_index = torch.accelerator.current_device_index()
+    return {
+        "type": "metadata",
+        "device_index": device_index,
+        "device_name": current_platform.get_device_name(device_index),
+        "device_capability": current_platform.get_device_capability(device_index),
+        "torch_version": str(torch.__version__),
+        "cuda_version": torch.version.cuda,
+        "triton_version": getattr(triton, "__version__", "unknown"),
+        "dtype": str(dtype),
+        "state_dtype": str(state_dtype),
+        "seed": 0,
+        "rep_ms": rep_ms,
+        "reference_config": {
+            "bv": 32,
+            "num_warps": 1,
+            "num_stages": 3,
+        },
+    }
+
+
+def main() -> None:
+    parser = FlexibleArgumentParser(
+        description="Benchmark Qwen3.5 GDN packed-decode launch configurations."
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        type=int,
+        nargs="+",
+        default=[1, 8, 14, 16, 19, 24, 32, 48, 64],
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["float16", "bfloat16"],
+        default="bfloat16",
+    )
+    parser.add_argument(
+        "--state-dtype",
+        choices=["float16", "bfloat16"],
+        default="float16",
+    )
+    parser.add_argument("--validate-wrapper", action="store_true")
+    parser.add_argument("--bvs", type=int, nargs="+", default=[16, 32, 64])
+    parser.add_argument(
+        "--num-warps",
+        type=int,
+        nargs="+",
+        default=[1, 2, 4],
+    )
+    parser.add_argument(
+        "--num-stages",
+        type=int,
+        nargs="+",
+        default=[1, 2, 3, 4],
+    )
+    parser.add_argument(
+        "--rep-ms",
+        type=int,
+        default=1000,
+        help="Measurement time in milliseconds for each launch configuration.",
+    )
+    args = parser.parse_args()
+    if not torch.accelerator.is_available():
+        parser.error("This benchmark requires a CUDA device.")
+    if args.rep_ms <= 0:
+        parser.error("--rep-ms must be greater than zero.")
+
+    dtype = getattr(torch, args.dtype)
+    state_dtype = getattr(torch, args.state_dtype)
+    print(
+        json.dumps(metadata(dtype, state_dtype, args.rep_ms), sort_keys=True),
+        flush=True,
+    )
+
+    if args.validate_wrapper:
+        for batch_size in args.batch_sizes:
+            print(
+                json.dumps(
+                    validate_wrapper(batch_size, dtype, state_dtype),
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+        return
+
+    configs = [
+        (bv, num_warps, num_stages)
+        for bv in args.bvs
+        for num_warps in args.num_warps
+        for num_stages in args.num_stages
+    ]
+    for batch_size in args.batch_sizes:
+        for bv, num_warps, num_stages in configs:
+            try:
+                result = benchmark(
+                    batch_size,
+                    dtype,
+                    state_dtype,
+                    bv,
+                    num_warps,
+                    num_stages,
+                    args.rep_ms,
+                )
+            except Exception as exc:
+                result = {
+                    "batch_size": batch_size,
+                    "bv": bv,
+                    "num_warps": num_warps,
+                    "num_stages": num_stages,
+                    "error": str(exc),
+                }
+            print(json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_fused_recurrent_packed_decode.py
+++ b/tests/kernels/test_fused_recurrent_packed_decode.py
@@ -9,29 +9,134 @@ from vllm.third_party.flash_linear_attention.ops import (
     fused_recurrent_gated_delta_rule,
     fused_recurrent_gated_delta_rule_packed_decode,
 )
+from vllm.third_party.flash_linear_attention.ops.fused_recurrent import (
+    _get_packed_decode_launch_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_packed_decode_launch_config_cache():
+    _get_packed_decode_launch_config.cache_clear()
+    yield
+    _get_packed_decode_launch_config.cache_clear()
+
+
+@pytest.mark.parametrize(
+    (
+        "batch_size",
+        "num_key_heads",
+        "num_value_heads",
+        "key_dim",
+        "value_dim",
+        "is_sm120",
+        "expected_bv",
+    ),
+    [
+        (1, 16, 16, 128, 128, True, 16),
+        (24, 16, 16, 128, 128, True, 16),
+        (25, 16, 16, 128, 128, True, 32),
+        (16, 8, 16, 128, 128, True, 32),
+        (16, 16, 8, 128, 128, True, 32),
+        (16, 16, 16, 64, 128, True, 32),
+        (16, 16, 16, 128, 64, True, 32),
+        (16, 16, 16, 128, 128, False, 32),
+    ],
+)
+def test_packed_decode_launch_config(
+    monkeypatch: pytest.MonkeyPatch,
+    batch_size: int,
+    num_key_heads: int,
+    num_value_heads: int,
+    key_dim: int,
+    value_dim: int,
+    is_sm120: bool,
+    expected_bv: int,
+):
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability",
+        lambda capability, device_id=0: is_sm120,
+    )
+
+    config = _get_packed_decode_launch_config(
+        batch_size,
+        num_key_heads,
+        num_value_heads,
+        key_dim,
+        value_dim,
+        device_index=0,
+    )
+
+    assert config == (expected_bv, 1, 3)
+
+
+def test_packed_decode_launch_config_cache_is_per_device(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[tuple[int, int]] = []
+
+    def is_sm120(capability: int, device_id: int = 0) -> bool:
+        calls.append((capability, device_id))
+        return device_id == 1
+
+    monkeypatch.setattr(
+        current_platform,
+        "is_device_capability",
+        is_sm120,
+    )
+    shape = (16, 16, 16, 128, 128)
+
+    assert _get_packed_decode_launch_config(*shape, 0) == (32, 1, 3)
+    assert _get_packed_decode_launch_config(*shape, 1) == (16, 1, 3)
+    assert _get_packed_decode_launch_config(*shape, 1) == (16, 1, 3)
+    assert calls == [(120, 0), (120, 1)]
+
 
 DEVICE = current_platform.device_type
 
-pytestmark = pytest.mark.skipif(
+requires_accelerator = pytest.mark.skipif(
     not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
     reason="Gated delta rule Triton kernels require a CUDA-alike or XPU device.",
 )
 
 
+@requires_accelerator
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("strided_mixed_qkv", [False, True])
+@pytest.mark.parametrize(
+    ("batch_size", "num_key_heads", "num_value_heads", "simulate_sm120"),
+    [
+        pytest.param(16, 4, 8, False, id="fallback-b16"),
+        pytest.param(32, 4, 8, False, id="fallback-b32"),
+        pytest.param(16, 16, 16, True, id="sm120-optimized"),
+    ],
+)
 def test_fused_recurrent_packed_decode_matches_reference(
-    dtype: torch.dtype, strided_mixed_qkv: bool
+    monkeypatch: pytest.MonkeyPatch,
+    dtype: torch.dtype,
+    strided_mixed_qkv: bool,
+    batch_size: int,
+    num_key_heads: int,
+    num_value_heads: int,
+    simulate_sm120: bool,
 ):
     torch.manual_seed(0)
 
-    # Small but representative GDN config (Qwen3Next defaults are K=128, V=128).
-    B = 32
-    H = 4
-    HV = 8  # grouped value attention: HV must be divisible by H
+    # Cover generic grouped-value fallback and Qwen3.5-0.8B's optimized shape.
+    B = batch_size
+    H = num_key_heads
+    HV = num_value_heads
     K = 128
     V = 128
     qkv_dim = 2 * (H * K) + (HV * V)
+
+    if simulate_sm120:
+        monkeypatch.setattr(
+            current_platform,
+            "is_device_capability",
+            lambda capability, device_id=0: capability == 120,
+        )
+        assert _get_packed_decode_launch_config(B, H, HV, K, V, 0) == (16, 1, 3)
 
     device = torch.device(DEVICE)
 
@@ -109,6 +214,7 @@ def test_fused_recurrent_packed_decode_matches_reference(
     torch.testing.assert_close(state_packed, state_ref, rtol=rtol, atol=atol)
 
 
+@requires_accelerator
 def test_packed_decode_keeps_beta_in_fp32():
     device = torch.device(DEVICE)
     dtype = torch.bfloat16
@@ -140,6 +246,7 @@ def test_packed_decode_keeps_beta_in_fp32():
     )
 
 
+@requires_accelerator
 def test_packed_decode_supports_large_batch_head_grid():
     B, H, HV, K, V = 1024, 8, 64, 1, 1
     device = torch.device(DEVICE)

--- a/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_recurrent.py
@@ -8,9 +8,13 @@
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
 # ruff: noqa: E501
 
+import functools
+
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import next_power_of_2
 
 from .op import exp, log
 
@@ -340,6 +344,30 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
 
+@functools.cache
+def _get_packed_decode_launch_config(
+    batch_size: int,
+    num_key_heads: int,
+    num_value_heads: int,
+    key_dim: int,
+    value_dim: int,
+    device_index: int,
+) -> tuple[int, int, int]:
+    tile_value_dim = min(next_power_of_2(value_dim), 32)
+    # The smaller V tile wins for Qwen3.5-0.8B's decode shape on SM120
+    # through B=24; larger profiled batches keep the existing launch.
+    if (
+        num_key_heads == 16
+        and num_value_heads == 16
+        and key_dim == 128
+        and value_dim == 128
+        and batch_size <= 24
+        and current_platform.is_device_capability(120, device_id=device_index)
+    ):
+        tile_value_dim = 16
+    return tile_value_dim, 1, 3
+
+
 def fused_recurrent_gated_delta_rule_packed_decode(
     mixed_qkv: torch.Tensor,
     a: torch.Tensor,
@@ -438,9 +466,12 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         raise ValueError(
             f"Packed decode kernel only supports NK=1 (got K={K}, BK={BK})."
         )
-    BV = min(triton.next_power_of_2(V), 32)
-    num_stages = 3
-    num_warps = 1
+    device_index = dev.index
+    if device_index is None:
+        device_index = torch.accelerator.current_device_index()
+    BV, num_warps, num_stages = _get_packed_decode_launch_config(
+        B, H, HV, K, V, device_index
+    )
 
     stride_mixed_qkv_tok = mixed_qkv.stride(0)
     stride_a_tok = a.stride(0)


### PR DESCRIPTION
## Review summary

- Applies `BV=16` only to SM120, Qwen3.5's `H=HV=16, K=V=128` packed-decode shape, and batches up to 24; every other path keeps `BV=32`.
- Rebased onto current `main` and preserves #53877's FP32 `beta` semantics and regression test.
- Post-rebase SM120 validation of all three PR-touched files: 29 tests passed, wrapper output/state were bit-exact for B1--64, and changed-file pre-commit passed.
- Current SM120 kernel measurements show 1.06x--1.20x speedup for B1--24; the advantage narrows and reverses at larger batches, so the selector remains conservatively capped at B24.

## Purpose

Tune the packed recurrent GDN decode launch on SM120 for the Qwen3.5 shape
`H=HV=16, K=V=128`. Batches up to 24 use `BV=16`; all other shapes and batch
sizes keep the existing `BV=32` launch.

This is complementary to #51954. That PR removes decode-time gate copies; this
change only selects a benchmark-backed launch configuration for the packed
recurrent kernel. Searches for the helper name, target shape, and SM120 GDN
keywords found no open PR implementing the same launch policy.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/kernels/test_fused_recurrent_packed_decode.py -q

.venv/bin/python benchmarks/kernels/benchmark_qwen_gdn_packed_decode.py \
  --validate-wrapper --batch-sizes 1 8 14 16 19 24 25 32 48 64

.venv/bin/python benchmarks/kernels/benchmark_qwen_gdn_packed_decode.py \
  --batch-sizes 1 8 14 16 19 24 25 32 48 64 \
  --bvs 16 32 --num-warps 1 --num-stages 3 --rep-ms 500

pre-commit run --files \
  vllm/third_party/flash_linear_attention/ops/fused_recurrent.py \
  tests/kernels/test_fused_recurrent_packed_decode.py \
  benchmarks/kernels/benchmark_qwen_gdn_packed_decode.py
```

## Test Result

RTX PRO 5000 72GB Blackwell (SM120); all three PR-touched files checksum-matched commit `9823c325bb`:

- 29 tests passed, including the upstream FP32-`beta` regression test.
- Packed output and recurrent state were bit-exact for batch sizes
  1, 8, 14, 16, 19, 24, 25, 32, 48, and 64.
- `BV=16` vs `BV=32` kernel-time ratios (`BV=32 / BV=16`) were 1.20x at B1,
  1.07x at B8, 1.18x at B14, 1.17x at B16, 1.10x at B19, and 1.06x at B24.
  The margin narrows to 1.02x at B32 and reverses at B48/B64, so the selector
  stays capped at B24.
- A serving A/B on the same GPU family observed 1.90% lower end-to-end
  latency with no correctness change.
- Nine CPU-capable selector tests and all changed-file pre-commit hooks passed
  after the rebase.

## AI Assistance

OpenAI Codex was used to help port the change, draft tests, build the benchmark,
and resolve the rebase conflict. The human submitter reviewed every changed
line, understands the change end-to-end, and personally ran or verified the test
results above.
