### PR TITLE
[Bugfix][Spec Decode] Honor draft eager mode in MRV2

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 import vllm.v1.worker.gpu.model_runner as model_runner_module
+from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -15,6 +16,11 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
+from vllm.v1.worker.gpu.spec_decode.multi_module_mtp.speculator import (
+    MultiModuleMTPSpeculator,
+)
 
 
 @pytest.mark.parametrize(
@@ -121,3 +127,33 @@ def test_append_block_ids_rejects_write_past_row_capacity():
         )
 
     assert block_tables.num_blocks.np[0, 1] == 3
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "speculator_cls", [EagleSpeculator, MultiModuleMTPSpeculator, DFlashSpeculator]
+)
+@pytest.mark.parametrize(
+    ("enforce_eager", "target_mode", "expected_mode"),
+    [
+        pytest.param(
+            True, CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.NONE, id="eager"
+        ),
+        pytest.param(
+            False,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            id="full",
+        ),
+        pytest.param(None, CUDAGraphMode.NONE, CUDAGraphMode.NONE, id="none"),
+    ],
+)
+def test_draft_speculator_resolves_cudagraph_mode(
+    speculator_cls,
+    enforce_eager: bool | None,
+    target_mode: CUDAGraphMode,
+    expected_mode: CUDAGraphMode,
+):
+    speculator = speculator_cls.__new__(speculator_cls)
+    speculator.speculative_config = SimpleNamespace(enforce_eager=enforce_eager)
+    assert speculator.resolve_cudagraph_mode(target_mode) == expected_mode

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -653,7 +653,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.speculator is not None:
             # After set_attn, so the speculator can size its cudagraph mode
             # to its own attention support.
-            self.speculator.init_cudagraph_manager(cudagraph_mode)
+            self.speculator.init_cudagraph_manager(
+                self.speculator.resolve_cudagraph_mode(cudagraph_mode)
+            )
 
         self.kv_caches: list[torch.Tensor] = []
         kv_caches_dict = init_kv_cache(

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -45,6 +45,9 @@ def _target_feeds_hc_residual(vllm_config: VllmConfig) -> bool:
 
 
 class BaseSpeculator(ABC):
+    def resolve_cudagraph_mode(self, cudagraph_mode: CUDAGraphMode) -> CUDAGraphMode:
+        return cudagraph_mode
+
     @abstractmethod
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         pass
@@ -85,6 +88,11 @@ class BaseSpeculator(ABC):
 
 
 class DraftModelSpeculator(BaseSpeculator):
+    def resolve_cudagraph_mode(self, cudagraph_mode: CUDAGraphMode) -> CUDAGraphMode:
+        if self.speculative_config.enforce_eager:
+            return CUDAGraphMode.NONE
+        return cudagraph_mode
+
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         self.vllm_config = vllm_config
         self.device = device


### PR DESCRIPTION
## Purpose

`SpeculativeConfig.enforce_eager` is a draft-side override for the target model's execution mode. Model Runner V1 already uses it when initializing proposer CUDA graph keys, but Model Runner V2 passes the resolved target CUDA graph mode directly to every speculator.

This change adds a common speculator CUDA graph mode resolver. Draft-model speculators resolve the mode to `NONE` when their nested `enforce_eager` flag is enabled; otherwise they preserve the target mode. The default `None`/`False` path and target-model CUDA graph mode are unchanged.

Duplicate-work check: I searched open issues and PRs for `enforce_eager`, `speculator`, and MRV2 draft eager handling. The related open SpeculativeConfig refactor (#36979) changes configuration initialization but does not modify MRV2 speculator CUDA graph mode resolution.

This contribution was implemented with assistance from OpenAI Codex. I reviewed every changed line and validated the behavior described below.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_model_runner_v2.py \
  -k draft_speculator -v

.venv/bin/ruff check \
  vllm/v1/worker/gpu/model_runner.py \
  vllm/v1/worker/gpu/spec_decode/speculator.py \
  tests/v1/worker/test_gpu_model_runner_v2.py

.venv/bin/ruff format --check \
  vllm/v1/worker/gpu/model_runner.py \
  vllm/v1/worker/gpu/spec_decode/speculator.py \
  tests/v1/worker/test_gpu_model_runner_v2.py
```

The unit test covers Eagle, multi-module MTP, and DFlash speculators with nested `enforce_eager=True`, `False`, and `None`.

Runtime validation used an equivalent DFlash/DSpark eager-mode resolution on an A2 8x910B3 system with DeepSeek-V4-Flash, TP8/EP8, target `FULL_DECODE_ONLY`, and draft `enforce_eager=true`. Target FULL graphs remained enabled, draft graph capture was skipped, and all 8 requests in an 8K-input/4K-output concurrency-8 serving run completed successfully.

## Test Result

- Pytest: `9 passed, 3 deselected`
- Ruff check: passed
- Ruff format check: passed
- `py_compile`: passed
- `git diff --check`: passed