### PR TITLE
[CPU] Support mamba prefix-caching block tables in the CPU conv/SSM wrappers

### DIFF
--- a/tests/kernels/mamba/cpu/test_cpu_causal_conv1d_block_table.py
+++ b/tests/kernels/mamba/cpu/test_cpu_causal_conv1d_block_table.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Block-table (mamba prefix caching) support in the CPU causal-conv1d ops.
+
+With ``mamba_cache_mode=all`` the scheduler hands the conv ops a 2-D
+per-sequence block table plus pointer tensors instead of the legacy 1-D
+slot-per-sequence ``cache_indices``. These tests pin the wrapper-level
+contract (mirroring the GPU kernel semantics documented in
+``mamba_mixer2.conv_ssm_forward``):
+
+  prefill: initial state read from ``table[seq, initial_state_idx[seq]]``,
+           final state written to ``table[seq, block_idx_last_scheduled]``,
+           and a snapshot written at every ``block_size_to_align`` boundary;
+  decode:  state read via ``initial_state_idx``, written via
+           ``block_idx_last_scheduled_token`` (migrating on transitions);
+           a (batch, 1) table with no pointers degrades to the legacy layout.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+
+if not current_platform.is_cpu():
+    pytest.skip("skipping CPU-only tests", allow_module_level=True)
+
+from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (  # noqa: E402
+    causal_conv1d_fn_cpu,
+    causal_conv1d_update_cpu,
+)
+
+DIM = 16
+KERNEL = 4
+STATE_LEN = KERNEL - 1
+BLOCK = 8
+
+
+def _ref_conv(seq: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor,
+              initial_state: torch.Tensor) -> torch.Tensor:
+    """Monolithic reference: silu(depthwise-causal-conv(seq)) given state."""
+    full = torch.cat([initial_state, seq], dim=-1)
+    out = F.conv1d(full.unsqueeze(0), weight.unsqueeze(1), bias, padding=0,
+                   groups=DIM)[0, :, -seq.shape[-1]:]
+    return F.silu(out)
+
+
+def _make_inputs(seqlen: int, seed: int = 0):
+    g = torch.Generator().manual_seed(seed)
+    x = torch.randn(DIM, seqlen, generator=g)
+    weight = torch.randn(DIM, KERNEL, generator=g) * 0.3
+    bias = torch.randn(DIM, generator=g) * 0.1
+    return x, weight, bias
+
+
+def test_prefill_block_table_snapshots_and_final_state():
+    seqlen = 3 * BLOCK + 5  # crosses three aligned boundaries, partial tail
+    x, weight, bias = _make_inputs(seqlen)
+    num_slots = 8
+    conv_states = torch.zeros(num_slots, DIM, STATE_LEN)
+    table = torch.tensor([[2, 4, 5, 7]], dtype=torch.int32)
+
+    out = causal_conv1d_fn_cpu(
+        x.clone(),
+        weight,
+        bias,
+        conv_states,
+        query_start_loc=torch.tensor([0, seqlen], dtype=torch.int32),
+        cache_indices=table,
+        has_initial_state=torch.tensor([False]),
+        activation="silu",
+        block_idx_first_scheduled_token=torch.tensor([0], dtype=torch.int32),
+        block_idx_last_scheduled_token=torch.tensor([3], dtype=torch.int32),
+        initial_state_idx=torch.tensor([0], dtype=torch.int32),
+        num_computed_tokens=torch.tensor([0], dtype=torch.int32),
+        block_size_to_align=BLOCK,
+    )
+
+    zero_state = torch.zeros(DIM, STATE_LEN)
+    ref_out = _ref_conv(x, weight, bias, zero_state)
+    torch.testing.assert_close(out, ref_out, rtol=1e-5, atol=1e-5)
+
+    # Snapshot at boundary P holds the conv window ending at token P;
+    # final (partial) state lives at the last scheduled block's slot.
+    full = torch.cat([zero_state, x], dim=-1)
+    for boundary_block, pos in ((0, BLOCK), (1, 2 * BLOCK), (2, 3 * BLOCK)):
+        slot = int(table[0, boundary_block])
+        torch.testing.assert_close(
+            conv_states[slot], full[:, pos:pos + STATE_LEN],
+            rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(
+        conv_states[int(table[0, 3])], full[:, -STATE_LEN:],
+        rtol=1e-6, atol=1e-6)
+
+
+def test_prefill_resume_from_cached_block_matches_monolithic():
+    """Warm resume: prefill the tail from a boundary snapshot; outputs must
+    match the monolithic cold prefill exactly."""
+    seqlen = 2 * BLOCK + 3
+    x, weight, bias = _make_inputs(seqlen, seed=1)
+    num_slots = 8
+    zero_state = torch.zeros(DIM, STATE_LEN)
+
+    # Cold: full prefill, capturing the 2*BLOCK boundary snapshot.
+    cold_states = torch.zeros(num_slots, DIM, STATE_LEN)
+    table = torch.tensor([[1, 3, 6]], dtype=torch.int32)
+    cold_out = causal_conv1d_fn_cpu(
+        x.clone(), weight, bias, cold_states,
+        query_start_loc=torch.tensor([0, seqlen], dtype=torch.int32),
+        cache_indices=table,
+        has_initial_state=torch.tensor([False]),
+        activation="silu",
+        block_idx_first_scheduled_token=torch.tensor([0], dtype=torch.int32),
+        block_idx_last_scheduled_token=torch.tensor([2], dtype=torch.int32),
+        initial_state_idx=torch.tensor([0], dtype=torch.int32),
+        num_computed_tokens=torch.tensor([0], dtype=torch.int32),
+        block_size_to_align=BLOCK,
+    )
+
+    # Warm: first 2*BLOCK tokens are a cache hit; resume the 3-token tail
+    # reading the initial state from block 1's snapshot.
+    warm_states = cold_states.clone()
+    tail = x[:, 2 * BLOCK:]
+    warm_out = causal_conv1d_fn_cpu(
+        tail.clone(), weight, bias, warm_states,
+        query_start_loc=torch.tensor([0, 3], dtype=torch.int32),
+        cache_indices=table,
+        has_initial_state=torch.tensor([True]),
+        activation="silu",
+        block_idx_first_scheduled_token=torch.tensor([2], dtype=torch.int32),
+        block_idx_last_scheduled_token=torch.tensor([2], dtype=torch.int32),
+        initial_state_idx=torch.tensor([1], dtype=torch.int32),
+        num_computed_tokens=torch.tensor([2 * BLOCK], dtype=torch.int32),
+        block_size_to_align=BLOCK,
+    )
+
+    torch.testing.assert_close(warm_out, cold_out[:, 2 * BLOCK:],
+                               rtol=1e-6, atol=1e-6)
+    ref_out = _ref_conv(x, weight, bias, zero_state)
+    torch.testing.assert_close(cold_out, ref_out, rtol=1e-5, atol=1e-5)
+
+
+def test_decode_block_table_gather_and_migration():
+    """Decode with a block table must read the current block's slot and
+    migrate state when the write block differs from the read block."""
+    _, weight, bias = _make_inputs(1, seed=2)
+    num_slots = 8
+    conv_state = torch.zeros(num_slots, DIM, STATE_LEN)
+    running = torch.randn(DIM, STATE_LEN)
+    conv_state[5] = running  # state lives in block idx 1 -> slot 5
+    table = torch.tensor([[2, 5, 7]], dtype=torch.int32)
+    xt = torch.randn(1, DIM, 1)
+
+    ref = _ref_conv(xt[0], weight, bias, running.clone())
+
+    out = causal_conv1d_update_cpu(
+        xt.clone(), conv_state, weight, bias, "silu",
+        conv_state_indices=table,
+        block_idx_last_scheduled_token=torch.tensor([2], dtype=torch.int32),
+        initial_state_idx=torch.tensor([1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(out[0], ref, rtol=1e-5, atol=1e-5)
+    # State migrated to the write block's slot and advanced by one token.
+    expected_state = torch.cat([running, xt[0]], dim=-1)[:, -STATE_LEN:]
+    torch.testing.assert_close(conv_state[7], expected_state,
+                               rtol=1e-6, atol=1e-6)
+
+
+def test_decode_width_one_table_without_pointers_is_legacy():
+    """Without prefix caching each sequence owns one block: a (batch, 1)
+    table and no pointer tensors must behave like 1-D cache_indices."""
+    _, weight, bias = _make_inputs(1, seed=3)
+    num_slots = 4
+    running = torch.randn(DIM, STATE_LEN)
+    xt = torch.randn(1, DIM, 1)
+
+    state_2d = torch.zeros(num_slots, DIM, STATE_LEN)
+    state_2d[3] = running
+    out_2d = causal_conv1d_update_cpu(
+        xt.clone(), state_2d, weight, bias, "silu",
+        conv_state_indices=torch.tensor([[3]], dtype=torch.int32),
+    )
+
+    state_1d = torch.zeros(num_slots, DIM, STATE_LEN)
+    state_1d[3] = running
+    out_1d = causal_conv1d_update_cpu(
+        xt.clone(), state_1d, weight, bias, "silu",
+        conv_state_indices=torch.tensor([3], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(out_2d, out_1d, rtol=0.0, atol=0.0)
+    torch.testing.assert_close(state_2d, state_1d, rtol=0.0, atol=0.0)

--- a/vllm/model_executor/layers/mamba/ops/cpu/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/causal_conv1d.py
@@ -162,6 +162,8 @@ def causal_conv1d_update_cpu(
     conv_state_indices: torch.Tensor | None = None,
     query_start_loc: torch.Tensor | None = None,
     pad_slot_id: int | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
     **kwargs,
 ) -> torch.Tensor:
     """CPU implementation for causal_conv1d_update."""
@@ -172,6 +174,46 @@ def causal_conv1d_update_cpu(
         pad_slot_id = kwargs.get("null_block_id", NULL_BLOCK_ID)
         if pad_slot_id is None:
             pad_slot_id = NULL_BLOCK_ID
+
+    if (
+        conv_state_indices is not None
+        and conv_state_indices.dim() == 2
+        and block_idx_last_scheduled_token is None
+    ):
+        # Without prefix caching each sequence owns exactly one mamba state
+        # block, so the block table is (batch, 1): flatten to the legacy
+        # one-slot-per-sequence layout the C++ vec kernel expects.
+        conv_state_indices = conv_state_indices[:, 0].contiguous()
+
+    if conv_state_indices is not None and conv_state_indices.dim() == 2:
+        # Mamba prefix caching: a per-sequence BLOCK TABLE plus pointers.
+        # The C++ vec kernel only understands one slot per sequence, so
+        # resolve the table here: the running conv state is read from the
+        # ``initial_state_idx`` block and lives at the
+        # ``block_idx_last_scheduled_token`` block afterwards. On a block
+        # transition (read != write slot), migrate the state first, then
+        # let the kernel read+write in place at the write slot.
+        write_idx = (
+            conv_state_indices.gather(
+                1, block_idx_last_scheduled_token.to(torch.int64).unsqueeze(1)
+            )
+            .squeeze(1)
+            .to(torch.int32)
+        )
+        if initial_state_idx is not None:
+            read_idx = (
+                conv_state_indices.gather(
+                    1, initial_state_idx.to(torch.int64).unsqueeze(1)
+                )
+                .squeeze(1)
+                .to(torch.int32)
+            )
+            moved = (read_idx != write_idx) & (write_idx != pad_slot_id)
+            for s in torch.nonzero(moved).flatten().tolist():
+                r, w = int(read_idx[s].item()), int(write_idx[s].item())
+                if r != pad_slot_id and r != NULL_BLOCK_ID and r >= 0:
+                    conv_state[w].copy_(conv_state[r])
+        conv_state_indices = write_idx
 
     return causal_conv1d_update_cpu_vec(
         x,

--- a/vllm/model_executor/layers/mamba/ops/cpu/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/causal_conv1d.py
@@ -20,9 +20,28 @@ def causal_conv1d_fn_cpu(
     has_initial_state: torch.Tensor | None = None,
     activation: str | None = "silu",
     pad_slot_id: int = PAD_SLOT_ID,
+    block_idx_first_scheduled_token: torch.Tensor | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    num_computed_tokens: torch.Tensor | None = None,
+    block_size_to_align: int | None = None,
     **kwargs,
 ) -> torch.Tensor:
-    """CPU implementation for causal_conv1d_fwd."""
+    """CPU implementation for causal_conv1d_fwd.
+
+    Supports both the legacy layout (1-D ``cache_indices``: one state slot per
+    sequence) and the mamba-prefix-caching layout (2-D ``cache_indices``: a
+    per-sequence block table). In the block-table layout, mirroring the GPU
+    kernel contract documented in ``mamba_mixer2.conv_ssm_forward``:
+
+      * the initial state is read from
+        ``cache_indices[seq, initial_state_idx[seq]]``,
+      * the end-of-step state is written to
+        ``cache_indices[seq, block_idx_last_scheduled_token[seq]]``,
+      * an additional snapshot is written at every ``block_size_to_align``
+        token boundary crossed by this step, into that boundary's block slot,
+        so prefix-cache hits can restore conv state at any block boundary.
+    """
     if isinstance(activation, bool) and activation:
         activation = "silu"
     elif isinstance(activation, bool):
@@ -41,21 +60,38 @@ def causal_conv1d_fn_cpu(
     ]
     weight = weight.unsqueeze(1)
 
+    block_table_mode = cache_indices is not None and cache_indices.dim() == 2
+
     for seq_idx, (bos, eos) in enumerate(seq_begin_end_idx):
         if bos == eos:
             continue
 
-        slot = (
-            int(cache_indices[seq_idx].item()) if cache_indices is not None else seq_idx
-        )
+        if cache_indices is None:
+            slot = seq_idx
+            block_row = None
+        elif block_table_mode:
+            block_row = cache_indices[seq_idx]
+            last_block = (
+                int(block_idx_last_scheduled_token[seq_idx].item())
+                if block_idx_last_scheduled_token is not None
+                else 0
+            )
+            slot = int(block_row[last_block].item())
+        else:
+            block_row = None
+            slot = int(cache_indices[seq_idx].item())
 
-        if slot == pad_slot_id:
+        if slot == pad_slot_id or slot == NULL_BLOCK_ID:
             continue
 
         seq_x = x[:, bos:eos].unsqueeze(0)
 
         if has_initial_state is not None and bool(has_initial_state[seq_idx].item()):
-            initial_state = conv_states[slot, :, :state_len].unsqueeze(0)
+            if block_table_mode and initial_state_idx is not None:
+                init_slot = int(block_row[int(initial_state_idx[seq_idx].item())].item())
+            else:
+                init_slot = slot
+            initial_state = conv_states[init_slot, :, :state_len].unsqueeze(0)
         else:
             initial_state = torch.zeros(
                 1,
@@ -79,7 +115,40 @@ def causal_conv1d_fn_cpu(
             seq_out = F.silu(seq_out)
 
         out[:, bos:eos] = seq_out.squeeze(0)
-        conv_states[slot, :, :state_len].copy_(conv_input[..., -state_len:].squeeze(0))
+
+        # Aligned boundary snapshots (block-table mode only). A boundary at
+        # global token position P (multiple of block_size_to_align) crossed by
+        # this step gets the conv window ending at P: conv_input[t : t+state_len]
+        # where t is P local to this step's tokens.
+        if (
+            block_table_mode
+            and block_size_to_align is not None
+            and block_size_to_align > 0
+        ):
+            computed = (
+                int(num_computed_tokens[seq_idx].item())
+                if num_computed_tokens is not None
+                else 0
+            )
+            seqlen = eos - bos
+            first_boundary = (
+                (computed + block_size_to_align) // block_size_to_align
+            ) * block_size_to_align
+            for pos in range(first_boundary, computed + seqlen, block_size_to_align):
+                t_local = pos - computed
+                boundary_block = pos // block_size_to_align - 1
+                if 0 <= boundary_block < block_row.shape[0]:
+                    b_slot = int(block_row[boundary_block].item())
+                    if b_slot not in (pad_slot_id, NULL_BLOCK_ID) and b_slot >= 0:
+                        conv_states[b_slot, :, :state_len].copy_(
+                            conv_input[..., t_local : t_local + state_len]
+                            .squeeze(0)
+                            .to(conv_states.dtype)
+                        )
+
+        conv_states[slot, :, :state_len].copy_(
+            conv_input[..., -state_len:].squeeze(0)
+        )
 
     return out.to(original_x_dtype)
 

--- a/vllm/model_executor/layers/mamba/ops/cpu/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/causal_conv1d.py
@@ -81,7 +81,9 @@ def causal_conv1d_fn_cpu(
             block_row = None
             slot = int(cache_indices[seq_idx].item())
 
-        if slot == pad_slot_id or slot == NULL_BLOCK_ID:
+        # Block 0 is the reserved null block only in the block-table layout;
+        # in the legacy layout slot 0 is a valid state slot.
+        if slot == pad_slot_id or (block_table_mode and slot == NULL_BLOCK_ID):
             continue
 
         seq_x = x[:, bos:eos].unsqueeze(0)

--- a/vllm/model_executor/layers/mamba/ops/cpu/mamba_ssm.py
+++ b/vllm/model_executor/layers/mamba/ops/cpu/mamba_ssm.py
@@ -61,6 +61,50 @@ def _mamba_chunk_scan_combined_fwd_cpu(
             d = d.squeeze(-1)
         D_1d = d.contiguous()
 
+    if return_intermediate_states and cu_chunk_seqlens is not None:
+        # Mamba prefix caching ('all' mode): the caller
+        # (mamba_mixer2.conv_ssm_forward) expects one state PER CHUNK,
+        # globally indexed by ``cu_chunk_seqlens``, so it can copy
+        # block-boundary snapshots into the paged state cache. Drive the C++
+        # kernel one chunk at a time, threading each sequence's running state
+        # through, and record the post-chunk state. Correctness over speed:
+        # this is the CPU reference path.
+        cu_seq = cu_seqlens.to(torch.int64)
+        cu_chunk = cu_chunk_seqlens.to(torch.int64)
+        num_chunks = cu_chunk.size(0) - 1
+        intermediates = torch.zeros(
+            num_chunks, nheads, headdim, dstate, dtype=torch.float32, device=x.device
+        )
+        seq_ptr = 0
+        for k in range(num_chunks):
+            cs = int(cu_chunk[k].item())
+            ce = int(cu_chunk[k + 1].item())
+            if ce == cs:
+                intermediates[k] = all_states[min(seq_ptr, batch - 1)]
+                continue
+            while seq_ptr + 1 < batch and cs >= int(cu_seq[seq_ptr + 1].item()):
+                seq_ptr += 1
+            running = all_states[seq_ptr : seq_ptr + 1]
+            chunk_cu = torch.tensor([0, ce - cs], dtype=torch.int32, device=x.device)
+            out_view = out[cs:ce]
+            assert out_view.is_contiguous()
+            ops.mamba_chunk_scan_fwd_cpu(
+                out_view,
+                running,
+                x[cs:ce].contiguous(),
+                dt_f[cs:ce].contiguous(),
+                A,
+                B[cs:ce].contiguous(),
+                C[cs:ce].contiguous(),
+                D_1d,
+                z[cs:ce].contiguous() if z is not None else None,
+                chunk_cu,
+            )
+            intermediates[k] = running[0]
+
+        out_dtype = state_dtype if state_dtype is not None else x.dtype
+        return intermediates.to(out_dtype)
+
     ops.mamba_chunk_scan_fwd_cpu(
         out,
         all_states,


### PR DESCRIPTION
## Purpose

Part of #54504. Make mamba prefix caching (`--mamba-cache-mode all`) work on the CPU backend for hybrid (Mamba2 + attention) models such as `nemotron_h`.

The v1 core already hashes, stores, and matches mamba-block state pages, and the GPU Triton kernels implement the block-table contract documented in `mamba_mixer2.conv_ssm_forward` (initial state read from `cache_indices[seq, initial_state_idx[seq]]`, final state written at `cache_indices[seq, block_idx_last_scheduled_token[seq]]`, snapshots at every `mamba_block_size` boundary). The CPU wrappers around the C++ kernels predate that contract and assume the legacy 1-D slot-per-sequence layout, so enabling caching either crashed (`a Tensor with 11 elements cannot be converted to Scalar`) or corrupted state.

Three wrapper-level changes (no C++ kernel changes):

1. **`causal_conv1d_fn_cpu`** — accept a 2-D block table: read the initial state from the hit block, write the final state to the last scheduled block, and write the conv window ending at every crossed `block_size_to_align` boundary into that boundary's block slot.
2. **`_mamba_chunk_scan_combined_fwd_cpu`** — when `return_intermediate_states` is requested with `cu_chunk_seqlens`, drive the existing C++ chunk-scan kernel one chunk at a time, threading each sequence's running state, and return per-chunk states so the mixer can fill boundary pages (same shape contract as the Triton path).
3. **`causal_conv1d_update_cpu`** — resolve the block table at decode: gather the read slot via `initial_state_idx` and the write slot via `block_idx_last_scheduled_token`, migrate conv state on block transitions, and hand the flattened slots to the C++ vec kernel. A `(batch, 1)` table without pointer tensors (caching disabled) degrades to the legacy layout. `NULL_BLOCK_ID` (= 0) is treated as null only in the block-table layout — slot 0 is valid in the legacy layout.

Correctness over speed throughout: these are reference-path wrappers; the per-chunk Python loop only runs when prefix caching requests intermediate states.

## Test Plan

- New unit tests: `tests/kernels/mamba/cpu/test_cpu_causal_conv1d_block_table.py` — prefill boundary snapshots + final-state placement vs a monolithic reference conv, warm resume from a cached boundary matching cold prefill exactly, decode gather/migration through the block table, and legacy-layout degradation.
- `tests/kernels/mamba/cpu/`: full suite.
- End-to-end on macOS arm64 CPU build (M4 Pro): two random-weight `nemotron_h` variants (~136M; pure-Mamba `M-M-M-M--` and hybrid `MEM*EMEME`), greedy outputs of a caching engine compared token-for-token against a caching-disabled reference engine across cold, byte-identical resend (full prefix hit), and grown-by-one-turn (partial hit) prompts; plus `vllm serve` + an OpenAI-API probe checking TTFT and `prefix_cache_{queries,hits}_total` deltas.

## Test Result

- Unit: 4 new tests pass; `tests/kernels/mamba/cpu/` 81 passed, 41 skipped (the skips are AMX/x86 gates; run on arm64).
- E2E gauntlet (both model variants): `REUSE: WORKS` — identical resend TTFT 268 ms → 198 ms with `num_cached_tokens=1536/1749`; grown-turn partial hit also reuses 1536 tokens; **greedy warm-vs-uncached outputs byte-identical** in all cases.
- Live serve: identical resend TTFT 222 ms → 150 ms, `prefix_cache_hits_total` +1536 per hit request (previously always 0 for hybrids), cold requests +0.

GPU path untouched; the #54504 observation that v0.28 GPU builds show no reuse for `nemotron_h` is not addressed here and likely needs its own look (this PR only fixes the CPU wrappers).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
