### PR TITLE
[Perf][KV Cache] Skip sliding-window prefix lookup on an empty cache

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -336,6 +336,38 @@ def test_sliding_window_possible_cached_prefix():
     )
 
 
+def test_sliding_window_empty_cache_skips_hash_lookups(monkeypatch):
+    block_size = 2
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=4,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(sliding_window_spec, block_pool)
+
+    def fail_on_lookup(*args, **kwargs):
+        raise AssertionError("empty prefix cache should not perform hash lookups")
+
+    monkeypatch.setattr(block_pool, "get_cached_block", fail_on_lookup)
+    computed_blocks, hit_length = manager.find_longest_cache_hit(
+        block_hashes=[BlockHash(str(i).encode()) for i in range(100)],
+        max_length=100 * block_size,
+        kv_cache_group_ids=[0],
+        block_pool=block_pool,
+        kv_cache_spec=sliding_window_spec,
+        drop_eagle_block=False,
+        alignment_tokens=block_size,
+    )
+
+    assert computed_blocks == ([],)
+    assert hit_length == 0
+
+
 def test_chunked_local_attention_remove_skipped_blocks():
     attention_spec = ChunkedLocalAttentionSpec(
         block_size=2,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -923,6 +923,13 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         assert alignment_tokens % kv_cache_spec.block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
         )
+
+        # Avoid walking every prompt block on a cold cache. Unlike full attention,
+        # sliding-window lookup searches from the end and cannot stop at the first
+        # miss, so the empty-cache case would otherwise scan the entire prompt.
+        if len(block_pool.cached_block_hash_to_block) == 0:
+            return tuple([] for _ in kv_cache_group_ids), 0
+
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,


### PR DESCRIPTION
## Purpose

`SlidingWindowManager.find_longest_cache_hit()` searches prompt hashes from
right to left because a usable sliding-window hit may occur after an earlier
miss. On a cold cache, that means it allocates the placeholder block table and
looks up every prompt block even though the shared cached-block map proves that
no lookup can succeed.

This change returns the existing empty-hit result immediately when
`BlockPool.cached_block_hash_to_block` is empty. Non-empty-cache behavior is
unchanged.

This is distinct from #53690: that PR skips
`FullAttentionManager.get_num_common_prefix_blocks()` during single-request
decode, while this change skips
`SlidingWindowManager.find_longest_cache_hit()` at request ingress when the GPU
prefix cache has no entries.

## Changes

- Add an O(1) empty-cache fast path before resolving or walking SWA prompt
  hashes.
- Add a regression test that fails if an empty cache performs any block-hash
  lookup and verifies the returned empty hit.

No public API, configuration, allocation, cache ownership, or model-output
behavior changes.

## Benchmark

CPU host-path microbenchmark on a 6 x RTX 3090 host (Intel Xeon Gold 6226R),
with GPU access disabled for the benchmark. Both arms used commit
`680e2177e473ed8dfaa9773f7ead185b369cab46`, Python 3.12.13, PyTorch
2.13.0+cu130, block size 16, sliding window 4096, an empty cache, 5 warmup
batches, 10 measured repetitions, and 100 calls per sample.

| Prompt tokens | Baseline mean | Patch mean | Hash lookups/call |
|---:|---:|---:|---:|
| 65,536 | 2.298278 ms | 0.000856 ms | 4,096 -> 0 |
| 262,144 | 9.177024 ms | 0.000830 ms | 16,384 -> 0 |
| 1,048,576 | 36.834053 ms | 0.000820 ms | 65,536 -> 0 |

This isolates scheduler/request-ingress host work; it is not an end-to-end TTFT
or CUDA-kernel benchmark. The meaningful result is the removal of linear work
and up to 36.83 ms of host latency in the tested 1M-token cold-cache case.

## Test plan and results

- New regression test against the unmodified base: failed as expected at the
  first `get_cached_block()` call.
- New regression test with this change: 1 passed.
- `pytest -q tests/v1/core/test_single_type_kv_cache_manager.py`: 14 passed.
- `pytest -q tests/v1/core/test_prefix_caching.py`: 91 passed, with 14 existing
  TorchScript deprecation warnings.
- Applicable repository pre-commit hooks `ruff-check`, `ruff-format`, `typos`,
  and `mypy-3.10`: passed.

The broad prefix-caching test used existing locally built vLLM extension
artifacts for import. No compiled artifact is included in this PR.

No model evaluation was run because the change only bypasses a provably empty
host-side cache lookup and does not affect model execution or token outputs.

## AI assistance disclosure

AI tools assisted with candidate screening, implementation, and validation.
The contributor reviewed the final diff and evidence line by line before
submission.
