### PR TITLE
[Distributed] Implement stubbed collective operations for Gloo backend in `DeviceCommunicatorBase`

### DIFF
--- a/tests/distributed/test_device_communicator_pynccl_disabled.py
+++ b/tests/distributed/test_device_communicator_pynccl_disabled.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import ray
+import torch
+
+from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
+from vllm.distributed.parallel_state import get_tp_group, set_custom_all_reduce
+
+from ..utils import (
+    ensure_model_parallel_initialized,
+    init_test_distributed_environment,
+    multi_process_parallel,
+)
+
+
+@ray.remote(num_gpus=1, max_calls=1)
+def fallback_collectives_gloo(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+) -> None:
+    with monkeypatch.context() as m:
+        m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        m.delenv("HIP_VISIBLE_DEVICES", raising=False)
+        m.setenv("VLLM_DISABLE_PYNCCL", "1")
+        set_custom_all_reduce(False)
+
+        device = torch.device(f"cuda:{rank}")
+        torch.accelerator.set_device_index(device)
+        init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+        ensure_model_parallel_initialized(tp_size, pp_size)
+
+        tp_group = get_tp_group()
+        comm = tp_group.device_communicator
+        assert comm is not None
+        assert comm.pynccl_comm is None
+
+        # Test tensor_model_parallel_all_reduce over Gloo fallback
+        for dtype in [torch.float16, torch.bfloat16, torch.float32]:
+            inp = torch.full((1024,), float(rank + 1), dtype=dtype, device=device)
+            out = tensor_model_parallel_all_reduce(inp)
+            expected_sum = sum(range(1, tp_size + 1))
+            torch.testing.assert_close(
+                out,
+                torch.full((1024,), float(expected_sum), dtype=dtype, device=device),
+            )
+
+        # Test all_gather over Gloo fallback
+        ag_inp = torch.full((4,), float(rank + 1), dtype=torch.float32, device=device)
+        ag_out = comm.all_gather(ag_inp, dim=0)
+        expected_ag = torch.cat(
+            [
+                torch.full((4,), float(r + 1), dtype=torch.float32, device=device)
+                for r in range(tp_size)
+            ],
+            dim=0,
+        )
+        torch.testing.assert_close(ag_out, expected_ag)
+
+        # Test all_gatherv with variable sizes and batched list of tensors
+        sizes = [2 + r * 2 for r in range(tp_size)]  # e.g. [2, 4] for tp_size=2
+        local_size = sizes[rank]
+        agv_inp1 = torch.full(
+            (local_size, 3), float(rank + 1), dtype=torch.float32, device=device
+        )
+        agv_inp2 = torch.full(
+            (local_size, 3), float((rank + 1) * 10), dtype=torch.float32, device=device
+        )
+
+        # Test single-tensor all_gatherv
+        agv_out = comm.all_gatherv(agv_inp1, dim=0, sizes=sizes)
+        expected_agv1 = torch.cat(
+            [
+                torch.full(
+                    (sizes[r], 3), float(r + 1), dtype=torch.float32, device=device
+                )
+                for r in range(tp_size)
+            ],
+            dim=0,
+        )
+        torch.testing.assert_close(agv_out, expected_agv1)
+
+        # Test list-of-tensors all_gatherv
+        agv_outs = comm.all_gatherv([agv_inp1, agv_inp2], dim=0, sizes=sizes)
+        assert isinstance(agv_outs, list) and len(agv_outs) == 2
+        torch.testing.assert_close(agv_outs[0], expected_agv1)
+        expected_agv2 = torch.cat(
+            [
+                torch.full(
+                    (sizes[r], 3),
+                    float((r + 1) * 10),
+                    dtype=torch.float32,
+                    device=device,
+                )
+                for r in range(tp_size)
+            ],
+            dim=0,
+        )
+        torch.testing.assert_close(agv_outs[1], expected_agv2)
+
+        # Test reduce_scatter over Gloo fallback
+        rs_inp = torch.arange(4 * tp_size, dtype=torch.float32, device=device) + rank
+        rs_out = comm.reduce_scatter(rs_inp, dim=0)
+        assert rs_out.shape == (4,)
+
+        # Test reduce_scatterv with non-uniform sizes
+        total_rs_size = sum(sizes)
+        rsv_inp = torch.full(
+            (total_rs_size, 2), float(rank + 1), dtype=torch.float32, device=device
+        )
+        rsv_out = comm.reduce_scatterv(rsv_inp, dim=0, sizes=sizes)
+        assert rsv_out.shape == (local_size, 2)
+        expected_rsv_sum = sum(range(1, tp_size + 1))
+        torch.testing.assert_close(
+            rsv_out,
+            torch.full(
+                (local_size, 2),
+                float(expected_rsv_sum),
+                dtype=torch.float32,
+                device=device,
+            ),
+        )
+
+        # Test gather over Gloo fallback (gather to rank 0)
+        g_inp = torch.tensor([10.0 + rank], dtype=torch.float32, device=device)
+        g_out = comm.gather(g_inp, dst=0, dim=0)
+        if rank == 0:
+            assert g_out is not None
+            expected_g = torch.tensor(
+                [10.0 + r for r in range(tp_size)],
+                dtype=torch.float32,
+                device=device,
+            )
+            torch.testing.assert_close(g_out, expected_g)
+        else:
+            assert g_out is None
+
+        # Test broadcast over Gloo fallback
+        bcast_tensor = torch.tensor([42.0 + rank], dtype=torch.float32, device=device)
+        bcast_out = comm.broadcast(bcast_tensor, src=0)
+        torch.testing.assert_close(
+            bcast_out,
+            torch.tensor([42.0], dtype=torch.float32, device=device),
+        )
+
+        # Test point-to-point send/recv over Gloo fallback
+        if tp_size == 2:
+            if rank == 0:
+                send_tensor = torch.tensor([123.45], dtype=torch.float32, device=device)
+                comm.send(send_tensor, dst=1)
+            elif rank == 1:
+                recv_tensor = comm.recv(torch.Size([1]), dtype=torch.float32, src=0)
+                torch.testing.assert_close(
+                    recv_tensor,
+                    torch.tensor([123.45], dtype=torch.float32, device=device),
+                )
+
+
+@pytest.mark.parametrize("tp_size", [2])
+@pytest.mark.parametrize("pipeline_parallel_size", [1])
+def test_fallback_collectives_pynccl_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pipeline_parallel_size: int,
+) -> None:
+    world_size = tp_size * pipeline_parallel_size
+    if world_size > torch.accelerator.device_count():
+        pytest.skip("Not enough GPUs to run the test.")
+    multi_process_parallel(
+        monkeypatch, tp_size, pipeline_parallel_size, fallback_collectives_gloo
+    )

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1578,9 +1578,19 @@ class VllmConfig:
                     )
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
-            # disable cudagraph when enforce eager execution
-            if self.model_config is not None and self.model_config.enforce_eager:
-                logger.info_once("Cudagraph is disabled under eager mode")
+            # disable cudagraph when enforce eager execution or when using
+            # host/CPU distributed backends without custom allreduce
+            from vllm.platforms import current_platform
+
+            if (self.model_config is not None and self.model_config.enforce_eager) or (
+                self.parallel_config.world_size > 1
+                and current_platform.dist_backend == "gloo"
+                and not current_platform.use_custom_allreduce()
+            ):
+                logger.info_once(
+                    "Cudagraph is disabled under eager mode or when "
+                    "distributed backend is Gloo without custom allreduce"
+                )
                 self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
                 # override related settings when enforce eager
                 self.compilation_config.max_cudagraph_capture_size = 0

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -230,7 +230,7 @@ class DeviceCommunicatorBase:
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
         if self._is_gloo():
