### PR TITLE
[Bugfix][Frontend] Truncate prompt_token_offsets with the prompt

### DIFF
--- a/tests/entrypoints/scale_out/render/test_render.py
+++ b/tests/entrypoints/scale_out/render/test_render.py
@@ -348,6 +348,42 @@ async def test_chat_render_default_no_token_offsets(client):
 
 
 @pytest.mark.asyncio
+async def test_completion_render_truncated_token_offsets(client):
+    """Truncation must shorten token_offsets together with token_ids.
+
+    An explicit truncation_side turns off tokenizer-level truncation, so the
+    tokenizer returns offsets for the whole prompt and they are reduced
+    afterwards -- separately from token_ids. GenerateRequest documents that the
+    two lists have equal length.
+    """
+    prompt = "The quick brown fox jumps over the lazy dog."
+    keep = 4
+    response = await client.post(
+        "/v1/completions/render",
+        json={
+            "model": MODEL_NAME,
+            "prompt": prompt,
+            "return_token_offsets": True,
+            "truncate_prompt_tokens": keep,
+            "truncation_side": "left",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    token_ids = data[0]["token_ids"]
+    offsets = data[0]["token_offsets"]
+
+    assert len(token_ids) == keep
+    assert len(offsets) == len(token_ids)
+
+    # Equal length is not enough: truncating from the left keeps the *last*
+    # tokens, so the surviving offsets must cover the end of the prompt.
+    assert offsets[-1][1] == len(prompt)
+    assert offsets[0][0] > 0
+
+
+@pytest.mark.asyncio
 async def test_completion_render_multiple_prompts_token_offsets(client):
     """Each prompt in a batch gets its own offsets aligned with its tokens."""
     prompts = ["Hello, world.", "Goodbye, world."]

--- a/tests/renderers/test_token_offsets.py
+++ b/tests/renderers/test_token_offsets.py
@@ -197,3 +197,45 @@ class TestProcessTokensForwardsOffsets:
         engine_input = renderer._process_tokens(tokens_prompt)
 
         assert "prompt_token_offsets" not in engine_input
+
+
+class TestTruncationKeepsOffsetsAligned:
+    """``prompt_token_offsets`` runs parallel to ``prompt_token_ids``, and both
+    ``TokensPrompt`` and the render API's ``GenerateRequest`` document that the
+    two have equal length. Only ``prompt_token_ids`` was being truncated.
+    """
+
+    @pytest.mark.parametrize("side", ["left", "right"])
+    def test_explicit_truncation_side_truncates_offsets(self, fast_tokenizer, side):
+        renderer = _make_base_renderer_with(fast_tokenizer)
+        text = "The quick brown fox jumps over the lazy dog."
+        keep = 4
+
+        untruncated = renderer._tokenize_prompt(
+            {"prompt": text},
+            TokenizeParams(max_total_tokens=1024, return_token_offsets=True),
+        )
+        full_offsets = untruncated["prompt_token_offsets"]
+        assert len(full_offsets) > keep
+
+        # An explicit truncation_side disables tokenizer-level truncation (see
+        # get_encode_kwargs), so the tokenizer returns the whole sequence and
+        # truncation happens in apply_post_tokenization.
+        params = TokenizeParams(
+            max_total_tokens=1024,
+            return_token_offsets=True,
+            truncate_prompt_tokens=keep,
+            truncation_side=side,
+        )
+        result = params.apply_post_tokenization(
+            fast_tokenizer, renderer._tokenize_prompt({"prompt": text}, params)
+        )
+
+        offsets = result["prompt_token_offsets"]
+        assert len(result["prompt_token_ids"]) == keep
+        assert len(offsets) == keep
+
+        # Equal length is not enough: the surviving offsets must be the ones
+        # belonging to the surviving tokens.
+        expected = full_offsets[-keep:] if side == "left" else full_offsets[:keep]
+        assert offsets == expected

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EmbedsPrompt, TextPrompt, TokensPrompt
@@ -414,24 +414,39 @@ class TokenizeParams:
 
         return tokens + [tokenizer.pad_token_id] * (pad_length - len(tokens))
 
-    def _token_truncation(self, tokenizer: TokenizerLike | None, tokens: _S) -> _S:
-        """Apply truncation to prompt tokens if necessary."""
+    def _truncation_slice(
+        self, tokenizer: TokenizerLike | None, length: int
+    ) -> slice | None:
+        """The slice truncation applies to a sequence of `length` tokens.
+
+        `None` means no truncation. Anything parallel to the prompt tokens
+        (see `prompt_token_offsets`) must be reduced with this same slice to
+        stay aligned with them.
+        """
         max_length = self.truncate_prompt_tokens
         if max_length is not None and max_length < 0:
             max_length = self.max_input_tokens
 
-        if max_length is None or max_length >= len(tokens):
-            return tokens
+        if max_length is None or max_length >= length:
+            return None
         if max_length == 0:
-            return tokens[:0]
+            return slice(0, 0)
 
         side = self.truncation_side or (
             tokenizer.truncation_side if tokenizer is not None else None
         )
         if side == "left":
-            return tokens[-max_length:]
+            return slice(-max_length, None)
 
-        return tokens[:max_length]
+        return slice(0, max_length)
+
+    def _token_truncation(self, tokenizer: TokenizerLike | None, tokens: _S) -> _S:
+        """Apply truncation to prompt tokens if necessary."""
+        truncation = self._truncation_slice(tokenizer, len(tokens))
+        if truncation is None:
+            return tokens
+
+        return tokens[truncation]
 
     def _token_len_check(self, tokenizer: TokenizerLike | None, tokens: _S) -> _S:
         """Apply length checks to prompt tokens if necessary."""
@@ -492,5 +507,10 @@ class TokenizeParams:
                 tokenizer,
                 prompt["prompt_embeds"],  # type: ignore[typeddict-item]
             )
+        offsets = cast(TokensPrompt, prompt).get("prompt_token_offsets")
+        if offsets is not None:
+            truncation = self._truncation_slice(tokenizer, len(offsets))
+            if truncation is not None:
+                prompt["prompt_token_offsets"] = offsets[truncation]  # type: ignore[typeddict-unknown-key]
 
         return prompt


### PR DESCRIPTION
## Purpose

`prompt_token_offsets` is the per-token `(start, end)` char range of the prompt
text. Its length is documented as equal to the token sequence, in two places:

`vllm/inputs/llm.py:118-122` (`TokensPrompt`):

> The list length equals the length of `prompt_token_ids`.

`vllm/entrypoints/scale_out/token_in_token_out/protocol.py:97-102`
(`GenerateRequest`, the render API's response model):

> List length equals `token_ids` length when present. None otherwise.

`TokenizeParams.apply_post_tokenization` truncates `prompt_token_ids` but never
touches `prompt_token_offsets`, so when truncation actually fires the offsets
keep their pre-truncation length and no longer describe the tokens they are
shipped with.

### Reachability

`get_encode_kwargs` (`vllm/renderers/params.py:315-340`) normally lets the
tokenizer truncate, and then `offset_mapping` comes back already truncated. But
when `truncation_side` is set explicitly it deliberately disables
tokenizer-level truncation, because the tokenizer's own side may differ from the
requested one:

```python
if self.truncation_side is not None and self.truncate_prompt_tokens is not None:
    return dict(truncation=False, add_special_tokens=self.add_special_tokens)
```

The tokenizer then returns the *whole* sequence plus whole-sequence offsets, and
`_token_truncation` slices only `prompt_token_ids` afterwards. So the trigger is
`return_token_offsets` + `truncate_prompt_tokens` + an explicit
`truncation_side`. All three are fields on `CompletionRequest`
(`vllm/entrypoints/openai/completion/protocol.py:85-89`, `:183`) and all three
are forwarded into `TokenizeParams` by `build_tok_params` (`:264-276`).

`POST /v1/completions/render` returns the rendered `GenerateRequest` straight to
the caller, and it is registered whenever the model supports `generate`
(`vllm/entrypoints/launchers/api_server/routers.py:51-54`) — no extra flag:

```
POST /v1/completions/render
{
  "model": "<generative model>",
  "prompt": "The quick brown fox jumps over the lazy dog.",
  "return_token_offsets": true,
  "truncate_prompt_tokens": 4,
  "truncation_side": "left"
}
```

The response has 4 entries in `token_ids` and the full untruncated count in
`token_offsets`. A consumer mapping token *i* back to a character span reads
the offsets of a token sequence that was discarded — silently, since both fields
are well-formed on their own.

`ServingRender.render_chat_request` already trims/extends
`assistant_tokens_mask` to `len(token_ids)` and warns when they disagree
(`vllm/entrypoints/scale_out/render/serving.py:125-142`); `token_offsets` is the
other array parallel to `token_ids` on that same response and has no such
handling.

## Approach

The truncation rule (how many, from which side) lived inside `_token_truncation`,
where only the token list could reach it. Factor that decision out into
`_truncation_slice`, which returns the `slice` to apply — or `None` for no
truncation — and have `_token_truncation` apply it. `apply_post_tokenization`
then applies the *same* slice to `prompt_token_offsets`, so the two cannot drift
apart.

Padding is intentionally not applied to the offsets: pad tokens have no source
characters, and `pad_prompt_tokens` is a pooling-only parameter while
`return_token_offsets` is only settable on the generate endpoints, so the two
never co-occur on a real request.

## End-to-end reproduction

The render server is CPU-only (`vllm launch render`), so this is reproducible
without a GPU. `tests/entrypoints/scale_out/render/test_render.py` already
covers `token_offsets` over HTTP with `RemoteLaunchRenderServer` and
`hmellor/tiny-random-LlamaForCausalLM`; commit `edd5a15b6d` adds the truncation
case there.

```
POST /v1/completions/render
{
  "model": "hmellor/tiny-random-LlamaForCausalLM",
  "prompt": "The quick brown fox jumps over the lazy dog.",
  "return_token_offsets": true,
  "truncate_prompt_tokens": 4,
  "truncation_side": "left"
}
```

On `main` this returns **200 OK** with 4 token ids and 13 offsets:

```text
INFO:     127.0.0.1:58798 - "POST /v1/completions/render HTTP/1.1" 200 OK

FAILED tests/entrypoints/scale_out/render/test_render.py::test_completion_render_truncated_token_offsets
  assert 13 == 4
   +  where 13 = len([[0, 0], [0, 3], [3, 9], [9, 15], [15, 18], [18, 19], ...])
   +  and   4 = len([278, 17366, 11203, 29889])
```

The offsets describe the whole prompt (`[0,0]` BOS, `[0,3]` = `"The"`) while the
token ids are the final four tokens (`" the"`, `" lazy"`, `" dog"`, `"."`). A
client zipping the two lists maps every kept token to the wrong characters, with
no error to signal it.

## Test Plan

```bash
pytest tests/renderers/test_token_offsets.py -v
pytest tests/entrypoints/scale_out/render/test_render.py -v
```

One parametrized test added to `tests/renderers/test_token_offsets.py`, whose
existing tests all already assert `len(offsets) == len(prompt_token_ids)` but
never combine offsets with truncation.

The test asserts more than equal length. It first tokenizes without truncation
to capture the true offsets, then asserts the truncated result equals
`full_offsets[-keep:]` for `truncation_side="left"` and `full_offsets[:keep]`
for `"right"` — so a fix that trimmed the offsets to the right *count* but the
wrong *end* would still fail.

## Test Result

Run on ubuntu-24.04 x86_64 / Python 3.12.3, installed with
`VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto`.

**Before** — the new test against `vllm/renderers/params.py` from `main`
(b383e1639). The offsets keep their untruncated length:

```text
$ python -m pytest -v tests/renderers/test_token_offsets.py     -k explicit_truncation_side_truncates_offsets
HEAD = b383e1639  ([Bugfix] Reset cached Mamba align metadata on profiling teardown (#54044))

collected 12 items / 10 deselected / 2 selected

...TestTruncationKeepsOffsetsAligned::test_explicit_truncation_side_truncates_offsets[left] FAILED  [ 50%]
...TestTruncationKeepsOffsetsAligned::test_explicit_truncation_side_truncates_offsets[right] FAILED [100%]

        offsets = result["prompt_token_offsets"]
        assert len(result["prompt_token_ids"]) == keep
>       assert len(offsets) == keep
E       assert 10 == 4
E        +  where 10 = len([(0, 3), (3, 9), (9, 15), (15, 19), (19, 25), (25, 30), ...])

======================= 2 failed, 10 deselected in 2.16s =======================
```

Note the preceding assertion passes: `prompt_token_ids` *was* truncated to 4.
Only the offsets were left at 10.

**After** — this branch, whole file:

```text
$ python -m pytest -v tests/renderers/test_token_offsets.py
HEAD = 78b4234f5  ([Bugfix][Frontend] Truncate prompt_token_offsets with the prompt)

collected 12 items
...
...TestTruncationKeepsOffsetsAligned::test_explicit_truncation_side_truncates_offsets[left] PASSED  [ 91%]
...TestTruncationKeepsOffsetsAligned::test_explicit_truncation_side_truncates_offsets[right] PASSED [100%]

============================== 12 passed in 7.25s ==============================
```

All ten pre-existing tests in the file pass unchanged.

**Whole-suite comparison.** `pytest tests/renderers` on `main` and on this
branch, in the same job:

```text
=========== SUITE main ===========
FAILED tests/renderers/test_cohere.py::test_async_cohere_renderer_does_not_block_event_loop - ImportError: ... requires the `cohere_melody` package
FAILED tests/renderers/test_hf.py::test_resolve_content_format_hf_defined[fixie-ai/ultravox-v0_5-llama-3_2-1b-string] - OSError: You are trying to access a gated repo.
FAILED tests/renderers/test_hf.py::test_resolve_content_format_hf_defined[meta-llama/Llama-Guard-3-1B-openai] - OSError: You are trying to access a gated repo.
FAILED tests/renderers/test_hf.py::test_resolve_content_format_fallbacks[google/paligemma-3b-mix-224-string] - OSError: You are trying to access a gated repo.
4 failed, 432 passed, 2 skipped in 270.53s

=========== SUITE fix/truncate-token-offsets ===========
FAILED tests/renderers/test_cohere.py::test_async_cohere_renderer_does_not_block_event_loop - ImportError: ... requires the `cohere_melody` package
FAILED tests/renderers/test_hf.py::test_resolve_content_format_hf_defined[Qwen/Qwen2.5-VL-3B-Instruct-openai] - huggingface_hub.errors.HfHubHTTPError
FAILED tests/renderers/test_hf.py::test_resolve_content_format_hf_defined[Qwen/Qwen3.5-4B-openai] - huggingface_hub.errors.HfHubHTTPError
FAILED tests/renderers/test_hf.py::test_resolve_content_format_hf_defined[fixie-ai/ultravox-v0_5-llama-3_2-1b-string] - pydantic_core.ValidationError: 1 validation error for ModelConfig
FAILED tests/renderers/test_hf.py::test_resolve_content_format_hf_defined[meta-llama/Llama-Guard-3-1B-openai] - OSError: You are trying to access a gated repo.
FAILED tests/renderers/test_hf.py::test_resolve_content_format_fallbacks[google/paligemma-3b-mix-224-string] - OSError: You are trying to access a gated repo.
6 failed, 432 passed, 2 skipped in 205.35s
```

I am flagging the difference rather than hiding it: the branch shows two extra
failures. Both are `test_hf.py::test_resolve_content_format_hf_defined`
parametrizations that hit the HF Hub — `HfHubHTTPError` and a `ModelConfig`
validation error from a config fetch that came back empty — after the same job
had already downloaded these repos once for the `main` run. They are Hub rate
limiting, not a behaviour change; this diff touches neither model config
resolution nor Hub access.

The pass counts confirm nothing regressed: both sides report 432 passed, and the
branch collects two *more* tests than `main` (the new parametrized test). So the
two Qwen parametrizations that passed on `main` are exactly offset by the two new
tests passing on the branch.


`pre-commit` hooks applicable to the changed files — `ruff-check`,
`ruff-format`, `typos`, `check-spdx-header` — pass, and
`python tools/pre_commit/mypy.py 3.12 vllm/renderers/params.py` reports
`Success: no issues found in 1 source file`.

## Not duplicating an existing PR

Searched open PRs for `prompt_token_offsets in:body`, `return_token_offsets
in:body`, `offset_mapping in:body` and `_token_truncation in:body`. The only
hits are on `_token_truncation`: #54364 (my own PR, which reorders padding and
truncation and does not touch offsets), #38143 (Responses API harmony path) and
#42482 (`max_tokens` as an upper bound). None of them truncates
`prompt_token_offsets`.

---
AI assistance was used to research and draft this change. I have reviewed every
changed line and run the tests above.



---

## Update — e2e evidence added

Commit `edd5a15b6d` adds `test_completion_render_truncated_token_offsets` to the
existing render e2e suite. Against `main` it fails with `assert 13 == 4` on a
200 OK response (see the reproduction section above); on this branch the whole
file passes:

```text
$ python -m pytest -v tests/entrypoints/scale_out/render/test_render.py
HEAD = edd5a15b6d
======================= 23 passed, 14 warnings in 34.82s =======================
```
