### PR TITLE
[Bugfix][NIXL] Don't assert when a failed transfer is cleaned up twice

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -2874,6 +2874,88 @@ def test_failed_request_skips_kv_postprocessing(
     assert invalid_blocks == {1, 2, 3}
 
 
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker.NixlWrapper",
+    FailingNixlWrapper,
+)
+def test_handles_failing_in_separate_polls_do_not_kill_the_engine(
+    default_vllm_config, dist_init
+):
+    """A request whose handles fail in different polls must not crash the engine.
+
+    One transfer handle is created per remote rank, and when a peer goes away
+    they do not all fail in the same poll: one errors while another is still
+    PROC. Each failure queues the request id on _failed_recv_reqs, so
+    get_finished() sees the id once per handle. The first pass pops the
+    metadata and reports the request; the second must tolerate finding nothing
+    and must not report the request again.
+
+    Either half taken alone kills the EngineCore. Asserting on the missing
+    metadata raises out of worker_busy_loop, and reporting the request twice
+    trips the scheduler's own assert in _update_from_kv_xfer_finished, which
+    only expects a finished recv for a request still waiting for KVs.
+    """
+    vllm_config = create_vllm_config()
+    connector = NixlConnector(
+        vllm_config, KVConnectorRole.WORKER, make_kv_cache_config(block_size=16)
+    )
+    connector.connector_worker = FakeNixlConnectorWorker(
+        vllm_config, connector.engine_id, hand_shake_latency=0
+    )
+    worker = connector.connector_worker
+
+    request_id = "test_two_handles_failing_in_separate_polls"
+    metadata = NixlConnectorMetadata()
+    metadata.add_new_req_to_recv(
+        request_id=request_id,
+        local_block_ids=([1, 2, 3],),
+        kv_transfer_params={
+            "remote_block_ids": ([4, 5, 6],),
+            "remote_engine_id": FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
+            "remote_request_id": f"prefill-{request_id}",
+            "remote_host": "localhost",
+            "remote_port": 1234,
+            "remote_tp_size": 1,
+        },
+    )
+    connector.bind_connector_metadata(metadata)
+    dummy_ctx = ForwardContext(no_compile_layers={}, attn_metadata={}, slot_mapping={})
+    connector.start_load_kv(dummy_ctx)
+    connector.bind_connector_metadata(NixlConnectorMetadata())
+    time.sleep(0.1)
+    connector.start_load_kv(dummy_ctx)
+
+    # Give the request a second handle, as a second remote rank would.
+    handles = worker._recving_transfers[request_id]
+    assert len(handles) == 1
+    first, second = handles[0], object()
+    worker._recving_transfers[request_id] = [first, second]
+
+    # Poll 1: the first handle has failed, the second is still running.
+    def first_failed(handle):
+        return "ERR" if handle is first else "PROC"
+
+    with patch.object(
+        worker.nixl_wrapper, "check_xfer_state", side_effect=first_failed
+    ):
+        _, done_recving = connector.get_finished(finished_req_ids=set())
+
+    assert request_id in done_recving
+    assert request_id not in worker._recving_metadata
+    assert worker._recving_transfers[request_id] == [second]
+
+    # Poll 2: the second handle fails too, and the same id is cleaned up again.
+    # The request was already reported, so it must not be reported a second
+    # time: the scheduler has since moved it out of WAITING_FOR_REMOTE_KVS to
+    # recompute locally, and asserts on a finished recv for a request in that
+    # state.
+    with patch.object(worker.nixl_wrapper, "check_xfer_state", return_value="ERR"):
+        _, done_recving = connector.get_finished(finished_req_ids=set())
+
+    assert request_id not in done_recving
+    assert request_id not in worker._recving_transfers
+
+
 def _set_test_speculative_config(
     vllm_config,
     *,

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -2885,15 +2885,14 @@ def test_handles_failing_in_separate_polls_do_not_kill_the_engine(
 
     One transfer handle is created per remote rank, and when a peer goes away
     they do not all fail in the same poll: one errors while another is still
-    PROC. Each failure queues the request id on _failed_recv_reqs, so
-    get_finished() sees the id once per handle. The first pass pops the
-    metadata and reports the request; the second must tolerate finding nothing
-    and must not report the request again.
+    PROC. The first failure reports the request via _failed_recv_reqs and
+    get_finished() pops its metadata; when the remaining handles fail in a
+    later poll, the request must be cleaned up without being reported again.
 
-    Either half taken alone kills the EngineCore. Asserting on the missing
-    metadata raises out of worker_busy_loop, and reporting the request twice
-    trips the scheduler's own assert in _update_from_kv_xfer_finished, which
-    only expects a finished recv for a request still waiting for KVs.
+    Reporting twice kills the EngineCore: the scheduler's assert in
+    _update_from_kv_xfer_finished only expects a finished recv for a request
+    still waiting for KVs, having moved this one out of
+    WAITING_FOR_REMOTE_KVS to recompute locally after the first report.
     """
     vllm_config = create_vllm_config()
     connector = NixlConnector(
@@ -2944,11 +2943,11 @@ def test_handles_failing_in_separate_polls_do_not_kill_the_engine(
     assert request_id not in worker._recving_metadata
     assert worker._recving_transfers[request_id] == [second]
 
-    # Poll 2: the second handle fails too, and the same id is cleaned up again.
-    # The request was already reported, so it must not be reported a second
-    # time: the scheduler has since moved it out of WAITING_FOR_REMOTE_KVS to
-    # recompute locally, and asserts on a finished recv for a request in that
-    # state.
+    # Poll 2: the second handle fails too. The request was already reported,
+    # so it must not be reported a second time: the scheduler has since moved
+    # it out of WAITING_FOR_REMOTE_KVS to recompute locally, and asserts on a
+    # finished recv for a request in that state. Its remaining handles are
+    # still released and the transfer entry removed.
     with patch.object(worker.nixl_wrapper, "check_xfer_state", return_value="ERR"):
         _, done_recving = connector.get_finished(finished_req_ids=set())
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2347,15 +2347,10 @@ class NixlBaseConnectorWorker:
 
         block_ids_for_blocksize_post_process = defaultdict(list)
         block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
-        already_failed = set[str]()
         for req_id in done_recving:
             # clean up metadata for completed requests
-            if (meta := self._recving_metadata.pop(req_id, None)) is None:
-                # (multi-read) A failed transfer reaches here once per handle: the
-                # handles of one request do not all fail in the same
-                # `_pop_done_transfers` poll, and each failure queues it again.
-                already_failed.add(req_id)
-                continue
+            meta = self._recving_metadata.pop(req_id, None)
+            assert meta is not None, f"{req_id} not found in recving_metadata list"
 
             # Skip KV sync and post-processing for failed requests
             if req_id in failed_recv_reqs:
@@ -2401,8 +2396,6 @@ class NixlBaseConnectorWorker:
                 block_ids_for_heterogeneous_attn_post_process.append(
                     meta.local_physical_block_ids[0]
                 )
-        done_recving -= already_failed
-
         for (
             block_size_ratio,
             block_ids_list,
@@ -2528,7 +2521,11 @@ class NixlBaseConnectorWorker:
 
             if not in_progress:
                 # Only report request as completed when all transfers are done.
-                done_req_ids.add(req_id)
+                # A request failed in an earlier poll was already reported via
+                # _failed_recv_reqs and its metadata popped by get_finished();
+                # don't report it again, just drop the remaining handles.
+                if req_id in self._recving_metadata:
+                    done_req_ids.add(req_id)
                 del transfers[req_id]
             else:
                 transfers[req_id] = in_progress
@@ -2543,11 +2540,15 @@ class NixlBaseConnectorWorker:
             req_id: The request ID.
             handle: The transfer handle.
         """
-        # Use .get() here as the metadata cleanup is handled by get_finished()
+        # (multi-read) One handle is created per remote rank, and they do not
+        # all fail in the same _pop_done_transfers poll. The request is
+        # reported failed on the first one, which pops its metadata in
+        # get_finished(); on the later failures only the handle cleanup is left.
         # TODO (NickLucche) handle failed transfer for HMA.
-        if (meta := self._recving_metadata.get(req_id)) and not self._is_hma_required:
-            self._invalid_block_ids.put(set(meta.local_block_ids[0]))
-        self._failed_recv_reqs.put(req_id)
+        if (meta := self._recving_metadata.get(req_id)) is not None:
+            if not self._is_hma_required:
+                self._invalid_block_ids.put(set(meta.local_block_ids[0]))
+            self._failed_recv_reqs.put(req_id)
         if handle is not None:
             self.nixl_wrapper.release_xfer_handle(handle)
         self.xfer_stats.record_failed_transfer()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2347,10 +2347,17 @@ class NixlBaseConnectorWorker:
 
         block_ids_for_blocksize_post_process = defaultdict(list)
         block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
+        reported_before = set[str]()
         for req_id in done_recving:
             # clean up metadata for completed requests
             meta = self._recving_metadata.pop(req_id, None)
-            assert meta is not None, f"{req_id} not found in recving_metadata list"
+            if meta is None:
+                # A failed transfer reaches here once per handle: the handles of
+                # one request do not all fail in the same poll, and each failure
+                # queues the request id again. The first pass popped the
+                # metadata and reported the request, so this is a repeat.
+                reported_before.add(req_id)
+                continue
 
             # Skip KV sync and post-processing for failed requests
             if req_id in failed_recv_reqs:
@@ -2396,6 +2403,11 @@ class NixlBaseConnectorWorker:
                 block_ids_for_heterogeneous_attn_post_process.append(
                     meta.local_physical_block_ids[0]
                 )
+
+        # The scheduler acted on these ids the first time they were reported and
+        # asserts on a finished recv for a request no longer waiting for KVs.
+        done_recving -= reported_before
+
         for (
             block_size_ratio,
             block_ids_list,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -2347,16 +2347,14 @@ class NixlBaseConnectorWorker:
 
         block_ids_for_blocksize_post_process = defaultdict(list)
         block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
-        reported_before = set[str]()
+        already_failed = set[str]()
         for req_id in done_recving:
             # clean up metadata for completed requests
-            meta = self._recving_metadata.pop(req_id, None)
-            if meta is None:
-                # A failed transfer reaches here once per handle: the handles of
-                # one request do not all fail in the same poll, and each failure
-                # queues the request id again. The first pass popped the
-                # metadata and reported the request, so this is a repeat.
-                reported_before.add(req_id)
+            if (meta := self._recving_metadata.pop(req_id, None)) is None:
+                # (multi-read) A failed transfer reaches here once per handle: the
+                # handles of one request do not all fail in the same
+                # `_pop_done_transfers` poll, and each failure queues it again.
+                already_failed.add(req_id)
                 continue
 
             # Skip KV sync and post-processing for failed requests
@@ -2403,10 +2401,7 @@ class NixlBaseConnectorWorker:
                 block_ids_for_heterogeneous_attn_post_process.append(
                     meta.local_physical_block_ids[0]
                 )
-
-        # The scheduler acted on these ids the first time they were reported and
-        # asserts on a finished recv for a request no longer waiting for KVs.
-        done_recving -= reported_before
+        done_recving -= already_failed
 
         for (
             block_size_ratio,


### PR DESCRIPTION
## Purpose

A request's KV is pulled with one transfer handle per remote rank. When a peer goes away the handles do not all fail in the same poll: one errors while another is still `PROC`. Each failure queues the request id on `_failed_recv_reqs`, so `get_finished()` sees the same id once per handle.

That repeat hits two engine-wide asserts:

- `base_worker.py` pops the request's metadata with a default and then asserts it is not None, so the second pass raises out of `worker_busy_loop`.
- Dropping that assert alone is not enough. The id is still returned in `done_recving`, and `Scheduler._update_from_kv_xfer_finished` asserts on a finished recv for a request it has already moved out of `WAITING_FOR_REMOTE_KVS` to recompute locally.

This tolerates the missing metadata and drops the repeat from `done_recving`, so a failed transfer costs its own request rather than the engine and every request batched with it. `_handle_failed_transfer` already reads the metadata with `.get()` and leaves cleanup to `get_finished`.

Observed on a 10-prefill/3-decode disaggregated deployment when three prefill nodes lost their NICs.

## Test Plan

`test_handles_failing_in_separate_polls_do_not_kill_the_engine` gives a request a second handle and fails them in two polls, asserting the second poll neither raises nor re-reports the request.

## Test Result

Both asserts reproduce against the unpatched worker and are gone after the change.