### PR TITLE
[Benchmark] Add multilingual character throughput metrics to bench serve (#51963)

### DIFF
--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -18,13 +18,17 @@ class _Tokenizer:
         return SimpleNamespace(input_ids=[0] * self.token_counts.get(text, 0))
 
 
-def _calculate(outputs: list[RequestFuncOutput]):
+def _calculate(outputs: list[RequestFuncOutput], use_tokenizer: bool = True):
     return calculate_metrics(
         input_requests=[],
         outputs=outputs,
         dur_s=2.0,
-        tokenizer=_Tokenizer(
-            {output.generated_text: output.output_tokens for output in outputs}
+        tokenizer=(
+            _Tokenizer(
+                {output.generated_text: output.output_tokens for output in outputs}
+            )
+            if use_tokenizer
+            else None
         ),
         selected_percentiles=[50.0],
         goodput_config_dict={},
@@ -64,7 +68,7 @@ def test_calculate_metrics_counts_unicode_output_characters():
         ]
     )
 
-    # Python's len() counts Unicode code points, not UTF-8 bytes.
+    # Python's character iteration counts Unicode code points, not UTF-8 bytes.
     assert metrics.total_output_chars == len("hello") + len(multilingual_text)
     assert metrics.output_char_throughput == pytest.approx(
         metrics.total_output_chars / 2.0
@@ -92,8 +96,26 @@ def test_calculate_metrics_handles_zero_tokens_and_whitespace():
         ]
     )
 
-    assert metrics.total_output_chars == 3
-    assert metrics.output_char_throughput == pytest.approx(1.5)
+    assert metrics.total_output_chars == 0
+    assert metrics.output_char_throughput == 0.0
+    assert metrics.mean_chars_per_token == 0.0
+
+
+def test_calculate_metrics_does_not_synthesize_token_ratio_without_usage():
+    metrics = _calculate(
+        [
+            RequestFuncOutput(
+                success=True,
+                generated_text="hello",
+                output_tokens=0,
+                latency=1.0,
+            )
+        ],
+        use_tokenizer=False,
+    )
+
+    assert metrics.total_output_chars == 5
+    assert metrics.total_output == 1
     assert metrics.mean_chars_per_token == 0.0
 
 

--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -121,7 +121,7 @@ def test_measured_zero_tokens_are_distinct_from_unmeasured_tokens():
             RequestFuncOutput(
                 success=True,
                 generated_text="hello",
-                output_tokens=0,
+                output_tokens=None,
                 latency=1.0,
             )
         ],

--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -121,7 +121,7 @@ def test_measured_zero_tokens_are_distinct_from_unmeasured_tokens():
             RequestFuncOutput(
                 success=True,
                 generated_text="hello",
-                output_tokens=None,
+                output_tokens=None,  # type: ignore[arg-type]
                 latency=1.0,
             )
         ],

