### PR TITLE
[Bugfix][Spec Decode] Avoid temporary Qwen3.5 MTP vocab allocations

### DIFF
--- a/tests/model_executor/test_qwen3_5_mtp.py
+++ b/tests/model_executor/test_qwen3_5_mtp.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock, patch
+
+import pytest
+from torch import nn
+
+
+def _make_vllm_config():
+    from vllm.config import CompilationMode
+
+    hf_config = Mock()
+    hf_config.tie_word_embeddings = False
+    hf_config.vocab_size = 128
+    hf_config.hidden_size = 64
+    hf_config.num_hidden_layers = 2
+    hf_config.mtp_num_hidden_layers = 1
+    hf_config.rms_norm_eps = 1e-6
+    hf_config.num_experts = 0
+
+    vllm_config = Mock()
+    vllm_config.model_config.hf_text_config = hf_config
+    vllm_config.cache_config.mamba_cache_mode = "align"
+    vllm_config.compilation_config.mode = CompilationMode.NONE
+    vllm_config.quant_config = None
+    return vllm_config
+
+
+@pytest.mark.parametrize(("pp_size", "should_allocate"), [(1, False), (2, True)])
+def test_qwen3_5_mtp_embedding_allocation_depends_on_pp(
+    pp_size: int, should_allocate: bool
+):
+    from vllm.model_executor.models import qwen3_5_mtp
+
+    mock_embedding = Mock(return_value=nn.Identity())
+    with patch.multiple(
+        qwen3_5_mtp,
+        VocabParallelEmbedding=mock_embedding,
+        ColumnParallelLinear=Mock(return_value=nn.Identity()),
+        Qwen3_5DecoderLayer=Mock(return_value=nn.Identity()),
+        Qwen3_5RMSNorm=Mock(return_value=nn.Identity()),
+        get_pp_group=Mock(return_value=Mock(world_size=pp_size)),
+        is_model_fused_shared_expert_compatible=Mock(return_value=False),
+        make_empty_intermediate_tensors_factory=Mock(),
+    ):
+        predictor = qwen3_5_mtp.Qwen3_5MultiTokenPredictor(
+            vllm_config=_make_vllm_config()
+        )
+
+    assert (predictor.embed_tokens is not None) is should_allocate
+    assert mock_embedding.call_count == int(should_allocate)
+
+
+def test_qwen3_5_mtp_skips_shared_vocab_modules_and_weights_for_pp1():
+    from vllm.model_executor.models import qwen3_5_mtp
+
+    mock_lm_head = Mock()
+    with patch.multiple(
+        qwen3_5_mtp,
+        Qwen3_5MultiTokenPredictor=Mock(return_value=nn.Module()),
+        ParallelLMHead=mock_lm_head,
+        LogitsProcessor=Mock(),
+        get_pp_group=Mock(return_value=Mock(world_size=1, is_last_rank=True)),
+    ):
+        model = qwen3_5_mtp.Qwen3_5MTP(vllm_config=_make_vllm_config())
+
+    assert model.lm_head is None
+    mock_lm_head.assert_not_called()
+
+    loader = Mock()
+    loader.load_weights.side_effect = lambda weights: {name for name, _ in weights}
+    weights = [
+        ("language_model.model.embed_tokens.weight", Mock()),
+        ("lm_head.weight", Mock()),
+        ("mtp.fc.weight", Mock()),
+    ]
+    with patch(
+        "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader",
+        return_value=loader,
+    ):
+        assert model.load_weights(weights) == {"model.fc.weight"}

--- a/tests/model_executor/test_qwen3_5_quantization.py
+++ b/tests/model_executor/test_qwen3_5_quantization.py
@@ -61,6 +61,7 @@ def test_qwen3_5_mtp_lm_head_receives_quant_config():
 
     mock_pp_group = Mock()
     mock_pp_group.is_last_rank = True
+    mock_pp_group.world_size = 2
 
     with (
         patch("vllm.model_executor.models.qwen3_5_mtp.Qwen3_5MultiTokenPredictor"),

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -81,10 +81,16 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         self.mtp_start_layer_idx = config.num_hidden_layers
         self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
 
-        self.embed_tokens = VocabParallelEmbedding(
-            self.vocab_size,
-            config.hidden_size,
-        )
+        # With no pipeline parallelism, this is attached from the target model
+        # after loading. Avoid materializing a temporary full-vocabulary copy.
+        self.embed_tokens: VocabParallelEmbedding | None
+        if get_pp_group().world_size == 1:
+            self.embed_tokens = None
+        else:
+            self.embed_tokens = VocabParallelEmbedding(
+                self.vocab_size,
+                config.hidden_size,
+            )
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
         # missing from hf_quant_config.json exclude_modules. Force unquantized.
@@ -141,6 +147,9 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        assert self.embed_tokens is not None, (
+            "embed_tokens must be shared from the target model before inference"
+        )
         return self.embed_tokens(input_ids)
 
     def forward(
@@ -240,7 +249,11 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
         )
 
-        if get_pp_group().is_last_rank:
+        self._share_target_vocab_weights = get_pp_group().world_size == 1
+        self.lm_head: ParallelLMHead | PPMissingLayer | None
+        if self._share_target_vocab_weights:
+            self.lm_head = None
+        elif get_pp_group().is_last_rank:
             self.lm_head = ParallelLMHead(
                 config.vocab_size,
                 config.hidden_size,
@@ -248,6 +261,7 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
                 prefix=maybe_prefix(prefix, "lm_head"),
             )
             if config.tie_word_embeddings:
+                assert self.model.embed_tokens is not None
                 self.lm_head = self.lm_head.tie_weights(self.model.embed_tokens)
         else:
             self.lm_head = PPMissingLayer()
@@ -299,14 +313,23 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
     ) -> torch.Tensor | None:
