### PR TITLE
Revert "[CI] Mark L4 GPU test steps with device: l4 for EKS migration (#54326)"

### DIFF
--- a/.buildkite/test_areas/crcr_report.yaml
+++ b/.buildkite/test_areas/crcr_report.yaml
@@ -1,6 +1,6 @@
 group: CRCR Report
 depends_on:
-  - image-build-cpu
+  - image-build
 steps:
   - label: ":satellite: Report nightly results to CRCR"
     key: crcr-report
@@ -8,6 +8,5 @@ steps:
     soft_fail: true
     allow_dependency_failure: true
     timeout_in_minutes: 15
-    device: cpu-small
     commands:
       - bash /vllm-workspace/.buildkite/scripts/crcr-report.sh

--- a/.buildkite/test_areas/disaggregated.yaml
+++ b/.buildkite/test_areas/disaggregated.yaml
@@ -6,7 +6,6 @@ steps:
   key: distributed-nixlconnector-pd-accuracy-4-gpus
   timeout_in_minutes: 55
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -34,7 +33,6 @@ steps:
   key: distributed-flashinfer-nixlconnector-pd-accuracy-4-gpus
   timeout_in_minutes: 55
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -47,7 +45,6 @@ steps:
   key: push-nixlconnector-pp-prefill-pd-accuracy-4-gpus
   timeout_in_minutes: 30
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -61,7 +58,6 @@ steps:
   key: dp-ep-distributed-nixlconnector-pd-accuracy-tests-4-gpus
   timeout_in_minutes: 30
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -89,7 +85,6 @@ steps:
   key: crosslayer-kv-layout-distributed-nixlconnector-pd-accuracy-tests-4-gpus
   timeout_in_minutes: 55
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -117,7 +112,6 @@ steps:
   key: hybrid-ssm-nixlconnector-pd-accuracy-tests-4-gpus
   timeout_in_minutes: 60
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -145,7 +139,6 @@ steps:
   key: nixlconnector-pd-edge-cases-2-gpus
   timeout_in_minutes: 40
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -162,7 +155,6 @@ steps:
   key: hybrid-ssm-nixlconnector-pd-prefix-cache-2-gpus
   timeout_in_minutes: 25
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -177,7 +169,6 @@ steps:
   key: multiconnector-nixl-offloading-pd-accuracy-2-gpus
   timeout_in_minutes: 40
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/
@@ -223,7 +214,6 @@ steps:
   key: multiconnector-nixl-offloading-pd-edge-cases-2-gpus
   timeout_in_minutes: 25
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
     - vllm/distributed/kv_transfer/kv_connector/v1/nixl/

--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -6,7 +6,6 @@ steps:
   key: distributed-comm-ops
   timeout_in_minutes: 25
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
   - vllm/distributed
@@ -37,7 +36,6 @@ steps:
   key: distributed-dp-tests-2-gpus
   timeout_in_minutes: 35
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
   - vllm/distributed/
@@ -80,7 +78,6 @@ steps:
   key: distributed-compile-rpc-tests-2-gpus
   timeout_in_minutes: 65
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
   - vllm/compilation/
@@ -103,7 +100,6 @@ steps:
   key: distributed-torchrun-shutdown-tests-2-gpus
   timeout_in_minutes: 30
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
   - vllm/distributed/
@@ -128,7 +124,6 @@ steps:
   key: distributed-torchrun-examples-4-gpus
   timeout_in_minutes: 45
   working_dir: "/vllm-workspace"
-  device: l4
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
@@ -171,7 +166,6 @@ steps:
   key: distributed-dp-tests-4-gpus
   timeout_in_minutes: 45
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
@@ -195,7 +189,6 @@ steps:
   key: distributed-compile-comm-4-gpus
   timeout_in_minutes: 70
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
@@ -314,7 +307,6 @@ steps:
   key: pipeline-context-parallelism-4-gpus
   timeout_in_minutes: 55
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/
@@ -331,7 +323,6 @@ steps:
   key: rayexecutorv2-4-gpus
   timeout_in_minutes: 45
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
   - vllm/v1/executor/ray_executor_v2.py

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -97,7 +97,6 @@ steps:
   key: v1-e2e-2-gpus
   timeout_in_minutes: 25 # TODO: Fix timeout after we have more confidence in the test stability
   optional: true
-  device: l4
   num_devices: 2
   source_file_dependencies:
     - vllm/compilation/

--- a/.buildkite/test_areas/expert_parallelism.yaml
+++ b/.buildkite/test_areas/expert_parallelism.yaml
@@ -32,7 +32,6 @@ steps:
   key: eplb-execution
   timeout_in_minutes: 25
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
   - vllm/distributed/eplb

--- a/.buildkite/test_areas/lora.yaml
+++ b/.buildkite/test_areas/lora.yaml
@@ -30,7 +30,6 @@ steps:
 - label: ":nvidia: (L4) LoRA TP (Distributed)"
   key: lora-tp-distributed
   timeout_in_minutes: 60
