### PR TITLE
[Perf] Pin Qwen VL rotary position IDs before H2D

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -743,7 +743,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_size)
 
-        pos_ids = pos_ids.to(cos.device, non_blocking=True)
+        pos_ids = async_tensor_h2d(pos_ids, device=cos.device)
         cos_combined = cos[pos_ids].flatten(1)
         sin_combined = sin[pos_ids].flatten(1)
 

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -85,6 +85,7 @@ from vllm.multimodal.processing import (
 )
 from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
+from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.encoder_cudagraph_defs import EncoderCudaGraphReplayBuffers
 
@@ -641,7 +642,7 @@ class Qwen2VisionTransformer(nn.Module):
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
 
-        pos_ids = pos_ids.to(cos.device, non_blocking=True)
+        pos_ids = async_tensor_h2d(pos_ids, device=cos.device)
         cos_combined = cos[pos_ids].flatten(1)
         sin_combined = sin[pos_ids].flatten(1)
         return cos_combined, sin_combined


### PR DESCRIPTION
## Summary

- upload Qwen2-VL rotary position IDs through `async_tensor_h2d`
- apply the same fix to the shared pattern in Qwen2.5-VL
- preserve tensor values and dtype while making `non_blocking` H2D genuinely asynchronous

## Context

This existing issue on `main` was exposed by the enhanced CPU/GPU synchronization checks in #53491, specifically [Buildkite build #85278](https://buildkite.com/vllm/ci/builds/85278). The repeated failures point to `Qwen2VisionTransformer.rot_pos_emb` and `Qwen2_5_VisionTransformer.rotary_pos_emb_thw`, where pageable CPU `pos_ids` tensors were copied with `non_blocking=True`.


## Duplicate-work check

I checked open PRs for #53491 references and for Qwen VL `pos_ids` / pinned H2D fixes. I did not find an open PR addressing these two paths.

## Testing

- `git diff --check` — passed
- `.venv/bin/python -m pre_commit run ruff-check --files vllm/model_executor/models/qwen2_vl.py vllm/model_executor/models/qwen2_5_vl.py` — passed
- `.venv/bin/python -m compileall -q vllm/model_executor/models/qwen2_vl.py vllm/model_executor/models/qwen2_5_vl.py` — passed

GPU model tests were not available in the local environment. No model evaluation was run because this only changes the host allocation/copy path; tensor values, dtype, and model computation are unchanged. The triggering coverage is the Qwen VL CI exercised in #53491 build #85278.

AI assistance was used to analyze the CI traces, identify the duplicate Qwen VL transfer pattern, implement the change, and prepare this PR.