### PR TITLE
[Bugfix][V1] Keep an encoder cache entry until its last occurrence is freed

### DIFF
--- a/tests/v1/core/test_encoder_cache_manager.py
+++ b/tests/v1/core/test_encoder_cache_manager.py
@@ -349,6 +349,43 @@ def test_free_request_with_duplicate_mm_hashes():
     assert "r1" not in manager.request_cached_ids
 
 
+def test_duplicate_mm_hash_stays_referenced_until_last_free():
+    """`cached` holds one reference per request, not per position, so freeing
+    the first of two occurrences must not release the entry."""
+    manager = EncoderCacheManager(cache_size=20)
+    req = MockRequest("r1", ["imgA", "imgA"], [4, 4])
+
+    manager.allocate(req, 0)
+    assert manager.check_and_update_cache(req, 1)
+
+    manager.free_encoder_input(req, 0)
+    assert manager.cached["imgA"] == {"r1"}
+    assert "imgA" not in manager.freeable
+    assert manager.num_freeable_slots == 16
+
+    manager.free_encoder_input(req, 1)
+    assert not manager.cached["imgA"]
+    assert manager.freeable["imgA"] == 4
+    assert manager.num_freeable_slots == 20
+
+
+def test_duplicate_mm_hash_is_not_evicted_before_last_use():
+    """An item repeated within one request (an image carried across
+    conversation turns) must not become reclaimable capacity while a later
+    occurrence still has to be spliced in, or the encoder recomputes it."""
+    manager = EncoderCacheManager(cache_size=8)
+    req = MockRequest("r1", ["imgA", "imgA"], [4, 4])
+    other = MockRequest("r2", ["imgB"], [8])
+
+    manager.allocate(req, 0)
+    assert manager.check_and_update_cache(req, 1)
+    manager.free_encoder_input(req, 0)
+
+    assert not manager.can_allocate(other, 0, int(1e9), 0)
+    assert manager.check_and_update_cache(req, 1)
+    assert manager.get_freed_mm_hashes() == []
+
+
 def test_encoder_decoder_cache_manager_reset():
     manager = EncoderDecoderCacheManager(cache_size=20)
 

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -242,6 +242,17 @@ class EncoderCacheManager:
         # The mm_hash not in cache or the req_id set is empty
         if not self.cached.get(mm_hash, None):
             return
+        # `cached` counts referencing requests, not positions, so one request
+        # that repeats an item (an image carried across conversation turns) has
+        # a single reference covering every occurrence. Hold it until the last
+        # occurrence is freed: dropping it at the first makes the entry
+        # evictable while the request still needs it, and the encoder then
+        # recomputes an item it already has.
+        if any(
+            request.mm_features[other_id].identifier == mm_hash
+            for other_id in self.request_cached_ids.get(req_id, ())
+        ):
+            return
         self.cached[mm_hash].discard(req_id)
         if not self.cached[mm_hash]:
             num_encoder_embeds = request.get_num_encoder_embeds(input_id)


### PR DESCRIPTION
## Purpose

`EncoderCacheManager.cached` maps `mm_hash -> set[request_id]`. It counts referencing *requests*, not referencing *positions*, so a request that uses the same multi-modal item more than once holds exactly one reference covering every occurrence — `check_and_update_cache` for the second occurrence hits `cached[mm_hash].add(request_id)`, which is a no-op on a set that already contains it.

`free_encoder_input` then dropped that single reference as soon as the **first** occurrence was freed:

```python
self.cached[mm_hash].discard(req_id)
if not self.cached[mm_hash]:
    self.freeable[mm_hash] = num_encoder_embeds
    self.num_freeable_slots += num_encoder_embeds
```

so the entry became reclaimable capacity while the request still had later occurrences to splice in. The scheduler frees each input id independently as its token span is consumed (`_free_encoder_inputs` in `vllm/v1/core/sched/scheduler.py`), so this is the ordinary path rather than an edge case. Once the entry is in `freeable`, any other request's `can_allocate` can evict it, `get_freed_mm_hashes` tells the workers to drop the tensor, and when the later occurrence reaches the encoder window `check_and_update_cache` misses and the encoder recomputes an item it had already computed.

The common trigger is an ordinary multi-turn vision conversation: the chat template inlines the same image once per turn, so a single request carries N features sharing one `mm_hash`, and every occurrence after the first can force a redundant encoder pass.

This is wasted encoder compute and cache thrash, not wrong output — the recompute path itself is correct, just unnecessary.

## Approach

Hold the request's reference until it has no cached input id left that maps to the same hash. The check runs over the request's own remaining cached ids, which is a handful of entries, and only on the free path.

`free()` still fully releases the entry, because it frees every cached input id and the last one finds no remaining occurrence.

## Test Plan

```bash
pytest tests/v1/core/test_encoder_cache_manager.py -v
```

Two new tests:

- `test_duplicate_mm_hash_stays_referenced_until_last_free` — freeing the first of two occurrences leaves the reference and `num_freeable_slots` untouched; freeing the second releases both.
- `test_duplicate_mm_hash_is_not_evicted_before_last_use` — with the entry still needed, a competing request cannot claim it as reclaimable capacity, the later occurrence still hits cache, and nothing is reported to the workers as freed.

The existing `test_free_request_with_duplicate_mm_hashes`, `test_basic_allocate_and_reuse` and `test_free_request_frees_all_inputs` are unchanged and still pass.

