### PR TITLE
[Bugfix][Kernel] Select batch-invariant matmul configs from runtime M

### DIFF
--- a/tests/v1/determinism/test_matmul_batch_invariant.py
+++ b/tests/v1/determinism/test_matmul_batch_invariant.py
@@ -21,9 +21,41 @@ from vllm.model_executor.determinism.batch_invariant_configs import (
     _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS,
     _get_tuned_matmul_arch_family,
 )
+from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+    trace_triton_kernel_specialization_args,
+)
 from vllm.platforms import current_platform
 
 DEVICE_TYPE = current_platform.device_type
+
+
+def _record_tuned_matmul_warmup(
+    monkeypatch,
+    table,
+    *,
+    stride_am=2048,
+    stride_bn=2048,
+):
+    calls = []
+
+    class RecordingKernel:
+        def warmup(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        batch_invariant_module,
+        "matmul_kernel_persistent_compiled",
+        RecordingKernel(),
+    )
+    monkeypatch.setattr(batch_invariant_module, "num_compute_units", lambda _: 1)
+    monkeypatch.setattr(config_module, "_TUNED_MATMUL_CONFIGS_FOR_DEVICE", table)
+    monkeypatch.setattr(config_module, "_TUNED_MATMUL_CONFIGS_RESOLVED", True)
+    monkeypatch.setattr(batch_invariant_module, "_WARMED_TUNED_MATMUL_CONFIGS", set())
+
+    batch_invariant_module._warmup_tuned_matmul_configs(
+        current_platform.current_device(), stride_am, 1, 1, stride_bn, False
+    )
+    return calls
 
 
 @skip_unsupported
