### PR TITLE
[Bugfix][Model Runner V2] Complete a forced reasoning end that extends the natural end

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -269,6 +269,9 @@ If `thinking_token_budget` is not specified, no explicit reasoning limit is appl
 !!! note
     `reasoning_end_str` can include a transition phrase before the reasoning end token. For example, setting `reasoning_end_str` to `"I have to give the solution based on the reasoning directly now.</think>"` instructs the model to emit that phrase when the budget is exhausted, making the reasoning termination more natural.
 
+!!! note
+    The forced string may also continue past the end token, for example `"</think>Final answer:"`, and the whole string is delivered. Keep such a continuation neutral: it should steer the model into answering, and for models that address their messages to recipients it must not contain addressing text, or it overrides the model's choice of whom to answer.
+
 ### Online Serving
 
 ```bash

--- a/tests/v1/worker/test_gpu_thinking_budget.py
+++ b/tests/v1/worker/test_gpu_thinking_budget.py
@@ -36,6 +36,16 @@ class MockMultiTokenEndReasoningConfig:
     natural_reasoning_end_token_ids = [END_A, END_B]
 
 
+class MockExtendedEndReasoningConfig:
+    """Forced end that continues past the natural end, as channel-framed models
+    need: closing the reasoning message does not commit the model to answering,
+    so the forced sequence also opens the next channel."""
+
+    reasoning_start_token_ids = [START]
+    reasoning_end_token_ids = [END, END_A, END_B]
+    natural_reasoning_end_token_ids = [END]
+
+
 class MockDistinctEndReasoningConfig:
     reasoning_start_token_ids = [START]
     reasoning_end_token_ids = [END_A, END_B]
@@ -284,6 +294,85 @@ def test_v2_thinking_budget_clamps_oversized_budget():
     out = _apply(state, logits, input_ids=[12], local_pos=[0])
 
     assert torch.all(out == 0)
+
+
+def _commit(req_states: RequestState, tokens: list[int], token: int) -> None:
+    req_states.all_token_ids.stage_write(3, len(tokens), [token])
+    req_states.total_len.stage_write_elem(3, len(tokens) + 1)
+    req_states.apply_staged_writes()
+    tokens.append(token)
+
+
+def test_v2_thinking_budget_continues_forced_end_after_natural_end():
+    """A forced end whose first tokens are the natural end must still be
+    completed: closing the reasoning section is not what commits the model."""
+    tokens = [1, START, 10, 11, 12]
+    req_states = _make_req_states(tokens, prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockExtendedEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    for expected_id in (END, END_A, END_B):
+        logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+        out = _apply(state, logits, input_ids=[tokens[-1]], local_pos=[0])
+        assert out[0, expected_id] == pytest.approx(1.0e9), tokens
+        _commit(req_states, tokens, expected_id)
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[tokens[-1]], local_pos=[0])
+    assert torch.all(out == 0)
+
+
+def test_v2_thinking_budget_continues_forced_end_across_draft_tokens():
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockExtendedEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((3, VOCAB_SIZE), device=DEVICE)
+    out = _apply(
+        state,
+        logits,
+        input_ids=[12, END, END_A],
+        local_pos=[0, 1, 2],
+    )
+
+    assert out[0, END] == pytest.approx(1.0e9)
+    assert out[1, END_A] == pytest.approx(1.0e9)
+    assert out[2, END_B] == pytest.approx(1.0e9)
+
+
+def test_v2_thinking_budget_forces_completed_end_only_once():
+    """The end marker that closes a later message is not another budget
+    overrun, even when the whole history arrives as one prompt."""
+    req_states = _make_req_states(
+        [1, START, 10, 11, 12, END, END_A, END_B, 20, 21, END],
+        prompt_len=11,
+    )
+    state = ThinkingBudgetState(req_states, MockExtendedEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[END], local_pos=[0])
+
+    assert torch.all(out == 0)
+
+
+def test_v2_thinking_budget_forces_end_of_section_after_completed_end():
+    """A section opened after a completed forced end gets its own budget."""
+    req_states = _make_req_states(
+        [1, START, 10, 11, 12, END, END_A, END_B, 20, START, 30, 31, 32],
+        prompt_len=13,
+    )
+    state = ThinkingBudgetState(req_states, MockExtendedEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[32], local_pos=[0])
+
+    assert out[0, END] == pytest.approx(1.0e9)
 
 
 def test_v2_thinking_budget_continues_end_prefix_from_prompt():

--- a/vllm/v1/worker/gpu/sample/thinking_budget.py
+++ b/vllm/v1/worker/gpu/sample/thinking_budget.py
@@ -49,6 +49,15 @@ class ThinkingBudgetState:
         if not self.enabled:
             return
 
+        # A forced end that merely extends the natural one closes the reasoning
+        # section with its first tokens, so the section-open guard below stops
+        # matching before the rest of the sequence is emitted. Such a sequence
+        # needs the continuation path.
+        self.continue_after_natural_end = (
+            len(end_ids) > len(natural_end_ids)
+            and end_ids[: len(natural_end_ids)] == natural_end_ids
+        )
+
         self.thinking_token_budget = UvaBackedTensor(
             self.max_num_reqs, dtype=torch.int32
         )
@@ -64,6 +73,11 @@ class ThinkingBudgetState:
         )
         self.cached_scan_pos = torch.zeros(
             self.max_num_reqs, dtype=torch.int32, device=self.device
+        )
+        # Position of the natural end whose forced continuation is already
+        # committed, so a later stray end marker cannot force a second one.
+        self.cached_done_anchor = torch.full(
+            (self.max_num_reqs,), -1, dtype=torch.int32, device=self.device
         )
         self._reset_reqs: list[int] = []
         self._budget_dirty = False
@@ -102,6 +116,7 @@ class ThinkingBudgetState:
             self.cached_last_start.index_fill_(0, idx, -1)
             self.cached_last_end.index_fill_(0, idx, -1)
             self.cached_scan_pos.index_fill_(0, idx, 0)
+            self.cached_done_anchor.index_fill_(0, idx, -1)
             self._reset_reqs.clear()
         if self._budget_dirty:
             self.thinking_token_budget.copy_to_uva()
@@ -131,9 +146,11 @@ class ThinkingBudgetState:
             self.cached_last_start,
             self.cached_last_end,
             self.cached_scan_pos,
+            self.cached_done_anchor,
             self.reasoning_start_token_ids,
             self.natural_reasoning_end_token_ids,
             self.reasoning_end_token_ids,
+            self.continue_after_natural_end,
         )
 
 
@@ -157,6 +174,27 @@ def _load_effective_token(
 
 
 @triton.jit
+def _forced_end_committed(
+    all_token_ids_ptr,
+    all_token_ids_stride,
+    req_state_idx,
+    total_len,
+    reasoning_end_token_ids_ptr,
+    anchor,
+    END_LEN: tl.constexpr,
+):
+    committed = (anchor >= 0) & (anchor + END_LEN <= total_len)
+    for j in tl.static_range(0, END_LEN):
+        pos = anchor + j
+        if pos < 0 or pos >= total_len:
+            pos = 0
+        expected = tl.load(reasoning_end_token_ids_ptr + j)
+        actual = tl.load(all_token_ids_ptr + req_state_idx * all_token_ids_stride + pos)
+        committed = committed & (actual == expected)
+    return committed
+
+
+@triton.jit
 def _update_committed_marker_cache_kernel(
     req_ids_ptr,
     thinking_token_budget_ptr,
@@ -166,12 +204,16 @@ def _update_committed_marker_cache_kernel(
     cached_last_start_ptr,
     cached_last_end_ptr,
     cached_scan_pos_ptr,
+    cached_done_anchor_ptr,
     reasoning_start_token_ids_ptr,
     natural_reasoning_end_token_ids_ptr,
+    reasoning_end_token_ids_ptr,
     START_LEN: tl.constexpr,
     NATURAL_END_LEN: tl.constexpr,
+    END_LEN: tl.constexpr,
     MAX_LEN: tl.constexpr,
     BLOCK: tl.constexpr,
+    CONTINUE_AFTER_NATURAL_END: tl.constexpr,
 ):
     req_state_idx = tl.load(req_ids_ptr + tl.program_id(0))
     budget = tl.load(thinking_token_budget_ptr + req_state_idx)
@@ -182,11 +224,15 @@ def _update_committed_marker_cache_kernel(
     scan_pos = tl.load(cached_scan_pos_ptr + req_state_idx)
     last_start = tl.load(cached_last_start_ptr + req_state_idx)
     last_end = tl.load(cached_last_end_ptr + req_state_idx)
+    done_anchor = -1
+    if CONTINUE_AFTER_NATURAL_END:
+        done_anchor = tl.load(cached_done_anchor_ptr + req_state_idx)
 
     if scan_pos > total_len:
         scan_pos = 0
         last_start = -1
         last_end = -1
+        done_anchor = -1
 
     if scan_pos == 0 and last_start < 0 and last_end < 0:
         # Cold scan: walk backward in vectorized blocks, stopping at the first
@@ -219,6 +265,22 @@ def _update_committed_marker_cache_kernel(
                 )
                 end_match = end_match & (actual == expected)
 
+            if CONTINUE_AFTER_NATURAL_END:
+                # A completed forced sequence also has to be recovered here, or
+                # a request recomputed from a prompt that already contains one
+                # would force a second copy of it.
+                row_ptr = all_token_ids_ptr + req_state_idx * all_token_ids_stride
+                forced_match = (offs < block_hi) & (offs + END_LEN <= total_len)
+                for j in tl.static_range(0, END_LEN):
+                    expected = tl.load(reasoning_end_token_ids_ptr + j)
+                    actual = tl.load(
+                        row_ptr + offs + j,
+                        mask=offs + j < total_len,
+                        other=-1,
+                    )
+                    forced_match = forced_match & (actual == expected)
+                done_anchor = tl.max(tl.where(forced_match, offs, -1), axis=0)
+
             last_start = tl.max(tl.where(start_match, offs, -1), axis=0)
             last_end = tl.max(tl.where(end_match, offs, -1), axis=0)
             block_hi = block_lo
@@ -248,6 +310,38 @@ def _update_committed_marker_cache_kernel(
 
     tl.store(cached_last_start_ptr + req_state_idx, last_start)
     tl.store(cached_last_end_ptr + req_state_idx, last_end)
+
+    if CONTINUE_AFTER_NATURAL_END:
+        if done_anchor >= 0:
+            # Rejected draft tokens can drop a sequence that was complete; let
+            # the continuation be forced again from wherever it now stands.
+            still_committed = _forced_end_committed(
+                all_token_ids_ptr,
+                all_token_ids_stride,
+                req_state_idx,
+                total_len,
+                reasoning_end_token_ids_ptr,
+                done_anchor,
+                END_LEN,
+            )
+            if still_committed == 0:
+                done_anchor = -1
+        section_closed = last_start >= 0 and last_end >= last_start
+        overran_budget = last_end - (last_start + START_LEN) >= budget
+        if section_closed and overran_budget and last_start > done_anchor:
+            just_committed = _forced_end_committed(
+                all_token_ids_ptr,
+                all_token_ids_stride,
+                req_state_idx,
+                total_len,
+                reasoning_end_token_ids_ptr,
+                last_end,
+                END_LEN,
+            )
+            if just_committed:
+                done_anchor = last_end
+        tl.store(cached_done_anchor_ptr + req_state_idx, done_anchor)
+
     new_scan_pos = total_len - (MAX_LEN - 1)
     if new_scan_pos < 0:
         new_scan_pos = 0
@@ -267,12 +361,14 @@ def _thinking_budget_kernel(
     expanded_local_pos_ptr,
     cached_last_start_ptr,
     cached_last_end_ptr,
+    cached_done_anchor_ptr,
     reasoning_start_token_ids_ptr,
     natural_reasoning_end_token_ids_ptr,
     reasoning_end_token_ids_ptr,
     START_LEN: tl.constexpr,
     NATURAL_END_LEN: tl.constexpr,
     END_LEN: tl.constexpr,
+    CONTINUE_AFTER_NATURAL_END: tl.constexpr,
 ):
     token_idx = tl.program_id(0).to(tl.int64)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
@@ -328,6 +424,39 @@ def _thinking_budget_kernel(
         if end_match:
             last_end = i
 
+    if CONTINUE_AFTER_NATURAL_END:
+        # The natural end that closed the section is the first part of the
+        # forced sequence, so the section is closed while the rest of the
+        # sequence still has to be emitted. Resume it from the natural end,
+        # which is where the model is being steered from, rather than from the
+        # tail: on the answer channel the tail matches nothing.
+        done_anchor = tl.load(cached_done_anchor_ptr + req_state_idx)
+        section_closed = last_start >= 0 and last_end >= last_start
+        overran_budget = last_end - (last_start + START_LEN) >= budget
+        if section_closed and overran_budget and last_start > done_anchor:
+            forced_len = 0
+            for j in tl.static_range(0, END_LEN):
+                pos = last_end + j
+                if pos < effective_len and forced_len == j:
+                    expected = tl.load(reasoning_end_token_ids_ptr + j)
+                    actual = _load_effective_token(
+                        all_token_ids_ptr,
+                        all_token_ids_stride,
+                        input_ids_ptr,
+                        cur_req_first_pos,
+                        req_state_idx,
+                        total_len,
+                        pos,
+                    )
+                    if actual == expected:
+                        forced_len = j + 1
+            if forced_len > 0 and forced_len < END_LEN:
+                force_token_id = tl.load(reasoning_end_token_ids_ptr + forced_len)
+                tl.store(
+                    logits_ptr + token_idx * logits_stride + force_token_id,
+                    1.0e9,
+                )
+
     if last_start < 0 or last_start <= last_end:
         return
 
@@ -381,9 +510,11 @@ def apply_thinking_budget(
     cached_last_start: torch.Tensor,
     cached_last_end: torch.Tensor,
     cached_scan_pos: torch.Tensor,
+    cached_done_anchor: torch.Tensor,
     reasoning_start_token_ids: torch.Tensor,
     natural_reasoning_end_token_ids: torch.Tensor,
     reasoning_end_token_ids: torch.Tensor,
+    continue_after_natural_end: bool,
 ) -> None:
     num_tokens = logits.shape[0]
     start_len = reasoning_start_token_ids.shape[0]
@@ -399,12 +530,16 @@ def apply_thinking_budget(
         cached_last_start,
         cached_last_end,
         cached_scan_pos,
+        cached_done_anchor,
         reasoning_start_token_ids,
         natural_reasoning_end_token_ids,
+        reasoning_end_token_ids,
         START_LEN=start_len,
         NATURAL_END_LEN=natural_end_len,
+        END_LEN=end_len,
         MAX_LEN=max(start_len, natural_end_len),
         BLOCK=_COLD_SCAN_BLOCK,
+        CONTINUE_AFTER_NATURAL_END=continue_after_natural_end,
     )
 
     _thinking_budget_kernel[(num_tokens,)](
@@ -419,10 +554,12 @@ def apply_thinking_budget(
         expanded_local_pos,
         cached_last_start,
         cached_last_end,
+        cached_done_anchor,
         reasoning_start_token_ids,
         natural_reasoning_end_token_ids,
         reasoning_end_token_ids,
         START_LEN=start_len,
         NATURAL_END_LEN=natural_end_len,
         END_LEN=end_len,
+        CONTINUE_AFTER_NATURAL_END=continue_after_natural_end,
     )


### PR DESCRIPTION
## Purpose

`thinking_token_budget` caps how many tokens a model may spend on reasoning. When the cap is hit, vLLM steers the model out of reasoning by injecting a configured "forced end" text into the output, one token per step. That works when the forced text is a single closing marker like `</think>`. It silently breaks when the forced text is longer and starts with the model's natural end marker. The kernel injects the first token, considers reasoning closed, and stops. The rest of the forced text never appears, and the model is not steered to the answer at all.

The shape is easy to configure by accident. For a model that wraps reasoning in `<think>...</think>` tags, a user who wants a steering phrase after the closing tag, for example `reasoning_end_str = "</think>Final answer:"`, has created exactly this sequence. It starts with the natural end, so the kernel delivers `</think>`, drops the steering phrase, and the user never learns it. The example in [docs/features/reasoning_outputs.md](https://github.com/vllm-project/vllm/blob/main/docs/features/reasoning_outputs.md) puts the phrase before the closing tag and is unaffected, which is why this has not been hit before. For MuseGlimmer, where #54462 enables the budget, any custom end string necessarily begins with the natural end marker `<|eom|>`, because the reasoning message has to be closed before anything else can be written, so every custom `--reasoning-config` for that model produces this shape too.

The mechanics: the MRv2 thinking-budget kernel ([`vllm/v1/worker/gpu/sample/thinking_budget.py`](https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/gpu/sample/thinking_budget.py)) forces one token per decode step and re-derives its position in the forced sequence by matching against the tail of the output, but it only runs while a reasoning section is open:

```python
if last_start < 0 or last_start <= last_end:
    return
