### PR TITLE
[Compile] Remove get_cached_compilation_config, read compilation config directly

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -1087,23 +1087,17 @@ def test_sequence_parallelism_requires_full_graph_compilation(
     ) == expected_enable_sp
 
 
-def test_cached_compilation_config(default_vllm_config):
+def test_custom_op_dispatch_follows_current_compilation_config(default_vllm_config):
     import torch
     from torch._inductor.utils import run_and_get_code
 
-    from vllm.config import get_cached_compilation_config, set_current_vllm_config
+    from vllm.config import set_current_vllm_config
     from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
     from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 
     dtype = torch.bfloat16
     device = torch.device(f"{DEVICE_TYPE}:0")
     batch_size, num_qo_heads, head_size = 8, 16, 128
-
-    # access and cache default compilation config
-    # default compilation config does not contain +quant_fp8 custom op. If this is
-    # used, the generated code would use inductor-generated triton kernel instead
-    # of the custom op `torch.ops._C.static_scaled_fp8_quant`.
-    get_cached_compilation_config()
 
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
@@ -1112,8 +1106,8 @@ def test_cached_compilation_config(default_vllm_config):
         )
     )
 
-    # set_current_vllm_config should clear cached compilation config and
-    # use the new compilation_config in vllm_config
+    # A CustomOp built inside the context must pick up custom_ops=["+quant_fp8"]
+    # and dispatch to the custom op rather than an inductor-generated kernel.
     with set_current_vllm_config(vllm_config):
         query_quant = QuantFP8(static=True, group_shape=GroupShape.PER_TENSOR)
         query_quant = torch.compile(query_quant)

--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -19,7 +19,6 @@ import torch
 from vllm.config import (
     CompilationConfig,
     VllmConfig,
-    get_cached_compilation_config,
     set_current_vllm_config,
 )
 from vllm.platforms import current_platform
@@ -112,7 +111,6 @@ def run_dispatch_test(
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(custom_ops=["all", "+apply_rotary_emb"])
     )
-    get_cached_compilation_config.cache_clear()
 
     with set_current_vllm_config(vllm_config):
         rope = test_case.rope_class(**test_case.rope_kwargs).to(device=device)

--- a/tests/kernels/moe/test_grouped_topk.py
+++ b/tests/kernels/moe/test_grouped_topk.py
@@ -12,7 +12,6 @@ import vllm.envs as envs
 from vllm.config import (
     CompilationConfig,
     VllmConfig,
-    get_cached_compilation_config,
     set_current_vllm_config,
 )
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
@@ -107,7 +106,6 @@ def test_grouped_topk(
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(custom_ops=["all", "+grouped_topk"])
     )
-    get_cached_compilation_config.cache_clear()
 
     set_random_seed(0)
     hidden_states = torch.randn((n_token, n_hidden), dtype=input_dtype, device="cuda")

--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -8,7 +8,6 @@ from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import (
     CompilationConfig,
     VllmConfig,
-    get_cached_compilation_config,
     set_current_vllm_config,
 )
 from vllm.model_executor.custom_op import CustomOp, op_registry
@@ -88,7 +87,6 @@ def test_enabled_ops(
             backend=backend, mode=compilation_mode, custom_ops=custom_ops
         )
     )
