### PR TITLE
ci: add MIG slice size to H200 job labels

### DIFF
--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -2,7 +2,7 @@ group: Basic Correctness
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) Basic Correctness"
+- label: ":nvidia: (H200 MIG 18GB) Basic Correctness"
   key: basic-correctness
   timeout_in_minutes: 68
   device: h200_18gb

--- a/.buildkite/test_areas/benchmarks.yaml
+++ b/.buildkite/test_areas/benchmarks.yaml
@@ -2,7 +2,7 @@ group: Benchmarks
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) Benchmarks CLI"
+- label: ":nvidia: (H200 MIG 18GB) Benchmarks CLI"
   key: benchmarks-cli-test
   timeout_in_minutes: 45
   device: h200_18gb

--- a/.buildkite/test_areas/cuda.yaml
+++ b/.buildkite/test_areas/cuda.yaml
@@ -2,7 +2,7 @@ group: CUDA
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) CUDA Platform"
+- label: ":nvidia: (H200 MIG 18GB) CUDA Platform"
   key: platform-tests
   timeout_in_minutes: 20
   device: h200_18gb
@@ -18,7 +18,7 @@ steps:
     - pytest -v -s cuda/test_platform_no_cuda_init.py
     - pytest -v -s cuda/test_cuda_compatibility_path.py
 
-- label: ":nvidia: (H200) CUDAGraph"
+- label: ":nvidia: (H200 MIG 35GB) CUDAGraph"
   device: h200_35gb
   key: cudagraph
   timeout_in_minutes: 30

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -2,7 +2,7 @@ group: Engine
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) Engine Core"
+- label: ":nvidia: (H200 MIG 18GB) Engine Core"
   key: engine
   timeout_in_minutes: 30
   device: h200_18gb
@@ -55,7 +55,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) E2E Scheduling"
+- label: ":nvidia: (H200 MIG 18GB) E2E Scheduling"
   key: e2e-scheduling-1-gpu
   timeout_in_minutes: 53
   device: h200_18gb
@@ -72,7 +72,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) E2E Core"
+- label: ":nvidia: (H200 MIG 35GB) E2E Core"
   device: h200_35gb
   key: e2e-core-1-gpu
   timeout_in_minutes: 40

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -2,7 +2,7 @@ group: Entrypoints
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) Entrypoints Unit"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Unit"
   device: h200_35gb
   key: entrypoints-unit-tests
   timeout_in_minutes: 40
@@ -25,7 +25,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (LLM)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (LLM)"
   device: h200_35gb
   key: entrypoints-integration-llm
   timeout_in_minutes: 60
@@ -48,7 +48,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (API Server)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (API Server)"
   key: entrypoints-integration-api-server
   device: h200_35gb
   timeout_in_minutes: 75
@@ -72,7 +72,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (API Server OpenAI - Part 1)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (API Server OpenAI - Part 1)"
   device: h200_35gb
   key: entrypoints-integration-api-server-openai-part-1
   timeout_in_minutes: 68
@@ -94,7 +94,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (API Server OpenAI - Part 2)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (API Server OpenAI - Part 2)"
   device: h200_35gb
   key: entrypoints-integration-api-server-openai-part-2
   timeout_in_minutes: 83
@@ -117,7 +117,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (API Server Generate)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (API Server Generate)"
   device: h200_35gb
   key: entrypoints-integration-api-server-generate
   timeout_in_minutes: 50
@@ -143,7 +143,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (Responses API)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (Responses API)"
   device: h200_35gb
   key: entrypoints-integration-responses-api
   timeout_in_minutes: 50
@@ -163,7 +163,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (Speech to Text)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (Speech to Text)"
   device: h200_35gb
   key: entrypoints-integration-speech_to_text
   timeout_in_minutes: 45
@@ -176,7 +176,7 @@ steps:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/speech_to_text
 
-- label: ":nvidia: (H200) Entrypoints Integration (Multimodal)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (Multimodal)"
   device: h200_35gb
   key: entrypoints-integration-multimodal
   timeout_in_minutes: 45
@@ -197,7 +197,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Entrypoints Integration (Pooling)"
+- label: ":nvidia: (H200 MIG 35GB) Entrypoints Integration (Pooling)"
   device: h200_35gb
   key: entrypoints-integration-pooling
   timeout_in_minutes: 75
@@ -210,7 +210,7 @@ steps:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -v -s entrypoints/pooling
 
