### PR TITLE
[Bugfix] Honor safetensors index tensor assignments

### DIFF
--- a/tests/model_executor/model_loader/test_filter_duplicate_safetensors.py
+++ b/tests/model_executor/model_loader/test_filter_duplicate_safetensors.py
@@ -127,6 +127,51 @@ def test_default_loader_only_yields_tensors_assigned_by_index(
     torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))
 
 
+@pytest.mark.skip_global_cleanup
+def test_multithread_loader_only_yields_tensors_assigned_by_index(tmp_path) -> None:
+    main_shard = tmp_path / "model-00001-of-00002.safetensors"
+    reused_shard = tmp_path / "model-00002-of-00002.safetensors"
+    save_file({"main.weight": torch.tensor([1.0])}, main_shard)
+    save_file(
+        {
+            "ple.weight": torch.tensor([2.0]),
+            "main.weight": torch.tensor([99.0]),
+            "unindexed.weight": torch.tensor([3.0]),
+        },
+        reused_shard,
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {},
+                "weight_map": {
+                    "main.weight": main_shard.name,
+                    "ple.weight": reused_shard.name,
+                },
+            }
+        )
+    )
+
+    loader = DefaultModelLoader(
+        LoadConfig(
+            load_format="safetensors",
+            use_tqdm_on_load=False,
+            model_loader_extra_config={"enable_multithread_load": True},
+        )
+    )
+    source = DefaultModelLoader.Source(
+        model_or_path=str(tmp_path),
+        revision=None,
+        fall_back_to_pt=False,
+    )
+
+    weights = sorted(loader._get_weights_iterator(source), key=lambda kv: kv[0])
+
+    assert [name for name, _ in weights] == ["main.weight", "ple.weight"]
+    torch.testing.assert_close(weights[0][1], torch.tensor([1.0]))
+    torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))
+
+
 if __name__ == "__main__":
     test_filter_duplicate_safetensors_files_missing_weight()
     test_filter_duplicate_safetensors_files_all_exist()

--- a/tests/model_executor/model_loader/test_filter_duplicate_safetensors.py
+++ b/tests/model_executor/model_loader/test_filter_duplicate_safetensors.py
@@ -78,12 +78,19 @@ def test_filter_duplicate_safetensors_files_all_exist():
         )
 
 
-@pytest.mark.skip_global_cleanup
-@pytest.mark.parametrize("load_format", ["auto", "safetensors"])
-@pytest.mark.parametrize("load_strategy", [None, "lazy", "eager"])
-def test_default_loader_only_yields_tensors_assigned_by_index(
-    tmp_path, load_format: str, load_strategy: str | None
-) -> None:
+def _write_index(tmp_path, weight_map: dict[str, str]) -> None:
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+
+
+def _write_reused_shard_checkpoint(tmp_path) -> None:
+    """A checkpoint whose second shard is reused from another model.
+
+    The index assigns ``main.weight`` to the first shard and ``ple.weight`` to
+    the second, but the second shard also stores a stale ``main.weight`` and an
+    entirely unindexed tensor.
+    """
     main_shard = tmp_path / "model-00001-of-00002.safetensors"
     reused_shard = tmp_path / "model-00002-of-00002.safetensors"
     save_file({"main.weight": torch.tensor([1.0])}, main_shard)
@@ -95,17 +102,42 @@ def test_default_loader_only_yields_tensors_assigned_by_index(
         },
         reused_shard,
     )
