### PR TITLE
[Perf][Sampler] Route small pure top-p batches to the PyTorch path

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -357,7 +357,9 @@ def apply_top_k_top_p(
             return apply_top_k_top_p_triton(logits, k, p)
         return apply_top_k_top_p_pytorch(logits, k, p, allow_cpu_sync=True)
 
-    if HAS_TRITON and logits.shape[0] >= 8:
+    # Triton performs poorly for pure top-p (no top-k) batches below ~40
+    # rows: it uses 1 program per row and serially sweeps the full vocab.
+    if HAS_TRITON and (k is not None or logits.shape[0] >= 40):
         return apply_top_k_top_p_triton(logits, k, p)
 
     # Use pytorch sort implementation for small batch sizes.


### PR DESCRIPTION
## Purpose

The Triton top-k/top-p kernel uses one program per row and serially sweeps the full vocab for rows that apply top-p without top-k truncation, so it pays a large vocab-proportional fixed cost on pure top-p batches. The PyTorch sort is faster below ~40 rows (measured on GB300, vocab 160k: PyTorch wins 1.1-1.7x at 8-32 rows, Triton wins from 40 rows).

k is None iff no request in the batch uses top-k, so pure top-p batches are detectable from the arguments alone. Batches with top-k now also take the Triton path below 8 rows, where it wins (1.1-1.6x).

## Microbenchmarks

<details>
<summary>Benchmark script</summary>

```python
# SPDX-License-Identifier: Apache-2.0
"""Sweep Triton vs PyTorch top-k/top-p masking on GB200 (SM100).

Re-evaluates the batch>=8 gate in
vllm/v1/sample/ops/topk_topp_sampler.py::apply_top_k_top_p using
origin/main (32ad1400d7).

Both implementations mask logits in place, so logits are restored from a
pristine copy between iterations OUTSIDE the timed region; only the
apply call is timed (CUDA events, median).
"""

import argparse
import itertools
import statistics

import torch

from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_pytorch
from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton

VOCAB = 160000
K_VAL = 64
P_VAL = 0.9


def make_inputs(batch, case, p_val=P_VAL, seed=0):
    g = torch.Generator(device="cuda").manual_seed(seed)
    src = torch.randn(batch, VOCAB, device="cuda", dtype=torch.float32, generator=g)
    k = p = None
    if case == "topk":
        k = torch.full((batch,), K_VAL, dtype=torch.int32, device="cuda")
    elif case == "topp":
        p = torch.full((batch,), p_val, dtype=torch.float32, device="cuda")
    elif case == "topk_topp":
        k = torch.full((batch,), K_VAL, dtype=torch.int32, device="cuda")
        p = torch.full((batch,), p_val, dtype=torch.float32, device="cuda")
    elif case == "topp_1off":
        # All rows at p_val except one row with top-p disabled.
        p = torch.full((batch,), p_val, dtype=torch.float32, device="cuda")
        p[0] = 1.0
    elif case == "topp_1on":
        # Only one row with top-p enabled, rest disabled (p == 1.0).
        p = torch.ones((batch,), dtype=torch.float32, device="cuda")
        p[0] = p_val
    elif case == "mixed":
        # Per-row cycle: k-only, p-only, both, neither. Disabled rows use
        # the production encodings k == vocab_size and p == 1.0.
        ks = [K_VAL, VOCAB, K_VAL, VOCAB]
        ps = [1.0, p_val, p_val, 1.0]
        k = torch.tensor(
            [ks[i % 4] for i in range(batch)], dtype=torch.int32, device="cuda"
        )
        p = torch.tensor(
            [ps[i % 4] for i in range(batch)], dtype=torch.float32, device="cuda"
        )
    else:
        raise ValueError(case)
    return src, k, p


def run_once(fn, src, k, p, work):
    work.copy_(src)
    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)
    start.record()
    fn(work, k, p)
    end.record()
    end.synchronize()
    return start.elapsed_time(end) * 1000.0  # us


def bench(fn, src, k, p, work, iters, warmup):
    for _ in range(warmup):
        run_once(fn, src, k, p, work)
    times = [run_once(fn, src, k, p, work) for _ in range(iters)]
    return statistics.median(times), min(times), max(times)


def main():
    ap = argparse.ArgumentParser()
    ap.add_argument(
        "--batches", type=int, nargs="+", default=[1, 2, 4, 8, 16, 32, 64, 128, 1024]
    )
    ap.add_argument(
        "--cases", nargs="+", default=["topk", "topp", "topk_topp", "mixed"]
    )
    ap.add_argument("--pvals", type=float, nargs="+", default=[P_VAL])
    ap.add_argument("--iters", type=int, default=None)
    ap.add_argument("--warmup", type=int, default=None)
    args = ap.parse_args()

    import subprocess

    sha = subprocess.check_output(
        ["git", "rev-parse", "--short", "HEAD"], text=True
    ).strip()
    props = torch.cuda.get_device_properties(0)
    print(f"# commit: {sha}")
    print(
        f"# device: {props.name} sm{props.major}{props.minor} "
        f"SMs={props.multi_processor_count}"
    )
    print(f"# torch {torch.__version__}, vocab={VOCAB}, k={K_VAL}, p={P_VAL}")
    print(f"# times are CUDA-event medians, microseconds")

    impls = [
        ("triton", apply_top_k_top_p_triton),
        ("pytorch", apply_top_k_top_p_pytorch),
    ]
    header = [
        "case",
        "p",
        "batch",
        "triton_us",
        "pytorch_us",
        "speedup",
        "tri_minmax",
        "pyt_minmax",
        "mask_match",
    ]
    # print("\t".join(header))
    data = []

    for case, p_val, batch in itertools.product(args.cases, args.pvals, args.batches):
        src, k, p = make_inputs(batch, case, p_val)
        work = torch.empty_like(src)
        big = batch >= 256
        iters = args.iters or (30 if big else 500)
        warmup = args.warmup or (10 if big else 50)
        res, mm, outs = {}, {}, {}
        # Alternate impl order per case to share clock/thermal state.
        order = impls if (batch.bit_count() % 2 == 0) else impls[::-1]
        for name, fn in order:
            res[name], lo, hi = bench(fn, src, k, p, work, iters, warmup)
            mm[name] = (round(lo), round(hi))
            outs[name] = work.clone()
        match = bool(torch.equal(outs["triton"].isfinite(), outs["pytorch"].isfinite()))
        sp = res["pytorch"] / res["triton"]
        print(f"{case}\t{p_val}\t{batch}")
        data.append(
            [
                case,
                p_val,
                batch,
                res["triton"],
                res["pytorch"],
                sp,
                mm["triton"],
                mm["pytorch"],
                match,
            ]
        )
        del src, work, outs
        torch.cuda.empty_cache()

    import pandas as pd

    df = pd.DataFrame(data, columns=header)
    print(df.to_markdown(index=False))


if __name__ == "__main__":
    main()
```

</details>

Results (**bold** cases where Triton loses to Torch)

| case      |   p |   batch |   triton_us |   pytorch_us |   speedup | tri_minmax   | pyt_minmax     | mask_match   |
|:----------|----:|--------:|------------:|-------------:|----------:|:-------------|:---------------|:-------------|
| topk      | 0.9 |       1 |     133.248 |      160.992 |  1.20821  | (129, 168)   | (138, 276)     | True         |
| topk      | 0.9 |       2 |     138.064 |      171.936 |  1.24534  | (133, 345)   | (150, 209)     | True         |
| topk      | 0.9 |       4 |     136.656 |      173.872 |  1.27233  | (133, 157)   | (154, 214)     | True         |
| topk      | 0.9 |       8 |     138.864 |      178.96  |  1.28874  | (134, 173)   | (173, 485)     | True         |
| topk      | 0.9 |      16 |     140.8   |      270.528 |  1.92136  | (136, 170)   | (265, 3238)    | True         |
| topk      | 0.9 |      32 |     141.184 |      427.552 |  3.02833  | (136, 192)   | (421, 504)     | True         |
| topk      | 0.9 |      64 |     147.488 |      745.568 |  5.05511  | (141, 168)   | (739, 767)     | True         |
| topk      | 0.9 |     128 |     153.6   |     2196.51  | 14.3002   | (148, 204)   | (2188, 2221)   | True         |
| topk      | 0.9 |    1024 |    1018.56  |    10028.7   |  9.84599  | (1014, 1022) | (10023, 10038) | True         |
| topp      | 0.9 |       1 |     669.936 |      173.344 |  **0.258747** | (661, 708)   | (152, 236)     | False        |
| topp      | 0.9 |       2 |     711.232 |      357.44  |  **0.502565** | (700, 752)   | (352, 383)     | False        |
| topp      | 0.9 |       4 |     709.472 |      371.168 |  **0.523161** | (698, 795)   | (365, 393)     | False        |
| topp      | 0.9 |       8 |     709.456 |      407.168 |  **0.573916** | (700, 748)   | (401, 426)     | False        |
| topp      | 0.9 |      16 |     711.456 |      496.992 |  **0.698556** | (701, 800)   | (490, 558)     | False        |
| topp      | 0.9 |      32 |     712.512 |      667.728 |  **0.937146** | (702, 861)   | (661, 709)     | False        |
| topp      | 0.9 |      64 |     711.648 |      987.184 |  1.38718  | (698, 736)   | (980, 1003)    | False        |
| topp      | 0.9 |     128 |     768     |     2518.02  |  3.27867  | (753, 806)   | (2510, 2545)   | False        |
| topp      | 0.9 |    1024 |    5207.74  |    11296.4   |  2.16916  | (5203, 5221) | (11274, 11309) | False        |
| topk_topp | 0.9 |       1 |     157.568 |      249.168 |  1.58134  | (149, 177)   | (227, 326)     | True         |
| topk_topp | 0.9 |       2 |     162.4   |      427.328 |  2.63133  | (156, 218)   | (413, 497)     | True         |
| topk_topp | 0.9 |       4 |     159.312 |      429.312 |  2.69479  | (154, 204)   | (410, 464)     | True         |
| topk_topp | 0.9 |       8 |     160.32  |      446.24  |  2.78343  | (154, 194)   | (440, 470)     | True         |
| topk_topp | 0.9 |      16 |     161.696 |      540.448 |  3.34237  | (155, 177)   | (534, 584)     | True         |
| topk_topp | 0.9 |      32 |     162.64  |      708.992 |  4.35927  | (155, 198)   | (702, 724)     | True         |
| topk_topp | 0.9 |      64 |     165.52  |     1041.97  |  6.29512  | (156, 189)   | (1035, 1905)   | True         |
| topk_topp | 0.9 |     128 |     175.136 |     2607.14  | 14.8864   | (169, 199)   | (2593, 2624)   | True         |
| topk_topp | 0.9 |    1024 |    1145.54  |    11955.4   | 10.4365   | (1142, 1150) | (11946, 11970) | True         |
| mixed     | 0.9 |       1 |     142.384 |      246.832 |  1.73357  | (137, 165)   | (222, 313)     | True         |
| mixed     | 0.9 |       2 |     724.416 |      426.544 |  **0.588811** | (716, 758)   | (410, 464)     | False        |
| mixed     | 0.9 |       4 |     722.624 |      426.176 |  **0.589762** | (715, 757)   | (406, 474)     | False        |
| mixed     | 0.9 |       8 |     722.4   |      444.256 |  **0.614972** | (715, 746)   | (439, 465)     | False        |
| mixed     | 0.9 |      16 |     724.272 |      539.584 |  **0.745002** | (715, 786)   | (532, 558)     | False        |
| mixed     | 0.9 |      32 |     725.312 |      707.648 |  **0.975646** | (717, 747)   | (701, 723)     | False        |
| mixed     | 0.9 |      64 |     732.288 |     1041.46  |  1.42219  | (720, 769)   | (1034, 1053)   | False        |
| mixed     | 0.9 |     128 |     726.016 |     2607.14  |  3.59102  | (714, 744)   | (2598, 2624)   | False        |
| mixed     | 0.9 |    1024 |    4858.54  |    11942.6   |  2.45806  | (4848, 4865) | (11937, 11954) | False        |

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

