### PR TITLE
[Kernel] Make prefix-prefill tiling independent of the KV page size

### DIFF
--- a/tests/kernels/attention/test_prefix_prefill.py
+++ b/tests/kernels/attention/test_prefix_prefill.py
@@ -981,29 +981,39 @@ def test_contexted_kv_attention_alibi_f32(
     )
 
 
-@pytest.mark.parametrize("head_size", [128])
+# Hybrid mamba + full-attention models get a non-power-of-2 attention page.
+NONSTANDARD_BLOCK_SIZE_SHAPES = [
+    (64, 1, 128, 544),
+    (8, 4, 256, 1040),
+    (8, 4, 256, 1056),
+]
+
+
+@pytest.mark.parametrize(
+    "num_heads,num_queries_per_kv,head_size,block_size", NONSTANDARD_BLOCK_SIZE_SHAPES
+)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @pytest.mark.parametrize("op", OPS)
 @torch.inference_mode()
 def test_qwen3_nonstandard_block_size(
+    num_heads: int,
+    num_queries_per_kv: int,
     head_size: int,
+    block_size: int,
     dtype: torch.dtype,
     device: str,
     op: Callable,
 ) -> None:
-    """
-    A separate test function specifically added
-    for Qwen3-Next-80B (Block Size 544).
-    """
+    """Non-power-of-2 pages must match, even when a tile straddles a page."""
     if not current_platform.is_rocm():
