### PR TITLE
[Bugfix] Guard slot mapping block table loads

### DIFF
--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 
 pytestmark = pytest.mark.skipif(
@@ -173,6 +174,72 @@ def test_dcp_slot_mapping_with_smaller_kernel_blocks(cp_rank: int):
     expected[second_start : second_start + 128] = torch.arange(
         9 * 128, 10 * 128, dtype=torch.int64, device=device
     )
+    assert torch.equal(actual, expected)
+
+
+def test_v1_slot_mapping_masks_out_of_range_block_indices():
+    from vllm.v1.worker.block_table import BlockTable
+
+    device = torch.device("cuda")
+    block_table = BlockTable(
+        block_size=16,
+        max_num_reqs=2,
+        max_num_blocks_per_req=1,
+        max_num_batched_tokens=2,
+        pin_memory=False,
+        device=device,
+        kernel_block_size=16,
+        cp_kv_cache_interleave_size=1,
+    )
+    block_table.add_row([5], row_idx=0)
+    block_table.add_row([9], row_idx=1)
+    block_table.commit_block_table(num_reqs=2)
+
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    block_table.compute_slot_mapping(
+        num_reqs=1,
+        query_start_loc=query_start_loc,
+        positions=positions,
+    )
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
+    assert torch.equal(block_table.slot_mapping.gpu[:2], expected)
+
+
+def test_v2_slot_mapping_masks_out_of_range_block_indices():
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16],
+        max_num_reqs=2,
+        max_num_batched_tokens=2,
+        max_num_blocks_per_group=[1],
+        device=device,
+        kernel_block_sizes=[16],
+    )
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([5],),
+        overwrite=True,
+    )
+    block_tables.append_block_ids(
+        req_index=1,
+        new_block_ids=([9],),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    actual = block_tables.compute_slot_mappings(
+        idx_mapping,
+        query_start_loc,
+        positions,
+        num_tokens_padded=2,
+    )[0]
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
     assert torch.equal(actual, expected)
 
 

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -464,14 +464,15 @@ class ComputeSlotMappingKernel(VllmJitKernel["ComputeSlotMappingKernel.CompileKe
                 virtual_block_indices * BLOCKS_PER_KV_BLOCK
                 + local_block_offsets // block_size
             )
+            in_range = block_indices < block_table_stride
             block_numbers = tl.load(
                 block_table_ptr + row_offset + block_indices,
-                mask=mask & is_local,
+                mask=mask & is_local & in_range,
                 other=0,
             ).to(tl.int64)
             slot_offsets = local_block_offsets % block_size
             slot_ids = block_numbers * block_size + slot_offsets
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+            slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
             tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
 
     def dispatch(  # type: ignore[override]

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -327,13 +327,13 @@ def _compute_slot_mappings_kernel(
 
         block_indices = local_positions // kernel_block_size
         block_offsets = local_positions % kernel_block_size
+        in_range = block_indices < block_table_stride
         block_numbers = tl.load(
             block_table_ptr + req_state_idx * block_table_stride + block_indices,
-            mask=is_local,
+            mask=is_local & in_range,
             other=0,
         )
         slot_ids = block_numbers * kernel_block_size + block_offsets
-        if CP_SIZE != 1:
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
 
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)


### PR DESCRIPTION
## Purpose

Fixes #53982.

Both `ComputeSlotMappingKernel` and the Model Runner V2 `_compute_slot_mappings_kernel()` can compute a block index beyond the width of a request's block-table row when an enabled cache group's table does not span the sequence in raw token positions. This can cause an out-of-bounds GPU read.

This change adds `block_indices < block_table_stride` to both load masks and emits `PAD_SLOT_ID` for out-of-range lanes. The explicit padding also covers the Model Runner V2 `CP_SIZE == 1` path, where the load's `other=0` would otherwise produce a valid-looking slot in block zero. In-range behavior is unchanged. After rebasing, the V2 load mask also preserves current `main`'s `is_real_req` protection for dummy request rows.

I rechecked current `main` and open PRs after rebasing. Current `main` now disables generic slot mapping for cache types such as `KpoolTailSpec` that provide their own mapping, but the generic kernels still lack a row-bound guard for any other enabled narrow group. The related #56437, #56438, and #56439 reference or carry this guard as a prerequisite rather than providing a separate focused fix.

OpenAI Codex assisted with investigation, implementation, test design, GPU validation, rebase conflict resolution, and PR preparation. I reviewed and understand all changed lines, ran the local checks, and validated the rebased GPU behavior on an NVIDIA RTX 4090.

## Test Plan

```bash
.venv/bin/python -m pytest --noconftest -o addopts= tests/v1/worker/test_gpu_block_table.py -k out_of_range_block_indices -vv
.venv/bin/python -m pytest --noconftest -o addopts= tests/v1/worker/test_gpu_block_table.py -vv
.venv/bin/python -m pytest --noconftest -o addopts= tests/v1/worker/test_jit_warmup_migration.py -vv
.venv/bin/pre-commit run --files tests/v1/worker/test_gpu_block_table.py vllm/v1/worker/block_table.py vllm/v1/worker/gpu/block_table.py
```

## Test Result

Revalidated after rebasing onto `main` at `eb87980585` on an NVIDIA RTX 4090 with driver 610.43.02, PyTorch 2.13.0+cu126, and CUDA runtime 12.6:

- During the original test-first implementation, both focused regression tests failed as expected before the production fix: the out-of-range lane produced slot `144` from the adjacent request row instead of `PAD_SLOT_ID`.
- Rebased focused regression tests: `2 passed, 10 deselected`.
- Rebased full GPU block-table module: `12 passed`.
- Rebased JIT warmup migration module: `5 passed`.
- All applicable changed-file pre-commit hooks passed.

The PR discussion also contains independent validation of equivalent guards on AMD MI325X and MI350X and NVIDIA B300, H200, and GB10 systems. I appreciate the contributors who shared those results and helped distinguish this bounds bug from unrelated memory-access failures.
