### PR TITLE
[Bugfix][Parser] Support bare call: and whitespace-free channel transitions in Gemma4 parser

### DIFF
--- a/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
+++ b/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+r"""Test suite comparing legacy vLLM Gemma-4 tool call regex vs Google reference parser.
+
+References:
+    1. Google Gemma-4 Canonical Chat Template & Transformers Reference:
+       ``transformers.models.gemma4`` & ``examples/tool_chat_template_gemma4.jinja``
+       Specifies optional ``<|tool_call>`` and ``<tool_call|>`` delimiters:
+       ``(?:<\|tool_call>)?call:(\w+)\{(.*?)\}(?:<tool_call\|>)?``
+    2. vLLM Offline Parser Reference:
+       ``vllm.tool_parsers.gemma4_utils.parse_tool_calls``
+    3. Failure Trigger in Live Generation:
+       When transitioning out of the reasoning channel (``<channel|>``), Gemma-4
+       frequently emits bare ``call:func{...}`` directly without whitespace or
+       ``<|tool_call>``. The legacy vLLM regex misses it, producing 0 tool calls
+       and triggering runtime stream errors.
+"""
+
+import re
+import pytest
+
+# ---------------------------------------------------------------------------
+# Regex Definitions
+# ---------------------------------------------------------------------------
+
+# Legacy vLLM parser regex (strictly requires <|tool_call> and <tool_call|>)
+LEGACY_VLLM_REGEX = re.compile(
+    r"<\|tool_call>call:([\w\-\.]+)\{(.*?)\}<tool_call\|>",
+    re.DOTALL,
+)
+
+# Google Canonical Specification (transformers.models.gemma4 / chat_template.jinja)
+GOOGLE_CANONICAL_REGEX = re.compile(
+    r"(?:<\|tool_call>)?call:([\w\-\.]+)\{(.*?)\}(?:<tool_call\|>)?",
+    re.DOTALL,
+)
+
+# vLLM Offline gemma4_utils.py Tier 2 Fallback Pattern
+VLLM_OFFLINE_TIER2_FALLBACK = re.compile(
+    r"(?:<call>|(?:^|\s)call:)(\w+)\{(.*?)\}",
+    re.DOTALL,
+)
+
+# Patched Unified Regex (handles canonical, bare call, turn boundary, and colon prefix)
+PATCHED_UNIFIED_REGEX = re.compile(
+    r"(?:<\|tool_call>:?)?call:([\w\-\.]+)\{(.*?)\}(?:<tool_call\|>|<turn\|>)?",
+    re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test Cases
+# ---------------------------------------------------------------------------
+
+class TestGemma4RegexComparison:
+    """Compare regex parsing behavior across standard and edge-case Gemma-4 outputs."""
+
+    def test_canonical_tag_wrapped_call(self):
+        """Case 1: Standard canonical format. All robust regexes succeed."""
+        text = '<|tool_call>call:bash{command:<|"|>ls -la /work<|"|>}<tool_call|>'
+
+        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
+        assert len(legacy_matches) == 1
+        assert legacy_matches[0][0] == "bash"
+
+        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
+        assert len(google_matches) == 1
+        assert google_matches[0][0] == "bash"
+
+        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
+        assert len(patched_matches) == 1
+        assert patched_matches[0][0] == "bash"
+
+    def test_bare_call_after_thought_channel(self):
+        """Case 2: Bare call: immediately after thought channel exit (<channel|>call:...).
+        
+        Gemma-4 frequently drops <|tool_call> when transitioning from <channel|>.
+        - Legacy vLLM regex: FAILS (0 matches -> fatal harness stream abort).
+        - vLLM gemma4_utils Tier 2: FAILS (expects whitespace or start of string before 'call:').
+        - Google Canonical regex: PASSES.
+        - Patched Unified regex: PASSES.
+        """
+        text = (
+            "<|channel>thought\n"
+            "I need to read the entry source file to inspect the crash point.\n"
+            "<channel|>"
+            'call:bash{command:<|"|>cat /work/src/entry.c<|"|>}'
+        )
+
+        # 1. Legacy vLLM regex fails completely
+        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
+        assert len(legacy_matches) == 0, "Legacy regex should fail on bare call"
+
+        # 2. Offline tier 2 fails because <channel|> is attached without whitespace
+        offline_matches = VLLM_OFFLINE_TIER2_FALLBACK.findall(text)
+        assert len(offline_matches) == 0, "Offline regex requires whitespace before call:"
+
+        # 3. Google canonical regex succeeds
+        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
+        assert len(google_matches) == 1
+        assert google_matches[0][0] == "bash"
+        assert '<|"|>cat /work/src/entry.c<|"|>' in google_matches[0][1]
+
+        # 4. Patched unified regex succeeds directly
+        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
+        assert len(patched_matches) == 1
+        assert patched_matches[0][0] == "bash"
+        assert '<|"|>cat /work/src/entry.c<|"|>' in patched_matches[0][1]
+
+    def test_turn_end_closure_instead_of_tool_call_end(self):
+        """Case 3: Model terminates tool call with <turn|> rather than <tool_call|>.
+        
+        - Legacy vLLM regex: FAILS.
+        - Google canonical regex: PASSES.
+        - Patched unified regex: PASSES.
+        """
+        text = '<|tool_call>call:gdb{args:<|"|>-batch -ex run /tmp/poc<|"|>}<turn|>'
+
+        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
+        assert len(legacy_matches) == 0
+
+        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
+        assert len(google_matches) == 1
+        assert google_matches[0][0] == "gdb"
+
+        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
+        assert len(patched_matches) == 1
+        assert patched_matches[0][0] == "gdb"
+
+    def test_colon_prefixed_tool_call(self):
+        """Case 4: Model emits <|tool_call>:call:... under attention stress.
+        
+        - Legacy vLLM regex: FAILS.
+        - Google canonical regex: PASSES (bare call match).
+        - Patched unified regex: PASSES.
+        """
+        text = '<|tool_call>:call:bash{command:<|"|>pytest<|"|>}'
+
+        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
+        assert len(legacy_matches) == 0
+
+        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
+        assert len(google_matches) == 1
+        assert google_matches[0][0] == "bash"
+
+        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
+        assert len(patched_matches) == 1
+        assert patched_matches[0][0] == "bash"
+
+    def test_multiple_sequential_tool_calls_mixed_syntax(self):
+        """Case 5: Multi-tool call payload with mixed canonical and bare syntax."""
+        text = (
+            '<|tool_call>call:read_file{path:<|"|>/work/Makefile<|"|>}<tool_call|>\n'
+            'call:bash{command:<|"|>make -j8<|"|>}'
+        )
+
+        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
+        # Legacy only catches the first one, dropping the second
+        assert len(legacy_matches) == 1
+        assert legacy_matches[0][0] == "read_file"
+
+        # Patched catches both
+        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
+        assert len(patched_matches) == 2
+        assert patched_matches[0][0] == "read_file"
+        assert patched_matches[1][0] == "bash"
+
+
+class TestGemma4EngineBareCallIntegration:
+    """Validate that the engine and offline utils properly extract bare tool calls."""
+
+    def test_offline_utils_bare_call_after_channel(self):
+        """Offline parse_tool_calls should extract bare calls immediately following <channel|>."""
+        from vllm.tool_parsers.gemma4_utils import parse_tool_calls
+
+        text = (
+            "<|channel>thought\n"
+            "I need to read the entry source file.\n"
+            "<channel|>"
+            'call:bash{command:<|"|>cat /work/src/entry.c<|"|>}'
+        )
+        tool_calls = parse_tool_calls(text)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "bash"
+        assert tool_calls[0]["arguments"] == {"command": "cat /work/src/entry.c"}
+
+    def test_engine_tool_parser_bare_call_extraction(self):
+        """Gemma4EngineToolParser should transition and extract bare calls without dropping them."""
+        import json
+        from unittest.mock import MagicMock
+        from vllm.entrypoints.openai.chat_completion.protocol import (
+            ChatCompletionRequest,
+            ChatCompletionToolsParam,
+        )
+        from vllm.tool_parsers.gemma4_engine_tool_parser import Gemma4EngineToolParser
+
+        tools = [
+            ChatCompletionToolsParam(
+                type="function",
+                function={
+                    "name": "bash",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                    },
+                },
+            )
+        ]
+        vocab = {
+            "<|tool_call>": 48,
+            "<tool_call|>": 49,
+            "<|channel>": 50,
+            "<channel|>": 51,
+        }
+        decode_map = {v: k for k, v in vocab.items()}
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.get_vocab.return_value = vocab
+        mock_tokenizer.decode.side_effect = lambda ids: decode_map.get(ids[0], f"tok{ids[0]}")
+
+        parser = Gemma4EngineToolParser(mock_tokenizer, tools=tools)
+        request = MagicMock(spec=ChatCompletionRequest)
+        request.tools = tools
+        request.tool_choice = "auto"
+
+        # Model output containing channel thought and immediate bare call
+        model_output = (
+            "<|channel>thought\n"
+            "Listing directory files.\n"
+            "<channel|>"
+            'call:bash{command:<|"|>ls -la /work<|"|>}'
+        )
+
+        result = parser.extract_tool_calls(model_output, request)
+        assert result.tools_called is True
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "bash"
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"command": "ls -la /work"}

