### PR TITLE
[Bugfix][XPU] Skip the CUDA capability gate in MoeWNA16Config on XPU

### DIFF
--- a/tests/quantization/test_moe_wna16.py
+++ b/tests/quantization/test_moe_wna16.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.quantization.moe_wna16 import (
     MoeWNA16Method,
 )
 from vllm.platforms import current_platform
+from vllm.platforms.interface import DeviceCapability
 
 
 def test_map_wna16_backend_supports_triton():
@@ -477,3 +478,83 @@ def test_compressed_tensors_wna16_moe_marlin_prep_with_unset_group_size():
     )
     assert layer.w13_weight_scale.shape == (num_experts, 1, 2 * intermediate_size)
     assert layer.w2_weight_scale.shape == (num_experts, 1, hidden_size)
+
+
+def _make_awq_moe_wna16_config() -> MoeWNA16Config:
+    return MoeWNA16Config(
+        linear_quant_method="awq",
+        weight_bits=4,
+        group_size=128,
+        has_zp=True,
+        lm_head_quantized=False,
+        modules_to_not_convert=None,
+        full_config={},
+    )
+
+
+def _force_device_capability(monkeypatch, capability):
+    monkeypatch.setattr(
+        current_platform, "get_device_capability", lambda *a, **k: capability
+    )
+
+
+def test_moe_wna16_config_accepts_awq_on_xpu(monkeypatch):
+    """XPU reports no CUDA-style device capability, so the AWQ capability
+    gate must not reject moe_wna16 there."""
+    monkeypatch.setattr(current_platform, "is_xpu", lambda: True)
+    _force_device_capability(monkeypatch, None)
+
+    _make_awq_moe_wna16_config()
+
+
+@pytest.mark.parametrize(
+    ("capability", "accepted"),
+    [
+        (DeviceCapability(major=7, minor=0), False),
+        (DeviceCapability(major=7, minor=5), True),
+        (DeviceCapability(major=9, minor=0), True),
+        (None, False),
+    ],
+)
+def test_moe_wna16_config_awq_capability_gate_on_cuda_like(
+    monkeypatch, capability, accepted
+):
+    monkeypatch.setattr(current_platform, "is_xpu", lambda: False)
+    _force_device_capability(monkeypatch, capability)
+
+    if accepted:
+        _make_awq_moe_wna16_config()
+    else:
+        with pytest.raises(ValueError, match="not supported"):
+            _make_awq_moe_wna16_config()
+
+
+def test_is_moe_wna16_compatible_awq_on_xpu(monkeypatch):
+    monkeypatch.setattr(current_platform, "is_xpu", lambda: True)
+    _force_device_capability(monkeypatch, None)
+
+    assert MoeWNA16Config.is_moe_wna16_compatible({"quant_method": "awq", "bits": 4})
+    assert MoeWNA16Config.is_moe_wna16_compatible(
+        {"quant_method": "gptq", "bits": 4, "desc_act": False}
+    )
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        (DeviceCapability(major=7, minor=0), False),
+        (DeviceCapability(major=7, minor=5), True),
+        (DeviceCapability(major=9, minor=0), True),
+        (None, False),
+    ],
+)
+def test_is_moe_wna16_compatible_awq_capability_gate_on_cuda_like(
+    monkeypatch, capability, expected
+):
+    monkeypatch.setattr(current_platform, "is_xpu", lambda: False)
+    _force_device_capability(monkeypatch, capability)
+
+    assert (
+        MoeWNA16Config.is_moe_wna16_compatible({"quant_method": "awq", "bits": 4})
+        is expected
+    )

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -83,7 +83,10 @@ class MoeWNA16Config(QuantizationConfig):
                 -1 if capability_tuple is None else capability_tuple.to_int()
             )
             awq_min_capability = AutoAWQConfig.get_min_capability()
