### PR TITLE
[CI] Return HTTP 400 for invalid trace replay parameters

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
@@ -112,6 +112,28 @@ async def test_generate_endpoint(client):
 
 
 @pytest.mark.asyncio
+async def test_generate_rejects_empty_trace_decode_token_ids(client):
+    response = await client.post(
+        GEN_ENDPOINT,
+        json={
+            "token_ids": [0],
+            "sampling_params": {"trace_decode_token_ids": []},
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["type"] == "BadRequestError"
+    assert "must be a non-empty list" in error["message"]
+
+    healthy_response = await client.post(
+        GEN_ENDPOINT,
+        json={"token_ids": [0], "sampling_params": {"max_tokens": 1}},
+    )
+    healthy_response.raise_for_status()
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(
     envs.VLLM_USE_RUST_FRONTEND,
     reason="sampling mask output is not supported by the Rust frontend",

--- a/tests/v1/sample/test_trace_replay_params.py
+++ b/tests/v1/sample/test_trace_replay_params.py
@@ -35,7 +35,7 @@ def test_sampling_params_trace_field_preserved_by_clone():
 
 def test_sampling_params_trace_field_rejects_empty_list():
     params = SamplingParams(trace_decode_token_ids=[])
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(VLLMValidationError, match="non-empty"):
         params._validate_trace_replay(
             _make_model_config(vocab_size=100), speculative_config=None
         )
@@ -43,7 +43,7 @@ def test_sampling_params_trace_field_rejects_empty_list():
 
 def test_sampling_params_trace_field_requires_single_output():
     params = SamplingParams(n=2, trace_decode_token_ids=[1])
-    with pytest.raises(ValueError, match="requires n=1"):
+    with pytest.raises(VLLMValidationError, match="requires n=1"):
         params._validate_trace_replay(
             _make_model_config(vocab_size=100), speculative_config=None
         )
@@ -52,7 +52,7 @@ def test_sampling_params_trace_field_requires_single_output():
 @pytest.mark.parametrize("invalid_ids", [[-1, 5], [1, "2"]])
 def test_sampling_params_trace_field_rejects_invalid_token_ids(invalid_ids):
     params = SamplingParams(trace_decode_token_ids=invalid_ids)
-    with pytest.raises(ValueError, match="non-negative integers"):
+    with pytest.raises(VLLMValidationError, match="non-negative integers"):
         params._validate_trace_replay(
             _make_model_config(vocab_size=100), speculative_config=None
         )
@@ -94,7 +94,9 @@ def test_validate_trace_replay_noop_when_unset():
 
 def test_trace_decode_token_ids_rejects_speculative_decoding():
     params = SamplingParams(trace_decode_token_ids=[1])
-    with pytest.raises(ValueError, match="not supported with speculative decoding"):
+    with pytest.raises(
+        VLLMValidationError, match="not supported with speculative decoding"
+    ):
         params._validate_trace_replay(
             _make_model_config(vocab_size=100), speculative_config=object()
         )
@@ -105,7 +107,9 @@ def test_trace_decode_token_ids_rejects_structured_outputs():
         trace_decode_token_ids=[1],
         structured_outputs=StructuredOutputsParams(json_object=True),
     )
-    with pytest.raises(ValueError, match="not supported with structured outputs"):
+    with pytest.raises(
+        VLLMValidationError, match="not supported with structured outputs"
+    ):
         params._validate_trace_replay(
             _make_model_config(vocab_size=100), speculative_config=None
         )

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -915,36 +915,40 @@ class SamplingParams(
             return
 
         if len(self.trace_decode_token_ids) == 0:
-            raise ValueError("trace_decode_token_ids must be a non-empty list.")
+            raise VLLMValidationError(
+                "trace_decode_token_ids must be a non-empty list."
+            )
         if self.n != 1:
-            raise ValueError("trace_decode_token_ids requires n=1.")
+            raise VLLMValidationError("trace_decode_token_ids requires n=1.")
         if not all(isinstance(t, int) and t >= 0 for t in self.trace_decode_token_ids):
-            raise ValueError(
+            raise VLLMValidationError(
                 "trace_decode_token_ids must contain non-negative integers."
             )
 
         if self.prompt_logprobs is not None:
-            raise ValueError(
+            raise VLLMValidationError(
                 "trace_decode_token_ids is not supported with prompt_logprobs."
             )
         if speculative_config is not None:
-            raise ValueError(
+            raise VLLMValidationError(
                 "trace_decode_token_ids is not supported with speculative decoding."
             )
         if self.structured_outputs is not None:
-            raise ValueError(
+            raise VLLMValidationError(
                 "trace_decode_token_ids is not supported with structured outputs."
             )
         if self.repetition_detection is not None:
-            raise ValueError(
+            raise VLLMValidationError(
                 "trace_decode_token_ids is not supported with repetition_detection."
             )
         if self.thinking_token_budget is not None:
-            raise ValueError(
+            raise VLLMValidationError(
                 "trace_decode_token_ids is not supported with thinking_token_budget."
             )
         if self.bad_words:
-            raise ValueError("trace_decode_token_ids is not supported with bad_words.")
+            raise VLLMValidationError(
+                "trace_decode_token_ids is not supported with bad_words."
+            )
 
         vocab_size = model_config.get_vocab_size()
         invalid_token_ids = [


### PR DESCRIPTION
- Raise `VLLMValidationError` consistently from trace-replay validation.
- Route empty token lists and incompatible trace settings through the established HTTP 400 path.
- Preserve the `BadRequestError` response type and actionable validation message.
- Add an API regression test for the exact `trace_decode_token_ids: []` payload.
- Verify that a valid generation request succeeds immediately after the rejected request.

The `Entrypoints Part 1` group in [AMD CI build 12440](https://buildkite.com/vllm/amd-ci/builds/12440/list) found that an empty trace-replay token list produced HTTP 500 instead of a client error. Formal bisection against the [last good nightly](https://buildkite.com/vllm/amd-ci/builds/12414/list) reproduced the predicate at `f956e1c343dc63720b50c01209bd5ada6d8589a2`, so there is no responsible PR in the 24-hour regression window. This was a latent validation bug exposed by Schemathesis coverage rather than a new engine regression. Returning the established validation exception keeps malformed client input out of the server-error path and leaves the engine healthy.
