### PR TITLE
[NIXL] Bump NIXL version to 1.4.1

### DIFF
--- a/.buildkite/scripts/install-kv-connectors.sh
+++ b/.buildkite/scripts/install-kv-connectors.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+# do-not-merge: resolve the NIXL 1.4.1 RC1 prerelease from TestPyPI for CI.
+export UV_PRERELEASE=allow
+export UV_INDEX_STRATEGY="${UV_INDEX_STRATEGY:-unsafe-best-match}"
+export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL:+${UV_EXTRA_INDEX_URL} }https://test.pypi.org/simple/"
+
 if python3 -c "import torch; raise SystemExit(0 if torch.version.hip is not None else 1)"; then
     uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
     exit 0

--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -2,7 +2,7 @@ lmcache >= 0.3.9
 # CuPy 14.1.0 imports pytest from cupy.testing._random, which breaks runtime
 # images. 14.1.1 fixes the root cause, so only 14.1.0 is excluded.
 cupy-cuda13x != 14.1.0
-nixl == 1.3.2
+nixl == 1.4.1rc1 # do-not-merge: test NIXL 1.4.1 RC1 integration (revert to a stable pin before merge)
 # CUDA 12 build. On the CUDA 13 image install-kv-connectors.sh swaps this for
 # the mooncake-transfer-engine-cuda13 variant of the same version.
 mooncake-transfer-engine >= 0.3.12


### PR DESCRIPTION



## Purpose

Bump NIXL version to 1.4.1

Currently points to a pre-release package to check if vLLM CI passes. Do not merge this; it will be removed once 1.4.1 is published.

## Test Plan

[ ] vLLM CI
[ ] Internal testing in progress

## Test Result

Pending

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