-    get_cached_compilation_config.cache_clear()
     with set_current_vllm_config(vllm_config):
         assert CustomOp.default_on() == default_on
 

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -53,7 +53,6 @@ from vllm.config.utils import (
 )
 from vllm.config.vllm import (
     VllmConfig,
-    get_cached_compilation_config,
     get_current_vllm_config,
     get_current_vllm_config_or_none,
     get_layers_from_vllm_config,
@@ -137,7 +136,6 @@ __all__ = [
     "update_config",
     # From vllm.config.vllm
     "VllmConfig",
-    "get_cached_compilation_config",
     "get_current_vllm_config",
     "get_current_vllm_config_or_none",
     "set_current_vllm_config",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2924,11 +2924,6 @@ def set_current_vllm_config(
 
     num_models_seen = compilation_counter.num_models_seen
     try:
-        # Clear the compilation config cache when context changes.
-        # This is needed since the old config may have been accessed
-        # and cached before the new config is set.
-        get_cached_compilation_config.cache_clear()
-
         _current_vllm_config = vllm_config
         _current_prefix = prefix
         yield
@@ -2957,14 +2952,6 @@ def set_current_vllm_config(
     finally:
         _current_vllm_config = old_vllm_config
         _current_prefix = old_prefix
-        # Clear the compilation config cache when context changes
-        get_cached_compilation_config.cache_clear()
-
-
-@lru_cache(maxsize=1)
-def get_cached_compilation_config():
-    """Cache config to avoid repeated calls to get_current_vllm_config()"""
-    return get_current_vllm_config().compilation_config
 
 
 def get_current_vllm_config() -> VllmConfig:

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -6,7 +6,7 @@ import inspect
 import torch
 import torch.nn as nn
 
-from vllm.config import get_cached_compilation_config
+from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.utils import maybe_disable_graph_partition
 from vllm.platforms import current_platform
@@ -174,7 +174,7 @@ class CustomOp(nn.Module):
     def dispatch_forward(self, compile_native: bool):
         # NOTE(woosuk): Here we assume that vLLM was built for only one
         # specific backend. Currently, we do not support dynamic dispatching.
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
 
         # NOTE(shen-shanshan): CustomOp object can be enforce enabled, e.g.,
         # enable device-specific kernels in ViT models when enabling graph
@@ -222,7 +222,7 @@ class CustomOp(nn.Module):
             return fn
 
         # Do not compile if global compilation disabled
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
         if compilation_config.mode == CompilationMode.NONE:
             return fn
 
@@ -271,7 +271,7 @@ class CustomOp(nn.Module):
     @classmethod
     def enabled(cls) -> bool:
         # if no name, then it was not registered
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
         custom_ops = compilation_config.custom_ops
         if not hasattr(cls, "name"):
             logger.warning_once(
@@ -300,7 +300,7 @@ class CustomOp(nn.Module):
         When PyTorch Inductor is used, 'none' is the default value,
         otherwise 'all'.
         """
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
         count_none = compilation_config.custom_ops.count("none")
         count_all = compilation_config.custom_ops.count("all")
         if count_none + count_all != 1:

--- a/vllm/model_executor/hw_agnostic/custom_op.py
+++ b/vllm/model_executor/hw_agnostic/custom_op.py
@@ -6,7 +6,7 @@ import inspect
 import torch
 import torch.nn as nn
 
-from vllm.config import get_cached_compilation_config
+from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.utils import maybe_disable_graph_partition
 from vllm.platforms import current_platform
@@ -148,7 +148,7 @@ class CustomOp(nn.Module):
         # The hw-agnostic CustomOp dispatches only between forward_native
         # (in-tree, used on every platform) and forward_oot (overridden by
         # an OOT plugin via register_oot).
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
 
         # NOTE(shen-shanshan): CustomOp object can be enforce enabled, e.g.,
         # enable device-specific kernels in ViT models when enabling graph
@@ -187,7 +187,7 @@ class CustomOp(nn.Module):
             return fn
 
         # Do not compile if global compilation disabled
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
         if compilation_config.mode == CompilationMode.NONE:
             return fn
 
@@ -236,7 +236,7 @@ class CustomOp(nn.Module):
     @classmethod
     def enabled(cls) -> bool:
         # if no name, then it was not registered
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
         custom_ops = compilation_config.custom_ops
         if not hasattr(cls, "name"):
             logger.warning_once(
@@ -261,7 +261,7 @@ class CustomOp(nn.Module):
         When PyTorch Inductor is used, 'none' is the default value,
         otherwise 'all'.
         """
-        compilation_config = get_cached_compilation_config()
+        compilation_config = get_current_vllm_config().compilation_config
         count_none = compilation_config.custom_ops.count("none")
         count_all = compilation_config.custom_ops.count("all")
         assert count_none + count_all == 1


### PR DESCRIPTION
## Purpose

Remove `get_cached_compilation_config()` and its two `cache_clear()` hooks in
`set_current_vllm_config`. The 8 call sites (`CustomOp` dispatch in
`model_executor/custom_op.py` + `hw_agnostic/custom_op.py`) now read
`get_current_vllm_config().compilation_config` directly.

### Why

The cache was added in #22204 ("Optimize configuration access with LRU cache in
custom ops"), but didn't have a benchmark. It is a stateful global memo with manual
invalidation, and that invalidation complexity creates surface area for bugs:

- Google's automated reviewer flagged the exact flaw on #22204 — *"the caching
  mechanism doesn't account for changes in the global configuration context,
  which can lead to stale cache data and incorrect behavior, especially in
  testing environments"* — and it merged anyway.
- 5 months later that became #31376: a `CustomOp` built after a config swap saw
  the stale `compilation_config`, so `custom_ops=["+quant_fp8"]` was ignored and
  `torch.compile` emitted an Inductor kernel instead of dispatching to
  `torch.ops._C.static_scaled_fp8_quant`. Silent. The fix was another
  hand-written `cache_clear()` line.
- The pattern has since spread to a second file, so it is now 8 implicit
  dependencies on those two lines staying in place.

### Measured cost of removing it

Microbenchmark, config context active, cache warm (5M iterations, 3 runs):

| | ns/call |
|---|---|
| `get_cached_compilation_config()` | ~16 |
| `get_current_vllm_config().compilation_config` | ~25 |
| delta | **~8.5 ns/call** |

Call volume (instrumented `LLM(...)` load + generation):

| phase | calls |
|---|---|
| model build (`JackFram/llama-68m`, 2 layers) | 29 |
| 16 prompts × 32 tokens of generation | **0** |

The call sites are all in `CustomOp.__init__` → `dispatch_forward` / `enabled` /
`default_on` — model-build / compile time, never the forward path. Extrapolating
to a large model (~1000 build-time calls) the cache saves **~8 µs, once, at
startup**. That is not a measurable improvement to anything a user observes, and
it is the justification for a memo that caused a silent correctness bug.

## Not a duplicate

`gh pr list --repo vllm-project/vllm --state open --search "compilation config cache"`
and `--search "get_current_vllm_config"` show no PR touching this. Directionally
consistent with #38661 ("Pass `vllm_config` to the Attention constructors"),
which is also reducing reliance on the ambient-global config path.

## Tests

- `tests/compile/test_config.py::test_cached_compilation_config` renamed to
  `test_custom_op_dispatch_follows_current_compilation_config` and stripped of
  the cache-priming lines. It still asserts the real user-facing behavior: a
  `CustomOp` built inside `set_current_vllm_config(cfg)` with
  `custom_ops=["+quant_fp8"]` dispatches to the custom op, not an Inductor
  kernel. **Passes.**
- Removed the now-dead `get_cached_compilation_config.cache_clear()` isolation
  calls from `tests/kernels/core/test_apply_rotary_emb.py`,
  `tests/kernels/moe/test_grouped_topk.py`,
  `tests/model_executor/test_enabled_custom_ops.py` (with no cache there is no
  stale state to clear; `set_current_vllm_config` already makes the new config
  current). All three collect clean.
- `tests/model_executor/test_enabled_custom_ops.py -k "not test_enabled_ops"`:
  4 passed. The `test_enabled_ops` params and several `tests/compile/test_config.py`
  cases fail identically **with and without this change** on my box (missing
  compiled `_C` ops / compile deps) — 25 failed / 66 passed on both
  `upstream/main` and this branch for
  `pytest tests/model_executor/test_enabled_custom_ops.py tests/compile/test_config.py`.
  Full compile/custom-op CI should confirm on a complete build.

## Model evaluation

No output/accuracy impact — this changes only how `compilation_config` is
retrieved, not its contents. Behavior is identical to the cache when a context
is active, and strictly more correct across a config swap (the #31376 case:
direct read returns the current config; the warm cache could return a stale one).

## AI assistance

This change was developed with AI assistance (Claude). 
