### PR TITLE
[Bugfix] Reconcile the connector local hit for divergent hybrid groups

### DIFF
--- a/tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py
+++ b/tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py
@@ -73,7 +73,7 @@ def _seed_owner(manager, n, hash_bs):
     manager.new_step_starts()
 
 
-def test_connector_local_hit_does_not_overreach_the_mamba_state_boundary():
+def test_connector_divergent_local_hit_reports_mamba_lag():
     """The connector local hit must not over-reach the Mamba state boundary.
 
     E7v2: with a capable KV connector (spec decode on) and a hybrid

--- a/tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py
+++ b/tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""E7v2 (LMCache #4674) - the connector local-prefix over-reach.
+
+Pure-CPU regression: with a capable KV connector and a hybrid
+full-attention + Mamba model, a Mamba group hit that lags the
+full-attention hit must never produce a connector-local prefix deeper
+than a valid Mamba state. Fails on main, passes with the connector
+path reconciliation.
+"""
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _manager(hash_bs, fa_bs, mamba_bs, use_eagle):
+    cfg = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=fa_bs,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=mamba_bs,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        cfg,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=hash_bs,
+        use_eagle=use_eagle,
+    )
+    assert manager.coordinator.enable_partial_hash_hits, "partial matching must be on"
+    return manager
+
+
+def _seed_owner(manager, n, hash_bs):
+    owner = make_request("owner", [7] * n, hash_bs, sha256)
+    computed, num_computed, _ = manager.get_computed_blocks(owner)
+    assert num_computed == 0
+    assert manager.allocate_slots(owner, n, 0, computed) is not None
+    manager.free(owner)
+    manager.new_step_starts()
+
+
+def test_connector_local_hit_does_not_overreach_the_mamba_state_boundary():
+    """The connector local hit must not over-reach the Mamba state boundary.
+
+    E7v2: with a capable KV connector (spec decode on) and a hybrid
+    full-attention + Mamba model, ``get_computed_blocks_for_connector``
+    used to report the **full-attention** hit as ``num_local`` whenever no
+    group ran deeper - even when the Mamba group lagged, so that boundary
+    had no valid Mamba state (align mode materializes state only at sparse
+    mamba-block positions, and under a sparse grid the Mamba hit can be 0
+    while full attention is deep). With no external tokens supplied,
+    serving that boundary writes a Mamba state that does not match the
+    full-attention prefix: silent corruption. The scheduler's
+    ``hit_diverged and num_external == 0`` fallback to
+    ``get_computed_blocks`` only fires when the connector supplies nothing,
+    and the reconciled path it lands on is itself incomplete for
+    align-mode boundaries (open PRs #53479/#53802), so the guard alone
+    does not close the defect.
+
+    Setup: a sparse mamba grid (state every 4 tokens, full attention every
+    2) makes the Mamba independent hit lag full attention; an owner request
+    seeds the shared prefix and a follower diverges after 10 tokens.
+
+    Invariant pinned: a servable connector-local prefix hit is a boundary
+    at which *every* group has a valid cached state, so ``num_local`` must
+    not run deeper than the Mamba group's hit, and the divergence must be
+    flagged.
+    """
+    # Sparse grid: mamba state every 4 tokens, full attention every 2. The
+    # Mamba independent hit lags (or is 0) while full attention goes deeper.
+    hash_bs, fa_bs, mamba_bs = 2, 2, 4
+    manager = _manager(hash_bs, fa_bs, mamba_bs, use_eagle=True)
+    _seed_owner(manager, 12, hash_bs)
+
+    # Follower shares the first 10 tokens, then diverges.
+    follower = make_request("follower", [7] * 10 + [9] * 2, hash_bs, sha256)
+    _blocks_per_group, hit_lengths = (
+        manager.coordinator.find_longest_cache_hit_per_group(
+            follower.block_hashes, follower.num_tokens - 1
+        )
+    )
+    fa_hit, mamba_hit = hit_lengths[0], hit_lengths[1]
+
+    # Premise of the bug: the Mamba group's independent hit lags full attention.
+    assert mamba_hit < fa_hit, (
+        f"need the Mamba hit lagging full attention to reach the over-reach; "
+        f"got FA={fa_hit}, mamba={mamba_hit}"
+    )
+
+    # The connector path, as the scheduler calls it for a capable connector.
+    blocks, num_local, _shared, hit_diverged = (
+        manager.get_computed_blocks_for_connector(follower)
+    )
+    assert hit_diverged, (
+        f"expected a diverged hit (mamba {mamba_hit} < fa {fa_hit}); "
+        f"got hit_diverged={hit_diverged}"
+    )
+
+    # The invariant (see docstring): never deeper than a valid Mamba state.
+    assert num_local <= mamba_hit, (
+        f"connector local prefix {num_local} runs deeper than the Mamba state "
+        f"boundary {mamba_hit} (full-attention hit {fa_hit}, hit_diverged="
+        f"{hit_diverged}); with no external tokens the Mamba state at {num_local} "
+        f"is absent, so the prefix is served misaligned."
+    )
+    assert blocks is not None

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -304,15 +304,17 @@ class KVCacheManager:
 
         Hybrid (Mamba + full-attention) models can have per-group prefix hits
         diverge under block pressure: the full-attention tail may be evicted
