### PR TITLE
[Bugfix][Core] Fail cleanly for unsupported DBO backends

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -816,7 +816,10 @@ def test_ubatching_rejects_unsupported_all2all_backend():
             "allgather_reducescatter is not supported"
         ),
     ):
-        VllmConfig(parallel_config=ParallelConfig(enable_dbo=True))
+        VllmConfig(
+            device_config=DeviceConfig(device="cpu"),
+            parallel_config=ParallelConfig(enable_dbo=True),
+        )
 
 
 @pytest.mark.parametrize("port", [1, 29550, 65535])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -808,6 +808,17 @@ def test_all2all_backend_has_portable_default():
     assert ParallelConfig().all2all_backend == "allgather_reducescatter"
 
 
+def test_ubatching_rejects_unsupported_all2all_backend():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Microbatching currently only supports.*"
+            "allgather_reducescatter is not supported"
+        ),
+    ):
+        VllmConfig(parallel_config=ParallelConfig(enable_dbo=True))
+
+
 @pytest.mark.parametrize("port", [1, 29550, 65535])
 def test_data_parallel_rpc_port_accepts_valid_ports(port: int):
     assert ParallelConfig(data_parallel_rpc_port=port).data_parallel_rpc_port == port

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1730,18 +1730,19 @@ class VllmConfig:
 
         if self.parallel_config.use_ubatching:
             a2a_backend = self.parallel_config.all2all_backend
-            assert a2a_backend in [
+            if a2a_backend not in [
                 "deepep_low_latency",
                 "deepep_high_throughput",
                 "nixl_ep",
-            ], (
-                "Microbatching currently only supports the deepep_low_latency, "
-                "deepep_high_throughput, and nixl_ep all2all backends. "
-                f"{a2a_backend} is not supported. To fix use "
-                "--all2all-backend=deepep_low_latency, "
-                "--all2all-backend=deepep_high_throughput, or "
-                "--all2all-backend=nixl_ep and install the matching kernels."
-            )
+            ]:
+                raise ValueError(
+                    "Microbatching currently only supports the "
+                    "deepep_low_latency, deepep_high_throughput, and nixl_ep "
+                    f"all2all backends. {a2a_backend} is not supported. To fix use "
+                    "--all2all-backend=deepep_low_latency, "
+                    "--all2all-backend=deepep_high_throughput, or "
+                    "--all2all-backend=nixl_ep and install the matching kernels."
+                )
 
             if not self.model_config.disable_cascade_attn:
                 self.model_config.disable_cascade_attn = True


### PR DESCRIPTION
## Purpose

Fixes #54493.

Replace the DBO all2all backend `assert` with a `ValueError` so unsupported configurations fail consistently even when Python assertions are disabled. The existing supported-backend list and remediation guidance are preserved.

This change was prepared with assistance from OpenAI Codex and reviewed by the contributor.

## Test Plan

```bash
python -m pytest --noconftest -o addopts= -q \
  tests/test_config.py::test_all2all_backend_has_portable_default \
  tests/test_config.py::test_ubatching_rejects_unsupported_all2all_backend
ruff check vllm/config/vllm.py tests/test_config.py
ruff format --check vllm/config/vllm.py tests/test_config.py
```

## Test Result

```text
2 passed, 15 warnings in 4.26s
All checks passed!
2 files already formatted
```

The warnings are from the source checkout version lookup and PyTorch JIT deprecations.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. (Not applicable.)
</details>
