### PR TITLE
[ROCm/MoRIIO] Route READ-mode remote KV load via async lifecycle (fix scheduler req_id_to_index KeyError)

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_async_read.py
+++ b/tests/v1/kv_connector/unit/test_moriio_async_read.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the MoRIIO READ-mode async KV-load fix (PR #54301).
+
+Background
+----------
+MoRIIO PD-disaggregation schedules decode requests whose ``request_id`` is the
+router-embedded compound id
+(``...___prefill_addr_...___decode_addr_..._<uuid>``). Previously READ mode
+returned ``load_kv_async=False`` from ``get_num_new_matched_tokens``, so the
+scheduler put the request straight into ``num_scheduled_tokens`` (RUNNING). For
+a step where the worker produced no output row for it, that compound req_id was
+absent from ``model_runner_output.req_id_to_index`` and the scheduler's
+unconditional index lookup in ``update_from_output`` raised ``KeyError`` ->
+``EngineDeadError`` (observed on the first inference request of MoRIIO 1P1D).
+
+The fix (connector-side, no core ``scheduler.py`` change, no monkeypatch of
+``Scheduler.update_from_output``): READ mode now returns ``load_kv_async=True``
+so the request is held in ``WAITING_FOR_REMOTE_KVS`` -- OUT of
+``num_scheduled_tokens`` -- until the worker reports the load done via
+``get_finished()`` -> ``finished_recving``. It is therefore never
+scheduled-but-unindexed and the KeyError cannot occur. This mirrors the
+existing WRITE-mode consumer lifecycle.
+
+These tests assert:
+  * READ mode advertises the async path (and WRITE mode is unchanged);
+  * the producer leg never loads KV;
+  * the tiny-prompt / nothing-to-load edge keeps the sync path (the scheduler
+    asserts ``num_external_computed_tokens > 0`` for async loads);
+  * the old scheduler monkeypatch is gone: importing/using the connector must
+    NOT wrap ``Scheduler.update_from_output``.
+
+CPU-only: no GPU / no ``mori`` runtime required (the scheduler-side connector
+object is built via ``__new__`` and only ``get_num_new_matched_tokens`` -- which
+reads just ``self.is_producer`` and ``self.mode`` -- is exercised).
+"""
+
+import pytest
+
+import vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector as moriio
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import MoRIIOMode
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
+    MoRIIOConnectorScheduler,
+)
+from vllm.v1.core.sched.scheduler import Scheduler
+
+from .utils import create_request
+
+pytestmark = pytest.mark.cpu_test
+
+# A representative MoRIIO PD compound req_id (host/port addresses + uuid), as
+# seen in the original crash logs (decode EngineCore KeyError).
+_MORIIO_COMPOUND_REQ = (
+    "cmpl-___prefill_addr_host:10.158.215.209,handshake:8405,"
+    "notify:61005___decode_addr_host:10.158.214.246,handshake:8405,"
+    "notify:61005_16f41eb3df75420fa6b78acc63bafd9a-0-b8ee174a"
+)
+
+
+def _make_scheduler_conn(mode: MoRIIOMode, is_producer: bool):
+    """Build a MoRIIOConnectorScheduler without running __init__.
+
+    ``get_num_new_matched_tokens`` only reads ``self.is_producer`` and
+    ``self.mode``, so this avoids needing the full VllmConfig / handshake ports
+    / mori runtime. Mirrors the ``make_nixl_scheduler`` __new__ pattern in
+    tests/v1/kv_connector/unit/utils.py.
+    """
+    conn = object.__new__(MoRIIOConnectorScheduler)
+    conn.mode = mode
+    conn.is_producer = is_producer
+    return conn
+
+
+def test_read_mode_uses_async_path():
+    """READ-mode consumer decode requests must advertise load_kv_async=True so
+    they are never scheduled-but-unindexed (the req_id_to_index KeyError)."""
+    conn = _make_scheduler_conn(MoRIIOMode.READ, is_producer=False)
+    request = create_request(
+        request_id=1, num_tokens=8, do_remote_prefill=True, max_tokens=16
+    )
+    request.request_id = _MORIIO_COMPOUND_REQ
+
+    num_external, load_kv_async = conn.get_num_new_matched_tokens(request, 0)
+
+    # len(prompt) - 1 - num_computed = 8 - 1 - 0 = 7 tokens loaded remotely.
+    assert num_external == 7
+    # The crux of the fix: async path (WAITING_FOR_REMOTE_KVS), not sync.
+    assert load_kv_async is True
+
+
+def test_read_mode_async_requires_positive_external_tokens():
+    """When there is nothing to load remotely, READ mode must keep the sync
+    path: the scheduler asserts num_external_computed_tokens > 0 for async
+    loads, so returning (<=0, True) would trip that assert."""
+    conn = _make_scheduler_conn(MoRIIOMode.READ, is_producer=False)
+
+    # Prompt of length 1 => len - 1 - 0 = 0 external tokens.
+    request = create_request(
+        request_id=2, num_tokens=1, do_remote_prefill=True, max_tokens=16
+    )
+    num_external, load_kv_async = conn.get_num_new_matched_tokens(request, 0)
+    assert num_external == 0
+    assert load_kv_async is False
+
+
+def test_write_mode_async_unchanged():
+    """WRITE mode (the pre-existing async consumer path) is left intact."""
+    conn = _make_scheduler_conn(MoRIIOMode.WRITE, is_producer=False)
+    request = create_request(
+        request_id=3, num_tokens=8, do_remote_prefill=True, max_tokens=16
+    )
+    num_external, load_kv_async = conn.get_num_new_matched_tokens(request, 0)
+    # WRITE mode loads the full prompt: len - num_computed = 8 - 0 = 8.
+    assert num_external == 8
+    assert load_kv_async is True
+
+
+def test_producer_never_loads_kv():
+    """The prefill/producer leg never pulls external KV, in either mode."""
+    for mode in (MoRIIOMode.READ, MoRIIOMode.WRITE):
+        conn = _make_scheduler_conn(mode, is_producer=True)
+        request = create_request(request_id=4, num_tokens=8, max_tokens=16)
+        assert conn.get_num_new_matched_tokens(request, 0) == (0, False)
+
+
+def test_scheduler_update_from_output_is_not_monkeypatched():
+    """Regression guard for PR #54301: the connector must fix this on its own
+    side, NOT by wrapping the core scheduler. The removed monkeypatch tagged
+    the wrapped function with ``_moriio_reqid_guarded``; that must never appear,
+    and the helper that installed it must no longer exist."""
+    assert not hasattr(Scheduler.update_from_output, "_moriio_reqid_guarded")
+    assert not hasattr(moriio, "_install_moriio_scheduler_reqid_guard")

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -505,7 +505,35 @@ class MoRIIOConnectorScheduler:
 
             return len(token_ids) - num_computed_tokens, True
 
-        return len(token_ids) - 1 - num_computed_tokens, False
+        # READ mode: pull all-but-one prompt token's KV from the remote prefill
+        # instance, computing the final token locally to sample the first
+        # decode token.
+        #
+        # Route this remote KV load through vLLM's ASYNC path
+        # (load_kv_async=True) instead of the synchronous one. On the async
+        # path the scheduler holds the request in WAITING_FOR_REMOTE_KVS and
+        # keeps it OUT of ``num_scheduled_tokens`` until the worker reports the
+        # load done via ``get_finished()`` -> ``finished_recving``. This is the
+        # same lifecycle WRITE mode already uses for its consumer leg.
+        #
+        # Doing so structurally removes the ``scheduler.update_from_output``
+        # ``req_id_to_index`` KeyError (PR #54301): with the synchronous path
+        # (load_kv_async=False) the decode request went straight to RUNNING and
+        # was placed in ``num_scheduled_tokens`` immediately, but for the step
+        # where the worker produced no output row for it, its compound PD
+        # req_id was absent from ``model_runner_output.req_id_to_index`` and the
+        # scheduler's unconditional index lookup raised ``KeyError`` ->
+        # ``EngineDeadError``. On the async path the request is never
+        # scheduled-but-unindexed, so the crash cannot occur -- and core
+        # ``scheduler.py`` stays upstream-clean (see PR #54301 review: "This
+        # should be fixed in the connector, not the scheduler.").
+        num_external_tokens = len(token_ids) - 1 - num_computed_tokens
+        if num_external_tokens > 0:
+            return num_external_tokens, True
+        # Nothing to load remotely (tiny prompt / full local hit): keep the
+        # synchronous path. The scheduler asserts num_external_computed_tokens
+        # > 0 for async loads, and there is no recv to await here.
+        return num_external_tokens, False
 
     def send_notify_block(
         self,
@@ -1943,14 +1971,21 @@ class MoRIIOConnectorWorker:
                 self._unmatched_write_completions |= fresh
                 done_recving = self._unmatched_write_completions
             else:
-                # READ mode: the scheduler treats KV loads as synchronous
-                # (load_kv_async=False), so requests go directly to RUNNING
-                # instead of WAITING_FOR_REMOTE_KVS. We still call
-                # _pop_done_transfers() to send the notify to the prefill
-                # side and clean up internal state, but we must NOT report
-                # these as done_recving because the scheduler doesn't
-                # expect a finished_recving signal for RUNNING requests.
-                self._pop_done_transfers()
+                # READ mode: the remote KV load now uses vLLM's ASYNC path
+                # (MoRIIOConnectorScheduler.get_num_new_matched_tokens returns
+                # load_kv_async=True), so the decode request waits in
+                # WAITING_FOR_REMOTE_KVS -- held OUT of num_scheduled_tokens --
+                # until we report it done here. _pop_done_transfers() returns
+                # the transfer_ids whose RDMA reads have fully landed (and, as
+                # before, sends the release notify to the prefill side and
+                # cleans up internal state). Surfacing them as done_recving
+                # makes the scheduler promote the request and schedule its
+                # forward, so it is NEVER scheduled-but-unindexed -- which is
+                # what previously raised the req_id_to_index KeyError in
+                # scheduler.update_from_output (PR #54301). Mirrors the
+                # WRITE-mode consumer's finished_recving handling above.
+                # transfer_ids are mapped to request_ids by the filter below.
+                done_recving = self._pop_done_transfers()
 
         done_recving = {
             self.transfer_id_to_request_id[id]


### PR DESCRIPTION
## Summary

In PD-disaggregation the MoRIIO connector's **READ mode** treated the remote KV load as **synchronous** (`get_num_new_matched_tokens` returned `load_kv_async=False`). The decode request — whose `request_id` is the router-embedded compound id (`...___prefill_addr_...___decode_addr_..._<uuid>`) — was therefore sent straight to `RUNNING` and into `scheduler_output.num_scheduled_tokens`. On a step where the worker produced no output row for it, that compound id was absent from `model_runner_output.req_id_to_index`, so the scheduler's unconditional `req_id_to_index[req_id]` lookup in `update_from_output` raised `KeyError` → `EngineDeadError`, on the first inference request of MoRIIO 1P1D/1P2D/2P2D runs.

## What changed (connector-side, per review)

Per @njhill's review ("This should be fixed in the connector, not the scheduler."), this is now fixed **entirely in the MoRIIO connector** — core `vllm/v1/core/sched/scheduler.py` is untouched. The earlier scheduler guard has been dropped.

The READ-mode load now uses vLLM's existing async KV-load lifecycle, mirroring what MoRIIO's WRITE-mode consumer leg already does:

- **`MoRIIOConnectorScheduler.get_num_new_matched_tokens`** (READ branch): returns `(n, True)` when `n > 0`, so the request is held in `WAITING_FOR_REMOTE_KVS` instead of being scheduled before its KV exists. Falls back to `(n, False)` only for the tiny-prompt / nothing-to-load edge case (the scheduler asserts `> 0` for async loads).
- **`MoRIIOConnectorWorker.get_finished`** (READ branch): now surfaces `done_recving = self._pop_done_transfers()` (previously discarded), giving the scheduler the `finished_recving` signal to promote the request out of `WAITING_FOR_REMOTE_KVS`.

The request is therefore **never scheduled-but-unindexed**, so the `KeyError` is structurally impossible while the core scheduler invariant (every scheduled req_id has an output row) is preserved untouched.

## Tests

Adds `tests/v1/kv_connector/unit/test_moriio_async_read.py` (CPU-only): asserts READ→async, edge-case→sync, WRITE unchanged, producer never loads, and that `Scheduler.update_from_output` is not wrapped/patched.

## Validation

Validated on 1P1D **GLM-5.3-FP8 WideEP PD-disagg (MI300X)**:
- **READ mode** — directly exercises the fix: async path triggers on the exact compound PD req_ids, `WAITING_FOR_REMOTE_KVS` promotion confirmed, endpoints reach startup and serve HTTP 200, **zero** `KeyError`/`EngineDeadError`.
- **WRITE mode** — no regression across a multi-hour run (128k tokens, 0 errors).

## Risk

The async path relies on `get_finished` reporting `done_recving` for every READ transfer (a missed signal would leave a request waiting in `WAITING_FOR_REMOTE_KVS` rather than crashing); the cluster run confirms the signal fires and requests complete.

---
🤖 This change was developed with AI assistance (Cursor); all changes were reviewed and validated by the author. See the `Co-authored-by` trailer on the commit.