### PR TITLE
docs: add gemma-2, SmolLM2, Qwen2.5-Coder, Llama-3.2-1B to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -127,7 +127,7 @@ Batch invariance has been tested and verified on the following models:
 - **Qwen3-VL (Vision-Language)**: `Qwen/Qwen3-VL-2B-Instruct`, `Qwen/Qwen3-VL-4B-Instruct` (single image and video inputs)
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3-30B-A3B-Thinking-2507-FP8`
 - **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
-- **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-3B-Instruct` for example
+- **Llama 3**: Llama3.1 and 3.2 series, `meta-llama/Llama-3.2-1B-Instruct`, `meta-llama/Llama-3.2-3B-Instruct` for example
 - **GPT-OSS**: `openai/gpt-oss-20b`, `openai/gpt-oss-120b`
 - **Mistral**: `mistralai/Mistral-7B-v0.3`
 - **Phi series**: `microsoft/Phi-3.5-mini-instruct`
@@ -135,6 +135,8 @@ Batch invariance has been tested and verified on the following models:
 - **Granite 3.1 (Dense)**: `ibm-granite/granite-3.1-2b-instruct`, `ibm-granite/granite-3.1-8b-instruct`
 - **EXAONE 4.0 series**: `LGAI-EXAONE/EXAONE-4.0-1.2B`, `LGAI-EXAONE/EXAONE-4.0.1-32B`, `LGAI-EXAONE/EXAONE-4.0-32B`
 - **OLMo 2**: `allenai/OLMo-2-0425-1B-Instruct`
+- **SmolLM2**: `HuggingFaceTB/SmolLM2-1.7B-Instruct`
+- **PLaMo3**: `pfnet/plamo-3-nict-2b-base`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Why this is not duplicating an existing PR

PR #53692 (open) adds gemma-3-1b-it, glm-4-9b-chat, and phi-4. This PR covers different model families: Gemma 2 (not Gemma 3), SmolLM2, Qwen2.5-Coder, Llama 3.2 (1B), and PLaMo3. No overlap.

## What this PR does

Adds model checkpoints to the batch invariance tested-models list in `docs/features/batch_invariance.md`, following the maintainer invitation to test and submit model validations.

Models added:
- `google/gemma-2-2b-it`
- `HuggingFaceTB/SmolLM2-1.7B-Instruct`
- `Qwen/Qwen2.5-Coder-1.5B-Instruct`
- `meta-llama/Llama-3.2-1B-Instruct`
- `pfnet/plamo-3-nict-2b-base`

## Test results

Hardware: NVIDIA H100 NVL (SM 9.0, 132 SMs, 93 GB)

**pfnet/plamo-3-nict-2b-base** — official `tests/v1/determinism/test_batch_invariance.py` (19/19):

vLLM: `0.28.1rc1.dev199+g7c5dc571c` (nightly)

```
19 passed, 34 warnings in 965.09s (0:16:05)
```

Full raw output: https://github.com/vllm-project/vllm/pull/54441#issuecomment-5512360726

**Earlier models** (gemma-2, SmolLM2, Qwen2.5-Coder, Llama-3.2-1B):

vLLM: latest (`vllm/vllm-openai:latest`)

Probe method: solo run (BS=1) vs. needle at slot 7 of 32-request batch (BS=32). Token IDs and fp32 logprob bits must match under `VLLM_BATCH_INVARIANT=1`; must diverge under `VLLM_BATCH_INVARIANT=0` (control).

```
PASS  HuggingFaceTB/SmolLM2-1.7B-Instruct
PASS  google/gemma-2-2b-it
PASS  Qwen/Qwen2.5-Coder-1.5B-Instruct
PASS  meta-llama/Llama-3.2-1B-Instruct
```

Full raw output: https://github.com/vllm-project/vllm/issues/27433#issuecomment-5469388324

Signed-off-by: Yuval Luria <yluria@redhat.com>