### PR TITLE
[ROCm] Rank ROCM_ATTN by whether its custom kernel applies on RDNA

### DIFF
--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -567,3 +567,67 @@ def test_unified_attn_drops_lhbnc_with_kv_connector():
 
     assert layouts
     assert all(layout.is_block_compact for layout in layouts)
+
+
+@pytest.mark.parametrize(
+    "is_gfx1x, head_size, expected_backend",
+    [
+        # On RDNA the custom paged-attention HIP kernel is only instantiated at
+        # head_size 128 (see `use_rocm_custom_paged_attention`), so anywhere else
+        # ROCM_ATTN runs the same kind of Triton kernel TRITON_ATTN does and
+        # should not keep the higher rank.
+        (True, 128, AttentionBackendEnum.ROCM_ATTN),
+        (True, 256, AttentionBackendEnum.TRITON_ATTN),
+        (True, 64, AttentionBackendEnum.TRITON_ATTN),
+        # CDNA has the kernel at 64 and 128 and its own ordering; untouched.
+        (False, 128, AttentionBackendEnum.ROCM_ATTN),
+        (False, 256, AttentionBackendEnum.ROCM_ATTN),
+    ],
+)
+def test_gfx1x_ranks_rocm_attn_by_whether_its_kernel_applies(
+    is_gfx1x,
+    head_size,
+    expected_backend,
+    mock_vllm_config,
+    mock_get_cdna_version,
+):
+    """The RDNA ordering follows the custom kernel it is justified by."""
+    from vllm.platforms.rocm import RocmPlatform
+
+    attn_selector_config = AttentionSelectorConfig(
+        head_size=head_size,
+        dtype=torch.float16,
+        kv_cache_dtype="auto",
+        block_size=16,
+        use_mla=False,
+        has_sink=False,
+        use_sparse=False,
+    )
+    with patch("vllm.platforms.rocm.on_gfx1x", return_value=is_gfx1x):
+        backend_path = RocmPlatform.get_attn_backend_cls(
+            selected_backend=None, attn_selector_config=attn_selector_config
+        )
+    assert backend_path == expected_backend.get_path()
+
+
+def test_gfx1x_demotion_keeps_rocm_attn_available(
+    mock_vllm_config, mock_get_cdna_version
+):
+    """Demoted, not excluded: forcing ROCM_ATTN at head_size 256 still works."""
+    from vllm.platforms.rocm import RocmPlatform
+
+    attn_selector_config = AttentionSelectorConfig(
+        head_size=256,
+        dtype=torch.float16,
+        kv_cache_dtype="auto",
+        block_size=16,
+        use_mla=False,
+        has_sink=False,
+        use_sparse=False,
+    )
+    with patch("vllm.platforms.rocm.on_gfx1x", return_value=True):
+        backend_path = RocmPlatform.get_attn_backend_cls(
+            selected_backend=AttentionBackendEnum.ROCM_ATTN,
+            attn_selector_config=attn_selector_config,
+        )
+    assert backend_path == AttentionBackendEnum.ROCM_ATTN.get_path()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -598,6 +598,25 @@ class RocmPlatform(Platform):
         # TODO: Make this explicit in the selector in a future PR.
         if is_encoder_decoder and AttentionBackendEnum.ROCM_ATTN in backend_priorities:
             backend_priorities.remove(AttentionBackendEnum.ROCM_ATTN)
+        # ROCM_ATTN is ranked ahead of TRITON_ATTN for its custom paged
+        # attention HIP kernel, but on RDNA that kernel is only instantiated at
+        # head_size 128 (see `use_rocm_custom_paged_attention`). Above that
+        # `chunked_prefill_paged_decode` takes its Triton branch, so the reason
+        # for the ranking does not apply and the two are Triton kernels either
+        # way -- and on a head_size 256 model the one that wins the ranking is
+        # the slower of the two at depth. Demote rather than exclude: the
+        # backend still works and stays available behind TRITON_ATTN.
+        if (
+            on_gfx1x()
+            and attn_selector_config.head_size != 128
+            and AttentionBackendEnum.ROCM_ATTN in backend_priorities
+            and AttentionBackendEnum.TRITON_ATTN in backend_priorities
+        ):
+            backend_priorities.remove(AttentionBackendEnum.ROCM_ATTN)
+            backend_priorities.insert(
+                backend_priorities.index(AttentionBackendEnum.TRITON_ATTN) + 1,
+                AttentionBackendEnum.ROCM_ATTN,
+            )
         for priority, backend in enumerate(backend_priorities):
             try:
                 backend_class = backend.get_class()


### PR DESCRIPTION
### Purpose

On RDNA, `ROCM_ATTN` is ranked above `TRITON_ATTN` by `_get_backend_priorities` because of its custom paged-attention HIP kernel. That kernel is only instantiated at `head_size == 128`: `use_rocm_custom_paged_attention`'s gfx1x branch requires it, and when it returns False `chunked_prefill_paged_decode` takes its Triton branch. So on a `head_size` 256 model both candidates are Triton kernels, the reason for the ranking does not apply, and the backend that wins the ranking is the slower of the two at decode.

This makes the ordering follow the thing that justifies it. On gfx1x, when `head_size != 128`, `ROCM_ATTN` is moved to just behind `TRITON_ATTN` instead of just ahead of it. **Demoted, not excluded** — it stays selectable and `--attention-backend ROCM_ATTN` keeps working. CDNA is untouched: its branch of the predicate covers 64 and 128 and has its own ordering with the AITER backends in it.

`get_valid_backends` already edits `backend_priorities` conditionally for the encoder-decoder case, with a `TODO: Make this explicit in the selector in a future PR`, and `AttentionSelectorConfig` already carries `head_size`, so nothing needs plumbing.

