### PR TITLE
[MoE] Complete MoE Oracle Class Migration for FP8, NVFP4, MXFP8, and WNA16 (#37753)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/__init__.py
@@ -2,11 +2,31 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.int8 import Int8MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.int_wna16 import (
+    WNA16MoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.mxfp8 import MxFp8MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoEKernelOracle,
+)
+from vllm.model_executor.layers.fused_moe.oracle.w4a8 import W4A8MoEKernelOracle
+from vllm.model_executor.layers.fused_moe.oracle.w4a8_int8 import (
+    W4A8Int8MoEKernelOracle,
 )
 
 __all__ = [
     "MoEKernelOracle",
     "UnquantizedMoEKernelOracle",
+    "Int8MoEKernelOracle",
+    "W4A8MoEKernelOracle",
+    "W4A8Int8MoEKernelOracle",
+    "Fp8MoEKernelOracle",
+    "NvFp4MoEKernelOracle",
+    "MxFp8MoEKernelOracle",
+    "WNA16MoEKernelOracle",
 ]
+
+

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     fp8_w8a8_moe_quant_config,
     fp8_w8a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     prepare_fp8_moe_layer_for_fi,
@@ -727,3 +728,90 @@ def make_fp8_moe_kernel(
     )
 
     return kernel
+
+
+class Fp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
+    """Class-based view of the FP8 MoE kernel oracle."""
+
+    def backend_enum_cls(self) -> type[Fp8MoeBackend]:
+        return Fp8MoeBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[Fp8MoeBackend]:
+        return _get_priority_backends(moe_config)
+
+    def backend_to_kernel_cls(
+        self, backend: Fp8MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: MoEBackend) -> Fp8MoeBackend:
+        return map_fp8_backend(runner_backend)
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = None,
+        activation_key: QuantKey | None = None,
+        allow_vllm_cutlass: bool = True,
+    ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        return select_fp8_moe_backend(
+            moe_config,
+            weight_key=weight_key,
+            activation_key=activation_key,
+            allow_vllm_cutlass=allow_vllm_cutlass,
+        )
+
+    def convert_to_kernel_format(
+        self,
+        backend: Fp8MoeBackend,
+        moe_config: FusedMoEConfig,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        layer: torch.nn.Module | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return convert_to_fp8_moe_kernel_format(
+            backend, moe_config, w13, w2, layer=layer
+        )
+
+    def make_quant_config(
+        self,
+        backend: Fp8MoeBackend,
+        w1_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        a1_scale: torch.Tensor | None = None,
+        a2_scale: torch.Tensor | None = None,
+        w1_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+        block_shape: list[int] | None = None,
+        per_act_token_quant: bool = False,
+        per_out_ch_quant: bool = False,
+        layer: torch.nn.Module | None = None,
+    ) -> FusedMoEQuantConfig:
+        return make_fp8_moe_quant_config(
+            backend,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            block_shape=block_shape,
+            per_act_token_quant=per_act_token_quant,
+            per_out_ch_quant=per_out_ch_quant,
+            layer=layer,
+        )
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        backend: Fp8MoeBackend,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> mk.FusedMoEKernel:
+        return make_fp8_moe_kernel(
+            quant_config, moe_config, experts_cls, backend, routing_tables
+        )
+

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     int4_w4a16_moe_quant_config,
     int8_w8a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
     BatchedMarlinExperts,
     MarlinExperts,
@@ -1719,3 +1720,78 @@ def convert_to_wna16_moe_kernel_format(
         )
     else:
         raise ValueError(f"Unsupported wna16 MoE backend: {backend.value}")
+
+
+class WNA16MoEKernelOracle(MoEKernelOracle[WNA16MoEBackend]):
+    """Class-based view of the WNA16 MoE kernel oracle."""
+
+    def backend_enum_cls(self) -> type[WNA16MoEBackend]:
+        return WNA16MoEBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[WNA16MoEBackend]:
+        return _get_priority_backends(moe_config)
+
+    def backend_to_kernel_cls(
+        self, backend: WNA16MoEBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: MoEBackend) -> WNA16MoEBackend:
+        return map_wna16_backend(runner_backend)
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = None,
+        activation_key: QuantKey | None = None,
+        weight_bits: int = 4,
+        is_awq: bool = False,
+        is_gptq: bool = False,
+        group_size: int = -1,
+        has_g_idx: bool = False,
+        has_zero_points: bool = False,
+        has_bias: bool = False,
+        is_act_int8: bool = False,
+        layer: torch.nn.Module | None = None,
+    ) -> tuple[WNA16MoEBackend, type[mk.FusedMoEExperts] | None]:
+        return select_wna16_moe_backend(
+            moe_config,
+            weight_bits=weight_bits,
+            is_awq=is_awq,
+            is_gptq=is_gptq,
+            group_size=group_size,
+            has_g_idx=has_g_idx,
+            has_zero_points=has_zero_points,
+            has_bias=has_bias,
+            is_act_int8=is_act_int8,
+            layer=layer,
+        )
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        backend: WNA16MoEBackend,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        w13_g_idx: torch.Tensor | None = None,
+        w2_g_idx: torch.Tensor | None = None,
+        w13_g_idx_sort_indices: torch.Tensor | None = None,
+        w2_g_idx_sort_indices: torch.Tensor | None = None,
+        is_k_full: bool = True,
+    ) -> mk.FusedMoEKernel:
+        return make_wna16_moe_kernel(
+            quant_config,
+            moe_config,
+            experts_cls,
+            backend,
+            routing_tables=routing_tables,
+            w13_g_idx=w13_g_idx,
+            w2_g_idx=w2_g_idx,
+            w13_g_idx_sort_indices=w13_g_idx_sort_indices,
+            w2_g_idx_sort_indices=w2_g_idx_sort_indices,
+            is_k_full=is_k_full,
+        )
+

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp8.py
@@ -1,12 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import torch
+
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     Fp8MoeBackend,
     backend_to_kernel_cls,