-- label: ":nvidia: (H200) OpenAI API Correctness"
+- label: ":nvidia: (H200 MIG 18GB) OpenAI API Correctness"
   key: openai-api-correctness
   timeout_in_minutes: 20
   device: h200_18gb

--- a/.buildkite/test_areas/expert_parallelism.yaml
+++ b/.buildkite/test_areas/expert_parallelism.yaml
@@ -2,7 +2,7 @@ group: Expert Parallelism
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) EPLB Algorithm"
+- label: ":nvidia: (H200 MIG 18GB) EPLB Algorithm"
   key: eplb-algorithm
   timeout_in_minutes: 20
   device: h200_18gb

--- a/.buildkite/test_areas/jit_monitor.yaml
+++ b/.buildkite/test_areas/jit_monitor.yaml
@@ -2,7 +2,7 @@ group: JIT Monitor
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) No Runtime JITs E2E"
+- label: ":nvidia: (H200 MIG 35GB) No Runtime JITs E2E"
   key: jit-monitor-no-runtime-jit
   device: h200_35gb
   timeout_in_minutes: 45

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -2,7 +2,7 @@ group: Kernels
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) vLLM IR"
+- label: ":nvidia: (H200 MIG 18GB) vLLM IR"
   key: vllm-ir-tests
   timeout_in_minutes: 35
   device: h200_18gb
@@ -14,7 +14,7 @@ steps:
     - pytest -v -s tests/ir
     - pytest -v -s tests/kernels/ir
 
-- label: ":nvidia: (H200) Core Operation Kernels Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) Core Operation Kernels Shard %N"
   device: h200_35gb
   key: kernels-core-operation-test
   timeout_in_minutes: 120
@@ -225,7 +225,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Mamba Kernels"
+- label: ":nvidia: (H200 MIG 35GB) Mamba Kernels"
   device: h200_35gb
   key: kernels-mamba-test
   timeout_in_minutes: 60

--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -2,7 +2,7 @@ group: LM Eval
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) LM Eval Small Models"
+- label: ":nvidia: (H200 MIG 35GB) LM Eval Small Models"
   device: h200_35gb
   key: lm-eval-small-models
   timeout_in_minutes: 45
@@ -291,7 +291,7 @@ steps:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/humming/config-act-fp8.txt
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=evals/gsm8k/configs/humming/config-act-int8.txt
 
-- label: ":nvidia: (H200) LM Eval TurboQuant KV Cache"
+- label: ":nvidia: (H200 MIG 18GB) LM Eval TurboQuant KV Cache"
   key: lm-eval-turboquant-kv-cache
   timeout_in_minutes: 55
   device: h200_18gb
@@ -347,7 +347,7 @@ steps:
     - uv pip install --system 'gpt-oss[eval]==0.0.5'
     - pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-spark.txt
 
-- label: ":nvidia: (H200) LM Eval KV-Offload"
+- label: ":nvidia: (H200 MIG 35GB) LM Eval KV-Offload"
   key: kv-offload-small
   timeout_in_minutes: 30
   device: h200_35gb
@@ -388,7 +388,7 @@ steps:
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_offloading.py -k "deepseek-v4-flash"
 
-- label: ":nvidia: (H200) MRCR Eval Small Models"
+- label: ":nvidia: (H200 MIG 35GB) MRCR Eval Small Models"
   device: h200_35gb
   timeout_in_minutes: 25
   source_file_dependencies:

--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -2,7 +2,7 @@ group: LoRA
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) LoRA Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) LoRA Shard %N"
   device: h200_35gb
   key: lora
   timeout_in_minutes: 40

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -2,7 +2,7 @@ group: Miscellaneous
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) V1 Sample + Logits"
+- label: ":nvidia: (H200 MIG 18GB) V1 Sample + Logits"
   key: v1-sample-logits
   timeout_in_minutes: 83
   device: h200_18gb
@@ -40,7 +40,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) V1 Core + KV + Metrics"
+- label: ":nvidia: (H200 MIG 35GB) V1 Core + KV + Metrics"
   device: h200_35gb
   key: v1-core-kv-metrics
   timeout_in_minutes: 80
@@ -132,7 +132,7 @@ steps:
     - pytest -v -s -m 'cpu_test' v1/ec_connector/unit
     - pytest -v -s -m 'cpu_test' v1/metrics
 