-    (tmp_path / "model.safetensors.index.json").write_text(
-        json.dumps(
-            {
-                "metadata": {},
-                "weight_map": {
-                    "main.weight": main_shard.name,
-                    "ple.weight": reused_shard.name,
-                },
-            }
-        )
+    _write_index(
+        tmp_path,
+        {"main.weight": main_shard.name, "ple.weight": reused_shard.name},
     )
+
+
+def _write_ordinary_checkpoint(tmp_path) -> None:
+    """A normal sharded checkpoint: each shard stores exactly its index entry."""
+    first_shard = tmp_path / "model-00001-of-00002.safetensors"
+    second_shard = tmp_path / "model-00002-of-00002.safetensors"
+    save_file({"main.weight": torch.tensor([1.0])}, first_shard)
+    save_file({"ple.weight": torch.tensor([2.0])}, second_shard)
+    _write_index(
+        tmp_path,
+        {"main.weight": first_shard.name, "ple.weight": second_shard.name},
+    )
+
+
+def _prepare(tmp_path, **load_config_kwargs):
+    loader = DefaultModelLoader(LoadConfig(**load_config_kwargs))
+    return loader._prepare_weights(
+        str(tmp_path),
+        None,
+        None,
+        fall_back_to_pt=False,
+        allow_patterns_overrides=None,
+    )
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize("load_format", ["auto", "safetensors"])
+@pytest.mark.parametrize("load_strategy", [None, "lazy", "eager"])
+def test_default_loader_only_yields_tensors_assigned_by_index(
+    tmp_path, load_format: str, load_strategy: str | None
+) -> None:
+    _write_reused_shard_checkpoint(tmp_path)
 
     loader = DefaultModelLoader(
         LoadConfig(
@@ -129,28 +161,7 @@ def test_default_loader_only_yields_tensors_assigned_by_index(
 
 @pytest.mark.skip_global_cleanup
 def test_multithread_loader_only_yields_tensors_assigned_by_index(tmp_path) -> None:
-    main_shard = tmp_path / "model-00001-of-00002.safetensors"
-    reused_shard = tmp_path / "model-00002-of-00002.safetensors"
-    save_file({"main.weight": torch.tensor([1.0])}, main_shard)
-    save_file(
-        {
-            "ple.weight": torch.tensor([2.0]),
-            "main.weight": torch.tensor([99.0]),
-            "unindexed.weight": torch.tensor([3.0]),
-        },
-        reused_shard,
-    )
-    (tmp_path / "model.safetensors.index.json").write_text(
-        json.dumps(
-            {
-                "metadata": {},
-                "weight_map": {
-                    "main.weight": main_shard.name,
-                    "ple.weight": reused_shard.name,
-                },
-            }
-        )
-    )
+    _write_reused_shard_checkpoint(tmp_path)
 
     loader = DefaultModelLoader(
         LoadConfig(
@@ -170,6 +181,44 @@ def test_multithread_loader_only_yields_tensors_assigned_by_index(tmp_path) -> N
     assert [name for name, _ in weights] == ["main.weight", "ple.weight"]
     torch.testing.assert_close(weights[0][1], torch.tensor([1.0]))
     torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))
+
+
+@pytest.mark.skip_global_cleanup
+def test_prepare_weights_skips_filtering_for_ordinary_checkpoint(tmp_path) -> None:
+    # Every shard stores exactly what the index assigns to it, so no allowlist
+    # is produced and the accelerated backends stay available.
+    _write_ordinary_checkpoint(tmp_path)
+
+    *_, indexed_weights_by_file = _prepare(tmp_path, load_format="safetensors")
+
+    assert indexed_weights_by_file is None
+
+
+@pytest.mark.skip_global_cleanup
+def test_prepare_weights_engages_filtering_for_reused_shard(tmp_path) -> None:
+    # The reused shard stores tensors the index did not assign to it, so the
+    # per-file allowlist is produced.
+    _write_reused_shard_checkpoint(tmp_path)
+
+    *_, indexed_weights_by_file = _prepare(tmp_path, load_format="safetensors")
+
+    assert indexed_weights_by_file == {
+        os.path.normpath(str(tmp_path / "model-00001-of-00002.safetensors")): {
+            "main.weight"
+        },
+        os.path.normpath(str(tmp_path / "model-00002-of-00002.safetensors")): {
+            "ple.weight"
+        },
+    }
+
+
+@pytest.mark.skip_global_cleanup
+def test_prepare_weights_skips_filtering_without_index(tmp_path) -> None:
+    save_file({"main.weight": torch.tensor([1.0])}, tmp_path / "model.safetensors")
+
+    *_, indexed_weights_by_file = _prepare(tmp_path, load_format="safetensors")
+
+    assert indexed_weights_by_file is None
 
 
 if __name__ == "__main__":

--- a/tests/model_executor/model_loader/test_filter_duplicate_safetensors.py
+++ b/tests/model_executor/model_loader/test_filter_duplicate_safetensors.py
@@ -6,7 +6,11 @@ import os
 import tempfile
 
 import pytest
+import torch
+from safetensors.torch import save_file
 
+from vllm.config.load import LoadConfig
+from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 from vllm.model_executor.model_loader.weight_utils import (
     filter_duplicate_safetensors_files,
 )
@@ -72,6 +76,55 @@ def test_filter_duplicate_safetensors_files_all_exist():
             hf_folder=tmpdir,
             index_file="model.safetensors.index.json",
         )
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize("load_format", ["auto", "safetensors"])
+@pytest.mark.parametrize("load_strategy", [None, "lazy", "eager"])
+def test_default_loader_only_yields_tensors_assigned_by_index(
+    tmp_path, load_format: str, load_strategy: str | None
+) -> None:
+    main_shard = tmp_path / "model-00001-of-00002.safetensors"
+    reused_shard = tmp_path / "model-00002-of-00002.safetensors"
+    save_file({"main.weight": torch.tensor([1.0])}, main_shard)
+    save_file(
+        {
+            "ple.weight": torch.tensor([2.0]),
+            "main.weight": torch.tensor([99.0]),
+            "unindexed.weight": torch.tensor([3.0]),
+        },
+        reused_shard,
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {},
+                "weight_map": {
+                    "main.weight": main_shard.name,
+                    "ple.weight": reused_shard.name,
+                },
+            }
+        )
+    )
+
+    loader = DefaultModelLoader(
+        LoadConfig(
+            load_format=load_format,
+            safetensors_load_strategy=load_strategy,
+            use_tqdm_on_load=False,
+        )
+    )
+    source = DefaultModelLoader.Source(
+        model_or_path=str(tmp_path),
+        revision=None,
+        fall_back_to_pt=False,
+    )
+
+    weights = list(loader._get_weights_iterator(source))
+
+    assert [name for name, _ in weights] == ["main.weight", "ple.weight"]
+    torch.testing.assert_close(weights[0][1], torch.tensor([1.0]))
+    torch.testing.assert_close(weights[1][1], torch.tensor([2.0]))
 
 
 if __name__ == "__main__":

--- a/tests/model_executor/model_loader/test_registry.py
+++ b/tests/model_executor/model_loader/test_registry.py
@@ -79,7 +79,7 @@ def test_default_loader_hf_still_falls_back_to_pt(tmp_path):
     # Control: load_format="hf" still picks up .pt weights via fallback.
     (tmp_path / "model.pt").write_bytes(b"\x00\x00\x00\x00")
     loader = DefaultModelLoader(LoadConfig(load_format="hf"))
-    _, files, use_safetensors = loader._prepare_weights(
+    _, files, use_safetensors, _ = loader._prepare_weights(
         str(tmp_path),
         None,
         None,

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -26,6 +26,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     filter_duplicate_safetensors_files,
     filter_files_not_needed_for_inference,
     get_quant_config,
+    get_safetensors_index_weights_by_file,
     instanttensor_weights_iterator,
     maybe_download_from_modelscope,
     multi_thread_pt_weights_iterator,
@@ -132,7 +133,7 @@ class DefaultModelLoader(BaseModelLoader):
         revision: str | None,
         fall_back_to_pt: bool,
         allow_patterns_overrides: list[str] | None,
-    ) -> tuple[str, list[str], bool]:
+    ) -> tuple[str, list[str], bool, dict[str, set[str]] | None]:
         """Prepare weights for the model.
 
         If the model is not local, it will be downloaded."""
@@ -239,14 +240,29 @@ class DefaultModelLoader(BaseModelLoader):
                 f"Cannot find any model weights with `{model_name_or_path}`"
             )
 
