### PR TITLE
[CI][Bugfix] Seed the IR layernorm native-semantics tests to stop a flake

### DIFF
--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import zlib
+
 import pytest
 import torch
 
@@ -19,6 +21,18 @@ from vllm.platforms import current_platform
 rms_norm_native = ir.ops.rms_norm.impls["native"].impl_fn
 
 IS_GPGPU_DEVICE = current_platform.is_cuda_alike() or current_platform.is_xpu()
+
+
+def seed_from_params(*params) -> None:
+    """Seed torch from the test parameters.
+
+    The scaling-property checks below compare two float paths that can legally
+    differ by a couple of ULP, so an unseeded draw occasionally lands on a
+    rounding boundary and fails. Deriving the seed from the parameters keeps
+    every parametrized invocation a distinct case while making it reproducible.
+    """
+    key = "|".join(str(p) for p in params).encode()
+    torch.manual_seed(zlib.crc32(key))
 
 
 @pytest.mark.skipif(
@@ -52,6 +66,7 @@ def test_rms_norm_registration():
 )
 class TestRMSNorm:
     def test_native_semantics(self, dtype, n_tokens, hidden_size, epsilon):
+        seed_from_params(dtype, n_tokens, hidden_size, epsilon)
         x, weight, epsilon = ir.ops.rms_norm.generate_inputs(
             num_tokens=4,
             hidden_size=8,
@@ -266,6 +281,7 @@ def test_vllm_c_fused_add_rms_norm_accepts_nd_input():
 )
 class TestFusedAddRMSNorm:
     def test_native_semantics(self, dtype, n_tokens, hidden_size, epsilon):
+        seed_from_params(dtype, n_tokens, hidden_size, epsilon)
         x, x_residual, weight, eps = ir.ops.fused_add_rms_norm.generate_inputs(
             num_tokens=4,
             hidden_size=8,


### PR DESCRIPTION
### Failure

`(MI300) vLLM IR` — [AMD CI #12400](https://buildkite.com/vllm/amd-ci/builds/12400/list?sid=01a043ef-be92-4025-986b-70efa0ad99e5&tab=output)

```
FAILED tests/kernels/ir/test_layernorm.py::TestRMSNorm::test_native_semantics[1e-05-4096-2048-dtype0]
AssertionError: Tensor-likes are not close!
Mismatched elements: 1 / 32 (3.1%)
Greatest absolute difference: 0.00390625 at index (0, 4) (up to 0.001 allowed)
Greatest relative difference: 0.0015382766723632812 (up to 0.001 allowed)
1 failed, 2046 passed, 120 skipped in 1202.92s
```

### Why it flakes

The failing assertion is the scaling property, that `rms_norm(2x)` matches
`rms_norm(x)`. That identity is not exact in floating point, since `rms_norm(x)`
divides by `sqrt(ms + eps)` while `rms_norm(2x)` reduces to `sqrt(ms + eps/4)`. The
tiny difference occasionally pushes a value across an fp16 rounding boundary, and
the weight multiply rounds a second time, leaving the two paths about two ULP apart.
At fp16 magnitude 4 one ULP is exactly `0.00390625`, the absolute difference above.

The inputs are drawn unseeded, so this is a fresh lottery every run. Measured on
MI300X, only fp16 is affected, at roughly 3e-4 per invocation, which over the 180
parametrized invocations works out to about 1% per run for `TestRMSNorm` and 2%
counting `TestFusedAddRMSNorm`, which has the same pattern.

### Fix

Seed `torch` from the test parameters in both `test_native_semantics` methods. Every
parametrized invocation stays a distinct case, but the draw is reproducible instead
of random. All 180 invocations pass with the existing tolerance, worst case using
67% of the allowed budget, so the assertion keeps its sensitivity.

### What this deliberately does not change

The two-ULP gap comes from the native reference rounding twice: it casts the
normalized value to the weight dtype before the weight multiply, while the current
kernels keep the product in fp32 and round once. Making the reference round once
also removes the flake, and we verified that locally, but we are not proposing it
here, because which side is normative is an open question upstream and the momentum
is the other way.

- #42379 fixed the kernels to round twice, citing `vllm/ir/ops/layernorm.py` as the
  spec. It merged, then was reverted in #46070 after a multimodal CI failure.
- #49616 reports that the revert causes NGRAM/greedy divergence on Qwen3-VL, and
  #49639 is trying to restore the double rounding in the kernels.
- #52243 keeps the reference's rounding order for `fused_add_rms_norm`, explicitly
  in preference to the single-rounding variant.

So this PR only stops the flake and leaves the semantics to those threads.

### Test plan

Native-semantics tests: 360 passed, stable across repeated runs. Full `tests/ir` and
`tests/kernels/ir` also pass.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

