### PR TITLE
[Bugfix] Exclude the compilation peak from memory profiling

### DIFF
--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -89,6 +89,60 @@ def test_memory_profiling():
     lib.cudaFree(handle2)
 
 
+@create_new_process_for_each_test()
+def test_memory_profiling_excludes_compilation_peak():
+    """A compile-time spike must not be charged as activation memory.
+
+    torch.compile and Inductor autotuning allocate large temporaries inside
+    profile_run(), which runs inside the memory_profiling window. They are
+    freed before the first real forward, so charging them as activation
+    headroom shrinks the KV cache until the compile cache is warm (#54122).
+    A peak recorded before compilation must still survive, because the
+    multimodal encoder pass runs before the backbone compiles.
+    """
+    from vllm.compilation.monitor import monitor_torch_compile
+    from vllm.config import CompilationMode, VllmConfig
+
+    vllm_config = VllmConfig()
+    vllm_config.compilation_config.mode = CompilationMode.VLLM_COMPILE
+
+    _warmup = torch.zeros(1, device="cuda")
+    del _warmup
+    torch.accelerator.empty_cache()
+
+    baseline_snapshot = MemorySnapshot()
+
+    weights = torch.randn(64, 1024, 1024, device="cuda", dtype=torch.float32)
+    weights_memory = 64 * 1024 * 1024 * 4  # 256 MiB
+
+    with memory_profiling(
+        baseline_snapshot=baseline_snapshot, weights_memory=weights_memory
+    ) as result:
+        # Encoder pass, before anything compiles: 512 MiB.
+        encoder_spike = torch.randn(128, 1024, 1024, device="cuda", dtype=torch.float32)
+        del encoder_spike
+
+        # Compilation allocates far more than any forward, then frees it: 2 GiB.
+        with monitor_torch_compile(vllm_config):
+            compile_spike = torch.randn(
+                512, 1024, 1024, device="cuda", dtype=torch.float32
+            )
+            del compile_spike
+
+        # The profiling forward itself: 256 MiB.
+        activation_spike = torch.randn(
+            64, 1024, 1024, device="cuda", dtype=torch.float32
+        )
+        del activation_spike
+
+    # The 2 GiB compile spike is excluded and the 512 MiB encoder peak, the
+    # largest real one, is kept. Without the fix this is the 2 GiB spike;
+    # discarding the peak outright instead would report the 256 MiB forward.
+    assert result.torch_peak_increase == 512 * 1024 * 1024
+
+    del weights
+
+
 def test_memory_snapshot_uses_psutil_on_integrated_gpu():
     """On integrated (UMA) GPUs, free_memory should come from psutil."""
     mock_cuda_free = 40 * 1024**3

--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -5,6 +5,8 @@ import contextlib
 import time
 from collections.abc import Generator
 
+import torch
+
 from vllm.config import CompilationMode, VllmConfig
 from vllm.logger import init_logger
 
@@ -12,6 +14,42 @@ logger = init_logger(__name__)
 
 # Shared global so backends.py can read the start time for Dynamo timing.
 torch_compile_start_time: float = 0.0
+
+# Peak torch-allocated bytes recorded before compilation started. Compilation
+# and Inductor autotuning allocate large temporaries inside profile_run(),
+# which runs inside the memory-profiling window. They are freed before the
+# first real forward, so leaving them in the allocator high-water mark charges
+# them as activation headroom and shrinks the KV cache on a cold start.
+# Clearing the counter alone would also drop a peak legitimately recorded
+# earlier in the same window, because a multimodal encoder pass runs before the
+# backbone compiles, so that value is kept here for memory_profiling() to fold
+# back in.
+peak_memory_before_compile: int = 0
+
+
+def _peak_allocated_bytes() -> int:
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_cuda_alike():
+        return 0
+
+    device = torch.device(current_platform.current_device())
+    return torch.accelerator.memory_stats(device).get("allocated_bytes.all.peak", 0)
+
+
+def _discard_compilation_peak(peak_before_compile: int) -> None:
+    """Drop the high-water mark left by compilation, keeping any earlier peak."""
+    global peak_memory_before_compile
+
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_cuda_alike():
+        return
+
+    peak_memory_before_compile = max(peak_memory_before_compile, peak_before_compile)
+    torch.accelerator.reset_peak_memory_stats(
+        torch.device(current_platform.current_device())
+    )
 
 
 @contextlib.contextmanager
