### PR TITLE
[Docs] Document DeepSeek-V4 reasoning_effort normalization

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -34,6 +34,7 @@ vLLM currently supports the following reasoning models:
     Gemma 4 reasoning is disabled by default; to enable it, pass `enable_thinking=True` in your `chat_template_kwargs` or set `reasoning_effort` (which enables it automatically).
     DeepSeek-V3.1 tool calling is supported in non-thinking mode.
     Holo2 reasoning is enabled by default. To disable it, you must also pass `thinking=False` in your `chat_template_kwargs`.
+    DeepSeek-V4 reasoning is enabled by default, with an implicit `reasoning_effort` of `high`. To disable it, pass `thinking=False` or `enable_thinking=False` in your `chat_template_kwargs`, or set `reasoning_effort="none"`. To keep thinking on without an effort prompt prefix, pass `reasoning_effort="low"` explicitly — omitting the field is not equivalent.
 
 ## Quickstart
 
@@ -319,7 +320,7 @@ for output in outputs:
 
 ## Automatic `enable_thinking` Activation
 
-Some models (such as Gemma 4, DeepSeek-V4-Pro and IBM Granite 3.2) require `enable_thinking: true` in their chat template kwargs to activate thinking mode — without it, reasoning tokens are never generated regardless of other settings.
+Some models (such as Gemma 4 and IBM Granite 3.2) require `enable_thinking: true` in their chat template kwargs to activate thinking mode — without it, reasoning tokens are never generated regardless of other settings.
 
 When you set `reasoning_effort` in a Chat Completions request (or `reasoning.effort` in a Responses API request), vLLM automatically injects `enable_thinking` into the chat template kwargs:
 
@@ -333,6 +334,25 @@ This means you no longer need to manually pass `chat_template_kwargs: {"enable_t
     If you explicitly set `enable_thinking` in `chat_template_kwargs`, your value takes priority over the automatic injection. This allows you to override the behavior if needed.
 
     For models whose templates don't declare `enable_thinking` (e.g., DeepSeek R1), the injected kwarg is harmlessly filtered out by `resolve_chat_template_kwargs`.
+
+### DeepSeek-V4 Effort Normalization
+
+DeepSeek-V4 does not follow the generic injection above. Its tokenizer wrapper normalizes `reasoning_effort` to the three levels the checkpoint's encoder defines (`low`, `high`, `max`) and selects the thinking mode itself:
+
+| Requested `reasoning_effort` | Mode | Effort applied | Prompt prefix |
+| ---------------------------- | -------- | -------------- | ------------------- |
+| not set | thinking | `high` | "Absolute maximum..." |
+| `minimal`, `low`, `medium` | thinking | `low` | none |
+| `high`, `xhigh`, unrecognized | thinking | `high` | "Absolute maximum..." |
+| `max` | thinking | `max` | "Beyond maximum..." |
+| `none` | chat | -- | none |
+
+Two consequences differ from the other reasoning models documented above:
+
+- Thinking is on by default. Omitting both `thinking` and `enable_thinking` enables it rather than disabling it.
+- Omitting `reasoning_effort` is not neutral: it applies `high`, which prepends an effort prompt prefix. A client that wants thinking without that prefix must pass `reasoning_effort="low"` explicitly.
+
+This normalization is shared by every DeepSeek-V4 checkpoint; the effort prompt texts themselves live in the checkpoint's own `encoding/encoding_dsv4.py`.
 
 ### Example
 


### PR DESCRIPTION
## Purpose

`docs/features/reasoning_outputs.md` does not describe how DeepSeek-V4 resolves `reasoning_effort`, and one existing statement about it is inverted. This PR documents the actual behavior of `vllm/tokenizers/deepseek_v4.py` and corrects the stale sentence.

Three changes, all in `docs/features/reasoning_outputs.md`:

1. **Corrects a false statement.** The "Automatic `enable_thinking` Activation" section lists DeepSeek-V4-Pro among the models that "require `enable_thinking: true` … without it, reasoning tokens are never generated regardless of other settings". The opposite has been true since #50580: when neither `thinking` nor `enable_thinking` is present, the tokenizer sets `thinking_enabled = True`.

2. **Adds DeepSeek-V4 to the defaults note**, alongside the existing Qwen3 / Granite / Gemma 4 / Holo2 entries, which is where a reader looks for a model's default thinking behavior.

3. **Adds a `DeepSeek-V4 Effort Normalization` subsection** with the mapping table. The normalization is model-specific and diverges from the generic `enable_thinking` injection documented just above it, so a reader following the generic rules currently gets the wrong answer.

The two behaviors that are most surprising, and the reason this is worth documenting rather than leaving to source reading:

- Omitting `reasoning_effort` is not neutral. With thinking on it resolves to `high`, which prepends the "Absolute maximum with no shortcuts permitted" prefix. A client that wants thinking *without* an effort directive has to pass `reasoning_effort="low"` explicitly.
- `minimal` / `low` / `medium` all collapse to `low` (no prefix), while unrecognized values go to `high`. The pre-#50580 mapping sent `minimal` / `medium` to `high`, so stale second-hand descriptions of this mapping are in circulation.

This exact gap produced #52083 ("massive spike in truncations and a drop in AL"), where the default change to `high` was only discovered by bisecting to #50580. The follow-up #52085 proposed a runtime warning and was closed as no longer needed now that DSV4-Pro-0813 shares the pattern — which settles the behavior as intended and stable, and therefore documentable.

## Why this is not duplicating an existing PR

Checked open PRs touching `docs/features/reasoning_outputs.md` and open PRs/issues matching DeepSeek-V4 + reasoning effort.

The closest is #52739 (`[Frontend] Map unsupported reasoning_effort to nearest supported level`), which also edits this file. It is a different concern and does not overlap: it adds a *serving-layer* opt-in flag (`--supported-reasoning-efforts`) that remaps values before rendering, and documents it in a new section appended near the end of the file. This PR documents the *model-side* normalization that DeepSeek-V4's tokenizer already applies unconditionally, and edits the defaults note and the auto-activation section. The two are complementary; the new subsection here is placed inside the existing "Automatic `enable_thinking` Activation" section, so the hunks do not collide.

#52085 (closed, unmerged) proposed a code-level warning for the same default. This PR takes the documentation route instead, which is what the closing rationale left open.

## Test Plan

Documentation-only change: no Python or Rust code paths are touched, so no test suite applies. Every claim in the added text was verified against source rather than against the PR descriptions that currently carry this information:

- `vllm/tokenizers/deepseek_v4.py` — the `thinking_enabled` default and the `reasoning_effort` branch chain, checked on `main` and at tag `v0.28.0`.
- `tests/tokenizers_/test_deepseek_v4.py` — `test_deepseek_v4_defaults_to_thinking_with_high_effort` and the parametrized mapping cases (`minimal`/`low`/`medium` → `low`, `high`/`xhigh`/`unexpected` → `high`, `max` → `max`, `none` → chat), which match the table added here row for row.
- `encoding/encoding_dsv4.py` in `deepseek-ai/DeepSeek-V4-Flash-0731` — `REASONING_EFFORT_PROMPTS` for the prefix texts (`low` maps to the empty string) and `DEFAULT_REASONING_EFFORT`.

## Test Result

No tests run — documentation only. Markdown rendering of the added table and section was checked locally.

## AI assistance

AI assistance was used to research the source files and issue history and to draft this change. The submitter has reviewed every changed line and verified each factual claim against the sources listed above.
