### PR TITLE
[Bugfix][Frontend] Always emit arguments.done for streaming tool call…

### DIFF
--- a/tests/entrypoints/openai/responses/test_streaming_events.py
+++ b/tests/entrypoints/openai/responses/test_streaming_events.py
@@ -124,3 +124,69 @@ class TestProcessorCompoundDeltas:
         types = [e.type for e in events]
         assert "response.reasoning_text.delta" in types
         assert "response.output_text.delta" in types
+
+
+class TestEmitSimpleToolCallDone:
+    """Regression test: arguments.done must always be emitted, even when
+    no argument deltas were streamed (e.g. zero-arg tool calls like
+    get_current_time())."""
+
+    def test_arguments_done_emitted_without_prior_deltas(self):
+        from dataclasses import dataclass, field
+
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            _StateType,
+            emit_simple_tool_call_done,
+        )
+
+        @dataclass
+        class FakeState:
+            output_index: int = 0
+            current_item_id: str = "fc_test"
+            accumulated_text: str = ""
+            tool_call_id: str = "call_test"
+            tool_call_name: str = "get_time"
+            tool_call_namespace: str | None = None
+            has_emitted_tool_call_delta: bool = False
+            current_state: _StateType = field(
+                default_factory=lambda: _StateType.TOOL_CALL
+            )
+
+        state = FakeState()
+        events = emit_simple_tool_call_done(state)
+
+        types = [e.type for e in events]
+        assert "response.function_call_arguments.done" in types
+        assert "response.output_item.done" in types
+
+    def test_arguments_done_emitted_with_prior_deltas(self):
+        from dataclasses import dataclass, field
+
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            _StateType,
+            emit_simple_tool_call_done,
+        )
+
+        @dataclass
+        class FakeState:
+            output_index: int = 0
+            current_item_id: str = "fc_test"
+            accumulated_text: str = '{"city": "Paris"}'
+            tool_call_id: str = "call_test"
+            tool_call_name: str = "get_weather"
+            tool_call_namespace: str | None = None
+            has_emitted_tool_call_delta: bool = True
+            current_state: _StateType = field(
+                default_factory=lambda: _StateType.TOOL_CALL
+            )
+
+        state = FakeState()
+        events = emit_simple_tool_call_done(state)
+
+        types = [e.type for e in events]
+        assert "response.function_call_arguments.done" in types
+        assert "response.output_item.done" in types
+        done_event = next(
+            e for e in events if e.type == "response.function_call_arguments.done"
+        )
+        assert done_event.arguments == '{"city": "Paris"}'

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -1071,17 +1071,16 @@ def emit_simple_tool_call_done(
     state: SimpleStreamingState,
 ) -> list[StreamingResponsesResponse]:
     events: list[StreamingResponsesResponse] = []
-    if state.has_emitted_tool_call_delta:
-        events.append(
-            ResponseFunctionCallArgumentsDoneEvent(
-                type="response.function_call_arguments.done",
-                sequence_number=-1,
-                output_index=state.output_index,
-                item_id=state.current_item_id,
-                arguments=state.accumulated_text,
-                name=state.tool_call_name,
-            )
+    events.append(
+        ResponseFunctionCallArgumentsDoneEvent(
+            type="response.function_call_arguments.done",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+            arguments=state.accumulated_text,
+            name=state.tool_call_name,
         )
+    )
     events.append(
         ResponseOutputItemDoneEvent(
             type="response.output_item.done",


### PR DESCRIPTION
## Summary

The simple streaming path (`emit_simple_tool_call_done`) conditionally skipped the `response.function_call_arguments.done` event when no argument deltas had been streamed. This caused clients waiting for `arguments.done` to hang on zero-argument tool calls (e.g. `get_current_time()`).

The Harmony streaming path (`emit_function_call_done_events`) always emits `arguments.done` unconditionally — this change makes the simple path consistent.

## Not a duplicate

No existing open PR addresses this specific streaming event gap. Searched: `arguments.done empty`, `emit_simple_tool_call_done`.

## Test Plan

bash
`pytest tests/entrypoints/openai/responses/test_streaming_events.py::TestEmitSimpleToolCallDone -v`

Two tests added:

- test_arguments_done_emitted_without_prior_deltas — verifies the fix (empty args → still get arguments.done)
- test_arguments_done_emitted_with_prior_deltas — verifies existing behavior preserved

AI Disclosure
AI assistance (Claude) was used for implementation. Human reviewer verified all changes.

cc @njhill @aarnphm @DarkLight1337 

