### PR TITLE
[CI][Test] Deflake the rms_norm scaling-property assertions

### DIFF
--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -12,6 +12,7 @@ from tests.ir.ir_test_utils import (
     clone_args,
     supported_providers,
 )
+from tests.utils import set_random_seed
 from vllm import ir
 from vllm.platforms import current_platform
 
@@ -51,7 +52,7 @@ def test_rms_norm_registration():
 )
 class TestRMSNorm:
     def test_native_semantics(self, dtype, n_tokens, hidden_size, epsilon):
-        torch.manual_seed(0)
+        set_random_seed(0)
         x, weight, epsilon = ir.ops.rms_norm.generate_inputs(
             num_tokens=4,
             hidden_size=8,
@@ -270,7 +271,7 @@ def test_vllm_c_fused_add_rms_norm_accepts_nd_input():
 )
 class TestFusedAddRMSNorm:
     def test_native_semantics(self, dtype, n_tokens, hidden_size, epsilon):
-        torch.manual_seed(0)
+        set_random_seed(0)
         x, x_residual, weight, eps = ir.ops.fused_add_rms_norm.generate_inputs(
             num_tokens=4,
             hidden_size=8,

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -12,7 +12,6 @@ from tests.ir.ir_test_utils import (
     clone_args,
     supported_providers,
 )
-from tests.kernels.allclose_default import get_default_rtol
 from vllm import ir
 from vllm.platforms import current_platform
 
@@ -52,6 +51,7 @@ def test_rms_norm_registration():
 )
 class TestRMSNorm:
     def test_native_semantics(self, dtype, n_tokens, hidden_size, epsilon):
+        torch.manual_seed(0)
         x, weight, epsilon = ir.ops.rms_norm.generate_inputs(
             num_tokens=4,
             hidden_size=8,
@@ -66,9 +66,13 @@ class TestRMSNorm:
         assert out.dtype == x.dtype
         assert out.device == x.device
 
-        # Check the scaling property of rms norm
+        # Check the scaling property of rms norm. This holds only
+        # approximately: epsilon does not scale with x, so
+        # rms_norm(2x) = x / sqrt(mean(x^2) + epsilon/4), which differs from
+        # rms_norm(x) by the epsilon term. Use the op's declared tolerance
+        # rather than a tighter hard-coded one.
         out2 = rms_norm_native(x * 2.0, weight, epsilon=epsilon)
-        torch.testing.assert_close(out2, out, rtol=get_default_rtol(out), atol=1e-3)
+        assert_close(ir.ops.rms_norm, out2, out)
 
         # Mean square should be approximately 1 (ignoring epsilon and weight scaling)
         combined_norm = out.float() / weight.float()
@@ -266,6 +270,7 @@ def test_vllm_c_fused_add_rms_norm_accepts_nd_input():
 )
 class TestFusedAddRMSNorm:
     def test_native_semantics(self, dtype, n_tokens, hidden_size, epsilon):
+        torch.manual_seed(0)
         x, x_residual, weight, eps = ir.ops.fused_add_rms_norm.generate_inputs(
             num_tokens=4,
             hidden_size=8,
@@ -304,7 +309,7 @@ class TestFusedAddRMSNorm:
         out2, _ = fused_add_rms_norm_native(
             x * 2.0, torch.zeros_like(x), weight, epsilon=epsilon
         )
-        torch.testing.assert_close(out2, out1, rtol=get_default_rtol(out), atol=1e-3)
+        assert_close(ir.ops.fused_add_rms_norm, out2, out1)
 
         # Check behavior with and without weight
         weight1 = torch.ones_like(weight)


### PR DESCRIPTION
## Purpose

TestRMSNorm.test_native_semantics and TestFusedAddRMSNorm.test_native_semantics check that rms_norm(2x) == rms_norm(x), against inputs drawn from an unseeded torch.randn and a hard-coded atol=1e-3.

Two problems. The property is only approximate: epsilon does not scale with x, so rms_norm(2x) = x / sqrt(mean(x^2) + epsilon/4), which differs from rms_norm(x) by the epsilon term. And 1e-3 is tighter than the tolerance the op itself declares for float16 -- layernorm.py sets atol=1e-2, rtol=2e-3, with a comment explaining that the default float16 tolerance is too tight here.

Seed the generator, and compare with the op's declared tolerance via the assert_close helper already used elsewhere in this file, so there is one source of truth for it.

Measured on MI300-class hardware, running the assertion itself over 20000 RNG states for the float16 / epsilon=1e-5 case (the parametrization that failed in AMD CI -- note the test hard-codes 4x8 and ignores its n_tokens/hidden_size parameters, so every parametrization draws the same shape):

  max |rms_norm(2x) - rms_norm(x)|            0.00390625
  fails under hard-coded atol=1e-3/rtol=1e-3  9/20000  (0.045%)
  fails under op-declared atol=1e-2/rtol=2e-3 0/20000  (0%)

0.00390625 is 2 ULP of float16 in [2,4) and matches the value in the CI failure exactly. With ~30 float16 epsilon=1e-5 draws per run before this change, that is roughly a 1.3% chance of a spurious failure per CI run from this arm alone. Seed 0, now pinned, has a max deviation of 0.00012207.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

