### PR TITLE
[Bugfix][Memory] Fix PYTORCH_ALLOC_CONF in KV-transfer and CuMem safeguards

### DIFF
--- a/tests/basic_correctness/test_mem.py
+++ b/tests/basic_correctness/test_mem.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+from contextlib import contextmanager
 
 import pytest
 import torch
@@ -31,6 +32,100 @@ def mapped_usage(allocator) -> int:
         for data in allocator.pointer_to_data.values()
         if not data.is_asleep
     )
+
+
+class _FakePool:
+    def snapshot(self):
+        return []
+
+
+@contextmanager
+def _fake_memory_pool(*args, **kwargs):
+    yield _FakePool(), object()
+
+
+def _mock_allocator_settings(monkeypatch, initial, fail_override=False):
+    current = [initial]
+    calls = []
+
+    monkeypatch.setattr(cumem, "use_memory_pool_with_allocator", _fake_memory_pool)
+    monkeypatch.setattr(cumem, "get_torch_allocator_settings", lambda: initial)
+
+    def set_settings(settings):
+        calls.append(settings)
+        current[0] = settings
+        if fail_override and settings.endswith("expandable_segments:False"):
+            raise ValueError("invalid override")
+
+    monkeypatch.setattr(torch._C, "_accelerator_setAllocatorSettings", set_settings)
+    return cumem.CuMemAllocator(), current, calls
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    "original",
+    [
+        (
+            "max_split_size_mb:64,garbage_collection_threshold:0.8,"
+            "expandable_segments:True"
+        ),
+        "expandable_segments:True,",
+    ],
+)
+def test_cumem_preserves_allocator_settings(monkeypatch, original):
+    allocator, current, calls = _mock_allocator_settings(monkeypatch, original)
+    separator = "" if original.endswith(",") else ","
+    override = f"{original}{separator}expandable_segments:False"
+
+    with allocator.use_memory_pool():
+        assert current[0] == override
+
+    assert current[0] == original
+    assert calls == [override, original]
+
+
+@pytest.mark.cpu_test
+def test_cumem_restores_allocator_settings_when_override_fails(monkeypatch):
+    original = "max_split_size_mb:64,expandable_segments:True"
+    allocator, current, _ = _mock_allocator_settings(
+        monkeypatch, original, fail_override=True
+    )
+
+    with (
+        pytest.raises(ValueError, match="invalid override"),
+        allocator.use_memory_pool(),
+    ):
+        pass
+
+    assert current[0] == original
+
+
+@pytest.mark.cpu_test
+def test_cumem_restores_allocator_settings_on_error(monkeypatch):
+    original = "max_split_size_mb:64,expandable_segments:True"
+    allocator, current, _ = _mock_allocator_settings(monkeypatch, original)
+
+    with (
+        pytest.raises(RuntimeError, match="pool body failed"),
+        allocator.use_memory_pool(),
+    ):
+        raise RuntimeError("pool body failed")
+
+    assert current[0] == original
+
+
+@pytest.mark.cpu_test
+def test_nested_cumem_pool_keeps_expandable_segments_disabled(monkeypatch):
+    original = "expandable_segments:True"
+    allocator, current, calls = _mock_allocator_settings(monkeypatch, original)
+
+    with allocator.use_memory_pool("outer"):  # noqa: SIM117
+        with allocator.use_memory_pool("inner"):
+            assert current[0] == f"{original},expandable_segments:False"
+        assert current[0] == f"{original},expandable_segments:False"
+
+    assert current[0] == original
+    assert calls == [f"{original},expandable_segments:False", original]
 
 
 def _wake_up_with_poisoned_mappings(allocator, byte_value: int = 0xA5) -> None:

--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -9,12 +9,69 @@ from vllm.utils.torch_utils import (
     common_broadcastable_dtype,
     current_stream,
     get_kv_cache_torch_dtype,
+    get_torch_allocator_settings,
     is_lossless_cast,
     is_quantized_kv_cache,
     set_default_torch_dtype,
     set_torch_threads_for_runtime,
     startup_omp_num_threads,
+    torch_allocator_uses_expandable_segments,
 )
