### PR TITLE
[ROCm] Add AITERConfig object for AITER op toggles

### DIFF
--- a/tests/config/test_aiter_config.py
+++ b/tests/config/test_aiter_config.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for AITERConfig: env-var defaults, JSON round-trip, hashing, and the
+VllmConfig / worker-process sync of the rocm_aiter_ops toggle cache."""
+
+import multiprocessing
+
+import pytest
+
+from vllm.config import AITERConfig, VllmConfig
+from vllm.platforms import current_platform
+
+# Class vars init_from_config writes; snapshot/restore so a test that mutates the
+# process-global rocm_aiter_ops cache does not leak into the next one.
+_TOGGLE_CACHE_VARS = (
+    "_AITER_ENABLED",
+    "_CUSTOM_ALL_REDUCE_ENABLED",
+    "_LINEAR_ENABLED",
+    "_FMOE_ENABLED",
+    "_MLA_ENABLED",
+    "_MHA_ENABLED",
+    "_SHUFFLE_KV_CACHE_ENABLED",
+    "_TRITON_UNIFIED_ATTN_ENABLED",
+    "_FP8BMM_ENABLED",
+    "_FP4BMM_ENABLED",
+    "_LINEAR_HIPBMM_ENABLED",
+    "_TRITON_ROTARY_EMBED",
+    "_MOE_SHARED_EXPERTS_ENABLED",
+    "_MOE_SITUV2_A8W4",
+    "_TRITON_UNQUANT_GEMM",
+    "_MOE_DISPATCH_POLICY",
+)
+
+
+@pytest.fixture
+def restore_toggle_cache():
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    saved = {v: getattr(rocm_aiter_ops, v) for v in _TOGGLE_CACHE_VARS}
+    try:
+        yield rocm_aiter_ops
+    finally:
+        for v, val in saved.items():
+            setattr(rocm_aiter_ops, v, val)
+
+
+def test_defaults_match_env_vars(monkeypatch: pytest.MonkeyPatch):
+    """Every field defaults from its VLLM_ROCM_USE_AITER* env var, so an
+    unset config reproduces prior behaviour."""
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER_MOE", "0")
+    monkeypatch.setenv("VLLM_ROCM_AITER_MOE_DISPATCH_POLICY", "2")
+
+    cfg = AITERConfig()
+
+    assert cfg.enabled is True
+    assert cfg.moe is False
+    assert cfg.moe_dispatch_policy == 2
+    # untouched field keeps its env default
+    assert cfg.mha is True
+
+
+def test_explicit_values_override_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER", "0")
+
+    cfg = AITERConfig(enabled=True, moe=False)
+
+    assert cfg.enabled is True
+    assert cfg.moe is False
+
+
+def test_json_dict_round_trip():
+    """The CLI passes --aiter-config as a JSON dict; EngineArgs then builds
+    AITERConfig(**dict)."""
+    payload = {"enabled": True, "moe": True, "mla": False}
+    cfg = AITERConfig(**payload)
+
+    assert (cfg.enabled, cfg.moe, cfg.mla) == (True, True, False)
+
+
+def test_compute_hash_reflects_fields():
+    base = AITERConfig(enabled=False)
+    same = AITERConfig(enabled=False)
+    flipped = AITERConfig(enabled=True)
+
+    assert base.compute_hash() == same.compute_hash()
+    assert base.compute_hash() != flipped.compute_hash()
+
+
+def test_init_from_config_syncs_toggle_cache(restore_toggle_cache):
+    """rocm_aiter_ops mirrors config into class vars for the hot path."""
+    rocm_aiter_ops = restore_toggle_cache
+
+    rocm_aiter_ops.init_from_config(
+        AITERConfig(enabled=True, moe=False, mla=True, moe_dispatch_policy=3)
+    )
+    assert rocm_aiter_ops._AITER_ENABLED is True
+    assert rocm_aiter_ops._FMOE_ENABLED is False
+    assert rocm_aiter_ops._MLA_ENABLED is True
+    assert rocm_aiter_ops._MOE_DISPATCH_POLICY == 3
+
+
+def test_refresh_env_variables_restores_every_synced_field(
+    restore_toggle_cache, monkeypatch: pytest.MonkeyPatch
+):
+    """refresh_env_variables() must reset every class var init_from_config()
+    writes, so a test that monkeypatches an env var and then calls it does not
+    leak state. Regression guard for _MOE_DISPATCH_POLICY, which init_from_config
+    writes but refresh_env_variables historically skipped."""
+    rocm_aiter_ops = restore_toggle_cache
+
+    rocm_aiter_ops.init_from_config(
+        AITERConfig(enabled=True, moe=False, moe_dispatch_policy=7)
+    )
+    assert rocm_aiter_ops._MOE_DISPATCH_POLICY == 7
+
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER", "0")
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER_MOE", "1")
+    monkeypatch.setenv("VLLM_ROCM_AITER_MOE_DISPATCH_POLICY", "0")
+    rocm_aiter_ops.refresh_env_variables()
+
+    assert rocm_aiter_ops._AITER_ENABLED is False
+    assert rocm_aiter_ops._FMOE_ENABLED is True
+    assert rocm_aiter_ops._MOE_DISPATCH_POLICY == 0
+
+
+# Override that differs from every env default it touches
+# (VLLM_ROCM_USE_AITER=False, _MOE=True, _MLA=True, dispatch policy 0).
+_EXPECTED = (True, False, False, 2)
+
+
+def _override_config() -> AITERConfig:
+    return AITERConfig(enabled=True, moe=False, mla=False, moe_dispatch_policy=2)
+
+
+def _toggle_tuple(ops) -> tuple:
+    return (
+        ops._AITER_ENABLED,
+        ops._FMOE_ENABLED,
+        ops._MLA_ENABLED,
+        ops._MOE_DISPATCH_POLICY,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific")
+def test_vllm_config_post_init_syncs_toggle_cache(restore_toggle_cache):
+    """VllmConfig.__post_init__ pushes aiter_config into the toggle cache for the
+    front-end / single-GPU path."""
+    rocm_aiter_ops = restore_toggle_cache
+
+    VllmConfig(aiter_config=_override_config())
+
+    assert _toggle_tuple(rocm_aiter_ops) == _EXPECTED
+
+
+def _worker_toggle_probe(vllm_config, q):
+    """Runs in a spawned process: mimics a worker receiving VllmConfig by value."""
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    # Fresh process, VllmConfig arrived by (multiprocessing) serialization but
+    # __post_init__ did not re-run -> cache still at import-time env defaults.
+    before = (
+        rocm_aiter_ops._AITER_ENABLED,
+        rocm_aiter_ops._FMOE_ENABLED,
+        rocm_aiter_ops._MLA_ENABLED,
+    )
+    # What WorkerBase.__init__ does:
+    rocm_aiter_ops.init_from_config(vllm_config.aiter_config)
+    after = _toggle_tuple(rocm_aiter_ops)
+    q.put({"before": before, "after": after})
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific")
+def test_worker_process_resyncs_toggle_cache(restore_toggle_cache):
+    """A worker gets VllmConfig by value but __post_init__ is not re-run there,
+    so WorkerBase.__init__ must call init_from_config to pick up overrides."""
+    vllm_config = VllmConfig(aiter_config=_override_config())
+
+    ctx = multiprocessing.get_context("spawn")
+    q = ctx.Queue()
+    p = ctx.Process(target=_worker_toggle_probe, args=(vllm_config, q))
+    p.start()
+    result = q.get(timeout=180)
+    p.join(timeout=30)
+
+    # Child started from env defaults (VLLM_ROCM_USE_AITER=False, _MOE/_MLA=True),
+    # not the override -> proves the boundary drops the __post_init__ sync.
+    assert result["before"] == (False, True, True)
+    # init_from_config in the worker recovers the configured values.
+    assert result["after"] == _EXPECTED
+
+
+def test_vllm_config_hash_includes_aiter_config():
+    """aiter_config feeds VllmConfig.compute_hash so a toggle change busts the
+    compilation cache."""
+    h_moe_on = VllmConfig(aiter_config=AITERConfig(moe=True)).compute_hash()
+    h_moe_off = VllmConfig(aiter_config=AITERConfig(moe=False)).compute_hash()
+    assert h_moe_on != h_moe_off

--- a/tests/config/test_aiter_config.py
+++ b/tests/config/test_aiter_config.py
@@ -7,11 +7,12 @@ import multiprocessing
 
 import pytest
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import AITERConfig, VllmConfig
 from vllm.platforms import current_platform
 
-# Class vars init_from_config writes; snapshot/restore so a test that mutates the
-# process-global rocm_aiter_ops class vars do not leak into the next one.
+# Class vars init_from_config writes; snapshot/restore so mutations from one test
+# don't leak into the next (they are process-global and pytest shares a process).
 _AITER_CLASS_VARS = (
     "_AITER_ENABLED",
     "_CUSTOM_ALL_REDUCE_ENABLED",
@@ -32,13 +33,14 @@ _AITER_CLASS_VARS = (
 )
 
 
-@pytest.fixture
-def restore_aiter_class_vars():
-    from vllm._aiter_ops import rocm_aiter_ops
-
+@pytest.fixture(autouse=True)
+def _restore_aiter_class_vars():
+    """Restore the process-global rocm_aiter_ops class vars after every test.
+    autouse: ``init_from_config`` / ``VllmConfig`` construction /
+    ``refresh_env_variables`` all mutate them in place."""
     saved = {v: getattr(rocm_aiter_ops, v) for v in _AITER_CLASS_VARS}
     try:
-        yield rocm_aiter_ops
+        yield
     finally:
         for v, val in saved.items():
             setattr(rocm_aiter_ops, v, val)
@@ -87,10 +89,8 @@ def test_compute_hash_reflects_fields():
     assert base.compute_hash() != flipped.compute_hash()
 
 
-def test_init_from_config_syncs_class_vars(restore_aiter_class_vars):
+def test_init_from_config_syncs_class_vars():
     """rocm_aiter_ops holds the config values in class vars for the hot path."""
-    rocm_aiter_ops = restore_aiter_class_vars
-
     rocm_aiter_ops.init_from_config(
         AITERConfig(enabled=True, moe=False, mla=True, moe_dispatch_policy=3)
     )
@@ -101,14 +101,12 @@ def test_init_from_config_syncs_class_vars(restore_aiter_class_vars):
 
 
 def test_refresh_env_variables_restores_every_synced_field(
-    restore_aiter_class_vars, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ):
     """refresh_env_variables() must reset every class var init_from_config()
     writes, so a test that monkeypatches an env var and then calls it does not
     leak state. Regression guard for _MOE_DISPATCH_POLICY, which init_from_config
     writes but refresh_env_variables historically skipped."""
-    rocm_aiter_ops = restore_aiter_class_vars
-
     rocm_aiter_ops.init_from_config(
         AITERConfig(enabled=True, moe=False, moe_dispatch_policy=7)
     )
@@ -143,11 +141,9 @@ def _class_var_tuple(ops) -> tuple:
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific")
-def test_vllm_config_post_init_syncs_class_vars(restore_aiter_class_vars):
+def test_vllm_config_post_init_syncs_class_vars():
     """VllmConfig.__post_init__ sets the AITER class vars from aiter_config for the
     front-end / single-GPU path."""
-    rocm_aiter_ops = restore_aiter_class_vars
-
     VllmConfig(aiter_config=_override_config())
 
     assert _class_var_tuple(rocm_aiter_ops) == _EXPECTED
@@ -172,7 +168,7 @@ def _worker_class_var_probe(vllm_config, q):
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific")
-def test_worker_process_resyncs_class_vars(restore_aiter_class_vars):
+def test_worker_process_resyncs_class_vars():
     """A worker gets VllmConfig by value but __post_init__ is not re-run there,
     so WorkerBase.__init__ must call init_from_config to pick up overrides."""
     vllm_config = VllmConfig(aiter_config=_override_config())

--- a/tests/config/test_aiter_config.py
+++ b/tests/config/test_aiter_config.py
@@ -156,6 +156,7 @@ def test_vllm_config_post_init_syncs_class_vars(restore_aiter_class_vars):
 def _worker_class_var_probe(vllm_config, q):
     """Runs in a spawned process: mimics a worker receiving VllmConfig by value."""
     from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.platforms import current_platform
 
     # Fresh process, VllmConfig arrived by (multiprocessing) serialization but
     # __post_init__ did not re-run -> class vars still at import-time env defaults.
@@ -165,7 +166,7 @@ def _worker_class_var_probe(vllm_config, q):
         rocm_aiter_ops._MLA_ENABLED,
     )
     # What WorkerBase.__init__ does:
-    rocm_aiter_ops.init_from_config(vllm_config.aiter_config)
+    current_platform.sync_process_config_state(vllm_config)
     after = _class_var_tuple(rocm_aiter_ops)
     q.put({"before": before, "after": after})
 

--- a/tests/config/test_aiter_config.py
+++ b/tests/config/test_aiter_config.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for AITERConfig: env-var defaults, JSON round-trip, hashing, and the
-VllmConfig / worker-process sync of the rocm_aiter_ops toggle cache."""
+VllmConfig / worker-process sync of the rocm_aiter_ops AITER class vars."""
 
 import multiprocessing
 
@@ -11,8 +11,8 @@ from vllm.config import AITERConfig, VllmConfig
 from vllm.platforms import current_platform
 
 # Class vars init_from_config writes; snapshot/restore so a test that mutates the
-# process-global rocm_aiter_ops cache does not leak into the next one.
-_TOGGLE_CACHE_VARS = (
+# process-global rocm_aiter_ops class vars do not leak into the next one.
+_AITER_CLASS_VARS = (
     "_AITER_ENABLED",
     "_CUSTOM_ALL_REDUCE_ENABLED",
     "_LINEAR_ENABLED",
@@ -33,10 +33,10 @@ _TOGGLE_CACHE_VARS = (
 
 
 @pytest.fixture
-def restore_toggle_cache():
+def restore_aiter_class_vars():
     from vllm._aiter_ops import rocm_aiter_ops
 
-    saved = {v: getattr(rocm_aiter_ops, v) for v in _TOGGLE_CACHE_VARS}
+    saved = {v: getattr(rocm_aiter_ops, v) for v in _AITER_CLASS_VARS}
     try:
         yield rocm_aiter_ops
     finally:
@@ -87,9 +87,9 @@ def test_compute_hash_reflects_fields():
     assert base.compute_hash() != flipped.compute_hash()
 
 
-def test_init_from_config_syncs_toggle_cache(restore_toggle_cache):
-    """rocm_aiter_ops mirrors config into class vars for the hot path."""
-    rocm_aiter_ops = restore_toggle_cache
+def test_init_from_config_syncs_class_vars(restore_aiter_class_vars):
+    """rocm_aiter_ops holds the config values in class vars for the hot path."""
+    rocm_aiter_ops = restore_aiter_class_vars
 
     rocm_aiter_ops.init_from_config(
         AITERConfig(enabled=True, moe=False, mla=True, moe_dispatch_policy=3)
@@ -101,13 +101,13 @@ def test_init_from_config_syncs_toggle_cache(restore_toggle_cache):
 
 
 def test_refresh_env_variables_restores_every_synced_field(
-    restore_toggle_cache, monkeypatch: pytest.MonkeyPatch
+    restore_aiter_class_vars, monkeypatch: pytest.MonkeyPatch
 ):
     """refresh_env_variables() must reset every class var init_from_config()
     writes, so a test that monkeypatches an env var and then calls it does not
     leak state. Regression guard for _MOE_DISPATCH_POLICY, which init_from_config
     writes but refresh_env_variables historically skipped."""
-    rocm_aiter_ops = restore_toggle_cache
+    rocm_aiter_ops = restore_aiter_class_vars
 
     rocm_aiter_ops.init_from_config(
         AITERConfig(enabled=True, moe=False, moe_dispatch_policy=7)
@@ -133,7 +133,7 @@ def _override_config() -> AITERConfig:
     return AITERConfig(enabled=True, moe=False, mla=False, moe_dispatch_policy=2)
 
 
-def _toggle_tuple(ops) -> tuple:
+def _class_var_tuple(ops) -> tuple:
     return (
         ops._AITER_ENABLED,
         ops._FMOE_ENABLED,
@@ -143,22 +143,22 @@ def _toggle_tuple(ops) -> tuple:
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific")
-def test_vllm_config_post_init_syncs_toggle_cache(restore_toggle_cache):
-    """VllmConfig.__post_init__ pushes aiter_config into the toggle cache for the
+def test_vllm_config_post_init_syncs_class_vars(restore_aiter_class_vars):
+    """VllmConfig.__post_init__ sets the AITER class vars from aiter_config for the
     front-end / single-GPU path."""
