### PR TITLE
[ROCm] Wire indexer_kv_dtype through on the MiniMax-M3 AMD path

### DIFF
--- a/vllm/models/minimax_m3/amd/model.py
+++ b/vllm/models/minimax_m3/amd/model.py
@@ -676,13 +676,19 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         # of wrapping the generic Attention module. Keep the same runtime scale
         # attributes so FP8 KV reads can honor vLLM's per-layer descale contract.
         set_default_quant_scales(self, register_buffer=True)
+        # Indexer side-cache dtype, mirroring --kv-cache-dtype for the main
+        # cache (--attention-config '{"indexer_kv_dtype": ...}').
+        self.indexer_kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype(
+            "bf16"
+        )
 
         # Shared top-k buffer: the indexer writes the selected blocks into it and
         # the attend impl reads them back (no Python value crosses the break).
         self.topk_indices_buffer = topk_indices_buffer
         self.attn_backend = MiniMaxM3SparseBackend
-        # Indexer and main attention are separate impls. On ROCm the SM100 gate
-        # is always False, so both pick Triton and the index cache stays bf16.
+        # Indexer and main attention are separate impls, each picking Triton vs
+        # MSA off its cache dtype (the SM100 gate is always False on ROCm, so
+        # the indexer stays on the Triton impl regardless of indexer_kv_dtype).
         # impl is AttentionImplBase (broader than AttentionLayerBase's annotation).
         self.impl: MiniMaxM3SparseImpl = select_main_impl_cls(  # type: ignore[assignment]
             topk_blocks=sparse_cfg["sparse_topk_blocks"],
@@ -715,6 +721,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             local_blocks=sparse_cfg.get("sparse_local_block", 0),
             score_type=sparse_cfg.get("sparse_score_type", "max"),
             cache_config=cache_config,
+            indexer_kv_dtype=self.indexer_kv_dtype,
             topk_indices_buffer=topk_indices_buffer,
         )
 


### PR DESCRIPTION
## Purpose

`MiniMaxM3SparseAttention` on ROCm (`vllm/models/minimax_m3/amd/model.py`) never reads `vllm_config.attention_config.indexer_kv_dtype` — it always constructs `MiniMaxM3Indexer` with the class's own `bf16` default, silently ignoring any `--attention-config '{"indexer_kv_dtype": ...}'` override. The NVIDIA counterpart (`nvidia/model.py`) already resolves and threads this through:

```python
self.indexer_kv_dtype = vllm_config.attention_config.resolve_indexer_kv_dtype("bf16")
```

The ROCm file just never picked this up — there's currently no code path for AMD to ever request anything but bf16 for the indexer side cache, regardless of what's configured.

This mirrors `nvidia/model.py`'s handling on the ROCm side: resolve `indexer_kv_dtype` from `attention_config` (default unchanged, `"bf16"`) and pass it through to `MiniMaxM3Indexer`.

## Why this matters independent of #47665

This doesn't change default behavior for anyone not setting the override. What it does fix:

1. Requesting `indexer_kv_dtype=fp8` on ROCm today will now correctly raise `NotImplementedError` from `select_indexer_impl_cls`'s existing Triton-impl dtype guard (`vllm/models/minimax_m3/common/indexer.py`), instead of silently ignoring the request and running bf16.
2. Once #47665 lands (relaxing that same guard to accept fp8 on the shared Triton indexer impl), ROCm picks up fp8 indexer support automatically through this same code path — no further AMD-side changes needed.

Found while root-causing an AMD-vs-NVIDIA AgentX throughput gap on InferenceX (MiniMax-M3, MI355X): the ROCm sparse-attention path forces `indexer_kv_dtype=bf16` where NVIDIA's SM100 path uses fp8, costing ~32% more KV bytes/token and an earlier concurrency cliff. #47665 fixes the shared kernel's capability; this fixes the fact that AMD's model wiring never asks for it.

## Test Plan

No behavior change for default (`bf16`) usage. Verified via source read + `ruff check` (no ROCm hardware available in this environment). Planning to validate end-to-end on a rented MI300X once #47665 is available to cherry-pick alongside this — will follow up with results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)