+
+
+@pytest.mark.parametrize(
+    ("settings", "expected"),
+    [
+        ("", False),
+        ("expandable_segments:True", True),
+        ("expandable_segments:False", False),
+        (" expandable_segments : True ", True),
+        ("max_split_size_mb:64,expandable_segments:True", True),
+        ("expandable_segments:False,expandable_segments:True", True),
+        ("expandable_segments:True,expandable_segments:False", False),
+        (
+            "roundup_power2_divisions:[256:1,512:2],expandable_segments:True",
+            True,
+        ),
+    ],
+)
+def test_torch_allocator_uses_expandable_segments(settings, expected):
+    assert torch_allocator_uses_expandable_segments(settings) is expected
+
+
+def test_get_torch_allocator_settings_uses_runtime_getter(monkeypatch):
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:False")
+    monkeypatch.setattr(
+        torch._C,
+        "_accelerator_getAllocatorSettings",
+        lambda: "expandable_segments:True",
+        raising=False,
+    )
+
+    assert get_torch_allocator_settings() == "expandable_segments:True"
+
+
+def test_get_torch_allocator_settings_env_fallback(monkeypatch):
+    monkeypatch.setattr(
+        torch._C, "_accelerator_getAllocatorSettings", None, raising=False
+    )
+    for env_var in (
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "PYTORCH_HIP_ALLOC_CONF",
+        "PYTORCH_ALLOC_CONF",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    assert get_torch_allocator_settings() == ""
+
+    monkeypatch.setenv("PYTORCH_ALLOC_CONF", "unified")
+    assert get_torch_allocator_settings() == "unified"
+
+    monkeypatch.setenv("PYTORCH_HIP_ALLOC_CONF", "hip")
+    assert get_torch_allocator_settings() == "hip"
+
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "")
+    assert get_torch_allocator_settings() == ""
 
 
 def test_nvfp4_4over6_cache_dtype() -> None:

--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -4,11 +4,37 @@
 """Tests for KV cache offloading configuration."""
 
 import pytest
+import torch
 
 from vllm.config import CacheConfig, KVTransferConfig, ParallelConfig, VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+from vllm.platforms import current_platform
 
 pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture(autouse=True)
