### PR TITLE
[Bugfix][Frontend] Treat an explicit null tool_choice as an absent one

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_tool_choice_null.py
+++ b/tests/entrypoints/openai/chat_completion/test_tool_choice_null.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""An explicit `"tool_choice": null` has to mean the same as an absent key.
+
+Clients that serialise their unset optional fields still send the key, and the
+OpenAI API treats a null the same as an omission: `auto` when tools are present.
+Left as a None it matches no branch downstream, so tool calls are never parsed
+and a structured-outputs request is rejected as if it had asked for tools.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+
+MESSAGES = [{"role": "user", "content": "what is the weather in Paris?"}]
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def test_null_tool_choice_defaults_to_auto_like_an_absent_one():
+    omitted = ChatCompletionRequest.model_validate(
+        {"model": "m", "messages": MESSAGES, "tools": TOOLS}
+    )
+    explicit_null = ChatCompletionRequest.model_validate(
+        {"model": "m", "messages": MESSAGES, "tools": TOOLS, "tool_choice": None}
+    )
+
+    assert omitted.tool_choice == "auto"
+    assert explicit_null.tool_choice == omitted.tool_choice
+
+
+def test_null_tool_choice_without_tools_matches_an_absent_one():
+    omitted = ChatCompletionRequest.model_validate({"model": "m", "messages": MESSAGES})
+    explicit_null = ChatCompletionRequest.model_validate(
+        {"model": "m", "messages": MESSAGES, "tool_choice": None}
+    )
+
+    assert explicit_null.tool_choice == omitted.tool_choice
+
+
+def test_null_tool_choice_does_not_conflict_with_structured_outputs():
+    """The conflict check reads `tool_choice`, so a null was taken for a tool
+    request and the caller was told it had asked for both."""
+    request = ChatCompletionRequest.model_validate(
+        {
+            "model": "m",
+            "messages": MESSAGES,
+            "structured_outputs": {"json": {"type": "object"}},
+            "tool_choice": None,
+        }
+    )
+
+    assert request.structured_outputs is not None
+
+
+@pytest.mark.parametrize(
+    "tool_choice,tools",
+    [
+        ("bogus", TOOLS),
+        ("auto", None),
+    ],
+)
+def test_invalid_tool_choice_is_still_rejected(tool_choice, tools):
+    payload = {"model": "m", "messages": MESSAGES, "tool_choice": tool_choice}
+    if tools is not None:
+        payload["tools"] = tools
+
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest.model_validate(payload)
+
+
+def test_explicit_none_tool_choice_is_untouched():
+    request = ChatCompletionRequest.model_validate(
+        {"model": "m", "messages": MESSAGES, "tools": TOOLS, "tool_choice": "none"}
+    )
+
+    assert request.tool_choice == "none"

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -912,6 +912,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 parameter="tools",
             )
 
+        # An explicit null means the field was not specified: clients that
+        # serialise their unset optional fields still send the key. Drop it so
+        # everything below, and the later validators that read it, see what an
+        # absent key gives them rather than a None that matches no branch.
+        if data.get("tool_choice") is None:
+            data.pop("tool_choice", None)
+
         # if "tool_choice" is not specified but tools are provided,
         # default to "auto" tool_choice
         if "tool_choice" not in data and data.get("tools"):


### PR DESCRIPTION
## Purpose

`"tool_choice": null` is not treated the same as an omitted `tool_choice`, and the difference is silent.

`check_tool_usage` applies the OpenAI default only on an absent key:

```python
if "tool_choice" not in data and data.get("tools"):
    data["tool_choice"] = "auto"
```

A client that serialises its unset optional fields sends the key anyway, so the value stays `None`. #19679 made that `None` skip the rest of validation (fixing a 500), but left it in the payload, and nothing further ever normalises it.

**Tools are then never parsed out of the reply.** In `chat_completion/serving.py` the branch chain reads:

```python
elif not request.tool_choice or request.tool_choice == "none":
    message = ...                       # content only, no tool_calls
elif (request.tools
      and (request.tool_choice == "auto" or request.tool_choice is None)
      and self.enable_auto_tools and tool_parser_cls):
    ...                                 # runs the tool parser
```

`not None` is true, so the first arm wins and the `request.tool_choice is None` in the second is unreachable. The request carries tools, the model emits a tool call, and the caller gets it back as plain assistant content.

**A structured-outputs request is also rejected.** `check_structured_outputs_count` reads `data.get("tool_choice", "none")`, which returns `None` when the key is present, so this is refused today:

```json
{"model": "m", "messages": [...], "structured_outputs": {"json": {...}}, "tool_choice": null}
```

```
You can only either use constraints for structured outputs or tools, not both.
```

There are no tools in that request at all. (`mode="before"` model validators run last-defined-first, so `check_tool_usage` sees the payload before this one does, which is why fixing it there fixes this too.)

## Fix

Drop the key when it is None, which is what #19679's title described:

```python
if data.get("tool_choice") is None:
    data.pop("tool_choice", None)
```

Everything after it, in this validator and in the ones that run later, then sees exactly what an absent key gives, and the field's declared default applies when there are no tools.

Behaviour of the two validators, before and after, on the same payloads:

| payload | before | after |
|---|---|---|
| tools, `tool_choice` omitted | `auto` | `auto` |
| tools, `tool_choice: null` | `None` | `auto` |
| tools, `tool_choice: "auto"` | `auto` | `auto` |
| tools, `tool_choice: "none"` | `none` | `none` |
| no tools, `tool_choice` omitted | absent | absent |
| no tools, `tool_choice: null` | `None` | absent |
| `structured_outputs`, `tool_choice` omitted | absent | absent |
| `structured_outputs`, `tool_choice: null` | **400** | absent |
| `structured_outputs` + tools, `tool_choice: null` | **400** | `auto` |
| `structured_outputs` + tools, `tool_choice: "required"` | `required` | `required` |
| `structured_outputs` + tools, named `tool_choice` | 400 | 400 |
| tools, `tool_choice: "bogus"` | 400 | 400 |
| no tools, `tool_choice: "auto"` | 400 | 400 |

Only the null rows move, and each moves onto the row for the same payload with the key omitted.

## Test

`tests/entrypoints/openai/chat_completion/test_tool_choice_null.py`, six cases: the null defaults to `auto` with tools and matches the absent key without them, a null alongside `structured_outputs` is accepted, `"none"` is untouched, and an invalid `tool_choice` and an `auto` without tools are both still rejected.

This machine has no vLLM build, so the two validators were exercised straight out of `protocol.py` against `pydantic` 2.12.5, with the test bodies run verbatim against a stand-in that applies them in the order pydantic does and holds the field's declared default.

Before:

```
FAIL test_null_tool_choice_defaults_to_auto_like_an_absent_one -> AssertionError
FAIL test_null_tool_choice_without_tools_matches_an_absent_one -> AssertionError
FAIL test_null_tool_choice_does_not_conflict_with_structured_outputs -> You can only either use constraints for structured outputs or tools, not both.
PASS test_invalid_tool_choice_is_still_rejected[bogus]
PASS test_invalid_tool_choice_is_still_rejected[auto]
PASS test_explicit_none_tool_choice_is_untouched
```

After: all six pass. `ruff check` and `ruff format --diff` are clean on both files. CI runs the file for real.

## Notes

- Not a duplicate: no open PR touches `check_tool_usage` for this, and the two related merged PRs are adjacent rather than overlapping. #19679 stopped the 500 by skipping validation on a null; #42752 handled `tool_choice: "none"` in streaming. Neither normalises the null.
- AI assistance was used in preparing this change.


---

Opened as a draft because this account cannot create a non-draft pull request on this repository; `draft: false` is refused. Ready for review as it stands, and I cannot mark it so myself.
