### PR TITLE
[Bugfix] Fail a zero-work waiting request instead of crashing EngineCore

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -145,6 +145,34 @@ def test_get_num_unfinished_requests():
         assert scheduler.get_num_unfinished_requests() == len(requests) - i - 1
 
 
+def test_zero_new_tokens_fails_request_not_engine():
+    """A waiting request with computed == num_tokens must not crash EngineCore.
+
+    The waiting-loop used to `assert num_new_tokens > 0`. KV-connector and
+    prefix-cache orderings can still produce that state (full local hit then
+    N-1 truncation, connector match covering the prompt suffix). Fail the
+    broken request and keep scheduling healthy neighbors.
+    """
+    scheduler = create_scheduler()
+    broken, healthy = create_requests(num_requests=2, num_tokens=16)
+    scheduler.add_request(broken)
+    scheduler.add_request(healthy)
+    # KVTransfer waiting path: num_computed_tokens > 0 skips prefix lookup
+    # and uses the stored count. Set it equal to the prompt so the request
+    # has zero local work.
+    broken.num_computed_tokens = broken.num_tokens
+
+    scheduler_output = scheduler.schedule()
+
+    assert broken.status == RequestStatus.FINISHED_ERROR
+    assert broken.request_id not in scheduler.requests
+    assert broken.request_id in scheduler_output.finished_req_ids
+    assert healthy.request_id in scheduler_output.num_scheduled_tokens
+    assert (
+        scheduler_output.num_scheduled_tokens[healthy.request_id] == healthy.num_tokens
+    )
+
+
 @pytest.mark.parametrize(
     "enable_prefix_caching, prompt_logprobs",
     [

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -996,7 +996,28 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, request_token_budget)
-                    assert num_new_tokens > 0
+                    if num_new_tokens <= 0:
+                        # A waiting request is supposed to have local work.
+                        # Several KV-connector / prefix-cache orderings can
+                        # still produce computed == num_tokens (NIXL/Mooncake
+                        # Mamba N-1 truncation after a full local hit, a
+                        # connector match that covers the prompt suffix,
+                        # hybrid per-group hit divergence). This used to be
+                        # `assert num_new_tokens > 0`, which killed EngineCore
+                        # and, under EP/DP lockstep, the whole prefill world.
+                        # Fail this request and keep scheduling the rest.
+                        logger.error(
+                            "Request %s has no tokens to schedule "
+                            "(computed=%s of %s). Failing the request "
+                            "instead of crashing the engine.",
+                            request.request_id,
+                            num_computed_tokens,
+                            request.num_tokens,
+                        )
+                        self.finish_requests(
+                            request.request_id, RequestStatus.FINISHED_ERROR
+                        )
+                        continue
 
                     # Apply Mamba alignment before encoder caps.
                     if self.need_mamba_block_aligned_split:


### PR DESCRIPTION
## Purpose

`Scheduler.schedule()` treats `num_new_tokens > 0` as a process-killing assert for waiting requests. That is a reasonable debug invariant and an unreasonable EngineCore death: one request with `computed == num_tokens` takes down the worker, and under EP/DP lockstep it takes down the whole prefill world.

This state is reachable from more than one KV-connector / prefix-cache ordering. Upstream has already fixed individual producers (#53523 for NIXL Mamba N-1 truncation after a full local hit; #46453 is still open for hybrid per-group divergence). A later connector or a Mooncake N-1 path can still land here. The assert must not be the blast radius.

This PR does **not** invent work and does **not** clamp connector hits in the scheduler (see #50864). If a waiting request has zero local tokens after the existing budget math, we `finish_requests(..., FINISHED_ERROR)` and continue scheduling neighbors.

Related: #30320, #46453, #53514, #53706.

## Why this is not a duplicate

- **#53523** fixes one NIXL Mamba truncation producer. This is the last-line severity guard for every remaining producer.
- **#50864** clamps the connector match so the assert never fires. Review there asked not to treat that as the fix. We fail the broken request instead of rewriting its hit count.
- No open PR replaces the waiting-loop assert with a request-level error.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_zero_new_tokens_fails_request_not_engine tests/v1/core/test_scheduler.py::test_add_requests tests/v1/core/test_scheduler.py::test_schedule -q
```

`test_zero_new_tokens_fails_request_not_engine` puts a zero-work request first in the waiting queue, then a healthy request. Before: `AssertionError` inside `schedule()`. After: broken request is `FINISHED_ERROR`, healthy request is scheduled.

No model-affecting change (token accounting / sampling paths untouched), so no model eval.

## Test Result

Test added. Please run `/ci run` on this PR. I will also run the commands above on a precompiled install of this tree.

## AI assistance

AI assistance was used to draft the patch and PR text. The submitting author reviewed every changed line and can defend the change end-to-end.


Made with [Cursor](https://cursor.com)