### PR TITLE
[Bugfix] MoE MBU: estimate distinct activated experts instead of perfect-load-balancing upper bound

### DIFF
--- a/tests/v1/metrics/test_perf_metrics.py
+++ b/tests/v1/metrics/test_perf_metrics.py
@@ -32,6 +32,7 @@ from vllm.v1.metrics.perf import (
     ModelMetrics,
     ParsedArgs,
     UnembedMetrics,
+    estimate_num_activated_experts,
 )
 
 
@@ -86,7 +87,15 @@ def create_mock_vllm_config(
     tensor_parallel_size=1,
     pipeline_parallel_size=1,
     enable_expert_parallel=False,
+    moe_activated_experts_estimator="expected_uniform",
 ) -> SimpleNamespace:
+    """Build a minimal mock VllmConfig covering the fields perf.py parsers read.
+
+    `moe_activated_experts_estimator` mirrors
+    `ObservabilityConfig.mfu_moe_activated_experts_estimator` and defaults to
+    the new S-MBU-style estimate; pass `"upper_bound"` to pin a test to the
+    legacy perfect-load-balancing formula.
+    """
     vllm_config = SimpleNamespace()
     vllm_config.model_config = MockModelConfig(hf_config, model_dtype)
 
@@ -100,6 +109,11 @@ def create_mock_vllm_config(
     vllm_config.parallel_config.tensor_parallel_size = tensor_parallel_size
     vllm_config.parallel_config.pipeline_parallel_size = pipeline_parallel_size
     vllm_config.parallel_config.enable_expert_parallel = enable_expert_parallel
+
+    vllm_config.observability_config = SimpleNamespace()
+    vllm_config.observability_config.mfu_moe_activated_experts_estimator = (
+        moe_activated_experts_estimator
+    )
 
     return vllm_config
 
@@ -463,7 +477,20 @@ def test_model_metrics_aggregation():
 
 
 def test_moe_expert_activation_proportional_scaling():
-    """Test that routed expert metrics scale proportionally with num_experts_per_tok."""
+    """Test that routed expert metrics scale proportionally with num_experts_per_tok.
+
+    Pinned to the legacy `upper_bound` estimator: with num_tokens=100 and
+    num_experts=64, `num_activated_tokens = num_tokens * top_k` already
+    exceeds num_experts for every top_k tested here, so
+    `min(num_activated_tokens, num_experts)` saturates to a *constant* 64
+    regardless of top_k, which is exactly what makes read/write bytes exact
+    linear functions of top_k below. The default `expected_uniform`
+    estimator is intentionally *not* a linear function of top_k (that
+    non-linearity is the point of the S-MBU fix -- see
+    `test_ffn_metrics_s_mbu_below_naive_upper_bound` below), so it would
+    break this proportionality assertion for reasons unrelated to what this
+    test is checking (FLOPS/dense-activation scaling).
+    """
     base_moe_config = Qwen3MoeConfig(
         hidden_size=2048,
         intermediate_size=8192,
@@ -494,9 +521,15 @@ def test_moe_expert_activation_proportional_scaling():
         n_shared_experts=2,  # Same shared experts
     )
 
-    base_vllm_config = create_mock_vllm_config(base_moe_config)
-    double_vllm_config = create_mock_vllm_config(double_experts_config)
-    triple_vllm_config = create_mock_vllm_config(triple_experts_config)
+    base_vllm_config = create_mock_vllm_config(
+        base_moe_config, moe_activated_experts_estimator="upper_bound"
+    )
+    double_vllm_config = create_mock_vllm_config(
+        double_experts_config, moe_activated_experts_estimator="upper_bound"
+    )
+    triple_vllm_config = create_mock_vllm_config(
+        triple_experts_config, moe_activated_experts_estimator="upper_bound"
+    )
 
     base_metrics = FfnMetrics.from_vllm_config(base_vllm_config)
     double_metrics = FfnMetrics.from_vllm_config(double_vllm_config)
@@ -758,6 +791,16 @@ def test_moe_per_gpu_with_expert_parallelism():
 def test_moe_per_gpu_expert_activation_accounting():
     """
     Test that MoE correctly accounts for expert activations with small batch sizes.
+
+    Pinned to the legacy `upper_bound` estimator, which this test exercises
+    directly (see inline comments below): with only 8 local experts after
+    expert-parallel sharding and top_k=8, `min(n, 8)` saturates to a
+    constant 8 for both the small and large batch, by construction. Under
+    the (more realistic) default `expected_uniform` estimator this
+    saturate-immediately behavior is exactly the bug being fixed -- a
+    10-token batch should *not* be assumed to touch every local expert; see
+    `test_ffn_metrics_s_mbu_below_naive_upper_bound` for a version of this
+    same small-vs-large-batch comparison under the new default.
     """
     hf_config = Qwen3MoeConfig(
         hidden_size=2048,
@@ -774,6 +817,7 @@ def test_moe_per_gpu_expert_activation_accounting():
         hf_config,
         data_parallel_size=8,
         enable_expert_parallel=True,
+        moe_activated_experts_estimator="upper_bound",
     )
     metrics = FfnMetrics.from_vllm_config(vllm_config)
 
@@ -1336,3 +1380,247 @@ def test_mla_attention_scaling_with_layers():
     assert double_metrics.get_num_flops(ctx) == 2 * base_metrics.get_num_flops(ctx)
     assert double_metrics.get_read_bytes(ctx) == 2 * base_metrics.get_read_bytes(ctx)
     assert double_metrics.get_write_bytes(ctx) == 2 * base_metrics.get_write_bytes(ctx)
+
+
+#### S-MBU: estimate_num_activated_experts() Tests ####
+
+
+def test_estimate_num_activated_experts_matches_closed_form():
+    """Test the estimator against a hand-computed closed-form value.
+
+    For num_tokens=6, top_k=2, num_experts=8, the expected number of
+    distinct experts hit under uniform-random routing with per-token
+    DISTINCT top-k picks is:
+        8 * (1 - (1 - 2/8) ** 6) = 8 * (1 - 0.75 ** 6) ~= 6.576 -> rounds to 7.
+    This is below the naive upper bound min(6 * 2, 8) = 8 (the legacy
+    "upper_bound" formula this function replaces), and strictly above the
+    old slot-independent estimate that ignores within-token distinctness
+    (treats the num_tokens * top_k = 12 activations as independent draws):
+        8 * (1 - (1 - 1/8) ** 12) ~= 6.389 -> rounds to 6.
+    """
+    num_tokens = 6
+    top_k = 2
+    num_experts = 8
+
+    expected = round(num_experts * (1 - (1 - top_k / num_experts) ** num_tokens))
+    assert expected == 7  # hand-computed reference value
+
+    result = estimate_num_activated_experts(num_tokens, top_k, num_experts)
+    assert result == expected
+    assert result < min(num_tokens * top_k, num_experts)  # naive upper bound
+
+    old_slot_independent = round(
+        num_experts * (1 - (1 - 1 / num_experts) ** (num_tokens * top_k))
+    )
+    assert old_slot_independent == 6  # hand-computed reference value
+    assert result > old_slot_independent
+
+
+def test_estimate_num_activated_experts_edge_cases():
+    """Test degenerate inputs: no tokens, no experts, non-positive top_k,
+    and top_k >= num_experts (every token's picks already span every
+    expert, so the result saturates to num_experts even at small
+    num_tokens)."""
+    assert estimate_num_activated_experts(0, 8, 64) == 0  # no tokens
+    assert estimate_num_activated_experts(100, 8, 0) == 0  # no experts
+    assert estimate_num_activated_experts(100, 0, 64) == 0  # top_k == 0
+    assert estimate_num_activated_experts(-5, 8, 64) == 0  # defensive, shouldn't occur
+    # defensive, shouldn't occur
+    assert estimate_num_activated_experts(100, -1, 64) == 0
+
+    # top_k >= num_experts: every token's top_k picks already cover every
+    # expert, regardless of how large top_k is beyond num_experts.
+    assert estimate_num_activated_experts(5, 64, 64) == 64
+    assert estimate_num_activated_experts(5, 100, 64) == 64
+
+
+def test_estimate_num_activated_experts_exact_at_single_token():
+    """Test the estimate is EXACT (not just close) at num_tokens == 1.
+
+    A single token's top_k picks are distinct by construction (top-k
+    routing never selects the same expert twice for one token), so the
+    estimator returns exactly min(top_k, num_experts) with zero
+    estimation error. This is the property that makes T=1 a ground-truth
+    check rather than just another sample point.
+    """
+    for top_k, num_experts in [(1, 8), (2, 8), (8, 8), (16, 8), (3, 64)]:
+        result = estimate_num_activated_experts(1, top_k, num_experts)
+        assert result == min(top_k, num_experts)
+
+
+def test_estimate_num_activated_experts_saturates_for_large_batches():
+    """Test the estimate saturates to num_experts as num_tokens grows large."""
+    assert estimate_num_activated_experts(10**6, 4, 32) == 32
+
+
+def test_estimate_num_activated_experts_observed_override():
+    """Test that a real observed union count, when supplied, wins outright.
+
+    This is the hook a future patch would use to wire in true per-step
+    routing telemetry (e.g. from EPLB); it must take priority over the
+    analytic estimate and be defensively clipped to [0, num_experts].
+    """
+    # Real telemetry says only 3 distinct experts were touched, even though
+    # the analytic estimate (or the naive upper bound) would say more.
+    assert (
+        estimate_num_activated_experts(1000, 8, 64, num_observed_activated_experts=3)
+        == 3
+    )
+
+    # Clipped to num_experts if the observed count is (erroneously) larger.
+    assert (
+        estimate_num_activated_experts(1000, 8, 64, num_observed_activated_experts=999)
+        == 64
+    )
+
+    # Clipped to 0 if negative.
+    assert (
+        estimate_num_activated_experts(1000, 8, 64, num_observed_activated_experts=-1)
+        == 0
+    )
+
+
+def test_estimate_num_activated_experts_never_exceeds_naive_upper_bound():
+    """Test S-MBU estimate <= naive upper bound for a broad parameter sweep.
+
+    The whole point of the fix is that the estimate must never overshoot
+    `min(num_tokens * top_k, num_experts)`; this is the safety property
+    that actually matters for callers (the fix can only reduce or match
+    estimated MoE weight-read bytes, never increase them). Sweep a grid of
+    (num_tokens, top_k, num_experts) triples and confirm this invariant
+    holds everywhere.
+
+    Note: this does *not* assert a strict inequality across the whole
+    sweep. Because the estimate is rounded to the nearest integer, ties
+    with the naive bound are expected (and correct, not a bug) at both
+    ends of the range: at num_tokens == 1 the two formulas coincide
+    exactly (see `test_estimate_num_activated_experts_exact_at_single_token`),
+    and for num_tokens * top_k >> num_experts the true expected value gets
+    rounded to num_experts, same as the naive bound. Strictness in the
+    interesting middle range is covered by
+    `test_estimate_num_activated_experts_matches_closed_form` and
+    `test_ffn_metrics_s_mbu_below_naive_upper_bound`.
+    """
+    for num_tokens in range(0, 200, 17):
+        for top_k in range(0, 40, 7):
+            for num_experts in range(0, 300, 11):
+                naive_upper_bound = min(num_tokens * top_k, num_experts)
+                estimate = estimate_num_activated_experts(
+                    num_tokens, top_k, num_experts
+                )
+                assert estimate <= naive_upper_bound
+
+
+def test_estimate_num_activated_experts_at_least_old_slot_independent_formula():
+    """Test the new (top-k-DISTINCT-aware) estimate is always >= the old
+    (pre-fix) formula that treated `num_tokens * top_k` as independent
+    slot draws with replacement.
+
+    Forcing a token's `top_k` picks to be distinct can only raise the
+    expected number of distinct experts touched relative to a model that
+    allows a token to (nonsensically) redraw the same expert multiple
+    times; this sweep is the property-test counterpart to the strict
+    inequality demonstrated on one concrete example in
+    `test_estimate_num_activated_experts_matches_closed_form`.
+    """
+    for num_tokens in range(1, 200, 17):
+        for top_k in range(1, 40, 7):
+            for num_experts in range(1, 300, 11):
+                new_estimate = estimate_num_activated_experts(
+                    num_tokens, top_k, num_experts
+                )
+                n = num_tokens * top_k
+                old_estimate = round(num_experts * (1 - (1 - 1 / num_experts) ** n))
+                assert new_estimate >= old_estimate
+
+
+#### S-MBU: FfnMetrics end-to-end Tests ####
+
+
+def test_ffn_metrics_s_mbu_below_naive_upper_bound():
+    """Test that the default S-MBU estimator reads fewer weight bytes than
+    the legacy upper-bound estimator for the same batch, and that small
+    batches are no longer assumed to saturate every local expert.
+
+    This is the end-to-end (ExecutionContext -> FfnMetrics) counterpart to
+    `test_estimate_num_activated_experts_never_exceeds_naive_upper_bound`,
+    and mirrors the small-vs-large-batch scenario in
+    `test_moe_per_gpu_expert_activation_accounting` (which is pinned to
+    `upper_bound`) under the new default instead.
+    """
+    hf_config = Qwen3MoeConfig(
+        hidden_size=2048,
+        intermediate_size=8192,
+        num_hidden_layers=12,
+        num_experts=64,
+        num_experts_per_tok=8,
+        moe_intermediate_size=14336,
+        n_shared_experts=0,
+    )
+
+    expected_uniform_config = create_mock_vllm_config(
+        hf_config, moe_activated_experts_estimator="expected_uniform"
+    )
+    upper_bound_config = create_mock_vllm_config(
+        hf_config, moe_activated_experts_estimator="upper_bound"
+    )
+    assert (
+        expected_uniform_config.observability_config.mfu_moe_activated_experts_estimator
+        == ("expected_uniform")
+    )
+
+    expected_uniform_metrics = FfnMetrics.from_vllm_config(expected_uniform_config)
+    upper_bound_metrics = FfnMetrics.from_vllm_config(upper_bound_config)
+    assert (
+        expected_uniform_metrics.moe_activated_experts_estimator == "expected_uniform"
+    )
+    assert upper_bound_metrics.moe_activated_experts_estimator == "upper_bound"
+
+    # Small batch, single request: num_activated_tokens = 10 * 8 = 80 for
+    # num_experts=64 -- well past the naive "always a new expert" regime.
+    small_ctx = ExecutionContext.from_single_request(
+        num_tokens=10, context_len=512, is_prefill=True
+    )
+
+    naive_weight_bytes = upper_bound_metrics.get_read_bytes_breakdown(small_ctx)[
+        "routed_up_gate_weights"
+    ]
+    s_mbu_weight_bytes = expected_uniform_metrics.get_read_bytes_breakdown(small_ctx)[
+        "routed_up_gate_weights"
+    ]
+
+    # The naive formula assumes all 64 experts get touched by only 10
+    # tokens (min(80, 64) == 64); the S-MBU estimate must be strictly
+    # smaller.
+    assert s_mbu_weight_bytes < naive_weight_bytes
+
+    # Total read bytes (all components, not just the routed-expert weight
+    # term) must also strictly decrease, since nothing else in the
+    # breakdown changes between the two estimator modes.
+    assert expected_uniform_metrics.get_read_bytes(
+        small_ctx
+    ) < upper_bound_metrics.get_read_bytes(small_ctx)
+
+    # Write bytes are untouched by this fix (MoE writes are pure
+    # activation traffic, not expert-weight traffic) and must be identical
+    # across both estimator modes.
+    assert expected_uniform_metrics.get_write_bytes(
+        small_ctx
+    ) == upper_bound_metrics.get_write_bytes(small_ctx)
+
+
+def test_ffn_moe_activation_estimator_parser_default():
+    """Test the parser defaults to 'expected_uniform' when unset, matching
+    `ObservabilityConfig.mfu_moe_activated_experts_estimator`'s default."""
+    hf_config = Qwen3MoeConfig(
+        hidden_size=2048,
+        intermediate_size=8192,
+        num_hidden_layers=4,
+        num_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=4096,
+    )
+    vllm_config = create_mock_vllm_config(hf_config)
+
+    result = FfnMetrics.get_parser().parse(vllm_config)
+    assert result.moe_activated_experts_estimator == "expected_uniform"

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -77,6 +77,21 @@ class ObservabilityConfig:
     enable_mfu_metrics: bool = False
     """Enable Model FLOPs Utilization (MFU) metrics."""
 
+    mfu_moe_activated_experts_estimator: Literal["expected_uniform", "upper_bound"] = (
+        "expected_uniform"
+    )
+    """How MoE MBU/MFU accounting (see `enable_mfu_metrics`) estimates the
+    number of distinct experts activated per step for routed-expert
+    weight-byte reads, when no real per-step routing telemetry is
+    available (none is wired in today). `expected_uniform` (default)
+    computes the expected number of distinct experts hit under a
+    uniform-random routing assumption -- a sparsity-aware (S-MBU style,
+    see MoE-CAP arXiv:2412.07067) estimate. `upper_bound` restores the
+    legacy `min(num_tokens * top_k, num_experts)` perfect-load-balancing
+    upper bound, which can overestimate routed-expert weight-read bytes
+    several-fold on bandwidth-bound / small-batch workloads; kept only for
+    comparison against pre-existing dashboards or baselines."""
+
     enable_mm_processor_stats: bool = False
     """Enable collection of timing statistics for multimodal processor operations.
     This is for internal use only (e.g., benchmarks) and is not exposed as a CLI

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -672,6 +672,9 @@ class EngineArgs:
         ObservabilityConfig.enable_layerwise_nvtx_tracing
     )
     enable_mfu_metrics: bool = ObservabilityConfig.enable_mfu_metrics
+    mfu_moe_activated_experts_estimator: Literal["expected_uniform", "upper_bound"] = (
+        ObservabilityConfig.mfu_moe_activated_experts_estimator
+    )
     enable_logging_iteration_details: bool = (
         ObservabilityConfig.enable_logging_iteration_details
     )
@@ -1515,6 +1518,10 @@ class EngineArgs:
             **observability_kwargs["enable_mfu_metrics"],
         )
         observability_group.add_argument(
+            "--mfu-moe-activated-experts-estimator",
+            **observability_kwargs["mfu_moe_activated_experts_estimator"],
+        )
+        observability_group.add_argument(
             "--enable-logging-iteration-details",
             **observability_kwargs["enable_logging_iteration_details"],
         )
@@ -1959,6 +1966,9 @@ class EngineArgs:
             cudagraph_metrics=self.cudagraph_metrics,
             enable_layerwise_nvtx_tracing=self.enable_layerwise_nvtx_tracing,
             enable_mfu_metrics=self.enable_mfu_metrics,
+            mfu_moe_activated_experts_estimator=(
+                self.mfu_moe_activated_experts_estimator
+            ),
             enable_mm_processor_stats=self.enable_mm_processor_stats,
             enable_logging_iteration_details=self.enable_logging_iteration_details,
             jit_monitor_mode=self.jit_monitor_mode,

--- a/vllm/v1/metrics/perf.py
+++ b/vllm/v1/metrics/perf.py
@@ -11,7 +11,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 import prometheus_client
 import torch
@@ -811,6 +811,102 @@ class MLAAttentionMetrics(ComponentMetrics):
 #### Ffn ####
 
 
+def estimate_num_activated_experts(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    num_observed_activated_experts: int | None = None,
+) -> int:
+    """Estimate the number of *distinct* MoE experts activated in a step.
+
+    This backs the Sparse Memory Bandwidth Utilization (S-MBU) style
+    accounting of MoE expert-weight bytes: the number of bytes that must be
+    streamed from memory for routed-expert weights is proportional to how
+    many *distinct* experts were touched, not to the (token, expert-slot)
+    activation count `num_tokens * top_k` itself.
+
+    Top-k routing selects `top_k` DISTINCT experts per token (a token never
+    routes to the same expert twice), so this is not simply `num_tokens *
+    top_k` independent draws. Under a uniform-routing assumption, the
+    probability a specific expert is *not* among a given token's `top_k`
+    picks is `1 - top_k / num_experts`; assuming tokens route independently
+    of one another, the probability that expert is untouched across all
+    `num_tokens` tokens is `(1 - top_k / num_experts) ** num_tokens`. Summed
+    over the `num_experts` experts (linearity of expectation):
+
+        E[num_distinct] = num_experts * (1 - (1 - top_k / num_experts) ** num_tokens)
+
+    This is the expected number of distinct experts under a
+    uniform-routing assumption with per-token distinct top-k picks -- a
+    modeled estimate. MoE-CAP's S-MBU indicator sum (arXiv:2412.07067) is
+    the observed quantity it approximates; real per-step routing telemetry
+    (see `num_observed_activated_experts` below) is exact and always
+    preferred when available.
+
+    Args:
+        num_tokens: Number of tokens in the step (already adjusted for
+            expert-parallel sharding by the caller if applicable).
+        top_k: Number of distinct experts routed to per token (i.e.
+            `num_experts_per_tok`).
+        num_experts: Number of routed experts the tokens draw from
+            (already adjusted for expert-parallel sharding by the caller
+            if applicable).
+        num_observed_activated_experts: If real per-step routing telemetry
+            is available (e.g. from an EPLB expert-load window, see
+            `vllm/distributed/eplb/eplb_state.py`, or a lightweight
+            per-step FusedMoE activation counter), pass the true observed
+            number of distinct activated experts here; it takes priority
+            over the analytic estimate below and is the exact quantity
+            MoE-CAP's S-MBU indicator sum reduces to. No such telemetry is
+            wired into the V1 metrics path today, so no current caller
+            passes it; it exists as an extension point for a future patch.
+            The value is clipped to `[0, num_experts]` defensively.
+
+    Returns:
+        The (estimated, or observed if provided) number of distinct
+        experts activated this step, in `[0, num_experts]`.
+
+    Properties of the estimate (absent an observed override):
+        - Exact at `num_tokens == 1`: returns exactly `min(top_k,
+          num_experts)` -- a single token's `top_k` picks are distinct by
+          construction, so there is no estimation error at T=1.
+        - Always `<= min(num_tokens * top_k, num_experts)`, the naive
+          "every activation is a never-before-seen expert until all are
+          exhausted" upper bound this function replaces (see FIXME
+          history on `FfnMetrics`).
+        - Always `>=` the old slot-independent estimate that ignores
+          within-token distinctness (treats each of the `num_tokens *
+          top_k` activations as an independent uniform draw with
+          replacement over `num_experts`): forcing `top_k` picks per token
+          to be distinct can only raise the expected number of distinct
+          experts touched relative to that looser model.
+
+    Note on routing skew:
+        This estimate assumes uniform routing. Routing skew (hot experts)
+        typically reduces the true distinct-expert count below the
+        uniform expectation, though strongly load-balanced routing can
+        slightly exceed it -- real telemetry (the
+        `num_observed_activated_experts` override above) captures either
+        case.
+    """
+    if top_k <= 0 or num_tokens <= 0 or num_experts <= 0:
+        return 0
+
+    if num_observed_activated_experts is not None:
+        return max(0, min(num_observed_activated_experts, num_experts))
+
+    if top_k >= num_experts:
+        # Every token's top-k picks already span every expert.
+        return num_experts
+
+    # (1 - top_k/E) ** num_tokens underflows gracefully to 0.0 for large
+    # num_tokens, so this saturates to num_experts without any
+    # special-casing.
+    prob_expert_untouched = (1 - top_k / num_experts) ** num_tokens
+    expected_distinct = num_experts * (1 - prob_expert_untouched)
+    return round(expected_distinct)
+
+
 class BaseFfnConfigParser(Parser):
     """
     Parses FFN and MoE configuration.
