### PR TITLE
[Bugfix] Autotune FlashInfer decode kernels before CUDA graph capture

### DIFF
--- a/tests/model_executor/test_flashinfer_autotune_warmup.py
+++ b/tests/model_executor/test_flashinfer_autotune_warmup.py
@@ -65,9 +65,9 @@ def _make_runner(
         "tuning_buckets",
     ),
     [
-        (1, 16, 8192, 64, (1, 2, 4, 8, 16, 32, 64)),
-        (8, 16, 8192, 64, (1, 2, 4, 8, 16, 32, 64)),
-        (8, 16, 100, 64, (1, 2, 4, 8, 16, 32, 64)),
+        (1, 16, 8192, 16, (1, 2, 4, 8, 16)),
+        (8, 16, 8192, 16, (1, 2, 4, 8, 16)),
+        (8, 16, 100, 12, (1, 2, 4, 8, 12)),
         (8, 128, 800, 100, (1, 2, 4, 8, 16, 32, 64, 100)),
     ],
 )
@@ -130,43 +130,46 @@ def test_flashinfer_autotune_adds_mla_decode_run_for_v1():
         _run_flashinfer_autotune_dummy_runs(runner)
 
     assert runner._dummy_run.call_count == 1
-    mla_decode_autotune.assert_called_once_with(runner, 64, 8, 1_048_576)
+    mla_decode_autotune.assert_called_once_with(runner, 16, 8, 1_048_576)
     autotune.assert_called_once_with(tuning_buckets=(1, 2, 4, 8, 16))
 
 
-def test_flashinfer_autotune_directly_tunes_deferred_moe_buckets():
-    import torch
+class _FakeMoERunner:
+    moe_config: Any
+    routed_experts: Any
 
-    class _FakeMoERunner:
-        moe_config: Any
-        routed_experts: Any
+
+def _make_deferred_moe(hidden_dim: int = 3584):
+    import torch
 
     moe_config = SimpleNamespace(
         use_deferred_moe_finalize=True,
         defer_moe_finalize_max_num_tokens=128,
         should_defer_moe_finalize=Mock(return_value=True),
-        hidden_dim=3584,
+        hidden_dim=hidden_dim,
         num_experts=896,
         in_dtype=torch.bfloat16,
         router_logits_dtype=torch.bfloat16,
     )
     moe_kernel = SimpleNamespace(supports_deferred_moe_finalize=Mock(return_value=True))
-    quant_method = SimpleNamespace(is_monolithic=True, moe_kernel=moe_kernel)
     routed_experts = SimpleNamespace(
-        quant_method=quant_method,
+        quant_method=SimpleNamespace(is_monolithic=True, moe_kernel=moe_kernel),
         w13_weight=torch.empty(0),
         forward_monolithic=Mock(),
     )
     moe = _FakeMoERunner()
     moe.moe_config = moe_config
     moe.routed_experts = routed_experts
-    model = SimpleNamespace(modules=Mock(return_value=[object(), moe]))
+    return moe
+
+
+def _run_deferred_moe_autotune(modules, buckets):
     runner = SimpleNamespace(
         scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
-        get_model=Mock(return_value=model),
+        get_model=Mock(
+            return_value=SimpleNamespace(modules=Mock(return_value=modules))
+        ),
     )
