### PR TITLE
[BugFix] V2 model runner: guard reused pinned input buffers under async scheduling

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -202,6 +202,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         self.output_copy_stream = torch.cuda.Stream(self.device)
 
+        # Inputs are staged into reused pinned CPU buffers with non_blocking
+        # H2D copies, so a step must not overwrite them until the previous
+        # step's DMA has landed. Blocking (sleep) event rather than a spin, to
+        # avoid holding the CUDA driver lock under contention. GPUModelRunner
+        # (V1) has this protocol as synchronize_input_prep(); V2 did not.
+        self.prepare_inputs_event: torch.cuda.Event | None = None
+        if self.scheduler_config.async_scheduling:
+            self.prepare_inputs_event = torch.cuda.Event(blocking=True)
+
         # Pipeline parallelism.
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.is_first_pp_rank = get_pp_group().is_first_rank
@@ -1566,6 +1575,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             empty_output = self.kv_connector.no_forward(scheduler_output)
             return self._merge_ec_connector_no_forward(scheduler_output, empty_output)
 
+        # Wait for the previous step's input DMAs before restaging the shared
+        # buffers. Real and dummy batches both reach this point, which is what
+        # makes it necessary under data parallelism: an idle rank's dummy batch
+        # stages its inputs through these same buffers.
+        if self.prepare_inputs_event is not None:
+            self.prepare_inputs_event.synchronize()
+
         if not dummy_run:
             # Common case.
             # Prepare all the inputs and copy to the input buffers.
@@ -1648,6 +1664,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 # indices from the previous real batch.
                 for_capture=dummy_run and batch_desc.cg_mode == CUDAGraphMode.FULL,
             )
+
+        # Input staging for this step is enqueued; make the next step wait on
+        # it rather than race it.
+        if self.prepare_inputs_event is not None:
+            self.prepare_inputs_event.record()
 
         input_ids = input_batch.input_ids
         inputs_embeds = None


### PR DESCRIPTION

Port to the V2 model runner the `prepare_inputs_event` protocol that the V1 runner already has, and that #34866 extended to V1's `_dummy_run`. Without it, `dp_size > 1` plus async scheduling plus spec decoding deadlocks the engine group.

Symptom
-------
With `--data-parallel-size 8 --async-scheduling` and a drafter, the server hangs after minutes to tens of minutes of load. There is no fault string of any kind -- no illegal memory access, no "Engine core died" -- so log grepping reports a healthy run. The only entry is `TimeoutError` out of `multiproc_executor.get_response` once the ~300s executor response timeout fires and tears the group down. Externally, some ranks read 0% GPU utilisation and others 100%, which inverts the intuitive reading: the 100% ranks are the stuck ones.

Python stacks taken while the deadlock was live (8x MI355X, DP8, TP1, EP off, draft model, 8 of 8 ranks captured with py-spy) show two distinct waits:

  ranks with nothing scheduled (GPU 0%) -- inside the per-step DP collective:
      all_reduce (torch/distributed/distributed_c10d.py)
      sync_cudagraph_and_dp_padding (vllm/v1/worker/gpu/dp_utils.py)
      dispatch_cg_and_sync_dp (vllm/v1/worker/gpu/dp_utils.py)
      execute_model (vllm/v1/worker/gpu/model_runner.py)
      _dummy_run (vllm/v1/worker/gpu/model_runner.py)
      execute_dummy_batch (vllm/v1/worker/gpu_worker.py)
    This all-reduce runs on get_dp_group().cpu_group, i.e. gloo on CPU, which is
    why these ranks show no GPU activity while blocked.

  ranks with real work (GPU 100%) -- main thread idle in worker_busy_loop with
  no task pending, while WorkerAsyncOutputCopy is stuck in:
      synchronize (torch/cuda/streams.py)
      get_output (vllm/v1/worker/gpu/async_utils.py)
    i.e. blocked on AsyncOutput.copy_event, waiting for the previous step's
    sampled-token copy. These ranks are not in the collective and cannot reach
    it.

  all engine cores -- step_with_batch_queue -> future.result() -> get_response,
    each blocked on its own worker.

The cycle: the idle ranks wait in the DP collective for the busy ranks; the busy ranks only enter it on their next forward; their engine cores will not dispatch that forward until the previous step's output lands; that output never lands.

Cause
-----
Under async scheduling the V2 runner stages each step's inputs with `non_blocking=True` H2D copies whose sources are CPU buffers that persist across steps -- `UvaBuffer` allocates them `pin_memory=True`, and `prepare_inputs` copies into `self.input_buffers.*`. Nothing prevents step N+1 from overwriting those buffers while step N's DMA is still reading them.

The V1 runner guards exactly this with a blocking CUDA event, synchronised before input prep and recorded after, exposed as
`GPUModelRunner.synchronize_input_prep()`. The V2 runner never implemented it:

  $ grep -c prepare_inputs_event vllm/v1/worker/gpu_model_runner.py   # V1
  5
  $ grep -c prepare_inputs_event vllm/v1/worker/gpu/model_runner.py   # V2
  0

Speculative decoding forces the V2 runner, so that configuration runs the unguarded path by construction. `dp_size > 1` is what makes it fire routinely
rather than rarely: an idle rank runs `execute_dummy_batch` -> `_dummy_run` ->
`execute_model(dummy_run=True)`, reaching input staging through the *same* `execute_model`. A single rank therefore alternates real and dummy staging through the same pinned buffers with no barrier between them -- the "back-to-back dummy steps, or a dummy step followed by execute_model" case described in #34866, in the runner where the protocol is absent altogether.

It surfaces as a hang rather than as the `cudaErrorIllegalAddress` of #34866 because of where the damage lands: when the affected step is the one whose sampled-token copy the rest of the group is queued behind, the rank stops producing output instead of faulting.

Fix
---
Create a blocking `prepare_inputs_event` in `__init__` when async scheduling is enabled, synchronise on it in `execute_model` immediately before the input staging block, and record it immediately after. Both the real and the dummy paths go through that single point, so an idle rank's dummy batch is ordered against the previous step's DMAs as well. The event is `None` when async scheduling is off, so the synchronous path is unchanged.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

