### PR TITLE
fix: require a real exit code before treating engine liveness monitors as dead

### DIFF
--- a/tests/v1/engine/test_startup_watch_processes.py
+++ b/tests/v1/engine/test_startup_watch_processes.py
@@ -251,6 +251,53 @@ def test_monitor_engine_liveness_ignores_spurious_sentinel_readiness(
     assert shutdown_calls == [1]
 
 
+def test_monitor_engine_liveness_polls_a_persistently_invalid_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A sentinel that never resolves to a real exit code -- a persistently
+    stale or invalid descriptor rather than a briefly spurious one -- must
+    stop being handed to connection.wait once recognized. Left in the wait
+    set, it would report ready on every single call and spin this loop at
+    full speed instead of blocking. A second, healthy process's real exit
+    must still be caught promptly while the first sits in fallback
+    polling."""
+    stuck = SimpleNamespace(sentinel=1, exitcode=None, name="stuck")
+    healthy = SimpleNamespace(sentinel=2, exitcode=None, name="healthy")
+
+    manager = object.__new__(CoreEngineProcManager)
+    manager.processes = [stuck, healthy]
+    manager.manager_stopped = Event()
+    manager.failed_proc_name = None
+
+    shutdown_calls = []
+    monkeypatch.setattr(manager, "shutdown", lambda: shutdown_calls.append(1))
+
+    wait_calls = []
+
+    def fake_wait(object_list, timeout=None):
+        wait_calls.append((set(object_list), timeout))
+        if len(wait_calls) == 1:
+            return [1]  # only the stuck sentinel is ready at first
+        healthy.exitcode = 1  # the healthy process actually exits now
+        return [2]
+
+    monkeypatch.setattr(engine_utils.connection, "wait", fake_wait)
+    monkeypatch.setattr(engine_utils.time, "sleep", lambda _: None)
+
+    manager.monitor_engine_liveness()
+
+    # The stuck sentinel was handed to connection.wait exactly once, then
+    # never again -- moved to bounded polling instead of staying in the
+    # wait set and reporting ready every call.
+    assert wait_calls[0] == ({1, 2}, 1)
+    assert all(1 not in sentinels for sentinels, _ in wait_calls[1:])
+    # Once something needed polling, the remaining wait used the shorter
+    # cadence instead of blocking for a full second.
+    assert all(timeout == 0.1 for _, timeout in wait_calls[1:])
+    assert manager.failed_proc_name == "healthy"
+    assert shutdown_calls == [1]
+
+
 def test_wait_for_engine_startup_reports_watched_process_exit():
     ctx = zmq.Context()
     handshake_socket = ctx.socket(zmq.ROUTER)

--- a/tests/v1/engine/test_startup_watch_processes.py
+++ b/tests/v1/engine/test_startup_watch_processes.py
@@ -157,6 +157,100 @@ class _FinishedProcess:
         return 1
 
 
+class _SpuriousThenDeadProcess:
+    """A process whose sentinel is already poll-ready (its pipe's write end
+    is closed), but whose exitcode only becomes real after `spurious_reads`
+    readiness events -- simulating a stale/invalid descriptor that reports
+    readiness before the process has actually exited."""
+
+    name = "RustFrontend"
+
+    def __init__(self, sentinel, spurious_reads: int):
+        self.sentinel = sentinel
+        self.remaining_spurious = spurious_reads
+
+    @property
+    def exitcode(self):
+        if self.remaining_spurious > 0:
+            self.remaining_spurious -= 1
+            return None
+        return 1
+
+
+def test_wait_for_engine_startup_ignores_spurious_sentinel_readiness():
+    ctx = zmq.Context()
+    handshake_socket = ctx.socket(zmq.ROUTER)
+    recv, send = connection.Pipe(duplex=False)
+    send.close()
+
+    parallel_config = SimpleNamespace(
+        data_parallel_size_local=1,
+        data_parallel_hybrid_lb=False,
+        data_parallel_external_lb=False,
+    )
+
+    proc = _SpuriousThenDeadProcess(recv, spurious_reads=2)
+
+    try:
+        launch = CoreEngineLaunch(
+            engine_manager=None,
+            coordinator=None,
+            addresses=EngineZmqAddresses(inputs=[], outputs=[]),
+            tensor_queue=None,
+        )
+        launch.watched_frontend_processes = [proc]
+        with pytest.raises(RuntimeError) as exc_info:
+            wait_for_engine_startup(
+                handshake_socket,
+                [CoreEngine()],
+                parallel_config,  # type: ignore[arg-type]
+                coordinated_dp=False,
+                cache_config=None,  # type: ignore[arg-type]
+                launch=launch,
+            )
+    finally:
+        recv.close()
+        handshake_socket.close(linger=0)
+        ctx.term()
+
+    # The first two readiness events were spurious (exitcode still None)
+    # and must not raise; only the third, real exit is reported.
+    assert proc.remaining_spurious == 0
+    assert "Frontend process failed during engine core initialization" in str(
+        exc_info.value
+    )
+    assert "Failed frontend proc(s): {'RustFrontend': 1}" in str(exc_info.value)
+
+
+def test_monitor_engine_liveness_ignores_spurious_sentinel_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    recv, send = connection.Pipe(duplex=False)
+    send.close()
+    proc = _SpuriousThenDeadProcess(recv, spurious_reads=2)
+    proc.name = "EngineCore"
+
+    manager = object.__new__(CoreEngineProcManager)
+    manager.processes = [proc]
+    manager.manager_stopped = Event()
+    manager.failed_proc_name = None
+
+    shutdown_calls = []
+    monkeypatch.setattr(manager, "shutdown", lambda: shutdown_calls.append(1))
+
+    try:
+        manager.monitor_engine_liveness()
+    finally:
+        recv.close()
+
+    # A sentinel that reports readiness twice with exitcode still None must
+    # not be mistaken for a dead process; only the real, non-zero exit on
+    # the third readiness event should be recorded and trigger shutdown.
+    assert proc.remaining_spurious == 0
+    assert manager.failed_proc_name == "EngineCore"
+    assert shutdown_calls == [1]
+
+
 def test_wait_for_engine_startup_reports_watched_process_exit():
     ctx = zmq.Context()
     handshake_socket = ctx.socket(zmq.ROUTER)

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -259,27 +259,53 @@ class CoreEngineProcManager:
 
         sentinel_to_proc = {proc.sentinel: proc for proc in self.processes}
         sentinels = set(sentinel_to_proc.keys())
+        # A sentinel this loop gave up waiting on directly, because it kept
+        # reporting ready without an exit code to show for it. Checked by
+        # polling its exitcode instead, on the cadence below, rather than
+        # left in `sentinels` where it would do the same thing again.
+        polled: list[BaseProcess] = []
 
-        while sentinels and not self.manager_stopped.is_set():
-            ready_sentinels = connection.wait(sentinels, timeout=1)
+        while (sentinels or polled) and not self.manager_stopped.is_set():
+            if sentinels:
+                # Once something needs polling, wake up often enough to
+                # poll it promptly; a healthy sentinel still wakes this
+                # up immediately on its own.
+                ready_sentinels = connection.wait(
+                    sentinels, timeout=0.1 if polled else 1
+                )
+            else:
+                time.sleep(0.1)
+                ready_sentinels = []
 
             died = False
             for sentinel in ready_sentinels:
-                proc = sentinel_to_proc[cast(int, sentinel)]
-                exitcode = proc.exitcode
-                if exitcode is None:
+                proc = sentinel_to_proc.pop(cast(int, sentinel))
+                sentinels.discard(sentinel)
+                if proc.exitcode is None:
                     # Sentinel readiness alone is not proof of death: on
                     # Linux, PollSelector maps POLLNVAL/POLLERR/POLLHUP to
                     # read readiness, so a stale or invalid descriptor can
                     # report "ready" while its process is still alive with
-                    # no exitcode populated. Keep watching it -- a real
-                    # future exit is still caught below -- and back off
-                    # briefly so a persistently-invalid descriptor cannot
-                    # spin this loop at full speed.
-                    time.sleep(0.1)
+                    # no exitcode populated -- and it stays ready this way
+                    # indefinitely, so re-selecting on it would spin this
+                    # loop at full speed instead of blocking. Move it to
+                    # bounded polling instead, the same way
+                    # MultiprocExecutor.start_worker_monitor does for the
+                    # same failure mode.
+                    polled.append(proc)
                     continue
                 died = True
-                if exitcode != 0 and not self.manager_stopped.is_set():
+                if proc.exitcode != 0 and not self.manager_stopped.is_set():
+                    self.failed_proc_name = proc.name
+            if died:
+                break
+
+            for proc in list(polled):
+                if proc.exitcode is None:
+                    continue
+                polled.remove(proc)
+                died = True
+                if proc.exitcode != 0 and not self.manager_stopped.is_set():
                     self.failed_proc_name = proc.name
             if died:
                 break

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -4,6 +4,7 @@
 import contextlib
 import os
 import threading
+import time
 import weakref
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
@@ -260,14 +261,27 @@ class CoreEngineProcManager:
         sentinels = set(sentinel_to_proc.keys())
 
         while sentinels and not self.manager_stopped.is_set():
-            died_sentinels = connection.wait(sentinels, timeout=1)
+            ready_sentinels = connection.wait(sentinels, timeout=1)
 
-            for sentinel in died_sentinels:
-                proc = sentinel_to_proc.pop(cast(int, sentinel))
+            died = False
+            for sentinel in ready_sentinels:
+                proc = sentinel_to_proc[cast(int, sentinel)]
                 exitcode = proc.exitcode
+                if exitcode is None:
+                    # Sentinel readiness alone is not proof of death: on
+                    # Linux, PollSelector maps POLLNVAL/POLLERR/POLLHUP to
+                    # read readiness, so a stale or invalid descriptor can
+                    # report "ready" while its process is still alive with
+                    # no exitcode populated. Keep watching it -- a real
+                    # future exit is still caught below -- and back off
+                    # briefly so a persistently-invalid descriptor cannot
+                    # spin this loop at full speed.
+                    time.sleep(0.1)
+                    continue
+                died = True
                 if exitcode != 0 and not self.manager_stopped.is_set():
                     self.failed_proc_name = proc.name
-            if died_sentinels:
+            if died:
                 break
 
         self.shutdown()
@@ -1298,7 +1312,13 @@ def wait_for_engine_startup(
                 )
             continue
         if len(events) > 1 or events[0][0] != handshake_socket:
-            # One of the local core, coordinator, or watched frontend processes exited.
+            # One of the local core, coordinator, or watched frontend processes
+            # may have exited -- a registered sentinel became poll-ready. That
+            # alone is not proof of death: on Linux, PollSelector maps
+            # POLLNVAL/POLLERR/POLLHUP to read readiness, so a stale or
+            # invalid descriptor can report "ready" while its process is
+            # still alive with no exitcode populated. Only processes with an
+            # actual non-None exitcode below count as failed.
             if isinstance(launch.engine_manager, CoreEngineProcManager):
                 finished = launch.engine_manager.finished_procs()
             else:
@@ -1307,10 +1327,17 @@ def wait_for_engine_startup(
                 finished[coord_process.name] = coord_process.exitcode
             failed_frontend_procs = {
                 proc.name: proc.exitcode
-                for fd, proc in frontend_process_by_fd.items()
+                for proc in frontend_process_by_fd.values()
                 if proc.exitcode is not None
-                or any(event_fd == fd for event_fd, _ in events)
             }
+            if not finished and not failed_frontend_procs:
+                # The ready sentinel(s) do not correspond to any process
+                # with a real exit code -- a spurious readiness event, not
+                # an actual failure. Back off briefly so a persistently
+                # invalid descriptor cannot spin this loop at full speed,
+                # then keep waiting.
+                time.sleep(0.1)
+                continue
             if failed_frontend_procs and not finished:
                 raise RuntimeError(
                     "Frontend process failed during engine core initialization. "


### PR DESCRIPTION
Fixes #54184.

## Root cause

`CoreEngineProcManager.monitor_engine_liveness()` treated any poll-ready process sentinel as proof that the process had died:

```python
died_sentinels = connection.wait(sentinels, timeout=1)
for sentinel in died_sentinels:
    proc = sentinel_to_proc.pop(cast(int, sentinel))
    exitcode = proc.exitcode
    if exitcode != 0 and not self.manager_stopped.is_set():
        self.failed_proc_name = proc.name
if died_sentinels:
    break
```

`exitcode` was only read to pick a name for the log line -- never to confirm the process had actually exited. As the issue's minimal reproducer shows, on Linux `PollSelector` maps `POLLNVAL`/`POLLERR`/`POLLHUP` to read readiness, so a stale/invalid sentinel descriptor can report ready while the process is still alive and `exitcode` is still `None`. Any non-empty `died_sentinels` broke the loop and called `self.shutdown()` unconditionally, tearing down every healthy `EngineCore`.

The startup-time path in `wait_for_engine_startup()` (zmq.Poller over the same kind of sentinels) had the same shape of bug in its frontend-process check:

```python
failed_frontend_procs = {
    proc.name: proc.exitcode
    for fd, proc in frontend_process_by_fd.items()
    if proc.exitcode is not None
    or any(event_fd == fd for event_fd, _ in events)
}
```

The `or any(event_fd == fd ...)` clause counted a frontend process as failed purely because its fd was in the ready set, regardless of `exitcode`. And the branch that builds `finished`/`failed_frontend_procs` always raised afterwards, even when both ended up empty -- exactly the `Failed core proc(s): {}` variant reported in the issue.

## Fix

Both paths now only treat a process as dead once it has a real, non-`None` exit code:
- `monitor_engine_liveness()`: a ready sentinel with `exitcode is None` is logged as spurious and monitoring continues (the loop only breaks, and `shutdown()` only runs unconditionally, once a real exit is observed).
- `wait_for_engine_startup()`: `failed_frontend_procs` now requires `exitcode is not None`; if a poll event fires but neither `finished` nor `failed_frontend_procs` has anything in it, the event is treated as spurious and polling continues instead of raising.

Both spurious-event branches back off briefly (`time.sleep(0.1)`) before re-polling, so a persistently-invalid descriptor can't spin either loop at full speed.

## Testing

Added `test_monitor_engine_liveness_ignores_spurious_sentinel_readiness` and `test_wait_for_engine_startup_ignores_spurious_sentinel_readiness` to `tests/v1/engine/test_startup_watch_processes.py`, following the existing `test_wait_for_engine_startup_reports_watched_process_exit` pattern (a real `multiprocessing.connection.Pipe()` whose write end is closed, so the read end is genuinely poll-ready). Both use a process double whose `exitcode` stays `None` for a couple of readiness events before finally reporting a real exit, and assert neither path shuts down/raises on the spurious events -- only on the real one. Confirmed both new tests fail against the pre-fix code and pass with the fix.

`tests/v1/engine/test_startup_watch_processes.py` (14 tests, including the 2 new ones): all passing. `ruff check` and `ruff format --check` clean on both changed files.

Thanks to the issue reporter for the extremely thorough diagnosis (byte-level reproduction, regression window, and the exact suggested fix direction) -- most of this PR is just implementing what was already laid out in #54184.
