### PR TITLE
[Bugfix][Reasoning] muse_glimmer: enable thinking_token_budget

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -269,6 +269,9 @@ If `thinking_token_budget` is not specified, no explicit reasoning limit is appl
 !!! note
     `reasoning_end_str` can include a transition phrase before the reasoning end token. For example, setting `reasoning_end_str` to `"I have to give the solution based on the reasoning directly now.</think>"` instructs the model to emit that phrase when the budget is exhausted, making the reasoning termination more natural.
 
+!!! note
+    Both strings must be spelled the way the model *generates* them, because they are matched against output token ids. If the chat template ends the generation prompt in the middle of a line, the first generated token carries the leading whitespace (` to` is not the same token as `to`), and a spelling that differs from the model's is never matched, so the budget silently never applies.
+
 ### Online Serving
 
 ```bash

--- a/tests/reasoning/test_muse_glimmer_reasoning_parser.py
+++ b/tests/reasoning/test_muse_glimmer_reasoning_parser.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Thinking-budget enablement tests for MuseGlimmer.
+
+MuseGlimmer has no `<think>`/`</think>` pair: reasoning is a channel, opened by
+naming `self` as the recipient (` to=self<|message|>`) and closed by `<|eom|>`.
+Without declared boundary strings, `ReasoningConfig.initialize_token_ids`
+returns early, `reasoning_config.enabled` stays False, and any request that
+sets `thinking_token_budget` is rejected with HTTP 400.
+
+A stub tokenizer keeps these checkpoint-free; the framing markers are the
+special tokens they are in the real vocabulary.
+"""
+
+import pytest
+
+from vllm.reasoning.muse_glimmer_reasoning_parser import MuseGlimmerReasoningParser
+
+_SPECIALS = ("<|message|>", "<|eom|>", "<|eot|>", "<|start|>")
+
+
+class _StubTokenizer:
+    """Longest-match tokenizer over the framing markers plus single characters."""
+
+    def __init__(self, specials=_SPECIALS):
+        pieces = list(specials) + [chr(c) for c in range(32, 127)]
+        self._id_to_text = pieces
+        self._text_to_id = {text: i for i, text in enumerate(pieces)}
+        self._ordered = sorted(pieces, key=len, reverse=True)
+
+    def get_vocab(self):
+        return dict(self._text_to_id)
+
+    def encode(self, text, add_special_tokens=False):
+        ids = []
+        pos = 0
+        while pos < len(text):
+            for piece in self._ordered:
+                if text.startswith(piece, pos):
+                    ids.append(self._text_to_id[piece])
+                    pos += len(piece)
+                    break
+            else:
+                raise AssertionError(f"unencodable text at {pos}: {text[pos:]!r}")
+        return ids
+
+    def decode(self, token_ids, **kwargs):
+        return "".join(self._id_to_text[i] for i in token_ids)
+
+
+@pytest.fixture
+def tok():
+    return _StubTokenizer()
+
+
+@pytest.fixture
+def parser(tok):
+    return MuseGlimmerReasoningParser(tok)
+
+
+def test_boundary_strings_are_what_the_model_generates(parser):
+    # The leading space matters: the generation prompt ends after
+    # `<|start|>assistant`, so the model emits ` to`, a different token from
+    # `to`, and the budget matcher compares token ids by exact slice.
+    assert parser.reasoning_start_str == " to=self<|message|>"
+    # The end string is the closing marker only. The full transition
+    # `<|eom|><|start|>assistant to=user<|message|>` would decide the next
+    # recipient, which on a tool turn belongs to the model.
+    assert parser.reasoning_end_str == "<|eom|>"
+
+
+def test_reasoning_config_enables_the_budget(tok, monkeypatch):
+    """`thinking_token_budget` must be enabled, with forced == natural end."""
+    from vllm.config import reasoning as reasoning_module
+    from vllm.config.reasoning import ReasoningConfig
+
+    monkeypatch.setattr(
+        reasoning_module, "cached_tokenizer_from_config", lambda model_config: tok
+    )
+    config = ReasoningConfig(reasoning_parser="muse_glimmer")
+    config.initialize_token_ids(model_config=None)
+
+    assert config.enabled, "a thinking_token_budget request would get HTTP 400"
+    assert config.reasoning_start_token_ids == tok.encode(" to=self<|message|>")
+    assert config.reasoning_end_token_ids == tok.encode("<|eom|>")
+    assert config.natural_reasoning_end_token_ids == tok.encode("<|eom|>")
+
+
+def test_cli_reasoning_end_str_still_overrides(tok, monkeypatch):
+    """A user-provided end string must win over the parser's declaration."""
+    from vllm.config import reasoning as reasoning_module
+    from vllm.config.reasoning import ReasoningConfig
+
+    monkeypatch.setattr(
+        reasoning_module, "cached_tokenizer_from_config", lambda model_config: tok
+    )
+    config = ReasoningConfig(
+        reasoning_parser="muse_glimmer",
+        reasoning_start_str=" to=self<|message|>",
+        reasoning_end_str="<|eom|><|start|>assistant to=user<|message|>",
+    )
+    config.initialize_token_ids(model_config=None)
+
+    assert config.enabled
+    assert config.reasoning_end_token_ids == tok.encode(
+        "<|eom|><|start|>assistant to=user<|message|>"
+    )
+    # The parser's own declaration remains the natural end.
+    assert config.natural_reasoning_end_token_ids == tok.encode("<|eom|>")

--- a/vllm/reasoning/muse_glimmer_reasoning_parser.py
+++ b/vllm/reasoning/muse_glimmer_reasoning_parser.py
@@ -28,6 +28,14 @@ _EOM = "<|eom|>"
 _EOT = "<|eot|>"
 _FUNCTION_CALLS_OPEN = "<atem:function_calls>"
 _REASONING_OPEN = "to=self<|message|>"
+# What the model GENERATES to open its reasoning channel, leading space and all.
+# The chat template renders the assistant header as
+# ``<|start|>assistant to=self<|message|>`` and ends the generation prompt after
+# ``<|start|>assistant``, so the space belongs to the first generated token: the
+# model emits `` to``, not ``to``, and the two are different ids.
+# ``thinking_token_budget`` matches these ids against the output by exact slice
+# and silently never fires if the spelling differs.
+_GENERATED_REASONING_OPEN = " to=self<|message|>"
 _ASSISTANT_TURN_OPEN = "<|start|>assistant"
 # A channel header: ``to=<recipient><|message|>`` where recipient is ``self``
 # (reasoning), ``user`` (final answer) or ``<tool>[.<fn>]`` (tool call).
@@ -134,6 +142,30 @@ class MuseGlimmerReasoningParser(ReasoningParser):
         """
         request.skip_special_tokens = False
         return request
+
+    @property
+    def reasoning_start_str(self) -> str:
+        """Opens a reasoning message; see ``_GENERATED_REASONING_OPEN``.
+
+        Declaring this and ``reasoning_end_str`` is what lets
+        ``ReasoningConfig.initialize_token_ids`` enable
+        ``thinking_token_budget`` for MuseGlimmer. Without them the config
+        returns early, ``reasoning_config.enabled`` stays False, and any
+        request carrying a budget is rejected with HTTP 400.
+        """
+        return _GENERATED_REASONING_OPEN
+
+    @property
+    def reasoning_end_str(self) -> str:
+        """The marker that ends a reasoning message, and only that.
+
+        Deliberately NOT the full transition
+        ``<|eom|><|start|>assistant to=user<|message|>``: that string does not
+        just end reasoning, it decides the next recipient, and forcing it on a
+        tool turn sends the answer to the user instead of the tool. Forcing the
+        bare marker leaves the recipient to the model.
+        """
+        return _EOM
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         """Whether the model has left reasoning and opened a TOOL channel.


### PR DESCRIPTION
## Purpose

Setting `thinking_token_budget` on any request served with `--reasoning-parser muse_glimmer` returns HTTP 400 with "reasoning_config is not configured. Please set --reasoning-parser and/or --reasoning-config", advice the user has already followed. The budget feature is unusable for this model.

The cause is that the parser declares no reasoning boundary strings. MuseGlimmer frames reasoning as a channel (a message addressed ` to=self` and closed by `<|eom|>`) rather than delimiting it with a `<think>`/`</think>` pair, so the base-class defaults of None apply, `ReasoningConfig.initialize_token_ids` returns early, `reasoning_config.enabled` stays False, and the input processor rejects every budgeted request.

This PR declares the two strings that the channel framing implies: ` to=self<|message|>` opens a reasoning message and `<|eom|>` closes it. With them declared, budgets are accepted and enforced. On our serving setup a request with `thinking_token_budget: 64` produced exactly 64 reasoning tokens followed by a normal answer, and 256 produced exactly 256.

The start string keeps its leading space deliberately. The chat template ends the generation prompt after `<|start|>assistant`, so the space belongs to the first generated token, and ` to` is a different token id from `to`. The budget machinery matches these ids against the output by exact slice, so the other spelling would silently never fire. A docs note about this trap is included.

## Why the end string is the bare marker

The full transition the model writes to start answering is `<|eom|><|start|>assistant to=user<|message|>`, and it looks like the natural forced-end string. It is not, because it does not just end reasoning, it decides the next recipient. Measured with one tool offered and a small budget, forcing the full transition made all 12 samples answer the user first. In 10 of the 12 the tool call never happened, and those answers fabricated the data the tool would have returned. The other 2 opened the tool channel after answering. A control without a budget chose the tool in 6 of 6 samples. Forcing the bare `<|eom|>` leaves the recipient with the model, and on this model the transition is then produced voluntarily (#44676 describes the corresponding failure class for `<think>`-family models, where the forced end lands inside tool-call arguments).

One semantic point to state explicitly: MuseGlimmer may open several reasoning messages in one turn, and the budget bounds each message, not the turn. That is the existing meaning of `thinking_token_budget` for every parser. Turn-level accounting is possible future work and is independent of this fix.

## Related work

- #54238 implements `count_reasoning_tokens` for MuseGlimmer. That is the usage-accounting side and is independent of this change, which is the enforcement side. They compose and can merge in either order.
- #44676 reports thinking-budget forced ends corrupting tool calls for `<think>`-family models. The end-string choice above avoids the MuseGlimmer variant of that failure.
- #52390 rewrites this parser for structured-output correctness. The two properties added here are independent of that rework and rebase trivially onto it.

Duplicate check, run before submission:

```
gh pr list --repo vllm-project/vllm --state open --search "muse_glimmer thinking_token_budget in:title,body"
gh pr list --repo vllm-project/vllm --state open --search "muse glimmer reasoning in:title,body"
```

The first returns only this PR and #54467. The second returns #54238, #54091, #54186, and #53404, which change reasoning-token accounting, the `reasoning_strength` template kwarg, and the structured-output gate. None of them touches budget enablement or the boundary strings.

## Test Plan

```
pytest tests/reasoning/test_muse_glimmer_reasoning_parser.py -q
```

Three checkpoint-free tests over a stub tokenizer: the two declared strings are exactly what the model generates (leading space pinned), `ReasoningConfig` ends up enabled with forced == natural == `<|eom|>`, and a user-provided `--reasoning-config` end string still overrides the parser's declaration while the parser's marker remains the natural end.

## Test Result

```
$ pytest test_muse_glimmer_reasoning_parser.py -q
3 passed in 13.45s
```

Against the real MuseGlimmer tokenizer the declared strings resolve to id slices `[328, 19669, 200023]` and `[200007]`, matching the segmentation the model emits (verified by sampling raw turns). End-to-end on our serving setup (Muse-Glimmer-30B, budgets 64/256): HTTP 400 before this change, exact-to-the-token enforcement with a normal answer after it. A full production run (6 seeds x 1874 requests, budget 3072 of max_tokens 4096) completed with zero requests at the token cap and zero parse failures.

---

AI assistance (Claude Code) was used in developing this change. All code was reviewed and validated by the submitter, and the measurements are from our own runs.


