### PR TITLE
[CI][Test] Deflake test_mem.py sleep-mode asserts via allocator bookeeping

### DIFF
--- a/tests/basic_correctness/test_mem.py
+++ b/tests/basic_correctness/test_mem.py
@@ -18,6 +18,21 @@ from ..utils import create_new_process_for_each_test, requires_fp8
 DEVICE_TYPE = current_platform.device_type
 
 
+def mapped_usage(allocator) -> int:
+    """Bytes the allocator still has mapped on the device.
+
+    `torch.accelerator.get_memory_info()` is a device-wide `cudaMemGetInfo` /
+    `hipMemGetInfo` query, so its delta also carries whatever else on the GPU
+    allocates or frees while we measure. The allocator's own bookkeeping is
+    process-local and exact.
+    """
+    return sum(
+        data.handle[1]
+        for data in allocator.pointer_to_data.values()
+        if not data.is_asleep
+    )
+
+
 def _wake_up_with_poisoned_mappings(allocator, byte_value: int = 0xA5) -> None:
     """Wake discarded allocations with deterministic nonzero contents."""
     original_create_and_map = cumem.create_and_map
@@ -82,11 +97,13 @@ def test_basic_cumem():
     output = x + y + z
     assert torch.allclose(output, torch.ones_like(output) * 3)
 
-    free_bytes = torch.accelerator.get_memory_info()[0]
+    # Track the allocator's own mapped bytes, not device-wide free memory.
+    mapped_bytes = mapped_usage(allocator)
+    assert mapped_bytes >= y.nbytes + z.nbytes
     allocator.sleep()
-    free_bytes_after_sleep = torch.accelerator.get_memory_info()[0]
-    assert free_bytes_after_sleep > free_bytes
+    assert mapped_usage(allocator) == 0
     allocator.wake_up()
+    assert mapped_usage(allocator) == mapped_bytes
 
     # they can be used together
     output = x + y + z
@@ -105,13 +122,14 @@ def test_discard_tags():
     with allocator.use_memory_pool("kv_cache"):
         kv = torch.ones(512, 512, device=DEVICE_TYPE)
 
-    free_bytes = torch.accelerator.get_memory_info()[0]
+    mapped_bytes = mapped_usage(allocator)
 
     # Discard kv_cache only — weights should remain valid
     allocator.discard("kv_cache")
 
-    free_bytes_after_discard = torch.accelerator.get_memory_info()[0]
-    assert free_bytes_after_discard > free_bytes
+    mapped_bytes_after_discard = mapped_usage(allocator)
+    assert mapped_bytes - mapped_bytes_after_discard >= kv.nbytes
+    assert mapped_bytes_after_discard >= weights.nbytes
 
     # Weights are still usable
     assert torch.allclose(weights, torch.ones_like(weights))
@@ -172,11 +190,12 @@ def test_cumem_with_cudagraph():
     with torch.cuda.graph(model_graph):
         y = model(x)
 
-    free_bytes = torch.accelerator.get_memory_info()[0]
+    mapped_bytes = mapped_usage(allocator)
+    assert mapped_bytes >= weight.nbytes + cache.nbytes
     allocator.sleep()
-    free_bytes_after_sleep = torch.accelerator.get_memory_info()[0]
-    assert free_bytes_after_sleep > free_bytes
+    assert mapped_usage(allocator) == 0
     allocator.wake_up()
+    assert mapped_usage(allocator) == mapped_bytes
 
     # after waking up, the content in the weight tensor
     # should be restored, but the content in the cache tensor


### PR DESCRIPTION
## Purpose

Three tests in `tests/basic_correctness/test_mem.py` — `test_basic_cumem`,
`test_discard_tags` and `test_cumem_with_cudagraph` — check that `sleep()` /
`discard()` released memory by asserting a strict increase in **device-wide**
free memory:

```python
# tests/basic_correctness/test_mem.py, pre-patch
free_bytes = torch.accelerator.get_memory_info()[0]
allocator.sleep()
free_bytes_after_sleep = torch.accelerator.get_memory_info()[0]
assert free_bytes_after_sleep > free_bytes
```

