### PR TITLE
[ROCm][CI] Enable HY-V4 model initialization on ROCm

### DIFF
--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -60,9 +60,9 @@ def test_registry_imports(model_arch):
         pytest.skip("Dots3 NOTE is only supported on CUDA")
 
     if model_arch in ("HYV4ForCausalLM", "HYV4MTPModel") and not (
-        current_platform.is_cuda()
+        current_platform.is_cuda() or current_platform.is_rocm()
     ):
-        pytest.skip("HY V4 is only supported on CUDA")
+        pytest.skip("HY V4 is only supported on CUDA and ROCm")
 
     if model_arch == "DeepseekV4ForConditionalGeneration" and not (
         current_platform.is_cuda()

--- a/vllm/models/hy_v4/__init__.py
+++ b/vllm/models/hy_v4/__init__.py
@@ -14,19 +14,18 @@ The package is organized like `vllm.models.deepseek_v32`: this module is the
 only public entry point and dispatches on the current platform, so registry
 entries never reach into a platform subpackage.
 
-Only NVIDIA is supported for now. The port also drops the reference
+NVIDIA and ROCm are supported. The port also drops the reference
 implementation's HPC/TPCP fusion paths, which depend on infrastructure that
 does not exist in this tree.
 """
 
 from vllm.platforms import current_platform
 
-if current_platform.is_rocm():
-    raise NotImplementedError("hy_v4 does not yet support ROCm.")
-elif current_platform.is_xpu():
+if current_platform.is_xpu():
     raise NotImplementedError("hy_v4 does not yet support XPU.")
 else:
-    # Covers Blackwell (sm100) and all other CUDA devices.
+    # The implementation is shared by CUDA and ROCm; platform-specific
+    # attention behavior is selected by the normal attention backend router.
     from .nvidia.model import HYV4ForCausalLM
     from .nvidia.mtp import HYV4MTP
 


### PR DESCRIPTION
HY-V4's platform entry point from [#54160](https://github.com/vllm-project/vllm/pull/54160) rejects ROCm, causing the two HY initialization failures in [AMD build 12635](https://buildkite.com/vllm/amd-ci/builds/12635/list?jid=01a06dbb-c994-4dda-9277-8d85dae8eecb&tab=output) and [build 12653](https://buildkite.com/vllm/amd-ci/builds/12653/list?jid=01a070cd-0530-4d60-a5fd-a77dcc439bad&tab=output). With the shared sparse-MLA sink capability from [#54404](https://github.com/vllm-project/vllm/pull/54404), HY and its MTP model can use the existing implementation on ROCm. This PR enables that path and removes the temporary initialization skip from [#55653](https://github.com/vllm-project/vllm/pull/55653).

- Allow the shared HY-V4 model and MTP imports on ROCm, retaining the XPU restriction.
- Run both HY registry-import cases on ROCm.
- Remove the six-line initialization guard so both original large-subset cases run again.

Prepared with AI assistance (OpenAI Codex).
