### PR TITLE
[Bugfix][Spec Decode] Drop FlashAttention's AOT schedule for a sliding-window DFlash drafter

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -15,7 +15,10 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    get_kv_cache_spec_sliding_window,
+)
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cp_utils import cp_local_slot
@@ -177,6 +180,19 @@ class DFlashSpeculator(DraftModelSpeculator):
             target_input_buffers,
             target_attn_groups,
         )
+
+        # FlashAttention's AOT split schedule is wrong for a windowed drafter,
+        # and `_get_sliding_window_configs` leaves it on or off depending on
+        # whether the target also runs FlashAttention. Decide it here instead.
+        for groups in self.attn_groups:
+            for group in groups:
+                builder = group.get_metadata_builder()
+                if getattr(
+                    builder, "aot_schedule", False
+                ) and get_kv_cache_spec_sliding_window(builder.kv_cache_spec):
+                    # `aot_schedule` belongs to FlashAttention's builder, not
+                    # to the base class this loop is typed against.
+                    builder.aot_schedule = False  # type: ignore[attr-defined]
 
         self.draft_kv_cache_group_ids = [
             gid for gid, g in enumerate(self.attn_groups) if g


### PR DESCRIPTION
### Purpose

A DFlash drafter runs sliding-window attention. FlashAttention's AOT split
schedule is computed for one window configuration shared by every layer, and
whether the drafter gets a correct one today is decided by accident.

`_get_sliding_window_configs` scans *every* `Attention` layer in the model and
skips those that are not `FlashAttentionImpl`. Exactly one distinct config
leaves `aot_schedule` on; more than one turns it off. So:

- target on FlashAttention -> target window + drafter window = 2 configs ->
  AOT off, and the drafter is correct by coincidence;
- target on any other backend (MLA, FlashInfer) -> the drafter is the only
  FlashAttention consumer -> 1 config -> AOT stays on, and the drafter runs a
  schedule built for the wrong geometry.

In the second case acceptance collapses to 1.0 under full CUDA graphs, and some
configurations hit an illegal memory access in `flash_fwd_combine`.

#39516 diagnosed the same scan as iterating the global layer set rather than
this builder's KV cache group, but was closed by turning an assert into a
`continue`. Scoping the scan would not fix this case either: the drafter really
is the only FlashAttention layer, so a per-group scan still finds exactly one
config.

### Fix

Decide it where the fact is known. `DFlashSpeculator.set_attn` clears
`aot_schedule` on its own builders whenever the group is windowed — not only
when the count rule would have left it on. A schedule derived from a window
configuration shared across the whole model does not describe the drafter's
geometry, so the count landing on 2 makes the drafter correct by luck rather
than by reason. In the target-on-FlashAttention case the end state is the same
as today; the difference is that it is now decided rather than inherited. The buffers that
full CUDA graphs need are unaffected — `max_num_splits` and the
`scheduler_metadata` buffer are sized in `__init__`, and
`_store_scheduler_metadata` is a no-op when no schedule is produced.

Scope is deliberately narrow:

- it runs over `self.attn_groups`, the drafter's own groups, so no target
  builder is reached;
- the `AutoRegressive` family (Eagle, MTP, Gemma4) and `MultiModuleMTP` are
  siblings of `DFlashSpeculator`, not subclasses, so they never execute it —
  `AutoRegressiveSpeculator` keeps AOT on purpose and refreshes it through
  `update_draft_decode_metadata()`;
- `DSparkSpeculator` does subclass `DFlashSpeculator` and so is covered. Its
  drafts run the same windowed blocks through `DFlashQwen3Model`, so the same
  argument applies, but I have measured only DFlash2;
- only groups whose `kv_cache_spec.sliding_window` is set, so a full-attention
  drafter keeps AOT.

### Test

GLM-5.3-Flash + DFlash2 (MLA target, FlashAttention drafter), GSM8K, 4xH200,
torch.compile and full CUDA graphs on: acceptance length 1.000 -> 5.542,
398.9 tok/s.

Qwen3.8-27B + DFlash2 (FlashAttention target) is unchanged, as expected: that
path already had two window configs and so already ran without AOT.
