### PR TITLE
[Bugfix] Honor server-default thinking_token_budget

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -255,8 +255,9 @@ To use this feature:
 - `--reasoning-parser` enables reasoning extraction.
 - `--reasoning-config` defines the reasoning boundary tokens (e.g., `reasoning_start_str`, `reasoning_end_str`). If not set, vLLM will attempt to automatically initialize these tokens from the reasoning parser.
 - `thinking_token_budget` (a sampling parameter) sets the per-request reasoning token limit.
+- `--override-generation-config '{"thinking_token_budget": N}'` sets a server-side default applied to requests that do not specify one. An explicit per-request value always takes precedence.
 
-If `thinking_token_budget` is not specified, no explicit reasoning limit is applied beyond normal generation constraints such as `max_tokens`.
+If `thinking_token_budget` is not specified on the request and no server-side default is configured, no explicit reasoning limit is applied beyond normal generation constraints such as `max_tokens`.
 
 `--reasoning-config` accepts a JSON object corresponding to  
 [ReasoningConfig][vllm.config.ReasoningConfig] with the following fields:

--- a/tests/entrypoints/openai/test_thinking_token_budget_defaults.py
+++ b/tests/entrypoints/openai/test_thinking_token_budget_defaults.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for thinking_token_budget propagation from default_sampling_params
+to SamplingParams in ChatCompletionRequest and CompletionRequest.
+
+Same bug class as https://github.com/vllm-project/vllm/issues/22519 (fixed for
+stop_token_ids in tests/entrypoints/openai/test_stop_token_ids.py): a value set
+at server startup via --override-generation-config landed in
+default_sampling_params but was silently discarded on every request, because
+to_sampling_params() passed self.thinking_token_budget straight through instead
+of falling back to the defaults.
+"""
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.completion.protocol import (
+    CompletionRequest,
+)
+
+
+class TestChatCompletionThinkingTokenBudget:
+    """thinking_token_budget defaulting in ChatCompletionRequest."""
+
+    @pytest.fixture
+    def minimal_chat_request(self):
+        return ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    def test_default_thinking_token_budget_applied(self, minimal_chat_request):
+        """Server-default thinking_token_budget is applied when client sends none."""
+        sampling_params = minimal_chat_request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"thinking_token_budget": 128},
+        )
+
+        assert sampling_params.thinking_token_budget == 128
+
+    def test_client_thinking_token_budget_overrides_default(self):
+        """An explicit per-request value wins over the server default."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            thinking_token_budget=1024,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"thinking_token_budget": 128},
+        )
+
+        assert sampling_params.thinking_token_budget == 1024
+
+    def test_no_default_and_no_request_value_stays_none(self, minimal_chat_request):
+        """Absent both, the field stays None (no budget enforced)."""
+        sampling_params = minimal_chat_request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert sampling_params.thinking_token_budget is None
+
+    def test_client_zero_budget_not_swallowed_by_default(self):
+        """0 is a meaningful budget and must not fall through to the server default."""
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            thinking_token_budget=0,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"thinking_token_budget": 128},
+        )
+
+        assert sampling_params.thinking_token_budget == 0
+
+
+class TestCompletionThinkingTokenBudget:
+    """thinking_token_budget defaulting in CompletionRequest."""
+
+    @pytest.fixture
+    def minimal_completion_request(self):
+        return CompletionRequest(
+            model="test-model",
+            prompt="hello",
+        )
+
+    def test_default_thinking_token_budget_applied(self, minimal_completion_request):
+        """Server-default thinking_token_budget is applied when client sends none."""
+        sampling_params = minimal_completion_request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"thinking_token_budget": 128},
+        )
+
+        assert sampling_params.thinking_token_budget == 128
+
+    def test_client_thinking_token_budget_overrides_default(self):
+        """An explicit per-request value wins over the server default."""
+        request = CompletionRequest(
+            model="test-model",
+            prompt="hello",
+            thinking_token_budget=1024,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"thinking_token_budget": 128},
+        )
+
+        assert sampling_params.thinking_token_budget == 1024
+
+    def test_no_default_and_no_request_value_stays_none(
+        self, minimal_completion_request
+    ):
+        """Absent both, the field stays None (no budget enforced)."""
+        sampling_params = minimal_completion_request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert sampling_params.thinking_token_budget is None
+
+    def test_client_zero_budget_not_swallowed_by_default(self):
+        """0 is a meaningful budget and must not fall through to the server default."""
+        request = CompletionRequest(
+            model="test-model",
+            prompt="hello",
+            thinking_token_budget=0,
+        )
+
+        sampling_params = request.to_sampling_params(
+            max_tokens=100,
+            default_sampling_params={"thinking_token_budget": 128},
+        )
+
+        assert sampling_params.thinking_token_budget == 0

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1741,6 +1741,7 @@ class ModelConfig:
             "top_p",
             "min_p",
             "max_new_tokens",
