### PR TITLE
[Kernel] Refactor Int8ScaledMMLinearLayerConfig to use QuantKey (#32268)

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -23,6 +23,13 @@ from vllm.model_executor.kernels.linear.base import (
     MMLinearKernel,
     MMLinearLayerConfig,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kDynamicTokenScale,
+    kStaticChannelScale,
+    kStaticTensorScale,
+    kStaticTokenScale,
+)
 from vllm.model_executor.kernels.linear.mixed_precision import (
     MPLinearKernel,
     MPLinearLayerConfig,
@@ -747,10 +754,22 @@ def init_int8_linear_kernel(
     input_symmetric: bool,
     module_name: str,
 ) -> Int8ScaledMMLinearKernel:
+    weight_scale = (
+        kStaticChannelScale if is_channelwise else kStaticTensorScale
+    )
+    weight_quant_key = QuantKey(torch.int8, weight_scale, symmetric=True)
+
+    if is_static_input_scheme:
+        act_scale = kStaticTokenScale
+    else:
+        act_scale = kDynamicTokenScale
+    activation_quant_key = QuantKey(
+        torch.int8, act_scale, symmetric=input_symmetric
+    )
+
     config = Int8ScaledMMLinearLayerConfig(
-        is_channelwise=is_channelwise,
-        is_static_input_scheme=is_static_input_scheme,
-        input_symmetric=input_symmetric,
+        weight_quant_key=weight_quant_key,
+        activation_quant_key=activation_quant_key,
     )
 
     kernel_type = choose_scaled_mm_linear_kernel(

--- a/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.fusion.quant_activation import (
 )
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
     QuantKey,
 )
 from vllm.platforms import current_platform
@@ -23,14 +24,25 @@ from ..base import MMLinearLayerConfig
 
 @dataclass
 class Int8ScaledMMLinearLayerConfig(MMLinearLayerConfig):
-    # TODO: Change to QuantKey like FP8ScaledMMLinearLayerConfig
-    is_static_input_scheme: bool
-    is_channelwise: bool
-    input_symmetric: bool
+    weight_quant_key: QuantKey
+    activation_quant_key: QuantKey
+
+    @property
+    def is_static_input_scheme(self) -> bool:
+        return self.activation_quant_key.scale.is_static
+
+    @property
+    def is_channelwise(self) -> bool:
+        return self.weight_quant_key.scale.group_shape == GroupShape.PER_CHANNEL
+
+    @property
+    def input_symmetric(self) -> bool:
+        return self.activation_quant_key.symmetric
 
 
 @dataclass
 class FP8ScaledMMLinearLayerConfig(MMLinearLayerConfig):
+
     weight_quant_key: QuantKey
     activation_quant_key: QuantKey
     weight_shape: tuple[int, int]


### PR DESCRIPTION
## Purpose
This PR refactors `Int8ScaledMMLinearLayerConfig` to adopt `QuantKey` dataclasses (`weight_quant_key` and `activation_quant_key`), bringing consistency with `FP8ScaledMMLinearLayerConfig` and aligning with vLLM's standard quantization descriptor architecture.

Backward-compatible properties (`is_static_input_scheme`, `is_channelwise`, `input_symmetric`) are preserved on the dataclass so existing kernel implementations continue to work seamlessly.

Fixes #32268

### Summary of Changes:
- **`vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py`**: Updated `Int8ScaledMMLinearLayerConfig` to store `weight_quant_key` and `activation_quant_key`, with property accessors for legacy flag queries.
- **`vllm/model_executor/kernels/linear/__init__.py`**: Updated `init_int8_linear_kernel` to initialize proper `QuantKey` instances using `kStaticChannelScale`/`kStaticTensorScale` and `kStaticTokenScale`/`kDynamicTokenScale`.

## Test Plan
1. Validate syntax and compilation of modified linear kernel modules:
```bash
python -m py_compile \
  vllm/model_executor/kernels/linear/scaled_mm/ScaledMMLinearKernel.py \
  vllm/model_executor/kernels/linear/__init__.py
