### PR TITLE
[ROCm][CI] Fix test_ray_v2_executor

### DIFF
--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -590,7 +590,7 @@ def initialize_ray_cluster(
             )
             ray.init(
                 address=ray_address,
-                num_gpus=parallel_config.world_size,
+                num_gpus=current_platform.device_count(),
                 runtime_env=parallel_config.ray_runtime_env,
             )
     else:


### PR DESCRIPTION
Root cause: The `test_colocated_tcpstore_ports_differ` test creates two colocated RayExecutorV2 engines on one host. On ROCm/XPU, ray_utils.py:582-595 launches a fresh Ray instance with num_gpus=parallel_config.world_size. Since each engine has world_size=1, Ray was told the node has only 1 GPU (despite the box having 8). The first engine grabbed that single advertised GPU; the second engine reused the same Ray instance, found no free GPU, and its placement group waited forever — the hang we observed.