-        return hf_folder, hf_weights_files, use_safetensors
+        indexed_weights_by_file = (
+            get_safetensors_index_weights_by_file(hf_folder, index_file)
+            if use_safetensors
+            else None
+        )
+        return (
+            hf_folder,
+            hf_weights_files,
+            use_safetensors,
+            indexed_weights_by_file,
+        )
 
     def _get_weights_iterator(
         self, source: "Source"
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
         extra_config = self.load_config.model_loader_extra_config
-        hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
+        (
+            hf_folder,
+            hf_weights_files,
+            use_safetensors,
+            indexed_weights_by_file,
+        ) = self._prepare_weights(
             source.model_or_path,
             source.subfolder,
             source.revision,
@@ -289,6 +305,7 @@ class DefaultModelLoader(BaseModelLoader):
                         self.load_config.use_tqdm_on_load,
                         self.load_config.safetensors_load_strategy,
                         local_expert_ids=self.local_expert_ids,
+                        indexed_weights_by_file=indexed_weights_by_file,
                         safetensors_prefetch_num_threads=(
                             self.load_config.safetensors_prefetch_num_threads
                         ),

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -280,12 +280,27 @@ class DefaultModelLoader(BaseModelLoader):
                 self.load_config.use_tqdm_on_load,
             )
         elif use_safetensors:
-            if self.load_config.load_format == "fastsafetensors":
+            # fastsafetensors/instanttensor iterators cannot filter tensors
+            # inside a reused shard, so indexed-subset checkpoints must take
+            # the standard filtered iterator to honor the index assignments.
+            use_special_format = self.load_config.load_format in (
+                "fastsafetensors",
+                "instanttensor",
+            )
+            if use_special_format and indexed_weights_by_file is not None:
+                logger.warning(
+                    "Checkpoint index assigns a subset of stored tensors; "
+                    "falling back from %s to the filtered safetensors "
+                    "iterator.",
+                    self.load_config.load_format,
+                )
+                use_special_format = False
+            if use_special_format and self.load_config.load_format == "fastsafetensors":
                 weights_iterator = fastsafetensors_weights_iterator(
                     hf_weights_files,
                     self.load_config.use_tqdm_on_load,
                 )
-            elif self.load_config.load_format == "instanttensor":
+            elif use_special_format and self.load_config.load_format == "instanttensor":
                 weights_iterator = instanttensor_weights_iterator(
                     hf_weights_files,
                     self.load_config.use_tqdm_on_load,
@@ -298,6 +313,7 @@ class DefaultModelLoader(BaseModelLoader):
                         max_workers=extra_config.get(
                             "num_threads", self.DEFAULT_NUM_THREADS
                         ),
+                        indexed_weights_by_file=indexed_weights_by_file,
                     )
                 else:
                     weights_iterator = safetensors_weights_iterator(

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -241,7 +241,9 @@ class DefaultModelLoader(BaseModelLoader):
             )
 
         indexed_weights_by_file = (
-            get_safetensors_index_weights_by_file(hf_folder, index_file)
+            get_safetensors_index_weights_by_file(
+                hf_folder, index_file, hf_weights_files
+            )
             if use_safetensors
             else None
         )
@@ -281,17 +283,19 @@ class DefaultModelLoader(BaseModelLoader):
             )
         elif use_safetensors:
             # fastsafetensors/instanttensor iterators cannot filter tensors