-    rocm_aiter_ops = restore_toggle_cache
+    rocm_aiter_ops = restore_aiter_class_vars
 
     VllmConfig(aiter_config=_override_config())
 
-    assert _toggle_tuple(rocm_aiter_ops) == _EXPECTED
+    assert _class_var_tuple(rocm_aiter_ops) == _EXPECTED
 
 
-def _worker_toggle_probe(vllm_config, q):
+def _worker_class_var_probe(vllm_config, q):
     """Runs in a spawned process: mimics a worker receiving VllmConfig by value."""
     from vllm._aiter_ops import rocm_aiter_ops
 
     # Fresh process, VllmConfig arrived by (multiprocessing) serialization but
-    # __post_init__ did not re-run -> cache still at import-time env defaults.
+    # __post_init__ did not re-run -> class vars still at import-time env defaults.
     before = (
         rocm_aiter_ops._AITER_ENABLED,
         rocm_aiter_ops._FMOE_ENABLED,
@@ -166,19 +166,19 @@ def _worker_toggle_probe(vllm_config, q):
     )
     # What WorkerBase.__init__ does:
     rocm_aiter_ops.init_from_config(vllm_config.aiter_config)
-    after = _toggle_tuple(rocm_aiter_ops)
+    after = _class_var_tuple(rocm_aiter_ops)
     q.put({"before": before, "after": after})
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific")
-def test_worker_process_resyncs_toggle_cache(restore_toggle_cache):
+def test_worker_process_resyncs_class_vars(restore_aiter_class_vars):
     """A worker gets VllmConfig by value but __post_init__ is not re-run there,
     so WorkerBase.__init__ must call init_from_config to pick up overrides."""
     vllm_config = VllmConfig(aiter_config=_override_config())
 
     ctx = multiprocessing.get_context("spawn")
     q = ctx.Queue()
