### PR TITLE
[Kimi K3][Kernel] Enable residual skinny GEMM on SM100

### DIFF
--- a/benchmarks/kernels/benchmark_k3_cutedsl_residual.py
+++ b/benchmarks/kernels/benchmark_k3_cutedsl_residual.py
@@ -16,6 +16,7 @@ import importlib.util
 import json
 import math
 import statistics
+import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
@@ -57,9 +58,10 @@ def parse_config(value: str) -> Config:
 
 def production_residual_config(m: int) -> Config | None:
     """The measured Latent-MoE residual config for M, from the K3 table."""
-    from vllm.models.kimi_k3.nvidia.low_latency_gemm import KIMI_K3_PROJECTIONS
+    from vllm.models.kimi_k3.nvidia.low_latency_gemm import _low_latency_table
 
-    spec = KIMI_K3_PROJECTIONS.get((N, K))
+    table = _low_latency_table()
+    spec = table.get((N, K)) if table is not None else None
     config = spec.residual_config(m) if spec is not None else None
     if config is None:
         return None
@@ -96,6 +98,7 @@ def load_kernel_class(path: Path):
     if spec is None or spec.loader is None:
         raise RuntimeError(f"cannot load CuTe kernel from {path}")
     module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module.CuteSkinnyGemm
 
@@ -277,8 +280,9 @@ def main() -> None:
     if not 0 <= args.config_shard < args.num_config_shards:
         raise ValueError("config shard must be in [0, num_config_shards)")
     torch.accelerator.set_device_index(0)
-    if torch.cuda.get_device_capability() != (10, 3):
-        raise RuntimeError("this benchmark requires SM103")
+    capability = torch.cuda.get_device_capability()
+    if capability not in ((10, 0), (10, 3)):
+        raise RuntimeError("this benchmark requires SM100 or SM103")
 
     kernel_class = load_kernel_class(args.kernel)
     properties = torch.cuda.get_device_properties(0)

--- a/tests/kernels/test_bf16_skinny_gemm.py
+++ b/tests/kernels/test_bf16_skinny_gemm.py
@@ -66,8 +66,12 @@ CUTE_CASES = [
 ]
 
 RESIDUAL_CUTE_CASES = [
-    (spec.n, spec.k, num_tokens)
-    for spec in k3_gemm.KIMI_K3_PROJECTIONS.values()
+    (capability, spec.n, spec.k, num_tokens)
+    for capability, table in (
+        ((10, 3), k3_gemm.KIMI_K3_PROJECTIONS),
+        ((10, 0), k3_gemm.KIMI_K3_PROJECTIONS_SM100),
+    )
+    for spec in table.values()
     for num_tokens, _ in spec.residual_configs
 ]
 
@@ -139,6 +143,13 @@ EXPECTED_RESIDUAL_CUTE_CONFIGS = {
     (7168, 3584, 2): (64, 7, 2, 8),
     (7168, 3584, 3): (64, 2, 1, 8),
     (7168, 3584, 4): (64, 2, 1, 8),
+}
+
+EXPECTED_RESIDUAL_CUTE_CONFIGS_SM100 = {
+    (7168, 3584, 1): (64, 4, 2, 8),
+    (7168, 3584, 2): (64, 4, 1, 8),
+    (7168, 3584, 3): (64, 4, 2, 4),
+    (7168, 3584, 4): (32, 2, 4, 4),
 }
 
 
@@ -244,6 +255,13 @@ def test_residual_cute_configs_match_measured_table() -> None:
         for num_tokens, config in spec.residual_configs
     }
     assert actual == EXPECTED_RESIDUAL_CUTE_CONFIGS
+
+    sm100_actual = {
+        (spec.n, spec.k, num_tokens): _config_tuple(config)
+        for spec in k3_gemm.KIMI_K3_PROJECTIONS_SM100.values()
+        for num_tokens, config in spec.residual_configs
+    }
+    assert sm100_actual == EXPECTED_RESIDUAL_CUTE_CONFIGS_SM100
 
 
 def test_glm52_projection_plans_are_separate() -> None:
@@ -596,6 +614,44 @@ def test_installation_is_shape_specific_and_unquantized(
     }
 
 
