### PR TITLE
[Bugfix][Quantization] Dispatch FP8_PER_CHANNEL_PER_TOKEN in ModelOpt MIXED_PRECISION

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -19,11 +19,12 @@ from vllm.model_executor.kernels.linear import (
     HummingNvFp4LinearKernel,
     MarlinNvFp4LinearKernel,
 )
-from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptFp8Config,
     ModelOptFp8LinearMethod,
     ModelOptFp8PbWoLinearMethod,
+    ModelOptFp8PcPtLinearMethod,
     ModelOptMixedPrecisionConfig,
     ModelOptMxFp8Config,
     ModelOptNvFp4Config,
@@ -219,6 +220,28 @@ def test_modelopt_mixed_precision_quantizes_parallel_lm_head():
         method = config.get_quant_method(_mock_lm_head(), prefix="lm_head")
 
     assert isinstance(method, ModelOptNvFp4LinearMethod)
+
+
+def test_modelopt_mixed_precision_dispatches_fp8_pc_pt_method():
+    """FP8_PER_CHANNEL_PER_TOKEN must reach ModelOptFp8PcPtLinearMethod.
+
+    Without a branch for it, get_quant_method falls through to
+    UnquantizedLinearMethod, the layer never registers weight_scale, and a
+    checkpoint carrying one fails to load.
+    """
+    config = _mixed_precision_config(
+        {
+            "model.layers.0.mlp.down_proj": {
+                "quant_algo": "FP8_PER_CHANNEL_PER_TOKEN"
+            }
+        }
+    )
+    layer = Mock(spec=LinearBase)
+    layer.__class__ = LinearBase
+
+    method = config.get_quant_method(layer, prefix="model.layers.0.mlp.down_proj")
+
+    assert isinstance(method, ModelOptFp8PcPtLinearMethod)
 
 
 def test_modelopt_mixed_precision_resolves_declared_packed_projection():

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -2418,6 +2418,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfigBase):
                 return ModelOptNvFp4W4A16LinearMethod(self.w4a16_nvfp4_config)
             if quant_algo == "MXFP8":
                 return ModelOptMxFp8LinearMethod(self.mxfp8_config)
+            if quant_algo == "FP8_PER_CHANNEL_PER_TOKEN":
+                return ModelOptFp8PcPtLinearMethod(self.fp8_config)
             # Layer not in quantized_layers — leave unquantized
             return UnquantizedLinearMethod()
 


### PR DESCRIPTION
## Purpose

`ModelOptFp8PcPtLinearMethod` is defined and `FP8_PER_CHANNEL_PER_TOKEN` is a recognised
ModelOpt `quant_algo`, but `ModelOptMixedPrecisionConfig.get_quant_method` has no branch for it.
The algo resolves correctly from `quantized_layers`, matches none of
`FP8` / `NVFP4` / `W4A16_NVFP4` / `MXFP8` / `FP8_PB_WO`, and falls through to
`UnquantizedLinearMethod`.

The layer therefore never registers `weight_scale`, and a checkpoint that carries one fails to
load:

```
ValueError: There is no module or parameter named
'...input_mix_weight_up.weight_scale' in <Model>.
The available parameters belonging to ...input_mix_weight_up (ReplicatedLinear) are:
{'...input_mix_weight_up.weight'}
```

Two lines, mirroring the branches immediately around it.

**Why per-channel matters rather than just using `FP8_PB_WO`:** blockwise FP8 requires both
dimensions divisible by 128. Shapes that fail that constraint have no working FP8 path at all
today. Concretely, on Qwen3.8-Flash-Next the hyper-connection projections are
`(320, 10240)`, `(10240, 320)` and `(4, 10240)` — `out % 128` is 64 or 4, `in % 128` is 64 —
so every one falls off the fast CUTLASS blockwise kernel. Per-output-channel scales carry no
block constraint, and they also slice cleanly across a fused `MergedColumnParallelLinear`,
which a blockwise scale cannot when a shard is narrower than one block.

## Test Plan

1. New unit test `test_modelopt_mixed_precision_dispatches_fp8_pc_pt_method` in
   `tests/quantization/test_modelopt.py`, placed with the existing mixed-precision dispatch
   tests. No GPU, no checkpoint — builds a `ModelOptMixedPrecisionConfig` declaring one layer as
   `FP8_PER_CHANNEL_PER_TOKEN` and asserts `get_quant_method` returns
   `ModelOptFp8PcPtLinearMethod`.

   ```
   pytest tests/quantization/test_modelopt.py -k mixed_precision
   ```

2. End-to-end: serve a `MIXED_PRECISION` checkpoint whose `quantized_layers` marks a set of
   linears `FP8_PER_CHANNEL_PER_TOKEN`, with matching `weight` + `weight_scale` tensors.

## Test Result

**Before** — the server fails during weight loading with the `ValueError` above, on a checkpoint
whose config and tensors are internally consistent.

**After** — the layers dispatch to `ModelOptFp8PcPtLinearMethod`, the checkpoint loads, and the
model serves normally. Verified on a GB10 (sm_121) with Qwen3.8-Flash-Next, 96 hyper-connection
projections converted to per-channel FP8 (mean weight reconstruction error 2.21%): coherent
output, and speculative-decode acceptance unchanged at 57.4% against 56.6% for the BF16 baseline.

Dispatch confirmed directly:

```
dispatched to: ModelOptFp8PcPtLinearMethod
```

For transparency on scope: the conversion was performance-neutral for those particular shapes on
that hardware, which is a property of the shapes rather than of this fix. The bug being fixed
here is that the scheme is unreachable at all through `MIXED_PRECISION`.