```

If `forced_ids[0]` is the natural end, forcing it closes the section, so on the next step the guard sees a closed section and disengages. A config that asked for an N-token sequence gets 1 token.

## Design

Resume the forced sequence from the natural end that closed the section rather than from the tail. The main risk in doing so is injecting the sequence twice, and two pieces of state prevent that:

1. `cached_done_anchor` remembers the position where a forced sequence has already been fully injected. The output can contain more end markers later, such as a second reasoning section closing or the end of the answer. Without the anchor, each of those would look like a fresh budget overrun and the kernel would inject the sequence again.
2. When a request's cached state is reset and the kernel rescans the whole output from scratch, for example after the request is recomputed from its prompt, the rescan also looks for a forced sequence that is already complete in the output and restores the anchor. Without this, the rescan would see the overrun, find no anchor, and inject a second copy of a sequence the output already contains.

Speculative decoding can retract tokens after the anchor was set, so the anchor is revalidated against the actual output on every step. If the forced sequence is no longer intact because draft tokens were rejected, the kernel resumes forcing it instead of treating it as done. Whether a forced sequence extends its natural end is known from the config, so the whole path is a compile-time branch (`CONTINUE_AFTER_NATURAL_END`, a `tl.constexpr`). For every reasoning configuration that does not have this shape the flag is False, the branch is compiled out, and the generated kernel is identical to the current one.

## Scope

For every in-tree parser, including `muse_glimmer` after #54462, the shipped defaults have forced end equal to natural end, so this path is compiled out and behavior is unchanged. The fix takes effect only when a user configures an end string of the form natural end marker plus extra text after it, like the `"</think>Final answer:"` example above. The docs change adds a note that such a continuation is delivered in full and should stay neutral steering text, without addressing the next message.

## Related work

- #46727 added this kernel and the natural/forced token-id split. It never exercises a forced string that begins with the natural end, which is the shape this PR fixes.
- #54462 enables `thinking_token_budget` for MuseGlimmer with forced end equal to natural end, which does not exercise this code path. It is what makes user-configured end strings for that model possible at all.
- #52677 forces `reasoning_end_str` to break repetition loops. It reads the same config field but triggers on repetition rather than budget exhaustion, has no continuation logic, and changes the V1 holder ([`thinking_budget_state.py`](https://github.com/vllm-project/vllm/blob/main/vllm/v1/sample/thinking_budget_state.py)), not the MRv2 kernel this PR fixes.
- #52106 and #51133 fix a performance problem (a full rescan of the output on every step) in the V1 holder. They touch a different file and fix a different bug, so there is no overlap with this change.

Duplicate check, run before submission:

```
gh pr list --repo vllm-project/vllm --state open --search "thinking budget forced end in:title,body"
gh pr list --repo vllm-project/vllm --state open --search "thinking_budget kernel in:title,body"
```

The first returns #52677 and #52106, both discussed above. The second returns nothing.

## Test Plan

```
pytest tests/v1/worker/test_gpu_thinking_budget.py -q
```

Four new tests over the smallest config with the broken shape (forced `[END, END_A, END_B]`, natural `[END]`):

- continuation after the natural end
- continuation across a spec-decode row with rejected drafts
- a completed end is forced only once
- a new section that overruns the budget is still enforced

## Test Result

On the branch as submitted, against current `main`, on an RTX 6000 Ada:

```
$ pytest test_gpu_thinking_budget.py -q
17 passed in 16.23s
```

As a control, the same tests were run once against the unpatched kernel to show they detect the bug rather than pass vacuously. Exactly the two continuation tests fail there, and the two guard tests pass:

```
$ pytest test_gpu_thinking_budget.py -q     # control: kernel WITHOUT this fix
FAILED ...::test_v2_thinking_budget_continues_forced_end_after_natural_end
FAILED ...::test_v2_thinking_budget_continues_forced_end_across_draft_tokens
2 failed, 15 passed in 12.77s
```

End to end, on Qwen3.6-27B-FP8 with DFlash speculative decoding (V2 model runner confirmed in the server log) and `reasoning_end_str = "</think>ZQX-42 VERDICT:"`, a sentinel the model cannot produce on its own: with this fix, the content began with the sentinel in 8 of 8 budgeted samples. With the unpatched kernel it did in 0 of 8, and those responses received only `</think>`. Speculative decoding was active in both runs, with a draft acceptance rate of 47.5% in the patched run and 67.5% in the unpatched one, meaning draft tokens were being accepted and rejected around the forced sequence throughout, and delivery still held in every sample.

---

AI assistance (Claude Code) was used in developing this change. All code was reviewed and validated by the submitter.


