### PR TITLE
[Bugfix][Multimodal] Frame the multi-modal hash digest input

### DIFF
--- a/tests/multimodal/test_hasher.py
+++ b/tests/multimodal/test_hasher.py
@@ -212,3 +212,43 @@ def test_hash_media_io_noop_config_preserves_hash():
     assert hasher.hash_kwargs("blake3", image=loaded) == hasher.hash_kwargs(
         "blake3", image=plain
     )
+
+
+# The digest input is a concatenation of byte chunks, so it has to be uniquely
+# decodable. Each case below is a pair of distinct processor kwargs that used to
+# serialize to the same bytes, which made two requests share an mm hash -- and
+# therefore share both the processor cache entry and the prefix-cache block key.
+IMAGE = b"\x89PNG\r\n\x1a\n"
+
+
+def _hash(**mm_processor_kwargs: object) -> str:
+    return MultiModalHasher.hash_kwargs(
+        "blake3", model_id="m", image=IMAGE, **mm_processor_kwargs
+    )
+
+
+def test_hash_collision_kwargs_key_value_boundary():
+    # Both used to flatten to b"ab" + b"c".
+    assert _hash(**{"ab": "c"}) != _hash(**{"a": "bc"})
+
+
+def test_hash_collision_nested_vs_flattened_key():
+    nested = _hash(size={"shortest_edge": 224})
+    flattened = _hash(**{"size.shortest_edge": 224})
+    assert nested != flattened
+
+
+def test_hash_collision_sequence_vs_mapping():
+    assert _hash(fps=[2, 4]) != _hash(fps={"0": 2, "1": 4})
+
+
+@pytest.mark.parametrize("empty", ["", b"", []])
+def test_hash_collision_none_vs_empty(empty):
+    assert _hash(video_pruning_rate=None) != _hash(video_pruning_rate=empty)
+
+
+def test_hash_collision_empty_container_vs_omitted():
+    omitted = _hash()
+    assert _hash(size={}) != omitted
+    assert _hash(size=[]) != omitted
+    assert _hash(size={}) != _hash(size=[])

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -18,6 +18,28 @@ from .media import MediaWithBytes
 
 logger = init_logger(__name__)
 
