### PR TITLE
[Bugfix][Kernel] Avoid prefill metadata JIT during inference

### DIFF
--- a/tests/model_executor/test_sparse_mla_triton_warmup.py
+++ b/tests/model_executor/test_sparse_mla_triton_warmup.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.model_executor.warmup import sparse_mla_triton_warmup as warmup_module
+
+
+def test_b12x_sparse_warms_prefill_chunk_metadata(monkeypatch) -> None:
+    vllm_config = SimpleNamespace(
+        attention_config=SimpleNamespace(
+            backend=SimpleNamespace(name="B12X_MLA_SPARSE")
+        )
+    )
+    runner = SimpleNamespace(
+        is_pooling_model=False,
+        attn_groups=(),
+        vllm_config=vllm_config,
+    )
+    worker = SimpleNamespace(
+        model_runner=runner,
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=3072,
+            max_num_seqs=8,
+        ),
+    )
+    warmed = []
+    monkeypatch.setattr(
+        warmup_module,
+        "_compile_prefill_chunk_metadata_kernel",
+        warmed.append,
+    )
+    executed = []
+    monkeypatch.setattr(
+        warmup_module,
+        "_execute_prefill_chunk_metadata_kernel",
+        lambda value: executed.append(value) or 2,
+    )
+
+    warmup_module.sparse_mla_triton_warmup(worker)
+
+    assert warmed == [vllm_config]
+    assert executed == [worker]

--- a/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
+++ b/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
@@ -33,6 +33,41 @@ def test_indexer_warmup_normalizes_zero_compress_ratios():
     assert {key.COMPRESS_RATIO for key in keys} == {1, 4, 128}
 
 
+def test_indexer_warmup_includes_pooled_selector_ratio():
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                compress_ratios=[1, 4],
+                index_kpool=16,
+            )
+        )
+    )
+
+    keys = BuildPrefillChunkMetadataKernel().get_warmup_keys(config)
+
+    assert {key.COMPRESS_RATIO for key in keys} == {1, 4, 16}
+
+
+def test_indexer_metadata_runtime_scalars_do_not_specialize():
+    kernel = BuildPrefillChunkMetadataKernel.kernel
+    runtime_scalar_names = {
+        "query_slice_start",
+        "query_slice_stop",
+        "DCP_RANK",
+        "DCP_WORLD",
+        "DCP_INTERLEAVE",
+    }
+
+    do_not_specialize = {
+        value if isinstance(value, str) else kernel.arg_names[value]
+        for value in kernel.do_not_specialize
+    }
+    assert do_not_specialize >= runtime_scalar_names
+    assert runtime_scalar_names.isdisjoint(
+        BuildPrefillChunkMetadataKernel.CompileKey.__dataclass_fields__
+    )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_indexer_builder_deepseek_v4_compressed_slot_mapping_uses_num_states():
     """Regression test: DeepseekV4 compression path must compute slot_mapping from

--- a/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
+++ b/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
@@ -4,6 +4,8 @@
 
 from typing import TYPE_CHECKING
 
+import torch
+
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -28,9 +30,9 @@ _GENERIC_SPARSE_MLA_BACKENDS = frozenset(
         "FLASHINFER_MLA_SPARSE_SM120",
     }
 )
-_INDEXER_PREFILL_CHUNK_METADATA_BACKENDS = frozenset({"DEEPSEEK_V32_INDEXER"})
-
-_INDEXER_PREFILL_CHUNK_METADATA_BACKENDS = frozenset({"DEEPSEEK_V32_INDEXER"})
+_PREFILL_CHUNK_METADATA_ONLY_BACKENDS = frozenset(
+    {"B12X_MLA_SPARSE", "DEEPSEEK_V32_INDEXER"}
+)
 
 
 def _attention_backend_name(backend: object) -> str | None:
@@ -41,6 +43,17 @@ def _attention_backend_name(backend: object) -> str | None:
         return get_name()
     except NotImplementedError:
         return None
+
+
+def _configured_attention_backend_name(
+    vllm_config: "VllmConfig",
+) -> str | None:
+    attention_config = getattr(vllm_config, "attention_config", None)
+    backend = getattr(attention_config, "backend", None)
+    if isinstance(backend, str):
+        return backend
+    name = getattr(backend, "name", None)
+    return name if isinstance(name, str) else None
 
 
 def _has_attention_backend(
@@ -75,6 +88,64 @@ def _compile_prefill_chunk_metadata_kernel(
     _BUILD_PREFILL_CHUNK_METADATA_KERNEL.warmup(vllm_config)
 
 
+def _execute_prefill_chunk_metadata_kernel(worker: "Worker") -> int:
+    """Populate Triton's in-process cache with runtime pointer variants."""
+    from vllm.v1.attention.backends.mla.indexer import (
+        _BUILD_PREFILL_CHUNK_METADATA_KERNEL,
+    )
+
+    parameter = next(worker.get_model().parameters(), None)
+    if parameter is None:
+        return 0
+    device = parameter.device
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    cu_compressed_seq_lens = torch.tensor(
+        [0, 1], dtype=torch.int32, device=device
+    )
+    token_to_seq = torch.empty((1,), dtype=torch.int32, device=device)
+    cu_compressed_seq_len_ks = torch.empty(
+        (1,), dtype=torch.int32, device=device
+    )
+    cu_compressed_seq_len_ke = torch.empty(
+        (1,), dtype=torch.int32, device=device
+    )
+    compress_ratios = {
+        key.COMPRESS_RATIO
+        for key in _BUILD_PREFILL_CHUNK_METADATA_KERNEL.get_warmup_keys(
+            worker.vllm_config
+        )
+    }
+    warmed = 0
+    for compress_ratio in sorted(compress_ratios):
+        aligned = torch.tensor(
+            [compress_ratio], dtype=torch.int32, device=device
+        )
+        unaligned_storage = torch.tensor(
+            [-1, compress_ratio], dtype=torch.int32, device=device
+        )
+        for uncompressed_seq_lens in (aligned, unaligned_storage[1:]):
+            _BUILD_PREFILL_CHUNK_METADATA_KERNEL(
+                query_start_loc,
+                uncompressed_seq_lens,
+                cu_compressed_seq_lens,
+                cu_compressed_seq_lens,
+                token_to_seq,
+                cu_compressed_seq_len_ks,
+                cu_compressed_seq_len_ke,
+                0,
+                1,
+                0,
+                1,
+                1,
+                num_reqs=1,
+                COMPRESS_RATIO=compress_ratio,
+            )
+            warmed += 1
+    if warmed:
+        torch.accelerator.synchronize()
+    return warmed
+
+
 def _compile_combine_topk_swa_indices_kernel(
     vllm_config: "VllmConfig",
 ) -> None:
