### PR TITLE
Fix output token state synchronization across PP ranks

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -845,6 +845,45 @@ def test_update_states_pp_async_multi_request_keeps_rank_state_consistent(
         )
 
 
+@pytest.mark.parametrize("is_last_rank", [False, True])
+def test_update_states_pp_async_spec_decode_trims_output_token_ids(
+    model_runner, dist_init, monkeypatch, is_last_rank: bool
+):
+    """Optimistic spec-decode placeholders must be trimmed on every PP rank.
+
+    If only the last rank trims, non-last ranks accumulate overshoot in
+    output_token_ids, discard masks diverge, and PP broadcast deadlocks.
+    """
+    req_id = "req_0"
+    model_runner.use_async_scheduling = True
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_model_runner.get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=is_last_rank, world_size=2),
+    )
+    model_runner._update_states(_schedule_new_request(req_id))
+
+    req_state = model_runner.requests[req_id]
+    req_index = model_runner.input_batch.req_id_to_index[req_id]
+    sampled_token_id = 101
+    req_state.output_token_ids.append(sampled_token_id)
+    req_state.prev_num_draft_len = 2
+    model_runner.input_batch.num_tokens_no_spec[req_index] = req_state.num_tokens
+
+    scheduler_output = _schedule_cached_requests(
+        req_ids=[req_id],
+        num_scheduled_tokens={req_id: 1},
+        new_token_ids=[],
+        num_computed_tokens=[req_state.num_tokens],
+        num_output_tokens=[1],
+    )
+    model_runner._update_states(scheduler_output)
+
+    assert req_state.output_token_ids == [sampled_token_id]
+    assert (
+        model_runner.input_batch.num_tokens_no_spec[req_index] == req_state.num_tokens
+    )
+
+
 def test_update_config(model_runner):
     # Simple update
     model_runner.update_config({"load_config": {"load_format": "dummy"}})

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1422,7 +1422,9 @@ class GPUModelRunner(
                         req_state.output_token_ids.extend(
                             new_token_ids[-num_new_tokens:]
                         )
-            elif num_output_tokens < len(req_state.output_token_ids):
+            # Independent of is_last_rank: the optimistic extend above runs on
+            # every PP rank, so non-last ranks must trim too (async spec decode).
+            if num_output_tokens < len(req_state.output_token_ids):
                 # Some output tokens were discarded due to a sync-KV-load
                 # failure, or output_token_ids was inflated by the optimistic
                 # extend above (async spec decode). Align the cached state.


### PR DESCRIPTION
## Purpose

Fixes #54260.

With pipeline parallelism, async scheduling, and speculative decoding enabled, all PP ranks optimistically extend `req_state.output_token_ids` with speculative token placeholders. However, the trimming logic was attached to `if not is_last_rank` as an `elif`, so only the last PP rank could trim rejected placeholders.

This caused non-last ranks to accumulate an incorrect output length. The resulting state divergence could make PP ranks disagree on whether to perform the sampled-token broadcast, eventually causing an NCCL deadlock.

This PR makes the trimming condition an independent `if`, ensuring that `output_token_ids` and `num_tokens_no_spec` are synchronized on every PP rank.

No open PR addressing this specific trimming bug was found. Related PP and speculative-decoding issues cover different failure modes.

## Test Plan

Add a regression test that simulates async speculative decoding on both:

- A non-last PP rank.
- The last PP rank.

The test adds optimistic speculative-token placeholders and verifies that `_update_states()` trims `output_token_ids` back to the scheduler-provided `num_output_tokens` on both ranks. It also verifies that `num_tokens_no_spec` remains consistent with the corrected request length.

Run:

```bash
.venv/bin/python -m pytest \
    tests/v1/worker/test_gpu_model_runner.py::test_update_states_pp_async_spec_decode_trims_output_token_ids \
    -v
```

Model evaluation is not applicable because this change does not modify model computation, sampling probabilities, or speculative-token acceptance logic.

## Test Result

```text
collected 2 items

test_update_states_pp_async_spec_decode_trims_output_token_ids[False] PASSED
test_update_states_pp_async_spec_decode_trims_output_token_ids[True]  PASSED

2 passed, 14 warnings in 9.82s
```

The two cases cover non-last and last PP ranks respectively.

## AI assistance
AI assistance was used to analyze the issue and help draft this change and PR description. The human submitter reviewed every changed line and is responsible for the implementation and test results.