### PR TITLE
[MoE] Re-enable TRITON_UNFUSED in the gpt-oss MXFP4 dispatch list

### DIFF
--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -1866,6 +1866,36 @@ def test_select_mxfp4_moe_backend_raises_with_unsupported_reasons(
         mxfp4_oracle.select_mxfp4_moe_backend(moe_config)
 
 
+def test_triton_unfused_is_offered_only_for_bf16_activation():
+    """TRITON_UNFUSED runs W4A16 whatever activation the checkpoint asks for,
+    so the auto priority list may only offer it when no activation key is
+    requested.
+
+    #45896 added it as an unconditional ROCm fallback placed after the
+    activation filter, which silently ran W4A16 for `amd/MiniMax-M3-MXFP4`;
+    #46491 reverted that. Reaching it through the priority list keeps the
+    filter in the path, and this pins that difference.
+    """
+    from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
+        Mxfp4MoeBackend,
+        _filter_by_activation,
+        _get_priority_backends_for_gpt_oss,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kFp8StaticTensorSym,
+        kMxfp4Dynamic,
+        kMxfp8Dynamic,
+    )
+
+    backends = _get_priority_backends_for_gpt_oss()
+    assert Mxfp4MoeBackend.TRITON_UNFUSED in backends
+    assert Mxfp4MoeBackend.TRITON_UNFUSED in _filter_by_activation(backends, None)
+    for activation_key in (kFp8StaticTensorSym, kMxfp8Dynamic, kMxfp4Dynamic):
+        assert Mxfp4MoeBackend.TRITON_UNFUSED not in _filter_by_activation(
+            backends, activation_key
+        )
+
+
 # Every activation-quantizing OCP MX scheme must map to a `quant_dtype` that
 # `moe_kernel_quantize_input` actually dispatches on. Its final `else` returns
 # the activation untouched, so a name it does not know (e.g. "mxfp6" instead of

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -330,9 +330,7 @@ def _get_priority_backends_for_gpt_oss() -> list[Mxfp4MoeBackend]:
         Mxfp4MoeBackend.TRITON,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-        # TRITON_UNFUSED has bug with MTP support
-        # TODO re-enable after kernel is fixed
-        # TRITON_UNFUSED
+        Mxfp4MoeBackend.TRITON_UNFUSED,
         Mxfp4MoeBackend.MARLIN,
         Mxfp4MoeBackend.BATCHED_MARLIN,
         Mxfp4MoeBackend.XPU,


### PR DESCRIPTION
## Purpose

Closes #49446.

`TRITON_UNFUSED` was taken out of `_get_priority_backends_for_gpt_oss()` in #40860 with a note about an MTP bug. MTP only exists in DeepSeek-V4, which selects through `select_deepseek_v4_mxfp4_moe_backend()`, and that function already auto-selects `TRITON_UNFUSED` on ROCm today. The gate sits on the list where MTP cannot occur and is absent on the one where it can. This restores it in the gpt-oss list only; the DeepSeek-V4 list keeps its gate, since I have no MXFP4 DeepSeek-V4 checkpoint to test MTP against.

The issue also asks for a warning that the backend ignores activation quantization. No warning can fire: `_filter_by_activation` drops it whenever an activation key is requested, and `BaseOAITritonExperts._supports_quant_scheme` accepts only `(kMxfp4Static, None)`. That is the difference from the fallback #46491 reverted, which sat after the filter. I pinned it with a test instead.

Only GELU and SWIGLUSTEP change backend, both off `MARLIN`, because `OAITritonExperts` accepts SWIGLUOAI alone while `UnfusedOAITritonExperts` covers the wider set. SWIGLUOAI stays on `TRITON`, SILU and SWIGLUOAI_UNINTERLEAVE stay on FlashInfer CUTLASS. With fp8-static, mxfp8-dynamic or mxfp4-dynamic requested, selection raises `NotImplementedError` before and after, never `TRITON_UNFUSED`.

## Test plan

1x H100 80GB, `openai/gpt-oss-20b`, nightly `a9a17e709` with the patch overlaid.

```
pytest tests/kernels/moe/test_modular_oai_triton_moe.py
pytest tests/kernels/moe/test_ocp_mx_moe.py
```

## Test result

`test_modular_oai_triton_moe.py` 21 passed, including all 10 `unfused=True` cases and the DeepSeek-V4-Flash topology test. `test_ocp_mx_moe.py` 15 passed, 135 skipped (CUDA host, most cases are ROCm). The new test fails against unpatched main, and fails again if `_filter_by_activation` is stubbed out, so both halves are load-bearing.

gsm8k, full 1319 items, chat template, greedy: TRITON auto stock 93.78%, TRITON auto patched 94.84%, TRITON_UNFUSED forced 94.54%. Repeat runs of one config move about a point, so the kernels are equivalent here.

gsm8k 500 items under ngram speculative decoding, which is the multi-token-per-step decode shape MTP produces: TRITON 94.80%, TRITON_UNFUSED 95.20%, no errors on either.

I could not run TP=2 EP, NCCL fails to init on my cluster for unrelated reasons.

#41764 refactors this same function and carries the comment forward, so whichever lands first the other needs a trivial rebase. Neither it nor #52240 re-enables the backend, so this is not a duplicate.

AI assistance was used for this change. I reviewed every changed line and ran the tests and evals above myself.
