### PR TITLE
[MoE] Gate Triton FP8 MoE kernel to CUDA compute capability >= 8.9

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -42,6 +42,12 @@ from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     batched_fused_marlin_moe,
     fused_marlin_moe,
 )
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+    TritonExperts,
+)
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEActivationFormat,
+)
 from vllm.model_executor.layers.fused_moe.utils import (
     moe_use_td_hw_supported,
 )
@@ -59,8 +65,13 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_test import (
     awq_marlin_quantize,
     marlin_quantize,
 )
-from vllm.model_executor.layers.quantization.utils.quant_utils import quantize_weights
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8DynamicTensorSym,
+    kFp8StaticTensorSym,
+    quantize_weights,
+)
 from vllm.platforms import current_platform
+from vllm.platforms.interface import DeviceCapability
 from vllm.scalar_type import ScalarType, scalar_types
 from vllm.triton_utils import tl
 from vllm.utils.math_utils import next_power_of_2
@@ -1986,3 +1997,37 @@ def test_unquantized_bf16_flashinfer_trtllm_backend(
 
     close = torch.isclose(trtllm_output, baseline_output, atol=1e-1, rtol=0.85)
     assert close.float().mean() > 0.925
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected_supported"),
+    [
+        ((8, 0), False),  # A100 (Ampere)
+        ((7, 5), False),  # T4 (Turing)
+        ((8, 9), True),  # L40 (Ada)
+        ((9, 0), True),  # H100 (Hopper)
+    ],
+)
+def test_triton_fp8_moe_capability_gating(monkeypatch, capability, expected_supported):
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(current_platform, "supports_fp8", lambda: True)
+
+    monkeypatch.setattr(
+        type(current_platform),
+        "get_device_capability",
+        classmethod(lambda cls, device_id=0: DeviceCapability(*capability)),
+    )
+
+    moe_config = make_dummy_moe_config()
+    supported, reason = TritonExperts.is_supported_config(
+        TritonExperts,
+        moe_config,
+        weight_key=kFp8StaticTensorSym,
+        activation_key=kFp8DynamicTensorSym,
+        activation_format=FusedMoEActivationFormat.Standard,
+    )
+
+    assert supported == expected_supported
+    if not expected_supported:
+        assert reason is not None and "compute capability >= 8.9" in reason

--- a/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/triton_moe.py
@@ -72,6 +72,21 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         activation_key: QuantKey | None,
         activation_format: mk.FusedMoEActivationFormat,
     ) -> tuple[bool, str | None]:
+        # Triton fp8e4nv requires FP8 Tensor Cores (SM89+ Ada/Hopper).
+        # Pre-SM89 GPUs (e.g. A100 / SM80) do not support native FP8 MMA in Triton.
+        if current_platform.is_cuda() and not current_platform.has_device_capability(
+            (8, 9)
+        ):
+            is_fp8 = any(
+                k is not None and k.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+                for k in (weight_key, activation_key)
+            )
+            if is_fp8:
+                return False, (
+                    "Triton FP8 MoE kernel requires "
+                    "compute capability >= 8.9 (Ada/Hopper+)"
+                )
+
         supported, reason = mk.FusedMoEExperts.is_supported_config(
             cls,
             moe_config,


### PR DESCRIPTION
## Purpose

Fixes #54219

When serving FP8 MoE checkpoints on A100 (SM80), Triton tries to compile `fp8e4nv` (`torch.float8_e4m3fn`) which isn't supported on Ampere hardware because native FP8 Tensor Cores were only added in SM89 (Ada) and SM90 (Hopper). The server crashes during warmup with:
```
ValueError: type fp8e4nv not supported in this architecture. The supported fp8 dtypes are ('fp8e4b15', 'fp8e5')
```

This PR gates FP8 configurations in `TritonExperts.is_supported_config` to CUDA devices with compute capability `>= (8, 9)`. On pre-SM89 GPUs, it cleanly returns `(False, "Triton FP8 MoE kernel requires compute capability >= 8.9 (Ada/Hopper+)")`, allowing vLLM to fail fast with a clear error or fall back to another supported backend.

Added a test in `tests/kernels/moe/test_moe.py` checking SM80, SM75, SM89, and SM90.

## Test Plan

```bash
pytest tests/kernels/moe/test_moe.py -k test_triton_fp8_moe_capability_gating -v
ruff check tests/kernels/moe/test_moe.py vllm/model_executor/layers/fused_moe/experts/triton_moe.py
```

## Test Result

```text
tests/kernels/moe/test_moe.py::test_triton_fp8_moe_capability_gating[capability0-False] PASSED [ 25%]
tests/kernels/moe/test_moe.py::test_triton_fp8_moe_capability_gating[capability1-False] PASSED [ 50%]
tests/kernels/moe/test_moe.py::test_triton_fp8_moe_capability_gating[capability2-True] PASSED [ 75%]
tests/kernels/moe/test_moe.py::test_triton_fp8_moe_capability_gating[capability3-True] PASSED [100%]

=============== 4 passed in 4.16s ================
```