### PR TITLE
[Prefix Cache] Support fine-grained SWA hits

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -14,6 +14,7 @@ import torch
 from tests.v1.core.test_prefix_caching import make_kv_cache_manager, make_request
 from vllm.distributed.kv_transfer.kv_connector.v1.base import SupportsHMA
 from vllm.utils.hashing import sha256
+from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
     KVCacheBlockCopy,
     get_block_hash,
@@ -21,6 +22,7 @@ from vllm.v1.core.kv_cache_utils import (
     init_none_hash,
 )
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KpoolTailSpec,
@@ -1798,13 +1800,101 @@ def test_hybrid_partial_hit_with_eagle_stays_within_group_blocks():
     assert manager.allocate_slots(req1, 4, num_computed, computed_blocks) is not None
 
 
-def test_hybrid_sliding_window_group_disables_partial_hash_hits():
+def test_hybrid_sliding_window_group_supports_partial_hash_hits():
     hash_block_size = 2
     sliding_window_block_size = 2 * hash_block_size
     mamba_block_size = 2 * sliding_window_block_size
+    manager = _make_swa_eagle_mamba_manager(
+        hash_block_size,
+        sliding_window_block_size,
+        mamba_block_size,
+        use_eagle=False,
+    )
+
+    tokens = list(range(mamba_block_size + hash_block_size))
+    request = make_request("0", tokens, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
+    assert manager.coordinator.enable_partial_hash_hits
+    assert (
+        manager.allocate_slots(request, mamba_block_size, num_computed, computed_blocks)
+        is not None
+    )
+    request.num_computed_tokens = mamba_block_size
+    manager.new_step_starts()
+    assert manager.allocate_slots(request, len(tokens) - mamba_block_size) is not None
+    request.num_computed_tokens = len(tokens)
+    manager.free(request)
+    manager.new_step_starts()
+
+    cached_request = make_request(
+        "1", tokens + [len(tokens), len(tokens) + 1], hash_block_size, sha256
+    )
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(cached_request)
+
+    assert num_computed == len(tokens)
+    assert len(computed_blocks.blocks[0]) * hash_block_size == num_computed
+    swa_source = computed_blocks.blocks[2][-1]
+    assert (
+        manager.allocate_slots(cached_request, 2, num_computed, computed_blocks)
+        is not None
+    )
+    copies, retained = manager.take_kv_cache_block_copies()
+    swa_tail = manager.get_blocks(cached_request.request_id).blocks[2][-1]
+    assert KVCacheBlockCopy(swa_source.block_id, swa_tail.block_id) in copies
+    manager.block_pool.free_blocks(retained)
+
+
+def test_hybrid_sliding_fine_retains_scheduler_fallback():
+    """Fine SWA retention must not discard the previous coarse hit.
+
+    Full attention can reach the 12-token hash boundary, but align-mode Mamba
+    rewinds the joint hit to 8. The SWA producer must retain both page spans so
+    reconciliation can use 8 instead of collapsing to zero.
+    """
+    hash_block_size = 2
+    sliding_window_block_size = 2 * hash_block_size
+    mamba_block_size = 2 * sliding_window_block_size
+    manager = _make_swa_eagle_mamba_manager(
+        hash_block_size,
+        sliding_window_block_size,
+        mamba_block_size,
+        use_eagle=False,
+        retention_interval=0,
+    )
+
+    tokens = list(range(14))
+    owner = make_request("owner", tokens, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(owner)
+    assert manager.coordinator.enable_partial_hash_hits
+    assert manager.coordinator.retention_interval == 0
+    assert (
+        manager.allocate_slots(owner, mamba_block_size, num_computed, computed_blocks)
+        is not None
+    )
+    owner.num_computed_tokens = mamba_block_size
+    manager.new_step_starts()
+    assert manager.allocate_slots(owner, len(tokens) - mamba_block_size) is not None
+    owner.num_computed_tokens = len(tokens)
+    manager.free(owner)
+    manager.new_step_starts()
+
+    replay = make_request("replay", tokens, hash_block_size, sha256)
+    _, num_computed, _ = manager.get_computed_blocks(replay)
+    assert num_computed == mamba_block_size, num_computed
+
+
+def _make_swa_eagle_mamba_manager(
+    hash_block_size: int,
+    sliding_window_block_size: int,
+    mamba_block_size: int,
+    use_eagle: bool = True,
+    retention_interval: int | None = None,
+):
+    """Full + align-mode Mamba + an optional EAGLE SWA draft group."""
     kv_cache_config = KVCacheConfig(
-        num_blocks=64,
+        num_blocks=128,
         kv_cache_tensors=[],
+        prefix_cache_retention_interval=retention_interval,
         kv_cache_groups=[
             KVCacheGroupSpec(
                 ["full"],
@@ -1833,40 +1923,283 @@ def test_hybrid_sliding_window_group_disables_partial_hash_hits():
                     dtype=torch.float32,
                     sliding_window=sliding_window_block_size,
                 ),
-                is_eagle_group=True,
+                is_eagle_group=use_eagle,
             ),
         ],
     )
-    manager = make_kv_cache_manager(
+    return make_kv_cache_manager(
         kv_cache_config=kv_cache_config,
         max_model_len=8192,
         enable_caching=True,
         hash_block_size=hash_block_size,
-        use_eagle=True,
+        use_eagle=use_eagle,
     )
 
-    tokens = list(range(3 * sliding_window_block_size))
-    request = make_request("0", tokens, hash_block_size, sha256)
-    computed_blocks, num_computed, _ = manager.get_computed_blocks(request)
-    assert not manager.coordinator.enable_partial_hash_hits
+
+def _run_swa_eagle_replay(manager, hash_block_size: int, mamba_block_size: int) -> int:
+    """Prefill a producer in two chunks, free it, and replay a longer request."""
+    tokens = list(range(22))
+    owner = make_request("owner", tokens, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(owner)
     assert (
-        manager.allocate_slots(request, mamba_block_size, num_computed, computed_blocks)
+        manager.allocate_slots(owner, mamba_block_size, num_computed, computed_blocks)
         is not None
     )
-    request.num_computed_tokens = mamba_block_size
+    owner.num_computed_tokens = mamba_block_size
     manager.new_step_starts()
-    assert manager.allocate_slots(request, len(tokens) - mamba_block_size) is not None
-    request.num_computed_tokens = len(tokens)
-    manager.free(request)
+    assert manager.allocate_slots(owner, len(tokens) - mamba_block_size) is not None
+    owner.num_computed_tokens = len(tokens)
+    manager.free(owner)
     manager.new_step_starts()
 
-    cached_request = make_request(
-        "1", tokens + [len(tokens), len(tokens) + 1], hash_block_size, sha256
+    replay = make_request("replay", tokens + [22, 23], hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(replay)
+    assert manager.coordinator.enable_partial_hash_hits
+    assert manager.allocate_slots(replay, 2, num_computed, computed_blocks) is not None
+    return num_computed
+
+
+def test_hybrid_sliding_eagle_converges_to_mamba_checkpoint():
+    """A fine EAGLE boundary can sit between restorable Mamba states.
+
+    The peek must span one SWA page, not one hash unit: a shorter peek misses
+    the next matchable endpoint and reconciliation rewinds to zero.
+    """
+    hash_block_size = 2
+    sliding_window_block_size = 2 * hash_block_size
+    mamba_block_size = 2 * sliding_window_block_size
+    manager = _make_swa_eagle_mamba_manager(
+        hash_block_size, sliding_window_block_size, mamba_block_size
     )
-    computed_blocks, num_computed, _ = manager.get_computed_blocks(cached_request)
 
-    assert num_computed == mamba_block_size
-    assert len(computed_blocks.blocks[0]) * hash_block_size == num_computed
+    # SWA hits walk 18 -> 8 -> 8 and settle on the Mamba checkpoint.
+    assert (
+        _run_swa_eagle_replay(manager, hash_block_size, mamba_block_size)
+        == mamba_block_size
+    )
+
+
+def test_sliding_window_fine_hit_validates_physical_page_span():
+    hash_block_size = 2
+    block_size = 4
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=6,
+    )
+    pool = BlockPool(
+        num_gpu_blocks=16,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    request = make_request("owner", list(range(12)), hash_block_size, sha256)
+    blocks = pool.get_new_blocks(3)
+    pool.cache_full_blocks(request, blocks, 0, 2, block_size, 0)
+    pool.cache_partial_block(request, blocks[2], 10, 0, block_size)
+
+    def find(drop_eagle_block: bool):
+        return SlidingWindowManager.find_longest_cache_hit(
+            block_hashes=request.block_hashes,
+            max_length=10,
+            kv_cache_group_ids=[0],
+            block_pool=pool,
+            kv_cache_spec=spec,
+            drop_eagle_block=drop_eagle_block,
+            alignment_tokens=hash_block_size,
+        )
+
+    hit_blocks, hit_length = find(False)
+    assert hit_length == 10
+    assert [block.block_id for block in hit_blocks[0]] == [
+        pool.null_block.block_id,
+        blocks[1].block_id,
+        blocks[2].block_id,
+    ]
+
+    # The eagle peek drops one SWA page from endpoint 10.
+    hit_blocks, hit_length = find(True)
+    assert hit_length == 6
+    assert [block.block_id for block in hit_blocks[0]] == [
+        blocks[0].block_id,
+        blocks[1].block_id,
+    ]
+
+    # A live endpoint is insufficient after an interior window page is evicted.
+    pool._maybe_evict_cached_block(blocks[1])
+    _, hit_length = find(False)
+    assert hit_length == 4
+
+
+def test_sliding_window_publishes_latest_reachable_partial_endpoint():
+    hash_block_size = 2
+    block_size = 6
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=6,
+    )
+    pool = BlockPool(
+        num_gpu_blocks=8,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    manager = SlidingWindowManager(
+        spec,
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+    request = make_request("owner", list(range(10)), hash_block_size, sha256)
+    blocks = pool.get_new_blocks(2)
+    manager.req_to_blocks[request.request_id] = blocks
+
+    manager.cache_blocks(request, num_tokens=10)
+
+    # Lookup is capped at N - 1, so an N-aligned prompt also publishes endpoint
+    # 8. Endpoint 10 remains useful to a longer consumer that shares the full
+    # producer prompt; both aliases point at the same physical page.
+    assert pool.get_cached_block(request.block_hashes[3], [0]) == [blocks[1]]
+    assert pool.get_cached_block(request.block_hashes[4], [0]) == [blocks[1]]
+
+    manager.use_eagle = True
+    request.shared_prefix_boundary = 10
+    # Endpoint 8 minus one SWA page is the replay cap. A shared-prefix boundary
+    # is already a reconciled hit and must not be dropped again.
+    # Sparse retention also protects the old scheduler-aligned fallback.
+    assert manager._reachable_hit_boundaries(request) == [2, 10, 6]
+
+
+def test_sliding_window_fine_retention_pins_physical_page_span():
+    hash_block_size = 2
+    block_size = 4
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=6,
+    )
+
+    def retained(boundary: int, use_eagle: bool):
+        mask = SlidingWindowManager.reachable_block_mask(
+            start_block=0,
+            end_block=4,
+            alignment_tokens=hash_block_size,
+            kv_cache_spec=spec,
+            use_eagle=use_eagle,
+            retention_interval=0,
+            reachable_boundaries=(boundary,),
+        )
+        assert mask is not None
+        return {idx for idx, keep in enumerate(mask) if keep}
+
+    # Reachable boundaries passed to the mask are actual hit positions. The
+    # 8-token non-EAGLE hit's six-token SWA span intersects pages 0-1.
+    assert retained(8, use_eagle=False) == {0, 1}
+    # The 6-token EAGLE hit is proved by endpoint 10, whose page 2 is pinned on
+    # top of the window pages 0-1.
+    assert retained(6, use_eagle=True) == {0, 1, 2}
+    # A shared-prefix junction is already a post-reconciliation hit. The
+    # 10-token hit spans pages 1-2 and its endpoint-14 proof adds page 3.
+    assert retained(10, use_eagle=True) == {1, 2, 3}
+    assert retained(10, use_eagle=False) == {1, 2}
+
+
+def _sliding_window_spec(block_size: int, sliding_window: int) -> SlidingWindowSpec:
+    return SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=sliding_window,
+    )
+
+
+def test_sliding_window_fine_lookup_rewinds_past_incomplete_spans():
+    hash_block_size = 2
+    block_size = 4
+    spec = _sliding_window_spec(block_size, sliding_window=6)
+
+    def run_one_case(
+        num_pages: int,
+        partial_at: int | None,
+        evict_page: int | None,
+        expected: int,
+    ) -> None:
+        pool = BlockPool(
+            num_gpu_blocks=16,
+            enable_caching=True,
+            hash_block_size=hash_block_size,
+        )
+        request = make_request("owner", list(range(12)), hash_block_size, sha256)
+        blocks = pool.get_new_blocks(3)
+        pool.cache_full_blocks(request, blocks, 0, num_pages, block_size, 0)
+        if partial_at is not None:
+            pool.cache_partial_block(
+                request, blocks[partial_at // block_size], partial_at, 0, block_size
+            )
+        if evict_page is not None:
+            pool._maybe_evict_cached_block(blocks[evict_page])
+        _, hit_length = SlidingWindowManager.find_longest_cache_hit(
+            block_hashes=request.block_hashes,
+            max_length=11,
+            kv_cache_group_ids=[0],
+            block_pool=pool,
+            kv_cache_spec=spec,
+            drop_eagle_block=False,
+            alignment_tokens=hash_block_size,
+        )
+        assert hit_length == expected
+
+    # Sparse endpoint 10 is usable: its window [5, 10) covers cached pages 1-2.
+    run_one_case(3, 10, None, 10)
+    # Evicting interior page 1 kills endpoint 10 and endpoint 8; the scan must
+    # rewind to page boundary 4 rather than claim a hit with a hole in it.
+    run_one_case(3, 10, 1, 4)
+    # Without a partial entry the deepest endpoint is a page boundary.
+    run_one_case(2, None, None, 8)
+    run_one_case(0, None, None, 0)
+
+
+def test_sliding_window_partial_tail_skips_null_blocks():
+    """Blocks below the window are nulled out, and cannot back an alias."""
+    hash_block_size = 2
+    block_size = 6
+    pool = BlockPool(
+        num_gpu_blocks=8, enable_caching=True, hash_block_size=hash_block_size
+    )
+    manager = SlidingWindowManager(
+        _sliding_window_spec(block_size, sliding_window=6),
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+    )
+    request = make_request("owner", list(range(10)), hash_block_size, sha256)
+    blocks = pool.get_new_blocks(1)
+    manager.req_to_blocks[request.request_id] = [blocks[0], pool.null_block]
+
+    manager.cache_blocks(request, num_tokens=10)
+
+    assert pool.get_cached_block(request.block_hashes[4], [0]) is None
+
+
+def test_sliding_window_dense_retention_below_page_keeps_every_block():
+    """A sub-page segment cannot express a tail, so nothing may be skipped."""
+    mask = SlidingWindowManager.reachable_block_mask(
+        start_block=0,
+        end_block=4,
+        alignment_tokens=2,
+        kv_cache_spec=_sliding_window_spec(block_size=4, sliding_window=6),
+        use_eagle=False,
+        retention_interval=None,
+    )
+    assert mask is None
 
 
 def test_opted_out_scratch_group_keeps_partial_hash_hits():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py
@@ -251,6 +251,35 @@ def test_coordinator_fine_grained_clips_when_one_group_missing_tail():
     assert hit == 32
 
 
+def test_coordinator_fine_swa_eagle_reaches_mamba_checkpoint():
+    """The external-store mirror uses the SWA page-sized EAGLE peek too."""
+    hash_block_size = 2
+    groups = [
+        KVCacheGroupSpec(["full"], _full(hash_block_size)),
+        KVCacheGroupSpec(["mamba"], _mamba_align(8)),
+        KVCacheGroupSpec(
+            ["swa"],
+            _swa(block_size=4, sliding_window=4),
+            is_eagle_group=True,
+        ),
+    ]
+    coord = _make_coord(groups, hash_block_size, use_eagle=True)
+    hs = _hashes(12)
+
+    # Full attention has every fine boundary through token 22. Sparse Mamba
+    # retention keeps token 8 and the prompt tail, while SWA keeps its physical
+    # pages and prompt-tail alias. Reconciliation must land on token 8.
+    exists = {(0, bytes(h)) for h in hs[:11]}
+    exists |= {(1, bytes(hs[i])) for i in (3, 10)}
+    exists |= {(2, bytes(hs[i])) for i in (1, 3, 5, 7, 9, 10)}
+    _masks, hit = coord.find_longest_cache_hit(
+        hs,
+        max_length=23,
+        cached_block_pool=ExternalCachedBlockPool(hash_block_size, exists),
+    )
+    assert hit == 8
+
+
 # ----- store_mask -----
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -384,12 +384,8 @@ class MooncakeStoreCoordinator:
                 # never drops a block, so a widened bound would match past the
                 # attention-verified hit and resume from speculative state (#43559).
                 if drop_eagle_block and not isinstance(spec, MambaSpec):
-                    eagle_margin = (
-                        self.hash_block_size
-                        if self.enable_partial_hash_hits
-                        and manager_cls.supports_fine_grained_hash_lookup
-                        and spec.block_size > self.hash_block_size
-                        else spec.block_size
+                    eagle_margin = manager_cls.eagle_drop_tokens(
+                        spec.block_size, alignment_tokens
                     )
                     _max_length = min(curr_hit_length + eagle_margin, max_length)
                 hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -846,18 +846,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 drop_eagle_block = use_eagle and idx not in eagle_verified
 
                 _max_length = curr_hit_length
-                # Eagle matches one extra drop unit (one hash unit for
-                # fine-grained managers, else one cache block) and then drops
-                # it, landing back at the candidate length. No margin for
+                # Eagle matches one extra manager-specific replay unit and then
+                # drops it, landing back at the candidate length. No margin for
                 # mamba: its finder never drops (draft models have no mamba
                 # layers), so the hit would grow past the candidate.
                 if drop_eagle_block and not isinstance(spec, MambaSpec):
-                    eagle_margin = (
-                        self.hash_block_size
-                        if self.enable_partial_hash_hits
-                        and manager_cls.supports_fine_grained_hash_lookup
-                        and group_block_size > self.hash_block_size
-                        else group_block_size
+                    eagle_margin = manager_cls.eagle_drop_tokens(
+                        group_block_size, self._cache_hit_alignment_tokens
                     )
                     _max_length = min(
                         curr_hit_length + eagle_margin, max_cache_hit_length

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -469,11 +469,8 @@ class SingleTypeKVCacheManager(ABC):
             return
 
         # Token boundaries whose reachable tail must be retained under sparse
-        # retention: the replay boundary (``num_prompt - 1``, capped by
-        # ``get_computed_blocks``) and any detected shared-prefix junction.
-        reachable_boundaries = [request.num_prompt_tokens - 1]
-        if request.shared_prefix_boundary:
-            reachable_boundaries.append(request.shared_prefix_boundary)
+        # retention: the replay hit and any shared-prefix junction.
+        reachable_boundaries = self._reachable_hit_boundaries(request)
 
         block_mask = self.reachable_block_mask(
             start_block=num_cached_blocks,
@@ -496,6 +493,54 @@ class SingleTypeKVCacheManager(ABC):
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks
+
+    def _partial_tail_boundaries(self, request: Request) -> tuple[int, ...]:
+        """Prefix lengths to publish as partial entries inside a cache block.
+
+        Empty (the default) disables partial-tail publication for the type.
+        """
+        return ()
+
+    def _publish_partial_tail(self, request: Request, num_tokens: int) -> None:
+        """Make prompt-tail prefixes that end inside a cache block reachable.
+
+        Callers opt in from their own ``cache_blocks``; the base never calls
+        this. Whether a mid-block prefix is replayable is type-specific, so the
+        decision stays with each manager.
+        """
+        if self.block_size == self.block_pool.hash_block_size:
+            return
+        boundaries = self._partial_tail_boundaries(request)
+        if not boundaries:
+            return
+
+        blocks = self.req_to_blocks[request.request_id]
+        # Deepest prefix first: it stays the block's primary hash and the
+        # shallower ones attach as aliases rather than evicting it.
+        for boundary_tokens in sorted(set(boundaries), reverse=True):
+            if (
+                boundary_tokens <= 0
+                or boundary_tokens > num_tokens
+                or boundary_tokens % self.block_size == 0
+            ):
+                continue
+            block_idx = boundary_tokens // self.block_size
+            # RSWA nulls out blocks that fall behind its window; never alias one.
+            if block_idx >= len(blocks) or blocks[block_idx].is_null:
+                continue
+            self.block_pool.cache_partial_block(
+                request=request,
+                block=blocks[block_idx],
+                num_tokens=boundary_tokens,
+                kv_cache_group_id=self.kv_cache_group_id,
+                block_size=self.block_size,
+            )
+
+    def _reachable_hit_boundaries(self, request: Request) -> list[int]:
+        boundaries = [request.num_prompt_tokens - 1]
+        if request.shared_prefix_boundary:
+            boundaries.append(request.shared_prefix_boundary)
+        return boundaries
 
     @classmethod
     def reachable_block_mask(
@@ -563,6 +608,19 @@ class SingleTypeKVCacheManager(ABC):
         """
 
         raise NotImplementedError
+
+    @classmethod
+    def eagle_drop_tokens(cls, block_size: int, alignment_tokens: int) -> int:
+        """Tokens the eagle peek drops from a matched endpoint.
+
+        The coordinator widens its lookup bound by this amount so the peek can
+        still land on the candidate length. Managers may override this when
+        their usable proof endpoints have a coarser replay quantum than their
+        hash lookup alignment.
+        """
+        if cls.supports_fine_grained_hash_lookup and alignment_tokens < block_size:
+            return alignment_tokens
+        return block_size
 
     @classmethod
     @abstractmethod
@@ -810,40 +868,13 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         retention_interval: int | None = None,
     ) -> None:
         super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        self._publish_partial_tail(request, num_tokens)
+
+    def _partial_tail_boundaries(self, request: Request) -> tuple[int, ...]:
+        # Only the final prompt hash boundary; intermediate hash boundaries
+        # inside the same cache block are intentionally skipped.
         hash_block_size = self.block_pool.hash_block_size
-        if self.block_size == hash_block_size:
-            return
-        self._cache_partial_tail_block(request, num_tokens)
-
-    def _cache_partial_tail_block(
-        self,
-        request: Request,
-        num_tokens: int,
-    ) -> None:
-        """Cache the prompt tail when it ends inside a cache block.
-
-        Only the final prompt hash boundary is registered as a partial
-        prefix-cache entry; intermediate hash boundaries inside the same cache
-        block are intentionally skipped.
-        """
-        hash_block_size = self.block_pool.hash_block_size
-        boundary_tokens = request.num_prompt_tokens // hash_block_size * hash_block_size
-        if boundary_tokens == 0 or boundary_tokens > num_tokens:
-            return
-        if boundary_tokens % self.block_size == 0:
-            return
-
-        blocks = self.req_to_blocks[request.request_id]
-        block_idx = boundary_tokens // self.block_size
-        if block_idx >= len(blocks):
-            return
-        self.block_pool.cache_partial_block(
-            request=request,
-            block=blocks[block_idx],
-            num_tokens=boundary_tokens,
-            kv_cache_group_id=self.kv_cache_group_id,
-            block_size=self.block_size,
-        )
+        return (request.num_prompt_tokens // hash_block_size * hash_block_size,)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         blocks = self.req_to_blocks[running_request_id]
@@ -903,6 +934,8 @@ class RSWAManager(FullAttentionManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
+    supports_fine_grained_hash_lookup: ClassVar[bool] = True
+
     def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
@@ -910,6 +943,39 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # multi-module MTP store-side lag can still reconstruct the window from
         # cached blocks.
         self.extra_retained_tokens = kv_cache_spec.extra_retained_tokens
+
+    @classmethod
+    def eagle_drop_tokens(cls, block_size: int, alignment_tokens: int) -> int:
+        # Sparse prompt-tail aliases do not exist at every hash boundary. A
+        # physical-page peek always reaches a page endpoint that can prove the
+        # post-drop SWA window, including after fixed-point reconciliation.
+        return block_size
+
+    def _reachable_hit_boundaries(self, request: Request) -> list[int]:
+        boundaries = super()._reachable_hit_boundaries(request)
+        hash_block_size = self.block_pool.hash_block_size
+        if hash_block_size >= self.block_size:
+            return boundaries
+
+        # The lookup is capped at ``num_prompt_tokens - 1``. Convert that cap to
+        # the actual reusable hit before handing it to retention; shared prefix
+        # boundaries are already post-reconciliation hit positions.
+        endpoint = boundaries[0] // hash_block_size * hash_block_size
+        replay_hit = endpoint - self.block_size if self.use_eagle else endpoint
+        boundaries[0] = max(0, replay_hit)
+
+        # A different hybrid group can still rewind reconciliation to the
+        # scheduler-aligned hit that was reachable before fine lookup was
+        # enabled. Keep its SWA page span as a compatibility floor; otherwise
+        # sparse retention can turn an existing coarse hit into a miss.
+        coarse_hit = (
+            (request.num_prompt_tokens - 1)
+            // self.scheduler_block_size
+            * self.scheduler_block_size
+        )
+        if coarse_hit not in boundaries:
+            boundaries.append(coarse_hit)
+        return boundaries
 
     @classmethod
     def _contiguous_blocks_for_hit(
@@ -942,9 +1008,21 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size == 1, "DCP not support sliding window attn now."
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        # Sliding-window cache hits must stay at the group's physical block
-        # granularity. resolve_block_hashes() converts finer-grained hashes to
-        # that view when the hybrid-cache alignment is smaller than block_size.
+        block_size = kv_cache_spec.block_size
+        if alignment_tokens < block_size:
+            assert block_size % alignment_tokens == 0
+            assert alignment_tokens == block_pool.hash_block_size
+            return cls._find_fine_grained_cache_hit(
+                block_hashes=block_hashes,
+                max_length=max_length,
+                kv_cache_group_ids=kv_cache_group_ids,
+                block_pool=block_pool,
+                kv_cache_spec=kv_cache_spec,
+                drop_eagle_block=drop_eagle_block,
+                alignment_tokens=alignment_tokens,
+            )
+
+        assert alignment_tokens % block_size == 0
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,
@@ -968,7 +1046,6 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             [block_pool.null_block] * max_num_blocks
             for _ in range(len(kv_cache_group_ids))
         )
-        block_size = kv_cache_spec.block_size
         num_contiguous_blocks = 0
         match_found = False
         # Search from right to left and early stop when a match is found.
@@ -1023,6 +1100,98 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         return computed_blocks, hit_length
 
     @classmethod
+    def _find_fine_grained_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: SlidingWindowSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        """Find a hash-granularity SWA hit backed by physical cache pages.
+
+        Candidate endpoints are the physical pages and the sparse partial-block
+        entries published by producers. An endpoint is usable only when every
+        physical page intersecting the post-eagle sliding window is still
+        cached. Returned lists stay in physical-page units, with nulls
+        preserving global block table indices before the live window.
+        """
+        assert isinstance(block_hashes, Sequence)
+        block_size = kv_cache_spec.block_size
+        max_endpoint = (
+            min(
+                max_length // alignment_tokens,
+                len(block_hashes),
+            )
+            * alignment_tokens
+        )
+        eagle_drop = (
+            cls.eagle_drop_tokens(block_size, alignment_tokens)
+            if drop_eagle_block
+            else 0
+        )
+
+        for endpoint in range(max_endpoint, eagle_drop, -alignment_tokens):
+            endpoint_hash = block_hashes[endpoint // alignment_tokens - 1]
+            endpoint_blocks = block_pool.get_cached_block(
+                endpoint_hash, kv_cache_group_ids
+            )
+            if endpoint_blocks is None:
+                continue
+
+            hit_length = endpoint - eagle_drop
+            window_start = max(0, hit_length - (kv_cache_spec.sliding_window - 1))
+            first_page = window_start // block_size
+            end_page = cdiv(hit_length, block_size)
+            endpoint_page = (endpoint - 1) // block_size
+            computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+                [block_pool.null_block] * end_page
+                for _ in range(len(kv_cache_group_ids))
+            )
+
+            complete = True
+            for page_idx in range(first_page, end_page):
+                cached: list[KVCacheBlock] | None
+                if page_idx == endpoint_page:
+                    cached = endpoint_blocks
+                else:
+                    page_end = (page_idx + 1) * block_size
+                    page_hash = block_hashes[page_end // alignment_tokens - 1]
+                    cached = block_pool.get_cached_block(page_hash, kv_cache_group_ids)
+                if cached is None:
+                    complete = False
+                    break
+                for group_blocks, block in zip(computed_blocks, cached):
+                    group_blocks[page_idx] = block
+
+            if complete:
+                return computed_blocks, hit_length
+
+        return tuple([] for _ in kv_cache_group_ids), 0
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        super().cache_blocks(request, num_tokens, retention_interval=retention_interval)
+        self._publish_partial_tail(request, num_tokens)
+
+    def _partial_tail_boundaries(self, request: Request) -> tuple[int, ...]:
+        # floor(N / H) serves a longer consumer; floor((N - 1) / H) is the
+        # latest endpoint an immediate replay can query, since lookup is capped
+        # at N - 1.
+        hash_block_size = self.block_pool.hash_block_size
+        prompt_tokens = request.num_prompt_tokens
+        return (
+            prompt_tokens // hash_block_size * hash_block_size,
+            (prompt_tokens - 1) // hash_block_size * hash_block_size,
+        )
+
+    @classmethod
     def reachable_block_mask(
         cls,
         start_block: int,
@@ -1039,7 +1208,10 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # Fast path: when the coordinator imposes no alignment constraint.
             return None
         block_size = kv_cache_spec.block_size * dcp_world_size
-        if alignment_tokens % block_size != 0:
+        fine_grained = (
+            dcp_world_size == 1 and alignment_tokens < kv_cache_spec.block_size
+        )
+        if not fine_grained and alignment_tokens % block_size != 0:
             # The mask is block-granular, so a sub-block alignment cannot be
             # represented exactly. This happens for hybrid offloading, where
             # ``alignment_tokens`` is the full-attention chunk size and need not
@@ -1047,6 +1219,8 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # Gemma). Fall back to dense: every block is reachable, which never
             # drops a block that could serve a hit.
             return None
+        if fine_grained:
+            assert kv_cache_spec.block_size % alignment_tokens == 0
 
         # Contiguous blocks a hit needs at a boundary (incl. the EAGLE peek).
         need = cls._contiguous_blocks_for_hit(
@@ -1071,6 +1245,8 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             else (None if retention_interval == 0 else retention_interval)
         )
         if segment_tokens is not None:
+            if segment_tokens < block_size:
+                return None
             per_segment = segment_tokens // block_size
             if need >= per_segment:
                 # Every block is reachable; cache them all.
@@ -1085,10 +1261,24 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # the ``need``-block tail ending on each boundary explicitly.
         if retention_interval is not None:
             for boundary_tokens in reachable_boundaries:
-                aligned = boundary_tokens // alignment_tokens * alignment_tokens
-                end = aligned // block_size + shift
-                for j in range(max(start_block, end - need), min(end_block, end)):
-                    mask[j - start_block] = True
+                if fine_grained:
+                    hit = boundary_tokens // alignment_tokens * alignment_tokens
+                    endpoint = hit + block_size if use_eagle else hit
+                    first = (
+                        max(0, hit - (kv_cache_spec.sliding_window - 1)) // block_size
+                    )
+                    end = cdiv(hit, block_size)
+                    for j in range(max(start_block, first), min(end_block, end)):
+                        mask[j - start_block] = True
+                    if use_eagle and endpoint > 0:
+                        endpoint_page = (endpoint - 1) // block_size
+                        if start_block <= endpoint_page < end_block:
+                            mask[endpoint_page - start_block] = True
+                else:
+                    aligned = boundary_tokens // alignment_tokens * alignment_tokens
+                    end = aligned // block_size + shift
+                    for j in range(max(start_block, end - need), min(end_block, end)):
+                        mask[j - start_block] = True
 
         return mask
 


### PR DESCRIPTION
## Purpose

Fixes #53786 by allowing `SlidingWindowManager` to participate safely in
fine-grained hybrid prefix-cache lookup when its physical KV page is larger
than the configured hash unit.

Previously, one SWA group with a larger physical page disabled
`enable_partial_hash_hits` for the entire hybrid coordinator. This forced full
attention and align-mode Mamba groups back to scheduler-page alignment even
when they could reuse a finer prefix.

This PR implements the three SWA semantics requested in the issue:

- map a hash-aligned candidate to the physical SWA pages intersecting its live
  window, with null block slots preserving global block-table indices;
- use a manager-specific EAGLE/MTP replay quantum so fixed-point reconciliation
  reaches a published SWA endpoint; and
- retain and revalidate every physical page needed to reconstruct the hit,
  including the proof page used by the EAGLE/MTP drop.

It reuses `BlockPool.cache_partial_block()` for sparse prompt-tail aliases and
the existing physical-page copy-on-write path. The same manager-specific replay
quantum is used by the core and Mooncake coordinators.

### Lookup and retention invariants

For a candidate hit `p`, the worker block table remains physical-page based.
The SWA lookup accepts `p` only if every page intersecting
`[max(0, p - (sliding_window - 1)), p)` is still cached. A live endpoint alias
alone is insufficient: an evicted interior page makes the candidate a miss and
the right-to-left search continues.

Sparse retention keeps both:

1. the deepest prompt-tail fine hit; and
2. the scheduler-aligned hit that was reachable before fine lookup was enabled.

The second boundary is a compatibility floor. Another hybrid group can rewind
the shared fixed point to that boundary; without retaining its SWA page span,
enabling fine lookup can turn an existing coarse hit into a zero-token miss.

For a prompt of length `N` and hash unit `H`, SWA publishes
`floor(N/H) * H` and, when distinct, `floor((N-1)/H) * H`. The first serves a
longer consumer. The second is reachable by immediate replay because cache
lookup is capped at `N-1`.

### Why the SWA EAGLE drop is one physical page

Fine lookup alignment does not imply that a reusable SWA alias exists at every
hash boundary: aliases are sparse prompt-tail entries, while full-page
endpoints are always published. Widening by one hash unit can therefore land
between aliases during hybrid fixed-point reconciliation and walk past an
otherwise valid Mamba checkpoint. Widening and dropping by one SWA physical
page reaches a guaranteed page endpoint; lookup then validates the complete
post-drop window.

The manager-level convergence test and an implementation mutation reproduce
the fixed point:

```text
H=2, SWA page=4, Mamba page=8, prompt=22, EAGLE enabled
hash-unit SWA drop: 22 -> 20 -> 6 -> 0
page-sized SWA drop: 22 -> 18 -> 8 -> 8
```

## Measured end-to-end change

Strict A/B was rerun on one H20 after #53614 merged, using
`origin/main` at `144e79c8106da23141ac010394b782f730cc7fe8` as the baseline and
the final production diff on top. The serving topology used a Qwen3.8 27B FP8
hybrid target plus a five-layer all-SWA DFlash
draft, hash unit 16, physical SWA/Mamba page 864, and sliding window 2,048.
Each entry is the median of three cold/warm pairs; all 32-token greedy outputs
were identical within and across versions.

| prompt | version | warm cached | warm TTFT | warm total | peak HBM |
|---:|---|---:|---:|---:|---:|
| 6,000 | current main | 5,184 | 238.945 ms | 308.693 ms | 77,307 MiB |
| 6,000 | this PR | 5,184 | 237.533 ms | 313.149 ms | 77,307 MiB |
| 6,001 | current main | 5,184 | 238.541 ms | 308.711 ms | 77,307 MiB |
| 6,001 | this PR | **6,000** | **66.324 ms** | **112.682 ms** | 77,307 MiB |

At the fine boundary, this PR reuses 816 additional tokens (+15.7% versus the
baseline hit), reducing median TTFT by 72.2% and total latency by 63.5%. The
6,000-token case is the compatibility control: align-mode Mamba cannot query
its prompt-tail endpoint because lookup is capped at `N-1`, so both versions
correctly fall back to 5,184 rather than the patched SWA path collapsing to 0.

To isolate #53786 from the independent DFlash/DSpark block-drop classification
tracked by #54163, the serving A/B used
`"disable_eagle_block_drop": true`. DFlash speculative decoding and its SWA KV
group remained active; only that unrelated target-KV drop policy was disabled.
EAGLE/MTP SWA drop behavior is covered directly by the manager fixed-point and
retention tests; reverting the SWA override to the base hash-unit drop was also
verified to collapse that fixed point to zero.

#53614 is included in both sides of this A/B. Its denser Mamba checkpoints do
not remove the SWA fine-hit veto: current main still stops at 5,184 tokens for
the 6,001-token replay, while this PR reaches the shared 6,000-token boundary.

## Scope

This PR fixes SWA participation in the existing fine-hit contract, whose
producer-side partial entries are prompt-tail aliases. It does not introduce a
new policy for publishing every generated-region boundary. Doing that naively
would conflict with partial-block hash promotion, multiply cache events, and
require local/remote agreement on alias lifetime; it is a separate BlockPool
and connector design rather than part of the three SWA manager semantics in
#53786.

`shared_prefix_boundary` is retained as a reachable boundary but is not itself
published as a new alias. Publishing it would similarly expand alias ownership
beyond prompt tails and is left as a follow-up design question.

Related work remains separate or complementary:

- merged #53614, now in this PR's base, publishes internal Mamba checkpoints;
- open #53945 concerns the EAGLE Mamba block-grid resume position;
- #54163 controls whether DFlash/DSpark should use the target-KV last-block
  drop; and
- #48435 concerns the broader reuse cliff under interleaved SWA eviction.

No commits from the open changes are included here.

## Duplicate-work check

The current #53786 discussion and open PRs were checked immediately before the
final update. `53786 in:body` returns only this PR. The closest open changes are
complementary: merged #53614 adds Mamba checkpoints but leaves the SWA veto in
place; #40156 optimizes coarse SWA search; #39171 addresses repeated EAGLE
drops; #50457 handles an all-sliding DFlash path with a broader model and
scheduler patch; and #53007 changes page-size selection. None implements fine
SWA prompt-tail lookup with physical-span validation, retention, and CoW.

## Test plan and results

```bash
VLLM_TARGET_DEVICE=cpu PYTHONPATH="$PWD" .venv/bin/python -m pytest -q \
  tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py \
  tests/v1/core/test_single_type_kv_cache_manager.py \
  tests/v1/core/test_prefix_caching.py \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py

VLLM_TARGET_DEVICE=cpu PYTHONPATH="$PWD" .venv/bin/python -m pytest -q \
  tests/v1/kv_connector/unit/test_mooncake_store_coordinator.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py \
  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py \
  tests/v1/kv_connector/unit/test_mooncake_store_worker.py

VLLM_TARGET_DEVICE=cpu PYTHONPATH="$PWD" \
  .venv/bin/python -m pytest -q tests/v1/core/

.venv/bin/pre-commit run --files <all five changed files>
.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files <all five changed files>
```

- focused manager/prefix/Mooncake coordinator suite: **205 passed**;
- Mooncake coordinator/HMA/scheduler/worker suites: **251 passed**;
- full `tests/v1/core/`: **629 passed, 1 failed, 2 errors**. The three
  source-only macOS failures are E2E startup tests requiring the unavailable
  compiled `vllm._C.init_cpu_memory_env`; they do not execute changed manager
  logic;
- file-scoped pre-commit: **all hooks passed**;
- manual Python 3.12 mypy: **passed**; and
- `git diff --check`: **passed**.

AI assistance (Claude Code and OpenAI Codex) was used for review,
implementation iteration, tests, and this description. The contributor
reviewed the code and measurements as required by `AGENTS.md`.