### Why that is the wrong instrument

`torch.accelerator.get_memory_info()` is not a query about this process. Its
docstring says the free value is what is *"available across all processes and
applications"*, and reading the headers shipped in the test image it resolves to
a plain `cudaMemGetInfo` / `hipMemGetInfo`: `at::accelerator::getMemoryInfo`
calls `at::getDeviceAllocator(device_type)->getMemoryInfo(device_index)`, and
the CUDA caching allocator's override (hipified for ROCm) forwards straight to
the driver query. The default `c10::DeviceAllocator::getMemoryInfo` in
`c10/core/CachingDeviceAllocator.h` is a `TORCH_CHECK_NOT_IMPLEMENTED(false,
...)`, so on this build there is no process-scoped variant in play. The delta
between two samples therefore carries whatever anything else on the GPU
allocated or freed in between, not just what `sleep()` unmapped.

The signal being asserted is tiny next to that. `test_basic_cumem` sleeps two
1024x1024 fp32 tensors — 8 MiB of user data, which the allocator reports as
`sleep freed 0.02 GiB`. `test_discard_tags` discards a single 512x512 fp32
tensor, 1 MiB. On a 192 GiB card, a co-tenant that **allocates** a few tens of
MiB inside the two-sample window makes `free_bytes_after_sleep` the smaller of
the two and trips the assertion — with a bare `AssertionError` carrying no
numbers. Nothing is wrong with the allocator when that happens.

Observed in AMD CI on 2026-08-26, on PR #52707 (unrelated, since merged) at head
`c09892e4f2c3`, MI300X:

```
File "/vllm-workspace/tests/basic_correctness/test_mem.py", line 70, in test_basic_cumem
  assert free_bytes_after_sleep > free_bytes
AssertionError
```

What process perturbed that device was never identified, and this PR does not
depend on identifying it: the assertion is sensitive to any of them.

### Fix

Ask the allocator what it has mapped instead of asking the driver what the
device has free. `CuMemAllocator` already tracks every handle it created in
`pointer_to_data` and already flips `data.is_asleep` in `sleep()`, `discard()`
and `wake_up()`. This PR adds a module-level helper in the test file that sums
the still-mapped handles:

```python
def mapped_usage(allocator) -> int:
    return sum(
        data.handle[1]
        for data in allocator.pointer_to_data.values()
        if not data.is_asleep
    )
```

The change is **entirely inside `tests/`** — one file, no production code. The
helper works for `XpuMemAllocator` as well without a second implementation:
`AllocationData` is a shared dataclass in `vllm/device_allocator/__init__.py`
(`handle`, `tag`, `cpu_backup_tensor`, `is_asleep`) and both allocators store it
in `pointer_to_data`, with `handle[1]` the allocation's size as the allocator
tracks it (`py_size_or_aligned_size` in the shared `HandleType`, i.e. rounded up
to allocation granularity). That rounding is why the cross-checks against
`nbytes` below are `>=` rather than `==`; the sleep/wake comparisons are between
two readings of the same quantity and so are exact.

Because the new reading is process-local and exact, the two sleep/wake tests can
assert exact values:

```python
mapped_bytes = mapped_usage(allocator)
assert mapped_bytes >= y.nbytes + z.nbytes   # not vacuous on an empty pool
allocator.sleep()
assert mapped_usage(allocator) == 0
allocator.wake_up()
assert mapped_usage(allocator) == mapped_bytes
```

`test_discard_tags` gets a two-sided bound instead — at least `kv.nbytes`
released, and at least `weights.nbytes` still mapped afterwards:

```python
assert mapped_bytes - mapped_bytes_after_discard >= kv.nbytes
assert mapped_bytes_after_discard >= weights.nbytes
```

The lower bound taken before `sleep()` is deliberate: `== 0` on its own would
pass on a pool that never held anything.

## Test Plan

Two things to establish: the patched tests still pass on a quiet GPU, and an A/B
under an induced co-tenant separates the two arms.

