### PR TITLE
[Bugfix][Frontend] Truncate pooling prompts before padding them

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_io_processor_unit.py
+++ b/tests/entrypoints/pooling/scoring/test_io_processor_unit.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ScoringIOProcessor post-tokenization helpers."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from vllm import TokensPrompt
+from vllm.entrypoints.pooling.scoring.io_processor import (
+    _apply_post_tokenization_to_token_type_ids,
+)
+from vllm.entrypoints.pooling.scoring.utils import compress_token_type_ids
+from vllm.renderers import TokenizeParams
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@dataclass
+class _DummyTokenizer:
+    truncation_side: str = "left"
+    # Outside the range of the prompt ids below, so a test can tell a pad
+    # token apart from a real one.
+    pad_token_id: int = 99999
+
+
+def test_token_type_ids_stay_aligned_with_a_truncated_padded_prompt():
+    """The cross-encoder segment boundary must survive truncate + pad.
+
+    `token_type_ids` are parallel to `prompt_token_ids` and are reduced to a
+    single boundary index by `compress_token_type_ids`. If the two arrays are
+    truncated and padded in different orders they no longer describe the same
+    positions, and the model is told the query segment is empty.
+    """
+    tokenizer = _DummyTokenizer()
+    num_query, num_doc = 20, 30
+    prompt = TokensPrompt(prompt_token_ids=list(range(num_query + num_doc)))
+    token_type_ids = [0] * num_query + [1] * num_doc
+
+    tok_params = TokenizeParams(
+        max_total_tokens=100,
+        pad_prompt_tokens=-1,
+        truncate_prompt_tokens=40,
+        truncation_side="left",
+    )
+
+    prompt = tok_params.apply_post_tokenization(tokenizer, prompt)
+    token_type_ids = _apply_post_tokenization_to_token_type_ids(
+        tokenizer, tok_params, token_type_ids
+    )
+
+    prompt_token_ids = prompt["prompt_token_ids"]
+    assert len(token_type_ids) == len(prompt_token_ids)
+
+    # Keeping the last 40 tokens drops the first 10 query tokens, so 10 query
+    # tokens survive and the document starts at index 10.
+    first_doc = compress_token_type_ids(token_type_ids)
+    assert first_doc == 10
+    assert prompt_token_ids[:first_doc] == list(range(10, num_query))
+    assert prompt_token_ids[first_doc:40] == list(range(num_query, 50))

--- a/tests/renderers/test_completions.py
+++ b/tests/renderers/test_completions.py
@@ -62,6 +62,9 @@ class MockVllmConfig:
 class DummyTokenizer:
     truncation_side: str = "left"
     max_chars_per_token: int = 1
+    # Deliberately outside the range of ids `encode` returns, so a test can
+    # tell a pad token apart from a real one.
+    pad_token_id: int = 99999
 
     def __post_init__(self) -> None:
         self._captured_encode_kwargs: dict = {}
@@ -427,6 +430,58 @@ class TestRenderPrompt:
         assert len(results) == 1
         assert len(results[0]["prompt_token_ids"]) == 5
         assert results[0]["prompt_token_ids"] == list(range(5))