-  device: l4
   num_devices: 4
   source_file_dependencies:
   - vllm/lora

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -150,7 +150,6 @@ steps:
 - label: ":nvidia: (L4) Extract Hidden States Integration"
   key: extract-hidden-states-integration-2-gpus
   timeout_in_minutes: 20
-  device: l4
   num_devices: 2
   working_dir: "/vllm-workspace"
   source_file_dependencies:
@@ -235,7 +234,6 @@ steps:
 - label: ":nvidia: (L4) Metrics, Tracing"
   key: metrics-tracing-2-gpus
   timeout_in_minutes: 25
-  device: l4
   num_devices: 2
   source_file_dependencies:
   - vllm/config/

--- a/.buildkite/test_areas/model_runner_v2.yaml
+++ b/.buildkite/test_areas/model_runner_v2.yaml
@@ -65,7 +65,6 @@ steps:
   key: model-runner-v2-distributed-2-gpus
   timeout_in_minutes: 40
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
     - vllm/v1/worker/gpu/
@@ -113,7 +112,6 @@ steps:
   key: model-runner-v2-pipeline-parallelism-4-gpus
   timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 4
   source_file_dependencies:
     - vllm/v1/worker/gpu/

--- a/.buildkite/test_areas/models_distributed.yaml
+++ b/.buildkite/test_areas/models_distributed.yaml
@@ -6,7 +6,6 @@ steps:
   key: distributed-model-tests-2-gpus
   timeout_in_minutes: 60
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
   - vllm/model_executor/model_loader/sharded_state_loader.py

--- a/.buildkite/test_areas/plugins.yaml
+++ b/.buildkite/test_areas/plugins.yaml
@@ -6,7 +6,6 @@ steps:
   key: plugin-tests-2-gpus
   timeout_in_minutes: 35
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   source_file_dependencies:
   - vllm/plugins/
@@ -97,7 +96,6 @@ steps:
   key: bitsandbytes-plugin-2-gpus
   timeout_in_minutes: 15
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   soft_fail: true
   optional: true

--- a/.buildkite/test_areas/rust_frontend.yaml
+++ b/.buildkite/test_areas/rust_frontend.yaml
@@ -140,7 +140,6 @@ steps:
 
 - label: ":nvidia: (L4) Rust Frontend Distributed"
   timeout_in_minutes: 25
-  device: l4
   num_devices: 4
   working_dir: "/vllm-workspace/tests"
   source_file_dependencies:

--- a/.buildkite/test_areas/torch_abi.yaml
+++ b/.buildkite/test_areas/torch_abi.yaml
@@ -1,11 +1,10 @@
 group: Torch ABI
 depends_on:
-  - image-build-cpu
+  - image-build
 steps:
 - label: ":nvidia: (L4) Torch Stable ABI Audit"
   key: torch-stable-abi-audit
   timeout_in_minutes: 5
-  device: cpu-small
   source_file_dependencies:
   - .buildkite/check-torch-abi.py
   - csrc/

--- a/.buildkite/test_areas/weight_loading.yaml
+++ b/.buildkite/test_areas/weight_loading.yaml
@@ -6,7 +6,6 @@ steps:
   key: weight-loading-multiple-gpu
   timeout_in_minutes: 50
   working_dir: "/vllm-workspace/tests"
-  device: l4
   num_devices: 2
   optional: true
   source_file_dependencies:


### PR DESCRIPTION
## Summary

Revert the L4-on-EKS routing from #54326 after a systemic failure on main build [86253](https://buildkite.com/vllm/ci/builds/86253): 16/31 l4-k8s jobs failed with `stack_error`.

**Root cause chain**: the full 31-job L4 wave hit `InsufficientInstanceCapacity` for g6.12xlarge **in us-west-2d** (2a/2b/2c had capacity) — CA scaled the EKS node group but ASG launches in 2d failed, leaving 16 pods pending; the agent-stack-k8s controller's default **10-minute pod-pending timeout** then hard-failed those jobs. On the old ASG, the same capacity shortage just queues jobs until capacity frees — the k8s path turned a queueing delay into failures. That behavioral gap is the real defect.

**Mitigation already applied cluster-side** (so a re-attempt can succeed without code changes): controller `pod-pending-timeout` raised 10m → 1h, so capacity shortages queue instead of fail. ASG AZ-rebalance killing running pods was fixed earlier today (`balanced-only`).

This revert restores all marked steps to gpu_4_queue/gpu_1_queue (ASG) while the capacity story is decided (options: exclude us-west-2d from the node group, g6e fallback instance types, or accept queueing with the new 1h timeout).

## Notes for reviewers (per repo AI policy)

- **AI assistance**: prepared with AI assistance (Kimi Code); root cause verified from ASG activity log (`InsufficientInstanceCapacity` in us-west-2d at 21:05 UTC) and agent-stack-k8s controller logs ("Pod has been pending too long. Failing job.").
- **Not a duplicate**: this reverts #54326.
- **Tests run**: none needed — restores previous CI routing config. The currently-failing main build 86253 can be retried after merge (or after the timeout fix, if the revert is not merged).
