### PR TITLE
[CI] Restore gpu_1_queue routing for torch-abi audit

### DIFF
--- a/.buildkite/test_areas/torch_abi.yaml
+++ b/.buildkite/test_areas/torch_abi.yaml
@@ -1,11 +1,10 @@
 group: Torch ABI
 depends_on:
-  - image-build-cpu
+  - image-build
 steps:
 - label: ":nvidia: (L4) Torch Stable ABI Audit"
   key: torch-stable-abi-audit
   timeout_in_minutes: 5
-  device: cpu-small
   source_file_dependencies:
   - .buildkite/check-torch-abi.py
   - csrc/


### PR DESCRIPTION
## Summary

Revert one queue move made in #54326 that turned out to be wrong. Both steps are 0-GPU in **compute**, but the queue determines the **image** the docker plugin runs them in — and both need the CUDA wheel/environment, not the CPU one:

- **Torch Stable ABI Audit**: the step statically audits the built wheel's `.so` files. On `gpu_1_queue` it ran in the CUDA image and passed (e.g. build 86222 at 11:27, pre-merge). On `small_cpu_queue_premerge` it runs in the `-cpu` image, where the CPU wheel ships extra `_C_AVX2.abi3.so` / `_C_AVX512.abi3.so` libraries that are not in the audit's allowlist — so the step now fails on every build that runs it. Restores `depends_on: image-build` + default routing (gpu_1_queue, CUDA image).
- **crcr-report**: intentionally stays on `cpu-small` (reviewer decision — it's `soft_fail` + `allow_dependency_failure`, and worst case its env needs `BUILDKITE_API_TOKEN`/`CRCR_CALLBACK_URL` provisioned on the small-cpu agents later).

The rest of #54326 (the `device: l4` markings for 2/4-GPU steps → EKS) is unaffected and working.

## Notes for reviewers (per repo AI policy)

- **AI assistance**: this fix was prepared with AI assistance (Kimi Code); failure analysis from build logs is described above.
- **Not a duplicate**: open-PR search for "torch abi" found only unrelated ABI work (#47059, #53441, #48962, #52635 — note #52635 is migrating the CPU extension to stable ABI, which may eventually make the CPU-wheel audit pass; the queue move can be revisited then).
- **Tests run**: yaml parse check on both files; evidence is the build history (86222 pass on gpu_1_queue vs 86214/86224/86228/86246/86250 failures on small_cpu_queue_premerge). Post-merge, torch-abi should go green on the next build that runs it.
