### PR TITLE
[KV Connector] Support piecewise Store and P/D loading with Mooncake

### DIFF
--- a/docs/features/mooncake_store_connector_usage.md
+++ b/docs/features/mooncake_store_connector_usage.md
@@ -136,6 +136,50 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct \
     }'
 ```
 
+#### Piecewise Store and P/D prefix loading
+
+By default, `MultiConnector` loads from the first connector with a cache hit.
+To let the decoder load a Store prefix and receive the remaining prompt KV
+from the prefiller, enable the `range_aware` load policy and put
+`MooncakeStoreConnector` before `MooncakeConnector` on both engines. The
+decoder configuration is:
+
+```json
+{
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_consumer",
+    "kv_connector_extra_config": {
+        "load_policy": "range_aware",
+        "connectors": [
+            {
+                "kv_connector": "MooncakeStoreConnector",
+                "kv_role": "kv_consumer"
+            },
+            {
+                "kv_connector": "MooncakeConnector",
+                "kv_role": "kv_consumer"
+            }
+        ]
+    }
+}
+```
+
+On the prefiller, use the same connector order with outer and
+`MooncakeConnector` roles set to `kv_producer`, and the Store role set to
+`kv_both`.
+
+For example, if Store covers tokens `[0, 1024)` and the prefiller covers
+`[0, 1056)`, the decoder loads `[0, 1024)` from Store and receives
+`[1024, 1056)` from the prefiller. The decoder's suffix block list selects the
+same end-anchored blocks on the prefiller, so the P/D transfer contains only
+that suffix. Boundaries between sources must be scheduler-block aligned; the
+final endpoint may be partial. Piecewise loading supports hybrid attention
+layouts, including packed Full/MLA and sliding-window groups. Requests with
+recurrent-state groups such as Mamba use single-source loading.
+
+If ranges cannot be composed at aligned boundaries, MultiConnector falls back
+to the single connector with the longest available prefix.
+
 To also offload newly completed decode KV blocks, add the following extra
 configuration to the decoder's `MooncakeStoreConnector` entry.
 

--- a/tests/v1/kv_connector/mooncake_integration/piecewise_store_pd_launcher.py
+++ b/tests/v1/kv_connector/mooncake_integration/piecewise_store_pd_launcher.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+import json
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--role", choices=("prefill", "decode"), required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--served-model-name", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--lookup-rpc-port", type=int, required=True)
+    parser.add_argument("--cache-prefix", required=True)
+    parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--block-size", type=int, default=16)
+    parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.75)
+    parser.add_argument("--kv-cache-dtype", default="auto")
+    parser.add_argument("--linear-backend", default="auto")
+    parser.add_argument("--device-name", default="mlx5_bond_0")
+    parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument("--disable-store-lookup", action="store_true")
+    args = parser.parse_args()
+
+    role = "kv_producer" if args.role == "prefill" else "kv_consumer"
+    store_extra = {
+        "cache_prefix": args.cache_prefix,
+        "lookup_rpc_port": args.lookup_rpc_port,
+        "store_tp_size": args.tensor_parallel_size,
+    }
+    if args.role == "decode":
+        store_extra["save_decode_cache"] = True
+    if args.disable_store_lookup:
+        store_extra["enable_lookup"] = False
+
+    config = {
+        "kv_connector": "MultiConnector",
+        "kv_role": role,
+        "kv_connector_extra_config": {
+            "load_policy": "range_aware",
+            "connectors": [
+                {
+                    "kv_connector": "MooncakeStoreConnector",
+                    "kv_role": "kv_both" if args.role == "prefill" else role,
+                    "kv_connector_extra_config": store_extra,
+                },
+                {
+                    "kv_connector": "MooncakeConnector",
+                    "kv_role": role,
+                    "kv_connector_extra_config": {
+                        "mooncake_protocol": "rdma",
+                        "device_name": args.device_name,
+                    },
+                },
+            ],
+        },
+    }
+    command = [
+        os.environ.get("VLLM_BIN", "vllm"),
+        "serve",
+        args.model,
+        "--served-model-name",
+        args.served_model_name,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(args.port),
+        "--tensor-parallel-size",
+        str(args.tensor_parallel_size),
+        "--block-size",
+        str(args.block_size),
+        "--max-model-len",
+        str(args.max_model_len),
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+        "--kv-cache-dtype",
+        args.kv_cache_dtype,
+        "--linear-backend",
+        args.linear_backend,
+        "--enable-prefix-caching",
+        "--enable-prompt-tokens-details",
+        "--kv-transfer-config",
+        json.dumps(config),
+    ]
+    if args.enforce_eager:
+        command.append("--enforce-eager")
+    os.execvp(command[0], command)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -14,10 +14,12 @@ import zmq.asyncio
 from tests.v1.attention.utils import dense_kv_cache_views
 from vllm import envs
 from vllm.config import set_current_vllm_config
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVLoadRange
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
     KVConnectorRole,
     MooncakeConnector,
     MooncakeConnectorMetadata,
+    MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
     MooncakeXferMetadata,
     MooncakeXferResponse,
@@ -38,6 +40,11 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheLayout,
+    MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
 )
 from vllm.v1.request import RequestStatus
 
@@ -65,6 +72,382 @@ def _make_test_kv_cache_config() -> KVCacheConfig:
             )
         ],
     )
+
+
+def _set_transfer_group_selector(
+    scheduler: MooncakeConnectorScheduler, *group_ids: int
+) -> None:
+    scheduler.kv_cache_config = MagicMock()
+    scheduler.kv_cache_config.select_transfer_block_ids.side_effect = (
+        lambda block_ids: tuple(block_ids[i] for i in group_ids)
+    )
+
+
+def test_piecewise_load_uses_only_suffix_destination_blocks():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    _set_transfer_group_selector(scheduler, 0)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 16
+    scheduler._piecewise_group_block_sizes = (16,)
+    scheduler._is_hma_required = False
+    scheduler.is_kv_producer = False
+    scheduler._reqs_need_recv = {}
+    params = {
+        "do_remote_prefill": True,
+        "remote_engine_id": "prefill",
+        "remote_bootstrap_addr": "127.0.0.1:1234",
+        "transfer_id": "transfer",
+    }
+    request = SimpleNamespace(request_id="req", kv_transfer_params=params)
+    blocks = MagicMock()
+    blocks.get_unhashed_block_ids_all_groups.return_value = [[10, 11, 12, 13, 14, 15]]
+
+    scheduler.update_state_after_alloc_for_range(request, blocks, KVLoadRange(64, 96))
+
+    assert scheduler._reqs_need_recv["req"] == (request, [[14, 15]])
+    assert params["do_remote_prefill"] is False
+
+
+def test_piecewise_load_rejects_non_terminal_range():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    scheduler.supports_load_range = True
+
+    with pytest.raises(ValueError, match="only supports a terminal"):
+        scheduler.update_state_after_alloc_for_range(
+            MagicMock(), MagicMock(), KVLoadRange(0, 16, is_terminal=False)
+        )
+
+
+def test_piecewise_load_rejects_incomplete_transfer_params():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    _set_transfer_group_selector(scheduler, 0)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 16
+    scheduler._piecewise_group_block_sizes = (16,)
+    scheduler._is_hma_required = False
+    scheduler.is_kv_producer = False
+    scheduler._reqs_need_recv = {}
+    request = SimpleNamespace(
+        request_id="req",
+        kv_transfer_params={
+            "do_remote_prefill": True,
+            "remote_engine_id": "prefill",
+            "remote_bootstrap_addr": "127.0.0.1:1234",
+        },
+    )
+
+    with pytest.raises(ValueError, match="transfer_id"):
+        scheduler.update_state_after_alloc_for_range(
+            request, MagicMock(), KVLoadRange(64, 96)
+        )
+
+    assert scheduler._reqs_need_recv == {}
+
+
+def test_remote_prefill_lookup_ignores_incomplete_transfer_params():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    scheduler.is_kv_producer = False
+    scheduler._has_mamba = False
+    request = SimpleNamespace(
+        request_id="req",
+        prompt_token_ids=list(range(96)),
+        kv_transfer_params={"do_remote_prefill": True},
+    )
+
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (0, False)
+
+
+def test_piecewise_load_maps_hybrid_attention_groups_and_partial_tail():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    _set_transfer_group_selector(scheduler, 0, 1)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 16
+    scheduler._piecewise_group_block_sizes = (16, 8)
+    scheduler._is_hma_required = True
+    scheduler.blocks_per_sw = [0, 3]
+    scheduler.is_kv_producer = False
+    scheduler._reqs_need_recv = {}
+    params = {
+        "do_remote_prefill": True,
+        "remote_engine_id": "prefill",
+        "remote_bootstrap_addr": "127.0.0.1:1234",
+        "transfer_id": "transfer",
+    }
+    request = SimpleNamespace(request_id="req", kv_transfer_params=params)
+    blocks = MagicMock()
+    blocks.get_unhashed_block_ids_all_groups.return_value = [
+        [10, 11, 12, 13],
+        [20, 21, 22, 23, 24, 25, 26, 27],
+    ]
+
+    scheduler.update_state_after_alloc_for_range(request, blocks, KVLoadRange(32, 60))
+
+    assert scheduler._reqs_need_recv["req"] == (
+        request,
+        [[12, 13], [25, 26, 27]],
+    )
+
+
+def test_piecewise_load_accepts_window_only_swa_blocks():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    _set_transfer_group_selector(scheduler, 0, 1)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 16
+    scheduler._piecewise_group_block_sizes = (16, 8)
+    scheduler._is_hma_required = True
+    scheduler.blocks_per_sw = [0, 3]
+    scheduler.is_kv_producer = False
+    scheduler._reqs_need_recv = {}
+    params = {
+        "do_remote_prefill": True,
+        "remote_engine_id": "prefill",
+        "remote_bootstrap_addr": "127.0.0.1:1234",
+        "transfer_id": "transfer",
+    }
+    request = SimpleNamespace(request_id="req", kv_transfer_params=params)
+    blocks = MagicMock()
+    blocks.get_unhashed_block_ids_all_groups.return_value = [
+        [10, 11, 12, 13],
+        [25, 26, 27],
+    ]
+
+    scheduler.update_state_after_alloc_for_range(request, blocks, KVLoadRange(32, 60))
+
+    assert scheduler._reqs_need_recv["req"] == (
+        request,
+        [[12, 13], [25, 26, 27]],
+    )
+
+
+def test_piecewise_load_accepts_omitted_swa_padding_blocks():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    _set_transfer_group_selector(scheduler, 0, 1, 2, 3, 4)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 256
+    scheduler._piecewise_group_block_sizes = (256, 128, 128, 128, 16)
+    scheduler._is_hma_required = True
+    scheduler.blocks_per_sw = [0, 3, 3, 3, 17]
+    scheduler.is_kv_producer = False
+    scheduler._reqs_need_recv = {}
+    params = {
+        "do_remote_prefill": True,
+        "remote_engine_id": "prefill",
+        "remote_bootstrap_addr": "127.0.0.1:1234",
+        "transfer_id": "transfer",
+    }
+    request = SimpleNamespace(request_id="req", kv_transfer_params=params)
+    blocks = MagicMock()
+    blocks.get_unhashed_block_ids_all_groups.return_value = [
+        [10, 11, 12, 13, 14],
+        [20, 21, 22],
+        [30, 31, 32],
+        [40, 41],
+        list(range(50, 66)),
+    ]
+
+    scheduler.update_state_after_alloc_for_range(
+        request, blocks, KVLoadRange(768, 1056)
+    )
+
+    assert scheduler._reqs_need_recv["req"] == (
+        request,
+        [
+            [13, 14],
+            [20, 21, 22],
+            [30, 31, 32],
+            [40, 41],
+            list(range(50, 66)),
+        ],
+    )
+
+
+def test_piecewise_load_rejects_unaligned_hybrid_boundary():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 256
+
+    with pytest.raises(ValueError, match="scheduler block size 256"):
+        scheduler.update_state_after_alloc_for_range(
+            MagicMock(), MagicMock(), KVLoadRange(16, 48)
+        )
+
+
+def test_piecewise_load_rejects_insufficient_suffix_blocks():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    _set_transfer_group_selector(scheduler, 0, 1)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 16
+    scheduler._piecewise_group_block_sizes = (16, 8)
+    scheduler._is_hma_required = False
+    scheduler.is_kv_producer = False
+    scheduler._reqs_need_recv = {}
+    request = SimpleNamespace(
+        request_id="req",
+        kv_transfer_params={
+            "do_remote_prefill": True,
+            "remote_engine_id": "prefill",
+            "remote_bootstrap_addr": "127.0.0.1:1234",
+            "transfer_id": "transfer",
+        },
+    )
+    blocks = MagicMock()
+    blocks.get_unhashed_block_ids_all_groups.return_value = [[10, 11], [20, 21]]
+
+    with pytest.raises(ValueError, match="more unhashed blocks"):
+        scheduler.update_state_after_alloc_for_range(
+            request, blocks, KVLoadRange(16, 48)
+        )
+
+    assert scheduler._reqs_need_recv == {}
+
+
+def test_piecewise_load_excludes_non_transfer_groups():
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    _set_transfer_group_selector(scheduler, 1, 2)
+    scheduler.supports_load_range = True
+    scheduler._scheduler_block_size = 16
+    scheduler._piecewise_group_block_sizes = (16, 16)
+    scheduler._is_hma_required = False
+    scheduler.is_kv_producer = False
+    scheduler._reqs_need_recv = {}
+    params = {
+        "do_remote_prefill": True,
+        "remote_engine_id": "prefill",
+        "remote_bootstrap_addr": "127.0.0.1:1234",
+        "transfer_id": "transfer",
+    }
+    request = SimpleNamespace(request_id="req", kv_transfer_params=params)
+    blocks = MagicMock()
+    blocks.get_unhashed_block_ids_all_groups.return_value = [
+        [10, 11, 12, 13],
+        [20, 21, 22, 23],
+        [30, 31, 32, 33],
+    ]
+
+    scheduler.update_state_after_alloc_for_range(request, blocks, KVLoadRange(32, 64))
+
+    assert scheduler._reqs_need_recv["req"] == (
+        request,
+        [[22, 23], [32, 33]],
+    )
+
+
+def test_piecewise_capability_accepts_hybrid_attention_but_not_mamba():
+    vllm_config = MagicMock()
+    vllm_config.cache_config.block_size = 16
+    vllm_config.cache_config.prefix_match_unit = None
+    vllm_config.parallel_config.decode_context_parallel_size = 1
+    vllm_config.kv_transfer_config.kv_role = "kv_consumer"
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+    full = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=64,
+        dtype=torch.float16,
+    )
+    swa = SlidingWindowSpec(
+        block_size=8,
+        num_kv_heads=4,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=32,
+    )
+    attention_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full"], full),
+            KVCacheGroupSpec(["swa"], swa),
+        ],
+    )
+
+    scheduler = MooncakeConnectorScheduler(vllm_config, "engine", attention_config)
+
+    assert scheduler.supports_load_range
+    assert scheduler._scheduler_block_size == 16
+    assert scheduler._piecewise_group_block_sizes == (16, 8)
+
+    packed_mla = UniformTypeKVCacheSpecs(
+        block_size=256,
+        kv_cache_specs={
+            "c4": MLAAttentionSpec(
+                block_size=256,
+                num_kv_heads=1,
+                head_size=512,
+                dtype=torch.uint8,
+                tokens_per_state=4,
+            ),
+            "c128": MLAAttentionSpec(
+                block_size=256,
+                num_kv_heads=1,
+                head_size=512,
+                dtype=torch.uint8,
+                tokens_per_state=128,
+            ),
+        },
+    )
+    packed_swa = UniformTypeKVCacheSpecs(
+        block_size=4,
+        kv_cache_specs={
+            "swa": SlidingWindowMLASpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=512,
+                dtype=torch.float32,
+                sliding_window=8,
+            )
+        },
+    )
+    packed_attention_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["c4", "c128"], packed_mla),
+            KVCacheGroupSpec(["swa"], packed_swa),
+        ],
+    )
+
+    scheduler = MooncakeConnectorScheduler(
+        vllm_config, "engine", packed_attention_config
+    )
+
+    assert scheduler.supports_load_range
+    assert scheduler._scheduler_block_size == 256
+    assert scheduler._piecewise_group_block_sizes == (256, 4)
+    assert scheduler.blocks_per_sw == [0, 3]
+
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((4, 8),),
+        dtypes=(torch.float16,),
+    )
+    recurrent_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full"], full),
+            KVCacheGroupSpec(["mamba"], mamba),
+        ],
+    )
+
+    scheduler = MooncakeConnectorScheduler(vllm_config, "engine", recurrent_config)
+
+    assert not scheduler.supports_load_range
+
+
+def test_piecewise_block_sizes_include_dcp_sharding():
+    vllm_config = MagicMock()
+    vllm_config.cache_config.block_size = 16
+    vllm_config.cache_config.prefix_match_unit = None
+    vllm_config.parallel_config.decode_context_parallel_size = 2
+    vllm_config.kv_transfer_config.kv_role = "kv_consumer"
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = True
+    cache_config = _make_test_kv_cache_config()
+
+    scheduler = MooncakeConnectorScheduler(vllm_config, "engine", cache_config)
+
+    assert scheduler._scheduler_block_size == 32
+    assert scheduler._piecewise_group_block_sizes == (32,)
 
 
 class FakeMooncakeWrapper:
@@ -686,6 +1069,20 @@ def patch_worker_dependencies():
         patch(
             "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector.make_zmq_socket"
         ) as mock_make_zmq,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.torch.accelerator.current_device_index",
+            return_value=0,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.current_platform.set_device"
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.get_current_attn_backends",
+            return_value=[],
+        ),
         patch("httpx.AsyncClient") as mock_async_client,
     ):
         # Mock PP group
@@ -1185,6 +1582,68 @@ def test_register_kv_caches(layout: KVCacheLayout, separate_kv_head_groups: bool
                 assert worker.kv_block_len_per_layer == [spec.page_size_bytes] * 2
                 assert worker.registered_layer_names == list(kv_caches)
                 assert worker.registered_layer_indices == [0, 1]
+
+
+def test_register_kv_caches_excludes_non_transfer_groups():
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_consumer"
+    )
+    spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=64,
+        dtype=torch.float16,
+    )
+    groups = [
+        KVCacheGroupSpec(
+            [f"model.layers.{i}.self_attn"],
+            spec,
+            enable_kv_transfer=i > 0,
+        )
+        for i in range(3)
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch_worker_dependencies(),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.threading.Event"
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.threading.Thread"
+        ) as mock_thread,
+    ):
+        connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            kv_cache_config,
+        )
+        worker = connector.connector_worker
+        mock_thread.return_value.is_alive.return_value = False
+        kv_caches = {
+            group.layer_names[0]: torch.zeros(
+                (2, spec.page_size_bytes), dtype=torch.uint8
+            )
+            for group in groups
+        }
+
+        with patch.object(worker.engine, "batch_register_memory", return_value=0):
+            connector.register_kv_caches(kv_caches)
+
+        assert worker.registered_layer_names == [
+            "model.layers.1.self_attn",
+            "model.layers.2.self_attn",
+        ]
+        assert worker.registered_layer_indices == [1, 2]
+        assert worker.registered_group_indices == [0, 1]
+        assert len(worker.kv_caches_base_addr) == 2
 
 
 def test_register_kv_caches_supports_mixed_mla_and_eagle_shapes():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
@@ -347,6 +347,16 @@ def test_recv_skips_swa_blocks_before_window():
     swa_hashes = {k.rsplit("@", 1)[-1] for k in swa_keys}
     assert swa_hashes == {hs[2].hex(), hs[3].hex()}
 
+    requested_keys.clear()
+    req.req_id = "r1"
+    assert req.load_spec is not None
+    req.load_spec.load_group_ids = (0,)
+    recv.request_queue.put(req)
+    recv._handle_request(recv.request_queue.get())
+
+    assert requested_keys
+    assert all("@group:0" in key for key in requested_keys)
+
 
 def test_chunked_token_database_hash_block_size_smaller_than_block_size():
     """DSv4-style: hash_block_size=4, group block_size=16 — process_tokens

--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -2,21 +2,26 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVLoadRange
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
     LoadSpec,
     MooncakeLookupResult,
     MooncakeStoreWorkerMetadata,
     ReqMeta,
     RequestTracker,
+    TailKeyBoundary,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler import (
     MooncakeStoreScheduler,
 )
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.sched.output import KVConnectorBlockState
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 
 
 def _make_bare_scheduler(
@@ -50,6 +55,7 @@ def _make_bare_scheduler(
     scheduler._next_store_job_id = 0
     scheduler._pinned_saves = {}
     scheduler._boundary_state_group_ids = frozenset({1})
+    scheduler._range_load_group_ids = (0,)
     return scheduler
 
 
@@ -98,7 +104,7 @@ def _make_decode_scheduler_output(
         ),
         num_scheduled_tokens={"req-0": num_scheduled_tokens},
         scheduled_spec_decode_tokens={},
-        kv_connector_block_state=_make_connector_block_state(block_ids=([0, 1, 2],)),
+        kv_connector_block_state=_make_connector_block_state(),
     )
 
 
@@ -211,6 +217,98 @@ def test_update_state_excludes_nontransfer_groups():
     scheduler.update_state_after_alloc(request, blocks, num_external_tokens=32)
 
     assert scheduler._unfinished_requests["req-1"][1] == ([1, 2],)
+
+
+def test_range_load_group_ids_use_transfer_group_indices():
+    groups = [
+        SimpleNamespace(kv_cache_spec=object(), enable_kv_transfer=False),
+        SimpleNamespace(kv_cache_spec=object(), enable_kv_transfer=True),
+        SimpleNamespace(
+            kv_cache_spec=MambaSpec(
+                block_size=16,
+                shapes=((1,),),
+                dtypes=(torch.float32,),
+                mamba_cache_mode="align",
+            ),
+            enable_kv_transfer=True,
+        ),
+    ]
+    kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+    vllm_config = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(
+            kv_role="kv_both",
+            kv_connector_extra_config={},
+        ),
+        kv_events_config=None,
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            world_size=1,
+        ),
+    )
+
+    module = "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.scheduler"
+    with (
+        patch(f"{module}.LookupKeyClient"),
+        patch(f"{module}.resolve_kv_cache_block_sizes", return_value=(16, 16)),
+        patch(f"{module}.partial_hash_hits_enabled", return_value=False),
+    ):
+        scheduler = MooncakeStoreScheduler(vllm_config, kv_cache_config)
+
+    assert scheduler._boundary_state_group_ids == frozenset({2})
+    assert scheduler._range_load_group_ids == (0,)
+
+
+def test_range_load_trims_payload_clears_stale_store_key_boundary():
+    scheduler = _make_bare_scheduler()
+    scheduler.load_specs["req-1"] = LoadSpec(
+        vllm_cached_tokens=0,
+        kvpool_cached_tokens=1584,
+        can_load=False,
+        tail_key_boundaries=(
+            TailKeyBoundary(0, 1584),
+            TailKeyBoundary(1, 1600),
+        ),
+    )
+    request = SimpleNamespace(request_id="req-1")
+    blocks = SimpleNamespace(get_block_ids=lambda: ([1, 2, 3, 4], [9, 10]))
+
+    scheduler.update_state_after_alloc_for_range(
+        request,
+        blocks,
+        KVLoadRange(0, 1568, is_terminal=False),
+    )
+
+    load_spec = scheduler.load_specs["req-1"]
+    assert load_spec.kvpool_cached_tokens == 1568
+    assert load_spec.load_group_ids == (0,)
+    assert load_spec.tail_key_boundaries == ()
+    assert load_spec.can_load is True
+
+
+def test_nonterminal_range_skips_state_for_pure_recurrent_model():
+    scheduler = _make_bare_scheduler()
+    scheduler._range_load_group_ids = ()
+    scheduler.load_specs["req-1"] = LoadSpec(
+        vllm_cached_tokens=0,
+        kvpool_cached_tokens=64,
+        can_load=False,
+    )
+
+    scheduler.update_state_after_alloc_for_range(
+        SimpleNamespace(request_id="req-1"),
+        SimpleNamespace(get_block_ids=lambda: ([9],)),
+        KVLoadRange(0, 32, is_terminal=False),
+    )
+
+    load_spec = scheduler.load_specs["req-1"]
+    assert scheduler.supports_load_range
+    assert load_spec.load_group_ids == ()
+    assert load_spec.kvpool_cached_tokens == 32
+    assert load_spec.can_load
 
 
 def _setup_decode_request(

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -4,19 +4,25 @@ import filecmp
 import shutil
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 
-from tests.v1.kv_connector.unit.utils import create_vllm_config
+from tests.v1.kv_connector.unit.utils import (
+    create_request,
+    create_scheduler,
+    create_vllm_config,
+)
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.distributed.kv_transfer.kv_connector.v1 import KVConnectorRole
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
+    KVLoadRange,
     SupportsHMA,
     supports_hma,
 )
@@ -30,8 +36,16 @@ from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
     NixlKVConnectorStats,
 )
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.outputs import KVConnectorOutput, KVConnectorWorkerMetadata
+from vllm.v1.request import RequestStatus
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 
@@ -99,12 +113,14 @@ class MockHMAConnector(KVConnectorBase_V1, SupportsHMA):
     """Mock connector that supports HMA for testing."""
 
     _supports_divergent_local_hybrid_hits = False
+    _supports_load_range = False
 
     def __new__(cls, *args, **kwargs):
         mock = MagicMock(spec_set=cls)
         mock.supports_divergent_local_hybrid_hits = (
             cls._supports_divergent_local_hybrid_hits
         )
+        mock.supports_load_range = cls._supports_load_range
         mock.get_kv_connector_stats.return_value = None
         return mock
 
@@ -137,10 +153,17 @@ class MockDivergentHMAConnector(MockHMAConnector):
     _supports_divergent_local_hybrid_hits = True
 
 
+class MockRangeHMAConnector(MockHMAConnector):
+    _supports_load_range = True
+
+
 # Register mock connectors
 KVConnectorFactory.register_connector("MockConnector", __name__, MockConnector.__name__)
 KVConnectorFactory.register_connector(
     "MockHMAConnector", __name__, MockHMAConnector.__name__
+)
+KVConnectorFactory.register_connector(
+    "MockRangeHMAConnector", __name__, MockRangeHMAConnector.__name__
 )
 KVConnectorFactory.register_connector(
     "MockDivergentHMAConnector",
@@ -167,6 +190,14 @@ def test_register_finished_partial_tail_notifies_every_connector():
     second.register_finished_partial_tail.assert_called_once_with(
         request, block_ids, offloads
     )
+
+
+def test_multi_connector_aggregates_load_errors(mc: MultiConnector):
+    first, second = mc._connectors
+    first.get_block_ids_with_load_errors.return_value = {1, 2}
+    second.get_block_ids_with_load_errors.return_value = {2, 3}
+
+    assert mc.get_block_ids_with_load_errors() == {1, 2, 3}
 
 
 @pytest.fixture
@@ -196,6 +227,492 @@ def mc() -> MultiConnector:
     )
 
     return mc
+
+
+def _make_policy_connector(
+    matches: list[tuple[int | None, bool]],
+    supports_range: list[bool],
+) -> MultiConnector:
+    connector = MultiConnector.__new__(MultiConnector)
+    connector._connectors = []
+    for match, supports in zip(matches, supports_range):
+        child = MagicMock(spec_set=KVConnectorBase_V1)
+        child.get_num_new_matched_tokens.return_value = match
+        child.supports_load_range = supports
+        child.load_range_alignment = None
+        connector._connectors.append(child)
+    connector._range_load = True
+    connector._scheduler_block_size = 16
+    connector._requests_to_connector = {}
+    connector._request_load_ranges = {}
+    connector._request_async_loads = {}
+    connector._async_loads_to_send = {}
+    connector._async_load_sources = {}
+    connector._pending_async_loads = {}
+    connector._extra_async_saves = {}
+    return connector
+
+
+def _make_hybrid_policy_config(
+    load_policy: str = "range_aware",
+    connector_name: str = "MockHMAConnector",
+):
+    child_config = {
+        "kv_connector": connector_name,
+        "kv_role": "kv_both",
+        "kv_connector_module_path": __name__,
+    }
+    return create_vllm_config(
+        kv_connector="MultiConnector",
+        kv_connector_extra_config={
+            "load_policy": load_policy,
+            "connectors": [child_config, child_config],
+        },
+    )
+
+
+def _make_unequal_group_cache_config() -> KVCacheConfig:
+    full = FullAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+    )
+    swa = SlidingWindowSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=16,
+    )
+    return KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["full"], full),
+            KVCacheGroupSpec(["swa"], swa),
+        ],
+    )
+
+
+def _make_recurrent_cache_config(*, wrapped: bool = False) -> KVCacheConfig:
+    mamba_spec = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+    )
+    group_spec = (
+        UniformTypeKVCacheSpecs(
+            block_size=16,
+            kv_cache_specs={"mamba": mamba_spec},
+        )
+        if wrapped
+        else mamba_spec
+    )
+    return KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["mamba"],
+                group_spec,
+            )
+        ],
+    )
+
+
+def test_range_aware_init_uses_scheduler_block_size_for_hybrid_groups():
+    connector = MultiConnector(
+        _make_hybrid_policy_config(),
+        KVConnectorRole.SCHEDULER,
+        _make_unequal_group_cache_config(),
+    )
+
+    assert connector._scheduler_block_size == 256
+
+
+def test_multi_connector_rejects_unknown_load_policy():
+    with pytest.raises(ValueError, match="Unknown MultiConnector load_policy"):
+        MultiConnector(
+            _make_hybrid_policy_config("range-aware"),
+            KVConnectorRole.SCHEDULER,
+            _make_unequal_group_cache_config(),
+        )
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_range_aware_recurrent_cache_requires_range_capable_children(wrapped: bool):
+    with pytest.raises(ValueError, match="requires every child connector"):
+        MultiConnector(
+            _make_hybrid_policy_config(),
+            KVConnectorRole.SCHEDULER,
+            _make_recurrent_cache_config(wrapped=wrapped),
+        )
+
+
+def test_range_aware_recurrent_cache_accepts_range_capable_children():
+    MultiConnector(
+        _make_hybrid_policy_config(connector_name="MockRangeHMAConnector"),
+        KVConnectorRole.SCHEDULER,
+        _make_recurrent_cache_config(),
+    )
+
+
+def test_range_aware_load_assigns_contiguous_ranges():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    leading, suffix = connector._connectors
+    leading.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    suffix.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96)
+    )
+    assert connector._async_loads_to_send == {"req": (0, 1)}
+
+
+def test_range_aware_load_gives_range_capable_leader_explicit_ownership():
+    connector = _make_policy_connector([(64, True), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    leading, suffix = connector._connectors
+    leading.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(0, 64, is_terminal=False)
+    )
+    suffix.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96)
+    )
+
+
+def test_range_aware_load_respects_scheduler_declining_external_load():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 0)
+
+    for child in connector._connectors:
+        child.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+        child.update_state_after_alloc_for_range.assert_not_called()
+    assert connector._async_loads_to_send == {}
+
+
+def test_scheduler_partial_local_tail_cancels_range_load():
+    scheduler = create_scheduler(_make_hybrid_policy_config())
+    connector = scheduler.connector
+    assert isinstance(connector, MultiConnector)
+    first, second = connector._connectors
+    first.get_num_new_matched_tokens.return_value = (0, True)
+    second.get_num_new_matched_tokens.return_value = (6, True)
+    second.supports_load_range = True
+    second.load_range_alignment = None
+
+    request = create_request(num_tokens=32, block_size=16)
+    scheduler.add_request(request)
+    scheduler._get_local_prefix_cache_hit = MagicMock(
+        return_value=(
+            scheduler.kv_cache_manager.empty_kv_cache_blocks,
+            6,
+            0,
+            False,
+        )
+    )
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == 26
+    assert request.status == RequestStatus.RUNNING
+    first.update_state_after_alloc.assert_called_once_with(
+        request, scheduler.kv_cache_manager.get_blocks(request.request_id), 0
+    )
+    second.update_state_after_alloc.assert_called_once_with(
+        request, scheduler.kv_cache_manager.get_blocks(request.request_id), 0
+    )
+    second.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_range_aware_load_rejects_changed_positive_token_count():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+
+    with pytest.raises(ValueError, match="expected 96, got 80"):
+        connector.update_state_after_alloc(request, MagicMock(), 80)
+
+
+def test_range_aware_load_extends_a_local_hit():
+    connector = _make_policy_connector([(32, True), (64, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 32) == (64, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 64)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 32)
+    second.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96)
+    )
+
+
+def test_range_aware_load_rounds_previous_range_to_next_alignment():
+    connector = _make_policy_connector([(60, True), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    assert connector._request_load_ranges["req"] == {
+        0: KVLoadRange(0, 48, is_terminal=False),
+        1: KVLoadRange(48, 96, is_terminal=True),
+    }
+
+
+def test_range_aware_load_does_not_trim_legacy_leader():
+    connector = _make_policy_connector([(60, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+    first.update_state_after_alloc_for_range.assert_not_called()
+    second.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_range_aware_load_does_not_mix_sync_and_async_ranges():
+    connector = _make_policy_connector([(64, False), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+    first.update_state_after_alloc_for_range.assert_not_called()
+    second.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_range_aware_load_falls_back_when_aligned_range_is_empty():
+    connector = _make_policy_connector([(12, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+
+
+def test_range_aware_load_combines_adjacent_and_scheduler_alignments():
+    connector = _make_policy_connector([(60, True), (96, True)], [True, True])
+    connector._connectors[0].load_range_alignment = 24
+    connector._connectors[1].load_range_alignment = 4
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    assert connector._request_load_ranges["req"] == {
+        0: KVLoadRange(0, 48, is_terminal=False),
+        1: KVLoadRange(48, 96, is_terminal=True),
+    }
+
+
+def test_range_aware_load_skips_unaligned_explicit_leader():
+    connector = _make_policy_connector(
+        [(32, True), (64, True), (96, True)], [True, True, True]
+    )
+    connector._connectors[0].load_range_alignment = 64
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 16) == (96, True)
+    assert connector._request_load_ranges["req"] == {
+        1: KVLoadRange(16, 80, is_terminal=False),
+        2: KVLoadRange(80, 112, is_terminal=True),
+    }
+
+
+def test_range_aware_load_falls_back_when_all_leaders_are_unaligned():
+    connector = _make_policy_connector([(32, True), (64, True)], [True, True])
+    for child in connector._connectors:
+        child.load_range_alignment = 64
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 16) == (64, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 64)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    for child in connector._connectors:
+        child.update_state_after_alloc_for_range.assert_not_called()
+
+
+@pytest.mark.parametrize("alignment", [0, -1])
+def test_range_aware_load_rejects_non_positive_alignment(alignment: int):
+    connector = _make_policy_connector([(64, True), (96, True)], [True, True])
+    connector._connectors[1].load_range_alignment = alignment
+
+    with pytest.raises(ValueError, match="load_range_alignment must be positive"):
+        connector.get_num_new_matched_tokens(SimpleNamespace(request_id="req"), 0)
+
+
+def test_range_aware_load_combines_three_sources():
+    connector = _make_policy_connector(
+        [(64, True), (96, True), (128, True)], [False, True, True]
+    )
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (128, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 128)
+
+    first, second, third = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 96, is_terminal=False)
+    )
+    third.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(96, 128)
+    )
+    assert connector._async_loads_to_send == {"req": (0, 1, 2)}
+
+
+def test_range_aware_load_skips_unsupported_intermediate_source():
+    connector = _make_policy_connector(
+        [(64, True), (96, True), (128, True)], [False, False, True]
+    )
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (128, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 128)
+
+    first, second, third = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    second.update_state_after_alloc_for_range.assert_not_called()
+    third.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 128)
+    )
+
+
+def test_range_aware_load_allows_unaligned_final_tail():
+    connector = _make_policy_connector([(64, True), (70, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (70, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 70)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc_for_range.assert_called_once_with(
+        request, blocks, KVLoadRange(64, 70)
+    )
+
+
+def test_range_aware_load_uses_one_source_for_equal_hits():
+    connector = _make_policy_connector([(96, True), (96, True)], [True, True])
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 96)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 96)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    assert connector._async_loads_to_send == {"req": (0,)}
+
+
+def test_range_aware_load_waits_for_all_async_sources():
+    scheduler = _make_policy_connector(
+        [(64, True), (96, True), (128, True)], [False, True, True]
+    )
+    request = SimpleNamespace(request_id="req")
+    assert scheduler.get_num_new_matched_tokens(request, 0) == (128, True)
+    scheduler.update_state_after_alloc(request, MagicMock(), 128)
+
+    metadata = scheduler.build_connector_meta(MagicMock())
+    assert metadata.pending_async_loads == {"req": (0, 1, 2)}
+
+    worker = _make_policy_connector(
+        [(0, False), (0, False), (0, False)], [False, True, True]
+    )
+    worker.bind_connector_metadata(metadata)
+    first, second, third = worker._connectors
+    first.get_finished.return_value = (None, {"req"})
+    second.get_finished.return_value = (None, None)
+    third.get_finished.return_value = (None, None)
+
+    assert worker.get_finished(set()) == (None, None)
+
+    first.get_finished.return_value = (None, None)
+    second.get_finished.return_value = (None, {"req"})
+    assert worker.get_finished(set()) == (None, None)
+
+    second.get_finished.return_value = (None, None)
+    third.get_finished.return_value = (None, {"req"})
+    assert worker.get_finished(set()) == (None, {"req"})
+
+    third.get_finished.return_value = (None, None)
+    first.get_finished.return_value = (None, {"req"})
+    assert worker.get_finished(set()) == (None, None)
+
+    first.get_finished.return_value = (None, None)
+    assert worker.get_finished({"req"}) == (None, None)
+    assert worker._async_load_sources == {}
+
+
+def test_range_aware_second_allocation_update_is_forwarded_as_no_load():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    request = SimpleNamespace(request_id="req")
+    assert connector.get_num_new_matched_tokens(request, 0) == (96, True)
+    connector.update_state_after_alloc(request, MagicMock(), 96)
+    for child in connector._connectors:
+        child.reset_mock()
+
+    blocks = MagicMock()
+    connector.update_state_after_alloc(request, blocks, 0)
+
+    for child in connector._connectors:
+        child.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+        child.update_state_after_alloc_for_range.assert_not_called()
+
+
+def test_default_load_policy_still_selects_first_hit():
+    connector = _make_policy_connector([(64, True), (96, True)], [False, True])
+    connector._range_load = False
+    load_ranges = connector._request_load_ranges = MagicMock()
+    async_loads = connector._request_async_loads = MagicMock()
+    request = SimpleNamespace(request_id="req")
+
+    assert connector.get_num_new_matched_tokens(request, 0) == (64, True)
+    connector.update_state_after_alloc(request, blocks := MagicMock(), 64)
+
+    first, second = connector._connectors
+    first.update_state_after_alloc.assert_called_once_with(request, blocks, 64)
+    second.update_state_after_alloc.assert_called_once_with(request, blocks, 0)
+    load_ranges.pop.assert_not_called()
+    async_loads.pop.assert_not_called()
+
+
+def test_prom_metrics_skips_configured_connector_without_exporter():
+    metrics = MultiKVConnectorPromMetrics.__new__(MultiKVConnectorPromMetrics)
+    supported = MagicMock()
+    metrics._prom_metrics = {"Supported": supported, "Unsupported": None}
+
+    metrics.observe(
+        {
+            "Supported": {"bytes": 1},
+            "Unsupported": {"bytes": 2},
+        },
+        engine_idx=3,
+    )
+
+    supported.observe.assert_called_once_with({"bytes": 1}, 3)
 
 
 # Helper function to compare directories recursively
@@ -873,6 +1390,9 @@ def test_multi_connector_overrides_all_base_methods():
         "role",
         "has_connector_metadata",
         "get_kv_connector_kv_cache_events",
+        "supports_load_range",
+        "load_range_alignment",
+        "update_state_after_alloc_for_range",
     }
 
     base_members = {

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -43,6 +43,7 @@ The class provides the following primitives:
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -78,6 +79,26 @@ CopyBlocksOp = Callable[
     ],
     None,
 ]
+
+
+@dataclass(frozen=True)
+class KVLoadRange:
+    """Half-open absolute token range assigned to one connector.
+
+    A boundary shared by two sources is aligned for both connectors and the
+    scheduler's KV block layout. Only a terminal range may end in a partial
+    scheduler block.
+    """
+
+    start_token: int
+    end_token: int
+    # The terminal range owns any recurrent state at end_token.
+    is_terminal: bool = True
+
+    @property
+    def num_tokens(self) -> int:
+        return self.end_token - self.start_token
+
 
 logger = init_logger(__name__)
 
@@ -506,6 +527,41 @@ class KVConnectorBase_V1(ABC):
                 external KV cache. 0 means nothing should be loaded.
         """
         pass
+
+    @property
+    def supports_load_range(self) -> bool:
+        """Whether this connector accepts an explicitly assigned load range.
+
+        MultiConnector only composes children whose lookup results agree on
+        synchronous versus asynchronous loading; otherwise it uses one child.
+        """
+        return False
+
+    @property
+    def load_range_alignment(self) -> int | None:
+        """Additional positive alignment for inter-source boundaries.
+
+        MultiConnector combines this value with the scheduler block size and
+        the neighboring connector's requirement. ``None`` adds no constraint.
+        """
+        return None
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> None:
+        """Load an absolute token range into the request's allocated blocks.
+
+        ``blocks`` is the request's complete allocated block table, not a view
+        sliced to ``load_range``. Implementations must locate each KV group's
+        destination blocks from the absolute token offsets. A later
+        ``update_state_after_alloc(request, blocks, 0)`` is allowed and must
+        remain a no-load operation. Load failures follow the
+        ``get_block_ids_with_load_errors`` contract.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def build_connector_meta(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -28,6 +28,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    KVLoadRange,
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
@@ -52,6 +53,7 @@ from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
 from vllm.utils.torch_utils import is_non_overlapping_and_dense
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -60,6 +62,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MambaSpec,
     SlidingWindowSpec,
+    iter_layer_specs,
 )
 from vllm.v1.request import RequestStatus
 from vllm.v1.worker.block_table import BlockTable
@@ -510,6 +513,23 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
             request, blocks, num_external_tokens
         )
 
+    @property
+    def supports_load_range(self) -> bool:
+        return bool(
+            self.connector_scheduler and self.connector_scheduler.supports_load_range
+        )
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.update_state_after_alloc_for_range(
+            request, blocks, load_range
+        )
+
     def build_connector_meta(
         self,
         scheduler_output: SchedulerOutput,
@@ -596,6 +616,16 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
 class MooncakeConnectorScheduler:
     """Implementation of Scheduler side methods"""
 
+    _REMOTE_PREFILL_FIELDS = (
+        "remote_engine_id",
+        "remote_bootstrap_addr",
+        "transfer_id",
+    )
+
+    @classmethod
+    def _missing_remote_prefill_fields(cls, params: dict[str, Any]) -> list[str]:
+        return [field for field in cls._REMOTE_PREFILL_FIELDS if field not in params]
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -603,7 +633,10 @@ class MooncakeConnectorScheduler:
         kv_cache_config: "KVCacheConfig",
     ):
         self.vllm_config = vllm_config
-        self.block_size = vllm_config.cache_config.block_size
+        self.kv_cache_config = kv_cache_config
+        self._scheduler_block_size, _ = resolve_kv_cache_block_sizes(
+            kv_cache_config, vllm_config
+        )
 
         assert vllm_config.kv_transfer_config
         self.is_kv_producer: bool = (
@@ -618,12 +651,28 @@ class MooncakeConnectorScheduler:
             not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
             and any(
                 not isinstance(g.kv_cache_spec, FullAttentionSpec)
-                for g in kv_cache_config.kv_cache_groups
+                for g in kv_cache_config.transfer_groups
             )
         )
+        transfer_groups = kv_cache_config.transfer_groups
         # GDN is represented as a MambaSpec in vLLM. This Mooncake MambaSpec
         # path is currently tested with GDN; Mamba2 is not validated yet.
-        self._has_mamba = kv_cache_config.has_mamba_layers
+        self._has_mamba = any(
+            isinstance(inner, MambaSpec)
+            for group in transfer_groups
+            for inner in iter_layer_specs(group.kv_cache_spec)
+        )
+        specs = [group.kv_cache_spec for group in transfer_groups]
+        # Attention pages are independently addressable. Recurrent-state pages
+        # cannot be safely composed from concurrent prefix sources.
+        self.supports_load_range = bool(specs) and all(
+            all(isinstance(inner, AttentionSpec) for inner in iter_layer_specs(spec))
+            for spec in specs
+        )
+        dcp = vllm_config.parallel_config.decode_context_parallel_size
+        self._piecewise_group_block_sizes = tuple(
+            spec.block_size * dcp for spec in specs
+        )
 
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
@@ -635,12 +684,22 @@ class MooncakeConnectorScheduler:
         self._reqs_not_processed: set[TransferId] = set()
 
         # Compute sliding window block counts per KV cache group.
-        sw_sizes_tokens: list[tuple[int, int]] = [
-            (g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size)
-            if isinstance(g.kv_cache_spec, SlidingWindowSpec)
-            else (0, self.block_size)
-            for g in kv_cache_config.kv_cache_groups
-        ]
+        sw_sizes_tokens: list[tuple[int, int]] = []
+        for spec in specs:
+            inner_specs = tuple(iter_layer_specs(spec))
+            windows = {
+                inner.sliding_window
+                for inner in inner_specs
+                if isinstance(inner, SlidingWindowSpec)
+            }
+            is_sliding_group = len(windows) == 1 and all(
+                isinstance(inner, SlidingWindowSpec) for inner in inner_specs
+            )
+            sw_sizes_tokens.append(
+                (windows.pop(), spec.block_size)
+                if is_sliding_group
+                else (0, spec.block_size)
+            )
         # cdiv(n_tokens, block_size) gives blocks/window; add 1 to
         # conservatively account for boundary overlap.
         self.blocks_per_sw = [
@@ -729,6 +788,14 @@ class MooncakeConnectorScheduler:
         if params.get("do_remote_prefill"):
             # Remote prefill: get all prompt blocks from remote.
             assert not self.is_kv_producer
+            missing = self._missing_remote_prefill_fields(params)
+            if missing:
+                logger.warning(
+                    "Ignoring remote prefill for request %s: missing %s",
+                    request.request_id,
+                    ", ".join(missing),
+                )
+                return 0, False
             token_ids = request.prompt_token_ids or []
             count = self._get_remote_prefill_token_count(len(token_ids)) - (
                 num_computed_tokens
@@ -756,15 +823,14 @@ class MooncakeConnectorScheduler:
 
         if params.get("do_remote_prefill"):
             assert not self.is_kv_producer
-            if all(
-                p in params
-                for p in ("remote_engine_id", "remote_bootstrap_addr", "transfer_id")
-            ):
+            if not self._missing_remote_prefill_fields(params):
                 # If remote_blocks and num_external_tokens = 0, we have
                 # a full prefix cache hit on the D worker. We need to call
                 # send_notif in _read_blocks to free the memory on the P.
                 unhashed_block_ids = (
-                    blocks.get_unhashed_block_ids_all_groups()
+                    self.kv_cache_config.select_transfer_block_ids(
+                        blocks.get_unhashed_block_ids_all_groups()
+                    )
                     if num_external_tokens > 0
                     else ()
                 )
@@ -787,6 +853,68 @@ class MooncakeConnectorScheduler:
             else:
                 # Add an empty list to worker to create event.
                 self._reqs_need_send[request.request_id] = (request, [])
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        load_range: KVLoadRange,
+    ) -> None:
+        """Receive destination blocks for the terminal prompt suffix."""
+        assert self.supports_load_range
+        if not load_range.is_terminal:
+            raise ValueError(
+                "MooncakeConnector only supports a terminal piecewise load range"
+            )
+        if load_range.start_token % self._scheduler_block_size:
+            raise ValueError(
+                f"Piecewise range start {load_range.start_token} is not aligned "
+                f"to scheduler block size {self._scheduler_block_size}"
+            )
+        logger.debug(
+            "MooncakeConnector range load: req_id=%s range=[%d, %d)",
+            request.request_id,
+            load_range.start_token,
+            load_range.end_token,
+        )
+
+        params = request.kv_transfer_params
+        assert params and params.get("do_remote_prefill")
+        assert not self.is_kv_producer
+        missing = self._missing_remote_prefill_fields(params)
+        if missing:
+            raise ValueError(f"Missing remote prefill fields: {', '.join(missing)}")
+        unhashed_block_ids = self.kv_cache_config.select_transfer_block_ids(
+            blocks.get_unhashed_block_ids_all_groups()
+        )
+        assert len(unhashed_block_ids) == len(self._piecewise_group_block_sizes)
+        range_blocks = [
+            cdiv(load_range.num_tokens, block_size)
+            for block_size in self._piecewise_group_block_sizes
+        ]
+        needed_blocks = []
+        for i, (group, needed) in enumerate(zip(unhashed_block_ids, range_blocks)):
+            if self._is_hma_required and self.blocks_per_sw[i]:
+                # Sliding-window groups may contain fewer real blocks than the
+                # window cap because padding/null blocks are omitted.
+                needed = min(needed, self.blocks_per_sw[i], len(group))
+            needed_blocks.append(needed)
+        if any(
+            len(group) < needed
+            for group, needed in zip(unhashed_block_ids, needed_blocks)
+        ):
+            raise ValueError(
+                "Piecewise suffix requires more unhashed blocks than allocated: "
+                f"needed={needed_blocks}, "
+                f"available={[len(group) for group in unhashed_block_ids]}"
+            )
+        local_block_ids = [
+            group[-needed:] if needed else []
+            for group, needed in zip(unhashed_block_ids, needed_blocks)
+        ]
+        local_block_ids = self.get_sw_clipped_blocks(local_block_ids)
+        self._reqs_need_recv[request.request_id] = (request, local_block_ids)
+        params["do_remote_prefill"] = False
 
     def build_connector_meta(
         self,
@@ -866,12 +994,13 @@ class MooncakeConnectorScheduler:
 
         # TODO: check whether block_ids actually ever be 0. If not we could
         # remove the conditional below
-        delay_free_blocks = any(len(group) > 0 for group in block_ids)
+        transfer_block_ids = self.kv_cache_config.select_transfer_block_ids(block_ids)
+        delay_free_blocks = any(len(group) > 0 for group in transfer_block_ids)
 
         if delay_free_blocks:
             self._reqs_need_send[request.request_id] = (
                 request,
-                self.get_sw_clipped_blocks(block_ids),
+                self.get_sw_clipped_blocks(transfer_block_ids),
             )
 
         return delay_free_blocks, None
@@ -1015,25 +1144,25 @@ class MooncakeConnectorWorker:
 
         self._tp_size: dict[EngineId, int] = {self.engine_id: self.tp_size}
         self._layer_specs: dict[str, KVCacheSpec] = {}
-        for group in kv_cache_config.kv_cache_groups:
+        for group in kv_cache_config.transfer_groups:
             group_spec = group.kv_cache_spec
             specs_by_layer = getattr(group_spec, "kv_cache_specs", {})
             for layer_name in group.layer_names:
                 self._layer_specs[layer_name] = specs_by_layer.get(
                     layer_name, group_spec
                 )
-        self._layer_group_indices: dict[str, int] = {
-            layer: group_index
-            for group_index, group in enumerate(kv_cache_config.kv_cache_groups)
-            for layer in group.layer_names
-        }
+        self._layer_group_indices = kv_cache_config.transfer_group_index_by_layer
         self.transfer_topo = TransferTopology(
             tp_rank=self.tp_rank,
             tp_size=self.tp_size,
             block_size=self.block_size,
             engine_id=self.engine_id,
             is_mla=self.use_mla,
-            is_mamba=kv_cache_config.has_mamba_layers,
+            is_mamba=any(
+                isinstance(inner, MambaSpec)
+                for group in kv_cache_config.transfer_groups
+                for inner in iter_layer_specs(group.kv_cache_spec)
+            ),
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
             attn_backends=self.attn_backends,
         )
@@ -1392,7 +1521,7 @@ class MooncakeConnectorWorker:
         block_arange = np.arange(self._physical_blocks_per_logical_kv_block).reshape(
             1, -1
         )
-        group_specs = self.kv_cache_config.kv_cache_groups
+        group_specs = self.kv_cache_config.transfer_groups
         return [
             BlockTable.map_to_kernel_blocks(
                 np.array(group),
@@ -1445,7 +1574,7 @@ class MooncakeConnectorWorker:
             local_block_ids_by_group: list[list[int]] = []
             remote_block_ids_by_group: list[list[int]] = []
             has_block_error = False
-            group_specs = self.kv_cache_config.kv_cache_groups
+            group_specs = self.kv_cache_config.transfer_groups
             for group_index, (local_group, remote_group) in enumerate(
                 zip(send_meta.local_block_ids, remote_block_ids_per_group)
             ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py
@@ -28,6 +28,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorRole,
     KVConnectorWorkerMetadata,
+    KVLoadRange,
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -228,6 +229,23 @@ class MooncakeStoreConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.update_state_after_alloc(
             request, blocks, num_external_tokens
+        )
+
+    @property
+    def supports_load_range(self) -> bool:
+        return bool(
+            self.connector_scheduler and self.connector_scheduler.supports_load_range
+        )
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        load_range: KVLoadRange,
+    ) -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.update_state_after_alloc_for_range(
+            request, blocks, load_range
         )
 
     def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -693,6 +693,7 @@ class LoadSpec:
     can_load: bool
     token_len: int = 0
     tail_key_boundaries: tuple[TailKeyBoundary, ...] = ()
+    load_group_ids: tuple[int, ...] | None = None
 
 
 @dataclass

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -8,6 +8,7 @@
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
+    KVLoadRange,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.coordinator import (  # noqa: E501
     partial_hash_hits_enabled,
@@ -90,6 +91,11 @@ class MooncakeStoreScheduler:
             spec.mamba_cache_mode == "align" for spec in mamba_groups.values()
         ), "MooncakeStoreScheduler requires mamba_cache_mode='align'"
         self._boundary_state_group_ids = frozenset(mamba_groups)
+        self._range_load_group_ids = tuple(
+            transfer_idx
+            for transfer_idx, group_id in enumerate(kv_cache_config.transfer_group_ids)
+            if group_id not in self._boundary_state_group_ids
+        )
 
         self._gpu_block_pool: BlockPool | None = None
         self._num_workers = vllm_config.parallel_config.world_size
@@ -200,6 +206,33 @@ class MooncakeStoreScheduler:
         )
 
         self.load_specs[request.request_id].can_load = True
+
+    @property
+    def supports_load_range(self) -> bool:
+        # A non-terminal range owns attention KV only. Pure recurrent models
+        # therefore schedule an empty Store load and leave the boundary state
+        # to the terminal connector.
+        return True
+
+    def update_state_after_alloc_for_range(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        load_range: KVLoadRange,
+    ) -> None:
+        load_spec = self.load_specs[request.request_id]
+        load_spec.vllm_cached_tokens = load_range.start_token
+        if load_range.end_token < load_spec.kvpool_cached_tokens:
+            # A partial-hash lookup may have recorded the key boundary for its
+            # original tail. Once MultiConnector trims that tail to an aligned
+            # range, the last full chunk must use its own hash instead.
+            load_spec.tail_key_boundaries = ()
+        if load_range.is_terminal:
+            load_spec.load_group_ids = None
+        else:
+            load_spec.kvpool_cached_tokens = load_range.end_token
+            load_spec.load_group_ids = self._range_load_group_ids
+        self.update_state_after_alloc(request, blocks, load_range.num_tokens)
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
@@ -419,7 +452,11 @@ class MooncakeStoreScheduler:
         meta: MooncakeStoreConnectorMetadata,
         scheduler_output: SchedulerOutput,
     ) -> None:
-        """Replace append-only mirrors with the core's current block tables."""
+        """Refresh save metadata for block tables changed in this step.
+
+        The core's block state is sparse. Requests without an entry retain the
+        block table already maintained by their scheduler tracker.
+        """
         save_metas = [req_meta for req_meta in meta.requests if req_meta.can_save]
         if not save_metas:
             return
@@ -430,10 +467,8 @@ class MooncakeStoreScheduler:
         )
         for req_meta in save_metas:
             block_ids = block_state.block_ids.get(req_meta.req_id)
-            assert block_ids is not None, (
-                f"Missing current block table for store request {req_meta.req_id}"
-            )
-            req_meta.block_ids = block_ids
+            if block_ids is not None:
+                req_meta.block_ids = block_ids
 
     def _reference_save_blocks(self, meta: MooncakeStoreConnectorMetadata) -> None:
         """Take a GPU block reference for every store job this step emits.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -1304,31 +1304,34 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         return invalid_block_ids
 
     def _handle_request(self, req_meta: ReqMeta):
-        token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
+        load_spec = req_meta.load_spec
+        assert load_spec is not None
+        token_len = load_spec.token_len
         req_id = req_meta.req_id
-        mask_num = (
-            req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
-            // self.block_size
-            * self.block_size
-        )
+        mask_num = load_spec.vllm_cached_tokens // self.block_size * self.block_size
 
         # Skip chunks the consumer's per-group spec wouldn't populate
         # locally (e.g. SWA pre-window) even if the producer stored them.
         load_mask_per_group = self.coord.load_mask(req_meta.block_hashes, token_len)
         tail_key_boundaries = {
             boundary.group_id: boundary.num_tokens
-            for boundary in (
-                req_meta.load_spec.tail_key_boundaries  # type: ignore[union-attr]
-            )
+            for boundary in load_spec.tail_key_boundaries
         }
 
         addr_list: list[list[int]] = []
         size_list: list[list[int]] = []
         key_list: list[str] = []
         block_id_list: list[int] = []
-        for g_idx, db in enumerate(self.token_databases):
+        load_group_ids = load_spec.load_group_ids
+        group_ids = (
+            range(len(self.token_databases))
+            if load_group_ids is None
+            else load_group_ids
+        )
+        for g_idx in group_ids:
             if not self.group_participates[g_idx]:
                 continue
+            db = self.token_databases[g_idx]
             mask = load_mask_per_group[g_idx]
             chunks: list[tuple[int, int]] = []
             store_shard_ids: list[StoreShardId] = []
@@ -1357,6 +1360,11 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             addr_list.extend(g_addrs)
             size_list.extend(g_sizes)
             block_id_list.extend(g_block_ids)
+
+        if not key_list:
+            self.set_finished_request(req_id)
+            self.request_queue.task_done()
+            return
 
         # Rotate aligned lists by tp_rank for load balancing.
         rotation = self.tp_rank % len(key_list)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -3,6 +3,7 @@
 import copy
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from math import lcm
 from typing import TYPE_CHECKING, Any, cast
 
 import torch
@@ -18,6 +19,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorRole,
     KVConnectorWorkerMetadata,
+    KVLoadRange,
     SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -28,6 +30,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
 )
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 
@@ -46,6 +49,7 @@ logger = init_logger(__name__)
 class MultiKVConnectorMetadata(KVConnectorMetadata):
     metadata: tuple[KVConnectorMetadata, ...]
     extra_async_saves: dict[str, int] | None = None
+    pending_async_loads: dict[str, tuple[int, ...]] | None = None
 
 
 @dataclass
@@ -116,7 +120,7 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
         metric_types: dict[type[PromMetric], type[PromMetricT]],
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
-        prom_metrics: dict[str, KVConnectorPromMetrics],
+        prom_metrics: dict[str, KVConnectorPromMetrics | None],
     ):
         super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
         self._prom_metrics = prom_metrics
@@ -124,20 +128,23 @@ class MultiKVConnectorPromMetrics(KVConnectorPromMetrics):
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         for connector_id, stats_data in transfer_stats_data.items():
             assert connector_id in self._prom_metrics, (
-                f"{connector_id} is not contained in the list of registered connectors "
-                f"with Prometheus metrics support: {self._prom_metrics.keys()}"
+                f"{connector_id} is not a configured connector: "
+                f"{self._prom_metrics.keys()}"
             )
-            self._prom_metrics[connector_id].observe(stats_data, engine_idx)
+            if connector_prom := self._prom_metrics[connector_id]:
+                connector_prom.observe(stats_data, engine_idx)
 
 
 class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     """
     A wrapper for using multiple KVConnectors at the same time.
 
-    The current logic is:
-    - Load KV from the first connector that advertises available tokens from
-      get_num_new_matched_tokens(), based on the order in the config.
+    The default logic is:
+    - Load KV from the first connector that advertises available tokens.
     - Save to all connectors.
+
+    With ``load_policy=range_aware``, ordered connectors may load contiguous,
+    non-overlapping ranges of the same prefix.
     """
 
     @classmethod
@@ -181,6 +188,12 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config
         )
 
+        assert vllm_config.kv_transfer_config is not None
+        extra_config = vllm_config.kv_transfer_config.kv_connector_extra_config
+        load_policy = extra_config.get("load_policy")
+        if load_policy not in (None, "range_aware"):
+            raise ValueError(f"Unknown MultiConnector load_policy: {load_policy!r}")
+
         self._connectors: list[KVConnectorBase_V1] = []
         self._ktc_kv_transfer_config = []
         for connector_cls, temp_config in self._get_connector_classes_and_configs(
@@ -189,7 +202,21 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             self._connectors.append(connector_cls(temp_config, role, kv_cache_config))
             self._ktc_kv_transfer_config.append(temp_config.kv_transfer_config)
 
-        assert vllm_config.kv_transfer_config is not None
+        self._range_load = load_policy == "range_aware"
+        self._scheduler_block_size = None
+        if self._range_load:
+            if (
+                role == KVConnectorRole.SCHEDULER
+                and kv_cache_config.has_mamba_layers
+                and not all(c.supports_load_range for c in self._connectors)
+            ):
+                raise ValueError(
+                    "MultiConnector range_aware loading with recurrent KV cache "
+                    "groups requires every child connector to support range loads"
+                )
+            self._scheduler_block_size, _ = resolve_kv_cache_block_sizes(
+                kv_cache_config, vllm_config
+            )
         self._all_support_hma = MultiConnector.all_children_support_hma(
             vllm_config.kv_transfer_config
         )
@@ -201,11 +228,15 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         # A mapping from request id to the index of the connector chosen to
         # load the request from (if any).
         self._requests_to_connector: dict[str, int] = {}
+        self._request_load_ranges: dict[str, dict[int, KVLoadRange]] = {}
+        self._request_async_loads: dict[str, tuple[int, ...]] = {}
+        self._async_loads_to_send: dict[str, tuple[int, ...]] = {}
+        self._async_load_sources: dict[str, set[int]] = {}
+        self._pending_async_loads: dict[str, set[int]] = {}
 
         # Keeps track of *additional* remaining async saves (beyond 1) to be
-        # finished per request. Not needed for async loads since we only allow
-        # a single connector to load.
-        # Propagated from scheduler to worker side via the connector metadata.
+        # finished per request. Propagated from scheduler to worker side via
+        # the connector metadata.
         self._extra_async_saves: dict[str, int] = {}
 
     @property
@@ -263,6 +294,20 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         assert isinstance(connector_metadata, MultiKVConnectorMetadata)
         if connector_metadata.extra_async_saves:
             self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        if self._range_load and connector_metadata.pending_async_loads:
+            sources = {
+                req_id: set(connector_ids)
+                for req_id, connector_ids in (
+                    connector_metadata.pending_async_loads.items()
+                )
+            }
+            self._async_load_sources.update(sources)
+            self._pending_async_loads.update(
+                {
+                    req_id: set(connector_ids)
+                    for req_id, connector_ids in sources.items()
+                }
+            )
         for c, cm in zip(self._connectors, connector_metadata.metadata):
             c.bind_connector_metadata(cm)
         super().bind_connector_metadata(connector_metadata)
@@ -315,12 +360,32 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     ) -> tuple[set[str] | None, set[str] | None]:
         finished_sending: set[str] = set()
         finished_recving: set[str] = set()
-        for c in self._connectors:
+        if self._range_load and self._async_load_sources:
+            for req_id in finished_req_ids:
+                self._pending_async_loads.pop(req_id, None)
+                self._async_load_sources.pop(req_id, None)
+
+        for i, c in enumerate(self._connectors):
             sending, recving = c.get_finished(finished_req_ids)
             if not recving and not sending:
                 continue
-            # Aggregate finished recving request ids.
-            finished_recving.update(recving or ())
+            if not self._range_load:
+                finished_recving.update(recving or ())
+            else:
+                for req_id in recving or ():
+                    sources = self._async_load_sources.get(req_id)
+                    if sources is not None and i not in sources:
+                        continue
+                    pending = self._pending_async_loads.get(req_id)
+                    if sources is not None and pending is None:
+                        continue
+                    if pending is None:
+                        finished_recving.add(req_id)
+                        continue
+                    pending.discard(i)
+                    if not pending:
+                        del self._pending_async_loads[req_id]
+                        finished_recving.add(req_id)
             # Aggregate finished sending request ids - only include
             # once we've drained the "extra" count (for cases where
             # more than one connector is async-saving the same request).
@@ -389,13 +454,42 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     # ==============================
     # Scheduler-side methods
     # ==============================
+    def _effective_load_range_alignment(self, connector: KVConnectorBase_V1) -> int:
+        assert self._scheduler_block_size is not None
+        connector_alignment = connector.load_range_alignment
+        if connector_alignment is None:
+            return self._scheduler_block_size
+        if connector_alignment <= 0:
+            raise ValueError(
+                "Connector load_range_alignment must be positive, got "
+                f"{connector_alignment} for {connector.__class__.__name__}"
+            )
+        return lcm(self._scheduler_block_size, connector_alignment)
+
     def get_num_new_matched_tokens(
         self,
         request: "Request",
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
-        to_return = (0, False)
-        for i, c in enumerate(self._connectors):
+        if not self._range_load:
+            to_return = (0, False)
+            for i, c in enumerate(self._connectors):
+                toks, load_async = c.get_num_new_matched_tokens(
+                    request, num_computed_tokens
+                )
+                if toks is None:
+                    return (None, False)
+                if to_return[0] == 0 and toks > 0:
+                    self._requests_to_connector[request.request_id] = i
+                    to_return = (toks, load_async)
+            return to_return
+
+        req_id = request.request_id
+        self._requests_to_connector.pop(req_id, None)
+        self._request_load_ranges.pop(req_id, None)
+        self._request_async_loads.pop(req_id, None)
+        matches: list[tuple[int, bool]] = []
+        for c in self._connectors:
             toks, load_async = c.get_num_new_matched_tokens(
                 request, num_computed_tokens
             )
@@ -403,17 +497,126 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             # we return None to indicate that we are not done yet.
             if toks is None:
                 return (None, False)
-            # The first connector that has new matched tokens will be assigned
-            # to this request.
-            if to_return[0] == 0 and toks > 0:
-                self._requests_to_connector[request.request_id] = i
-                to_return = (toks, load_async)
-        return to_return
+            matches.append((toks, load_async))
+
+        covered = num_computed_tokens
+        ranges: dict[int, KVLoadRange] = {}
+        for i, ((toks, load_async), connector) in enumerate(
+            zip(matches, self._connectors)
+        ):
+            endpoint = num_computed_tokens + toks
+            if endpoint <= covered:
+                continue
+            if ranges:
+                if not connector.supports_load_range:
+                    continue
+                alignment = self._effective_load_range_alignment(connector)
+                previous_connector = next(reversed(ranges))
+                previous = self._connectors[previous_connector]
+                if previous.supports_load_range:
+                    alignment = lcm(
+                        alignment,
+                        self._effective_load_range_alignment(previous),
+                    )
+                if covered % alignment:
+                    aligned_covered = covered // alignment * alignment
+                    if not previous.supports_load_range:
+                        return self._select_single_load(req_id, matches)
+                    previous_range = ranges[previous_connector]
+                    if aligned_covered <= previous_range.start_token:
+                        break
+                    ranges[previous_connector] = KVLoadRange(
+                        previous_range.start_token,
+                        aligned_covered,
+                        is_terminal=False,
+                    )
+                    covered = aligned_covered
+            elif (
+                connector.supports_load_range
+                and covered % self._effective_load_range_alignment(connector)
+            ):
+                continue
+            ranges[i] = KVLoadRange(covered, endpoint, is_terminal=False)
+            covered = endpoint
+
+        if not ranges:
+            return self._select_single_load(req_id, matches)
+
+        terminal_connector = next(reversed(ranges))
+        terminal_range = ranges[terminal_connector]
+        ranges[terminal_connector] = KVLoadRange(
+            terminal_range.start_token,
+            terminal_range.end_token,
+            is_terminal=True,
+        )
+
+        if len(ranges) == 1:
+            return self._select_single_load(req_id, matches)
+
+        async_loads = tuple(i for i in ranges if matches[i][1])
+        if async_loads and len(async_loads) != len(ranges):
+            # A range request has one scheduler-level completion state. Mixing
+            # sync and async children can acknowledge tokens that a sync child
+            # has not loaded in the step where the request is parked.
+            return self._select_single_load(req_id, matches)
+
+        longest_single = max(matches, key=lambda match: match[0])
+        if longest_single[0] > covered - num_computed_tokens:
+            return self._select_single_load(req_id, matches)
+
+        self._request_load_ranges[req_id] = ranges
+        if async_loads:
+            self._request_async_loads[req_id] = async_loads
+        return covered - num_computed_tokens, bool(async_loads)
+
+    def _select_single_load(
+        self, request_id: str, matches: list[tuple[int, bool]]
+    ) -> tuple[int, bool]:
+        """Fall back to the connector with the longest complete prefix."""
+        chosen = max(range(len(matches)), key=lambda i: matches[i][0])
+        toks, load_async = matches[chosen]
+        if toks > 0:
+            self._requests_to_connector[request_id] = chosen
+            if load_async:
+                self._request_async_loads[request_id] = (chosen,)
+        return (toks, load_async) if toks > 0 else (0, False)
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
     ):
-        chosen_connector = self._requests_to_connector.get(request.request_id, -1)
+        req_id = request.request_id
+        if self._range_load:
+            load_ranges = self._request_load_ranges.pop(req_id, None)
+            async_loads = self._request_async_loads.pop(req_id, None)
+            if load_ranges is not None:
+                expected_tokens = sum(r.num_tokens for r in load_ranges.values())
+                if num_external_tokens == 0:
+                    load_ranges = None
+                elif num_external_tokens != expected_tokens:
+                    raise ValueError(
+                        "Range load token count changed after lookup: "
+                        f"expected {expected_tokens}, got {num_external_tokens} "
+                        f"for request {req_id}"
+                    )
+            if num_external_tokens > 0 and async_loads:
+                self._async_loads_to_send[req_id] = async_loads
+            if load_ranges is not None:
+                first_connector = next(iter(load_ranges))
+                for i, c in enumerate(self._connectors):
+                    load_range = load_ranges.get(i)
+                    if load_range is None:
+                        c.update_state_after_alloc(request, blocks, 0)
+                    elif i == first_connector and not c.supports_load_range:
+                        c.update_state_after_alloc(
+                            request, blocks, load_range.num_tokens
+                        )
+                    else:
+                        c.update_state_after_alloc_for_range(
+                            request, blocks, load_range
+                        )
+                return
+
+        chosen_connector = self._requests_to_connector.get(req_id, -1)
         for i, c in enumerate(self._connectors):
             if i == chosen_connector:
                 # Forward call to the chosen connector (if any).
@@ -437,6 +640,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         if self._extra_async_saves:
             metadata.extra_async_saves = self._extra_async_saves
             self._extra_async_saves = {}
+        if self._range_load and self._async_loads_to_send:
+            metadata.pending_async_loads = self._async_loads_to_send
+            self._async_loads_to_send = {}
         return metadata
 
     def update_connector_output(self, connector_output: KVConnectorOutput):
@@ -515,6 +721,9 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             self._extra_async_saves[request.request_id] = async_saves - 1
 
         self._requests_to_connector.pop(request.request_id, None)
+        self._request_load_ranges.pop(request.request_id, None)
+        self._request_async_loads.pop(request.request_id, None)
+        self._async_loads_to_send.pop(request.request_id, None)
 
         return async_saves > 0, kv_txfer_params
 
@@ -657,7 +866,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
     ) -> KVConnectorPromMetrics:
-        prom_metrics: dict[str, KVConnectorPromMetrics] = {}
+        prom_metrics: dict[str, KVConnectorPromMetrics | None] = {}
         seen_classes: set[type] = set()
         for connector_cls, temp_config in cls._get_connector_classes_and_configs(
             vllm_config
@@ -668,8 +877,7 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
             connector_prom = connector_cls.build_prom_metrics(
                 temp_config, metric_types, labelnames, per_engine_labelvalues
             )
-            if connector_prom is not None:
-                prom_metrics[connector_cls.__name__] = connector_prom
+            prom_metrics[connector_cls.__name__] = connector_prom
         return MultiKVConnectorPromMetrics(
             vllm_config,
             metric_types,


### PR DESCRIPTION
## Purpose

This PR depends on #54240.

This stacked PR implements the range-load API introduced by the preceding
`MultiConnector` framework PR for `MooncakeStoreConnector` and
`MooncakeConnector`.

With `load_policy=range_aware` and `MooncakeStoreConnector` configured before
`MooncakeConnector`, the Store connector can load `[0, S)` while
`MooncakeConnector` receives only the assigned P/D suffix `[S, N)`. For an
8192-token Store hit and a 9216-token prompt, the P/D transfer therefore
contains only `[8192, 9216)`.

`MooncakeStoreConnector` accepts explicit ranges, trims stale partial-hash tail
metadata when an aligned boundary shortens its load, and maps scheduler cache
groups to the worker's transferable-group indices. `MooncakeConnector` maps
the assigned suffix to the end-anchored destination blocks already allocated
for the request.
Both scheduler block lists and worker transfer regions use the same
transfer-enabled group order, so local-only groups are excluded without
shifting region indices.

The range-load path supports scheduler-block-aligned starts, partial final
ranges, DCP-scaled per-group block sizes, and attention-only hybrid KV caches
containing Full/MLA and sliding-window groups, including omitted
sliding-window padding blocks. `MooncakeConnector` does not advertise range
loading for recurrent-state groups such as Mamba/GDN; those models should use
the default single-source policy.

This PR also adds focused Mooncake and Mooncake Store scheduler tests, a
reusable in-tree launcher, and configuration documentation.

## Test Plan

### Unit and static checks

```bash
pre-commit run --files \
  docs/features/mooncake_store_connector_usage.md \
  tests/v1/kv_connector/mooncake_integration/piecewise_store_pd_launcher.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py \
  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/connector.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py

