### PR TITLE
[Bugfix] Warn when level-2 sleep weights are woken without a reload

### DIFF
--- a/tests/basic_correctness/test_mem.py
+++ b/tests/basic_correctness/test_mem.py
@@ -452,3 +452,35 @@ def test_deep_sleep_fp8_kvcache_mrv1_with_undefined_remap(
     actual = llm.generate(prompt, sampling_params)
 
     assert expected[0].outputs[0].text == actual[0].outputs[0].text
+
+
+@create_new_process_for_each_test("fork" if current_platform.is_cuda() else "spawn")
+def test_level2_wake_without_reload_warns_and_reload_restores(monkeypatch):
+    """Level-2 sleep discards weights; waking them without a reload must warn
+    (they hold garbage), and collective_rpc("reload_weights") must clear the
+    flag and restore correct generation."""
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    llm = LLM(
+        "hmellor/tiny-random-LlamaForCausalLM",
+        enable_sleep_mode=True,
+        enforce_eager=True,
+        gpu_memory_utilization=0.2,
+    )
+    prompt = "How are you?"
+    sampling_params = SamplingParams(temperature=0, max_tokens=10)
+    expected = llm.generate(prompt, sampling_params)
+
+    def weights_discarded(worker) -> bool:
+        return worker._weights_discarded
+
+    llm.sleep(level=2)
+    assert all(llm.collective_rpc(weights_discarded))
+
+    llm.wake_up()
+    assert all(llm.collective_rpc(weights_discarded))
+
+    llm.collective_rpc("reload_weights")
+    assert not any(llm.collective_rpc(weights_discarded))
+
+    actual = llm.generate(prompt, sampling_params)
+    assert expected[0].outputs[0].text == actual[0].outputs[0].text

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -202,6 +202,9 @@ class Worker(WorkerBase):
         # Buffers saved before sleep
         self._sleep_saved_buffers: dict[str, torch.Tensor] = {}
         self._sleep_saved_draft_buffers: dict[str, torch.Tensor] = {}
+        # True while level-2 sleep has discarded the weights and neither
+        # reload_weights nor a weight update has restored them.
+        self._weights_discarded = False
 
         # Weight transfer engine is created in `load_model` once the model
         # is available, since the engine needs a reference to the model.
@@ -248,6 +251,7 @@ class Worker(WorkerBase):
                 self._sleep_saved_draft_buffers = {
                     name: buffer.cpu().clone() for name, buffer in draft.named_buffers()
                 }
+            self._weights_discarded = True
 
         self._get_sleep_mode_backend().suspend(level)
 
@@ -287,6 +291,14 @@ class Worker(WorkerBase):
                     if name in self._sleep_saved_draft_buffers:
                         buffer.data.copy_(self._sleep_saved_draft_buffers[name].data)
             self._sleep_saved_draft_buffers = {}
+
+        if wake_weights and self._weights_discarded:
+            logger.warning(
+                "Weights were discarded by level-2 sleep and have not been "
+                "restored; generation will produce garbage until they are "
+                'reloaded, e.g. via collective_rpc("reload_weights") or a '
+                "weight update."
+            )
 
         self.synchronize_device()
 
@@ -507,6 +519,7 @@ class Worker(WorkerBase):
     def reload_weights(self, *args, **kwargs) -> None:
         with set_current_vllm_config(self.vllm_config):
             self.model_runner.reload_weights(*args, **kwargs)
+        self._weights_discarded = False
 
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
@@ -1421,6 +1434,7 @@ class Worker(WorkerBase):
             self.weight_transfer_engine.finish_weight_update()
             self.weight_transfer_engine.reset_weight_update_target()
             self._weight_update_active = False
+            self._weights_discarded = False
 
         # Weight transfer bypasses GPUModelRunner.reload_weights().
         if not self._weight_update_is_draft:


### PR DESCRIPTION
## Purpose

Addresses the silent-garbage footgun in #21336.

Level-2 sleep discards the model parameters — `Worker.sleep(level=2)` backs up only named buffers — and the [sleep-mode docs](https://docs.vllm.ai/en/latest/features/sleep_mode.html) require restoring weights after wake, e.g. `collective_rpc("reload_weights")`. But nothing enforces or surfaces this at runtime. Measured on 2× RTX PRO 6000 (SM120), main @ 94a54f581:

```
sleep?level=2  →  wake_up  →  chat completion
returns: '!!!!!!!!!!!!'        # garbage from uninitialized weight memory, zero warnings
```

The only related log line is an INFO at sleep time. This PR adds a `_weights_discarded` flag on the GPU worker:

- set in `sleep(level=2)`;
- cleared by `reload_weights()` and by `finish_weight_update()` (the weight-transfer path deliberately bypasses `reload_weights`);
- `wake_up` with the weights tag logs a prominent warning while the flag is set.

**Warning-only by design:** colocated RLHF trainers can restore weights via custom worker RPCs or direct CUDA-IPC writes that vLLM cannot observe, so a hard error would break legitimate flows.

**Duplicate-work check:** searched open/closed PRs for wake_up/sleep/weights-reload work — nearest are #52487 (reloads *draft* weights after level-2 wake) and #52597 (opt-in page-poisoning debug flag); neither surfaces this condition. The request-hang aspect of #21336 is separately covered by #45326/#44406.

## Test Plan

Hardware: RTX PRO 6000 Blackwell (SM120), torch 2.13.0+cu132.

```
pytest tests/basic_correctness/test_mem.py::test_level2_wake_without_reload_warns_and_reload_restores
pytest "tests/basic_correctness/test_mem.py::test_end_to_end[hmellor/tiny-random-LlamaForCausalLM]"
```

Plus e2e: `vllm serve Qwen/Qwen3-0.6B -tp 2 --enable-sleep-mode` → `/sleep?level=2` → `/wake_up`, checking server logs.

## Test Result

- New regression test **passed**: flag is set across sleep(2)/wake, cleared by `collective_rpc("reload_weights")`, and post-reload greedy output matches pre-sleep output exactly.
- Existing `test_end_to_end` sleep/wake test **passed** (no regression).
- E2E server: warning emitted once per TP worker at wake time:
  `WARNING [gpu_worker.py:296] Weights were discarded by level-2 sleep and have not been restored; generation will produce garbage until they are reloaded, e.g. via collective_rpc("reload_weights") or a weight update.`
- Ruff check/format clean.

---

AI assistance was used for this change (Claude Code); the submitter has reviewed the diff and test results.