### PR TITLE
[Bugfix] Set _enable_mm_lora on DiffusionGemma to fix image-input engine crash

### DIFF
--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -186,6 +186,16 @@ class DiffusionGemmaForConditionalGeneration(
         self.config = config
         self.model_dtype = vllm_config.model_config.dtype
 
+        # _process_image_input is borrowed from Gemma4ForConditionalGeneration
+        # (see the class-attribute assignments below) and reads
+        # self._enable_mm_lora, which Gemma4 sets in its own __init__. Mirror
+        # that assignment here; without it, any request with an image raises
+        # AttributeError and takes down the whole engine core.
+        lora_config = vllm_config.lora_config
+        self._enable_mm_lora = bool(
+            lora_config is not None and lora_config.enable_tower_connector_lora
+        )
+
         # DiffusionGemma's full-attention layers have NO v_proj — V is
         # computed from k_proj's output (`value_states = key_states` before
         # k_norm in `DiffusionGemmaDecoderTextAttention.forward`). This is


### PR DESCRIPTION
## Purpose

Since v0.28.0, sending **any image** to a served DiffusionGemma model fatally crashes the EngineCore (all in-flight requests die); text-only requests are unaffected.

`DiffusionGemmaForConditionalGeneration` borrows the Gemma4 multimodal methods as unbound class attributes:

```python
_process_image_input = Gemma4ForConditionalGeneration._process_image_input
embed_multimodal = Gemma4ForConditionalGeneration.embed_multimodal
```

but #42662 ([LoRA][Gemma4] Support vision tower LoRA) made `_process_image_input` read `self._enable_mm_lora`, which is set only in `Gemma4ForConditionalGeneration.__init__`. DiffusionGemma never sets it, so the first image request raises

```
AttributeError: 'DiffusionGemmaForConditionalGeneration' object has no attribute '_enable_mm_lora'
```

inside `_execute_mm_encoder` and takes the engine down. v0.27.1 and earlier are unaffected (the attribute did not exist).

This PR mirrors Gemma4's assignment in DiffusionGemma's `__init__`. With tower/connector LoRA off it evaluates to `False`, which follows the exact pre-#42662 memory-chunked encoder path.

## Test Plan

Reproduced and verified on an A100 (sm_80) with `nvidia/diffusiongemma-26B-A4B-it-NVFP4` on v0.28.0:

```
vllm serve nvidia/diffusiongemma-26B-A4B-it-NVFP4 \
  --max-model-len 65536 --attention-backend triton_attn
# then POST /v1/chat/completions with an image_url content part
```

## Test Result

- Before: the request above raises the AttributeError, EngineCore dies, every subsequent request fails.
- After (this patch applied to the same install): the image is answered correctly, and a follow-up text battery (5/5 GSM-style questions) passes on the same still-alive engine.
