### PR TITLE
[Bugfix] Release async worker outputs before the next dequeue

### DIFF
--- a/tests/v1/executor/test_multiproc_executor.py
+++ b/tests/v1/executor/test_multiproc_executor.py
@@ -36,6 +36,23 @@ class _PayloadLifetimeCheckingQueue:
         raise _ExitWorkerLoop
 
 
+class _AsyncOutputLifetimeCheckingQueue:
+    def __init__(self) -> None:
+        self.output_ref: weakref.ReferenceType[_RpcPayload] | None = None
+        self.dequeue_count = 0
+
+    def get(self):
+        self.dequeue_count += 1
+        if self.dequeue_count == 1:
+            output = _RpcPayload()
+            self.output_ref = weakref.ref(output)
+            return output
+
+        assert self.output_ref is not None
+        assert self.output_ref() is None
+        raise _ExitWorkerLoop
+
+
 def test_worker_rpc_payload_released_before_next_dequeue():
     queue = _PayloadLifetimeCheckingQueue()
     worker_proc: Any = WorkerProc.__new__(WorkerProc)
@@ -46,6 +63,19 @@ def test_worker_rpc_payload_released_before_next_dequeue():
 
     with pytest.raises(_ExitWorkerLoop):
         worker_proc.worker_busy_loop()
+
+    assert queue.dequeue_count == 2
+
+
+def test_async_output_released_before_next_dequeue():
+    queue = _AsyncOutputLifetimeCheckingQueue()
+    worker_proc: Any = WorkerProc.__new__(WorkerProc)
+    worker_proc.async_output_queue = queue
+    worker_proc.worker = SimpleNamespace()
+    worker_proc.enqueue_output = lambda output: None
+
+    with pytest.raises(_ExitWorkerLoop):
+        worker_proc.async_output_busy_loop()
 
     assert queue.dequeue_count == 2
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -1025,6 +1025,7 @@ class WorkerProc:
         while True:
             output = self.async_output_queue.get()
             self.enqueue_output(output)
+            del output
 
     def worker_busy_loop(self):
         """Main busy loop for Multiprocessing Workers"""


### PR DESCRIPTION
# [Bugfix] Release async worker outputs before the next dequeue

## Purpose

This bug is triggered on every output when the V1 engine uses async scheduling
with the local `MultiprocExecutor`. Each worker deterministically keeps its
most recently published `AsyncModelRunnerOutput` alive while waiting for the
next output. This is not a timing race: after at least one output is produced,
the worker always retains the last output throughout the following idle
interval, potentially indefinitely.

The severity is potentially high when an output contains large device tensors.

The affected configuration surface is:

- the V1 engine with async scheduling enabled;
- local `MultiprocExecutor` workers, normally selected by multi-process local
  tensor or pipeline parallel deployments; and
- outputs that retain device tensors, including `AsyncOutput` sampling data
  and `AsyncPoolingOutput` pooling data.

This does not affect the single-process `UniProcExecutor` path. Although the
stale reference is always retained in the affected configuration, the amount
of retained memory depends on the output. It is usually small for ordinary
sampled-token outputs, but can reach tens or hundreds of MiB with large batches
and unrestricted logprobs, and can also be material for sampling masks or
pooling outputs. On an A100, a production `AsyncOutput` configured with batch
size 64, vocabulary size 128,256, and unrestricted logprobs retained
99,223,552 bytes (94.63 MiB) until another queue item arrived.

Python evaluates the right-hand side of:

```python
output = self.async_output_queue.get()
```

before replacing the previous local value. Therefore, after
`enqueue_output(output)` has already serialized and published the result, the
previous `AsyncOutput` remains alive for the entire idle interval.

This matters because `AsyncOutput` deliberately retains GPU sampler tensors
until its asynchronous D2H copies complete. Large batches, unrestricted
logprobs, sampling masks, and pooling outputs can therefore leave substantial
GPU memory allocated after the response has already reached the frontend.

Release the loop-local reference immediately after enqueueing the result.

## Why this is not duplicate work

#51979 fixed the same lifetime pattern for worker RPC input payloads by ensuring
they are released before the next blocking dequeue. It did not change
`async_output_busy_loop`, which retains output-side GPU tensors.

Open-PR searches for `async_output_busy_loop`, `WorkerAsyncOutputCopy`, and
async-output memory release found no PR addressing this path. #51207 also
touches `multiproc_executor.py`, but implements a shared-memory tensor arena and
does not modify async output lifetime.

## Test Plan

- Extend `tests/v1/executor/test_multiproc_executor.py` with a weak-reference
  regression test that checks the previous output has been collected when the
  loop begins its next dequeue.
- Run the relevant multiprocess executor unit and timeout tests.
- Run all pre-commit hooks applicable to the changed files.
- Validate the lifetime with a CUDA-backed `AsyncModelRunnerOutput` on an
  NVIDIA A100.

## Test Result

- `.venv/bin/python -m pytest tests/v1/executor/test_multiproc_executor.py -v`
  - 3 passed
- `.venv/bin/python -m pytest tests/v1/executor/test_multiproc_executor_timeout.py -q`
  - 5 passed
- `.venv/bin/pre-commit run --files vllm/v1/executor/multiproc_executor.py tests/v1/executor/test_multiproc_executor.py`
  - all applicable hooks passed
- `git diff --check`
  - passed

A100 CUDA lifetime reproduction through the actual
`WorkerProc.async_output_busy_loop`:

1. A production `AsyncOutput` constructed from `SamplerOutput` and
   `LogprobsTensors`, using batch size 64, vocabulary size 128,256, and
   unrestricted logprobs:

| State | Output alive at next dequeue | CUDA allocated |
| --- | ---: | ---: |
| main-equivalent loop | yes | 99,223,552 bytes |
| patched loop | no | 0 bytes |

2. A synthetic `AsyncModelRunnerOutput` holding a 256 MiB CUDA tensor, used to
   verify that the lifetime behavior scales with the retained payload:

| State | Output alive at next dequeue | CUDA allocated |
| --- | ---: | ---: |
| main-equivalent loop | yes | 268,435,456 bytes |
| patched loop | no | 0 bytes |

In both reproductions, the queue checks the weak reference when the worker
starts its next blocking dequeue. The unpatched loop still owns the previous
output at that point; explicitly deleting the loop-local reference after
`enqueue_output()` releases it before the dequeue.

## AI Assistance

OpenAI Codex was used for implementation, testing, and drafting.