-- label: ":nvidia: (H200) Extract Hidden States Integration"
+- label: ":nvidia: (H200 MIG 18GB) Extract Hidden States Integration"
   key: extract-hidden-states-integration
   timeout_in_minutes: 20
   device: h200_18gb
@@ -162,7 +162,7 @@ steps:
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     - pytest -v -s -m 'distributed' tests/v1/kv_connector/extract_hidden_states_integration
 
-- label: ":nvidia: (H200) Regression"
+- label: ":nvidia: (H200 MIG 18GB) Regression"
   key: regression
   timeout_in_minutes: 30
   device: h200_18gb
@@ -185,7 +185,7 @@ steps:
   - pytest -v -s test_regression.py
   working_dir: "/vllm-workspace/tests" # optional
 
-- label: ":nvidia: (H200) Examples"
+- label: ":nvidia: (H200 MIG 35GB) Examples"
   device: h200_35gb
   key: examples
   timeout_in_minutes: 40
@@ -268,7 +268,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Python-only Installation"
+- label: ":nvidia: (H200 MIG 18GB) Python-only Installation"
   key: python-only-installation
   depends_on: ~
   optional: true
@@ -293,7 +293,7 @@ steps:
       - setup.py
       - vllm/platforms/rocm.py
 
-- label: ":nvidia: (H200) Async Engine, Inputs, Utils, Worker"
+- label: ":nvidia: (H200 MIG 35GB) Async Engine, Inputs, Utils, Worker"
   device: h200_35gb
   key: async-engine-inputs-utils-worker
   timeout_in_minutes: 25
@@ -440,7 +440,7 @@ steps:
     - pytest -v -s v1/determinism/test_cutlass_batch_invariance.py
     - pytest -v -s v1/determinism/test_online_batch_invariance.py
 
-- label: ":nvidia: (H200) Acceptance Length (Large Models)"
+- label: ":nvidia: (H200 MIG 35GB) Acceptance Length (Large Models)"
   device: h200_35gb
   key: acceptance-length-test-large-models
   timeout_in_minutes: 20

--- a/.buildkite/test_areas/model_executor.yaml
+++ b/.buildkite/test_areas/model_executor.yaml
@@ -2,7 +2,7 @@ group: Model Executor
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) Model Executor"
+- label: ":nvidia: (H200 MIG 35GB) Model Executor"
   device: h200_35gb
   key: model-executor
   timeout_in_minutes: 60

--- a/.buildkite/test_areas/model_runner_v2.yaml
+++ b/.buildkite/test_areas/model_runner_v2.yaml
@@ -2,7 +2,7 @@ group: Model Runner V2
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) Model Runner V2 Core"
+- label: ":nvidia: (H200 MIG 35GB) Model Runner V2 Core"
   device: h200_35gb
   key: model-runner-v2-core-tests
   timeout_in_minutes: 35
@@ -24,7 +24,7 @@ steps:
   # Temporary hack filter to exclude ngram spec decoding based tests.
   - pytest -v -s entrypoints/llm/test_struct_output_generate.py -k "xgrammar and not speculative_config6 and not speculative_config7 and not speculative_config8 and not speculative_config0"
 
-- label: ":nvidia: (H200) Model Runner V2 Examples"
+- label: ":nvidia: (H200 MIG 35GB) Model Runner V2 Examples"
   device: h200_35gb
   key: model-runner-v2-examples
   timeout_in_minutes: 35
@@ -126,7 +126,7 @@ steps:
     - pytest -v -s distributed/test_pp_cudagraph.py -k "not ray"
     - pytest -v -s v1/distributed/test_pp_dp_v2.py
 
-- label: ":nvidia: (H200) Model Runner V2 Spec Decode"
+- label: ":nvidia: (H200 MIG 35GB) Model Runner V2 Spec Decode"
   device: h200_35gb
   key: model-runner-v2-spec-decode
   timeout_in_minutes: 50

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -2,7 +2,7 @@ group: Models - Basic
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) Basic Models (Initialization)"
+- label: ":nvidia: (H200 MIG 18GB) Basic Models (Initialization)"
   key: basic-models-tests-initialization
   timeout_in_minutes: 25
   device: h200_18gb
@@ -15,7 +15,7 @@ steps:
     # Run a subset of model initialization tests
     - pytest -v -s models/test_initialization.py::test_can_initialize_small_subset
 
