### PR TITLE
[CI] Add explicit step keys to 18 hardware test steps

### DIFF
--- a/.buildkite/hardware_tests/ascend_npu.yaml
+++ b/.buildkite/hardware_tests/ascend_npu.yaml
@@ -2,6 +2,7 @@ group: Hardware
 depends_on: ~
 steps:
   - label: "Ascend NPU Test"
+    key: ascend-npu-test
     soft_fail: true
     timeout_in_minutes: 20
     no_plugin: true

--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -2,6 +2,7 @@ group: CPU
 depends_on: []
 steps:
 - label: CPU-Kernel Tests
+  key: cpu-kernel-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -59,6 +60,7 @@ steps:
 #       bash .buildkite/scripts/hardware_ci/run-cpu-compatibility-test.sh"
 
 - label: CPU-Language Generation and Pooling Model Tests
+  key: cpu-language-generation-and-pooling-model-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -76,6 +78,7 @@ steps:
       pytest -x -v -s tests/v1/e2e/test_cpu_linear_attn_chunked_prefix.py"
 
 - label: CPU-Quantization Model Tests
+  key: cpu-quantization-model-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -97,6 +100,7 @@ steps:
       pytest -x -v -s tests/quantization/test_cpu_w8a8.py"
       
 - label: CPU-Distributed Tests (PP+TP)
+  key: cpu-distributed-tests-pp-tp
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -116,6 +120,7 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-cpu-distributed-smoke-test.sh tp_pp"
 
 - label: CPU-Distributed Tests (DP+TP)
+  key: cpu-distributed-tests-dp-tp
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -126,6 +131,7 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-cpu-distributed-smoke-test.sh dp_tp"
 
 - label: CPU-Multi-Modal Model Tests %N
+  key: cpu-multi-modal-model-tests-n
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -140,6 +146,7 @@ steps:
   parallelism: 4
 
 - label: CPU-Qwen2.5-VL Multimodal Tests
+  key: cpu-qwen2-5-vl-multimodal-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -153,6 +160,7 @@ steps:
       VLLM_CI_ENV=0 pytest -x -v -s tests/models/multimodal/generation/test_qwen2_5_vl.py"
 
 - label: "Arm CPU Test"
+  key: arm-cpu-test
   depends_on: []
   soft_fail: false
   device: arm_cpu

--- a/.buildkite/hardware_tests/gh200.yaml
+++ b/.buildkite/hardware_tests/gh200.yaml
@@ -1,6 +1,7 @@
 group: Hardware
 steps:
   - label: "GH200 Test"
+    key: gh200-test
     soft_fail: true
     device: gh200
     no_plugin: true

--- a/.buildkite/hardware_tests/intel.yaml
+++ b/.buildkite/hardware_tests/intel.yaml
@@ -2,6 +2,7 @@ group: Hardware
 depends_on: ~
 steps:
   - label: "Intel HPU Test"
+    key: intel-hpu-test
     soft_fail: true
     device: intel_hpu
     no_plugin: true

--- a/.buildkite/hardware_tests/intel_xpu_ci/test-intel.yaml
+++ b/.buildkite/hardware_tests/intel_xpu_ci/test-intel.yaml
@@ -16,6 +16,7 @@ steps:
         - exit_status: -10  # Agent was lost
           limit: 2
   - label: "XPU example Test"
+    key: xpu-example-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 50
@@ -37,6 +38,7 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh example'
   - label: "XPU V1 test"
+    key: xpu-v1-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 70
@@ -59,6 +61,7 @@ steps:
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh v1'
     parallelism: 2
   - label: "XPU W8A8 FP8 Linear Examples"
+    key: xpu-w8a8-fp8-linear-examples
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60
@@ -81,6 +84,7 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh w8a8-fp8-linear'
   - label: "XPU server test"
+    key: xpu-server-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 45
@@ -102,6 +106,7 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh server'
   - label: "XPU quantization test"
+    key: xpu-quantization-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60
@@ -123,6 +128,7 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh quantization'
   - label: "XPU compressed tensors FP8 test"
+    key: xpu-compressed-tensors-fp8-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60
@@ -145,6 +151,7 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh compressed-tensors-fp8'
   - label: "XPU Graph"
+    key: xpu-graph
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60


### PR DESCRIPTION
## Why

Steps without an explicit `key:` in `.buildkite` job YAMLs get one derived from their label by the ci-infra pipeline generator. Keyless steps are invisible to key-based CI automation, and `/ci retry` on a new commit fails at bootstrap for them: the retry flow passes the failed jobs' step keys as `VLLM_CI_ONLY_STEP_KEYS`, but the generator validated those keys before label-derived keys were assigned, failing with `Unknown CI step key(s)` (reported in Slack, e.g. retrying `-nvidia--h200-rust-frontend-openai-coverage` / `ascend-npu-test` after a rebase).

The generator-side root-cause fix is in vllm-project/ci-infra (PR linked below). This PR is complementary hardening on the vLLM side.

## What

Adds an explicit `key:` to the 18 keyless steps under `.buildkite/hardware_tests` (`cpu.yaml`, `intel_xpu_ci/test-intel.yaml`, `ascend_npu.yaml`, `gh200.yaml`, `intel.yaml`). Each key is **identical to the label-derived key the generator already produces**, so the uploaded pipeline is unchanged — no step identity changes, in-flight retries and Buildkite history are unaffected.

The 7 keyless steps under `.buildkite/test_areas` are intentionally **not** touched here — they are covered by #53085.

## Not a duplicate

- #53085 (draft) adds explicit keys to the 7 keyless **test_areas** steps with new, cleaner key names. This PR covers only **hardware_tests** steps and deliberately preserves the existing label-derived keys, so the two PRs touch disjoint files and don't conflict.
- ci-infra PR (root-cause fix for the `/ci retry` bootstrap failure): https://github.com/vllm-project/ci-infra/pull/500

## Test commands run and results

- Parsed all 241 steps in `.buildkite/image_build`, `.buildkite/test_areas`, `.buildkite/hardware_tests` with the same key-derivation logic as ci-infra's `_generate_step_key`: effective key set is **byte-identical before/after** this change, with zero duplicates.
- Every added `key:` verified to equal the generator's label-derived key for that step.
- `pre-commit run --files <changed files>`: passed (shellcheck env failed to bootstrap locally due to an SSL issue downloading the tool; no shell files changed, hook skipped).
- ci-infra generator test suite against this tree: 112 passed, including a new case selecting steps by label-derived key.

## Model evaluation

Not applicable — CI metadata change only; no output/accuracy/serving surface.

## AI-assistance disclosure

AI assistance was used in creating this change (diagnosis, key derivation check, and edits drafted/verified by an AI agent under human direction). Every changed line was reviewed by the human submitter.