--- a/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
+++ b/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
@@ -135,6 +135,18 @@ class TestGemma4FallbackFormats:
 
         assert parse_tool_calls(text) == []
 
+    def test_nested_object_argument_not_truncated(self):
+        """A nested ``{...}`` argument must not stop at its own closing brace."""
+        text = 'call:tool{config:{mode:<|"|>x<|"|>}}'
+
+        tool_calls = parse_tool_calls(text)
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "tool"
+        # _parse_tool_arguments stringifies nested values; the important
+        # thing is "mode" survives instead of being truncated to "{}".
+        assert tool_calls[0]["arguments"] == {"config": "{'mode': 'x'}"}
+
 
 class TestGemma4EngineBareCallIntegration:
     """Validate that the engine and offline utils properly extract bare tool calls."""

--- a/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
+++ b/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
@@ -1,84 +1,74 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-r"""Test suite comparing legacy vLLM Gemma-4 tool call regex vs Google reference parser.
+r"""Behavioral tests for the offline Gemma-4 tool call parser.
+
+Exercises ``vllm.tool_parsers.gemma4_utils.parse_tool_calls`` directly so
+regressions in the production tiered regex are caught. Covers the known
+Gemma-4 output variations:
+
+    * canonical ``<|tool_call>call:name{...}<tool_call|>``
+    * ``<turn|>`` used as the closing delimiter
+    * bare ``call:name{...}`` right after a ``<channel|>`` transition (no
+      whitespace)
+    * colon-prefixed ``<|tool_call>:call:name{...}``
+    * hyphen- and dot-containing tool names in the bare fallback
 
 References:
