### PR TITLE
[Tests][ROCm] Register DeepEP in the modular-kernel test sweep

### DIFF
--- a/tests/kernels/moe/modular_kernel_tools/mk_objects.py
+++ b/tests/kernels/moe/modular_kernel_tools/mk_objects.py
@@ -218,7 +218,9 @@ if has_deep_ep() and not current_platform.has_device_capability(100):
         backend="deepep_low_latency",
     )
 
-if has_deep_ep_v2() and current_platform.has_device_capability(100):
+if has_deep_ep_v2() and (
+    current_platform.is_rocm() or current_platform.has_device_capability(100)
+):
     from vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_v2 import (
         DeepEPV2PrepareAndFinalize,
     )


### PR DESCRIPTION
`DeepEPV2PrepareAndFinalize` only registers for `test_modular_kernel_combinations.py` when `current_platform.has_device_capability(100)` (Blackwell). On ROCm, `get_device_capability()` derives from the GCN arch, so gfx950 reports `(9, 5)` and the check is always false -- this prepare/finalize implementation is never registered and the sweep never generates the `AiterExperts x DeepEPV2PrepareAndFinalize` combination.

That is the exact pair behind two AITER/DeepEP defects that reached serving before being caught (#53261, #53282): a wrong `num_local_tokens` shape that silently zeroed MoE output, and a BF16 path fault. Both components are already registered with matching `standard_format` and fp8 blocked-quantization support, so the sweep would have generated and caught this pair directly instead of surfacing as a broken model.

Widen the guard to also register when running on ROCm, alongside the existing Blackwell path. `has_deep_ep_v2()` is unchanged, so this only takes effect where the underlying `ElasticBuffer` API and a compatible NCCL/RCCL are actually present.

Verified `current_platform.is_rocm()` / `has_device_capability(100)` directly on MI350X (gfx950): `is_rocm()` is `True`, `has_device_capability(100)` is `False`, confirming the guard was unconditionally skipping ROCm before this change.

## Test plan
- Ran `tests/kernels/moe/test_modular_kernel_combinations.py` on MI350X (gfx950) with the guard widened -- confirmed the `AiterExperts x DeepEPV2PrepareAndFinalize` combination is now generated and exercised where it previously wasn't.