### PR TITLE
[Bugfix] Avoid global config lookup in sparse indexer forward

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -769,6 +769,7 @@ class SparseAttnIndexer(CustomOp):
         # during model construction) and pass them into the custom op, rather
         # than threading them through per-step metadata.
         parallel_config = get_current_vllm_config().parallel_config
+        self._parallel_config = parallel_config
         self.dcp_world_size = parallel_config.decode_context_parallel_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.use_pcp = parallel_config.prefill_context_parallel_size > 1
@@ -787,9 +788,7 @@ class SparseAttnIndexer(CustomOp):
         (it's set up in Worker.initialize_from_config, ahead of warmup/serving).
         """
         if self._cp_kv_cache_interleave_size is None:
-            value = (
-                get_current_vllm_config().parallel_config.cp_kv_cache_interleave_size
-            )
+            value = self._parallel_config.cp_kv_cache_interleave_size
             if isinstance(get_forward_context().attn_metadata, dict):
                 self._cp_kv_cache_interleave_size = value
             return value


### PR DESCRIPTION
## Purpose

Fix the DeepSeek-V4-Flash startup regression seen in Buildkite CI #86195. During memory profiling, `SparseAttnIndexer` reads the current vLLM config from a global context after the model-construction context has exited, causing EngineCore initialization to fail.

## Fix

Keep a reference to the `ParallelConfig` captured during model construction and read the late-adjusted `cp_kv_cache_interleave_size` from that object during forward.

This preserves the post-construction PD+DCP interleave adjustment introduced by #50611 while avoiding a forward-time `get_current_vllm_config()` call.

## AI assistance

AI assistance was used to diagnose the CI failure, prepare the code change, run validation, and draft this PR. The PR remains a draft so the human submitter can review every changed line and validate the change end-to-end before marking it ready.