@@ -27,6 +65,7 @@ def monitor_torch_compile(
     """
     global torch_compile_start_time
     torch_compile_start_time = time.perf_counter()
+    peak_before_compile = _peak_allocated_bytes()
 
     compilation_config = vllm_config.compilation_config
     depyf_cm = None
@@ -44,6 +83,7 @@ def monitor_torch_compile(
     except Exception:
         raise
     else:
+        _discard_compilation_peak(peak_before_compile)
         total_compile_time = time.perf_counter() - torch_compile_start_time
         if compilation_config.mode == CompilationMode.VLLM_COMPILE:
             if is_encoder:

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -286,9 +286,12 @@ def memory_profiling(
     The increase of `non_torch_memory` from creating the current vLLM instance
     until after profiling to get (c.).
     """
+    from vllm.compilation import monitor as compilation_monitor
+
     gc.collect()
     torch.accelerator.empty_cache()
     torch.accelerator.reset_peak_memory_stats(baseline_snapshot.device_)
+    compilation_monitor.peak_memory_before_compile = 0
 
     result = MemoryProfilingResult(
         before_create=baseline_snapshot,
@@ -304,6 +307,14 @@ def memory_profiling(
     torch.accelerator.empty_cache()
 
     result.after_profile.measure()
+
+    # On a cold start the model compiles inside this window. Compilation's own
+    # high-water mark was dropped when it finished; fold back the peak that
+    # predates it so a pre-compilation spike is still accounted for.
+    result.after_profile.torch_peak = max(
+        result.after_profile.torch_peak,
+        compilation_monitor.peak_memory_before_compile,
+    )
 
     diff_profile = result.after_profile - result.before_profile
     diff_from_create = result.after_profile - result.before_create


### PR DESCRIPTION
## Purpose

Closes #54122.

On a cold start `torch.compile` and Inductor autotuning run inside `profile_run()`, which sits inside the `memory_profiling()` window. In the AOT path `decorators.py` already splits the two phases into separate `with` blocks, and `monitor_profiling_run()` asserts compilation is finished before the profiling forward begins, but nothing clears the allocator high-water mark between them. Compilation's temporaries are freed before that forward, so `transient_peak_headroom` charges them as activation memory and the KV cache shrinks until the compile cache is warm.

This drops the high-water mark when compilation finishes. Clearing the counter alone would also discard a peak recorded earlier in the same window, since `profile_run()` runs the multimodal encoder before the backbone compiles, so the pre-compilation value is carried over and folded back in.

## Test plan

1x H100 80GB, `RedHatAI/Qwen3-30B-A3B-2507-W4A16`, nightly `46638857f` with the patch overlaid. Cold means `VLLM_CACHE_ROOT` and `TORCHINDUCTOR_CACHE_DIR` wiped, warm means the same boot repeated.

```
pytest tests/utils_/test_mem_utils.py
```

## Test result

`max_num_seqs=1, max_model_len=256`, where the compile spike is larger than the forward:

| | peak activation | KV cache | KV tokens |
| --- | --- | --- | --- |
| cold, before | 0.57 GiB | 50.69 GiB | 553,664 |
| warm, before | 0.04 GiB | 51.22 GiB | 559,424 |
| cold, after | 0.04 GiB | 51.22 GiB | 559,424 |
| warm, after | 0.04 GiB | 51.22 GiB | 559,424 |

Cold and warm now agree exactly. Instrumenting the allocator shows why: at the start of the profiling forward the peak already sat 0.582 GiB above allocated, entirely from compilation, and the forward itself never exceeded it.

At default batch settings on the same model the forward dominates the compile spike, and the numbers are unchanged before and after (2.84 GiB peak activation, 510,160 tokens cold), so the change is a no-op where the peak was already real. The reporter's 176B TP4 case is the same mechanism with the compile spike much larger, 35.03 GiB against 1.06 GiB.

The new test allocates a 512 MiB spike before a 2 GiB compile window and a 256 MiB spike after. It reports 512 MiB with this change, 2048 MiB without it, and 256 MiB if the pre-compilation peak is discarded rather than carried over, so both halves are pinned.

`test_mem_utils.py` uses `@create_new_process_for_each_test()`, which forks after CUDA is initialised and fails on my cluster for the pre-existing `test_memory_profiling` too. I ran the new test's body directly in a fresh process instead; the three results above are from that.

## Notes

#49115 moves compilation out of the window as a side effect of running FlashInfer MoE autotune early, but only when `enable_flashinfer_autotune` is set, FlashInfer is present and the device is SM90+. This fixes the general path instead, so the two are not duplicates.

AI assistance was used for this change. I reviewed every changed line and ran the tests and measurements above myself.
