### PR TITLE
[Rust Frontend][CI] Remove TCP port races from mock-engine tests

### DIFF
--- a/rust/src/mock-engine/src/tests.rs
+++ b/rust/src/mock-engine/src/tests.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-use std::net::TcpListener;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -15,13 +14,6 @@ use vllm_engine_core_client::test_utils::IpcNamespace;
 use vllm_engine_core_client::{EngineCoreClient, EngineCoreClientConfig, TransportMode};
 
 use crate::{Opt, run};
-
-fn free_tcp_address() -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind free port");
-    let port = listener.local_addr().expect("local addr").port();
-    drop(listener);
-    format!("tcp://127.0.0.1:{port}")
-}
 
 fn client_config(handshake_address: String, engine_count: usize) -> EngineCoreClientConfig {
     EngineCoreClientConfig {
@@ -96,8 +88,9 @@ async fn shutdown_mock(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn mock_engine_connects_over_tcp() {
-    let handshake_address = free_tcp_address();
+async fn mock_engine_connects_over_ipc() {
+    let ipc = IpcNamespace::new().expect("ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
     let (client, shutdown, task) = connect_with_mock(handshake_address, 1, 1).await;
     assert_eq!(client.engine_count(), 1);
     assert_eq!(client.engine_identities()[0], &[0, 0]);
@@ -107,18 +100,9 @@ async fn mock_engine_connects_over_tcp() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn mock_engine_connects_over_ipc() {
+async fn mock_engine_registers_multiple_identities() {
     let ipc = IpcNamespace::new().expect("ipc namespace");
     let handshake_address = ipc.handshake_endpoint();
-    let (client, shutdown, task) = connect_with_mock(handshake_address, 1, 1).await;
-    assert_eq!(client.engine_count(), 1);
-    assert_eq!(client.engine_identities()[0], &[0, 0]);
-    shutdown_mock(client, shutdown, task).await;
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn mock_engine_registers_multiple_identities() {
-    let handshake_address = free_tcp_address();
     let (client, shutdown, task) = connect_with_mock(handshake_address, 2, 1).await;
     assert_eq!(client.engine_count(), 2);
     assert_eq!(client.engine_identities(), vec![&[0, 0][..], &[1, 0][..]]);
@@ -127,7 +111,8 @@ async fn mock_engine_registers_multiple_identities() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn chunk_size_one_outputs_one_token_per_update() {
-    let handshake_address = free_tcp_address();
+    let ipc = IpcNamespace::new().expect("ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
     let (client, shutdown, task) = connect_with_mock(handshake_address, 1, 1).await;
     let mut stream = client.call(sample_request("req-1", 3)).await.expect("call");
 
@@ -147,7 +132,8 @@ async fn chunk_size_one_outputs_one_token_per_update() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn chunk_size_clips_final_output_to_max_tokens() {
-    let handshake_address = free_tcp_address();
+    let ipc = IpcNamespace::new().expect("ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
     let (client, shutdown, task) = connect_with_mock(handshake_address, 1, 4).await;
     let mut stream = client.call(sample_request("req-clip", 6)).await.expect("call");
 
@@ -164,7 +150,8 @@ async fn chunk_size_clips_final_output_to_max_tokens() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn abort_cancels_active_request_and_emits_terminal_output() {
-    let handshake_address = free_tcp_address();
+    let ipc = IpcNamespace::new().expect("ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
     let (client, shutdown, task) = connect_with_mock(handshake_address, 1, 1).await;
     let mut stream = client.call(sample_request("req-abort", 1_000_000)).await.expect("call");
     let first = stream.next().await.expect("first").expect("first ok");
@@ -189,7 +176,8 @@ async fn abort_cancels_active_request_and_emits_terminal_output() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn utility_requests_return_minimal_success_responses() {
-    let handshake_address = free_tcp_address();
+    let ipc = IpcNamespace::new().expect("ipc namespace");
+    let handshake_address = ipc.handshake_endpoint();
     let (client, shutdown, task) = connect_with_mock(handshake_address, 1, 1).await;
 
     assert!(!client.is_sleeping().await.expect("is sleeping"));


### PR DESCRIPTION
- Give every mock-engine behavior test a unique, retained `IpcNamespace`.
- Remove the probe-release-bind `free_tcp_address` helper and the redundant TCP smoke test that depended on it.
- Preserve the TCP test's engine metadata assertions in the IPC connection test.
- Keep connection, identity registration, output chunking, abort, and utility request coverage unchanged.
- Leave race-free TCP `:0` binding coverage at the engine-core-client transport layer that owns the final socket bind.

The selected Rust Cargo job in [AMD CI build 12447](https://buildkite.com/vllm/amd-ci/builds/12447/list?sid=01a051e6-e2f5-42f5-b99f-f17a8af62533&tab=output) failed in `rust/src/mock-engine/src/tests.rs::chunk_size_one_outputs_one_token_per_update` with `Address already in use (os error 98)` / `AddrInUse` while the frontend client was connecting. The test suite selected a supposedly free TCP port by binding `127.0.0.1:0`, reading the assigned port, and dropping that listener before ZeroMQ performed the real bind. Under concurrent `cargo nextest` execution, the released port could be assigned to another test or process in that gap.

These tests exercise mock-engine protocol behavior, not TCP listener ownership. The current client API accepts an endpoint string and performs the bind later; it cannot safely transfer a held TCP listener or publish the endpoint selected by a `:0` bind before the mock engine connects. Retained per-test IPC namespaces therefore remove the irrelevant allocation race at the leaf test helper without adding sleeps, retries, or test serialization. The lower-level `bind_local_sockets_resolves_zero_port_bindings` test continues to verify that engine-core-client lets the final ZeroMQ owner bind TCP port `0` and reports the resolved endpoints.

The AMD Rust Cargo step is configured with `no_gpu: true`, while the general-CI step uses a `cpu-medium` device. Both run the same `run-rust-frontend-cargo-ci.sh test` command, and the mock-engine package has no CUDA, HIP, ROCm, or Torch dependency.

For the affected `2c7d7dd` SHA, the [general-CI Rust Cargo job](https://buildkite.com/vllm/ci/builds/86207#01a051c6-35da-48db-85d1-67d027a756eb) was blocked and never ran, so there is no exact-SHA CUDA/general-CI pass. The closest [general-CI Rust Cargo run](https://buildkite.com/vllm/ci/builds/86168#01a04f21-698d-48dc-89e3-7c02b7198e7c) passed the same 1,633-test suite with an identical complete `rust/` tree. The [AMD failure](https://buildkite.com/vllm/amd-ci/builds/12447#01a051e6-e3ea-413d-ac94-f1ebabaee0e6) reported 64 tests running concurrently, and the AMD container shares the host network namespace. Runner scheduling and host port pressure therefore changed the probability of hitting the latent race; no accelerator backend code was involved.

## AI assistance

OpenAI Codex was used for failure investigation, bisection, implementation guidance, test analysis, and drafting this description. The human submitter must review every changed line, validate the reported results, and understand and defend the change end-to-end before requesting review.