### PR TITLE
[Bugfix] Align VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE runtime default with the declared default

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -55,6 +55,21 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+def test_deepep_v2_allow_hybrid_mode_defaults_to_true(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The default declared in the TYPE_CHECKING block of envs.py is True;
+    # the runtime default must match it.
+    monkeypatch.delenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", raising=False)
+    assert envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE is True
+
+    monkeypatch.setenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "0")
+    assert envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE is False
+
+    monkeypatch.setenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "1")
+    assert envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE is True
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1944,7 +1944,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # DeepEP v2: enable two-tier NVLink+RDMA hybrid mode
     "VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE": lambda: bool(
-        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "0"))
+        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "1"))
     ),
     # DeepEP v2: use fewer SMs at slight throughput cost
     "VLLM_DEEPEP_V2_PREFER_OVERLAP": lambda: bool(


### PR DESCRIPTION
## Summary

Fixes #54281. `VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE` is declared with a default of `True` in the `TYPE_CHECKING` block of `vllm/envs.py`, but the runtime resolver read `"0"`, so the effective default was `False` — DeepEP v2 two-tier NVLink+RDMA hybrid mode was silently disabled unless the variable was set explicitly. The mismatch existed since the variable was introduced in #41183 (`e2f993dc`); all sibling DeepEP v2 variables are consistent between their declarations and their runtime defaults.

## Change

One character in `vllm/envs.py`: the `os.getenv` fallback for `VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE` is `"1"` instead of `"0"`, matching the declared default of `True`. Explicit `0`/`1` overrides are unaffected (the parsing logic is unchanged). Plus a regression test in `tests/test_envs.py` in the style of `test_p2p_side_channel_defaults_and_override` that pins the default and the overrides.

## Why this is not duplicating an existing PR

Checked `gh pr list --repo vllm-project/vllm --state open --search "54281 in:body"` and searched open PRs for `VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE`: no open PR addresses this variable or issue (the only hit, #51398, is an unrelated, closed DeepEP v2 feature PR).

## Tests

Reproduced on `main` (9662ab0) with a minimal local env (`uv venv --python 3.12` + CPU torch; `tests/test_envs.py` run with `--noconftest` because the tests/conftest.py GPU/model fixtures are irrelevant to env parsing):

- Before fix: `import vllm.envs as e; e.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE` → `False` (bug reproduced).
- After fix: unset → `True`; `VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE=0` → `False`; `=1` → `True`.
- New regression test `test_deepep_v2_allow_hybrid_mode_defaults_to_true`: **fails on unpatched code** (`assert False is True`), **passes with the fix**.
- Full `tests/test_envs.py`: 53 passed; 4 unrelated failures caused only by missing optional packages in the minimal env (`pydantic`, `transformers`, …) in tests exercising `compile_factors()`/`SamplingParams`, not by this change.
- `ruff check` and `ruff format --check` on both changed files: clean (line length 88).

## Model evaluation

Not applicable — this change does not affect model output, accuracy, or serving code paths; it only corrects an environment-variable default to match its documented value.

## AI assistance disclosure

This change was prepared with AI assistance (an autonomous agent operating on behalf of the submitter). The submitter reviewed every changed line and the test results above.
