### PR TITLE
[MoE] enable all2all fi_one_sided by default only for GB200/GB300

### DIFF
--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -30,6 +30,7 @@ from vllm.distributed.device_communicators.base_device_communicator import (
     DeviceCommunicatorBase,
 )
 from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
+from vllm.engine.arg_utils import EngineArgs
 from vllm.utils.flashinfer import (
     has_flashinfer_nvlink_one_sided,
     has_flashinfer_nvlink_two_sided,
@@ -101,6 +102,28 @@ def test_default_ep_communicator_uses_platform_all2all_backend(
         )
     else:
         assert isinstance(device_communicator.all2all_manager, AgRsAll2AllManager)
+
+
+@pytest.mark.parametrize(
+    ("is_cuda", "expected_backend"),
+    [
+        (True, "flashinfer_nvlink_one_sided"),
+        (False, "allgather_reducescatter"),
+    ],
+)
+def test_engine_args_resolves_all2all_backend_default(
+    monkeypatch, is_cuda, expected_backend
+):
+    """`EngineArgs` mirrors this field from `ParallelConfig`, and
+    `create_engine_config()` passes the value straight back. The default must
+    therefore arrive as a resolved string; leaking a `FieldInfo` through makes
+    every launch without `--all2all-backend` fail config validation."""
+    monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: is_cuda)
+
+    backend = EngineArgs().all2all_backend
+
+    assert backend == expected_backend
+    assert ParallelConfig(all2all_backend=backend).all2all_backend == expected_backend
 
 
 # ---------------------------------------------------------------------------

--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -14,7 +14,22 @@ import pytest
 import torch
 import torch.multiprocessing as mp
 
+from vllm.config import (
+    ParallelConfig,
+    VllmConfig,
+    get_current_vllm_config,
+    set_current_vllm_config,
+)
 from vllm.distributed import get_ep_group
