### PR TITLE
[Bugfix] Resolve --kv-cache-dtype auto to fp8_ds_mla for DeepSeek-V4 on SM120

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -4,10 +4,13 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.config import set_current_vllm_config
+from vllm.models.deepseek_v4.attention import _resolve_dsv4_kv_cache_dtype
 from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
+    DeepseekV4FlashInferMLASparseBackend,
     _required_sm120_sparse_topk,
 )
 from vllm.platforms.interface import DeviceCapability
@@ -92,3 +95,42 @@ def test_sm120_dsv4_required_topk_tracks_dspark_width() -> None:
 
     assert _required_sm120_sparse_topk(causal, 128) == 128
     assert _required_sm120_sparse_topk(dspark, 128) == 192
+
+
+@pytest.mark.parametrize("requested", ["auto", "fp8", "fp8_e4m3"])
+def test_dsv4_fp8_ds_mla_layout_resolves_auto_and_fp8(requested: str) -> None:
+    """The fp8_ds_mla layout has no unquantized fallback, so the default
+    "auto" must resolve to fp8_ds_mla instead of crashing (#47174)."""
+    cache_config = SimpleNamespace(cache_dtype=requested)
+    dtype_str, torch_dtype = _resolve_dsv4_kv_cache_dtype(True, requested, cache_config)
+    assert dtype_str == "fp8_ds_mla"
+    assert torch_dtype == torch.uint8
+    assert cache_config.cache_dtype == "fp8_ds_mla"
+
+
+def test_dsv4_fp8_ds_mla_layout_rejects_bf16_with_actionable_error() -> None:
+    with pytest.raises(ValueError, match="--kv-cache-dtype fp8"):
+        _resolve_dsv4_kv_cache_dtype(True, "bfloat16", None)
+
+
+def test_dsv4_plain_layout_keeps_auto_as_bf16() -> None:
+    dtype_str, torch_dtype = _resolve_dsv4_kv_cache_dtype(False, "auto", None)
+    assert dtype_str == "auto"
+    assert torch_dtype == torch.bfloat16
+
+
+def test_sm120_dsv4_backend_accepts_auto_kv_cache_dtype(monkeypatch) -> None:
+    monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+
+    reason = DeepseekV4FlashInferMLASparseBackend.supports_combination(
+        head_size=512,
+        dtype=torch.bfloat16,
+        kv_cache_dtype="auto",
+        block_size=256,
+        use_mla=True,
+        has_sink=False,
+        use_sparse=True,
+        use_mm_prefix=False,
+        device_capability=DeviceCapability(12, 0),
+    )
+    assert reason is None

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -102,10 +102,15 @@ def _resolve_dsv4_kv_cache_dtype(
     """
     if use_fp8_ds_mla_layout:
         # fp8_ds_mla block format: UE8M0 block-scaled fp8 packed as uint8.
-        assert kv_cache_dtype.startswith("fp8"), (
-            f"DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, "
-            f"got {kv_cache_dtype}"
-        )
+        # The layout has no unquantized fallback, so "auto" resolves to it
+        # rather than to the model dtype.
+        if kv_cache_dtype != "auto" and not kv_cache_dtype.startswith("fp8"):
+            raise ValueError(
+                "DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache "
+                f"formats ('fp8', 'fp8_e4m3', 'fp8_ds_mla'), got "
+                f"{kv_cache_dtype!r}; use --kv-cache-dtype fp8 or leave it "
+                "unset"
+            )
         if kv_cache_dtype != "fp8_ds_mla":
             if cache_config is not None:
                 cache_config.cache_dtype = "fp8_ds_mla"

--- a/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py
@@ -152,7 +152,8 @@ class DeepseekV4FlashInferMLASparseBackend(DeepseekV4SparseMLABackend):
                 return "kv_cache_dtype not supported"
             return None
         if device_capability.major == 12:
-            if kv_cache_dtype not in ("fp8", "fp8_e4m3", "fp8_ds_mla"):
+            # "auto" resolves to fp8_ds_mla in _resolve_dsv4_kv_cache_dtype.
+            if kv_cache_dtype not in (None, "auto", "fp8", "fp8_e4m3", "fp8_ds_mla"):
                 return "kv_cache_dtype not supported"
             from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
 


### PR DESCRIPTION
## Purpose

Fixes #47174

On SM120 (consumer/workstation Blackwell, e.g. RTX PRO 6000), the DeepSeek-V4 sparse-MLA attention path hardcodes the `fp8_ds_mla` KV block layout (`DeepseekV4FlashInferSM120Attention.use_fp8_ds_mla_layout = True`), which has no unquantized fallback. The default `--kv-cache-dtype auto` (i.e. the plain `vllm serve deepseek-ai/DeepSeek-V4-Flash` command from the model card) therefore crashed engine init with a bare assert:

```
AssertionError: DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, got auto
```

This PR:
- resolves `auto` to `fp8_ds_mla` in `_resolve_dsv4_kv_cache_dtype`, mirroring the existing `fp8` → `fp8_ds_mla` upgrade (incl. the `cache_config` write-back that drives the 576B page-size specs), with the existing `info_once` log;
- replaces the bare assert with an actionable `ValueError` for genuinely unsupported values (e.g. `bfloat16`);
- accepts `auto`/`None` in the SM12x branch of `DeepseekV4FlashInferMLASparseBackend.supports_combination`, matching the SM10x branch.

Behavior on SM10x (H100 etc.) is unchanged: that path uses the plain KV row layout (`use_fp8_ds_mla_layout = False`) and `auto` still resolves to bf16 rows, covered by a new regression test.

**Duplicate-work check:** no open PR references #47174 (checked `gh pr list --search "47174 in:body"` on 2026-08-28); the issue has no linked fix.

## Test Plan

Hardware: 8× RTX PRO 6000 Blackwell Server Edition (SM120, CC 12.0), driver 580.178.04, torch 2.13.0+cu132, FlashInfer 0.6.18rc10 (the SM120 sparse-MLA decode path requires a FlashInfer build containing flashinfer-ai/flashinfer#4380; the current 0.6.17 pin refuses to start independently of this change).

Unit tests:
```
pytest tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py -v
```

E2E (repro of the issue, using a 4-layer DeepSeek-V4-Flash config with `--load-format dummy` on 1 GPU):
```python
from vllm import LLM
llm = LLM(model=<4-layer DSV4-Flash config>, load_format='dummy', enforce_eager=True, max_model_len=4096)  # kv_cache_dtype defaults to auto
llm.generate('Hello')
```

## Test Result

- Unit: **11 passed** (5 pre-existing + 6 new: `auto`/`fp8`/`fp8_e4m3` resolve to `fp8_ds_mla` + write-back, `bfloat16` raises actionable ValueError, plain layout keeps `auto` → bf16, SM12x `supports_combination` accepts `auto`).
- E2E before: `AssertionError: DeepseekV4 fp8_ds_mla layout only supports fp8 kv-cache, got auto` at `vllm/models/deepseek_v4/attention.py:105`.
- E2E after: boots with `INFO ... Using DeepSeek's fp8_ds_mla KV cache format.` and generates — identical behavior to the previous `--kv-cache-dtype fp8` workaround.
- Full-model sanity on the same machine (unrelated to this diff path, exercised via `--kv-cache-dtype fp8`): DeepSeek-V4-Flash TP4 serves coherent greedy output on current main.

This change only affects engine startup dtype resolution (crash → boot); it introduces no new numeric path: `auto` now takes exactly the code path `fp8` already took.

---

AI assistance was used for this change (Claude Code); the submitter has reviewed the diff and test results.