### PR TITLE
[Bugfix][Multimodal] Avoid caching full prompts in fallback

### DIFF
--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -1559,14 +1559,11 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             # let BPE merge tokens across a segment boundary, silently
             # changing how a non-special-token placeholder is tokenized.
             new_token_ids = flatten_2d_lists(
-                [
-                    cached_encode(tokenizer, text, add_special_tokens=False)
-                    for text in out_texts
-                ]
+                [tokenizer.encode(text, add_special_tokens=False) for text in out_texts]
             )
         else:
-            new_token_ids = cached_encode(
-                tokenizer, "".join(out_texts), add_special_tokens=False
+            new_token_ids = tokenizer.encode(
+                "".join(out_texts), add_special_tokens=False
             )
 
         return new_token_ids, result


### PR DESCRIPTION
## Purpose

Fix a memory-retention regression introduced by #53560 (`[MM] Cache common
token sequences`).

When a multimodal placeholder crosses a BPE boundary, the shared text fallback
decodes and re-encodes the complete user prompt. Before #53560 this encoding
bypassed the cache; it now enters the process-wide `cached_encode` LRU with
2048 entries. Distinct long prompts are therefore retained as Python token
lists until eviction.

This is triggered by ordinary MiniCPM-V image-chat requests, without malformed
inputs or special flags. Short prompts have little impact, but long-running
multi-user services with diverse long prompts can retain hundreds of MiB or
more. Other multimodal models can be affected when their placeholders also
cross BPE boundaries.

Keep caching reusable placeholder/replacement sequences, but encode the
reconstructed fallback prompt directly with
`tokenizer.encode(..., add_special_tokens=False)`. This restores the previous
cache boundary without changing token matching, placeholder positions, or
model outputs.

### Duplicate-work check

No open PR found by searching `fallback prompt cache`, `multimodal prompt
memory`, and `cached_encode` addresses this regression. Open PR #47583 targets
a different frontend prompt-encoding path.

## Test Plan

```bash
python -m pytest tests/multimodal/test_processing.py -q
python -m pytest tests/models/multimodal/processing/test_minicpmv.py \
  -k prompt_has_dif_BPE_boundaries_in_context -v
ruff check vllm/multimodal/processing/processor.py \
  tests/multimodal/test_processing.py
ruff format --check vllm/multimodal/processing/processor.py \
  tests/multimodal/test_processing.py
```

## Test Result

- Multimodal processing suite: **92 passed**.
- MiniCPM-V BPE-boundary test: **1 passed**.
- Ruff check, Ruff format check, and `git diff --check`: **passed**.
- Memory experiment with 256 distinct approximately 32K-token prompts:

  | Implementation | Cached entries | RSS growth |
  | --- | ---: | ---: |
  | `cached_encode` (before) | 256 | 364 MiB |
  | direct `tokenizer.encode` (after) | 0 | 2 MiB |

Model-output evaluation is not required: the change only alters caching of the
reconstructed prompt and preserves the encoded token sequence.

## AI assistance

This PR was prepared with AI assistance for implementation, testing and drafting.