-    p = ctx.Process(target=_worker_toggle_probe, args=(vllm_config, q))
+    p = ctx.Process(target=_worker_class_var_probe, args=(vllm_config, q))
     p.start()
     result = q.get(timeout=180)
     p.join(timeout=30)
@@ -191,7 +191,7 @@ def test_worker_process_resyncs_toggle_cache(restore_toggle_cache):
 
 
 def test_vllm_config_hash_includes_aiter_config():
-    """aiter_config feeds VllmConfig.compute_hash so a toggle change busts the
+    """aiter_config feeds VllmConfig.compute_hash so a field change busts the
     compilation cache."""
     h_moe_on = VllmConfig(aiter_config=AITERConfig(moe=True)).compute_hash()
     h_moe_off = VllmConfig(aiter_config=AITERConfig(moe=False)).compute_hash()

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -4,9 +4,13 @@ import ctypes
 import functools
 import os
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import torch
 from torch._ops import OpOverload
+
+if TYPE_CHECKING:
+    from vllm.config import AITERConfig
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -1729,16 +1733,14 @@ class rocm_aiter_ops:
         - Triton ops: triton_rotary_embed, triton_fp8_bmm, triton_gemm_a8w8_blockscale
     """
 
-    _MOE_DISPATCH_POLICY: int | None = None
+    # Cached class var like the toggles below; kept in sync by
+    # refresh_env_variables() and init_from_config().
+    _MOE_DISPATCH_POLICY: int = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
 
     @classmethod
     @if_aiter_supported
     def get_moe_dispatch_policy(cls) -> int:
-        """Cached MoE sorting dispatch policy."""
-        if cls._MOE_DISPATCH_POLICY is None:
-            import vllm.envs as envs
-
-            cls._MOE_DISPATCH_POLICY = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
+        """MoE sorting dispatch policy for AITER fused-MoE kernels."""
         return cls._MOE_DISPATCH_POLICY
 
     # Check if the env variable is set
@@ -1772,6 +1774,11 @@ class rocm_aiter_ops:
         the environment variables.
         for example, after monkey patching the env variables in the unit test,
         you can call this function to reload the env variables.
+
+        This is the env-var path; ``init_from_config`` is the config-driven
+        equivalent that syncs the same class vars from ``VllmConfig.aiter_config``.
+        Tests that monkeypatch ``VLLM_ROCM_USE_AITER*`` directly use this;
+        the engine syncs via ``init_from_config``.
         """
         cls._AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
         cls._CUSTOM_ALL_REDUCE_ENABLED = envs.VLLM_ROCM_USE_AITER_CUSTOM_AR
@@ -1788,6 +1795,40 @@ class rocm_aiter_ops:
         cls._MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
         cls._MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
         cls._TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
+        cls._MOE_DISPATCH_POLICY = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
+
+    @classmethod
+    def init_from_config(cls, aiter_config: "AITERConfig") -> None:
+        """Point the toggle cache at ``VllmConfig.aiter_config``.
+
+        Called once per process (front-end in ``VllmConfig.__post_init__``,
+        workers in ``WorkerBase.__init__``). ``aiter_config`` defaults every
+        field from the matching ``VLLM_ROCM_USE_AITER*`` env var, so this
+        preserves prior behaviour when the config is left unset.
+
+        This is the config-driven path; ``refresh_env_variables`` syncs the
+        same class vars straight from the env vars for tests that monkeypatch
+        them without going through ``VllmConfig``.
+
+        Args:
+            aiter_config: The ``AITERConfig`` from ``VllmConfig``.
+        """
+        cls._AITER_ENABLED = aiter_config.enabled
+        cls._CUSTOM_ALL_REDUCE_ENABLED = aiter_config.custom_all_reduce
+        cls._LINEAR_ENABLED = aiter_config.linear
+        cls._FMOE_ENABLED = aiter_config.moe
+        cls._MLA_ENABLED = aiter_config.mla
+        cls._MHA_ENABLED = aiter_config.mha
+        cls._SHUFFLE_KV_CACHE_ENABLED = aiter_config.shuffle_kv_cache_layout
+        cls._TRITON_UNIFIED_ATTN_ENABLED = aiter_config.unified_attention
+        cls._FP8BMM_ENABLED = aiter_config.fp8bmm
+        cls._FP4BMM_ENABLED = aiter_config.fp4bmm
+        cls._LINEAR_HIPBMM_ENABLED = aiter_config.linear_hipbmm
+        cls._TRITON_ROTARY_EMBED = aiter_config.triton_rope
+        cls._MOE_SHARED_EXPERTS_ENABLED = aiter_config.moe_shared_experts
+        cls._MOE_SITUV2_A8W4 = aiter_config.moe_situv2_a8w4
+        cls._TRITON_UNQUANT_GEMM = aiter_config.triton_gemm
+        cls._MOE_DISPATCH_POLICY = aiter_config.moe_dispatch_policy
 
     @staticmethod
     def get_aiter_activation_type(activation_str: str):

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1733,16 +1733,6 @@ class rocm_aiter_ops:
         - Triton ops: triton_rotary_embed, triton_fp8_bmm, triton_gemm_a8w8_blockscale
     """
 
-    # Cached class var like the toggles below; kept in sync by
-    # refresh_env_variables() and init_from_config().
-    _MOE_DISPATCH_POLICY: int = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
-
-    @classmethod
-    @if_aiter_supported
-    def get_moe_dispatch_policy(cls) -> int:
-        """MoE sorting dispatch policy for AITER fused-MoE kernels."""
-        return cls._MOE_DISPATCH_POLICY
-
     # Check if the env variable is set
     _AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
     _CUSTOM_ALL_REDUCE_ENABLED = envs.VLLM_ROCM_USE_AITER_CUSTOM_AR
@@ -1760,6 +1750,7 @@ class rocm_aiter_ops:
     _TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
     _MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
     _MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
