### PR TITLE
[Test] Assert co-located RayExecutorV2 stores publish distinct ports

### DIFF
--- a/tests/distributed/test_ray_v2_executor.py
+++ b/tests/distributed/test_ray_v2_executor.py
@@ -107,19 +107,28 @@ def assert_executor(executor, tp_size, pp_size):
         assert handle.node_id is not None
 
 
-def test_dist_init_store_owns_port(monkeypatch):
-    """The rank-0 actor keeps the selected TCPStore port bound."""
+def _detached_rank0_worker() -> ray_executor_v2.RayWorkerProc:
+    """A RayWorkerProc that can create its dist-init store without Ray."""
     worker = ray_executor_v2.RayWorkerProc.__new__(ray_executor_v2.RayWorkerProc)
     worker._parallel_config = SimpleNamespace(world_size=1)
+    return worker
+
+
+def _assert_port_held(port: int):
+    with socket.socket() as contender, pytest.raises(OSError) as exc_info:
+        contender.bind(("127.0.0.1", port))
+    assert exc_info.value.errno == errno.EADDRINUSE
+
+
+def test_dist_init_store_owns_port(monkeypatch):
+    """The rank-0 actor keeps the selected TCPStore port bound."""
     monkeypatch.setattr(ray.util, "get_node_ip_address", lambda: "127.0.0.1")
+    worker = _detached_rank0_worker()
 
     init_method = worker.create_dist_init_method()
     port = urlsplit(init_method).port
     assert port is not None and port != 0
-
-    with socket.socket() as contender, pytest.raises(OSError) as exc_info:
-        contender.bind(("127.0.0.1", port))
-    assert exc_info.value.errno == errno.EADDRINUSE
+    _assert_port_held(port)
 
     reused_store = TCPStore(
         "127.0.0.1",
@@ -131,6 +140,23 @@ def test_dist_init_store_owns_port(monkeypatch):
     )
     worker._dist_init_store.set("key", "value")
     assert reused_store.get("key") == b"value"
+
+
+def test_colocated_dist_init_stores_hold_distinct_ports(monkeypatch):
+    """Replicas sharing a host must never publish the same TCPStore port.
+
+    Each rank-0 store binds a kernel-assigned ephemeral port and keeps it
+    for the actor's lifetime, so concurrently live replicas cannot collide.
+    """
+    monkeypatch.setattr(ray.util, "get_node_ip_address", lambda: "127.0.0.1")
+    workers = [_detached_rank0_worker() for _ in range(3)]
+
+    ports = [urlsplit(w.create_dist_init_method()).port for w in workers]
+    assert len(set(ports)) == len(workers)
+    for worker, port in zip(workers, ports):
+        assert port == worker._dist_init_store.port
+        assert port >= 1024
+        _assert_port_held(port)
 
 
 @pytest.mark.parametrize("tp_size, pp_size", [(1, 1), (2, 1), (4, 1), (2, 2)])


### PR DESCRIPTION
## Purpose

Follow-up requested by @AndreasKaratzas when merging #50969 (https://github.com/vllm-project/vllm/pull/50969#issuecomment-5457958170): that PR removed `test_colocated_tcpstore_ports_differ` together with the `_select_tcpstore_port` formula it patched, but the invariant that test guarded is externally meaningful and should keep coverage on the new path.

Invariant: replicas sharing a host must never publish the same rank-0 TCPStore port. With `create_dist_init_method()` each rank-0 actor binds a kernel-assigned ephemeral port and holds the store for its lifetime, so concurrently live replicas cannot collide.

## Changes

`tests/distributed/test_ray_v2_executor.py`:

- Add `test_colocated_dist_init_stores_hold_distinct_ports`: three detached rank-0 `RayWorkerProc`s call `create_dist_init_method()`; asserts the published ports are pairwise distinct, each equals the port its own store actually bound, none is a privileged port, and all are still held (a contender `bind` gets `EADDRINUSE`) while the replicas are alive.
- Factor the detached-worker construction and the held-port check into `_detached_rank0_worker()` / `_assert_port_held()` shared with the existing `test_dist_init_store_owns_port`; that test's assertions are unchanged.

Effectiveness check: pinning `TCPStore(port=...)` to a fixed value makes the new test fail with `len({29517}) == 1 != 3` — torch's `multi_tenant` store silently reuses the in-process server, so a regression to a fixed or derived port would publish one port for every replica, which is exactly the collision the original regression test was written for.

## Test Plan

Run inside the `vllm/vllm-openai` nightly image (2026-08-20, aarch64/GB200):

```bash
pytest tests/distributed/test_ray_v2_executor.py -k dist_init_store -v
```

## Test Result

- `test_dist_init_store_owns_port` PASSED, `test_colocated_dist_init_stores_hold_distinct_ports` PASSED (2 passed in 13.6s).
- Mutation run with the store pinned to a fixed port: the new test FAILED as intended.
- Full file `pytest tests/distributed/test_ray_v2_executor.py -v` on 4 GPUs in the same image: 23 passed in 9m34s.
- `pre-commit run --files tests/distributed/test_ray_v2_executor.py`: all hooks passed.

## Notes

- Not a duplicate: no open PR touches this test file or the colocated-port coverage (`gh pr list --search "colocated tcpstore"` / `"50969 in:body"`).
- AI assistance (Claude Code) was used; the change was reviewed line by line and the tests above were run by the submitter.