-    buckets = (1, 2, 4, 8, 16, 32, 64, 128)
-
     with (
         patch("vllm.model_executor.layers.fused_moe.MoERunner", _FakeMoERunner),
         patch(
@@ -176,15 +179,38 @@ def test_flashinfer_autotune_directly_tunes_deferred_moe_buckets():
         patch("vllm.utils.flashinfer.autotune") as autotune,
     ):
         _run_flashinfer_deferred_moe_autotune(runner)
+    return get_buckets, autotune
+
+
+def test_flashinfer_autotune_directly_tunes_deferred_moe_buckets():
+    moe = _make_deferred_moe()
+    buckets = (1, 2, 4, 8, 16, 32, 64, 128)
+
+    get_buckets, autotune = _run_deferred_moe_autotune([object(), moe], buckets)
 
     get_buckets.assert_called_once_with(128)
     autotune.assert_called_once_with(tuning_buckets=buckets)
-    moe_config.should_defer_moe_finalize.assert_called_once_with(128)
+    moe_kernel = moe.routed_experts.quant_method.moe_kernel
+    moe.moe_config.should_defer_moe_finalize.assert_called_once_with(128)
     moe_kernel.supports_deferred_moe_finalize.assert_called_once_with()
-    routed_experts.forward_monolithic.assert_called_once()
-    call = routed_experts.forward_monolithic.call_args.kwargs
+    moe.routed_experts.forward_monolithic.assert_called_once()
+    call = moe.routed_experts.forward_monolithic.call_args.kwargs
     assert call["x"].shape == (128, 3584)
     assert call["router_logits"].shape == (128, 896)
+
+
+def test_flashinfer_autotune_tunes_each_deferred_moe_geometry_once():
+    # Identical layers share one cache key, so only the first needs a
+    # dispatcher call; a differently shaped layer still gets its own.
+    same_a, same_b = _make_deferred_moe(), _make_deferred_moe()
+    other = _make_deferred_moe(hidden_dim=1792)
+    buckets = (1, 2, 4, 8, 16, 32, 64, 128)
+
+    _run_deferred_moe_autotune([same_a, same_b, other], buckets)
+
+    same_a.routed_experts.forward_monolithic.assert_called_once()
+    same_b.routed_experts.forward_monolithic.assert_not_called()
+    other.routed_experts.forward_monolithic.assert_called_once()
 
 
 @pytest.mark.parametrize("use_v2_model_runner", [False, True])
@@ -225,36 +251,6 @@ def test_flashinfer_mla_decode_autotune_uses_initialized_attention_geometry(
         runner.block_tables.get_dummy_block_tables.assert_called_once_with(16)
     else:
         table.get_device_tensor.assert_called_once_with(16)
-
-
-def test_flashinfer_mla_decode_autotune_expands_static_block_table_batch():
-    import torch
-
-    layer = object()
-    static_block_table = torch.ones((16, 37), dtype=torch.int32)
-    group = SimpleNamespace(
-        backend=_Backend(),
-        layer_names=["model.layers.0.self_attn.attn"],
-        kv_cache_group_id=0,
-    )
-    runner = _make_runner(use_v2_model_runner=True)
-    runner.attn_groups = [[group]]
-    runner.vllm_config.compilation_config = SimpleNamespace(
-        static_forward_context={group.layer_names[0]: layer}
-    )
-    runner.block_tables = SimpleNamespace(
-        get_dummy_block_tables=Mock(return_value=(static_block_table,))
-    )
-
-    with patch(
-        "vllm.v1.attention.backends.mla.flashinfer_mla.flashinfer_mla_decode_autotune"
-    ) as decode_autotune:
-        _run_flashinfer_mla_decode_autotune(runner, 64, 8, 1_048_576)
-
-    block_table = decode_autotune.call_args.args[1]
-    assert block_table.shape == (64, 37)
-    assert block_table.dtype == static_block_table.dtype
-    assert not block_table.any()
 
 
 def test_flashinfer_mla_decode_autotune_builds_uniform_decode_metadata():

--- a/tests/model_executor/test_flashinfer_autotune_warmup.py
+++ b/tests/model_executor/test_flashinfer_autotune_warmup.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from vllm.model_executor.warmup.kernel_warmup import (
+    _run_flashinfer_autotune_dummy_runs,
+    _run_flashinfer_deferred_moe_autotune,
+    _run_flashinfer_mla_decode_autotune,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+class _Backend:
+    @staticmethod
+    def get_name() -> str:
+        return "FLASHINFER_MLA"
+
+
+def _make_runner(
+    *,
+    use_v2_model_runner: bool,
+    flashinfer_mla: bool = True,
+    query_len: int = 8,
+    max_num_seqs: int = 16,
+    max_num_batched_tokens: int = 8192,
+    max_model_len: int = 1_048_576,
+    dcp_size: int = 1,
+):
+    backend = _Backend() if flashinfer_mla else SimpleNamespace(get_name=lambda: "X")
+    runner = SimpleNamespace(
+        _dummy_run=Mock(),
+        get_model=Mock(return_value=SimpleNamespace(modules=Mock(return_value=[]))),
+        attn_groups=[[SimpleNamespace(backend=backend)]],
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=max_num_batched_tokens,
+            max_num_seqs=max_num_seqs,
+        ),
+        max_model_len=max_model_len,
+        model_state=SimpleNamespace(max_model_len=max_model_len),
+        vllm_config=SimpleNamespace(
+            kernel_config=SimpleNamespace(linear_backend=None),
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=dcp_size,
+            ),
+            use_v2_model_runner=use_v2_model_runner,
+        ),
+    )
+    runner.decode_query_len = query_len
+    runner.uniform_decode_query_len = query_len
+    return runner
+
+
+@pytest.mark.parametrize(
+    (
+        "query_len",
+        "max_num_seqs",
+        "max_num_batched_tokens",
+        "max_decode_batch_size",
+        "tuning_buckets",
+    ),
+    [
+        (1, 16, 8192, 64, (1, 2, 4, 8, 16, 32, 64)),
+        (8, 16, 8192, 64, (1, 2, 4, 8, 16, 32, 64)),
+        (8, 16, 100, 64, (1, 2, 4, 8, 16, 32, 64)),
+        (8, 128, 800, 100, (1, 2, 4, 8, 16, 32, 64, 100)),
+    ],
+)
+def test_flashinfer_autotune_adds_mla_decode_run_for_v2(
+    query_len: int,
+    max_num_seqs: int,
+    max_num_batched_tokens: int,
+    max_decode_batch_size: int,
+    tuning_buckets: tuple[int, ...],
+):
+    runner = _make_runner(
+        use_v2_model_runner=True,
+        query_len=query_len,
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+    )
+
+    with (
+        patch("vllm.utils.flashinfer.autotune") as autotune,
+        patch(
+            "vllm.utils.flashinfer.flashinfer_get_hybrid_num_tokens_buckets",
+            return_value=tuning_buckets,
+        ) as get_buckets,
+        patch(
+            "vllm.model_executor.warmup.kernel_warmup."
+            "_run_flashinfer_mla_decode_autotune"
+        ) as mla_decode_autotune,
+    ):
+        _run_flashinfer_autotune_dummy_runs(runner)
+
+    # The generic pass needs one full-model dummy. The MLA-specific pass must
+    # not run the model again, otherwise it retriggers MoE autotuning.
+    runner._dummy_run.assert_called_once_with(
+        num_tokens=max_num_batched_tokens,
+        skip_eplb=True,
+        is_profile=True,
+        randomize_inputs=True,
+    )
+    mla_decode_autotune.assert_called_once_with(
+        runner, max_decode_batch_size, query_len, 1_048_576
+    )
+    get_buckets.assert_called_once_with(max_decode_batch_size)
+    autotune.assert_called_once_with(tuning_buckets=tuning_buckets)
+
+
+def test_flashinfer_autotune_adds_mla_decode_run_for_v1():
+    runner = _make_runner(use_v2_model_runner=False)
+
+    with (
+        patch("vllm.utils.flashinfer.autotune") as autotune,
+        patch(
+            "vllm.utils.flashinfer.flashinfer_get_hybrid_num_tokens_buckets",
+            return_value=(1, 2, 4, 8, 16),
+        ),
+        patch(
+            "vllm.model_executor.warmup.kernel_warmup."
+            "_run_flashinfer_mla_decode_autotune"
+        ) as mla_decode_autotune,
+    ):
+        _run_flashinfer_autotune_dummy_runs(runner)
+
+    assert runner._dummy_run.call_count == 1
+    mla_decode_autotune.assert_called_once_with(runner, 64, 8, 1_048_576)
+    autotune.assert_called_once_with(tuning_buckets=(1, 2, 4, 8, 16))
+
+
+def test_flashinfer_autotune_directly_tunes_deferred_moe_buckets():
+    import torch
+
+    class _FakeMoERunner:
+        moe_config: Any
+        routed_experts: Any
+
+    moe_config = SimpleNamespace(
+        use_deferred_moe_finalize=True,
+        defer_moe_finalize_max_num_tokens=128,
+        should_defer_moe_finalize=Mock(return_value=True),
+        hidden_dim=3584,
+        num_experts=896,
+        in_dtype=torch.bfloat16,
+        router_logits_dtype=torch.bfloat16,
+    )
+    moe_kernel = SimpleNamespace(supports_deferred_moe_finalize=Mock(return_value=True))
+    quant_method = SimpleNamespace(is_monolithic=True, moe_kernel=moe_kernel)
+    routed_experts = SimpleNamespace(
+        quant_method=quant_method,
+        w13_weight=torch.empty(0),
+        forward_monolithic=Mock(),
+    )
+    moe = _FakeMoERunner()
+    moe.moe_config = moe_config
+    moe.routed_experts = routed_experts
+    model = SimpleNamespace(modules=Mock(return_value=[object(), moe]))
+    runner = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+        get_model=Mock(return_value=model),
+    )
+    buckets = (1, 2, 4, 8, 16, 32, 64, 128)
+
+    with (
+        patch("vllm.model_executor.layers.fused_moe.MoERunner", _FakeMoERunner),
+        patch(
+            "vllm.utils.flashinfer.flashinfer_get_hybrid_num_tokens_buckets",
+            return_value=buckets,
+        ) as get_buckets,
+        patch("vllm.utils.flashinfer.autotune") as autotune,
+    ):
+        _run_flashinfer_deferred_moe_autotune(runner)
+
+    get_buckets.assert_called_once_with(128)
+    autotune.assert_called_once_with(tuning_buckets=buckets)
+    moe_config.should_defer_moe_finalize.assert_called_once_with(128)
+    moe_kernel.supports_deferred_moe_finalize.assert_called_once_with()
+    routed_experts.forward_monolithic.assert_called_once()
+    call = routed_experts.forward_monolithic.call_args.kwargs
+    assert call["x"].shape == (128, 3584)
+    assert call["router_logits"].shape == (128, 896)
+
+
+@pytest.mark.parametrize("use_v2_model_runner", [False, True])
+def test_flashinfer_mla_decode_autotune_uses_initialized_attention_geometry(
+    use_v2_model_runner: bool,
+):
+    import torch
+
+    layer = object()
+    block_table = torch.empty((16, 37), dtype=torch.int32)
+    group = SimpleNamespace(
+        backend=_Backend(),
+        layer_names=["model.layers.0.self_attn.attn"],
+        kv_cache_group_id=0,
+    )
+    runner = _make_runner(use_v2_model_runner=use_v2_model_runner)
+    runner.attn_groups = [[group]]
+    runner.vllm_config.compilation_config = SimpleNamespace(
+        static_forward_context={group.layer_names[0]: layer}
+    )
+    if use_v2_model_runner:
+        runner.block_tables = SimpleNamespace(
+            get_dummy_block_tables=Mock(return_value=(block_table,))
+        )
+    else:
+        table = SimpleNamespace(get_device_tensor=Mock(return_value=block_table))
+        runner.input_batch = SimpleNamespace(
+            block_table=SimpleNamespace(block_tables=[table])
+        )
+
+    with patch(
+        "vllm.v1.attention.backends.mla.flashinfer_mla.flashinfer_mla_decode_autotune"
+    ) as decode_autotune:
+        _run_flashinfer_mla_decode_autotune(runner, 16, 8, 1_048_576)
+
+    decode_autotune.assert_called_once_with(layer, block_table, 16, 8, 1_048_576)
+    if use_v2_model_runner:
+        runner.block_tables.get_dummy_block_tables.assert_called_once_with(16)
+    else:
+        table.get_device_tensor.assert_called_once_with(16)
+
+
+def test_flashinfer_mla_decode_autotune_expands_static_block_table_batch():
+    import torch
+
+    layer = object()
+    static_block_table = torch.ones((16, 37), dtype=torch.int32)
+    group = SimpleNamespace(
+        backend=_Backend(),
+        layer_names=["model.layers.0.self_attn.attn"],
+        kv_cache_group_id=0,
+    )
+    runner = _make_runner(use_v2_model_runner=True)
+    runner.attn_groups = [[group]]
+    runner.vllm_config.compilation_config = SimpleNamespace(
+        static_forward_context={group.layer_names[0]: layer}
+    )
+    runner.block_tables = SimpleNamespace(
+        get_dummy_block_tables=Mock(return_value=(static_block_table,))
+    )
+
+    with patch(
+        "vllm.v1.attention.backends.mla.flashinfer_mla.flashinfer_mla_decode_autotune"
+    ) as decode_autotune:
+        _run_flashinfer_mla_decode_autotune(runner, 64, 8, 1_048_576)
+
+    block_table = decode_autotune.call_args.args[1]
+    assert block_table.shape == (64, 37)
+    assert block_table.dtype == static_block_table.dtype
+    assert not block_table.any()
+
+
+def test_flashinfer_mla_decode_autotune_builds_uniform_decode_metadata():
+    import torch
+
+    from vllm.v1.attention.backends.mla.flashinfer_mla import (
+        FlashInferMLAImpl,
+        flashinfer_mla_decode_autotune,
+    )
+
+    impl = object.__new__(FlashInferMLAImpl)
+    impl.forward_mqa = Mock()
+    impl.num_heads = 12
+    layer = SimpleNamespace(
+        impl=impl,
+        kv_cache=torch.empty((3, 64, 576), dtype=torch.bfloat16),
+        kv_cache_dtype="auto",
+        # K3 keeps the global head count on the layer while the backend impl
+        # owns the TP-local runtime count used by the decode dispatcher.
+        num_heads=96,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+    )
+    block_table = torch.ones((16, 16392), dtype=torch.int32)
+
+    flashinfer_mla_decode_autotune(layer, block_table, 16, 8, 1_048_576)
+
+    query, kv_cache, metadata, called_layer = impl.forward_mqa.call_args.args
+    assert query.shape == (128, 12, 576)
+    assert query.dtype == torch.bfloat16
+    assert kv_cache is layer.kv_cache
+    assert called_layer is layer
+    assert metadata.num_decodes == 16
+    assert metadata.num_decode_tokens == 128
+    assert metadata.max_query_len == 8
+    assert metadata.max_seq_len == 1_048_576
+    assert metadata.query_start_loc.tolist() == list(range(0, 129, 8))
+    assert metadata.decode is not None
+    assert metadata.decode.block_table is block_table
+    assert metadata.decode.block_table.shape == (16, 16392)
+    assert not metadata.decode.block_table.any()
+    assert metadata.decode.seq_lens.tolist() == [1_048_576] * 16
+
+
+def test_flashinfer_autotune_skips_decode_run_for_other_attention_backend():
+    runner = _make_runner(use_v2_model_runner=True, flashinfer_mla=False)
+
+    _run_flashinfer_autotune_dummy_runs(runner)
+
+    assert runner._dummy_run.call_count == 1
+
+
+def test_flashinfer_autotune_skips_mla_decode_run_for_native_dcp():
+    runner = _make_runner(use_v2_model_runner=True, dcp_size=2)
+
+    _run_flashinfer_autotune_dummy_runs(runner)
+
+    assert runner._dummy_run.call_count == 1
+
+
+@pytest.mark.parametrize("query_len", [1, 8])
+def test_mla_tuning_keys_cover_full_graph_capture_keys(query_len: int):
+    # This intentionally couples to FlashInfer internals. A failure means its
+    # MLA cache-key contract changed and this warmup must be revalidated.
+    import torch
+
+    mla_core = pytest.importorskip("flashinfer.mla._core")
+    from flashinfer.autotuner import AutoTuner
+    from flashinfer.fused_moe.utils import get_hybrid_num_tokens_buckets
+
+    def _inputs(batch_size: int) -> list[torch.Tensor]:
+        return [
+            torch.empty((batch_size, query_len, 8, 576), dtype=torch.bfloat16),
+            torch.empty((batch_size, 8192), dtype=torch.int32),
+            torch.empty((batch_size,), dtype=torch.int32),
+            torch.empty((batch_size, query_len, 8, 512), dtype=torch.bfloat16),
+        ]
+
+    def _make_runners(max_seq_len: int):
+        kv_cache = torch.empty((1, 1, 64, 576), dtype=torch.bfloat16)
+        workspace_buffer = torch.empty(1024, dtype=torch.int8)
+
+        common_attrs = {
+            "kv_cache": kv_cache,
+            "workspace_buffer": workspace_buffer,
+            "qk_nope_head_dim": 128,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64,
+            "page_size": 64,
+            "max_seq_len": max_seq_len,
+            "sinks": None,
+            "enable_pdl": False,
+            "is_var_seq": False,
+            "uses_shared_paged_kv_idx": False,
+        }
+
+        trt = object.__new__(mla_core.TrtllmGenMlaDecodeRunner)
+        trt.__dict__.update(common_attrs)
+        trt.sparse_mla_top_k = 0
+        trt.bmm1_scale = 1.0
+        trt.bmm2_scale = 1.0
+        trt.skip_softmax_threshold_scale_factor = None
+        trt.return_lse = False
+
+        cute = object.__new__(mla_core.CuteDslMlaDecodeRunner)
+        cute.__dict__.update(common_attrs)
+        cute._resolved_cute_dsl_impl = "monolithic"
+        cute.cute_dsl_impl = "auto"
+        cute.enable_dcp = False
+        cute.cp_world = 1
+        return trt, cute
+
+    default_config = mla_core._mla_decode_tuning_config(
+        get_hybrid_num_tokens_buckets(8192),
+        num_pages=1,
+        profile_seq_len=1_048_576,
+    )
+    capture_buckets = get_hybrid_num_tokens_buckets(16)
+    tuning_config = mla_core._mla_decode_tuning_config(
+        capture_buckets,
+        num_pages=1,
+        profile_seq_len=1_048_576,
+    )
+    full_context_runners = _make_runners(max_seq_len=1_048_576)
+    full_context_cute = full_context_runners[1]
+    tuner = AutoTuner()
+
+    for batch_size in capture_buckets:
+        inputs = _inputs(batch_size)
+        cache_key = AutoTuner._get_cache_key(
+            "trtllm_batch_decode_mla",
+            full_context_cute,
+            tuple(tuple(t.shape) for t in inputs),
+            tuning_config,
+            full_context_cute.get_cache_key_extras(inputs),
+        )
+        tuner.profiling_cache[cache_key] = (-1, None)
+
+    # Outside the nested override, every FULL graph capture batch hits the
+    # actual FlashInfer CuTe runner key instead of runner 0 (TRTLLM-GEN).
+    for batch_size in range(1, 17):
+        inputs = _inputs(batch_size)
+        is_hit, runner_id, tactic, _ = tuner.search_cache(
+            "trtllm_batch_decode_mla",
+            list(full_context_runners),
+            tuple(tuple(t.shape) for t in inputs),
+            default_config,
+            inputs,
+        )
+        assert (is_hit, runner_id, tactic) == (True, 1, -1)
+
+    # The old max_seq_len=8 dummy generates a real CuTe key that cannot cover
+    # a FULL capture lookup at max_seq_len=1,048,576. The miss selects runner
+    # 0, which is exactly FlashInfer's TRTLLM-GEN fallback behavior.
+    short_context_cute = _make_runners(max_seq_len=8)[1]
+    inputs = _inputs(8)
+    full_context_extras = full_context_cute.get_cache_key_extras(inputs)
+    assert (1_048_576 + 127) // 128 in full_context_extras
+    short_context_key = AutoTuner._get_cache_key(
+        "trtllm_batch_decode_mla",
+        short_context_cute,
+        tuple(tuple(t.shape) for t in inputs),
+        tuning_config,
+        short_context_cute.get_cache_key_extras(inputs),
+    )
+    short_context_tuner = AutoTuner()
+    short_context_tuner.profiling_cache[short_context_key] = (-1, None)
+    is_hit, runner_id, tactic, _ = short_context_tuner.search_cache(
+        "trtllm_batch_decode_mla",
+        list(full_context_runners),
+        tuple(tuple(t.shape) for t in inputs),
+        default_config,
+        inputs,
+    )
+    assert (is_hit, runner_id, tactic) == (False, 0, -1)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -8,7 +8,7 @@ happen during model execution.
 
 import sys
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import torch
 
