### PR TITLE
[Bugfix][Core] Reject non-positive output processing chunk sizes

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -55,6 +55,30 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+def test_output_proc_chunk_size_defaults_and_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    getter = environment_variables["VLLM_V1_OUTPUT_PROC_CHUNK_SIZE"]
+    monkeypatch.delenv("VLLM_V1_OUTPUT_PROC_CHUNK_SIZE", raising=False)
+    assert getter() == 128
+
+    monkeypatch.setenv("VLLM_V1_OUTPUT_PROC_CHUNK_SIZE", "1")
+    assert getter() == 1
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_output_proc_chunk_size_rejects_non_positive_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+):
+    monkeypatch.setenv("VLLM_V1_OUTPUT_PROC_CHUNK_SIZE", value)
+
+    with pytest.raises(
+        ValueError,
+        match=r"VLLM_V1_OUTPUT_PROC_CHUNK_SIZE must be greater than 0",
+    ):
+        environment_variables["VLLM_V1_OUTPUT_PROC_CHUNK_SIZE"]()
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -363,6 +363,14 @@ def disable_compile_cache() -> bool:
     return bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0")))
 
 
+def get_v1_output_proc_chunk_size() -> int:
+    env_name = "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE"
+    value = int(os.getenv(env_name, "128"))
+    if value <= 0:
+        raise ValueError(f"{env_name} must be greater than 0, got {value}")
+    return value
+
+
 def use_aot_compile() -> bool:
     from vllm.utils.torch_utils import is_torch_equal_or_newer
 
@@ -1414,9 +1422,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Setting this too high can result in a higher variance of
     # inter-message latencies. Setting it too low can negatively impact
     # TTFT and overall throughput.
-    "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE": lambda: int(
-        os.getenv("VLLM_V1_OUTPUT_PROC_CHUNK_SIZE", "128")
-    ),
+    "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE": get_v1_output_proc_chunk_size,
     # If set, vLLM will disable the MLA attention optimizations.
     "VLLM_MLA_DISABLE": lambda: bool(int(os.getenv("VLLM_MLA_DISABLE", "0"))),
     # If set, vLLM will pick up the provided Flash Attention MLA


### PR DESCRIPTION
## Purpose

`VLLM_V1_OUTPUT_PROC_CHUNK_SIZE` controls how many engine outputs the V1
async output handler processes before yielding to the event loop. The value is
used as the step argument to `range()` without validation:

- `0` raises `ValueError` and stops the output handler.
- A negative value produces an empty range, so pending outputs are silently
  skipped.

Validate the value when the environment variable is read so invalid
configurations fail early with a clear error. The default value (`128`) and all
positive overrides keep their existing behavior.

## Changes

- Parse and validate `VLLM_V1_OUTPUT_PROC_CHUNK_SIZE` in a dedicated getter.
- Reject zero and negative values with a descriptive `ValueError`.
- Cover the default, a positive override, zero, and a negative value in the
  existing environment-variable test suite.

## Test Plan

```bash
.venv/bin/python -m pytest tests/test_envs.py -v
.venv/bin/pre-commit run --files vllm/envs.py tests/test_envs.py
```

## Test Result

Before the fix, the new non-positive-value regression cases fail because both
`0` and `-1` are accepted. Downstream, zero crashes `range()` while a negative
step skips the output-processing loop.

After the fix:

```text
59 passed, 16 warnings in 15.60s
All applicable pre-commit hooks passed.
```

Model evaluation: not applicable. This change only rejects invalid
configuration values and does not change model outputs, accuracy, or valid
serving behavior.

## AI Assistance

OpenAI Codex assisted with this change.
