### PR TITLE
[Qwen-Flash-Next] Fix Qwen4Exp PLE prefill memory amplification

### DIFF
--- a/benchmarks/kernels/benchmark_qwen4_exp_ple_conv.py
+++ b/benchmarks/kernels/benchmark_qwen4_exp_ple_conv.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Benchmark Qwen4Exp PLE packed-varlen convolution against dense packing."""
+
+import argparse
+import gc
+import statistics
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import partial
+
+import pandas as pd
+import torch
+import torch.nn.functional as F
+from flashinfer.testing import bench_gpu_time_with_cupti
+
+from vllm.models.qwen4_exp.nvidia.ops.ple_conv import varlen_dilated_conv1d
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    lengths: tuple[int, ...]
+
+    @property
+    def num_tokens(self) -> int:
+        return sum(self.lengths)
+
+
+def balanced_lengths(num_tokens: int, batch_size: int) -> tuple[int, ...]:
+    base, remainder = divmod(num_tokens, batch_size)
+    return tuple(base + (sequence < remainder) for sequence in range(batch_size))
+
+
+INCIDENT_LENGTHS = (9584, *(966 for _ in range(22)), 965, 965)
+LATENCY_CASES = (
+    Case("single-long", (32768,)),
+    Case("uniform-25", balanced_lengths(32766, 25)),
+    Case("incident-skew-25", INCIDENT_LENGTHS),
+    Case("uniform-512", (64,) * 512),
+)
+MEMORY_CASES = (
+    Case("uniform-8k", balanced_lengths(8192, 25)),
+    Case("uniform-16k", balanced_lengths(16384, 25)),
+    LATENCY_CASES[1],
+    LATENCY_CASES[2],
+)
+
+
+def query_start_loc(lengths: tuple[int, ...], device: torch.device) -> torch.Tensor:
+    starts = torch.zeros(len(lengths) + 1, dtype=torch.int64, device=device)
+    torch.cumsum(
+        torch.tensor(lengths, dtype=torch.int64, device=device),
+        dim=0,
+        out=starts[1:],
+    )
+    return starts
+
+
+def dense_dilated_conv1d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    conv_state: torch.Tensor,
+    starts: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+    dilation: int,
+    max_len: int,
+) -> torch.Tensor:
+    """Previous PLE prefill implementation used as the benchmark baseline."""
+    num_tokens, channels = x.shape
+    num_sequences = starts.numel() - 1
+    state_len = (weight.shape[1] - 1) * dilation
+    lengths = starts[1:] - starts[:-1]
+    positions = torch.arange(num_tokens, device=x.device, dtype=torch.int64)
+    sequence_indices = torch.searchsorted(starts[1:], positions, right=True)
+    column_indices = positions - starts[sequence_indices]
+
+    packed_tokens = x.new_zeros((num_sequences, max_len, channels))
+    packed_tokens[sequence_indices, column_indices] = x
+    packed_tokens = packed_tokens.transpose(1, 2).contiguous()
+
+    state = conv_state.index_select(0, state_indices)[..., :state_len].to(x.dtype)
+    initial_state = torch.where(
+        has_initial_state.view(num_sequences, 1, 1),
+        state,
+        torch.zeros_like(state),
+    )
+    history = torch.cat((initial_state, packed_tokens), dim=-1)
+    conv_output = F.conv1d(
+        history,
+        weight.unsqueeze(1).contiguous(),
+        groups=channels,
+        dilation=dilation,
+    )
+    conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+    output = torch.empty_like(x)
+    output.copy_(conv_output[sequence_indices, column_indices])
+    state_starts = lengths.view(num_sequences, 1, 1)
+    state_offsets = torch.arange(state_len, device=x.device, dtype=torch.int64).view(
+        1, 1, state_len
+    )
+    next_state = history.gather(
+        dim=2,
+        index=(state_starts + state_offsets).expand(-1, channels, -1),
+    )
+    existing_state = conv_state.index_select(0, state_indices)
+    existing_state[..., :state_len] = next_state.to(conv_state.dtype)
+    conv_state.index_copy_(0, state_indices, existing_state)
+    return output
+
+
+def make_case_tensors(
+    case: Case,
+    channels: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, ...]:
+    torch.manual_seed(0)
+    x = torch.randn(case.num_tokens, channels, device=device, dtype=torch.bfloat16)
+    weight = torch.randn(channels, 4, device=device, dtype=torch.bfloat16)
+    state = torch.randn(
+        len(case.lengths) + 1,
+        channels,
+        9,
+        device=device,
+        dtype=torch.float32,
+    )
+    starts = query_start_loc(case.lengths, device)
+    state_indices = torch.arange(
+        1, len(case.lengths) + 1, device=device, dtype=torch.int64
+    )
+    has_initial_state = torch.ones(len(case.lengths), device=device, dtype=torch.bool)
+    return x, weight, state, starts, state_indices, has_initial_state
+
+
+def check_correctness(device: torch.device) -> None:
+    case = Case("correctness", (2, 5, 19, 3))
+    x, weight, state, starts, state_indices, has_initial_state = make_case_tensors(
+        case, 37, device
+    )
+    dense_state = state.clone()
+    varlen_state = state.clone()
+    expected = dense_dilated_conv1d(
+        x,
+        weight,
+        dense_state,
+        starts,
+        state_indices,
+        has_initial_state,
+        dilation=3,
+        max_len=max(case.lengths),
+    )
+    actual = varlen_dilated_conv1d(
+        x,
+        weight,
+        varlen_state,
+        starts,
+        state_indices,
+        has_initial_state,
+        dilation=3,
+    )
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(varlen_state, dense_state, rtol=0, atol=0)
+
+
+def measure_peak_gib(run: Callable[[], torch.Tensor]) -> float:
+    warmup_output = run()
+    torch.accelerator.synchronize()
+    del warmup_output
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    baseline = torch.cuda.memory_allocated()
+    output = run()
+    torch.accelerator.synchronize()
+    peak = torch.cuda.max_memory_allocated() - baseline
+    del output
+    return peak / 2**30
+
+
+def benchmark_us(
+    run: Callable[[], torch.Tensor],
+    dry_run_time_ms: int,
+    repeat_time_ms: int,
+) -> float:
+    for _ in range(3):
+        run()
+    torch.accelerator.synchronize()
+    samples = bench_gpu_time_with_cupti(
+        run,
+        dry_run_time_ms=dry_run_time_ms,
+        repeat_time_ms=repeat_time_ms,
+        use_cuda_graph=False,
+        cold_l2_cache=True,
+    )
+    return statistics.median(samples) * 1e3
+
+
+def run_memory_cases(channels: int, device: torch.device) -> pd.DataFrame:
+    rows = []
+    for case in MEMORY_CASES:
+        tensors = make_case_tensors(case, channels, device)
+        x, weight, state, starts, state_indices, has_initial_state = tensors
+
+        run_varlen = partial(
+            varlen_dilated_conv1d,
+            x,
+            weight,
+            state,
+            starts,
+            state_indices,
+            has_initial_state,
+            dilation=3,
+        )
+
+        varlen_peak = measure_peak_gib(run_varlen)
+        dense_peak = None
+        run_dense = None
+        dense_state = None
+        if case.name in {"uniform-25", "incident-skew-25"}:
+            dense_state = state.clone()
+            run_dense = partial(
+                dense_dilated_conv1d,
+                x,
+                weight,
+                dense_state,
+                starts,
+                state_indices,
+                has_initial_state,
+                dilation=3,
+                max_len=max(case.lengths),
+            )
+            dense_peak = measure_peak_gib(run_dense)
+        rows.append(
+            {
+                "case": case.name,
+                "batch": len(case.lengths),
+                "tokens": case.num_tokens,
+                "max_len": max(case.lengths),
+                "dense_rows/token": (
+                    len(case.lengths) * max(case.lengths) / case.num_tokens
+                ),
+                "varlen_peak_gib": varlen_peak,
+                "dense_peak_gib": dense_peak,
+            }
+        )
+        del (
+            tensors,
+            x,
+            weight,
+            state,
+            starts,
+            state_indices,
+            has_initial_state,
+            run_varlen,
+            run_dense,
+            dense_state,
+        )
+        gc.collect()
+        torch.cuda.empty_cache()
+    return pd.DataFrame(rows)
+
+
+def run_latency_cases(
+    channels: int,
+    device: torch.device,
+    dry_run_time_ms: int,
+    repeat_time_ms: int,
+) -> pd.DataFrame:
+    rows = []
+    element_size = torch.tensor([], dtype=torch.bfloat16).element_size()
+    for case in LATENCY_CASES:
+        tensors = make_case_tensors(case, channels, device)
+        x, weight, state, starts, state_indices, has_initial_state = tensors
+        dense_state = state.clone()
+
+        run_varlen = partial(
+            varlen_dilated_conv1d,
+            x,
+            weight,
+            state,
+            starts,
+            state_indices,
+            has_initial_state,
+            dilation=3,
+        )
+        run_dense = partial(
+            dense_dilated_conv1d,
+            x,
+            weight,
+            dense_state,
+            starts,
+            state_indices,
+            has_initial_state,
+            dilation=3,
+            max_len=max(case.lengths),
+        )
+
+        varlen_us = benchmark_us(run_varlen, dry_run_time_ms, repeat_time_ms)
+        dense_us = benchmark_us(run_dense, dry_run_time_ms, repeat_time_ms)
+        ideal_bytes = (
+            2 * case.num_tokens * channels + channels * weight.shape[1]
+        ) * element_size
+        rows.append(
+            {
+                "case": case.name,
+                "batch": len(case.lengths),
+                "tokens": case.num_tokens,
+                "max_len": max(case.lengths),
+                "varlen_us": varlen_us,
+                "dense_us": dense_us,
+                "speedup": dense_us / varlen_us,
+                "varlen_ideal_gbps": ideal_bytes / (varlen_us * 1e3),
+                "dense_ideal_gbps": ideal_bytes / (dense_us * 1e3),
+            }
+        )
+        del (
+            tensors,
+            x,
+            weight,
+            state,
+            starts,
+            state_indices,
+            has_initial_state,
+            dense_state,
+            run_varlen,
+            run_dense,
+        )
+        gc.collect()
+        torch.cuda.empty_cache()
+    return pd.DataFrame(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("memory", "latency", "all"), default="all")
+    parser.add_argument("--channels", type=int, default=10240)
+    parser.add_argument("--dry-run-time-ms", type=int, default=25)
+    parser.add_argument("--repeat-time-ms", type=int, default=100)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    check_correctness(device)
+    print(
+        pd.Series(
+            {
+                "gpu": torch.cuda.get_device_name(device),
+                "torch": torch.__version__,
+                "cuda": torch.version.cuda,
+                "dtype": "bfloat16",
+                "channels": args.channels,
+                "cupti_cold_l2": True,
+                "cuda_graph": False,
+            },
+            name="value",
+        ).to_string()
+    )
+    if args.mode in ("memory", "all"):
+        memory = run_memory_cases(args.channels, device)
+        print("\nPeak incremental allocation")
+        print(memory.to_string(index=False, float_format=lambda value: f"{value:.3f}"))
+    if args.mode in ("latency", "all"):
+        latency = run_latency_cases(
+            args.channels,
+            device,
+            args.dry_run_time_ms,
+            args.repeat_time_ms,
+        )
+        print("\nCUPTI latency (eager production operator, cold L2)")
+        print(latency.to_string(index=False, float_format=lambda value: f"{value:.3f}"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/models/qwen4_exp/test_ple.py
+++ b/tests/models/qwen4_exp/test_ple.py
@@ -18,11 +18,20 @@ from vllm.models.qwen4_exp.common.ple import (
     copy_ple_embedding_shard_,
 )
 from vllm.models.qwen4_exp.nvidia import ple_layer as ple_layer_module
+from vllm.models.qwen4_exp.nvidia.ops.ple_conv import varlen_dilated_conv1d
 from vllm.models.qwen4_exp.nvidia.ple_layer import (
     Qwen4ExpNGramEmbedding,
     Qwen4ExpPLEFp8EmbeddingMethod,
     Qwen4ExpPLELayer,
     _get_ple_embedding_quant_method,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+requires_ple_conv = pytest.mark.skipif(
+    not current_platform.is_cuda() or not HAS_TRITON,
+    reason="PLE varlen convolution requires CUDA and Triton",
 )
 
 
@@ -399,3 +408,148 @@ def test_ple_short_conv_uses_fallback_when_profile_metadata_is_omitted(
     output = module._short_conv(inputs)
 
     assert output is expected
+
+
+@requires_ple_conv
+@pytest.mark.parametrize(
+    "dtype,rtol,atol",
+    [
+        pytest.param(torch.float32, 1e-5, 1e-5, id="float32"),
+        pytest.param(torch.bfloat16, 2e-2, 2e-2, id="bfloat16"),
+    ],
+)
+def test_ple_varlen_dilated_conv_matches_dense_reference(
+    dtype: torch.dtype,
+    rtol: float,
+    atol: float,
+) -> None:
+    torch.manual_seed(0)
+    lengths = [2, 5, 19, 3]
+    channels = 37
+    kernel_width = 4
+    dilation = 3
+    state_len = (kernel_width - 1) * dilation
+
+    query_start_loc = torch.tensor(
+        [0, *torch.tensor(lengths).cumsum(0).tolist()],
+        dtype=torch.int64,
+        device="cuda",
+    )
+    x = torch.randn(sum(lengths), channels, dtype=dtype, device="cuda")
+    weight = torch.randn(channels, kernel_width, dtype=dtype, device="cuda")
+    conv_state = torch.randn(
+        5,
+        channels,
+        state_len,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    original_state = conv_state.clone()
+    state_indices = torch.tensor(
+        [1, 2, 3, NULL_BLOCK_ID], dtype=torch.int64, device="cuda"
+    )
+    has_initial_state = torch.tensor(
+        [True, True, True, True], dtype=torch.bool, device="cuda"
+    )
+
+    actual = varlen_dilated_conv1d(
+        x,
+        weight,
+        conv_state,
+        query_start_loc,
+        state_indices,
+        has_initial_state,
+        dilation,
+    )
+
+    expected = torch.zeros_like(x)
+    expected_state = original_state.clone()
+    offset = 0
+    for sequence, length in enumerate(lengths):
+        slot = state_indices[sequence].item()
+        sequence_x = x[offset : offset + length]
+        if slot != NULL_BLOCK_ID:
+            if has_initial_state[sequence].item():
+                initial_state = original_state[slot : slot + 1, :, :state_len].to(dtype)
+            else:
+                initial_state = torch.zeros(
+                    1, channels, state_len, dtype=dtype, device="cuda"
+                )
+            history = torch.cat((initial_state, sequence_x.T.unsqueeze(0)), dim=-1)
+            expected[offset : offset + length] = (
+                F.silu(
+                    F.conv1d(
+                        history,
+                        weight.unsqueeze(1),
+                        groups=channels,
+                        dilation=dilation,
+                    )
+                )
+                .squeeze(0)
+                .T
+            )
+            expected_state[slot, :, :state_len] = history[0, :, -state_len:].to(
+                expected_state.dtype
+            )
+        offset += length
+
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+    torch.testing.assert_close(conv_state, expected_state, rtol=0, atol=0)
+
+
+@requires_ple_conv
+@pytest.mark.parametrize("split", [1, 8, 9, 10])
+def test_ple_varlen_dilated_conv_preserves_chunk_continuity(split: int) -> None:
+    torch.manual_seed(1)
+    total_tokens = 31
+    channels = 37
+    kernel_width = 4
+    dilation = 3
+    state_len = (kernel_width - 1) * dilation
+    x = torch.randn(total_tokens, channels, dtype=torch.bfloat16, device="cuda")
+    weight = torch.randn(channels, kernel_width, dtype=torch.bfloat16, device="cuda")
+    initial_state = torch.randn(
+        2,
+        channels,
+        state_len,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    state_indices = torch.ones(1, dtype=torch.int64, device="cuda")
+    has_initial_state = torch.ones(1, dtype=torch.bool, device="cuda")
+
+    full_state = initial_state.clone()
+    full_output = varlen_dilated_conv1d(
+        x,
+        weight,
+        full_state,
+        torch.tensor([0, total_tokens], dtype=torch.int64, device="cuda"),
+        state_indices,
+        has_initial_state,
+        dilation,
+    )
+
+    chunked_state = initial_state.clone()
+    first_output = varlen_dilated_conv1d(
+        x[:split],
+        weight,
+        chunked_state,
+        torch.tensor([0, split], dtype=torch.int64, device="cuda"),
+        state_indices,
+        has_initial_state,
+        dilation,
+    )
+    second_output = varlen_dilated_conv1d(
+        x[split:],
+        weight,
+        chunked_state,
+        torch.tensor([0, total_tokens - split], dtype=torch.int64, device="cuda"),
+        state_indices,
+        has_initial_state,
+        dilation,
+    )
+
+    torch.testing.assert_close(
+        torch.cat((first_output, second_output)), full_output, rtol=2e-2, atol=2e-2
+    )
+    torch.testing.assert_close(chunked_state, full_state, rtol=0, atol=0)

--- a/vllm/models/qwen4_exp/nvidia/ops/ple_conv.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/ple_conv.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Packed varlen dilated short convolution for Qwen4Exp PLE."""
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+
+@triton.jit
+def _varlen_dilated_conv1d_kernel(
+    x_ptr,
+    weight_ptr,
+    conv_state_ptr,
+    query_start_loc_ptr,
+    sequence_indices_ptr,
+    state_indices_ptr,
+    has_initial_state_ptr,
+    output_ptr,
+    num_tokens,
+    stride_x_token,
+    stride_x_channel,
+    stride_weight_channel,
+    stride_weight_width,
+    stride_state_sequence,
+    stride_state_channel,
+    stride_state_token,
+    stride_output_token,
+    stride_output_channel,
+    CHANNELS: tl.constexpr,
+    KERNEL_WIDTH: tl.constexpr,
+    DILATION: tl.constexpr,
+    STATE_LEN: tl.constexpr,
+    HAS_STATE_CACHE: tl.constexpr,
+    NULL_STATE_INDEX: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    token_offsets = tl.program_id(0) * BLOCK_T + tl.arange(0, BLOCK_T)
+    channel_offsets = tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)
+    token_mask = token_offsets < num_tokens
+    channel_mask = channel_offsets < CHANNELS
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    sequence_indices = tl.load(
+        sequence_indices_ptr + token_offsets, mask=token_mask, other=0
+    ).to(tl.int64)
+    query_starts = tl.load(
+        query_start_loc_ptr + sequence_indices, mask=token_mask, other=0
+    ).to(tl.int64)
+    local_positions = token_offsets - query_starts
+    state_indices = tl.load(
+        state_indices_ptr + sequence_indices,
+        mask=token_mask,
+        other=NULL_STATE_INDEX,
+    ).to(tl.int64)
+    valid_state = token_mask & (state_indices != NULL_STATE_INDEX)
+    safe_state_indices = tl.maximum(state_indices, 0)
+
+    if HAS_STATE_CACHE:
+        has_initial_state = tl.load(
+            has_initial_state_ptr + sequence_indices,
+            mask=valid_state,
+            other=False,
+        ).to(tl.int1)
+
+    acc = tl.zeros((BLOCK_T, BLOCK_C), dtype=tl.float32)
+    for tap in tl.static_range(KERNEL_WIDTH):
+        source_positions = local_positions - (KERNEL_WIDTH - 1 - tap) * DILATION
+        from_input = valid_state & (source_positions >= 0)
+        source_rows = tl.maximum(token_offsets - (KERNEL_WIDTH - 1 - tap) * DILATION, 0)
+        x = tl.load(
+            x_ptr
+            + source_rows[:, None] * stride_x_token
+            + channel_offsets[None, :] * stride_x_channel,
+            mask=from_input[:, None] & channel_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+
+        if HAS_STATE_CACHE:
+            from_state = valid_state & has_initial_state & (source_positions < 0)
+            state_positions = tl.maximum(STATE_LEN + source_positions, 0)
+            state = tl.load(
+                conv_state_ptr
+                + safe_state_indices[:, None] * stride_state_sequence
+                + channel_offsets[None, :] * stride_state_channel
+                + state_positions[:, None] * stride_state_token,
+                mask=from_state[:, None] & channel_mask[None, :],
+                other=0.0,
+            ).to(x_ptr.dtype.element_ty)
+            state = state.to(tl.float32)
+        else:
+            state = tl.zeros((BLOCK_T, BLOCK_C), dtype=tl.float32)
+
+        weight = tl.load(
+            weight_ptr
+            + channel_offsets * stride_weight_channel
+            + tap * stride_weight_width,
+            mask=channel_mask,
+            other=0.0,
+        ).to(tl.float32)
+        acc += (x + state) * weight[None, :]
+
+    acc *= tl.sigmoid(acc)
+    acc = tl.where(valid_state[:, None], acc, 0.0)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(
+        output_ptr
+        + token_offsets[:, None] * stride_output_token
+        + channel_offsets[None, :] * stride_output_channel,
+        acc,
+        mask=token_mask[:, None] & channel_mask[None, :],
+    )
+
+
+@triton.jit
+def _update_varlen_conv_state_kernel(
+    x_ptr,
+    conv_state_ptr,
+    query_start_loc_ptr,
+    state_indices_ptr,
+    has_initial_state_ptr,
+    stride_x_token,
+    stride_x_channel,
+    stride_state_sequence,
+    stride_state_channel,
+    stride_state_token,
+    CHANNELS: tl.constexpr,
+    STATE_LEN: tl.constexpr,
+    NULL_STATE_INDEX: tl.constexpr,
+    BLOCK_STATE: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    sequence_index = tl.program_id(0)
+    channel_offsets = tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)
+    state_offsets = tl.arange(0, BLOCK_STATE)
+    channel_mask = channel_offsets < CHANNELS
+    state_mask = state_offsets < STATE_LEN
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    query_start = tl.load(query_start_loc_ptr + sequence_index).to(tl.int64)
+    query_end = tl.load(query_start_loc_ptr + sequence_index + 1).to(tl.int64)
+    query_len = query_end - query_start
+    state_index = tl.load(state_indices_ptr + sequence_index).to(tl.int64)
+    valid_sequence = (state_index != NULL_STATE_INDEX) & (query_len > 0)
+    safe_state_index = tl.maximum(state_index, 0)
+    has_initial_state = tl.load(
+        has_initial_state_ptr + sequence_index,
+        mask=valid_sequence,
+        other=False,
+    ).to(tl.int1)
+
+    source_positions = query_len - STATE_LEN + state_offsets
+    from_input = valid_sequence & state_mask & (source_positions >= 0)
+    source_rows = tl.maximum(query_start + source_positions, 0)
+    x = tl.load(
+        x_ptr
+        + source_rows[:, None] * stride_x_token
+        + channel_offsets[None, :] * stride_x_channel,
+        mask=from_input[:, None] & channel_mask[None, :],
+        other=0.0,
+    )
+
+    from_state = (
+        valid_sequence & state_mask & has_initial_state & (source_positions < 0)
+    )
+    prior_state_offsets = tl.maximum(STATE_LEN + source_positions, 0)
+    prior_state = tl.load(
+        conv_state_ptr
+        + safe_state_index * stride_state_sequence
+        + channel_offsets[None, :] * stride_state_channel
+        + prior_state_offsets[:, None] * stride_state_token,
+        mask=from_state[:, None] & channel_mask[None, :],
+        other=0.0,
+    ).to(x_ptr.dtype.element_ty)
+    next_state = tl.where(from_input[:, None], x, prior_state)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(
+        conv_state_ptr
+        + safe_state_index * stride_state_sequence
+        + channel_offsets[None, :] * stride_state_channel
+        + state_offsets[:, None] * stride_state_token,
+        next_state,
+        mask=valid_sequence & state_mask[:, None] & channel_mask[None, :],
+    )
+
+
+def varlen_dilated_conv1d(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    conv_state: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+    dilation: int,
+) -> torch.Tensor:
+    """Apply packed varlen dilated depthwise convolution and update its state."""
+    num_tokens, channels = x.shape
+    kernel_width = weight.shape[1]
+    state_len = (kernel_width - 1) * dilation
+    num_sequences = query_start_loc.numel() - 1
+
+    assert x.ndim == 2 and x.stride(1) == 1
+    assert weight.shape[0] == channels and weight.stride(1) == 1
+    assert dilation > 0
+    assert state_indices.numel() >= num_sequences
+    assert has_initial_state.numel() >= num_sequences
+    assert query_start_loc.device == x.device
+    assert state_indices.device == x.device
+    assert has_initial_state.device == x.device
+
+    has_state_cache = conv_state.ndim == 3 and conv_state.shape[0] > 0
+    if has_state_cache:
+        assert conv_state.shape[1] == channels
+        assert conv_state.shape[2] >= state_len
+        state_strides = conv_state.stride()
+    else:
+        assert conv_state.numel() == 0
+        state_strides = (0, 0, 0)
+
+    output = torch.empty_like(x)
+    if num_tokens == 0:
+        return output
+
+    positions = torch.arange(num_tokens, dtype=query_start_loc.dtype, device=x.device)
+    sequence_indices = torch.searchsorted(query_start_loc[1:], positions, right=True)
+
+    block_t = 8
+    block_c = min(triton.next_power_of_2(channels), 256)
+    grid = (triton.cdiv(num_tokens, block_t), triton.cdiv(channels, block_c))
+    launch_pdl = current_platform.is_arch_support_pdl()
+    _varlen_dilated_conv1d_kernel[grid](
+        x,
+        weight,
+        conv_state,
+        query_start_loc,
+        sequence_indices,
+        state_indices,
+        has_initial_state,
+        output,
+        num_tokens,
+        x.stride(0),
+        x.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        state_strides[0],
+        state_strides[1],
+        state_strides[2],
+        output.stride(0),
+        output.stride(1),
+        CHANNELS=channels,
+        KERNEL_WIDTH=kernel_width,
+        DILATION=dilation,
+        STATE_LEN=state_len,
+        HAS_STATE_CACHE=has_state_cache,
+        NULL_STATE_INDEX=NULL_BLOCK_ID,
+        BLOCK_T=block_t,
+        BLOCK_C=block_c,
+        launch_pdl=launch_pdl,
+        num_warps=4,
+    )
+
+    if has_state_cache and state_len > 0:
+        block_state = triton.next_power_of_2(state_len)
+        state_grid = (num_sequences, triton.cdiv(channels, block_c))
+        _update_varlen_conv_state_kernel[state_grid](
+            x,
+            conv_state,
+            query_start_loc,
+            state_indices,
+            has_initial_state,
+            x.stride(0),
+            x.stride(1),
+            state_strides[0],
+            state_strides[1],
+            state_strides[2],
+            CHANNELS=channels,
+            STATE_LEN=state_len,
+            NULL_STATE_INDEX=NULL_BLOCK_ID,
+            BLOCK_STATE=block_state,
+            BLOCK_C=block_c,
+            launch_pdl=launch_pdl,
+            num_warps=4,
+        )
+    return output

--- a/vllm/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm/models/qwen4_exp/nvidia/ple_layer.py
@@ -45,6 +45,7 @@ from vllm.v1.attention.backends.short_conv_attn import (
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 from ..common.ple import PLEVocabParallelEmbedding
+from .ops.ple_conv import varlen_dilated_conv1d
 
 
 class Qwen4ExpPLEGroupedNorm(nn.Module):
@@ -753,7 +754,6 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
         if has_initial_states_p is None:
             raise ValueError("has_initial_states_p is required for prefill short-conv")
 
-        output = torch.empty_like(x_p)
         q_starts = query_start_loc_p.to(torch.int64)
         if state_indices_tensor_p.numel() < num_prefills:
             raise ValueError(
@@ -768,96 +768,23 @@ class Qwen4ExpPLELayer(nn.Module, MambaBase):
                 f"need >= {num_prefills}."
             )
         if num_prefills == 0 or x_p.numel() == 0:
-            return output
-        lengths = q_starts[1:] - q_starts[:-1]
-        # Use the CPU-computed packing width from the metadata builder instead
-        # of synchronizing on lengths.max().
-        max_len = metadata.max_prefill_query_len
-        if max_len <= 0:
-            return output
-
-        hidden_size = x_p.shape[1]
-        positions = torch.arange(
-            num_prefill_tokens, device=x_p.device, dtype=torch.int64
-        )
-        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
-        col_indices = positions - q_starts[req_indices]
-
-        packed_tokens = x_p.new_zeros((num_prefills, max_len, hidden_size))
-        packed_tokens[req_indices, col_indices] = x_p
-        packed_tokens = packed_tokens.transpose(1, 2).contiguous()
+            return torch.empty_like(x_p)
 
         state_indices = state_indices_tensor_p[:num_prefills].to(
             device=conv_state.device, dtype=torch.int64
         )
-        valid_state = state_indices != NULL_BLOCK_ID
-        state_indices = torch.where(
-            valid_state, state_indices, torch.zeros_like(state_indices)
-        )
         has_initial = has_initial_states_p[:num_prefills].to(
             device=conv_state.device, dtype=torch.bool
         )
-        if self.conv_state_len > 0:
-            if conv_state.shape[0] == 0:
-                state = conv_state.new_zeros(
-                    (num_prefills, hidden_size, self.conv_state_len),
-                    dtype=x_p.dtype,
-                )
-            else:
-                state = conv_state.index_select(0, state_indices)[
-                    ..., : self.conv_state_len
-                ].to(x_p.dtype)
-            use_initial_mask = (valid_state & has_initial).view(num_prefills, 1, 1)
-            initial_state = torch.where(
-                use_initial_mask,
-                state,
-                torch.zeros_like(state),
-            )
-            history = torch.cat((initial_state, packed_tokens), dim=-1)
-        else:
-            history = packed_tokens
-
-        conv_output = F.conv1d(
-            history,
-            conv_weights.unsqueeze(1).contiguous(),
-            groups=history.size(1),
+        return varlen_dilated_conv1d(
+            x=x_p,
+            weight=conv_weights,
+            conv_state=conv_state,
+            query_start_loc=q_starts,
+            state_indices=state_indices,
+            has_initial_state=has_initial,
             dilation=self.short_conv_dilation,
         )
-        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
-
-        token_positions = torch.arange(max_len, device=x_p.device, dtype=torch.int64)
-        valid_tokens = token_positions.view(1, max_len) < lengths.view(num_prefills, 1)
-        valid_output_mask = valid_tokens & valid_state.to(device=x_p.device).view(
-            num_prefills, 1
-        )
-        conv_output.masked_fill_(~valid_output_mask.unsqueeze(-1), 0)
-        output.copy_(conv_output[req_indices, col_indices])
-
-        if self.conv_state_len > 0 and conv_state.shape[0] > 0:
-            state_starts = lengths.to(device=history.device, dtype=torch.int64).view(
-                num_prefills, 1, 1
-            )
-            state_offsets = torch.arange(
-                self.conv_state_len, device=history.device, dtype=torch.int64
-            ).view(1, 1, self.conv_state_len)
-            next_state = history.gather(
-                dim=2,
-                index=(state_starts + state_offsets).expand(-1, history.size(1), -1),
-            )
-            # Write back without a host synchronization. Valid, non-empty rows
-            # receive their new state; padding and zero-length rows keep the
-            # current cache value.
-            existing_state = conv_state.index_select(0, state_indices)
-            existing_base_state = existing_state[..., : self.conv_state_len]
-            update_mask = valid_state & (lengths.to(device=conv_state.device) > 0)
-            safe_next_state = torch.where(
-                update_mask.view(num_prefills, 1, 1),
-                next_state.to(conv_state.dtype),
-                existing_base_state,
-            )
-            existing_state[..., : self.conv_state_len] = safe_next_state
-            conv_state.index_copy_(0, state_indices, existing_state)
-        return output
 
     def _short_conv_dilated_spec_batched(
         self,


### PR DESCRIPTION
## Summary

Replace the dense-packing implementation of the NVIDIA Qwen4Exp PLE prefill
short convolution with a packed-varlen Triton kernel.

The previous path allocated intermediate tensors proportional to
`num_prefills * max_prefill_len * channels`. A mixed batch containing one long
prefill and many short prefills could therefore use several times more memory
than the scheduled token count suggests and deterministically OOM the engine.

The new path operates directly on the flattened prefill-token buffer and has
activation memory proportional to the actual token count. It also fuses SiLU
into the convolution and updates the convolution state without constructing a
dense batch.

## Root cause

`Qwen4ExpPLELayer._short_conv_dilated_prefill_batched` previously performed the
following operations:

1. Pad every prefill to the longest prefill in the engine step.
2. Materialize a `[num_prefills, max_len, channels]` tensor.
3. Transpose it into another contiguous tensor.
4. Concatenate convolution history.
5. Run `F.conv1d`, SiLU, and another contiguous transpose.

Its peak memory was therefore governed by:

```text
O(num_prefills * max_len * channels)
```

rather than by the number of scheduled tokens. The Qwen3.8-Flash-Next PLE
configuration has 10,240 convolution channels (`hidden_size=2560`,
`hc_count=4`), so the padding multiplier is particularly expensive.

The production failure that motivated this change scheduled 25 image-prefill
requests and 32,766 tokens in one step. The longest chunk was approximately
9,584 tokens. Dense packing expanded this to 239,600 token rows, or 7.31 times
the actual token count. One BF16 tensor of that shape is approximately 4.57 GiB,
and multiple non-in-place intermediates overlapped in lifetime.

Startup memory profiling did not protect against this shape. Its dummy workload
split 32,768 tokens uniformly into 512 requests of 64 tokens, where dense
packing has no padding overhead. The runtime failure was instead the opposite
shape: one long request mixed with many shorter requests.

## Implementation

Add `varlen_dilated_conv1d`, implemented as two Triton kernels:

- The output kernel maps each flattened token to its sequence using
  `query_start_loc`, applies the depthwise width-4/dilation-3 causal
  convolution, reads prior state when necessary, and fuses SiLU.
- A separate state-update kernel writes the final nine history positions for
  each sequence. Keeping state write-back separate avoids cross-program races
  when several token tiles belong to the same sequence.

The implementation preserves the existing `NULL_BLOCK_ID` behavior and the
FP32 convolution-state cache. It supports chunks shorter than, equal to, and
longer than the nine-token state window.

The allocation complexity becomes:

```text
O(total_prefill_tokens * channels + num_prefills * state_len * channels)
```

This change is intentionally limited to the NVIDIA prefill path. It does not
change decode, speculative decode, the AMD implementation, PLE n-gram
generation, the PLE gate, or projection kernels.

## Relationship to existing work

Duplicate-work searches were run with:

```bash
gh pr list --repo vllm-project/vllm --state open \
  --search "qwen4_exp PLE varlen convolution"
gh pr list --repo vllm-project/vllm --state open \
  --search "Qwen4Exp short conv OOM"
gh pr list --repo vllm-project/vllm --state open --search "PLE conv"
gh pr list --repo vllm-project/vllm --state open --search "qwen4_exp"
gh issue list --repo vllm-project/vllm --state open \
  --search "qwen4_exp PLE convolution OOM"
```

Draft PR #54517 was opened after this work began and now overlaps the same
prefill OOM fix. It is broader: it replaces the prefill, decode, and speculative
convolution paths and also fuses PLE n-gram, gate, and projection work. This
patch is the narrow prefill-only alternative and carries a standalone
old-versus-new memory/latency benchmark.

The two implementations must not be merged independently. If #54517 remains
the preferred direction, this patch and its benchmark should be used only as
review evidence for that PR.

## Correctness tests

The tests compare the Triton implementation against the previous dense PyTorch
implementation for both FP32 and BF16. They cover unequal sequence lengths,
initial state, state write-back, and `NULL_BLOCK_ID`.

A separate continuity test splits one logical prefill at positions 1, 8, 9,
and 10, then checks that chunked execution produces the same output and final
state as one unsplit execution. These split points cover both sides of the
nine-token state-window boundary.

```bash
CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest \
  tests/models/qwen4_exp/test_ple.py \
  -k varlen_dilated_conv -vv
```

Result:

```text
6 passed, 10 deselected, 14 warnings in 2.78s
```

Targeted lint:

```bash
.venv/bin/pre-commit run ruff-check --files \
  vllm/models/qwen4_exp/nvidia/ple_layer.py \
  vllm/models/qwen4_exp/nvidia/ops/ple_conv.py \
  tests/models/qwen4_exp/test_ple.py \
  benchmarks/kernels/benchmark_qwen4_exp_ple_conv.py

.venv/bin/pre-commit run ruff-format --files \
  vllm/models/qwen4_exp/nvidia/ple_layer.py \
  vllm/models/qwen4_exp/nvidia/ops/ple_conv.py \
  tests/models/qwen4_exp/test_ple.py \
  benchmarks/kernels/benchmark_qwen4_exp_ple_conv.py

git diff --check
```

Result: all passed.

## Peak-memory benchmark

The benchmark uses the production BF16 channel count of 10,240, kernel width
4, and dilation 3. `incident-skew-25` reproduces the incident distribution:
one 9,584-token prefill plus 24 shorter prefills, totaling 32,766 tokens.

```bash
CUDA_VISIBLE_DEVICES=0 .venv/bin/python \
  benchmarks/kernels/benchmark_qwen4_exp_ple_conv.py \
  --mode memory --channels 10240
```

| Case | Batch | Tokens | Max length | Dense rows / token | Varlen peak | Dense peak |
|---|---:|---:|---:|---:|---:|---:|
| uniform-8k | 25 | 8,192 | 328 | 1.001x | 0.156 GiB | N/A |
| uniform-16k | 25 | 16,384 | 656 | 1.001x | 0.313 GiB | N/A |
| uniform-25 | 25 | 32,766 | 1,311 | 1.000x | 0.625 GiB | 3.139 GiB |
| incident-skew-25 | 25 | 32,766 | 9,584 | 7.312x | 0.625 GiB | 22.865 GiB |

The new peak is determined by total tokens: the uniform and incident-shaped
32,766-token cases both use 0.625 GiB. The old peak grows with the longest
sequence and reaches 22.865 GiB for the incident-shaped batch.

## Kernel latency benchmark

Following the vLLM kernel-microbenchmark guidance, correctness is checked before
timing. Measurements use FlashInfer's CUPTI timer, cold L2, eager launches, a
25 ms dry run, and a 100 ms measurement interval. CUDA graphs are disabled
because production prefill is eager and the operator-boundary allocation and
token-to-sequence mapping are part of the path being replaced.

```bash
CUDA_VISIBLE_DEVICES=0 .venv/bin/python \
  benchmarks/kernels/benchmark_qwen4_exp_ple_conv.py \
  --mode latency --channels 10240 \
  --dry-run-time-ms 25 --repeat-time-ms 100
```

| Case | Batch | Tokens | Max length | Varlen | Dense | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| single-long | 1 | 32,768 | 32,768 | 1,110.136 us | 10,830.442 us | 9.756x |
| uniform-25 | 25 | 32,766 | 1,311 | 1,213.559 us | 10,755.310 us | 8.863x |
| incident-skew-25 | 25 | 32,766 | 9,584 | 1,213.303 us | 59,526.331 us | 49.061x |
| uniform-512 | 512 | 32,768 | 64 | 1,307.142 us | 12,021.192 us | 9.197x |

Benchmark environment:

```text
GPU: NVIDIA B200
PyTorch: 2.13.0+cu130
CUDA runtime: 13.0
FlashInfer: 0.6.17
dtype: bfloat16
channels: 10240
```

## GSM8K evaluation

The end-to-end accuracy check used the OpenAI-compatible vLLM server with TP4,
EP4, MTP3, BF16, and the modified kernel. Because this is a chat checkpoint,
lm-eval used `local-chat-completions` with the model chat template. The output
limit was raised from the task wrapper's 256-token default to 2,048 so that
reasoning was not truncated before the final answer.

```bash
HF_HUB_OFFLINE=1 .venv/bin/lm_eval run \
  --model local-chat-completions \
  --model_args \
  'model=qwen3.8-flash-next,base_url=http://127.0.0.1:8000/v1/chat/completions,tokenizer=/mnt/models/Qwen/Qwen3.8-Flash-Next,num_concurrent=128,max_length=32768,max_gen_toks=2048,timeout=1200' \
  --tasks gsm8k \
  --num_fewshot 5 \
  --apply_chat_template \
  --gen_kwargs 'temperature=0' \
  --output_path /tmp/qwen38_varlen_gsm8k_full \
  --log_samples
```

| Filter | Accuracy | Standard error |
|---|---:|---:|
| flexible-extract | 0.9227 | 0.0074 |
| strict-match | 0.9196 | 0.0075 |

All 1,319 requests completed with non-empty responses.

## End-to-end multimodal benchmark

The serving configuration matches the production failure topology and the
existing old-kernel reference run:

```bash
env -u VLLM_PLE_CPU_OFFLOAD \
  CUDA_VISIBLE_DEVICES=0,1,2,3 \
  HF_HUB_OFFLINE=1 \
  VLLM_ENGINE_READY_TIMEOUT_S=1800 \
  .venv/bin/vllm serve /mnt/models/Qwen/Qwen3.8-Flash-Next \
  --served-model-name qwen3.8-flash-next \
  --dtype bfloat16 \
  --tensor-parallel-size 4 \
  --enable-expert-parallel \
  --max-model-len 32768 \
  --max-num-seqs 512 \
  --max-num-batched-tokens 32768 \
  --enable-prefix-caching \
  --no-enable-flashinfer-autotune \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --api-server-count 1 \
  --port 8000
```

The client uses the first 1,500 records of the fixed multimodal dataset at
concurrency 512, with `max_tokens=3072`, `temperature=0`, no retries, and one
OpenAI-compatible endpoint:

```bash
.venv/bin/python /tmp/qwen38_bench/run_fixed_1500.py \
  --dataset /mnt/data/k3_b200_20k_repro \
  --output-dir /tmp/qwen38_bench/results/1xtep4_mtp3_bf16_msl32768_bt32768_varlen_s512_c512_20260831 \
  --base-url http://127.0.0.1:8000/v1 \
  --model qwen3.8-flash-next \
  --limit 1500 \
  --concurrency 512 \
  --max-tokens 3072 \
  --temperature 0 \
  --reasoning-effort none \
  --request-timeout-s 1200 \
  --warmup-s 120 \
  --config-label qwen4_exp_ple_varlen_tp4_ep4_mtp3_bf16_s512_c512
```

Dataset identity:

```text
selection SHA-256: 912845ef1dab6d9fcc483622bd6ec3ac8c6aab531a802f77897050af8f195370
prompt SHA-256:    87936700304fd3d5ddc28561be103837edc8153684b399ea885b0f2f1592fdbd
```

Result:

| Metric | Varlen result |
|---|---:|
| Successful requests | **1,500/1,500 (100%)** |
| Failed requests / retries | **0 / 0** |
| Elapsed time | **411.435 s** |
| Sample throughput | **3.6458 samples/s** |
| Input throughput | **18,584.3 tokens/s** |
| Output throughput | **4,597.1 tokens/s** |
| Total throughput | **23,181.4 tokens/s** |
| Input tokens | 7,646,233 |
| Output tokens | 1,891,424 |
| Total tokens | 9,537,657 |
| Mean request latency | 120.37 s |
| P50 request latency | **128.72 s** |
| P90 request latency | 155.30 s |
| P95 request latency | **169.62 s** |
| P99 request latency | 193.99 s |
| Maximum request latency | 216.79 s |

The post-run health check returned HTTP 200. No request failed and the engine
did not restart or report a CUDA OOM.

For comparison, the historical old-kernel run on the same 1,500 records and
same serving/client configuration completed 1,500/1,500 in 404.375 seconds:

```text
3.7094 samples/s
18,908.8 input tokens/s
4,694.2 output tokens/s
23,602.9 total tokens/s
P50 latency: 128.54 s
P95 latency: 170.79 s
```

Relative to that historical run, the varlen run was 1.72% lower in sample
throughput, with P50 latency 0.14% higher and P95 latency 0.68% lower. This is
an end-to-end historical comparison across different vLLM revisions, not an
isolated kernel A/B measurement. The result is therefore primarily a stability
and accuracy check: the OOM-triggering C512 multimodal workload completed
without failure, while the CUPTI benchmark above supplies the controlled
old-versus-new kernel comparison.

## AI assistance disclosure

AI assistance was used to analyze the failure, implement the Triton kernel and
tests, construct and run the benchmarks, and draft this description. The human
submitter must review every changed line, understand and defend the kernel and
state semantics, reproduce the relevant tests, and validate the reported
results before submission.