### PR TITLE
[Perf] Pin CPU tensors before non_blocking H2D in three MM paths

### DIFF
--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -259,10 +259,7 @@ class MMEncoderAttention(CustomOp):
         sequence_lengths = add_padding_to_seqlens(
             sequence_lengths, len(sequence_lengths), 0
         )
-        sequence_lengths = torch.from_numpy(sequence_lengths).to(
-            device, non_blocking=True
-        )
-        return sequence_lengths
+        return async_tensor_h2d(sequence_lengths, device=device)
 
     @classmethod
     def maybe_recompute_cu_seqlens(

--- a/vllm/model_executor/models/kanana_v.py
+++ b/vllm/model_executor/models/kanana_v.py
@@ -38,6 +38,7 @@ from vllm.multimodal.processing import (
 from vllm.sequence import IntermediateTensors
 from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
+from vllm.utils.torch_utils import async_tensor_h2d
 
 from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsPP
 from .qwen2_vl import Qwen2VisionTransformer
@@ -323,10 +324,7 @@ class CustomQwen2VLVE(Qwen2VisionTransformer):
             grid_thw_np[:, 0],
         ).cumsum(axis=0, dtype=np.int32)
         cu_seqlens = np.concatenate([np.zeros(1, dtype=np.int32), cu_seqlens])
-        cu_seqlens = torch.from_numpy(cu_seqlens).to(
-            self.device,
-            non_blocking=True,
-        )
+        cu_seqlens = async_tensor_h2d(cu_seqlens, device=self.device)
 
         # Shape to (S, B, D) with batch dimension 1 as expected by the blocks.
         x = x.unsqueeze(1)

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -37,6 +37,7 @@ from vllm.model_executor.models.vision import (
 )
 from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.kimi_k25 import KimiK25VisionConfig
+from vllm.utils.torch_utils import async_tensor_h2d
 
 logger = init_logger(__name__)
 
@@ -821,9 +822,7 @@ class MoonViT3dPretrainedModel(nn.Module):
         merge_gather_idx = build_image_merge_gather_idx(
             grid_thw_list, self.merge_kernel_size
         )
-        metadata["merge_gather_idx"] = torch.from_numpy(merge_gather_idx).to(
-            device=device, non_blocking=True
-        )
+        metadata["merge_gather_idx"] = async_tensor_h2d(merge_gather_idx, device=device)
         return metadata
 
 


### PR DESCRIPTION
## Summary

Route three multimodal-path `torch.from_numpy(...).to(device, non_blocking=True)` sites through `async_tensor_h2d`, which pins the host tensor first:

- `MMEncoderAttention.maybe_compute_seq_lens` — called per FlashInfer MM encoder invocation to build `sequence_lengths`
- `CustomQwen2VLVE.forward` `cu_seqlens` in Kanana-V vision tower
- `MoonViT3dPretrainedModel.prepare_encoder_cudagraph_metadata` `merge_gather_idx` for Kimi-K2.5 vision CUDA-graph metadata

## Context

Same class of stall #53491 adds a stricter check for: `torch.from_numpy` returns a pageable CPU tensor, and `.to(device, non_blocking=True)` on it is silently staged through the CUDA driver, blocking the host. #54266 fixes the same pattern for Qwen2-VL and Qwen2.5-VL rotary position IDs; this PR covers three disjoint sites on the MM path.

## Duplicate-work check

Searched open PRs for `#53491 in:body`, `sequence_lengths pin_memory`, `mm_encoder_attention async`, and Kanana / Kimi VL H2D fixes; only #54266 is in flight and it covers a disjoint file set.

## Testing

- `.venv/bin/python -m pre_commit run --files vllm/model_executor/layers/attention/mm_encoder_attention.py vllm/model_executor/models/kanana_v.py vllm/model_executor/models/kimi_k25_vit.py` — passed (ruff, mypy, typos, SPDX, etc.)

The change is a pattern swap to an existing helper; there is no observable-behavior change to test beyond what CI covers. Once #53491 lands its runtime checker, this becomes CI-enforced.

AI assistance was used for code search and drafting; every line was reviewed by the submitter.
