### PR TITLE
[Perf][KV Connector] Pin token_indices before non_blocking H2D in hf3fs helper

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/gather_scatter_helper.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/gather_scatter_helper.py
@@ -4,6 +4,7 @@ import torch
 
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import async_tensor_h2d
 
 
 @triton.jit
@@ -140,9 +141,9 @@ def scatter_kv_caches(
     assert len(kv_cache_strides) == 4
 
     device = src_tensor.device
-    token_indices_tensor = torch.tensor(
-        token_indices, dtype=torch.int32, device="cpu"
-    ).to(device, non_blocking=True)
+    token_indices_tensor = async_tensor_h2d(
+        token_indices, device=device, dtype=torch.int32
+    )
 
     grid = (num_layers, num_tokens_in_block)
     BLOCK_SIZE = 128
@@ -196,9 +197,9 @@ def gather_kv_caches(
     assert len(kv_cache_strides) == 4
 
     device = dst_tensor.device
-    token_indices_tensor = torch.tensor(
-        token_indices, dtype=torch.int32, device="cpu"
-    ).to(device, non_blocking=True)
+    token_indices_tensor = async_tensor_h2d(
+        token_indices, device=device, dtype=torch.int32
+    )
 
     grid = (num_layers, num_tokens_in_block)
     BLOCK_SIZE = 128


### PR DESCRIPTION
## Summary

Route both `torch.tensor(list, device="cpu").to(device, non_blocking=True)` sites in the hf3fs KV connector scatter/gather helper through `async_tensor_h2d`, which pins the host tensor first:

- `scatter_kv_caches` `token_indices_tensor`
- `gather_kv_caches` `token_indices_tensor`

## Context

Same class of stall #53491 adds a stricter check for: `torch.tensor(list, device="cpu")` without `pin_memory=True` yields a pageable CPU tensor, and the subsequent `.to(device, non_blocking=True)` is silently staged by the CUDA driver and blocks the host. Follows the same pattern as #54266 (Qwen VL rotary position IDs) and #54292 (three MM encoder paths); this PR covers the two hf3fs scatter/gather sites, which are on the KV connector data-path.

## Duplicate-work check

Searched open PRs for `gather_scatter_helper in:body`, `hf3fs token_indices pin`, and `#53491 in:body`; only #54266 and my own #54292 are in flight, both on disjoint file sets.

## Testing

- `.venv/bin/python -m pre_commit run --files vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/utils/gather_scatter_helper.py` — passed (ruff, mypy, typos, SPDX, etc.)

Pattern swap to an existing helper; behavior is identical modulo the CPU-side pin, which is enforced by CI once #53491 lands its runtime checker.

AI assistance was used for code search and drafting; every line was reviewed by the submitter.
