### PR TITLE
[Bugfix][Multimodal] Fall back when an installed torchcodec fails to import

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import itertools
+import logging
 import subprocess
 import sys
 import threading
@@ -1475,19 +1476,25 @@ def test_glm46v_duration_estimation_from_fps():
 
 
 @pytest.mark.parametrize(
-    "exc",
+    ("exc", "warns"),
     [
-        ImportError("No module named 'torchcodec'"),
-        RuntimeError("Could not load libtorchcodec."),
-        OSError(
-            "Could not load this library: "
-            "/opt/venv/lib/python3.12/site-packages/torchcodec/"
-            "libtorchcodec_image.so"
+        (
+            ModuleNotFoundError("No module named 'torchcodec'", name="torchcodec"),
+            False,
+        ),
+        (RuntimeError("Could not load libtorchcodec."), True),
+        (
+            OSError(
+                "Could not load this library: "
+                "/opt/venv/lib/python3.12/site-packages/torchcodec/"
+                "libtorchcodec_image.so"
+            ),
+            True,
         ),
     ],
     ids=["absent", "no_system_ffmpeg", "unloadable_shared_object"],
 )
-def test_unusable_torchcodec_falls_back_to_placeholder(exc):
+def test_unusable_torchcodec_falls_back_to_placeholder(exc, warns, caplog):
     """A torchcodec that fails to import must degrade to the placeholder.
 
     An absent torchcodec raises ImportError, a missing system ffmpeg raises
@@ -1507,7 +1514,10 @@ def test_unusable_torchcodec_falls_back_to_placeholder(exc):
         return real_import(name, *args, **kwargs)
 
     try:
-        with patch.object(builtins, "__import__", fake_import):
+        with (
+            patch.object(builtins, "__import__", fake_import),
+            caplog.at_level(logging.WARNING),
+        ):
             reloaded = importlib.reload(module)
 
             # The guard swallowed the failure and bound the placeholder rather
@@ -1516,5 +1526,10 @@ def test_unusable_torchcodec_falls_back_to_placeholder(exc):
             # torchcodec for real, so the error a call raises depends on
             # whether the host has a working torchcodec installed.
             assert isinstance(reloaded.VideoDecoder, _PlaceholderModuleAttr)
+
+        # torchcodec is not built for every platform, so an absent one is
+        # normal and must stay quiet. An installed but unusable one is not.
+        logged = "failed to import" in caplog.text
+        assert logged is warns
     finally:
         importlib.reload(module)

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -40,6 +40,7 @@ from vllm.multimodal.video_decoders.pynvvideocodec import (
 )
 from vllm.platforms import current_platform
 from vllm.transformers_utils.processor import get_video_processor_cls_name_from_config
+from vllm.utils.import_utils import _PlaceholderModuleAttr
 
 from .utils import (
     create_edit_list_trimmed_video,
@@ -1509,8 +1510,11 @@ def test_unusable_torchcodec_falls_back_to_placeholder(exc):
         with patch.object(builtins, "__import__", fake_import):
             reloaded = importlib.reload(module)
 
-        # The placeholder defers the failure to use time.
-        with pytest.raises(ModuleNotFoundError):
-            reloaded.VideoDecoder()
+            # The guard swallowed the failure and bound the placeholder rather
+            # than letting the exception escape the import. Assert that here
+            # instead of calling the placeholder: its __getattr__ re-imports
+            # torchcodec for real, so the error a call raises depends on
+            # whether the host has a working torchcodec installed.
+            assert isinstance(reloaded.VideoDecoder, _PlaceholderModuleAttr)
     finally:
         importlib.reload(module)

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import numpy.typing as npt
@@ -1470,3 +1471,46 @@ def test_glm46v_duration_estimation_from_fps():
     assert len(indices) > 0
     assert len(indices) % 2 == 0
     assert all(0 <= idx < 90 for idx in indices)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ImportError("No module named 'torchcodec'"),
+        RuntimeError("Could not load libtorchcodec."),
+        OSError(
+            "Could not load this library: "
+            "/opt/venv/lib/python3.12/site-packages/torchcodec/"
+            "libtorchcodec_image.so"
+        ),
+    ],
+    ids=["absent", "no_system_ffmpeg", "unloadable_shared_object"],
+)
+def test_unusable_torchcodec_falls_back_to_placeholder(exc):
+    """A torchcodec that fails to import must degrade to the placeholder.
+
+    An absent torchcodec raises ImportError, a missing system ffmpeg raises
+    RuntimeError, and an installed shared object that cannot be loaded raises
+    OSError from torch.ops.load_library. None of them may escape the guard, or
+    an unusable optional dependency takes down the video path that imports it.
+    """
+    import builtins
+    import importlib
+
+    module = importlib.import_module("vllm.multimodal.video_decoders.torchcodec")
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torchcodec" or name.startswith("torchcodec."):
+            raise exc
+        return real_import(name, *args, **kwargs)
+
+    try:
+        with patch.object(builtins, "__import__", fake_import):
+            reloaded = importlib.reload(module)
+
+        # The placeholder defers the failure to use time.
+        with pytest.raises(ModuleNotFoundError):
+            reloaded.VideoDecoder()
+    finally:
+        importlib.reload(module)

--- a/tests/utils_/test_import_utils.py
+++ b/tests/utils_/test_import_utils.py
@@ -1,11 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import builtins
 import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vllm.utils.import_utils import PlaceholderModule, _has_module, import_plugin
+from vllm.utils.import_utils import (
+    PlaceholderModule,
+    _has_module,
+    check_torchcodec_available,
+    import_plugin,
+)
 
 
 def _raises_module_not_found():
@@ -135,3 +141,46 @@ class TestImportPlugin:
         ):
             result = import_plugin("nonexistent_plugin_xyz")
             assert result is None
+
+
+class TestCheckTorchcodecAvailable:
+    """Tests for check_torchcodec_available with an unusable torchcodec."""
+
+    _LIB_PATH = (
+        "/opt/venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_image.so"
+    )
+
+    @staticmethod
+    def _import_raising(exc: Exception):
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torchcodec":
+                raise exc
+            return real_import(name, *args, **kwargs)
+
+        return patch.object(builtins, "__import__", fake_import)
+
+    def test_load_library_oserror_is_reported_without_the_library_path(self):
+        """An installed torchcodec whose shared objects cannot be loaded raises
+        OSError from torch.ops.load_library, not RuntimeError. It must surface as
+        a RuntimeError that does not echo the host library path.
+        """
+        exc = OSError(f"Could not load this library: {self._LIB_PATH}")
+
+        with self._import_raising(exc), pytest.raises(RuntimeError) as exc_info:
+            check_torchcodec_available()
+
+        assert self._LIB_PATH not in str(exc_info.value)
+
+    def test_missing_ffmpeg_runtimeerror_is_still_trimmed(self):
+        """The existing RuntimeError path keeps its message trimming."""
+        marker = (
+            "The following exceptions were raised as we tried to load libtorchcodec:"
+        )
+        exc = RuntimeError(f"Could not load libtorchcodec.\n{marker}\n{self._LIB_PATH}")
+
+        with self._import_raising(exc), pytest.raises(RuntimeError) as exc_info:
+            check_torchcodec_available()
+
+        assert str(exc_info.value) == "Could not load libtorchcodec."

--- a/vllm/multimodal/video_decoders/torchcodec.py
+++ b/vllm/multimodal/video_decoders/torchcodec.py
@@ -6,6 +6,7 @@ from typing import Literal
 import numpy as np
 import numpy.typing as npt
 
+from vllm.logger import init_logger
 from vllm.utils.import_utils import PlaceholderModule, check_torchcodec_available
 
 from .base import (
@@ -14,9 +15,22 @@ from .base import (
     check_frame_pixel_limit,
 )
 
+logger = init_logger(__name__)
+
 try:
     from torchcodec.decoders import VideoDecoder
-except (ImportError, RuntimeError):
+except Exception:
+    # A broken optional dependency fails somewhere inside its own import chain,
+    # so the exception is whatever that chain raises: ImportError when absent,
+    # RuntimeError when the system ffmpeg libraries are missing, and OSError
+    # from torch.ops.load_library when an installed shared object cannot be
+    # loaded. Fall back for all of them, and log the cause so that an installed
+    # but unusable torchcodec is not silently swallowed.
+    logger.warning(
+        "torchcodec was found but failed to import; "
+        "the torchcodec video backend will be unavailable",
+        exc_info=True,
+    )
     VideoDecoder = PlaceholderModule("torchcodec").placeholder_attr(  # type: ignore[assignment]
         "decoders.VideoDecoder"
     )

--- a/vllm/multimodal/video_decoders/torchcodec.py
+++ b/vllm/multimodal/video_decoders/torchcodec.py
@@ -19,18 +19,22 @@ logger = init_logger(__name__)
 
 try:
     from torchcodec.decoders import VideoDecoder
-except Exception:
+except Exception as exc:
     # A broken optional dependency fails somewhere inside its own import chain,
-    # so the exception is whatever that chain raises: ImportError when absent,
-    # RuntimeError when the system ffmpeg libraries are missing, and OSError
-    # from torch.ops.load_library when an installed shared object cannot be
-    # loaded. Fall back for all of them, and log the cause so that an installed
-    # but unusable torchcodec is not silently swallowed.
-    logger.warning(
-        "torchcodec was found but failed to import; "
-        "the torchcodec video backend will be unavailable",
-        exc_info=True,
-    )
+    # so the exception is whatever that chain raises: ModuleNotFoundError when
+    # absent, RuntimeError when the system ffmpeg libraries are missing, and
+    # OSError from torch.ops.load_library when an installed shared object
+    # cannot be loaded. Fall back for all of them.
+    if not (isinstance(exc, ModuleNotFoundError) and exc.name == "torchcodec"):
+        # torchcodec is optional and is not built for every platform, so an
+        # absent one is normal and stays quiet. Anything else means it is
+        # installed but unusable, which is worth surfacing rather than
+        # swallowing.
+        logger.warning(
+            "torchcodec is installed but failed to import; "
+            "the torchcodec video backend will be unavailable",
+            exc_info=True,
+        )
     VideoDecoder = PlaceholderModule("torchcodec").placeholder_attr(  # type: ignore[assignment]
         "decoders.VideoDecoder"
     )

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -627,3 +627,12 @@ def check_torchcodec_available():
         if marker in message:
             raise RuntimeError(message.split(marker, 1)[0].rstrip()) from None
         raise e
+    except OSError:
+        # An installed torchcodec whose shared objects cannot be loaded fails in
+        # torch.ops.load_library, which raises OSError rather than RuntimeError.
+        # Its message embeds the full library path, so replace it.
+        raise RuntimeError(
+            "Failed to import torchcodec: it is installed but its native "
+            "libraries could not be loaded. Install the system ffmpeg "
+            "libraries, or uninstall torchcodec to use another video backend."
+        ) from None


### PR DESCRIPTION
## Purpose

Fixes #54097. An absent `torchcodec` is handled, an installed-but-unloadable one is fatal.

`vllm/multimodal/video_decoders/torchcodec.py` guarded its import with `except (ImportError, RuntimeError)`. When torchcodec is installed but its shared objects can't be loaded, which happens on a host with no system ffmpeg, the failure surfaces from `torch.ops.load_library` as `OSError` and escapes the guard. The `PlaceholderModule` fallback never applies, so the lazy backend import inside `decode_video` raises instead of degrading to a clear error.

`check_torchcodec_available()` has the same gap and one more. It catches only `RuntimeError`, so the `OSError` reaches the caller raw, carrying the absolute library path that the `RuntimeError` branch immediately above it exists to trim out.

Two notes on scope, both from comparing notes with the reporter on the issue:

The original title said this kills startup. That was measured on an older preview build (`0.1.dev20073+g8e685d198`) whose multimodal import chain is eager. On `main` the backend import is lazy inside `decode_video` via `import_module(f".{backend}", __name__)`, so `import vllm.multimodal` completes fine and the damage is scoped to video requests. @jschmied retitled the issue accordingly.

The guard now catches `Exception` rather than adding `OSError` to the tuple. A broken optional dependency fails somewhere inside its own import chain, so the exception is whatever that chain happens to raise, and enumerating types doesn't close the class. #54153 is the same root cause one package over, where a broken `boto3` escapes `except ImportError` as `AttributeError`. This matches `_has_module` in the same file and the existing guard in `transformers_utils/processors/muse_glimmer.py`, which already uses `except Exception`. The warning log matters as much as the catch, so an unusable dependency doesn't get silently swallowed. That generalisation is @aniketwaghh's, from #54153.

## Test Plan

```bash
.venv/bin/python -m pytest tests/multimodal/test_video.py -q
.venv/bin/python -m pytest tests/utils_/test_import_utils.py -q
.venv/bin/ruff check <changed files>
.venv/bin/ruff format --check <changed files>
python tools/pre_commit/mypy.py "3.12" <changed files>
```

Reproduction used a `torchcodec` package whose `__init__` raises `OSError` the way `torch.ops.load_library` does, installed with real dist-info so it looks installed rather than absent.

## Test Result

Behaviour against that broken torchcodec, on `cacc429`:

| | before | after |
|---|---|---|
| `import vllm.multimodal` | ok | ok |
| lazy backend import (what `decode_video` does) | `OSError: Could not load this library: /opt/.../libtorchcodec_image.so` | falls back to the placeholder |
| `check_torchcodec_available()` | same raw `OSError`, full path leaked | `RuntimeError` naming the cause, no path |

New tests, both watched failing before the fix:

- `tests/multimodal/test_video.py::test_unusable_torchcodec_falls_back_to_placeholder`, parametrized over `absent` / `no_system_ffmpeg` / `unloadable_shared_object`. Before the fix the first two pass and `unloadable_shared_object` fails, which is exactly the gap. After, 3 passed.
- `tests/utils_/test_import_utils.py::TestCheckTorchcodecAvailable`, two cases: the `OSError` path must not echo the library path, and the existing `RuntimeError` trimming must be unchanged. Before the fix the `OSError` one fails and the `RuntimeError` one passes. After, both pass.

Suite results, same machine, clean checkout vs this branch:

```
tests/multimodal/test_video.py     clean: 16 failed, 49 passed, 15 skipped
                                  branch: 16 failed, 52 passed, 15 skipped   (+3 new)
tests/utils_/test_import_utils.py  clean:  1 failed,  5 passed
                                  branch:  1 failed,  7 passed               (+2 new)
```

The failures are identical on both sides and environmental, not from this change. The 16 in `test_video.py` are `ModuleNotFoundError: No module named 'av'` (pyav not installed locally). The 1 in `test_import_utils.py` is `test_placeholder_module_error_handling` failing with `No package metadata was found for vllm`, because I ran from source without a built vLLM. I confirmed both by running the same files on a stashed clean tree.

`ruff check`, `ruff format --check` and `mypy 3.12` are all clean on the four changed files.

No model evaluation: this changes only import-guard behaviour for an optional dependency and doesn't touch decode output, accuracy or serving. With torchcodec working, every path is byte-identical to before.

## Not a duplicate

Checked per AGENTS.md. No open PR references #54097. #54161 covers the `boto3` half of the same root cause under #54153 and touches only `transformers_utils/s3_utils.py`, so there's no file overlap. @false200 raised folding torchcodec into that PR and the reporter of #54153 asked to keep it boto3-only, which is where it stands. The two prior widenings on this dependency, #47888 (merged) and #48265 (closed unmerged), cover `ImportError` and `RuntimeError`.

## AI assistance

AI assistance was used for this change. I reviewed every changed line, ran the commands above myself, and can defend the change end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when optional video codec support is unavailable or its native libraries fail to load.
  - Video decoding now safely falls back when the codec cannot be used.
  - Error messages no longer expose host-specific native library paths.
  - Added diagnostic warnings for installed but unusable codec support, while keeping warnings quiet when the codec is not installed.

- **Tests**
  - Added coverage for codec import failures, fallback behavior, and sanitized error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->