### PR TITLE
[Bugfix][Responses] Backfill required fields that arrive as explicit null

### DIFF
--- a/tests/entrypoints/openai/responses/test_function_call_parsing.py
+++ b/tests/entrypoints/openai/responses/test_function_call_parsing.py
@@ -5,7 +5,11 @@
 import json
 
 import pytest
-from openai.types.responses import ResponseFunctionToolCall, ResponseOutputMessage
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseReasoningItem,
+)
 
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
@@ -377,3 +381,75 @@ def test_assistant_output_style_content_coerced():
     assert item.content[0].annotations == []
     assert item.status == "completed"
     assert item.id.startswith("msg_")
+
+
+def test_explicit_null_fields_are_backfilled_like_absent_ones():
+    """An SDK round-tripping a previous response serialises an unset optional
+    field as an explicit null rather than dropping the key. `id`, `status` and
+    `annotations` are all required here, so a null has to be backfilled the same
+    way an absent key is; left alone the item falls out of the union as a raw
+    dict and the request is rejected."""
+    request_data = {
+        "model": "test-model",
+        "input": [
+            {"type": "reasoning", "id": None, "summary": []},
+            {
+                "type": "message",
+                "role": "assistant",
+                "id": None,
+                "status": None,
+                "content": [
+                    {"type": "output_text", "text": "world", "annotations": None}
+                ],
+            },
+        ],
+    }
+
+    request = ResponsesRequest(**request_data)
+
+    reasoning, message = request.input
+    assert isinstance(reasoning, ResponseReasoningItem), type(reasoning)
+    assert reasoning.id.startswith("rs_")
+    assert isinstance(message, ResponseOutputMessage), type(message)
+    assert message.id.startswith("msg_")
+    assert message.status == "completed"
+    assert message.content[0].annotations == []
+
+
+def test_supplied_fields_are_never_overwritten():
+    """The null backfill must not reach values the caller actually set."""
+    request_data = {
+        "model": "test-model",
+        "input": [
+            {"type": "reasoning", "id": "rs_mine", "summary": []},
+            {
+                "type": "message",
+                "role": "assistant",
+                "id": "msg_mine",
+                "status": "incomplete",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "world",
+                        "annotations": [
+                            {
+                                "type": "url_citation",
+                                "url": "https://example.com",
+                                "title": "t",
+                                "start_index": 0,
+                                "end_index": 1,
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+
+    request = ResponsesRequest(**request_data)
+
+    reasoning, message = request.input
+    assert reasoning.id == "rs_mine"
+    assert message.id == "msg_mine"
+    assert message.status == "incomplete"
+    assert len(message.content[0].annotations) == 1

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -538,7 +538,11 @@ class ResponsesRequest(OpenAIBaseModel):
                     processed_input.append(item)
 
             elif item_type == "reasoning":
-                if "id" not in item:
+                # `is None` rather than `not in`: an SDK that round-trips a
+                # previous response serialises an unset optional field as an
+                # explicit null, and these fields are typed as required here, so
+                # skipping the backfill leaves the item to fail the outer union.
+                if item.get("id") is None:
                     item = {**item, "id": f"rs_{random_uuid()}"}
                 try:
                     processed_input.append(ResponseReasoningItem(**item))
@@ -559,9 +563,9 @@ class ResponsesRequest(OpenAIBaseModel):
 
                 original_item = item
                 item = dict(item)
-                if "id" not in item:
+                if item.get("id") is None:
                     item["id"] = f"msg_{random_uuid()}"
-                if "status" not in item:
+                if item.get("status") is None:
                     item["status"] = "completed"
                 # ResponseOutputText requires annotations
                 new_content = []
@@ -569,7 +573,7 @@ class ResponsesRequest(OpenAIBaseModel):
                     if (
                         isinstance(c, dict)
                         and c.get("type") == "output_text"
-                        and "annotations" not in c
+                        and c.get("annotations") is None
                     ):
                         c = {**c, "annotations": []}
                     new_content.append(c)


### PR DESCRIPTION
## Purpose

Fixes #54224.

`ResponsesRequest.input_item_parsing` backfills the fields that the `openai` types mark as required but the Responses API accepts as optional on input. Each backfill asks whether the key is present:

```python
if "id" not in item:                 # reasoning item
if "id" not in item:                 # assistant message
if "status" not in item:             # assistant message
if "annotations" not in c:           # output_text part
```

An SDK that round-trips an item out of a previous response serialises an unset optional field as an explicit `null` rather than dropping the key, so the key is there, the backfill is skipped, and `ResponseReasoningItem(**item)` / `ResponseOutputMessage(**item)` raises `ValidationError`. The `except` branch re-appends the item unchanged, and the outer `input` union then rejects the whole request with a 400 and a 200-entry validation dump whose top hit is `{'type': 'string_type', 'loc': ('body', 'input', n, 'str'), 'input': None}`. The same payload with the key omitted, or with a real string id, is accepted, and the real OpenAI endpoint accepts it either way.

The reported case is `id`, but `status` and `annotations` are the same check on the same items and fail the same way, so all four move together.

## Fix

Test the value rather than the key, so a null and an absent key take the same path:

```python
if item.get("id") is None:
if item.get("status") is None:
if c.get("annotations") is None:
```

A value the caller actually set is still never overwritten, and an item that is malformed for some other reason still falls through to Pydantic unchanged.

## Test

Two tests in `tests/entrypoints/openai/responses/test_function_call_parsing.py`, next to the existing `test_assistant_output_style_content_coerced`:

- `test_explicit_null_fields_are_backfilled_like_absent_ones` sends a reasoning item with `id: null` and an assistant message with `id: null`, `status: null` and `annotations: null`, and asserts both come back as the coerced `ResponseReasoningItem` / `ResponseOutputMessage` with the synthetic values.
- `test_supplied_fields_are_never_overwritten` sends real values for all four and asserts they survive.

This machine has no vLLM build, so the validator was exercised directly out of `protocol.py` against `openai` 2.43.0 and `pydantic`, with the two new test bodies run against it verbatim:

Before the change:

```
FAIL test_explicit_null_fields_are_backfilled_like_absent_ones -> AssertionError <class 'dict'>
PASS test_supplied_fields_are_never_overwritten
PASS test_assistant_output_style_content_coerced
PASS test_assistant_string_content_stays_easyinput
PASS test_function_call_dict_converted_to_object
```

After:

```
PASS test_explicit_null_fields_are_backfilled_like_absent_ones
PASS test_supplied_fields_are_never_overwritten
PASS test_assistant_output_style_content_coerced
PASS test_assistant_string_content_stays_easyinput
PASS test_function_call_dict_converted_to_object
```

`ruff check` and `ruff format --diff` are clean on both files. CI runs the file for real.

## Notes

- Not a duplicate: no open or merged PR touches `input_item_parsing`, and #54224 has no linked PR.
- AI assistance was used in preparing this change.