@@ -96,16 +167,32 @@ def sparse_mla_triton_warmup(worker: "Worker") -> None:
         return
 
     vllm_config = runner.vllm_config
+    warmed_prefill_chunk = False
     try:
         if _has_attention_backend(runner, _DEEPSEEK_V4_SPARSE_MLA_BACKENDS):
             _compile_sparse_swa_prefill_metadata_kernel(vllm_config)
             _compile_prefill_chunk_metadata_kernel(vllm_config)
+            warmed_prefill_chunk = True
             _compile_combine_topk_swa_indices_kernel(vllm_config)
         elif _has_attention_backend(runner, _GENERIC_SPARSE_MLA_BACKENDS):
             _compile_sparse_swa_prefill_metadata_kernel(vllm_config)
             _compile_prefill_chunk_metadata_kernel(vllm_config)
-        elif _has_attention_backend(runner, _INDEXER_PREFILL_CHUNK_METADATA_BACKENDS):
+            warmed_prefill_chunk = True
+        elif (
+            _configured_attention_backend_name(vllm_config)
+            in _PREFILL_CHUNK_METADATA_ONLY_BACKENDS
+            or _has_attention_backend(
+                runner, _PREFILL_CHUNK_METADATA_ONLY_BACKENDS
+            )
+        ):
             _compile_prefill_chunk_metadata_kernel(vllm_config)
