### PR TITLE
[Rust Frontend] Bound recursive argument parsers

### DIFF
--- a/rust/src/parser/src/tool/minimax_m3.rs
+++ b/rust/src/parser/src/tool/minimax_m3.rs
@@ -12,6 +12,7 @@ use super::parameters::{ParamElement, ParamInput, ToolSchemas};
 use super::utils::{MarkerScanState, parse_buffered_event, safe_text_len, take_until_marker};
 use super::{Result, ToolCallDelta, ToolParser, ToolParserOutput};
 use crate::tool::Tool;
+use crate::utils::recursion::ParserRecursionGuard;
 
 const NAMESPACE: &str = "]<]minimax[>[";
 const TOOL_CALL_START: &str = "]<]minimax[>[<tool_call>";
@@ -279,6 +280,7 @@ fn parse_invoke_params(invoke_body: &str) -> ModalResult<Vec<(String, ParamInput
 /// Parse a MiniMax M3 parameter element.
 fn parameter_element(input: &mut &str) -> ModalResult<ParamElement> {
     let name = open_element_tag(input)?.to_string();
+    let _guard = ParserRecursionGuard::enter()?;
     let value = element_body(input, &name)?;
     close_element_tag(input, &name)?;
     Ok(ParamElement { name, value })
@@ -389,10 +391,11 @@ mod tests {
 
     use super::{
         ELEMENT_END_START, ELEMENT_START, INVOKE_END, INVOKE_START, MinimaxM3ToolParser,
-        TOOL_CALL_END, TOOL_CALL_START, ToolParser,
+        TOOL_CALL_END, TOOL_CALL_START, ToolParser, parse_invoke_params,
     };
     use crate::tool::test_utils::{collect_stream, split_by_chars, test_tools};
     use crate::tool::{Tool, ToolParserEvent, ToolParserTestExt as _};
+    use crate::utils::recursion::MAX_PARSER_RECURSION_DEPTH;
 
     fn element(name: &str, body: &str) -> String {
         format!("{ELEMENT_START}{name}>{body}{ELEMENT_END_START}{name}>")
@@ -506,6 +509,23 @@ mod tests {
             ),
         ]
         .join("")
+    }
+
+    fn nested_element(depth: usize) -> String {
+        format!(
+            "{}leaf{}",
+            format!("{ELEMENT_START}node>").repeat(depth),
+            format!("{ELEMENT_END_START}node>").repeat(depth)
+        )
+    }
+
+    #[test]
+    fn minimax_m3_recursion_limit_accepts_boundary_and_rejects_next_depth() {
+        assert!(parse_invoke_params(&nested_element(MAX_PARSER_RECURSION_DEPTH)).is_ok());
+        assert!(matches!(
+            parse_invoke_params(&nested_element(MAX_PARSER_RECURSION_DEPTH + 1)),
+            Err(winnow::error::ErrMode::Cut(_))
+        ));
     }
 
     #[test]

--- a/rust/src/parser/src/unified/gemma4.rs
+++ b/rust/src/parser/src/unified/gemma4.rs
@@ -14,6 +14,7 @@ use super::{Result, UnifiedParser, UnifiedParserOutput, token_id};
 use crate::reasoning::last_reasoning_boundary;
 use crate::tool::{Tool, ToolCallDelta};
 use crate::unified::parsing_failed;
+use crate::utils::recursion::ParserRecursionGuard;
 use crate::utils::{incomplete, parse_buffered_event, partial_prefix_len, safe_text_len_mul};
 
 const REASONING_START: &str = "<|channel>thought\n";
@@ -442,12 +443,16 @@ fn gemma4_string<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
 
 /// Parse a nested Gemma4 object.
 fn gemma4_object(input: &mut &str) -> ModalResult<Map<String, Value>> {
-    delimited(literal("{"), gemma4_args, literal("}")).parse_next(input)
+    literal("{").parse_next(input)?;
+    let _guard = ParserRecursionGuard::enter()?;
+    terminated(gemma4_args, literal("}")).parse_next(input)
 }
 
 /// Parse a Gemma4 array value.
 fn gemma4_array_value(input: &mut &str) -> ModalResult<Vec<Value>> {
-    delimited(literal("["), gemma4_array_content, literal("]")).parse_next(input)
+    literal("[").parse_next(input)?;
+    let _guard = ParserRecursionGuard::enter()?;
+    terminated(gemma4_array_content, literal("]")).parse_next(input)
 }
 
 /// Parse Gemma4 array content.
@@ -519,6 +524,7 @@ mod tests {
     };
     use crate::tool::Tool;
     use crate::unified::{UnifiedParserError, UnifiedParserEvent, parsing_failed};
+    use crate::utils::recursion::MAX_PARSER_RECURSION_DEPTH;
 
     const CHANNEL_START_ID: u32 = 256;
     const CHANNEL_END_ID: u32 = 257;
@@ -718,6 +724,18 @@ mod tests {
     fn gemma4_parse_array_handles_bare_values() {
         let parsed = parse_gemma4_array("42,true,114.514").unwrap();
         assert_eq!(Value::Array(parsed), json!([42, true, 114.514]));
+    }
+
+    #[test]
+    fn gemma4_parser_rejects_excessive_recursion_and_recovers_input() {
+        let depth = MAX_PARSER_RECURSION_DEPTH * 2;
+        let nested_value = format!("{}0{}", "[".repeat(depth), "]".repeat(depth));
+        let input = format!("<|tool_call>call:set{{value:{nested_value}}}<tool_call|>");
+        let mut parser = test_parser();
+
+        let error = parser.parse_chunk(&input).unwrap_err();
+        assert!(error.to_report_string().contains("parser recursion limit exceeded"));
+        assert_eq!(parser.reset(), input);
     }
 
     #[test]

--- a/rust/src/parser/src/utils.rs
+++ b/rust/src/parser/src/utils.rs
@@ -9,6 +9,8 @@ use winnow::stream::{FindSlice, Offset, Partial, Stream};
 
 use crate::tool::{Result, ToolParserError};
 
+pub(crate) mod recursion;
+
 /// Return the byte length of the longest proper prefix of `token` that is also
 /// a suffix of `buffer`.
 ///

--- a/rust/src/parser/src/utils/recursion.rs
+++ b/rust/src/parser/src/utils/recursion.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+//! Recursion-depth tracking for synchronous parsers.
+
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use winnow::error::{ContextError, ErrMode, ModalResult, StrContext};
+
+/// Maximum number of recursive parser frames active on one thread.
+pub(crate) const MAX_PARSER_RECURSION_DEPTH: usize = 128;
+
+thread_local! {
+    static PARSER_RECURSION_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Bounds recursive parser calls on the current thread.
+///
+/// Keep the guard alive for the duration of one recursive parser frame. Its
+/// thread-local depth is restored on return, parse errors, and unwinding.
+pub(crate) struct ParserRecursionGuard {
+    previous_depth: usize,
+    // Dropping on another thread would restore the wrong TLS counter.
+    _not_send: PhantomData<Rc<()>>,
+}
+
+impl ParserRecursionGuard {
+    /// Enters one recursive parser frame.
+    ///
+    /// Returns a cut error when the current thread has reached the recursion
+    /// limit. The returned guard must stay alive for the full recursive call;
+    /// dropping it restores the preceding depth.
+    pub(crate) fn enter() -> ModalResult<Self> {
+        PARSER_RECURSION_DEPTH.with(|depth| {
+            let previous_depth = depth.get();
+            if previous_depth >= MAX_PARSER_RECURSION_DEPTH {
+                let mut error = ContextError::new();
+                error.push(StrContext::Label("parser recursion limit exceeded"));
+                return Err(ErrMode::Cut(error));
+            }
+
+            depth.set(previous_depth + 1);
+            Ok(Self {
+                previous_depth,
+                _not_send: PhantomData,
+            })
+        })
+    }
+}
+
+impl Drop for ParserRecursionGuard {
+    fn drop(&mut self) {
+        PARSER_RECURSION_DEPTH.with(|depth| depth.set(self.previous_depth));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use winnow::error::ErrMode;
+
+    use super::{MAX_PARSER_RECURSION_DEPTH, ParserRecursionGuard};
+
+    fn enter_recursively(depth: usize) -> winnow::error::ModalResult<()> {
+        if depth == 0 {
+            return Ok(());
+        }
+
+        let _guard = ParserRecursionGuard::enter()?;
+        enter_recursively(depth - 1)
+    }
+
+    #[test]
+    fn enforces_limit_and_restores_depth() {
+        assert!(enter_recursively(MAX_PARSER_RECURSION_DEPTH).is_ok());
+        assert!(matches!(
+            enter_recursively(MAX_PARSER_RECURSION_DEPTH + 1),
+            Err(ErrMode::Cut(_))
+        ));
+        assert!(enter_recursively(MAX_PARSER_RECURSION_DEPTH).is_ok());
+    }
+
+    #[test]
+    fn restores_depth_after_unwind() {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = ParserRecursionGuard::enter().unwrap();
+            panic!("test unwind");
+        }));
+
+        assert!(result.is_err());
+        assert!(enter_recursively(MAX_PARSER_RECURSION_DEPTH).is_ok());
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes #50927.

Gemma4 argument parsing and MiniMax M3 parameter parsing contain hand-written recursive grammars. Deeply nested model output can exhaust a worker thread stack and terminate the process.

This change adds a shared thread-local RAII guard with a maximum of 128 active recursive parser frames. Gemma4 enters the guard after recognizing an object or array opener, and MiniMax M3 enters it after recognizing an element opener. The guard returns a cut error at the limit and restores the previous depth on normal return, parse errors, and unwinding. Its thread-bound marker keeps increment and restoration on the same thread.

The parser audit found these as the two hand-written recursive model-output parsing paths in the Rust parser crate. JSON parsing continues to use serde_json's built-in recursion limit.

Related: #50944.

## Test Plan

- cargo test -p vllm-parser
- cargo clippy -p vllm-parser --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Test Result

- 426 parser tests passed.
- Clippy completed with warnings denied.
- Formatting and diff checks passed.
