### PR TITLE
[Bugfix] Fix DeepEP hybrid mode default

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -129,7 +129,6 @@ def test_precompiled_install_flags_are_orthogonal() -> None:
     with patch.dict(os.environ, {"VLLM_USE_PRECOMPILED_RUST": "1"}, clear=True):
         assert environment_variables["VLLM_USE_PRECOMPILED"]() is False
         assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is True
-
     # ...and the reverse: requesting precompiled C extensions (here via a
     # wheel location, which enables VLLM_USE_PRECOMPILED) must not flip the
     # Rust frontend flag.
@@ -150,6 +149,13 @@ def test_precompiled_install_flags_are_orthogonal() -> None:
     ):
         assert environment_variables["VLLM_USE_PRECOMPILED"]() is True
         assert environment_variables["VLLM_USE_PRECOMPILED_RUST"]() is True
+
+
+def test_deepep_hybrid_mode_defaults_to_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", raising=False)
+    assert environment_variables["VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE"]() is True
 
 
 def test_rust_bench_auto_path_missing_fails_fast() -> None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1945,7 +1945,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # DeepEP v2: enable two-tier NVLink+RDMA hybrid mode
     "VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE": lambda: bool(
-        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "0"))
+        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "1"))
     ),
     # DeepEP v2: use fewer SMs at slight throughput cost
     "VLLM_DEEPEP_V2_PREFER_OVERLAP": lambda: bool(


### PR DESCRIPTION
The runtime parser now matches the declared default and enables DeepEP v2 hybrid mode when the variable is unset.

Test: python3 -m py_compile vllm/envs.py tests/test_envs.py
Focused pytest could not start because tblib is unavailable in the environment.

AI assistance was used.