+from vllm.distributed.device_communicators.all2all import (
+    AgRsAll2AllManager,
+    All2AllManagerBase,
+    FlashInferNVLinkOneSidedManager,
+)
+from vllm.distributed.device_communicators.base_device_communicator import (
+    DeviceCommunicatorBase,
+)
+from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
 from vllm.utils.flashinfer import (
     has_flashinfer_nvlink_one_sided,
     has_flashinfer_nvlink_two_sided,
@@ -23,6 +38,70 @@ from vllm.utils.import_utils import has_deep_ep_v2
 from vllm.utils.network_utils import get_open_port
 
 from ..utils import init_test_distributed_environment
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_backend"),
+    [
+        pytest.param(
+            "cuda",
+            "flashinfer_nvlink_one_sided",
+            marks=pytest.mark.skipif(
+                not has_flashinfer_nvlink_one_sided(),
+                reason="FlashInfer NVLink one-sided not available",
+            ),
+        ),
+        ("non_cuda", "allgather_reducescatter"),
+    ],
+)
+def test_default_ep_communicator_uses_platform_all2all_backend(
+    monkeypatch, platform, expected_backend
+):
+    def init_device_communicator(
+        self,
+        cpu_group,
+        device,
+        device_group,
+        unique_name,
+        global_ranks,
+        global_world_size,
+        *,
+        use_all2all,
+    ):
+        self.cpu_group = cpu_group
+        self.device = device
+        self.device_group = device_group
+        self.unique_name = unique_name
+        self.world_size = 1
+        self.use_all2all = unique_name.startswith("ep:") and use_all2all
+        self.all2all_backend = get_current_vllm_config().parallel_config.all2all_backend
+        self.all2all_manager = None
+
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform.is_cuda", lambda: platform == "cuda"
+    )
+    monkeypatch.setattr(DeviceCommunicatorBase, "__init__", init_device_communicator)
+    monkeypatch.setattr(All2AllManagerBase, "__init__", lambda self, *args: None)
+
+    vllm_config = VllmConfig(parallel_config=ParallelConfig())
+    with set_current_vllm_config(vllm_config):
+        device_comm_cls = CudaCommunicator
+        device_communicator = device_comm_cls(
+            cpu_group=object(),
+            device=torch.device("cuda:0"),
+            device_group=object(),
+            unique_name="ep:test",
+            use_all2all=True,
+        )
+
+    assert device_communicator.all2all_backend == expected_backend
+    if platform == "cuda":
+        assert isinstance(
+            device_communicator.all2all_manager, FlashInferNVLinkOneSidedManager
+        )
+    else:
+        assert isinstance(device_communicator.all2all_manager, AgRsAll2AllManager)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -78,11 +78,18 @@ def test_default_ep_communicator_uses_platform_all2all_backend(
         self.all2all_backend = get_current_vllm_config().parallel_config.all2all_backend
         self.all2all_manager = None
 
+    def init_all2all_manager(self, cpu_group, tcp_store_group=None):
+        # The real base __init__ needs DP/TP groups, which aren't initialized
+        # here. Set only what the manager subclasses read on construction.
+        self.cpu_group = cpu_group
+        self.rank = 0
+        self.world_size = 1
+
     monkeypatch.setattr(
         "vllm.platforms.current_platform.is_cuda", lambda: platform == "cuda"
     )
     monkeypatch.setattr(DeviceCommunicatorBase, "__init__", init_device_communicator)
-    monkeypatch.setattr(All2AllManagerBase, "__init__", lambda self, *args: None)
+    monkeypatch.setattr(All2AllManagerBase, "__init__", init_all2all_manager)
 
     vllm_config = VllmConfig(parallel_config=ParallelConfig())
     with set_current_vllm_config(vllm_config):

--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -88,6 +88,9 @@ def test_default_ep_communicator_uses_platform_all2all_backend(
     monkeypatch.setattr(
         "vllm.platforms.current_platform.is_cuda", lambda: platform == "cuda"
     )
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform.has_device_capability", lambda _: True
+    )
     monkeypatch.setattr(DeviceCommunicatorBase, "__init__", init_device_communicator)
     monkeypatch.setattr(All2AllManagerBase, "__init__", init_all2all_manager)
 
@@ -128,6 +131,9 @@ def test_engine_args_resolves_all2all_backend_default(
     therefore arrive as a resolved string; leaking a `FieldInfo` through makes
     every launch without `--all2all-backend` fail config validation."""
     monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: is_cuda)
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform.has_device_capability", lambda _: True
+    )
     monkeypatch.setattr(
         "vllm.utils.flashinfer.has_flashinfer_nvlink_one_sided", lambda: True
     )

--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -128,6 +128,9 @@ def test_engine_args_resolves_all2all_backend_default(
     therefore arrive as a resolved string; leaking a `FieldInfo` through makes
     every launch without `--all2all-backend` fail config validation."""
     monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: is_cuda)
+    monkeypatch.setattr(
+        "vllm.utils.flashinfer.has_flashinfer_nvlink_one_sided", lambda: True
+    )
 
     backend = EngineArgs().all2all_backend
 

--- a/tests/distributed/test_mnnvl_alltoall.py
+++ b/tests/distributed/test_mnnvl_alltoall.py
@@ -91,7 +91,9 @@ def test_default_ep_communicator_uses_platform_all2all_backend(
     monkeypatch.setattr(DeviceCommunicatorBase, "__init__", init_device_communicator)
     monkeypatch.setattr(All2AllManagerBase, "__init__", init_all2all_manager)
 
-    vllm_config = VllmConfig(parallel_config=ParallelConfig())
+    vllm_config = VllmConfig(
+        parallel_config=ParallelConfig(enable_expert_parallel=True)
+    )
     with set_current_vllm_config(vllm_config):
         device_comm_cls = CudaCommunicator
         device_communicator = device_comm_cls(
@@ -130,7 +132,8 @@ def test_engine_args_resolves_all2all_backend_default(
     backend = EngineArgs().all2all_backend
 
     assert backend == expected_backend
-    assert ParallelConfig(all2all_backend=backend).all2all_backend == expected_backend
+    config = ParallelConfig(all2all_backend=backend, enable_expert_parallel=True)
+    assert config.all2all_backend == expected_backend
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -775,8 +775,20 @@ def test_data_parallel_rpc_port_has_fixed_default():
     assert ParallelConfig().data_parallel_rpc_port == 29550
 
 
-def test_all2all_backend_has_portable_default():
-    assert ParallelConfig().all2all_backend == "allgather_reducescatter"
+@pytest.mark.parametrize(
+    ("is_cuda", "expected_backend"),
+    [
+        (True, "flashinfer_nvlink_one_sided"),
+        (False, "allgather_reducescatter"),
+    ],
+)
+def test_all2all_backend_default_is_platform_dependent(
+    monkeypatch, is_cuda, expected_backend
+):
+    """Non-CUDA platforms must keep the portable default (#53952); CUDA opts
+    into the faster one-sided backend."""
+    monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: is_cuda)
+    assert ParallelConfig().all2all_backend == expected_backend
 
 
 @pytest.mark.parametrize("port", [1, 29550, 65535])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -793,8 +793,22 @@ def test_all2all_backend_default_needs_cuda_and_expert_parallel(
     """Only CUDA with expert parallel gets the one-sided backend; everything
     else keeps the portable default (#53952)."""
     monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: is_cuda)
+    monkeypatch.setattr(
+        "vllm.utils.flashinfer.has_flashinfer_nvlink_one_sided", lambda: True
+    )
     config = ParallelConfig(enable_expert_parallel=enable_expert_parallel)
     assert config.all2all_backend == expected_backend
+
+
+def test_all2all_backend_falls_back_without_flashinfer_one_sided(monkeypatch):
+    """FlashInferNVLinkOneSidedManager asserts on this module, so a CUDA
+    install without it must keep serving instead of failing at startup."""
+    monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: True)
+    monkeypatch.setattr(
+        "vllm.utils.flashinfer.has_flashinfer_nvlink_one_sided", lambda: False
+    )
+    config = ParallelConfig(enable_expert_parallel=True)
+    assert config.all2all_backend == "allgather_reducescatter"
 
 
 def test_all2all_backend_explicit_one_sided_downgrades_without_expert_parallel(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -776,19 +776,39 @@ def test_data_parallel_rpc_port_has_fixed_default():
 
 
 @pytest.mark.parametrize(
-    ("is_cuda", "expected_backend"),
+    ("is_cuda", "enable_expert_parallel", "expected_backend"),
     [
-        (True, "flashinfer_nvlink_one_sided"),
-        (False, "allgather_reducescatter"),
+        (True, True, "flashinfer_nvlink_one_sided"),
+        # Without expert parallel the naive AllGather+ReduceScatter path
+        # dispatches through the generic manager interface, which the
+        # one-sided manager does not implement.
+        (True, False, "allgather_reducescatter"),
+        (False, True, "allgather_reducescatter"),
+        (False, False, "allgather_reducescatter"),
     ],
 )
-def test_all2all_backend_default_is_platform_dependent(
-    monkeypatch, is_cuda, expected_backend
+def test_all2all_backend_default_needs_cuda_and_expert_parallel(
+    monkeypatch, is_cuda, enable_expert_parallel, expected_backend
 ):
-    """Non-CUDA platforms must keep the portable default (#53952); CUDA opts
-    into the faster one-sided backend."""
+    """Only CUDA with expert parallel gets the one-sided backend; everything
+    else keeps the portable default (#53952)."""
     monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: is_cuda)
-    assert ParallelConfig().all2all_backend == expected_backend
+    config = ParallelConfig(enable_expert_parallel=enable_expert_parallel)
+    assert config.all2all_backend == expected_backend
+
+
+def test_all2all_backend_explicit_one_sided_downgrades_without_expert_parallel(
+    monkeypatch,
+):
+    """Without expert parallel, DP deployments reach naive_dp_ep.prepare(),
+    which dispatches through the generic manager interface, so an explicit
+    request must be downgraded rather than crash there."""
+    monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: True)
+    config = ParallelConfig(
+        all2all_backend="flashinfer_nvlink_one_sided",
+        enable_expert_parallel=False,
+    )
+    assert config.all2all_backend == "allgather_reducescatter"
 
 
 @pytest.mark.parametrize("port", [1, 29550, 65535])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -794,16 +794,33 @@ def test_all2all_backend_default_needs_cuda_and_expert_parallel(
     else keeps the portable default (#53952)."""
     monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: is_cuda)
     monkeypatch.setattr(
+        "vllm.platforms.current_platform.has_device_capability", lambda _: True
+    )
+    monkeypatch.setattr(
         "vllm.utils.flashinfer.has_flashinfer_nvlink_one_sided", lambda: True
     )
     config = ParallelConfig(enable_expert_parallel=enable_expert_parallel)
     assert config.all2all_backend == expected_backend
 
 
+def test_all2all_backend_falls_back_before_blackwell(monkeypatch):
+    """No unquantized MoE kernel accepts this backend below SM100, so the
+    backend oracle would raise while loading the model (L4, DP+EP)."""
+    monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: True)
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform.has_device_capability", lambda _: False
+    )
+    config = ParallelConfig(enable_expert_parallel=True)
+    assert config.all2all_backend == "allgather_reducescatter"
+
+
 def test_all2all_backend_falls_back_without_flashinfer_one_sided(monkeypatch):
     """FlashInferNVLinkOneSidedManager asserts on this module, so a CUDA
     install without it must keep serving instead of failing at startup."""
     monkeypatch.setattr("vllm.platforms.current_platform.is_cuda", lambda: True)
+    monkeypatch.setattr(
+        "vllm.platforms.current_platform.has_device_capability", lambda _: True
+    )
     monkeypatch.setattr(
         "vllm.utils.flashinfer.has_flashinfer_nvlink_one_sided", lambda: False
     )

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -192,7 +192,13 @@ class ParallelConfig:
       with 4 experts and 2 ranks, rank 0 will have experts [0, 2] and rank 1
       will have experts [1, 3]. This strategy can help improve load balancing
       for grouped expert models with no redundant experts."""
-    all2all_backend: All2AllBackend = "allgather_reducescatter"
+    all2all_backend: All2AllBackend = Field(
+        default_factory=lambda: (
+            "flashinfer_nvlink_one_sided"
+            if current_platform.is_cuda()
+            else "allgather_reducescatter"
+        )
+    )
     """All2All backend for MoE expert parallel communication. Available options:
 
     - "allgather_reducescatter": All2all based on allgather and reducescatter
@@ -492,6 +498,15 @@ class ParallelConfig:
                 self.all2all_backend,
             )
             self.all2all_backend = "allgather_reducescatter"
