### PR TITLE
[Bugfix] Do not adjust `dcp_kv_cache_interleave_size` for CPU offloading

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2772,17 +2772,25 @@ class VllmConfig:
             and self.kv_transfer_config.kv_connector is not None
             and self.parallel_config.cp_kv_cache_interleave_size != local_block_size
         ):
-            interleave = self.parallel_config.cp_kv_cache_interleave_size
-            self.parallel_config.cp_kv_cache_interleave_size = local_block_size
-            logger.info_once(
-                "When using PD disaggregation with DCP "
-                "(decode_context_parallel_size=%d), "
-                "cp_kv_cache_interleave_size is automatically adjusted "
-                "from %d to block_size %d for block-level alignment.",
-                dcp_size,
-                interleave,
-                local_block_size,
+            from vllm.distributed.kv_transfer.kv_connector.factory import (
+                KVConnectorFactory,
             )
+
+            connector_cls = KVConnectorFactory.get_connector_class(
+                self.kv_transfer_config
+            )
+            if connector_cls.requires_dcp_block_aligned_interleave:
+                interleave = self.parallel_config.cp_kv_cache_interleave_size
+                self.parallel_config.cp_kv_cache_interleave_size = local_block_size
+                logger.info_once(
+                    "When using PD disaggregation with DCP "
+                    "(decode_context_parallel_size=%d), "
+                    "cp_kv_cache_interleave_size is automatically adjusted "
+                    "from %d to block_size %d for block-level alignment.",
+                    dcp_size,
+                    interleave,
+                    local_block_size,
+                )
 
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -173,6 +173,14 @@ class KVConnectorBase_V1(ABC):
     Base class for KV connectors.
     """
 
+    requires_dcp_block_aligned_interleave: bool = True
+    """Whether this connector needs cp_kv_cache_interleave_size pinned to block_size
+    when decode_context_parallel_size > 1.
+
+    Connectors that only move KV within the same DCP rank (e.g. CPU offloading) should
+    set this to False.
+    """
+
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:
         """Whether external hits can complete divergent local hybrid hits.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -83,6 +83,8 @@ class DecodeBenchConnector(KVConnectorBase_V1, SupportsHMA):
     testing of the decoder with larger input sequence lengths.
     """
 
+    requires_dcp_block_aligned_interleave = False
+
     def __init__(
         self,
         vllm_config: "VllmConfig",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -47,6 +47,8 @@ from vllm.v1.request import Request
 
 
 class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
+    requires_dcp_block_aligned_interleave = False
+
     @property
     def requires_kv_delivery(self) -> bool:
         # Runs as kv_both, but is a best-effort cache: a dropped save is just a

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -54,6 +54,8 @@ _DISK_ONLY_KEYS = (
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
     """CPU KV cache offloading with custom kernel transfers and BlockPool LRU."""
 
+    requires_dcp_block_aligned_interleave = False
+
     @property
     def requires_kv_delivery(self) -> bool:
         # Runs as kv_both, but is a best-effort cache: a dropped save is just a


### PR DESCRIPTION



## Purpose

Fix engine crash when DCP and CPU offloading has been used simultaneously in sparse indexer models, which has been introduced by #50611.

Main reason #50611 adjusts `cp_kv_cache_interleave_size` is to enforce each block to contain only tokens in single DCP rank (which is required for NIXL that reads blockwise). CPU offloading has no such restriction, so we can safely release the adjustment.

By doing that, we can recover the DCP + CPU offloading combination for sparse indexer models (including Kimi K3), which previously hit the CUDA graph accuracy guard at https://github.com/vllm-project/vllm/blob/e79961c946e5b12da44ba0556567b418cd50fe20/vllm/v1/attention/backends/mla/indexer.py#L543-L548

## Test Plan

Run Kimi-K3 with DCP8 + CPU Offloading with success

## Test Result

##### Before

```log
...
(Worker_TP1_DCP1_EP1 pid=1696) INFO 08-31 01:07:24 [factory.py:57] Creating offloading spec with name: CPUOffloadingSpec
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055] WorkerProc hit an exception.
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055] Traceback (most recent call last):
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 1047, in _execute_worker_rpc
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     output = func(*args, **kwargs)
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/worker/worker_base.py", line 348, in initialize_from_config
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     self.worker.initialize_from_config(kv_cache_config)  # type: ignore
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     return func(*args, **kwargs)
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 730, in initialize_from_config
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     self.model_runner.initialize_kv_cache(
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/worker/gpu/model_runner.py", line 577, in initialize_kv_cache
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     self.attn_group, attn_cg_support, self.kernel_block_sizes = init_attn_backend(
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]                                                                 ^^^^^^^^^^^^^^^^^^
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/worker/gpu/attn_utils.py", line 139, in init_attn_backend
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     group.create_metadata_builders(
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/worker/utils.py", line 284, in create_metadata_builders
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     builder_cls(
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]   File "/app/.venv/lib/python3.12/site-packages/vllm/v1/attention/backends/mla/indexer.py", line 544, in __init__
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055]     raise NotImplementedError(
(Worker_TP4_DCP4_EP4 pid=1699) ERROR 08-31 01:07:24 [multiproc_executor.py:1055] NotImplementedError: DCP sparse indexer currently supports only cp_kv_cache_interleave_size=1 (got 64).
```

##### After

```log
(Worker_TP7_DCP7_EP7 pid=1610) INFO 08-31 03:21:50 [factory.py:57] Creating offloading spec with name: CPUOffloadingSpec
(Worker_TP6_DCP6_EP6 pid=1609) INFO 08-31 03:21:51 [shared_offload_region.py:133] Created map file /dev/shm/vllm_offload_efdf02d5-7bd6-4b05-a129-d1be7a8bb447.mmap (360.76 GB)
(Worker_TP3_DCP3_EP3 pid=1606) INFO 08-31 03:21:51 [shared_offload_region.py:119] Opened existing mmap file /dev/shm/vllm_offload_efdf02d5-7bd6-4b05-a129-d1be7a8bb447.mmap
...
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