-    1. Google Gemma-4 Canonical Chat Template & Transformers Reference:
-       ``transformers.models.gemma4`` & ``examples/tool_chat_template_gemma4.jinja``
-       Specifies optional ``<|tool_call>`` and ``<tool_call|>`` delimiters:
-       ``(?:<\|tool_call>)?call:(\w+)\{(.*?)\}(?:<tool_call\|>)?``
-    2. vLLM Offline Parser Reference:
-       ``vllm.tool_parsers.gemma4_utils.parse_tool_calls``
-    3. Failure Trigger in Live Generation:
-       When transitioning out of the reasoning channel (``<channel|>``), Gemma-4
-       frequently emits bare ``call:func{...}`` directly without whitespace or
-       ``<|tool_call>``. The legacy vLLM regex misses it, producing 0 tool calls
-       and triggering runtime stream errors.
+    1. Google Gemma-4 canonical chat template / transformers reference.
+    2. vLLM offline parser: ``vllm.tool_parsers.gemma4_utils.parse_tool_calls``.
 """
 
-import re
-import pytest
-
-# ---------------------------------------------------------------------------
-# Regex Definitions
-# ---------------------------------------------------------------------------
-
-# Legacy vLLM parser regex (strictly requires <|tool_call> and <tool_call|>)
-LEGACY_VLLM_REGEX = re.compile(
-    r"<\|tool_call>call:([\w\-\.]+)\{(.*?)\}<tool_call\|>",
-    re.DOTALL,
-)
-
-# Google Canonical Specification (transformers.models.gemma4 / chat_template.jinja)
-GOOGLE_CANONICAL_REGEX = re.compile(
-    r"(?:<\|tool_call>)?call:([\w\-\.]+)\{(.*?)\}(?:<tool_call\|>)?",
-    re.DOTALL,
-)
-
-# vLLM Offline gemma4_utils.py Tier 2 Fallback Pattern
-VLLM_OFFLINE_TIER2_FALLBACK = re.compile(
-    r"(?:<call>|(?:^|\s)call:)(\w+)\{(.*?)\}",
-    re.DOTALL,
-)
-
-# Patched Unified Regex (handles canonical, bare call, turn boundary, and colon prefix)
-PATCHED_UNIFIED_REGEX = re.compile(
-    r"(?:<\|tool_call>:?)?call:([\w\-\.]+)\{(.*?)\}(?:<tool_call\|>|<turn\|>)?",
-    re.DOTALL,
-)
+from vllm.tool_parsers.gemma4_utils import parse_tool_calls
 
 
-# ---------------------------------------------------------------------------
-# Test Cases
-# ---------------------------------------------------------------------------
-
-class TestGemma4RegexComparison:
-    """Compare regex parsing behavior across standard and edge-case Gemma-4 outputs."""
+class TestGemma4CanonicalFormats:
+    """Tier 1: standard ``<|tool_call>`` delimited calls."""
 
     def test_canonical_tag_wrapped_call(self):
-        """Case 1: Standard canonical format. All robust regexes succeed."""
         text = '<|tool_call>call:bash{command:<|"|>ls -la /work<|"|>}<tool_call|>'
 
-        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
-        assert len(legacy_matches) == 1
-        assert legacy_matches[0][0] == "bash"
+        tool_calls = parse_tool_calls(text)
 
-        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
-        assert len(google_matches) == 1
-        assert google_matches[0][0] == "bash"
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "bash"
+        assert tool_calls[0]["arguments"] == {"command": "ls -la /work"}
 
-        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
-        assert len(patched_matches) == 1
-        assert patched_matches[0][0] == "bash"
+    def test_turn_end_closure_instead_of_tool_call_end(self):
+        """Gemma-4 sometimes closes the call with ``<turn|>``."""
+        text = '<|tool_call>call:gdb{args:<|"|>-batch -ex run /tmp/poc<|"|>}<turn|>'
+
+        tool_calls = parse_tool_calls(text)
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "gdb"
+        assert tool_calls[0]["arguments"] == {"args": "-batch -ex run /tmp/poc"}
+
+    def test_multiple_sequential_canonical_calls(self):
+        text = (
+            '<|tool_call>call:read_file{path:<|"|>/work/Makefile<|"|>}<tool_call|>\n'
+            '<|tool_call>call:bash{command:<|"|>make -j8<|"|>}<tool_call|>'
+        )
+
+        tool_calls = parse_tool_calls(text)
+
+        assert [tc["name"] for tc in tool_calls] == ["read_file", "bash"]
+
+    def test_strict_mode_ignores_fallback_formats(self):
+        text = '<channel|>call:bash{command:<|"|>ls<|"|>}'
+
+        assert parse_tool_calls(text, strict=True) == []
+        assert len(parse_tool_calls(text)) == 1
+
+
+class TestGemma4FallbackFormats:
+    """Tier 2: bare ``call:`` variations emitted when the model drops
+    ``<|tool_call>``."""
 
     def test_bare_call_after_thought_channel(self):
-        """Case 2: Bare call: immediately after thought channel exit (<channel|>call:...).
-        
-        Gemma-4 frequently drops <|tool_call> when transitioning from <channel|>.
-        - Legacy vLLM regex: FAILS (0 matches -> fatal harness stream abort).
-        - vLLM gemma4_utils Tier 2: FAILS (expects whitespace or start of string before 'call:').
-        - Google Canonical regex: PASSES.
-        - Patched Unified regex: PASSES.
+        """Bare ``call:`` glued to ``<channel|>`` with no whitespace.
+
+        This is the regression the fallback tier exists for: the legacy
+        strict regex produced 0 tool calls here and aborted the stream.
         """
         text = (
             "<|channel>thought\n"
@@ -87,92 +77,70 @@ class TestGemma4RegexComparison:
             'call:bash{command:<|"|>cat /work/src/entry.c<|"|>}'
         )
 
