### PR TITLE
[Bugfix][CPU] Extract per-ISA _C variants for precompiled CPU wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1008,6 +1008,10 @@ class precompiled_wheel_utils:
                     exact_members.update(
                         {
                             "vllm/_C.abi3.so",
+                            # x86 CPU wheels ship per-ISA variants of _C;
+                            # CpuPlatform.import_kernels() selects one at runtime.
+                            "vllm/_C_AVX512.abi3.so",
+                            "vllm/_C_AVX2.abi3.so",
                             "vllm/_C_stable_libtorch.abi3.so",
                             "vllm/_moe_C_stable_libtorch.abi3.so",
                             "vllm/_qutlass_C.abi3.so",


### PR DESCRIPTION
## Purpose

x86 CPU wheels ship **three** variants of the C extension — `_C` (AVX512+AMX), `_C_AVX512`, and `_C_AVX2` — and `CpuPlatform.import_kernels()` selects one at runtime based on the host ISA.

The precompiled extraction list in `setup.py` only carried `vllm/_C.abi3.so`, so the python-only build documented in `docs/getting_started/installation/cpu.md` produced a source tree missing the AVX512 and AVX2 libraries:

```bash
VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu \
  uv pip install --editable .
```

On any x86 host **without AMX**, the resulting install cannot load kernels. The failure is silent at import and fatal later — `import_kernels()` only emits `logger.warning_once`, so `import vllm` succeeds and the process dies during engine startup:

```
WARNING [cpu.py:514] Failed to import from vllm._C_AVX2: ModuleNotFoundError("No module named 'vllm._C_AVX2'")
...
ERROR [multiproc_executor.py:944] AttributeError: '_OpNamespace' '_C' object has no attribute 'init_cpu_memory_env'
RuntimeError: Engine core initialization failed.
```

AMX is Sapphire-Rapids-and-newer Xeon only, so this affects all AMD x86 parts, all Intel consumer parts, and pre-SPR Xeons — i.e. most hardware people develop on locally, which is the audience the python-only build exists for.

**Root cause.** The variants have been declared as build targets since #35466 (AVX2) and #36968 (AVX512). Both updated `ext_modules` and the runtime dispatch in `vllm/platforms/cpu.py`, but neither updated the precompiled extraction list. `git log -S 'vllm/_C_AVX2.abi3.so' -- setup.py` returns nothing, so the entry was never present — an omission, not a deliberate exclusion. The published CPU wheel does contain all three:

```
146.6 MB  vllm/_C.abi3.so
 82.1 MB  vllm/_C_AVX2.abi3.so
 95.1 MB  vllm/_C_AVX512.abi3.so
```

The change is strictly additive: the extraction loop matches against members that actually exist in the wheel, so on platforms where these variants are never built (e.g. aarch64, where `cpu_extension.cmake` gates them behind x86) the new entries simply never match.

**Why CI did not catch it.** `tests/standalone_tests/python_only_compile.sh` has CUDA and ROCm branches but no CPU branch — it fetches `wheels.vllm.ai/<commit>/vllm/metadata.json`, never the `cpu/` variant. Its only functional assertion is `python3 -c 'import vllm'`, which passes with this bug present because the failure is a warning rather than an import error. Extending that script to cover the CPU variant and to exercise a real op would prevent recurrence; I'm happy to follow up in a separate PR since it touches CI configuration.

## Test Plan

Host: Intel Core Ultra 7 255H (x86_64, AVX2, **no AVX512/AMX**), Linux, Python 3.12, torch 2.13.0+cpu.

A/B against the same CPU wheel via `VLLM_PRECOMPILED_WHEEL_LOCATION`, deleting `vllm/_C*.abi3.so` before each pass so the extraction step is what differs:

```bash
rm -f vllm/_C*.abi3.so
VLLM_USE_PRECOMPILED=1 VLLM_TARGET_DEVICE=cpu \
VLLM_PRECOMPILED_WHEEL_LOCATION=<cpu wheel> \
  uv pip install --editable . --no-build-isolation --torch-backend cpu
ls vllm/_C*.so

# end-to-end: facebook/opt-125m, dtype=float32, enforce_eager, 20 tokens
python smoke.py
```

Also run:

```bash
pre-commit run
python -m pytest tests/kernels/test_onednn.py -q
```

## Test Result

**Before (main):**

```
$ ls vllm/_C*.so
vllm/_C.abi3.so

$ python smoke.py
AttributeError: '_OpNamespace' '_C' object has no attribute 'init_cpu_memory_env'
exit 1
```

**After (this PR):**

```
$ ls vllm/_C*.so
vllm/_C.abi3.so   vllm/_C_AVX2.abi3.so   vllm/_C_AVX512.abi3.so

$ python smoke.py
PROMPT: The capital of France is
OUTPUT:  the capital of the French Republic.
exit 0
```

Zero `Failed to import from vllm._C` warnings after the change (grep count 0).

```
$ pre-commit run
all hooks passed

$ python -m pytest tests/kernels/test_onednn.py -q
200 passed in 224.55s
```

**Model evaluation:** not applicable. This changes only which prebuilt artifacts are copied into the source tree during a python-only install. It does not touch kernels, model code, or numerics — the kernels are unchanged, they were simply absent before.

## Not a duplicate

- `gh pr list --state open --search "_C_AVX2 OR _C_AVX512 OR precompiled extraction"` — nothing addressing this
- `gh pr list --state all --search "precompiled cpu wheel kernels missing"` — nothing addressing this
- No open or closed issue reports it. #39334 shows a similar downstream symptom on an AVX2-only host but has a different root cause (source build, `undefined symbol` / libtorch ABI mismatch); it was auto-closed as stale without diagnosis.

## AI assistance disclosure

Per `docs/contributing/README.md`, AI assistance (Claude) was used to investigate the root cause, run the A/B reproduction above, and draft this description. The commit carries a `Co-authored-by: Claude` trailer. I reviewed every changed line, ran the reproduction and the tests myself, and understand the change end-to-end.
