### PR TITLE
[Bugfix] Clamp the kv-cache-memory fully-utilize suggestion by memory other processes allocated since startup

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -828,6 +828,33 @@ class Worker(WorkerBase):
                 - non_kv_cache_memory
                 - redundancy_buffer_memory
             )
+            # The init snapshot predates memory that other processes allocate
+            # while this worker loads and profiles (another tenant, or a
+            # helper the engine itself spawns later, such as a CPU-offload
+            # worker holding its own CUDA context). Advising from the stale
+            # snapshot promises that memory to the KV cache, and pinning the
+            # advised value then OOMs during warmup. Clamp by what is
+            # attainable now: current free memory plus the pool this run
+            # already holds, minus the activation headroom a future run needs.
+            current_free_memory, _ = torch.accelerator.get_memory_info(
+                self.init_snapshot.device_
+            )
+            attainable_gpu_limit = (
+                current_free_memory
+                + self.available_kv_cache_memory_bytes
+                - self.peak_activation_memory
+                - redundancy_buffer_memory
+            )
+            if attainable_gpu_limit < kv_cache_memory_bytes_to_gpu_limit:
+                logger.info(
+                    "Other processes allocated %s GiB on this device since "
+                    "startup; lowering the fully-utilize suggestion "
+                    "accordingly.",
+                    format_gib(
+                        kv_cache_memory_bytes_to_gpu_limit - attainable_gpu_limit
+                    ),
+                )
+                kv_cache_memory_bytes_to_gpu_limit = attainable_gpu_limit
             kv_cache_memory_bytes_to_requested_limit = (
                 int(self.requested_memory)
                 - non_kv_cache_memory


### PR DESCRIPTION
## Summary

The boot-time suggestion "or `--kv-cache-memory=N` to fully utilize gpu memory" is computed from `init_snapshot.free_memory`, taken before the model loads. Anything another process allocates on the device after that snapshot — a co-tenant, or a helper the engine itself spawns later that holds its own CUDA context (e.g. a CPU-offload worker) — is invisible to the formula. The suggestion then over-promises, and pinning the printed value OOMs during warmup.

This PR clamps the suggestion by what is attainable at suggestion time: `current_free + kv_pool_this_run_holds − peak_activation − buffer`. Algebraically this equals the existing formula minus exactly the externally-allocated bytes, so the no-external-tenant case is unchanged; when the clamp engages, a log line reports how much other processes took.

## How this was found (experiment → result)

Measured on 4× RTX 5090 (sm120), TP=4, serving Qwen3.8-Flash-Next with PLE CPU offload (the offload worker holds a ~682 MiB CUDA context that spawns after the init snapshot):

1. Boot with default utilization → advisory prints `--kv-cache-memory=7160348160` (6.67 GiB) "to fully utilize gpu memory".
2. Reboot pinned at 7,160,348,160 → **OOM during warmup**: "Tried to allocate 722.00 MiB. GPU 0 … 617.62 MiB is free. … Process 1120 has 682.00 MiB memory in use." Process 1120 is the engine's own PLE offload worker.
3. Reboot pinned at 6,900,000,000 (advisory minus the co-process footprint plus margin) → boots clean, KV pool 846,813 tokens.

The failing delta matches the co-process allocation to within the 150 MiB redundancy buffer.

## AI assistance disclosure

Per the AI-assisted contributions policy: this fix was developed with AI assistance (Claude Fable 5 via Claude Code). Procedure: the OOM was hit during live tuning, the co-process was identified from the OOM report, the advisory formula was traced to `gpu_worker.py`, and the clamp was derived so it reduces to the current behavior when no external allocation occurred. The failing and passing boots above are from live runs on the described hardware; the submitting human reviewed the change and is responsible for it. Commit carries `Co-authored-by: Claude` and DCO sign-off.