### PR TITLE
[Doc] Fix broken anchor links in fusions.md quick reference table

### DIFF
--- a/docs/design/fusions.md
+++ b/docs/design/fusions.md
@@ -20,16 +20,16 @@ or just on the low or high end.
 
 | Fusion                                                                         | `PassConfig` flag            | Fused operations                               | Default at                     | E2E Speedup        | Fullgraph | `num_tokens` |
 | ------------------------------------------------------------------------------ | ---------------------------- | ---------------------------------------------- | ------------------------------ | ------------------ | --------- | ------------ |
-| [AllReduce + RMSNorm](#allreduce--rmsnorm-fuse_allreduce_rms)                  | `fuse_allreduce_rms`         | All-reduce → RMSNorm (+residual_add) (→ quant) | O2 (Hopper/Blackwell + TP > 1) | 5-20%              | No        | Low          |
-| [Attention + Quant](#attention--quantization-fuse_attn_quant)                  | `fuse_attn_quant`            | Attention output → FP8/NVFP4 quant             | Off by default                 | 3-7%               | Yes       | Always       |
-| [MLA Attention + Quant](#attention--quantization-fuse_attn_quant)              | `fuse_attn_quant`            | MLA Attention output → FP8/NVFP4 quant         | Off by default                 | TBD                | Yes       | Always       |
-| [RoPE + KV-Cache Update](#rope--kv-cache-update-fuse_rope_kvcache)             | `fuse_rope_kvcache`          | Rotary embedding → KV cache write              | O2 (ROCm/AITER only)           | 2-4%               | No        | Low          |
-| [QK Norm + RoPE](#qk-norm--rope-enable_qk_norm_rope_fusion)                    | `enable_qk_norm_rope_fusion` | Q/K RMSNorm → rotary embedding                 | Off by default                 | 2-3%               | No        | Low          |
+| [AllReduce + RMSNorm](#allreduce-rmsnorm-fuse_allreduce_rms)                  | `fuse_allreduce_rms`         | All-reduce → RMSNorm (+residual_add) (→ quant) | O2 (Hopper/Blackwell + TP > 1) | 5-20%              | No        | Low          |
+| [Attention + Quant](#attention-quantization-fuse_attn_quant)                  | `fuse_attn_quant`            | Attention output → FP8/NVFP4 quant             | Off by default                 | 3-7%               | Yes       | Always       |
+| [MLA Attention + Quant](#attention-quantization-fuse_attn_quant)              | `fuse_attn_quant`            | MLA Attention output → FP8/NVFP4 quant         | Off by default                 | TBD                | Yes       | Always       |
+| [RoPE + KV-Cache Update](#rope-kv-cache-update-fuse_rope_kvcache)             | `fuse_rope_kvcache`          | Rotary embedding → KV cache write              | O2 (ROCm/AITER only)           | 2-4%               | No        | Low          |
+| [QK Norm + RoPE](#qk-norm-rope-enable_qk_norm_rope_fusion)                    | `enable_qk_norm_rope_fusion` | Q/K RMSNorm → rotary embedding                 | Off by default                 | 2-3%               | No        | Low          |
 | [Sequence Parallelism](#sequence-parallelism-enable_sp)                        | `enable_sp`                  | AllReduce → ReduceScatter + AllGather          | Off by default                 | Prereq for AsyncTP | Yes       | High         |
-| [AsyncTP GEMM + collective](#asynctp-gemm--collective-overlap-fuse_gemm_comms) | `fuse_gemm_comms`            | GEMM → reduce-scatter / all-gather → GEMM      | Off by default                 | 7-10%              | Yes       | High         |
-| [RMSNorm + Quant](#rmsnorm--quantization-fuse_norm_quant)                      | `fuse_norm_quant`            | RMSNorm (+residual add) → FP8/FP4 quant        | O1 (conditional)               | 1-4%               | No        | Always       |
-| [SiLU+Mul + Quant](#silumul--quantization-fuse_act_quant)                      | `fuse_act_quant`             | SiLU+Mul activation → FP8/FP4 quant            | O1 (conditional)               | 1-4%               | No        | Always       |
-| [RMSNorm + Padding](#rmsnorm--padding-fuse_act_padding)                        | `fuse_act_padding`           | Residual add + RMSNorm → padding               | O1 (ROCm/AITER only)           | TBD                | No        | Always       |
+| [AsyncTP GEMM + collective](#asynctp-gemm-collective-overlap-fuse_gemm_comms) | `fuse_gemm_comms`            | GEMM → reduce-scatter / all-gather → GEMM      | Off by default                 | 7-10%              | Yes       | High         |
+| [RMSNorm + Quant](#rmsnorm-quantization-fuse_norm_quant)                      | `fuse_norm_quant`            | RMSNorm (+residual add) → FP8/FP4 quant        | O1 (conditional)               | 1-4%               | No        | Always       |
+| [SiLU+Mul + Quant](#silumul-quantization-fuse_act_quant)                      | `fuse_act_quant`             | SiLU+Mul activation → FP8/FP4 quant            | O1 (conditional)               | 1-4%               | No        | Always       |
+| [RMSNorm + Padding](#rmsnorm-padding-fuse_act_padding)                        | `fuse_act_padding`           | Residual add + RMSNorm → padding               | O1 (ROCm/AITER only)           | TBD                | No        | Always       |
 | [MLA Dual RMSNorm](#mla-dual-rmsnorm-fuse_mla_dual_rms_norm)                   | `fuse_mla_dual_rms_norm`     | Paired Q + KV RMSNorm (+ FP8 quant) → 1 kernel | O1 (ROCm/AITER only)           | 1-2%               | No        | Always       |
 
 ## Support Matrix
@@ -53,7 +53,7 @@ The table below lists the quantization schemes supported by each fusion on each 
 | `fuse_mla_dual_rms_norm`     | —                                        | —                                        | —                                        | —             | BF16                                     |
 
 \* `fuse_attn_quant` support depends on the attention backend in use; not all backends support
-fused quantization output. See the [`fuse_attn_quant` section](#attention--quantization-fuse_attn_quant)
+fused quantization output. See the [`fuse_attn_quant` section](#attention-quantization-fuse_attn_quant)
 for per-backend details.
 
 † `enable_sp` and `fuse_gemm_comms` are only autoconfigured for SM90 today;


### PR DESCRIPTION
## Purpose

Fix 10 broken in-page anchor links in `docs/design/fusions.md`.

The Quick Reference table (and the `fuse_attn_quant` note below it) links to section headings using GitHub-style slugs with double hyphens, e.g. `#allreduce--rmsnorm-fuse_allreduce_rms`. However, MkDocs' `toc` extension collapses whitespace runs into a single separator, so the heading ids actually rendered on the published site use single hyphens, e.g. `#allreduce-rmsnorm-fuse_allreduce_rms`. As a result, clicking any of these links on <https://docs.vllm.ai/en/latest/design/fusions/> does not navigate anywhere.

This PR updates the anchors to match the ids MkDocs generates. No content changes.

## Test Plan

Extract all heading `id=` attributes and in-page `href="#..."` links from the rendered page at `https://docs.vllm.ai/en/latest/design/fusions/` and diff them.

## Test Result

Before (current live site): 8 unique link targets have no matching element id — `allreduce--rmsnorm-fuse_allreduce_rms`, `attention--quantization-fuse_attn_quant`, `rope--kv-cache-update-fuse_rope_kvcache`, `qk-norm--rope-enable_qk_norm_rope_fusion`, `asynctp-gemm--collective-overlap-fuse_gemm_comms`, `rmsnorm--quantization-fuse_norm_quant`, `silumul--quantization-fuse_act_quant`, `rmsnorm--padding-fuse_act_padding`.

After: every anchor used in this file matches a heading id present on the rendered page (verified against the live ids; the two links already using single hyphens, `#sequence-parallelism-enable_sp` and `#mla-dual-rmsnorm-fuse_mla_dual_rms_norm`, were already correct and are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
