### PR TITLE
[Fix] Raise clear error for unknown source fps in Qwen3-VL video backend

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1755,3 +1755,18 @@ def test_glm5next_read_frames_dense_walk_matches_stock(tmp_path):
         assert abs(round(float(np.asarray(frame).mean())) - idx) <= 1
     # One initial seek, then pure walking -- no re-seek churn.
     assert cap.seeks == 1
+
+
+@pytest.mark.parametrize(
+    "backend_cls",
+    [Qwen3VLVideoBackend, Qwen2VLVideoBackend],
+    ids=["qwen3_vl", "qwen2_vl"],
+)
+def test_video_backend_rejects_unknown_source_fps(backend_cls):
+    """A container reporting 0 fps (VFR/unknown) must raise a clear
+    ValueError instead of ZeroDivisionError."""
+    target = VideoTargetMetadata(num_frames=-1, fps=2, max_duration=300)
+    # Decoders report fps=0.0 for unknown/variable frame rate clips.
+    source = VideoSourceMetadata(total_frames_num=150, original_fps=0.0, duration=0.0)
+    with pytest.raises(ValueError, match="unknown frame rate"):
+        backend_cls.compute_frames_index_to_sample(source, target)

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -356,6 +356,14 @@ class Qwen3VLVideoBackend(VideoBackend):
         min_frames = kwargs.get("min_frames", 4)
         max_frames = kwargs.get("max_frames", 768)
 
+        # vLLM reports original_fps == 0 for clips with unknown/variable fps
+        # (VFR, malformed, streaming); fail loudly instead of dividing by zero.
+        if original_fps <= 0:
+            raise ValueError(
+                "Qwen3-VL video sampling needs a known source fps, but the "
+                "container reported 0 (variable or unknown frame rate)."
+            )
+
         # Refer to:
         # https://github.com/huggingface/transformers/blob/v5.9.0/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py#L119-L125
         num_frames = int(total_frames_num / original_fps * fps)


### PR DESCRIPTION
## Motivation

`Qwen3VLVideoBackend.compute_frames_index_to_sample` divides by `source.original_fps` without validating it. Decoders report `original_fps == 0` for clips with an unknown or variable frame rate (VFR, malformed containers), so serving such a video crashed with a bare `ZeroDivisionError: float division by zero`. The sibling `Qwen2VLVideoBackend` already guards against this; the Qwen3-VL backend was missing the same check.

## Modifications

- Added an `original_fps <= 0` guard to `Qwen3VLVideoBackend.compute_frames_index_to_sample` that raises a descriptive `ValueError`, mirroring the existing Qwen2-VL behavior.
- Added a parameterized regression test `test_video_backend_rejects_unknown_source_fps` covering both the Qwen3-VL and Qwen2-VL backends.

## Verification

- `pytest tests/multimodal/test_video.py::test_video_backend_rejects_unknown_source_fps -v` -> 2 passed (`qwen3_vl`, `qwen2_vl`).
- On unpatched `main`, the same call raises `ZeroDivisionError: float division by zero`; with this patch it raises a `ValueError` that names the cause.