### PR TITLE
[Bugfix][Quantization] Decline CUTLASS int8 w8a8 on SM100+ so Triton fallback is reachable

### DIFF
--- a/tests/model_executor/kernels/test_cutlass_int8_sm_gate.py
+++ b/tests/model_executor/kernels/test_cutlass_int8_sm_gate.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Device-free capability gate for the CUTLASS int8 w8a8 kernel (#54311).
+
+CUTLASS int8 is only wired for SM < 100; the SM100/SM120 dispatchers pass a
+nullptr int8 func and the C++ hard-errors. ``is_supported`` must decline on
+SM100+ so kernel selection can reach the Triton int8 fallback. These assert the
+gate directly by mocking the platform predicate, no GPU needed.
+"""
+
+import pytest
+
+import vllm.model_executor.kernels.linear.scaled_mm.cutlass as cutlass_mod
+from vllm.model_executor.kernels.linear.scaled_mm.cutlass import (
+    CutlassInt8ScaledMMLinearKernel,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_cuda(monkeypatch):
+    # The first check is is_cuda(); force it True so the compute-capability
+    # gate is the only thing under test (CI runners are CPU-only).
+    monkeypatch.setattr(cutlass_mod.current_platform, "is_cuda", lambda: True)
+
+
+@pytest.mark.parametrize("cc", [121, 120, 100])
+def test_cutlass_int8_declines_on_sm100_plus(cc):
+    # sm_100 (B200), sm_120 (RTX 5090), sm_121 (GB10 / DGX Spark).
+    supported, reason = CutlassInt8ScaledMMLinearKernel.is_supported(cc)
+    assert supported is False
+    assert reason is not None
+
+
+@pytest.mark.parametrize("cc", [90, 89, 80, 75])
+def test_cutlass_int8_supported_below_sm100(cc):
+    supported, reason = CutlassInt8ScaledMMLinearKernel.is_supported(cc)
+    assert supported is True
+    assert reason is None
+
+
+def test_cutlass_int8_supported_when_capability_unknown():
+    # compute_capability=None must not spuriously decline (back-compat).
+    supported, _ = CutlassInt8ScaledMMLinearKernel.is_supported(None)
+    assert supported is True

--- a/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/cutlass.py
@@ -37,6 +37,16 @@ class CutlassInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
     ) -> tuple[bool, str | None]:
         if not current_platform.is_cuda():
             return False, "requires CUDA."
+        # CUTLASS int8 w8a8 is only wired for SM < 100; the SM100/SM120
+        # dispatchers pass a nullptr int8 func and the C++ hard-errors
+        # ("Int8 not supported on SM<n>"). Decline so kernel selection can fall
+        # back to the Triton int8 kernel on Blackwell. See #54311.
+        if compute_capability is not None and compute_capability >= 100:
+            return (
+                False,
+                "CUTLASS int8 w8a8 is not supported on SM100+ (Blackwell); "
+                "use the Triton int8 kernel.",
+            )
         return True, None
 
     @classmethod


### PR DESCRIPTION
## Purpose

Fixes #54311. `CutlassInt8ScaledMMLinearKernel.is_supported()` takes `compute_capability` but ignores it and always returns `True` on CUDA. So CUTLASS claims every int8 w8a8 layer — but the SM100/SM120 dispatchers wire the int8 func as `nullptr` (`scaled_mm_c3x_sm120.cu`: `nullptr, // int8 not supported on SM120`, same on `sm100`), so the C++ hard-errors at runtime:

```
Int8 not supported on SM121. Use FP8 quantization instead, or run on older arch (SM < 100).
```

The working `TritonInt8ScaledMMLinearKernel` — next in `_POSSIBLE_INT8_KERNELS[CUDA]` — never gets a chance.

## Fix

Decline in `is_supported()` when `compute_capability >= 100` (SM100/SM120/SM121 Blackwell; CUTLASS int8 is only wired for SM < 100), mirroring the sibling `AiterInt8ScaledMMLinearKernel`'s capability guard. Kernel selection then falls through to `TritonInt8`, which overrides `is_supported()` and supports these arches. FP8 is unaffected (SM120 wires the fp8 func).

## Verified on a GB10 (sm_121)

```
CutlassInt8ScaledMMLinearKernel.is_supported(121)
  -> (False, 'CUTLASS int8 w8a8 is not supported on SM100+ (Blackwell); use the Triton int8 kernel.')
TritonInt8ScaledMMLinearKernel.is_supported(121) -> (True, None)
_POSSIBLE_INT8_KERNELS[CUDA] == [Cutlass, Triton, Humming]  # Triton now reachable
```

## Tests

Device-free (`tests/model_executor/kernels/test_cutlass_int8_sm_gate.py`): declines on SM100/120/121, stays supported on SM90/89/80/75, and `compute_capability=None` stays supported (back-compat).
