### PR TITLE
[Bugfix] Bound cache_salt length to prevent DoS via scheduler CPU exhaustion

### DIFF
--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -141,6 +141,7 @@ class AnthropicMessagesRequest(BaseModel):
     cache_salt: str | None = Field(
         default=None,
         min_length=1,
+        max_length=1024,
         description=(
             "If specified, the prefix cache will be salted with the provided "
             "string to prevent an attacker to guess prompts in multi-user "

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -467,6 +467,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     cache_salt: str | None = Field(
         default=None,
         min_length=1,
+        max_length=1024,
         description=(
             "If specified, the prefix cache will be salted with the provided "
             "string to prevent an attacker to guess prompts in multi-user "

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -199,6 +199,7 @@ class CompletionRequest(OpenAIBaseModel):
     cache_salt: str | None = Field(
         default=None,
         min_length=1,
+        max_length=1024,
         description=(
             "If specified, the prefix cache will be salted with the provided "
             "string to prevent an attacker to guess prompts in multi-user "

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -252,6 +252,7 @@ class ResponsesRequest(OpenAIBaseModel):
     cache_salt: str | None = Field(
         default=None,
         min_length=1,
+        max_length=1024,
         description=(
             "If specified, the prefix cache will be salted with the provided "
             "string to prevent an attacker to guess prompts in multi-user "

--- a/vllm/entrypoints/pooling/base/protocol.py
+++ b/vllm/entrypoints/pooling/base/protocol.py
@@ -82,6 +82,8 @@ class PoolingBasicRequestMixin(OpenAIBaseModel):
     )
     cache_salt: str | None = Field(
         default=None,
+        min_length=1,
+        max_length=1024,
         description=(
             "If specified, the prefix cache will be salted with the provided "
             "string to prevent an attacker to guess prompts in multi-user "

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -124,6 +124,7 @@ class GenerateRequest(BaseModel):
     cache_salt: str | None = Field(
         default=None,
         min_length=1,
+        max_length=1024,
         description=(
             "If specified, the prefix cache will be salted with the provided "
             "string to prevent an attacker to guess prompts in multi-user "


### PR DESCRIPTION
## Summary

- Adds `max_length=1024` to the `cache_salt` Pydantic `Field` on all six API protocol models: completions, chat completions, responses, pooling, Anthropic, and scale-out (token-in-token-out).
- The field previously had only `min_length=1` (or no constraint at all on the pooling endpoint) and no upper bound, allowing an attacker to send arbitrarily large salt strings that are serialized via `pickle.dumps` + `sha256` on the single-threaded EngineCore scheduler, stalling all concurrent requests.
- A 1024-character limit is generous for any legitimate salt (the documented expected value is ~43 characters for 256-bit base64) while preventing resource-exhaustion abuse.
- Also adds the missing `min_length=1` constraint on the pooling endpoint for consistency.

Addresses GHSA-wpww-v874-ph2p.

## Files changed

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/completion/protocol.py` | Add `max_length=1024` |
| `vllm/entrypoints/openai/chat_completion/protocol.py` | Add `max_length=1024` |
| `vllm/entrypoints/openai/responses/protocol.py` | Add `max_length=1024` |
| `vllm/entrypoints/anthropic/protocol.py` | Add `max_length=1024` |
| `vllm/entrypoints/scale_out/token_in_token_out/protocol.py` | Add `max_length=1024` |
| `vllm/entrypoints/pooling/base/protocol.py` | Add `min_length=1` + `max_length=1024` |

## Test plan

- [x] All pre-commit hooks pass (ruff-check, ruff-format, mypy, typos, etc.)
- Pydantic validation will now reject any `cache_salt` longer than 1024 characters with an HTTP 422 before it reaches the scheduler
- Existing valid salts (recommended ~43 chars) are unaffected


Made with [Cursor](https://cursor.com)