### PR TITLE
[Bugfix][Multimodal] Release Qwen2.5-VL and Qwen3-VL RoPE caches with the model

### DIFF
--- a/tests/models/test_language_model_cache_is_weak.py
+++ b/tests/models/test_language_model_cache_is_weak.py
@@ -17,6 +17,7 @@ import torch.nn as nn
 
 from vllm.model_executor.models.interfaces import _language_model_by_module
 from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VisionTransformer
+from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
 from vllm.utils.cache import LRUCache
 
 pytestmark = pytest.mark.cpu_test
@@ -86,4 +87,22 @@ def test_qwen2_5_vl_rope_cache_does_not_pin_model():
 
     assert ref() is None, (
         "the Qwen2.5-VL RoPE cache is keeping the model alive after shutdown"
+    )
+
+
+def test_qwen3_vl_rope_cache_is_released_with_model():
+    model = object.__new__(Qwen3_VisionTransformer)
+    model._rot_pos_ids_cache = LRUCache(capacity=1024)
+
+    first = model.rot_pos_ids(2, 2, 2)
+    assert model.rot_pos_ids(2, 2, 2) is first
+
+    model_ref = weakref.ref(model)
+    tensor_ref = weakref.ref(first)
+    del model, first
+    gc.collect()
+
+    assert model_ref() is None
+    assert tensor_ref() is None, (
+        "the Qwen3-VL RoPE cache outlives the model after shutdown"
     )

--- a/tests/models/test_language_model_cache_is_weak.py
+++ b/tests/models/test_language_model_cache_is_weak.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Model caches must not keep models alive after in-process teardown.
+"""The `get_language_model` cache must not own the models it keys on.
 
-Module-level caches can pin every model loaded in the process for the life of
-the interpreter. In-process teardown (``VLLM_ENABLE_V1_MULTIPROCESSING=0``)
-then keeps weights and other model-owned allocations resident after shutdown.
+A strong-keyed module-level dict pins every model ever loaded in the process
+for the life of the interpreter. In-process teardown
+(``VLLM_ENABLE_V1_MULTIPROCESSING=0``) then keeps the weights -- and the KV
+cache aliased onto the model's layers -- resident after engine shutdown.
 """
 
 import gc
@@ -12,15 +13,8 @@ import weakref
 
 import pytest
 import torch.nn as nn
-from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
-    Qwen2_5_VLVisionConfig,
-)
-from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLVisionConfig
 
 from vllm.model_executor.models.interfaces import _language_model_by_module
-from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VisionTransformer
-from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
-from vllm.utils.cache import LRUCache
 
 pytestmark = pytest.mark.cpu_test
 
@@ -63,85 +57,3 @@ def test_cached_entry_is_dropped_with_its_key():
     gc.collect()
 
     assert not any(isinstance(k, _MultiModalModel) for k in _language_model_by_module)
-
-
-def test_qwen2_5_vl_rope_cache_does_not_pin_model(
-    monkeypatch: pytest.MonkeyPatch, default_vllm_config
-):
-    monkeypatch.setattr(
-        "vllm.model_executor.models.qwen2_5_vl.is_vit_use_data_parallel",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        "vllm.model_executor.models.qwen2_5_vl.Qwen2_5_VisionPatchMerger",
-        lambda **_: nn.Identity(),
-    )
-    model = Qwen2_5_VisionTransformer(
-        Qwen2_5_VLVisionConfig(
-            depth=0,
-            hidden_size=8,
-            intermediate_size=8,
-            num_heads=1,
-            in_channels=3,
-            patch_size=2,
-            spatial_merge_size=1,
-            temporal_patch_size=1,
-            window_size=2,
-            out_hidden_size=8,
-            fullatt_block_indexes=[],
-        )
-    )
-    assert isinstance(model._rope_by_thw_cache, LRUCache)
-
-    first = model.get_rope_by_thw(1, 2, 2)
-    assert model.get_rope_by_thw(1, 2, 2) is first
-
-    ref = weakref.ref(model)
-    del model, first
-    gc.collect()
-
-    assert ref() is None, (
-        "the Qwen2.5-VL RoPE cache is keeping the model alive after shutdown"
-    )
-
-
-def test_qwen3_vl_rope_cache_is_released_with_model(
-    monkeypatch: pytest.MonkeyPatch, default_vllm_config
-):
-    monkeypatch.setattr(
-        "vllm.model_executor.models.qwen3_vl.is_vit_use_data_parallel",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        "vllm.model_executor.models.qwen3_vl.Qwen3_VisionPatchMerger",
-        lambda **_: nn.Identity(),
-    )
-    model = Qwen3_VisionTransformer(
-        Qwen3VLVisionConfig(
-            depth=0,
-            hidden_size=8,
-            intermediate_size=8,
-            num_heads=1,
-            in_channels=3,
-            patch_size=2,
-            spatial_merge_size=1,
-            temporal_patch_size=1,
-            out_hidden_size=8,
-            num_position_embeddings=4,
-            deepstack_visual_indexes=[],
-        )
-    )
-    assert isinstance(model._rot_pos_ids_cache, LRUCache)
-
-    first = model.rot_pos_ids(2, 2, 1)
-    assert model.rot_pos_ids(2, 2, 1) is first
-
-    model_ref = weakref.ref(model)
-    tensor_ref = weakref.ref(first)
-    del model, first
-    gc.collect()
-
-    assert model_ref() is None
-    assert tensor_ref() is None, (
-        "the Qwen3-VL RoPE cache outlives the model after shutdown"
-    )

