### PR TITLE
[Bugfix][Frontend] Truncate prompt_is_token_ids with the prompt

### DIFF
--- a/tests/renderers/test_chat_utils_prompt_embeds.py
+++ b/tests/renderers/test_chat_utils_prompt_embeds.py
@@ -27,6 +27,7 @@ from vllm.entrypoints.chat_utils import (
     parse_chat_messages_async,
 )
 from vllm.exceptions import VLLMValidationError
+from vllm.renderers import TokenizeParams
 from vllm.renderers.hf import (
     _PROMPT_EMBEDS_PLACEHOLDER_SPAN_MISMATCH_ERROR,
     _build_mixed_prompt_embeds,
@@ -575,3 +576,49 @@ async def test_end_to_end_multi_message_conversation(tokenizer, parse_fn):
     assert mask.count(False) == LEN_SYS + LEN_USR
     assert torch.equal(embeds[positions[0][0] : positions[0][0] + LEN_SYS], t_sys)
     assert torch.equal(embeds[positions[1][0] : positions[1][0] + LEN_USR], t_usr)
+
+
+def test_truncation_keeps_the_mixed_mask_aligned_with_the_prompt():
+    """`prompt_is_token_ids` must be truncated with `prompt_token_ids`.
+
+    The mask is positional: the engine pairs it element-wise with the prompt
+    tokens to decide which positions read a real token id and which read a row
+    of `prompt_embeds`. Truncating the prompt without truncating the mask
+    leaves the two describing different positions, so embed placeholders stop
+    being recognised as such.
+    """
+    hidden_size = 8
+    placeholder_token_id = 0
+    num_head, embed_len, num_tail = 10, 5, 5
+
+    token_ids = (
+        list(range(1, num_head + 1))
+        + [placeholder_token_id] * embed_len
+        + list(range(1, num_tail + 1))
+    )
+    tensors = [torch.randn(embed_len, hidden_size)]
+    positions = [(num_head, embed_len)]
+    embeds, mask = _build_mixed_prompt_embeds(token_ids, tensors, positions)
+
+    prompt = {
+        "prompt_token_ids": token_ids,
+        "prompt_embeds": embeds,
+        "prompt_is_token_ids": mask,
+    }
+    keep = 8
+    tok_params = TokenizeParams(
+        max_total_tokens=100,
+        truncate_prompt_tokens=keep,
+        truncation_side="left",
+    )
+
+    result = tok_params.apply_post_tokenization(None, prompt)
+
+    # Keeping the last 8 of 20 positions starts inside the embed span, so the
+    # first 3 surviving positions are embed rows and the rest are real tokens.
+    # Comparing contents rather than lengths is what pins the alignment: a
+    # mask reduced from the wrong side has the right length and still
+    # describes the wrong positions.
+    assert result["prompt_is_token_ids"] == [False] * 3 + [True] * num_tail
+    assert result["prompt_token_ids"] == token_ids[-keep:]
+    assert torch.equal(result["prompt_embeds"], embeds[-keep:])

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -420,8 +420,8 @@ class TokenizeParams:
         """The slice truncation applies to a sequence of `length` tokens.
 
         `None` means no truncation. Anything parallel to the prompt tokens
-        (see `prompt_token_offsets`) must be reduced with this same slice to
-        stay aligned with them.
+        (see `prompt_token_offsets` and `prompt_is_token_ids`) must be reduced
+        with this same slice to stay aligned with them.
         """
         max_length = self.truncate_prompt_tokens
         if max_length is not None and max_length < 0:
@@ -516,5 +516,10 @@ class TokenizeParams:
             truncation = self._truncation_slice(tokenizer, len(offsets))
             if truncation is not None:
                 prompt["prompt_token_offsets"] = offsets[truncation]  # type: ignore[typeddict-unknown-key]
+        is_token_ids = cast(EmbedsPrompt, prompt).get("prompt_is_token_ids")
+        if is_token_ids is not None:
+            truncation = self._truncation_slice(tokenizer, len(is_token_ids))
+            if truncation is not None:
+                prompt["prompt_is_token_ids"] = is_token_ids[truncation]  # type: ignore[typeddict-unknown-key]
 
         return prompt


### PR DESCRIPTION
Follow-up to #54407, which fixed the same class of defect for
`prompt_token_offsets`. Rebased onto it now that it has merged, so this PR is
down to applying the existing `_truncation_slice` to the one remaining
parallel array.

## The bug

`EmbedsPrompt.prompt_is_token_ids` is a per-position mask paired element-wise
with `prompt_token_ids`: `True` means the position reads a real token id,
`False` means it reads a row of `prompt_embeds`. The contract is already
written down -- "Must be the same length as `prompt_token_ids` when both are
set" (`vllm/inputs/llm.py:143`).

`TokenizeParams.apply_post_tokenization` truncates `prompt_token_ids` and
`prompt_embeds`, but never touches the mask. With `truncate_prompt_tokens`
set, the prompt shrinks and the mask does not, so the two end up describing
different positions.

`_truncation_slice`'s docstring already said anything parallel to the prompt
tokens must be reduced with the same slice; `prompt_is_token_ids` was the
remaining case, so I also extended that docstring to name it.

## Reachability

The mask is only built on the mixed-mode path, and that path is reachable
straight from the OpenAI API. Against a server started with
`--enable-prompt-embeds`:

```bash
curl -X POST http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
        "model": "<model>",
        "messages": [{"role": "user", "content": [
          {"type": "prompt_embeds", "data": "<base64 torch tensor>"},
          {"type": "text", "text": "Summarize."}
        ]}],
        "truncate_prompt_tokens": 8
      }'
```

`truncate_prompt_tokens` is an ordinary field on `ChatCompletionRequest`
(`vllm/entrypoints/openai/chat_completion/protocol.py:277`) and is passed
through by `build_tok_params`. The call chain is
`render_chat_async` -> `render_messages_async` (which calls
`_apply_prompt_embeds_to_prompt` and sets `prompt_is_token_ids`,
`vllm/renderers/hf.py:1043`) -> `tokenize_prompts_async` ->
`_tokenize_singleton_prompt_async` -> `apply_post_tokenization`. The mask is
then handed to the engine unchanged by `_process_embeds`
(`vllm/renderers/base.py:828`).

## What the stale mask does

Both consumers assume the documented equal length:

- `vllm/v1/worker/gpu_input_batch.py:377-379` assigns the mask into
  `self.is_token_ids[req_index, :num_prompt_tokens]`, where
  `num_prompt_tokens` is the *truncated* length. A longer mask raises
  `ValueError: could not broadcast input array from shape (N,) into shape
  (M,)` inside the engine core.
- `vllm/v1/request.py:154-157` zips the mask with `prompt_token_ids` to zero
  out embed placeholders. `zip` stops at the shorter sequence, so with
  `truncation_side="left"` the surviving tokens are paired with the mask
  entries for the positions that were dropped. The placeholder ids that this
  code exists to zero out are left in place -- the comment there notes they
  "may lie outside the embedding".

## Scope

Padding deliberately is not handled: `_token_padding` rejects a non-list
sequence with "Cannot pad tokens for embedding inputs", so an embeds prompt
never completes padding in the first place.

## Not a duplicate

Searched open PRs for `prompt_is_token_ids in:body`,
`apply_post_tokenization in:body`, `_build_mixed_prompt_embeds in:body`,
`EmbedsPrompt in:body` and `is_token_ids in:body`. The only hits touching this
area were #54407 (now merged, `prompt_token_offsets`) and #45925 (a docs
change). Nothing truncates the mask.

