### PR TITLE
[Bugfix] Stop advertising fp8_e5m2 where the KV writer stores e4m3

### DIFF
--- a/tests/v1/attention/test_triton_kv_writer_fp8_format.py
+++ b/tests/v1/attention/test_triton_kv_writer_fp8_format.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""A KV-cache backend must not advertise an fp8 format its writer cannot store.
+
+``triton_reshape_and_cache_flash`` stores ``current_platform.fp8_dtype()``, an e4m3
+variant on every platform, while ``chunked_prefill_paged_decode`` and ``prefix_prefill``
+decode an ``fp8_e5m2`` cache as ``torch.float8_e5m2``. Writing e4m3 bits under an e5m2
+label reinterprets them rather than converting, and the request still succeeds, so the
+failure is silent.
+"""
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.rocm_attn import RocmAttentionBackend
+from vllm.v1.attention.backends.triton_attn import TritonAttentionBackend
+from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+    _is_supported_kv_cache_dtype,
+)
+
+# Both backends route KV writes through triton_reshape_and_cache_flash:
+# TritonAttentionBackend unconditionally, RocmAttentionBackend for any block size that
+# is not 16 or 32 -- and get_supported_kernel_block_sizes permits MultipleOf(16).
+_TRITON_WRITER_BACKENDS = (TritonAttentionBackend, RocmAttentionBackend)
+
+
+def test_the_kernel_stores_an_e4m3_variant():
+    """The premise. If this ever changes, the rest of the file needs rewriting."""
+    assert current_platform.fp8_dtype() in (
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+    )
+
+
+def test_e5m2_is_refused_by_the_writer():
+    """Refused for a format reason, so it must hold on every device."""
+    assert not _is_supported_kv_cache_dtype("fp8_e5m2")
+
+
+def test_unquantized_dtypes_are_untouched():
+    """A control: the refusal is about the fp8 format, not about caching in general."""
+    assert _is_supported_kv_cache_dtype("auto")
+    assert _is_supported_kv_cache_dtype("float32")
+
+
+def test_backends_do_not_advertise_a_format_the_writer_refuses():
+    for backend in _TRITON_WRITER_BACKENDS:
+        advertised = set(backend.supported_kv_cache_dtypes)
+        assert "fp8_e5m2" not in advertised, (
+            f"{backend.__name__} advertises fp8_e5m2, but its KV writer stores "
+            f"{current_platform.fp8_dtype()}; the cache would be decoded as e5m2"
+        )
+
+
+def test_backends_still_advertise_the_format_the_writer_does_store():
+    """The other control: e4m3 must not have been swept away with e5m2."""
+    for backend in _TRITON_WRITER_BACKENDS:
+        advertised = set(backend.supported_kv_cache_dtypes)
+        assert {"fp8", "fp8_e4m3"} <= advertised, (
+            f"{backend.__name__} no longer advertises the fp8 format it can store"
+        )

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -172,7 +172,6 @@ class RocmAttentionBackend(AttentionBackend):
         "bfloat16",
         "fp8",
         "fp8_e4m3",
-        "fp8_e5m2",
     ]
 
     @staticmethod

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -297,7 +297,6 @@ class TritonAttentionBackend(AttentionBackend):
         "bfloat16",
         "fp8",
         "fp8_e4m3",
-        "fp8_e5m2",
         "int4_per_token_head",
         "int8_per_token_head",
         "fp8_per_token_head",

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -23,6 +23,13 @@ def _is_supported_kv_cache_dtype(kv_cache_dtype: str) -> bool:
         or is_quantized_kv_cache(kv_cache_dtype)
     ):
         return False
+    if kv_cache_dtype == "fp8_e5m2":
+        # This kernel stores ``current_platform.fp8_dtype()``, an e4m3 variant on
+        # every platform, while ``chunked_prefill_paged_decode`` and
+        # ``prefix_prefill`` decode an fp8_e5m2 cache as ``torch.float8_e5m2``.
+        # Writing e4m3 bits under an e5m2 label reinterprets them rather than
+        # converting, so refuse the format here instead of storing the wrong bits.
+        return False
     if kv_cache_dtype.startswith("fp8"):
         return current_platform.has_device_capability(89) or current_platform.is_xpu()
     if kv_cache_dtype == "bfloat16":
@@ -395,9 +402,11 @@ def triton_reshape_and_cache_flash(
     page_stride = key_cache.stride()[1]
 
     assert _is_supported_kv_cache_dtype(kv_cache_dtype), (
-        f"Triton reshape-and-cache cannot store kv_cache_dtype={kv_cache_dtype} "
-        f"on this device: an FP8 KV cache needs native fp8e4nv (SM89+). Use "
-        f"--kv-cache-dtype bfloat16 (or float16 on SM75)."
+        f"Triton reshape-and-cache cannot store kv_cache_dtype={kv_cache_dtype}. "
+        f"This kernel stores {current_platform.fp8_dtype()}, so fp8_e5m2 would be "
+        f"reinterpreted rather than converted; an FP8 KV cache also needs native "
+        f"fp8e4nv (SM89+). Use --kv-cache-dtype fp8_e4m3, or bfloat16 "
+        f"(float16 on SM75)."
     )
     kv_cache_torch_dtype = (
         current_platform.fp8_dtype()


### PR DESCRIPTION
`triton_reshape_and_cache_flash` stores `current_platform.fp8_dtype()`. That is an **e4m3**
variant on every platform — `Platform.fp8_dtype()` returns `torch.float8_e4m3fn` and no
platform overrides it to e5m2. The readers honour what the user asked for:

```python
# chunked_prefill_paged_decode.py, prefix_prefill.py
elif kv_cache_dtype == "fp8_e5m2":
    target_dtype = torch.float8_e5m2
```

So an `fp8_e5m2` cache written by this kernel holds e4m3 bits and is decoded as e5m2. That
is a reinterpretation, not a conversion:

```
values                          [1.0,  2.0,  3.5,  0.25   ]
stored e4m3, read back as e5m2  [0.5,  2.0,  6.0,  0.03125]
correct if converted to e5m2    [1.0,  2.0,  3.5,  0.25   ]
```

Both `TritonAttentionBackend` and `RocmAttentionBackend` list `fp8_e5m2` in
`supported_kv_cache_dtypes`, so the request is accepted and the failure is silent.

## Measured

Qwen3-0.6B, bfloat16, greedy, `max_tokens=16`, prompt `"The capital of France is"`, on
MI250. Block size selects the writer: `RocmAttentionBackend.do_kv_cache_update` uses the C++
writer for block sizes 16 and 32 and the Triton writer otherwise, while
`get_supported_kernel_block_sizes()` returns `MultipleOf(16)`.

| `--kv-cache-dtype` | block 64 → Triton writer | block 16 → C++ writer |
| --- | --- | --- |
| `auto` | `' Paris. The capital of Italy is Rome. …'` | same |
| `fp8_e4m3` | `' Paris. The capital of Italy is Rome. …'` | same |
| **`fp8_e5m2`** | **`' Parislocklocklocklocklocklock…'`** | **`RuntimeError` in `reshape_and_cache`** |

The same request the C++ writer refuses outright is silently mis-stored by the Triton one,
and only the block size decides which runs.

The mechanism shows in the cache bytes. For the `fp8_e5m2` run, **0.0% of the stored bytes
are non-finite when read as e4m3**, and the byte statistics are identical to the `fp8_e4m3`
run — the cache contains e4m3 values under an e5m2 label.

The comment on `get_supported_kernel_block_sizes` notes that qwen3-next (block_size 544) and
qwen3_5 (784, 1056) are dynamically routed to the Triton writer, so for those architectures
the routing is not the user's choice at all.

## Fix

Drop `fp8_e5m2` from the two backends whose KV writes go through this kernel, and refuse it
in `_is_supported_kv_cache_dtype` as defence in depth. To be precise about the scope of that
second half: it gates only this writer, so it protects any backend that routes here and
nothing else — the per-token-head and DiffKV writers have their own paths, and DiffKV does
not advertise FP8 today. The user gets the standard "unsupported KV cache dtype for this
backend" at startup instead of fluent nonsense at generation time.

`fp8` and `fp8_e4m3` are untouched — they are the format the kernel actually stores, and the
table above shows them correct on both writers.

This is a narrowing, not a feature removal: nothing was ever storing e5m2. Supporting it
properly means teaching the kernel to convert to the requested format, which is a larger
change than declaring the current state honestly.

## One format, not the family

Every `CacheDType` the platform accepts was swept at both writers — 15 dtypes x block size
16 (C++ writer) and 64 (Triton writer), same model and prompt:

* exact at both writers: `auto`, `fp8`, `fp8_e4m3`, `turboquant_k8v4`, `int8_per_token_head`
* refused loudly at both: `fp8_inc`, `fp8_ds_mla`, `nvfp4`, `nvfp4_4over6`
* degraded identically at both, i.e. ordinary quantisation loss with the writer not the
  variable: `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc`,
  `int4_per_token_head`, `fp8_per_token_head`
* **writer-dependent: `fp8_e5m2` alone**

So this is one format with a wrong label, not a symptom of something broader.

## Tests

`tests/v1/attention/test_triton_kv_writer_fp8_format.py`, CPU only:

```
on origin/main:  2 failed, 3 passed
on this branch:  5 passed
```

Same result on both vendors — MI250 (gfx90a) and an RTX 4090 (SM89), the latter on the vLLM
nightly. That matters because the mechanism is platform-independent by construction:
`Platform.fp8_dtype()` returns `torch.float8_e4m3fn` and no platform overrides it, and
`TritonAttentionBackend.do_kv_cache_update` selects the Triton writer without consulting the
platform.

The three that pass on **both** sides are the controls — the kernel still stores an e4m3
variant, unquantized dtypes are unaffected, and both backends still advertise `fp8` and
`fp8_e4m3`. Without them, removing a dtype would look like a fix no matter how much it broke.

## Relationship to #49077

#49077 ("TRITON_ATTN support for KV cache dtype fp8 on SM75 to pre-SM89", open) edits the
same function, `_is_supported_kv_cache_dtype`, and rewrites the same failure message at the
end of `triton_reshape_and_cache_flash`. The two changes are complementary in intent and will
conflict textually — whichever lands second needs a trivial rebase that keeps both arms:

* #49077 adds an `fp8`/`fp8_e4m3` arm that **widens** support, by supplying a software
  conversion where the hardware has no native `fp8e4nv`.
* this PR adds an `fp8_e5m2` arm that **narrows** it, because no conversion exists there at
  all and the kernel silently stores a different format.

It is also the best available answer to the obvious objection, "why refuse e5m2 instead of
converting it?" #49077 is what converting actually costs for *one* format on *some* hardware:
a dedicated CUDA conversion helper, LLVM bitcode linked into Triton, and changes to `setup.py`
and `MANIFEST.in`. Until someone does that work for e5m2, the honest state of the code is that
this kernel cannot store it.

#49077 does not fix this bug. Its new arm covers `("fp8", "fp8_e4m3")` only; `fp8_e5m2` falls
through unchanged.

## Related

I found this while auditing capability gates on ROCm. `_is_supported_kv_cache_dtype` gates
fp8 on `has_device_capability(89)` with no platform guard, and
`RocmPlatform.get_device_capability()` derives `(9, 0)` from `gfx90a`, so `9.0 >= 8.9` and
the check passes on hardware with no fp8 unit. That accidental pass turns out to be harmless
for e4m3 — the Triton store is correct there, measured — so this PR fixes the format
mismatch and leaves the capability question alone.

This change was prepared with AI assistance; the measurements above were run and reproduced
by the author.

Signed-off-by: Mazukiri <maihoangduc04@gmail.com>