-- label: ":nvidia: (H200) Basic Models (Extra Initialization) Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) Basic Models (Extra Initialization) Shard %N"
   device: h200_35gb
   key: basic-models-tests-extra-initialization
   timeout_in_minutes: 100
@@ -30,7 +30,7 @@ steps:
     - pytest -v -s models/test_initialization.py -k 'not test_can_initialize_small_subset' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   parallelism: 4
 
-- label: ":nvidia: (H200) Basic Models (Other)"
+- label: ":nvidia: (H200 MIG 35GB) Basic Models (Other)"
   device: h200_35gb
   key: basic-models-tests-other
   timeout_in_minutes: 35

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -2,7 +2,7 @@ group: Models - Language
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) Language Models (Standard)"
+- label: ":nvidia: (H200 MIG 18GB) Language Models (Standard)"
   key: language-models-tests-standard
   timeout_in_minutes: 30
   device: h200_18gb
@@ -23,7 +23,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Language Models (Extra Standard) Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) Language Models (Extra Standard) Shard %N"
   device: h200_35gb
   key: language-models-tests-extra-standard
   timeout_in_minutes: 40
@@ -57,7 +57,7 @@ steps:
       - tests/models/language/pooling/test_classification.py
       - vllm/_aiter_ops.py
       - vllm/platforms/rocm.py
-- label: ":nvidia: (H200) Language Models (Hybrid) Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) Language Models (Hybrid) Shard %N"
   device: h200_35gb
   key: language-models-tests-hybrid
   timeout_in_minutes: 65
@@ -104,7 +104,7 @@ steps:
     - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
     - pytest -v -s models/language/generation -m hybrid_model -k 'granite-4.0-tiny-preview'
 
-- label: ":nvidia: (H200) Language Models (Extended Generation)"
+- label: ":nvidia: (H200 MIG 35GB) Language Models (Extended Generation)"
   device: h200_35gb
   key: language-models-test-extended-generation
   timeout_in_minutes: 80
@@ -133,7 +133,7 @@ steps:
       - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
       - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
 
-- label: ":nvidia: (H200) Language Models (PPL)"
+- label: ":nvidia: (H200 MIG 18GB) Language Models (PPL)"
   key: language-models-test-ppl
   timeout_in_minutes: 30
   device: h200_18gb
@@ -145,7 +145,7 @@ steps:
   commands:
     - pytest -v -s models/language/generation_ppl_test
 
-- label: ":nvidia: (H200) Language Models (Extended Pooling) Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) Language Models (Extended Pooling) Shard %N"
   device: h200_35gb
   key: language-models-test-extended-pooling
   timeout_in_minutes: 120
@@ -169,7 +169,7 @@ steps:
       commands:
       - pytest -v -s models/language/pooling -m 'not core_model' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
-- label: ":nvidia: (H200) Language Models (MTEB)"
+- label: ":nvidia: (H200 MIG 18GB) Language Models (MTEB)"
   key: language-models-test-mteb
   timeout_in_minutes: 68
   device: h200_18gb

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -2,7 +2,7 @@ group: Models - Multimodal
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) Multimodal Models (Standard) 1: qwen2"
+- label: ":nvidia: (H200 MIG 18GB) Multimodal Models (Standard) 1: qwen2"
   key: multi-modal-models-standard-1-qwen2
   timeout_in_minutes: 68
   device: h200_18gb
@@ -22,7 +22,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Models (Standard) 2: qwen3 + gemma"
+- label: ":nvidia: (H200 MIG 18GB) Multimodal Models (Standard) 2: qwen3 + gemma"
   key: multi-modal-models-standard-2-qwen3-gemma
   timeout_in_minutes: 75
   device: h200_18gb
@@ -43,7 +43,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Models (Standard) 3: llava + qwen2_vl"
+- label: ":nvidia: (H200 MIG 35GB) Multimodal Models (Standard) 3: llava + qwen2_vl"
   device: h200_35gb
   key: multi-modal-models-standard-3-llava-qwen2-vl
   timeout_in_minutes: 40
@@ -62,7 +62,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Models (Standard) 4: other + whisper"
+- label: ":nvidia: (H200 MIG 35GB) Multimodal Models (Standard) 4: other + whisper"
   device: h200_35gb
   key: multi-modal-models-standard-4-other-whisper
   timeout_in_minutes: 75
@@ -99,7 +99,7 @@ steps:
     - pytest -v -s models/multimodal/processing --ignore models/multimodal/processing/test_tensor_schema.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   parallelism: 4
 
