### PR TITLE
[Bugfix][Frontend] Copy caller's prompt list at streaming-session entry

### DIFF
--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from vllm.engine.protocol import StreamingInput
+from vllm.inputs import tokens_input
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.v1.engine.async_llm import AsyncLLM
@@ -242,3 +243,146 @@ async def test_streaming_session_does_not_mutate_caller_prompt():
     # not the caller's object.
     first_chunk = next(p for p in processed_prompts if p == caller_prompt)
     assert first_chunk is not caller_prompt
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_does_not_mutate_structured_tokens_prompt():
+    """Structured TokensInput prompts must not be mutated either.
+
+    Regression for the structured-input path of #54215: the nested
+    ``prompt_token_ids`` list inside a ``tokens_input(...)`` dict was
+    retained and extended by streaming updates just like a bare list.
+    """
+    request_id = "test-mutate-structured"
+    sampling_params = SamplingParams(max_tokens=4)
+
+    llm = MagicMock(spec=AsyncLLM)
+    llm.vllm_config = MagicMock()
+    llm.vllm_config.cache_config.kv_sharing_fast_prefill = False
+    llm.model_config = MagicMock()
+    llm.model_config.max_model_len = 2048
+    llm.log_requests = False
+    llm.errored = False
+    llm._pause_cond = asyncio.Condition()
+    llm._paused = False
+    llm._run_output_handler = MagicMock()
+    llm.get_supported_tasks = AsyncMock(return_value=("generate",))
+
+    processed_prompts = []
+
+    def fake_process_inputs(**kwargs):
+        req = MagicMock()
+        req.request_id = f"req-{len(processed_prompts)}"
+        req.external_req_id = None
+        req.prompt_embeds = None
+        req.sampling_params = kwargs.get("params")
+        processed_prompts.append(kwargs["prompt"])
+        return req
+
+    async def fake_add_request(req, *args, **kwargs):
+        pass
+
+    llm.input_processor = MagicMock()
+    llm.input_processor.process_inputs = MagicMock(side_effect=fake_process_inputs)
+    llm.input_processor.assign_request_id = MagicMock()
+    llm._add_request = fake_add_request
+    llm._add_streaming_input_request = AsyncLLM._add_streaming_input_request.__get__(
+        llm, AsyncLLM
+    )
+
+    caller_ids = [100 + (i % 40) for i in range(64)]
+    caller_prompt = tokens_input(prompt_token_ids=caller_ids)
+
+    async def input_generator() -> AsyncGenerator[StreamingInput, None]:
+        yield StreamingInput(prompt=caller_prompt, sampling_params=sampling_params)
+        yield StreamingInput(prompt=[777] * 7, sampling_params=sampling_params)
+        yield StreamingInput(prompt=[888] * 5, sampling_params=sampling_params)
+
+    queue = await llm._add_streaming_input_request(
+        request_id, input_generator(), sampling_params
+    )
+    await queue._input_stream_task
+
+    # The caller's nested token list must be untouched by the session.
+    assert len(caller_ids) == 64
+    assert [100 + (i % 40) for i in range(64)] == caller_ids
+    assert 777 not in caller_ids and 888 not in caller_ids
+    # The input processor must have received a copy of the nested list,
+    # not the caller's object.
+    first_chunk = next(p for p in processed_prompts if p == caller_prompt)
+    assert first_chunk["prompt_token_ids"] is not caller_ids
+    assert first_chunk["prompt_token_ids"] == caller_ids
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_does_not_mutate_enc_dec_prompt():
+    """Encoder-decoder structured prompts must not be mutated either.
+
+    Regression for the enc-dec variant of #54215: with
+    ``EncoderDecoderInput`` the decoder ``prompt_token_ids`` list is
+    nested under ``decoder_prompt`` and was retained (without copy)
+    until streaming updates extended it in the client process.
+    """
+    request_id = "test-mutate-enc-dec"
+    sampling_params = SamplingParams(max_tokens=4)
+
+    llm = MagicMock(spec=AsyncLLM)
+    llm.vllm_config = MagicMock()
+    llm.vllm_config.cache_config.kv_sharing_fast_prefill = False
+    llm.model_config = MagicMock()
+    llm.model_config.is_encoder_decoder = True
+    llm.model_config.max_model_len = 2048
+    llm.log_requests = False
+    llm.errored = False
+    llm._pause_cond = asyncio.Condition()
+    llm._paused = False
+    llm._run_output_handler = MagicMock()
+    llm.get_supported_tasks = AsyncMock(return_value=("generate",))
+
+    processed_prompts = []
+
+    def fake_process_inputs(**kwargs):
+        req = MagicMock()
+        req.request_id = f"req-{len(processed_prompts)}"
+        req.external_req_id = None
+        req.prompt_embeds = None
+        req.sampling_params = kwargs.get("params")
+        processed_prompts.append(kwargs["prompt"])
+        return req
+
+    async def fake_add_request(req, *args, **kwargs):
+        pass
+
+    llm.input_processor = MagicMock()
+    llm.input_processor.process_inputs = MagicMock(side_effect=fake_process_inputs)
+    llm.input_processor.assign_request_id = MagicMock()
+    llm._add_request = fake_add_request
+    llm._add_streaming_input_request = AsyncLLM._add_streaming_input_request.__get__(
+        llm, AsyncLLM
+    )
+
+    caller_ids = [100 + (i % 40) for i in range(64)]
+    caller_prompt = {
+        "type": "enc_dec",
+        "encoder_prompt": {"type": "token", "prompt_token_ids": [7, 8, 9]},
+        "decoder_prompt": tokens_input(prompt_token_ids=caller_ids),
+    }
+
+    async def input_generator() -> AsyncGenerator[StreamingInput, None]:
+        yield StreamingInput(prompt=caller_prompt, sampling_params=sampling_params)
+        yield StreamingInput(prompt=[777] * 7, sampling_params=sampling_params)
+        yield StreamingInput(prompt=[888] * 5, sampling_params=sampling_params)
+
+    queue = await llm._add_streaming_input_request(
+        request_id, input_generator(), sampling_params
+    )
+    await queue._input_stream_task
+
+    # The caller's nested decoder token list must be untouched.
+    assert len(caller_ids) == 64
+    assert [100 + (i % 40) for i in range(64)] == caller_ids
+    assert 777 not in caller_ids and 888 not in caller_ids
+    # The input processor must receive a copy of the nested list.
+    first_chunk = next(p for p in processed_prompts if p == caller_prompt)
+    assert first_chunk["decoder_prompt"]["prompt_token_ids"] is not caller_ids
+    assert first_chunk["decoder_prompt"]["prompt_token_ids"] == caller_ids

