### PR TITLE
[Model][LoRA] Enable tower and connector LoRA for Isaac

### DIFF
--- a/vllm/model_executor/models/isaac.py
+++ b/vllm/model_executor/models/isaac.py
@@ -799,6 +799,7 @@ class IsaacForConditionalGeneration(
     }
 
     supports_encoder_tp_data = True
+    supports_tower_connector_lora = True
 
     # To ensure correct weight loading and mapping.
     hf_to_vllm_mapper = WeightsMapper(
@@ -1014,6 +1015,14 @@ class IsaacForConditionalGeneration(
         """
         return MultiModelKeys.from_string_field(
             language_model="language_model",
-            connector="vision_embedding.linear_fc2",  # The final linear layer
-            tower_model="vision_embedding",
+            connector=["vision_embedding.linear_fc1", "vision_embedding.linear_fc2"],
+            tower_model="vision_embedding.transformer",
         )
+
+    def get_num_mm_encoder_tokens(self, num_image_tokens: int) -> int:
+        merge_size = self.config.vision_config.pixel_shuffle_scale_factor
+        return num_image_tokens * merge_size**2
+
+    def get_num_mm_connector_tokens(self, num_vision_tokens: int) -> int:
+        merge_size = self.config.vision_config.pixel_shuffle_scale_factor
+        return num_vision_tokens // merge_size**2


### PR DESCRIPTION
## Purpose

Enable tower and connector LoRA for `IsaacForConditionalGeneration`.

Isaac applies pixel shuffle to the vision features before the projection layers, so the language model sees fewer image tokens than the vision transformer processes. This change adds the token-count conversions needed to calculate the correct LoRA activation lengths for the vision transformer and both projection layers.

Part of #31479.

I checked the issue discussion and searched open PRs for Isaac tower/connector LoRA. I found no existing contribution covering this model.

## Test Plan

- `uvx pre-commit run ruff-check --files vllm/model_executor/models/isaac.py`
- `uvx pre-commit run ruff-format --files vllm/model_executor/models/isaac.py`
- `uvx pre-commit run typos --files vllm/model_executor/models/isaac.py`
- `uvx pre-commit run mypy-3.10 --files vllm/model_executor/models/isaac.py`
- `git diff --check`
- Baseline, tower-only, and connector-only inference using synthetic rank-1 LoRA adapters

## Test Result

- All listed pre-commit hooks passed.
- `git diff --check` passed.
- Model: `PerceptronAI/Isaac-0.2-2B-Preview`
- Hardware: NVIDIA T4
- Baseline, tower-only, and connector-only requests completed without token-count, activation-mapping, or tensor-shape errors.
- Cumulative logprob:
  - baseline: `-2.7696505123`
  - tower: `-2.7698014590`
  - connector: `-2.7627788614`

The tower and connector adapters both changed the cumulative log probability relative to the baseline, confirming that both adapter paths affected computation. This was a functionality check, not a model-quality evaluation.

## AI assistance

I used Codex to investigate the issue and validate the change.