### PR TITLE
[MRV2] Add reduced sampling for tensor-parallel decoding

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,6 +158,63 @@ def test_v2_model_runner_env_tri_state(monkeypatch, env_value, expected):
     assert envs.VLLM_USE_V2_MODEL_RUNNER is expected
 
 
+@pytest.mark.parametrize(
+    (
+        "enable_reduced_sampling",
+        "use_v2_model_runner",
+        "tensor_parallel_size",
+        "enable_batch_sharded_sampling",
+        "lora_enabled",
+        "speculative_enabled",
+        "return_sampling_mask",
+        "is_diffusion",
+        "should_raise",
+    ),
+    [
+        (True, False, 2, False, False, False, False, False, True),
+        (True, True, 1, False, False, False, False, False, True),
+        (True, True, 2, True, False, False, False, False, True),
+        (True, True, 2, False, True, False, False, False, True),
+        (True, True, 2, False, False, True, False, False, False),
+        (True, True, 2, False, False, False, True, False, True),
+        (True, True, 2, False, False, False, False, True, True),
+        (True, True, 2, False, False, False, False, False, False),
+        (False, False, 1, True, True, True, True, True, False),
+    ],
+)
+def test_reduced_sampling_validation(
+    enable_reduced_sampling,
+    use_v2_model_runner,
+    tensor_parallel_size,
+    enable_batch_sharded_sampling,
+    lora_enabled,
+    speculative_enabled,
+    return_sampling_mask,
+    is_diffusion,
+    should_raise,
+) -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            enable_reduced_sampling=enable_reduced_sampling,
+            return_sampling_mask=return_sampling_mask,
+            is_diffusion=is_diffusion,
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=tensor_parallel_size,
+            enable_batch_sharded_sampling=enable_batch_sharded_sampling,
+        ),
+        lora_config=object() if lora_enabled else None,
+        speculative_config=object() if speculative_enabled else None,
+        use_v2_model_runner=use_v2_model_runner,
+    )
+
+    if should_raise:
+        with pytest.raises(ValueError, match="Reduced sampling"):
+            VllmConfig._validate_reduced_sampling(config)
+    else:
+        VllmConfig._validate_reduced_sampling(config)
+
+
 def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
     """ROCm keeps DeepSeek V3.2 and V4 on their compiled MRV1 paths."""
     from vllm.config.vllm import (

--- a/tests/v1/sample/test_head_dtype.py
+++ b/tests/v1/sample/test_head_dtype.py
@@ -7,12 +7,16 @@ fp32, which is required for RL training-inference consistency.
 """
 
 import math
+import types
 
 import pytest
 import torch
 
 from vllm import LLM, SamplingParams
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.logits_processor import (
+    LogitsProcessor,
+    compute_local_logits,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     UnquantizedEmbeddingMethod,
@@ -25,11 +29,12 @@ class _FakeLmHead:
         weight: torch.Tensor,
         quantized: bool = False,
         shard_indices: object | None = None,
+        tp_size: int = 1,
     ):
         self.weight = weight
         self.quant_method = object() if quantized else UnquantizedEmbeddingMethod()
         self.shard_indices = shard_indices
-        self.tp_size = 1
+        self.tp_size = tp_size
 
 
 def _build_processor(vocab_size: int) -> LogitsProcessor:
@@ -186,11 +191,147 @@ def test_replicated_lm_head_skips_tp_communication_and_preserves_processing(
     assert torch.equal(top, expected.argmax(dim=-1))
 
 
+def test_compute_local_logits_uses_vocab_shard_metadata(default_vllm_config):
+    vocab_size, hidden_size = 127, 8
+    lp = LogitsProcessor(vocab_size)
+    hidden_states = torch.randn(2, hidden_size)
+    lm_head = _FakeLmHead(
+        torch.randn(64, hidden_size),
+        shard_indices=types.SimpleNamespace(
+            org_vocab_start_index=64,
+            org_vocab_end_index=127,
+            num_elements_padded=64,
+            num_org_vocab_padding=1,
+            num_added_elements_padded=0,
+        ),
+        tp_size=2,
+    )
+
+    def fail_gather(logits: torch.Tensor) -> None:
+        raise AssertionError("The TP logits gather must be skipped")
+
+    lp._gather_logits = fail_gather
+    logits, metadata = compute_local_logits(
+        lambda hidden: lp(lm_head, hidden), hidden_states
+    )
+
+    assert logits is not None and logits.shape == (2, 64)
+    assert metadata is not None
+    assert metadata.vocab_size == vocab_size
+    assert metadata.vocab_start_index == 64
+    assert metadata.local_vocab_size == 64
+    assert torch.isfinite(logits[..., :-1]).all()
+    assert torch.isneginf(logits[..., -1]).all()
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "shard_indices"),
+    [
+        pytest.param(1, None, id="replicated-head"),
+        pytest.param(2, object(), id="missing-shard-metadata"),
+        pytest.param(
+            2,
+            types.SimpleNamespace(
+                org_vocab_start_index=0,
+                num_elements_padded=16,
+                num_org_vocab_padding=0,
+                num_added_elements_padded=1,
+            ),
+            id="added-vocabulary",
+        ),
+    ],
+)
+def test_compute_local_logits_falls_back_for_unsupported_head(
+    default_vllm_config, tp_size: int, shard_indices: object | None
+):
+    vocab_size, hidden_size = 16, 8
+    lp = LogitsProcessor(vocab_size)
+    lp._gather_logits = lambda logits: logits
+    hidden_states = torch.randn(2, hidden_size)
+    lm_head = _FakeLmHead(
+        torch.randn(vocab_size, hidden_size),
+        tp_size=tp_size,
+        shard_indices=shard_indices,
+    )
+
+    logits, metadata = compute_local_logits(
+        lambda hidden: lp(lm_head, hidden), hidden_states
+    )
+
+    assert logits is not None and logits.shape == (2, vocab_size)
+    assert metadata is None
+
+
+def test_compute_local_logits_recomputes_multiple_projections(
+    default_vllm_config,
+):
+    vocab_size, hidden_size = 128, 8
+    lp = LogitsProcessor(vocab_size)
+    hidden_states = torch.randn(2, hidden_size)
+    lm_head = _FakeLmHead(
+        torch.randn(64, hidden_size),
+        shard_indices=types.SimpleNamespace(
+            org_vocab_start_index=0,
+            org_vocab_end_index=64,
+            num_elements_padded=64,
+            num_org_vocab_padding=0,
+            num_added_elements_padded=0,
+        ),
+        tp_size=2,
+    )
+    lp._gather_logits = lambda logits: torch.cat((logits, logits), dim=-1)
+    num_calls = 0
+
+    def compute_logits(hidden: torch.Tensor) -> torch.Tensor:
+        nonlocal num_calls
+        num_calls += 1
+        first = lp(lm_head, hidden)
+        second = lp(lm_head, hidden)
+        assert first is not None and second is not None
+        return first + second
+
+    logits, metadata = compute_local_logits(compute_logits, hidden_states)
+
+    assert logits is not None and logits.shape == (2, vocab_size)
+    assert metadata is None
+    assert num_calls == 2
+
+
+def test_compute_local_logits_recomputes_model_postprocessing(default_vllm_config):
+    vocab_size, hidden_size = 128, 8
+    lp = LogitsProcessor(vocab_size)
+    hidden_states = torch.randn(2, hidden_size)
+    lm_head = _FakeLmHead(
+        torch.randn(64, hidden_size),
+        shard_indices=types.SimpleNamespace(
+            org_vocab_start_index=0,
+            org_vocab_end_index=64,
+            num_elements_padded=64,
+            num_org_vocab_padding=0,
+            num_added_elements_padded=0,
+        ),
+        tp_size=2,
+    )
+    lp._gather_logits = lambda logits: torch.cat((logits, logits), dim=-1)
+    num_calls = 0
+
+    def compute_logits(hidden: torch.Tensor) -> torch.Tensor:
+        nonlocal num_calls
+        num_calls += 1
+        logits = lp(lm_head, hidden)
+        assert logits is not None
+        return logits + 1
+
+    logits, metadata = compute_local_logits(compute_logits, hidden_states)
+
+    assert logits is not None and logits.shape == (2, vocab_size)
+    assert metadata is None
+    assert num_calls == 2
+
+
 def test_get_top_tokens_honors_head_dtype(default_vllm_config):
     # The spec-decode local-argmax path (get_top_tokens) must run the lm_head
     # in head_dtype too, not just _get_logits.
-    import types
-
     vocab_size, hidden_size = 64, 16
     lp = _build_processor(vocab_size)
     lp.head_dtype = torch.float32

--- a/tests/v1/worker/test_gpu_sampler_flags.py
+++ b/tests/v1/worker/test_gpu_sampler_flags.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 import torch
@@ -9,8 +11,13 @@ pytest.importorskip("triton")
 if not torch.cuda.is_available():
     pytest.skip("CUDA required for sampler flag tests", allow_module_level=True)
 
+import vllm.v1.worker.gpu.sample.sampler as sampler_module
 from vllm.sampling_params import SamplingParams
 from vllm.v1.worker.gpu.sample.sampler import Sampler
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+    reduced_greedy_verify,
+)
 from vllm.v1.worker.gpu.states import RequestState
 
 DEVICE = torch.device("cuda")
@@ -32,13 +39,30 @@ def _make_sampler() -> Sampler:
         vocab_size=VOCAB_SIZE,
         device=DEVICE,
     )
-    return Sampler(
-        max_num_reqs=4,
-        vocab_size=VOCAB_SIZE,
-        device=DEVICE,
-        req_states=req_states,
-        reasoning_config=MockReasoningConfig(),
+    with patch.object(
+        sampler_module,
+        "get_tensor_model_parallel_world_size",
+        return_value=2,
+    ):
+        return Sampler(
+            max_num_reqs=4,
+            vocab_size=VOCAB_SIZE,
+            device=DEVICE,
+            req_states=req_states,
+            reasoning_config=MockReasoningConfig(),
+        )
+
+
+def _can_use_reduced_sampling(
+    sampler: Sampler,
+    idx_mapping_np: np.ndarray,
+    local_vocab_size: int = 16,
+    dtype: torch.dtype = torch.float32,
+) -> bool:
+    local_logits = torch.empty(
+        (len(idx_mapping_np), local_vocab_size), dtype=dtype, device=DEVICE
     )
+    return sampler.can_use_reduced_sampling(idx_mapping_np, local_logits)
 
 
 @pytest.mark.parametrize(
@@ -88,3 +112,266 @@ def test_logits_processing_cache_only_checks_active_requests():
 
     assert not np.any(sampler.needs_logits_processing[sampling_only])
     assert np.any(sampler.needs_logits_processing[with_processing])
+
+
+def test_reduced_sampling_requires_bounded_top_k():
+    sampler = _make_sampler()
+    idx_mapping_np = np.array([0], dtype=np.int32)
+
+    sampler.add_request(0, 1, SamplingParams(temperature=0.7, top_p=0.9))
+    assert not _can_use_reduced_sampling(sampler, idx_mapping_np)
+
+    sampler.add_request(0, 1, SamplingParams(temperature=0.7, top_k=2, top_p=0.9))
+    assert _can_use_reduced_sampling(sampler, idx_mapping_np)
+
+    sampler.add_request(0, 1, SamplingParams(temperature=0.7, top_k=8))
+    assert not _can_use_reduced_sampling(sampler, idx_mapping_np)
+
+
+def test_reduced_sampling_ignores_greedy_top_k_in_mixed_batch():
+    sampler = _make_sampler()
+    sampler.add_request(0, 1, SamplingParams(temperature=0.0))
+    sampler.add_request(1, 1, SamplingParams(temperature=0.7, top_k=2))
+
+    assert _can_use_reduced_sampling(sampler, np.array([0, 1], dtype=np.int32))
+
+
+@pytest.mark.parametrize("attribute", ["return_sampling_mask", "compute_nans"])
+def test_reduced_sampling_falls_back_for_full_vocab_outputs(attribute):
+    sampler = _make_sampler()
+    sampler.add_request(0, 1, SamplingParams(temperature=0.0))
+    setattr(sampler, attribute, True)
+
+    assert not _can_use_reduced_sampling(sampler, np.array([0], dtype=np.int32))
+
+
+def test_reduced_sampling_falls_back_for_inexact_fp32_token_ids():
+    sampler = _make_sampler()
+    sampler.add_request(0, 1, SamplingParams(temperature=0.0))
+    sampler.sampling_states.vocab_size = 2**24
+
+    assert not _can_use_reduced_sampling(sampler, np.array([0], dtype=np.int32))
+
+
+@pytest.mark.parametrize(
+    "sampling_params",
+    [
+        SamplingParams(temperature=0.0, logit_bias={1: 1.0}),
+        SamplingParams(temperature=0.0, frequency_penalty=0.1),
+        SamplingParams(temperature=0.0, _bad_words_token_ids=[[1]]),
+        SamplingParams(temperature=0.0, thinking_token_budget=3),
+        SamplingParams(temperature=0.7, top_k=2, min_p=0.1),
+        SamplingParams(temperature=0.0, logprobs=1),
+        SamplingParams(temperature=0.0, logprob_token_ids=[1]),
+    ],
+)
+def test_reduced_sampling_falls_back_for_full_vocab_features(sampling_params):
+    sampler = _make_sampler()
+    sampler.add_request(0, 1, sampling_params)
+
+    assert not _can_use_reduced_sampling(sampler, np.array([0], dtype=np.int32))
+
+
+def test_reduced_sampling_falls_back_for_explicit_random_seed():
+    sampler = _make_sampler()
+    sampler.add_request(
+        0,
+        1,
+        SamplingParams(temperature=0.7, top_k=2, seed=1),
+    )
+
+    assert not _can_use_reduced_sampling(sampler, np.array([0], dtype=np.int32))
+
+
+def test_reduced_sampling_accounts_for_logits_dtype_in_traffic_check():
+    sampler = _make_sampler()
+    sampler.add_request(0, 1, SamplingParams(temperature=0.7, top_k=4))
+    idx_mapping_np = np.array([0], dtype=np.int32)
+
+    assert _can_use_reduced_sampling(sampler, idx_mapping_np, dtype=torch.float32)
+    assert not _can_use_reduced_sampling(sampler, idx_mapping_np, dtype=torch.bfloat16)
+
+
+def test_reduced_greedy_requires_smaller_candidate_payload():
+    sampler = _make_sampler()
+    sampler.add_request(0, 1, SamplingParams(temperature=0.0))
+    idx_mapping_np = np.array([0], dtype=np.int32)
+
+    assert not _can_use_reduced_sampling(sampler, idx_mapping_np, local_vocab_size=2)
+    assert _can_use_reduced_sampling(sampler, idx_mapping_np, local_vocab_size=3)
+
+
+def test_reduced_speculative_verification_requires_all_greedy():
+    sampler = _make_sampler()
+    sampler.add_request(0, 1, SamplingParams(temperature=0.0))
+    sampler.add_request(1, 1, SamplingParams(temperature=0.7))
+    sampler.sampling_states.apply_staged_writes()
+    rejection_sampler = object.__new__(RejectionSampler)
+    rejection_sampler.sampler = sampler
+    rejection_sampler.draft_sample_method = "greedy"
+    rejection_sampler.synthetic_conditional_rates = None
+
+    assert rejection_sampler.can_use_reduced_sampling(np.array([0], dtype=np.int32))
+    assert not rejection_sampler.can_use_reduced_sampling(
+        np.array([0, 1], dtype=np.int32)
+    )
+
+    rejection_sampler.draft_sample_method = "probabilistic"
+    assert not rejection_sampler.can_use_reduced_sampling(np.array([0], dtype=np.int32))
+
+    rejection_sampler.draft_sample_method = "greedy"
+    rejection_sampler.synthetic_conditional_rates = torch.ones(1, device=DEVICE)
+    assert not rejection_sampler.can_use_reduced_sampling(np.array([0], dtype=np.int32))
+
+
+def test_reduced_greedy_verify_accepts_prefix_and_emits_target():
+    # Request 0 accepts token 5, then rejects token 8 in favor of token 6.
+    # Request 1 accepts token 3 and emits bonus token 4.
+    target_argmax = torch.tensor([5, 6, 7, 3, 4], device=DEVICE)
+    draft_sampled = torch.tensor([99, 5, 8, 99, 3], device=DEVICE)
+    cu_num_logits = torch.tensor([0, 3, 5], device=DEVICE, dtype=torch.int32)
+
+    sampled, num_sampled = reduced_greedy_verify(
+        target_argmax, draft_sampled, cu_num_logits, num_speculative_steps=2
+    )
+
+    assert num_sampled.tolist() == [2, 2]
+    assert sampled[0, :2].tolist() == [5, 6]
+    assert sampled[1, :2].tolist() == [3, 4]
+
+
+def test_reduced_random_sampling_maps_global_candidate(monkeypatch):
+    sampler = _make_sampler()
+    sampler.tp_size = 2
+    sampler.add_request(0, 1, SamplingParams(temperature=0.7, top_k=2))
+    sampler.sampling_states.apply_staged_writes()
+    idx_mapping_np = np.array([0], dtype=np.int32)
+    expanded_idx_mapping = torch.tensor([0], device=DEVICE)
+    local_logits = torch.tensor([[0.1, 0.9, 0.8, 0.2]], device=DEVICE)
+    top_k, top_p = sampler.sampling_states.get_top_k_top_p(
+        expanded_idx_mapping, idx_mapping_np
+    )
+
+    def fake_all_gather(candidates: torch.Tensor, dim: int):
+        remote = candidates.clone()
+        remote[:, 2:] += local_logits.shape[-1]
+        return torch.cat((candidates, remote), dim=dim)
+
+    monkeypatch.setattr(
+        sampler_module, "tensor_model_parallel_all_gather", fake_all_gather
+    )
+    monkeypatch.setattr(
+        sampler_module,
+        "gumbel_sample",
+        lambda *args, **kwargs: torch.tensor([2], device=DEVICE),
+    )
+
+    sampled = sampler._sample_reduced(
+        local_logits,
+        top_k,
+        top_p,
+        expanded_idx_mapping,
+        idx_mapping_np,
+        sampler.sampling_states.temperature.gpu,
+        sampler.sampling_states.seeds.gpu,
+        torch.tensor([3], device=DEVICE),
+        vocab_start_index=10,
+    )
+
+    assert sampled.tolist() == [15]
+
+
+def test_full_logits_fallback_skips_reduced_sampling(monkeypatch):
+    sampler = _make_sampler()
+    sampler.tp_size = 2
+    sampler.use_flashinfer = False
+    sampler.add_request(
+        0, prompt_len=1, sampling_params=SamplingParams(temperature=0.7, top_k=2)
+    )
+    sampler.sampling_states.apply_staged_writes()
+
+    idx_mapping_np = np.array([0], dtype=np.int32)
+    expanded_idx_mapping = torch.tensor([0], device=DEVICE)
+    idx_mapping = expanded_idx_mapping.clone()
+    pos = torch.tensor([3], device=DEVICE)
+    input_ids = torch.tensor([1], device=DEVICE)
+    expanded_local_pos = torch.tensor([0], device=DEVICE)
+    full_logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+
+    def fail_reduced_sample(*args, **kwargs):
+        pytest.fail("Full logits must not enter the reduced sampling path")
+
+    def fake_gumbel_sample(*args, **kwargs):
+        return torch.tensor([0], device=DEVICE)
+
+    monkeypatch.setattr(
+        sampler,
+        "apply_sampling_params",
+        lambda logits, *args, **kwargs: logits,
+    )
+    monkeypatch.setattr(sampler, "_sample_reduced", fail_reduced_sample)
+    monkeypatch.setattr(
+        sampler_module,
+        "apply_top_k_top_p",
+        lambda logits, *args, **kwargs: logits,
+    )
+    monkeypatch.setattr(sampler_module, "gumbel_sample", fake_gumbel_sample)
+
+    sampled, processed_logits = sampler.sample(
+        full_logits,
+        expanded_idx_mapping,
+        idx_mapping,
+        idx_mapping_np,
+        pos,
+        input_ids,
+        expanded_local_pos,
+        return_logprobs=True,
+        use_reduced_sampling=False,
+    )
+
+    assert sampled.tolist() == [0]
+    assert processed_logits is full_logits
+
+
+def test_reduced_all_greedy_skips_topk_filter_and_gumbel(monkeypatch):
+    sampler = _make_sampler()
+    sampler.tp_size = 2
+    sampler.add_request(
+        0, prompt_len=1, sampling_params=SamplingParams(temperature=0.0)
+    )
+    sampler.sampling_states.apply_staged_writes()
+    idx_mapping_np = np.array([0], dtype=np.int32)
+    expanded_idx_mapping = torch.tensor([0], device=DEVICE)
+    pos = torch.tensor([3], device=DEVICE)
+    local_logits = torch.tensor([[0.1, 0.9, 0.8, 0.2]], device=DEVICE)
+
+    def fake_all_gather(packed_candidates: torch.Tensor, dim: int):
+        assert dim == -1
+        assert packed_candidates.shape == (1, 2)
+        remote_candidates = torch.tensor([[1.1, 5.0]], device=DEVICE)
+        return torch.cat((packed_candidates, remote_candidates), dim=dim)
+
+    def fail_redundant_path(*args, **kwargs):
+        pytest.fail("all-greedy reduced sampling must only use max/argmax")
+
+    monkeypatch.setattr(
+        sampler_module, "tensor_model_parallel_all_gather", fake_all_gather
+    )
+    monkeypatch.setattr(torch, "topk", fail_redundant_path)
+    monkeypatch.setattr(sampler_module, "apply_top_k_top_p", fail_redundant_path)
+    monkeypatch.setattr(sampler_module, "gumbel_sample", fail_redundant_path)
+    monkeypatch.setattr(sampler_module, "flashinfer_sample", fail_redundant_path)
+
+    sampled = sampler._sample_reduced(
+        local_logits,
+        top_k=None,
+        top_p=None,
+        expanded_idx_mapping=expanded_idx_mapping,
+        idx_mapping_np=idx_mapping_np,
+        temperature=sampler.sampling_states.temperature.gpu,
+        seeds=sampler.sampling_states.seeds.gpu,
+        pos=pos,
+        vocab_start_index=0,
+    )
+
+    assert sampled.tolist() == [5]

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -273,6 +273,11 @@ class ModelConfig:
     predetermined token sequence while still computing real logprobs. Reserved
     for debugging and RL workflows: enabling it reserves a per-request trace
     buffer, so it is off by default."""
+    enable_reduced_sampling: bool = False
+    """Whether to reduce tensor-parallel sampling communication by avoiding a
+    full-vocabulary all-gather. Greedy batches reduce local argmax pairs; random
+    batches reduce local top-k candidates. Unsupported sampling features fall
+    back to full-vocabulary logits."""
     disable_sliding_window: bool = False
     """Whether to disable sliding window. If True, we will disable the sliding
     window functionality of the model, capping to sliding window size. If the
@@ -436,6 +441,7 @@ class ModelConfig:
             "logprobs_mode",
             "use_fp64_gumbel",
             "enable_trace_replay",
+            "enable_reduced_sampling",
             "disable_cascade_attn",
             "skip_tokenizer_init",
             "served_model_name",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1647,6 +1647,7 @@ class VllmConfig:
         self._resolve_allow_missing_mm_embeddings()
         self._resolve_mm_processor_device()
         self._validate_mm_processor_device()
+        self._validate_reduced_sampling()
 
         if self.use_v2_model_runner:
             self._validate_v2_model_runner()
@@ -2781,6 +2782,31 @@ class VllmConfig:
                 dcp_size,
                 interleave,
                 local_block_size,
+            )
+
+    def _validate_reduced_sampling(self) -> None:
+        model_config = self.model_config
+        if model_config is None or not model_config.enable_reduced_sampling:
+            return
+
+        blockers: list[str] = []
+        if not self.use_v2_model_runner:
+            blockers.append("it is only implemented by Model Runner V2")
+        if self.parallel_config.tensor_parallel_size <= 1:
+            blockers.append("tensor_parallel_size is 1")
+        if self.parallel_config.enable_batch_sharded_sampling:
+            blockers.append("batch-sharded sampling is also enabled")
+        if self.lora_config is not None:
+            blockers.append("LoRA is enabled")
+        if model_config.return_sampling_mask:
+            blockers.append("sampling distribution replay is enabled")
+        if model_config.is_diffusion:
+            blockers.append("diffusion models use a custom sampling path")
+        if blockers:
+            raise ValueError(
+                "Reduced sampling was explicitly enabled via "
+                "--enable-reduced-sampling, but is not supported in "
+                f"this configuration because {'; '.join(blockers)}."
             )
 
     def validate_block_size(self) -> None:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -548,6 +548,7 @@ class EngineArgs:
     logprobs_mode: LogprobsMode = ModelConfig.logprobs_mode
     use_fp64_gumbel: bool = ModelConfig.use_fp64_gumbel
     enable_trace_replay: bool = ModelConfig.enable_trace_replay
+    enable_reduced_sampling: bool = ModelConfig.enable_reduced_sampling
     disable_log_stats: bool = False
     aggregate_engine_logging: bool = False
     revision: str | None = ModelConfig.revision
@@ -894,6 +895,10 @@ class EngineArgs:
         model_group.add_argument("--use-fp64-gumbel", **model_kwargs["use_fp64_gumbel"])
         model_group.add_argument(
             "--enable-trace-replay", **model_kwargs["enable_trace_replay"]
+        )
+        model_group.add_argument(
+            "--enable-reduced-sampling",
+            **model_kwargs["enable_reduced_sampling"],
         )
         model_group.add_argument(
             "--disable-sliding-window", **model_kwargs["disable_sliding_window"]
@@ -1784,6 +1789,7 @@ class EngineArgs:
             logprobs_mode=self.logprobs_mode,
             use_fp64_gumbel=self.use_fp64_gumbel,
             enable_trace_replay=self.enable_trace_replay,
+            enable_reduced_sampling=self.enable_reduced_sampling,
             disable_sliding_window=self.disable_sliding_window,
             disable_cascade_attn=self.disable_cascade_attn,
             skip_tokenizer_init=self.skip_tokenizer_init,

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -3,6 +3,8 @@
 """A layer that compute logits from hidden_stats."""
 
 from collections.abc import Callable
+from contextvars import ContextVar
+from dataclasses import dataclass
 from functools import cache
 
 import torch
@@ -24,6 +26,75 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class LocalLogitsMetadata:
+    """Vocabulary layout for logits produced without a TP gather."""
+
+    vocab_size: int
+    vocab_start_index: int
+    local_vocab_size: int
+
+
+_local_logits_context: ContextVar[
+    list[tuple[torch.Tensor, LocalLogitsMetadata]] | None
+] = ContextVar("local_logits_context", default=None)
+
+
+def compute_local_logits(
+    compute_logits: Callable[[torch.Tensor], torch.Tensor | None],
+    hidden_states: torch.Tensor,
+) -> tuple[torch.Tensor | None, LocalLogitsMetadata | None]:
+    """Compute local logits when supported, otherwise return full logits."""
+    captures: list[tuple[torch.Tensor, LocalLogitsMetadata]] = []
+    token = _local_logits_context.set(captures)
+    try:
+        logits = compute_logits(hidden_states)
+    finally:
+        _local_logits_context.reset(token)
+
+    if len(captures) == 1 and isinstance(logits, torch.Tensor):
+        captured_logits, metadata = captures[0]
+        if logits is captured_logits and logits.shape[-1] == metadata.local_vocab_size:
+            return logits, metadata
+
+    if captures:
+        logits = compute_logits(hidden_states)
+    return logits, None
+
+
+def _get_local_logits_metadata(
+    logits_processor: "LogitsProcessor", lm_head: VocabParallelEmbedding
+) -> LocalLogitsMetadata | None:
+    """Return shard metadata when the active context can skip the TP gather."""
+    context = _local_logits_context.get()
+    if (
+        context is None
+        or hasattr(logits_processor, "base_layer")
+        or getattr(lm_head, "tp_size", 1) <= 1
+    ):
+        return None
+
+    shard_indices = getattr(lm_head, "shard_indices", None)
+    required_indices = (
+        "org_vocab_start_index",
+        "num_elements_padded",
+        "num_org_vocab_padding",
+        "num_added_elements_padded",
+    )
+    if shard_indices is None or any(
+        not hasattr(shard_indices, name) for name in required_indices
+    ):
+        return None
+    if shard_indices.num_added_elements_padded > 0:
+        return None
+
+    return LocalLogitsMetadata(
+        vocab_size=logits_processor.org_vocab_size,
+        vocab_start_index=shard_indices.org_vocab_start_index,
+        local_vocab_size=shard_indices.num_elements_padded,
+    )
 
 
 @cache
@@ -102,9 +173,13 @@ class LogitsProcessor(PluggableLayer):
         embedding_bias: torch.Tensor | None = None,
         skip_gather: bool = False,
     ) -> torch.Tensor | None:
+        local_metadata = None
         if self.logits_as_input:
             logits = hidden_states
         else:
+            if not skip_gather:
+                local_metadata = _get_local_logits_metadata(self, lm_head)
+                skip_gather = local_metadata is not None
             # Get the logits for the next tokens.
             logits = self._get_logits(
                 hidden_states, lm_head, embedding_bias, skip_gather
@@ -117,6 +192,14 @@ class LogitsProcessor(PluggableLayer):
 
             if self.scale != 1.0:
                 logits *= self.scale
+
+            if local_metadata is not None:
+                num_vocab_padding = lm_head.shard_indices.num_org_vocab_padding
+                if num_vocab_padding > 0:
+                    logits[..., -num_vocab_padding:] = -float("inf")
+                context = _local_logits_context.get()
+                assert context is not None
+                context.append((logits, local_metadata))
         return logits
 
     def _gather_logits(self, logits: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -32,6 +32,7 @@ import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.distributed.communication_op import tensor_model_parallel_all_gather
 from vllm.distributed.parallel_state import (
     get_dcp_group,
     get_pp_group,
@@ -43,6 +44,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
     bind_routed_experts_capturer,
 )
+from vllm.model_executor.layers.logits_processor import compute_local_logits
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
@@ -447,6 +449,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 return_sampling_mask=self.model_config.return_sampling_mask,
             )
             custom = self.model_state.custom_sampler(self.sampler)
+            if custom and self.model_config.enable_reduced_sampling:
+                raise ValueError("Reduced sampling does not support custom samplers.")
 
             if custom:
                 self.sampler, self.rejection_sampler = custom
@@ -831,7 +835,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     @torch.inference_mode()
     def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
         num_reqs = hidden_states.shape[0]
+        # Profile the full-logits fallback, which is the peak-memory path even
+        # when reduced sampling is enabled.
         logits = self.model.compute_logits(hidden_states)
+        assert logits is not None
         dummy_input_batch = InputBatch.make_dummy(
             num_reqs, num_reqs, self.input_buffers
         )
@@ -1401,8 +1408,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         input_batch: InputBatch,
         grammar_output: GrammarOutput | None,
     ) -> tuple[SamplerOutput, torch.Tensor, torch.Tensor]:
+        assert self.sampler is not None
         shard_metadata = None
         global_input_batch = input_batch
+        use_reduced_sampling = False
+        local_logits_metadata = None
         if self.batch_sharder is not None:
             # Shard the inputs along the batch dimension to sample in parallel
             # across TP ranks.
@@ -1418,7 +1428,43 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             logits = logits[:, : self.vocab_size]
         else:
             sample_hidden_states = hidden_states[input_batch.logits_indices]
-            logits = self.model.compute_logits(sample_hidden_states)
+            if self.model_config.enable_reduced_sampling:
+                logits, local_logits_metadata = compute_local_logits(
+                    self.model.compute_logits, sample_hidden_states
+                )
+                assert logits is not None
+                if local_logits_metadata is not None:
+                    use_reduced_sampling = True
+                    can_use_reduced_verification = True
+                    if (
+                        input_batch.num_draft_tokens > 0
+                        and self.rejection_sampler is not None
+                    ):
+                        can_use_reduced_verification = isinstance(
+                            self.rejection_sampler, RejectionSampler
+                        ) and self.rejection_sampler.can_use_reduced_sampling(
+                            input_batch.idx_mapping_np
+                        )
+                    needs_full_logits = (
+                        local_logits_metadata.vocab_size != self.vocab_size
+                        or grammar_output is not None
+                        or not can_use_reduced_verification
+                        or not self.sampler.can_use_reduced_sampling(
+                            input_batch.idx_mapping_np, logits
+                        )
+                    )
+                    if needs_full_logits:
+                        logits = tensor_model_parallel_all_gather(logits, dim=-1)
+                        logits = logits[..., : self.vocab_size].contiguous()
+                        use_reduced_sampling = False
+                else:
+                    logger.warning_once(
+                        "Reduced sampling is unavailable for %s; using full logits.",
+                        type(self.model).__name__,
+                    )
+            else:
+                logits = self.model.compute_logits(sample_hidden_states)
+            assert logits is not None
 
         if grammar_output is not None:
             # Apply grammar bitmask to the logits in-place.
@@ -1436,23 +1482,40 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # all-padding block to the gather below.
             sampler_output = None
         elif input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:
-            assert self.sampler is not None
-            sampler_output = self.sampler(logits, input_batch)
+            if use_reduced_sampling:
+                assert local_logits_metadata is not None
+                sampler_output = self.sampler(
+                    logits,
+                    input_batch,
+                    use_reduced_sampling=True,
+                    vocab_start_index=local_logits_metadata.vocab_start_index,
+                )
+            else:
+                sampler_output = self.sampler(logits, input_batch)
         else:
             # Rejection sampling for spec decoding.
             assert self.rejection_sampler is not None
             assert self.speculator is not None
-            sampler_output = self.rejection_sampler(
-                logits,
-                input_batch,
-                # Draft logits are needed for probabilistic rejection sampling.
-                self.speculator.draft_logits,
-            )
+            # Draft logits are needed for probabilistic rejection sampling.
+            draft_logits = self.speculator.draft_logits
+            if use_reduced_sampling:
+                assert local_logits_metadata is not None
+                assert isinstance(self.rejection_sampler, RejectionSampler)
+                sampler_output = self.rejection_sampler(
+                    logits,
+                    input_batch,
+                    draft_logits,
+                    use_reduced_sampling=True,
+                    vocab_start_index=local_logits_metadata.vocab_start_index,
+                )
+            else:
+                sampler_output = self.rejection_sampler(
+                    logits, input_batch, draft_logits
+                )
 
         if shard_metadata is not None:
             # Gather the sharded sampler outputs from the TP ranks into a single
             # sampler output.
-            assert self.sampler is not None
             sampler_output = gather_sampler_output(
                 sampler_output,
                 shard_metadata,

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -7,6 +7,10 @@ import torch
 import vllm.envs as envs
 from vllm.config.model import PROCESSED_LOGPROBS_MODES, LogprobsMode
 from vllm.config.reasoning import ReasoningConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
 from vllm.sampling_params import SamplingParams
 from vllm.v1.sample.ops.topk_topp_sampler import (
     apply_top_k_top_p,
@@ -47,6 +51,7 @@ class Sampler:
         self.logprobs_mode = logprobs_mode
         self.compute_nans = envs.VLLM_COMPUTE_NANS_IN_LOGITS  # False by default.
         self.use_fp64_gumbel = use_fp64_gumbel
+        self.tp_size = get_tensor_model_parallel_world_size()
 
         self.req_states = req_states
         self.sampling_states = SamplingStates(max_num_reqs, vocab_size)
@@ -123,6 +128,9 @@ class Sampler:
         self,
         logits: torch.Tensor,
         input_batch: InputBatch,
+        *,
+        use_reduced_sampling: bool = False,
+        vocab_start_index: int | None = None,
     ) -> SamplerOutput:
         expanded_idx_mapping = input_batch.expanded_idx_mapping
         idx_mapping = input_batch.idx_mapping
@@ -147,6 +155,8 @@ class Sampler:
             input_ids,
             expanded_local_pos,
             return_logprobs=logprobs_dims is not None,
+            use_reduced_sampling=use_reduced_sampling,
+            vocab_start_index=vocab_start_index,
         )
 
         if self.trace_replay_state is not None:
@@ -271,6 +281,162 @@ class Sampler:
             logits, expanded_idx_mapping, idx_mapping_np
         )
 
+    def can_use_reduced_sampling(
+        self, idx_mapping_np: np.ndarray, local_logits: torch.Tensor
+    ) -> bool:
+        """Return whether candidate reduction preserves the sampler contract."""
+        if self.return_sampling_mask or self.compute_nans:
+            return False
+
+        if np.any(self.logit_bias_state.use_logit_bias[idx_mapping_np]):
+            return False
+        if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):
+            return False
+        if np.any(self.penalties_state.use_penalty[idx_mapping_np]):
+            return False
+
+        thinking_state = self.thinking_budget_state
+        if thinking_state.enabled and np.any(
+            thinking_state.use_thinking_budget[idx_mapping_np]
+        ):
+            return False
+
+        states = self.sampling_states
+        if np.any(states.min_p.np[idx_mapping_np] != 0.0):
+            return False
+        if states.max_num_logprobs(idx_mapping_np) != NO_LOGPROBS:
+            return False
+        if self.logprob_token_ids_state.max_num_token_ids(idx_mapping_np) > 0:
+            return False
+
+        vocab_size = states.vocab_size
+        if vocab_size >= 2**24:
+            return False
+
+        full_logits_bytes = local_logits.element_size() * local_logits.shape[-1]
+        temperatures = states.temperature.np[idx_mapping_np]
+        random_mask = temperatures != 0.0
+        if not np.any(random_mask):
+            return full_logits_bytes > 8
+
+        random_req_indices = idx_mapping_np[random_mask]
+        if states.any_explicit_seed(random_req_indices):
+            # Candidate positions are not global token IDs, so their Gumbel RNG
+            # keys differ from the full-vocabulary path.
+            return False
+
+        random_top_k = states.top_k.np[random_req_indices]
+        max_top_k = int(random_top_k.max())
+        if np.any(random_top_k >= vocab_size):
+            return False
+
+        # Candidate pairs are packed as two FP32 values. Only use the reduced
+        # path when that payload is smaller than gathering the local logits.
+        candidate_bytes = 8 * max_top_k
+        return candidate_bytes < full_logits_bytes
+
+    def _sample_reduced(
+        self,
+        local_logits: torch.Tensor,
+        top_k: torch.Tensor | None,
+        top_p: torch.Tensor | None,
+        expanded_idx_mapping: torch.Tensor,
+        idx_mapping_np: np.ndarray,
+        temperature: torch.Tensor,
+        seeds: torch.Tensor,
+        pos: torch.Tensor,
+        vocab_start_index: int,
+    ) -> torch.Tensor:
+        """Reduced sampling via local top-k + TP all-gather.
+
+        Each TP rank selects its top-k logits locally, all-gathers only those
+        k values and global indices, then samples from that candidate set.
+        Communication is O(B * 2 * k * tp_size), instead of O(B * V).
+
+        All-greedy batches use a dedicated local-max/global-argmax path and
+        skip top-k filtering and Gumbel sampling. The Gumbel fallback serves
+        mixed and all-random batches.
+
+        Args:
+            local_logits: Processed shard-local logits with shape
+                [num_tokens, local_vocab_size].
+            top_k: Per-token top_k values [num_tokens] or None.
+            top_p: Per-token top_p values [num_tokens] or None.
+            expanded_idx_mapping: [num_tokens] mapping to request state idx.
+            idx_mapping_np: [num_tokens] numpy mapping (for GPU-sync-free
+                access to sampling states).
+            temperature: [max_num_reqs] per-request temperature.
+            seeds: [max_num_reqs] per-request random seeds.
+            pos: [num_tokens] position within request (for RNG seeding).
+            vocab_start_index: Global token ID of the first local logit.
+
+        Returns:
+            Sampled global token IDs [num_tokens].
+        """
+        _, local_vocab_size = local_logits.shape
+
+        temperatures = self.sampling_states.temperature.np[idx_mapping_np]
+        random_mask = temperatures != 0.0
+        all_greedy = not np.any(random_mask)
+        if all_greedy:
+            k_for_topk = 1
+        else:
+            assert top_k is not None
+            random_top_k = self.sampling_states.top_k.np[idx_mapping_np][random_mask]
+            k_for_topk = int(random_top_k.max())
+            assert 0 < k_for_topk < local_vocab_size
+
+        if all_greedy:
+            local_vals, local_idx = local_logits.max(dim=-1, keepdim=True)
+        else:
+            local_vals, local_idx = torch.topk(local_logits, k_for_topk, dim=-1)
+        local_global_idx = local_idx + vocab_start_index
+
+        # Pack values and token IDs into one FP32 tensor to avoid paying for
+        # two tensor-parallel collectives. FP32 represents practical vocab IDs
+        # exactly (up to 2**24), unlike FP16/BF16.
+        packed_candidates = torch.cat(
+            (local_vals.float(), local_global_idx.float()), dim=-1
+        )
+        gathered_candidates = tensor_model_parallel_all_gather(
+            packed_candidates, dim=-1
+        )
+
+        # all_gather concatenates rank-local chunks, giving the layout
+        # [rank0_vals, rank0_ids, rank1_vals, rank1_ids, ...].
+        gathered_candidates = gathered_candidates.unflatten(
+            -1, (self.tp_size, 2, k_for_topk)
+        )
+        gathered_vals = gathered_candidates[..., 0, :].flatten(-2).contiguous()
+        gathered_idx = (
+            gathered_candidates[..., 1, :].flatten(-2).to(torch.int64).contiguous()
+        )
+
+        if all_greedy:
+            sample_pos = gathered_vals.argmax(dim=-1, keepdim=True)
+            return gathered_idx.gather(dim=-1, index=sample_pos).squeeze(-1)
+
+        # Clamp top_k to cand_size: rows with top_k = vocab_size (meaning
+        # "no top_k") would otherwise produce negative gather indices when
+        # cand_size < vocab_size.
+        cand_size = gathered_vals.shape[-1]
+        if top_k is not None:
+            top_k = top_k.to(torch.long).clamp(min=1, max=cand_size).to(torch.int32)
+        gathered_vals = apply_top_k_top_p(gathered_vals, top_k, top_p)
+        sample_pos = gumbel_sample(
+            gathered_vals,
+            expanded_idx_mapping,
+            temperature,
+            seeds,
+            pos,
+            apply_temperature=False,
+            use_fp64=self.use_fp64_gumbel,
+        )
+        sample_pos = sample_pos.unsqueeze(-1)
+
+        # Map candidate position → global token ID.
+        return gathered_idx.gather(dim=-1, index=sample_pos).squeeze(-1).to(torch.int64)
+
     def sample(
         self,
         logits: torch.Tensor,
@@ -281,6 +447,8 @@ class Sampler:
         input_ids: torch.Tensor,
         expanded_local_pos: torch.Tensor,
         return_logprobs: bool = False,
+        use_reduced_sampling: bool = False,
+        vocab_start_index: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         processed_logits = self.apply_sampling_params(
             logits,
@@ -292,6 +460,29 @@ class Sampler:
             expanded_local_pos,
             skip_top_k_top_p=True,
         )
+
+        # The runner enables this path only for shard-local logits. Full-logits
+        # fallbacks must use the standard path to avoid offsetting token IDs.
+        if use_reduced_sampling:
+            assert self.tp_size > 1
+            assert vocab_start_index is not None
+            top_k, top_p = self.sampling_states.get_top_k_top_p(
+                expanded_idx_mapping, idx_mapping_np
+            )
+            sampled = self._sample_reduced(
+                processed_logits,
+                top_k,
+                top_p,
+                expanded_idx_mapping,
+                idx_mapping_np,
+                self.sampling_states.temperature.gpu,
+                self.sampling_states.seeds.gpu,
+                pos,
+                vocab_start_index,
+            )
+            return sampled, processed_logits
+
+        # Standard sampling path for full-vocabulary logits.
         top_k, top_p = self.sampling_states.get_top_k_top_p(
             expanded_idx_mapping, idx_mapping_np
         )

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -20,6 +20,7 @@ from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+    reduced_greedy_verify,
     rejection_sample,
 )
 
@@ -81,6 +82,7 @@ class RejectionSampler:
     ):
         self.sampler = sampler
         self.num_speculative_steps = spec_config.num_speculative_tokens
+        self.draft_sample_method = spec_config.draft_sample_method
         self.enable_adaptive_verification = spec_config.enable_adaptive_verification
         rejection_sample_method = spec_config.rejection_sample_method
         self.use_block_verification: bool = False
@@ -96,6 +98,64 @@ class RejectionSampler:
             )
         elif rejection_sample_method == "block":
             self.use_block_verification = True
+
+    def can_use_reduced_sampling(self, idx_mapping_np: np.ndarray) -> bool:
+        """Return whether greedy verification needs only target argmaxes."""
+        temperatures = self.sampler.sampling_states.temperature.np[idx_mapping_np]
+        return (
+            self.draft_sample_method == "greedy"
+            and self.synthetic_conditional_rates is None
+            and not np.any(temperatures != 0.0)
+        )
+
+    def _reduced_greedy_verify(
+        self,
+        local_logits: torch.Tensor,
+        input_batch: InputBatch,
+        vocab_start_index: int,
+    ) -> SamplerOutput:
+        draft_sampled = input_batch.input_ids[input_batch.logits_indices]
+        pos = input_batch.positions[input_batch.logits_indices]
+        processed_logits = self.sampler.apply_sampling_params(
+            local_logits,
+            input_batch.expanded_idx_mapping,
+            input_batch.idx_mapping,
+            input_batch.idx_mapping_np,
+            pos,
+            draft_sampled,
+            input_batch.expanded_local_pos,
+        )
+        target_argmax = self.sampler._sample_reduced(
+            processed_logits,
+            top_k=None,
+            top_p=None,
+            expanded_idx_mapping=input_batch.expanded_idx_mapping,
+            idx_mapping_np=input_batch.idx_mapping_np,
+            temperature=self.sampler.sampling_states.temperature.gpu,
+            seeds=self.sampler.sampling_states.seeds.gpu,
+            pos=pos,
+            vocab_start_index=vocab_start_index,
+        )
+        sampled, num_sampled = reduced_greedy_verify(
+            target_argmax,
+            draft_sampled,
+            input_batch.cu_num_logits,
+            self.num_speculative_steps,
+        )
+        num_sampled, num_rejected = get_num_sampled_and_rejected(
+            num_sampled,
+            input_batch.seq_lens,
+            input_batch.cu_num_logits,
+            input_batch.idx_mapping,
+            self.sampler.req_states.prefill_len.gpu,
+        )
+        return SamplerOutput(
+            sampled_token_ids=sampled,
+            logprobs_tensors=None,
+            num_nans=None,
+            num_sampled=num_sampled,
+            num_rejected=num_rejected,
+        )
 
     def _get_logprobs_tensors(
         self,
@@ -262,7 +322,18 @@ class RejectionSampler:
         logits: torch.Tensor,
         input_batch: InputBatch,
         draft_logits: torch.Tensor | None = None,
+        *,
+        use_reduced_sampling: bool = False,
+        vocab_start_index: int | None = None,
     ) -> SamplerOutput:
+        if use_reduced_sampling:
+            assert vocab_start_index is not None
+            assert self.can_use_reduced_sampling(input_batch.idx_mapping_np)
+            assert self.sampler.can_use_reduced_sampling(
+                input_batch.idx_mapping_np, logits
+            )
+            return self._reduced_greedy_verify(logits, input_batch, vocab_start_index)
+
         # NOTE(woosuk): We intentionally compute num_nans before sampling to make clear
         # that num_nans is computed before applying penalties and temperature.
         num_nans = get_num_nans(logits) if self.sampler.compute_nans else None

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -7,6 +7,73 @@ from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand32
 
 
 @triton.jit
+def _reduced_greedy_verify_kernel(
+    target_argmax_ptr,
+    draft_sampled_ptr,
+    cu_num_logits_ptr,
+    sampled_ptr,
+    sampled_stride,
+    num_sampled_ptr,
+):
+    req_idx = tl.program_id(0)
+    start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(cu_num_logits_ptr + req_idx + 1).to(tl.int64)
+    num_draft_tokens = end_idx - start_idx - 1
+
+    accepted_length = tl.zeros((), tl.int64)
+    verifying = True
+    for i in range(num_draft_tokens):
+        if verifying:
+            logit_idx = start_idx + i
+            target_token = tl.load(target_argmax_ptr + logit_idx)
+            draft_token = tl.load(draft_sampled_ptr + logit_idx + 1)
+            accepted = (draft_token >= 0) & (draft_token == target_token)
+            tl.store(
+                sampled_ptr + req_idx * sampled_stride + i,
+                tl.where(accepted, draft_token, target_token),
+            )
+            accepted_length += accepted
+            verifying = accepted
+
+    if verifying:
+        bonus_token = tl.load(target_argmax_ptr + end_idx - 1)
+        tl.store(
+            sampled_ptr + req_idx * sampled_stride + accepted_length,
+            bonus_token,
+        )
+
+    tl.store(num_sampled_ptr + req_idx, accepted_length + 1)
+
+
+def reduced_greedy_verify(
+    target_argmax: torch.Tensor,
+    draft_sampled: torch.Tensor,
+    cu_num_logits: torch.Tensor,
+    num_speculative_steps: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Verify greedy drafts using one global target argmax per position."""
+    assert target_argmax.ndim == 1
+    assert draft_sampled.ndim == 1
+    assert cu_num_logits.ndim == 1
+
+    num_reqs = cu_num_logits.shape[0] - 1
+    sampled = draft_sampled.new_empty(
+        (num_reqs, num_speculative_steps + 1), dtype=torch.int64
+    )
+    num_sampled = draft_sampled.new_empty(num_reqs, dtype=torch.int32)
+    _reduced_greedy_verify_kernel[(num_reqs,)](
+        target_argmax,
+        draft_sampled,
+        cu_num_logits,
+        sampled,
+        sampled.stride(0),
+        num_sampled,
+        num_warps=1,
+    )
+    return sampled, num_sampled
+
+
+@triton.jit
 def _compute_max_and_sumexp(logits):
     max = tl.max(logits, axis=0)
     sumexp = tl.where(


### PR DESCRIPTION
## Purpose

This PR adds an opt-in reduced sampling path that avoids gathering full-vocabulary logits during supported tensor-parallel decoding workloads.

With `--enable-reduced-sampling`:

- Greedy sampling gathers one local `(max_logit, global_token_id)` pair per TP rank.
- Bounded top-k sampling gathers only local top-k candidate values and global token IDs.
- Greedy speculative decoding verifies draft tokens using reduced target argmaxes.
- Unsupported cases automatically fall back to the existing full-logits path.

The feature is disabled by default and requires Model Runner V2 with `tensor_parallel_size > 1`.

Related RFC/issue: https://github.com/vllm-project/vllm/issues/54333

## Implementation

The implementation is model-agnostic and does not modify individual model files.

- `LogitsProcessor` exposes shard-local logits and vocabulary metadata when the standard vocab-parallel head supports it.
- Model Runner V2 decides whether to keep local logits or perform the normal full-vocabulary all-gather.
- `Sampler` implements reduced greedy and bounded top-k sampling.
- `RejectionSampler` adds reduced verification for all-greedy speculative decoding.
- Configuration and tests cover supported cases and fail-closed behavior.

For greedy sampling, communication is reduced from `O(B × V)` to `O(B × TP)`.

For bounded top-k sampling, communication becomes `O(B × K × TP)`. The reduced path is used only when its candidate payload is smaller than the full local-logits payload.

## Compatibility and fallback

Reduced sampling supports:

- All-greedy decoding.
- Random sampling with bounded `top_k`.
- Bounded top-k combined with top-p.
- Eligible mixed greedy/random batches.
- Greedy target plus greedy draft speculative decoding.
- Standard FP16, BF16, and FP32 vocab-parallel heads.

The batch falls back to full logits when it uses features requiring the complete vocabulary distribution, including:

- Logit bias, allowed tokens, bad words, or penalties.
- Thinking budgets, `min_p`, grammar, or structured output.
- Output logprobs or explicit logprob token IDs.
- NaN counting or sampling-distribution replay.
- Random sampling without bounded top-k or with an explicit seed.
- Probabilistic speculative decoding.
- Unsupported vocabulary-shard metadata or model logits postprocessing.
- Cases where candidate communication would not be smaller.

The configuration is rejected when used with Model Runner V1, TP=1, batch-sharded sampling, LoRA, diffusion models, or custom samplers.

## Known limitations

- Exact ties at the top-k cutoff may not preserve every token retained by the full threshold-based implementation.
- Random reduced sampling is distributionally equivalent outside tie cases, but not guaranteed to be bit-for-bit identical to every full-logits backend.
- Out-of-tree models that modify the captured logits tensor in place may require a future explicit local-logits contract.
- Fallback currently applies to the whole sampler batch rather than individual requests.

## Test Plan

```bash
.venv/bin/python -m pytest tests/test_config.py -k reduced_sampling -v

.venv/bin/python -m pytest \
  tests/v1/sample/test_head_dtype.py \
  -k compute_local_logits -v

.venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_sampler_flags.py \
  -k reduced -v
```

Multi-GPU validation:

- Compare greedy outputs with reduced sampling enabled and disabled.
- Compare greedy speculative acceptance and output tokens.
- Validate bounded top-k sampling and all full-logits fallback cases.
- Measure latency for TP=2+.

## Test Result

### Test configuration

- GPU: L20X
- Number of GPUs: equal to the tensor-parallel size
  - TP=2: 2× L20X
  - TP=4: 4× L20X
- Sequence length: 8K
- Latency unit: milliseconds; lower is better
- Sampling configurations:
  - Greedy: `temperature=0`
  - Top-k/top-p: `temperature=0.6`, `top_k=20`, `top_p=0.95`

### Performance results

| Model | Hardware | Sampling | Batch | Speculative | Baseline E2E | Reduced E2E | E2E reduction | Baseline sampling | Reduced sampling | Sampling reduction |
|---|---|---|---:|---|---:|---:|---:|---:|---:|---:|
| Qwen3.6 | 2× L20X, TP=2 | Greedy | 512 | None | 34.55 | 33.65 | 3% | 1.065 | 0.122 | 89% |
| Qwen3.6 | 2× L20X, TP=2 | Top-k/top-p | 512 | None | 36.90 | 34.90 | 5% | 3.240 | 1.326 | 59% |
| Qwen3.6 | 2× L20X, TP=2 | Greedy | 256 | None | 21.43 | 21.00 | 2% | 0.554 | 0.097 | 82% |
| Qwen3.6 | 2× L20X, TP=2 | Greedy | 256 | MTP-1 | 26.30 | 24.70 | 6% | 1.045 | 0.114 | 89% |
| Qwen3.6 | 2× L20X, TP=2 | Top-k/top-p | 256 | None | 22.39 | 21.56 | 4% | 1.657 | 0.724 | 56% |
| Qwen3-235B | 4× L20X, TP=4 | Top-k/top-p | 128 | None | 34.90 | 33.70 | 3% | 0.611 | 0.235 | 62% |
| Qwen3-235B | 4× L20X, TP=4 | Greedy | 128 | None | 33.65 | 33.432 | 1% | 0.224 | 0.060 | 73% |

Across the measured configurations:

- Sampling latency is reduced by **56%–89%**.
- End-to-end latency is reduced by **1%–6%**.
- Greedy sampling achieves a sampling-latency reduction of **73%–89%**.
- Top-k/top-p sampling achieves a sampling-latency reduction of **56%–62%**.
- Greedy MTP-1 speculative decoding reduces sampling latency by **89%** and end-to-end latency by **6%**.
- Performance improvements are observed on both TP=2 and TP=4.

The end-to-end improvement is smaller than the sampling improvement because sampling is only one component of the decode step. Model execution and other runtime overhead remain unchanged.