-        while a deeper Mamba state survives, or vice versa. Report the
-        full-attention hit as the local prefix - the connector transfers the
-        remaining suffix and the Mamba state is transferred unconditionally by
-        nixl's ``_apply_prefix_caching`` - and flag when that hit ran deeper
-        than a lagging group. Such a hit only has a valid Mamba state at its
-        boundary if the connector supplies it, so the caller must fall back to
-        ``get_computed_blocks`` to reconcile when no external tokens are found.
+        while a deeper Mamba state survives, or vice versa. The reported local
+        prefix is always a boundary at which every group has a valid cached
+        state. A group deeper than full attention (its full-attention blocks
+        evicted) yields the reconciled boundary unflagged; a lagging group
+        (e.g. a Mamba state that does not exist at the full-attention
+        boundary) yields the reconciled boundary flagged ``hit_diverged``,
+        which the caller reconciles via ``get_computed_blocks`` when no
+        external tokens backfill it; converged hits use the full-attention
+        boundary itself.
 
-        Non-hybrid models and already-convergent hits use ``get_computed_blocks``.
+        Non-hybrid models use ``get_computed_blocks``.
 
         Returns:
             The ``get_computed_blocks`` triple (blocks, number of local computed
@@ -333,16 +335,24 @@ class KVCacheManager:
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
             request.block_hashes, request.num_tokens - 1
         )
-        if any(hit > per_group_hits[fa_group_id] for hit in per_group_hits):
-            # A lagging group hit deeper than full attention means its
-            # full-attention blocks were evicted; use the reconciled boundary
-            # that every group agrees on.
+        fa_hit = per_group_hits[fa_group_id]
+        if any(hit > fa_hit for hit in per_group_hits):
+            # A group hit deeper than full attention means its full-attention
+            # blocks were evicted; use the reconciled boundary that every
+            # group agrees on.
             return *self.get_computed_blocks(request), False
+        if any(hit < fa_hit for hit in per_group_hits):
+            # A group (the Mamba state) lags full attention: no valid Mamba
+            # state exists at the full-attention boundary, so serving it would
+            # be misaligned. Use the reconciled boundary and flag the
+            # divergence; the scheduler reconciles again when no external
+            # tokens back the deeper hit.
+            return *self.get_computed_blocks(request), True
 
-        num_local = per_group_hits[fa_group_id]
+        num_local = fa_hit
         blocks = self.create_kv_cache_blocks(computed)
         # Per-group lookups do not detect an uncached shared prefix (boundary 0).
-        return blocks, num_local, 0, min(per_group_hits) < num_local
+        return blocks, num_local, 0, False
 
     def allocate_slots(
         self,


### PR DESCRIPTION
## Purpose

Fixes LMCache [#4674](https://github.com/LMCache/LMCache/issues/4674), which reports silent output corruption when hybrid Mamba and full-attention prefix hits diverge behind a capable KV connector.

In `KVCacheManager.get_computed_blocks_for_connector`, a lagging hybrid group now causes the connector path to use the reconciled boundary and set `hit_diverged=True`. The connector is not given a boundary deeper than the lagging group's valid state. This PR also gives the regression test a name that states the pinned divergence behavior.

## Test Plan

- `VLLM_TARGET_DEVICE=cpu ./.venv/bin/python -m pytest tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py -q`
- `VLLM_TARGET_DEVICE=cpu ./.venv/bin/python -m pytest tests/v1/core/prefix_cache/ tests/v1/core/test_prefix_caching.py tests/v1/core/test_single_type_kv_cache_manager.py tests/v1/core/test_mamba_align_chunk_split.py -q`
- `./.venv/bin/ruff check vllm/v1/core/kv_cache_manager.py tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py`
- `./.venv/bin/ruff format --check vllm/v1/core/kv_cache_manager.py tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py`
- `./.venv/bin/mypy vllm/v1/core/kv_cache_manager.py`
- `./.venv/bin/mypy --follow-imports skip tests/v1/core/prefix_cache/test_e7v2_connector_overreach.py`

## Test Result

- Connector regression: 1 passed.
- Adjacent regression scope: 185 passed.
- Ruff check: passed.
- Ruff format check: passed.
- Mypy: passed for both touched files.

## Duplicate-work check (per AGENTS.md)

- `gh pr list --state open --search "hybrid connector local hit kv_cache_manager"`: the only adjacent open PR is #42524, which addresses D-side prefix-cache hit-rate efficiency under PD disaggregation (allocation/pull path). This PR fixes a correctness invariant in `get_computed_blocks_for_connector` — a lagging hybrid group being served a boundary with no valid state. Different failure mode, different fix surface; no open PR addresses this bug.
- LMCache/LMCache#4674 is closed on the LMCache side; the vLLM-side boundary condition it exposed is what this PR fixes.

## AI assistance disclosure (per AGENTS.md)

AI assistance was used in developing and testing this change. The submitter reviewed every changed line, ran the test plan above, and takes full responsibility for the change end-to-end.
