### PR TITLE
[Bugfix] Upcast E8M0 block scales on every platform, not just ROCm/XPU

### DIFF
--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -158,6 +158,44 @@ def test_w8a8_block_fp8_matmul(M, N, K, block_size, out_dtype, seed):
     assert rel_diff < 0.001
 
 
+@torch.inference_mode()
+def test_w8a8_block_fp8_matmul_e8m0_scales():
+    # DeepSeek-V4-style checkpoints store block scales in exponent-only
+    # E8M0, which Triton cannot bind directly; the kernel upcasts them to
+    # fp32 before launch. Regression test for
+    # https://github.com/vllm-project/vllm/issues/47818.
+    M, N, K = 83, 512, 7168
+    block_size = [128, 128]
+    out_dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    fp8_max, fp8_min = fp8_info.max, fp8_info.min
+
+    A_fp32 = (torch.rand(M, K, dtype=torch.float32) - 0.5) * 2 * fp8_max
+    A_fp8 = A_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+    B_fp32 = (torch.rand(N, K, dtype=torch.float32) - 0.5) * 2 * fp8_max
+    B_fp8 = B_fp32.clamp(min=fp8_min, max=fp8_max).to(torch.float8_e4m3fn)
+
+    n_tiles = (N + block_size[0] - 1) // block_size[0]
+    k_tiles = (K + block_size[1] - 1) // block_size[1]
+
+    # Power-of-two scales round-trip E8M0 <-> fp32 exactly.
+    As = torch.exp2(torch.randint(-8, 0, (M, k_tiles)).to(torch.float32))
+    Bs = torch.exp2(torch.randint(-8, 0, (n_tiles, k_tiles)).to(torch.float32))
+
+    ref_out = w8a8_triton_block_scaled_mm(A_fp8, B_fp8, As, Bs, block_size, out_dtype)
+    out = w8a8_triton_block_scaled_mm(
+        A_fp8,
+        B_fp8,
+        As.to(torch.float8_e8m0fnu),
+        Bs.to(torch.float8_e8m0fnu),
+        block_size,
+        out_dtype,
+    )
+    assert torch.equal(out, ref_out)
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda(), reason="CUTLASS only supported on CUDA platform."
 )

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -917,14 +917,13 @@ def w8a8_triton_block_scaled_mm(
     assert len(block_size) == 2
     block_n, block_k = block_size[0], block_size[1]
 
-    # Triton cannot currently bind E8M0 scale tensors directly. On ROCm,
+    # Triton cannot currently bind E8M0 scale tensors directly.
     # DeepSeek-V4 checkpoints store block scales in exponent-only E8M0 format,
     # so decode them to fp32 before launching the kernel.
-    if current_platform.is_rocm() or current_platform.is_xpu():
-        if As.dtype == torch.float8_e8m0fnu:
-            As = _upcast_e8m0_to_fp32(As).contiguous()
-        if Bs.dtype == torch.float8_e8m0fnu:
-            Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
+    if As.dtype == torch.float8_e8m0fnu:
+        As = _upcast_e8m0_to_fp32(As).contiguous()
+    if Bs.dtype == torch.float8_e8m0fnu:
+        Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
 
     assert A.shape[-1] == B.shape[-1]
     assert A.shape[:-1] == As.shape[:-1] and A.is_contiguous()


### PR DESCRIPTION
> This pull request was developed and reviewed with support from the Linux Club of Peking University (LCPU). For questions, please contact linuxclub@pku.edu.cn.

Fixes #47818


## Purpose

`w8a8_triton_block_scaled_mm` decodes exponent-only E8M0 block scales to fp32
before launching the Triton kernel, because Triton cannot bind an
`torch.float8_e8m0fnu` tensor as a kernel argument. That decode is currently
gated on the platform:

```python
# vllm/model_executor/layers/quantization/utils/fp8_utils.py
# Triton cannot currently bind E8M0 scale tensors directly. On ROCm,
# DeepSeek-V4 checkpoints store block scales in exponent-only E8M0 format,
# so decode them to fp32 before launching the kernel.
if current_platform.is_rocm() or current_platform.is_xpu():
    if As.dtype == torch.float8_e8m0fnu:
        As = _upcast_e8m0_to_fp32(As).contiguous()
    if Bs.dtype == torch.float8_e8m0fnu:
        Bs = _upcast_e8m0_to_fp32(Bs).contiguous()
```

The limitation is Triton's, not the platform's. The checkpoint format is also
not platform-specific: DeepSeek-V4-style checkpoints ship E8M0 block scales
regardless of which GPU loads them. On CUDA, any path that reaches this Triton
fallback with E8M0 scales therefore hands Triton a dtype it cannot bind.

This is what #47818 runs into on SM120 (RTX PRO 6000 / Blackwell), where the
CUTLASS C3X `dispatch_scaled_mm` path is unavailable and the Triton fallback is
taken.

## Change

Drop the platform condition; keep the dtype condition, which is the one that
actually decides whether work is needed. Scales that are not E8M0 are untouched,
so this is a no-op for every existing configuration.

Net: 11 lines in one file, plus a regression test.

## Test Plan

```bash
pytest tests/kernels/quantization/test_block_fp8.py -k e8m0 -q
```

`test_w8a8_block_fp8_matmul_e8m0_scales` runs the same matmul twice — once with
fp32 scales, once with the identical values as `torch.float8_e8m0fnu` — and
asserts the outputs are bit-identical. The scales are powers of two
(`torch.exp2(randint(-8, 0))`) so they round-trip E8M0 ↔ fp32 exactly and
`torch.equal` is the right assertion rather than a tolerance.

The module is skipped below SM90, so this needs an SM90+ device.

## Test Result

On an RTX 5090 (SM120, `torch.cuda.get_device_capability() == (12, 0)`), against
`main` @ `87b9b5b`:

Without the fix — the exact failure mode from #47818, surfacing as Triton
refusing to bind the dtype:

```
E       KeyError: 'float8_e8m0fnu'
.venv/lib/python3.12/site-packages/triton/_utils.py:119: KeyError
1 failed, 477 deselected in 1.22s
```

With the fix:

```
1 passed, 477 deselected in 1.20s
```

The rest of `test_block_fp8.py` is unaffected: no other test in the file uses
E8M0 scales, so the dtype condition is never true for them.

## AI assistance

This PR contains AI-generated code. The analysis and patch were produced with
Claude; the submitter reviewed every changed line and ran the test.

Commits carry:

```
Co-authored-by: Claude <noreply@anthropic.com>
```


