### PR TITLE
[Bugfix] Use nixl package on HCU

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -47,6 +47,10 @@ from vllm.distributed.kv_transfer.kv_transfer_state import (
     ensure_kv_transfer_shutdown,
     has_kv_transfer_group,
 )
+from vllm.distributed.nixl_utils import (
+    _get_nixl_module_name,
+    is_nixl_available,
+)
 from vllm.forward_context import ForwardContext
 from vllm.outputs import RequestOutput
 from vllm.platforms import current_platform
@@ -203,21 +207,18 @@ class FakeNixlWrapper:
 def _make_fake_nixl_pkg():
     """Context manager that creates a temporary package making
        `from nixl._api import nixl_agent` resolve to our FakeNixlWrapper.
-       Also creates rixl package for ROCm compatibility.
 
     Automatically cleans up the temporary directory when done.
     """
     with tempfile.TemporaryDirectory() as td:
-        # Create both nixl and rixl packages for cross-platform compatibility
-        for pkg_name in ["nixl", "rixl"]:
-            pkg_root = os.path.join(td, pkg_name, "_api")
-            os.makedirs(pkg_root, exist_ok=True)
+        pkg_root = os.path.join(td, "nixl", "_api")
+        os.makedirs(pkg_root, exist_ok=True)
 
-            # Get the source code of FakeNixlWrapper class and dedent it
-            fake_nixl_source = inspect.getsource(FakeNixlWrapper)
-            fake_nixl_source = textwrap.dedent(fake_nixl_source)
+        # Get the source code of FakeNixlWrapper class and dedent it
+        fake_nixl_source = inspect.getsource(FakeNixlWrapper)
+        fake_nixl_source = textwrap.dedent(fake_nixl_source)
 
-            stub = f"""\
+        stub = f"""\
 # Copy of FakeNixlWrapper implementation for Ray workers
 import uuid
 from collections import defaultdict
@@ -227,18 +228,27 @@ from collections import defaultdict
 # Export as nixl_agent
 nixl_agent = FakeNixlWrapper
 """
-            with open(os.path.join(pkg_root, "__init__.py"), "w") as f:
-                f.write(stub)
+        with open(os.path.join(pkg_root, "__init__.py"), "w") as f:
+            f.write(stub)
 
-            # Mock nixlXferTelemetry class
-            pkg_root2 = os.path.join(td, pkg_name, "_bindings")
-            os.makedirs(pkg_root2, exist_ok=True)
-            with open(os.path.join(pkg_root2, "__init__.py"), "w") as f:
-                f.write("class nixlXferTelemetry: pass")
-            # touch parent package
-            open(os.path.join(td, pkg_name, "__init__.py"), "w").close()
+        # Mock nixlXferTelemetry class
+        pkg_root2 = os.path.join(td, "nixl", "_bindings")
+        os.makedirs(pkg_root2, exist_ok=True)
+        with open(os.path.join(pkg_root2, "__init__.py"), "w") as f:
+            f.write("class nixlXferTelemetry: pass")
+        # touch parent package
+        open(os.path.join(td, "nixl", "__init__.py"), "w").close()
 
         yield td
+
+
+def test_nixl_package_name():
+    assert _get_nixl_module_name("NixlWrapper") == "nixl._api"
+    assert _get_nixl_module_name("nixlXferTelemetry") == "nixl._bindings"
+
+    with patch("importlib.util.find_spec", return_value=None) as find_spec:
+        assert not is_nixl_available()
+        find_spec.assert_called_once_with("nixl")
 
 
 def test_basic_interface():

--- a/vllm/distributed/nixl_utils.py
+++ b/vllm/distributed/nixl_utils.py
@@ -7,7 +7,6 @@ import sys
 from typing import Any
 
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -21,7 +20,7 @@ def _maybe_set_ucx_rcache_limit() -> None:
     if "UCX_RCACHE_MAX_UNRELEASED" in os.environ:
         return
 
-    if "nixl" in sys.modules or "rixl" in sys.modules:
+    if "nixl" in sys.modules:
         logger.warning_once(
             "NIXL was already imported, we can't reset "
             "UCX_RCACHE_MAX_UNRELEASED. "
@@ -37,10 +36,9 @@ def _maybe_set_ucx_rcache_limit() -> None:
 
 
 def _get_nixl_module_name(name: str) -> str:
-    package_name = "rixl" if current_platform.is_rocm() else "nixl"
     if name == "nixlXferTelemetry":
-        return f"{package_name}._bindings"
-    return f"{package_name}._api"
+        return "nixl._bindings"
+    return "nixl._api"
 
 
 def _load_nixl_attr(name: str) -> Any:
@@ -80,10 +78,10 @@ def __getattr__(name: str) -> Any:
 
 
 def is_nixl_available() -> bool:
-    """Lightweight check for nixl/rixl package without importing it."""
+    """Lightweight check for the nixl package without importing it."""
     import importlib.util
 
-    pkg = "rixl" if current_platform.is_rocm() else "nixl"
+    pkg = "nixl"
     return importlib.util.find_spec(pkg) is not None
 
 


### PR DESCRIPTION
## Summary

HCU identifies as ROCm through `current_platform.is_rocm()`, but its installed Python package is `nixl`, not `rixl`. Always resolve NIXL imports and availability checks through `nixl`, and update the fake-package fixture and regression assertions accordingly.

## Validation

- `python3 -m compileall -q vllm/distributed/nixl_utils.py tests/v1/kv_connector/unit/test_nixl_connector.py`
- Focused package-selection checks for `nixl._api`, `nixl._bindings`, and `find_spec("nixl")`

Full pytest collection was unavailable locally because the existing `tblib` test dependency is not installed.