### PR TITLE
[Bugfix][Kimi-K3] Fix two crashes that make --use-replayssm unusable

### DIFF
--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -708,7 +708,15 @@ def test_checkpoint_metadata_on_prefill_only_step_under_recoverssm():
         builder.kv_cache_spec,
         "align",
     )
-    actual = builder.build(0, common_attn_metadata)
+    # The -1 fill is what the runner passes on a prefill-only step, and it is
+    # what makes the mask all-False rather than absent. Omitting the kwarg
+    # takes the `num_decode_draft_tokens_cpu is None` branch, which sets the
+    # mask to None and never reaches the guard under test.
+    actual = builder.build(
+        0,
+        common_attn_metadata,
+        num_decode_draft_tokens_cpu=torch.full((2,), -1, dtype=torch.int32),
+    )
 
     # Same expectation as the non-RecoverSSM case: every row is its own
     # checkpoint row, because non_spec_query_start_loc is the full

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -655,27 +655,6 @@ def test_aligned_block_table_matches_shared_gdn():
     torch.testing.assert_close(actual, expected)
 
 
-def test_gdn_builder_stores_base_fields():
-    """The GDN builder must expose what AttentionMetadataBuilder.__init__ stores.
-
-    _get_recoverssm_context reads self.layer_names, and it is the only reader,
-    so a builder that drops the field raises AttributeError at the first
-    cudagraph capture and nowhere else. self.device has no reader today and
-    would have gone the same way.
-    """
-    builder = _make_builder(
-        KimiK3KDAMetadataBuilder,
-        num_speculative_tokens=1,
-        full_cuda_graph=False,
-        mamba_cache_mode="align",
-        use_recoverssm=True,
-    )
-    assert builder.layer_names == ["layer.0"]
-    assert builder.device == DEVICE
-    assert builder.kv_cache_spec is not None
-    assert builder.vllm_config is not None
-
-
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_checkpoint_metadata_on_prefill_only_step_under_recoverssm():
     """A prefill-only step under RecoverSSM must build checkpoint metadata.

--- a/tests/models/kimi_k3/test_kda_metadata.py
+++ b/tests/models/kimi_k3/test_kda_metadata.py
@@ -653,3 +653,72 @@ def test_aligned_block_table_matches_shared_gdn():
     )
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_gdn_builder_stores_base_fields():
+    """The GDN builder must expose what AttentionMetadataBuilder.__init__ stores.
+
+    _get_recoverssm_context reads self.layer_names, and it is the only reader,
+    so a builder that drops the field raises AttributeError at the first
+    cudagraph capture and nowhere else. self.device has no reader today and
+    would have gone the same way.
+    """
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=1,
+        full_cuda_graph=False,
+        mamba_cache_mode="align",
+        use_recoverssm=True,
+    )
+    assert builder.layer_names == ["layer.0"]
+    assert builder.device == DEVICE
+    assert builder.kv_cache_spec is not None
+    assert builder.vllm_config is not None
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_checkpoint_metadata_on_prefill_only_step_under_recoverssm():
+    """A prefill-only step under RecoverSSM must build checkpoint metadata.
+
+    num_decode_draft_tokens is filled with -1 and only written on spec-decode
+    rows, so a prefill-only step leaves the >= 0 mask all False: non-None with
+    num_spec_decodes == 0. Without RecoverSSM the classification clears such a
+    mask to None, but that clearing carries `not self.use_recoverssm`, so here
+    the mask survives and any reader guarding on `masks is not None` instead of
+    `num_spec_decodes > 0` reads an unbound local.
+    """
+    device = torch.device("cuda")
+    batch = BatchSpec(seq_lens=[50, 32], query_lens=[50, 16])
+    common_attn_metadata = create_common_attn_metadata(
+        batch, BLOCK_SIZE, device, arange_block_indices=True
+    ).replace(is_prefilling=torch.tensor([True, True]))
+    builder = _make_builder(
+        KimiK3KDAMetadataBuilder,
+        num_speculative_tokens=1,
+        full_cuda_graph=False,
+        mamba_cache_mode="align",
+        num_prefill_checkpoint_blocks=1,
+        use_recoverssm=True,
+        device=device,
+    )
+    assert isinstance(builder, KimiK3KDAMetadataBuilder)
+    builder.mamba_aligned_state_indices = mamba_get_block_table_tensor(
+        common_attn_metadata.block_table_tensor,
+        common_attn_metadata.seq_lens,
+        builder.kv_cache_spec,
+        "align",
+    )
+    actual = builder.build(0, common_attn_metadata)
+
+    # Same expectation as the non-RecoverSSM case: every row is its own
+    # checkpoint row, because non_spec_query_start_loc is the full
+    # query_start_loc when num_spec_decodes == 0.
+    assert actual.checkpoint is not None
+    torch.testing.assert_close(
+        actual.checkpoint.state_indices,
+        torch.tensor([2, NULL_BLOCK_ID], dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(
+        actual.checkpoint.checkpoint_offsets,
+        torch.tensor([48, 0], dtype=torch.int32, device=device),
+    )

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -221,3 +221,18 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
     assert meta.spec_query_start_loc.shape == (batch.batch_size + 1,)
     assert meta.num_accepted_tokens is not None
     assert meta.num_accepted_tokens.shape == (batch.batch_size,)
+
+
+def test_builder_stores_base_fields():
+    """The builder must expose what AttentionMetadataBuilder.__init__ stores.
+
+    It assigns its own fields rather than calling super(), so a field can be
+    dropped silently. layer_names has exactly one reader --
+    KimiK3KDAMetadataBuilder._get_recoverssm_context -- and device has none, so
+    neither absence shows up until something reaches for it.
+    """
+    builder = _create_gdn_builder()
+    assert builder.layer_names == ["layer.0"]
+    assert builder.device == DEVICE
+    assert builder.kv_cache_spec is not None
+    assert builder.vllm_config is not None

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -226,10 +226,10 @@ def test_full_cudagraph_spec_metadata_uses_request_count():
 def test_builder_stores_base_fields():
     """The builder must expose what AttentionMetadataBuilder.__init__ stores.
 