+            "thinking_token_budget",
         ]
         if any(p in config for p in available_params):
             diff_sampling_param = {

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -686,6 +686,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_p = default_sampling_params.get(
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
+        if (thinking_token_budget := self.thinking_token_budget) is None:
+            thinking_token_budget = default_sampling_params.get("thinking_token_budget")
 
         # Merge server-default stop_token_ids (e.g., model-specific tokens
         # like </call> for gpt-oss) with any request-specified ones
@@ -742,7 +744,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             structured_outputs=self.extract_structured_outputs(),
             logit_bias=self.logit_bias,
             bad_words=self.bad_words,
-            thinking_token_budget=self.thinking_token_budget,
+            thinking_token_budget=thinking_token_budget,
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -341,6 +341,8 @@ class CompletionRequest(OpenAIBaseModel):
             min_p = default_sampling_params.get(
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
+        if (thinking_token_budget := self.thinking_token_budget) is None:
+            thinking_token_budget = default_sampling_params.get("thinking_token_budget")
 
         # Merge server-default stop_token_ids (e.g., model-specific tokens
         # like </call> for gpt-oss) with any request-specified ones
@@ -399,7 +401,7 @@ class CompletionRequest(OpenAIBaseModel):
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
             repetition_detection=self.repetition_detection,
-            thinking_token_budget=self.thinking_token_budget,
+            thinking_token_budget=thinking_token_budget,
             routed_experts_prompt_start=self.routed_experts_prompt_start,
         )
 


### PR DESCRIPTION
## Purpose

`--override-generation-config '{"thinking_token_budget": N}'` is silently ignored. The value
reaches the model's default sampling params but never reaches the per-request
`SamplingParams`, so no thinking budget is ever enforced — the server starts cleanly, every
request succeeds, and the knob simply does nothing. In practice `thinking_token_budget` is
per-request-only today.

Two changes, both required — either alone is a no-op:

1. **`vllm/config/model.py`** — `ModelConfig.get_diff_sampling_param()` filters the
   generation config through an `available_params` allowlist that omits
   `thinking_token_budget`, so the key is dropped while the defaults dict is built from
   `override_generation_config` and the CLI value never leaves config.

2. **`vllm/entrypoints/openai/{chat_completion,completion}/protocol.py`** —
   `to_sampling_params()` passes `self.thinking_token_budget` straight through on both
   request types, so even a populated defaults dict is read by nobody. Adds the
   `default_sampling_params` fallback to each, mirroring the `min_p` pattern immediately
   above it.

**Precedence after the fix:** an explicit per-request value wins; the server default fills
in only when the request omits the field. The guard is `is None` rather than a falsy check,
so an explicit budget of `0` is preserved rather than falling through to the server default.

No behavior change for anyone not setting `thinking_token_budget` in
`--override-generation-config`: with the key absent the fallback yields `None`, which is
exactly what is passed today.

### Prior art

Same bug class as #22519 — server-default `stop_token_ids` (e.g. gpt-oss `</call>`) were
loaded into `default_sampling_params` at startup and then discarded on every request because
`to_sampling_params()` never fell back to the defaults. That fix covered both
`ChatCompletionRequest` and `CompletionRequest` and landed with a unit test at
`tests/entrypoints/openai/test_stop_token_ids.py`. This change follows the same shape, and
the new test file sits beside it.

### Not a duplicate — but part of a pattern worth naming

I checked open PRs and issues before opening this. **No open PR covers
`thinking_token_budget`**; the nearest, #44510, is Model Runner V2 support for the existing
per-request path, not the server default.

However, this is at least the **third open instance of the same `available_params`
omission**:

- #50769 / #50767 — `presence_penalty` / `frequency_penalty` silently dropped
- #51036 — `repetition_detection` has no server-side default
- #45591 / #45978 — `eos_token_id` from the generation config
- #48517 — generation-config stop token IDs

Each adds one more key to the same allowlist. That repetition suggests the allowlist itself
may be the wrong mechanism, and I'd rather ask than quietly add a fourth entry:

**Is `available_params` intended to be HuggingFace-`generation_config.json`-only?** Every
current entry — `repetition_penalty`, `temperature`, `top_k`, `top_p`, `min_p`,
`max_new_tokens` — is a stock HF field. `thinking_token_budget` is vLLM-native. If the
allowlist is deliberately scoped to the HF mapping, then adding native keys to it is the
wrong shape even though it produces the right result, and all four PRs above want one
general fix instead.

I'm happy to rework this into that general form, or to rebase on top of whichever of the
above lands first. Note also that #50769 frames this as a bugfix while #51036 frames the
same mechanism as a feature — a maintainer steer on which is correct would help all of us.

### AI assistance disclosure

Per `AGENTS.md`: this change was developed with AI assistance (Claude), attributed via the
`Co-authored-by:` commit trailer. I have reviewed every changed line, and the test commands
and results below were run locally by me.

## Test Plan

New unit tests, no GPU required:

```bash
pytest tests/entrypoints/openai/test_thinking_token_budget_defaults.py -v
```

Eight cases, four per request type (`ChatCompletionRequest`, `CompletionRequest`):

- server default applied when the request omits the field
- an explicit per-request value overrides the server default
- neither set → stays `None` (no budget enforced, no behavior change)
- an explicit `0` is not swallowed by the server default

Manual end-to-end check against a reasoning model:

```bash
vllm serve <reasoning-model> \
  --reasoning-parser qwen3 \
  --reasoning-config '{}' \
  --override-generation-config '{"thinking_token_budget": 128}'

# request omits the field -> reasoning should terminate at the budget
curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"model":"<m>","messages":[{"role":"user","content":"Think about primes."}]}'
```

## Test Result

Run against this branch, editable install via `VLLM_USE_PRECOMPILED=1 uv pip install -e .`
(`vllm 0.28.1rc1.dev120+g29d504796`, torch 2.13.0+cu130), Python 3.12, pytest 9.1.1:

```
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestChatCompletionThinkingTokenBudget::test_default_thinking_token_budget_applied PASSED
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestChatCompletionThinkingTokenBudget::test_client_thinking_token_budget_overrides_default PASSED
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestChatCompletionThinkingTokenBudget::test_no_default_and_no_request_value_stays_none PASSED
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestChatCompletionThinkingTokenBudget::test_client_zero_budget_not_swallowed_by_default PASSED
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestCompletionThinkingTokenBudget::test_default_thinking_token_budget_applied PASSED
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestCompletionThinkingTokenBudget::test_client_thinking_token_budget_overrides_default PASSED
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestCompletionThinkingTokenBudget::test_no_default_and_no_request_value_stays_none PASSED
tests/entrypoints/openai/test_thinking_token_budget_defaults.py::TestCompletionThinkingTokenBudget::test_client_zero_budget_not_swallowed_by_default PASSED

8 passed, 14 warnings in 1.20s
```

**Without the source change** (reverting only `vllm/`, keeping the tests) the two
server-default cases fail — one per endpoint — while the other six still pass:

```
F...F...                                                                 [100%]

>       assert sampling_params.thinking_token_budget == 128
E       assert None == 128

FAILED TestChatCompletionThinkingTokenBudget::test_default_thinking_token_budget_applied - assert None == 128
FAILED TestCompletionThinkingTokenBudget::test_default_thinking_token_budget_applied - assert None == 128
2 failed, 6 passed, 14 warnings in 1.13s
```

Those six are the guards that the fix changes nothing else — per-request values, the unset
case, and the explicit-`0` case all already behave correctly today.

Independently reproduced on a stock `vllm==0.28.0` install: a server default of 128 resolves
to `None` before the change.

Note `--reasoning-config` must also be set, or `v1/engine/input_processor.py` raises for any
request carrying a budget. That is unchanged by this PR.

## Documentation

`docs/features/reasoning_outputs.md` previously described `thinking_token_budget` only as a
per-request limit, which is accurate today and incomplete after this change. Updated to
document the server-side default and the precedence rule.