### PR TITLE
[Bugfix][Reasoning] Bound-check the Hunyuan A13B side sequence

### DIFF
--- a/tests/reasoning/test_hunyuan_a13b_reasoning_parser.py
+++ b/tests/reasoning/test_hunyuan_a13b_reasoning_parser.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.reasoning.hunyuan_a13b_reasoning_parser import HunyuanA13BReasoningParser
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+# The parser matches hard-coded token id sequences, so the ids below are the ones it
+# looks for rather than anything a tokenizer produces. `extract_reasoning_streaming`
+# never touches the tokenizer.
+THINK_START_IDS = [14023, 771, 397]  # "<think>\n"
+RESPONSE_START_IDS = [198, 524, 27963, 397, 27, 9399, 397]  # "\n</think>\n<answer>\n"
+ORDINARY_TOKEN = 5000
+
+
+class StubTokenizer:
+    def get_vocab(self) -> dict[str, int]:
+        return {}
+
+
+def _feed(parser: HunyuanA13BReasoningParser, token_ids: list[int]) -> list:
+    """Stream one token at a time, which is what the parser asserts it receives."""
+    messages = []
+    previous_ids: list[int] = []
+    previous_text = ""
+    for token_id in token_ids:
+        delta_text = f"<{token_id}>"
+        current_ids = previous_ids + [token_id]
+        messages.append(
+            parser.extract_reasoning_streaming(
+                previous_text,
+                previous_text + delta_text,
+                delta_text,
+                previous_ids,
+                current_ids,
+                [token_id],
+            )
+        )
+        previous_ids = current_ids
+        previous_text += delta_text
+    return messages
+
+
+def test_streaming_reaches_the_response_state():
+    parser = HunyuanA13BReasoningParser(StubTokenizer())
+    _feed(parser, THINK_START_IDS + [ORDINARY_TOKEN] + RESPONSE_START_IDS)
+    assert parser.current_state == "response"
+
+
+@pytest.mark.parametrize("matched", range(1, len(RESPONSE_START_IDS)))
+def test_partial_response_start_falls_back_to_reasoning(matched: int):
+    """A prefix of the response-start sequence followed by ordinary text is not a
+    transition, so the buffered tokens have to come back as reasoning.
+
+    `expected_sequence_side` is `response_start_ids_fast`, one token shorter than
+    `response_start_ids`, and it used to be indexed without a length check. Diverging
+    after six of the seven tokens therefore raised `IndexError` instead of taking this
+    fallback, while every earlier divergence took it.
+    """
+    parser = HunyuanA13BReasoningParser(StubTokenizer())
+    prefix = RESPONSE_START_IDS[:matched] + [ORDINARY_TOKEN]
+    token_ids = THINK_START_IDS + [ORDINARY_TOKEN] + prefix
+    messages = [message for message in _feed(parser, token_ids) if message is not None]
+
+    assert parser.current_state == "think"
+    buffered = messages[-1]
+    assert buffered.content is None
+    assert buffered.reasoning == "".join(f"<{tid}>" for tid in prefix)

--- a/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
+++ b/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
@@ -151,9 +151,13 @@ class HunyuanA13BReasoningParser(ReasoningParser):
 
         def check_token_with_sequence(token):
             if self.current_state == "idle" or self.current_state == "think":
-                return (
-                    token == self.expected_sequence[self.sequence_index]
-                    or token == self.expected_sequence_side[self.sequence_index]
+                return token == self.expected_sequence[self.sequence_index] or (
+                    # The side sequence can be shorter than the main one
+                    # (response_start_ids_fast is six tokens against seven),
+                    # so length-check before indexing it, as check_last_token
+                    # below already does.
+                    self.sequence_index < len(self.expected_sequence_side)
+                    and token == self.expected_sequence_side[self.sequence_index]
                 )
             else:
                 return token == self.expected_sequence[self.sequence_index]


### PR DESCRIPTION
## Purpose

`HunyuanA13BReasoningParser.extract_reasoning_streaming` raises `IndexError` on one specific partial match of the response-start sequence, instead of taking the fallback that every other partial match takes.

`check_token_with_sequence` reads both expected sequences at the same index:

```python
def check_token_with_sequence(token):
    if self.current_state == "idle" or self.current_state == "think":
        return (
            token == self.expected_sequence[self.sequence_index]
            or token == self.expected_sequence_side[self.sequence_index]
        )
```

In the `think` state those are `response_start_ids` (7 tokens, `\n</think>\n<answer>\n`) and `response_start_ids_fast` (6 tokens). Python evaluates `or` left to right, so the side read happens only when the main one misses, which is exactly the case that matters: once six tokens have matched and `sequence_index` is 6, a token that is not the seventh indexes a six-long list at 6.

Measured by driving the state machine one token at a time, diverging after each prefix length of the response-start sequence:

| tokens matched before diverging | before | after |
| --- | --- | --- |
| 1 | falls back, emits buffered reasoning | same |
| 2 | falls back | same |
| 3 | falls back | same |
| 4 | falls back | same |
| 5 | falls back | same |
| **6** | **`IndexError: list index out of range`** | falls back |
| full well-formed stream (control) | reaches `response` state | same |

So it is the one divergence point out of six that crashes, and the crash is in the branch whose whole job is to recover from a sequence that started to match and then did not.

## Fix

`check_last_token`, in the same method, already guards the side sequence with `self.sequence_index - 1 < len(self.expected_sequence_side)`. Apply the same check before the side read. The guard only fires where the index was previously out of range, so no path that works today changes; after the fix the six-token case emits exactly the buffered text the five-token case does.

## Test

`tests/reasoning/test_hunyuan_a13b_reasoning_parser.py` is new; this parser had no test file. Two tests: a well-formed stream reaching the `response` state, and one parametrized over every divergence point in the response-start sequence asserting the buffered tokens come back as reasoning content.

## How this was validated

vLLM cannot be built or imported on the machine this was written on, so the state machine was checked by extracting `extract_reasoning_streaming` with `ast` and driving it against a stub `self` holding the same literal id lists `__init__` sets. That harness produced the table above, and reproduces the `IndexError` on the unpatched source and its absence on the patched one. The test file itself is therefore reasoned rather than executed locally, and CI is the first place it runs. Flagging that explicitly rather than implying otherwise.

`ruff check` and `ruff format --check` are clean on both files (the parser file was clean before and is clean after).

AI assistance was used in preparing this change.

Draft because this account cannot open a non-draft pull request here.