### PR TITLE
[V1] Fix KV cache capacity discrepancy between cold and warm starts under torch.compile (#54383)

### DIFF
--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vllm.config.compilation import CompilationMode
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.v1.worker import gpu_worker, startup_plan
 from vllm.v1.worker.gpu_worker import maybe_rocm_profiling_fallback
@@ -221,3 +221,62 @@ def test_execute_model_waits_previous_pp_send_before_forward(
 
     assert log == ["wait:prev-tensor", "forward", "isend"]
     assert worker._pp_send_work == [tensor_handle]
+
+
+@pytest.mark.parametrize(
+    ("mode", "expect_warmup_pass"),
+    [
+        (CompilationMode.VLLM_COMPILE, True),
+        (CompilationMode.NONE, False),
+    ],
+)
+def test_compilation_warmup_before_memory_profiling(mode, expect_warmup_pass):
+    worker = _plan_worker()
+    worker.vllm_config.compilation_config = SimpleNamespace(
+        mode=mode,
+        cudagraph_mode=SimpleNamespace(name="NONE"),
+    )
+    worker.cache_config.kv_cache_memory_bytes = None
+    worker.cache_config.gpu_memory_utilization = 0.9
+    worker.model_config = SimpleNamespace(multimodal_config=None)
+    worker.model_runner = SimpleNamespace(
+        model_memory_usage=10 * GiB_bytes,
+        profile_run=MagicMock(),
+        profile_cudagraph_memory=MagicMock(return_value=0),
+    )
+    worker.device = "cuda:0"
+    worker.requested_memory = 70 * GiB_bytes
+    worker.determine_available_memory = (
+        gpu_worker.Worker.determine_available_memory.__get__(worker)
+    )
+
+    mock_profile_result = _profile_result(consumed=2 * GiB_bytes)
+    mock_profile_result.non_kv_cache_memory = 2 * GiB_bytes
+    mock_snapshot = SimpleNamespace(free_memory=78 * GiB_bytes, device_="cuda:0")
+
+    @contextmanager
+    def mock_mem_profiling(*args, **kwargs):
+        yield mock_profile_result
+
+    with (
+        patch.object(gpu_worker, "maybe_apply_startup_plan"),
+        patch.object(gpu_worker, "MemorySnapshot", return_value=mock_snapshot),
+        patch.object(gpu_worker, "memory_profiling", side_effect=mock_mem_profiling),
+        patch.object(gpu_worker.torch.accelerator, "empty_cache") as mock_empty_cache,
+        patch.object(gpu_worker.torch.accelerator, "synchronize") as mock_sync,
+        patch.object(gpu_worker, "maybe_save_startup_plan"),
+    ):
+        available_mem = worker.determine_available_memory()
+        assert available_mem == 68 * GiB_bytes
+
+        if expect_warmup_pass:
+            # profile_run called twice: 1. warmup 2. inside profiler
+            assert worker.model_runner.profile_run.call_count == 2
+            mock_empty_cache.assert_called_once()
+            mock_sync.assert_called_once()
+            assert worker.init_snapshot == mock_snapshot
+        else:
+            # profile_run called only once inside profiler
+            assert worker.model_runner.profile_run.call_count == 1
+            mock_empty_cache.assert_not_called()
+            mock_sync.assert_not_called()

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -252,7 +252,6 @@ def test_compilation_warmup_before_memory_profiling(mode, expect_warmup_pass):
 
     mock_profile_result = _profile_result(consumed=2 * GiB_bytes)
     mock_profile_result.non_kv_cache_memory = 2 * GiB_bytes
-    mock_snapshot = SimpleNamespace(free_memory=78 * GiB_bytes, device_="cuda:0")
 
     @contextmanager
     def mock_mem_profiling(*args, **kwargs):
@@ -260,7 +259,6 @@ def test_compilation_warmup_before_memory_profiling(mode, expect_warmup_pass):
 
     with (
         patch.object(gpu_worker, "maybe_apply_startup_plan"),
-        patch.object(gpu_worker, "MemorySnapshot", return_value=mock_snapshot),
         patch.object(gpu_worker, "memory_profiling", side_effect=mock_mem_profiling),
         patch.object(gpu_worker.torch.accelerator, "empty_cache") as mock_empty_cache,
         patch.object(gpu_worker.torch.accelerator, "synchronize") as mock_sync,
@@ -274,7 +272,6 @@ def test_compilation_warmup_before_memory_profiling(mode, expect_warmup_pass):
             assert worker.model_runner.profile_run.call_count == 2
             mock_empty_cache.assert_called_once()
             mock_sync.assert_called_once()
-            assert worker.init_snapshot == mock_snapshot
         else:
             # profile_run called only once inside profiler
             assert worker.model_runner.profile_run.call_count == 1

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -231,6 +231,9 @@ def test_execute_model_waits_previous_pp_send_before_forward(
     ],
 )
 def test_compilation_warmup_before_memory_profiling(mode, expect_warmup_pass):
+    """Ensure compilation warmup runs before memory profiling when
+    torch.compile is active, and is skipped in eager mode.
+    """
     worker = _plan_worker()
     worker.vllm_config.compilation_config = SimpleNamespace(
         mode=mode,
@@ -255,6 +258,7 @@ def test_compilation_warmup_before_memory_profiling(mode, expect_warmup_pass):
 
     @contextmanager
     def mock_mem_profiling(*args, **kwargs):
+        """Yield the mock memory profiling result."""
         yield mock_profile_result
 
     with (

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -555,6 +555,16 @@ class Worker(WorkerBase):
                 getattr(self.parallel_config, "_api_process_count", 1),
             )
 
+        # When torch.compile is enabled, we run a compilation
+        # pass first to trigger JIT compilation and purge
+        # temporary compiler buffers (ASTs, Triton workspace, etc.)
+        if self.vllm_config.compilation_config.mode != CompilationMode.NONE:
+            self.model_runner.profile_run()
+            gc.collect()
+            torch.accelerator.empty_cache()
+            torch.accelerator.synchronize()
+            self.init_snapshot = MemorySnapshot(device=self.device)
+
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -563,7 +563,6 @@ class Worker(WorkerBase):
             gc.collect()
             torch.accelerator.empty_cache()
             torch.accelerator.synchronize()
-            self.init_snapshot = MemorySnapshot(device=self.device)
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.


### PR DESCRIPTION
### Purpose
Fixes #54383.

### Root Cause
During engine startup in `vllm/v1/worker/gpu_worker.py:determine_available_memory()`, `self.model_runner.profile_run()` is called inside the `memory_profiling` context manager. On cold boots, lazy `torch.compile` (Inductor & Triton) JIT compilation triggers during this profiling pass, allocating temporary compiler ASTs, lowering buffers, and kernel workspace that spike `torch_peak`.

Because vLLM permanently subtracts `torch_peak` from available device VRAM when sizing the KV cache pool, servers started on cold caches permanently lost KV cache capacity compared to warm restarts.

### Fix
1. In `GPUWorker.determine_available_memory()`, if `torch.compile` is enabled (`compilation_config.mode != CompilationMode.NONE`), execute an unprofiled compilation warmup pass first.
2. Flush temporary compiler scratchpads via `gc.collect()`, `empty_cache()`, and `synchronize()`.
3. Perform `memory_profiling()` on the pre-compiled graph to capture strictly steady-state inference activation memory.

### Empirical Validation

#### Setup 1: NVIDIA A100-80GB (`Qwen3-4B-Thinking`, `--max-model-len 8192`)
| Build / Condition | KV Cache Tokens | Blocks | Delta vs. Warm |
| :--- | :--- | :--- | :--- |
| **Unpatched (`main`) Cold Boot** | 452,800 | 28,300 | **−1,520 tokens (−95 blocks)** |
| **Unpatched (`main`) Warm Boot** | 454,320 | 28,395 | Reference |
| **Patched (`ab3f9a47`) Cold Boot** | **454,320** | **28,395** | **0 tokens delta (100% Parity)** |
| **Patched (`ab3f9a47`) Warm Boot** | **454,320** | **28,395** | **0 tokens delta (100% Parity)** |

#### Setup 2: 2× NVIDIA RTX 4090 (verified by @vitalyrodnenko, `Qwen3-32B-AWQ`, TP=2, util 0.85)
| Build / Condition | Blocks | KV GiB/GPU | Delta vs. Warm |
| :--- | :--- | :--- | :--- |
| **Unpatched (`main`) Cold Boot** | 5,070 | 9.90 GiB | **−245 blocks (−4.61%)** |
| **Unpatched (`main`) Warm Boot** | 5,315 | 10.38 GiB | Reference |
| **Patched (`ab3f9a47`) Cold Boot** | **5,311** | **10.37 GiB** | **0 blocks delta (100% Parity)** |
| **Patched (`ab3f9a47`) Warm Boot** | **5,311** | **10.37 GiB** | **0 blocks delta (100% Parity)** |

### Testing
- Added parameterized unit tests in `tests/v1/worker/test_gpu_worker.py` verifying that compilation warmup executes when compilation is enabled and is cleanly skipped in eager mode.

---
*Disclaimer: AI assistance was used for unit test setup and documentation for this PR.*