-            # inside a reused shard, so indexed-subset checkpoints must take
-            # the standard filtered iterator to honor the index assignments.
+            # inside a reused shard. `indexed_weights_by_file` is only set when
+            # a shard really does store unindexed tensors, so ordinary indexed
+            # checkpoints keep using these accelerated backends and only
+            # subset checkpoints take the standard filtered iterator.
             use_special_format = self.load_config.load_format in (
                 "fastsafetensors",
                 "instanttensor",
             )
             if use_special_format and indexed_weights_by_file is not None:
                 logger.warning(
-                    "Checkpoint index assigns a subset of stored tensors; "
-                    "falling back from %s to the filtered safetensors "
-                    "iterator.",
+                    "Checkpoint shards store tensors the index does not "
+                    "assign to them; falling back from %s to the filtered "
+                    "safetensors iterator so the index is honored.",
                     self.load_config.load_format,
                 )
                 use_special_format = False

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1008,11 +1008,22 @@ def multi_thread_safetensors_weights_iterator(
     hf_weights_files: list[str],
     use_tqdm_on_load: bool,
     max_workers: int = 4,
+    indexed_weights_by_file: Mapping[str, set[str]] | None = None,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Multi-Thread iterate over the weights in the model safetensor files."""
 
     def _load_file(st_file: str):
         result = load_file(st_file, device="cpu")
+        if indexed_weights_by_file is not None:
+            indexed_weights = indexed_weights_by_file.get(os.path.normpath(st_file))
+            if indexed_weights is None:
+                raise ValueError(
+                    f"Safetensors shard {st_file!r} is not present in the "
+                    "checkpoint index"
+                )
+            for name in list(result):
+                if name not in indexed_weights:
+                    del result[name]
         return result
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -13,7 +13,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import IO, Any
@@ -599,6 +599,24 @@ def filter_duplicate_safetensors_files(
     return hf_weights_files
 
 
+def get_safetensors_index_weights_by_file(
+    hf_folder: str, index_file: str
+) -> dict[str, set[str]] | None:
+    """Return the tensor names assigned to each shard by the index."""
+    index_file_name = os.path.join(hf_folder, index_file)
+    if not os.path.isfile(index_file_name):
+        return None
+
+    with open(index_file_name) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    weights_by_file: dict[str, set[str]] = defaultdict(set)
+    for weight_name, filename in weight_map.items():
+        shard_path = os.path.normpath(os.path.join(hf_folder, filename))
+        weights_by_file[shard_path].add(weight_name)
+    return dict(weights_by_file)
+
+
 def filter_files_not_needed_for_inference(hf_weights_files: list[str]) -> list[str]:
     """
     Exclude files that are not needed for inference.
@@ -832,6 +850,7 @@ def safetensors_weights_iterator(
     safetensors_load_strategy: str | None = None,
     local_expert_ids: set[int] | None = None,
     *,
+    indexed_weights_by_file: Mapping[str, set[str]] | None = None,
     safetensors_prefetch_num_threads: int = DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS,
     safetensors_prefetch_block_size: int = DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
@@ -846,6 +865,14 @@ def safetensors_weights_iterator(
         loading_desc += " (eager)"
 
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
+
+    if indexed_weights_by_file is not None:
+        logger.info_once(
+            "Restricting safetensors loading to %d tensor entries assigned "
+            "by the checkpoint index across %d shards.",
+            sum(len(names) for names in indexed_weights_by_file.values()),
+            len(indexed_weights_by_file),
+        )
 
     fs_type = _get_fs_type(sorted_files)
     is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
@@ -918,10 +945,20 @@ def safetensors_weights_iterator(
         disable=not enable_tqdm(use_tqdm_on_load),
         bar_format=_BAR_FORMAT,
     ):
+        indexed_weights = None
+        if indexed_weights_by_file is not None:
+            indexed_weights = indexed_weights_by_file.get(os.path.normpath(st_file))
+            if indexed_weights is None:
+                raise ValueError(
+                    f"Safetensors shard {st_file!r} is not present in the "
+                    "checkpoint index"
+                )
         if safetensors_load_strategy == "eager":
             with open(st_file, "rb") as f:
                 state_dict = load(f.read())
             for name, param in state_dict.items():
+                if indexed_weights is not None and name not in indexed_weights:
+                    continue
                 if not should_skip_weight(name, local_expert_ids):
                     yield name, param
         elif safetensors_load_strategy == "torchao":
@@ -939,6 +976,8 @@ def safetensors_weights_iterator(
             with safe_open(st_file, framework="pt") as f:
                 state_dict = {}
                 for name in f.keys():  # noqa: SIM118
+                    if indexed_weights is not None and name not in indexed_weights:
+                        continue
                     if should_skip_weight(name, local_expert_ids):
                         continue
                     state_dict[name] = f.get_tensor(name)
@@ -957,6 +996,8 @@ def safetensors_weights_iterator(
         else:
             with safe_open(st_file, framework="pt") as f:
                 for name in f.keys():  # noqa: SIM118
+                    if indexed_weights is not None and name not in indexed_weights:
+                        continue
                     if should_skip_weight(name, local_expert_ids):
                         continue
                     param = f.get_tensor(name)

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -600,9 +600,21 @@ def filter_duplicate_safetensors_files(
 
 
 def get_safetensors_index_weights_by_file(
-    hf_folder: str, index_file: str
+    hf_folder: str, index_file: str, hf_weights_files: list[str]
 ) -> dict[str, set[str]] | None:
-    """Return the tensor names assigned to each shard by the index."""
+    """Return per-shard tensor allowlists, but only when the index needs them.
+
+    A safetensors index assigns each tensor name to exactly one shard. Almost
+    every checkpoint stores in each shard exactly the tensors the index assigns
+    to it, and for those this returns ``None`` so that all loader paths keep
+    their current behavior, including the accelerated backends that cannot
+    filter within a shard.
+
+    An allowlist is returned only when a shard actually stores tensors the
+    index did not assign to it, which happens when a checkpoint reuses a shard
+    from another model. Detecting this reads safetensors headers, not tensor
+    data.
+    """
     index_file_name = os.path.join(hf_folder, index_file)
     if not os.path.isfile(index_file_name):
         return None
@@ -614,7 +626,18 @@ def get_safetensors_index_weights_by_file(
     for weight_name, filename in weight_map.items():
         shard_path = os.path.normpath(os.path.join(hf_folder, filename))
         weights_by_file[shard_path].add(weight_name)
-    return dict(weights_by_file)
+
+    for st_file in hf_weights_files:
+        indexed_weights = weights_by_file.get(os.path.normpath(st_file))
+        if indexed_weights is None:
+            # Shard is not covered by the index, so there is nothing to
+            # enforce. Leave the existing behavior untouched.
+            return None
+        with safe_open(st_file, framework="pt") as f:
+            stored_weights = set(f.keys())
+        if stored_weights - indexed_weights:
+            return dict(weights_by_file)
+    return None
 
 
 def filter_files_not_needed_for_inference(hf_weights_files: list[str]) -> list[str]:


### PR DESCRIPTION
## Purpose

**Symptom:** loading a TP4 Qwen3.8 Flash Next AWQ checkpoint (222,747 tensors) produced wrong weights. The checkpoint reuses 33 official PLE shards, from which its index selects only 129 tensors — but those files also store 1,024 unindexed FP8 expert tensors, some carrying names the index assigns to *different* AWQ shards. Those stale tensors were loaded and silently overwrote the correct ones.

**Root cause:** a safetensors index assigns each tensor name to exactly one shard. `DefaultModelLoader` uses `weight_map` only to filter the shard *file* list, then hands those files to the standard safetensors iterator, which yields *every* tensor stored in each file. The per-file assignment is never enforced, so any checkpoint that intentionally reuses a shard containing extra tensors loads them.

**Fix:** treat `weight_map` as a per-file tensor allowlist. `_prepare_weights` now also returns the index's per-shard tensor sets, and the iterators drop tensors the index did not assign to that shard.

The allowlist is only built when it is actually needed: `get_safetensors_index_weights_by_file` compares each selected shard's stored tensor names against its index assignment and returns `None` unless some shard really does store unindexed tensors. Detection reads safetensors headers via `safe_open(...).keys()`, never tensor data, and returns as soon as the first mismatching shard is found. So ordinary sharded checkpoints — and checkpoints with no index at all — keep every existing loader path unchanged, including the accelerated backends.

Coverage per path:

- default/lazy and torchao: filtered inside `safe_open` before `get_tensor`, so unindexed tensors are never materialized.
- eager and multithreaded: the shard is decoded as a unit, so unindexed tensors are dropped immediately after decode and never reach weight loading. Correct, but without the memory saving of the lazy paths.
- A shard absent from the index raises rather than loading unfiltered.

`fastsafetensors` and `instanttensor` cannot filter within a shard at all. Rather than let them silently bypass the index, reused-shard checkpoints fall back to the filtered standard iterator with a warning. Ordinary indexed checkpoints are unaffected and keep using these backends.

**Duplicate-work check:** no open vLLM PR implements per-file index tensor filtering. Searched `safetensors index` and `model loader tensor filter`; nearby loader PRs address EP filtering or other formats, not this index contract.

**AI assistance:** OpenAI Codex assisted with implementation, tests, and PR preparation. I supplied the production reproducer, reviewed every changed line, and ran the tests below.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/model_executor/model_loader/test_filter_duplicate_safetensors.py \
  tests/model_executor/model_loader/test_registry.py -vv

.venv/bin/python -m pytest \
  tests/model_executor/model_loader/test_ep_weight_filter.py \
  -k EpFilterOnSyntheticMoeWeights -vv

.venv/bin/pre-commit run --files \
  vllm/model_executor/model_loader/default_loader.py \
  vllm/model_executor/model_loader/weight_utils.py \
  tests/model_executor/model_loader/test_filter_duplicate_safetensors.py \
  tests/model_executor/model_loader/test_registry.py
```

The regression builds two shards sharing a `main.weight`: the indexed shard holds `1.0`, the reused shard holds stale `99.0` plus an unindexed tensor. It asserts only `main.weight=1.0` and `ple.weight=2.0` are yielded, across `auto` and explicit `safetensors` load formats and default/lazy/eager strategies, plus a separate case for `enable_multithread_load` (sorted before asserting, since `as_completed` does not preserve file order).

Three further tests pin when filtering engages at all: an ordinary sharded checkpoint and a checkpoint with no index must both produce no allowlist, while the reused-shard checkpoint must produce the expected per-shard sets.

## Test Result

- `test_filter_duplicate_safetensors.py`: `12 passed`.
- `test_registry.py`: `6 passed`.
- Existing synthetic EP iterator regression: `5 passed`.
- Pre-commit on all changed files: passed (ruff, ruff format, mypy, SPDX).
- Negative control: with the allowlist built unconditionally, `test_prepare_weights_skips_filtering_for_ordinary_checkpoint` fails with `assert {...: {'main.weight'}, ...: {'ple.weight'}} is None`, confirming the test pins the accelerated-backend regression rather than passing vacuously.
- Real checkpoint: the equivalent change completed TP4 loading of the 222,747-tensor Qwen3.8 Flash Next AWQ model and kept all 1,024 unindexed FP8 expert tensors out of weight loading. That run predates this PR's shard-header detection; the isolated validation above was run on CPU without a GPU.
- No model compute path changed.