### PR TITLE
[Perf][Spec Decode] Avoid strided-view D2H stall on dynamic-K draft token copy

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4981,9 +4981,18 @@ class GPUModelRunner(
             if not zeros_only:
                 # Trigger async copy of draft token ids to cpu.
                 self.draft_token_ids_copy_stream.wait_stream(default_stream)
-                self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens].copy_(
-                    draft_token_ids, non_blocking=True
-                )
+                if num_spec_tokens == self.num_spec_tokens:
+                    self.draft_token_ids_cpu[:num_reqs].copy_(
+                        draft_token_ids, non_blocking=True
+                    )
+                else:
+                    # [:num_reqs, :num_spec_tokens] is a gapped view when
+                    # K < config K, forcing pageable staging (#53491);
+                    # split per-row instead.
+                    for i in range(num_reqs):
+                        self.draft_token_ids_cpu[i, :num_spec_tokens].copy_(
+                            draft_token_ids[i], non_blocking=True
+                        )
             else:
                 # No copy needed, just zero-out cpu tensor.
                 self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens] = 0


### PR DESCRIPTION
## Summary

`self.draft_token_ids_cpu` is `[max_num_reqs, self.num_spec_tokens]` pinned. When DSD picks a runtime K smaller than the buffer's config K, `self.draft_token_ids_cpu[:num_reqs, :num_spec_tokens]` is a **gapped strided view** (row stride = config K, but only runtime K per row is data). `cudaMemcpyAsync` on a strided pinned destination falls back to pageable staging and blocks the host — exactly the class of stall the stricter check in #53491 catches, and it defeats the whole point of the `draft_token_ids_copy_stream` side stream.

Keep the fast path when `num_spec_tokens == self.num_spec_tokens` (the slice collapses to `[:num_reqs, :]` and is dense); otherwise split into per-row copies so each destination is a dense sub-view — same pattern as #53412 for XD-RoPE and njhill's original mrope fix in #51841.

## Context

Continues the sync-elimination sweep against the checker in #53491. njhill's #54299 covered a broad set of non-pinned H2D cases and the earlier merged PRs (#54266, #54292, #54293, #54295) pinned host tensors on the MM / KV connector / sparse MLA paths. This one is the DSD spec-decode D2H-strided case that was missed.

## Duplicate-work check

Searched open PRs for `draft_token_ids_cpu in:body`, `draft_token_ids_copy_stream`, and `#53491 in:body`. None cover this site.

## Testing

- `.venv/bin/python -m pre_commit run --files vllm/v1/worker/gpu_model_runner.py` — passed (ruff, mypy, typos, SPDX, etc.)

Static K workloads hit the fast-path branch and their behavior is byte-identical. Dynamic K workloads trade one strided `copy_` (which was silently blocking) for `num_reqs` per-row `copy_` calls on the same side stream — same pattern established in #53412.

AI assistance was used for code search and drafting; every line was reviewed by the submitter.