+
+        if (
+            self.all2all_backend == "flashinfer_nvlink_one_sided"
+            and not current_platform.is_cuda()
+        ):
+            raise ValueError(
+                "all2all_backend='flashinfer_nvlink_one_sided' is only "
+                "supported on CUDA. Use 'allgather_reducescatter' on ROCm."
+            )
 
         if self.data_parallel_size_local > self.data_parallel_size:
             raise ValueError(

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -523,6 +523,18 @@ class ParallelConfig:
             )
             self.all2all_backend = "allgather_reducescatter"
 
+        if self.all2all_backend == "flashinfer_nvlink_one_sided":
+            # Only reachable with expert parallel enabled, which keeps the
+            # FlashInfer import (~3s) off non-EP startup paths.
+            from vllm.utils.flashinfer import has_flashinfer_nvlink_one_sided
+
+            if not has_flashinfer_nvlink_one_sided():
+                logger.warning_once(
+                    "FlashInfer trtllm_moe_alltoall is unavailable; falling "
+                    "back to the 'allgather_reducescatter' all2all backend."
+                )
+                self.all2all_backend = "allgather_reducescatter"
+
         if self.data_parallel_size_local > self.data_parallel_size:
             raise ValueError(
                 f"data_parallel_size_local ({self.data_parallel_size_local}) "

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -512,14 +512,20 @@ class ParallelConfig:
             self.all2all_backend == "flashinfer_nvlink_one_sided"
             and not self.enable_expert_parallel
         ):