--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -170,3 +170,74 @@ async def test_generate_with_async_generator():
     assert outputs[2].finished is True
     # Both inputs were processed
     assert inputs_received == ["Hello", " world"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_session_does_not_mutate_caller_prompt():
+    """Streaming sessions must not mutate the caller-provided prompt list.
+
+    Regression test for #54215: tokens from later stream chunks used to be
+    appended to the list object passed in the first chunk, so any later
+    request reusing that list silently carried the session's tokens.
+    """
+    request_id = "test-mutate"
+    sampling_params = SamplingParams(max_tokens=4)
+
+    llm = MagicMock(spec=AsyncLLM)
+    llm.vllm_config = MagicMock()
+    llm.vllm_config.cache_config.kv_sharing_fast_prefill = False
+    llm.model_config = MagicMock()
+    llm.model_config.max_model_len = 2048
+    llm.log_requests = False
+    llm.errored = False
+    llm._pause_cond = asyncio.Condition()
+    llm._paused = False
+    llm._run_output_handler = MagicMock()
+    llm.get_supported_tasks = AsyncMock(return_value=("generate",))
+
+    # Record the prompt objects handed to the input processor.
+    processed_prompts = []
+    added = []
+
+    def fake_process_inputs(**kwargs):
+        req = MagicMock()
+        req.request_id = f"req-{len(processed_prompts)}"
+        req.external_req_id = None
+        req.prompt_embeds = None
+        req.sampling_params = kwargs.get("params")
+        processed_prompts.append(kwargs["prompt"])
+        return req
+
+    async def fake_add_request(req, *args, **kwargs):
+        added.append(req)
+
+    llm.input_processor = MagicMock()
+    llm.input_processor.process_inputs = MagicMock(side_effect=fake_process_inputs)
+    llm.input_processor.assign_request_id = MagicMock()
+    llm._add_request = fake_add_request
+    # Bind the real method: the spec-based mock would otherwise replace it
+    # with an AsyncMock that never runs handle_inputs.
+    llm._add_streaming_input_request = AsyncLLM._add_streaming_input_request.__get__(
+        llm, AsyncLLM
+    )
+
+    P = [100 + (i % 40) for i in range(64)]
+
+    async def input_generator() -> AsyncGenerator[StreamingInput, None]:
+        yield StreamingInput(prompt=P, sampling_params=sampling_params)
+        yield StreamingInput(prompt=[777] * 7, sampling_params=sampling_params)
+        yield StreamingInput(prompt=[888] * 5, sampling_params=sampling_params)
+
+    queue = await llm._add_streaming_input_request(
+        request_id, input_generator(), sampling_params
+    )
+    await queue._input_stream_task
+
+    # The caller's list must be untouched by the session.
+    assert len(P) == 64
+    assert [100 + (i % 40) for i in range(64)] == P
+    # The session's chunk tokens must not leak into the caller's list.
+    assert 777 not in P and 888 not in P
+    # The input processor must have received a copy, not the caller's object.
+    assert processed_prompts[1] is not P
+    assert processed_prompts[1] == P

--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -221,10 +221,10 @@ async def test_streaming_session_does_not_mutate_caller_prompt():
         llm, AsyncLLM
     )
 
-    P = [100 + (i % 40) for i in range(64)]
+    caller_prompt = [100 + (i % 40) for i in range(64)]
 
     async def input_generator() -> AsyncGenerator[StreamingInput, None]:
-        yield StreamingInput(prompt=P, sampling_params=sampling_params)
+        yield StreamingInput(prompt=caller_prompt, sampling_params=sampling_params)
         yield StreamingInput(prompt=[777] * 7, sampling_params=sampling_params)
         yield StreamingInput(prompt=[888] * 5, sampling_params=sampling_params)
 
@@ -234,10 +234,11 @@ async def test_streaming_session_does_not_mutate_caller_prompt():
     await queue._input_stream_task
 
     # The caller's list must be untouched by the session.
-    assert len(P) == 64
-    assert [100 + (i % 40) for i in range(64)] == P
+    assert len(caller_prompt) == 64
+    assert [100 + (i % 40) for i in range(64)] == caller_prompt
     # The session's chunk tokens must not leak into the caller's list.
-    assert 777 not in P and 888 not in P
-    # The input processor must have received a copy, not the caller's object.
-    assert processed_prompts[1] is not P
-    assert processed_prompts[1] == P
+    assert 777 not in caller_prompt and 888 not in caller_prompt
+    # The input processor must have received a copy for the first chunk,
+    # not the caller's object.
+    first_chunk = next(p for p in processed_prompts if p == caller_prompt)
+    assert first_chunk is not caller_prompt

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -497,6 +497,29 @@ class AsyncLLM(EngineClient):
                         # Copy so session updates never mutate the caller's
                         # list object (see issue #54215).
                         prompt = list(prompt)
+                    elif isinstance(prompt, dict) and isinstance(
+                        prompt.get("prompt_token_ids"), list
+                    ):
+                        prompt = {
+                            **prompt,
+                            "prompt_token_ids": list(prompt["prompt_token_ids"]),
+                        }
+                    elif (
+                        isinstance(prompt, dict)
+                        and isinstance(prompt.get("decoder_prompt"), dict)
+                        and isinstance(
+                            prompt["decoder_prompt"].get("prompt_token_ids"), list
+                        )
+                    ):
+                        prompt = {
+                            **prompt,
+                            "decoder_prompt": {
+                                **prompt["decoder_prompt"],
+                                "prompt_token_ids": list(
+                                    prompt["decoder_prompt"]["prompt_token_ids"]
+                                ),
+                            },
+                        }
                     req = self.input_processor.process_inputs(
                         request_id=internal_req_id,
                         prompt=prompt,

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -492,9 +492,14 @@ class AsyncLLM(EngineClient):
                     else:
                         sp = sampling_params
                     # TODO(nick): Avoid re-validating reused sampling parameters
+                    prompt = input_chunk.prompt
+                    if isinstance(prompt, list):
+                        # Copy so session updates never mutate the caller's
+                        # list object (see issue #54215).
+                        prompt = list(prompt)
                     req = self.input_processor.process_inputs(
                         request_id=internal_req_id,
-                        prompt=input_chunk.prompt,
+                        prompt=prompt,
                         params=sp,
                         resumable=True,
                         **inputs,  # type: ignore[arg-type]


### PR DESCRIPTION
Streaming sessions extended the caller-provided prompt list in place: RequestState retained the prompt by reference and
OutputProcessor.apply_streaming_update() appended chunk tokens to it, so any request reusing that list sent a polluted prompt (see #54215). Pass a defensive copy to the input processor in handle_inputs.

Test: tests/v1/streaming_input/test_async_llm_streaming.py::test_streaming_session_does_not_mutate_caller_prompt passes with this change and fails without it.

Fixes #54215

## Purpose

Streaming sessions extended the caller-provided prompt list in place: `RequestState` retained the prompt by reference and `OutputProcessor.apply_streaming_update()` appended stream-chunk tokens to it in the client process, so any request that reused the same list object silently sent a polluted prompt (64 → 76 tokens). This PR passes a defensive `list()` copy to the input processor at the streaming-session entry (`AsyncLLM.handle_inputs`), so the caller's object is never retained or mutated by the session.

## Test Plan

1. Regression test (mock-based, no GPU):
   ```
   pytest tests/v1/streaming_input/test_async_llm_streaming.py \
     -k test_streaming_session_does_not_mutate_caller_prompt -v
   ```
   (pytest 9.1.1 + pytest-asyncio 1.4.0)
2. End-to-end on v0.28.0 / RTX 3090 with the self-contained dummy-model repro from #54215 (`load_format=dummy`, `skip_tokenizer_init`, no weights/tokenizer needed).

## Test Result

- Regression test: **PASSED with this change**; the same test **fails on unpatched code** with `assert processed_prompts[1] is not P` (the input processor previously received the caller's original object by reference).
- E2E, fixed call site (session followed by a request reusing the same list object):
  ```
  P len before session: 64
  P len after  session: 64     <- fixed: no in-place mutation
  base   = [1783, 31001, 1783, 31001]
  reuse  = [1783, 31001, 1783, 31001]   (same list object, now clean)
  ```
  Before the fix the same script showed `P len after session: 76` and `reuse = [6645, 888, 6645, 888]`.
- Docs: no user-facing behavior change; no doc update needed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
