### PR TITLE
[Misc] Log FlashInfer JIT compilation on first kernel use

### DIFF
--- a/tests/utils_/test_flashinfer.py
+++ b/tests/utils_/test_flashinfer.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
+import re
+import sys
+import time
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+import vllm.utils.flashinfer as fi_utils
+
+_FAKE_MODULE_NAME = "fake_flashinfer_module"
+_FAKE_KERNEL_NAME = "slow_kernel"
+_QUALNAME = f"{_FAKE_MODULE_NAME}.{_FAKE_KERNEL_NAME}"
+LOGGER_NAME = "vllm.utils.flashinfer"
+
+
+@pytest.fixture()
+def wrapped_kernel(monkeypatch):
+    """Build a _lazy_import_wrapper around a fake slow FlashInfer kernel.
+
+    FlashInfer JIT-compiles kernels on first use (vllm-project/vllm#38246),
+    so the fake kernel stands in for a slow cold first call. The slow path is
+    shortened so the test stays fast.
+    """
+    calls = {"count": 0}
+
+    def make(sleep_s: float = 0.0):
+        module = ModuleType(_FAKE_MODULE_NAME)
+
+        def slow_kernel(*args, **kwargs):
+            calls["count"] += 1
+            if sleep_s:
+                time.sleep(sleep_s)
+            return "done"
+
+        setattr(module, _FAKE_KERNEL_NAME, slow_kernel)
+        monkeypatch.setitem(sys.modules, _FAKE_MODULE_NAME, module)
+        monkeypatch.setattr(fi_utils, "has_flashinfer", lambda: True)
+        monkeypatch.setattr(fi_utils, "has_flashinfer_jit_cache", lambda: False)
+        return fi_utils._lazy_import_wrapper(_FAKE_MODULE_NAME, _FAKE_KERNEL_NAME)
+
+    return make, calls
+
+
+def test_first_call_logs_jit_compile(caplog_vllm, disable_log_dedup, wrapped_kernel):
+    """Cold first call logs before/after with elapsed time; warm path quiet."""
+    make, calls = wrapped_kernel
+    wrapper = make(sleep_s=0.05)
+
+    with caplog_vllm.at_level(logging.INFO, logger=LOGGER_NAME):
+        assert wrapper() == "done"
+        assert wrapper() == "done"  # warm path
+
+    assert calls["count"] == 2
+    messages = [record.getMessage() for record in caplog_vllm.records]
+    before = [msg for msg in messages if "may JIT-compile kernels on first use" in msg]
+    after = [msg for msg in messages if "finished first use in" in msg]
+
+    assert len(before) == 1
+    assert _QUALNAME in before[0]
+    assert "flashinfer-jit-cache" in before[0]
+
+    assert len(after) == 1
+    assert _QUALNAME in after[0]
+    assert re.search(r"in \d+\.\d\d seconds\.$", after[0]), after[0]
+
+
+def test_first_call_quiet_with_jit_cache(caplog_vllm, monkeypatch, wrapped_kernel):
+    """Pre-compiled kernels (flashinfer-jit-cache) -> cold path stays quiet."""
+    make, calls = wrapped_kernel
+    wrapper = make()
+    monkeypatch.setattr(fi_utils, "has_flashinfer_jit_cache", lambda: True)
+
+    with caplog_vllm.at_level(logging.INFO, logger=LOGGER_NAME):
+        assert wrapper() == "done"
+
+    assert calls["count"] == 1
+    assert not any(
+        "JIT-compile" in record.getMessage() for record in caplog_vllm.records
+    )
+
+
+def test_missing_flashinfer_uses_fallback_without_logs(caplog_vllm, monkeypatch):
+    """Without FlashInfer the fallback runs and nothing is logged."""
+    monkeypatch.setattr(fi_utils, "has_flashinfer", lambda: False)
+    fallback = MagicMock(return_value="fallback")
+    wrapper = fi_utils._lazy_import_wrapper(
+        _FAKE_MODULE_NAME, _FAKE_KERNEL_NAME, fallback_fn=fallback
+    )
+
+    with caplog_vllm.at_level(logging.INFO, logger=LOGGER_NAME):
+        assert wrapper() == "fallback"
+
+    fallback.assert_called_once()
+    assert not any(
+        "JIT-compile" in record.getMessage() for record in caplog_vllm.records
+    )
+
+
+def test_failed_first_call_keeps_logging_enabled(
+    caplog_vllm, disable_log_dedup, monkeypatch, wrapped_kernel
+):
+    """A failed cold call must not silence logging of the retry."""
+    _make, calls = wrapped_kernel
+    monkeypatch.setattr(fi_utils, "has_flashinfer", lambda: True)
+    monkeypatch.setattr(fi_utils, "has_flashinfer_jit_cache", lambda: False)
+
+    module = ModuleType(_FAKE_MODULE_NAME)
+
+    def flaky_kernel():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("compile failed")
+        return "done"
+
+    setattr(module, _FAKE_KERNEL_NAME, flaky_kernel)
+    monkeypatch.setitem(sys.modules, _FAKE_MODULE_NAME, module)
+    wrapper = fi_utils._lazy_import_wrapper(_FAKE_MODULE_NAME, _FAKE_KERNEL_NAME)
+
+    with caplog_vllm.at_level(logging.INFO, logger=LOGGER_NAME):
+        with pytest.raises(RuntimeError, match="compile failed"):
+            wrapper()
+        assert wrapper() == "done"
+        assert wrapper() == "done"  # warm path
+
+    messages = [record.getMessage() for record in caplog_vllm.records]
+    before = [msg for msg in messages if "may JIT-compile kernels on first use" in msg]
+    after = [msg for msg in messages if "finished first use in" in msg]
+    assert len(before) == 2
+    assert len(after) == 1

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -11,6 +11,7 @@ import importlib
 import importlib.util
 import os
 import shutil
+import time
 from collections.abc import Callable
 from typing import Any, NoReturn
 
@@ -51,6 +52,17 @@ FLASHINFER_CUBINS_REPOSITORY = os.environ.get(
     "FLASHINFER_CUBINS_REPOSITORY",
     "https://edge.urm.nvidia.com/artifactory/sw-kernelinferencelibrary-public-generic-local/",  # noqa: E501
 )
+
+
+@functools.cache
+def has_flashinfer_jit_cache() -> bool:
+    """Return `True` if the flashinfer-jit-cache package is available.
+
+    The package ships pre-compiled FlashInfer kernels. Without it, kernels
+    are JIT-compiled on first use, which can take several minutes without
+    any output (see vllm-project/vllm#38246).
+    """
+    return importlib.util.find_spec("flashinfer_jit_cache") is not None
 
 
 @functools.cache
@@ -161,7 +173,10 @@ def _get_submodule(module_name: str) -> Any | None:
 
 # General lazy import wrapper
 def _lazy_import_wrapper(
-    module_name: str, attr_name: str, fallback_fn: Callable[..., Any] = _missing
+    module_name: str,
+    attr_name: str,
+    fallback_fn: Callable[..., Any] = _missing,
+    log_jit_compile: bool = True,
 ):
     """Create a lazy import wrapper for a specific function."""
 
