### PR TITLE
[Perf][MLA Sparse] Pin req_id_per_token before non_blocking H2D on XPU and ROCm

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import np_to_pinned_tensor
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -515,7 +516,7 @@ class ROCMAiterMLASparseMetadataBuilder(
         self._prev_req_extent = new_req_extent
         self._prev_indices_extent = new_indices_extent
         self.req_id_per_token_buffer[:new_req_extent].copy_(
-            torch.from_numpy(req_id_per_token), non_blocking=True
+            np_to_pinned_tensor(req_id_per_token), non_blocking=True
         )
         query_lens = (
             common_attn_metadata.query_start_loc[1:]

--- a/vllm/v1/attention/backends/mla/xpu_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/xpu_mla_sparse.py
@@ -13,7 +13,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     get_mla_dims,
 )
-from vllm.utils.torch_utils import is_quantized_kv_cache
+from vllm.utils.torch_utils import is_quantized_kv_cache, np_to_pinned_tensor
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -158,7 +158,7 @@ class XPUMLASparseMetadataBuilder(AttentionMetadataBuilder[XPUMLASparseMetadata]
         # Zero-fill for cudagraphs
         self.req_id_per_token_buffer.fill_(0)
         self.req_id_per_token_buffer[: req_id_per_token.shape[0]].copy_(
-            torch.from_numpy(req_id_per_token), non_blocking=True
+            np_to_pinned_tensor(req_id_per_token), non_blocking=True
         )
 
         req_id_per_token = self.req_id_per_token_buffer[:num_tokens]


### PR DESCRIPTION
## Summary

Route the two `buffer.copy_(torch.from_numpy(...), non_blocking=True)` sites on the sparse-MLA metadata path through `np_to_pinned_tensor` so the copy source is pinned:

- `XPUMLASparseMetadataBuilder.build` `req_id_per_token_buffer`
- ROCm AITER sparse MLA metadata builder `req_id_per_token_buffer`

## Context

Same class of stall #53491 adds a stricter check for: `torch.from_numpy(...)` returns a pageable CPU tensor, and `buffer.copy_(src, non_blocking=True)` with a pageable source is silently staged by the CUDA driver and blocks the host. Continues the sweep in #54266, #54292, #54293.

## Note on the alternative approach

The CUDA sparse backends (flashinfer / flashattn / flashmla) already build `req_id_per_token` on device via `CommonAttentionMetadata.token_to_req_indices`, avoiding the numpy pipeline entirely. Converging XPU and ROCm onto the same path is the more principled fix but a larger refactor. This PR just pins the source of the existing H2D so it stays async; happy to follow up with the refactor if reviewers prefer.

## Duplicate-work check

Searched open PRs for `xpu_mla_sparse in:body`, `rocm_aiter_mla_sparse in:body`, `req_id_per_token pin`, and `#53491 in:body`. None open.

## Testing

- `.venv/bin/python -m pre_commit run --files vllm/v1/attention/backends/mla/xpu_mla_sparse.py vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py` — passed (ruff, mypy, typos, SPDX, etc.)

No available XPU or ROCm hardware to run the runtime path end-to-end; the change is a pattern swap to an existing helper with no semantic drift. Once #53491 lands its runtime checker, this becomes CI-enforced on any test that exercises these builders.

AI assistance was used for code search and drafting; every line was reviewed by the submitter.