+        assert self.lm_head is not None, (
+            "lm_head must be shared from the target model before inference"
+        )
         return self.logits_processor(self.lm_head, hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        shared_weight_names = ("embed_tokens", "lm_head")
+
         def remap_weight_names(weights):
             for name, weight in weights:
+                if self._share_target_vocab_weights and any(
+                    key in name for key in shared_weight_names
+                ):
+                    continue
                 if name.startswith("mtp."):
                     name = name.replace("mtp.", "model.")
-                elif any(key in name for key in ["embed_tokens", "lm_head"]):
+                elif any(key in name for key in shared_weight_names):
                     if "embed_tokens" in name:
                         name = name.replace("language_model.", "")
                 else:


### PR DESCRIPTION
## Purpose

Fixes #53887.

With pipeline parallelism disabled (PP=1), the generic MTP proposer shares the target model's token embedding and LM head with the draft model after the draft model has loaded. `Qwen3_5MTP` still constructs both full-vocabulary modules up front, and its weight loader maps the target checkpoint's embedding and LM-head tensors into them before the proposer replaces them with the target modules.

For `RedHatAI/Qwen3.8-27B-INT4`, each unquantized BF16 vocabulary table is `248320 x 5120 x 2 bytes = 2425 MiB`. These two temporary modules therefore add 4850 MiB to the loading peak and can cause an OOM before the existing sharing step is reached.

This PR leaves `embed_tokens` and `lm_head` unallocated for PP=1 and filters their tensors out of the draft-model weight loader. The existing proposer then attaches the target modules before inference. PP>1 retains its existing allocation and loading paths unchanged.

## Relationship to existing PRs

#47953, and the alternative #47833, address a different point in the lifecycle: the generic proposer's post-load decision to share MTP embeddings. They do not prevent Qwen3.5 MTP from allocating and loading its temporary embedding and LM head before that decision is reached.

I also checked the #53887 discussion and searched open vLLM PRs on 2026-08-28; no open PR addresses these pre-sharing allocations.

## Test Plan

```bash
python -m pytest \
  tests/model_executor/test_qwen3_5_mtp.py \
  tests/model_executor/test_qwen3_5_quantization.py -q

python -m pytest \
  tests/v1/spec_decode/test_mtp.py::test_mtp_load_model_unified -q

pre-commit run --files \
  vllm/model_executor/models/qwen3_5_mtp.py \
  tests/model_executor/test_qwen3_5_mtp.py \
  tests/model_executor/test_qwen3_5_quantization.py
```

End-to-end validation used `RedHatAI/Qwen3.8-27B-INT4@2fb0debc365fb6c1683d7d3ad7722470919627a8` with PP=1 on an NVIDIA B300. GPU memory was sampled with `nvidia-smi` every 100 ms during model loading. Both the legacy and V2 model runners were exercised.

## Test Result

- Model-specific unit tests: 5 passed.
- Existing MTP post-load sharing test: 1 passed on a GPU node.
- All applicable pre-commit hooks passed, including Ruff and mypy.

| Configuration | Loading-window peak | Reported model memory |
| --- | ---: | ---: |
| Upstream, legacy model runner | 25826 MiB | 18.50 GiB |
| Patched, legacy model runner | 20974 MiB | 18.50 GiB |
| Patched, V2 model runner | 20934 MiB | 18.52 GiB |

The upstream and patched legacy-runner measurements used the same vLLM base revision. The patch reduced the loading peak by 4852 MiB, matching the theoretical 4850 MiB for the two omitted BF16 tables within sampling and allocator granularity. The unchanged reported model memory shows that only the temporary copies were removed; the MTP layer itself remains resident.

For four temperature-zero prompts, the patched legacy and V2 runners produced the same text and token usage as upstream. All three MTP runs created 137 draft tokens and accepted 116 (84.7%).


## AI assistance disclosure

OpenAI Codex assisted with investigation, testing, model evaluation. The submitter reviewed every changed line and the reported results before submission.