-        # 1. Legacy vLLM regex fails completely
-        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
-        assert len(legacy_matches) == 0, "Legacy regex should fail on bare call"
+        tool_calls = parse_tool_calls(text)
 
-        # 2. Offline tier 2 fails because <channel|> is attached without whitespace
-        offline_matches = VLLM_OFFLINE_TIER2_FALLBACK.findall(text)
-        assert len(offline_matches) == 0, "Offline regex requires whitespace before call:"
-
-        # 3. Google canonical regex succeeds
-        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
-        assert len(google_matches) == 1
-        assert google_matches[0][0] == "bash"
-        assert '<|"|>cat /work/src/entry.c<|"|>' in google_matches[0][1]
-
-        # 4. Patched unified regex succeeds directly
-        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
-        assert len(patched_matches) == 1
-        assert patched_matches[0][0] == "bash"
-        assert '<|"|>cat /work/src/entry.c<|"|>' in patched_matches[0][1]
-
-    def test_turn_end_closure_instead_of_tool_call_end(self):
-        """Case 3: Model terminates tool call with <turn|> rather than <tool_call|>.
-        
-        - Legacy vLLM regex: FAILS.
-        - Google canonical regex: PASSES.
-        - Patched unified regex: PASSES.
-        """
-        text = '<|tool_call>call:gdb{args:<|"|>-batch -ex run /tmp/poc<|"|>}<turn|>'
-
-        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
-        assert len(legacy_matches) == 0
-
-        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
-        assert len(google_matches) == 1
-        assert google_matches[0][0] == "gdb"
-
-        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
-        assert len(patched_matches) == 1
-        assert patched_matches[0][0] == "gdb"
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "bash"
+        assert tool_calls[0]["arguments"] == {"command": "cat /work/src/entry.c"}
 
     def test_colon_prefixed_tool_call(self):
