### PR TITLE
[Bugfix] Don't fail the request when a LoRA resolver raises

### DIFF
--- a/tests/entrypoints/openai/completion/test_lora_resolvers.py
+++ b/tests/entrypoints/openai/completion/test_lora_resolvers.py
@@ -87,6 +87,8 @@ class MockLoRAResolver(LoRAResolver):
                 lora_int_id=2,
                 lora_path="/fake/path/invalid-lora",
             )
+        elif lora_name == "raising-lora":
+            raise KeyError("peft_type")
         return None
 
 
@@ -237,6 +239,29 @@ async def test_serving_completion_resolver_add_lora_fails(
     assert isinstance(response, ErrorResponse)
     assert response.error.code == HTTPStatus.BAD_REQUEST.value
     assert invalid_model in response.error.message
+
+
+@pytest.mark.asyncio
+async def test_serving_completion_resolver_raises(mock_serving_setup, monkeypatch):
+    """A resolver that raises must not fail the request or stop the loop."""
+    monkeypatch.setenv("VLLM_ALLOW_RUNTIME_LORA_UPDATING", "true")
+
+    mock_engine, serving_completion = mock_serving_setup
+
+    raising_model = "raising-lora"
+    req = CompletionRequest(
+        model=raising_model,
+        prompt="what is 1+1?",
+    )
+
+    response = await serving_completion.create_completion(req)
+
+    mock_engine.add_lora.assert_not_awaited()
+    mock_engine.generate.assert_not_called()
+
+    assert isinstance(response, ErrorResponse)
+    assert response.error.code == HTTPStatus.BAD_REQUEST.value
+    assert raising_model in response.error.message
 
 
 @pytest.mark.asyncio

--- a/tests/plugins_tests/lora_resolvers/test_filesystem_resolver.py
+++ b/tests/plugins_tests/lora_resolvers/test_filesystem_resolver.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 import os
 import shutil
 
@@ -63,3 +64,19 @@ async def test_nonlora_adapter(adapter_cache, pa_files):
 
     pa_request = await fs_resolver.resolve_lora(MODEL_NAME, PA_NAME)
     assert pa_request is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_adapter_config(adapter_cache):
+    """An adapter_config.json without the keys the resolver reads should be
+    skipped, not raise out of resolve_lora."""
+    lora_name = "malformed_adapter"
+    model_files = adapter_cache / lora_name
+    os.makedirs(model_files)
+    with open(os.path.join(model_files, "adapter_config.json"), "w") as f:
+        json.dump({"unrelated_key": "value"}, f)
+
+    fs_resolver = FilesystemResolver(adapter_cache)
+    assert fs_resolver is not None
+
+    assert await fs_resolver.resolve_lora(MODEL_NAME, lora_name) is None

--- a/vllm/entrypoints/openai/models/serving.py
+++ b/vllm/entrypoints/openai/models/serving.py
@@ -288,7 +288,8 @@ class OpenAIServingModels:
         Returns:
             LoRARequest if found and loaded successfully.
             ErrorResponse (404) if no resolver finds the adapter.
-            ErrorResponse (400) if adapter(s) are found but none load.
+            ErrorResponse (400) if adapter(s) are found but none load, or if
+            every resolver that had a candidate failed while resolving it.
         """
         async with self.lora_resolver_lock[lora_name]:
             # First check if this LoRA is already loaded
@@ -298,10 +299,29 @@ class OpenAIServingModels:
             base_model_name = self.model_config.model
             unique_id = self.lora_id_counter.inc(1)
             found_adapter = False
+            resolver_failed = False
 
             # Try to resolve using available resolvers
             for resolver in self.lora_resolvers:
-                lora_request = await resolver.resolve_lora(base_model_name, lora_name)
+                try:
+                    lora_request = await resolver.resolve_lora(
+                        base_model_name, lora_name
+                    )
+                except Exception as e:
+                    # A resolver is third party code and may raise on input it
+                    # does not recognize. Keep going so the remaining resolvers
+                    # still get a turn instead of failing the whole request.
+                    # Exception rather than BaseException so a cancelled
+                    # request still propagates.
+                    resolver_failed = True
+                    logger.warning(
+                        "LoRA resolver %s raised while resolving '%s': %s. "
+                        "Trying next resolver.",
+                        resolver.__class__.__name__,
+                        lora_name,
+                        e,
+                    )
+                    continue
 
                 if lora_request is not None:
                     found_adapter = True
@@ -331,6 +351,17 @@ class OpenAIServingModels:
                 return create_error_response(
                     message=(
                         f"LoRA adapter '{lora_name}' was found but could not be loaded."
+                    ),
+                    err_type="BadRequestError",
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            elif resolver_failed:
+                # Something was there to resolve but a resolver errored on it,
+                # which is not the same as the adapter not existing.
+                return create_error_response(
+                    message=(
+                        f"LoRA adapter '{lora_name}' could not be resolved, "
+                        "see the server logs for details."
                     ),
                     err_type="BadRequestError",
                     status_code=HTTPStatus.BAD_REQUEST,

--- a/vllm/plugins/lora_resolvers/filesystem_resolver.py
+++ b/vllm/plugins/lora_resolvers/filesystem_resolver.py
@@ -4,8 +4,11 @@ import json
 import os
 
 import vllm.envs as envs
+from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
+
+logger = init_logger(__name__)
 
 
 class FilesystemResolver(LoRAResolver):
@@ -34,8 +37,8 @@ class FilesystemResolver(LoRAResolver):
                 with open(adapter_config_path) as file:
                     adapter_config = json.load(file)
                 if (
-                    adapter_config["peft_type"] == "LORA"
-                    and adapter_config["base_model_name_or_path"] == base_model_name
+                    adapter_config.get("peft_type") == "LORA"
+                    and adapter_config.get("base_model_name_or_path") == base_model_name
                 ):
                     lora_request = LoRARequest(
                         lora_name=lora_name,
@@ -43,6 +46,14 @@ class FilesystemResolver(LoRAResolver):
                         lora_path=lora_path,
                     )
                     return lora_request
+                logger.warning(
+                    "Skipping %s: adapter_config.json is not a LoRA adapter for "
+                    "base model %s (peft_type=%r, base_model_name_or_path=%r).",
+                    lora_path,
+                    base_model_name,
+                    adapter_config.get("peft_type"),
+                    adapter_config.get("base_model_name_or_path"),
+                )
         return None
 
 


### PR DESCRIPTION
## Purpose

`resolve_lora()` is called unguarded in `OpenAIServingModels.resolve_lora`. The
`try` there only wraps `add_lora`:

```python
for resolver in self.lora_resolvers:
    lora_request = await resolver.resolve_lora(base_model_name, lora_name)   # not guarded

    if lora_request is not None:
        ...
        try:
            await self.engine_client.add_lora(lora_request)
        except BaseException as e:
            ... "Trying next resolver."
```

A resolver that raises therefore takes down the request with a 500 and aborts the
loop, so the resolvers after it never get a turn. Resolvers are a plugin point, so
this is reachable from any third party implementation.

`FilesystemResolver` is one that does it: it reads `peft_type` and
`base_model_name_or_path` straight out of `adapter_config.json`, so anything in
`VLLM_LORA_RESOLVER_CACHE_DIR` missing either key raises `KeyError`. The dir is
scanned by adapter name without checking the file is a PEFT LoRA config first, so
a half-finished download or a checkpoint dir holding an `adapter_config.json` is
enough, and `base_model_name_or_path` is Optional in PEFT anyway.

This guards the call, logs the resolver that raised, and keeps going, reporting
400 rather than 404 since something was there to resolve (per @linitra24 on
#53461). The docstring already documented a found-but-unloadable 400.
`FilesystemResolver` also uses `.get()` so the common case doesn't raise at all.
`Exception` not `BaseException`, so cancellation still propagates.

**Not a duplicate:** searched open PRs for `lora resolver`, `adapter_config`,
`filesystem_resolver`. #46287 is path containment, #41479 a `/pooling` 404
fall-through.

## Test Plan

```bash
pytest tests/entrypoints/openai/completion/test_lora_resolvers.py
pytest tests/plugins_tests/lora_resolvers/test_filesystem_resolver.py -k malformed
```

`test_serving_completion_resolver_raises` adds a `raising-lora` case to the
existing `MockLoRAResolver` and checks the request comes back 400 instead of
blowing up. Neither test needs network or a GPU.

## Test Result

vLLM 0.28.0, Python 3.12, pytest 9.1.1. Reverting just the `serving.py` guard:

```
test_serving_completion_resolver_raises FAILED
>           raise KeyError("peft_type")
E           KeyError: 'peft_type'
=================== 1 failed, 4 passed, 1 warning in 13.85s ====================
```

With it:

```
======================== 5 passed, 1 warning in 13.98s =========================
```

`test_malformed_adapter_config` passes on the resolver side. `ruff check` and
`ruff format --check` clean on all four files.

`json.load` on a truncated file raises `JSONDecodeError`, which the guard now also
catches.

Rebased onto main on 2026-09-18 to clear the conflict. The only conflict was in
the `resolve_lora` docstring, where main had added a trailing blank line and this
branch had reworded the `Returns:` block; both are kept. The code is unchanged, so
the pytest numbers above are from before the rebase. `ruff check` and `ruff format
--check` were rerun on the rebased files and are clean, including the pydocstyle
rules #52136 added since this PR was opened.

`resolve_lora` on main still calls `resolver.resolve_lora()` outside the `try`, so
the fix still applies as written.

## AI assistance

Written with AI assistance (Claude). I reviewed every line and ran the tests above
myself.

---

Replaces #53461, which I had to abandon after a bad `--depth 1` force-push
stripped the branch history and made GitHub read the whole tree as changed.