+    _MOE_DISPATCH_POLICY: int = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
     # TODO: Consolidate under _LINEAR_ENABLED
     _TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
     # Lazily probed: whether aiter.topk_softmax supports the
@@ -1794,8 +1785,8 @@ class rocm_aiter_ops:
         cls._TRITON_ROTARY_EMBED = envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
         cls._MOE_SHARED_EXPERTS_ENABLED = envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
         cls._MOE_SITUV2_A8W4 = envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
-        cls._TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
         cls._MOE_DISPATCH_POLICY = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
+        cls._TRITON_UNQUANT_GEMM = envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
 
     @classmethod
     def init_from_config(cls, aiter_config: "AITERConfig") -> None:
@@ -1827,8 +1818,8 @@ class rocm_aiter_ops:
         cls._TRITON_ROTARY_EMBED = aiter_config.triton_rope
         cls._MOE_SHARED_EXPERTS_ENABLED = aiter_config.moe_shared_experts
         cls._MOE_SITUV2_A8W4 = aiter_config.moe_situv2_a8w4
-        cls._TRITON_UNQUANT_GEMM = aiter_config.triton_gemm
         cls._MOE_DISPATCH_POLICY = aiter_config.moe_dispatch_policy
+        cls._TRITON_UNQUANT_GEMM = aiter_config.triton_gemm
 
     @staticmethod
     def get_aiter_activation_type(activation_str: str):
@@ -1944,6 +1935,12 @@ class rocm_aiter_ops:
         # _MOE_SITUV2_A8W4 is a variant of aiter fused moe, so aiter
         # fused moe must be enabled as well.
         return cls.is_fused_moe_enabled() and cls._MOE_SITUV2_A8W4
+
+    @classmethod
+    @if_aiter_supported
+    def get_moe_dispatch_policy(cls) -> int:
+        """MoE sorting dispatch policy for AITER fused-MoE kernels."""
+        return cls._MOE_DISPATCH_POLICY
 
     @classmethod
     @if_aiter_supported

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1759,17 +1759,13 @@ class rocm_aiter_ops:
 
     @classmethod
     def refresh_env_variables(cls):
-        """
-        Since the environment variables are assigned when the module is imported,
-        This is a helper function to reload all the env variables from
-        the environment variables.
-        for example, after monkey patching the env variables in the unit test,
-        you can call this function to reload the env variables.
+        """Re-read the AITER enablement class vars from their ``VLLM_ROCM_USE_AITER*``
+        env vars.
 
