### PR TITLE
[transformer] Improvements for embedding rewiring

### DIFF
--- a/tests/models/transformers/test_backend.py
+++ b/tests/models/transformers/test_backend.py
@@ -5,6 +5,7 @@
 import contextlib
 import os
 import tempfile
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -484,6 +485,114 @@ def test_replaced_embedding_exposes_one_vpe(vpe):
 
     lm_head = ParallelLMHead(VOCAB_SIZE, HIDDEN_SIZE)
     assert lm_head.tie_weights(composed.embed).weight is composed.embed.weight
+
+
+class FakeVocabModel(nn.Module):
+    """An HF model's embedding accessors, incl. a Gemma-style PLE table.
+
+    Mirrors `Gemma4PreTrainedModel.get_per_layer_input_embeddings`, whose raw
+    accessor returns `self.base_model.embed_tokens_per_layer` and so raises
+    `AttributeError` when per-layer embeddings are disabled.
+    """
+
+    def __init__(self, per_layer: bool):
+        super().__init__()
+        self.embed_tokens = ScaledWordEmbedding(
+            VOCAB_SIZE, HIDDEN_SIZE, embed_scale=EMBED_SCALE
+        )
+        if per_layer:
+            self.embed_tokens_per_layer = ScaledWordEmbedding(
+                VOCAB_SIZE, HIDDEN_SIZE, embed_scale=EMBED_SCALE
+            )
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def get_per_layer_input_embeddings(self):
+        return self.embed_tokens_per_layer
+
+    def set_per_layer_input_embeddings(self, value):
+        self.embed_tokens_per_layer = value
+
+
+class FakeUnifiedVocabModel(nn.Module):
+    """An HF model whose class defines no per-layer accessors at all.
+
+    Mirrors `Gemma4UnifiedModel`, which has neither
+    `get_per_layer_input_embeddings` nor its setter.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = ScaledWordEmbedding(
+            VOCAB_SIZE, HIDDEN_SIZE, embed_scale=EMBED_SCALE
+        )
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+
+class EmbeddingReplacementStub(nn.Module):
+    """Just enough of the backend to exercise `_replace_input_embeddings`."""
+
+    _replace_input_embeddings = Base._replace_input_embeddings
+
+
+def run_replace_input_embeddings(model, hidden_size_per_layer_input):
+    stub = EmbeddingReplacementStub()
+    stub.model = model
+    stub.quant_config = None
+    stub.text_config = SimpleNamespace(
+        hidden_size_per_layer_input=hidden_size_per_layer_input
+    )
+    stub._replace_input_embeddings()
+    return stub.model
+
+
+def test_replace_input_embeddings_with_ple(vpe):
+    """PLE on: both the input table and the per-layer table become `vpe`."""
+    model = run_replace_input_embeddings(
+        FakeVocabModel(per_layer=True), hidden_size_per_layer_input=HIDDEN_SIZE
+    )
+
+    assert isinstance(model.get_input_embeddings(), vpe)
+    assert isinstance(model.embed_tokens_per_layer, vpe)
+
+
+def test_replace_input_embeddings_without_ple(vpe):
+    """PLE off: the per-layer accessor is never called, input table still replaced.
+
+    The config gate must skip the accessor, which would otherwise raise
+    `AttributeError` exactly as Gemma4's does for a non-PLE checkpoint.
+    """
+    model = run_replace_input_embeddings(
+        FakeVocabModel(per_layer=False), hidden_size_per_layer_input=0
+    )
+
+    assert isinstance(model.get_input_embeddings(), vpe)
+    with pytest.raises(AttributeError):
+        model.get_per_layer_input_embeddings()
+
+
+def test_replace_input_embeddings_without_ple_accessors(vpe):
+    """No per-layer accessors: left alone even when the config gate is set.
+
+    `Gemma4UnifiedModel` defines neither accessor, yet its checkpoints still
+    carry a `hidden_size_per_layer_input` entry on the text config, so the
+    config gate on its own would not keep the per-layer branch away from it.
+    """
+    model = run_replace_input_embeddings(
+        FakeUnifiedVocabModel(), hidden_size_per_layer_input=HIDDEN_SIZE
+    )
+
+    assert isinstance(model.get_input_embeddings(), vpe)
+    assert not hasattr(model, "embed_tokens_per_layer")
 
 
 MULTIMODAL_MODEL = "llava-hf/llava-onevision-qwen2-0.5b-ov-hf"

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -169,12 +169,8 @@ class Base(
         # Create attention instances for KV cache allocation
         self.attention_instances = self.create_attention_instances()
 
-        # Input embeddings
-        input_embeddings = self.model.get_input_embeddings()
-        if not isinstance(input_embeddings, PPMissingLayer):
-            self.model.set_input_embeddings(
-                replace_embedding_class(input_embeddings, self.quant_config)
-            )
+        # Replace input embeddings (and per-layer PLE tables) with vLLM's
+        self._replace_input_embeddings()
 
         # Initialize any parameters that have not had their modules replaced
         self.init_parameters(self.model)
@@ -186,6 +182,30 @@ class Base(
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states"], self.text_config.hidden_size
         )
+
+    def _replace_input_embeddings(self):
+        """Swap the model's vocab embeddings for vLLM's `VocabParallelEmbedding`,
+        including per-layer embeddings.
+        """
+        input_embeddings = self.model.get_input_embeddings()
+        if not isinstance(input_embeddings, PPMissingLayer):
+            self.model.set_input_embeddings(
+                replace_embedding_class(input_embeddings, self.quant_config)
+            )
+
+        get_per_layer_embeddings = getattr(
+            self.model, "get_per_layer_input_embeddings", None
+        )
+        if callable(get_per_layer_embeddings) and getattr(
+            self.text_config, "hidden_size_per_layer_input", 0
+        ):
+            per_layer_embeddings = get_per_layer_embeddings()
+            if per_layer_embeddings is not None and not isinstance(
+                per_layer_embeddings, PPMissingLayer
+            ):
+                self.model.set_per_layer_input_embeddings(
+                    replace_embedding_class(per_layer_embeddings, self.quant_config)
+                )
 
     def _patch_config(self):
         """


### PR DESCRIPTION
## Purpose

This small PR ensures that both vocab embedding tables a model exposes are routed through `VocabParallelEmbedding`: 

1. The input embeddings, as before
2. The per-layer embeddings (PLE) that for example Gemma3n/Gemma4 keep 

## Test Plan

Any existing and already correctly rewired model is unaffected. Only models that contain per-layer vocab embedding tables (PLE), such as Gemma4 will also be rewired correctly. Specific test cases are added to mimic models with PLE and all their embeddings are correctly replaced.

## Test Result

Route per-layer (PLE) input embeddings through VocabParallelEmbedding, like the main input embeddings already are.

cc @hmellor 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
