### PR TITLE
[Tracing] Add gen_ai.usage.cache_read.input_tokens span attribute (takeover of #44325)

### DIFF
--- a/tests/v1/tracing/test_tracing.py
+++ b/tests/v1/tracing/test_tracing.py
@@ -89,6 +89,10 @@ def test_traces(
             assert attributes.get(SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS) == len(
                 outputs[0].prompt_token_ids
             )
+            assert (
+                attributes.get(SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)
+                == outputs[0].num_cached_tokens
+            )
             completion_tokens = sum(len(o.token_ids) for o in outputs[0].outputs)
             assert (
                 attributes.get(SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS)

--- a/tests/v1/tracing/test_tracing.py
+++ b/tests/v1/tracing/test_tracing.py
@@ -44,7 +44,9 @@ def test_traces(
                 gpu_memory_utilization=0.3,
                 disable_log_stats=False,
             )
-            prompts = ["This is a short prompt"]
+            # Longer than one KV block so a repeat request can hit the
+            # prefix cache (cached tokens are counted in whole blocks).
+            prompts = ["The quick brown fox jumps over the lazy dog. " * 10]
             outputs = llm.generate(prompts, sampling_params=sampling_params)
             print(f"test_traces outputs is : {outputs}")
 
@@ -102,6 +104,37 @@ def test_traces(
             assert attributes.get(SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE) > 0
             assert attributes.get(SpanAttributes.GEN_AI_LATENCY_TIME_TO_FIRST_TOKEN) > 0
             assert attributes.get(SpanAttributes.GEN_AI_LATENCY_E2E) > 0
+
+            # A second identical request reads the prefix cache (enabled by
+            # default), so its span must report a nonzero cache read. The
+            # first request has num_cached_tokens == 0, which cannot
+            # distinguish a correct attribute from a missing or constant one.
+            outputs = llm.generate(prompts, sampling_params=sampling_params)
+            assert outputs[0].num_cached_tokens > 0
+
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                all_spans = trace_service.get_all_spans()
+                llm_request_spans = [s for s in all_spans if s["name"] == "llm_request"]
+                if len(llm_request_spans) == 2:
+                    break
+                time.sleep(0.5)
+
+            assert len(llm_request_spans) == 2, (
+                f"Expected 2 'llm_request' spans after the second request, "
+                f"but got {len(llm_request_spans)}."
+            )
+
+            attributes = next(
+                s["attributes"]
+                for s in llm_request_spans
+                if s["attributes"].get(SpanAttributes.GEN_AI_REQUEST_ID)
+                == outputs[0].request_id
+            )
+            assert (
+                attributes.get(SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS)
+                == outputs[0].num_cached_tokens
+            )
         finally:
             if llm is not None:
                 shutdown_timeout = 60.0 if current_platform.is_rocm() else 5.0

--- a/vllm/tracing/utils.py
+++ b/vllm/tracing/utils.py
@@ -23,6 +23,7 @@ class SpanAttributes:
     # Attribute names copied from OTel semantic conventions to avoid version conflicts
     GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
     GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
+    GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
     GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
     GEN_AI_REQUEST_TOP_P = "gen_ai.request.top_p"
     GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature"

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -783,6 +783,9 @@ class OutputProcessor:
             SpanAttributes.GEN_AI_LATENCY_E2E: e2e_time,
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE: queued_time,
             SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS: prompt_length,
+            SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: (
+                req_state.num_cached_tokens
+            ),
             SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS: (
                 metrics.num_generation_tokens
             ),


### PR DESCRIPTION
- Adds `gen_ai.usage.cache_read.input_tokens` to the `llm_request` span, from `num_cached_tokens`.
- Original 8-line change is unchanged; the author's commit is preserved.
- `pytest tests/v1/tracing/test_tracing.py` on H100 passes
- Takeover of #44325 (inactive since 2026-07-01); no other open PR adds cache attributes to spans. Closes #41788.
- AI-assisted; all changes reviewed and tests run by me.