### PR TITLE
[Bugfix][Quantization][MoE] Route weight only NVFP4 checkpoints through W4A16

### DIFF
--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -582,45 +582,6 @@ def test_modelopt_nvfp4_config_dispatches_w4a16_method():
     assert config.quant_method == "W4A16_NVFP4"
 
 
-def _weight_only_nvfp4_config(input_activations=None):
-    """A compressed-tensors style quantization_config (as it appears in
-    config.json) that labels itself NVFP4 but quantizes weights only."""
-    return {
-        "quant_method": "modelopt",
-        "quant_algo": "NVFP4",
-        "group_size": 16,
-        "config_groups": {
-            "group_0": {
-                "targets": ["Linear"],
-                "weights": {"num_bits": 4, "type": "float", "group_size": 16},
-                "input_activations": input_activations,
-                "output_activations": None,
-            }
-        },
-        "ignore": [],
-    }
-
-
-def test_modelopt_nvfp4_weight_only_promoted_to_w4a16():
-    """A checkpoint labelled ``quant_algo="NVFP4"`` with no activation
-    quantization (``input_activations`` is null in every config group) must
-    be treated as W4A16. Otherwise the W4A4 MoE path folds an uninitialised
-    input scale into the dequant alphas and zeroes every expert (#54189).
-    """
-    config = ModelOptNvFp4Config.from_config(_weight_only_nvfp4_config())
-    assert config.quant_method == "W4A16_NVFP4"
-    assert config.LinearMethodCls is ModelOptNvFp4W4A16LinearMethod
-
-
-def test_modelopt_nvfp4_with_activations_stays_w4a4():
-    """A genuine W4A4 checkpoint (activations are quantized) keeps the NVFP4
-    path, so the promotion does not regress activation-quantized models."""
-    act = {"num_bits": 4, "type": "float", "dynamic": True}
-    config = ModelOptNvFp4Config.from_config(_weight_only_nvfp4_config(act))
-    assert config.quant_method == "NVFP4"
-    assert config.LinearMethodCls is ModelOptNvFp4LinearMethod
-
-
 @pytest.mark.parametrize(
     ("linear_backend", "kernel_cls"),
     [("auto", MarlinNvFp4LinearKernel), ("humming", HummingNvFp4LinearKernel)],

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -582,6 +582,45 @@ def test_modelopt_nvfp4_config_dispatches_w4a16_method():
     assert config.quant_method == "W4A16_NVFP4"
 
 
+def _weight_only_nvfp4_config(input_activations=None):
+    """A compressed-tensors style quantization_config (as it appears in
+    config.json) that labels itself NVFP4 but quantizes weights only."""
+    return {
+        "quant_method": "modelopt",
+        "quant_algo": "NVFP4",
+        "group_size": 16,
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {"num_bits": 4, "type": "float", "group_size": 16},
+                "input_activations": input_activations,
+                "output_activations": None,
+            }
+        },
+        "ignore": [],
+    }
+
+
+def test_modelopt_nvfp4_weight_only_promoted_to_w4a16():
+    """A checkpoint labelled ``quant_algo="NVFP4"`` with no activation
+    quantization (``input_activations`` is null in every config group) must
+    be treated as W4A16. Otherwise the W4A4 MoE path folds an uninitialised
+    input scale into the dequant alphas and zeroes every expert (#54189).
+    """
+    config = ModelOptNvFp4Config.from_config(_weight_only_nvfp4_config())
+    assert config.quant_method == "W4A16_NVFP4"
+    assert config.LinearMethodCls is ModelOptNvFp4W4A16LinearMethod
+
+
+def test_modelopt_nvfp4_with_activations_stays_w4a4():
+    """A genuine W4A4 checkpoint (activations are quantized) keeps the NVFP4
+    path, so the promotion does not regress activation-quantized models."""
+    act = {"num_bits": 4, "type": "float", "dynamic": True}
+    config = ModelOptNvFp4Config.from_config(_weight_only_nvfp4_config(act))
+    assert config.quant_method == "NVFP4"
+    assert config.LinearMethodCls is ModelOptNvFp4LinearMethod
+
+
 @pytest.mark.parametrize(
     ("linear_backend", "kernel_cls"),
     [("auto", MarlinNvFp4LinearKernel), ("humming", HummingNvFp4LinearKernel)],

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1081,6 +1081,22 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
     ) -> "ModelOptNvFp4Config":
         is_checkpoint_nvfp4_serialized = "NVFP4" in quant_method
 
+        # A checkpoint can declare quant_algo "NVFP4" yet quantize weights
+        # only (input_activations is null in every config group). The W4A4
+        # MoE path then folds an uninitialized input_scale that was never
+        # loaded and can zero every expert, so route it through W4A16.
+        if quant_method == "NVFP4":
+            config_groups = original_config.get("config_groups")
+            if (
+                isinstance(config_groups, dict)
+                and config_groups
+                and all(
+                    isinstance(group, dict) and group.get("input_activations") is None
+                    for group in config_groups.values()
+                )
+            ):
+                quant_method = "W4A16_NVFP4"
+
         if group_size is None:
             group_size = 16  # Default value
 


### PR DESCRIPTION
## Purpose

Fixes #54189.

A ModelOpt NVFP4 checkpoint can label itself `quant_algo` NVFP4 while quantizing weights only, leaving `input_activations` null in every config group. There is no activation scale to load, so the W4A4 fused MoE path folds an uninitialized `input_scale` into the dequant alphas:

```
layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
```

When that buffer holds 0.0, every weight scale becomes 0, every expert goes dead, and the model emits repeated token garbage with no error anywhere. The buffer value is undefined and depends on the allocator, which is why the issue shows up on some hardware (GB10, sm121) but not others (RTX PRO 6000, sm120, where the caching allocator handed back a page holding 1.0 so the fold was a no op).

This detects the weight only case at config parse time. If a checkpoint labels itself NVFP4 but every config group has `input_activations` null, it is promoted to `W4A16_NVFP4`, which routes the MoE layer through the Marlin path. Marlin dequantizes the weights to bf16 and never reads an input scale, so there is no uninitialized value to fold. Genuine W4A4 checkpoints keep the existing path.

## Test Plan

New config parse tests in `tests/quantization/test_modelopt.py` (CPU only, no GPU needed):

```
pytest tests/quantization/test_modelopt.py -k "weight_only_promoted or with_activations_stays"
```

- `test_modelopt_nvfp4_weight_only_promoted_to_w4a16` asserts a weight only NVFP4 config is promoted to `W4A16_NVFP4` and dispatches `ModelOptNvFp4W4A16LinearMethod`.
- `test_modelopt_nvfp4_with_activations_stays_w4a4` asserts an activation quantized config stays on `NVFP4` so the promotion does not regress real W4A4 models.

To reproduce end to end on sm120, set `PYTORCH_NO_CUDA_MEMORY_CACHING=1` with `--enforce-eager` so the MoE `input_scale` buffer is allocated fresh and reads back as 0.0, the value that triggers the bug. Serve a weight only NVFP4 checkpoint (GLM 5.3 Flash) and send any prompt.

## Test Result

Both new tests pass.

End to end on sm120 with the buffer reading 0.0:
- Before: repeated token garbage.
- After: the checkpoint loads through Marlin and responds correctly.

This lines up with the sm120 vs sm121 split in the issue. Because the value read from the uninitialized buffer depends on the allocator, the failure is intermittent across setups, and forcing raw allocations makes it deterministic.

---

Developed with AI assistance (Claude). I reviewed every changed line, ran the tests, and validated the fix end to end on sm120.