-        This is the env-var path; ``init_from_config`` is the config-driven
-        equivalent that syncs the same class vars from ``VllmConfig.aiter_config``.
-        Tests that monkeypatch ``VLLM_ROCM_USE_AITER*`` directly use this;
-        the engine syncs via ``init_from_config``.
+        They are read once at import (see the class ``Note``), so call this
+        after monkeypatching an env var in a test to pick up the new value.
+        ``init_from_config`` is the equivalent entry point when the values
+        come from an ``AITERConfig`` instead.
         """
         cls._AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
         cls._CUSTOM_ALL_REDUCE_ENABLED = envs.VLLM_ROCM_USE_AITER_CUSTOM_AR
@@ -1790,16 +1786,13 @@ class rocm_aiter_ops:
 
     @classmethod
     def init_from_config(cls, aiter_config: "AITERConfig") -> None:
-        """Point the toggle cache at ``VllmConfig.aiter_config``.
+        """Set the AITER enablement class vars from ``aiter_config``.
 
-        Called once per process (front-end in ``VllmConfig.__post_init__``,
-        workers in ``WorkerBase.__init__``). ``aiter_config`` defaults every
-        field from the matching ``VLLM_ROCM_USE_AITER*`` env var, so this
-        preserves prior behaviour when the config is left unset.
-
-        This is the config-driven path; ``refresh_env_variables`` syncs the
-        same class vars straight from the env vars for tests that monkeypatch
-        them without going through ``VllmConfig``.
+        Called once per process -- ``VllmConfig.__post_init__`` for the
+        front-end / single-GPU path, ``WorkerBase.__init__`` for worker
+        subprocesses (pickle does not re-run ``__post_init__`` there). Each
+        ``AITERConfig`` field defaults from the matching ``VLLM_ROCM_USE_AITER*``
+        env var, so an unset config reproduces the import-time values.
 
         Args:
             aiter_config: The ``AITERConfig`` from ``VllmConfig``.

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1766,6 +1766,12 @@ class rocm_aiter_ops:
         after monkeypatching an env var in a test to pick up the new value.
         ``init_from_config`` is the equivalent entry point when the values
         come from an ``AITERConfig`` instead.
+
+        Teardown / test only. This ignores any ``AITERConfig`` and reverts to
+        the raw env vars, so never call it on a live engine that was
+        configured via ``--aiter-config`` -- it would silently drop the
+        config's values. The one in-tree caller is ``cleanup_dist_env_and_memory``
+        at engine shutdown, where nothing reads the class vars afterwards.
         """
         cls._AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
         cls._CUSTOM_ALL_REDUCE_ENABLED = envs.VLLM_ROCM_USE_AITER_CUSTOM_AR

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm.config.aiter import AITERConfig
 from vllm.config.attention import AttentionConfig
 from vllm.config.cache import CacheConfig
 from vllm.config.compilation import (
@@ -64,6 +65,8 @@ from vllm.config.weight_transfer import WeightTransferConfig
 # __all__ should only contain classes and functions.
 # Types and globals should be imported from their respective modules.
 __all__ = [
+    # From vllm.config.aiter
+    "AITERConfig",
     # From vllm.config.attention
     "AttentionConfig",
     # From vllm.config.cache

--- a/vllm/config/aiter.py
+++ b/vllm/config/aiter.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Configuration for ROCm AITER operations."""
+
+from pydantic import Field
+
+import vllm.envs as envs
+from vllm.config.utils import config, get_hash_factors, hash_factors
+
+
+@config
+class AITERConfig:
+    """Configuration for ROCm AITER (AI Tensor Engine for ROCm) operations.
+
+    AITER provides optimized kernels for AMD GPUs (attention, MoE, GEMM,
+    normalization, ...). Historically every feature was toggled by its own
+    `VLLM_ROCM_USE_AITER*` environment variable, read once at module import.
+    This object is the typed replacement: it is built once with the rest of
+    `VllmConfig`, travels to every worker by value, and is part of the
+    compilation cache hash.
+
+    Every field defaults to its corresponding environment variable, so leaving
+    the config unset reproduces the previous behaviour exactly. `enabled`
+    remains the master switch - when it is `False` no AITER path is taken
+    regardless of the per-feature fields.
+
+    Only used on ROCm; inert (and unused) on other platforms.
+    """
+
+    enabled: bool = Field(default_factory=lambda: envs.VLLM_ROCM_USE_AITER)
+    """Master switch for all AITER operations.
+    Corresponds to `VLLM_ROCM_USE_AITER`."""
+
+    linear: bool = Field(default_factory=lambda: envs.VLLM_ROCM_USE_AITER_LINEAR)
+    """AITER GEMM / linear / quantization ops.
+    Corresponds to `VLLM_ROCM_USE_AITER_LINEAR`."""
+
+    linear_hipbmm: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_USE_AITER_LINEAR_HIPBMM
+    )
+    """AITER hipBLASLt batched-matmul linear path (CDNA > 2).
+    Corresponds to `VLLM_ROCM_USE_AITER_LINEAR_HIPBMM`."""
+
+    moe: bool = Field(default_factory=lambda: envs.VLLM_ROCM_USE_AITER_MOE)
+    """AITER fused Mixture-of-Experts ops.
+    Corresponds to `VLLM_ROCM_USE_AITER_MOE`."""
+
+    moe_shared_experts: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS
+    )
+    """AITER fused shared-expert path (requires `moe`).
+    Corresponds to `VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS`."""
+
+    moe_situv2_a8w4: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4
+    )
+    """AITER SITU v2 a8w4 fused-MoE variant (requires `moe`).
+    Corresponds to `VLLM_ROCM_USE_AITER_MOE_SITUV2_A8W4`."""
+
+    moe_dispatch_policy: int = Field(
+        default_factory=lambda: envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
+    )
+    """MoE sorting dispatch policy for AITER fused-MoE kernels.
+    Corresponds to `VLLM_ROCM_AITER_MOE_DISPATCH_POLICY`."""
+
+    mla: bool = Field(default_factory=lambda: envs.VLLM_ROCM_USE_AITER_MLA)
+    """AITER Multi-head Latent Attention ops.
+    Corresponds to `VLLM_ROCM_USE_AITER_MLA`."""
+
+    mha: bool = Field(default_factory=lambda: envs.VLLM_ROCM_USE_AITER_MHA)
+    """AITER Multi-Head Attention ops (incl. flash_attn_varlen).
+    Corresponds to `VLLM_ROCM_USE_AITER_MHA`."""
+
+    unified_attention: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
+    )
+    """AITER Triton unified attention for V1 attention.
+    Corresponds to `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION`."""
+
+    fp8bmm: bool = Field(default_factory=lambda: envs.VLLM_ROCM_USE_AITER_FP8BMM)
+    """AITER FP8 batched matrix multiply.
+    Corresponds to `VLLM_ROCM_USE_AITER_FP8BMM`."""
+
+    fp4bmm: bool = Field(default_factory=lambda: envs.VLLM_ROCM_USE_AITER_FP4BMM)
+    """AITER FP4 batched matrix multiply (CDNA 4).
+    Corresponds to `VLLM_ROCM_USE_AITER_FP4BMM`."""
+
+    triton_rope: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_USE_AITER_TRITON_ROPE
+    )
+    """AITER Triton rotary position embeddings.
+    Corresponds to `VLLM_ROCM_USE_AITER_TRITON_ROPE`."""
+
+    triton_gemm: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_USE_AITER_TRITON_GEMM
+    )
+    """AITER Triton unquantized GEMM.
+    Corresponds to `VLLM_ROCM_USE_AITER_TRITON_GEMM`."""
+
+    custom_all_reduce: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_USE_AITER_CUSTOM_AR
+    )
+    """Use AITER's CustomAllreduce as the custom-allreduce backend.
+    Corresponds to `VLLM_ROCM_USE_AITER_CUSTOM_AR`."""
+
+    shuffle_kv_cache_layout: bool = Field(
+        default_factory=lambda: envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
+    )
+    """Shuffle the ROCm KV-cache layout for AITER MLA kernels.
+    Corresponds to `VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT`."""
+
+    def compute_hash(self) -> str:
+        """Every field selects kernels / fusion passes / weight layout, so all
+        of them feed the compilation cache key."""
+        return hash_factors(get_hash_factors(self, set()))

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -27,6 +27,7 @@ from vllm.triton_utils import HAS_TRITON
 from vllm.utils import random_uuid
 from vllm.utils.hashing import safe_hash
 
+from .aiter import AITERConfig
 from .attention import AttentionConfig
 from .cache import CacheConfig
 from .compilation import CompilationConfig, CompilationMode, CUDAGraphMode
@@ -365,6 +366,8 @@ class VllmConfig:
     """Mamba configuration."""
     kernel_config: KernelConfig = Field(default_factory=KernelConfig)
     """Kernel configuration."""
+    aiter_config: AITERConfig = Field(default_factory=AITERConfig)
+    """ROCm AITER operations configuration. Only used on ROCm."""
     lora_config: LoRAConfig | None = None
     """LoRA configuration."""
     speculative_config: SpeculativeConfig | None = None
@@ -518,6 +521,10 @@ class VllmConfig:
             vllm_factors.append(self.kernel_config.compute_hash())
         else:
             vllm_factors.append(None)
+        if self.aiter_config:
+            vllm_factors.append(self.aiter_config.compute_hash())
+        else:
+            vllm_factors.append("None")
         if self.kv_transfer_config:
             vllm_factors.append(self.kv_transfer_config.compute_hash())
         else:
@@ -1452,6 +1459,12 @@ class VllmConfig:
         # must happen after compilation mode and backend are decided,
         # but before fusion defaults are applied as those may depend on op priority.
         self.kernel_config.set_platform_defaults(self)
+
+        # Sync ROCm AITER op toggles from aiter_config. Runs here for the
+        # front-end / engine-core process and the single-GPU (UniProcExecutor)
+        # path; worker subprocesses re-sync in WorkerBase.__init__ because
+        # pickle does not re-run __post_init__.
+        self._maybe_sync_aiter_ops()
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
@@ -2782,6 +2795,22 @@ class VllmConfig:
                 interleave,
                 local_block_size,
             )
+
+    def _maybe_sync_aiter_ops(self) -> None:
+        """Push ``aiter_config`` into the ``rocm_aiter_ops`` toggle cache.
+
+        ``rocm_aiter_ops`` mirrors its toggles into class variables at import
+        time (from env vars) so the hot path is a plain attribute read. This
+        re-points that cache at ``aiter_config``, which is the typed,
+        cache-hashed, worker-serialized source of truth.
+        """
+        from vllm.platforms import current_platform
+
+        if not current_platform.is_rocm() or self.aiter_config is None:
+            return
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        rocm_aiter_ops.init_from_config(self.aiter_config)
 
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1460,11 +1460,11 @@ class VllmConfig:
         # but before fusion defaults are applied as those may depend on op priority.
         self.kernel_config.set_platform_defaults(self)
 
-        # Sync ROCm AITER op toggles from aiter_config. Runs here for the
-        # front-end / engine-core process and the single-GPU (UniProcExecutor)
-        # path; worker subprocesses re-sync in WorkerBase.__init__ because
-        # pickle does not re-run __post_init__.
-        self._maybe_sync_aiter_ops()
+        # Apply per-process config state (e.g. ROCm AITER class vars from
+        # aiter_config). Runs here for the front-end / engine-core process and
+        # the single-GPU (UniProcExecutor) path; worker subprocesses re-apply
+        # in WorkerBase.__init__ because pickle does not re-run __post_init__.
+        current_platform.sync_process_config_state(self)
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
@@ -2795,22 +2795,6 @@ class VllmConfig:
                 interleave,
                 local_block_size,
             )
-
-    def _maybe_sync_aiter_ops(self) -> None:
-        """Set the ``rocm_aiter_ops`` AITER enablement class vars from ``aiter_config``.
-
-        ``rocm_aiter_ops`` reads these into class variables at import (from
-        env vars) so the hot path is a plain attribute read. When an
-        ``AITERConfig`` is present it is the source of truth instead: typed,
-        part of the compilation hash, and serialized to workers.
-        """
-        from vllm.platforms import current_platform
-
-        if not current_platform.is_rocm() or self.aiter_config is None:
-            return
-        from vllm._aiter_ops import rocm_aiter_ops
-
-        rocm_aiter_ops.init_from_config(self.aiter_config)
 
     def validate_block_size(self) -> None:
         """Validate block_size against DCP and mamba constraints.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1431,6 +1431,14 @@ class VllmConfig:
             if "-quant_fp8" not in custom_ops:
                 custom_ops.append("+quant_fp8")
 
+        # Apply per-process config state (e.g. ROCm AITER class vars from
+        # aiter_config). Must precede apply_config_platform_defaults, which
+        # reads rocm_aiter_ops.is_*_enabled() to decide custom_ops. Runs here
+        # for the front-end / engine-core / single-GPU (UniProcExecutor) path;
+        # worker subprocesses re-apply in WorkerBase.__init__ because pickle
+        # does not re-run __post_init__.
+        current_platform.sync_process_config_state(self)
+
         current_platform.apply_config_platform_defaults(self)
 
         if self.compilation_config.mode is None:
@@ -1459,12 +1467,6 @@ class VllmConfig:
         # must happen after compilation mode and backend are decided,
         # but before fusion defaults are applied as those may depend on op priority.
         self.kernel_config.set_platform_defaults(self)
-
-        # Apply per-process config state (e.g. ROCm AITER class vars from
-        # aiter_config). Runs here for the front-end / engine-core process and
-        # the single-GPU (UniProcExecutor) path; worker subprocesses re-apply
-        # in WorkerBase.__init__ because pickle does not re-run __post_init__.
-        current_platform.sync_process_config_state(self)
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2797,12 +2797,12 @@ class VllmConfig:
             )
 
     def _maybe_sync_aiter_ops(self) -> None:
-        """Push ``aiter_config`` into the ``rocm_aiter_ops`` toggle cache.
+        """Set the ``rocm_aiter_ops`` AITER enablement class vars from ``aiter_config``.
 
-        ``rocm_aiter_ops`` mirrors its toggles into class variables at import
-        time (from env vars) so the hot path is a plain attribute read. This
-        re-points that cache at ``aiter_config``, which is the typed,
-        cache-hashed, worker-serialized source of truth.
+        ``rocm_aiter_ops`` reads these into class variables at import (from
+        env vars) so the hot path is a plain attribute read. When an
+        ``AITERConfig`` is present it is the source of truth instead: typed,
+        part of the compilation hash, and serialized to workers.
         """
         from vllm.platforms import current_platform
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -34,6 +34,7 @@ from typing_extensions import TypeIs
 
 import vllm.envs as envs
 from vllm.config import (
+    AITERConfig,
     AttentionConfig,
     CacheConfig,
     CompilationConfig,
@@ -686,6 +687,7 @@ class EngineArgs:
     attention_config: AttentionConfig = get_field(VllmConfig, "attention_config")
     mamba_config: MambaConfig = get_field(VllmConfig, "mamba_config")
     kernel_config: KernelConfig = get_field(VllmConfig, "kernel_config")
+    aiter_config: AITERConfig = get_field(VllmConfig, "aiter_config")
     enable_flashinfer_autotune: bool = get_field(
         KernelConfig, "enable_flashinfer_autotune"
     )
@@ -781,6 +783,8 @@ class EngineArgs:
             self.mamba_config = MambaConfig(**self.mamba_config)
         if isinstance(self.kernel_config, dict):
             self.kernel_config = KernelConfig(**self.kernel_config)
+        if isinstance(self.aiter_config, dict):
+            self.aiter_config = AITERConfig(**self.aiter_config)
         if isinstance(self.ec_manager_config, dict):
             self.ec_manager_config = EncoderCacheManagerConfig(**self.ec_manager_config)
         if isinstance(self.eplb_config, dict):
@@ -1673,6 +1677,7 @@ class EngineArgs:
         )
         vllm_group.add_argument("--reasoning-config", **vllm_kwargs["reasoning_config"])
         vllm_group.add_argument("--kernel-config", **vllm_kwargs["kernel_config"])
+        vllm_group.add_argument("--aiter-config", **vllm_kwargs["aiter_config"])
         vllm_group.add_argument(
             "--additional-config", **vllm_kwargs["additional_config"]
         )
@@ -2544,6 +2549,7 @@ class EngineArgs:
             attention_config=attention_config,
             mamba_config=mamba_config,
             kernel_config=kernel_config,
+            aiter_config=self.aiter_config,
             lora_config=lora_config,
             speculative_config=speculative_config,
             diffusion_config=diffusion_config,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -586,6 +586,21 @@ class Platform:
         pass
 
     @classmethod
+    def sync_process_config_state(cls, vllm_config: "VllmConfig") -> None:
+        """
+        Apply process-global state derived from ``vllm_config`` that must be
+        set once per process and does not survive pickling into a worker
+        subprocess.
+
+        Called from ``VllmConfig.__post_init__`` (front-end / engine-core /
+        single-GPU path) and again from ``WorkerBase.__init__`` in each worker
+        subprocess, where ``__post_init__`` is not re-run.
+
+        Default: no-op.
+        """
+        pass
+
+    @classmethod
     def _find_non_ssm_backend(
         cls, vllm_config: "VllmConfig"
     ) -> "type[AttentionBackend] | None":

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -922,6 +922,16 @@ class RocmPlatform(Platform):
             parallel_config.worker_cls = "vllm.v1.worker.gpu_worker.Worker"
 
     @classmethod
+    def sync_process_config_state(cls, vllm_config: "VllmConfig") -> None:
+        # rocm_aiter_ops reads the VLLM_ROCM_USE_AITER* env vars into class
+        # vars at import for a plain-attribute-read hot path; point them at
+        # aiter_config, which is typed, part of the compilation hash, and
+        # serialized to workers.
+        from vllm._aiter_ops import rocm_aiter_ops
+
+        rocm_aiter_ops.init_from_config(vllm_config.aiter_config)
+
+    @classmethod
     def verify_model_arch(cls, model_arch: str) -> None:
         if model_arch in _ROCM_UNSUPPORTED_MODELS:
             raise ValueError(

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -100,6 +100,13 @@ class WorkerBase:
             vllm_config.compilation_config.ir_enable_torch_wrap
         )
 
+        # pickle does not re-run VllmConfig.__post_init__ in worker
+        # subprocesses, so re-sync the ROCm AITER toggle cache here.
+        if current_platform.is_rocm():
+            from vllm._aiter_ops import rocm_aiter_ops
+
+            rocm_aiter_ops.init_from_config(vllm_config.aiter_config)
+
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Get specifications for KV cache implementation."""
         raise NotImplementedError

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -101,11 +101,8 @@ class WorkerBase:
         )
 
         # pickle does not re-run VllmConfig.__post_init__ in worker
