### PR TITLE
[Bugfix][GDN] Run Qwen GDN cores as eager breaks in breakable CUDA graph

### DIFF
--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -6,6 +6,9 @@ Unit tests for the breakable cudagraph primitives.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import threading
 from contextlib import nullcontext
 from unittest.mock import patch
@@ -485,3 +488,47 @@ def test_nested_decorated_op_runs_inline(cuda_capture_stream):
     # 0 -> +2 -> +1 (inner) -> +10 (outer) -> +100 = 113
     assert torch.equal(x, torch.full((4,), 113.0, device="cuda"))
     assert inner_calls == 2  # replay invokes the outer's lambda again
+
+
+def test_qwen_gdn_custom_ops_are_eager_breaks():
+    """Both Qwen GDN registrations must use the breakable graph wrapper."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    env = os.environ.copy()
+    env["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
+    script = (
+        "from tests.v1.cudagraph.test_breakable_cudagraph import "
+        "_assert_qwen_gdn_custom_ops_are_eager_breaks; "
+        "_assert_qwen_gdn_custom_ops_are_eager_breaks()"
+    )
+    subprocess.run([sys.executable, "-c", script], check=True, env=env)
+
+
+def _assert_qwen_gdn_custom_ops_are_eager_breaks() -> None:
+    from importlib import import_module
+
+    from vllm.utils import torch_utils
+
+    op_names = (
+        "qwen_gdn_attention_core",
+        "qwen_gdn_attention_core_fused_norm_packed",
+    )
+    registered_ops = {}
+    original_register = torch_utils.direct_register_custom_op
+
+    def record_qwen_gdn_op(op_name, op_func, *args, **kwargs):
+        if op_name in op_names:
+            registered_ops[op_name] = op_func
+            return
+        original_register(op_name, op_func, *args, **kwargs)
+
+    with patch.object(torch_utils, "direct_register_custom_op", record_qwen_gdn_op):
+        qwen_gdn_linear_attn = import_module(
+            "vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn"
+        )
+
+    for op_name in op_names:
+        assert registered_ops[op_name].__wrapped__ is getattr(
+            qwen_gdn_linear_attn, op_name
+        )

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -12,6 +12,7 @@ from torch import nn
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
@@ -1948,7 +1949,7 @@ def gdn_attention_core_fake(
 
 direct_register_custom_op(
     op_name="qwen_gdn_attention_core",
-    op_func=qwen_gdn_attention_core,
+    op_func=eager_break_during_capture(qwen_gdn_attention_core),
     mutates_args=["a_or_z_out", "core_attn_out"],
     fake_impl=gdn_attention_core_fake,
 )
@@ -1981,7 +1982,7 @@ def gdn_attention_core_fused_norm_packed_fake(
 
 direct_register_custom_op(
     op_name="qwen_gdn_attention_core_fused_norm_packed",
-    op_func=qwen_gdn_attention_core_fused_norm_packed,
+    op_func=eager_break_during_capture(qwen_gdn_attention_core_fused_norm_packed),
     mutates_args=["core_attn_out"],
     fake_impl=gdn_attention_core_fused_norm_packed_fake,
 )


### PR DESCRIPTION
## Purpose

When breakable cudagraph is enabled, Qwen3.5 on CUDA can abort during model warm-up. This PR fixes Qwen GDN (Gated Delta Net) recurrent attention under the explicit `VLLM_USE_BREAKABLE_CUDAGRAPH=1` path.

The Qwen GDN custom-op implementations read request-specific metadata from the current `ForwardContext` to select the execution path and address/update recurrent state. Normal compiled PIECEWISE execution already keeps these ops outside cudagraphs through `splitting_ops`, but breakable capture does not consume that list. Without explicit eager breaks, capture-time branches and state addressing can be frozen into a graph, and replay does not re-enter the Python op with the current request metadata.

This PR wraps both Qwen GDN custom-op registrations with `eager_break_during_capture`:

- `qwen_gdn_attention_core`
- `qwen_gdn_attention_core_fused_norm_packed`

Both ops write to caller-owned output buffers, as required by the breakable cudagraph contract. When breakable cudagraph is disabled, the helper returns the original function. The wrapper does not introduce an eager break in FULL mode. This change does not modify GDN kernels, metadata construction, state allocation, graph dispatch, the normal PIECEWISE splitting list, or automatic enablement of breakable cudagraph for Qwen.

This is the CUDA/ROCm counterpart of #51928, which applies the same eager-break invariant to the XPU-specific `gdn_attention_core_xpu` op. An open-PR search of `vllm-project/vllm` on 2026-08-29 found no PR covering these two Qwen GDN registrations.

AI assistance was used for source tracing, reproducer construction, the initial patch, test drafting, and preparation of this PR description. The submitting author ran the tests below and is responsible for reviewing and understanding the final change.

## Test Plan

```bash
.venv/bin/python -m pytest -q \
  tests/v1/cudagraph/test_breakable_cudagraph.py

.venv/bin/pre-commit run --files \
  vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py \
  tests/v1/cudagraph/test_breakable_cudagraph.py

git diff --check origin/main...HEAD
```

The new test starts a fresh interpreter with `VLLM_USE_BREAKABLE_CUDAGRAPH=1` set before the Qwen module is imported, then verifies that both registered GDN ops use the eager-break wrapper. Existing tests in the same file cover capture segmentation, output propagation, replay ordering, and nested decorated calls.

The model evaluation used Qwen3.5-2B BF16 on an NVIDIA GeForce RTX 5090 D with PyTorch `2.13.0+cu130`, CUDA 13.0, TP/DP=1/1, the stock Triton GDN prefill backend, FLASH_ATTN, greedy sampling, B1/I64/O32, and capture sizes `[1, 256]`. Each mode ran the same prompt twice in one engine process. I64 deliberately reused the 256-token capture bucket rather than matching the capture shape.

## Test Result
### Unit and static checks

- `tests/v1/cudagraph/test_breakable_cudagraph.py`: **15 passed**
- all pre-commit hooks for the two changed files: **passed**
- `git diff --check origin/main...HEAD`: **passed**
- tracked diff scope: **2 expected files only**

### Qwen3.5-2B correctness

| Source / mode | Process result | Token comparison | Repeated request |
|---|---:|---:|---:|
| base normal PIECEWISE | `rc=0` | 32/32 match fixed eager | exact |
| base breakable PIECEWISE | `rc=-6`, no output JSON | unavailable | unavailable |
| fixed eager | `rc=0` | 32/32 reference token IDs | exact |
| fixed normal PIECEWISE | `rc=0` | 32/32 match fixed eager | exact |
| fixed breakable PIECEWISE | `rc=0` | 32/32 match fixed eager | exact |

The base breakable failure occurred during model warm-up after graph capture, before a request result was produced. The fixed B1/I64/O32 run covers prefill and subsequent recurrent decode-state updates.

No performance improvement is claimed. The unfixed breakable path aborts, so it does not provide a valid latency baseline. ROCm/AITER was not tested locally.