@@ -108,6 +108,21 @@ def _warmup_kimi_k3_gemm_rs_ar() -> None:
         logger.info_once("Warmed up %d Kimi-K3 GEMM-RS/AR variants.", compiled)
 
 
+def _is_attention_backend(backend, name: str) -> bool:
+    try:
+        return backend.get_name() == name
+    except NotImplementedError:
+        return False
+
+
+def _has_attention_backend(runner: "GPUModelRunner", name: str) -> bool:
+    return any(
+        _is_attention_backend(group.backend, name)
+        for groups in runner.attn_groups
+        for group in groups
+    )
+
+
 def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
     from vllm.model_executor.warmup.minimax_m3_msa_warmup import (
         minimax_m3_msa_warmup,
@@ -198,12 +213,6 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
     # FlashInfer attention warmup
     # Only warmup if the model has FlashInfer attention groups
     # and is not a pooling model
-    def _is_flashinfer_backend(backend):
-        try:
-            return backend.get_name() == "FLASHINFER"
-        except NotImplementedError:
-            return False
-
     if (
         not worker.model_runner.is_pooling_model
         and worker.model_runner.attn_groups
@@ -211,7 +220,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False):
         # backends don't support this dummy run. Once we remove
         # `build_for_cudagraph_capture`, we can change it to `any`.
         and all(
-            _is_flashinfer_backend(group.backend)
+            _is_attention_backend(group.backend, "FLASHINFER")
             for groups in worker.model_runner.attn_groups
             for group in groups
         )
@@ -248,6 +257,7 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
 
 
 _FLASHINFER_BF16_AUTOTUNE_MAX_TOKENS = 32
+_FLASHINFER_DECODE_AUTOTUNE_MIN_BATCH_SIZE = 64
 
 
 def _flashinfer_autotune_token_counts(runner: "GPUModelRunner") -> tuple[int, ...]:
@@ -261,6 +271,104 @@ def _flashinfer_autotune_token_counts(runner: "GPUModelRunner") -> tuple[int, ..
     return (max_tokens,)
 
 
+def _run_flashinfer_mla_decode_autotune(
+    runner: "GPUModelRunner",
+    batch_size: int,
+    query_len: int,
+    max_seq_len: int,
+) -> None:
+    from vllm.v1.attention.backends.mla.flashinfer_mla import (
+        flashinfer_mla_decode_autotune,
+    )
+
+    runner_any = cast(Any, runner)
+    if runner.vllm_config.use_v2_model_runner:
+        block_tables = runner_any.block_tables.get_dummy_block_tables(batch_size)
+    else:
+        block_tables = tuple(
+            table.get_device_tensor(batch_size)
+            for table in runner.input_batch.block_table.block_tables
+        )
+    block_tables = tuple(
+        table
+        if table.shape[0] == batch_size
+        else table.new_zeros((batch_size, *table.shape[1:]))
+        for table in block_tables
+    )
+
+    static_forward_context = (
+        runner.vllm_config.compilation_config.static_forward_context
+    )
+    for groups in runner.attn_groups:
+        for group in groups:
+            if not _is_attention_backend(group.backend, "FLASHINFER_MLA"):
+                continue
+            layer = static_forward_context[group.layer_names[0]]
+            flashinfer_mla_decode_autotune(
+                layer,
+                block_tables[group.kv_cache_group_id],
+                batch_size,
+                query_len,
+                max_seq_len,
+            )
+
+
+def _run_flashinfer_deferred_moe_autotune(runner: "GPUModelRunner") -> None:
+    """Tune the unfinalized decode path without another model forward."""
+    import vllm.utils.flashinfer as fi_utils
+    from vllm.model_executor.layers.fused_moe import MoERunner
+
+    max_num_batched_tokens = runner.scheduler_config.max_num_batched_tokens
+    for module in runner.get_model().modules():
+        if not isinstance(module, MoERunner):
+            continue
+
+        moe_config = module.moe_config
+        if not moe_config.use_deferred_moe_finalize:
+            continue
+
+        max_deferred_tokens = moe_config.defer_moe_finalize_max_num_tokens
+        num_tokens = max_num_batched_tokens
+        if max_deferred_tokens > 0:
+            num_tokens = min(num_tokens, max_deferred_tokens)
+        if not moe_config.should_defer_moe_finalize(num_tokens):
+            continue
+
+        routed_experts = module.routed_experts
+        quant_method = routed_experts.quant_method
+        moe_kernel = getattr(quant_method, "moe_kernel", None)
+        if (
+            not quant_method.is_monolithic
+            or moe_kernel is None
+            or not moe_kernel.supports_deferred_moe_finalize()
+        ):
+            continue
+
+        tuning_buckets = fi_utils.flashinfer_get_hybrid_num_tokens_buckets(num_tokens)
+        logger.info(
+            "Running FlashInfer deferred MoE autotune with token buckets %s.",
+            tuning_buckets,
+        )
+        device = routed_experts.w13_weight.device
+        hidden_states = torch.randn(
+            num_tokens,
+            moe_config.hidden_dim,
+            dtype=moe_config.in_dtype,
+            device=device,
+        )
+        router_logits = torch.randn(
+            num_tokens,
+            moe_config.num_experts,
+            dtype=moe_config.router_logits_dtype,
+            device=device,
+        )
+        with fi_utils.autotune(tuning_buckets=tuning_buckets):
+            routed_experts.forward_monolithic(
+                x=hidden_states,
+                router_logits=router_logits,
+            )
+
+
 def _run_flashinfer_autotune_dummy_runs(runner: "GPUModelRunner") -> None:
     for num_tokens in _flashinfer_autotune_token_counts(runner):
         logger.info("Running FlashInfer autotune with %d tokens.", num_tokens)
@@ -269,6 +377,70 @@ def _run_flashinfer_autotune_dummy_runs(runner: "GPUModelRunner") -> None:
             skip_eplb=True,
             is_profile=True,
             randomize_inputs=True,
+        )
+
+    # Some decode consumers fuse the final top-k reduction, changing the
+    # FlashInfer MoE output from (tokens, hidden) to (tokens, 0). The generic
+    # full-model profile does not exercise that path. Invoke only each live
+    # deferred MoE dispatcher so its capture keys are tuned without repeating
+    # the whole model forward.
+    _run_flashinfer_deferred_moe_autotune(runner)
+
+    if not _has_attention_backend(runner, "FLASHINFER_MLA"):
+        return
+    if runner.vllm_config.parallel_config.decode_context_parallel_size > 1:
+        # Native DCP selects CuTeDSL explicitly; there is no backend choice to
+        # autotune, and its decode metadata has a different distributed shape.
+        return
+
+    import vllm.utils.flashinfer as fi_utils
+
+    runner_any = cast(Any, runner)
+    use_v2_model_runner = runner.vllm_config.use_v2_model_runner
+    query_len = (
+        runner_any.decode_query_len
+        if use_v2_model_runner
+        else runner.uniform_decode_query_len
+    )
+    max_decode_batch_size = min(
+        runner.scheduler_config.max_num_seqs,
+        runner.scheduler_config.max_num_batched_tokens // query_len,
+    )
+    if max_decode_batch_size == 0:
+        return
+    # FlashInfer MLA otherwise profiles every batch bucket supported by any
+    # candidate runner (currently through B8192 for TRTLLM-GEN), regardless of
+    # the dummy input size. Bound that sweep while retaining the low-batch
+    # B32/B64 profiles used by decode-oriented deployments.
+    max_tuning_batch_size = max(
+        max_decode_batch_size,
+        _FLASHINFER_DECODE_AUTOTUNE_MIN_BATCH_SIZE,
+    )
+    tuning_buckets = fi_utils.flashinfer_get_hybrid_num_tokens_buckets(
+        max_tuning_batch_size
+    )
+    max_model_len = (
+        runner_any.model_state.max_model_len
+        if use_v2_model_runner
+        else runner.max_model_len
+    )
+    logger.info(
+        "Running FlashInfer MLA decode autotune with %d tokens, "
+        "batch buckets %s, and max sequence length %d.",
+        max_tuning_batch_size * query_len,
+        tuning_buckets,
+        max_model_len,
+    )
+    with fi_utils.autotune(tuning_buckets=tuning_buckets):
+        # FULL CUDA graph capture uses max_seq_len=max_model_len, and
+        # FlashInfer includes it in the MLA runner cache key. Invoke only the
+        # dense MLA dispatcher with the initialized layer/cache geometry so
+        # this key matches capture without rerunning the whole model (and MoE).
+        _run_flashinfer_mla_decode_autotune(
+            runner,
+            max_tuning_batch_size,
+            query_len,
+            max_model_len,
         )
 
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -257,7 +257,6 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
 
 
 _FLASHINFER_BF16_AUTOTUNE_MAX_TOKENS = 32
-_FLASHINFER_DECODE_AUTOTUNE_MIN_BATCH_SIZE = 64
 
 
 def _flashinfer_autotune_token_counts(runner: "GPUModelRunner") -> tuple[int, ...]:
@@ -289,12 +288,6 @@ def _run_flashinfer_mla_decode_autotune(
             table.get_device_tensor(batch_size)
             for table in runner.input_batch.block_table.block_tables
         )
-    block_tables = tuple(
-        table
-        if table.shape[0] == batch_size
-        else table.new_zeros((batch_size, *table.shape[1:]))
-        for table in block_tables
-    )
 
     static_forward_context = (
         runner.vllm_config.compilation_config.static_forward_context
@@ -319,6 +312,7 @@ def _run_flashinfer_deferred_moe_autotune(runner: "GPUModelRunner") -> None:
     from vllm.model_executor.layers.fused_moe import MoERunner
 
     max_num_batched_tokens = runner.scheduler_config.max_num_batched_tokens
+    tuned: set[tuple] = set()
     for module in runner.get_model().modules():
         if not isinstance(module, MoERunner):
             continue
@@ -343,6 +337,23 @@ def _run_flashinfer_deferred_moe_autotune(runner: "GPUModelRunner") -> None:
             or not moe_kernel.supports_deferred_moe_finalize()
         ):
             continue
+
+        # Layers agreeing on these properties produce identical autotune cache
+        # keys, so one dispatcher call already covers the rest.
+        signature = (
+            num_tokens,
+            moe_config.hidden_dim,
+            moe_config.num_experts,
+            moe_config.in_dtype,
+            moe_config.router_logits_dtype,
+            type(quant_method),
+            type(moe_kernel),
+            tuple(routed_experts.w13_weight.shape),
+            routed_experts.w13_weight.dtype,
+        )
+        if signature in tuned:
+            continue
+        tuned.add(signature)
 
         tuning_buckets = fi_utils.flashinfer_get_hybrid_num_tokens_buckets(num_tokens)
         logger.info(
@@ -410,14 +421,10 @@ def _run_flashinfer_autotune_dummy_runs(runner: "GPUModelRunner") -> None:
         return
     # FlashInfer MLA otherwise profiles every batch bucket supported by any
     # candidate runner (currently through B8192 for TRTLLM-GEN), regardless of
-    # the dummy input size. Bound that sweep while retaining the low-batch
-    # B32/B64 profiles used by decode-oriented deployments.
-    max_tuning_batch_size = max(
-        max_decode_batch_size,
-        _FLASHINFER_DECODE_AUTOTUNE_MIN_BATCH_SIZE,
-    )
+    # the dummy input size. Limit the sweep to batches this scheduler can
+    # execute; scheduler settings are part of the autotune cache fingerprint.
     tuning_buckets = fi_utils.flashinfer_get_hybrid_num_tokens_buckets(
-        max_tuning_batch_size
+        max_decode_batch_size
     )
     max_model_len = (
         runner_any.model_state.max_model_len
@@ -427,7 +434,7 @@ def _run_flashinfer_autotune_dummy_runs(runner: "GPUModelRunner") -> None:
     logger.info(
         "Running FlashInfer MLA decode autotune with %d tokens, "
         "batch buckets %s, and max sequence length %d.",
-        max_tuning_batch_size * query_len,
+        max_decode_batch_size * query_len,
         tuning_buckets,
         max_model_len,
     )
@@ -438,7 +445,7 @@ def _run_flashinfer_autotune_dummy_runs(runner: "GPUModelRunner") -> None:
         # this key matches capture without rerunning the whole model (and MoE).
         _run_flashinfer_mla_decode_autotune(
             runner,
-            max_tuning_batch_size,
+            max_decode_batch_size,
             query_len,
             max_model_len,
         )

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -218,6 +218,9 @@ flashinfer_convert_sf_to_mma_layout = _lazy_import_wrapper(
 flashinfer_b12x_fused_moe = _lazy_import_wrapper(
     "flashinfer.fused_moe", "b12x_fused_moe"
 )
+flashinfer_get_hybrid_num_tokens_buckets = _lazy_import_wrapper(
+    "flashinfer.fused_moe.utils", "get_hybrid_num_tokens_buckets"
+)
 trtllm_fp4_block_scale_moe = _lazy_import_wrapper(
     "flashinfer", "trtllm_fp4_block_scale_moe"
 )

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -15,11 +15,13 @@ from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
+    MLACommonDecodeMetadata,
     MLACommonImpl,
     MLACommonMetadata,
     MLACommonMetadataBuilder,
     QueryLenSupport,
 )
+from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
@@ -113,6 +115,75 @@ def _get_multi_ctas_kv_counter_buffer(
             min_bytes, dtype=torch.uint8, device=device
         )
     return _fi_multi_ctas_kv_counter
+
+
+@torch.inference_mode()
+def flashinfer_mla_decode_autotune(
+    layer: Any,
+    block_table: torch.Tensor,
+    batch_size: int,
+    query_len: int,
+    max_seq_len: int,
+) -> None:
+    """Run only the dense MLA decode dispatcher for an autotune sweep.
+
+    A full-model dummy forward also reaches every linear and MoE operator in
+    the model. This helper instead recreates the tensors passed to
+    ``forward_mqa`` from the initialized attention layer and KV cache, so an
+    MLA-only tuning pass cannot retrigger unrelated operator autotuning.
+    """
+    impl = layer.impl
+    assert isinstance(impl, FlashInferMLAImpl)
+    assert batch_size > 0 and query_len > 0
+    assert block_table.shape[0] == batch_size
+
+    kv_cache = layer.kv_cache
+    assert kv_cache.numel() > 0
+    query_dtype = kv_cache.dtype
+    if is_quantized_kv_cache(layer.kv_cache_dtype):
+        query_dtype = current_platform.fp8_dtype()
+        kv_cache = kv_cache.view(query_dtype)
+
+    num_tokens = batch_size * query_len
+    query = torch.zeros(
+        num_tokens,
+        impl.num_heads,
+        layer.kv_lora_rank + layer.qk_rope_head_dim,
+        dtype=query_dtype,
+        device=kv_cache.device,
+    )
+    query_start_loc = torch.arange(
+        0,
+        num_tokens + 1,
+        query_len,
+        dtype=torch.int32,
+        device=kv_cache.device,
+    )
+    seq_lens = torch.full(
+        (batch_size,),
+        max_seq_len,
+        dtype=torch.int32,
+        device=kv_cache.device,
+    )
+    metadata = MLACommonMetadata(
+        num_reqs=batch_size,
+        max_query_len=query_len,
+        max_seq_len=max_seq_len,
+        num_actual_tokens=num_tokens,
+        query_start_loc=query_start_loc,
+        slot_mapping=torch.full(
+            (num_tokens,), -1, dtype=torch.int64, device=kv_cache.device
+        ),
+        num_decodes=batch_size,
+        num_decode_tokens=num_tokens,
+        num_prefills=0,
+        decode=MLACommonDecodeMetadata(
+            block_table=block_table.zero_(),
+            seq_lens=seq_lens,
+            dcp_tot_seq_lens=None,
+        ),
+    )
+    impl.forward_mqa(query, kv_cache, metadata, layer)
 
 
 class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):


### PR DESCRIPTION
## Decode autotune failures

### Decode MoE

Kimi-K3 decode defers MoE finalization so the consumer can fuse the final
top-k reduction. That changes the monolithic FlashInfer MoE output signature
from `(tokens, hidden)` to `(tokens, 0)`. The existing generic full-model
autotune dummy does not exercise this deferred-finalize path. FULL decode graph
capture therefore misses the `(B, 0)` cache entries, falls back to
`MoERunner tactic=-1`, and captures that default tactic into the serving graph.

This change finds live deferred-finalize `MoERunner` modules and directly calls
their monolithic dispatcher under bounded token buckets. It tunes the actual
`(B, 0)` signatures without running the full model a second time. Layers with
the same tuning geometry are deduplicated, so each cache shape is warmed only
once. In the K3 validation below, all scheduler-reachable buckets received
tuned cache entries instead of the `tactic=-1` fallback. For the measured B12
workload, Nsight Systems shows that the tuned path and the `tactic=-1` fallback
launch exactly the same two MoE BMM kernel names. Thus this example changes the
autotune result from a miss to a hit, but does not change the selected MoE
kernels or their performance.

### Decode MLA

The generic FlashInfer autotune dummy is prefill-shaped, so dense
`trtllm_batch_decode_mla` never enters the autotuner. Its runner cache key also
includes the decode query length and maximum sequence length. For DSpark q=8,
FULL decode graph capture queries `q=8, max_seq_len=1,048,576`, misses the cache,
selects runner 0 (`TrtllmGenMlaDecodeRunner`), and captures TRTLLM-GEN into the
serving graph.

This change adds a dispatcher-only MLA decode pass. It uses the live attention
layer and KV-cache geometry, the actual decode query length, the graph-capture
`max_model_len`, and batch buckets reachable under the scheduler's configured
sequence and token limits. It does not repeat a full-model forward or retrigger
MoE autotuning. Native DCP, which selects CuTeDSL explicitly, is left unchanged.

## Real-weight B12 result

Compared direct parent `82936c409d` with benchmark commit `3eb140ae66` on two
4x-GB300 nodes. The follow-up at HEAD only deduplicates identical MoE warmups
and replaces the fixed B64 tuning floor with scheduler-reachable buckets; it
does not change the measured B12 capture key or selected kernels. Both arms
used the same benchmark-only barrier/harness overlay; the E2E runs did not use
a profiler.

- Model: Kimi-K3 target plus K3-DSpark draft, real weights loaded with
  `fastsafetensors` lazy loading.
- Parallelism: TP8, DCP1, one data-parallel replica.
- Speculative decode: 7 draft tokens, q=8 target verification,
  `draft_sample_method=probabilistic`, `rejection_sample_method=block`.
- Attention: FlashInfer MLA target, TokenSpeed MLA draft, FP8 E4M3 KV cache.
- Limits: `max_num_seqs=16`, `max_num_batched_tokens=8192`,
  `max_model_len=1,048,576`, FULL decode CUDA graphs.
- Workload: B12 with initial KV lengths
  `[52469, 45817, 49103, 86848, 82695, 38414, 79487, 73857, 87522, 52702, 133725, 50835]`
  (833,474 tokens total), 512 output tokens per request, ignore EOS.
- Measurement: release all 12 requests together at the decode barrier, require
  the target q=8 graph, and retain only the stable decode interval.

| Stable decode metric | Parent main | This change | Difference |
| --- | ---: | ---: | ---: |
| Kept steps | 393 | 399 | — |
| Step latency, median | 56.489 ms | 36.169 ms | -36.0% (1.56x) |
| Step latency, p90 | 56.964 ms | 36.638 ms | -35.7% |
| Stable emitted tokens | 5,429 | 5,428 | matched |
| Stable decode time | 22.213 s | 14.446 s | -35.0% |
| Aggregate decode throughput | 244.4 tok/s | 375.7 tok/s | +53.7% |
| Draft acceptance rate | 2.04% | 1.83% | -0.22 pp |

The step-latency comparison isolates target-step execution from the small
acceptance difference. Both arms completed all 12 requests and emitted all
6,144 requested tokens.

## Decode-only kernel attribution

Nsight Systems collection started only after the B12 prefill barrier, so the
profiles contain decode rather than model loading or prefill. The table reports
medians across the dominant full-B12 graph on all eight ranks, excluding the
first eight graph executions per rank (3,112 parent and 3,160 fixed rank-steps).
Kernel duration is shown together with its share of target graph wall time.

| Profiled target graph | Parent main | This change | Difference |
| --- | ---: | ---: | ---: |
| Graph wall time | 50.220 ms | 29.913 ms | -40.4% |
| Decode MLA | 23.562 ms (46.91%) | 3.196 ms (10.70%) | -86.4% |
| Decode MoE BMM | 10.083 ms (20.08%) | 10.169 ms (34.05%) | +0.9% |
| MLA + MoE BMM | 33.644 ms (66.99%) | 13.365 ms (44.75%) | -60.3% |

Parent MLA consists of 24
`fmha...QkvE4m3...ForGen` launches per graph (0.982 ms median each). The fixed
graph instead contains 24 CuTeDSL split-KV launches plus 24 reductions (0.128
ms and 0.005 ms median each), confirming that the serving graph captured CuTe
rather than TRTLLM-GEN. MoE changes from a cache miss with `tactic=-1` to a
tuned cache hit, but in this B12 example the two BMM kernel names are exactly
the same before and after, with the same approximately 10.1 ms cost; the 0.9%
difference is noise. Thus the B12 speedup comes from MLA, while the MoE change
removes a real cache-miss/default-tactic bug without changing the selected MoE
kernels or efficiency in this example.

Nsight Systems adds instrumentation overhead, so these profiled graph times
are used for attribution only; the unprofiled E2E table above is the performance
result.

## Validation

- `tests/model_executor/test_flashinfer_autotune_warmup.py`: 14 passed with
  FlashInfer 0.6.18.
- All pre-commit hooks passed, including Ruff and mypy.

This remains a Draft for final human review.
