### PR TITLE
[Bugfix] Resolve admission deadlock for blocked-waiting statuses

### DIFF
--- a/tests/v1/core/test_skipped_waiting_deadlock.py
+++ b/tests/v1/core/test_skipped_waiting_deadlock.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock, patch
+
+from vllm.v1.request import RequestStatus
+from vllm.v1.structured_output import StructuredOutputGrammar
+
+from .utils import create_requests, create_scheduler
+
+
+def test_traversal_past_unschedulable_head():
+    """Verify that requests parked in skipped_waiting statuses are not stranded
+    behind an unschedulable queue head when nothing is running."""
+    BLOCK_SIZE = 16
+    NUM_BLOCKS = 10
+
+    scheduler = create_scheduler(
+        max_num_seqs=100,
+        max_num_batched_tokens=1000,
+        block_size=BLOCK_SIZE,
+        num_blocks=NUM_BLOCKS,
+    )
+
+    # Priority policy ensures predictable queue order
+    scheduler.vllm_config.scheduler_config.policy = "priority"
+
+    # 1. Parked request (low priority)
+    req_grammar = create_requests(1, num_tokens=BLOCK_SIZE, req_ids=["req_grammar"])[0]
+    req_grammar.priority = 1
+    req_grammar.structured_output_request = Mock()
+    req_grammar.structured_output_request.grammar = None  # Compiling
+    req_grammar.status = RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+    scheduler.skipped_waiting.add_request(req_grammar)
+    scheduler.requests[req_grammar.request_id] = req_grammar
+
+    # 2. Blocker request (high priority, too large to fit in 10 blocks)
+    req_blocker = create_requests(
+        1, num_tokens=BLOCK_SIZE * 15, req_ids=["req_blocker"]
+    )[0]
+    req_blocker.priority = 0
+    req_blocker.status = RequestStatus.WAITING
+    scheduler.waiting.add_request(req_blocker)
+
+    # First schedule(): req_blocker is head, but too large (15 > 10 blocks).
+    # Since nothing is running, scheduler MUST continue scanning and check req_grammar.
+    # req_grammar is checked, but grammar is still None, so it remains parked.
+    scheduler.schedule()
+    assert len(scheduler.running) == 0
+    assert req_grammar.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+    assert req_blocker.status == RequestStatus.WAITING
+
+    # Now simulate grammar compilation finishing
+    req_grammar.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
+
+    # Second schedule(): req_blocker is still head and too large.
+    # Scheduler MUST scan past it, see req_grammar, promote it
+    # to WAITING, and schedule it!
+    scheduler.schedule()
+    assert req_grammar.status == RequestStatus.RUNNING
+    assert req_blocker.status == RequestStatus.WAITING
+    assert req_grammar in scheduler.running
+
+
+@patch("time.time")
+def test_blocked_waiting_timeout(mock_time):
+    """Verify that requests parked in skipped_waiting for too long are aborted."""
+    mock_time.return_value = 0.0
+
+    scheduler = create_scheduler(
+        max_num_seqs=100,
+        max_num_batched_tokens=1000,
+        block_size=16,
+        num_blocks=10,
+    )
+
+    # Create a parked request
+    req_grammar = create_requests(1, num_tokens=16, req_ids=["req_grammar"])[0]
+    req_grammar.structured_output_request = Mock()
+    req_grammar.structured_output_request.grammar = None
+    req_grammar.status = RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+    scheduler.skipped_waiting.add_request(req_grammar)
+    scheduler.requests[req_grammar.request_id] = req_grammar
+
+    # First schedule(): marks blocked_since to 0.0
+    scheduler.schedule()
+    assert getattr(req_grammar, "blocked_since", None) == 0.0
+    assert req_grammar.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+
+    # Fast forward just below timeout
+    mock_time.return_value = 59.9
+    scheduler.schedule()
+    assert req_grammar.status == RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+
+    # Fast forward past timeout
+    mock_time.return_value = 60.1
+    scheduler.schedule()
+
+    # Request should be aborted
+    assert req_grammar.status == RequestStatus.FINISHED_ABORTED
+    assert len(scheduler.skipped_waiting) == 0
+
+
+@patch("time.time")
+def test_blocked_waiting_timeout_reset_and_exclusion(mock_time):
+    """Verify WAITING_FOR_STREAMING_REQ exclusion, promotion-before-timeout,
+    and resetting blocked_since on promotion."""
+    mock_time.return_value = 0.0
+
+    scheduler = create_scheduler(
+        max_num_seqs=100,
+        max_num_batched_tokens=1000,
+        block_size=16,
+        num_blocks=10,
+    )
+
+    # 1. Test WAITING_FOR_STREAMING_REQ has no timeout
+    req_streaming = create_requests(1, num_tokens=16, req_ids=["req_streaming"])[0]
+    req_streaming.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+    scheduler.skipped_waiting.add_request(req_streaming)
+    scheduler.requests[req_streaming.request_id] = req_streaming
+
+    scheduler.schedule()
+    # blocked_since should be explicitly cleared or not set
+    assert getattr(req_streaming, "blocked_since", None) is None
+
+    mock_time.return_value = 100.0
+    scheduler.schedule()
+    # Still not aborted
+    assert req_streaming.status == RequestStatus.WAITING_FOR_STREAMING_REQ
+
+    # 2. Test promotion before timeout (promoted at t=60.1)
+    req_grammar = create_requests(1, num_tokens=16, req_ids=["req_grammar"])[0]
+    req_grammar.structured_output_request = Mock()
+    req_grammar.structured_output_request.grammar = None
+    req_grammar.status = RequestStatus.WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+    scheduler.skipped_waiting.add_request(req_grammar)
+    scheduler.requests[req_grammar.request_id] = req_grammar
+
+    mock_time.return_value = 100.0
+    scheduler.schedule()
+    assert req_grammar.blocked_since == 100.0
+
+    # Advance past 60s, but make grammar ready
+    mock_time.return_value = 160.1
+    req_grammar.structured_output_request.grammar = Mock(spec=StructuredOutputGrammar)
+    scheduler.schedule()
+
+    # Promotion succeeded: status -> RUNNING (or WAITING if capacity limits it)
+    assert req_grammar.status == RequestStatus.RUNNING
+    assert req_grammar.blocked_since is None

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -198,6 +198,12 @@ class SchedulerConfig:
     while a larger value (e.g., 10) reduces host overhead and may increase throughput
     by batching multiple tokens before sending."""
 
+    blocked_waiting_timeout_s: float = Field(default=60.0, ge=0.0)
+    """Timeout in seconds for requests stuck in blocked-waiting statuses (e.g.,
+    WAITING_FOR_REMOTE_KVS). If the condition isn't met within this time,
+    the request is aborted. 0.0 means 0s timeout. This operates as a safety
+    net to prevent scheduler deadlocks. Excludes WAITING_FOR_STREAMING_REQ."""
+
     @staticmethod
     def default_factory(**kwargs):
         """

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1548,6 +1548,10 @@ class EngineArgs:
             description=SchedulerConfig.__doc__,
         )
         scheduler_group.add_argument(
+            "--blocked-waiting-timeout-s",
+            **scheduler_kwargs["blocked_waiting_timeout_s"],
+        )
+        scheduler_group.add_argument(
             "--max-num-batched-tokens",
             **{
                 **scheduler_kwargs["max_num_batched_tokens"],

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -749,6 +749,7 @@ class EngineArgs:
     async_scheduling: bool | None = SchedulerConfig.async_scheduling
 
     stream_interval: int = SchedulerConfig.stream_interval
+    blocked_waiting_timeout_s: float = SchedulerConfig.blocked_waiting_timeout_s
 
     kv_sharing_fast_prefill: bool = CacheConfig.kv_sharing_fast_prefill
     optimization_level: OptimizationLevel = VllmConfig.optimization_level
@@ -2384,6 +2385,7 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,
+            blocked_waiting_timeout_s=self.blocked_waiting_timeout_s,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -75,8 +75,6 @@ from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
 
-_BLOCKED_WAITING_TIMEOUT_S = 60.0
-
 
 class Scheduler(SchedulerInterface):
     def __init__(
@@ -850,7 +848,7 @@ class Scheduler(SchedulerInterface):
                                 request.blocked_since = time.time()
                             elif (
                                 time.time() - request.blocked_since
-                                > _BLOCKED_WAITING_TIMEOUT_S
+                                > self.scheduler_config.blocked_waiting_timeout_s
                             ):
                                 self.finish_requests(
                                     request_id, RequestStatus.FINISHED_ABORTED

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -75,6 +75,8 @@ from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
 
+_BLOCKED_WAITING_TIMEOUT_S = 60.0
+
 
 class Scheduler(SchedulerInterface):
     def __init__(
@@ -819,6 +821,7 @@ class Scheduler(SchedulerInterface):
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
+            temporarily_deferred: list[Request] = []
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if input_budget <= draft_slots:
@@ -836,17 +839,37 @@ class Scheduler(SchedulerInterface):
                 request_id = request.request_id
 
                 # try to promote blocked statuses while traversing skipped queue.
-                if self._is_blocked_waiting_status(
-                    request.status
-                ) and not self._try_promote_blocked_waiting_request(request):
-                    if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
-                        logger.debug(
-                            "%s is still in WAITING_FOR_REMOTE_KVS state.",
-                            request_id,
-                        )
-                    request_queue.pop_request()
-                    step_skipped_waiting.prepend_request(request)
-                    continue
+                if self._is_blocked_waiting_status(request.status):
+                    if self._try_promote_blocked_waiting_request(request):
+                        # Reset blocked_since on successful promotion
+                        request.blocked_since = None
+                    else:
+                        # Exclude WAITING_FOR_STREAMING_REQ from timeout
+                        if request.status != RequestStatus.WAITING_FOR_STREAMING_REQ:
+                            if request.blocked_since is None:
+                                request.blocked_since = time.time()
+                            elif (
+                                time.time() - request.blocked_since
+                                > _BLOCKED_WAITING_TIMEOUT_S
+                            ):
+                                self.finish_requests(
+                                    request_id, RequestStatus.FINISHED_ABORTED
+                                )
+                                continue
+                        else:
+                            # clear blocked_since for client-paced wait
+                            request.blocked_since = None
+
+                        if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                            logger.debug(
+                                "%s is still in WAITING_FOR_REMOTE_KVS state.",
+                                request_id,
+                            )
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
+                        continue
+                else:
+                    request.blocked_since = None
 
                 if (
                     request.num_stale_output_tokens > 0
@@ -1054,7 +1077,11 @@ class Scheduler(SchedulerInterface):
                             num_external_computed_tokens,
                         )
                         if num_new_tokens == 0:
-                            break
+                            if self.running:
+                                break
+                            request_queue.pop_request()
+                            temporarily_deferred.append(request)
+                            continue
                         if (
                             pad_spec_decode
                             and num_new_tokens != 1 + self.num_spec_tokens
@@ -1091,7 +1118,11 @@ class Scheduler(SchedulerInterface):
 
                     if num_new_tokens == 0:
                         # The request cannot be scheduled.
-                        break
+                        if self.running:
+                            break
+                        request_queue.pop_request()
+                        temporarily_deferred.append(request)
+                        continue
 
                 # During async KV load, no forward pass is run yet.
                 # Allocate speculative lookahead slots later to avoid
@@ -1142,7 +1173,11 @@ class Scheduler(SchedulerInterface):
                     # manager
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
-                    break
+                    if self.running:
+                        break
+                    request_queue.pop_request()
+                    temporarily_deferred.append(request)
+                    continue
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that
@@ -1255,6 +1290,13 @@ class Scheduler(SchedulerInterface):
             # re-queue requests skipped in this pass ahead of older skipped items.
             if step_skipped_waiting:
                 self.skipped_waiting.prepend_requests(step_skipped_waiting)
+
+            # Re-queue ordinary requests that were temporarily deferred due to
+            # resource exhaustion (not blocked-waiting status). These go back
+            # into self.waiting so they are reconsidered next step without
+            # polluting the skipped_waiting / deferred metrics.
+            for req in temporarily_deferred:
+                self.waiting.add_request(req)
 
             # DP prefill balancing: on a step that admitted prefills (release),
             # record whether it was capacity-bound.

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -96,6 +96,7 @@ class Request:
         self.arrival_time = arrival_time if arrival_time is not None else time.time()
 
         self.status = RequestStatus.WAITING
+        self.blocked_since: float | None = None
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: int | str | None = None
 


### PR DESCRIPTION
## Problem

Requests parked in `skipped_waiting` under `WAITING_FOR_REMOTE_KVS`,
`WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR`, or `WAITING_FOR_STREAMING_REQ`
could permanently count against `max_num_seqs` if they were never promoted.
This could leave the scheduler with no schedulable capacity while `/health`
continued to report the engine as healthy, resulting in an admission deadlock.

## Root Cause

The WAITING-queue scan could stop at an unschedulable request even when
nothing was currently running and therefore nothing could free the required
resources. Requests further back in the queue, including requests that could
be promoted from `skipped_waiting`, were consequently never reached.

In addition, blocked-waiting requests had no generic timeout safety net when
the condition they were waiting for never became true.

## Fix

This change addresses both failure modes.

### 1. Continue scanning when the scheduler is genuinely deadlocked

At the three genuine resource-exhaustion sites in the WAITING-queue scan
(speculative-decoding padding, Mamba block alignment, and encoder
`num_new_tokens == 0`), the scheduler now continues scanning when
`self.running` is empty instead of stopping at the unschedulable head.

Requests temporarily deferred for this purpose are stored in a scoped
`temporarily_deferred` list and merged back into `self.waiting` after the
scan. They are deliberately not placed in `skipped_waiting`, preserving the
existing distinction between temporarily deferred requests and requests
counted against scheduler capacity.

The change is intentionally limited to these three resource-exhaustion
cases. Existing policy/capacity breaks, including DP prefill cadence,
chunked-prefill-disabled policy, maximum-running-request capacity, and the
max-model-length unpadded-schedule condition, remain unchanged.

### 2. Add a generic timeout safety net

Requests in the three blocked-waiting statuses are tagged with
`blocked_since` when first encountered. If a request remains blocked for more
than 60 seconds, it is explicitly aborted through
`finish_requests(request_id, RequestStatus.FINISHED_ABORTED)`.

The 60-second timeout is a starting value and can be made configurable through
`SchedulerConfig` if experience with the fix indicates that configurability
is desirable.

The existing `WAITING_FOR_STREAMING_REQ` promotion logic is intentionally
unchanged. The timeout provides a generic backstop while the separate
promotion work in PR #52717 addresses the underlying promotion behavior.

## Behavior change

Requests that remain indefinitely blocked in these statuses will now receive
an explicit `FINISHED_ABORTED` outcome after the timeout instead of hanging
forever and silently consuming scheduler admission capacity.

This is a correctness fix for an existing deadlock condition, not a scheduler
redesign.

## Testing

Added `tests/v1/core/test_skipped_waiting_deadlock.py` covering:

- traversal past an unschedulable WAITING-queue head when nothing is running;
- timeout-based abortion of a request stuck in a blocked-waiting status.

The regression test was stash-verified: it fails with the fix removed and
passes with the fix present.

Existing scheduler tests were also run. The only unrelated failure was
`test_async_scheduling_pp_allows_rescheduling_with_output_placeholders`,
which also fails on clean `main` on the test machine because fewer than two
GPUs are available. That pre-existing environment limitation was not
modified as part of this change.

## Relationship to existing work

This generalizes the approach proposed by unmerged PR #45406 from a
single blocked-waiting status to the relevant blocked-waiting statuses,
while also providing the generic timeout safety net described above. It does
not duplicate the separate promotion work in PR #52717.

Fixes #53130