### PR TITLE
[Misc][Examples] Use `dtype` instead of deprecated `torch_dtype`

### DIFF
--- a/examples/rl/rlhf_ipc_fsdp_ep.py
+++ b/examples/rl/rlhf_ipc_fsdp_ep.py
@@ -104,7 +104,7 @@ class FSDPTrainWorker:
         torch.accelerator.set_device_index(0)
 
         model = AutoModelForCausalLM.from_pretrained(
-            model_name, torch_dtype=torch.bfloat16
+            model_name, dtype=torch.bfloat16
         )
 
         for layer in model.model.layers:

--- a/examples/rl/rlhf_nccl_fsdp_ep.py
+++ b/examples/rl/rlhf_nccl_fsdp_ep.py
@@ -97,7 +97,7 @@ class FSDPTrainWorker:
         torch.accelerator.set_device_index(0)
 
         model = AutoModelForCausalLM.from_pretrained(
-            model_name, torch_dtype=torch.bfloat16
+            model_name, dtype=torch.bfloat16
         )
 
         for layer in model.model.layers:

--- a/examples/rl/rlhf_sparse_nccl.py
+++ b/examples/rl/rlhf_sparse_nccl.py
@@ -66,7 +66,7 @@ class TrainModel:
     def __init__(self, model_name: str):
         self.model = AutoModelForCausalLM.from_pretrained(
             model_name,
-            torch_dtype=torch.bfloat16,
+            dtype=torch.bfloat16,
         ).to("cuda:0")
         self.model.eval()
 


### PR DESCRIPTION
Fixes #54187.

transformers deprecated `torch_dtype` in favour of `dtype` in 4.56 (huggingface/transformers#39782). requirements/common.txt pins `transformers >= 5.10.4`, so a version check isn't needed here.

The issue mentions one call site, there are three:

- examples/rl/rlhf_nccl_fsdp_ep.py
- examples/rl/rlhf_ipc_fsdp_ep.py
- examples/rl/rlhf_sparse_nccl.py