-            # Without expert parallel, MoE layers take the naive
-            # AllGather+ReduceScatter path, which dispatches through the
-            # generic all2all manager interface. The one-sided manager only
-            # implements its own FlashInfer path, so it would raise there.
             logger.debug(
                 "Expert parallel is disabled; using the "
                 "'allgather_reducescatter' all2all backend instead of "
                 "'flashinfer_nvlink_one_sided'."
+            )
+            self.all2all_backend = "allgather_reducescatter"
+
+        if (
+            self.all2all_backend == "flashinfer_nvlink_one_sided"
+            and not current_platform.has_device_capability(100)
+        ):
+            logger.debug(
+                "Device is pre-Blackwell; using the 'allgather_reducescatter' "
+                "all2all backend instead of 'flashinfer_nvlink_one_sided'."
             )
             self.all2all_backend = "allgather_reducescatter"
 

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -508,6 +508,21 @@ class ParallelConfig:
                 "supported on CUDA. Use 'allgather_reducescatter' on ROCm."
             )
 
+        if (
+            self.all2all_backend == "flashinfer_nvlink_one_sided"
+            and not self.enable_expert_parallel
+        ):
+            # Without expert parallel, MoE layers take the naive
+            # AllGather+ReduceScatter path, which dispatches through the
+            # generic all2all manager interface. The one-sided manager only
+            # implements its own FlashInfer path, so it would raise there.
+            logger.debug(
+                "Expert parallel is disabled; using the "
+                "'allgather_reducescatter' all2all backend instead of "
+                "'flashinfer_nvlink_one_sided'."
+            )
+            self.all2all_backend = "allgather_reducescatter"
+
         if self.data_parallel_size_local > self.data_parallel_size:
             raise ValueError(
                 f"data_parallel_size_local ({self.data_parallel_size_local}) "

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -502,7 +502,7 @@ class EngineArgs:
     enable_ep_weight_filter: bool = ParallelConfig.enable_ep_weight_filter
     moe_backend: MoEBackend = KernelConfig.moe_backend
     linear_backend: LinearBackend = KernelConfig.linear_backend
-    all2all_backend: All2AllBackend = ParallelConfig.all2all_backend
+    all2all_backend: All2AllBackend = get_field(ParallelConfig, "all2all_backend")
     enable_elastic_ep: bool = ParallelConfig.enable_elastic_ep
     enable_dbo: bool = ParallelConfig.enable_dbo
     ubatch_size: int = ParallelConfig.ubatch_size


### PR DESCRIPTION
## Purpose

Enable flashinfer_nvlink_one_sided backend for all2all by default. As performance e2e tests show, flashinfer_nvlink_one_sided outperforms current default backend for all2all allgather_reducescatter by 8% on disaggregated serving of Qwen3.5 397B NVFP4.

Previous attempt to enable onesided by default was merged in PR https://github.com/vllm-project/vllm/pull/53311
But it was reverted due to problems with AMD CI tests by this PR https://github.com/vllm-project/vllm/pull/53952
A solution is to use onesided all2all backend only in case of GB200/GB300 is used in the rest cases fall back to AGRS. It was done in PR https://github.com/vllm-project/vllm/pull/53900

## Test Result

### Aggregated serving of Qwen3.5 NVFP4 on GB200 cluster ISL/OSL = 8k/1 (prefill-only)

Recipe for srt-slurm: [agrs-qwen35-agg-gb200.yaml](https://github.com/user-attachments/files/31344956/agrs-qwen35-agg-gb200.yaml)

<details>
<summary>Results</summary>

```
============ Serving Benchmark Result ============
Successful requests:                     4096      
Benchmark measurement start (UTC):       2026-08-23T07:12:34.792438+00:00
Benchmark measurement end (UTC):         2026-08-23T07:17:41.121113+00:00
Benchmark duration (s):                  306.33    
Total input tokens:                      67108864  
Total generated tokens:                  4096      
Request throughput (req/s):              13.37     
Output token throughput (tok/s):         13.37     
Peak output token throughput (tok/s):    13.60     
Total Token throughput (tok/s):          219088.08 
---------------Time to First Token----------------
Mean TTFT (ms):                          35911.90  
Median TTFT (ms):                        38117.01  
P99 TTFT (ms):                           47665.72  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          35911.90  
Median E2EL (ms):                        38117.01  
P99 E2EL (ms):                           47665.72  
==================================================
```
</details>

Recipe for srt-slurm: [onesided-qwen35-agg-gb200.yaml](https://github.com/user-attachments/files/31344969/onesided-qwen35-agg-gb200.yaml)

<details>
<summary>Results</summary>

```
============ Serving Benchmark Result ============
Successful requests:                     4096      
Benchmark measurement start (UTC):       2026-08-23T07:28:20.906523+00:00
Benchmark measurement end (UTC):         2026-08-23T07:30:44.257619+00:00
Benchmark duration (s):                  143.35    
Total input tokens:                      33554432  
Total generated tokens:                  4096      
Request throughput (req/s):              28.57     
Output token throughput (tok/s):         28.57     
Peak output token throughput (tok/s):    29.60     
Total Token throughput (tok/s):          234100.26 
---------------Time to First Token----------------
Mean TTFT (ms):                          16756.92  
Median TTFT (ms):                        17704.91  
P99 TTFT (ms):                           24432.65  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
----------------End-to-end Latency----------------
Mean E2EL (ms):                          16756.92  
Median E2EL (ms):                        17704.91  
P99 E2EL (ms):                           24432.65  
==================================================
```
</details>

Total Token throughput **+6.4%** for flashinfer_nvlink_one_sided.

Also, since workload is prefill-only this means that **prefill e2e speed up** is **+6.4%** for flashinfer_nvlink_one_sided.

### Disaggregated serving of Qwen3.5 397B NVFP4 on GB200 cluster ISL/OSL = 8k/1k

Recipe for srt-slurm: [agrs-qwen35-disagg-gb200.yaml](https://github.com/user-attachments/files/31344967/agrs-qwen35-disagg-gb200.yaml)

<details>
<summary>Results</summary>

```
============ Serving Benchmark Result ============
Successful requests:                     16384
Benchmark measurement start (UTC):       2026-08-21T13:58:46.909140+00:00
Benchmark measurement end (UTC):         2026-08-21T14:04:17.983068+00:00
Benchmark duration (s):                  331.07
Total input tokens:                      134217728
Total generated tokens:                  16777216
Request throughput (req/s):              49.49
Output token throughput (tok/s):         50675.14
Peak output token throughput (tok/s):    55616.60
Total Token throughput (tok/s):          456076.23
---------------Time to First Token----------------
Mean TTFT (ms):                          3617.93
Median TTFT (ms):                        1164.76
P99 TTFT (ms):                           33376.05
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.46
Median TPOT (ms):                        36.54
P99 TPOT (ms):                           36.58
---------------Inter-token Latency----------------
Mean ITL (ms):                           3297.61
Median ITL (ms):                         3649.41
P99 ITL (ms):                            3674.07
----------------End-to-end Latency----------------
Mean E2EL (ms):                          39891.64
Median E2EL (ms):                        38481.03
P99 E2EL (ms):                           69761.65
==================================================
```
</details>

Recipe for srt-slurm: [onesided-qwen35-disagg-gb200.yaml](https://github.com/user-attachments/files/31318265/onesided-qwen35-disagg-gb200.yaml)
<details>
<summary>Results</summary>

```
============ Serving Benchmark Result ============
Successful requests:                     16380
Benchmark measurement start (UTC):       2026-08-21T13:55:26.660008+00:00
Benchmark measurement end (UTC):         2026-08-21T14:00:30.608585+00:00
Benchmark duration (s):                  303.95
Total input tokens:                      134184960
Total generated tokens:                  16773120
Request throughput (req/s):              53.89
Output token throughput (tok/s):         55184.07
Peak output token throughput (tok/s):    61702.70
Total Token throughput (tok/s):          496656.66
---------------Time to First Token----------------
Mean TTFT (ms):                          6216.73
Median TTFT (ms):                        3186.26
P99 TTFT (ms):                           33960.10
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.21
Median TPOT (ms):                        30.31
P99 TPOT (ms):                           30.54
---------------Inter-token Latency----------------
Mean ITL (ms):                           2716.92
Median ITL (ms):                         3030.37
P99 ITL (ms):                            3062.17
----------------End-to-end Latency----------------
Mean E2EL (ms):                          36102.81
Median E2EL (ms):                        34085.26
P99 E2EL (ms):                           62558.25
==================================================
```
</details>

Total Token throughput **+8%** for flashinfer_nvlink_one_sided.

Also, since we have `Output token throughput` metric in PD serving it means that **decode e2e speed up** by **+8%** for flashinfer_nvlink_one_sided.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
