### PR TITLE
[Bugfix][Quantization] Fix MXFP8 startup crash on layers below mm_mxfp8 shape limits

### DIFF
--- a/tests/kernels/quantization/test_flashinfer_mxfp8_trtllm.py
+++ b/tests/kernels/quantization/test_flashinfer_mxfp8_trtllm.py
@@ -50,7 +50,9 @@ def test_flashinfer_trtllm_mxfp8_linear_numerics(
     x = torch.randn((m, k), dtype=torch.bfloat16, device="cuda")
     weight = torch.randn((n, k), dtype=torch.bfloat16, device="cuda")
     layer = _make_layer(weight)
-    kernel = FlashInferTrtllmMxfp8LinearKernel(Mxfp8LinearLayerConfig())
+    kernel = FlashInferTrtllmMxfp8LinearKernel(
+        Mxfp8LinearLayerConfig(weight_shape=(n, k))
+    )
     kernel.process_weights_after_loading(layer)
 
     output = kernel.apply_weights(layer, x)
@@ -69,7 +71,9 @@ def test_flashinfer_trtllm_mxfp8_custom_ops() -> None:
     x = torch.randn((7, 512), dtype=torch.bfloat16, device="cuda")
     weight = torch.randn((256, 512), dtype=torch.bfloat16, device="cuda")
     layer = _make_layer(weight)
-    kernel = FlashInferTrtllmMxfp8LinearKernel(Mxfp8LinearLayerConfig())
+    kernel = FlashInferTrtllmMxfp8LinearKernel(
+        Mxfp8LinearLayerConfig(weight_shape=(256, 512))
+    )
     kernel.process_weights_after_loading(layer)
 
     torch.library.opcheck(
@@ -104,7 +108,9 @@ def test_flashinfer_trtllm_mxfp8_linear_cuda_graph() -> None:
     m, n, k = 7, 130, 512
     weight = torch.randn((n, k), dtype=torch.bfloat16, device="cuda")
     layer = _make_layer(weight)
-    kernel = FlashInferTrtllmMxfp8LinearKernel(Mxfp8LinearLayerConfig())
+    kernel = FlashInferTrtllmMxfp8LinearKernel(
+        Mxfp8LinearLayerConfig(weight_shape=(n, k))
+    )
     kernel.process_weights_after_loading(layer)
 
     static_x = torch.randn((m, k), dtype=torch.bfloat16, device="cuda")

--- a/tests/kernels/quantization/test_mxfp8_kernel_selection.py
+++ b/tests/kernels/quantization/test_mxfp8_kernel_selection.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MXFP8 linear kernel selection logic (CPU-only)
+
+Run `pytest tests/kernels/quantization/test_mxfp8_kernel_selection.py`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from vllm.model_executor.kernels.linear import (
+    FlashInferCutedslMxfp8LinearKernel,
+    FlashInferCutlassMxfp8LinearKernel,
+    MarlinMxfp8LinearKernel,
+    Mxfp8LinearLayerConfig,
+    init_mxfp8_linear_kernel,
+)
+from vllm.platforms import PlatformEnum
+
+pytestmark = pytest.mark.cpu_test
+
+# Kernels backed by FlashInfer mm_mxfp8, which requires N, K >= 128 and
+# K % 32 == 0.
+_MM_MXFP8_KERNELS = [
+    FlashInferCutedslMxfp8LinearKernel,
+    FlashInferCutlassMxfp8LinearKernel,
+]
+
+_SUPPORTED_SHAPE = (4096, 4096)
+# (N, K): N < 128, K < 128, K % 32 != 0.
+_UNSUPPORTED_SHAPES = [(64, 4096), (4096, 64), (4096, 4112)]
+
+
+@pytest.mark.parametrize("kernel_cls", _MM_MXFP8_KERNELS)
+def test_mm_mxfp8_kernels_accept_supported_shape(kernel_cls):
+    config = Mxfp8LinearLayerConfig(weight_shape=_SUPPORTED_SHAPE)
+    can_implement, reason = kernel_cls.can_implement(config)
+    assert can_implement, reason
+
+
+@pytest.mark.parametrize("kernel_cls", _MM_MXFP8_KERNELS)
+@pytest.mark.parametrize("weight_shape", _UNSUPPORTED_SHAPES)
+def test_mm_mxfp8_kernels_reject_unsupported_shape(kernel_cls, weight_shape):
+    config = Mxfp8LinearLayerConfig(weight_shape=weight_shape)
+    can_implement, reason = kernel_cls.can_implement(config)
+    assert not can_implement
+    assert reason
+
+
+@pytest.mark.parametrize(
+    ("weight_shape", "expected_kernel_cls"),
+    [
+        (_SUPPORTED_SHAPE, FlashInferCutedslMxfp8LinearKernel),
+        ((64, 4096), MarlinMxfp8LinearKernel),
+    ],
+)
+def test_init_mxfp8_linear_kernel_falls_back_on_unsupported_shape(
+    weight_shape, expected_kernel_cls
+):
+    """A layer that mm_mxfp8 cannot handle must fall through to the next
+    kernel in the CUDA priority list instead of being selected and failing
+    in apply_weights."""
+    with (
+        patch("vllm.model_executor.kernels.linear.current_platform") as platform,
+        patch.object(
+            FlashInferCutedslMxfp8LinearKernel,
+            "is_supported",
+            return_value=(True, None),
+        ),
+        patch.object(
+            FlashInferCutlassMxfp8LinearKernel,
+            "is_supported",
+            return_value=(True, None),
+        ),
+        patch.object(
+            MarlinMxfp8LinearKernel, "is_supported", return_value=(True, None)
+        ),
+    ):
+        platform._enum = PlatformEnum.CUDA
+        kernel = init_mxfp8_linear_kernel(weight_shape=weight_shape)
+
+    assert isinstance(kernel, expected_kernel_cls)
+    assert kernel.config == Mxfp8LinearLayerConfig(weight_shape=weight_shape)

--- a/tests/kernels/test_minimax_m3_amd_ops.py
+++ b/tests/kernels/test_minimax_m3_amd_ops.py
@@ -409,7 +409,7 @@ def test_mxfp8_linear_emulation_bf16_at_load(
     layer.weight = torch.nn.Parameter(w_fp8.clone(), requires_grad=False)
     layer.weight_scale = torch.nn.Parameter(w_scale.clone(), requires_grad=False)
 
-    kernel = EmulationMxfp8LinearKernel(Mxfp8LinearLayerConfig())
+    kernel = EmulationMxfp8LinearKernel(Mxfp8LinearLayerConfig(weight_shape=(N, K)))
     kernel.process_weights_after_loading(layer)
 
     if dequant_at_load:

--- a/tests/model_executor/kernels/test_b12x_linear.py
+++ b/tests/model_executor/kernels/test_b12x_linear.py
@@ -66,7 +66,7 @@ from vllm.platforms import PlatformEnum
             "MarlinMxfp8LinearKernel",
             "EmulationMxfp8LinearKernel",
             init_mxfp8_linear_kernel,
-            {},
+            {"weight_shape": (2048, 2048)},
         ),
         (
             B12xTensorFP8ScaledMMLinearKernel,
@@ -363,7 +363,7 @@ def test_b12x_tensor_fp8_apply_quantizes_and_uses_packed_weight(
 
 def test_b12x_mxfp8_can_implement_supported_config() -> None:
     can_implement, reason = B12xMxfp8LinearKernel.can_implement(
-        Mxfp8LinearLayerConfig()
+        Mxfp8LinearLayerConfig(weight_shape=(256, 512))
     )
 
     assert can_implement

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -841,7 +841,7 @@ def test_inc_mxfp8_linear_scheme_delegates_to_kernel(monkeypatch) -> None:
     kernel = DummyKernel()
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp8_linear.init_mxfp8_linear_kernel",
-        lambda: kernel,
+        lambda weight_shape: kernel,
     )
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp8_linear.ModelWeightParameter",
@@ -880,7 +880,7 @@ def test_inc_mxfp8_linear_scheme_delegates_to_kernel(monkeypatch) -> None:
 def test_inc_mxfp8_linear_scheme_requires_block_32_input(monkeypatch) -> None:
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp8_linear.init_mxfp8_linear_kernel",
-        lambda: object(),
+        lambda weight_shape: object(),
     )
     scheme = INCMxfp8LinearScheme()
 

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -842,10 +842,10 @@ def choose_mp_linear_kernel(
     )
 
 
-def init_mxfp8_linear_kernel() -> Mxfp8LinearKernel:
+def init_mxfp8_linear_kernel(weight_shape: tuple[int, int]) -> Mxfp8LinearKernel:
     """Select and instantiate the best MXFP8 linear kernel for the
-    current platform."""
-    config = Mxfp8LinearLayerConfig()
+    current platform and layer shape."""
+    config = Mxfp8LinearLayerConfig(weight_shape=weight_shape)
 
     platform = current_platform._enum
     possible = list(_POSSIBLE_MXFP8_KERNELS.get(platform, []))

--- a/vllm/model_executor/kernels/linear/mxfp8/Mxfp8LinearKernel.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/Mxfp8LinearKernel.py
@@ -13,9 +13,12 @@ class Mxfp8LinearLayerConfig:
 
     All MXFP8 layers share the same structure: FP8-E4M3 weights with
     uint8 (E8M0) per-block scales at block size 32.
+
+    Attributes:
+        weight_shape: The layer's `(out_features, in_features)`, i.e. `(N, K)`.
     """
 
-    pass
+    weight_shape: tuple[int, int]
 
 
 class Mxfp8LinearKernel(ABC):

--- a/vllm/model_executor/kernels/linear/mxfp8/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/flashinfer.py
@@ -33,6 +33,25 @@ class FlashInferCutlassMxfp8LinearKernel(Mxfp8LinearKernel):
 
     @classmethod
     def can_implement(cls, c: Mxfp8LinearLayerConfig) -> tuple[bool, str | None]:
+        N, K = c.weight_shape
+        if K < 128:
+            return (
+                False,
+                f"mm_mxfp8 requires K >= 128, got K={K}. "
+                f"in_features is too small for mm_mxfp8.",
+            )
+        if K % MXFP8_BLOCK_SIZE != 0:
+            return (
+                False,
+                f"mm_mxfp8 requires K to be divisible by {MXFP8_BLOCK_SIZE}, "
+                f"got K={K}.",
+            )
+        if N < 128:
+            return (
+                False,
+                f"mm_mxfp8 requires N >= 128, got N={N}. "
+                f"out_features is too small for mm_mxfp8.",
+            )
         return True, None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -61,19 +80,6 @@ class FlashInferCutlassMxfp8LinearKernel(Mxfp8LinearKernel):
 
         input_shape = x.shape
         input_2d = x.view(-1, K)
-        min_dim = 128
-
-        assert min_dim <= K, (
-            f"mm_mxfp8 requires K >= {min_dim}, got K={K}. "
-            f"in_features is too small for mm_mxfp8."
-        )
-        assert K % MXFP8_BLOCK_SIZE == 0, (
-            f"mm_mxfp8 requires K to be divisible by {MXFP8_BLOCK_SIZE}, got K={K}."
-        )
-        assert min_dim <= N, (
-            f"mm_mxfp8 requires N >= {min_dim}, got N={N}. "
-            f"out_features is too small for mm_mxfp8."
-        )
 
         input_mxfp8, input_scale = mxfp8_e4m3_quantize(
             input_2d, is_sf_swizzled_layout=True
@@ -116,6 +122,25 @@ class FlashInferCutedslMxfp8LinearKernel(Mxfp8LinearKernel):
 
     @classmethod
     def can_implement(cls, c: Mxfp8LinearLayerConfig) -> tuple[bool, str | None]:
+        N, K = c.weight_shape
+        if K < 128:
+            return (
+                False,
+                f"mm_mxfp8 requires K >= 128, got K={K}. "
+                f"in_features is too small for mm_mxfp8.",
+            )
+        if K % MXFP8_BLOCK_SIZE != 0:
+            return (
+                False,
+                f"mm_mxfp8 requires K to be divisible by {MXFP8_BLOCK_SIZE}, "
+                f"got K={K}.",
+            )
+        if N < 128:
+            return (
+                False,
+                f"mm_mxfp8 requires N >= 128, got N={N}. "
+                f"out_features is too small for mm_mxfp8.",
+            )
         return True, None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -145,19 +170,6 @@ class FlashInferCutedslMxfp8LinearKernel(Mxfp8LinearKernel):
 
         input_shape = x.shape
         input_2d = x.view(-1, K)
-        min_dim = 128
-
-        assert min_dim <= K, (
-            f"mm_mxfp8 requires K >= {min_dim}, got K={K}. "
-            f"in_features is too small for mm_mxfp8."
-        )
-        assert K % MXFP8_BLOCK_SIZE == 0, (
-            f"mm_mxfp8 requires K to be divisible by {MXFP8_BLOCK_SIZE}, got K={K}."
-        )
-        assert min_dim <= N, (
-            f"mm_mxfp8 requires N >= {min_dim}, got N={N}. "
-            f"out_features is too small for mm_mxfp8."
-        )
 
         input_mxfp8, input_scale = mxfp8_e4m3_quantize(
             input_2d, is_sf_swizzled_layout=True

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_mxfp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_mxfp8.py
@@ -34,9 +34,6 @@ class CompressedTensorsW8A8Mxfp8(CompressedTensorsScheme):
     - Activations dynamically quantized to MXFP8 during inference
     """
 
-    def __init__(self):
-        self.kernel = init_mxfp8_linear_kernel()
-
     @classmethod
     def get_min_capability(cls) -> int:
         return 75
@@ -79,6 +76,8 @@ class CompressedTensorsW8A8Mxfp8(CompressedTensorsScheme):
             weight_loader=weight_loader,
         )
         layer.register_parameter("weight_scale", weight_scale)
+
+        self.kernel = init_mxfp8_linear_kernel(weight_shape=layer.weight.shape)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         self.kernel.process_weights_after_loading(layer)

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp8_linear.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp8_linear.py
@@ -17,9 +17,6 @@ from .inc_scheme import INCLinearScheme
 
 
 class INCMxfp8LinearScheme(INCLinearScheme):
-    def __init__(self) -> None:
-        self.kernel = init_mxfp8_linear_kernel()
-
     @classmethod
     def get_min_capability(cls) -> int:
         return 75
@@ -71,6 +68,8 @@ class INCMxfp8LinearScheme(INCLinearScheme):
             weight_loader=extra_weight_attrs.get("weight_loader"),
         )
         layer.register_parameter("weight_scale", weight_scale)
+
+        self.kernel = init_mxfp8_linear_kernel(weight_shape=layer.weight.shape)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         self.kernel.process_weights_after_loading(layer)

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1779,8 +1779,6 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
                 "Dynamic quantization is not supported."
             )
 
-        self.kernel = init_mxfp8_linear_kernel()
-
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -1836,6 +1834,8 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
             weight_loader=weight_loader,
         )
         layer.register_parameter("weight_scale", weight_scale)
+
+        self.kernel = init_mxfp8_linear_kernel(weight_shape=layer.weight.shape)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Idempotent: the emulation kernel may dequant the weight to BF16 at load

--- a/vllm/model_executor/layers/quantization/online/mxfp8.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp8.py
@@ -40,10 +40,6 @@ class Mxfp8OnlineLinearMethod(_Fp8OnlineLinearBase):
     FP8 with block-32 scales) during weight loading.
     """
 
-    def __init__(self):
-        super().__init__()
-        self.kernel = init_mxfp8_linear_kernel()
-
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -70,6 +66,8 @@ class Mxfp8OnlineLinearMethod(_Fp8OnlineLinearBase):
             params_dtype,
             **extra_weight_attrs,
         )
+
+        self.kernel = init_mxfp8_linear_kernel(weight_shape=layer.weight.shape)
 
     def process_weights_after_loading(self, layer: Module) -> None:
         if getattr(layer, "_already_called_process_weights_after_loading", False):


### PR DESCRIPTION
## Purpose

`vllm serve Qwen/Qwen3.5-0.8B --quantization mxfp8` dies in the profile run on a B200 with `AssertionError: mm_mxfp8 requires N >= 128, got N=32`. The layer is the GDN `in_proj_ba` (weight 32 x 1024). The larger Qwen3.5 sizes and Qwen3-Next have N=64 or N=96 there, so the whole family fails to start with online MXFP8.

`FlashInferCutlassMxfp8LinearKernel` and `FlashInferCutedslMxfp8LinearKernel` return `True` from `can_implement` for every layer. The `mm_mxfp8` shape limits (N >= 128, K >= 128, K % 32 == 0) are only asserts inside `apply_weights`, so on SM100 a layer below the limits is still selected instead of falling through to Marlin.

`Mxfp8LinearLayerConfig` gains `weight_shape` and the two kernels check the limits in `can_implement`. The compressed-tensors, INC and online MXFP8 schemes select the kernel in `create_weights` instead of `__init__`, the per-layer pattern `Fp8LinearMethod` already uses. ModelOpt already selects in `create_weights` since #49381, so there this PR only forwards the weight shape, including the BMM re-selection where the weight can be `[batch, N, K]`. No kernel code changes. `MarlinMxfp8LinearKernel.can_implement` is also unconditional; I left that for a follow-up.

## Test plan

```
pytest tests/kernels/quantization/test_mxfp8_kernel_selection.py tests/kernels/quantization/test_flashinfer_mxfp8_trtllm.py tests/quantization/test_modelopt.py
pytest tests/kernels/quantization/test_mxfp4_kernel_selection.py tests/model_executor/kernels/test_b12x_linear.py tests/kernels/test_minimax_m3_amd_ops.py tests/quantization/test_auto_round.py -k "mxfp8 or inc or selection or b12x or minimax"
```

On a B200 I ran `LLM("Qwen/Qwen3.5-0.8B", quantization="mxfp8")` on `main` and with this patch applied, then generated 8 tokens.

## Test result

135 tests pass and 11 skip on CPU, on the rebased branch (main 54020c3c3e). `pre-commit run` is clean on the changed files. The B200 run below is from the original base d1922cb5a; the rebase changed no kernel code.

B200, vLLM 0.28.1rc1.dev49+gd1922cb5a, FlashInfer 0.6.17, CUDA 13.0:

| arm | startup | MXFP8 kernels selected | output for "The capital of France is" |
|---|---|---|---|
| `main` | fails in `profile_run` after 52 s: `AssertionError: mm_mxfp8 requires N >= 128, got N=32` | `FlashInferCutedslMxfp8LinearKernel` | none |
| this PR | ok | `FlashInferCutedslMxfp8LinearKernel`, `MarlinMxfp8LinearKernel` | ` Paris.` |

`in_proj_ba` is the only quantized linear in this model with N < 128, so it is the layer Marlin took (padded to N=64, the log shows the Marlin padding warning). Every other layer still gets the FlashInfer kernel.

## Notes

Developed with Claude Code. I reviewed every line and ran the tests myself.

@stecasta adapted this change for SM12x and measured a throughput gain on DGX Spark over all-Marlin MXFP8, see https://github.com/vllm-project/vllm/pull/54223#issuecomment-5760441790.

Duplicate check: no open PR adds shape checks to any MXFP8 `can_implement`. #49381 landed and already moved the ModelOpt kernel selection into `create_weights`; this PR is rebased on it. #51808 adds an `activation_quant_key` argument to `init_mxfp8_linear_kernel`; I will rebase if it lands first. #52275 changes the TRT-LLM kernel in the same file and does not touch selection.