-        """Case 4: Model emits <|tool_call>:call:... under attention stress.
-        
-        - Legacy vLLM regex: FAILS.
-        - Google canonical regex: PASSES (bare call match).
-        - Patched unified regex: PASSES.
-        """
+        """``<|tool_call>:call:...`` — stray colon after the open tag."""
         text = '<|tool_call>:call:bash{command:<|"|>pytest<|"|>}'
 
-        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
-        assert len(legacy_matches) == 0
+        tool_calls = parse_tool_calls(text)
 
-        google_matches = GOOGLE_CANONICAL_REGEX.findall(text)
-        assert len(google_matches) == 1
-        assert google_matches[0][0] == "bash"
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "bash"
+        assert tool_calls[0]["arguments"] == {"command": "pytest"}
 
-        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
-        assert len(patched_matches) == 1
-        assert patched_matches[0][0] == "bash"
+    def test_bare_call_with_leading_whitespace(self):
+        text = 'some prose\ncall:bash{command:<|"|>make -j8<|"|>}'
 
-    def test_multiple_sequential_tool_calls_mixed_syntax(self):
-        """Case 5: Multi-tool call payload with mixed canonical and bare syntax."""
-        text = (
-            '<|tool_call>call:read_file{path:<|"|>/work/Makefile<|"|>}<tool_call|>\n'
-            'call:bash{command:<|"|>make -j8<|"|>}'
-        )
+        tool_calls = parse_tool_calls(text)
 
-        legacy_matches = LEGACY_VLLM_REGEX.findall(text)
-        # Legacy only catches the first one, dropping the second
-        assert len(legacy_matches) == 1
-        assert legacy_matches[0][0] == "read_file"
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "bash"
+        assert tool_calls[0]["arguments"] == {"command": "make -j8"}
 
-        # Patched catches both
-        patched_matches = PATCHED_UNIFIED_REGEX.findall(text)
-        assert len(patched_matches) == 2
-        assert patched_matches[0][0] == "read_file"
-        assert patched_matches[1][0] == "bash"
+    def test_fragmented_call_tag_from_multimodal(self):
+        """``<call>name{...}`` — fragmented special token from MM inputs."""
+        text = '<call>get_weather{city:<|"|>Paris<|"|>}'
+
+        tool_calls = parse_tool_calls(text)
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "get_weather"
+        assert tool_calls[0]["arguments"] == {"city": "Paris"}
+
+    def test_hyphenated_tool_name(self):
+        text = 'call:web-search{query:<|"|>gemma 4 release<|"|>}'
+
+        tool_calls = parse_tool_calls(text)
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "web-search"
+        assert tool_calls[0]["arguments"] == {"query": "gemma 4 release"}
+
+    def test_dotted_tool_name(self):
+        text = 'call:fs.read_file{path:<|"|>/work/Makefile<|"|>}'
+
+        tool_calls = parse_tool_calls(text)
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "fs.read_file"
+        assert tool_calls[0]["arguments"] == {"path": "/work/Makefile"}
+
+    def test_no_tool_call_returns_empty(self):
+        text = "Just some reasoning text with no call in it."
+
+        assert parse_tool_calls(text) == []
 
 
 class TestGemma4EngineBareCallIntegration:
     """Validate that the engine and offline utils properly extract bare tool calls."""
 
     def test_offline_utils_bare_call_after_channel(self):