@@ -939,6 +1035,21 @@ class FfnQuantizationConfigParser(Parser):
         return args
 
 
+class FfnMoeActivationEstimatorParser(Parser):
+    """
+    Parses the MoE activated-experts estimation mode used for MBU/MFU
+    weight-byte accounting.
+
+    Provides: moe_activated_experts_estimator
+    """
+
+    def parse(self, args: ParsedArgs, vllm_config: VllmConfig) -> ParsedArgs:
+        args.moe_activated_experts_estimator = (
+            vllm_config.observability_config.mfu_moe_activated_experts_estimator
+        )
+        return args
+
+
 class FfnMetrics(ComponentMetrics):
     # From BaseConfigParser
     num_hidden_layers: int = Field(..., gt=0)
@@ -959,6 +1070,11 @@ class FfnMetrics(ComponentMetrics):
 
     # From BaseConfigParser, can be overridden InterleaveMoeLayerStep or MoeLayerFreq
     num_moe_layers: int = Field(..., ge=0)
+
+    # From FfnMoeActivationEstimatorParser
+    moe_activated_experts_estimator: Literal["expected_uniform", "upper_bound"] = Field(
+        "expected_uniform"
+    )
 
     # FIXME: might have to make this more granular
     # (i.e. dense_weight_byte_size, moe_routed_weight_byte_size,
