### PR TITLE
[Bugfix][Distributed] Fail clearly when a confirmed local shm reader can't attach

### DIFF
--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -723,12 +723,17 @@ def test_shm_ring_buffer_attach_to_missing_segment_stays_unused():
     ShmRingBuffer.__reduce__ -- it is a legitimately unused object, not an
     error by itself. Callers that require a working attach must check for
     this themselves (see MessageQueue.create_from_handle)."""
-    buffer = ShmRingBuffer(
-        n_reader=1,
-        max_chunk_bytes=24 * 1024 * 1024,
-        max_chunks=10,
-        name="vllm-test-x",
-    )
+    with mock.patch.object(
+        shm_broadcast.shared_memory,
+        "SharedMemory",
+        side_effect=FileNotFoundError(),
+    ):
+        buffer = ShmRingBuffer(
+            n_reader=1,
+            max_chunk_bytes=24 * 1024 * 1024,
+            max_chunks=10,
+            name="vllm-test-x",
+        )
     assert not hasattr(buffer, "shared_memory")
 
 
@@ -744,7 +749,14 @@ def test_create_from_handle_raises_when_mandatory_local_attach_fails():
         local_subscribe_addr="ignored-because-we-fail-before-connecting",
         local_notify_addr="ignored-because-we-fail-before-connecting",
     )
-    with pytest.raises(RuntimeError, match="vllm-test-x"):
+    with (
+        mock.patch.object(
+            shm_broadcast.shared_memory,
+            "SharedMemory",
+            side_effect=FileNotFoundError(),
+        ),
+        pytest.raises(RuntimeError, match="vllm-test-x"),
+    ):
         MessageQueue.create_from_handle(handle, rank=0)
 
 

--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -17,6 +17,7 @@ import torch.distributed as dist
 
 from vllm.distributed.device_communicators import shm_broadcast
 from vllm.distributed.device_communicators.shm_broadcast import (
+    Handle,
     MessageQueue,
     ShmRingBuffer,
     _rebuild_tensor,
@@ -715,51 +716,36 @@ def test_shm_ring_buffer_creation_checks_free_space():
         ShmRingBuffer(n_reader=1, max_chunk_bytes=24 * 1024 * 1024, max_chunks=10)
 
 
-def test_shm_ring_buffer_attach_retries_then_succeeds():
-    total_bytes = (24 * 1024 * 1024 + 2) * 10
-    attached = mock.Mock(size=total_bytes)
-    with (
-        mock.patch.object(
-            shm_broadcast.shared_memory,
-            "SharedMemory",
-            side_effect=[
-                FileNotFoundError(),
-                FileNotFoundError(),
-                attached,
-            ],
-        ) as mock_shared_memory,
-        mock.patch.object(shm_broadcast.time, "sleep") as mock_sleep,
-        mock.patch.object(shm_broadcast, "VLLM_SHM_ATTACH_TIMEOUT_S", 5.0),
-    ):
-        buffer = ShmRingBuffer(
-            n_reader=1,
-            max_chunk_bytes=24 * 1024 * 1024,
-            max_chunks=10,
-            name="fake-name",
-        )
-    assert buffer.shared_memory is attached
-    assert mock_shared_memory.call_count == 3
-    assert mock_sleep.call_count == 2
+def test_shm_ring_buffer_attach_to_missing_segment_stays_unused():
+    """A ShmRingBuffer attaching to a name that was never created (e.g. a
+    directly pickled object deserialized where a local attach isn't
+    required) must stay silent, per the documented pickling contract in
+    ShmRingBuffer.__reduce__ -- it is a legitimately unused object, not an
+    error by itself. Callers that require a working attach must check for
+    this themselves (see MessageQueue.create_from_handle)."""
+    buffer = ShmRingBuffer(
+        n_reader=1,
+        max_chunk_bytes=24 * 1024 * 1024,
+        max_chunks=10,
+        name="vllm-test-x",
+    )
+    assert not hasattr(buffer, "shared_memory")
 
 
-def test_shm_ring_buffer_attach_raises_after_timeout():
-    with (
-        mock.patch.object(
-            shm_broadcast.shared_memory,
-            "SharedMemory",
-            side_effect=FileNotFoundError(),
-        ),
-        mock.patch.object(shm_broadcast.time, "sleep"),
-        mock.patch.object(shm_broadcast, "VLLM_SHM_ATTACH_TIMEOUT_S", 0.0),
-        pytest.raises(RuntimeError, match="fake-name") as exc_info,
-    ):
-        ShmRingBuffer(
-            n_reader=1,
-            max_chunk_bytes=24 * 1024 * 1024,
-            max_chunks=10,
-            name="fake-name",
-        )
-    assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+def test_create_from_handle_raises_when_mandatory_local_attach_fails():
+    """When a rank is confirmed to be a local reader (present in
+    handle.local_reader_ranks) but the writer's shm segment can't be
+    attached, create_from_handle must fail clearly and immediately, not
+    return a half-constructed MessageQueue whose later use raises a
+    confusing AttributeError far from the real cause."""
+    handle = Handle(
+        local_reader_ranks=[0],
+        buffer_handle=(1, 24 * 1024 * 1024, 10, "vllm-test-x"),
+        local_subscribe_addr="ignored-because-we-fail-before-connecting",
+        local_notify_addr="ignored-because-we-fail-before-connecting",
+    )
+    with pytest.raises(RuntimeError, match="vllm-test-x"):
+        MessageQueue.create_from_handle(handle, rank=0)
 
 
 def test_remote_subscribe_addr_unique_concurrent_writers(

--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -715,6 +715,53 @@ def test_shm_ring_buffer_creation_checks_free_space():
         ShmRingBuffer(n_reader=1, max_chunk_bytes=24 * 1024 * 1024, max_chunks=10)
 
 
+def test_shm_ring_buffer_attach_retries_then_succeeds():
+    total_bytes = (24 * 1024 * 1024 + 2) * 10
+    attached = mock.Mock(size=total_bytes)
+    with (
+        mock.patch.object(
+            shm_broadcast.shared_memory,
+            "SharedMemory",
+            side_effect=[
+                FileNotFoundError(),
+                FileNotFoundError(),
+                attached,
+            ],
+        ) as mock_shared_memory,
+        mock.patch.object(shm_broadcast.time, "sleep") as mock_sleep,
+        mock.patch.object(shm_broadcast, "VLLM_SHM_ATTACH_TIMEOUT_S", 5.0),
+    ):
+        buffer = ShmRingBuffer(
+            n_reader=1,
+            max_chunk_bytes=24 * 1024 * 1024,
+            max_chunks=10,
+            name="fake-name",
+        )
+    assert buffer.shared_memory is attached
+    assert mock_shared_memory.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+def test_shm_ring_buffer_attach_raises_after_timeout():
+    with (
+        mock.patch.object(
+            shm_broadcast.shared_memory,
+            "SharedMemory",
+            side_effect=FileNotFoundError(),
+        ),
+        mock.patch.object(shm_broadcast.time, "sleep"),
+        mock.patch.object(shm_broadcast, "VLLM_SHM_ATTACH_TIMEOUT_S", 0.0),
+        pytest.raises(RuntimeError, match="fake-name") as exc_info,
+    ):
+        ShmRingBuffer(
+            n_reader=1,
+            max_chunk_bytes=24 * 1024 * 1024,
+            max_chunks=10,
+            name="fake-name",
+        )
+    assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+
 def test_remote_subscribe_addr_unique_concurrent_writers(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -344,14 +344,11 @@ class ShmRingBuffer:
                     # when attaching to an existing block.
                     assert self.shared_memory.size >= self.total_bytes_of_buffer
                 except FileNotFoundError:
-                    # This object may be deserialized on a node that never
-                    # attaches to it (e.g. a directly pickled ShmRingBuffer,
-                    # or a remote-node deserialize of a Handle whose local
-                    # attach wasn't required); in that case it is legitimately
-                    # unused, so we suppress the error here. Callers that
-                    # require a working local attach (e.g.
-                    # MessageQueue.create_from_handle for a confirmed local
-                    # reader) must check for this and fail clearly themselves.
+                    # we might deserialize the object in a different node
+                    # in this case, this object is not used,
+                    # and we should suppress the error. Callers that require
+                    # a working local attach (e.g. create_from_handle) must
+                    # check for this and fail clearly themselves.
                     pass
 
     def handle(self):
@@ -573,25 +570,12 @@ class MessageQueue:
             assert handle.buffer_handle is not None
             self.buffer = ShmRingBuffer(*handle.buffer_handle)
             if not hasattr(self.buffer, "shared_memory"):
-                # `rank` was already confirmed to be on the writer's node
-                # (see in_the_same_node_as / create_from_process_group), so
-                # attaching to the writer's shm segment is mandatory here.
-                # ShmRingBuffer itself stays silent on a missing segment to
-                # support the legitimate case of a handle deserialized where
-                # local attach isn't required; this is the point where we
-                # know it *was* required, so fail clearly instead of letting
-                # the half-constructed buffer surface a confusing
-                # AttributeError far away from the real cause.
                 name = handle.buffer_handle[3]
                 raise RuntimeError(
-                    f"Rank {rank} was confirmed to be on the writer's node "
-                    f"but failed to attach to its shared memory ring buffer "
-                    f"{name!r}. Possible causes: the writer process exited "
-                    "before or while creating the segment, the shared "
-                    "memory mount is exhausted (see --shm-size / "
-                    "--ipc=host), or this process does not actually share "
-                    "a /dev/shm namespace with the writer despite being on "
-                    "the same host."
+                    f"Rank {rank} is a local reader but could not attach to "
+                    f"shared memory ring buffer {name!r}. The segment may "
+                    "have been unlinked, the handle may be stale, or the "
+                    "processes may not share a /dev/shm namespace."
                 )
             self.current_idx = 0
             self.local_reader_rank = handle.local_reader_ranks.index(rank)

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from _typeshed import SizedBuffer
 
 VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
+VLLM_SHM_ATTACH_TIMEOUT_S = envs.VLLM_SHM_ATTACH_TIMEOUT_S
 # Cap on how long an idle reader parks before re-reading the authoritative SHM
 # written-flag. Bounds lost-notify recovery latency to ~5s while the periodic
 # wakeup stays negligible (one flag check per reader every 5s).
@@ -335,19 +336,45 @@ class ShmRingBuffer:
                 "multiprocessing.resource_tracker.register",
                 lambda *args, **kwargs: None,
             ):
-                try:
-                    self.shared_memory = shared_memory.SharedMemory(name=name)
-                    # See https://docs.python.org/3/library/multiprocessing.shared_memory.html # noqa
-                    # Some platforms allocate memory based on page size,
-                    # so the shared memory block size may be larger or equal
-                    # to the requested size. The size parameter is ignored
-                    # when attaching to an existing block.
-                    assert self.shared_memory.size >= self.total_bytes_of_buffer
-                except FileNotFoundError:
-                    # we might deserialize the object in a different node
-                    # in this case, this object is not used,
-                    # and we should suppress the error
-                    pass
+                # The writer creates the segment before this reader ever
+                # learns its name (readers only attach after receiving the
+                # writer's handle), so a missing segment here is not the
+                # legitimate cross-node case it may once have been: this
+                # branch is only reached for ranks already confirmed to be
+                # on the writer's node (see MessageQueue.create_from_handle).
+                # A FileNotFoundError means either a transient race (the
+                # writer hasn't finished creating the segment yet) or a real
+                # failure, so retry with backoff before giving up.
+                backoff_s = 0.05
+                deadline = time.monotonic() + VLLM_SHM_ATTACH_TIMEOUT_S
+                while True:
+                    try:
+                        self.shared_memory = shared_memory.SharedMemory(name=name)
+                        # See https://docs.python.org/3/library/multiprocessing.shared_memory.html # noqa
+                        # Some platforms allocate memory based on page size,
+                        # so the shared memory block size may be larger or
+                        # equal to the requested size. The size parameter is
+                        # ignored when attaching to an existing block.
+                        assert self.shared_memory.size >= self.total_bytes_of_buffer
+                        break
+                    except FileNotFoundError as e:
+                        if time.monotonic() >= deadline:
+                            raise RuntimeError(
+                                f"Failed to attach to shared memory segment "
+                                f"{name!r} after retrying for "
+                                f"{VLLM_SHM_ATTACH_TIMEOUT_S:.1f} seconds. This "
+                                "process was already confirmed to be on the "
+                                "same node as the writer, so the segment "
+                                "should exist. Possible causes: the writer "
+                                "process crashed or exited before creating "
+                                "the segment; the shared memory mount "
+                                f"({SHM_PATH}) is exhausted (see --shm-size / "
+                                "--ipc=host); or this container/pod does not "
+                                "actually share a /dev/shm namespace with the "
+                                "writer."
+                            ) from e
+                        time.sleep(backoff_s)
+                        backoff_s = min(backoff_s * 2, 1.0)
 
     def handle(self):
         return (

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -60,7 +60,6 @@ if TYPE_CHECKING:
     from _typeshed import SizedBuffer
 
 VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
-VLLM_SHM_ATTACH_TIMEOUT_S = envs.VLLM_SHM_ATTACH_TIMEOUT_S
 # Cap on how long an idle reader parks before re-reading the authoritative SHM
 # written-flag. Bounds lost-notify recovery latency to ~5s while the periodic
 # wakeup stays negligible (one flag check per reader every 5s).
@@ -336,45 +335,24 @@ class ShmRingBuffer:
                 "multiprocessing.resource_tracker.register",
                 lambda *args, **kwargs: None,
             ):
-                # The writer creates the segment before this reader ever
-                # learns its name (readers only attach after receiving the
-                # writer's handle), so a missing segment here is not the
-                # legitimate cross-node case it may once have been: this
-                # branch is only reached for ranks already confirmed to be
-                # on the writer's node (see MessageQueue.create_from_handle).
-                # A FileNotFoundError means either a transient race (the
-                # writer hasn't finished creating the segment yet) or a real
-                # failure, so retry with backoff before giving up.
-                backoff_s = 0.05
-                deadline = time.monotonic() + VLLM_SHM_ATTACH_TIMEOUT_S
-                while True:
-                    try:
-                        self.shared_memory = shared_memory.SharedMemory(name=name)
-                        # See https://docs.python.org/3/library/multiprocessing.shared_memory.html # noqa
-                        # Some platforms allocate memory based on page size,
-                        # so the shared memory block size may be larger or
-                        # equal to the requested size. The size parameter is
-                        # ignored when attaching to an existing block.
-                        assert self.shared_memory.size >= self.total_bytes_of_buffer
-                        break
-                    except FileNotFoundError as e:
-                        if time.monotonic() >= deadline:
-                            raise RuntimeError(
-                                f"Failed to attach to shared memory segment "
-                                f"{name!r} after retrying for "
-                                f"{VLLM_SHM_ATTACH_TIMEOUT_S:.1f} seconds. This "
-                                "process was already confirmed to be on the "
-                                "same node as the writer, so the segment "
-                                "should exist. Possible causes: the writer "
-                                "process crashed or exited before creating "
-                                "the segment; the shared memory mount "
-                                f"({SHM_PATH}) is exhausted (see --shm-size / "
-                                "--ipc=host); or this container/pod does not "
-                                "actually share a /dev/shm namespace with the "
-                                "writer."
-                            ) from e
-                        time.sleep(backoff_s)
-                        backoff_s = min(backoff_s * 2, 1.0)
+                try:
+                    self.shared_memory = shared_memory.SharedMemory(name=name)
+                    # See https://docs.python.org/3/library/multiprocessing.shared_memory.html # noqa
+                    # Some platforms allocate memory based on page size,
+                    # so the shared memory block size may be larger or equal
+                    # to the requested size. The size parameter is ignored
+                    # when attaching to an existing block.
+                    assert self.shared_memory.size >= self.total_bytes_of_buffer
+                except FileNotFoundError:
+                    # This object may be deserialized on a node that never
+                    # attaches to it (e.g. a directly pickled ShmRingBuffer,
+                    # or a remote-node deserialize of a Handle whose local
+                    # attach wasn't required); in that case it is legitimately
+                    # unused, so we suppress the error here. Callers that
+                    # require a working local attach (e.g.
+                    # MessageQueue.create_from_handle for a confirmed local
+                    # reader) must check for this and fail clearly themselves.
+                    pass
 
     def handle(self):
         return (
@@ -594,6 +572,27 @@ class MessageQueue:
         if rank in handle.local_reader_ranks:
             assert handle.buffer_handle is not None
             self.buffer = ShmRingBuffer(*handle.buffer_handle)
+            if not hasattr(self.buffer, "shared_memory"):
+                # `rank` was already confirmed to be on the writer's node
+                # (see in_the_same_node_as / create_from_process_group), so
+                # attaching to the writer's shm segment is mandatory here.
+                # ShmRingBuffer itself stays silent on a missing segment to
+                # support the legitimate case of a handle deserialized where
+                # local attach isn't required; this is the point where we
+                # know it *was* required, so fail clearly instead of letting
+                # the half-constructed buffer surface a confusing
+                # AttributeError far away from the real cause.
+                name = handle.buffer_handle[3]
+                raise RuntimeError(
+                    f"Rank {rank} was confirmed to be on the writer's node "
+                    f"but failed to attach to its shared memory ring buffer "
+                    f"{name!r}. Possible causes: the writer process exited "
+                    "before or while creating the segment, the shared "
+                    "memory mount is exhausted (see --shm-size / "
+                    "--ipc=host), or this process does not actually share "
+                    "a /dev/shm namespace with the writer despite being on "
+                    "the same host."
+                )
             self.current_idx = 0
             self.local_reader_rank = handle.local_reader_ranks.index(rank)
             self._is_local_reader = True

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
-    VLLM_SHM_ATTACH_TIMEOUT_S: float = 5.0
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
     VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE: int = 256
@@ -723,12 +722,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Interval in seconds to log a warning message when the ring buffer is full
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
-    ),
-    # Max seconds a reader retries attaching to an existing shm ring buffer
-    # before raising. Should be short: on the correct path the writer has
-    # already created the segment, so attach is near-instant.
-    "VLLM_SHM_ATTACH_TIMEOUT_S": lambda: float(
-        os.environ.get("VLLM_SHM_ATTACH_TIMEOUT_S", "5.0")
     ),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.
@@ -2251,7 +2244,6 @@ def compile_factors() -> dict[str, object]:
         "VLLM_RPC_BASE_PATH",
         "VLLM_USE_MODELSCOPE",
         "VLLM_RINGBUFFER_WARNING_INTERVAL",
-        "VLLM_SHM_ATTACH_TIMEOUT_S",
         "VLLM_DEBUG_DUMP_PATH",
         "VLLM_PORT",
         "VLLM_CACHE_ROOT",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
+    VLLM_SHM_ATTACH_TIMEOUT_S: float = 5.0
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
     VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE: int = 256
@@ -722,6 +723,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Interval in seconds to log a warning message when the ring buffer is full
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
+    ),
+    # Max seconds a reader retries attaching to an existing shm ring buffer
+    # before raising. Should be short: on the correct path the writer has
+    # already created the segment, so attach is near-instant.
+    "VLLM_SHM_ATTACH_TIMEOUT_S": lambda: float(
+        os.environ.get("VLLM_SHM_ATTACH_TIMEOUT_S", "5.0")
     ),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.
@@ -2244,6 +2251,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_RPC_BASE_PATH",
         "VLLM_USE_MODELSCOPE",
         "VLLM_RINGBUFFER_WARNING_INTERVAL",
+        "VLLM_SHM_ATTACH_TIMEOUT_S",
         "VLLM_DEBUG_DUMP_PATH",
         "VLLM_PORT",
         "VLLM_CACHE_ROOT",


### PR DESCRIPTION
## Purpose

Addresses #54259 (draft — see "What this does not fix" below).

`ShmRingBuffer.__init__` silently swallows `FileNotFoundError` when attaching to an existing shared-memory segment:

```python
try:
    self.shared_memory = shared_memory.SharedMemory(name=name)
    ...
except FileNotFoundError:
    # we might deserialize the object in a different node
    # in this case, this object is not used,
    # and we should suppress the error
    pass
```

This leaves `self.shared_memory` unset. Any later access (`handle()`, `get_data()`, `get_metadata()`) then raises a confusing `AttributeError: 'ShmRingBuffer' object has no attribute 'shared_memory'` far from the real cause — exactly what #54259 reports on a two-node Ray TP=2 cold boot.

### What changed (v2 of this PR)

An earlier version of this PR added a retry-with-backoff loop and a hard timeout directly inside `ShmRingBuffer.__init__`. On review that was wrong on two counts:

- The writer creates its shm segment (`ShmRingBuffer.__init__` in the "creator" branch) strictly before it builds and broadcasts the `Handle` naming that segment (`MessageQueue.__init__` → `export_handle`). A reader can only learn the segment's name after the writer already created it, so "not yet created" is not a real window a reader-side retry closes — a missing segment at attach time means it's either already gone or never coming.
- `ShmRingBuffer.__reduce__` documents that this class can legitimately be pickled and deserialized somewhere a local attach isn't expected to work. Adding a hard failure inside `__init__` itself would have broken that contract, since the class has no way to distinguish "attach was mandatory" from "attach was optional" at that point.

This version reverts `ShmRingBuffer.__init__`'s attach branch to its original behavior (stay silent on `FileNotFoundError`, preserving the documented pickling contract) and instead adds an explicit check in `MessageQueue.create_from_handle` — the one call site that actually knows a working local attach is mandatory, because `rank` is already confirmed to be on the writer's node (`rank in handle.local_reader_ranks`, populated by `in_the_same_node_as`'s real `/dev/shm` probe). If the buffer it just constructed has no `shared_memory` attribute there, it raises immediately with a clear `RuntimeError` naming the segment. Since a handle is only ever broadcast after the writer's segment creation has already succeeded, "writer hadn't created it yet" or "shm exhausted at creation time" aren't consistent with the reader having a handle at all — the more plausible causes are: the writer unlinked the segment after publishing the handle, the reader received a stale handle, or the processes don't actually share a `/dev/shm` namespace despite being classified same-node.

Net effect: the confusing `AttributeError` becomes an actionable `RuntimeError` at the correct call site, without changing `ShmRingBuffer`'s documented cross-node semantics anywhere else.

### What this does not fix

This PR does not explain why the segment is missing on the reporter's two-node Ray TP=2 DGX Spark setup, and does not add any retry — given the causal ordering above, a reader-side retry can't recover a segment that was never created or was already torn down. The underlying writer-side lifecycle (why the segment isn't there when a confirmed-local reader attaches) is still open. I'm asking the reporter to test this patch and report what error they now see, since that should narrow down whether the segment is missing entirely or was torn down early.

## Why this is not a duplicate

No open PR touches `ShmRingBuffer.__init__`'s attach branch or `MessageQueue.create_from_handle`: #53851 only changes long-wait diagnostic wording; #50548 and #53217 fix unrelated functions (`acquire_read` caching, `enqueue` OOB); #53740 fixes a different function (`in_the_same_node_as`) on Windows. Closed issue #24580 has the same `AttributeError` symptom but was auto-closed stale with no fix.

## Test commands and results

```
$ .venv/bin/python -m pytest tests/distributed/test_shm_broadcast.py -k "attach or free_space or mandatory" -v
6 passed
```

```
$ .venv/bin/python -m pytest tests/distributed/test_shm_broadcast.py -v
24 passed, 6 failed, 1 skipped
```
The 6 failures (`test_shm_broadcast`, `test_message_queue_shutdown_busy`, `test_message_queue_shutdown_idle`, `test_message_queue_idle_wake`, `test_message_queue_busy_to_idle`, `test_tensor_broadcast`) are pre-existing on unmodified `main` in this environment (macOS arm64 `MPSGraph`/Objective-C fork() aborts in forked distributed test processes — verified via `git stash`), not caused by this change.

```
$ pre-commit run --files vllm/distributed/device_communicators/shm_broadcast.py tests/distributed/test_shm_broadcast.py
ruff check...........Passed
ruff format...........Passed
mypy for Python 3.10...Passed
```

CI's own pre-commit/test job hasn't run yet — the "preliminary authorization" check failed because this account doesn't have the maintainer-applied `verified`/`ready`/`ready-run-all-tests` label yet, not because of a lint or test failure.

## Model evaluation

Not applicable — control-flow/error-handling change in the CPU-side shared-memory IPC bootstrap; no effect on model output, accuracy, or serving behavior.

## AI assistance

AI assistance was used for investigation, implementation, and testing, including responding to review feedback that identified a correctness/scope problem with the first version of this PR. I reviewed every changed line and ran the test/lint commands above myself.