-        # subprocesses, so set the ROCm AITER class vars from the config here.
-        if current_platform.is_rocm():
-            from vllm._aiter_ops import rocm_aiter_ops
-
-            rocm_aiter_ops.init_from_config(vllm_config.aiter_config)
+        # subprocesses, so re-apply the per-process config state here.
+        current_platform.sync_process_config_state(vllm_config)
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Get specifications for KV cache implementation."""

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -101,7 +101,7 @@ class WorkerBase:
         )
 
         # pickle does not re-run VllmConfig.__post_init__ in worker
-        # subprocesses, so re-sync the ROCm AITER toggle cache here.
+        # subprocesses, so set the ROCm AITER class vars from the config here.
         if current_platform.is_rocm():
             from vllm._aiter_ops import rocm_aiter_ops
 


### PR DESCRIPTION
## Summary

ROCm AITER features are toggled by ~16 loose `VLLM_ROCM_USE_AITER*` env vars, read once at import into the `rocm_aiter_ops` class-var cache. This adds `vllm/config/aiter.py::AITERConfig`, a typed sub-config on `VllmConfig` that becomes the source of truth for that cache.

- `AITERConfig` on `VllmConfig` + `--aiter-config`; included in `VllmConfig.compute_hash()`.
- Every field defaults from its existing env var, so an unset config reproduces current behavior exactly. `enabled` stays the master switch.
- `rocm_aiter_ops.init_from_config()` syncs the cache once per process: `VllmConfig.__post_init__` (front-end / single-GPU) and `WorkerBase.__init__` (worker subprocesses, since pickle does not re-run `__post_init__`).
- Hot path (`is_*_enabled`) stays a plain class-var read.
- `_MOE_DISPATCH_POLICY` normalized from a lazy `None`-sentinel getter to an eager class var like the other toggles, and added to `refresh_env_variables()`.

Supersedes #41159. This is the config-object prerequisite discussed in #53938

## Not a duplicate

The only related PR is #41159 (DRAFT, ~4 months stale, ~150 commits behind). This is a fresh minimal implementation off current `main`.

## Testing

- `pytest tests/config/test_aiter_config.py` -> 9 passed (env-var defaults, explicit override, JSON round-trip, `compute_hash` sensitivity, `init_from_config` sync, `refresh_env_variables` completeness, front-end + worker-subprocess sync, `VllmConfig.compute_hash` includes `aiter_config`).
- End-to-end on gfx1201 (RX 9070 XT, ROCm 7.1): `LLM("facebook/opt-125m", aiter_config={...})` with every AITER env var set opposite to the override; verified the `rocm_aiter_ops` toggle cache matches the config in both the front-end process and the worker subprocess (via `collective_rpc`), and that fields omitted from the override fall through to their env var.
- `pre-commit run --files` on all changed files -> passed.

## Behavior / eval

No output or accuracy impact: every field defaults from the current env var, so an unset config behaves identically to today. No eval run for that reason.

## AI assistance

AI-assisted (Claude). I reviewed every changed line and ran the tests above.
