### PR TITLE
[Rust Frontend] Add MiMo tool parser

### DIFF
--- a/rust/src/chat/src/parser/tool/mod.rs
+++ b/rust/src/chat/src/parser/tool/mod.rs
@@ -44,6 +44,7 @@ pub mod names {
     pub const QWEN3_CODER: &str = "qwen3_coder";
     pub const QWEN3_XML: &str = "qwen3_xml";
     pub const SEED_OSS: &str = "seed_oss";
+    pub const MIMO: &str = "mimo";
 }
 
 /// Constructor signature for one registered tool parser implementation.
@@ -90,6 +91,7 @@ impl ToolParserFactory {
             .register_parser::<Phi4MiniJsonToolParser>(names::PHI4_MINI_JSON)
             .register_parser::<Qwen3XmlToolParser>(names::QWEN3_XML)
             .register_parser::<Qwen3CoderToolParser>(names::QWEN3_CODER)
+            .register_parser::<Qwen3XmlToolParser>(names::MIMO)
             .register_parser::<SeedOssToolParser>(names::SEED_OSS);
 
         factory
@@ -131,7 +133,8 @@ impl ToolParserFactory {
             .register_pattern("minimax", names::MINIMAX_M2)
             .register_pattern("mm-m2", names::MINIMAX_M2)
             .register_pattern("seed-oss", names::SEED_OSS)
-            .register_pattern("seedoss", names::SEED_OSS);
+            .register_pattern("seedoss", names::SEED_OSS)
+            .register_pattern("mimo", names::MIMO);
 
         factory
     }

--- a/rust/src/chat/src/parser/tool/tests.rs
+++ b/rust/src/chat/src/parser/tool/tests.rs
@@ -97,6 +97,24 @@ fn factory_distinguishes_qwen_tool_formats() {
 }
 
 #[test]
+fn factory_routes_mimo_models_to_qwen3_xml_format() {
+    let factory = ToolParserFactory::new();
+
+    for model in [
+        "XiaomiMiMo/MiMo-7B-RL",
+        "XiaomiMiMo/MiMo-V2-Flash",
+        "XiaomiMiMo/MiMo-V2.5-Pro",
+        "XiaomiMiMo/MiMo-V2.5-Omni",
+    ] {
+        assert_eq!(
+            factory.resolve_name_for_model(model),
+            Some(names::MIMO),
+            "{model}"
+        );
+    }
+}
+
+#[test]
 fn factory_parses_qwen2_5_coder_template_with_hermes() {
     let factory = ToolParserFactory::new();
     let tool_call = r#"<tool_call>


### PR DESCRIPTION
## Summary
- register `mimo` as a tool-call parser name in the Rust frontend's `ToolParserFactory`, resolving to the existing `Qwen3XmlToolParser`
- add `mimo` model-ID pattern matching (`XiaomiMiMo/...`) so MiMo models auto-resolve to that parser without an explicit `--tool-call-parser` override
- add a roundtrip-style resolution test covering the original MiMo-7B-RL model plus all three MiMo-V2 variants (Flash, V2.5-Pro, V2.5-Omni)

## Why
MiMo has no tool-call format of its own — it reuses Qwen3's plain XML tool-calling format. Python's frontend already aliases `--tool-call-parser mimo` to the same underlying implementation used for `qwen3_xml` (`vllm/tool_parsers/__init__.py`), so this ports that mapping decision to Rust rather than adding new parsing logic. No new parser implementation was needed — `Qwen3XmlToolParser` already exists and is fully tested.

## Duplicate-work check
This does not duplicate an existing PR. I checked roadmap issue #44280 and all open `rust`-labeled PRs immediately before submission; no open PR touches the MiMo tool parser. #49578 ("Add MiMo reasoning parser") covers the separate reasoning-parser side and does not overlap with this change.

## Testing
Passed:
```text
cargo fmt -p vllm-chat -- --check
cargo test -p vllm-chat 
cargo clippy -p vllm-chat --all-targets -- -D warnings
```

## Model evaluation
No model-generation evaluation was run because this change only registers an existing, already-tested parser under an additional name/pattern — it does not alter parsing logic, inference, sampling, or model execution. Coverage is the model-ID resolution test added in this PR, plus the existing `Qwen3XmlToolParser` test suite that this change reuses unmodified.

## AI assistance
Claude (Anthropic) was used to assist with research, code review, and debugging. The human submitter is responsible for reviewing every changed line and defending the change end-to-end.

Related: #44280