### PR TITLE
[Bugfix][Multimodal] Forward only present RoPE grid kwargs

### DIFF
--- a/tests/models/transformers/test_get_rope_index_kwargs.py
+++ b/tests/models/transformers/test_get_rope_index_kwargs.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Grid-kwargs forwarding of `MultiModalMixin.get_mrope_input_positions`.
+
+Grid kwargs for absent modalities must not be passed as explicit `None` to
+HF `get_rope_index`: not every signature accepts them (HunYuanVL has no
+`video_grid_thw` parameter).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.transformers.multimodal import MultiModalMixin
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
+
+pytestmark = pytest.mark.cpu_test
+
+_ABSENT = object()
+
+
+def _image_feature(grid_thw, offset=2, length=4):
+    # `gather_kwargs` only needs `key in data` and `data[key].data`.
+    data = {"image_grid_thw": SimpleNamespace(data=grid_thw)}
+    return MultiModalFeatureSpec(
+        data=data,
+        modality="image",
+        identifier="image-0",
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+class _HunYuanStyleModel:
+    """`get_rope_index` signature like HunYuanVL: no `video_grid_thw`."""
+
+    def __init__(self):
+        self.kwargs = None
+
+    def get_rope_index(
+        self, input_ids, mm_token_type_ids, image_grid_thw=None, attention_mask=None
+    ):
+        self.kwargs = {
+            "mm_token_type_ids": mm_token_type_ids,
+            "image_grid_thw": image_grid_thw,
+        }
+        return torch.zeros(4, 1, input_ids.shape[1], dtype=torch.int64), torch.zeros(
+            1, 1, dtype=torch.int64
+        )
+
+
+class _QwenStyleModel:
+    """`get_rope_index` signature like Qwen2-VL; sentinels detect omissions."""
+
+    def __init__(self):
+        self.kwargs = None
+
+    def get_rope_index(self, input_ids, image_grid_thw=_ABSENT, video_grid_thw=_ABSENT):
+        self.kwargs = {
+            "image_grid_thw": image_grid_thw,
+            "video_grid_thw": video_grid_thw,
+        }
+        return torch.zeros(3, 1, input_ids.shape[1], dtype=torch.int64), torch.zeros(
+            1, 1, dtype=torch.int64
+        )
+
+
+def test_omits_absent_grid_kwargs():
+    # Pristine main fails here: HunYuanVL's signature has no `video_grid_thw`
+    # parameter, but it is passed unconditionally.
+    model = _HunYuanStyleModel()
+
+    grid = torch.tensor([1, 4, 4])
+    positions, delta = MultiModalMixin.get_mrope_input_positions(
+        SimpleNamespace(model=model), [1] * 10, [_image_feature(grid)]
+    )
+
+    assert torch.equal(model.kwargs["image_grid_thw"], grid.unsqueeze(0))
+    assert torch.equal(
+        model.kwargs["mm_token_type_ids"],
+        torch.tensor([[0, 0, 1, 1, 1, 1, 0, 0, 0, 0]]),
+    )
+    assert positions.shape == (4, 10)
+    assert delta == 0
+
+
+def test_forwards_present_image_grid():
+    model = _QwenStyleModel()
+
+    MultiModalMixin.get_mrope_input_positions(
+        SimpleNamespace(model=model), [1] * 8, [_image_feature(torch.tensor([1, 2, 2]))]
+    )
+
+    assert torch.equal(model.kwargs["image_grid_thw"], torch.tensor([[1, 2, 2]]))
+    assert model.kwargs["video_grid_thw"] is _ABSENT

--- a/vllm/model_executor/models/transformers/multimodal.py
+++ b/vllm/model_executor/models/transformers/multimodal.py
@@ -1254,10 +1254,15 @@ class MultiModalMixin(SupportsMultiModal, SupportsMRoPE):
                 mm_token_type_ids[offset : offset + length] = mm_token_type_id
             kwargs["mm_token_type_ids"] = mm_token_type_ids.unsqueeze(0)
 
+        # Only forward grids for modalities that are present because
+        # `get_rope_index` signatures vary across Transformers models.
+        if image_grid_thw is not None:
+            kwargs["image_grid_thw"] = image_grid_thw
+        if video_grid_thw is not None:
+            kwargs["video_grid_thw"] = video_grid_thw
+
         mrope_positions, mrope_position_delta = self.model.get_rope_index(
             input_ids=torch.tensor(input_tokens).unsqueeze(0),
-            image_grid_thw=image_grid_thw,
-            video_grid_thw=video_grid_thw,
             **kwargs,
         )
 


### PR DESCRIPTION
## Purpose

The Transformers multimodal backend currently passes `image_grid_thw` and `video_grid_thw` to HF `get_rope_index` even when the corresponding modality is absent.

Not every Transformers implementation accepts both arguments. HunYuanVL, for example, has no `video_grid_thw` parameter, so an image-only HunyuanOCR request fails with:

```text
TypeError: HunYuanVLModel.get_rope_index() got an unexpected keyword argument 'video_grid_thw'
```

I searched existing vLLM PRs/issues and found no overlapping fix.

## Fix

Only forward a grid kwarg when that grid is actually present.

This keeps the change generic, with no model- or hardware-specific path.

## Tests

* Focused CPU regression test:

  * pristine `main`: FAIL with the `video_grid_thw` TypeError
  * patched: PASS
* Verifies present `image_grid_thw` and `mm_token_type_ids` are still forwarded correctly.
* Relevant M-RoPE tests: **11/11 PASS**.
* Real HunyuanOCR validation on Radeon PRO W7900D (`gfx1100`, TP=1):

  * before: fails at this exact `video_grid_thw` boundary
  * after: passes this boundary and completes greedy OCR

The real-model run used two other post-#53615 fixes as local prerequisites; those are separate issues and are **not included in this PR**.

Hub-dependent suites could not run on the offline validation host; the same environmental failures were reproduced on pristine `main`.

## Evidence

Full reproducible validation package:

https://github.com/AIwork4me/HunyuanOCR-ROCm/tree/8c606bbb38c5554bc725e00ddbeabf706bc0623f/validation-53615

## AI assistance

ZCode Agent assisted with implementation and testing. I reviewed the complete diff and validation evidence and am responsible for the submitted change.