+    make_fp8_moe_kernel,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kMxfp8Dynamic,
@@ -139,3 +147,49 @@ def select_mxfp8_moe_backend(
 
     # TODO: add debug log with reason.
     raise ValueError("No MXFP8 MoE backends available.")
+
+
+class MxFp8MoEKernelOracle(MoEKernelOracle[Fp8MoeBackend]):
+    """Class-based view of the MXFP8 MoE kernel oracle."""
+
+    def backend_enum_cls(self) -> type[Fp8MoeBackend]:
+        return Fp8MoeBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[Fp8MoeBackend]:
+        return list(_SUPPORTED_BACKENDS)
+
+    def backend_to_kernel_cls(
+        self, backend: Fp8MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return _mxfp8_backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: MoEBackend) -> Fp8MoeBackend:
+        backend = _BACKEND_NAME_MAP.get(runner_backend)
+        if backend is None:
+            raise ValueError(
+                f"moe_backend='{runner_backend}' is not supported for MXFP8 MoE."
+            )
+        return backend
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: "QuantKey | None" = None,
+        activation_key: "QuantKey | None" = None,
+    ) -> tuple[Fp8MoeBackend, type[mk.FusedMoEExperts] | None]:
+        return select_mxfp8_moe_backend(moe_config)
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        backend: Fp8MoeBackend,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> mk.FusedMoEKernel:
+        return make_fp8_moe_kernel(
+            quant_config, moe_config, experts_cls, backend, routing_tables
+        )
+

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.fused_moe.config import (
     nvfp4_moe_quant_config,
     nvfp4_w4a16_moe_quant_config,
 )
