### PR TITLE
[Bugfix][WideEP] Fix VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE default

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -55,6 +55,21 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+def test_deepep_v2_allow_hybrid_mode_defaults_to_true(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The runtime default must match the declared `bool = True` and DeepEP's
+    # own ElasticBuffer default (allow_hybrid_mode=True).
+    monkeypatch.delenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", raising=False)
+    assert envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE is True
+
+    monkeypatch.setenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "0")
+    assert envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE is False
+
+    monkeypatch.setenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "1")
+    assert envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE is True
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1944,8 +1944,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL", "0"))
     ),
     # DeepEP v2: enable two-tier NVLink+RDMA hybrid mode
+    # (on by default, matching DeepEP's ElasticBuffer default)
     "VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE": lambda: bool(
-        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "0"))
+        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "1"))
     ),
     # DeepEP v2: use fewer SMs at slight throughput cost
     "VLLM_DEEPEP_V2_PREFER_OVERLAP": lambda: bool(


### PR DESCRIPTION
## Purpose

Fixes #54281

`VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE` is declared as `bool = True` in the `TYPE_CHECKING` block, but the runtime lambda defaulted to `"0"`, so the flag always resolved to `False` unless the env var was explicitly set. This silently disabled DeepEP v2 hybrid NVLink+RDMA mode in multi-node serving, and diverges from DeepEP's own upstream default (`ElasticBuffer(allow_hybrid_mode=True)`).

Both lines were introduced in the same commit (e2f993dc41, "[WideEP] Integrate DeepEP v2 (#41183)") — this looks like a copy-paste slip from the two neighboring flags (`VLLM_DEEPEP_V2_PREFER_OVERLAP` / `VLLM_DEEPEP_V2_ALLOW_MULTIPLE_REDUCTION`), which are declared `False` with a `"0"` default.

This PR flips the runtime default to `"1"` so the resolved value matches both the declaration and upstream DeepEP. Users can still opt out with `VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE=0`.

## Test Plan

Added a regression test in `tests/test_envs.py` (`test_deepep_v2_allow_hybrid_mode_defaults_to_true`) asserting the flag defaults to `True` and that the env-var override still works both ways (`"0"` → `False`, `"1"` → `True`):

```bash
PYTHONPATH=. python -m pytest --noconftest tests/test_envs.py -v
```

(`--noconftest` because this suite doesn't need the shared conftest's torch/transformers imports; run in a CPU-only venv.)

## Test Result

- New test **fails on the pre-fix code** (`assert False is True`), confirming it exposes the bug.
- After the fix, the full `tests/test_envs.py` suite passes: **57/57**.
- Standalone check: `envs.VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE` resolves `False` before the change, `True` after; explicit `VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE=0` still resolves `False`.
- `pre-commit run --files vllm/envs.py tests/test_envs.py` — all checks pass.

## Duplicate-work check

Searched open PRs by issue number and by keywords (`DEEPEP_V2_ALLOW_HYBRID_MODE`, `hybrid mode`); no open PR addressed this at submission time.

## AI-assistance disclosure

This PR was created with AI assistance (OpenClaw agent, qwen3.8-max), disclosed via the `Assisted-by:` commit trailer per repo policy. The human submitter reviewed every changed line and ran the tests above. The change restores a config flag's documented default; it does not affect model outputs or accuracy.