**Host.** `smci355-ccs-aus-n08-17`, 8x MI355X (288 GiB/GPU), otherwise idle.
`HIP_VISIBLE_DEVICES=0` for both arms, so the test and the co-tenant share one
device.

**Image.** `vllm/vllm-openai-rocm:nightly-f94666b60d4c58ec0807d22c837cfae322a1dde9`
with this branch's Python source overlaid onto the image's compiled `.so` files.
That nightly is 219 commits behind `origin/main`; only the Python tree under
test was replaced, so this is not a clean build of the branch.

**Co-tenant.** A separate Python process on the same device, driven by a script
on the test node (`/home/okorzh/testmem/coten.sh`), cycling: allocate 128 MiB,
sleep 50 ms, x64, then free everything and repeat. In essence:

```python
# reproduction of the co-tenant; the runner script wraps this
import torch, time
while True:
    bufs = []
    for _ in range(64):
        bufs.append(torch.empty(128 << 20, dtype=torch.uint8, device="cuda"))
        time.sleep(0.05)
    del bufs
```

Note this ramps to ~8 GiB resident before freeing, i.e. a harsher perturbation
than the tens of MiB the argument needs; the failing phase is the allocating
one. The logs record it only as `neighbour pid <n> running on GPU0`.

**Invocation**, looped per run:

```bash
pytest -q -l tests/basic_correctness/test_mem.py::test_basic_cumem
```

with the patch reversed to pristine `main` for the control arm. Traceback
verbosity was not uniform across the control sessions and no log records the
command line, which is why only one control session's failures carry the inner
assertion (see Test Result).

**Arms:**

| Arm | Tree | Co-tenant | Runs |
|---|---|---|---|
| control | pristine `main` (patch reversed) | yes | `test_basic_cumem` x18, four sessions |
| patched | this branch | yes | `test_basic_cumem` x10 |
| full suite | this branch | no | `tests/basic_correctness/test_mem.py`, all 13 |

The patched and full-suite arms were re-run on this commit after the production
part was reverted; the numbers below are from those re-runs, not from the
earlier four-file variant (which was also tested, under the same procedure). The
control arm is pristine `main` and is unaffected by which version of the fix is
being tested, so those sessions were not repeated.

Plus `ruff check` and `ruff format` with ruff 0.14.0, the rev pinned in
`.pre-commit-config.yaml`.

## Test Result

### A/B under the co-tenant

| Arm | Runs | Passed | Failed |
|---|---|---|---|
| control (pristine `main`) | 18 | 5 | **13** |
| **patched (this PR)** | 10 | **10** | **0** |

Control, four sessions: 8/10 failed, 2/2 failed, 0/1 failed, 3/5 failed.
Control is not 100% failure — the outcome depends on where the co-tenant happens
to be in its allocate/free cycle when the two samples are taken. That is the
flake; the aggregate, not any single session, is the measurement.

Of the 13 control failures, 3 — all in the 5-run session — have a traceback that
reaches the assertion, and it is the same one as the CI failure:

```
File "/work/tests/basic_correctness/test_mem.py", line 88, in test_basic_cumem
  assert free_bytes_after_sleep > free_bytes
AssertionError
```

(Line 88 in the tree under test; the CI job ran an older revision of the file
where the same statement is at line 70.) The other sessions record only the
wrapper failure (`RuntimeError: Test subprocess 'test_basic_cumem' failed (exit
code 1)`) or, in one session, a truncated traceback that stops inside the
subprocess wrapper and never reaches the assertion. So the inner cause is
confirmed on 3 of 13; the remaining 10 are the same test failing under the same
conditions, not independently attributed.

On those same three failing runs the allocator reports that it did its job:

```
INFO [cumem.py:278] CuMemAllocator: sleep freed 0.02 GiB memory in total,
of which 0.02 GiB is backed up in CPU and the rest 0.00 GiB is discarded directly.
```

That line is the diagnosis in one place: 0.02 GiB really was released, and the
device-wide reading still went the other way.

### Full file, patched, idle GPU

```
13 passed, 14 warnings in 515.56s (0:08:35)
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

