### PR TITLE
[Bugfix][Spec Decode] Take the DFlash draft's RoPE layout from its own config

### DIFF
--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -75,26 +75,6 @@ def dflash_has_any_non_causal(config: Qwen3Config) -> bool:
     )
 
 
-def dflash_target_rope_is_neox_style(target_model: nn.Module) -> bool | None:
-    """The target's RoPE layout, from its first attention layer.
-
-    A DFlash head must rotate Q/K the way the target it was distilled against
-    does, and a mismatch is silent — acceptance collapses but nothing errors and
-    the output stays correct. Draft checkpoints do not carry this, so take it
-    from the target. None if the target uses no RoPE.
-    """
-    language_model = (
-        target_model.get_language_model()
-        if hasattr(target_model, "get_language_model")
-        else target_model
-    )
-    for module in language_model.modules():
-        style = getattr(module, "is_neox_style", None)
-        if isinstance(style, bool):
-            return style
-    return None
-
-
 def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
     spec_config = vllm_config.speculative_config
     config = spec_config.draft_model_config.hf_config
@@ -316,11 +296,11 @@ class DFlashQwen3DecoderLayer(nn.Module):
         # non-causal) from the draft config.
         sliding_window, causal = _resolve_layer_attention(config, layer_idx)
 
-        # RoPE layout, copied off the target at load time by the draft loader
-        # (see `dflash_target_rope_is_neox_style`). Checkpoints do not carry it:
-        # a head distilled from an interleaved-RoPE target must rotate the way
-        # that target does, or every drafted Q/K is wrong and acceptance
-        # collapses with no error raised.
+        # RoPE layout. The rotation applies to the draft's own Q/K, so this is
+        # fixed by how the head was distilled, not by the target: a neox-trained
+        # head on an interleaved target still needs neox. A mismatch is silent --
+        # acceptance collapses and nothing errors -- so a checkpoint that was
+        # distilled the other way has to say so here.
         is_neox_style = getattr(config, "is_neox_style", True)
 
         self.self_attn = DFlashQwen3Attention(

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -81,21 +81,6 @@ class DFlashProposer(SpecDecodeBaseProposer):
         )
 
     @override
-    def load_model(self, target_model: torch.nn.Module) -> None:
-        from vllm.model_executor.models.qwen3_dflash import (
-            dflash_target_rope_is_neox_style,
-        )
-
-        draft_model_config = self.speculative_config.draft_model_config
-        assert draft_model_config is not None
-        # The drafter must rotate Q/K the way its target does. Take that from the
-        # built target before super() constructs the draft.
-        is_neox_style = dflash_target_rope_is_neox_style(target_model)
-        if is_neox_style is not None:
-            draft_model_config.hf_config.is_neox_style = is_neox_style
-        super().load_model(target_model)
-
-    @override
     def _create_draft_vllm_config(self) -> VllmConfig:
         base = super()._create_draft_vllm_config()
         # The draft model is text-only — clear the target's multimodal

--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
@@ -15,17 +15,11 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     from vllm.compilation.backends import set_model_tag
     from vllm.model_executor.models.qwen3_dflash import (
         dflash_has_any_non_causal,
-        dflash_target_rope_is_neox_style,
     )
 
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
     draft_model_config = speculative_config.draft_model_config
-    # The drafter must rotate Q/K the way its target does. Take that from the
-    # built target before super() constructs the draft.
-    is_neox_style = dflash_target_rope_is_neox_style(target_model)
-    if is_neox_style is not None:
-        draft_model_config.hf_config.is_neox_style = is_neox_style
     # Select an attention backend that supports the drafter's attention: mixing
     # a non-causal layer onto a causal-only backend would fail.
     draft_vllm_config = replace(


### PR DESCRIPTION
### Purpose

The DFlash loader reads `is_neox_style` off the target and stamps it onto the
draft config, in both the MRV2 and the pre-MRV2 path:

```python
is_neox_style = dflash_target_rope_is_neox_style(target_model)
if is_neox_style is not None:
    draft_model_config.hf_config.is_neox_style = is_neox_style
```

@zzw09773 showed in #53063 why that is wrong: the rotation applies to the
draft's own Q/K, so the layout that has to hold is the one the head was
distilled under, and taking it from the target is only right when the two
happen to agree. On `zai-org/GLM-5.3` they do not — the target reports
interleaved, `incoai/GLM-5.3-DFlash2` needs neox, and acceptance is 1.03
against 7.78 forced to neox.

`zai-org/GLM-5.3-Flash` breaks the same mechanism from the other side:
`qk_rope_head_dim: 0` leaves its attention with no rope at all, so the walk
reaches the sparse indexer's rope instead — acceptance 1.0 against 5.5. This PR
began as a fix for that case alone; what follows covers both.

### Fix

Drop the inference. `DFlashQwen3DecoderLayer` already reads

```python
is_neox_style = getattr(config, "is_neox_style", True)
```

so a checkpoint distilled under the interleaved convention states it in its own
config, and everything else keeps the default. #51655 added both the
configurability and the inference; this keeps the first and removes the second,
which leaves the drafter strictly more controllable than it was before #51655,
when `get_rope` took no layout argument at all.

### Trade

The risk this takes on is the mirror of the one it removes: a draft distilled
interleaved that does not declare it would now rotate neox, silently. No
released checkpoint is in that position, and the failure it replaces is not
hypothetical.

### Test

GLM-5.3-Flash + DFlash2, GSM8K, 4xH200, torch.compile and full CUDA graphs:
acceptance 1.0 -> 5.5. GLM-5.3 + `incoai/GLM-5.3-DFlash2` is #53063's
measurement above. Targets whose layout is neox are unaffected — the resolved
value is the same one the inference produced.