-            if device_capability < awq_min_capability:
+            # XPU reports no CUDA-style device capability
+            # (get_device_capability() is None), and the WNA16 kernels used
+            # on XPU do not depend on it, so skip the CUDA capability gate.
+            if not current_platform.is_xpu() and device_capability < awq_min_capability:
                 raise ValueError(
                     "The quantization method moe_wna16 + awq is not supported "
                     "for the current GPU. "
@@ -181,7 +184,7 @@ class MoeWNA16Config(QuantizationConfig):
         awq_compatible = (
             quant_method == "awq"
             and num_bits == 4
-            and device_capability >= awq_min_capability
+            and (device_capability >= awq_min_capability or current_platform.is_xpu())
         )
 
         return gptq_compatible or awq_compatible


### PR DESCRIPTION
## Purpose
`MoeWNA16Config` gates the AWQ layout behind a CUDA SM capability check (`device_capability >= AutoAWQConfig.get_min_capability()`, i.e. 75). On XPU, `XPUPlatform.get_device_capability()` deliberately returns `None` (the CUDA SM-version concept does not apply), so `device_capability` always resolves to `-1` and native-AWQ checkpoints are unconditionally rejected on XPU:

- `MoeWNA16Config.__init__` raises `ValueError: The quantization method moe_wna16 + awq is not supported for the current GPU. Minimum capability: 75. Current capability: -1.` — this also breaks the `MoeWNA16Config.from_config` fallback that `AutoAWQConfig.get_quant_method` uses for RoutedExperts layers whose shapes are not Marlin-compatible.
- `MoeWNA16Config.is_moe_wna16_compatible()` returns `False` for AWQ, so `override_quantization_method` never converts even when the user forces `--quantization moe_wna16`.

Fixes #54350

## Approach
Skip the CUDA capability gate when `current_platform.is_xpu()`, in both `MoeWNA16Config.__init__` and `is_moe_wna16_compatible()`:

```python
if not current_platform.is_xpu() and device_capability < awq_min_capability:
    raise ValueError(...)
```

The WNA16 compute path dispatched on XPU is a generic dispatch and does not depend on the CUDA capability, so the check was an overly conservative CUDA-era gate rather than a real hardware limitation. This mirrors the existing treatment in `AutoAWQMarlinLinearMethod.__init__`, which already skips marlin verification on CPU/XPU with the comment "Skip Marlin verification on CPU/XPU - they use dedicated WNA16 kernels".

Note on the companion issue #54349: the original crash reported there (native AWQ MoE routed into `AWQMoeMarlin` on XPU) no longer reproduces on current `main` — `AutoAWQMoEMethod.__init__` now selects its backend via `select_wna16_moe_backend`, and the oracle's XPU priority list routes to `XPUExpertsWNA16`. The capability-gate ValueError fixed here is what remains of that code path on `main`, and it is what the reporter hit after applying the #54349 patch locally.

## Test Plan
Added unit tests in `tests/quantization/test_moe_wna16.py` that monkeypatch `current_platform` (existing convention in the test suite):

- `MoeWNA16Config(linear_quant_method="awq")` constructs successfully on XPU (capability `None`)
- `MoeWNA16Config.__init__` still rejects AWQ below `min_capability` (70) and accepts at the boundary (75) on CUDA-like platforms, including the `None` → reject case
- `is_moe_wna16_compatible` returns True for AWQ on XPU; GPTQ unaffected
- `is_moe_wna16_compatible` capability-gate semantics unchanged on CUDA-like platforms

```
$ pytest tests/quantization/test_moe_wna16.py -q
20 passed, 5 skipped
```

Both new XPU tests fail on `main` without the fix (`ValueError` / `assert False`).

End-to-end verification on real XPU hardware (Intel Arc Pro B60, both patches applied on top of the 0.21.0-xpu image) was done by the issue reporter in #54350: `QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ` loads all 48 MoE layers and serves coherent completions and tool calls via the OpenAI-compatible API.

