### PR TITLE
[CI] Revert "Add explicit step keys to 18 hardware test steps" (#54330)

### DIFF
--- a/.buildkite/hardware_tests/ascend_npu.yaml
+++ b/.buildkite/hardware_tests/ascend_npu.yaml
@@ -2,7 +2,6 @@ group: Hardware
 depends_on: ~
 steps:
   - label: "Ascend NPU Test"
-    key: ascend-npu-test
     soft_fail: true
     timeout_in_minutes: 20
     no_plugin: true

--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -2,7 +2,6 @@ group: CPU
 depends_on: []
 steps:
 - label: CPU-Kernel Tests
-  key: cpu-kernel-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -60,7 +59,6 @@ steps:
 #       bash .buildkite/scripts/hardware_ci/run-cpu-compatibility-test.sh"
 
 - label: CPU-Language Generation and Pooling Model Tests
-  key: cpu-language-generation-and-pooling-model-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -78,7 +76,6 @@ steps:
       pytest -x -v -s tests/v1/e2e/test_cpu_linear_attn_chunked_prefix.py"
 
 - label: CPU-Quantization Model Tests
-  key: cpu-quantization-model-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -100,7 +97,6 @@ steps:
       pytest -x -v -s tests/quantization/test_cpu_w8a8.py"
       
 - label: CPU-Distributed Tests (PP+TP)
-  key: cpu-distributed-tests-pp-tp
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -120,7 +116,6 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-cpu-distributed-smoke-test.sh tp_pp"
 
 - label: CPU-Distributed Tests (DP+TP)
-  key: cpu-distributed-tests-dp-tp
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -131,7 +126,6 @@ steps:
       bash .buildkite/scripts/hardware_ci/run-cpu-distributed-smoke-test.sh dp_tp"
 
 - label: CPU-Multi-Modal Model Tests %N
-  key: cpu-multi-modal-model-tests-n
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -146,7 +140,6 @@ steps:
   parallelism: 4
 
 - label: CPU-Qwen2.5-VL Multimodal Tests
-  key: cpu-qwen2-5-vl-multimodal-tests
   depends_on: []
   device: intel_cpu
   no_plugin: true
@@ -160,7 +153,6 @@ steps:
       VLLM_CI_ENV=0 pytest -x -v -s tests/models/multimodal/generation/test_qwen2_5_vl.py"
 
 - label: "Arm CPU Test"
-  key: arm-cpu-test
   depends_on: []
   soft_fail: false
   device: arm_cpu

--- a/.buildkite/hardware_tests/gh200.yaml
+++ b/.buildkite/hardware_tests/gh200.yaml
@@ -1,7 +1,6 @@
 group: Hardware
 steps:
   - label: "GH200 Test"
-    key: gh200-test
     soft_fail: true
     device: gh200
     no_plugin: true

--- a/.buildkite/hardware_tests/intel.yaml
+++ b/.buildkite/hardware_tests/intel.yaml
@@ -2,7 +2,6 @@ group: Hardware
 depends_on: ~
 steps:
   - label: "Intel HPU Test"
-    key: intel-hpu-test
     soft_fail: true
     device: intel_hpu
     no_plugin: true

--- a/.buildkite/hardware_tests/intel_xpu_ci/test-intel.yaml
+++ b/.buildkite/hardware_tests/intel_xpu_ci/test-intel.yaml
@@ -16,7 +16,6 @@ steps:
         - exit_status: -10  # Agent was lost
           limit: 2
   - label: "XPU example Test"
-    key: xpu-example-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 50
@@ -38,7 +37,6 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh example'
   - label: "XPU V1 test"
-    key: xpu-v1-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 70
@@ -61,7 +59,6 @@ steps:
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh v1'
     parallelism: 2
   - label: "XPU W8A8 FP8 Linear Examples"
-    key: xpu-w8a8-fp8-linear-examples
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60
@@ -84,7 +81,6 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh w8a8-fp8-linear'
   - label: "XPU server test"
-    key: xpu-server-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 45
@@ -106,7 +102,6 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh server'
   - label: "XPU quantization test"
-    key: xpu-quantization-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60
@@ -128,7 +123,6 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh quantization'
   - label: "XPU compressed tensors FP8 test"
-    key: xpu-compressed-tensors-fp8-test
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60
@@ -151,7 +145,6 @@ steps:
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'bash .buildkite/scripts/hardware_ci/run-intel-ci-test.sh compressed-tensors-fp8'
   - label: "XPU Graph"
-    key: xpu-graph
     depends_on:
       - image-build-xpu
     timeout_in_minutes: 60


### PR DESCRIPTION
## Why

Reverts #54330.

The postmerge build for that commit ([vllm/ci #86199](https://buildkite.com/vllm/ci/builds/86199)) failed at bootstrap: `buildkite-agent pipeline upload` was rejected — `The number of jobs in this upload exceeds your organization limit of 750`.

Analysis of the generated pipeline artifacts (86199 vs. the previous green main build 86192):

- The added keys introduced **zero** new steps — the command-step set is identical (329) in both builds.
- A `.buildkite`-only diff causes nearly every step to render as a block+command pair (650 raw steps vs. 591 on 86192; only 8 steps matched the diff vs. 67), which crosses the 750-job upload limit once groups and `parallelism` expansions are counted.

The change itself is sound (verified: effective key set of all 241 steps byte-identical before/after), but main should not carry red builds while any CI-metadata-only commit exceeds the upload limit. This revert restores the previous state; the explicit keys can be re-landed once the limit is raised or the generator stops emitting a block+command pair per skipped step.

**Note:** this revert is itself a `.buildkite`-only change, so its own postmerge build is expected to fail bootstrap the same way until the underlying limit issue is addressed.

## Not a duplicate

Revert of my own #54330; no existing revert PR open (checked `gh pr list --repo vllm-project/vllm --state open`).

## Test commands run and results

- `git revert --no-commit 8fa4c6cdb3` applied cleanly on top of `origin/main` (b383e16396).
- Diff verified to be exactly the inverse of #54330: 5 files, 18 deletions, matching the original 18 additions.
- `pre-commit` hooks on commit: all applicable hooks passed (`shellcheck` skipped — its toolchain download fails locally with an SSL error; no shell files changed).

## Model evaluation

Not applicable — CI metadata revert; no output/accuracy/serving surface.

## AI-assistance disclosure

AI assistance was used in creating this revert (prepared and verified by an AI agent under human direction).