--- a/tests/models/test_language_model_cache_is_weak.py
+++ b/tests/models/test_language_model_cache_is_weak.py
@@ -9,11 +9,13 @@ then keeps weights and other model-owned allocations resident after shutdown.
 
 import gc
 import weakref
-from types import MethodType
 
 import pytest
-import torch
 import torch.nn as nn
+from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
+    Qwen2_5_VLVisionConfig,
+)
+from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLVisionConfig
 
 from vllm.model_executor.models.interfaces import _language_model_by_module
 from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VisionTransformer
@@ -63,20 +65,33 @@ def test_cached_entry_is_dropped_with_its_key():
     assert not any(isinstance(k, _MultiModalModel) for k in _language_model_by_module)
 
 
-def test_qwen2_5_vl_rope_cache_does_not_pin_model():
-    model = object.__new__(Qwen2_5_VisionTransformer)
-    model._rope_by_thw_cache = LRUCache(capacity=1024)
-    model.get_window_index_thw = MethodType(
-        lambda self, t, h, w: (torch.arange(t * h * w), torch.tensor([t * h * w])),
-        model,
+def test_qwen2_5_vl_rope_cache_does_not_pin_model(
+    monkeypatch: pytest.MonkeyPatch, default_vllm_config
+):
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen2_5_vl.is_vit_use_data_parallel",
+        lambda: True,
     )
-    model.rotary_pos_emb_thw = MethodType(
-        lambda self, t, h, w: (
-            torch.zeros(t * h * w, 1, 2),
-            torch.zeros(t * h * w, 1, 2),
-        ),
-        model,
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen2_5_vl.Qwen2_5_VisionPatchMerger",
+        lambda **_: nn.Identity(),
     )
+    model = Qwen2_5_VisionTransformer(
+        Qwen2_5_VLVisionConfig(
+            depth=0,
+            hidden_size=8,
+            intermediate_size=8,
+            num_heads=1,
+            in_channels=3,
+            patch_size=2,
+            spatial_merge_size=1,
+            temporal_patch_size=1,
+            window_size=2,
+            out_hidden_size=8,
+            fullatt_block_indexes=[],
+        )
+    )
+    assert isinstance(model._rope_by_thw_cache, LRUCache)
 
     first = model.get_rope_by_thw(1, 2, 2)
     assert model.get_rope_by_thw(1, 2, 2) is first
@@ -90,12 +105,36 @@ def test_qwen2_5_vl_rope_cache_does_not_pin_model():
     )
 
 
-def test_qwen3_vl_rope_cache_is_released_with_model():
-    model = object.__new__(Qwen3_VisionTransformer)
-    model._rot_pos_ids_cache = LRUCache(capacity=1024)
+def test_qwen3_vl_rope_cache_is_released_with_model(
+    monkeypatch: pytest.MonkeyPatch, default_vllm_config
+):
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_vl.is_vit_use_data_parallel",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_vl.Qwen3_VisionPatchMerger",
+        lambda **_: nn.Identity(),
+    )
+    model = Qwen3_VisionTransformer(
+        Qwen3VLVisionConfig(
+            depth=0,
+            hidden_size=8,
+            intermediate_size=8,
+            num_heads=1,
+            in_channels=3,
+            patch_size=2,
+            spatial_merge_size=1,
+            temporal_patch_size=1,
+            out_hidden_size=8,
+            num_position_embeddings=4,
+            deepstack_visual_indexes=[],
+        )
+    )
+    assert isinstance(model._rot_pos_ids_cache, LRUCache)
 
-    first = model.rot_pos_ids(2, 2, 2)
-    assert model.rot_pos_ids(2, 2, 2) is first
+    first = model.rot_pos_ids(2, 2, 1)
+    assert model.rot_pos_ids(2, 2, 1) is first
 
     model_ref = weakref.ref(model)
     tensor_ref = weakref.ref(first)

