### PR TITLE
[Perf] Fuse temperature scaling into the sampler's softmax

### DIFF
--- a/tests/v1/worker/test_gpu_gumbel_sample.py
+++ b/tests/v1/worker/test_gpu_gumbel_sample.py
@@ -21,7 +21,13 @@ pytest.importorskip("triton")
 if not torch.cuda.is_available():
     pytest.skip("CUDA required for Gumbel sampler tests", allow_module_level=True)
 
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.sample.gumbel import (
+    _sm_count,
+    _temperature_softmax_combine_kernel,
+    apply_temperature,
+    gumbel_sample,
+    temperature_softmax,
+)
 
 DEVICE = "cuda"
 VOCAB_SIZE = 200_000
@@ -424,3 +430,112 @@ def test_logits_cache_narrower_than_logits_is_rejected():
             logits_cache=cache,
             logits_cache_col=torch.tensor(0, dtype=torch.int32, device=DEVICE),
         )
+
+
+def _reference_probs(
+    logits: torch.Tensor,
+    idx_mapping: torch.Tensor,
+    temperature: torch.Tensor,
+) -> torch.Tensor:
+    """What `temperature_softmax` replaces: scale in place, then softmax."""
+    scaled = logits.to(torch.float32)
+    apply_temperature(scaled, idx_mapping, temperature)
+    return scaled.softmax(dim=-1, dtype=torch.float32)
+
+
+# `temperature_softmax` splits each row across programs when the batch alone
+# cannot occupy every SM, so the batch sizes below must straddle the SM count to
+# cover both the split and the single-program path.
+@pytest.mark.parametrize("num_tokens", [1, 8, 64, 130, 512])
+@pytest.mark.parametrize("vocab_size", [1024, 4097, 151_936])
+def test_temperature_softmax_matches_reference(num_tokens: int, vocab_size: int):
+    gen = torch.Generator(device=DEVICE).manual_seed(4321)
+    logits = torch.randn(
+        num_tokens, vocab_size, generator=gen, device=DEVICE, dtype=torch.bfloat16
+    )
+    idx_mapping = torch.arange(num_tokens, device=DEVICE, dtype=torch.int32)
+    # Cover the temperature==0 and ==1 shortcuts alongside ordinary values.
+    temperature = torch.tensor(
+        [(0.0, 1.0, 0.5, 2.0)[i % 4] for i in range(num_tokens)],
+        device=DEVICE,
+        dtype=torch.float32,
+    )
+    probs = temperature_softmax(logits, idx_mapping, temperature)
+    expected = _reference_probs(logits, idx_mapping, temperature)
+    torch.testing.assert_close(probs, expected, rtol=0, atol=1e-6)
+    assert torch.isfinite(probs).all()
+
+
+def test_temperature_softmax_split_and_single_paths_agree():
+    """The split path must reproduce the single-program path exactly.
+
+    Both paths run over identical data; only the launch geometry differs, so a
+    disagreement means the cross-program max/sum combine is wrong.
+    """
+    num_sms = _sm_count(torch.accelerator.current_device_index())
+    vocab_size = 151_936
+    gen = torch.Generator(device=DEVICE).manual_seed(99)
+    row = torch.randn(1, vocab_size, generator=gen, device=DEVICE, dtype=torch.bfloat16)
+    temperature = torch.full((1,), 0.7, device=DEVICE, dtype=torch.float32)
+    idx = torch.zeros(1, device=DEVICE, dtype=torch.int32)
+
+    split = temperature_softmax(row, idx, temperature)
+
+    # Repeat the same row past the SM count so the single-program path is taken,
+    # then compare any one of its rows against the split result.
+    wide = row.expand(num_sms + 1, vocab_size).contiguous()
+    single = temperature_softmax(
+        wide,
+        torch.zeros(num_sms + 1, device=DEVICE, dtype=torch.int32),
+        temperature,
+    )
+    torch.testing.assert_close(split[0], single[0], rtol=0, atol=1e-7)
+
+
+def test_temperature_softmax_combine_compiles_once_across_batch_sizes():
+    """The combine kernel must not recompile as the running batch size changes.
+
+    `NUM_SPLITS_POW2` is a `tl.constexpr`, so tying it to the actual split count
+    gives it a new value at several batch sizes. Warmup only covers one, leaving
+    the rest to compile mid-inference -- a latency spike vLLM's jit_monitor
+    flags. Batch sizes below straddle every split count the heuristic can pick.
+    """
+    device = torch.accelerator.current_device_index()
+    num_sms = _sm_count(device)
+    batch_sizes = [1, 2, 4, 8, 16, 32, num_sms]
+    vocab_size = 151_936
+    temperature = torch.full((1,), 0.8, device=DEVICE, dtype=torch.float32)
+
+    _temperature_softmax_combine_kernel.device_caches.pop(device, None)
+    for num_tokens in batch_sizes:
+        gen = torch.Generator(device=DEVICE).manual_seed(num_tokens)
+        logits = torch.randn(
+            num_tokens, vocab_size, generator=gen, device=DEVICE, dtype=torch.bfloat16
+        )
+        idx = torch.zeros(num_tokens, device=DEVICE, dtype=torch.int32)
+        temperature_softmax(logits, idx, temperature)
+
+    variants = len(_temperature_softmax_combine_kernel.device_caches[device][0])
+    assert variants == 1, (
+        f"combine kernel compiled {variants} variants across batch sizes "
+        f"{batch_sizes}; each extra variant is a JIT compile during inference"
+    )
+
+
+def test_temperature_softmax_rows_are_distributions():
+    gen = torch.Generator(device=DEVICE).manual_seed(7)
+    # Wide dynamic range stresses the max subtraction that keeps exp() finite.
+    logits = (
+        torch.randn(4, 151_936, generator=gen, device=DEVICE, dtype=torch.bfloat16) * 40
+    )
+    idx = torch.arange(4, device=DEVICE, dtype=torch.int32)
+    temperature = torch.full((4,), 0.25, device=DEVICE, dtype=torch.float32)
+    probs = temperature_softmax(logits, idx, temperature)
+    assert torch.isfinite(probs).all()
+    assert (probs >= 0).all()
+    torch.testing.assert_close(
+        probs.double().sum(dim=-1),
+        torch.ones(4, device=DEVICE, dtype=torch.float64),
+        rtol=0,
+        atol=1e-4,
+    )

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -512,6 +512,30 @@ def flashinfer_sample(
     return next_token_ids.view(-1)
 
 
+def flashinfer_sample_from_probs(
+    probs: torch.Tensor,
+    k: torch.Tensor | None,
+    p: torch.Tensor | None,
+) -> torch.Tensor:
+    """Sample with FlashInfer from probabilities that the caller already
+    normalized, for the cases `flashinfer_sample` would softmax internally.
+
+    Exactly one of `k` and `p` must be given.
+    """
+    import flashinfer
+
+    assert (k is None) != (p is None)
+    if k is None:
+        next_token_ids = flashinfer.sampling.top_p_sampling_from_probs(
+            probs, p, deterministic=True
+        )
+    else:
+        next_token_ids = flashinfer.sampling.top_k_sampling_from_probs(
+            probs, k, deterministic=True
+        )
+    return next_token_ids.view(-1)
+
+
 def _to_tensor_scalar_tuple(x):
     if isinstance(x, torch.Tensor):
         return (x, 0)

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import functools
+
 import torch
 
 from vllm.triton_utils import HAS_TRITON, tl, tldevice, triton
@@ -110,6 +112,122 @@ def _temperature_softmax_kernel(
         tl.store(probs_row_ptr + block, tl.exp(x - max_val) * inv_sum, mask=mask)
 
 
+# One program per row leaves every SM beyond `num_tokens` idle, and the row is long
+# enough that the serial pass over it then dominates. When the batch is small, split
+# each row across several programs that reduce their slice independently; the combine
+# pass folds the per-slice (max, sum) pairs before normalizing.
+_SPLIT_BLOCK_SIZE = 1024
+# Programs to aim for once splitting, as a multiple of the SM count. Splitting trades
+# a smaller block size (and so a less efficient inner loop) for parallelism, which only
+# pays when there is idle hardware to fill.
+_SPLIT_PROGRAMS_PER_SM = 8
+
+
+@functools.cache
+def _sm_count(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+@functools.cache
+def _combine_num_splits_pow2(vocab_size: int) -> int:
+    """Upper bound on `num_splits`, rounded up to a power of two.
+
+    The combine kernel takes this as a `tl.constexpr`, so deriving it from the
+    actual split count would recompile the kernel every time the running batch
+    size moves it to a new power of two -- during inference, since warmup only
+    covers one batch size. Slices are never smaller than `_SPLIT_BLOCK_SIZE`,
+    so this bound holds for every batch size and is constant per model. The
+    lanes above `num_splits` are masked off and cost nothing measurable.
+    """
+    return triton.next_power_of_2(triton.cdiv(vocab_size, _SPLIT_BLOCK_SIZE))
+
+
+@triton.jit
+def _temperature_softmax_partial_kernel(
+    logits_ptr,
+    logits_stride,
+    expanded_idx_mapping_ptr,
+    temperature_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    partial_stride,
+    vocab_size,
+    split_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    split_idx = tl.program_id(1)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+    temperature = tl.load(temperature_ptr + req_state_idx).to(tl.float32)
+    denom = tl.where(temperature == 0.0, 1.0, temperature)
+    row_ptr = logits_ptr + token_idx * logits_stride
+
+    start = split_idx * split_size
+    end = tl.minimum(start + split_size, vocab_size)
+    max_val = float("-inf")
+    sum_exp = 0.0
+    for offset in range(start, end, BLOCK_SIZE):
+        block = offset + tl.arange(0, BLOCK_SIZE)
+        mask = block < end
+        x = tl.load(row_ptr + block, mask=mask, other=float("-inf"))
+        x = x.to(tl.float32) / denom
+        new_max = tl.maximum(max_val, tl.max(x, axis=0))
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(
+            tl.where(mask, tl.exp(x - new_max), 0.0), axis=0
+        )
+        max_val = new_max
+    tl.store(partial_max_ptr + token_idx * partial_stride + split_idx, max_val)
+    tl.store(partial_sum_ptr + token_idx * partial_stride + split_idx, sum_exp)
+
+
+@triton.jit
+def _temperature_softmax_combine_kernel(
+    logits_ptr,
+    probs_ptr,
+    logits_stride,
+    probs_stride,
+    expanded_idx_mapping_ptr,
+    temperature_ptr,
+    partial_max_ptr,
+    partial_sum_ptr,
+    partial_stride,
+    vocab_size,
+    split_size,
+    num_splits,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_SPLITS_POW2: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    split_idx = tl.program_id(1)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+    temperature = tl.load(temperature_ptr + req_state_idx).to(tl.float32)
+    denom = tl.where(temperature == 0.0, 1.0, temperature)
+
+    splits = tl.arange(0, NUM_SPLITS_POW2)
+    split_mask = splits < num_splits
+    partial_base = token_idx * partial_stride + splits
+    partial_max = tl.load(
+        partial_max_ptr + partial_base, mask=split_mask, other=float("-inf")
+    )
+    partial_sum = tl.load(partial_sum_ptr + partial_base, mask=split_mask, other=0.0)
+    max_val = tl.max(partial_max, axis=0)
+    sum_exp = tl.sum(
+        tl.where(split_mask, partial_sum * tl.exp(partial_max - max_val), 0.0), axis=0
+    )
+    inv_sum = 1.0 / sum_exp
+
+    row_ptr = logits_ptr + token_idx * logits_stride
+    probs_row_ptr = probs_ptr + token_idx * probs_stride
+    start = split_idx * split_size
+    end = tl.minimum(start + split_size, vocab_size)
+    for offset in range(start, end, BLOCK_SIZE):
+        block = offset + tl.arange(0, BLOCK_SIZE)
+        mask = block < end
+        x = tl.load(row_ptr + block, mask=mask, other=0.0)
+        x = x.to(tl.float32) / denom
+        tl.store(probs_row_ptr + block, tl.exp(x - max_val) * inv_sum, mask=mask)
+
+
 def temperature_softmax(
     logits: torch.Tensor,
     expanded_idx_mapping: torch.Tensor,
@@ -131,15 +249,66 @@ def temperature_softmax(
     """
     num_tokens, vocab_size = logits.shape
     probs = torch.empty_like(logits, dtype=torch.float32)
-    _temperature_softmax_kernel[(num_tokens,)](
+    if num_tokens == 0:
+        return probs
+
+    num_sms = _sm_count(logits.device.index)
+    num_splits = min(
+        triton.cdiv(_SPLIT_PROGRAMS_PER_SM * num_sms, num_tokens),
+        triton.cdiv(vocab_size, _SPLIT_BLOCK_SIZE),
+    )
+    if num_tokens > num_sms or num_splits <= 1:
+        # One program per row already occupies every SM, so splitting would only pay
+        # the smaller block size and a second pass over the row.
+        _temperature_softmax_kernel[(num_tokens,)](
+            logits,
+            probs,
+            logits.stride(0),
+            probs.stride(0),
+            expanded_idx_mapping,
+            temperature,
+            vocab_size,
+            BLOCK_SIZE=8192,
+        )
+        return probs
+
+    # Round the slice up to a whole number of blocks so no program straddles one.
+    split_size = _SPLIT_BLOCK_SIZE * triton.cdiv(
+        triton.cdiv(vocab_size, num_splits), _SPLIT_BLOCK_SIZE
+    )
+    num_splits = triton.cdiv(vocab_size, split_size)
+    partial_max = torch.empty(
+        (num_tokens, num_splits), device=logits.device, dtype=torch.float32
+    )
+    partial_sum = torch.empty_like(partial_max)
+    grid = (num_tokens, num_splits)
+    _temperature_softmax_partial_kernel[grid](
+        logits,
+        logits.stride(0),
+        expanded_idx_mapping,
+        temperature,
+        partial_max,
+        partial_sum,
+        partial_max.stride(0),
+        vocab_size,
+        split_size,
+        BLOCK_SIZE=_SPLIT_BLOCK_SIZE,
+    )
+    _temperature_softmax_combine_kernel[grid](
         logits,
         probs,
         logits.stride(0),
         probs.stride(0),
         expanded_idx_mapping,
         temperature,
+        partial_max,
+        partial_sum,
+        partial_max.stride(0),
         vocab_size,
-        BLOCK_SIZE=8192,
+        split_size,
+        num_splits,
+        BLOCK_SIZE=_SPLIT_BLOCK_SIZE,
+        NUM_SPLITS_POW2=_combine_num_splits_pow2(vocab_size),
     )
     return probs
 

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -65,6 +65,86 @@ def apply_temperature(
 
 
 @triton.jit
+def _temperature_softmax_kernel(
+    logits_ptr,
+    probs_ptr,
+    logits_stride,
+    probs_stride,
+    expanded_idx_mapping_ptr,
+    temperature_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+    temperature = tl.load(temperature_ptr + req_state_idx).to(tl.float32)
+    # Divide rather than multiply by a reciprocal so the scaled logits match
+    # _temperature_kernel bit for bit. Dividing by 1.0 is exact, so folding
+    # temperature 1 (and greedy's 0) into the divisor reproduces that kernel's
+    # early return without a branch.
+    denom = tl.where(temperature == 0.0, 1.0, temperature)
+    row_ptr = logits_ptr + token_idx * logits_stride
+
+    # Pass 1: online max and normalizer in a single read of the row.
+    max_val = float("-inf")
+    sum_exp = 0.0
+    for start in range(0, vocab_size, BLOCK_SIZE):
+        block = start + tl.arange(0, BLOCK_SIZE)
+        mask = block < vocab_size
+        x = tl.load(row_ptr + block, mask=mask, other=float("-inf"))
+        x = x.to(tl.float32) / denom
+        new_max = tl.maximum(max_val, tl.max(x, axis=0))
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(
+            tl.where(mask, tl.exp(x - new_max), 0.0), axis=0
+        )
+        max_val = new_max
+
+    # Pass 2: normalize and write the probabilities.
+    inv_sum = 1.0 / sum_exp
+    probs_row_ptr = probs_ptr + token_idx * probs_stride
+    for start in range(0, vocab_size, BLOCK_SIZE):
+        block = start + tl.arange(0, BLOCK_SIZE)
+        mask = block < vocab_size
+        x = tl.load(row_ptr + block, mask=mask, other=0.0)
+        x = x.to(tl.float32) / denom
+        tl.store(probs_row_ptr + block, tl.exp(x - max_val) * inv_sum, mask=mask)
+
+
+def temperature_softmax(
+    logits: torch.Tensor,
+    expanded_idx_mapping: torch.Tensor,
+    temperature: torch.Tensor,
+) -> torch.Tensor:
+    """Temperature scaling fused into the softmax.
+
+    Equivalent to `apply_temperature` followed by
+    `logits.softmax(dim=-1, dtype=torch.float32)`, but avoids writing the
+    scaled logits back to memory and reading them again.
+
+    Args:
+        logits: Logits of shape `[num_tokens, vocab_size]`.
+        expanded_idx_mapping: Maps each token to its request state index.
+        temperature: Per-request-state temperatures.
+
+    Returns:
+        FP32 probabilities of shape `[num_tokens, vocab_size]`.
+    """
+    num_tokens, vocab_size = logits.shape
+    probs = torch.empty_like(logits, dtype=torch.float32)
+    _temperature_softmax_kernel[(num_tokens,)](
+        logits,
+        probs,
+        logits.stride(0),
+        probs.stride(0),
+        expanded_idx_mapping,
+        temperature,
+        vocab_size,
+        BLOCK_SIZE=8192,
+    )
+    return probs
+
+
+@triton.jit
 def tl_rand64(seed, offset, includes_zero: tl.constexpr):
     lo, hi, _, _ = tl.randint4x(seed, offset)
     lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -11,12 +11,16 @@ from vllm.sampling_params import SamplingParams
 from vllm.v1.sample.ops.topk_topp_sampler import (
     apply_top_k_top_p,
     flashinfer_sample,
+    flashinfer_sample_from_probs,
     flashinfer_sampler_supported,
 )
 from vllm.v1.worker.gpu.input_batch import InputBatch, get_num_sampled_and_rejected
 from vllm.v1.worker.gpu.metrics.logits import get_num_nans
 from vllm.v1.worker.gpu.sample.bad_words import BadWordsState
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+from vllm.v1.worker.gpu.sample.gumbel import (
+    gumbel_sample,
+    temperature_softmax,
+)
 from vllm.v1.worker.gpu.sample.logit_bias import LogitBiasState
 from vllm.v1.worker.gpu.sample.logprob import (
     LogprobTokenIdsState,
@@ -59,6 +63,8 @@ class Sampler:
             TraceReplayState(req_states) if enable_trace_replay else None
         )
         self.needs_logits_processing = np.zeros(max_num_reqs, dtype=bool)
+        # Subset of the above that actually mutates the logits in place.
+        self.needs_inplace_processing = np.zeros(max_num_reqs, dtype=bool)
         self.num_speculative_tokens = num_speculative_tokens
         self.return_sampling_mask = return_sampling_mask
         self.use_flashinfer = (
@@ -79,7 +85,7 @@ class Sampler:
 
         states = self.sampling_states
         temperature = states.temperature.np[req_idx]
-        self.needs_logits_processing[req_idx] = (
+        self.needs_inplace_processing[req_idx] = (
             self.logit_bias_state.use_logit_bias[req_idx]
             or self.penalties_state.use_penalty[req_idx]
             or self.bad_words_state.num_bad_words.np[req_idx] > 0
@@ -87,6 +93,9 @@ class Sampler:
                 self.thinking_budget_state.enabled
                 and self.thinking_budget_state.use_thinking_budget[req_idx]
             )
+        )
+        self.needs_logits_processing[req_idx] = (
+            self.needs_inplace_processing[req_idx]
             or (temperature != 0.0 and temperature != 1.0)
             or states.min_p.np[req_idx] != 0.0
             or states.top_k.np[req_idx] != states.vocab_size
@@ -214,8 +223,18 @@ class Sampler:
         input_ids: torch.Tensor,
         expanded_local_pos: torch.Tensor,
         skip_top_k_top_p: bool = False,
+        skip_temperature: bool = False,
     ) -> torch.Tensor:
         if not np.any(self.needs_logits_processing[idx_mapping_np]):
+            return logits
+
+        # The FP32 copy exists so the processors below can write in place. When
+        # temperature is fused into a later softmax and no in-place processor
+        # runs, nothing writes to the logits, so the copy is pure memory traffic
+        # and the fused kernel can read the original dtype directly.
+        if skip_temperature and not np.any(
+            self.needs_inplace_processing[idx_mapping_np]
+        ):
             return logits
 
         # Copy logits to a new FP32 tensor.
@@ -255,10 +274,12 @@ class Sampler:
             expanded_local_pos,
         )
 
-        # Apply temperature in place.
-        self.sampling_states.apply_temperature(
-            logits, expanded_idx_mapping, idx_mapping_np
-        )
+        # Apply temperature in place, unless the caller folds it into a
+        # later softmax.
+        if not skip_temperature:
+            self.sampling_states.apply_temperature(
+                logits, expanded_idx_mapping, idx_mapping_np
+            )
 
         # Apply min_p in place.
         self.sampling_states.apply_min_p(logits, expanded_idx_mapping, idx_mapping_np)
@@ -282,16 +303,6 @@ class Sampler:
         expanded_local_pos: torch.Tensor,
         return_logprobs: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        processed_logits = self.apply_sampling_params(
-            logits,
-            expanded_idx_mapping,
-            idx_mapping,
-            idx_mapping_np,
-            pos,
-            input_ids,
-            expanded_local_pos,
-            skip_top_k_top_p=True,
-        )
         top_k, top_p = self.sampling_states.get_top_k_top_p(
             expanded_idx_mapping, idx_mapping_np
         )
@@ -304,9 +315,37 @@ class Sampler:
             or self.sampling_states.any_greedy(idx_mapping_np)
             or self.sampling_states.any_explicit_seed(idx_mapping_np)
         )
+        # With exactly one of top_k/top_p set, flashinfer_sample softmaxes the
+        # logits itself, so temperature can be folded into that softmax instead
+        # of costing a separate read-modify-write pass over the whole vocab.
+        # Only safe when nothing downstream reads the scaled logits back.
+        fuse_temperature = (
+            use_flashinfer
+            and (top_k is None) != (top_p is None)
+            and not self.return_sampling_mask
+            and self.sampling_states.no_min_p(idx_mapping_np)
+        )
+        processed_logits = self.apply_sampling_params(
+            logits,
+            expanded_idx_mapping,
+            idx_mapping,
+            idx_mapping_np,
+            pos,
+            input_ids,
+            expanded_local_pos,
+            skip_top_k_top_p=True,
+            skip_temperature=fuse_temperature,
+        )
 
         # Sample the next token.
-        if use_flashinfer:
+        if fuse_temperature:
+            probs = temperature_softmax(
+                processed_logits,
+                expanded_idx_mapping,
+                self.sampling_states.temperature.gpu,
+            )
+            sampled = flashinfer_sample_from_probs(probs, top_k, top_p).to(torch.int64)
+        elif use_flashinfer:
             sampled = flashinfer_sample(processed_logits, top_k, top_p).to(torch.int64)
         else:
             processed_logits = apply_top_k_top_p(processed_logits, top_k, top_p)

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -91,6 +91,9 @@ class SamplingStates:
             return
         apply_min_p(logits, expanded_idx_mapping, self.min_p.gpu)
 
+    def no_min_p(self, idx_mapping_np: np.ndarray) -> bool:
+        return bool(np.all(self.min_p.np[idx_mapping_np] == 0.0))
+
     def get_top_k_top_p(
         self, expanded_idx_mapping: torch.Tensor, idx_mapping_np: np.ndarray
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:


### PR DESCRIPTION
When exactly one of top_k/top_p is set, `flashinfer_sample` softmaxes the logits itself, so the separate in-place temperature kernel costs a full read-modify-write pass over `[num_tokens, vocab_size]` for nothing. This folds the scaling into that softmax.

Once temperature no longer mutates the logits, the FP32 materialization in `apply_sampling_params` is also unnecessary whenever no in-place logits processor runs, since the fused kernel widens the logits in-register. `needs_inplace_processing` is split out of `needs_logits_processing` to detect that case.

That fused kernel launched one program per row, which leaves most of the GPU idle when the batch is smaller than the SM count. The second commit splits each row across programs in that regime and keeps the single-program kernel above it.

## Results

Logits->probs stage, RTX 3080 (sm_86, 68 SMs), Qwen3-0.6B, vocab 151936. Baseline is the current FP32 copy + temperature kernel + torch softmax. Device time from the profiler, median of 3. Measured achievable copy bandwidth on this part is 679 GB/s, so figures at or above it indicate L2 is serving part of the second read pass.

| batch | baseline | this PR | speedup | GB/s at 8 B/elem |
|------:|---------:|--------:|--------:|-----------------:|
| 32 | 214.3 us | 60.1 us | 3.56x | 647 |
| 64 | 430.0 us | 116.9 us | 3.68x | 666 |
| 128 | 841.9 us | 225.1 us | 3.74x | 691 |
| 256 | 1694.9 us | 454.7 us | 3.73x | 684 |

### Small-batch launch geometry

The second commit only changes batches at or below the SM count. Device time against one-program-per-row, median of 3, spreads at or under 0.5% on both parts.

| batch | RTX 3080 (68 SMs) | H100 NVL (132 SMs) |
|------:|------------------:|-------------------:|
| 1 | 14.5x | 14.44x |
| 8 | 4.40x | 9.36x |
| 32 | 1.55x | 4.42x |
| 64 | 1.14x | 2.60x |
| at SM count | 1.14x | 1.46x |
| above SM count | 1.00x | 1.00x |

Above the SM count the split path is not taken, so those rows run identical code and measure 1.00x on both parts. Splitting into only two or three slices is worse than not splitting at all -- 0.77x at batch 32 on the 3080 when forced, and 0.674-0.810x across every batch on H100 -- which is why the fallback exists rather than a lower threshold.

### End-to-end

H100 NVL, Qwen3-0.6B, distinct 1024-token prompts, per-decode-step from the delta of two generate lengths, one process per arm, 8 runs as ABBA plus BAAB pooled.

| batch | one program per row | split rows | delta | Mann-Whitney p |
|------:|--------------------:|-----------:|------:|---------------:|
| 1 | 1.6805 ms | 1.6365 ms | **-2.62%** | 1.4e-14 |
| 8 | 1.9801 ms | 1.9391 ms | **-2.07%** | 1.4e-14 |

Run-position bias on that machine measured -0.12% at p=0.92, so the arm effect is about 20x the positional noise. The result also agrees with the device-time accounting, which predicts roughly 2% at these batch sizes.

I could not resolve this end-to-end on the 3080: there the position bias is about 7%, and a design balancing order only within a single sweep produced a spurious +6.96% at p=6.3e-06 that reversed sign when the sweep order was mirrored. Pooling both orders gave -0.30% at p=0.535. Only the H100 numbers above are reported as an end-to-end result.

## Correctness

GSM8K, 1319 questions, 5-shot, run at temperature 0.8 with top_p or top_k rather than greedy, since greedy disables the flashinfer path entirely and would not exercise this change.

| sampling | reps | baseline | this PR | delta |
|---|---:|---|---|---|
| top_p=0.95 | 3 | 0.3397 / 0.3252 / 0.3374 | identical, incl. output token counts | bit-identical |
| top_k=50 | 4 | mean 0.3137 | mean 0.3266 | +1.29 pp, 95% CI [-0.49, +3.07], not significant |

Outputs are not bit-identical on the top_k branch because the softmax reduction order differs from torch's by about 1 ulp, which is the statistical-equivalence guarantee `flashinfer_sample` already documents.

For the small-batch commit specifically, GSM8K at 128 questions with `max_num_seqs=32` so that every sampler call stays in the split regime (575 and 640 calls respectively, zero falling back):

| sampling | one program per row | split rows | completions |
|---|---:|---:|---|
| top_p=0.95 | 0.3281 | 0.3281 | 128/128 byte-identical |
| top_k=50 | 0.2656 | 0.2656 | 128/128 byte-identical |

Kernel equivalence against the single-program kernel holds to 4.7e-10 on H100 and 1.2e-07 on the 3080, across batches 1 to 512, vocabs 128 to 262144, bf16/fp16/fp32 logits, padded row strides, mixed and repeated index mappings, and temperature 0 and 1.

`pytest tests/v1/sample/test_topk_topp_sampler.py tests/v1/sample/test_sampler.py tests/v1/worker/test_gpu_sampler_flags.py tests/v1/worker/test_gpu_gumbel_sample.py` -- 214 passed, 3 skipped.

`temperature_softmax` had no test coverage before this PR. The added tests parametrize batch sizes across the threshold so both paths run, and they were checked to fail when the cross-slice max/sum combine, the slice bounds, or the numerical-stability max are broken.

## Notes

Both changes are guarded to the case where nothing downstream reads the scaled logits back: flashinfer in use, exactly one of top_k/top_p set, min_p inactive, and `return_sampling_mask` off. `PROCESSED_LOGPROBS_MODES` already disables flashinfer.

The fused kernel divides rather than multiplying by a reciprocal so the scaled logits match `_temperature_kernel`, per the existing convention noted in `gumbel_noised_argmax`.

The combine kernel's `NUM_SPLITS_POW2` is pinned to a per-model constant rather than derived from the actual split count, which would otherwise recompile the kernel as the serving batch size moves. Verified on H100: batch 1 selects 149 splits and batch 32 selects 30, with no recompile between them.

Warmup does not reach the fused path at all, so the first real decode step pays the Triton compile: 4544 us against 125 us steady state on H100. This is pre-existing rather than introduced here -- `SamplingParams.for_sampler_warmup()` sets top_p and top_k and min_p together, while the fused gate requires exactly one of top_k/top_p and no min_p -- but this commit makes it two kernels to compile instead of one. Fixing it needs a second warmup decode step with different per-request parameters, since the gate is batch-level, which seemed like a warmup-design question for maintainers rather than a drive-by change here.

The `num_tokens <= sm_count` threshold is conservative on high-SM parts. On H100 the split path still wins 1.46x at the cutoff and, when forced above it, keeps winning to about batch 384 (1.75x at 133, 1.19x at 256). It is left at the SM count because extending it also requires raising the split count to stay clear of the two-to-three-slice regime, and a rule tuned for 132 SMs measured slightly negative at batch 160 on the 68-SM part. Someone with Hopper hardware may want to revisit it.

Not a duplicate of #48928, which changes the speculative-decoding rejection sampler; this is the main sampling path.

Neither machine could lock clocks, so absolute microseconds are conservative on both; ratios are unaffected since both arms ran under identical conditions in every comparison.

*This PR description was formatted with AI assistance.*
