### PR TITLE
[Doc] Context extension: overrides must target text_config for composite models

### DIFF
--- a/docs/features/context_extension.md
+++ b/docs/features/context_extension.md
@@ -54,6 +54,22 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
+!!! warning "Models with a nested `text_config`"
+    For multimodal and other composite models whose Hugging Face config nests the language
+    model settings under `text_config` (for example the Qwen3-VL series), the override must
+    target the nested config:
+
+    ```bash
+    vllm serve Qwen/Qwen3-VL-8B-Instruct \
+      --hf-overrides '{"text_config": {"rope_parameters": {"factor": 4.0, "original_max_position_embeddings": 32768, "rope_theta": 1000000, "rope_type": "yarn"}}}' \
+      --max-model-len 131072
+    ```
+
+    A top-level `"rope_parameters"` override is applied to the outer config, while vLLM reads
+    RoPE settings from `text_config`, so the extension is silently not applied. This typically
+    surfaces as a startup error saying that the requested `max_model_len` is greater than the
+    derived `max_model_len`.
+
 ### Key Parameters
 
 The available parameters depend on the `rope_type` you choose. For detailed information about all supported RoPE types and their specific parameters, please refer to the [Hugging Face Transformers RoPE documentation](https://huggingface.co/docs/transformers/main/en/internal/rope_utils#transformers.RopeParameters).


### PR DESCRIPTION
## Purpose

Document a silent failure mode of `--hf-overrides` on the context extension page.

For multimodal / composite models whose HF config nests the language model settings under `text_config` (e.g. Qwen3-VL: no rope keys at the top level, all under `text_config`), a top-level `rope_parameters` override is applied to the outer config, while vLLM reads RoPE settings from `hf_text_config`. The extension is therefore silently not applied, and the user typically hits a confusing startup error saying the requested `max_model_len` is greater than the derived `max_model_len` — with no hint that their override went to the wrong config object.

Mechanism: `ModelConfig._apply_dict_overrides` only recurses into a key when that key already exists on the top-level config as a nested `PretrainedConfig`; otherwise the dict is set at the top level. So the working form for composite models is `--hf-overrides '{"text_config": {"rope_parameters": {...}}}'`, which this page currently doesn't mention (we lost a few hours to exactly this while extending a model to 1M context on rented GPUs).

## Test Plan

Docs-only change. `markdownlint-cli2` (the pre-commit hook) passes on the edited file.

## Test Result

0 errors; the admonition renders in the same style as the existing note on the page.