-        """Offline parse_tool_calls should extract bare calls immediately following <channel|>."""
-        from vllm.tool_parsers.gemma4_utils import parse_tool_calls
-
+        """parse_tool_calls extracts bare calls immediately following <channel|>."""
         text = (
             "<|channel>thought\n"
             "I need to read the entry source file.\n"
@@ -185,9 +153,10 @@ class TestGemma4EngineBareCallIntegration:
         assert tool_calls[0]["arguments"] == {"command": "cat /work/src/entry.c"}
 
     def test_engine_tool_parser_bare_call_extraction(self):
-        """Gemma4EngineToolParser should transition and extract bare calls without dropping them."""
+        """Gemma4EngineToolParser extracts bare calls without dropping them."""
         import json
         from unittest.mock import MagicMock
+
         from vllm.entrypoints.openai.chat_completion.protocol import (
             ChatCompletionRequest,
             ChatCompletionToolsParam,
@@ -215,7 +184,9 @@ class TestGemma4EngineBareCallIntegration:
         decode_map = {v: k for k, v in vocab.items()}
         mock_tokenizer = MagicMock()
         mock_tokenizer.get_vocab.return_value = vocab
-        mock_tokenizer.decode.side_effect = lambda ids: decode_map.get(ids[0], f"tok{ids[0]}")
+        mock_tokenizer.decode.side_effect = lambda ids: decode_map.get(
+            ids[0], f"tok{ids[0]}"
+        )
 
         parser = Gemma4EngineToolParser(mock_tokenizer, tools=tools)
         request = MagicMock(spec=ChatCompletionRequest)

--- a/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
+++ b/tests/tool_parsers/test_gemma4_regex_and_bare_calls.py
@@ -147,6 +147,21 @@ class TestGemma4FallbackFormats:
         # thing is "mode" survives instead of being truncated to "{}".
         assert tool_calls[0]["arguments"] == {"config": "{'mode': 'x'}"}
 
+    def test_truncated_call_is_rejected(self):
+        """A call cut off before its closing brace must not be emitted."""
+        text = "call:add{a:1,b:2"
+
+        assert parse_tool_calls(text) == []
+
+    def test_nested_call_like_text_is_not_a_second_call(self):
+        """Argument text that looks like ``call:name{...}`` isn't a real call."""
+        text = 'call:outer{payload:call:inner{x:<|"|>y<|"|>}}'
+
+        tool_calls = parse_tool_calls(text)
+
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "outer"
+
 
 class TestGemma4EngineBareCallIntegration:
     """Validate that the engine and offline utils properly extract bare tool calls."""

--- a/vllm/parser/gemma4.py
+++ b/vllm/parser/gemma4.py
@@ -335,10 +335,19 @@ def gemma4_config() -> ParserEngineConfig:
                 ParserState.TOOL_PREAMBLE,
                 (EventType.REASONING_END, EventType.TOOL_CALL_START),
             ),
+            (ParserState.REASONING, "CALL_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.REASONING_END, EventType.TOOL_CALL_START),
+            ),
             # -- Tool call transitions --
             (ParserState.CONTENT, "TOOL_START"): Transition(
                 ParserState.TOOL_PREAMBLE,
                 (EventType.REASONING_END, EventType.TOOL_CALL_START),
+            ),
+            # Bare call: emitted without <|tool_call> prefix (e.g. immediately after <channel|>)
+            (ParserState.CONTENT, "CALL_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.TOOL_CALL_START,),
             ),
             (ParserState.TOOL_PREAMBLE, "TOOL_END"): Transition(
                 ParserState.CONTENT,

--- a/vllm/tool_parsers/gemma4_utils.py
+++ b/vllm/tool_parsers/gemma4_utils.py
@@ -115,8 +115,8 @@ def parse_tool_calls(text: str, *, strict: bool = False) -> list[dict]:
         return results
 
     # Tier 2: Fallback for known Gemma4 output variations.
-    # Matches: <call>name{args}, call:name{args}, or bare call:name{args}<eos>
-    fallback_pattern = r"(?:<call>|(?:^|\s)call:)(\w+)\{(.*?)\}"
+    # Matches: <call>name{args}, call:name{args}, <channel|>call:name{args}, or bare call:name{args}<eos>
+    fallback_pattern = r"(?:<call>|(?:^|\s|<channel\|>|:)call:)([\w\-\.]+)\{(.*?)\}"
     for match in re.finditer(fallback_pattern, text, re.DOTALL):
         name, args_str = match.group(1), match.group(2)
         results.append(

--- a/vllm/tool_parsers/gemma4_utils.py
+++ b/vllm/tool_parsers/gemma4_utils.py
@@ -42,7 +42,7 @@ _STRING_DELIM = '<|"|>'
 _DELIM_LEN = len(_STRING_DELIM)
 
 
-def _scan_balanced_braces(text: str, start: int) -> str:
+def _scan_balanced_braces(text: str, start: int) -> tuple[str, int, bool]:
     """Extract a brace-balanced argument span starting just past ``{``.
 
     Tracks nesting depth and skips over ``<|"|>``-quoted spans so braces
@@ -54,9 +54,11 @@ def _scan_balanced_braces(text: str, start: int) -> str:
         start: Index just past the opening ``{``.
 
     Returns:
-        The argument string up to (but excluding) the matching closing
-        ``}``. If the text ends before the braces balance, returns
-        everything from ``start`` to the end of ``text``.
+        A ``(args_str, end, complete)`` tuple: ``args_str`` is the argument
+        span up to (but excluding) the matching closing ``}``; ``end`` is
+        the index just past that ``}`` (or ``len(text)`` if the braces
+        never balance); ``complete`` is ``False`` when ``text`` ended
+        before the braces balanced, meaning the call is truncated.
     """
     depth = 1
     i = start
@@ -72,8 +74,9 @@ def _scan_balanced_braces(text: str, start: int) -> str:
         elif text[i] == "}":
             depth -= 1
         i += 1
-    end = i - 1 if depth == 0 else i
-    return text[start:end]
+    if depth > 0:
+        return text[start:i], i, False
+    return text[start : i - 1], i, True
 
 
 def _parse_tool_arguments(args_str: str) -> dict[str, str]:
@@ -154,11 +157,20 @@ def parse_tool_calls(text: str, *, strict: bool = False) -> list[dict]:
     # Matches: <call>name{, call:name{, <channel|>call:name{, or bare call:name{
     # The closing `}` is found by balanced-brace scanning (not the regex)
     # so nested objects like config:{"mode":"x"} aren't truncated at the
-    # first `}`.
-    fallback_open_pattern = r"(?:<call>|(?:^|\s|<channel\|>|:)call:)([\w\-\.]+)\{"
-    for match in re.finditer(fallback_open_pattern, text, re.DOTALL):
+    # first `}`. Truncated calls (no matching `}` before the text ends) are
+    # skipped rather than emitted with incomplete arguments, and the next
+    # search resumes past the whole balanced span so argument text that
+    # itself looks like `call:name{...}` isn't re-matched as another call.
+    fallback_open_pattern = re.compile(
+        r"(?:<call>|(?:^|\s|<channel\|>|:)call:)([\w\-\.]+)\{", re.DOTALL
+    )
+    search_pos = 0
+    while match := fallback_open_pattern.search(text, search_pos):
         name = match.group(1)
-        args_str = _scan_balanced_braces(text, match.end())
+        args_str, end_pos, complete = _scan_balanced_braces(text, match.end())
+        search_pos = end_pos
+        if not complete:
+            break
         results.append(
             {
                 "name": name,

--- a/vllm/tool_parsers/gemma4_utils.py
+++ b/vllm/tool_parsers/gemma4_utils.py
@@ -38,6 +38,42 @@ do not need a transformers dependency for output parsing.
 import regex as re
 
 _TOOL_RESPONSE_START_TAG = "<|tool_response>"
+_STRING_DELIM = '<|"|>'
+_DELIM_LEN = len(_STRING_DELIM)
+
+
+def _scan_balanced_braces(text: str, start: int) -> str:
+    """Extract a brace-balanced argument span starting just past ``{``.
+
+    Tracks nesting depth and skips over ``<|"|>``-quoted spans so braces
+    inside quoted values don't affect the count, e.g.
+    ``config:{"mode":"x"}}`` closes on the *second* ``}``.
+
+    Args:
+        text: Full text being scanned.
+        start: Index just past the opening ``{``.
+
+    Returns:
+        The argument string up to (but excluding) the matching closing
+        ``}``. If the text ends before the braces balance, returns
+        everything from ``start`` to the end of ``text``.
+    """
+    depth = 1
+    i = start
+    n = len(text)
+    while i < n and depth > 0:
+        if text[i : i + _DELIM_LEN] == _STRING_DELIM:
+            i += _DELIM_LEN
+            next_delim = text.find(_STRING_DELIM, i)
+            i = n if next_delim == -1 else next_delim + _DELIM_LEN
+            continue
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    end = i - 1 if depth == 0 else i
+    return text[start:end]
 
 
 def _parse_tool_arguments(args_str: str) -> dict[str, str]:
@@ -115,10 +151,14 @@ def parse_tool_calls(text: str, *, strict: bool = False) -> list[dict]:
         return results
 
     # Tier 2: Fallback for known Gemma4 output variations.
-    # Matches: <call>name{args}, call:name{args}, <channel|>call:name{args}, or bare call:name{args}<eos>
-    fallback_pattern = r"(?:<call>|(?:^|\s|<channel\|>|:)call:)([\w\-\.]+)\{(.*?)\}"
-    for match in re.finditer(fallback_pattern, text, re.DOTALL):
-        name, args_str = match.group(1), match.group(2)
+    # Matches: <call>name{, call:name{, <channel|>call:name{, or bare call:name{
+    # The closing `}` is found by balanced-brace scanning (not the regex)
+    # so nested objects like config:{"mode":"x"} aren't truncated at the
+    # first `}`.
+    fallback_open_pattern = r"(?:<call>|(?:^|\s|<channel\|>|:)call:)([\w\-\.]+)\{"
+    for match in re.finditer(fallback_open_pattern, text, re.DOTALL):
+        name = match.group(1)
+        args_str = _scan_balanced_braces(text, match.end())
         results.append(
             {
                 "name": name,


### PR DESCRIPTION
## Summary

Fixes #54256.

When serving Gemma-4 with reasoning and tool calling, the model frequently transitions directly out of reasoning (`<channel|>`) into emitting a tool call (`call:func{...}`) without re-emitting the optional `<|tool_call>` prefix. 

This PR ensures the Gemma4 parser handles bare `call:` transitions from both `CONTENT` and `REASONING` states, and fixes the offline fallback regex in `gemma4_utils.py` when `<channel|>` directly precedes `call:` without whitespace.

## Root Cause

1. In `vllm/parser/gemma4.py`, transitioning from `REASONING` to `CONTENT` on `THINK_END` left the FSM without a transition on `CALL_PREFIX` (`"call:"`). When the model dropped `<|tool_call>`, the tool call was silently dropped.
2. In `vllm/tool_parsers/gemma4_utils.py`, the fallback regex `r"(?:<call>|(?:^|\s)call:)(\w+)\{(.*?)\}"` required whitespace before `call:`, missing attached delimiters like `<channel|>call:...`.
3. Related to #53444 (which added `:` opener handling within `TOOL_PREAMBLE`, but still required `<|tool_call>` to reach `TOOL_PREAMBLE`) and #53363 / #53255 (empty `tool_calls` with `finish_reason="tool_calls"`).

## Fix

1. **`vllm/parser/gemma4.py`**:
   - Added `(ParserState.CONTENT, "CALL_PREFIX") -> ParserState.TOOL_NAME` transition emitting `EventType.TOOL_CALL_START`.
   - Added `(ParserState.REASONING, "CALL_PREFIX") -> ParserState.TOOL_NAME` transition emitting `(EventType.REASONING_END, EventType.TOOL_CALL_START)`.
2. **`vllm/tool_parsers/gemma4_utils.py`**:
   - Updated fallback pattern to `r"(?:<call>|(?:^|\s|<channel\|>|:)call:)([\w\-\.]+)\{(.*?)\}"`.
3. **Tests** (`tests/tool_parsers/test_gemma4_regex_and_bare_calls.py`):
   - Exercises the production `vllm.tool_parsers.gemma4_utils.parse_tool_calls` directly (no copied local regex constants), so regressions in the real tiered pattern are caught. Cases assert both the parsed function name and arguments:
     - Tier 1: canonical tag-wrapped calls, `<turn|>` closure, multiple sequential calls, `strict=True` ignoring fallback shapes
     - Tier 2: bare `call:` glued to `<channel|>` (no whitespace), colon-prefixed `<|tool_call>:call:...`, leading-whitespace bare call, fragmented `<call>` tag, hyphen- and dot-containing tool names, no-call -> empty
   - Retains the `Gemma4EngineToolParser` + offline `parse_tool_calls` integration cases.

## Verification

```bash
.venv/bin/python -m pytest tests/tool_parsers/test_gemma4_regex_and_bare_calls.py tests/tool_parsers/test_gemma4_tool_parser.py
```
- 67/67 tests pass (13 in `test_gemma4_regex_and_bare_calls.py` + 54 existing).
- Verified against live Blackwell GPU deployment.

## AI assistance

AI assistance (Claude Code) was used to refactor the regression tests to exercise the production parser. All changes were reviewed line-by-line by the submitter.