@@ -58,7 +90,9 @@ def test_compiled_addmm_selects_tuned_config_from_runtime_m(monkeypatch):
             return launch
 
     monkeypatch.setattr(
-        batch_invariant_module, "matmul_kernel_persistent", RecordingKernel()
+        batch_invariant_module,
+        "matmul_kernel_persistent_compiled",
+        RecordingKernel(),
     )
     monkeypatch.setattr(batch_invariant_module, "num_compute_units", lambda _: 1)
     monkeypatch.setattr(
@@ -169,43 +203,48 @@ def test_compiled_matmul_runtime_m_dispatch_is_correct(monkeypatch):
         torch._dynamo.reset()
 
 
-def test_tuned_matmul_warmup_covers_all_table_shapes(monkeypatch):
-    calls = []
-
-    class RecordingKernel:
-        def warmup(self, *args, **kwargs):
-            calls.append((args, kwargs))
-
-    monkeypatch.setattr(
-        batch_invariant_module, "matmul_kernel_persistent", RecordingKernel()
+def test_compiled_kernel_does_not_change_eager_m_specialization():
+    eager_args = trace_triton_kernel_specialization_args(
+        batch_invariant_module.matmul_kernel_persistent
     )
-    monkeypatch.setattr(batch_invariant_module, "num_compute_units", lambda _: 1)
-    monkeypatch.setattr(
-        config_module,
-        "_TUNED_MATMUL_CONFIGS_FOR_DEVICE",
+    compiled_kernel = batch_invariant_module.matmul_kernel_persistent_compiled
+
+    assert "M" in eager_args
+    assert "M" not in trace_triton_kernel_specialization_args(compiled_kernel)
+
+
+def test_tuned_matmul_warmup_covers_all_table_configs(monkeypatch):
+    calls = _record_tuned_matmul_warmup(
+        monkeypatch,
         _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS["ada"],
     )
-    monkeypatch.setattr(config_module, "_TUNED_MATMUL_CONFIGS_RESOLVED", True)
-    monkeypatch.setattr(batch_invariant_module, "_WARMED_TUNED_MATMUL_CONFIGS", set())
 
-    batch_invariant_module._warmup_tuned_matmul_configs(
-        current_platform.current_device(), 2048, 1, 1, 2048, False
-    )
-
-    def contains(runtime_m, block_m, block_n, num_warps, num_stages):
-        return any(
-            args[4] == runtime_m
-            and kwargs["BLOCK_SIZE_M"] == block_m
-            and kwargs["BLOCK_SIZE_N"] == block_n
-            and kwargs["num_warps"] == num_warps
-            and kwargs["num_stages"] == num_stages
-            for args, kwargs in calls
+    expected_configs = {
+        (
+            bucket.block_m,
+            bucket.block_n,
+            shape_config.block_k,
+            8,
+            bucket.num_warps,
+            bucket.num_stages,
         )
+        for shape_config in _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS["ada"].values()
+        for _, bucket in shape_config.m_buckets
+    }
+    warmed_configs = {
+        (
+            kwargs["BLOCK_SIZE_M"],
+            kwargs["BLOCK_SIZE_N"],
+            kwargs["BLOCK_SIZE_K"],
+            kwargs["GROUP_SIZE_M"],
+            kwargs["num_warps"],
+            kwargs["num_stages"],
+        )
+        for _, kwargs in calls
+    }
 
-    assert contains(2, 16, 128, 8, 2)
-    assert contains(16, 128, 64, 8, 4)
-    assert contains(1, 16, 32, 8, 5)
-    assert contains(2, 16, 64, 4, 4)
+    assert warmed_configs == expected_configs
+    assert {args[4] for args, _ in calls} == {2}
     assert any(kwargs["C_LARGE"] for _, kwargs in calls if kwargs["BLOCK_SIZE_N"] == 64)
     assert {args[9:11] for args, _ in calls} == {(1, 16)}
     assert {kwargs["HAS_BIAS"] for _, kwargs in calls} == {False}

--- a/tests/v1/determinism/test_matmul_batch_invariant.py
+++ b/tests/v1/determinism/test_matmul_batch_invariant.py
@@ -11,7 +11,12 @@ import pytest
 import torch
 from utils import skip_unsupported
 
-from vllm.model_executor.determinism.batch_invariant import matmul_batch_invariant
+import vllm.model_executor.determinism.batch_invariant as batch_invariant_module
+import vllm.model_executor.determinism.batch_invariant_configs as config_module
+from vllm.model_executor.determinism.batch_invariant import (
+    addmm_batch_invariant,
+    matmul_batch_invariant,
+)
 from vllm.model_executor.determinism.batch_invariant_configs import (
     _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS,
     _get_tuned_matmul_arch_family,
@@ -19,6 +24,191 @@ from vllm.model_executor.determinism.batch_invariant_configs import (
 from vllm.platforms import current_platform
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@skip_unsupported
+@pytest.mark.parametrize("with_bias", [False, True], ids=["no_bias", "bias"])
+def test_batch_invariant_matmul_custom_op_schema(monkeypatch, with_bias):
+    monkeypatch.setattr(
+        batch_invariant_module, "_warmup_tuned_matmul_configs", lambda *args: None
+    )
+    a = torch.rand((8, 64), dtype=torch.bfloat16, device=DEVICE_TYPE)
+    b = torch.rand((64, 32), dtype=torch.bfloat16, device=DEVICE_TYPE)
+    bias = (
+        torch.rand((32,), dtype=torch.bfloat16, device=DEVICE_TYPE)
+        if with_bias
+        else None
+    )
+
+    torch.library.opcheck(
+        torch.ops.vllm.batch_invariant_matmul.default,
+        (a, b, bias),
+    )
+
+
+def test_compiled_addmm_selects_tuned_config_from_runtime_m(monkeypatch):
+    has_bias_values = []
+
+    class RecordingKernel:
+        def __getitem__(self, grid):
+            def launch(a, b, c, *args, **meta):
+                has_bias_values.append(meta["HAS_BIAS"])
+                c.fill_(meta["BLOCK_SIZE_M"])
+
+            return launch
+
+    monkeypatch.setattr(
+        batch_invariant_module, "matmul_kernel_persistent", RecordingKernel()
+    )
+    monkeypatch.setattr(batch_invariant_module, "num_compute_units", lambda _: 1)
+    monkeypatch.setattr(
+        config_module,
+        "_TUNED_MATMUL_CONFIGS_FOR_DEVICE",
+        _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS["ada"],
+    )
+    monkeypatch.setattr(config_module, "_TUNED_MATMUL_CONFIGS_RESOLVED", True)
+
+    compile_count = 0
+
+    def counting_backend(graph_module, example_inputs):
+        nonlocal compile_count
+        compile_count += 1
+        return graph_module.forward
+
+    compiled_addmm = torch.compile(
+        addmm_batch_invariant,
+        backend=counting_backend,
+        dynamic=True,
+        fullgraph=True,
+    )
+    b = torch.empty((2048, 4096), dtype=torch.bfloat16, device=DEVICE_TYPE)
+    bias = torch.empty((4096,), dtype=torch.bfloat16, device=DEVICE_TYPE)
+
+    small = compiled_addmm(
+        bias, torch.empty((8, 2048), dtype=torch.bfloat16, device=DEVICE_TYPE), b
+    )
+    large = compiled_addmm(
+        bias, torch.empty((2048, 2048), dtype=torch.bfloat16, device=DEVICE_TYPE), b
+    )
+
+    assert compile_count == 1
+    assert has_bias_values == [True, True]
+    assert torch.all(small == 16)
+    assert torch.all(large == 128)
+
+
+@pytest.mark.parametrize(
+    "dtype,b_shape,has_table",
+    [
+        pytest.param(torch.bfloat16, (64, 32), True, id="untuned-shape"),
+        pytest.param(torch.float16, (2048, 4096), True, id="untuned-dtype"),
+        pytest.param(torch.bfloat16, (2048, 4096), False, id="untuned-device"),
+    ],
+)
+def test_compiled_matmul_keeps_untuned_paths_in_graph(
+    monkeypatch, dtype, b_shape, has_table
+):
+    monkeypatch.setattr(
+        config_module,
+        "_TUNED_MATMUL_CONFIGS_FOR_DEVICE",
+        _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS["ada"] if has_table else None,
+    )
+    monkeypatch.setattr(config_module, "_TUNED_MATMUL_CONFIGS_RESOLVED", True)
+    graphs = []
+
+    def inspect_backend(graph_module, example_inputs):
+        graphs.append(graph_module.graph)
+        return graph_module.forward
+
+    compiled_matmul = torch.compile(
+        matmul_batch_invariant,
+        backend=inspect_backend,
+        dynamic=True,
+        fullgraph=True,
+    )
+    K, N = b_shape
+    a = torch.empty((8, K), dtype=dtype, device=DEVICE_TYPE)
+    b = torch.empty(b_shape, dtype=dtype, device=DEVICE_TYPE)
+
+    compiled_matmul(a, b)
+
+    assert len(graphs) == 1
+    assert "vllm.batch_invariant_matmul" not in str(graphs[0])
+
+
+@skip_unsupported
+def test_compiled_matmul_runtime_m_dispatch_is_correct(monkeypatch):
+    monkeypatch.setattr(
+        config_module,
+        "_TUNED_MATMUL_CONFIGS_FOR_DEVICE",
+        _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS["ada"],
+    )
+    monkeypatch.setattr(config_module, "_TUNED_MATMUL_CONFIGS_RESOLVED", True)
+    torch._dynamo.reset()
+
+    compiled_matmul = torch.compile(
+        matmul_batch_invariant,
+        dynamic=True,
+        fullgraph=True,
+    )
+    torch.manual_seed(42)
+    b = torch.rand((2048, 4096), dtype=torch.bfloat16, device=DEVICE_TYPE)
+    shared_row = torch.rand((2048,), dtype=torch.bfloat16, device=DEVICE_TYPE)
+    first_row_outputs = []
+
+    try:
+        for m in (8, 256):
+            a = torch.rand((m, 2048), dtype=torch.bfloat16, device=DEVICE_TYPE)
+            a[0] = shared_row
+            actual = compiled_matmul(a, b)
+            expected = torch.matmul(a, b)
+            torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-1)
+            first_row_outputs.append(actual[0])
+        assert torch.equal(*first_row_outputs)
+    finally:
+        torch._dynamo.reset()
+
+
+def test_tuned_matmul_warmup_covers_all_table_shapes(monkeypatch):
+    calls = []
+
+    class RecordingKernel:
+        def warmup(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        batch_invariant_module, "matmul_kernel_persistent", RecordingKernel()
+    )
+    monkeypatch.setattr(batch_invariant_module, "num_compute_units", lambda _: 1)
+    monkeypatch.setattr(
+        config_module,
+        "_TUNED_MATMUL_CONFIGS_FOR_DEVICE",
+        _BATCH_INVARIANT_MATMUL_TUNED_CONFIGS["ada"],
+    )
+    monkeypatch.setattr(config_module, "_TUNED_MATMUL_CONFIGS_RESOLVED", True)
+    monkeypatch.setattr(batch_invariant_module, "_WARMED_TUNED_MATMUL_CONFIGS", set())
+
+    batch_invariant_module._warmup_tuned_matmul_configs(
+        current_platform.current_device(), 2048, 1, 1, 2048, False
+    )
+
+    def contains(runtime_m, block_m, block_n, num_warps, num_stages):
+        return any(
+            args[4] == runtime_m
+            and kwargs["BLOCK_SIZE_M"] == block_m
+            and kwargs["BLOCK_SIZE_N"] == block_n
+            and kwargs["num_warps"] == num_warps
+            and kwargs["num_stages"] == num_stages
+            for args, kwargs in calls
+        )
+
+    assert contains(2, 16, 128, 8, 2)
+    assert contains(16, 128, 64, 8, 4)
+    assert contains(1, 16, 32, 8, 5)
+    assert contains(2, 16, 64, 4, 4)
+    assert any(kwargs["C_LARGE"] for _, kwargs in calls if kwargs["BLOCK_SIZE_N"] == 64)
+    assert {args[9:11] for args, _ in calls} == {(1, 16)}
+    assert {kwargs["HAS_BIAS"] for _, kwargs in calls} == {False}
 
 
 @skip_unsupported

--- a/vllm/model_executor/determinism/batch_invariant.py
+++ b/vllm/model_executor/determinism/batch_invariant.py
@@ -11,13 +11,15 @@ import vllm.envs as envs
 from vllm.model_executor.determinism.batch_invariant_configs import (
     _get_descriptor_matmul_config,
     _get_matmul_config,
+    _get_tuned_matmul_configs_for_device,
+    _get_tuned_matmul_shape_config,
     resolve_tuned_matmul_configs,
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.mem_utils import get_max_shared_memory_bytes
 from vllm.utils.platform_utils import num_compute_units
-from vllm.utils.torch_utils import is_torch_equal_or_newer
+from vllm.utils.torch_utils import direct_register_custom_op, is_torch_equal_or_newer
 
 
 def _matmul_launch_metadata(
@@ -277,9 +279,125 @@ def matmul_descriptor_persistent(
     return c
 
 
-def matmul_persistent(
-    a: torch.Tensor, b: torch.Tensor, bias: torch.Tensor | None = None
-):
+_WARMED_TUNED_MATMUL_CONFIGS: set[tuple[int, ...]] = set()
+
+
+def _warmup_tuned_matmul_configs(
+    device_index: int,
+    stride_am: int,
+    stride_ak: int,
+    stride_bk: int,
+    stride_bn: int,
+    has_bias: bool,
+) -> None:
+    device_configs = _get_tuned_matmul_configs_for_device()
+    warmup = getattr(matmul_kernel_persistent, "warmup", None)
+    if device_configs is None or warmup is None:
+        return
+
+    from vllm.model_executor.warmup.jit_warmup_triton_helper import (
+        TritonWarmupTensor,
+        triton_scalar_specialization_rep,
+    )
+
+    pointer = TritonWarmupTensor(torch.bfloat16)
+    num_sms = num_compute_units(device_index)
+    stride_am = triton_scalar_specialization_rep(stride_am)
+    stride_ak = triton_scalar_specialization_rep(stride_ak)
+    stride_bk = triton_scalar_specialization_rep(stride_bk)
+    stride_bn = triton_scalar_specialization_rep(stride_bn)
+    cache_key = (
+        id(device_configs),
+        id(matmul_kernel_persistent),
+        device_index,
+        num_sms,
+        stride_am,
+        stride_ak,
+        stride_bk,
+        stride_bn,
+        has_bias,
+    )
+    if cache_key in _WARMED_TUNED_MATMUL_CONFIGS:
+        return
+
+    default: dict[str, int] = {}
+    warmed_specializations = set()
+
+    def warm_shape(m: int, N: int, K: int, config: dict[str, int]) -> None:
+        runtime_m = triton_scalar_specialization_rep(m)
+        a_large = m * K > 2**31
+        b_large = K * N > 2**31
+        c_large = m * N > 2**31
+        specialization = (
+            runtime_m,
+            config["BLOCK_SIZE_M"],
+            config["BLOCK_SIZE_N"],
+            config["BLOCK_SIZE_K"],
+            config["GROUP_SIZE_M"],
+            config["num_warps"],
+            config["num_stages"],
+            a_large,
+            b_large,
+            c_large,
+        )
+        if specialization in warmed_specializations:
+            return
+        warmed_specializations.add(specialization)
+        divisible = triton_scalar_specialization_rep(N)
+        warmup(
+            pointer,
+            pointer,
+            pointer,
+            pointer if has_bias else None,
+            runtime_m,
+            divisible,
+            triton_scalar_specialization_rep(K),
+            stride_am,
+            stride_ak,
+            stride_bk,
+            stride_bn,
+            divisible,
+            1,
+            NUM_SMS=num_sms,
+            A_LARGE=a_large,
+            B_LARGE=b_large,
+            C_LARGE=c_large,
+            HAS_BIAS=has_bias,
+            **config,
+            grid=(1,),
+        )
+
+    # Warm all table entries because output projections can run outside the
+    # backbone profiling graph.
+    for (N, K), shape_config in device_configs.items():
+        min_m = 1
+        for max_m, _ in shape_config.m_buckets:
+            config = _get_matmul_config(max_m, N, K, torch.bfloat16, default)
+            for m in range(min_m, max_m + 1):
+                warm_shape(m, N, K, config)
+            min_m = max_m + 1
+
+        # Values above the last bucket reuse its tile. Warm the two scalar
+        # specialization classes for every reachable A_LARGE/C_LARGE state.
+        # Sampling 16 values after each transition is sufficient to include
+        # both a multiple of 16 and a non-multiple.
+        tail_starts = {
+            min_m,
+            max(min_m, 2**31 // K + 1),
+            max(min_m, 2**31 // N + 1),
+        }
+        max_runtime_m = torch.iinfo(torch.int32).max
+        for start in tail_starts:
+            for m in range(start, min(start + 16, max_runtime_m + 1)):
+                warm_shape(m, N, K, config)
+    _WARMED_TUNED_MATMUL_CONFIGS.add(cache_key)
+
+
+def _matmul_persistent_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
     assert a.dtype == b.dtype, "Incompatible dtypes"
@@ -351,6 +469,48 @@ def matmul_persistent(
         **_get_matmul_config(M, N, K, dtype, configs[dtype]),
     )
     return c
+
+
+def _matmul_persistent_compiled(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    _warmup_tuned_matmul_configs(
+        a.device.index,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        bias is not None,
+    )
+    return _matmul_persistent_impl(a, b, bias)
+
+
+def _matmul_persistent_fake(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.empty((a.shape[0], b.shape[1]), device=a.device, dtype=a.dtype)
+
+
+direct_register_custom_op(
+    "batch_invariant_matmul",
+    _matmul_persistent_compiled,
+    fake_impl=_matmul_persistent_fake,
+)
+
+
+def matmul_persistent(
+    a: torch.Tensor, b: torch.Tensor, bias: torch.Tensor | None = None
+) -> torch.Tensor:
+    if (
+        torch.compiler.is_compiling()
+        and _get_tuned_matmul_shape_config(b.shape[1], a.shape[1], a.dtype) is not None
+    ):
+        return torch.ops.vllm.batch_invariant_matmul(a, b, bias)
+    return _matmul_persistent_impl(a, b, bias)
 
 
 @triton.jit

--- a/vllm/model_executor/determinism/batch_invariant.py
+++ b/vllm/model_executor/determinism/batch_invariant.py
@@ -279,6 +279,13 @@ def matmul_descriptor_persistent(
     return c
 
 
+matmul_kernel_persistent_compiled = triton.jit(
+    matmul_kernel_persistent.fn,
+    launch_metadata=_matmul_launch_metadata,
+    do_not_specialize=["M"],
+)
+
+
 _WARMED_TUNED_MATMUL_CONFIGS: set[tuple[int, ...]] = set()
 
 
@@ -291,7 +298,7 @@ def _warmup_tuned_matmul_configs(
     has_bias: bool,
 ) -> None:
     device_configs = _get_tuned_matmul_configs_for_device()
-    warmup = getattr(matmul_kernel_persistent, "warmup", None)
+    warmup = getattr(matmul_kernel_persistent_compiled, "warmup", None)
     if device_configs is None or warmup is None:
         return
 
@@ -308,7 +315,7 @@ def _warmup_tuned_matmul_configs(
     stride_bn = triton_scalar_specialization_rep(stride_bn)
     cache_key = (
         id(device_configs),
-        id(matmul_kernel_persistent),
+        id(matmul_kernel_persistent_compiled),
         device_index,
         num_sms,
         stride_am,
@@ -324,12 +331,14 @@ def _warmup_tuned_matmul_configs(
     warmed_specializations = set()
 
     def warm_shape(m: int, N: int, K: int, config: dict[str, int]) -> None:
-        runtime_m = triton_scalar_specialization_rep(m)
+        # M selects the tile in the runtime custom op, but the kernel itself
+        # must accept every M value for that tile. Keep its i32 warmup value
+        # generic so Triton does not compile M=1/divisible-by-16 variants.
+        runtime_m = 2
         a_large = m * K > 2**31
         b_large = K * N > 2**31
         c_large = m * N > 2**31
         specialization = (
-            runtime_m,
             config["BLOCK_SIZE_M"],
             config["BLOCK_SIZE_N"],
             config["BLOCK_SIZE_K"],
@@ -367,28 +376,26 @@ def _warmup_tuned_matmul_configs(
             grid=(1,),
         )
 
-    # Warm all table entries because output projections can run outside the
-    # backbone profiling graph.
+    # Warm all table entries so later compiled calls can select any tuned
+    # shape/M bucket after the JIT monitor starts. M itself is not a Triton
+    # specialization.
     for (N, K), shape_config in device_configs.items():
         min_m = 1
         for max_m, _ in shape_config.m_buckets:
             config = _get_matmul_config(max_m, N, K, torch.bfloat16, default)
-            for m in range(min_m, max_m + 1):
-                warm_shape(m, N, K, config)
+            warm_shape(min_m, N, K, config)
             min_m = max_m + 1
 
-        # Values above the last bucket reuse its tile. Warm the two scalar
-        # specialization classes for every reachable A_LARGE/C_LARGE state.
-        # Sampling 16 values after each transition is sufficient to include
-        # both a multiple of 16 and a non-multiple.
+        # Values above the last bucket reuse its tile. Warm each large-index
+        # state reachable by the current table shapes.
         tail_starts = {
             min_m,
             max(min_m, 2**31 // K + 1),
             max(min_m, 2**31 // N + 1),
         }
         max_runtime_m = torch.iinfo(torch.int32).max
-        for start in tail_starts:
-            for m in range(start, min(start + 16, max_runtime_m + 1)):
+        for m in tail_starts:
+            if m <= max_runtime_m:
                 warm_shape(m, N, K, config)
     _WARMED_TUNED_MATMUL_CONFIGS.add(cache_key)
 
@@ -397,6 +404,7 @@ def _matmul_persistent_impl(
     a: torch.Tensor,
     b: torch.Tensor,
     bias: torch.Tensor | None = None,
+    kernel: Any = matmul_kernel_persistent,
 ) -> torch.Tensor:
     # Check constraints.
     assert a.shape[1] == b.shape[0], "Incompatible dimensions"
@@ -447,7 +455,7 @@ def _matmul_persistent_impl(
             "num_warps": 8,
         },
     }
-    matmul_kernel_persistent[grid](
+    kernel[grid](
         a,
         b,
         c,  #
@@ -484,7 +492,7 @@ def _matmul_persistent_compiled(
         b.stride(1),
         bias is not None,
     )
-    return _matmul_persistent_impl(a, b, bias)
+    return _matmul_persistent_impl(a, b, bias, kernel=matmul_kernel_persistent_compiled)
 
 
 def _matmul_persistent_fake(

--- a/vllm/model_executor/determinism/batch_invariant_configs.py
+++ b/vllm/model_executor/determinism/batch_invariant_configs.py
@@ -295,27 +295,25 @@ def resolve_tuned_matmul_configs() -> None:
     _TUNED_MATMUL_CONFIGS_RESOLVED = True
 
 
-def _get_tuned_matmul_shape_config(
-    N: int,
-    K: int,
-    dtype: torch.dtype,
-) -> _MatmulShapeConfig | None:
-    if not _TUNED_MATMUL_CONFIGS_RESOLVED:
-        resolve_tuned_matmul_configs()
-    if dtype != torch.bfloat16:
-        return None
-    device_configs = _TUNED_MATMUL_CONFIGS_FOR_DEVICE
-    if device_configs is None:
-        return None
-    return device_configs.get((N, K))
-
-
 def _get_tuned_matmul_configs_for_device() -> (
     dict[tuple[int, int], _MatmulShapeConfig] | None
 ):
     if not _TUNED_MATMUL_CONFIGS_RESOLVED:
         resolve_tuned_matmul_configs()
     return _TUNED_MATMUL_CONFIGS_FOR_DEVICE
+
+
+def _get_tuned_matmul_shape_config(
+    N: int,
+    K: int,
+    dtype: torch.dtype,
+) -> _MatmulShapeConfig | None:
+    if dtype != torch.bfloat16:
+        return None
+    device_configs = _get_tuned_matmul_configs_for_device()
+    if device_configs is None:
+        return None
+    return device_configs.get((N, K))
 
 
 def _get_matmul_config(

--- a/vllm/model_executor/determinism/batch_invariant_configs.py
+++ b/vllm/model_executor/determinism/batch_invariant_configs.py
@@ -295,6 +295,29 @@ def resolve_tuned_matmul_configs() -> None:
     _TUNED_MATMUL_CONFIGS_RESOLVED = True
 
 
+def _get_tuned_matmul_shape_config(
+    N: int,
+    K: int,
+    dtype: torch.dtype,
+) -> _MatmulShapeConfig | None:
+    if not _TUNED_MATMUL_CONFIGS_RESOLVED:
+        resolve_tuned_matmul_configs()
+    if dtype != torch.bfloat16:
+        return None
+    device_configs = _TUNED_MATMUL_CONFIGS_FOR_DEVICE
+    if device_configs is None:
+        return None
+    return device_configs.get((N, K))
+
+
+def _get_tuned_matmul_configs_for_device() -> (
+    dict[tuple[int, int], _MatmulShapeConfig] | None
+):
+    if not _TUNED_MATMUL_CONFIGS_RESOLVED:
+        resolve_tuned_matmul_configs()
+    return _TUNED_MATMUL_CONFIGS_FOR_DEVICE
+
+
 def _get_matmul_config(
     M: int,
     N: int,
@@ -302,14 +325,7 @@ def _get_matmul_config(
     dtype: torch.dtype,
     default: dict[str, int],
 ) -> dict[str, int]:
-    if not _TUNED_MATMUL_CONFIGS_RESOLVED:
-        resolve_tuned_matmul_configs()
-    if dtype != torch.bfloat16:
-        return default
-    device_configs = _TUNED_MATMUL_CONFIGS_FOR_DEVICE
-    if device_configs is None:
-        return default
-    shape_config = device_configs.get((N, K))
+    shape_config = _get_tuned_matmul_shape_config(N, K, dtype)
     if shape_config is None:
         return default
     # Values above the tuned range reuse the largest bucket;


### PR DESCRIPTION
# [Bugfix] Select batch-invariant matmul configs from runtime M under `torch.compile`

Fixes #54243.

## Problem

The tuned batch-invariant matmul table is keyed by `(architecture, N, K, M bucket)`,
but Dynamo evaluates the Python lookup while tracing. The resulting Triton tile is
therefore fixed in a dynamic graph even though `M` remains a runtime value.

## What this changes

- Route only compiled BF16 shapes that have tuned table entries through a vLLM
  custom op. Its implementation runs after tracing and selects the tile from the
  actual runtime `M`.
- Keep eager execution, FP16/FP32, architectures without a table, and untuned
  `(N, K)` shapes on the existing path.
- Prewarm the reachable table specializations before inference so runtime dispatch
  does not introduce Triton JIT compilation after vLLM enables its JIT monitor.
- Add tests for runtime `M=8`/`M=2048` selection in one compiled graph, bias,
  fallback paths, custom-op schema, real Triton correctness/bitwise invariance, and
  warmup coverage.

This does not change table contents, tuning policy, eager behavior, or public APIs.

## Validation

- `python -m pytest -q tests/v1/determinism/test_matmul_batch_invariant.py`
    - `34 passed, 8 skipped`
- All applicable pre-commit hooks passed for the three changed files.
- `git diff --check` passed.
- Qwen/Qwen3-1.7B completed compiled V1 inference on SM120 with BF16, default
  `FULL_AND_PIECEWISE` CUDA Graph mode, compile range `(1, 8192)`, and
  `jit_monitor_mode="error"`.
- A second process using the same cache reported direct binary graph-cache loading
  and completed strict-JIT inference. The unpatched upstream control loaded its
  graph cache but failed on the first request with inference-time JIT of
  `matmul_kernel_persistent`.

The SM120 check deliberately selected the existing upstream Ada table because SM120
does not yet have an upstream table. It validates control flow and JIT coverage, not
Ada performance.

## Review requested

Please validate numerical/bitwise behavior on native Ada and Hopper and measure the
table-wide cold-start cost before marking this ready. The local check does not cover
multi-device execution in one process, and no startup-time result here is intended as
a performance claim.

## Related work

PR #49131 explores shape-adaptive SM80 tile configuration. This patch is narrower: it
restores reachability of the existing architecture tables' M buckets in vLLM's
current dynamic compiled path.

## AI assistance disclosure

Claude and Codex contributed review

