### PR TITLE
[Bugfix] Initialize video pruning for Qwen3.5

### DIFF
--- a/tests/model_executor/test_qwen3_5_video_pruning.py
+++ b/tests/model_executor/test_qwen3_5_video_pruning.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from vllm.config.multimodal import MultiModalConfig
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [Qwen3_5ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration],
+    ids=["dense", "moe"],
+)
+@pytest.mark.parametrize("video_pruning_method", ["evs", "vidcom2"])
+def test_video_pruning_config_is_initialized(model_cls, video_pruning_method):
+    multimodal_config = MultiModalConfig(
+        video_pruning_rate=0.3,
+        video_pruning_method=video_pruning_method,
+    )
+    model_config = Mock(
+        hf_config=SimpleNamespace(
+            vision_config=SimpleNamespace(out_hidden_size=64),
+        ),
+        multimodal_config=multimodal_config,
+    )
+    vllm_config = Mock(model_config=model_config, quant_config=None)
+
+    with (
+        patch("vllm.model_executor.models.qwen3_5.cached_tokenizer_from_config"),
+        patch("vllm.model_executor.models.qwen3_5.Qwen3_VisionTransformer"),
+        patch("vllm.model_executor.models.qwen3_5.Qwen3_5ForCausalLM") as dense_lm,
+        patch("vllm.model_executor.models.qwen3_5.Qwen3_5MoeForCausalLM") as moe_lm,
+        patch.object(model_cls, "_mark_tower_model", return_value=nullcontext()),
+        patch.object(model_cls, "_mark_language_model", return_value=nullcontext()),
+        patch.object(Qwen3_5MoeForConditionalGeneration, "set_moe_parameters"),
+    ):
+        dense_lm.return_value.make_empty_intermediate_tensors = Mock()
+        moe_lm.return_value.make_empty_intermediate_tensors = Mock()
+        model = model_cls(vllm_config=vllm_config)
+
+    assert model.video_pruning_method == video_pruning_method
+    assert model.video_pruning_rate == 0.3
+    assert model.is_multimodal_pruning_enabled

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -494,10 +494,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
         self.model_config = vllm_config.model_config
         self.multimodal_config = multimodal_config
         self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
-        self.is_multimodal_pruning_enabled = (
-            multimodal_config.is_multimodal_pruning_enabled()
-        )
-        self.video_pruning_rate = self.multimodal_config.video_pruning_rate
+        self._init_video_pruning(multimodal_config)
         self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
 
         # attributes needed by EVS-related functions inherited from Qwen3-VL
@@ -713,10 +710,7 @@ class Qwen3_5MoeForConditionalGeneration(
         self.model_config = vllm_config.model_config
         self.multimodal_config = multimodal_config
         self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
-        self.is_multimodal_pruning_enabled = (
-            multimodal_config.is_multimodal_pruning_enabled()
-        )
-        self.video_pruning_rate = self.multimodal_config.video_pruning_rate
+        self._init_video_pruning(multimodal_config)
         self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
 
         # attributes needed by EVS-related functions inherited from Qwen3-VL


### PR DESCRIPTION
## Motivation

Fixes #54170.

The custom dense and MoE Qwen3.5 conditional-generation constructors bypass `Qwen3VLForConditionalGeneration.__init__` and initialize the video-pruning state themselves.

After `video_pruning_method` became part of that state, these constructors continued to initialize only the enabled flag and pruning rate. Consequently, a normal Qwen3.5 video inference request with a non-zero pruning rate reaches the inherited Qwen3-VL pruning path and raises:

`AttributeError: 'Qwen3_5ForConditionalGeneration' object has no attribute 'video_pruning_method'`

The same incomplete initialization exists in the Qwen3.5 MoE constructor.

## What this PR does

- Use the existing `_init_video_pruning()` helper in both Qwen3.5 constructors.
- Remove the duplicated partial initialization.
- Add parameterized regression coverage for:
  - Qwen3.5 dense
  - Qwen3.5 MoE
  - `evs`
  - `vidcom2`

## Why this is not a duplicate

I checked open PRs using the issue number and Qwen3.5 video-pruning keywords. No overlapping open PR was found.

## Testing

- Targeted Qwen3.5 video-pruning and adjacent quantization constructor tests:
  - `6 passed`
- Ruff lint:
  - passed
- Ruff formatting check:
  - passed

## Model evaluation

A full Qwen3.5-9B-AWQ checkpoint evaluation was not run because this is an initialization-only fix and the test server had limited disk capacity.

The regression tests instantiate both affected model classes and verify that both supported pruning methods initialize the complete inherited pruning contract. No output or accuracy behavior is intentionally changed.

## AI assistance

AI assistance was used for issue investigation, implementation, and targeted
testing.

- [x] I have reviewed every changed line and can explain and defend the change.