## Tests

New test: `tests/renderers/test_chat_utils_prompt_embeds.py::test_truncation_keeps_the_mixed_mask_aligned_with_the_prompt`.
It builds a realistic mixed prompt with the existing `_build_mixed_prompt_embeds`
helper (10 real tokens, a 5-token embed span, 5 real tokens), truncates to the
last 8, and checks the mask still marks the right positions.

I do not have a GPU, so I ran this on a CPU runner on my fork
(`ubuntu-latest`, editable install), re-run after the rebase. Against
`vllm/renderers/params.py` from `main`:

```
>       assert result["prompt_is_token_ids"] == [False] * 3 + [True] * num_tail
E       assert [True, True, ...ue, True, ...] == [False, False...ue, True, ...]
E         At index 0 diff: True != False
E         Left contains 12 more items, first extra item: True

1 failed, 80 deselected
```

The assertion is on the contents, not just the length, so it fails on the
misalignment itself: index 0 of the surviving prompt is an embed row, but the
stale mask still reports the very first token of the untruncated prompt.

With the fix, the whole file passes:

```
81 passed in 41.09s
```

Whole-suite check, `pytest tests/renderers` run on both revisions:

| | result |
| --- | --- |
| `main` | 4 failed, 436 passed, 2 skipped |
| this branch | 4 failed, 437 passed, 2 skipped |

The 4 failures are byte-identical on both sides and are environmental, not
regressions: one needs the optional `cohere_melody` package, and three are
gated Hugging Face repos the runner cannot access.

Lint: `ruff check`, `ruff format --diff`, `typos`, the SPDX pre-commit hook and
`mypy` (3.12) all pass on the two changed files.

AI assistance was used to research and draft this change. I have reviewed every
changed line and run the tests above.