python -W ignore::DeprecationWarning -m pytest -q \
  -W ignore::pytest.PytestUnraisableExceptionWarning \
  tests/v1/kv_connector/unit/test_multi_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py \
  tests/v1/kv_connector/unit/test_mooncake_store_hma_e2e.py
```

### RDMA cluster tests

The in-tree integration launcher is available at:

https://github.com/ScaleX-IO/vllm/blob/4d0c82af87/tests/v1/kv_connector/mooncake_integration/piecewise_store_pd_launcher.py

The standalone RDMA E2E scripts are available at:

https://github.com/ScaleX-IO/vllm/tree/decode-offloading-e2e-tests/examples/disaggregated/mooncake_store_connector/piecewise_prefix_cluster

The following scenarios were tested:

1. Single-node 1P1D functional serving.
2. Single-node 1P1D performance comparison.
3. Two-node 1P1D performance comparison.

Environment:

- Alibaba Cloud Linux 3, x86_64
- Python 3.12.13
- PyTorch 2.13.0 with CUDA 13.0
- NVIDIA driver 580.105.08
- Two compute nodes, each with 8 NVIDIA H20-3e GPUs and 192 logical CPUs
- RDMA-tested revision: `7bc12d5211c658238d36e12bf13a1759895d6097`
- RDMA transport over `mlx5_bond_0`
- `DeepSeek-V4-Flash-0731`, Prefill TP2 and Decode TP2
- FP8 KV cache, block size 256, DeepGEMM linear backend
- GPU memory utilization 0.82
- Standalone Mooncake Store on the Decode node
- Performance transfer settings: 32 QPs, 32 workers, 1 MiB slices, and one
  load-receive thread
- Functional E2E: one node, 4 GPUs, 64 CPUs, max model length 2048, eager
  execution, a 1024-token Store hit, a 32-token P/D suffix, and 8 output tokens
- Single-node performance E2E: one node, 4 GPUs, 64 CPUs, max model length
  10240, CUDA Graph, an 8192-token Store hit, a 1024-token P/D range, 1 output
  token, concurrency 1, 5 warmups, and 20 measured requests per arm
- Two-node performance E2E: Prefill on `vllm-h20-01` and Decode plus Store on
  `vllm-h20-02`, 2 GPUs and 64 CPUs per node, max model length 10240, CUDA
  Graph, the same prompt settings, 3 warmups, and 3 measured requests per arm

The performance workload used an 8193-token base plus a 1023-token delta. Each
arm used a separate Store namespace and seed pass, so Baseline and Piecewise
both had an 8192-token Store hit. Baseline disabled Decode-side Store lookup.
Piecewise loaded the Store prefix on Decode and received `[8192, 9216)` from
Prefill. Outputs were compared between the two arms.

## Test Result

### Unit and static checks

```text
All pre-commit hooks passed.
146 passed in 78.61s
```

### RDMA functional test

- Store supplied `[0, 1024)`.
- Mooncake P/D transfer supplied `[1024, 1056)`.
- The generated token IDs were
  `[16, 223, 1162, 45449, 344, 25126, 1353, 513]`.
- The continuation matched the single-source reference token for token.
- No Store, RDMA, scheduler, or serving error was observed.

### RDMA performance tests

| Scenario | Measured requests / arm | Baseline median TTFT | Piecewise median TTFT | Improvement | Output match |
|---|---:|---:|---:|---:|---:|
| Single-node 1P1D | 20 | 305.444 ms | 300.309 ms | 1.681% | 20/20 |
| Two-node 1P1D | 3 | 305.226 ms | 297.379 ms | 2.571% | 3/3 |

Single-node P/D transfer metrics:

| Metric per TP rank and request | Baseline | Piecewise | Change |
|---|---:|---:|---:|
| P/D blocks | 58 | 26 | -55.2% |
| MB per transfer | 49.161 | 18.575 | -62.2% |
| Transfer descriptors | 2722 | 738 | -72.9% |
| Transfer time | 5.513 ms | 1.403 ms | -74.5% |

The two-node run reproduced the 58-to-26 block reduction. Mooncake reported
zero failed transfers, failed receives, or Store keys in both runs.

## AI Assistance

AI assistance was used for code inspection, implementation, and test preparation.
The human author reviewed the changes and test results.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR and the problem it solves.
- [x] The test plan and reproducible commands.
- [x] Unit, model-output, RDMA correctness, and performance results.
- [x] Configuration documentation and a reusable non-Slurm launcher.

</details>