--- a/tests/models/test_language_model_cache_is_weak.py
+++ b/tests/models/test_language_model_cache_is_weak.py
@@ -1,20 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""The `get_language_model` cache must not own the models it keys on.
+"""Model caches must not keep models alive after in-process teardown.
 
-A strong-keyed module-level dict pins every model ever loaded in the process
-for the life of the interpreter. In-process teardown
-(``VLLM_ENABLE_V1_MULTIPROCESSING=0``) then keeps the weights -- and the KV
-cache aliased onto the model's layers -- resident after engine shutdown.
+Module-level caches can pin every model loaded in the process for the life of
+the interpreter. In-process teardown (``VLLM_ENABLE_V1_MULTIPROCESSING=0``)
+then keeps weights and other model-owned allocations resident after shutdown.
 """
 
 import gc
 import weakref
+from types import MethodType
 
 import pytest
+import torch
 import torch.nn as nn
 
 from vllm.model_executor.models.interfaces import _language_model_by_module
+from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VisionTransformer
+from vllm.utils.cache import LRUCache
 
 pytestmark = pytest.mark.cpu_test
 
@@ -57,3 +60,30 @@ def test_cached_entry_is_dropped_with_its_key():
     gc.collect()
 
     assert not any(isinstance(k, _MultiModalModel) for k in _language_model_by_module)
+
+
+def test_qwen2_5_vl_rope_cache_does_not_pin_model():
+    model = object.__new__(Qwen2_5_VisionTransformer)
+    model._rope_by_thw_cache = LRUCache(capacity=1024)
+    model.get_window_index_thw = MethodType(
+        lambda self, t, h, w: (torch.arange(t * h * w), torch.tensor([t * h * w])),
+        model,
+    )
+    model.rotary_pos_emb_thw = MethodType(
+        lambda self, t, h, w: (
+            torch.zeros(t * h * w, 1, 2),
+            torch.zeros(t * h * w, 1, 2),
+        ),
+        model,
+    )
+
+    first = model.get_rope_by_thw(1, 2, 2)
+    assert model.get_rope_by_thw(1, 2, 2) is first
+
+    ref = weakref.ref(model)
+    del model, first
+    gc.collect()
+
+    assert ref() is None, (
+        "the Qwen2.5-VL RoPE cache is keeping the model alive after shutdown"
+    )

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -27,7 +27,7 @@
 """Inference-only Qwen2.5-VL model compatible with HuggingFace weights."""
 
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from functools import lru_cache, partial
+from functools import partial
 from typing import Annotated, Any, Literal, TypeAlias
 
 import einops
@@ -82,6 +82,7 @@ from vllm.multimodal.video_prune.evs import (
 )
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.utils.cache import LRUCache
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.utils.torch_utils import PIN_MEMORY, async_tensor_h2d
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -647,6 +648,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
         self.spatial_merge_size = vision_config.spatial_merge_size
         self.fullatt_block_indexes = vision_config.fullatt_block_indexes
         self.spatial_merge_unit = self.spatial_merge_size**2