-- label: ":nvidia: (H200) Multimodal Processor"
+- label: ":nvidia: (H200 MIG 18GB) Multimodal Processor"
   key: multi-modal-processor
   timeout_in_minutes: 98
   device: h200_18gb
@@ -119,7 +119,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Accuracy Eval (Small Models)"
+- label: ":nvidia: (H200 MIG 35GB) Multimodal Accuracy Eval (Small Models)"
   device: h200_35gb
   key: multi-modal-accuracy-eval-small-models
   timeout_in_minutes: 30
@@ -145,7 +145,7 @@ steps:
       - vllm/platforms/rocm.py
       - vllm/model_executor/model_loader/
 
-- label: ":nvidia: (H200) Multimodal Models (Extended Generation 1)"
+- label: ":nvidia: (H200 MIG 35GB) Multimodal Models (Extended Generation 1)"
   device: h200_35gb
   key: multi-modal-models-extended-generation-1
   optional: true
@@ -166,7 +166,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Models (PPL)"
+- label: ":nvidia: (H200 MIG 35GB) Multimodal Models (PPL)"
   device: h200_35gb
   key: multi-modal-models-extended-ppl
   optional: true
@@ -184,7 +184,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Models (Extended Generation 2) Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) Multimodal Models (Extended Generation 2) Shard %N"
   device: h200_35gb
   key: multi-modal-models-extended-generation-2
   parallelism: 4
@@ -204,7 +204,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Models (Extended Generation 3)"
+- label: ":nvidia: (H200 MIG 35GB) Multimodal Models (Extended Generation 3)"
   device: h200_35gb
   key: multi-modal-models-extended-generation-3
   optional: true
@@ -223,7 +223,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Multimodal Models (Extended Pooling)"
+- label: ":nvidia: (H200 MIG 18GB) Multimodal Models (Extended Pooling)"
   key: multi-modal-models-extended-pooling
   optional: true
   device: h200_18gb

--- a/.buildkite/test_areas/plugins.yaml
+++ b/.buildkite/test_areas/plugins.yaml
@@ -62,7 +62,7 @@ steps:
       - vllm/platforms/rocm.py
 
 
-- label: ":nvidia: (H200) GGUF Plugin"
+- label: ":nvidia: (H200 MIG 18GB) GGUF Plugin"
   key: gguf-plugin
   device: h200_18gb
   timeout_in_minutes: 30
@@ -75,7 +75,7 @@ steps:
     - pip install "vllm-gguf-plugin >= 0.0.2"
     - pytest -v -s plugins_tests/gguf
 
-- label: ":nvidia: (H200) BitsAndBytes Plugin"
+- label: ":nvidia: (H200 MIG 18GB) BitsAndBytes Plugin"
   key: bitsandbytes-plugin
   device: h200_18gb
   timeout_in_minutes: 30

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -2,7 +2,7 @@ group: PyTorch
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) PyTorch Compilation"
+- label: ":nvidia: (H200 MIG 35GB) PyTorch Compilation"
   device: h200_35gb
   key: pytorch-compilation-unit-tests
   timeout_in_minutes: 60
@@ -54,7 +54,7 @@ steps:
       - csrc/
       - vllm/platforms/rocm.py
 
-- label: ":nvidia: (H200) PyTorch Compilation H100 Cases"
+- label: ":nvidia: (H200 MIG 18GB) PyTorch Compilation H100 Cases"
   key: pytorch-compilation-unit-tests-h100
   timeout_in_minutes: 30
   device: h200_18gb
@@ -121,7 +121,7 @@ steps:
   commands:
   - pytest -s -v compile/passes --ignore compile/passes/distributed
 
-- label: ":nvidia: (H200) PyTorch Fullgraph"
+- label: ":nvidia: (H200 MIG 35GB) PyTorch Fullgraph"
   device: h200_35gb
   key: pytorch-fullgraph-test
   timeout_in_minutes: 90
@@ -195,7 +195,7 @@ steps:
   commands:
   - pytest -s -v compile/fullgraph/test_full_cudagraph.py
 
-- label: ":nvidia: (H200) PyTorch Nightly Dependency Override Check"
+- label: ":nvidia: (H200 MIG 18GB) PyTorch Nightly Dependency Override Check"
   key: pytorch-nightly-dependency-override-check
   # if this test fails, it means the nightly torch version is not compatible with some
   # of the dependencies. Please check the error message and add the package to whitelist