+
+    def test_padding_with_left_truncation_keeps_the_prompt(self):
+        """Padding must not be truncated away.
+
+        `padding` and `truncate_prompt_tokens`/`truncation_side` are all
+        settable on one pooling request. Padding to the full input length
+        before truncating from the left leaves a prompt made entirely of pad
+        tokens, and the request still succeeds -- so the model embeds nothing
+        but padding.
+        """
+        renderer = _build_renderer(MockModelConfig())
+        pad_id = renderer.tokenizer.pad_token_id
+
+        prompts = renderer.render_prompts(
+            _preprocess_prompt(renderer.model_config, "x" * 50)
+        )
+        results = renderer.tokenize_prompts(
+            prompts,
+            TokenizeParams(
+                max_total_tokens=100,
+                pad_prompt_tokens=-1,
+                truncate_prompt_tokens=5,
+                truncation_side="left",
+            ),
+        )
+
+        assert len(results) == 1
+        token_ids = results[0]["prompt_token_ids"]
+
+        # The sentinel: on a padding-first pipeline every surviving id is a
+        # pad token, so the prompt reaches the model with no content at all.
+        assert set(token_ids) != {pad_id}
+
+        # Transformers semantics: truncate to 5, then pad out to the full
+        # input length.
+        assert token_ids[:5] == list(range(45, 50))
+        assert token_ids[5:] == [pad_id] * 95
+
+    def test_padding_without_truncation_is_unchanged(self):
+        renderer = _build_renderer(MockModelConfig())
+        pad_id = renderer.tokenizer.pad_token_id
+
+        prompts = renderer.render_prompts(
+            _preprocess_prompt(renderer.model_config, "x" * 50)
+        )
+        results = renderer.tokenize_prompts(
+            prompts,
+            TokenizeParams(max_total_tokens=100, pad_prompt_tokens=-1),
+        )
+
+        assert len(results) == 1
+        assert results[0]["prompt_token_ids"] == list(range(50)) + [pad_id] * 50
 
     def test_explicit_side_text_pretokenization_guard(self):
         renderer = _build_renderer(MockModelConfig(), max_chars_per_token=1)

--- a/vllm/entrypoints/pooling/scoring/io_processor.py
+++ b/vllm/entrypoints/pooling/scoring/io_processor.py
@@ -55,6 +55,27 @@ def _apply_post_tokenization_to_token_type_ids(
     tok_params: TokenizeParams,
     token_type_ids: list[int],
 ) -> list[int]:
+    # Must stay in the same order as `TokenizeParams._validate_tokens`, which
+    # truncates before padding. These ids are parallel to the prompt tokens
+    # and locate the query/document boundary for the cross-encoder; applying
+    # the two steps in a different order silently misplaces that boundary.
+    max_length = tok_params.truncate_prompt_tokens
+    if max_length is not None and max_length < 0:
+        max_length = tok_params.max_input_tokens
+
+    if max_length is not None and max_length < len(token_type_ids):
+        if max_length == 0:
+            token_type_ids = token_type_ids[:0]
+        else:
+            side = tok_params.truncation_side or (
+                tokenizer.truncation_side if tokenizer is not None else None
+            )
+            token_type_ids = (
+                token_type_ids[-max_length:]
+                if side == "left"
+                else token_type_ids[:max_length]
+            )
+
     pad_length = tok_params.pad_prompt_tokens
     if pad_length is not None and pad_length < 0:
         pad_length = tok_params.max_input_tokens
@@ -65,22 +86,7 @@ def _apply_post_tokenization_to_token_type_ids(
             pad_length - len(token_type_ids)
         )
 
-    max_length = tok_params.truncate_prompt_tokens
-    if max_length is not None and max_length < 0:
-        max_length = tok_params.max_input_tokens
-
-    if max_length is None or max_length >= len(token_type_ids):
-        return token_type_ids
-    if max_length == 0:
-        return token_type_ids[:0]
-
-    side = tok_params.truncation_side or (
-        tokenizer.truncation_side if tokenizer is not None else None
-    )
-    if side == "left":
-        return token_type_ids[-max_length:]
-
-    return token_type_ids[:max_length]
+    return token_type_ids
 
 
 class ScoringIOProcessor(PoolingIOProcessor):

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -462,9 +462,13 @@ class TokenizeParams:
 
     def _validate_tokens(self, tokenizer: TokenizerLike | None, tokens: _S) -> _S:
         """Apply all validators to a token sequence."""
+        # Truncation runs before padding, matching the Transformers pipeline
+        # these parameters are named after. Padding first would let a
+        # subsequent left-side truncation keep only the pad tokens it just
+        # appended, discarding the prompt entirely.
         for validator in (
-            self._token_padding,
             self._token_truncation,
+            self._token_padding,
             self._token_len_check,
         ):
             tokens = validator(tokenizer, tokens)


### PR DESCRIPTION
## Purpose

