### PR TITLE
[Bugfix] Reject a KV cache dtype that silently reinterprets the model's bits

### DIFF
--- a/tests/config/test_kv_cache_dtype_matches_model.py
+++ b/tests/config/test_kv_cache_dtype_matches_model.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""An explicit unquantized KV cache dtype must match the model dtype.
+
+`get_fp8_kv_cache_data_type` maps "auto", "float16" and "bfloat16" alike to
+`Fp8KVCacheDataType::kAuto`, and that branch of `DISPATCH_BY_KV_CACHE_DTYPE` only
+instantiates the cache type equal to the source type. No instantiation exists in which the
+two differ, so the cross-dtype copy the kernel implements is unreachable and the cache
+receives the model dtype's bits, read back as the requested dtype.
+
+Measured on a bfloat16 model with `--kv-cache-dtype float16`: the cache holds
+0.1621 -> 1.537, 188 -> 3.617, 436 -> 3.926 -- each the bit reinterpretation, matching to
+four significant figures -- and the model emits fluent nonsense with no error and no
+non-finite value.
+
+The quantized dtypes are unaffected: their branches instantiate `OutT != InT` and convert.
+"""
+
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+
+MODEL = "hmellor/tiny-random-LlamaForCausalLM"
+
+
+def _build(model_dtype: str, cache_dtype: str):
+    return EngineArgs(
+        model=MODEL, dtype=model_dtype, kv_cache_dtype=cache_dtype, max_model_len=128
+    ).create_engine_config()
+
+
+@pytest.mark.parametrize(
+    "model_dtype, cache_dtype",
+    [("bfloat16", "float16"), ("float16", "bfloat16")],
+)
+def test_mismatched_unquantized_cache_dtype_is_rejected(model_dtype, cache_dtype):
+    """The combination that silently reinterprets bits must not start."""
+    with pytest.raises(ValueError, match="cannot be used with a"):
+        _build(model_dtype, cache_dtype)
+
+
+@pytest.mark.parametrize(
+    "model_dtype, cache_dtype",
+    [
+        ("bfloat16", "auto"),
+        ("float16", "auto"),
+        # naming the model's own dtype is just `auto` spelled out
+        ("bfloat16", "bfloat16"),
+        ("float16", "float16"),
+        # quantized caches do convert, and must keep working
+        ("bfloat16", "fp8"),
+        ("bfloat16", "fp8_e4m3"),
+    ],
+)
+def test_supported_combinations_still_build(model_dtype, cache_dtype):
+    """Everything that has a real conversion, or needs none, is untouched.
+
+    These are the cases a user actually reaches -- `auto` and the fp8 family -- so they
+    carry the weight of showing the guard is narrow rather than a blanket refusal.
+    """
+    config = _build(model_dtype, cache_dtype)
+    assert config.cache_config.cache_dtype == cache_dtype

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -26,6 +26,7 @@ from vllm.transformers_utils.runai_utils import is_runai_obj_uri
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils import random_uuid
 from vllm.utils.hashing import safe_hash
+from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 
 from .attention import AttentionConfig
 from .cache import CacheConfig
@@ -1038,6 +1039,46 @@ class VllmConfig:
             "expandable_segments is automatically disabled)."
         )
 
+    def _verify_unquantized_kv_cache_dtype(self) -> None:
+        """An explicit unquantized KV cache dtype must match the model dtype.
+
+        `get_fp8_kv_cache_data_type` in csrc/attention/dtype_fp8.cuh maps "auto",
+        "float16" and "bfloat16" alike to `Fp8KVCacheDataType::kAuto`, and the kAuto
+        branch of `DISPATCH_BY_KV_CACHE_DTYPE` only ever instantiates the cache type
+        equal to the *source* type -- `FN(uint16_t, uint16_t, kAuto)`,
+        `FN(__nv_bfloat16, __nv_bfloat16, kAuto)`. There is no instantiation in which the
+        two differ, so `CopyWithScaleOp`'s `static_cast<OutT>(src)` is a no-op and the
+        cache receives the model dtype's *bits*, while the tensor was allocated with the
+        requested dtype and is read back as such.
+
+        The result is a bit reinterpretation with no error and no non-finite value: on a
+        bfloat16 model a float16 cache holds `0.1621 -> 1.537`, `436 -> 3.926`, and the
+        model produces fluent nonsense. Until the dispatch can express a cross-dtype
+        unquantized copy, refusing the combination is the only way to keep the failure
+        visible.
+
+        The quantized dtypes are unaffected -- their branches do instantiate
+        `OutT != InT` and convert through `fp8::scaled_convert`.
+        """
+        if self.model_config is None:
+            return
+        cache_dtype = self.cache_config.cache_dtype
+        # The unquantized set, mirroring get_fp8_kv_cache_data_type's kAuto arm.
+        if cache_dtype not in ("float16", "bfloat16"):
+            return
+        requested = STR_DTYPE_TO_TORCH_DTYPE[cache_dtype]
+        model_dtype = self.model_config.dtype
+        if requested is model_dtype:
+            return
+        raise ValueError(
+            f"--kv-cache-dtype {cache_dtype} cannot be used with a "
+            f"{model_dtype} model: the unquantized cache write has no conversion "
+            f"between the two, so the cache would hold {model_dtype} bits read back as "
+            f"{requested}, silently. Use --kv-cache-dtype auto to store the cache in the "
+            f"model dtype, pass --dtype {cache_dtype} to run the model in that dtype "
+            f"instead, or use a quantized cache dtype such as fp8, which does convert."
+        )
+
     def _verify_sampling_replay_config(self) -> None:
         model_config = self.model_config
         if model_config is None or not model_config.return_sampling_mask:
@@ -1167,6 +1208,8 @@ class VllmConfig:
 
         if self.lora_config is not None:
             self.lora_config.verify_with_model_config(self.model_config)
+
+        self._verify_unquantized_kv_cache_dtype()
 
         if (
             self.mamba_config.enable_stochastic_rounding


### PR DESCRIPTION
`--kv-cache-dtype float16` on a bfloat16 model produces fluent nonsense, with no error, no
warning and no non-finite value:

    model bfloat16, kv auto/bfloat16 -> ' Paris. The capital of Italy is Rome'
    model bfloat16, kv float16       -> ' Paris,, therefore, proclaimedondunct'
    model float16,  kv auto/float16  -> ' Paris. The capital of Italy is Rome'
    model float16,  kv bfloat16      -> ' Parislocklocklocklocklocklocklock'

The cache holds the model dtype's **bits**, read back as the requested dtype. Predicted from
the bfloat16-cache quantiles and matched against the float16-cache ones:

    bf16 value    bits    read as fp16   observed
        0.1621  0x3E25          1.5361      1.537   p50
           188  0x433C          3.6172      3.617   p99.9
           436  0x43DA          3.9258      3.926   max

Not a precision loss: the captured K/V peak at 420 against fp16's 65504, with 0.0000%
overflow and 0.0000% of values destroyed.

The cache tensor really is allocated at the requested dtype -- `kv_caches[0].dtype` reads
back `torch.float16` for `--kv-cache-dtype float16` and `torch.bfloat16` for `auto` on the
same bfloat16 model -- which is what makes the two disagree.

## Cause

`get_fp8_kv_cache_data_type` (csrc/attention/dtype_fp8.cuh) maps "auto", "float16" and
"bfloat16" alike to `Fp8KVCacheDataType::kAuto`, and that branch of
`DISPATCH_BY_KV_CACHE_DTYPE` is diagonal only:

    kAuto:     FN(float, float)      FN(uint16_t, uint16_t)      FN(__nv_bfloat16, __nv_bfloat16)
    kFp8E4M3:  FN(float, uint8_t)    FN(uint16_t, uint8_t)       FN(__nv_bfloat16, uint8_t)

The fp8 rows instantiate `OutT != InT` and convert through `fp8::scaled_convert`. The
unquantized row never does, so `CopyWithScaleOp`'s `dst = static_cast<OutT>(src)` -- which
is already correct -- is unreachable, and the store degenerates to a bit copy. The cache
tensor is meanwhile allocated with the requested dtype, so the two disagree. Every dispatch
site keys on the non-cache tensor; the cache's own dtype is never read.

## Scope

Every dispatch site was measured directly, at op level: allocate the cache at the requested
dtype, feed it the model dtype, then read the raw 16-bit words back and compare them both
against the source's own bit pattern and against an honest conversion. Both mismatch
directions, gfx90a, vLLM 0.26.0:

| dispatch site | bf16 model / fp16 cache | fp16 model / bf16 cache | matched dtypes | `auto` |
| --- | --- | --- | --- | --- |
| `reshape_and_cache`               | raw bits | raw bits | ok | ok |
| `reshape_and_cache_flash`         | raw bits | raw bits | ok | ok |
| `concat_and_cache_mla`            | raw bits | raw bits | ok | ok |
| `concat_and_cache_mla_rope_fused` | raw bits | raw bits | ok | ok |
| `gather_and_maybe_dequant_cache`  | raw bits | raw bits | ok | ok |
| `indexer_k_quant_and_cache`       | not affected | not affected | -- | -- |

"raw bits" is 100% of written words equal to the source's own bit pattern and 0.0-0.3% equal
to the converted value. The last two columns are the negative control: same harness, same
ops, correct output -- the defect is in the dtype pair, not in the measurement.

`indexer_k_quant_and_cache` is exempt for a reason worth stating, because it narrows the
claim: its string argument is a *scale format*, not a cache dtype, and the call hardcodes
`fp8_e4m3` internally. `auto`, `float16`, `bfloat16` and `fp8_e4m3` produce byte-identical
output; only `ue8m0` differs. It never reaches the `kAuto` arm.

Four of the five are cache writes. `gather_and_maybe_dequant_cache` keys on the
*destination*, so it is the same defect on the read side: an fp16 cache gathered into a
bfloat16 workspace. A seventh site, `fused_minimax_m3_qknorm_rope_kv_insert`, uses the same
macro on main but is not in the release measured here.

End to end, on two model architectures and two vLLM versions:

* `reshape_and_cache`, Qwen3-0.6B (280 native calls, 0 Triton) -- above;
* `concat_and_cache_mla`, DeepSeek-V2-Lite, **stock unpatched vLLM** (324 calls):
  cache max 17.875 -> 2.7793, again the exact reinterpretation of `0x418F`, output
  ' Paris,and in is is'.

The macro is identical in the AMD and NVIDIA `quant_utils.cuh`, and #38922's own traceback
shows the CUDA flash backend entering it.

### How much of vLLM advertises this configuration

`--kv-cache-dtype float16` and `--kv-cache-dtype bfloat16` are not obscure. **25 attention
backends list one or both in `supported_kv_cache_dtypes`**, so backend validation accepts the
request and it reaches the writer:

```
AttentionBackend (the base)      FlashAttentionBackend        FlashInferBackend
FlexAttentionBackend             CutlassMLABackend            FlashAttnMLABackend
FlashAttnMLASparseBackend        FlashInferMLABackend         FlashInferMLASparseTRTLLMBackend
FlashMLABackend                  FlashMLASparseBackend        TritonMLABackend
AiterMLABackend                  ROCMAiterMLASparseBackend    AiterFlashAttentionBackend
RocmAiterUnifiedAttentionBackend RocmAttentionBackend         TritonAttentionBackend
TritonAttentionDiffKVBackend     XPUMLASparseBackend          HpcAttentionBackend
DeepseekV4FlashInferMLASparseBackend  MiniMaxM3IndexerBackend  MiniMaxM3SparseBackend
CacheOnlyAttentionBackend
```

`FlashAttentionBackend` is the NVIDIA default, and #38922's traceback is that backend
reaching `reshape_and_cache_flash`. The CPU backend is the informative counter-example: it
advertises only `auto` and the fp8 family, so it never exposes this and this patch does not
change its behaviour.


The Triton writer is **not** affected: `tl.store` does convert across dtypes, verified
directly. Same config, block size 16 versus 64 -- which selects the C++ writer versus the
Triton one -- is correct at 64 and corrupt at 16.

## Fix

This rejects the combination at config time rather than teaching the dispatch a cross-dtype
copy, which would mean new template instantiations on both vendors' headers. It restores the
loud failure that #38922 removed while fixing the crash it was aimed at; a follow-up can make
the dispatch express the conversion and lift the restriction.

The guard is narrow: `auto`, a cache dtype naming the model's own dtype, and every quantized
dtype are untouched.

`CacheDType` admits exactly `auto`, `float16`, `bfloat16` and the quantized family, and
`get_fp8_kv_cache_data_type` maps exactly the first three to `kAuto`, so the two sets line up
and there is no unquantized spelling the guard misses.

It also gives a legible message to a case that currently fails obscurely: `--dtype float32
--kv-cache-dtype float16` is an accepted combination today and dies with a Triton
`CompilationError` at `175:24` on the reader side. That is loud, so it was never the bug --
but a config error naming both dtypes is better than a compile failure inside a kernel.

That narrowness is what keeps #43330 and #43138 working: their case is `--kv-cache-dtype
bfloat16` on a bfloat16 model, which names the model's own dtype and is accepted here. What
this rejects is only the pair for which no conversion is instantiated anywhere in the C++
dispatch.

**One thing the guard does take away.** On the Triton writer the mismatched pair currently
produces *correct* output, because `tl.store` converts. So a deployment that lands on the
Triton path -- block size 64 or larger on the backends that route there -- loses a
configuration that happens to work for it today. That configuration buys nothing: both dtypes
are 16 bits wide, so there is no memory saved, and the only reason to ask for one while
running the other is a mistake. Rejecting it uniformly seemed better than leaving correctness
dependent on the block size, but it is a real behaviour change and worth a reviewer's
attention rather than a footnote.

    without this patch:  2 failed, 6 passed
    with this patch:     8 passed

The six supported combinations pass on both sides -- they are the control that the guard
refuses only what has no conversion.

This change was prepared with AI assistance; the measurements above were run and reproduced
by the author.

## Why this has not been caught

The Triton half of this has been fixed twice, and the C++ half was never in the frame.
#43330 ("Allow native KV cache dtype in Triton cache update", merged) unblocked explicit
native dtypes in `triton_reshape_and_cache_flash.py`, and #43138 set out to remove a further
over-strict assert in the same file -- since superseded, since `_NATIVE_KV_CACHE_DTYPES` on
current main already holds `{"auto", "float16", "bfloat16", "float32", "half", "float"}` and
the assert it targets no longer exists there. Both are correct, and both touch only the Triton
writer -- the one path that already converts.

So the combination is being deliberately opened up by people who verified it on the path
where it works. #43330's own test plan is `--kv-cache-dtype bfloat16` on a served model.
On a block size of 16 or 32, which is the default, that request takes the C++ writer
instead and is silently reinterpreted.

Signed-off-by: Mazukiri <maihoangduc04@gmail.com>

