### PR TITLE
[MoE] Unify Int8, W4A8, and W4A8_Int8 MoE Oracles with Class Structure (#37753)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/__init__.py
@@ -2,11 +2,22 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.int8 import Int8MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.w4a8 import W4A8MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.w4a8_int8 import (
+    W4A8Int8MoEKernelOracle,
 )
 
 __all__ = [
     "MoEKernelOracle",
     "UnquantizedMoEKernelOracle",
+    "Int8MoEKernelOracle",
+    "W4A8MoEKernelOracle",
+    "W4A8Int8MoEKernelOracle",
 ]
+
+
+

--- a/vllm/model_executor/layers/fused_moe/oracle/int8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int8.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     int8_w8a8_moe_quant_config,
     int8_w8a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kInt8DynamicTokenSym,
@@ -319,3 +320,81 @@ def make_int8_moe_kernel(
     )
 
     return kernel
+
+
+class Int8MoEKernelOracle(MoEKernelOracle[Int8MoeBackend]):
+    """Class-based view of the Int8 MoE kernel oracle."""
+
+    def backend_enum_cls(self) -> type[Int8MoeBackend]:
+        return Int8MoeBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[Int8MoeBackend]:
+        return _get_priority_backends(moe_config)
+
+    def backend_to_kernel_cls(
+        self, backend: Int8MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: MoEBackend) -> Int8MoeBackend:
+        return map_int8_backend(runner_backend)
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = kInt8StaticChannelSym,
+        activation_key: QuantKey | None = kInt8DynamicTokenSym,
+    ) -> tuple[Int8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        return select_int8_moe_backend(moe_config, weight_key, activation_key)
+
+    def convert_to_kernel_format(
+        self,
+        backend: Int8MoeBackend,
+        moe_config: FusedMoEConfig,
+        w13_weight: torch.Tensor,
+        w2_weight: torch.Tensor,
+        layer: torch.nn.Module | None = None,
+        w13_scale: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return convert_to_int8_moe_kernel_format(
+            backend, w13_weight, w2_weight, layer=layer, w13_scale=w13_scale
+        )
+
+    def make_quant_config(
+        self,
+        backend: Int8MoeBackend,
+        w1_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        a1_scale: torch.Tensor | None = None,
+        a2_scale: torch.Tensor | None = None,
+        w1_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+        per_act_token_quant: bool = False,
+        layer: torch.nn.Module | None = None,
+    ) -> FusedMoEQuantConfig:
+        return make_int8_moe_quant_config(
+            backend,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            per_act_token_quant=per_act_token_quant,
+            layer=layer,
+        )
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        backend: Int8MoeBackend,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> mk.FusedMoEKernel:
+        return make_int8_moe_kernel(
+            backend, quant_config, moe_config, experts_cls, routing_tables
+        )
+

--- a/vllm/model_executor/layers/fused_moe/oracle/w4a8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/w4a8.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     int4_w4afp8_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8DynamicTokenSym,
@@ -193,3 +194,56 @@ def make_w4a8_moe_kernel(
         prepare_finalize,
         experts,
     )
+
+
+class W4A8MoEKernelOracle(MoEKernelOracle[W4A8MoeBackend]):
+    """Class-based view of the W4A8 MoE kernel oracle."""
+
+    def backend_enum_cls(self) -> type[W4A8MoeBackend]:
+        return W4A8MoeBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[W4A8MoeBackend]:
+        return [W4A8MoeBackend.CUTLASS]
+
+    def backend_to_kernel_cls(
+        self, backend: W4A8MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: str) -> W4A8MoeBackend:
+        if runner_backend in ("auto", "cutlass"):
+            return W4A8MoeBackend.CUTLASS
+        raise ValueError(f"Unsupported runner backend: {runner_backend}")
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = kInt4Static,
+        activation_key: QuantKey | None = kFp8DynamicTokenSym,
+    ) -> tuple[W4A8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        return select_w4a8_moe_backend(moe_config, weight_key, activation_key)
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        backend: W4A8MoeBackend,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        b_strides1: torch.Tensor | None = None,
+        b_strides2: torch.Tensor | None = None,
+        group_size: int = 128,
+    ) -> mk.FusedMoEKernel:
+        assert b_strides1 is not None and b_strides2 is not None
+        return make_w4a8_moe_kernel(
+            quant_config,
+            moe_config,
+            experts_cls,
+            b_strides1,
+            b_strides2,
+            group_size,
+            routing_tables,
+        )
+

--- a/vllm/model_executor/layers/fused_moe/oracle/w4a8_int8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/w4a8_int8.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     FusedMoEQuantDesc,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     QuantKey,
@@ -358,3 +359,46 @@ def make_w4a8_int8_moe_kernel(
     )
 
     return kernel
+
+
+class W4A8Int8MoEKernelOracle(MoEKernelOracle[W4A8Int8MoeBackend]):
+    """Class-based view of the W4A8 Int8 MoE kernel oracle."""
+
+    def backend_enum_cls(self) -> type[W4A8Int8MoeBackend]:
+        return W4A8Int8MoeBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[W4A8Int8MoeBackend]:
+        return _get_priority_backends(moe_config)
+
+    def backend_to_kernel_cls(
+        self, backend: W4A8Int8MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: MoEBackend) -> W4A8Int8MoeBackend:
+        return map_w4a8_int8_backend(runner_backend)
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = None,
+        activation_key: QuantKey | None = None,
+    ) -> tuple[W4A8Int8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        return select_w4a8_int8_moe_backend(
+            moe_config, weight_key=weight_key, activation_key=activation_key
+        )
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        backend: W4A8Int8MoeBackend,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> mk.FusedMoEKernel:
+        return make_w4a8_int8_moe_kernel(
+            quant_config, moe_config, experts_cls, routing_tables
+        )
+


### PR DESCRIPTION
## Purpose
This PR migrates the Int8, W4A8, and W4A8_Int8 MoE kernel selection logic to inherit from the `MoEKernelOracle` abstract base class introduced in #37776. 

It provides concrete class-based views (`Int8MoEKernelOracle`, `W4A8MoEKernelOracle`, `W4A8Int8MoEKernelOracle`) that delegate to the existing module-level functions to keep execution bit-identical while establishing an extensible class hierarchy.

Fixes #37753

### Summary of Changes:
- **`vllm/model_executor/layers/fused_moe/oracle/int8.py`**: Added `Int8MoEKernelOracle` subclassing `MoEKernelOracle[Int8MoeBackend]`.
- **`vllm/model_executor/layers/fused_moe/oracle/w4a8.py`**: Added `W4A8MoEKernelOracle` subclassing `MoEKernelOracle[W4A8MoeBackend]`.
- **`vllm/model_executor/layers/fused_moe/oracle/w4a8_int8.py`**: Added `W4A8Int8MoEKernelOracle` subclassing `MoEKernelOracle[W4A8Int8MoeBackend]`.
- **`vllm/model_executor/layers/fused_moe/oracle/__init__.py`**: Re-exported all oracle classes in `__all__`.

## Test Plan
1. Validate syntax and bytecode compilation of modified files:
```bash
python -m py_compile \
  vllm/model_executor/layers/fused_moe/oracle/int8.py \
  vllm/model_executor/layers/fused_moe/oracle/w4a8.py \
  vllm/model_executor/layers/fused_moe/oracle/w4a8_int8.py \
  vllm/model_executor/layers/fused_moe/oracle/__init__.py
