### PR TITLE
[Bugfix][Executor] Avoid false worker shutdown on spurious sentinel readiness

### DIFF
--- a/tests/v1/executor/test_executor.py
+++ b/tests/v1/executor/test_executor.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 from collections.abc import Callable
 from concurrent.futures import Future
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -87,6 +88,54 @@ def test_multiproc_executor_worker_termination_timeout(
     proc = _FakeProcess(clock, exits_at=exits_at)
     executor._ensure_worker_termination([proc])
     assert proc.terminate_called is expected_terminate
+
+
+def test_worker_monitor_ignores_spurious_sentinel_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class Process:
+        sentinel = 17
+        name = "Worker"
+
+        def __init__(self):
+            self.exitcode: int | None = None
+
+    proc = Process()
+    executor = object.__new__(MultiprocExecutor)
+    executor.workers = [SimpleNamespace(proc=proc)]
+    executor.shutting_down = False
+    executor.is_failed = False
+    events = []
+    executor.shutdown = lambda: events.append(("shutdown", proc.exitcode))
+    executor.failure_callback = lambda: events.append(("callback", proc.exitcode))
+
+    wait_calls = []
+
+    def report_ready(*_args, **_kwargs):
+        wait_calls.append(1)
+        return [proc.sentinel]
+
+    def finish_process(seconds):
+        events.append(("sleep", seconds))
+        proc.exitcode = 1
+
+    monkeypatch.setattr(
+        multiproc_executor_module.multiprocessing.connection,
+        "wait",
+        report_ready,
+    )
+    monkeypatch.setattr(
+        multiproc_executor_module.time,
+        "sleep",
+        finish_process,
+    )
+
+    executor.start_worker_monitor(inline=True)
+
+    assert wait_calls == [1]
+    assert events == [("sleep", 1), ("shutdown", 1), ("callback", 1)]
+    assert executor.is_failed
+    assert executor.failure_callback is None
 
 
 class CustomMultiprocExecutor(MultiprocExecutor):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -303,19 +303,55 @@ class MultiprocExecutor(Executor):
         # logs an error, shuts down the executor and invokes the failure
         # callback to inform the engine.
         def monitor_workers():
-            sentinels = [h.proc.sentinel for h in workers]
-            died = multiprocessing.connection.wait(sentinels)
+            sentinel_to_proc = {h.proc.sentinel: h.proc for h in workers}
+            polled_procs: list[BaseProcess] = []
+            failed_proc: BaseProcess | None = None
+
+            while failed_proc is None:
+                executor = self_ref()
+                if not executor or getattr(executor, "shutting_down", False):
+                    logger.debug("MultiprocWorkerMonitor: shutdown already initiated")
+                    return
+                del executor
+
+                if sentinel_to_proc:
+                    timeout = 1 if polled_procs else None
+                    ready = multiprocessing.connection.wait(
+                        sentinel_to_proc, timeout=timeout
+                    )
+                else:
+                    time.sleep(1)
+                    ready = []
+
+                for sentinel in ready:
+                    proc = sentinel_to_proc.pop(cast(int, sentinel))
+                    if proc.exitcode is None:
+                        logger.warning(
+                            "Worker sentinel for %s became ready while the process "
+                            "was still alive; falling back to exit-code polling.",
+                            proc.name,
+                        )
+                        polled_procs.append(proc)
+                    else:
+                        failed_proc = proc
+                        break
+
+                if failed_proc is None:
+                    failed_proc = next(
+                        (proc for proc in polled_procs if proc.exitcode is not None),
+                        None,
+                    )
+
             _self = self_ref()
             if not _self or getattr(_self, "shutting_down", False):
                 logger.debug("MultiprocWorkerMonitor: shutdown already initiated")
                 return
             _self.is_failed = True
-            proc = next(h.proc for h in workers if h.proc.sentinel == died[0])
             logger.error(
                 "Worker proc %s died unexpectedly (exit code: %s), "
                 "shutting down executor.",
-                proc.name,
-                proc.exitcode,
+                failed_proc.name,
+                failed_proc.exitcode,
             )
             _self.shutdown()
             callback = _self.failure_callback


### PR DESCRIPTION
## Purpose

Prevent `MultiprocExecutor` from shutting down healthy workers when a process sentinel becomes ready before the process has actually exited.

`start_worker_monitor()` previously treated any sentinel readiness event as proof of worker death. On Linux, a stale or invalid descriptor can be reported as ready while `proc.exitcode` is still `None`. The monitor would then mark the executor as failed, shut down every worker, and invoke the engine failure callback.

The monitor now requires a non-`None` exit code before declaring a worker dead. A spuriously ready sentinel is removed from the wait set, and that process is monitored using bounded exit-code polling. The normal path remains blocking and does not add periodic wakeups.

This was found while auditing other process-sentinel consumers after #54184 and #54204. No open issue or pull request was found for the `MultiprocWorkerMonitor` path.

OpenAI Codex assisted with identifying, implementing, and testing this change. The human contributor will review every changed line before requesting maintainer review.

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  --confcutdir=tests/v1/executor \
  tests/v1/executor/test_executor.py::test_worker_monitor_ignores_spurious_sentinel_readiness \
  tests/v1/executor/test_executor.py::test_multiproc_executor_worker_termination_timeout

pre-commit run --files \
  vllm/v1/executor/multiproc_executor.py \
  tests/v1/executor/test_executor.py
```

## Test Result

```text
3 passed
```

All applicable pre-commit checks passed, including Ruff, formatting, mypy, SPDX, and sign-off validation.

Behavioral result:

```text
Before: sentinel ready + exitcode=None -> executor marked failed and workers shut down
After:  sentinel ready + exitcode=None -> continue monitoring until a real exit code appears
```

A repository-level pytest run encountered the known macOS PyTorch segmentation fault in `torch.accelerator.empty_host_cache()` during global test cleanup. The scoped CPU-only tests above bypass that unrelated cleanup and pass.

Model evaluation and documentation updates are not applicable because this change only affects worker-process supervision.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and failure mode are described.
- [x] The test commands are provided.
- [x] The before-and-after behavior and test results are provided.
- [x] Documentation impact was considered; no update is required.

</details>