### PR TITLE
[Frontend] Add Responses SSE keepalive

### DIFF
--- a/vllm/entrypoints/openai/responses/api_router.py
+++ b/vllm/entrypoints/openai/responses/api_router.py
@@ -15,6 +15,7 @@ from vllm.entrypoints.openai.responses.protocol import (
     StreamingResponsesResponse,
 )
 from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+from vllm.entrypoints.openai.sse_keep_alive import with_sse_keep_alive
 from vllm.entrypoints.serve.utils.api_utils import (
     load_aware_call,
     validate_json_request,
@@ -72,8 +73,13 @@ async def create_responses(request: ResponsesRequest, raw_request: Request):
     elif isinstance(generator, ResponsesResponse):
         return JSONResponse(content=generator.model_dump(mode="json", by_alias=True))
 
+    args = getattr(raw_request.app.state, "args", None)
+    keep_alive_interval = getattr(args, "sse_keep_alive_interval", 0)
     return StreamingResponse(
-        content=_convert_stream_to_sse_events(generator), media_type="text/event-stream"
+        content=with_sse_keep_alive(
+            _convert_stream_to_sse_events(generator), float(keep_alive_interval)
+        ),
+        media_type="text/event-stream",
     )
 
 
@@ -102,8 +108,13 @@ async def retrieve_responses(
         )
     elif isinstance(response, ResponsesResponse):
         return JSONResponse(content=response.model_dump(mode="json", by_alias=True))
+    args = getattr(raw_request.app.state, "args", None)
+    keep_alive_interval = getattr(args, "sse_keep_alive_interval", 0)
     return StreamingResponse(
-        content=_convert_stream_to_sse_events(response), media_type="text/event-stream"
+        content=with_sse_keep_alive(
+            _convert_stream_to_sse_events(response), float(keep_alive_interval)
+        ),
+        media_type="text/event-stream",
     )
 
 


### PR DESCRIPTION
## Summary\n\nAdd the existing SSE keep-alive wrapper to the OpenAI Responses streaming endpoints.\n\n## Motivation\n\nResponses streams can remain silent while requests wait for scheduler capacity, prefill, or long reasoning gaps. Without a comment frame, intermediaries and clients can hit idle timeouts even though the request is still progressing.\n\n## Changes\n\n- Wrap streaming output from POST /v1/responses and GET /v1/responses/{response_id} with with_sse_keep_alive.\n- Reuse the existing --sse-keep-alive-interval setting.\n- Keep the default disabled when the interval is zero or unset.\n- Emit only SSE comment frames; terminal event ordering and payloads are unchanged.\n\n## Validation\n\n- Python compileall passed.\n- git diff --check passed.\n- Isolated async integration probe passed, including silent-start, interleaving, cancellation, and StreamingResponse delivery.\n- The full pytest module could not run in the temporary environment because the checkout requires the project test/runtime dependency set (notably torch).