--- a/.buildkite/test_areas/quantization.yaml
+++ b/.buildkite/test_areas/quantization.yaml
@@ -2,7 +2,7 @@ group: Quantization
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) Quantization Shard %N"
+- label: ":nvidia: (H200 MIG 35GB) Quantization Shard %N"
   device: h200_35gb
   key: quantization
   timeout_in_minutes: 40
@@ -21,7 +21,7 @@ steps:
   # parameter. It was not exercised by the previous L4 job.
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py -k 'not test_compressed_tensors_w4a8_fp8' --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
 
-- label: ":nvidia: (H200) Quantized Fusions"
+- label: ":nvidia: (H200 MIG 35GB) Quantized Fusions"
   device: h200_35gb
   key: quantized-fusions
   timeout_in_minutes: 20
@@ -52,7 +52,7 @@ steps:
   commands:
     - pytest -s -v tests/quantization/test_blackwell_moe.py
 
-- label: ":nvidia: (H200) Quantized Models"
+- label: ":nvidia: (H200 MIG 35GB) Quantized Models"
   device: h200_35gb
   key: quantized-models-test
   timeout_in_minutes: 65

--- a/.buildkite/test_areas/ray_compat.yaml
+++ b/.buildkite/test_areas/ray_compat.yaml
@@ -2,7 +2,7 @@ group: Ray Compatibility
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) Ray Dependency Compatibility Check"
+- label: ":nvidia: (H200 MIG 18GB) Ray Dependency Compatibility Check"
   key: ray-dependency-compatibility-check
   # Informational only — does not block the pipeline.
   # If this fails, it means the PR introduces a dependency that

--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -2,7 +2,7 @@ group: Rust Frontend E2E
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) Rust Frontend OpenAI Coverage"
+- label: ":nvidia: (H200 MIG 18GB) Rust Frontend OpenAI Coverage"
   timeout_in_minutes: 30
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -37,7 +37,7 @@ steps:
   - pytest -v -s entrypoints/serve/instrumentator/test_uds.py
   - pytest -v -s v1/sample/test_logprobs_e2e.py -k "test_prompt_logprobs_e2e_server"
 
-- label: ":nvidia: (H200) Rust Frontend Serve/Admin Coverage"
+- label: ":nvidia: (H200 MIG 18GB) Rust Frontend Serve/Admin Coverage"
   timeout_in_minutes: 25
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -66,7 +66,7 @@ steps:
   # /tokenizer_info is not implemented in the Rust frontend (the CLI flag is accepted as a no-op).
   - pytest -v -s entrypoints/serve/tokenize/test_tokenization.py -k "not tokenizer_info"
 
-- label: ":nvidia: (H200) Rust Frontend Core Correctness"
+- label: ":nvidia: (H200 MIG 18GB) Rust Frontend Core Correctness"
   timeout_in_minutes: 20
   device: h200_18gb
   working_dir: "/vllm-workspace/tests"
@@ -80,7 +80,7 @@ steps:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - pytest -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
 
-- label: ":nvidia: (H200) Rust Frontend Tool Use"
+- label: ":nvidia: (H200 MIG 35GB) Rust Frontend Tool Use"
   device: h200_35gb
   timeout_in_minutes: 25
   working_dir: "/vllm-workspace/tests"

--- a/.buildkite/test_areas/samplers.yaml
+++ b/.buildkite/test_areas/samplers.yaml
@@ -2,7 +2,7 @@ group: Samplers
 depends_on: 
   - image-build
 steps:
-- label: ":nvidia: (H200) Samplers"
+- label: ":nvidia: (H200 MIG 35GB) Samplers"
   device: h200_35gb
   key: samplers-test
   timeout_in_minutes: 40

--- a/.buildkite/test_areas/spec_decode.yaml
+++ b/.buildkite/test_areas/spec_decode.yaml
@@ -2,7 +2,7 @@ group: Spec Decode
 depends_on:
   - image-build
 steps:
-- label: ":nvidia: (H200) V1 Spec Decode"
+- label: ":nvidia: (H200 MIG 35GB) V1 Spec Decode"
   device: h200_35gb
   key: v1-spec-decode
   timeout_in_minutes: 40
@@ -30,7 +30,7 @@ steps:
       depends_on:
       - image-build-amd
 
