### PR TITLE
[Perf][Spec Decode] Pin drift-lookup CPU tensor before H2D on async-spec MM path

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2243,10 +2243,16 @@ class GPUModelRunner(
                     non_blocking=True,
                 )
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):
+            # Fancy-indexing the pinned tensor with a numpy array allocates a
+            # fresh unpinned CPU tensor, so the subsequent .to(non_blocking=True)
+            # silently stages through pageable memory (#53491). Route through
+            # async_tensor_h2d so the intermediate is pinned first.
             drift = self.num_computed_tokens[req_indices_gpu].to(
                 torch.int64
-            ) - self.input_batch.num_computed_tokens_cpu_tensor[req_indices].to(
-                device=self.device, dtype=torch.int64, non_blocking=True
+            ) - async_tensor_h2d(
+                self.input_batch.num_computed_tokens_cpu_tensor[req_indices],
+                device=self.device,
+                dtype=torch.int64,
             )
             target = self.mrope_positions if self.uses_mrope else self.xdrope_positions
             target.gpu[:, :total_num_scheduled_tokens] += drift


### PR DESCRIPTION
## Summary

Route `self.input_batch.num_computed_tokens_cpu_tensor[req_indices]` through `async_tensor_h2d` on the async-spec-decode + M/XD-RoPE drift path in `_prepare_inputs`.

`num_computed_tokens_cpu_tensor` is a pinned buffer, but fancy-indexing it with a numpy array (`req_indices`, built earlier in the same function via `np.repeat(...)`) allocates a fresh unpinned CPU tensor. The subsequent `.to(device, non_blocking=True)` therefore silently stages through pageable memory - the class of stall #53491 adds a stricter check for. Triggers only when both `use_async_spec_decode` and one of `uses_mrope` / `uses_xdrope_dim > 0` are set.

Continues the sync-elimination sweep against the checker in #53491 (prior batches: #54266, #54292, #54293, #54295, #54299, #54375).

## Duplicate-work check

Searched open PRs for `num_computed_tokens_cpu_tensor`, `use_async_spec_decode drift`, and `#53491 in:body`. None cover this site.

## Testing

- `.venv/bin/python -m pre_commit run --files vllm/v1/worker/gpu_model_runner.py` - passed (ruff, mypy, typos, SPDX, etc.)

Pattern swap to an existing helper; async-spec + non-MM and non-async-spec + MM paths are untouched.

AI assistance was used for code search and drafting; every line was reviewed by the submitter.
