### PR TITLE
[Perf] Add fused-MoE tuned configs for NVIDIA H20 (Hy3 E=192, N=192/384, fp8_w8a8, up to 1.93x)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=192,N=192,device_name=NVIDIA_H20,dtype=fp8_w8a8.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=192,N=192,device_name=NVIDIA_H20,dtype=fp8_w8a8.json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.7.1",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/vllm/model_executor/layers/fused_moe/configs/E=192,N=384,device_name=NVIDIA_H20,dtype=fp8_w8a8.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=192,N=384,device_name=NVIDIA_H20,dtype=fp8_w8a8.json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.7.1",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
## Purpose

Add fused-MoE tuned configs for **NVIDIA H20** covering the Hy3 MoE family shapes: **E=192** routed experts (top-8, hidden 4096, moe intermediate 1536). There are currently **no tuned configs for E=192 on any device** in the tree, so all deployments of this family on the Triton fused-MoE path fall back to the default heuristic config ("Using default MoE config, performance might be sub-optimal").

Two shapes are added, `dtype=fp8_w8a8` (per-tensor):

- `E=192,N=192` — TP8 (the reference 8xH20 deployment)
- `E=192,N=384` — TP4

Note on quantization: the public `tencent/Hy3-FP8` checkpoint uses per-tensor FP8 (`quant_method: "fp8"`, `activation_scheme: "static"`, no `weight_block_size` in `quantization_config`), so these configs carry no `block_shape` suffix — same convention as the existing Mixtral FP8 config files.

## Test Plan

- Hardware: single NVIDIA H20 (96 GB, driver 535.161.08). GPU UUIDs logged for every run; each tuned-vs-default comparison ran inside one job on one GPU.
- Software: official `vllm 0.28.0+cu129` wheel, `benchmarks/kernels/benchmark_moe.py` from the `v0.28.0` tag (2cf0a691), torch 2.13.0+cu129, triton 3.7.1.
- Tune each shape with `--tune`, then validate tuned-vs-default with `VLLM_TUNED_CONFIG_FOLDER`, 2 repeats per batch size across the standard 18-batch list.

## Test Result

### E=192, N=192 (TP8) — geomean **1.245x**, no regressions

| batch | default (us) | tuned (us) | speedup |
|---|---|---|---|
| 1 | 27.77 | 26.91 | 1.032x |
| 2 | 35.84 | 35.81 | 1.001x |
| 4 | 52.05 | 50.41 | 1.033x |
| 8 | 80.31 | 74.72 | 1.075x |
| 16 | 122.94 | 106.25 | 1.157x |
| 24 | 149.96 | 128.50 | 1.167x |
| 32 | 173.50 | 142.42 | 1.218x |
| 48 | 194.57 | 169.39 | 1.149x |
| 64 | 210.41 | 178.38 | 1.180x |
| 96 | 237.59 | 188.40 | 1.261x |
| 128 | 305.22 | 196.27 | 1.555x |
| 256 | 312.35 | 221.94 | 1.407x |
| 512 | 327.40 | 245.81 | 1.332x |
| 1024 | 634.22 | 329.31 | 1.926x |
| 1536 | 666.99 | 474.49 | 1.406x |
| 2048 | 708.27 | 591.55 | 1.197x |
| 3072 | 1005.44 | 793.84 | 1.267x |
| 4096 | 1337.84 | 994.77 | 1.345x |

### E=192, N=384 (TP4) — geomean **1.173x**, no regressions

| batch | default (us) | tuned (us) | speedup |
|---|---|---|---|
| 1 | 32.09 | 32.09 | 1.000x |
| 2 | 45.38 | 45.30 | 1.002x |
| 4 | 67.08 | 66.03 | 1.016x |
| 8 | 107.93 | 105.52 | 1.023x |
| 16 | 166.06 | 159.41 | 1.042x |
| 24 | 209.30 | 199.26 | 1.050x |
| 32 | 240.12 | 224.45 | 1.070x |
| 48 | 300.58 | 273.60 | 1.099x |
| 64 | 316.91 | 283.33 | 1.119x |
| 96 | 337.66 | 309.45 | 1.091x |
| 128 | 461.90 | 316.66 | 1.459x |
| 256 | 476.80 | 324.51 | 1.469x |
| 512 | 514.28 | 368.25 | 1.397x |
| 1024 | 965.04 | 559.50 | 1.725x |
| 1536 | 997.80 | 760.12 | 1.313x |
| 2048 | 1037.16 | 990.61 | 1.047x |
| 3072 | 1515.60 | 1280.98 | 1.183x |
| 4096 | 2042.41 | 1586.67 | 1.287x |

The gains concentrate in the mid-to-large batch range because with 192 experts and top-8, tokens per expert stay small even at large M (batch 512 -> ~21 tokens/expert): the tuned tables keep `BLOCK_SIZE_M=16` up to batch 512 where the default heuristic has already switched to a 64-tile (and a 128-tile at batch 1024), leaving most of each tile empty.

Raw tuning sweeps, A/B CSVs, and full environment captures (wheel/source/model-config SHA-256) are archived and can be posted on request.