## Test Result

Run on ubuntu-24.04 x86_64 / Python 3.12.3 / torch 2.13.0+cpu, installed with
`VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto`.

**On `main` (96242aa50) with only the two new tests applied** — both fail:

```text
=========== BEFORE  fix/encoder-cache-repeated-item ===========
$ python -m pytest -v tests/v1/core/test_encoder_cache_manager.py -k duplicate_mm_hash_stays_referenced_until_last_free or duplicate_mm_hash_is_not_evicted_before_last_use
HEAD = 96242aa50  ([Bugfix][MRV2] Release layer-bound KV cache memory in shutdown() (#54246))

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /home/runner/work/vllm/vllm/.venv/bin/python
collecting ... collected 19 items / 17 deselected / 2 selected

tests/v1/core/test_encoder_cache_manager.py::test_duplicate_mm_hash_stays_referenced_until_last_free FAILED [ 50%]
tests/v1/core/test_encoder_cache_manager.py::test_duplicate_mm_hash_is_not_evicted_before_last_use FAILED [100%]

=========================== short test summary info ============================
FAILED tests/v1/core/test_encoder_cache_manager.py::test_duplicate_mm_hash_stays_referenced_until_last_free - AssertionError: assert set() == {'r1'}
  
  Extra items in the right set:
  'r1'
  
  Full diff:
  + set()
  - {
  -     'r1',
  - }
FAILED tests/v1/core/test_encoder_cache_manager.py::test_duplicate_mm_hash_is_not_evicted_before_last_use - assert not True
 +  where True = can_allocate(<tests.v1.core.test_encoder_cache_manager.MockRequest object at 0x7fbb48106120>, 0, 1000000000, 0)
 +    where can_allocate = <vllm.v1.core.encoder_cache_manager.EncoderCacheManager object at 0x7fbb48106930>.can_allocate
 +    and   1000000000 = int(1000000000.0)
======================= 2 failed, 17 deselected in 0.75s =======================
(pytest exit 1)
```

**On this branch** — the whole file passes:

```text
=========== AFTER   fix/encoder-cache-repeated-item ===========
$ python -m pytest -v tests/v1/core/test_encoder_cache_manager.py
HEAD = b28564003  ([Bugfix][V1] Keep an encoder cache entry until its last occurrence is freed)

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /home/runner/work/vllm/vllm/.venv/bin/python
collecting ... collected 19 items

tests/v1/core/test_encoder_cache_manager.py::test_basic_allocate_and_reuse PASSED [  5%]
tests/v1/core/test_encoder_cache_manager.py::test_freeing_decreases_refcount_and_moves_to_freeable PASSED [ 10%]
tests/v1/core/test_encoder_cache_manager.py::test_free_request_frees_all_inputs PASSED [ 15%]
tests/v1/core/test_encoder_cache_manager.py::test_eviction_when_cache_is_full PASSED [ 21%]
tests/v1/core/test_encoder_cache_manager.py::test_get_cached_input_ids PASSED [ 26%]
tests/v1/core/test_encoder_cache_manager.py::test_has_cache_restores_from_freeable PASSED [ 31%]
tests/v1/core/test_encoder_cache_manager.py::test_get_freed_mm_hashes_clears_freed_list PASSED [ 36%]
tests/v1/core/test_encoder_cache_manager.py::test_reallocated_hash_is_not_reported_as_freed PASSED [ 42%]
tests/v1/core/test_encoder_cache_manager.py::test_schedule_request_multi_images_respect_space_limit PASSED [ 47%]
tests/v1/core/test_encoder_cache_manager.py::test_schedule_request_multi_images_respect_compute_limit PASSED [ 52%]
tests/v1/core/test_encoder_cache_manager.py::test_encoder_cache_with_is_embed_mask PASSED [ 57%]
tests/v1/core/test_encoder_cache_manager.py::test_encoder_cache_mask_based_retrieval PASSED [ 63%]
tests/v1/core/test_encoder_cache_manager.py::test_reset_clears_all_state PASSED [ 68%]
tests/v1/core/test_encoder_cache_manager.py::test_reset_allows_fresh_allocations PASSED [ 73%]
tests/v1/core/test_encoder_cache_manager.py::test_free_request_with_duplicate_mm_hashes PASSED [ 78%]
tests/v1/core/test_encoder_cache_manager.py::test_duplicate_mm_hash_stays_referenced_until_last_free PASSED [ 84%]
tests/v1/core/test_encoder_cache_manager.py::test_duplicate_mm_hash_is_not_evicted_before_last_use PASSED [ 89%]
tests/v1/core/test_encoder_cache_manager.py::test_encoder_decoder_cache_manager_reset PASSED [ 94%]
tests/v1/core/test_encoder_cache_manager.py::test_encoder_decoder_cache_manager_reset_allows_fresh_allocations PASSED [100%]

============================== 19 passed in 6.13s ==============================
(pytest exit 0)
```

**The suite as CI runs it** (`.buildkite/test-amd.yaml`: `pytest -v -s -m 'cpu_test' v1/core`), `main` against this branch on the same machine:

```text
main    470 passed, 80 deselected, 14 warnings in 457.43s (0:07:37)
branch  472 passed, 80 deselected, 14 warnings in 438.42s (0:07:18)
```

Nothing fails on either side. The two extra passes are the new tests.

---
AI assistance was used to research and draft this change. I have reviewed every changed line.
