### PR TITLE
[Doc] Fix griffe warnings in HYV4 tool parser

### DIFF
--- a/vllm/tool_parsers/hy_v4_tool_parser.py
+++ b/vllm/tool_parsers/hy_v4_tool_parser.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import ast
 import json
-from typing import Any, TypedDict
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import regex as re
 
@@ -25,6 +26,9 @@ from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
 from vllm.tool_parsers.utils import partial_tag_overlap
+
+if TYPE_CHECKING:
+    from xgrammar import StructuralTag
 
 logger = init_logger(__name__)
 
@@ -576,9 +580,9 @@ class HYV4ToolExtractor:
         previous_text: str,
         current_text: str,
         delta_text: str,
-        previous_token_ids,
-        current_token_ids,
-        delta_token_ids,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
         tools: list[ToolSchema] | None,
         *,
         guided: bool = False,
@@ -989,7 +993,7 @@ class HYV4ToolParser(ToolParser):
         request: ChatCompletionRequest | ResponsesRequest,
         *,
         reasoning: bool = False,
-    ):
+    ) -> StructuralTag | None:
         """Build a structural tag matching HYV4's tool tokens.
 
         Overridden only to pass the per-checkpoint ``token_suffix`` through to
@@ -1106,9 +1110,9 @@ class HYV4ToolParser(ToolParser):
         previous_text: str,
         current_text: str,
         delta_text: str,
-        previous_token_ids,
-        current_token_ids,
-        delta_token_ids,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
         delta = self._extractor.extract_tool_calls_streaming(


### PR DESCRIPTION
## Purpose

The docs build emits four griffe warnings for `vllm/tool_parsers/hy_v4_tool_parser.py`:

```
WARNING -  griffe: vllm/tool_parsers/hy_v4_tool_parser.py:600: No type or annotation for parameter 'previous_token_ids'
WARNING -  griffe: vllm/tool_parsers/hy_v4_tool_parser.py:601: No type or annotation for parameter 'current_token_ids'
WARNING -  griffe: vllm/tool_parsers/hy_v4_tool_parser.py:602: No type or annotation for parameter 'delta_token_ids'
WARNING -  griffe: vllm/tool_parsers/hy_v4_tool_parser.py:1009: No type or annotation for returned value 1
```

The docstrings document these parameters and the return value, but the signatures have no annotations for them, so griffe has nothing to render.

Fix:

- Annotate `previous_token_ids` / `current_token_ids` / `delta_token_ids` as `Sequence[int]` on both `extract_tool_calls_streaming` definitions (`HYV4ToolExtractor` and `HYV4ToolParser`). This matches the `ToolParser` base class signature and every other tool parser (`hermes`, `hy_v3`, `llama`, ...).
- Annotate `HYV4ToolParser.get_structural_tag` as returning `StructuralTag | None`, which is what `get_model_structural_tag` returns. `StructuralTag` is imported under `TYPE_CHECKING` so the module keeps deferring the `xgrammar` import (the file already has `from __future__ import annotations`).

Annotations only, no behaviour change.

### Not a duplicate

Checked before opening:

```bash
gh pr list --repo vllm-project/vllm --state open --search "hy_v4 tool parser"
gh pr list --repo vllm-project/vllm --state open --search "hy_v4_tool_parser in:body"
gh pr list --repo vllm-project/vllm --state open --search "griffe"
```

No open PR touches this file. The `griffe` search returns #51342, which fixes an unrelated annotation in `benchmarks/benchmark_throughput.py`.

## Test Plan

Reproduce the warnings with griffe directly (before/after the change), and run the tool parser suite.

## Test Result

Griffe, on the parent commit:

```
vllm/tool_parsers/hy_v4_tool_parser.py:600: No type or annotation for parameter 'previous_token_ids'
vllm/tool_parsers/hy_v4_tool_parser.py:601: No type or annotation for parameter 'current_token_ids'
vllm/tool_parsers/hy_v4_tool_parser.py:602: No type or annotation for parameter 'delta_token_ids'
vllm/tool_parsers/hy_v4_tool_parser.py:1009: No type or annotation for returned value 1
```

Same check on this branch: no warnings.

```bash
python -m pytest tests/tool_parsers -q --ignore=tests/tool_parsers/test_cohere_command_tool_parser.py
# 968 passed, 3 skipped, 34 xfailed in 291.74s
```

(`test_cohere_command_tool_parser.py` fails to collect locally because the optional `cohere_melody` package is not installed. Unrelated to this change and also present on `main`.)

```bash
pre-commit run  # all hooks pass, including mypy
```

No model evaluation: this is an annotation-only docs fix with no effect on output, accuracy, or serving.

AI assistance was used to prepare this change. I have reviewed every changed line and run the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtAwLBuvjcHVNvNDpxmDEx