### PR TITLE
[ROCm][Kimi-K3][DCP] Enable MLA query replication

### DIFF
--- a/tests/v1/attention/test_dcp_utils.py
+++ b/tests/v1/attention/test_dcp_utils.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import vllm.envs as envs
+from vllm.config import ParallelConfig
+from vllm.v1.attention.ops.dcp import resolve_dcp_q_replicate
+
+
+@pytest.mark.parametrize(
+    ("env_override", "configured", "dcp_size", "pcp_size", "expected"),
+    [
+        # Unset env: the model/config default decides.
+        (None, True, 2, 1, True),
+        (None, False, 2, 1, False),
+        # Explicit env wins either way, including forcing it off.
+        (True, False, 2, 1, True),
+        (False, True, 2, 1, False),
+        # DCP inactive: nothing to replicate across.
+        (True, True, 1, 1, False),
+        # PCP active: DCP groups are strided, so the head mapping breaks.
+        (True, True, 2, 2, False),
+    ],
+)
+def test_resolve_dcp_q_replicate(
+    monkeypatch,
+    env_override: bool | None,
+    configured: bool,
+    dcp_size: int,
+    pcp_size: int,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(
+        envs,
+        "is_set",
+        lambda name: name == "VLLM_DCP_Q_REPLICATE" and env_override is not None,
+    )
+    monkeypatch.setattr(envs, "VLLM_DCP_Q_REPLICATE", bool(env_override))
+    parallel_config = cast(
+        ParallelConfig,
+        SimpleNamespace(
+            dcp_q_replicate=configured,
+            decode_context_parallel_size=dcp_size,
+            prefill_context_parallel_size=pcp_size,
+        ),
+    )
+
+    assert resolve_dcp_q_replicate(parallel_config) is expected

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -322,6 +322,60 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
     torch.testing.assert_close(layer.W_UK_T, old_w_uk_t + 100)
 
 
+def test_mla_fp8_qrep_gathers_scalar_weight_scale(monkeypatch):
+    class FakeDCPGroup:
+        def all_gather(self, input_: torch.Tensor, dim: int = 0) -> torch.Tensor:
+            assert input_.dim() > 0
+            return torch.cat([input_, input_], dim=dim)
+
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.kv_lora_rank = 2
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 3
+    layer.v_head_dim = 4
+    layer.kv_b_proj = torch.nn.Module()
+    layer.kv_b_proj.weight = torch.nn.Parameter(
+        torch.arange(28.0, dtype=torch.float16).reshape(14, 2)
+    )
+    layer.kv_b_proj.quant_method = None
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = True
+    layer.is_amx_bmm_enabled = False
+    layer.dcp_q_replicate = True
+    layer.q_pad_num_heads = None
+    layer.quant_config = None
+    layer.layer_name = "test"
+    layer.impl = SimpleNamespace(process_weights_after_loading=lambda act_dtype: None)
+
+    monkeypatch.setattr(mla_attention_module, "get_dcp_group", FakeDCPGroup)
+    monkeypatch.setattr(mla_attention_module, "is_global_first_rank", lambda: False)
+    monkeypatch.setattr(
+        mla_attention_module, "set_default_quant_scales", lambda *_, **__: None
+    )
+
+    fp8_bmm_calls = []
+
+    def fake_triton_fp8_bmm(x, w, w_scale, **kwargs):
+        fp8_bmm_calls.append((w.shape, w_scale.shape))
+        return x.new_empty((*x.shape[:-1], w.shape[-2]))
+
+    monkeypatch.setattr(
+        mla_attention_module.rocm_aiter_ops,
+        "triton_fp8_bmm",
+        fake_triton_fp8_bmm,
+    )
+
+    with torch.no_grad():
+        layer.process_weights_after_loading(torch.float32)
+
+    assert layer.W_K_scale.shape == (2,)
+    assert any(
+        w_shape[0] == 4 and scale_shape == (2,)
+        for w_shape, scale_shape in fp8_bmm_calls
+    )
+
+
 # Validate parameter combinations during collection, before GPU fixtures run.
 PREFILL_BACKENDS_TO_TEST: list[MLAPrefillBackendEnum] = []
 if current_platform.is_cuda():

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1157,14 +1157,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 "DCP query replication is unsupported on head-padding MLA "
                 "backends (q_pad_num_heads)."
             )
