### PR TITLE
[ROCm] Enable Navi custom paged attention at gqa_ratio 1 and 2

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -414,7 +414,7 @@ def use_rocm_custom_paged_attention(
             and (qtype == torch.half or qtype == torch.bfloat16)
             and head_size == 128
             and block_size == 16
-            and (gqa_ratio >= 3 and gqa_ratio <= 16)
+            and (gqa_ratio >= 1 and gqa_ratio <= 16)
             and max_seq_len <= 128 * 1024
             and alibi_slopes is None
             and kv_cache_dtype == "auto"


### PR DESCRIPTION
## Purpose

The gfx11 branch of `use_rocm_custom_paged_attention` admits `gqa_ratio` 3 through 16. This lowers that bound to 1, which is what the CDNA branch of the same function already uses.

The bound is a performance heuristic rather than a capability limit, and #17004 says so directly: the kernel "supports gqa_ratio up to 16, and shows performance gains over the existing kernel when gqa_ratio is 3 or higher", so 3 was chosen as the point where it paid. That was a measurement against the Triton fallback as it stood in May 2025, and that fallback has changed since. Re-measured on gfx1100, the heuristic now points the wrong way: the excluded ratios are where the custom kernel helps most.

#50603 asks for this from the other side. Its model is `gqa_ratio` 2 with head_dim 128 on gfx1100, and the second item in its Ask section asks whether the custom kernel can be extended to that ratio so RDNA3 stops falling back to Triton. Nothing needs extending; the kernel already runs there and the gate is what excludes it. This does not address that report's garbled-output symptom, and the measurements linked below argue against the theory behind it rather than for it, since the Triton kernel's relative error is flat from 1K to 32K.

## Test Plan

**At the kernel.** Both paths driven through `chunked_prefill_paged_decode` with only the gate forced, so nothing about argument marshalling differs between arms. Pure decode, one query token over a fully cached context. Reference is fp32 computed from the pre-paging KV rather than from the cache, so a paging bug cannot cancel itself out. Median of 10 timed iterations after 3 warm-ups. Five shapes at `gqa_ratio` 1, 2, 3, 4 crossed with six context lengths, 30 cells, run twice in separate containers.

**On a model.** `gemma-3-27b-it-w4a16` (32/16, so `gqa_ratio` 2 at any TP that divides evenly), TP=2, CUDA graphs on, decode tok/s by 64-vs-8 differencing, one fresh container per cell so the source edit cannot leak between arms. The whole six-cell sweep run twice with the arms in opposite orders, because run A measured stock before widened at every context and drift over the forty minutes would then land on the same arm each time.

**Routing.** Under TP=2 attention runs in worker processes, so a counter in the parent sees nothing useful. The dispatch's own verdict is written out from inside each worker, keyed `(gqa_ratio, head_size, block_size, sliding_window, use_custom)`.

2x RX 7900 XT (gfx1100), vLLM 0.27.1.dev5, ROCm 10.0, torch 2.12, bf16, head_size 128, block_size 16. The same sweeps on a 0.23.1 container give the same shape with slightly larger margins.

## Test Result

Triton time / CK time, so above 1.0 means the excluded kernel is the faster one. Means of the two rounds:

| shape | gqa | admitted today? | 1K | 2K | 4K | 8K | 16K | 32K |
|---|---:|---|---:|---:|---:|---:|---:|---:|
| 8/8 | 1 | **no** | 2.05x | 2.07x | 2.72x | 2.25x | 3.56x | 4.06x |
| 8/4 | 2 | **no** | 2.27x | 2.57x | 3.11x | 3.66x | 5.56x | 6.00x |
| 32/16 | 2 | **no** | 2.01x | 2.13x | 1.71x | 1.71x | 2.34x | 2.44x |
| 12/4 | 3 | yes | 2.25x | 2.52x | 2.81x | 3.61x | 5.62x | 6.04x |
| 16/4 | 4 | yes | 2.39x | 2.44x | 2.83x | 3.53x | 5.80x | 6.01x |

The admitted rows are the control: they show the advantage the gate was written to capture. The excluded rows show the same advantage, at the same magnitude, being declined. No cell in either round has the custom kernel slower, the worst cell of the sixty is 1.70x, and round to round the spread is at most 5.8%.

End to end:

| ctx | stock | widened | run A | run B |
|---|---:|---:|---:|---:|
| 1024 | 43.75 | 44.87 | 1.026x | 1.023x |
| 8192 | 23.39 | 24.91 | 1.065x | 1.103x |
| 32768 | 8.50 | 9.94 | **1.168x** | **1.167x** |

Same arm and context across the two passes agree to 0.7% in five of the six cells and 2.8% in the sixth, so the 1024 gain is small but reproducible rather than noise. The gain grows with context because of what moves: gemma-3-27b is 62 layers with `sliding_window_pattern: 6`, so only the ~10 full-attention layers can reach the custom kernel and the ~52 sliding layers fail the gate's `sliding_window == 0` condition in both arms. At 32K those ten layers carry most of the KV traffic.

Routing, on both ranks:

| layer | before | after |
|---|---|---|
| full attention, `window=0` | `use_custom=False` | `use_custom=True` |
| sliding, `window=1023` | `use_custom=False` | `use_custom=False` |

Those layers arrive at head_size 128 and block_size 16 with a native KV layout, so `gqa_ratio` is the only gate condition they fail.

**Numerics.** Against the fp32 reference the custom kernel sits a little above Triton, 2.89e-03 to 4.71e-03 against 2.12e-03 to 3.37e-03 over the same 30 cells. That is a different accumulation order, and it is the same gap the already-admitted ratios 3 and 4 show, so it is a property of the kernel rather than something this change introduces.

**What this does not cover.** One machine and one architecture: gfx1100, bf16, TP=2. The end-to-end evidence is at `gqa_ratio` 2; `gqa_ratio` 1 is measured at the kernel only, on the 8/8 shape. head_size 128 and block_size 16 are the only values the gfx11 branch admits at all, so nothing else was reachable to test. No test covers this gate today and this PR does not add one; if a shape-level test would help review it, that is easy to add.

**Two interactions worth flagging.** #34741 rewrites this same expression to give gfx12 its own lower bound while deliberately keeping gfx11 as it is, so whichever of the two lands first, the other is a one-line rebase. And #53856 matters for ordering: widening this gate is what lets `gqa_ratio` 2 reach the custom kernel, and forcing that kernel onto gqa 2 on gfx1100 reproduces exactly the unwritten-V-padding NaN that #53856 fixes, in the same cells and with the same fix. That fault needs poisoned padding to appear and vLLM zero-fills the backing allocation, so it is latent rather than triggered today, but the safer order is #53856 first.

Probe, both rounds of raw rows, the routing records and the environment: https://github.com/cadamcat/dual-radeon-vllm/tree/main/benchmarks/vllm-50603 (Stage 1 and Stage 4).

## AI assistance

The sweeps, the analysis and this description were produced with an AI agent; the change and the measurement design were reviewed by me, the runs were executed on my own hardware, and the commit carries a `Co-authored-by:` trailer.