-- label: ":nvidia: (H200) Spec Decode Eagle 1: DeepSeek + Qwen"
+- label: ":nvidia: (H200 MIG 35GB) Spec Decode Eagle 1: DeepSeek + Qwen"
   key: spec-decode-eagle-1-deepseek-qwen
   timeout_in_minutes: 25
   device: h200_35gb
@@ -57,7 +57,7 @@ steps:
       - tests/v1/e2e/spec_decode/
       - vllm/platforms/rocm.py
 
-- label: ":nvidia: (H200) Spec Decode Eagle 2: Llama 3 + Qwen VL + Other"
+- label: ":nvidia: (H200 MIG 35GB) Spec Decode Eagle 2: Llama 3 + Qwen VL + Other"
   key: spec-decode-eagle-2-llama3-qwen-vl-other
   timeout_in_minutes: 25
   device: h200_35gb
@@ -96,7 +96,7 @@ steps:
   commands:
     - pytest -v -s v1/e2e/spec_decode/eagle/
 
-- label: ":nvidia: (H200) Spec Decode Speculators + MTP"
+- label: ":nvidia: (H200 MIG 35GB) Spec Decode Speculators + MTP"
   key: spec-decode-speculators-mtp
   timeout_in_minutes: 50
   device: h200_35gb
@@ -141,7 +141,7 @@ steps:
     - pytest -v -s v1/e2e/spec_decode/speculators/
     - pytest -v -s v1/e2e/spec_decode/mtp/
 
-- label: ":nvidia: (H200) Spec Decode N-Gram + Suffix"
+- label: ":nvidia: (H200 MIG 35GB) Spec Decode N-Gram + Suffix"
   key: spec-decode-ngram-suffix
   timeout_in_minutes: 20
   device: h200_35gb
@@ -170,7 +170,7 @@ steps:
       - tests/v1/e2e/spec_decode/
       - vllm/platforms/rocm.py
 
-- label: ":nvidia: (H200) Spec Decode Draft Model"
+- label: ":nvidia: (H200 MIG 18GB) Spec Decode Draft Model"
   key: spec-decode-draft-model
   timeout_in_minutes: 45
   device: h200_18gb
@@ -269,7 +269,7 @@ steps:
       - tests/v1/e2e/spec_decode/test_mtp_parallel_load.py
       - vllm/platforms/rocm.py
 
-- label: ":nvidia: (H200) Spec Decode AL DFlash Nightly"
+- label: ":nvidia: (H200 MIG 35GB) Spec Decode AL DFlash Nightly"
   key: spec-decode-dflash-nightly
   timeout_in_minutes: 90
   device: h200_35gb
@@ -305,7 +305,7 @@ steps:
       - tests/v1/e2e/spec_decode/
       - vllm/platforms/rocm.py
 
-- label: ":nvidia: (H200) Spec Decode AL DSpark Nightly"
+- label: ":nvidia: (H200 MIG 35GB) Spec Decode AL DSpark Nightly"
   key: spec-decode-dspark-nightly
   timeout_in_minutes: 60
   device: h200_35gb
@@ -345,7 +345,7 @@ steps:
       - tests/v1/e2e/spec_decode/
       - vllm/platforms/rocm.py
 
-- label: ":nvidia: (H200) Spec Decode AL MTP + Other Acceptance Nightly"
+- label: ":nvidia: (H200 MIG 35GB) Spec Decode AL MTP + Other Acceptance Nightly"
   key: spec-decode-mtp-other-acceptance-nightly
   timeout_in_minutes: 60
   device: h200_35gb


### PR DESCRIPTION
## Summary

Jobs running on H200 MIG slices currently show just `(H200)` in their Buildkite step labels, making them indistinguishable from jobs running on full H200 GPUs. This PR updates the labels to include the MIG slice size:

- `device: h200_18gb` → label shows `(H200 MIG 18GB)`
- `device: h200_35gb` → label shows `(H200 MIG 35GB)`
- `device: h200` (full GPU) → label unchanged, still `(H200)`

**85 labels updated across 23 test area files.**

## Not a duplicate

Checked for existing PRs touching MIG labels — none found.

## Testing

No functional changes — this is a label-only change in Buildkite CI YAML files. Verified that:
- Every step with `device: h200_18gb` now has `(H200 MIG 18GB)` in its label
- Every step with `device: h200_35gb` now has `(H200 MIG 35GB)` in its label
- Steps with `device: h200` or no device field are unchanged

AI assistance was used to make this change.