@@ -172,10 +187,36 @@ def _lazy_import_wrapper(
         mod = _get_submodule(module_name)
         return getattr(mod, attr_name, None) if mod else None
 
+    qualname = f"{module_name}.{attr_name}"
+    first_call_logged = False
+
     def wrapper(*args, **kwargs):
+        nonlocal first_call_logged
         impl = _get_impl()
         if impl is None:
             return fallback_fn(*args, **kwargs)
+        # Without flashinfer-jit-cache, FlashInfer may JIT-compile kernels on
+        # first use, which can take several minutes without emitting any log
+        # (see vllm-project/vllm#38246). Log around the first call so users
+        # don't mistake the compilation for a hang; keep the warm path quiet.
+        if log_jit_compile and not first_call_logged and not has_flashinfer_jit_cache():
+            logger.info_once(
+                "FlashInfer %s may JIT-compile kernels on first use; this "
+                "can take several minutes without further output. Install "
+                "flashinfer-jit-cache to download pre-compiled kernels "
+                "instead (e.g. `pip install flashinfer-jit-cache --index-url "
+                "https://flashinfer.ai/whl/cu<CUDA_VERSION>`).",
+                qualname,
+            )
+            start = time.perf_counter()
+            result = impl(*args, **kwargs)
+            first_call_logged = True
+            logger.info_once(
+                "FlashInfer %s finished first use in %.2f seconds.",
+                qualname,
+                time.perf_counter() - start,
+            )
+            return result
         return impl(*args, **kwargs)
 
     return wrapper
@@ -242,6 +283,9 @@ autotune = _lazy_import_wrapper(
     "flashinfer.autotuner",
     "autotune",
     fallback_fn=lambda *args, **kwargs: contextlib.nullcontext(),
+    # The context manager returns instantly; kernel tuning inside it is
+    # covered by flashinfer-ai/flashinfer#2942.
+    log_jit_compile=False,
 )
 
 
@@ -1170,6 +1214,7 @@ __all__ = [
     "flashinfer_trtllm_batch_decode_sparse_mla_dsv4",
     "flashinfer_xqa_batch_decode_with_kv_cache",
     "autotune",
+    "has_flashinfer_jit_cache",
     "has_flashinfer_moe",
     "has_flashinfer_comm",
     "has_flashinfer_nvlink_two_sided",


### PR DESCRIPTION
# [Misc] Log FlashInfer JIT compilation on first kernel use

## Problem

When `flashinfer-jit-cache` is not installed, FlashInfer JIT-compiles kernels **on first call** and emits no logs for up to ~10 minutes, which looks exactly like a hang (#38246; seen on B200 DeepSeek-R1 in #38241). There is no existing vLLM log that covers this window (the only nearby messages are `debug_once` availability checks in `vllm/utils/flashinfer.py`).

## Approach

Instrument the vLLM-side boundary instead of patching FlashInfer internals.

1. `vllm/utils/flashinfer.py::has_flashinfer_jit_cache()` — new cached helper checking for the `flashinfer_jit_cache` package (same detection as upstream `flashinfer.jit.env`, wheel installed via `pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu<CUDA_VERSION>`, as in our Dockerfile).
2. `_lazy_import_wrapper(...)` gains `log_jit_compile: bool = True`. On the **cold first call** through any of the MoE/gemm/quant wrappers it logs, at INFO on the local first rank (`info_once` semantics):
   - before: `FlashInfer flashinfer.fused_moe.trtllm_fp8_block_scale_moe may JIT-compile kernels on first use; this can take several minutes without further output. Install flashinfer-jit-cache to download pre-compiled kernels instead (e.g. \`pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu<CUDA_VERSION>\`).`
   - after: `FlashInfer flashinfer.fused_moe.trtllm_fp8_block_scale_moe finished first use in 312.47 seconds.`
3. The **warm path stays quiet**: a per-wrapper flag suppresses logging after the first successful call; the fallback (FlashInfer missing) path and setups with `flashinfer-jit-cache` installed log nothing. A failed first call keeps logging enabled so the retry is also labelled.
4. The `autotune` wrapper passes `log_jit_compile=False`: it returns a context manager instantly (never blocks on compile), and progress bars for the tuning phase are the scope of flashinfer-ai/flashinfer#2942 — this PR covers the compilation half that PR cannot.

`flashinfer-jit-cache` is what the vLLM Docker images already install, so default container users see no new logs; only the bare pip path (the one that produced #38246/#38241) gets the visibility.

## Tests

New `tests/utils_/test_flashinfer.py` (CPU-only, no flashinfer/torch-GPU needed): injects a fake slow FlashInfer module into `sys.modules`, drives `_lazy_import_wrapper`, and asserts the before/after messages, the kernel-qualified name, the jit-cache hint, the elapsed-time formatting, warm-path silence, jit-cache silence, fallback silence, and failure-retry re-logging. Also re-ran the closest existing consumer tests (`tests/kernels/attention/test_use_trtllm_attention.py`, `tests/utils_/`). ruff check/format and mypy are clean on the changed files.

Closes #38246.
