### PR TITLE
[Bugfix][Rust Frontend][Parser] Reject empty HY tool call names

### DIFF
--- a/rust/src/chat/src/output/default/unified.rs
+++ b/rust/src/chat/src/output/default/unified.rs
@@ -317,7 +317,9 @@ mod tests {
     use futures::{StreamExt as _, stream};
     use vllm_parser::reasoning::ReasoningError;
     use vllm_parser::tool::{Tool, ToolCallDelta};
-    use vllm_parser::unified::{Gemma4UnifiedParser, UnifiedParserError, UnifiedParserOutput};
+    use vllm_parser::unified::{
+        Gemma4UnifiedParser, HyV4UnifiedParser, UnifiedParserError, UnifiedParserOutput,
+    };
     use vllm_text::DecodedText;
     use vllm_tokenizer::test_utils::TestTokenizer;
     use vllm_tokenizer::{TokenAnchor, TokenAttribution};
@@ -926,6 +928,62 @@ mod tests {
                     kind: AssistantBlockKind::Text,
                     delta: "<|tool_call>call:write_file{content:<|\"|>hello world<|\"|>"
                         .to_string(),
+                    token_count: None,
+                },
+                AssistantEvent::Done {
+                    usage: done_usage(0),
+                    finish_reason: crate::FinishReason::Stop(None),
+                    kv_transfer_params: None,
+                    ec_transfer_params: None,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn unified_stream_falls_back_for_hy_v4_empty_function_name() {
+        let tokenizer = [
+            "<think>",
+            "</think>",
+            "<tool_calls>",
+            "</tool_calls>",
+            "<tool_call>",
+            "</tool_call>",
+            "<arg_key>",
+            "</arg_key>",
+            "<arg_value>",
+            "</arg_value>",
+        ]
+        .into_iter()
+        .enumerate()
+        .fold(TestTokenizer::new(), |tokenizer, (index, token)| {
+            tokenizer.with_regular_token(token, 1000 + index as u32)
+        });
+        let tools = vec![Tool {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": { "city": { "type": "string" } }
+            }),
+            strict: None,
+        }];
+        let parser = HyV4UnifiedParser::new(&tools, Arc::new(tokenizer)).unwrap();
+        let raw = "<tool_calls><tool_call><arg_key>city</arg_key><arg_value>Beijing</arg_value></tool_call></tool_calls>";
+        let stream = stream::iter([finished_delta(raw)].into_iter().map(Ok));
+        let events = unified_event_stream(stream, Box::new(parser))
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<crate::Result<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(
+            events,
+            vec![
+                AssistantEvent::TextDelta {
+                    kind: AssistantBlockKind::Text,
+                    delta: raw.to_string(),
                     token_count: None,
                 },
                 AssistantEvent::Done {

--- a/rust/src/parser/src/tool/hy.rs
+++ b/rust/src/parser/src/tool/hy.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use winnow::ascii::multispace0 as ws0;
 use winnow::combinator::{alt, delimited, eof, repeat, seq, terminated};
+use winnow::error::{ContextError, ErrMode, StrContext, StrContextValue};
 use winnow::prelude::*;
 use winnow::stream::Partial;
 use winnow::token::{literal, rest, take_until};
@@ -224,9 +225,16 @@ impl ToolParser for HyToolParser {
     }
 
     fn reset(&mut self) -> String {
+        let restore_tool_block_start =
+            matches!(self.mode, HyMode::ToolBlock { .. }) && self.emitted_tool_count == 0;
         self.mode = HyMode::Text;
         self.emitted_tool_count = 0;
-        std::mem::take(&mut self.buffer)
+        let buffer = std::mem::take(&mut self.buffer);
+        if restore_tool_block_start {
+            format!("{}{buffer}", self.markers.tool_calls_start)
+        } else {
+            buffer
+        }
     }
 }
 
@@ -307,10 +315,19 @@ fn tool_call_event(
     .parse_next(input)?;
     let mut body_input = body;
     let (name, params) = parse_tool_call_body(&mut body_input, markers, dialect)?;
+    let name = name.trim();
+    if name.is_empty() {
+        let mut error = ContextError::new();
+        error.push(StrContext::Label("HY function name"));
+        error.push(StrContext::Expected(StrContextValue::Description(
+            "non-empty function name",
+        )));
+        return Err(ErrMode::Cut(error));
+    }
     let raw_params = parse_tool_call_params(params, markers)?;
 
     Ok(HyEvent::ToolCall {
-        name: name.trim().to_string(),
+        name: name.to_string(),
         raw_params,
     })
 }
@@ -724,6 +741,18 @@ mod tests {
     }
 
     #[test]
+    fn hy_v3_whitespace_only_function_name_fails_fast() {
+        let mut parser = HyToolParser::new(&test_tools(), "", HyDialect::V3);
+        let error = parser
+            .parse_complete(
+                "<tool_calls><tool_call>  <tool_sep><arg_key>city</arg_key><arg_value>Beijing</arg_value></tool_call></tool_calls>",
+            )
+            .unwrap_err();
+
+        assert!(error.to_report_string().contains("non-empty function name"));
+    }
+
+    #[test]
     fn hy_v4_parse_complete_extracts_compact_calls_with_and_without_arguments() {
         let mut parser = HyToolParser::new(&test_tools(), "", HyDialect::V4);
         let output = parser
@@ -795,5 +824,17 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_report_string().starts_with("tool parser parsing failed:"));
+    }
+
+    #[test]
+    fn hy_v4_empty_function_name_fails_fast() {
+        let mut parser = HyToolParser::new(&test_tools(), "", HyDialect::V4);
+        let error = parser
+            .parse_complete(
+                "<tool_calls><tool_call><arg_key>city</arg_key><arg_value>Beijing</arg_value></tool_call></tool_calls>",
+            )
+            .unwrap_err();
+
+        assert!(error.to_report_string().contains("non-empty function name"));
     }
 }


### PR DESCRIPTION



## Purpose

 The Rust HY parser accepted empty or whitespace-only function names and emitted tool calls with `name: ""`. Clients cannot match such a call to any declared tool, which can cause tool dispatch or request validation to fail instead of treating the malformed model output as text.

 Validate trimmed function names in the shared HY V3/V4 parser before emitting tool events, aligning empty-name handling with the  Python HY4 parser. When the first tool call is malformed, restore the consumed `<tool_calls>` marker so the unified output path can fall back to the complete original text.

## Test Plan

```
  cargo nextest run -p vllm-parser \
    -E 'test(hy_v4_empty_function_name_fails_fast) | test(hy_v3_whitespace_only_function_name_fails_fast)'

  cargo nextest run -p vllm-chat \
    -E 'test(unified_stream_falls_back_for_hy_v4_empty_function_name)'
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

