### PR TITLE
[Frontend] Forward cache salt for content parts

### DIFF
--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -157,6 +157,8 @@ class ServingTokens(GenerateBaseServing):
                     mm_parser.parse_video(url, uuid)
             mm_data, mm_uuids = await tracker.resolve_items()
             prompt = TokensPrompt(prompt_token_ids=request.token_ids)
+            if request.cache_salt is not None:
+                prompt["cache_salt"] = request.cache_salt
             if mm_data:
                 prompt["multi_modal_data"] = mm_data
             if mm_uuids:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`/inference/v1/generate` accepts a top-level `cache_salt`, but the `content_parts` path rebuilds a `TokensPrompt` without copying it. As a result, otherwise-correct callers can reuse prefix-cache blocks created under a different model version.

Forward the non-null request salt into the `TokensPrompt`, matching the endpoint's text and preprocessed-feature paths.

This does not duplicate an existing change. I reviewed the merged content-parts PR #51478 and searched open PRs for `cache_salt content_parts`, `cache salt content parts`, and `TokensPrompt cache_salt`; none address this path.

OpenAI Codex assisted with the code and PR preparation. This is a draft pending the submitter's line-by-line review.

## Test Plan

Run the existing token-generation serving tests and all staged pre-commit hooks. No tests are changed by this PR.

Model evaluation is not applicable: this does not change model computation or sampling behavior; it preserves an existing cache-key input while constructing the engine prompt.

## Test Result

- `VLLM_TARGET_DEVICE=cpu uv run --no-sync python -m pytest tests/entrypoints/scale_out/token_in_token_out/test_generate_stream.py -q` — 12 passed
- `uv run --no-sync pre-commit run` — all hooks passed, including Ruff and mypy

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**
