### PR TITLE
[Perf][Kernel][Attention] Reorder causal-prefill launches in Triton unified attention

### DIFF
--- a/tests/kernels/attention/test_triton_unified_attention.py
+++ b/tests/kernels/attention/test_triton_unified_attention.py
@@ -227,6 +227,95 @@ def test_triton_unified_attn(
     )
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    (
+        "num_query_heads",
+        "num_kv_heads",
+        "head_size",
+        "block_size",
+        "window_size",
+    ),
+    [
+        (8, 8, 128, 16, (-1, -1)),
+        (8, 2, 64, 16, (-1, -1)),
+        (8, 2, 128, 16, (-1, -1)),
+        (8, 2, 256, 16, (-1, -1)),
+        (32, 1, 128, 16, (-1, -1)),
+        (8, 2, 128, 32, (-1, -1)),
+        (8, 2, 256, 544, (-1, -1)),
+        pytest.param(8, 2, 128, 16, (63, 0), id="sliding-window-fallback"),
+    ],
+)
+@torch.inference_mode()
+def test_triton_unified_attn_causal_prefill_reorder_bitwise(
+    dtype: torch.dtype,
+    num_query_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    block_size: int,
+    window_size: tuple[int, int],
+) -> None:
+    """Requesting launch reordering must not change any output bit."""
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    seq_lens = [(4, 37), (16, 65), (32, 97)]
+    query_lens = [query_len for query_len, _ in seq_lens]
+    kv_lens = [kv_len for _, kv_len in seq_lens]
+    num_blocks = 8 if block_size == 544 else 64
+
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+    )
+    value_cache = torch.randn_like(key_cache)
+    cu_query_lens = torch.tensor([0, *query_lens], dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
+    max_num_blocks = (max(kv_lens) + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0,
+        num_blocks,
+        (len(seq_lens), max_num_blocks),
+        dtype=torch.int32,
+    )
+    output_base = torch.full_like(query, float("nan"))
+    output_reordered = torch.full_like(query, float("nan"))
+
+    def run(output: torch.Tensor, reorder_causal_prefill: bool) -> None:
+        unified_attention(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            out=output,
+            cu_seqlens_q=cu_query_lens,
+            max_seqlen_q=max(query_lens),
+            seqused_k=kv_lens_tensor,
+            max_seqlen_k=max(kv_lens),
+            softmax_scale=head_size**-0.5,
+            causal=True,
+            window_size=window_size,
+            block_table=block_tables,
+            softcap=0.0,
+            q_descale=None,
+            k_descale=None,
+            v_descale=None,
+            reorder_causal_prefill=reorder_causal_prefill,
+        )
+
+    run(output_base, False)
+    run(output_reordered, True)
+
+    assert torch.isfinite(output_base).all()
+    assert torch.isfinite(output_reordered).all()
+    assert torch.equal(
+        output_base.contiguous().view(torch.int16),
+        output_reordered.contiguous().view(torch.int16),
+    )
+
+
 @pytest.mark.parametrize(
     "seq_lens", [[(1, 1328), (5, 18), (129, 463)], [(1, 523), (1, 37), (1, 2011)]]
 )

--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -131,6 +131,16 @@ def test_make_metadata_with_slice_mixed_batch(mixed_small_metadata):
     assert torch.equal(result.seq_lens, torch.tensor([40, 48]))
 
 
+def test_make_metadata_with_slice_preserves_is_prefilling(mixed_small_metadata):
+    """Request-phase metadata must follow the request slice, not token slice."""
+    mixed_small_metadata.is_prefilling = torch.tensor([False, True, False])
+    ubatch_slice = UBatchSlice(slice(1, 3), slice(1, 7))
+
+    result = _make_metadata_with_slice(ubatch_slice, mixed_small_metadata)
+
+    assert torch.equal(result.is_prefilling, torch.tensor([True, False]))
+
+
 def test_split_attn_metadata_decode_batch(large_decode_metadata):
     """Test splitting decode batch into two equal parts"""
     num_tokens = large_decode_metadata.num_reqs

--- a/tests/v1/attention/test_triton_attention_metadata_builder.py
+++ b/tests/v1/attention/test_triton_attention_metadata_builder.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Triton causal-prefill launch-order classification."""
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import BatchSpec, create_common_attn_metadata
+from vllm.v1.attention.backends.triton_attn import (
+    TritonAttentionMetadata,
+    TritonAttentionMetadataBuilder,
+)
+
+BLOCK_SIZE = 16
+DEVICE = torch.device("cpu")
+
+
+def _create_builder() -> TritonAttentionMetadataBuilder:
+    builder = object.__new__(TritonAttentionMetadataBuilder)
+    builder.device = DEVICE
+    builder.seq_threshold_3D = 0
+    builder.num_par_softmax_segments = 1
+    builder.softmax_segm_output = torch.empty(0)
+    builder.softmax_segm_max = torch.empty(0)
+    builder.softmax_segm_expsum = torch.empty(0)
+    builder.rswa_window = None
+    builder.persistent_rswa_prefix_lens = None
+    builder.reorder_causal_prefill = True
+    return builder
+
+
+def _build_metadata(
+    seq_lens: list[int],
+    query_lens: list[int],
+    is_prefilling: list[bool] | None,
+) -> TritonAttentionMetadata:
+    common = create_common_attn_metadata(
+        BatchSpec(seq_lens=seq_lens, query_lens=query_lens),
+        block_size=BLOCK_SIZE,
+        device=DEVICE,
+    )
+    if is_prefilling is not None:
+        common.is_prefilling = torch.tensor(is_prefilling, dtype=torch.bool)
+    return _create_builder().build(0, common)
+
+
+@pytest.mark.parametrize(
+    ("seq_lens", "query_lens", "is_prefilling", "expected_reorder"),
+    [
+        pytest.param([8, 12], [1, 1], [False, False], False, id="regular_decode"),
+        pytest.param([8, 12], [4, 4], [False, False], False, id="spec_decode_only"),
+        pytest.param([32], [32], [True], True, id="prefill"),
+        pytest.param(
+            [8, 32], [4, 32], [False, True], True, id="mixed_spec_and_prefill"
+        ),
+        pytest.param([33], [1], [True], False, id="final_single_token_prefill"),
+        pytest.param([8], [4], None, False, id="phase_metadata_unavailable"),
+    ],
+)
+def test_triton_metadata_computes_final_prefill_reorder_decision(
+    seq_lens: list[int],
+    query_lens: list[int],
+    is_prefilling: list[bool] | None,
+    expected_reorder: bool,
+) -> None:
+    metadata = _build_metadata(seq_lens, query_lens, is_prefilling)
+
+    assert metadata.reorder_causal_prefill is expected_reorder
+
+
+@pytest.mark.parametrize(
+    ("reorder_enabled", "query_len"),
+    [
+        pytest.param(False, 4, id="feature_disabled"),
+        pytest.param(True, 1, id="single_token_query"),
+    ],
+)
+def test_triton_metadata_skips_unneeded_phase_reduction(
+    reorder_enabled: bool,
+    query_len: int,
+) -> None:
+    common = create_common_attn_metadata(
+        BatchSpec(seq_lens=[8], query_lens=[query_len]),
+        block_size=BLOCK_SIZE,
+        device=DEVICE,
+    )
+    is_prefilling = MagicMock()
+    common.is_prefilling = cast(torch.Tensor, is_prefilling)
+    builder = _create_builder()
+    builder.reorder_causal_prefill = reorder_enabled
+
+    metadata = builder.build(0, common)
+
+    assert metadata.reorder_causal_prefill is False
+    is_prefilling.__getitem__.assert_not_called()
+    is_prefilling.any.assert_not_called()
+
+
+def test_triton_cudagraph_capture_disables_prefill_reorder() -> None:
+    common = create_common_attn_metadata(
+        BatchSpec(seq_lens=[32], query_lens=[32]),
+        block_size=BLOCK_SIZE,
+        device=DEVICE,
+    )
+    common.is_prefilling = torch.tensor([True])
+
+    metadata = _create_builder().build_for_cudagraph_capture(common)
+
+    assert metadata.reorder_causal_prefill is False

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -91,6 +91,7 @@ if TYPE_CHECKING:
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
     VLLM_BATCH_INVARIANT: bool = False
     VLLM_TRITON_USE_TD: bool | None = None
+    VLLM_TRITON_ATTN_PREFILL_REORDER: bool = False
     VLLM_GPU_SYNC_CHECK: Literal["warn", "error"] | None = None
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
@@ -628,6 +629,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # ``0`` forces TD off.  Useful for A/B benchmarking the TD path.
     "VLLM_TRITON_USE_TD": lambda: {"1": True, "0": False}.get(
         os.getenv("VLLM_TRITON_USE_TD", "").strip()
+    ),
+    # Reorder independent causal prefill programs in Triton unified attention.
+    # Disabled by default because performance is workload and device dependent.
+    "VLLM_TRITON_ATTN_PREFILL_REORDER": lambda: bool(
+        int(os.getenv("VLLM_TRITON_ATTN_PREFILL_REORDER", "0"))
     ),
     # If set, enable PyTorch's GPU<->CPU synchronization debug mode around
     # the worker's `execute_model` and `sample_tokens` calls. Valid values

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -415,7 +415,7 @@ class CommonAttentionMetadata:
     sparse metadata for DeepSeek V4 C128A layers."""
 
     is_prefilling: torch.Tensor | None = None
-    """(batch_size,) bool tensor: True if request is still in prefill phase
+    """CPU (batch_size,) bool tensor: True if request is still in prefill phase
     (num_computed_tokens < num_prompt_tokens). Used by some backends to
     distinguish actual decodes from short extends."""
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -66,6 +66,8 @@ class TritonAttentionMetadata:
 
     num_actual_tokens: int  # Number of tokens excluding padding.
     max_query_len: int
+    # Host-side phase decision; the wrapper also applies kernel eligibility.
+    reorder_causal_prefill: bool
     query_start_loc: torch.Tensor
     max_seq_len: int
     seq_lens: torch.Tensor
@@ -175,6 +177,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         )
         self.rswa_window = model_config.rswa_window
         self.persistent_rswa_prefix_lens: torch.Tensor | None = None
+        self.reorder_causal_prefill = envs.VLLM_TRITON_ATTN_PREFILL_REORDER
         if self.rswa_window is not None:
             self.persistent_rswa_prefix_lens = torch.empty(
                 vllm_config.scheduler_config.max_num_seqs,
@@ -186,6 +189,10 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         self, common_attn_metadata: CommonAttentionMetadata
     ) -> TritonAttentionMetadata:
         attn_metadata = self.build(0, common_attn_metadata)
+        # Launch order is a host-side choice frozen into a full CUDA graph.
+        # Capture the original mapping; eager and piecewise runs classify each
+        # real batch independently.
+        attn_metadata.reorder_causal_prefill = False
         # When doing full graph capture, setting seq_lens to
         # max_model_len will cause graph capture to be extremely
         # slow, so here we set it to 1.
@@ -201,6 +208,17 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         max_query_len = common_attn_metadata.max_query_len
+
+        reorder_causal_prefill = False
+        if self.reorder_causal_prefill and max_query_len > 1:
+            is_prefilling = common_attn_metadata.is_prefilling
+            # Do not infer phase from query length: speculative verification
+            # can schedule multiple query tokens in a decode-only batch.
+            if is_prefilling is not None:
+                assert is_prefilling.device.type == "cpu", (
+                    "CommonAttentionMetadata.is_prefilling must be a CPU tensor"
+                )
+                reorder_causal_prefill = bool(is_prefilling[:num_reqs].any().item())
 
         max_seq_len = common_attn_metadata.max_seq_len
         query_start_loc = common_attn_metadata.query_start_loc
@@ -228,6 +246,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         attn_metadata = TritonAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
             max_query_len=max_query_len,
+            reorder_causal_prefill=reorder_causal_prefill,
             query_start_loc=query_start_loc,
             max_seq_len=max_seq_len,
             seq_lens=seq_lens,
@@ -686,6 +705,7 @@ class TritonAttentionImpl(AttentionImpl):
             mm_prefix_clamp_sliding_window=getattr(
                 layer, "mm_prefix_clamp_sliding_window", False
             ),
+            reorder_causal_prefill=attn_metadata.reorder_causal_prefill,
         )
 
         return output

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -289,6 +289,7 @@ def kernel_unified_attention(
     # instead of letting them override it. Default False preserves the
     # original (causal AND SW) OR mm_prefix behavior for all other models.
     MM_PREFIX_CLAMP_SW: tl.constexpr = False,
+    REORDER_CAUSAL_PREFILL: tl.constexpr = False,
 ):
     # Per-(token, head) scale caches: used iff KV_QUANT_MODE in {2, 3}.
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE >= 2) and (
@@ -302,8 +303,27 @@ def kernel_unified_attention(
             "USE_TD requires BLOCK_SIZE to be a multiple of TILE_SIZE",
         )
 
-    q_block_global_idx = tl.program_id(0)
-    kv_head_idx = tl.program_id(1)
+    tl.static_assert(
+        not REORDER_CAUSAL_PREFILL
+        or (
+            USE_CAUSAL
+            and not USE_PER_SEQ_CAUSAL
+            and not USE_MM_PREFIX
+            and not USE_R_SWA
+            and SLIDING_WINDOW <= 0
+            and CHUNK_LOOKBACK < 0
+            and not IS_3D
+        )
+    )
+
+    if REORDER_CAUSAL_PREFILL:
+        linear_program_idx = tl.program_id(0)
+        num_kv_heads = num_query_heads // num_queries_per_kv
+        q_block_global_idx = linear_program_idx // num_kv_heads
+        kv_head_idx = linear_program_idx % num_kv_heads
+    else:
+        q_block_global_idx = tl.program_id(0)
+        kv_head_idx = tl.program_id(1)
     segm_idx = tl.program_id(2) if IS_3D else 0
 
     (
@@ -318,6 +338,13 @@ def kernel_unified_attention(
 
     if q_block_local_idx * BLOCK_Q >= cur_batch_query_len:
         return
+
+    # Later causal query blocks have longer KV prefixes. Launch them first
+    # within each sequence and keep equal-cost KV-head programs adjacent to
+    # reduce the long-running launch tail.
+    if REORDER_CAUSAL_PREFILL:
+        num_local_q_blocks = cdiv_fn(cur_batch_query_len, BLOCK_Q)
+        q_block_local_idx = num_local_q_blocks - 1 - q_block_local_idx
 
     if IS_3D:
         tiles_per_segment = cdiv_fn(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
@@ -847,6 +874,8 @@ def unified_attention(
     # Gemma4: clamp mm_prefix bidirectional ranges by the sliding window.
     # Default False keeps the original behavior for every other model.
     mm_prefix_clamp_sliding_window: bool = False,
+    # Reverse q-blocks per sequence and make KV head the fastest grid index.
+    reorder_causal_prefill: bool = False,
 ):
     # Resolve causal: bool or per-seq tensor.
     use_per_seq_causal = isinstance(causal, torch.Tensor)
@@ -1049,6 +1078,16 @@ def unified_attention(
         or is_batch_invariant
     )
 
+    reorder_causal_prefill = (
+        reorder_causal_prefill
+        and use_causal
+        and not use_per_seq_causal
+        and not use_mm_prefix
+        and not use_rswa
+        and sliding_window_val <= 0
+        and chunk_lookback < 0
+        and not use_3d
+    )
     # The kernel signature is the same for 2D and 3D — only the launch
     # grid + a handful of constexpr toggles differ.  Per-token-head scale
     # caches and their strides are passed as ``None`` when the
@@ -1075,7 +1114,11 @@ def unified_attention(
 
     grid: tuple[Any, ...]
     if not use_3d:
-        grid = (total_num_q_blocks, num_kv_heads)
+        grid = (
+            (total_num_q_blocks * num_kv_heads,)
+            if reorder_causal_prefill
+            else (total_num_q_blocks, num_kv_heads)
+        )
         tile_size = TILE_SIZE_PREFILL
     else:
         grid = (total_num_q_blocks, num_kv_heads, num_par_softmax_segments)
@@ -1163,6 +1206,7 @@ def unified_attention(
         USE_TD=use_td,
         USE_TD_QO=use_td_qo,
         MM_PREFIX_CLAMP_SW=mm_prefix_clamp_sliding_window,
+        REORDER_CAUSAL_PREFILL=reorder_causal_prefill,
         **launch_kwargs,
     )
 

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -231,6 +231,11 @@ def _make_metadata_with_slice(
 
     block_table_tensor = attn_metadata.block_table_tensor[request_slice]
     slot_mapping = attn_metadata.slot_mapping[token_slice]
+    is_prefilling = (
+        attn_metadata.is_prefilling[request_slice]
+        if attn_metadata.is_prefilling is not None
+        else None
+    )
 
     return CommonAttentionMetadata(
         query_start_loc=query_start_loc,
@@ -245,6 +250,7 @@ def _make_metadata_with_slice(
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,
+        is_prefilling=is_prefilling,
     )
 
 


### PR DESCRIPTION
## Purpose

This is an opt-in kernel performance optimization, not a bug fix. It preserves the existing mapping by default and changes only the launch order of supported causal 2-D Triton unified-attention prefill workloads.

### Problem

Triton unified attention currently launches causal-prefill programs with a 2-D `(q_block, kv_head)` grid. For the target ragged-prefill workload, later query blocks have longer KV prefixes and finish later, leaving a launch tail.

The optimization must not be selected from `max_query_len > 1` alone. Speculative verification can schedule multiple target tokens in a pure-decode batch, so query length describes the shape but not the request phase.

### Changes

This PR adds one opt-in launch-order strategy for the causal 2-D kernel:

1. Flatten `(q_block, kv_head)` and make KV head the fastest-changing index.
2. Reverse q-blocks locally within each sequence, launching the blocks with the longest causal KV prefixes first.
3. Propagate the existing CPU `is_prefilling` request metadata through microbatch slicing and use it to compute the final host-side `TritonAttentionMetadata.reorder_causal_prefill` decision.
4. Enable the reordered mapping only when all of the following are true:
   - `VLLM_TRITON_ATTN_PREFILL_REORDER=1`;
   - at least one real request is still in prefill;
   - `max_query_len > 1`;
   - the wrapper selects the supported causal 2-D path.

The environment variable defaults to `0` because the performance effect is device- and workload-dependent. The metadata builder skips the CPU phase reduction entirely when the option is disabled or the query is single-token.

The launch order does not change the attention reduction performed by an individual Triton program or the output region owned by that program.


### Scope and fallback behavior

The reordered variant is limited to causal attention without per-sequence causal masks, multimodal prefix masks, R-SWA, sliding window, chunk lookback, or the 3-D split-KV path. The wrapper normalizes the flag to `False` before JIT dispatch for every unsupported path.

The original mapping is retained for:

- regular decode;
- pure speculative decode, including `max_query_len > 1` verification steps;
- single-token final prefill chunks;
- missing phase metadata;
- full CUDA Graph capture;
- every unsupported mask/kernel configuration listed above.

This PR does not change the default attention backend and does not claim a performance improvement for Full CUDA Graph prefill.

## Performance

Environment: NVIDIA GeForce RTX 5090 D (SM120), CUDA 13.0, Python 3.12.3, PyTorch 2.13.0+cu130, Triton 3.7.1, pytest 9.1.0, `Hq/Hkv/D=8/2/256`, block size 544.


| Workload | Base | Reordered | Improvement |
| --- | ---: | ---: | ---: |
| Single prefill | 0.788256 ms | 0.743040 ms | 5.74% |
| Mixed, ascending request order | 0.387584 ms | 0.370688 ms | 4.36% |
| Mixed, descending request order | 0.377376 ms | 0.371264 ms | 1.62% |

## Test Plan

### Unit and metadata tests

```bash
.venv/bin/python -m pytest -q \
  tests/v1/attention/test_triton_attention_metadata_builder.py \
  tests/v1/attention/test_attention_splitting.py::test_make_metadata_with_slice_preserves_is_prefilling
```

The matrix covers regular decode, pure speculative decode with query length 4, prefill, mixed speculative-decode/prefill, a single-token final prefill chunk, missing phase metadata, default-off/single-token short circuits, microbatch request slicing, and Full CUDA Graph capture.

The metadata-builder cases use a new focused file because no existing Triton metadata-builder test suite covered this host-side classification; the ubatch case extends the existing attention-splitting suite.

### Kernel correctness tests

```bash
.venv/bin/python -m pytest -q \
  tests/kernels/attention/test_triton_unified_attention.py \
  -k causal_prefill_reorder_bitwise
```

The test compares the base and requested-reorder mappings with `torch.equal` for BF16 and FP16 across MHA/GQA/MQA, head sizes 64/128/256, block sizes 16/32/544, and a sliding-window case that must normalize back to the base mapping.

### Extended regression tests

```bash
.venv/bin/python -m pytest -q \
  tests/v1/attention/test_attention_splitting.py \
  tests/v1/attention/test_triton_attention_metadata_builder.py

.venv/bin/python -m pytest -q \
  tests/kernels/attention/test_triton_unified_attention.py
```

### End-to-end correctness

Run the same model, revision, prompts, greedy sampling parameters, and engine configuration with `VLLM_TRITON_ATTN_PREFILL_REORDER=0` and `=1`. Compare token IDs and saved digests for:

- single and chunked prefill;
- mixed prefill/decode batches;
- pure speculative decode with more than one verification token;
- eager, piecewise CUDA Graph, and Full CUDA Graph execution.


## Test Result
```text
89 passed
tests/test_envs.py
tests/v1/attention/test_attention_splitting.py
tests/v1/attention/test_triton_attention_metadata_builder.py

16 passed, 1874 deselected
tests/kernels/attention/test_triton_unified_attention.py
-k causal_prefill_reorder_bitwise

pre-commit on all 8 changed files: passed
git diff --check: passed
```

## Relationship to existing PRs
- #28497 optimized the unified-attention kernel primarily for AMD/MI300 using launch configuration, `exp2`, cache modifiers, mask simplification, and 2-D grid/XCD locality. There is conceptual overlap in grid locality, but #28497 did not implement per-sequence q-block reversal, a real request-phase gate, or validation for this CUDA/SM120 workload.
- #53930 warns that speculative decode with `max_seqlen_q > 1` selects the 2-D path but does not change behavior. This PR addresses the related phase-gating ambiguity for this launch-order feature.
- #52879 changes speculative-decode scratch sizing and 2-D/3-D path selection.This PR changes traversal only after the causal 2-D path is selected.



## AI assistance disclosure
AI assistance was used in creating this change (diagnosis, key derivation check, and edits drafted/verified by an AI agent under human direction). Every changed line was reviewed by the human submitter