+        self._rope_by_thw_cache = LRUCache(capacity=1024)
         use_data_parallel = is_vit_use_data_parallel()
         self.tp_size = (
             1
@@ -795,8 +797,11 @@ class Qwen2_5_VisionTransformer(nn.Module):
 
         return index_new, cu_seqlens_tmp
 
-    @lru_cache(maxsize=1024)  # noqa: B019
     def get_rope_by_thw(self, t, h, w):
+        cache_key = (t, h, w)
+        if cache_key in self._rope_by_thw_cache:
+            return self._rope_by_thw_cache[cache_key]
+
         window_index_thw, cu_seqlens_window_thw = self.get_window_index_thw(t, h, w)
         cos_thw, sin_thw = self.rotary_pos_emb_thw(t, h, w)
 
@@ -809,13 +814,15 @@ class Qwen2_5_VisionTransformer(nn.Module):
         cu_seqlens_thw = torch.repeat_interleave(
             torch.tensor([h * w], dtype=torch.int32), t
         )
-        return (
+        result = (
             cos_thw,
             sin_thw,
             window_index_thw,
             cu_seqlens_window_thw,
             cu_seqlens_thw,
         )
+        self._rope_by_thw_cache[cache_key] = result
+        return result
 
     def compute_attn_mask_seqlen(
         self,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -110,6 +110,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.tokenizers.protocol import TokenizerLike
 from vllm.tokenizers.registry import cached_tokenizer_from_config
 from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.cache import LRUCache
 from vllm.utils.collection_utils import is_list_of
 from vllm.utils.math_utils import round_up
 from vllm.utils.torch_utils import PIN_MEMORY
@@ -581,6 +582,7 @@ class Qwen3_VisionTransformer(nn.Module):
             else []
         )
         self.num_grid_per_side = int(self.num_position_embeddings**0.5)
+        self._rot_pos_ids_cache = LRUCache(capacity=1024)
 
         use_data_parallel = is_vit_use_data_parallel()
         self.tp_size = (
@@ -672,9 +674,11 @@ class Qwen3_VisionTransformer(nn.Module):
     def device(self) -> torch.device:
         return self.patch_embed.proj.weight.device
 
-    @staticmethod
-    @lru_cache(maxsize=1024)
-    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
+    def rot_pos_ids(self, h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
+        cache_key = (h, w, spatial_merge_size)
+        if cache_key in self._rot_pos_ids_cache:
+            return self._rot_pos_ids_cache[cache_key]
+
         hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
         h_div = h // spatial_merge_size
         w_div = w // spatial_merge_size
@@ -697,7 +701,9 @@ class Qwen3_VisionTransformer(nn.Module):
         wpos_ids = wpos_ids.transpose(0, 2, 1, 3)
         wpos_ids = wpos_ids.flatten()
 
-        return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
+        result = torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
+        self._rot_pos_ids_cache[cache_key] = result
+        return result
 
     def rot_pos_emb(self, grid_thw: list[list[int]]):
         max_grid_size = max(max(h, w) for _, h, w in grid_thw)


### PR DESCRIPTION
## Purpose

Fix deterministic GPU memory retention when Qwen2.5-VL or Qwen3-VL is shut down in-process after serving a multimodal request.

`Qwen2_5_VisionTransformer.get_rope_by_thw` is an instance method decorated with a class-level `functools.lru_cache`. Because `self` is part of every cache key, the cache wrapper strongly references each vision tower that has processed a request.

`Qwen3_VisionTransformer.rot_pos_ids` uses a class-level static `lru_cache`, which similarly keeps cached position tensors alive for the life of the interpreter.

Replace both class-level caches with bounded per-instance `LRUCache` objects. This preserves the existing 1024-entry limit and cache-hit behavior while tying cached data to the lifetime of the owning model.

### Duplicate-work check

I searched open PRs and issues for `get_rope_by_thw`, `rot_pos_ids`, Qwen VL memory leaks, RoPE cache lifetime, and related terms. No open work covers these caches.

#54162 fixes generic holders of the top-level model during in-process shutdown, and #54246 detaches layer-bound KV-cache tensors. This change is complementary: it removes Qwen-specific class-level caches that outlive the vision modules.

### AI assistance disclosure

AI assistance was used to investigate the reference chains, implement the changes, and prepare the validation.

## Test Plan

Run all configured pre-commit hooks that apply to the changed files:

```bash
.venv/bin/pre-commit run --files \
  vllm/model_executor/models/qwen2_5_vl.py \
  vllm/model_executor/models/qwen3_vl.py
```

Run end-to-end validation with real Qwen2.5-VL and Qwen3-VL models, serve multimodal requests, shut down the in-process engines, drop engine references, run garbage collection and `torch.cuda.empty_cache()`, and verify that the vision modules and cached tensors are released.

## Test Result

### Linters

```text
ruff check: passed
ruff format: passed
mypy: passed
all other applicable pre-commit hooks: passed
git diff --check: passed
```

### Qwen2.5-VL end-to-end GPU result

- Hardware: 2x NVIDIA A100-PCIE-40GB, driver 595.71.05.
- Model: Qwen2.5-VL-3B-Instruct, downloaded from ModelScope.
- Runtime: PyTorch 2.11.0+cu128, Model Runner V2, eager execution.
- Configuration: `max_model_len=512`, `gpu_memory_utilization=0.35`, `VLLM_ENABLE_V1_MULTIPROCESSING=0`.
- Input: one real 224x224 image.
- Both arms completed the request and generated one token.

| Arm | Live CUDA allocation | After shutdown | Vision module alive |
|---|---:|---:|---|
| Original class-level cache | 13,915,090,432 B | 1,354,216,448 B | yes |
| Per-instance cache | 13,915,090,432 B | 10,617,344 B | no |

The patched arm releases an additional 1.251 GiB after shutdown and reduces retained CUDA allocations by 99.22%.

### Qwen3-VL end-to-end GPU result

- Model: Qwen3-VL-2B-Instruct, downloaded from ModelScope.
- The request completed successfully and generated `Blue`.
- Live CUDA allocation: 12,602,890,752 B.
- Allocation after shutdown: 279,577,088 B.
- Vision module alive after shutdown: no.
- Cached tensor alive after shutdown: no.

No documentation update is required because this fixes resource lifetime without changing user-facing behavior.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [x] Documentation impact considered.
</details>