+# Framing for the digest input. The hash is built by feeding a stream of byte
+# chunks to `hasher.update`, so the stream must be uniquely decodable: without
+# an explicit length in front of every chunk and a tag in front of every
+# container, distinct inputs serialize to identical bytes and share a cache
+# entry. See `test_hash_collision_*` in tests/multimodal/test_hasher.py.
+_LENGTH_BYTES = 8
+_TAG_NONE = b"\x00"
+_TAG_SEQUENCE = b"\x01"
+_TAG_MAPPING = b"\x02"
+_TAG_LEAF = b"\x03"
+
+
+def _encode_length(value: int) -> bytes:
+    return value.to_bytes(_LENGTH_BYTES, "little")
+
+
+def _framed(chunk: bytes | memoryview) -> Iterable[bytes | memoryview]:
+    """Yield *chunk* preceded by its size in bytes."""
+    size = chunk.nbytes if isinstance(chunk, memoryview) else len(chunk)
+    yield _encode_length(size)
+    yield chunk
+
 
 @functools.lru_cache(maxsize=3)
 def _get_hasher_factory(
@@ -49,22 +71,29 @@ def _get_hasher_factory(
 
 
 class MultiModalHasher:
+    """Derives multi-modal cache keys.
+
+    Every method here yields *framed* chunks: each chunk is preceded by its
+    length and each container by its kind, so that the concatenation fed to the
+    digest is uniquely decodable and distinct inputs cannot share a key.
+    """
+
     @classmethod
     def serialize_item(cls, obj: object) -> Iterable[bytes | memoryview]:
         # Simple cases
         if isinstance(obj, (bytes, memoryview)):
-            return (obj,)
+            return _framed(obj)
         if isinstance(obj, str):
-            return (obj.encode("utf-8"),)
+            return _framed(obj.encode("utf-8"))
         if isinstance(obj, (int, float)):
-            return (np.array(obj).tobytes(),)
+            return _framed(np.array(obj).tobytes())
 
         if isinstance(obj, Image.Image):
             exif = obj.getexif()
             if Image.ExifTags.Base.ImageID in exif and isinstance(
                 exif[Image.ExifTags.Base.ImageID], uuid.UUID
             ):
-                return (exif[Image.ExifTags.Base.ImageID].bytes,)
+                return _framed(exif[Image.ExifTags.Base.ImageID].bytes)
 
             data = {"mode": obj.mode, "data": np.asarray(obj)}
             palette = obj.palette
@@ -80,7 +109,7 @@ class MultiModalHasher:
             if Image.ExifTags.Base.ImageID in exif and isinstance(
                 exif[Image.ExifTags.Base.ImageID], uuid.UUID
             ):
-                return (exif[Image.ExifTags.Base.ImageID].bytes,)
+                return _framed(exif[Image.ExifTags.Base.ImageID].bytes)
 
             if obj.io_config:
                 return cls.iter_item_to_bytes(
@@ -140,7 +169,7 @@ class MultiModalHasher:
             "No serialization method found for %s. Falling back to pickle.", type(obj)
         )
 
-        return (pickle.dumps(obj),)
+        return _framed(pickle.dumps(obj))
 
     @classmethod
     def iter_item_to_bytes(
@@ -148,18 +177,36 @@ class MultiModalHasher:
         key: str,
         obj: object,
     ) -> Iterable[bytes | memoryview]:
+        """Yield the digest input for a single ``key``/``obj`` pair."""
+        yield from _framed(key.encode("utf-8"))
+        yield from cls.iter_value_to_bytes(obj)
+
+    @classmethod
+    def iter_value_to_bytes(
+        cls,
+        obj: object,
+    ) -> Iterable[bytes | memoryview]:
+        """Yield the digest input for a value, tagged by its container kind.
+
+        Containers carry their kind and length so that a nested structure can
+        never serialize to the same bytes as a differently shaped one (a list
+        and a mapping keyed by stringified indices, for example).
+        """
         if obj is None:
-            yield key.encode("utf-8")
-            return
-        # Recursive cases
-        if isinstance(obj, (list, tuple)):
-            for i, elem in enumerate(obj):
-                yield from cls.iter_item_to_bytes(f"{key}.{i}", elem)
+            yield _TAG_NONE
+        elif isinstance(obj, (list, tuple)):
+            yield _TAG_SEQUENCE
+            yield _encode_length(len(obj))
+            for elem in obj:
+                yield from cls.iter_value_to_bytes(elem)
         elif isinstance(obj, dict):
+            yield _TAG_MAPPING
+            yield _encode_length(len(obj))
             for k, v in obj.items():
-                yield from cls.iter_item_to_bytes(f"{key}.{k}", v)
+                yield from _framed(str(k).encode("utf-8"))
+                yield from cls.iter_value_to_bytes(v)
         else:
-            yield key.encode("utf-8")
+            yield _TAG_LEAF
             yield from cls.serialize_item(obj)
 
     @classmethod

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -34,11 +34,22 @@ def _encode_length(value: int) -> bytes:
     return value.to_bytes(_LENGTH_BYTES, "little")
 
 
+# Below this size, joining a chunk to its length header costs less than the
+# extra `hasher.update` call that keeping them apart would need. Above it, the
+# copy would be the dominant cost, so the header is fed separately. The bytes
+# reaching the digest are identical either way.
+_INLINE_HEADER_MAX_BYTES = 256
+
+
 def _framed(chunk: bytes | memoryview) -> Iterable[bytes | memoryview]:
     """Yield *chunk* preceded by its size in bytes."""
     size = chunk.nbytes if isinstance(chunk, memoryview) else len(chunk)
-    yield _encode_length(size)
-    yield chunk
+    header = _encode_length(size)
+    if size <= _INLINE_HEADER_MAX_BYTES:
+        yield header + bytes(chunk)
+    else:
+        yield header
+        yield chunk
 
 
 @functools.lru_cache(maxsize=3)
@@ -195,13 +206,11 @@ class MultiModalHasher:
         if obj is None:
             yield _TAG_NONE
         elif isinstance(obj, (list, tuple)):
-            yield _TAG_SEQUENCE
-            yield _encode_length(len(obj))
+            yield _TAG_SEQUENCE + _encode_length(len(obj))
             for elem in obj:
                 yield from cls.iter_value_to_bytes(elem)
         elif isinstance(obj, dict):
-            yield _TAG_MAPPING
-            yield _encode_length(len(obj))
+            yield _TAG_MAPPING + _encode_length(len(obj))
             for k, v in obj.items():
                 yield from _framed(str(k).encode("utf-8"))
                 yield from cls.iter_value_to_bytes(v)

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -34,22 +34,11 @@ def _encode_length(value: int) -> bytes:
     return value.to_bytes(_LENGTH_BYTES, "little")
 
 
-# Below this size, joining a chunk to its length header costs less than the
-# extra `hasher.update` call that keeping them apart would need. Above it, the
-# copy would be the dominant cost, so the header is fed separately. The bytes
-# reaching the digest are identical either way.
-_INLINE_HEADER_MAX_BYTES = 256
-
-
 def _framed(chunk: bytes | memoryview) -> Iterable[bytes | memoryview]:
     """Yield *chunk* preceded by its size in bytes."""
     size = chunk.nbytes if isinstance(chunk, memoryview) else len(chunk)
-    header = _encode_length(size)
-    if size <= _INLINE_HEADER_MAX_BYTES:
-        yield header + bytes(chunk)
-    else:
-        yield header
-        yield chunk
+    yield _encode_length(size)
+    yield chunk
 
 
 @functools.lru_cache(maxsize=3)
@@ -206,11 +195,13 @@ class MultiModalHasher:
         if obj is None:
             yield _TAG_NONE
         elif isinstance(obj, (list, tuple)):
-            yield _TAG_SEQUENCE + _encode_length(len(obj))
+            yield _TAG_SEQUENCE
+            yield _encode_length(len(obj))
             for elem in obj:
                 yield from cls.iter_value_to_bytes(elem)
         elif isinstance(obj, dict):
-            yield _TAG_MAPPING + _encode_length(len(obj))
+            yield _TAG_MAPPING
+            yield _encode_length(len(obj))
             for k, v in obj.items():
                 yield from _framed(str(k).encode("utf-8"))
                 yield from cls.iter_value_to_bytes(v)


### PR DESCRIPTION
## Purpose

`MultiModalHasher.hash_kwargs` builds a cache key by feeding a stream of byte chunks to `hasher.update`. That stream is not uniquely decodable:

- `iter_item_to_bytes` yields `key.encode()` immediately followed by the value bytes, with no length prefix.
- Nested containers are flattened into dotted key strings (`f"{key}.{i}"` / `f"{key}.{k}"`), so a nested mapping and a flat dotted key produce identical chunks, as do a list and a mapping keyed by stringified indices.
- `None` yields the key alone, which is byte-identical to a value that serializes to zero bytes.
- An empty list or mapping yields nothing at all, which is byte-identical to omitting the key.

Distinct inputs therefore derive the same `mm_hash`. That hash is the identity for the multi-modal processor cache **and** it is fed into prefix-cache block hashing as an extra key (`_gen_mm_extra_hash_keys` in `vllm/v1/core/kv_cache_utils.py`), so a collision silently serves one request the processed features and KV blocks belonging to another.

### Reachability

`ProcessorInputs.get_mm_hashes` hashes `model_id`, the media item, and the
request's processing options. Since #54918 those options are nested under two
fixed keys rather than splatted at the top level:

```python
hash_factors = {
    "media_io_kwargs": media_io_kwargs,
    "mm_processor_kwargs": mm_processor_kwargs,
}
hash_factors = {key: value for key, value in hash_factors.items() if value}
...
hasher.hash_kwargs(
    hash_algorithm,
    model_id=model_id,
    **{modality: item},
    **hash_factors,
)
```

The nesting does not help, because `iter_item_to_bytes` flattens a nested
mapping into dotted keys and then emits the key bytes with no length prefix:

```python
elif isinstance(obj, dict):
    for k, v in obj.items():
        yield from cls.iter_item_to_bytes(f"{key}.{k}", v)
else:
    yield key.encode("utf-8")
    yield from cls.serialize_item(obj)
```

So every collision shape still reaches the digest one level down, as
`mm_processor_kwargs.<caller key>`. Replaying the flattening for the real call
shape on current `main`, each pair below produces a byte-identical stream:

| request `mm_processor_kwargs` pair | flattens to the same digest input |
|---|---|
| `{"ab": "c"}` vs `{"a": "bc"}` | key `mm_processor_kwargs.abc`, no value bytes |
| `{"size": {"shortest_edge": 224}}` vs `{"size.shortest_edge": 224}` | key `mm_processor_kwargs.size.shortest_edge` + the 8 bytes of `224` |
| `{"fps": [2, 4]}` vs `{"fps": {"0": 2, "1": 4}}` | keys `mm_processor_kwargs.fps.0` / `.fps.1` + the same value bytes |
| `{"video_pruning_rate": None}` vs `{"video_pruning_rate": ""}` | key `mm_processor_kwargs.video_pruning_rate`, no value bytes |
| `{"size": {}}` vs `{}` | nothing at all -- an empty container and an omitted key both contribute zero bytes |

`hf_processor_mm_kwargs` is per-request input — `prompt.get("mm_processor_kwargs")`
in `vllm/renderers/base.py` and `RenderParams.mm_processor_kwargs` — so both the
key names and the values inside that dict are caller-controlled.

`tests/multimodal/test_processing.py::test_processor_inputs_hashes_distinguish_kwargs_shapes`
asserts these five pairs through `ProcessorInputs.get_mm_hashes`, i.e. at the
call site rather than on the hasher alone.

This is the same defect class as GHSA-c65p-x677-fgj6 (fixed in #17378). Per `SECURITY.md`, hash collisions are LOW severity and are fixed via public PR rather than under embargo, which is why this is filed here rather than as an advisory.

## Approach

Make the digest input uniquely decodable:

- every byte chunk is preceded by its length;
- every container is preceded by a tag for its kind and its element count, replacing the dotted-key flattening;
- `None` gets its own tag, so it can no longer alias an empty value.

The framing invariant is uniform — every method in the module yields framed chunks — so there is no double framing and `serialize_item`'s recursive returns need no special case. The cost is 8 bytes per chunk, negligible against hashing the media payload itself.

Digests change for every input. mm hashes are process-local (in-memory processor cache, encoder cache, prefix-cache block keys), so the only effect of an upgrade is a cold cache, never incorrect reuse.

### Deliberately out of scope

- Primitive leaves are still untyped, so a `str` and the `bytes` of its UTF-8 encoding hash alike. Tagging leaves by `type(obj).__name__` would fix that but would also make the same image hash differently when loaded through different PIL decoders (`PngImageFile` vs `JpegImageFile`), regressing the "same image, same hash" property that `test_hash_collision_image_mode` documents. Worth a separate change.
- Nested mapping key order still affects the digest (only the top level is sorted). That causes spurious cache misses, not collisions.

## Test Plan

```bash
pytest tests/multimodal/test_hasher.py -v
```

Five new regression tests, one per collision shape: key/value boundary shift, nested vs flattened key, sequence vs mapping, `None` vs empty (parametrized over `""`, `b""`, `[]`), and empty container vs omitted key.

Six of the seven resulting cases fail on `main`. The exception is `test_hash_collision_none_vs_empty[[]]`: an empty list currently serializes to no bytes at all rather than to the bytes `None` produces, so that pair does not collide today. The neighbouring shape — an empty container against an omitted key — is covered by `test_hash_collision_empty_container_vs_omitted`, which does fail on `main`. The `[]` case is kept as a regression guard.

## Test Result

Re-verified on 2026-09-14 after merging current `main` into the branch (it was 791
commits behind). Fork runner `34873264781`, head `0d949f8e5c`, baseline `main`.

**BEFORE** -- the branch's `test_hasher.py` against `main`'s `vllm/multimodal/hasher.py`:

```text
tests/multimodal/test_hasher.py::test_hash_collision_kwargs_key_value_boundary FAILED
tests/multimodal/test_hasher.py::test_hash_collision_nested_vs_flattened_key FAILED
tests/multimodal/test_hasher.py::test_hash_collision_sequence_vs_mapping FAILED
tests/multimodal/test_hasher.py::test_hash_collision_none_vs_empty[0] FAILED
tests/multimodal/test_hasher.py::test_hash_collision_none_vs_empty[1] FAILED
tests/multimodal/test_hasher.py::test_hash_collision_none_vs_empty[empty2] PASSED
tests/multimodal/test_hasher.py::test_hash_collision_empty_container_vs_omitted FAILED

E  AssertionError: assert '34c49f4a8d3883d5a09ff092f470a0f689a9623809a778e7d3d38c300f3d6e6e'
                       != '34c49f4a8d3883d5a09ff092f470a0f689a9623809a778e7d3d38c300f3d6e6e'

=========== 6 failed, 1 passed, 18 deselected in 2.33s ============
```

The digests are literally equal, not merely "some assertion failed".
`test_hash_collision_none_vs_empty[[]]` still passes on `main` for the reason given
in the Test Plan above, and is kept as a regression guard.

**AFTER** -- full branch checkout: `25 passed in 7.60s`.

**Suite**, `pytest tests/multimodal`, `main` vs the branch on the same runner:

```text
main    23 failed, 547 passed, 8 skipped in 563.06s
branch  23 failed, 554 passed, 8 skipped in 541.95s
```

The 23 failures are a byte-identical set on both sides (diffing the two `FAILED`
lists is empty) -- all of them `ValidationError: Model architectures [...] failed to
be inspected`, i.e. checkpoints this environment cannot inspect. The 7 extra passes
are the new cases.

### Preprocessing cost

`vllm bench mm-processor` builds an `LLM` and needs a GPU, which I do not have. Every
stage it reports except `encoder_forward_secs`, however, comes from the renderer's
`TimingContext` and runs on CPU inside `BaseMultiModalProcessor.apply`. Driving that
same `apply` through `get_dummy_processor_inputs` (real `Qwen/Qwen2-VL-2B-Instruct`
processor; prompt and media built by vLLM) gives the same stage names. `miss` is
`cache=None`; `hit` is a primed processor cache.

| case | `get_mm_hashes` main -> branch (ms) | `preprocessor_total` main -> branch (ms) | hash delta |
|---|---|---|---|
| image x1 [miss] | 14.54 -> 14.68 | 51.44 -> 51.70 | +1.0% |
| image x8 [miss] | 110.03 -> 112.48 | 432.87 -> 442.56 | +2.2% |
| video x1 [miss] | 7.92 -> 7.92 | 48.61 -> 49.61 | +0.0% |
| image x1 [hit] | 14.40 -> 14.79 | 14.61 -> 15.00 | +2.7% |
| image x8 [hit] | 110.41 -> 111.83 | 110.99 -> 112.39 | +1.3% |
| video x1 [hit] | 7.96 -> 7.95 | 8.16 -> 8.14 | -0.1% |

Minimum over 3 A/B repeats, warmup repeat discarded, order alternating. Medians agree
(+0.1% to +3.3%). The framing costs roughly **2% of the hashing stage**; the
`main`-side run-to-run spread is 0.1-4.6%, so the cost is small but sits at the edge
of what this harness resolves -- I am not claiming it is zero.

Where that lands: hashing is 16-28% of preprocessing on a cache miss, and **97-99.5%**
on a cache hit (the HF processor is skipped), so the hit regime is the honest worst
case and its measured total delta is +2.7% / +1.3% / -0.3%. The encoder forward pass
is the one thing not measured here, and its absence is conservative -- including it
can only shrink hashing's share of end-to-end time.

---
AI assistance was used to research and draft this change. I have reviewed every changed line.