--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
+from vllm.benchmarks.serve import _build_generation_result, calculate_metrics
+
+
+class _Tokenizer:
+    def __init__(self, token_counts: dict[str, int]):
+        self.token_counts = token_counts
+
+    def __call__(self, text: str, *, add_special_tokens: bool):
+        del add_special_tokens
+        return SimpleNamespace(input_ids=[0] * self.token_counts.get(text, 0))
+
+
+def _calculate(outputs: list[RequestFuncOutput]):
+    return calculate_metrics(
+        input_requests=[],
+        outputs=outputs,
+        dur_s=2.0,
+        tokenizer=_Tokenizer(
+            {output.generated_text: output.output_tokens for output in outputs}
+        ),
+        selected_percentiles=[50.0],
+        goodput_config_dict={},
+    )[0]
+
+
+def test_calculate_metrics_counts_unicode_output_characters():
+    multilingual_text = "\u0e2a\u0e27\u0e31\u0e2a\u0e14\u0e35\u4e16\u754c"
+    metrics = _calculate(
+        [
+            RequestFuncOutput(
+                success=True,
+                generated_text="hello",
+                output_tokens=5,
+                latency=1.0,
+                ttft=0.1,
+            ),
+            RequestFuncOutput(
+                success=True,
+                generated_text=multilingual_text,
+                output_tokens=4,
+                latency=1.0,
+                ttft=0.1,
+            ),
+            RequestFuncOutput(
+                success=True,
+                generated_text="",
+                output_tokens=0,
+                latency=1.0,
+                ttft=0.1,
+            ),
+            RequestFuncOutput(
+                success=False,
+                generated_text="failed response",
+                output_tokens=10,
+            ),
+        ]
+    )
+
+    # Python's len() counts Unicode code points, not UTF-8 bytes.
+    assert metrics.total_output_chars == len("hello") + len(multilingual_text)
+    assert metrics.output_char_throughput == pytest.approx(
+        metrics.total_output_chars / 2.0
+    )
+    assert metrics.mean_chars_per_token == pytest.approx(metrics.total_output_chars / 9)
+    assert metrics.total_output == 9
+    assert metrics.output_throughput == pytest.approx(9 / 2.0)
+
+
+def test_calculate_metrics_handles_zero_tokens_and_whitespace():
+    metrics = _calculate(
+        [
+            RequestFuncOutput(
+                success=True,
+                generated_text="   ",
+                output_tokens=0,
+                latency=1.0,
+            ),
+            RequestFuncOutput(
+                success=True,
+                generated_text="",
+                output_tokens=0,
+                latency=1.0,
+            ),
+        ]
+    )
+
+    assert metrics.total_output_chars == 3
+    assert metrics.output_char_throughput == pytest.approx(1.5)
+    assert metrics.mean_chars_per_token == 0.0
+
+
+def test_character_metrics_are_json_serializable():
+    metrics = _calculate(
+        [
+            RequestFuncOutput(
+                success=True,
+                generated_text="\u4f60\u597d",
+                output_tokens=2,
+                latency=1.0,
+            )
+        ]
+    )
+
+    result = _build_generation_result(
+        metrics,
+        benchmark_duration=2.0,
+        outputs=[
+            RequestFuncOutput(
+                success=True,
+                generated_text="\u4f60\u597d",
+                output_tokens=2,
+                latency=1.0,
+            )
+        ],
+        actual_output_lens=[2],
+        goodput_config_dict={},
+    )
+    assert result["total_output_chars"] == 2
+    assert result["output_char_throughput"] == pytest.approx(1.0)
+    assert result["mean_chars_per_token"] == pytest.approx(1.0)
+    serialized = json.dumps(result, ensure_ascii=False)
+    assert json.loads(serialized) == result

--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -6,7 +6,11 @@ from types import SimpleNamespace
 import pytest
 
 from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
-from vllm.benchmarks.serve import _build_generation_result, calculate_metrics
+from vllm.benchmarks.serve import (
+    _build_generation_result,
+    _format_mean_chars_per_token,
+    calculate_metrics,
+)
 
 
 class _Tokenizer:
@@ -101,6 +105,36 @@ def test_calculate_metrics_handles_zero_tokens_and_whitespace():
     assert metrics.mean_chars_per_token == 0.0
 
 
