### PR TITLE
[Bugfix] Abort encode() requests when the caller stops early

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -3,10 +3,12 @@
 
 import asyncio
 import time
+from collections.abc import Iterable
 from contextlib import ExitStack
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from vllm import SamplingParams
 from vllm.assets.image import ImageAsset
@@ -21,11 +23,13 @@ from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import PromptType
-from vllm.outputs import RequestOutput
+from vllm.outputs import PoolingOutput, PoolingRequestOutput, RequestOutput
 from vllm.platforms import current_platform
+from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import RequestOutputKind
 from vllm.utils.torch_utils import set_default_torch_num_threads
 from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.output_processor import RequestOutputCollector
 from vllm.v1.metrics.loggers import (
     AggregatedLoggingStatLogger,
     LoggingStatLogger,
@@ -1016,3 +1020,46 @@ async def test_pause_keep_multi_request():
         for result in results:
             assert result.finished
             assert len(result.outputs[0].token_ids) == 10
+
+
+class MockEncodeEngine:
+    def __init__(self, collector: RequestOutputCollector):
+        self._collector = collector
+        self.log_requests = False
+        self.aborted: list[str] = []
+
+    async def add_request(
+        self, request_id: str, *args, **kwargs
+    ) -> RequestOutputCollector:
+        return self._collector
+
+    async def abort(
+        self, request_id: str | Iterable[str], internal: bool = False
+    ) -> None:
+        assert isinstance(request_id, str)
+        self.aborted.append(request_id)
+
+
+@pytest.mark.asyncio
+async def test_encode_aborts_when_caller_stops_early():
+    request_id = "encode-abort-0"
+    collector = RequestOutputCollector(RequestOutputKind.DELTA, request_id=request_id)
+    collector.put(
+        PoolingRequestOutput(
+            request_id=request_id,
+            outputs=PoolingOutput(data=torch.tensor([1.0])),
+            prompt_token_ids=[1],
+            finished=False,
+            num_cached_tokens=0,
+        )
+    )
+    engine = MockEncodeEngine(collector)
+
+    generator = AsyncLLM.encode(
+        engine, prompt="prompt", pooling_params=PoolingParams(), request_id=request_id
+    )
+    async for _ in generator:
+        break
+    await generator.aclose()
+
+    assert engine.aborted == [request_id]

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -892,9 +892,10 @@ class AsyncLLM(EngineClient):
                 finished = out.finished
                 yield out
 
-        # If the request is disconnected by the client, generate()
-        # is cancelled. So, we abort the request if we end up here.
-        except asyncio.CancelledError:
+        # If the request is disconnected by the client, encode()
+        # is cancelled or the generator is garbage collected. So,
+        # we abort the request if we end up here.
+        except (asyncio.CancelledError, GeneratorExit):
             if q is not None:
                 await self.abort(q.request_id, internal=True)
             if self.log_requests:


### PR DESCRIPTION
## Purpose

`AsyncLLM.generate()` catches `GeneratorExit` alongside `asyncio.CancelledError`. `encode()` catches only `asyncio.CancelledError`.

`GeneratorExit` derives from `BaseException`, so neither that handler nor the later `except Exception` catches it. Closing the generator early (client disconnect, `break` out of the `async for`, or garbage collection) falls through to `finally`, which only closes the output queue. `self.abort()` never runs, so the pooling request keeps running in EngineCore and the scheduler until it finishes on its own.

This is the defect fixed for `generate()` in #19225; `encode()` was not updated.

## Test Plan

```bash
pytest -v -s tests/v1/engine/test_async_llm.py::test_encode_aborts_when_caller_stops_early
```

The test drives the real `AsyncLLM.encode` with a stub that records aborts, consumes one output, closes the generator, and asserts the request was aborted.

Unit-level rather than the live-engine style used elsewhere in this file: the behaviour under test is which exception the handler catches, and a stub reaches it without pooling-model scaffolding that would dwarf a one-line fix. Happy to switch if you would rather it match the surrounding suite.

## Test Result

```text
1 passed, 2 warnings in 4.29s
```

With the change to `async_llm.py` reverted:

```text
E       AssertionError: assert [] == ['encode-abort-0']
1 failed, 2 warnings in 2.82s
```

The two warnings are pre-existing `pytest.mark.asyncio(scope=...)` deprecations from other tests in the file.

`pre-commit run --files` passes on both changed files.