-            cpu_input = input_.cpu()
+            cpu_input = input_.contiguous().cpu()
             dist.all_reduce(cpu_input, group=self.device_group)
             input_.copy_(cpu_input)
             return input_
@@ -475,7 +475,7 @@ class DeviceCommunicatorBase:
             dim += input_.dim()
 
         if self._is_gloo():
-            cpu_input = input_.cpu()
+            cpu_input = input_.contiguous().cpu()
             if self.rank_in_group == dst:
                 cpu_gather_list = [
                     torch.empty_like(cpu_input) for _ in range(world_size)
@@ -516,7 +516,7 @@ class DeviceCommunicatorBase:
         if dst is None:
             dst = (self.rank_in_group + 1) % self.world_size
         if self._is_gloo():
-            cpu_tensor = tensor.cpu()
+            cpu_tensor = tensor.contiguous().cpu()
             torch.distributed.send(cpu_tensor, self.ranks[dst], self.device_group)
         else:
             torch.distributed.send(tensor, self.ranks[dst], self.device_group)
@@ -543,7 +543,7 @@ class DeviceCommunicatorBase:
         if self.world_size == 1:
             return tensor
         if self._is_gloo():
-            cpu_tensor = tensor.cpu()
+            cpu_tensor = tensor.contiguous().cpu()
             torch.distributed.broadcast(cpu_tensor, self.ranks[src], self.device_group)
             tensor.copy_(cpu_tensor)
         else:

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -216,7 +216,24 @@ class DeviceCommunicatorBase:
         self.all2all_backend = all2all_backend
         self.all2all_manager: All2AllManagerBase | None = None
 
+    # NOTE(fallback-collectives): Gloo is a CPU-only distributed backend.
+    # The fallback collective methods below (all_reduce, all_gather, etc.)
+    # stage tensors through host memory (.cpu() / .copy_()). For simplicity
+    # and minimal memory footprint in this fallback path, standard pageable
+    # host memory is used. A future optimization can introduce a pinned memory
+    # staging buffer pool for asynchronous D2H/H2D transfers to improve throughput.
+    def _is_gloo(self) -> bool:
+        return (
+            self.device_group is not None
+            and dist.get_backend(self.device_group) == dist.Backend.GLOO
+        )
+
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
+        if self._is_gloo():
+            cpu_input = input_.cpu()
+            dist.all_reduce(cpu_input, group=self.device_group)
+            input_.copy_(cpu_input)
+            return input_
         dist.all_reduce(input_, group=self.device_group)
         return input_
 
@@ -239,17 +256,22 @@ class DeviceCommunicatorBase:
         output_tensor = torch.empty(
             output_size, dtype=input_.dtype, device=input_.device
         )
-        # All-gather.
-        dist.all_gather_into_tensor(output_tensor, input_, group=self.device_group)
+        if self._is_gloo():
+            cpu_input = input_.contiguous().cpu()
+            cpu_output = torch.empty(output_size, dtype=input_.dtype, device="cpu")
+            dist.all_gather_into_tensor(cpu_output, cpu_input, group=self.device_group)
+            output_tensor.copy_(cpu_output)
+        else:
+            # All-gather.
+            dist.all_gather_into_tensor(output_tensor, input_, group=self.device_group)
         # Reshape
         output_tensor = output_tensor.reshape((self.world_size,) + input_size)
         output_tensor = output_tensor.movedim(0, dim)
-        output_tensor = output_tensor.reshape(
+        return output_tensor.reshape(
             input_size[:dim]
             + (self.world_size * input_size[dim],)
             + input_size[dim + 1 :]
         )
-        return output_tensor
 
     def all_gatherv(
         self,
@@ -257,7 +279,88 @@ class DeviceCommunicatorBase:
         dim: int = 0,
         sizes: list[int] | None = None,
     ) -> torch.Tensor | list[torch.Tensor]:
-        raise NotImplementedError
+        if dim != 0:
+            raise NotImplementedError("only dim 0 all-gatherv is supported")
+        world_size = self.world_size
+        if world_size == 1:
+            if isinstance(input_, torch.Tensor):
+                return input_
+            return list(input_)
+
+        if sizes is not None and all(s == sizes[0] for s in sizes):
+            sizes = None
+
+        def _all_gather_single(
+            inp: torch.Tensor, sizes: list[int] | None = None
+        ) -> torch.Tensor:
+            input_size = inp.size()
+            if sizes is not None:
+                assert len(sizes) == world_size
+                assert inp.shape[dim] == sizes[self.rank_in_group], (
+                    f"{inp.shape[dim]} != {sizes[self.rank_in_group]}"
+                )
+                output_size = (sum(sizes),) + input_size[1:]
+            else:
+                output_size = (input_size[0] * world_size,) + input_size[1:]
+
+            output_tensor = torch.empty(output_size, dtype=inp.dtype, device=inp.device)
+            if self._is_gloo():
+                cpu_input = inp.contiguous().cpu()
+                if sizes is not None:
+                    max_s = max(sizes)
+                    padded_input = torch.zeros(
+                        (max_s,) + input_size[1:],
+                        dtype=inp.dtype,
+                        device="cpu",
+                    )
+                    padded_input[: inp.shape[0]].copy_(cpu_input)
+                    padded_gather_list = [
+                        torch.empty(
+                            (max_s,) + input_size[1:],
+                            dtype=inp.dtype,
+                            device="cpu",
+                        )
+                        for _ in range(world_size)
+                    ]
+                    dist.all_gather(
+                        padded_gather_list, padded_input, group=self.device_group
+                    )
+                    cpu_gather_list = [
+                        padded_gather_list[i][: sizes[i]] for i in range(world_size)
+                    ]
+                    cpu_output = torch.cat(cpu_gather_list, dim=0)
+                else:
+                    cpu_output = torch.empty(output_size, dtype=inp.dtype, device="cpu")
+                    dist.all_gather_into_tensor(
+                        cpu_output, cpu_input, group=self.device_group
+                    )
+                output_tensor.copy_(cpu_output)
+            else:
+                # Native collective fallback for non-CUDA, non-GLOO platforms.
+                if sizes is not None:
+                    gather_list = [
+                        torch.empty(
+                            (s,) + input_size[1:],
+                            dtype=inp.dtype,
+                            device=inp.device,
+                        )
+                        for s in sizes
+                    ]
+                    dist.all_gather(
+                        gather_list, inp.contiguous(), group=self.device_group
+                    )
+                    torch.cat(gather_list, dim=0, out=output_tensor)
+                else:
+                    dist.all_gather_into_tensor(
+                        output_tensor,
+                        inp.contiguous(),
+                        group=self.device_group,
+                    )
+            return output_tensor
+
+        if isinstance(input_, torch.Tensor):
+            return _all_gather_single(input_, sizes)
+        return [_all_gather_single(inp, sizes) for inp in input_]
 
     def reduce_scatter(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
         world_size = self.world_size
@@ -284,10 +387,18 @@ class DeviceCommunicatorBase:
             output_shape, dtype=input_tensor.dtype, device=input_tensor.device
         )
 
-        # Perform reduce-scatter operation
-        torch.distributed.reduce_scatter_tensor(
-            output_tensor, input_tensor, group=self.device_group
-        )
+        if self._is_gloo():
+            cpu_input = input_tensor.cpu()
+            cpu_output = torch.empty(
+                output_shape, dtype=input_tensor.dtype, device="cpu"
+            )
+            dist.reduce_scatter_tensor(cpu_output, cpu_input, group=self.device_group)
+            output_tensor.copy_(cpu_output)
+        else:
+            # Perform reduce-scatter operation
+            torch.distributed.reduce_scatter_tensor(
+                output_tensor, input_tensor, group=self.device_group
+            )
 
         # Reshape before returning
         return output_tensor.movedim(0, dim).contiguous()
@@ -295,7 +406,57 @@ class DeviceCommunicatorBase:
     def reduce_scatterv(
         self, input_: torch.Tensor, dim: int = -1, sizes: list[int] | None = None
     ) -> torch.Tensor:
-        raise NotImplementedError
+        world_size = self.world_size
+        if world_size == 1:
+            return input_
+        assert -input_.dim() <= dim < input_.dim(), (
+            f"Invalid dim ({dim}) for input tensor with shape {input_.size()}"
+        )
+        if dim < 0:
+            dim += input_.dim()
+
+        input_tensor = input_.movedim(0, dim).contiguous()
+
+        if sizes is not None:
+            assert len(sizes) == world_size, f"{len(sizes)} == {world_size}"
+            assert input_tensor.shape[0] == sum(sizes)
+            chunk_size = sizes[self.rank_in_group]
+        else:
+            assert input_tensor.shape[0] % world_size == 0
+            chunk_size = input_tensor.shape[0] // world_size
+
+        output_shape = (chunk_size,) + input_tensor.shape[1:]
+        output = torch.empty(
+            output_shape, dtype=input_tensor.dtype, device=input_tensor.device
+        )
+
+        if self._is_gloo():
+            cpu_input = input_tensor.cpu()
+            cpu_output = torch.empty(
+                output_shape, dtype=input_tensor.dtype, device="cpu"
+            )
+            if sizes is not None and sizes.count(sizes[0]) != len(sizes):
+                # PyTorch Gloo does not support uneven list-of-splits in
+                # reduce_scatter, so perform all_reduce then slice locally.
+                dist.all_reduce(cpu_input, group=self.device_group)
+                offset = sum(sizes[: self.rank_in_group])
+                cpu_output = cpu_input[offset : offset + chunk_size]
+            else:
+                dist.reduce_scatter_tensor(
+                    cpu_output, cpu_input, group=self.device_group
+                )
+            output.copy_(cpu_output)
+        else:
+            # Native collective fallback for non-CUDA, non-GLOO platforms.
+            if sizes is not None and sizes.count(sizes[0]) != len(sizes):
+                input_splits = list(input_tensor.split(sizes, dim=0))
+                dist.reduce_scatter(output, input_splits, group=self.device_group)
+            else:
+                dist.reduce_scatter_tensor(
+                    output, input_tensor, group=self.device_group
+                )
+
+        return output.movedim(0, dim).contiguous()
 
     def gather(
         self, input_: torch.Tensor, dst: int = 0, dim: int = -1
@@ -313,27 +474,52 @@ class DeviceCommunicatorBase:
             # Convert negative dim to positive.
             dim += input_.dim()
 
-        # Allocate output tensor.
-        if self.rank_in_group == dst:
-            gather_list = [torch.empty_like(input_) for _ in range(world_size)]
+        if self._is_gloo():
+            cpu_input = input_.cpu()
+            if self.rank_in_group == dst:
+                cpu_gather_list = [
+                    torch.empty_like(cpu_input) for _ in range(world_size)
+                ]
+            else:
+                cpu_gather_list = None
+            torch.distributed.gather(
+                cpu_input,
+                cpu_gather_list,
+                dst=self.ranks[dst],
+                group=self.device_group,
+            )
+            if self.rank_in_group == dst:
+                assert cpu_gather_list is not None
+                cpu_output = torch.cat(cpu_gather_list, dim=dim)
+                return cpu_output.to(input_.device)
+            return None
         else:
-            gather_list = None
-        # Gather.
-        torch.distributed.gather(
-            input_, gather_list, dst=self.ranks[dst], group=self.device_group
-        )
-        if self.rank_in_group == dst:
-            output_tensor = torch.cat(gather_list, dim=dim)
-        else:
-            output_tensor = None
-        return output_tensor
+            # Allocate output tensor.
+            if self.rank_in_group == dst:
+                gather_list = [torch.empty_like(input_) for _ in range(world_size)]
+            else:
+                gather_list = None
+            # Gather.
+            torch.distributed.gather(
+                input_, gather_list, dst=self.ranks[dst], group=self.device_group
+            )
+            if self.rank_in_group == dst:
+                assert gather_list is not None
+                output_tensor = torch.cat(gather_list, dim=dim)
+            else:
+                output_tensor = None
+            return output_tensor
 
     def send(self, tensor: torch.Tensor, dst: int | None = None) -> None:
         """Sends a tensor to the destination rank in a blocking way"""
         """NOTE: `dst` is the local rank of the destination rank."""
         if dst is None:
             dst = (self.rank_in_group + 1) % self.world_size
-        torch.distributed.send(tensor, self.ranks[dst], self.device_group)
+        if self._is_gloo():
+            cpu_tensor = tensor.cpu()
+            torch.distributed.send(cpu_tensor, self.ranks[dst], self.device_group)
+        else:
+            torch.distributed.send(tensor, self.ranks[dst], self.device_group)
 
     def recv(
         self, size: torch.Size, dtype: torch.dtype, src: int | None = None
@@ -343,15 +529,25 @@ class DeviceCommunicatorBase:
         if src is None:
             src = (self.rank_in_group - 1) % self.world_size
 
-        tensor = torch.empty(size, dtype=dtype, device=self.device)
-        torch.distributed.recv(tensor, self.ranks[src], self.device_group)
-        return tensor
+        if self._is_gloo():
+            cpu_tensor = torch.empty(size, dtype=dtype, device="cpu")
+            torch.distributed.recv(cpu_tensor, self.ranks[src], self.device_group)
+            return cpu_tensor.to(self.device)
+        else:
+            tensor = torch.empty(size, dtype=dtype, device=self.device)
+            torch.distributed.recv(tensor, self.ranks[src], self.device_group)
+            return tensor
 
     def broadcast(self, tensor: torch.Tensor, src: int = 0) -> torch.Tensor:
         """Broadcast a tensor from source rank to all ranks."""
         if self.world_size == 1:
             return tensor
-        torch.distributed.broadcast(tensor, self.ranks[src], self.device_group)
+        if self._is_gloo():
+            cpu_tensor = tensor.cpu()
+            torch.distributed.broadcast(cpu_tensor, self.ranks[src], self.device_group)
+            tensor.copy_(cpu_tensor)
+        else:
+            torch.distributed.broadcast(tensor, self.ranks[src], self.device_group)
         return tensor
 
     def destroy(self):

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -87,9 +87,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         from vllm.distributed.device_communicators.symm_mem import SymmMemCommunicator
 
         self.pynccl_comm: PyNcclCommunicator | None = None
-        disable_pynccl = (
-            envs.VLLM_DISABLE_PYNCCL or current_platform.dist_backend == "gloo"
-        )
+        disable_pynccl = envs.VLLM_DISABLE_PYNCCL or self._is_gloo()
         if self.world_size > 1 and not disable_pynccl:
             self.pynccl_comm = PyNcclCommunicator(
                 group=self.cpu_group if tcp_store_group is None else tcp_store_group,

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -56,7 +56,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
         else:
             from vllm.distributed.parallel_state import _ENABLE_CUSTOM_ALL_REDUCE
 
-            use_custom_allreduce = _ENABLE_CUSTOM_ALL_REDUCE
+            use_custom_allreduce = (
+                _ENABLE_CUSTOM_ALL_REDUCE and current_platform.use_custom_allreduce()
+            )
             use_torch_symm_mem = envs.VLLM_ALLREDUCE_USE_SYMM_MEM
             # FlashInfer all-reduce does not provide a fixed reduction order.
             use_flashinfer_allreduce = (
@@ -85,7 +87,10 @@ class CudaCommunicator(DeviceCommunicatorBase):
         from vllm.distributed.device_communicators.symm_mem import SymmMemCommunicator
 
         self.pynccl_comm: PyNcclCommunicator | None = None
-        if self.world_size > 1:
+        disable_pynccl = (
+            envs.VLLM_DISABLE_PYNCCL or current_platform.dist_backend == "gloo"
+        )
+        if self.world_size > 1 and not disable_pynccl:
             self.pynccl_comm = PyNcclCommunicator(
                 group=self.cpu_group if tcp_store_group is None else tcp_store_group,
                 device=self.device,
@@ -227,6 +232,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             "CUSTOM",
             "SYMM_MEM",
             "PYNCCL",
+            "TORCH_DISTRIBUTED",
         ]
         enabled_ar_backends: list[str] = []
         if self.fi_ar_comm is not None and not self.fi_ar_comm.disabled:
@@ -265,6 +271,10 @@ class CudaCommunicator(DeviceCommunicatorBase):
             enabled_ar_backends.append("SYMM_MEM")
         if self.pynccl_comm is not None and not self.pynccl_comm.disabled:
             enabled_ar_backends.append("PYNCCL")
+        if not enabled_ar_backends:
+            enabled_ar_backends.append(
+                "GLOO" if self._is_gloo() else "TORCH_DISTRIBUTED"
+            )
 
         logger.info_once(
             "Using %s all-reduce backends (in dispatch order) for group "
@@ -332,9 +342,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             return out
         pynccl_comm = self.pynccl_comm
         if pynccl_comm is None or pynccl_comm.disabled:
-            out = input_.clone()
-            torch.distributed.all_reduce(out, group=self.device_group)
-            return out
+            return super().all_reduce(input_.clone())
         assert pynccl_comm is not None
         out = pynccl_comm.all_reduce(input_)
         if out is None:
@@ -342,8 +350,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             # this usually happens during testing.
             # when we run the model, allreduce only happens for the TP
             # group, where we always have either custom allreduce or pynccl.
-            out = input_.clone()
-            torch.distributed.all_reduce(out, group=self.device_group)
+            out = super().all_reduce(input_.clone())
         return out
 
     def custom_all_gather(self, input_: torch.Tensor) -> torch.Tensor | None:
@@ -397,6 +404,8 @@ class CudaCommunicator(DeviceCommunicatorBase):
     def reduce_scatter(self, input_: torch.Tensor, dim: int = -1):
         world_size = self.world_size
         pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            return super().reduce_scatter(input_, dim)
         assert pynccl_comm is not None
         if dim < 0:
             # Convert negative dim to positive.
@@ -426,6 +435,8 @@ class CudaCommunicator(DeviceCommunicatorBase):
     ):
         world_size = self.world_size
         pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            return super().reduce_scatterv(input_, dim, sizes)
         assert pynccl_comm is not None
         if dim < 0:
             # Convert negative dim to positive.
@@ -552,7 +563,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         if pynccl_comm is not None and not pynccl_comm.disabled:
             pynccl_comm.send(tensor, dst)
         else:
-            torch.distributed.send(tensor, self.ranks[dst], self.device_group)
+            super().send(tensor, dst)
 
     def recv(
         self, size: torch.Size, dtype: torch.dtype, src: int | None = None
@@ -562,13 +573,13 @@ class CudaCommunicator(DeviceCommunicatorBase):
         if src is None:
             src = (self.rank_in_group - 1) % self.world_size
 
-        tensor = torch.empty(size, dtype=dtype, device=self.device)
         pynccl_comm = self.pynccl_comm
         if pynccl_comm is not None and not pynccl_comm.disabled:
+            tensor = torch.empty(size, dtype=dtype, device=self.device)
             pynccl_comm.recv(tensor, src)
+            return tensor
         else:
-            torch.distributed.recv(tensor, self.ranks[src], self.device_group)
-        return tensor
+            return super().recv(size, dtype, src)
 
     def broadcast(self, tensor: torch.Tensor, src: int = 0) -> torch.Tensor:
         """Broadcast a tensor from source rank to all ranks."""
@@ -580,7 +591,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             pynccl_comm.broadcast(tensor, src)
             return tensor
         else:
-            raise ValueError("No PyNCCL communicator found")
+            return super().broadcast(tensor, src)
 
     def destroy(self):
         if self.pynccl_comm is not None:
@@ -624,6 +635,8 @@ class CudaCommunicator(DeviceCommunicatorBase):
             raise NotImplementedError("only dim 0 all-gatherv is supported")
         world_size = self.world_size
         pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            return super().all_gatherv(input_, dim, sizes)
         assert pynccl_comm is not None and not pynccl_comm.disabled
 
         # 'sizes' is not needed if all inputs in the same group have the same

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1588,9 +1588,14 @@ def init_distributed_environment(
     rank: int = -1,
     distributed_init_method: str = "env://",
     local_rank: int = -1,
-    backend: str = "nccl",
+    backend: str | None = None,
     timeout: timedelta | None = None,
 ):
+    from vllm.platforms import current_platform
+
+    if backend is None:
+        backend = current_platform.dist_backend or "nccl"
+
     logger.debug(
         "world_size=%d rank=%d local_rank=%d distributed_init_method=%s backend=%s",
         world_size,
@@ -1647,9 +1652,13 @@ def init_distributed_environment(
             "distributed_init_method must be provided when initializing "
             "distributed environment"
         )
-        if not torch.distributed.is_backend_available(backend):
-            logger.warning(
-                "Distributed backend %s is not available; falling back to gloo.",
+        if (
+            backend == "nccl"
+            and (envs.VLLM_DISABLE_PYNCCL or current_platform.dist_backend == "gloo")
+        ) or not torch.distributed.is_backend_available(backend):
+            logger.info(
+                "Distributed backend %s is disabled or unavailable; "
+                "falling back to gloo.",
                 backend,
             )
             assert torch.distributed.is_gloo_available(), (

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -211,7 +211,13 @@ class CudaPlatformBase(Platform):
     device_type: str = "cuda"
     dispatch_key: str = "CUDA"
     ray_device_key: str = "GPU"
-    dist_backend: str = "nccl"
+
+    @property
+    def dist_backend(self) -> str:
+        if envs.VLLM_DISABLE_PYNCCL:
+            return "gloo"
+        return "nccl"
+
     device_control_env_var: str = "CUDA_VISIBLE_DEVICES"
     ray_noset_device_env_vars: list[str] = [
         "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",
@@ -592,6 +598,15 @@ class CudaPlatformBase(Platform):
         group_size: int,
         timeout: timedelta,
     ) -> ProcessGroup:
+        if backend == "gloo":
+            from vllm.distributed.utils import init_gloo_process_group
+
+            return init_gloo_process_group(
+                prefix_store=prefix_store,
+                group_rank=group_rank,
+                group_size=group_size,
+                timeout=timeout,
+            )
         assert is_nccl_available()
         pg: ProcessGroup = ProcessGroup(
             prefix_store,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -165,7 +165,9 @@ class Platform:
     simple_compile_backend: str = "inductor"
 
     # The backend used for distributed communication.
-    dist_backend: str = ""
+    @property
+    def dist_backend(self) -> str:
+        return ""
 
     supported_quantization: list[str] = []
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -501,7 +501,13 @@ class RocmPlatform(Platform):
     device_type: str = "cuda"
     dispatch_key: str = "CUDA"
     ray_device_key: str = "GPU"
-    dist_backend: str = "nccl"
+
+    @property
+    def dist_backend(self) -> str:
+        if envs.VLLM_DISABLE_PYNCCL:
+            return "gloo"
+        return "nccl"
+
     # rocm shares the same device control env var as CUDA
     device_control_env_var: str = "CUDA_VISIBLE_DEVICES"
     ray_noset_device_env_vars: list[str] = [
@@ -1010,6 +1016,15 @@ class RocmPlatform(Platform):
         group_size: int,
         timeout: timedelta,
     ) -> ProcessGroup:
+        if backend == "gloo":
+            from vllm.distributed.utils import init_gloo_process_group
+
+            return init_gloo_process_group(
+                prefix_store=prefix_store,
+                group_rank=group_rank,
+                group_size=group_size,
+                timeout=timeout,
+            )
         assert is_nccl_available()
         pg: ProcessGroup = ProcessGroup(
             prefix_store,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1465,9 +1465,13 @@ def init_worker_distributed_environment(
     rank: int,
     distributed_init_method: str | None = None,
     local_rank: int = -1,
-    backend: str = "nccl",
+    backend: str | None = None,
 ) -> None:
     """Initialize the distributed environment."""
+    from vllm.platforms import current_platform
+
+    if backend is None:
+        backend = current_platform.dist_backend or "nccl"
     parallel_config = vllm_config.parallel_config
     from vllm.model_executor.determinism.batch_invariant import init_batch_invariance
 


### PR DESCRIPTION
This PR was motivated by RCCL breaking TP=2 on RDNA setups (see, e.g., #38587 and the ROCm issues linked there). An old version of RCCL doesn't have these problems, but overriding containers' shipped RCCL versions with the old one is hacky, impeding accessibility. This PR immediately solves the RDNA RCCL issue by:

1. Implementing the previously stubbed collective operations using Gloo in `DeviceCommunicatorBase`. I.e., this PR implements the stubs left behind by #20154.
2. Completely prevents loading PyNCCL when flag-disabled. This is necessary because even _loading_ the library seems to cause crashes when unsupported versions are used with RDNA.

This PR, however, is a minimum-functionality fix for correctness and availability. This implementation is SLOW _and_ precludes CUDA graph capture (by requiring eager mode). In a follow-up PR, I plan to introduce a simple host-pinned shared memory collective backend implementation. That should enable line-rate inter-card communication for consumer PCIe topologies currently left behind by RCCL's brokenness. Scoped separately because this PR is long enough and should introduce no regressions by itself.

## Purpose

- To enable TP on consumer AMD hardware without RCCL version hacking.

## Test Plan

Demonstrate functional serving using TP=2 with `VLLM_DISABLE_PYNCCL=1`:

```bash
vllm serve meta-llama/Llama-3.2-1B -tp 2 --device-ids 0,1
```

Correctness tests for new communicator implementations:
```bash
python -m pytest tests/distributed/test_device_communicator_pynccl_disabled.py -v -s
```

## Test Results

vLLM launch (CachyOS with two 7900 XTXs, each on PCIe 4.0 x8):

```bash
$ vllm serve meta-llama/Llama-3.2-1B --gpu-memory-utilization 0.9 --max-num-seqs 1 -tp 2 --device-ids 0,1
...
(APIServer pid=124992) INFO 08-29 15:11:30 [vllm.py:1593] Cudagraph is disabled under eager mode or when distributed backend is Gloo without custom allreduce
...
(Worker pid=125273) INFO 08-29 15:11:39 [cuda_communicator.py:278] Using ['GLOO'] all-reduce backends (in dispatch order) for group 'tp:0' out of potential backends: ['FLASHINFER', 'NCCL_SYMM_MEM', 'QUICK_REDUCE', 'AITER_CUSTOM', 'CUSTOM', 'SYMM_MEM', 'PYNCCL', 'TORCH_DISTRIBUTED'].
...
(APIServer pid=124992) INFO:     Started server process [124992]
(APIServer pid=124992) INFO:     Waiting for application startup.
(APIServer pid=124992) INFO:     Application startup complete.
(APIServer pid=124992) INFO:     127.0.0.1:52008 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=124992) INFO 08-29 15:12:17 [loggers.py:310] Engine 000: Avg prompt throughput: 1.1 tokens/s, Avg generation throughput: 6.4 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
```

Request completion:

```bash
$ curl http://localhost:8000/v1/completions \
        -H "Content-Type: application/json" \
        -d '{
      "model": "meta-llama/Llama-3.2-1B",
      "prompt": "Tensor parallelism in deep learning is a technique that",
      "max_tokens": 64,
      "temperature": 0.5
    }'
{"id":"cmpl-aa9a99a6433dac52","object":"text_completion","created":1788041532,"model":"meta-llama/Llama-3.2-1B","choices":[{"index":0,"text":" allows for parallel execution of computation across multiple processors, which can significantly improve the performance of deep learning models. This technique is particularly useful in the context of large-scale deep learning models, where the number of parameters and the complexity of the computation can make it challenging to parallelize the model on a single processor. Tensor parallelism","logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.28.1rc1.dev103+gb89ca6688-tp2-47bc2e90","usage":{"prompt_tokens":11,"total_tokens":75,"completion_tokens":64,"prompt_tokens_details":null,"completion_tokens_details":null},"kv_transfer_params":null,"ec_transfer_params":null,"metrics":null}
```


`pytest` results:

```bash
============================ 1 passed, 14 warnings in 9.29s ============================
```

## AI Assistance

I used AI assistance in developing this PR's code (Antigravity with Gemini 3.7 Flash high). All design decisions were made by me, and I reviewed all code myself. I ran the new tests manually and did not allow the AI to use git. I wrote this PR description and will write any comments or responses to feedback.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