+from vllm.model_executor.layers.fused_moe.oracle.base import MoEKernelOracle
 from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.b12x_moe import (
     prepare_nvfp4_moe_layer_for_b12x,
@@ -640,3 +641,94 @@ def make_nvfp4_moe_kernel(
     )
 
     return kernel
+
+
+class NvFp4MoEKernelOracle(MoEKernelOracle[NvFp4MoeBackend]):
+    """Class-based view of the NVFP4 MoE kernel oracle."""
+
+    def backend_enum_cls(self) -> type[NvFp4MoeBackend]:
+        return NvFp4MoeBackend
+
+    def get_priority_backends(
+        self, moe_config: FusedMoEConfig
+    ) -> list[NvFp4MoeBackend]:
+        return _get_priority_backends(moe_config)
+
+    def backend_to_kernel_cls(
+        self, backend: NvFp4MoeBackend
+    ) -> list[type[mk.FusedMoEExperts]]:
+        return backend_to_kernel_cls(backend)
+
+    def map_backend(self, runner_backend: MoEBackend) -> NvFp4MoeBackend:
+        return map_nvfp4_backend(runner_backend)
+
+    def select_backend(
+        self,
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None = None,
+        activation_key: QuantKey | None = None,
+    ) -> tuple[NvFp4MoeBackend, type[mk.FusedMoEExperts] | None]:
+        return select_nvfp4_moe_backend(
+            moe_config, weight_key=weight_key, activation_key=activation_key
+        )
+
+    def convert_to_kernel_format(
+        self,
+        backend: NvFp4MoeBackend,
+        moe_config: FusedMoEConfig,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        layer: torch.nn.Module | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return convert_to_nvfp4_moe_kernel_format(
+            backend, moe_config, w13, w2, layer=layer
+        )
+
+    def make_quant_config(
+        self,
+        backend: NvFp4MoeBackend,
+        w1_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+        w1_global_scale: torch.Tensor | None = None,
+        w2_global_scale: torch.Tensor | None = None,
+        a1_scale: torch.Tensor | None = None,
+        a2_scale: torch.Tensor | None = None,
+        a1_global_scale: torch.Tensor | None = None,
+        a2_global_scale: torch.Tensor | None = None,
+        w1_bias: torch.Tensor | None = None,
+        w2_bias: torch.Tensor | None = None,
+        layer: torch.nn.Module | None = None,
+    ) -> FusedMoEQuantConfig:
+        return make_nvfp4_moe_quant_config(
+            backend,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            w1_global_scale=w1_global_scale,
+            w2_global_scale=w2_global_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            a1_global_scale=a1_global_scale,
+            a2_global_scale=a2_global_scale,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            layer=layer,
+        )
+
+    def make_kernel(
+        self,
+        quant_config: FusedMoEQuantConfig,
+        moe_config: FusedMoEConfig,
+        backend: NvFp4MoeBackend,
+        experts_cls: type[mk.FusedMoEExperts],
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+        per_token_activation: bool = False,
+    ) -> mk.FusedMoEKernel:
+        return make_nvfp4_moe_kernel(
+            quant_config,
+            moe_config,
+            experts_cls,
+            backend,
+            routing_tables=routing_tables,
+            per_token_activation=per_token_activation,
+        )
+


### PR DESCRIPTION
## Purpose
This PR completes the MoE oracle class structure migration started in #37776 and #37753 by implementing concrete `MoEKernelOracle` subclasses for the remaining MoE backends:
- `Fp8MoEKernelOracle` in `vllm/model_executor/layers/fused_moe/oracle/fp8.py`
- `NvFp4MoEKernelOracle` in `vllm/model_executor/layers/fused_moe/oracle/nvfp4.py`
- `MxFp8MoEKernelOracle` in `vllm/model_executor/layers/fused_moe/oracle/mxfp8.py`
- `WNA16MoEKernelOracle` in `vllm/model_executor/layers/fused_moe/oracle/int_wna16.py`

All oracle classes are now uniformly exported in `vllm/model_executor/layers/fused_moe/oracle/__init__.py`.

Fixes #37753

## Test Plan
1. Validate syntax and bytecode compilation of modified oracle modules:
```bash
python -m py_compile \
  vllm/model_executor/layers/fused_moe/oracle/fp8.py \
  vllm/model_executor/layers/fused_moe/oracle/nvfp4.py \
  vllm/model_executor/layers/fused_moe/oracle/mxfp8.py \
  vllm/model_executor/layers/fused_moe/oracle/int_wna16.py \
  vllm/model_executor/layers/fused_moe/oracle/__init__.py