-        pytest.skip("544 block size optimization is only for ROCm.")
+        pytest.skip("Non-power-of-2 block sizes are only exercised on ROCm CI.")
 
     test_contexted_kv_attention(
-        num_heads=64,
-        num_queries_per_kv=1,
+        num_heads=num_heads,
+        num_queries_per_kv=num_queries_per_kv,
         head_size=head_size,
-        block_size=544,
+        block_size=block_size,
         sliding_window=0,
         dtype=dtype,
         kv_cache_dtype="auto",

--- a/vllm/v1/attention/ops/prefix_prefill.py
+++ b/vllm/v1/attention/ops/prefix_prefill.py
@@ -948,20 +948,10 @@ def context_attention_fwd(
         extra_kargs = {}
 
     real_block_size = v_cache.shape[3]
-    is_pow2 = real_block_size > 0 and (real_block_size & (real_block_size - 1) == 0)
-    # For standard models involving powers of 2,
-    # follow the original logic (Llama 128/64)
-    # For non-standard models (Qwen3-next block_size 544), set to 32.
-    if is_pow2:
-        BLOCK_M = 128
-        BLOCK_N = 64
-    else:
-        BLOCK_M = 32
-        BLOCK_N = 32
-
-    # TRITON_BLOCK_SIZE is kept at 32 to ensure
-    # correct alignment logic when the kernel handles
-    # non-standard sizes (such as 544).
+    # _paged_kv_cache_offsets resolves context tokens against PHYSICAL_BLOCK_SIZE
+    # individually, so tiles need not divide the page size.
+    BLOCK_M = 128
+    BLOCK_N = 64
     TRITON_BLOCK_SIZE = 32
 
     grid_fn = lambda META: (batch, head, triton.cdiv(max_input_len, META["BLOCK_M"]))


### PR DESCRIPTION
## Purpose

Hybrid mamba + full-attention models are given an attention page sized to match
the mamba page (544, 1040, 1056, ...), a multiple of the kernel alignment rather
than a power of two. `context_attention_fwd` keyed its tile sizes off that,
collapsing `BLOCK_M`/`BLOCK_N` from 128/64 down to 32/32.

That collapse is vestigial. It landed in #31380, the same commit that introduced
`PHYSICAL_BLOCK_SIZE` so page addressing would stop riding on the tile width.
Since then `_paged_kv_cache_offsets` resolves each context token individually, so
a tile may straddle a page; and `BLOCK_M` (query rows) and `BLOCK_N`
(current-chunk KV columns) never index the paged cache at all. Neither tile can
depend on the page being a power of two.

Power-of-two pages already selected 128/64 and are byte-for-byte unaffected.

The context tile width (`TRITON_BLOCK_SIZE`) is deliberately left at 32. Sweeping
it showed the best value depends on both page size and `head_size` — 32 wins when
it divides the page (544 = 32x17, 1056 = 32x33), 64/128 win when it does not
(1040 = 16x65) — which wants an autotuner rather than a new constant.

## Test Plan

Correctness is checked against an fp32 reference built by gathering K/V out of
the paged cache, rather than against the stock kernel, so "differs from before"
is distinguishable from "wrong". The harness is validated by a negative control
that forces the pre-#31380 addressing and must be flagged.

```
pytest tests/kernels/attention/test_prefix_prefill.py
pytest tests/kernels/attention/test_prefix_prefill.py -k qwen3_nonstandard
```

`test_qwen3_nonstandard_block_size` is extended from one shape to three, adding
`head_size` 256 with pages 1040 and 1056 (Qwen3.5-MoE / Qwen3.8-Flash-Next),
where the query tile is the dominant consumer of registers.

## Test Result

MI355X (gfx950), ROCm 7.2, torch 2.12, triton 3.7.1.

Full file, run on this branch and on an unmodified `origin/main` worktree:
**8 failed, 184 passed, 224 skipped** on both, with an identical failure set. All
8 pre-existing failures are in `chunked_prefill_paged_decode` at `head_size` 128
/ `num_queries_per_kv` 1 and are untouched by this change. The extended
`qwen3_nonstandard` selection is 12 passed.

Randomized correctness: 600 ragged batches across pages 128/512/544/1040/1056/
2048, `head_size` 64/128/256, MQA and GQA, sliding window, non-causal, and the
`k=None` cache-sourced path. Max abs deviation from the fp32 reference is
identical before and after the change in every case. 200 repeats are bitwise
identical, and re-checking after compiling 27 tile configs in-process rules out a
JIT-cache effect.

Kernel time, `triton.testing.do_bench`, interleaved A/B in one process, spread
across repeats <= 1.4%:

| shape | page 544, head_size 128 | page 1040, head_size 256 |
|---|---|---|
| 8192q + 0ctx | 1.370 -> 0.644 ms (2.13x) | 1.112 -> 0.720 ms (1.54x) |
| 4096q + 4096ctx | 2.247 -> 0.876 ms (2.56x) | 1.836 -> 1.068 ms (1.72x) |
| 2048q + 6144ctx | 2.638 -> 0.959 ms (2.75x) | 2.218 -> 1.291 ms (1.72x) |
| 512q + 8192ctx | 3.202 -> 1.151 ms (2.78x) | 2.779 -> 1.642 ms (1.69x) |
| ragged batch | 6.033 -> 2.484 ms (2.43x) | 5.639 -> 3.744 ms (1.51x) |

On accuracy: the change alters bf16 accumulation order, so outputs shift within
bf16 noise. What is verified is that the deviation from an fp32 reference is
*unchanged* by this patch on every shape tested above, i.e. the new tiling is no
further from exact arithmetic than the old one. An end-to-end model eval has not
been run yet; happy to add one if reviewers want it beyond the kernel-level
evidence.

## Not a duplicate

- No open PR touches `prefix_prefill` tiling.
- #53383 also edits `prefix_prefill.py` but adds a separate route for short-query
  / long-context (spec-decode verify) and explicitly leaves `_fwd_kernel` alone.
  Textual overlap in `context_attention_fwd` is possible; the changes are
  independent.
- #38454 is test-only.
- #35923 and #38454 concern whether hybrid non-standard block sizes *run*, not
  how they are tiled.

## Notes for reviewers

- The non-power-of-two page is produced in `Platform.check_and_update_config`,
  which is platform-agnostic, so CUDA hybrid models were taking the 32/32
  collapse too and should see the same benefit. The extended test keeps the
  pre-existing ROCm-only skip; dropping it would widen coverage but I have only
  validated on gfx950.
- Separately noticed and *not* addressed here: the context loop's block-table
  load is unmasked, which is only safe while `query_len >= BLOCK_SIZE`. The
  values are always correct (the lanes are dropped by the K/V mask), but the
  address can leave the row. Both fixes I tried (masking, clamping) cost 5-12%,
  apparently by defeating scalarization of that load, so this deserves its own
  change rather than being folded into a perf PR.

AI assistance was used for this change.