`TokenizeParams._validate_tokens` runs its validators in this order:

```python
for validator in (
    self._token_padding,
    self._token_truncation,
    self._token_len_check,
):
```

Padding runs **before** truncation. `_token_padding` appends pad tokens up to
`max_input_tokens`, and `_token_truncation` with `truncation_side="left"` then
keeps only the *last* N tokens — which are precisely the pad tokens that padding
just appended. The prompt's actual content is discarded, the request succeeds,
and the model embeds nothing but padding. No error, no warning.

`padding` is documented as "using the same names as the Transformers tokenizer",
but the Transformers pipeline truncates and *then* pads
([`pad_truncation`](https://huggingface.co/docs/transformers/en/pad_truncation)).

### Reachability

`padding` became settable over HTTP in #51157 (merged 2026-08-27).
`PoolingBasicRequestMixin` (`vllm/entrypoints/pooling/base/protocol.py:41-63`)
exposes `truncate_prompt_tokens`, `padding` and `truncation_side` on the *same*
request model, and routes `padding` through
`tok_params.with_kwargs(padding=self.padding)` → `pad_prompt_tokens = max_length`
(`vllm/renderers/params.py:273-277`). All three are therefore settable on one
request:

```
POST /v1/embeddings
{
  "model": "<embedding model>",
  "input": "Hello",
  "padding": "max_length",
  "truncate_prompt_tokens": 8,
  "truncation_side": "left"
}
```

With `max_model_len=512`: the tokenizer returns ~3 ids → `_token_padding`
extends to 512 → `_token_truncation` (left) returns `tokens[-8:]` → **8 pad
tokens, zero content tokens** → `_token_len_check` passes → 200 OK with an
embedding of pure padding.

`truncation_side` does not have to be sent explicitly: `_token_truncation` falls
back to `tokenizer.truncation_side` (`params.py:428-430`), so any tokenizer
whose own default is `"left"` hits this with just `padding` +
`truncate_prompt_tokens`.

This is also why it is easy to miss — with `truncation_side="right"` the result
coincidentally matches Transformers, so the bug only shows on the left side.

## Approach

Run `_token_truncation` before `_token_padding`, matching the Transformers
pipeline the parameters are named after. Truncation then applies to real
content, and padding fills out the remainder.

The reordering is safe with respect to `_token_len_check`, which still runs
last: `_token_padding` pads to at most `max_input_tokens`, and `__post_init__`
already rejects `truncate_prompt_tokens > max_input_tokens`
(`params.py:239-251`), so neither step can push the sequence past the limit.

## Test Plan

```bash
pytest tests/renderers/test_completions.py -v
```

Two tests added to the existing `TestRenderPrompt` class:

- `test_padding_with_left_truncation_keeps_the_prompt` — the regression. The
  sentinel is `set(token_ids) != {pad_id}`: it asserts the prompt is not made
  *entirely* of pad tokens, which is what proves the degenerate value reached
  the consumer, rather than asserting that some exception was raised (nothing
  raises here — that is the point). `DummyTokenizer.pad_token_id` is 99999,
  deliberately outside the range of ids `encode` returns, so a pad token can
  never be confused with a real one.
- `test_padding_without_truncation_is_unchanged` — pins the behaviour of
  padding on its own, so the reorder cannot silently change the case #51157
  added.

The existing `tests/entrypoints/pooling/embed/test_online.py::test_padding`
only checks `usage.prompt_tokens` grows and never combines `padding` with
`truncate_prompt_tokens`, so this interaction was untested.

## Test Result

Run on ubuntu-24.04 x86_64 / Python 3.12.3, installed with
`VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto`.

**Before** — the new tests against `vllm/renderers/params.py` from `main`
(4fc943b86). The prompt is 100% pad tokens:

```text
=========== BEFORE  fix/pad-after-truncate ===========
$ python -m pytest -v tests/renderers/test_completions.py -k padding_with_left_truncation_keeps_the_prompt or padding_without_truncation_is_unchanged
HEAD = 4fc943b86  ([Multimodal] Deprecate PyAV video decoder backend (#54231))

collected 28 items / 26 deselected / 2 selected

tests/renderers/test_completions.py::TestRenderPrompt::test_padding_with_left_truncation_keeps_the_prompt FAILED [ 50%]
tests/renderers/test_completions.py::TestRenderPrompt::test_padding_without_truncation_is_unchanged PASSED [100%]

        # The sentinel: on a padding-first pipeline every surviving id is a
        # pad token, so the prompt reaches the model with no content at all.
>       assert set(token_ids) != {pad_id}
E       assert {99999} != {99999}
E
E         Both sets are equal

tests/renderers/test_completions.py:464: AssertionError
================== 1 failed, 1 passed, 26 deselected in 0.83s ==================
```

**After** — this branch, whole file:

```text
=========== AFTER   fix/pad-after-truncate ===========
$ python -m pytest -v tests/renderers/test_completions.py
HEAD = 48d3b41a2  ([Bugfix][Frontend] Truncate pooling prompts before padding them)

collected 28 items

tests/renderers/test_completions.py::TestRenderPrompt::test_truncation_left PASSED [ 35%]
tests/renderers/test_completions.py::TestRenderPrompt::test_truncation_right PASSED [ 39%]
tests/renderers/test_completions.py::TestRenderPrompt::test_explicit_side_left_text PASSED [ 64%]
tests/renderers/test_completions.py::TestRenderPrompt::test_explicit_side_right_text PASSED [ 67%]
tests/renderers/test_completions.py::TestRenderPrompt::test_padding_with_left_truncation_keeps_the_prompt PASSED [ 71%]
tests/renderers/test_completions.py::TestRenderPrompt::test_padding_without_truncation_is_unchanged PASSED [ 75%]

============================== 28 passed in 9.61s ==============================
```

Every pre-existing test in the file — including all four truncation-side tests —
passes unchanged, which is the evidence that the reorder does not alter
truncation-only or padding-only behaviour.

`pre-commit` hooks applicable to the two changed files — `ruff-check`,
`ruff-format`, `typos`, `check-spdx-header` — pass.

### Not fixed here

`_token_padding` uses `tokenizer.pad_token_id` unguarded, so a tokenizer with no
configured pad token would splice `None` into `prompt_token_ids`. I could not
identify a commonly served pooling model whose tokenizer reports
`pad_token_id is None`, so I have left it alone rather than add a guard for a
path I cannot demonstrate. Happy to add it if maintainers want it covered.

---
AI assistance was used to research and draft this change. I have reviewed every
changed line and run the tests above.


---

## Follow-up commit `ac5d07e1a` — keep `token_type_ids` aligned

`vllm/entrypoints/pooling/scoring/io_processor.py` keeps a second copy of the
pad/truncate logic for the `token_type_ids` array that runs parallel to
`prompt_token_ids` on cross-encoder scoring requests
(`_apply_post_tokenization_to_token_type_ids`). It also padded before
truncating, so once `_validate_tokens` was reordered the two arrays no longer
described the same positions.

`compress_token_type_ids` reduces that array to one index — where the document
segment begins — and the model applies it to `prompt_token_ids`. With a
20-token query + 30-token document, `padding` to 100, `truncate_prompt_tokens=40`
and `truncation_side="left"`:

| | `len(prompt_token_ids)` | `len(token_type_ids)` | boundary |
|---|---|---|---|
| main | 40 (all pad) | 40 | 0 |
| this PR, before `ac5d07e1a` | 100 | 40 | 0 |
| this PR, after `ac5d07e1a` | 100 | 100 | 10 |

10 is correct: left-truncating to 40 drops the first 10 query tokens, so 10
query tokens survive and the document starts at index 10. A boundary of 0 tells
the cross-encoder the query segment is empty.

`tests/entrypoints/pooling/scoring/test_io_processor_unit.py` asserts both the
matching lengths and the boundary. The boundary assertion is the load-bearing
one — the length check alone passes on `main`, where both arrays are wrong in
the same way (`assert 0 == 10` is the failure on `main`).
