### PR TITLE
[Bugfix] DeepSeek-V3.2: render tools after the system prompt

### DIFF
--- a/tests/tokenizers_/test_deepseek_v32.py
+++ b/tests/tokenizers_/test_deepseek_v32.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.tokenizers.deepseek_v32 import get_deepseek_v32_tokenizer
+
+
+class FakeHfTokenizer:
+    vocab_size = 100
+
+    def get_added_vocab(self) -> dict[str, int]:
+        return {"</think>": 100}
+
+    def encode(
+        self,
+        text: str,
+        add_special_tokens: bool = False,
+        **kwargs,
+    ) -> list[int]:
+        self.last_encode = (text, add_special_tokens, kwargs)
+        return [len(text)]
+
+
+def _tokenizer():
+    return get_deepseek_v32_tokenizer(FakeHfTokenizer())
+
+
+_ONE_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "tool_beta",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def test_deepseek_v32_tools_render_after_the_system_prompt():
+    """Tools attach to the existing system message, not a newly inserted one."""
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "system", "content": "SYSTEM_MARKER"},
+            {"role": "user", "content": "Weather?"},
+        ],
+        tools=_ONE_TOOL,
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert prompt.index("SYSTEM_MARKER") < prompt.index("## Tools")
+    assert "SYSTEM_MARKER\n\n## Tools" in prompt
+
+
+def test_deepseek_v32_tools_attach_to_a_leading_developer_message():
+    """A leading developer message carries the tools.
+
+    `render_message` emits the tools block before the developer content, so this
+    checks attachment and a single rendering rather than ordering.
+    """
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "developer", "content": "DEVELOPER_MARKER"},
+            {"role": "user", "content": "Weather?"},
+        ],
+        tools=_ONE_TOOL,
+        tokenize=False,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert "DEVELOPER_MARKER" in prompt
+    assert "tool_beta" in prompt
+
+
+def test_deepseek_v32_tools_still_rendered_without_a_leading_system_message():
+    """With no system/developer message to attach to, one is inserted."""
+    prompt = _tokenizer().apply_chat_template(
+        [{"role": "user", "content": "Weather?"}],
+        tools=_ONE_TOOL,
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert "tool_beta" in prompt
+
+
+def test_deepseek_v32_request_tools_replace_message_tools():
+    """Request-level tools win; rendering both would emit the block twice."""
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {
+                "role": "system",
+                "content": "SYSTEM_MARKER",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "tool_alpha",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "Weather?"},
+        ],
+        tools=_ONE_TOOL,
+        tokenize=False,
+        thinking=True,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert "tool_beta" in prompt
+    assert "tool_alpha" not in prompt
+
+
+def test_deepseek_v32_caller_messages_are_not_mutated():
+    """Attaching tools must not write into the caller's messages."""
+    messages = [
+        {"role": "system", "content": "SYSTEM_MARKER"},
+        {"role": "user", "content": "Weather?"},
+    ]
+
+    _tokenizer().apply_chat_template(
+        messages, tools=_ONE_TOOL, tokenize=False, thinking=True
+    )
+
+    assert "tools" not in messages[0]

--- a/vllm/tokenizers/deepseek_v32.py
+++ b/vllm/tokenizers/deepseek_v32.py
@@ -34,10 +34,20 @@ def get_deepseek_v32_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             if not thinking:
                 thinking_mode = "chat"
             conversation = kwargs.get("conversation", messages)
-            messages = conversation.copy()
+            messages = list(conversation)
             if tools is not None and len(tools) > 0:
-                messages.insert(0, {"role": "system"})
-                messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                # Tools belong on the leading system/developer message; a new
+                # one renders the tools block ahead of the system prompt.
+                # Request-level tools replace any already on that message.
+                if messages and messages[0].get("role") in ("system", "developer"):
+                    head = dict(messages[0])
+                    head["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                    messages[0] = head
+                else:
+                    messages.insert(
+                        0,
+                        {"role": "system", "tools": tools},  # type: ignore[typeddict-unknown-key]
+                    )
 
             # Historical reasoning content is dropped when a new user message
             # is introduced


### PR DESCRIPTION
## Purpose
Fixes #54911

When a request carries tools, `deepseek_v32.py` inserts a new **empty** system message to
hold them instead of using the system message that's already there:

```python
messages.insert(0, {"role": "system"})
messages[0]["tools"] = tools
```

That empty message renders as `""` + `"\n\n"` + the tools block, so the whole `## Tools`
section ends up **in front of the system prompt**.

Running the checkpoint's own `encoding/test_input.json` through the encoder and diffing
against its `encoding/test_output.txt`, we diverge at token 1, the first token after BOS:

<img width="723" height="314" alt="image" src="https://github.com/user-attachments/assets/ed4a0da4-6817-4b4d-9e3d-05b22cdfbecc" />

DeepSeek's reference encoder attaches tools to the existing message
([`test_encoding_dsv32.py`](https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/test_encoding_dsv32.py)
does `messages[0]["tools"] = test_dict["tools"]`), and the golden output starts with the
system prompt, not the tools:

```
<｜begin▁of▁sentence｜>You are a helpful Assistant.

## Tools
```

#52255 fixes this same pattern in `deepseek_v4.py`, but its diff only touches that file.
V3.2 has the identical bug and nothing open covers it. This is the companion fix, kept
deliberately identical to #52255 so the two wrappers don't drift.

## Changes

- Attach request-level tools to the leading `system`/`developer` message, inserting one only
  when there's nothing to attach to.
- Copy that message first, since `list(conversation)` is shallow and `messages[0]` is still
  the caller's dict.
- Request-level tools now replace tools already on the message instead of rendering both,
  which emitted `## Tools` twice.
- Add `tests/tokenizers_/test_deepseek_v32.py`. This module had no tests at all, which is
  why the V4 version of this bug got caught and this one didn't.

Four of the five tests follow #52255's shapes. Two needed different assertions because V3.2
isn't V4: `render_message` deliberately emits tools *before* `developer` content, and V3.2
doesn't render tool schemas as JSON. The fifth is new. It checks the caller's messages
aren't mutated, which is what keeps the `dict()` copy from being deleted later as redundant.

## Test Plan

```bash
.venv/bin/python -m pytest tests/tokenizers_/test_deepseek_v32.py -v
.venv/bin/python -m pytest tests/tokenizers_/test_deepseek_v4.py -v
.venv/bin/pre-commit run --files \
    vllm/tokenizers/deepseek_v32.py tests/tokenizers_/test_deepseek_v32.py
```

## Test Result

Linux x86_64, Python 3.12.13, torch 2.13.0+cu132.

```
tests/tokenizers_/test_deepseek_v32.py    5 passed
tests/tokenizers_/test_deepseek_v4.py    35 passed   (no regression)
both together                            40 passed
```

pre-commit clean, including `ruff check`, `ruff format`, `mypy` and `typos`.

Two pre-existing issues turned up while testing, both reproducing on `main` and neither
touched here: `TOOLS_SYSTEM_TEMPLATE` is 7 blank lines off from the golden, and a leading
`developer` message crashes in thinking mode (`drop_thinking_messages` drops it while the
render loop still iterates the original count). Happy to file the second separately.

## Note for reviewers

This changes the prompt for every V3.2 request that passes tools, so it invalidates existing
prefix caches and may move eval numbers. Same caveat #52255 carries for V4.

AI assistance was used here. I've reviewed every line, reproduced the divergence against the
checkpoint's golden files, and run the tests and lint myself.