@@ -991,6 +1107,7 @@ class FfnMetrics(ComponentMetrics):
             InterleaveMoeLayerStepParser(),
             MoeLayerFreqParser(),
             FfnQuantizationConfigParser(),
+            FfnMoeActivationEstimatorParser(),
         )
 
     def get_num_flops_breakdown(
@@ -1087,8 +1204,35 @@ class FfnMetrics(ComponentMetrics):
         if Lm:
             # MoE routed expert reads
             if E:
-                # FIXME: Assume perfect load balancing for now.
-                num_activated_experts = min(num_activated_tokens, num_experts)
+                # Number of *distinct* routed experts whose weights must be
+                # streamed from memory this step. `min(num_activated_tokens,
+                # num_experts)` (the historical "assume perfect load
+                # balancing" upper bound) overestimates this whenever
+                # num_activated_tokens exceeds num_experts, since it
+                # implicitly assumes every (token, expert-slot) activation
+                # lands on a never-before-seen expert until all experts are
+                # exhausted. See `estimate_num_activated_experts()` for the
+                # S-MBU-style (sparsity-aware) estimate used by default --
+                # it accounts for top-k routing selecting `E` DISTINCT
+                # experts per token, not `T * E` independent slot draws; set
+                # `moe_activated_experts_estimator="upper_bound"` via
+                # `--mfu-moe-activated-experts-estimator` to restore the
+                # legacy behavior.
+                if self.moe_activated_experts_estimator == "upper_bound":
+                    num_activated_experts = min(num_activated_tokens, num_experts)
+                else:
+                    # Pass the token count (T) and experts-per-token (E)
+                    # factors separately -- rather than their pre-multiplied
+                    # product `num_activated_tokens` -- since the estimator
+                    # needs per-token top-k distinctness, not a flattened
+                    # (token, expert-slot) count. T and E are the un-EP-
+                    # scaled per-step values; EP sharding is applied only to
+                    # `num_experts` above, mirroring the pre-existing
+                    # per-GPU-local-expert-pool approximation also used by
+                    # the legacy `upper_bound` path.
+                    num_activated_experts = estimate_num_activated_experts(
+                        T, E, num_experts
+                    )
 
                 read_bytes["routed_up_gate_input"] = int(
                     num_activated_tokens * D * self.activation_byte_size * Lm


### PR DESCRIPTION
## Purpose

### Problem

`FfnMetrics.get_read_bytes_breakdown()` in `vllm/v1/metrics/perf.py` (behind
`--enable-mfu-metrics`, off by default) estimates routed-expert weight-read
bytes for MoE MBU/MFU accounting using:

```python
# FIXME: Assume perfect load balancing for now.
num_activated_experts = min(num_activated_tokens, num_experts)
```

where `num_activated_tokens = num_tokens * top_k`. This is an **upper
bound**, not an estimate: it implicitly assumes every single (token,
expert-slot) activation lands on a never-before-seen expert until all
`num_experts` are exhausted. In practice, once a batch is even moderately
sized, many activations re-hit experts that were already touched earlier in
the same step, so the true number of distinct activated experts is smaller
-- often much smaller in bandwidth-bound, small-batch, or unified-memory
regimes where the MoE-weight-read term dominates memory traffic.

MoE-CAP (arXiv:2412.07067, "MoE-CAP: Benchmarking Cost, Accuracy and
Performance of Sparse Mixture-of-Experts Systems") defines Sparse Memory
Bandwidth Utilization (S-MBU) precisely to correct this: it sums an
indicator `1[l, i]` over whether expert `i` in layer `l` was *actually*
activated, rather than assuming a perfectly load-balanced upper bound. The
paper reports vanilla (perfect-load-balancing) MBU overestimating true
memory traffic by **over 260% on Mixtral-8x7B**, while S-MBU tracks
profiled memory usage to within 1%. We independently measured a similar
effect on Qwen3-30B-A3B (up to ~2.44x overestimate of activated-expert
bytes vs. the measured per-step union) on a GB10 unified-memory box; raw
traces available on request -- this is the concrete motivation for fixing
vLLM's own MBU formula before using it to reason about MoE serving on
bandwidth-bound / unified-memory hardware.

### Fix

This PR does not have access to real per-step routing telemetry at the
point `FfnMetrics` computes its estimate (see "Investigation" below), so
instead of the naive upper bound it computes the **expected** number of
distinct experts activated under a uniform-random-routing assumption.

Top-k routing selects `top_k` **distinct** experts per token (a token never
routes to the same expert twice), so the right model is not "`num_tokens *
top_k` independent draws with replacement" -- it is `num_tokens` tokens,
each contributing a distinct size-`top_k` subset. Under uniform routing,
the probability a specific expert is untouched by one token is `1 - top_k /
num_experts`; assuming tokens route independently of each other, the
probability it stays untouched across all `num_tokens` tokens is `(1 -
top_k / num_experts) ** num_tokens`. Summed over `num_experts` experts
(linearity of expectation):

```
E[num_distinct] = num_experts * (1 - (1 - top_k / num_experts) ** num_tokens)
```

This is a new helper, `estimate_num_activated_experts(num_tokens, top_k,
num_experts, num_observed_activated_experts=None)`, in
`vllm/v1/metrics/perf.py`. It is:

- **Exact at `num_tokens == 1`.** A single token's `top_k` picks are
  distinct by construction, so the estimator returns exactly `min(top_k,
  num_experts)` with zero estimation error at that point -- this is a
  ground-truth check, not just an approximation property.
- **Always <= the naive upper bound** `min(num_tokens * top_k,
  num_experts)` (verified by a parameter sweep in the test suite).
- **Always >= the old (pre-fix) slot-independent formula** that ignores
  within-token distinctness and treats each of the `num_tokens * top_k`
  activations as an independent uniform draw with replacement: forcing a
  token's `top_k` picks to be distinct can only raise the expected number
  of distinct experts touched relative to that looser model (also verified
  by a parameter sweep).
- **This is a modeled estimate, not the S-MBU indicator sum itself.** It is
  the expected number of distinct experts under a uniform-routing
  assumption with per-token distinct top-k picks; MoE-CAP's S-MBU
  indicator sum is the observed quantity it approximates.
- **Forward-compatible with real routing telemetry.** The function accepts
  an optional `num_observed_activated_experts` argument; if a future patch
  wires in the true per-step union (e.g. from EPLB's expert-load window,
  see `vllm/distributed/eplb/eplb_state.py`, or a lightweight per-step
  FusedMoE activation counter), that value is used directly and takes
  priority over the analytic estimate. No caller supplies this today --
  see "Open question" below.

**Honesty note (uniform vs. real routing):** this closed-form estimate is
still an approximation. Routing skew (hot experts) typically reduces the
true distinct-expert count below the uniform expectation, though strongly
load-balanced routing can slightly exceed it -- real telemetry (the
`num_observed_activated_experts` hook above) captures either case. So this
fix is a principled improvement in the right direction under the stated
uniform-routing assumption, but is not guaranteed to match real telemetry
in either direction; closing that gap requires the observed-union hook
described above.

### Backward compatibility

The old behavior is preserved and selectable via a new
`ObservabilityConfig` field, `mfu_moe_activated_experts_estimator`
(`Literal["expected_uniform", "upper_bound"]`, default
`"expected_uniform"`), exposed as `--mfu-moe-activated-experts-estimator`.
Passing `upper_bound` reproduces the exact legacy
`min(num_activated_tokens, num_experts)` formula bit-for-bit, for
comparison against existing dashboards/baselines. This follows the file's
existing `Parser` -> `ParsedArgs` -> pydantic-field convention (see
`FfnMoeActivationEstimatorParser`), and mirrors two existing
`Literal`-toggle precedents in the very same `ObservabilityConfig` class --
`per_request_spec_decode_metrics` and `jit_monitor_mode` -- both wired
through `EngineArgs` and the CLI the same way this field is. If maintainers
prefer a plain formula fix instead, we are happy to drop the `upper_bound`
mode and the flag entirely.

Only `get_read_bytes_breakdown()`'s routed-expert weight terms
(`routed_up_gate_weights`, `routed_down_weights`) are affected. Dense FFN,
attention, unembedding, and MoE *write*-byte accounting (which is pure
activation traffic, not expert-weight traffic, and does not reference
`num_activated_experts`) are untouched. At the call site, the token-count
(`T`) and experts-per-token (`E`, i.e. `num_experts_per_tok`) factors are
now passed to the estimator separately instead of pre-multiplied, since the
estimator needs per-token top-k distinctness rather than a flattened
(token, expert-slot) count; the legacy `upper_bound` branch is untouched
and still computes `min(num_activated_tokens, num_experts)` exactly as
before.

### Investigation: is real per-step routing telemetry available here?

No. `ExecutionContext` (the input to all `ComponentMetrics.get_*_bytes*`
methods) is built purely from `SchedulerOutput`-level per-request token and
context-length counts (see `ExecutionContext.add()`); it carries zero
per-expert routing information, and nothing in the V1 engine's metrics path
threads routing decisions through to it.

The only real per-expert telemetry in the repo is
`EplbStats.global_expert_load_window` in
`vllm/distributed/eplb/eplb_state.py` (shape `(window_size,
num_moe_layers, num_physical_experts)`), populated when Expert-Parallelism
Load Balancing (`enable_eplb`) is turned on. It is not a safe source to
wire in directly for this fix, because:

1. It's gated behind a separate, off-by-default subsystem (EPLB), so it
   would not help the common case.
2. It's a live per-rank GPU tensor; reading it triggers a GPU sync (see the
   `gpu_sync_debug.gpu_sync_allowed` guard around EPLB state access),
   which would undermine this module's design as a cheap, CPU-side
   analytic estimate computed every step.
3. It's windowed across multiple steps, not a strict single-step union,
   and organized per EP rank rather than per the aggregate
   `ExecutionContext` this module already works with.

Given the "CPU-only, no live-run" constraint on this change and the above,
I left the observed-telemetry path as a documented extension point
(`num_observed_activated_experts` parameter) rather than wiring EPLB in
directly. **Open question for maintainers:** is there appetite for a
follow-up that threads a real per-step activated-expert count from EPLB
(when enabled) or a new lightweight FusedMoE-level counter into this call
site? Happy to scope that as a separate PR.

## Test Plan

```
python -m pytest tests/v1/metrics/test_perf_metrics.py --confcutdir=tests/v1/metrics
ruff check vllm/v1/metrics/perf.py vllm/config/observability.py vllm/engine/arg_utils.py tests/v1/metrics/test_perf_metrics.py
ruff format --check vllm/v1/metrics/perf.py vllm/config/observability.py vllm/engine/arg_utils.py tests/v1/metrics/test_perf_metrics.py
```

No GPU, no model load, no live server -- pure closed-form math and mocked
`VllmConfig`s, consistent with the rest of this test file.

## Test Result

`python -m pytest tests/v1/metrics/test_perf_metrics.py --confcutdir=tests/v1/metrics`:
**65 passed** (48 test functions, some parametrized). `ruff check` and
`ruff format --check` both clean on all four changed files.

Tests added/changed in `tests/v1/metrics/test_perf_metrics.py`:

- `test_estimate_num_activated_experts_matches_closed_form`: exact
  closed-form check against a hand-computed reference value
  (`num_tokens=6, top_k=2, num_experts=8` -> `7`, vs. naive upper bound
  `min(12, 8) = 8` and old slot-independent formula `6`).
- `test_estimate_num_activated_experts_edge_cases`: zero/negative inputs,
  `num_experts=0`, `top_k=0`, and `top_k >= num_experts` saturation.
- `test_estimate_num_activated_experts_exact_at_single_token` (new): the
  `num_tokens == 1` exactness property called out above, across several
  `(top_k, num_experts)` pairs.
- `test_estimate_num_activated_experts_saturates_for_large_batches`:
  approaches `num_experts` as `num_tokens` grows large.
- `test_estimate_num_activated_experts_observed_override`: the
  `num_observed_activated_experts` hook takes priority and is clipped to
  `[0, num_experts]`.
- `test_estimate_num_activated_experts_never_exceeds_naive_upper_bound`: a
  parameter sweep over `(num_tokens, top_k, num_experts)` asserting
  `estimate <= min(num_tokens * top_k, num_experts)` everywhere.
- `test_estimate_num_activated_experts_at_least_old_slot_independent_formula`
  (new): a parameter sweep asserting the new estimate is always >= the old
  (pre-fix) slot-independent formula.
- `test_ffn_metrics_s_mbu_below_naive_upper_bound`: end-to-end
  `FfnMetrics`-level check that, for the same batch, the default estimator
  produces strictly fewer routed-expert weight-read bytes (and fewer total
  read bytes) than the legacy `upper_bound` estimator, while write bytes
  are unaffected.
- `test_ffn_moe_activation_estimator_parser_default`: the new parser
  defaults to `"expected_uniform"`.

Two pre-existing tests
(`test_moe_expert_activation_proportional_scaling`,
`test_moe_per_gpu_expert_activation_accounting`) that depended on the
legacy formula's saturate-at-`num_experts` behavior are pinned to
`moe_activated_experts_estimator="upper_bound"` with comments explaining
why, so their original intent and pass/fail behavior is preserved
unchanged.

### Files changed

- `vllm/v1/metrics/perf.py`: new `estimate_num_activated_experts()`
  helper (top-k-aware, distinct-picks-per-token formula); new
  `FfnMoeActivationEstimatorParser`; new
  `FfnMetrics.moe_activated_experts_estimator` field; fixed FIXME site in
  `get_read_bytes_breakdown()`.
- `vllm/config/observability.py`: new
  `ObservabilityConfig.mfu_moe_activated_experts_estimator` field.
- `vllm/engine/arg_utils.py`: new `--mfu-moe-activated-experts-estimator`
  CLI flag, wired through `EngineArgs` and `create_observability_config()`.
- `tests/v1/metrics/test_perf_metrics.py`: new tests (above) + two
  existing tests pinned to the legacy estimator.

### References

- MoE-CAP: Benchmarking Cost, Accuracy and Performance of Sparse
  Mixture-of-Experts Systems. arXiv:2412.07067.


### AI assistance disclosure

Per the [AI Assisted Contributions](https://docs.vllm.ai/en/latest/contributing/#ai-assisted-contributions)
guideline: this PR was developed with non-trivial AI assistance (Claude). The submitter
reviewed all changed lines, the analysis and formula derivation were independently
re-verified (including a hand-checked `T=1 -> k` boundary case), and the tests in
`tests/v1/metrics/test_perf_metrics.py` were run locally on the submitted tree
(65 passed). Commits carry `Co-Authored-By` trailers.
