### PR TITLE
[Bugfix] Update shared expert config during elastic EP reconfiguration

### DIFF
--- a/tests/model_executor/layers/test_shared_experts.py
+++ b/tests/model_executor/layers/test_shared_experts.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import MagicMock
 
 import torch
 
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
 
 
@@ -21,14 +23,24 @@ def _moe_config(*, enable_eplb: bool) -> FusedMoEConfig:
     )
 
 
-def test_set_moe_config_updates_overlap_decision():
+def test_moe_runner_updates_shared_experts_overlap_decision():
+    old_moe_config = _moe_config(enable_eplb=True)
     shared_experts = SharedExperts.__new__(SharedExperts)
     torch.nn.Module.__init__(shared_experts)
-    shared_experts._moe_config = _moe_config(enable_eplb=True)
+    shared_experts._moe_config = old_moe_config
+
+    runner = MoERunner.__new__(MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.moe_config = old_moe_config
+    runner.routed_experts = MagicMock()
+    runner._shared_experts = shared_experts
+
     assert shared_experts._disable_shared_experts_overlap
 
     new_moe_config = _moe_config(enable_eplb=False)
-    shared_experts._set_moe_config(new_moe_config)
+    runner._set_moe_config(new_moe_config)
 
+    assert runner.moe_config is new_moe_config
+    runner.routed_experts._set_moe_config.assert_called_once_with(new_moe_config)
     assert shared_experts._moe_config is new_moe_config
     assert not shared_experts._disable_shared_experts_overlap

--- a/tests/model_executor/layers/test_shared_experts.py
+++ b/tests/model_executor/layers/test_shared_experts.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+from typing import cast
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
+
+
+def _moe_config(*, enable_eplb: bool) -> FusedMoEConfig:
+    parallel_config = SimpleNamespace(
+        enable_eplb=enable_eplb,
+        all2all_backend="deepep_low_latency",
+        use_fi_nvl_two_sided_kernels=False,
+    )
+    return cast(
+        FusedMoEConfig,
+        SimpleNamespace(moe_parallel_config=parallel_config),
+    )
+
+
+def test_set_moe_config_updates_overlap_decision():
+    shared_experts = SharedExperts.__new__(SharedExperts)
+    torch.nn.Module.__init__(shared_experts)
+    shared_experts._moe_config = _moe_config(enable_eplb=True)
+    assert shared_experts._disable_shared_experts_overlap
+
+    new_moe_config = _moe_config(enable_eplb=False)
+    shared_experts._set_moe_config(new_moe_config)
+
+    assert shared_experts._moe_config is new_moe_config
+    assert not shared_experts._disable_shared_experts_overlap

--- a/tests/model_executor/layers/test_shared_experts.py
+++ b/tests/model_executor/layers/test_shared_experts.py
@@ -27,6 +27,7 @@ def test_moe_runner_updates_shared_experts_overlap_decision():
     old_moe_config = _moe_config(enable_eplb=True)
     shared_experts = SharedExperts.__new__(SharedExperts)
     torch.nn.Module.__init__(shared_experts)
+    shared_experts._layer = SimpleNamespace(shard_sequence_parallel=False)
     shared_experts._moe_config = old_moe_config
 
     runner = MoERunner.__new__(MoERunner)

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -73,7 +73,7 @@ class SharedExperts(torch.nn.Module):
 
     # TODO(bnell): Hack for elastic_ep. Get rid of this
     def _set_moe_config(self, new_moe_config: FusedMoEConfig):
-        self.moe_config = new_moe_config
+        self._moe_config = new_moe_config
 
     @property
     def _disable_shared_experts_overlap(self) -> bool:


### PR DESCRIPTION
## Purpose

Fix the `SharedExperts` elastic-EP reconfiguration path. The constructor
stores the active `FusedMoEConfig` in `_moe_config`, and the overlap policy
reads that field. The setter currently writes a different `moe_config`
attribute, so reconfiguration leaves the decision bound to stale state.

## Why this is not duplicate work

Fresh issue/PR searches on 2026-08-10 for `_set_moe_config`,
`_moe_config`, shared experts, and elastic EP found no other open or merged
fix. Current `main` at `ea3115e30` still contains the mismatched assignment.

## Changes

- update the same `_moe_config` field that the runtime reads;
- add a CPU-only regression test through `MoERunner._set_moe_config` that
  changes the EPLB setting and verifies the shared-expert overlap decision.

## Validation

- `VLLM_TARGET_DEVICE=empty .venv/bin/python -m pytest tests/model_executor/layers/test_shared_experts.py -v` — 1 passed
- `pre-commit run --files vllm/model_executor/layers/fused_moe/runner/shared_experts.py tests/model_executor/layers/test_shared_experts.py` — all applicable hooks passed
- `pre-commit run mypy-3.12 --files vllm/model_executor/layers/fused_moe/runner/shared_experts.py tests/model_executor/layers/test_shared_experts.py --hook-stage manual` — passed
- negative control: restoring the old `self.moe_config` assignment makes the regression fail because `SharedExperts._moe_config` remains the old EPLB-enabled config

Model evaluation is not applicable: this changes runtime configuration
propagation and its overlap-policy decision, not model outputs or accuracy.

## AI assistance

AI assistance was used for implementation, rebase conflict-risk review, test
adaptation, and validation. The PR remains draft until the submitting human
reviews every changed line as required by `AGENTS.md`.