This is the same shape of change as #46597, which promotes `ROCM_AITER_FA` above `ROCM_ATTN` only when `is_mha_enabled()` — narrow, gated on the condition that makes the ranking's reason apply, and explicitly not a global reorder because that "would regress Radeon". Same argument here, in the other direction and on the other architecture.

### Interaction with the open PRs in this area

**#53231** (`[ROCm] TurboQuant KV cache support for Gemma 4`) inserts at the same anchor in `get_valid_backends`, so this will conflict textually and want a trivial rebase. It does not conflict semantically: it removes the kv-first backends when the global cache dtype is `turboquant_*`, and the block here is guarded on both `ROCM_ATTN` and `TRITON_ATTN` still being in the list, so it is a no-op once that has fired. Composition was checked over plain, `+turboquant`, `+encoder-decoder`, `head_size` 128 and CDNA orderings.

**#46597** touches the same two files but its `rocm.py` hunk is in `_get_backend_priorities`, not `get_valid_backends`, so the hunks do not overlap; and its condition is gated on gfx9 while this one is gated on `on_gfx1x()`, so the two never fire on the same machine.

### Measurements

2x RX 7900 XT (gfx1100), TP=2, ROCm 10.0, vLLM 0.27.1.dev5. `Qwen3.8-27B-AWQ-INT4`: `head_dim` 256, 24 query heads over 4 KV heads, hybrid SSM. 11 context rungs from 500 to 32 000, two rounds each, a rung reported only when its two rounds agree within 8%. 44 measurements per arm, 0 errors, decode 11 of 11 rungs on every arm.

Decode, tok/s. `A` is what the selector picks today, `C` is what it would pick after this change; `B` and `D` are the same two backends each carrying the open PR that repairs its weak half (#45916 for `ROCM_ATTN`, #52684 for `TRITON_ATTN`).

| ctx | A `ROCM_ATTN` | B `+#45916` | C `TRITON_ATTN` | D `+#52684` | C/A | D/B |
|---|---:|---:|---:|---:|---:|---:|
| 500 | 38.45 | 49.62 | 49.23 | 49.33 | 1.28x | 0.994 |
| 8 000 | 12.38 | 45.82 | 47.25 | 47.28 | 3.82x | 1.032 |
| 16 000 | 7.17 | 42.18 | 45.27 | 45.37 | 6.31x | 1.076 |
| 32 000 | 3.90 | 36.43 | 41.91 | 41.95 | **10.74x** | **1.151** |

The `D/B` column is why this is not just a restatement of #45916: after both of those PRs land, the ordering still costs 15.1% of decode at 32 K.

### The cost, stated plainly

`ROCM_ATTN` is the better backend at prefill, and this change gives that up. Fitted `t(n) = a + b*n + c*n²` over the chart-grade rungs: `c` is 2.79 ns/tok² for A and 3.23 for B against 18.17 for C and 5.84 for D. At 32 K prefill is 964.8 tok/s on A and 692.0 on C, so on today's tree the switch costs **1.39x of prefill** to buy 10.74x of decode; with #52684 in it costs **4.4%** to buy 15.1%. A prefill-dominated workload on this shape would prefer the current order, and `--attention-backend ROCM_ATTN` still expresses that.

### Scope of the evidence

The **mechanism** is a property of the predicate and needs no benchmark: on RDNA `use_rocm_custom_paged_attention` requires `head_size == 128`, so for any model with a different head size `ROCM_ATTN` runs its Triton fallback and the reason it outranks `TRITON_ATTN` does not apply. That holds for every affected model by construction.

The **measurement** is one model: `Qwen3.8-27B-AWQ-INT4`, `head_dim` 256, 24 query heads over 4 KV heads, one machine, one pass per arm. Whether the ranking actually inverts depends on shape, and I have one shape. `head_size` 64 is disqualified by the same predicate and demoted by the same condition with no data behind it; if you would rather the condition read `head_size > 128` so it covers only what was measured, say so and I will narrow it.

The second model would have been Gemma 4, also `head_dim` 256. It is absent for two reasons: it does not load on this ROCm image (`AmbiguousGlobalPerLayerAttributeError`, fixed upstream in #49797 but not in this build), and `Gemma4ModelConfig.verify_and_update_config` forces `TRITON_ATTN` for heterogeneous head dims anyway, so it would not exercise the default ordering even if it loaded.

The predicate has other conditions (`block_size`, `gqa_ratio`, dtype, `kv_cache_dtype`, sliding window) that also disqualify the custom kernel and that this patch deliberately does not mirror, to keep the condition to the one part the data speaks to. If you would rather it mirrored all of them, say so and I will change it.

Full data, four serve logs, the md5 of every file state, and a `check.py` that reads all 57 numbers above back out of the raw rows: https://github.com/cadamcat/dual-radeon-vllm/tree/main/benchmarks/gfx1100-backend-matrix-2026-08-30

Background and the whole four-arm matrix: https://github.com/vllm-project/vllm/issues/54438

### Test Plan

`tests/v1/attention/test_rocm_attention_backends_selection.py` gains two tests: one parametrised over `(gfx1x, head_size)` asserting the selected backend for 128, 256 and 64 on RDNA and for 128 and 256 on CDNA, and one asserting that an explicit `--attention-backend ROCM_ATTN` at `head_size` 256 still resolves, so the demotion cannot silently become an exclusion.

### Test Result

To be filled in from CI. Locally this repository's own four-arm A/B is the behavioural evidence; the two unit tests above are the regression guard.

---

This change was drafted with AI assistance. The measurements were run on real hardware and every number was reviewed and re-derived from the raw rows by the submitter.