+            warmed_prefill_chunk = True
+        if warmed_prefill_chunk:
+            warmed = _execute_prefill_chunk_metadata_kernel(worker)
+            logger.info(
+                "Warmed up %d sparse MLA prefill metadata runtime variants.",
+                warmed,
+            )
 
     except Exception:
         logger.warning("Skipping sparse MLA Triton warmup.", exc_info=True)

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -8,10 +8,7 @@ import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.logger import init_logger
-from vllm.model_executor.warmup.jit_warmup import (
-    VllmJitKernel,
-    WarmupIntRange,
-)
+from vllm.model_executor.warmup.jit_warmup import VllmJitKernel
 from vllm.model_executor.warmup.jit_warmup_triton_helper import (
     TritonPointerInputVariant,
     TritonWarmupTensor,
@@ -228,17 +225,20 @@ class BuildPrefillChunkMetadataKernel(
 
     @dataclass(frozen=True)
     class CompileKey:
-        query_slice_start: int
-        query_slice_stop: int
-        DCP_RANK: int
-        DCP_WORLD: int
-        DCP_INTERLEAVE: int
         BLOCK_SIZE: int
         COMPRESS_RATIO: int
         input_variant: TritonPointerInputVariant
 
     @staticmethod
-    @triton.jit
+    @triton.jit(
+        do_not_specialize=[
+            "query_slice_start",
+            "query_slice_stop",
+            "DCP_RANK",
+            "DCP_WORLD",
+            "DCP_INTERLEAVE",
+        ]
+    )
     def kernel(
         # Inputs
         query_start_loc_ptr,
@@ -317,43 +317,26 @@ class BuildPrefillChunkMetadataKernel(
     def dispatch(  # type: ignore[override]
         self,
         *,
-        query_slice_start: int,
-        query_slice_stop: int,
-        DCP_RANK: int,
-        DCP_WORLD: int,
-        DCP_INTERLEAVE: int,
         BLOCK_SIZE: int,
         COMPRESS_RATIO: int,
         input_variant: TritonPointerInputVariant,
     ) -> CompileKey:
         return self.CompileKey(
-            query_slice_start=query_slice_start,
-            query_slice_stop=query_slice_stop,
-            DCP_RANK=DCP_RANK,
-            DCP_WORLD=DCP_WORLD,
-            DCP_INTERLEAVE=DCP_INTERLEAVE,
             BLOCK_SIZE=BLOCK_SIZE,
             COMPRESS_RATIO=COMPRESS_RATIO,
             input_variant=input_variant,
         )
 
     def get_warmup_keys(self, vllm_config: VllmConfig) -> list[CompileKey]:
-        max_tokens = max(1, min(vllm_config.scheduler_config.max_num_batched_tokens, 8))
         hf_config = vllm_config.model_config.hf_config
-        parallel_config = vllm_config.parallel_config
-        dcp_world = parallel_config.decode_context_parallel_size
-        dcp_interleave = parallel_config.cp_kv_cache_interleave_size
-        dcp_rank = get_dcp_group().rank_in_group if dcp_world > 1 else 0
         compress_ratios = tuple(
             max(1, int(ratio))
             for ratio in (getattr(hf_config, "compress_ratios", None) or (1,))
         )
+        index_kpool = getattr(hf_config, "index_kpool", None)
+        if index_kpool and index_kpool > 1 and index_kpool not in compress_ratios:
+            compress_ratios = compress_ratios + (index_kpool,)
         return self._trace_dispatch(self.dispatch)(
-            query_slice_start=WarmupIntRange(0, 2),
-            query_slice_stop=(1, 2 * max_tokens - 1, 2 * max_tokens),
-            DCP_RANK=dcp_rank,
-            DCP_WORLD=dcp_world,
-            DCP_INTERLEAVE=dcp_interleave,
             BLOCK_SIZE=self.BLOCK_SIZE,
             COMPRESS_RATIO=list(compress_ratios),
             input_variant=_BUILD_PREFILL_CHUNK_METADATA_INPUT_VARIANTS,
@@ -371,11 +354,11 @@ class BuildPrefillChunkMetadataKernel(
             int32_ptr,
             int32_ptr,
             int32_ptr,
-            compile_key.query_slice_start,
-            compile_key.query_slice_stop,
-            compile_key.DCP_RANK,
-            compile_key.DCP_WORLD,
-            compile_key.DCP_INTERLEAVE,
+            0,
+            1,
+            0,
+            1,
+            1,
             BLOCK_SIZE=compile_key.BLOCK_SIZE,
             COMPRESS_RATIO=compile_key.COMPRESS_RATIO,
             grid=(1,),


### PR DESCRIPTION
## Purpose

Prevent `BuildPrefillChunkMetadataKernel` from compiling a new Triton variant during the first real sparse-MLA prefill.

The existing compile-only warmup leaves two gaps:

- request slice and decode-context-parallel scalar values are part of the compile key even though they do not change the algorithm;
- Triton's compile-only `kernel.warmup()` does not populate the in-process `JITFunction.run` cache used by the first real launch.

This change:

- marks `query_slice_start`, `query_slice_stop`, `DCP_RANK`, `DCP_WORLD`, and `DCP_INTERLEAVE` as non-specialized runtime scalars and removes them from `CompileKey`;
- includes the GLM pooled-selector `index_kpool` compression ratio in warmup keys;
- executes one valid metadata row for each compression-ratio and pointer-alignment key after compile-only warmup;
- lets an explicitly configured `B12X_MLA_SPARSE` backend select the early warmup even before attention groups are available, while preserving `DEEPSEEK_V32_INDEXER` selection.

Related to the broader warmup migration in #50175 and zero-runtime-JIT tracking in #49349. Field findings were first recorded in https://github.com/vllm-project/vllm/pull/50175#issuecomment-5461508640; this PR is a focused fix against current `main`.

## Test Plan

```bash
python3 -m pytest -q tests/model_executor/test_sparse_mla_triton_warmup.py
python3 -m pytest -q tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py \
  -k 'indexer_warmup or metadata_runtime_scalars'
python3 -m py_compile \
  vllm/model_executor/warmup/sparse_mla_triton_warmup.py \
  vllm/v1/attention/backends/mla/indexer.py \
  tests/model_executor/test_sparse_mla_triton_warmup.py \
  tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
```

Run a fresh-cache four-worker sparse-MLA server with verbose JIT monitoring, then exercise deterministic short generation, strict structured output, a 32,933-token three-needle prompt, and 32K/128K prefill requests.

## Test Result

- Configured-backend warmup test: `1 passed`.
- Compression-ratio and scalar-specialization tests: `3 passed`.
- Python compilation and `git diff --check`: passed.
- Four RTX PRO 6000 Blackwell workers each logged four sparse-MLA metadata runtime variants warmed.
- Short generation, structured output, and all three long-context needles passed.
- 32K and 128K prefill requests completed.
- No `BuildPrefillChunkMetadataKernel` inference-time JIT warning appeared after the change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described and related upstream work is linked.
- [x] The focused test commands are provided.
- [x] Unit and live GPU results are recorded.
- [x] No user-facing documentation change is required.
</details>