+def test_sm100_installation_registers_residual_warmups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLinear(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.quant_method = k3_gemm.UnquantizedLinearMethod()
+            self.weight = torch.empty(7168, 3584)
+
+    root = nn.Module()
+    root.up_proj = FakeLinear()
+    monkeypatch.setattr(k3_gemm, "LinearBase", FakeLinear)
+    monkeypatch.setattr(
+        k3_gemm,
+        "_low_latency_table",
+        lambda: k3_gemm.KIMI_K3_PROJECTIONS_SM100,
+    )
+    residual_warmups: set[SkinnyGemmConfig] = set()
+    monkeypatch.setattr(k3_gemm.shape_dynamic_skinny_gemm, "is_available", lambda: True)
+    monkeypatch.setattr(
+        k3_gemm.shape_dynamic_skinny_gemm,
+        "request_warmup_configs",
+        lambda dtype, configs, *, has_residual=False: (
+            residual_warmups.update(configs) if has_residual else None
+        ),
+    )
+
+    k3_gemm.enable_kimi_k3_low_latency_gemm(root, torch.bfloat16)
+
+    assert isinstance(root.up_proj.quant_method, k3_gemm.KimiK3LowLatencyLinearMethod)
+    assert residual_warmups == {
+        config
+        for _, config in k3_gemm.KIMI_K3_PROJECTIONS_SM100[
+            (7168, 3584)
+        ].residual_configs
+    }
+
+
 @pytest.mark.parametrize(
     "dtype,platform_enabled",
     [(torch.float16, True), (torch.bfloat16, False)],
@@ -894,14 +950,21 @@ def test_dsv3_cuda_graph_capture_tile_branches(num_tokens: int) -> None:
     assert cosine > 0.999
 
 
-@pytest.mark.parametrize("n,k,num_tokens", RESIDUAL_CUTE_CASES)
-def test_cute_residual_epilogue(n: int, k: int, num_tokens: int) -> None:
-    _require_sm103_and_cute()
+@pytest.mark.parametrize("capability,n,k,num_tokens", RESIDUAL_CUTE_CASES)
+def test_cute_residual_epilogue(
+    capability: tuple[int, int], n: int, k: int, num_tokens: int
+) -> None:
+    _require_capability_and_cute(capability)
     torch.manual_seed(42 + num_tokens)
     x = torch.randn(num_tokens, k, dtype=torch.bfloat16, device="cuda")
     weight = torch.randn(n, k, dtype=torch.bfloat16, device="cuda")
     residual = torch.randn(num_tokens, n, dtype=torch.bfloat16, device="cuda")
-    spec = k3_gemm.KIMI_K3_PROJECTIONS[(n, k)]
+    table = (
+        k3_gemm.KIMI_K3_PROJECTIONS
+        if capability == (10, 3)
+        else k3_gemm.KIMI_K3_PROJECTIONS_SM100
+    )
+    spec = table[(n, k)]
     config = spec.residual_config(num_tokens)
     assert config is not None
 
@@ -933,10 +996,17 @@ def test_cute_residual_epilogue_all_supported_token_counts(num_tokens: int) -> N
     torch.testing.assert_close(output.float(), reference, rtol=2e-2, atol=2e-1)
 
 
-@pytest.mark.parametrize("num_tokens", range(1, 5))
-def test_cute_residual_epilogue_cuda_graph_capture(num_tokens: int) -> None:
-    _require_sm103_and_cute()
-    spec = k3_gemm.KIMI_K3_PROJECTIONS[(7168, 3584)]
+@pytest.mark.parametrize("capability,n,k,num_tokens", RESIDUAL_CUTE_CASES)
+def test_cute_residual_epilogue_cuda_graph_capture(
+    capability: tuple[int, int], n: int, k: int, num_tokens: int
+) -> None:
+    _require_capability_and_cute(capability)
+    table = (
+        k3_gemm.KIMI_K3_PROJECTIONS
+        if capability == (10, 3)
+        else k3_gemm.KIMI_K3_PROJECTIONS_SM100
+    )
+    spec = table[(n, k)]
     config = spec.residual_config(num_tokens)
     assert config is not None
     x = torch.randn(num_tokens, spec.k, dtype=torch.bfloat16, device="cuda")
@@ -971,6 +1041,38 @@ class _SkinnyGemmSpy:
 
     def is_available(self) -> bool:
         return self._real.is_available()
+
+
+@pytest.mark.parametrize("num_tokens", range(1, 5))
+def test_kimi_routed_output_transform_uses_sm100_residual_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+    num_tokens: int,
+) -> None:
+    _require_capability_and_cute((10, 0))
+    from vllm.models.kimi_k3.nvidia.model import KimiRoutedOutputTransform
+
+    latent_dim, hidden_dim = 3584, 7168
+    torch.manual_seed(7 + num_tokens)
+    latent = torch.randn(num_tokens, latent_dim, dtype=torch.bfloat16, device="cuda")
+    residual = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+    weight = torch.randn(hidden_dim, latent_dim, dtype=torch.bfloat16, device="cuda")
+    spec = k3_gemm.KIMI_K3_PROJECTIONS_SM100[(hidden_dim, latent_dim)]
+    method = k3_gemm.KimiK3LowLatencyLinearMethod(
+        k3_gemm._build_plan(spec), k3_gemm._build_residual_plan(spec)
+    )
+    up_proj = SimpleNamespace(weight=weight, quant_method=method)
+    transform = KimiRoutedOutputTransform(None, up_proj)
+    spy = _SkinnyGemmSpy(k3_gemm.shape_dynamic_skinny_gemm)
+    monkeypatch.setattr(k3_gemm, "shape_dynamic_skinny_gemm", spy)
+
+    output = transform(latent, residual)
+
+    reference = latent.float() @ weight.float().t() + residual.float()
+    cosine = torch.nn.functional.cosine_similarity(
+        output.float().flatten(), reference.flatten(), dim=0
+    ).item()
+    assert cosine > 0.999
+    assert spy.calls == [num_tokens]
 
 
 @pytest.mark.parametrize("num_tokens", [1, 2, 3, 4])
@@ -1015,20 +1117,37 @@ def test_latent_moe_production_layout_residual(
     )
 
 
-def test_residual_dispatch_falls_back_to_addmm(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fallback = torch.randn(2, 3)
+def test_residual_dispatch_falls_back_to_inplace_addmm() -> None:
     residual = torch.randn(2, 3)
     x = torch.randn(2, 4)
     weight = torch.randn(3, 4)
-    monkeypatch.setattr(torch, "addmm", lambda *args: fallback)
+    expected = residual + x @ weight.t()
     # CPU tensors fail the runtime check, forcing the addmm fallback.
     method = k3_gemm.KimiK3LowLatencyLinearMethod({}, {})
 
     output = method.apply_with_residual(SimpleNamespace(weight=weight), x, residual)
 
-    assert output is fallback
+    assert output is residual
+    torch.testing.assert_close(output, expected)
+
+
+def test_kimi_routed_output_transform_dispatches_residual_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.models.kimi_k3.nvidia.model import KimiRoutedOutputTransform
+
+    expected = torch.randn(2, 3)
+    method = k3_gemm.KimiK3LowLatencyLinearMethod({}, {})
+    monkeypatch.setattr(method, "apply_with_residual", lambda *args: expected)
+    up_proj = SimpleNamespace(
+        weight=torch.randn(3, 4),
+        quant_method=method,
+    )
+    transform = KimiRoutedOutputTransform(None, up_proj)
+
+    output = transform(torch.randn(2, 4), torch.randn(2, 3))
+
+    assert output is expected
 
 
 def test_fallback_preserves_default_method() -> None:

--- a/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
@@ -380,6 +380,12 @@ KIMI_K3_PROJECTIONS_SM100: dict[tuple[int, int], ProjectionSpec] = {
             (1, _cute(1, 64, 4, 2)),
             (2, _cute(2, 64, 4, 2)),
         ),
+        residual_configs=(
+            (1, _cute(1, 64, 4, 2)),
+            (2, _cute(2, 64, 4, 1)),
+            (3, _cute(3, 64, 4, 2, 4)),
+            (4, _cute(4, 32, 2, 4, 4)),
+        ),
         name="routed_expert_up_proj",
     ),
     (7168, 8448): ProjectionSpec(
@@ -768,7 +774,7 @@ class KimiK3LowLatencyLinearMethod(_KimiK3LowLatencyApply, UnquantizedLinearMeth
             output = _run_residual_plan(self._residual_plan, x, layer.weight, residual)
             if output is not None:
                 return output
-        return torch.addmm(residual, x, layer.weight.t())
+        return residual.addmm_(x, layer.weight.t())
 
 
 class KimiK3LowLatencyEmbeddingMethod(

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -103,6 +103,7 @@ from vllm.models.kimi_k3.nvidia.latent_moe_runner import (
     LatentMoERunner,
 )
 from vllm.models.kimi_k3.nvidia.low_latency_gemm import (
+    KimiK3LowLatencyLinearMethod,
     enable_kimi_k3_low_latency_gemm,
 )
 from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
@@ -345,6 +346,11 @@ class KimiRoutedOutputTransform(nn.Module):
         if self.norm is not None:
             hidden_states = self.norm(hidden_states)
         if residual is not None:
+            quant_method = self.up_proj.quant_method
+            if isinstance(quant_method, KimiK3LowLatencyLinearMethod):
+                return quant_method.apply_with_residual(
+                    self.up_proj, hidden_states, residual
+                )
             return residual.addmm_(hidden_states, self.up_proj.weight.t())
         hidden_states, _ = self.up_proj(hidden_states)
         return hidden_states


### PR DESCRIPTION
## Summary
This PR connects Kimi-K3's existing residual skinny-GEMM API to the production latent-MoE output transform and adds measured SM100 configurations for the local `BF16[M, 3584] @ BF16[7168, 3584].T + residual` routed up-projection. For supported decode token counts, the CuTeDSL kernel performs the GEMM and residual add in one epilogue; unsupported token counts, layouts, dtypes, and devices retain the existing in-place `residual.addmm_` fallback.

This extends #53534 rather than duplicating it: #53534 installed SM100 low-latency methods for ordinary linear calls, but the SM100 residual table was empty and `KimiRoutedOutputTransform` called `addmm_` directly, so `apply_with_residual` had no production caller. #54151 optimizes SP communication around the latent tail and does not cover this residual up-projection. This change has no DeepGEMM dependency and is independent of shared-expert fusion.

The dispatch is intentionally local to `KimiRoutedOutputTransform`. Existing whole-tail fusion may bypass this transform for some TP8/PP2 small-batch configurations; this PR accelerates paths that reach the native/fallback latent output transform.

## Performance
Measured on one NVIDIA B200 GPU with CUDA 13.0 and PyTorch 2.13.0. Each point is the median of 31 measurements, each measurement replays a CUDA Graph 200 times, and eight weight/residual pairs rotate over more than 3x L2 capacity.

| Local tokens `M` | cuBLAS `addmm` | CuTe residual GEMM | Latency change |
| ---: | ---: | ---: | ---: |
| 1 | 12.533 us | 9.395 us | **-25.03%** |
| 2 | 12.928 us | 10.386 us | **-19.66%** |
| 3 | 11.913 us | 11.375 us | **-4.52%** |
| 4 | 12.289 us | 12.049 us | **-1.96%** |

All selected-kernel correctness checks achieved cosine similarity above 0.999998 against an FP32 reference.

## Test Plan
```bash
uv run pre-commit run --files \
  benchmarks/kernels/benchmark_k3_cutedsl_residual.py \
  tests/kernels/test_bf16_skinny_gemm.py \
  vllm/models/kimi_k3/nvidia/low_latency_gemm.py \
  vllm/models/kimi_k3/nvidia/model.py

uv run pytest -q tests/kernels/test_bf16_skinny_gemm.py -k residual

uv run --no-project python benchmarks/kernels/benchmark_k3_cutedsl_residual.py \
  --kernel vllm/model_executor/kernels/linear/cute_dsl/_skinny_gemm.py \
  --output /tmp/k3-residual-m1.jsonl --mode selected --m 1 \
  --repeats 31 --replays 200 --cache-multiplier 3
```

Full Kimi-K3 accuracy was tested with the default MoE and KV-cache configuration on two B200 nodes using TP8, PP2, and EP8:

```bash
# Run on both nodes; use NODE_RANK=0 on the API node and add --headless on rank 1.
VLLM_HOST_IP=$HOST_IP vllm serve /gpfs/mszn/models/moonshotai/Kimi-K3 \
  --served-model-name Kimi-K3 --trust-remote-code \
  --tensor-parallel-size 8 --pipeline-parallel-size 2 \
  --nnodes 2 --node-rank $NODE_RANK \
  --master-addr 192.168.5.2 --master-port 29995 \
  --distributed-executor-backend mp \
  --enable-expert-parallel --all2all-backend deepep_v2 \
  --load-format fastsafetensors --max-model-len 8192 \
  --max-num-seqs 128 --max-num-batched-tokens 32768 \
  --no-enable-prefix-caching \
  --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'

uv run --no-project --with 'lm-eval[api]==0.4.12' lm_eval \
  --model local-chat-completions \
  --model_args model=Kimi-K3,base_url=http://127.0.0.1:8000/v1/chat/completions,num_concurrent=64,timeout=900,tokenizer=/gpfs/mszn/models/moonshotai/Kimi-K3,trust_remote_code=True \
  --tasks gsm8k --gen_kwargs temperature=0.0,max_tokens=1500 \
  --apply_chat_template --seed 0 --log_samples
```

## Test Results
- Pre-commit: all applicable hooks passed, including Ruff, mypy, typos, SPDX, and signoff checks.
- B200 residual test selection: `16 passed, 24 skipped, 312 deselected`; the skipped cases require SM103.
- Full GSM8K (`lm-eval` 0.4.12, 1319 samples, 5-shot):

| Filter | Exact match | Stderr |
| --- | ---: | ---: |
| flexible-extract | 0.9750 | 0.0043 |
| strict-match | 0.9757 | 0.0042 |

## AI Assistance
This change was developed with assistance from OpenAI Codex. The human submitter reviewed every changed line and the benchmark, kernel-correctness, and model-accuracy results.