+def test_measured_zero_tokens_are_distinct_from_unmeasured_tokens():
+    measured_zero = _calculate(
+        [
+            RequestFuncOutput(
+                success=True,
+                generated_text="",
+                output_tokens=0,
+                latency=1.0,
+            )
+        ]
+    )
+    unmeasured = _calculate(
+        [
+            RequestFuncOutput(
+                success=True,
+                generated_text="hello",
+                output_tokens=0,
+                latency=1.0,
+            )
+        ],
+        use_tokenizer=False,
+    )
+
+    assert measured_zero.total_output == 0
+    assert measured_zero.mean_chars_per_token == 0.0
+    assert unmeasured.total_output == 1
+    assert unmeasured.mean_chars_per_token is None
+    assert _format_mean_chars_per_token(measured_zero.mean_chars_per_token) == "0.00"
+
+
 def test_calculate_metrics_does_not_synthesize_token_ratio_without_usage():
     metrics = _calculate(
         [
@@ -116,7 +150,26 @@ def test_calculate_metrics_does_not_synthesize_token_ratio_without_usage():
 
     assert metrics.total_output_chars == 5
     assert metrics.total_output == 1
-    assert metrics.mean_chars_per_token == 0.0
+    assert metrics.mean_chars_per_token is None
+    assert _format_mean_chars_per_token(metrics.mean_chars_per_token) == "N/A"
+
+    result = _build_generation_result(
+        metrics,
+        benchmark_duration=2.0,
+        outputs=[
+            RequestFuncOutput(
+                success=True,
+                generated_text="hello",
+                output_tokens=0,
+                latency=1.0,
+            )
+        ],
+        actual_output_lens=[1],
+        goodput_config_dict={},
+    )
+    assert result["mean_chars_per_token"] is None
+    serialized = json.dumps(result)
+    assert '"mean_chars_per_token": null' in serialized
 
 
 def test_character_metrics_are_json_serializable():

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -602,7 +602,7 @@ def calculate_metrics(
             output_len = outputs[i].output_tokens
             generated_text = outputs[i].generated_text or ""
             total_output_chars += sum(not char.isspace() for char in generated_text)
-            output_tokens_measured = output_len > 0
+            output_tokens_measured = bool(output_len and output_len > 0)
 
             if not output_len:
                 if tokenizer is None:

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -353,7 +353,7 @@ class BenchmarkMetrics:
     rtfx: float = 0.0  # Inverse Real-Time Factor for ASR benchmarks
     total_output_chars: int = 0
     output_char_throughput: float = 0.0
-    mean_chars_per_token: float = 0.0
+    mean_chars_per_token: float | None = None
 
 
 @dataclass
@@ -784,13 +784,22 @@ def calculate_metrics(
         total_output_chars=total_output_chars,
         output_char_throughput=total_output_chars / dur_s,
         mean_chars_per_token=(
-            total_output_chars / measured_output_tokens
-            if measured_output_tokens > 0 and not has_unmeasured_output_tokens
-            else 0.0
+            None
+            if has_unmeasured_output_tokens
+            else (
+                total_output_chars / measured_output_tokens
+                if measured_output_tokens > 0
+                else 0.0
+            )
         ),
     )
 
     return metrics, actual_output_lens
+
+
+def _format_mean_chars_per_token(value: float | None) -> str:
+    """Format the character/token ratio for the terminal summary."""
+    return "N/A" if value is None else f"{value:.2f}"
 
 
 def _build_generation_result(
@@ -1290,8 +1299,9 @@ async def benchmark(
             )
         )
         print(
-            "{:<40} {:<10.2f}".format(
-                "Mean characters per token:", metrics.mean_chars_per_token
+            "{:<40} {:<10}".format(
+                "Mean characters per token:",
+                _format_mean_chars_per_token(metrics.mean_chars_per_token),
             )
         )
         print(

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -586,6 +586,8 @@ def calculate_metrics(
     """
     actual_output_lens: list[int] = []
     total_output_chars = 0
+    measured_output_tokens = 0
+    has_unmeasured_output_tokens = False
     total_input = 0
     completed = 0
     good_completed = 0
@@ -598,11 +600,16 @@ def calculate_metrics(
     for i in range(len(outputs)):
         if outputs[i].success:
             output_len = outputs[i].output_tokens
-            total_output_chars += len(outputs[i].generated_text or "")
+            generated_text = outputs[i].generated_text or ""
+            total_output_chars += sum(not char.isspace() for char in generated_text)
+            output_tokens_measured = output_len > 0
 
             if not output_len:
                 if tokenizer is None:
+                    # Preserve the historical fallback for token throughput,
+                    # but do not use it as a measured token count.
                     output_len = 1
+                    has_unmeasured_output_tokens = True
                 else:
                     # We use the tokenizer to count the number of output tokens
                     # for some serving backends instead of looking at
@@ -610,10 +617,11 @@ def calculate_metrics(
                     # bundled together
                     # Note : this may inflate the output token count slightly
                     output_len = len(
-                        tokenizer(
-                            outputs[i].generated_text, add_special_tokens=False
-                        ).input_ids
+                        tokenizer(generated_text, add_special_tokens=False).input_ids
                     )
+                    output_tokens_measured = True
+            if output_tokens_measured:
+                measured_output_tokens += output_len
             actual_output_lens.append(output_len)
             total_input += outputs[i].prompt_len
             tpot = 0.0
@@ -776,7 +784,9 @@ def calculate_metrics(
         total_output_chars=total_output_chars,
         output_char_throughput=total_output_chars / dur_s,
         mean_chars_per_token=(
-            total_output_chars / total_output_tokens if total_output_tokens > 0 else 0.0
+            total_output_chars / measured_output_tokens
+            if measured_output_tokens > 0 and not has_unmeasured_output_tokens
+            else 0.0
         ),
     )
 

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -351,6 +351,9 @@ class BenchmarkMetrics:
     max_output_tokens_per_s: float
     max_concurrent_requests: int
     rtfx: float = 0.0  # Inverse Real-Time Factor for ASR benchmarks
+    total_output_chars: int = 0
+    output_char_throughput: float = 0.0
+    mean_chars_per_token: float = 0.0
 
 
 @dataclass
@@ -582,6 +585,7 @@ def calculate_metrics(
         A tuple of the benchmark metrics and the actual output lengths.
     """
     actual_output_lens: list[int] = []
+    total_output_chars = 0
     total_input = 0
     completed = 0
     good_completed = 0
@@ -594,6 +598,7 @@ def calculate_metrics(
     for i in range(len(outputs)):
         if outputs[i].success:
             output_len = outputs[i].output_tokens
+            total_output_chars += len(outputs[i].generated_text or "")
 
             if not output_len:
                 if tokenizer is None:
@@ -730,15 +735,16 @@ def calculate_metrics(
         else:
             print("tip: install termplotlib and gnuplot to plot the metrics")
 
+    total_output_tokens = sum(actual_output_lens)
     metrics = BenchmarkMetrics(
         completed=completed,
         failed=len(failed_outputs),
         total_input=total_input,
-        total_output=sum(actual_output_lens),
+        total_output=total_output_tokens,
         request_throughput=completed / dur_s,
         request_goodput=good_completed / dur_s,
-        output_throughput=sum(actual_output_lens) / dur_s,
-        total_token_throughput=(total_input + sum(actual_output_lens)) / dur_s,
+        output_throughput=total_output_tokens / dur_s,
+        total_token_throughput=(total_input + total_output_tokens) / dur_s,
         mean_ttft_ms=np.mean(ttfts or 0)
         * 1000,  # ttfts is empty if streaming is not supported by the endpoint
         std_ttft_ms=np.std(ttfts or 0) * 1000,
@@ -767,9 +773,50 @@ def calculate_metrics(
         max_output_tokens_per_s=max_output_tokens_per_s,
         max_concurrent_requests=max_concurrent_requests,
         rtfx=input_audio_duration / dur_s,
+        total_output_chars=total_output_chars,
+        output_char_throughput=total_output_chars / dur_s,
+        mean_chars_per_token=(
+            total_output_chars / total_output_tokens if total_output_tokens > 0 else 0.0
+        ),
     )
 
     return metrics, actual_output_lens
+
+
+def _build_generation_result(
+    metrics: BenchmarkMetrics,
+    benchmark_duration: float,
+    outputs: list[RequestFuncOutput],
+    actual_output_lens: list[int],
+    goodput_config_dict: dict[str, float],
+) -> dict[str, Any]:
+    """Build the JSON-serializable result for a generation benchmark."""
+    return {
+        "duration": benchmark_duration,
+        "completed": metrics.completed,
+        "failed": metrics.failed,
+        "total_input_tokens": metrics.total_input,
+        "total_output_tokens": metrics.total_output,
+        "total_output_chars": metrics.total_output_chars,
+        "request_throughput": metrics.request_throughput,
+        "request_goodput": metrics.request_goodput if goodput_config_dict else None,
+        "output_throughput": metrics.output_throughput,
+        "output_char_throughput": metrics.output_char_throughput,
+        "mean_chars_per_token": metrics.mean_chars_per_token,
+        "total_token_throughput": metrics.total_token_throughput,
+        "input_lens": [output.prompt_len for output in outputs],
+        "output_lens": actual_output_lens,
+        "ttfts": [output.ttft for output in outputs],
+        "itls": [output.itl for output in outputs],
+        "latencies": [output.latency for output in outputs],
+        "start_times": [output.start_time for output in outputs],
+        "queue_times": [output.client_queue_time for output in outputs],
+        "generated_texts": [output.generated_text for output in outputs],
+        "errors": [output.error for output in outputs],
+        "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
+        "max_concurrent_requests": metrics.max_concurrent_requests,
+        "rtfx": metrics.rtfx,
+    }
 
 
 async def benchmark(
@@ -1190,6 +1237,12 @@ async def benchmark(
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
     if isinstance(metrics, BenchmarkMetrics) and tokenizer:
         print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))
+    if isinstance(metrics, BenchmarkMetrics):
+        print(
+            "{:<40} {:<10}".format(
+                "Total generated characters:", metrics.total_output_chars
+            )
+        )
     print(
         "{:<40} {:<10.2f}".format(
             "Request throughput (req/s):", metrics.request_throughput
@@ -1220,6 +1273,17 @@ async def benchmark(
                     metrics.max_output_tokens_per_s,
                 )
             )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Output character throughput (char/s):",
+                metrics.output_char_throughput,
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Mean characters per token:", metrics.mean_chars_per_token
+            )
+        )
         print(
             "{:<40} {:<10.2f}".format(
                 "Peak concurrent requests:", metrics.max_concurrent_requests
@@ -1278,29 +1342,13 @@ async def benchmark(
 
     result: dict[str, Any]
     if isinstance(metrics, BenchmarkMetrics):
-        result = {
-            "duration": benchmark_duration,
-            "completed": metrics.completed,
-            "failed": metrics.failed,
-            "total_input_tokens": metrics.total_input,
-            "total_output_tokens": metrics.total_output,
-            "request_throughput": metrics.request_throughput,
-            "request_goodput": metrics.request_goodput if goodput_config_dict else None,
-            "output_throughput": metrics.output_throughput,
-            "total_token_throughput": metrics.total_token_throughput,
-            "input_lens": [output.prompt_len for output in outputs],
-            "output_lens": actual_output_lens,
-            "ttfts": [output.ttft for output in outputs],
-            "itls": [output.itl for output in outputs],
-            "latencies": [output.latency for output in outputs],
-            "start_times": [output.start_time for output in outputs],
-            "queue_times": [output.client_queue_time for output in outputs],
-            "generated_texts": [output.generated_text for output in outputs],
-            "errors": [output.error for output in outputs],
-            "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
-            "max_concurrent_requests": metrics.max_concurrent_requests,
-            "rtfx": metrics.rtfx,
-        }
+        result = _build_generation_result(
+            metrics,
+            benchmark_duration,
+            outputs,
+            actual_output_lens,
+            goodput_config_dict,
+        )
     else:
         result = {
             "duration": benchmark_duration,


### PR DESCRIPTION
### Description
This PR adds character-level throughput metrics (`output_char_throughput` and `mean_chars_per_token`) to `vllm bench serve` to address benchmarking distortion for non-Latin / multilingual workloads where token-to-character ratios vary significantly.

### Fixes
Fixes #51963

### Changes
- Integrated `total_output_chars`, `output_char_throughput`, and `mean_chars_per_token` calculations.
- Formatted terminal table output and added JSON output support in `--save-result`.
- Added CPU unit tests covering multilingual Unicode (CJK/Thai) and empty edge cases.