### PR TITLE
[Bugfix][Frontend] Normalize null assistant content with tool_calls

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2930,7 +2930,34 @@ def test_postprocess_messages_null_arguments_string():
     _postprocess_messages(messages)
     tool_calls = messages[0]["tool_calls"]
     assert tool_calls is not None
+    assert messages[0]["content"] == ""
     assert tool_calls[0]["function"]["arguments"] == {}
+
+
+def test_postprocess_messages_null_content_with_tool_calls():
+    """Assistant content=null + tool_calls must not reach templates as None.
+
+    OpenAI agent clients commonly send this shape. Jinja chat templates that
+    render {{ content }} would otherwise emit the literal string "None".
+    """
+    messages: list[ConversationMessage] = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": '{"cmd": "ls"}'},
+                }
+            ],
+        }
+    ]
+    _postprocess_messages(messages)
+    assert messages[0]["content"] == ""
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == {
+        "cmd": "ls"
+    }
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -2036,6 +2036,16 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
     # so, for messages that have tool_calls, parse the string (which we get
     # from openAI format) to dict
     for message in messages:
+        if (
+            message.get("role") == "assistant"
+            and message.get("content") is None
+            and "tool_calls" in message
+        ):
+            # Agent clients send assistant messages with content=null and
+            # tool_calls. Templates that render {{ content }} emit a literal
+            # "None" into the context, which degrades multi-turn generation.
+            message["content"] = ""
+
         if message["role"] == "assistant" and "tool_calls" in message:
             tool_calls = message.get("tool_calls")
             if not isinstance(tool_calls, list):


### PR DESCRIPTION
## Summary

- Normalize assistant messages with `content: null` and `tool_calls` to use an empty string before chat templating.
- Prevents Jinja templates that render `{{ content }}` from injecting the literal string `None` into the prompt.
- Adds regression coverage in `test_chat_utils.py`.

## Problem

OpenAI agent clients (OpenAI SDK, pi, etc.) commonly send assistant turns as `content: null` plus `tool_calls`. When those messages reach `apply_chat_template`, templates that unconditionally render assistant content emit `None` as text. Over many tool-calling turns in an agent session, this silently degrades generation into repetition loops and looks like a model quality issue rather than a preprocessing bug.

Reported in #54337 with reproduction on GLM chat templates; the fix is protocol-layer and model-agnostic.

## Fix

Extend `_postprocess_messages` in `vllm/entrypoints/chat_utils.py` to coerce `content=None` to `""` for assistant messages that include `tool_calls`, alongside the existing tool-call argument normalization.

## Test plan

- [x] Smoke-tested `_postprocess_messages` locally (null content becomes `""`, arguments still parsed)
- [ ] `pytest tests/entrypoints/unit_tests/test_chat_utils.py::test_postprocess_messages_null_content_with_tool_calls -q`
- [ ] `pytest tests/entrypoints/unit_tests/test_chat_utils.py::test_postprocess_messages_null_arguments_string -q`

Fixes #54337
