### PR TITLE
[Model] Honor cap_pixels_per_frame in Qwen3-VL memory profiling

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl.py
@@ -184,3 +184,46 @@ def test_processor_multi_video_list_kwargs(
     assert len(video_phs) == 2, (
         f"Expected exactly 2 video placeholders, got {len(video_phs)}"
     )
+
+
+@pytest.mark.parametrize("model_id", [MODEL_ID])
+def test_dummy_video_spreads_budget_when_frame_cap_enabled(model_id: str) -> None:
+    """Regression test for memory profiling with ``cap_pixels_per_frame``.
+
+    With the HF per-frame pixel cap enabled (transformers#48071) and a
+    raised video budget, a 2-frame profiling dummy would be processed at
+    only 2 * cap pixels, underestimating the largest possible video (a
+    fully sampled one still fills the whole ``longest_edge`` budget). The
+    dummy builder must spread the budget over enough frames that the cap
+    is not binding.
+    """
+    # 16 capped frames' worth of budget on top of the default per-frame
+    # ceiling (max_video_tokens=768 at patch 16, merge 2 -> 786,432
+    # pixels per frame).
+    per_frame_cap = 768 * (16 * 2) ** 2
+    budget = per_frame_cap * 16
+    size = {"longest_edge": budget, "shortest_edge": 4096}
+
+    capped_ctx = build_model_context(
+        model_id,
+        mm_processor_kwargs={"size": size, "cap_pixels_per_frame": True},
+        limit_mm_per_prompt={"image": 0, "video": 1},
+    )
+    capped = MULTIMODAL_REGISTRY.create_processor(capped_ctx.model_config)
+    capped_dummy = capped.dummy_inputs.get_dummy_mm_data(1024, {"video": 1}, {})
+    capped_frames = capped_dummy["video"][0][0].shape[0]
+    assert capped_frames == 16, (
+        f"Expected the dummy to spread the budget over 16 frames, got {capped_frames}"
+    )
+
+    uncapped_ctx = build_model_context(
+        model_id,
+        mm_processor_kwargs={"size": size},
+        limit_mm_per_prompt={"image": 0, "video": 1},
+    )
+    uncapped = MULTIMODAL_REGISTRY.create_processor(uncapped_ctx.model_config)
+    uncapped_dummy = uncapped.dummy_inputs.get_dummy_mm_data(1024, {"video": 1}, {})
+    uncapped_frames = uncapped_dummy["video"][0][0].shape[0]
+    assert uncapped_frames == 2, (
+        f"Expected the uncapped dummy to keep 2 frames, got {uncapped_frames}"
+    )

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -111,7 +111,7 @@ from vllm.tokenizers.protocol import TokenizerLike
 from vllm.tokenizers.registry import cached_tokenizer_from_config
 from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.utils.collection_utils import is_list_of
-from vllm.utils.math_utils import round_up
+from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.torch_utils import PIN_MEMORY
 from vllm.v1.worker.encoder_cudagraph_defs import EncoderCudaGraphReplayBuffers
 
@@ -1140,6 +1140,28 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
         # video_max_pixels contains the temporal compression factor,
         # so we divide by 2 to get the maximum number of image pixels.
         video_max_pixels = video_size["longest_edge"]
+
+        # With the HF processor's per-frame pixel cap enabled
+        # (cap_pixels_per_frame, huggingface/transformers#48071), a 2-frame
+        # dummy is processed at only 2 * cap pixels, so memory profiling
+        # underestimates the largest possible item: a fully sampled video
+        # still reaches the whole longest_edge budget. Spread the budget
+        # over enough frames that the cap is not binding for the dummy.
+        # This takes precedence over a shrinking num_frames override, which
+        # would otherwise reintroduce the under-profiling.
+        if mm_kwargs.get("cap_pixels_per_frame"):
+            max_video_tokens = mm_kwargs.get(
+                "max_video_tokens",
+                getattr(video_processor, "max_video_tokens", 768),
+            )
+            patch_size = mm_kwargs.get("patch_size", video_processor.patch_size)
+            merge_size = mm_kwargs.get("merge_size", video_processor.merge_size)
+            per_frame_cap = max_video_tokens * (patch_size * merge_size) ** 2
+            target_num_frames = max(
+                target_num_frames,
+                min(video_processor.max_frames, cdiv(video_max_pixels, per_frame_cap)),
+            )
+
         target_video_width, target_video_height = (
             self.info.get_image_size_with_most_features(
                 max_pixels=video_max_pixels // temporal_patch_size


### PR DESCRIPTION
## Purpose

Follow-up to #52754, which was closed after review feedback that the per-frame video cost knob belongs in the HF processor. That knob has now merged as huggingface/transformers#48071: an opt-in boolean `cap_pixels_per_frame` on the Qwen3-VL video processor that applies the qwen-vl-utils per-frame pixel ceiling (`max_video_tokens` patches per frame, 768 by default), so short clips cost tokens proportional to duration instead of filling the whole `size["longest_edge"]` budget.

This PR makes vLLM's memory profiling honor that cap. With `cap_pixels_per_frame` active and a raised video budget (e.g. the Qwen3.8 model card's "Long Video Understanding" recipe, which lifts the budget to ~224K video tokens for hour-scale sampling), the current 2-frame profiling dummy gets processed at only `2 * cap` pixels. Profiling then underestimates the largest possible video item, because a fully sampled video still reaches the entire budget, and the vision encoder can OOM at runtime. The fix derives the numeric per-frame cap from the processor attributes and spreads the profiling budget over enough frames that the cap is not binding for the dummy. When the kwarg is absent, nothing changes.

## Test Plan

New regression test:

```
pytest tests/models/multimodal/processing/test_qwen3_vl.py::test_dummy_video_spreads_budget_when_frame_cap_enabled
```

With a budget worth 16 capped frames, the dummy must spread to 16 frames when `cap_pixels_per_frame` is set, and stay at 2 frames when it is not. Also ran the whole file to check the existing processor tests still pass.

End-to-end, the change was validated serving `Qwen/Qwen3.8-27B-FP8` on an RTX PRO 6000 (96 GB) with the model card's long-video recipe expressed as serve config:

```
--mm-processor-kwargs '{"size": {"longest_edge": 469762048, "shortest_edge": 4096}, "cap_pixels_per_frame": true}'
```

## Test Result

```
tests/models/multimodal/processing/test_qwen3_vl.py .......                [100%]
7 passed
```

End-to-end on the 96 GB card: profiling reserves the same peak encoder memory with the cap on as with it off (~26 GiB for the max-size video, encoder budget 229,376 tokens), instead of the ~2-frame underestimate; a 90 s 1080p clip then processes at ~66K tokens (vs ~184K uncapped) and an hour-scale video still fills the full budget without an encoder OOM.