-            if (
-                self.is_aiter_triton_fp4_bmm_enabled
-                or self.is_aiter_triton_fp8_bmm_enabled
-            ):
-                raise NotImplementedError(
-                    "DCP query replication is not implemented for the aiter "
-                    "FP4/FP8 MLA BMM paths."
-                )
 
         assert kv_b_proj_weight.shape == (
             self.kv_lora_rank,
@@ -1200,6 +1192,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             self.W_V, self.W_V_scale = quark_quantize_weight_to_mxfp4(
                 W_UV.permute(1, 2, 0)
             )
+
+            if self.dcp_q_replicate:
+                self.W_K = get_dcp_group().all_gather(
+                    self.W_K.contiguous(), dim=0
+                )
+                self.W_K_scale = get_dcp_group().all_gather(
+                    self.W_K_scale.contiguous(), dim=0
+                )
         elif self.is_aiter_triton_fp8_bmm_enabled:
             W_K = W_UK.transpose(0, 1)  # 16 512 128
             W_V = W_UV.permute(1, 2, 0)  # 16 128 512
@@ -1209,6 +1209,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             self.W_V, self.W_V_scale = dynamic_per_batched_tensor_quant(
                 W_V, dtype=current_platform.fp8_dtype()
             )
+
+            if self.dcp_q_replicate:
+                self.W_K = get_dcp_group().all_gather(
+                    self.W_K.contiguous(), dim=0
+                )
+                self.W_K_scale = get_dcp_group().all_gather(
+                    self.W_K_scale.contiguous(), dim=0
+                )
 
             # The kernel operates on non-padded inputs. Hence, pre-compiling
             # triton kernel to avoid runtime compilation for unseen batch sizes

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1214,9 +1214,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 self.W_K = get_dcp_group().all_gather(
                     self.W_K.contiguous(), dim=0
                 )
-                self.W_K_scale = get_dcp_group().all_gather(
-                    self.W_K_scale.contiguous(), dim=0
-                )
+                self.W_K_scale = _dcp_all_gather_scale(self.W_K_scale, dim=0)
 
             # The kernel operates on non-padded inputs. Hence, pre-compiling
             # triton kernel to avoid runtime compilation for unseen batch sizes
@@ -1482,6 +1480,12 @@ def dynamic_per_batched_tensor_quant(
     scale = DTYPE_MAX / amax
     x_scl_sat = (x * scale).clamp(min=-DTYPE_MAX, max=DTYPE_MAX)
     return x_scl_sat.to(dtype).contiguous(), scale.float().reciprocal()
+
+
+def _dcp_all_gather_scale(scale: torch.Tensor, dim: int = 0) -> torch.Tensor:
+    if scale.dim() == 0:
+        scale = scale.reshape(1)
+    return get_dcp_group().all_gather(scale.contiguous(), dim=dim)
 
 
 @CustomOp.register(

--- a/vllm/models/kimi_k3/amd/linear.py
+++ b/vllm/models/kimi_k3/amd/linear.py
@@ -7,7 +7,7 @@ from typing import Any
 import torch
 from torch import nn
 
-from vllm.config import CacheConfig, VllmConfig
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_world_size,
@@ -22,6 +22,7 @@ from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
+    DCPGroupColumnParallelLinear,
     MergedColumnParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
@@ -67,6 +68,7 @@ from vllm.models.kimi_k3.amd.ops.attn_res import attn_res
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.ops.dcp import resolve_dcp_q_replicate
 
 logger = init_logger(__name__)
 
@@ -351,6 +353,17 @@ class KimiMLAAttention(nn.Module):
         self.use_nope = use_nope
         assert self.use_nope is True
         assert num_heads % tp_size == 0
+        # Under DCP the KV cache is sharded across the group, so decode
+        # all-gathers the query every layer. Sharding the query projection over
+        # DCP *groups* instead makes each rank materialize the group's whole
+        # head set, dropping that collective; ``MultiHeadLatentAttentionWrapper``
+        # picks the replicated path up from ``qrep_active`` and takes this
+        # rank's shard back via ``_local_view`` for prefill.
+        q_proj_cls = (
+            DCPGroupColumnParallelLinear
+            if resolve_dcp_q_replicate(get_current_vllm_config().parallel_config)
+            else ColumnParallelLinear
+        )
         if self.q_lora_rank is not None:
             self.fused_qkv_a_proj = MergedColumnParallelLinear(
                 self.hidden_size,
@@ -373,7 +386,7 @@ class KimiMLAAttention(nn.Module):
                 self.q_lora_rank,
                 eps=config.rms_norm_eps,
             )
-            self.q_b_proj = ColumnParallelLinear(
+            self.q_b_proj = q_proj_cls(
                 self.q_lora_rank,
                 self.num_heads * self.qk_head_dim,
                 bias=False,
@@ -381,7 +394,7 @@ class KimiMLAAttention(nn.Module):
                 prefix=f"{prefix}.q_b_proj",
             )
         else:
-            self.q_proj = ColumnParallelLinear(
+            self.q_proj = q_proj_cls(
                 self.hidden_size,
                 self.num_heads * self.qk_head_dim,
                 bias=False,

--- a/vllm/v1/attention/ops/dcp.py
+++ b/vllm/v1/attention/ops/dcp.py
@@ -28,7 +28,38 @@ logger = init_logger(__name__)
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
 
+    from vllm.config.parallel import ParallelConfig
     from vllm.distributed.parallel_state import GroupCoordinator
+
+
+def resolve_dcp_q_replicate(parallel_config: ParallelConfig) -> bool:
+    """Whether MLA decode should replicate the Q projection within a DCP group.
+
+    Replicating lets every rank materialize the group's full head set, so decode
+    can skip the per-layer query all-gather at the cost of computing the (small)
+    projection redundantly. ``VLLM_DCP_Q_REPLICATE`` overrides the model default
+    in ``ParallelConfig.dcp_q_replicate`` when it is set explicitly.
+
+    DCP must be active, and PCP must be disabled. The PCP condition is
+    load-bearing rather than conservative: ``DCPGroupColumnParallelLinear``
+    identifies a rank's slot in its DCP group as ``tp_rank % dcp_size``, which
+    only agrees with the real group layout while DCP groups are contiguous runs
+    of TP ranks. With PCP > 1 ``initialize_model_parallel`` builds them across
+    the PCP axis first (``all_ranks.transpose(-1, -2)``), so the groups become
+    strided and the replicated head order stops lining up with ``_local_view``
+    and the gathered ``W_UK_T``.
+    """
+    # The env var predates the config field and still wins if set explicitly.
+    requested = (
+        envs.VLLM_DCP_Q_REPLICATE
+        if envs.is_set("VLLM_DCP_Q_REPLICATE")
+        else bool(parallel_config.dcp_q_replicate)
+    )
+    return (
+        requested
+        and parallel_config.decode_context_parallel_size > 1
+        and parallel_config.prefill_context_parallel_size <= 1
+    )
 
 
 # LSE/output combine


### PR DESCRIPTION
## Purpose

With decode context parallelism (DCP), Kimi-K3 MLA decode normally all-gathers the query once per layer because the KV cache is sharded across the DCP group. Query replication changes that tradeoff: each DCP rank materializes the group's full query head set locally, so decode can skip the per-layer query all-gather and only combine the local-shard attention results.

This is useful for the Kimi-K3 ROCm path because the model already uses the shared MLA wrapper and the DCP output/LSE merge logic. The missing pieces were enabling the Kimi-K3 query projection to opt into the replicated layout, and teaching the AITER FP4/FP8 MLA BMM paths to use the replicated query representation instead of rejecting it.

## Changes

- Adds a shared resolver for `dcp_q_replicate`, so the enablement rule is centralized.
- Enables the Kimi-K3 ROCm query projection to use the DCP-group replicated projection when qrep is active.
- Keeps qrep disabled for PCP layouts, because PCP changes the rank ordering inside DCP groups and the replicated head order would no longer match the local view and gathered MLA weights.
- Enables query replication for the AITER FP4/FP8 MLA BMM decode paths by selecting the local DCP view only when the query was actually all-gathered, and otherwise using the already replicated query directly.
- Fixes the AITER FP8 path to gather scalar weight scales safely under DCP by reshaping zero-dimensional scales before the gather.

Default behavior is unchanged: qrep remains off unless enabled by model defaults or `VLLM_DCP_Q_REPLICATE`.

## Validation

- Rebased onto current `main`.
- `git diff --check` passes.
- Python AST parse passes for the touched modules/tests.
- Targeted regression test for FP8 qrep scalar scale gathering passes in the ROCm container environment.
- Short GSM8K, 5-shot, `lm_eval`, concurrency 64, no draft: `exact_match = 1.0` on 50 samples.
- Full GSM8K, 5-shot, `lm_eval`, concurrency 64, no draft: flexible-extract `exact_match = 0.9636 +/- 0.0052`, strict-match `exact_match = 0.9629 +/- 0.0052` on 1319 samples.

## Notes

- The full GSM8K run used qrep enabled with the AITER FP8 MLA BMM path enabled.
- 4K/4K serving perf is still being rerun separately and is intentionally not reported here yet.