-    It assigns its own fields rather than calling super(), so a field can be
-    dropped silently. layer_names has exactly one reader --
+    It used to assign its own fields instead of calling super(), which silently
+    dropped layer_names and device. layer_names has exactly one reader --
     KimiK3KDAMetadataBuilder._get_recoverssm_context -- and device has none, so
-    neither absence shows up until something reaches for it.
+    neither absence showed up until something reached for it.
     """
     builder = _create_gdn_builder()
     assert builder.layer_names == ["layer.0"]

--- a/vllm/models/kimi_k3/nvidia/kda_metadata.py
+++ b/vllm/models/kimi_k3/nvidia/kda_metadata.py
@@ -588,7 +588,7 @@ class KimiK3KDAMetadataBuilder(GDNAttentionMetadataBuilder):
             # prepare checkpoint metadata
             assert m.seq_lens_cpu_upper_bound is not None
             request_rows = list(range(m.num_reqs))
-            if spec_sequence_masks_cpu is not None:
+            if num_spec_decodes > 0:
                 # get non spec request rows
                 request_rows = active_non_spec_mask_cpu.nonzero().flatten().tolist()
             all_query_lens = query_start_loc_cpu.diff().tolist()

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -96,6 +96,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self.compilation_config = vllm_config.compilation_config
         self.speculative_config = vllm_config.speculative_config
         self.kv_cache_spec = kv_cache_spec
+        self.layer_names = layer_names
         from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
             _resolve_gdn_prefill_backend,
         )

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -92,11 +92,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         vllm_config: VllmConfig,
         device: torch.device,
     ):
-        self.vllm_config = vllm_config
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
         self.compilation_config = vllm_config.compilation_config
         self.speculative_config = vllm_config.speculative_config
-        self.kv_cache_spec = kv_cache_spec
-        self.layer_names = layer_names
         from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
             _resolve_gdn_prefill_backend,
         )


### PR DESCRIPTION
### Purpose

`--use-replayssm` selects the RecoverSSM path on Kimi-K3. It cannot start: it
raises during cudagraph capture, and after that is fixed it raises again on the
first `execute_model`.

**1. `GDNAttentionMetadataBuilder` never calls its base `__init__`.**

```
AttributeError: 'KimiK3KDAMetadataBuilder' object has no attribute 'layer_names'
  kda_metadata.py, in _get_recoverssm_context
    layers = [forward_context[layer_name] for layer_name in self.layer_names]
```

`AttentionMetadataBuilder.__init__` stores `kv_cache_spec`, `layer_names`,
`vllm_config` and `device`. This builder calls none of it and assigns four
fields by hand, leaving out `layer_names` and `device`. `layer_names` has one
reader, `_get_recoverssm_context`; `device` has none yet. Calling `super()`
restores both and matches `flash_attn`, `mamba_attn` and `triton_attn`.

**2. The checkpoint block's guard does not match the one that binds its
variable.**

```
UnboundLocalError: cannot access local variable 'active_non_spec_mask_cpu'
  kda_metadata.py, in build
    request_rows = active_non_spec_mask_cpu.nonzero().flatten().tolist()
```

`active_non_spec_mask_cpu` is bound only under `num_spec_decodes > 0`, which is
what the sibling `has_initial_state` use guards on. The checkpoint block guards
on `spec_sequence_masks_cpu is not None`.

The reachable case is an all-False mask, not a zero draft sum.
`num_decode_draft_tokens` is filled with `-1` and written only on spec-decode
rows, so on a prefill-only step `num_decode_draft_tokens_cpu >= 0` is entirely
False. Without RecoverSSM the classification clears that mask to `None`; the
clearing carries `not self.use_recoverssm`, so under RecoverSSM a non-None
all-False mask survives with `num_spec_decodes == 0`. This is therefore every
prefill step under `align` with checkpoint blocks, not a rare corner, which is
why it fires on the first `execute_model`.

The root cause is a dropped normalization clause. This file states it
"intentionally mirror[s] GDNAttentionMetadataBuilder", and the shared builder
keeps `spec_sequence_masks_cpu is not None` equivalent to `num_spec_decodes > 0`
at the source:

```python
# vllm/v1/attention/backends/gdn_attn.py
spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
num_spec_decodes = spec_sequence_masks_cpu.sum().item()
if (
    num_spec_decodes == 0
    or num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item()
    == 0
):
    num_spec_decodes = 0
    spec_sequence_masks = None
    spec_sequence_masks_cpu = None
```

That invariant is why guarding on the mask is safe there. The Kimi copy dropped
the `num_spec_decodes == 0` disjunct and moved the count into the `else`, and
adding `not self.use_recoverssm` then made the gap reachable. Restoring the
clause is the other possible fix; it is left as a follow-up because it would
make the mask `None` again and so stop the regression test below from
distinguishing the two guards.

`num_spec_decodes > 0` is also the correct guard, not just the bound one:
`checkpoint_offsets` is consumed by `_store_cache_checkpoints_kernel` on a grid
of its own `numel()`, with `seq_idx` indexing `non_spec_query_start_loc`. At
`num_spec_decodes == 0` that tensor is the full `query_start_loc`, so
`request_rows` must be every row — the fallback value. Masking there would have
shortened `request_rows` against a full-length start-loc array.

### Not a duplicate

`active_non_spec_mask_cpu` returns no results in this repo's issues or PRs. The
`RecoverSSM` hits are #51855 (closed, added this path), #52506 and #54255
(FlashInfer backends), #54103 (ROCm). None touches either line.

### Test

Two regression tests added. The existing RecoverSSM tests set
`builder.recoverssm_context = Mock()`, so `_get_recoverssm_context` returns
early and the `layer_names` read never executes -- which is why CI is green on
a path that cannot start.

Kimi-K3-MXFP4, 16×GB300, aggregated, TP16 × DCP8 × PP1, DSpark
`num_speculative_tokens=4`, `mamba_cache_mode=align`, `mamba-backend=triton`,
`VLLM_USE_V2_MODEL_RUNNER=1`, 3600 s per point. Three arms one flag apart.

| | base | +triton | +`--use-replayssm` |
|---|---|---|---|
| c64, tok/s/GPU | 3,760.3 | 3,816.9 | **3,940.8** |
| c64, ITL p90 ms | 166.94 | 170.48 | **165.28** |
| c128, tok/s/GPU | 2,749.9 | 2,706.1 | **2,828.5** |
| c128, ITL p90 ms | 205.23 | 204.00 | **192.51** |

+3.2% at c64 and +4.5% at c128 over the triton control, in ITL.

### Limitations

- The throughput arms use synthetic acceptance with `ignore_eos`, so a stale
  recurrent state would not show in them. GSM8K with
  `rejection_sample_method=standard`, 1319 questions, 5 shots, same config one
  flag apart: **0.9530 off / 0.9545 on**, invalid 0.08% / 0.15%. Two questions
  on 1319, and in the wrong direction for a staleness bug.
- Kimi-K3 / NVIDIA KDA only. Fix 1 is in shared GDN code; the AMD KDA builder
  has no RecoverSSM or checkpoint path and does not read either field, so it is
  unaffected.
- Single configuration, no repeats, so no error bars.

### AI assistance

Written with Claude Code. Both crashes were reproduced on hardware and the
tracebacks are verbatim.