+def allocator_env_fallback(monkeypatch):
+    """Exercise the PyTorch 2.11 environment fallback without cached state."""
+    monkeypatch.setattr(
+        torch._C, "_accelerator_getAllocatorSettings", None, raising=False
+    )
+    for env_var in (
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "PYTORCH_HIP_ALLOC_CONF",
+        "PYTORCH_ALLOC_CONF",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def _mock_allocator_platform(monkeypatch, *, cuda_alike: bool, xpu: bool):
+    monkeypatch.setattr(current_platform, "is_cuda_alike", lambda: cuda_alike)
+    monkeypatch.setattr(current_platform, "is_xpu", lambda: xpu)
+
+
+@pytest.fixture
+def accelerator_vmm_platform(monkeypatch):
+    _mock_allocator_platform(monkeypatch, cuda_alike=True, xpu=False)
 
 
 class _StubLMCacheMPConnector:
@@ -126,9 +152,11 @@ def _build_config(
 @pytest.mark.parametrize(
     "kv_connector", ["NixlConnector", "MooncakeConnectorV1", "SomeOOTConnector"]
 )
-def test_kv_connector_rejects_expandable_segments(monkeypatch, kv_connector):
+def test_kv_connector_rejects_expandable_segments(
+    monkeypatch, kv_connector, accelerator_vmm_platform
+):
     """KV connectors that pin KV cache memory (e.g. via ibv_reg_mr) are
-    invalidated when expandable_segments lets the CUDA VMM allocator remap
+    invalidated when expandable_segments lets the accelerator VMM allocator remap
     the underlying physical pages. We can't enumerate every connector that
     does this (especially OOT ones), so reject the combination whenever any
     connector is configured."""
@@ -137,7 +165,18 @@ def test_kv_connector_rejects_expandable_segments(monkeypatch, kv_connector):
         _build_config(kv_connector=kv_connector)
 
 
-def test_kv_connector_allows_expandable_segments_with_sleep_mode(monkeypatch):
+@pytest.mark.parametrize("env_var", ["PYTORCH_HIP_ALLOC_CONF", "PYTORCH_ALLOC_CONF"])
+def test_kv_connector_rejects_alloc_conf_alias(
+    monkeypatch, accelerator_vmm_platform, env_var
+):
+    monkeypatch.setenv(env_var, "expandable_segments:True")
+    with pytest.raises(ValueError, match="expandable_segments"):
+        _build_config(kv_connector="NixlConnector")
+
+
+def test_kv_connector_allows_expandable_segments_with_sleep_mode(
+    monkeypatch, accelerator_vmm_platform
+):
     """Sleep mode routes KV allocations through CuMemAllocator's pool, which
     auto-disables expandable_segments (see #40812)."""
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
@@ -146,17 +185,32 @@ def test_kv_connector_allows_expandable_segments_with_sleep_mode(monkeypatch):
 
 def test_kv_connector_allows_expandable_segments_with_cumem_allocator(
     monkeypatch,
+    accelerator_vmm_platform,
 ):
     """Manual CuMem allocation must also bypass expandable_segments."""
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     _build_config(kv_connector="NixlConnector", enable_cumem_allocator=True)
 
 
-def test_kv_connector_allows_other_alloc_conf(monkeypatch):
+def test_kv_connector_allows_other_alloc_conf(monkeypatch, accelerator_vmm_platform):
     """Other PYTORCH_CUDA_ALLOC_CONF values must not be rejected."""
     monkeypatch.setenv(
         "PYTORCH_CUDA_ALLOC_CONF", "max_split_size_mb:512,expandable_segments:False"
     )
+    _build_config(kv_connector="NixlConnector")
+
+
+def test_xpu_kv_connector_rejects_expandable_segments(monkeypatch):
+    """XPU VMM cannot use the CUDA/ROCm CuMem exemption."""
+    _mock_allocator_platform(monkeypatch, cuda_alike=False, xpu=True)
+    monkeypatch.setenv("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+    with pytest.raises(ValueError, match="expandable_segments"):
+        _build_config(kv_connector="NixlConnector", enable_cumem_allocator=True)
+
+
+def test_non_vmm_platform_ignores_expandable_segments(monkeypatch):
+    _mock_allocator_platform(monkeypatch, cuda_alike=False, xpu=False)
+    monkeypatch.setenv("PYTORCH_ALLOC_CONF", "expandable_segments:True")
     _build_config(kv_connector="NixlConnector")
 
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -26,6 +26,10 @@ from vllm.transformers_utils.runai_utils import is_runai_obj_uri
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils import random_uuid
 from vllm.utils.hashing import safe_hash
+from vllm.utils.torch_utils import (
+    get_torch_allocator_settings,
+    torch_allocator_uses_expandable_segments,
+)
 
 from .attention import AttentionConfig
 from .cache import CacheConfig
@@ -1009,7 +1013,12 @@ class VllmConfig:
         ):
             return
 
-        # PyTorch's expandable_segments allocator uses CUDA VMM, which can
+        from vllm.platforms import current_platform
+
+        if not (current_platform.is_cuda_alike() or current_platform.is_xpu()):
+            return
+
+        # PyTorch's expandable_segments allocator uses accelerator VMM, which can
         # remap a virtual address range to different physical pages over the
         # engine's lifetime. KV connectors that pin KV cache memory (e.g.
         # NixlConnector via ibv_reg_mr, MooncakeConnector) end up with their
@@ -1020,28 +1029,30 @@ class VllmConfig:
         # pins memory, so we conservatively reject the combination whenever
         # any KV connector is configured.
         #
-        # CuMem allocator is exempt: CuMemAllocator.use_memory_pool toggles
-        # expandable_segments off around its pool (see #40812), so the KV
-        # cache allocated within that context lands on stable physical pages
-        # even when the env var is set.
-        if "expandable_segments:True" not in os.environ.get(
-            "PYTORCH_CUDA_ALLOC_CONF", ""
-        ):
+        # CuMem allocator is exempt on CUDA/ROCm: CuMemAllocator.use_memory_pool
+        # toggles expandable_segments off around its pool (see #40812), so the
+        # KV cache allocated within that context lands on stable physical pages.
+        allocator_settings = get_torch_allocator_settings()
+        if not torch_allocator_uses_expandable_segments(allocator_settings):
             return
-        if self.model_config is not None and (self.model_config.enable_cumem_allocator):
+        if (
+            current_platform.is_cuda_alike()
+            and self.model_config is not None
+            and self.model_config.enable_cumem_allocator
+        ):
             return
 
         raise ValueError(
             f"KV connector {self.kv_transfer_config.kv_connector} is "
-            "incompatible with PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True "
-            "unless enable_cumem_allocator is also enabled. PyTorch's CUDA VMM "
-            "allocator can remap KV cache virtual addresses to different "
+            "incompatible with the PyTorch allocator setting "
+            "expandable_segments:True. PyTorch's accelerator VMM allocator "
+            "can remap KV cache virtual addresses to different "
             "physical pages, invalidating any pinned/registered KV memory "
             "(e.g. IB memory regions registered by NIXL or Mooncake). Either "
-            "unset expandable_segments:True or enable the cumem allocator "
-            "(sleep mode does this automatically and also "
-            "routes KV allocations through CuMemAllocator's pool, where "
-            "expandable_segments is automatically disabled)."
+            "disable expandable_segments in PYTORCH_ALLOC_CONF (or a legacy "
+            "PYTORCH_CUDA_ALLOC_CONF/PYTORCH_HIP_ALLOC_CONF). On CUDA/ROCm, "
+            "the cumem allocator is also safe because it disables expandable "
+            "segments around its pool; sleep mode enables it automatically."
         )
 
     def _verify_sampling_replay_config(self) -> None:

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -10,7 +10,6 @@
 # the only successful approach is to call cuda driver API in C.
 import atexit
 import gc
-import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -21,7 +20,11 @@ from vllm.device_allocator import AllocationData, HandleType
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.system_utils import find_loaded_library
-from vllm.utils.torch_utils import PIN_MEMORY
+from vllm.utils.torch_utils import (
+    PIN_MEMORY,
+    get_torch_allocator_settings,
+    torch_allocator_uses_expandable_segments,
+)
 
 logger = init_logger(__name__)
 
@@ -136,6 +139,7 @@ class CuMemAllocator:
         self.pointer_to_data: dict[int, AllocationData] = {}
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
+        self._allocator_settings_context_depth = 0
         # Creating strong references to the two callbacks here to prevent
         # these ephemeral bound-method objects being garbage collected.
         # See discussions in https://github.com/vllm-project/vllm/pull/22724
@@ -373,16 +377,26 @@ class CuMemAllocator:
 
         # Expandable segments are incompatible with the memory pool used for
         # sleep mode (see https://github.com/pytorch/pytorch/issues/147851).
-        # If the user has enabled expandable segments via
-        # PYTORCH_CUDA_ALLOC_CONF, temporarily disable them for the duration
-        # of the memory pool context and restore on exit.
-        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
-        expandable_was_enabled = "expandable_segments:True" in conf
-        if expandable_was_enabled:
-            torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+        # Temporarily disable expandable segments for the outermost pool context.
+        allocator_settings_to_restore: str | None = None
+        if self._allocator_settings_context_depth == 0:
+            allocator_settings = get_torch_allocator_settings()
+            if torch_allocator_uses_expandable_segments(allocator_settings):
+                separator = "" if allocator_settings.rstrip().endswith(",") else ","
+                override = f"{allocator_settings}{separator}expandable_segments:False"
+                try:
+                    torch._C._accelerator_setAllocatorSettings(override)
+                except Exception:
+                    try:
+                        torch._C._accelerator_setAllocatorSettings(allocator_settings)
+                    except Exception:
+                        logger.exception("Failed to restore PyTorch allocator settings")
+                    raise
+                allocator_settings_to_restore = allocator_settings
 
         old_tag = self.current_tag
         self.current_tag = tag
+        self._allocator_settings_context_depth += 1
         try:
             with use_memory_pool_with_allocator(
                 self.python_malloc_callback, self.python_free_callback
@@ -412,8 +426,11 @@ class CuMemAllocator:
                         unmap_and_release(handle)
         finally:
             self.current_tag = old_tag
-            if expandable_was_enabled:
-                torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+            self._allocator_settings_context_depth -= 1
+            if allocator_settings_to_restore is not None:
+                torch._C._accelerator_setAllocatorSettings(
+                    allocator_settings_to_restore
+                )
 
     def get_current_usage(self) -> int:
         """

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 import numpy.typing as npt
+import regex as re
 import torch
 from packaging import version
 from packaging.version import Version
@@ -73,6 +74,36 @@ T = TypeVar("T")
 
 
 PIN_MEMORY = is_pin_memory_available()
+
+
+_PYTORCH_ALLOCATOR_ENV_VARS = (
+    "PYTORCH_CUDA_ALLOC_CONF",
+    "PYTORCH_HIP_ALLOC_CONF",
+    "PYTORCH_ALLOC_CONF",
+)
+_EXPANDABLE_SEGMENTS_PATTERN = re.compile(
+    r"(?:^|,)\s*expandable_segments\s*:\s*(True|False)\s*(?=,|$)"
+)
+
+
+def get_torch_allocator_settings() -> str:
+    """Return allocator settings, falling back to PyTorch's env precedence."""
+    get_settings = getattr(torch._C, "_accelerator_getAllocatorSettings", None)
+    if get_settings is not None:
+        return get_settings()
+
+    # The getter is unavailable in PyTorch 2.11, which is used by ROCm.
+    # Match PyTorch's first-present-variable precedence, including empty values.
+    for env_var in _PYTORCH_ALLOCATOR_ENV_VARS:
+        if env_var in os.environ:
+            return os.environ[env_var]
+    return ""
+
+
+def torch_allocator_uses_expandable_segments(settings: str) -> bool:
+    """Return whether the settings enable expandable segments."""
+    values = _EXPANDABLE_SEGMENTS_PATTERN.findall(settings)
+    return bool(values) and values[-1] == "True"
 
 
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:


### PR DESCRIPTION
## Purpose

PyTorch accepts the backend-specific `PYTORCH_CUDA_ALLOC_CONF` and `PYTORCH_HIP_ALLOC_CONF` variables as well as the unified `PYTORCH_ALLOC_CONF` name. Two allocator safeguards in vLLM currently inspect only `PYTORCH_CUDA_ALLOC_CONF`:

1. The KV-transfer compatibility check can miss `PYTORCH_ALLOC_CONF=expandable_segments:True`, even though PyTorch has enabled expandable segments. This bypasses the existing protection for pinned or registered KV memory whose physical backing must remain stable.
2. `CuMemAllocator.use_memory_pool()` can miss the same unified setting. When it recognizes the legacy setting, it replaces the complete allocator input with `expandable_segments:False` and later restores  `expandable_segments:True`, dropping settings such as `max_split_size_mb` and `garbage_collection_threshold`.

This PR makes both paths use the same allocator-settings semantics:

- Prefer PyTorch's runtime allocator-settings getter when available. On versions without it, including PyTorch 2.11, follow PyTorch's first-present environment precedence: `PYTORCH_CUDA_ALLOC_CONF`, `PYTORCH_HIP_ALLOC_CONF`, then `PYTORCH_ALLOC_CONF`.
- Parse `expandable_segments` as a complete option, including whitespace and duplicate-key last-value-wins behavior.
- Apply the safety gate on CUDA, ROCm, and XPU, whose expandable allocators use remappable virtual memory, while leaving CPU and TPU connector configs unaffected.
- In the outermost CuMem pool, snapshot the allocator-settings string exposed by PyTorch, append a final `expandable_segments:False` override, and restore the snapshot verbatim on normal or exceptional exit. Nested pools do not retoggle the process-global setting.

Fresh-process checks against `origin/main` and this PR produced:

| Case | `origin/main` | This PR |
|---|---|---|
| Unified setting + `NixlConnector` `VllmConfig` | accepted | rejected |
| Unified setting + native offloading config | accepted | rejected |
| Effective `expandable_segments` inside a CUDA CuMem pool | `True` | `False` |
| Legacy setting + other options after leaving a CuMem pool | reset to defaults | preserved |

The `NixlConnector` row covers full `VllmConfig` construction and the admission check. It does not claim that a NIXL agent, memory registration, or cross-node KV transfer was exercised.

### Limitations

PyTorch 2.11 does not expose the allocator-settings getter to Python, so the environment fallback cannot observe runtime changes made after PyTorch cached the environment. On newer PyTorch versions, the getter exposes the last parsed settings string rather than a canonical serialization of every effective allocator field. Consequently, arbitrary third-party partial setter calls cannot always be reconstructed; the environment and full-string paths covered by this PR remain observable.

The nesting logic provides LIFO restoration for one CuMem allocator instance; it does not introduce thread-local allocator settings.

### Relationship to existing PRs

I searched open PRs for `PYTORCH_ALLOC_CONF`, allocator settings, `expandable_segments`, CuMem, and KV connectors. The closest related changes are:

- [#51096](https://github.com/vllm-project/vllm/pull/51096) uses the same snapshot/append/restore mechanism in `gpu_worker._scoped_allocator_max_split`. It does not change the KV-transfer gate or `CuMemAllocator.use_memory_pool()` addressed here. If it lands first, this PR will rebase and consolidate the shared helper where appropriate.
- [#43923](https://github.com/vllm-project/vllm/pull/43923) temporarily disables expandable segments for custom-allreduce CUDA IPC. It changes a separate allocation scope and does not cover the unified-variable KV/CuMem paths here.
- [#42405](https://github.com/vllm-project/vllm/pull/42405) and [#48243](https://github.com/vllm-project/vllm/pull/48243) adjust connector exemption policy. This PR instead fixes how the active allocator setting is detected and preserved while retaining the existing conservative policy.

This PR intentionally does not modify the `gpu_worker`, custom-allreduce, Sharded-RDT warning, or `collect-env` diagnostic paths.

## Test Plan

Allocator parsing, runtime getter, and environment fallback:

```bash
.venv/bin/python -m pytest tests/utils_/test_torch_utils.py \
  -k torch_allocator -q
```

KV connector checks for unified and legacy settings, CUDA/ROCm/XPU gating, CPU/TPU exclusion, and existing exemptions:

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_config.py \
  -k 'expandable_segments or alloc_conf' -q
```

CuMem setting preservation, trailing commas, exceptions, and nested pools:

```bash
.venv/bin/python -m pytest tests/basic_correctness/test_mem.py \
  -k 'cumem_preserves_allocator_settings or cumem_restores_allocator_settings or nested_cumem_pool' -q
```

Real CUDA CuMem smoke test with the unified variable:

```bash
env -u PYTORCH_CUDA_ALLOC_CONF -u PYTORCH_HIP_ALLOC_CONF \
  PYTORCH_ALLOC_CONF=expandable_segments:True \
  .venv/bin/python -m pytest \
  tests/basic_correctness/test_mem.py::test_basic_cumem -q -s
```

Formatting and repository checks:

```bash
.venv/bin/pre-commit run --files \
  vllm/utils/torch_utils.py \
  vllm/config/vllm.py \
  vllm/device_allocator/cumem.py \
  tests/utils_/test_torch_utils.py \
  tests/v1/kv_connector/unit/test_config.py \
  tests/basic_correctness/test_mem.py
git diff --check
```

Model evaluation is not applicable because this change does not modify model code, operators, kernels, sampling, or generated outputs.

## Test Result

Tested on an NVIDIA GeForce RTX 5090 D with PyTorch `2.13.0+cu130`:

```text
10 passed, 33 deselected  # allocator helper
11 passed, 6 deselected   # KV connector/platform compatibility
5 passed, 13 deselected   # CuMem preservation/error/nesting
1 passed                  # real CUDA CuMem smoke test
pre-commit: passed
git diff --check: passed
```

The CUDA runtime checks used real allocator settings, a real CuMem pool, and PyTorch allocator snapshots. The CUDA/ROCm/XPU/CPU/TPU gate branches were covered with platform stubs; no ROCm, XPU, or TPU hardware integration test was run.

## AI assistance

This change was developed with OpenAI Codex assistance. I reviewed every changed line, understand the implementation end-to-end, and personally reran the tests reported above.
