### PR TITLE
[Core] Fix priority scheduling: allow waiting high-priority request to preempt running lower-priority one at max_num_seqs

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -12,12 +12,14 @@ from vllm.config import (
     CacheConfig,
     ECTransferConfig,
     KVTransferConfig,
+    LoRAConfig,
     ModelConfig,
     SchedulerConfig,
     SpeculativeConfig,
     VllmConfig,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
     MultiModalKwargsItem,
@@ -2659,6 +2661,7 @@ def create_scheduler_with_priority(
     use_ec_connector: bool = False,
     ec_role: str | None = None,
     use_v2_model_runner: bool | None = None,
+    lora_config: LoRAConfig | None = None,
 ) -> Scheduler:
     """Create scheduler with priority policy enabled.
 
@@ -2733,6 +2736,7 @@ def create_scheduler_with_priority(
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
+        lora_config=lora_config,
     )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
@@ -3346,6 +3350,395 @@ def test_priority_scheduling_heap_property():
     # Verify requests were scheduled in priority order (lowest value first)
     expected_priorities = sorted(priorities)
     assert scheduled_priorities == expected_priorities
+
+
+@pytest.mark.parametrize("use_v2_model_runner", [False, True])
+def test_priority_waiting_preemption_at_max_num_seqs(use_v2_model_runner):
+    """A high-priority WAITING request preempts the lowest-priority RUNNING
+    request when the running queue is full (max_num_seqs, issue #40004).
+
+    Scenario: max_num_seqs = 2, plenty of KV blocks (no cache pressure).
+    - Two low-priority requests (priority 5) fill the running queue.
+    - A high-priority request (priority 0) arrives while both are decoding.
+    - The scheduler preempts one low-priority runner to admit the
+      high-priority waiting request.
+    - Once the high-priority request finishes, the preempted request is
+      re-queued and scheduled again.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,  # Plenty of blocks, no KV pressure.
+        use_v2_model_runner=use_v2_model_runner,
+    )
+
+    # Two low-priority requests fill the running queue.
+    lo_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    for req in lo_requests:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    assert {req.request_id for req in scheduler.running} == {"lo1", "lo2"}
+
+    # Both requests decode one token.
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1", "lo2"],
+        req_id_to_index={"lo1": 0, "lo2": 1},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # A high-priority request arrives.
+    hi_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["hi"],
+    )[0]
+    scheduler.add_request(hi_req)
+
+    # The running queue is full; the high-priority waiting request must
+    # preempt a low-priority runner. Both runners have priority 5, so the
+    # latest-arrived one (lo2, arrival 2.0) is the victim.
+    output = scheduler.schedule()
+
+    scheduled_ids = set(output.num_scheduled_tokens)
+    assert "hi" in scheduled_ids
+    assert "lo1" in scheduled_ids
+    # The victim was scheduled earlier in this same step; its scheduling
+    # must have been rolled back when it was preempted.
+    assert "lo2" not in scheduled_ids
+
+    lo2_req = scheduler.requests["lo2"]
+    assert lo2_req.status == RequestStatus.PREEMPTED
+    assert lo2_req.num_preemptions == 1
+    assert len(scheduler.waiting) == 1
+    assert lo2_req in scheduler.waiting
+    assert {req.request_id for req in scheduler.running} == {"lo1", "hi"}
+
+    # Decode the survivors.
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1", "hi"],
+        req_id_to_index={"lo1": 0, "hi": 1},
+        sampled_token_ids=[[97], [96]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+    scheduler.finish_requests("hi", RequestStatus.FINISHED_STOPPED)
+
+    # The preempted request is re-queued and runs again once a slot frees.
+    output = scheduler.schedule()
+    assert len(scheduler.waiting) == 0
+    assert lo2_req.status == RequestStatus.RUNNING
+    assert {req.request_id for req in scheduler.running} == {"lo1", "lo2"}
+    if use_v2_model_runner:
+        # V2 emits the resumed request as a NewRequestData.
+        assert [req.req_id for req in output.scheduled_new_reqs] == ["lo2"]
+    else:
+        assert len(output.scheduled_new_reqs) == 0
+        assert "lo2" in output.scheduled_cached_reqs.resumed_req_ids
+
+
+def test_priority_waiting_no_preemption_when_not_higher_priority():
+    """A lower-priority waiting request must NOT preempt a higher-priority
+    running request when the running queue is full."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+    )
+
+    hi_requests = create_requests_with_priority(
+        num_requests=2,
+        priorities=[0, 1],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["hi1", "hi2"],
+    )
+    for req in hi_requests:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    model_output = ModelRunnerOutput(
+        req_ids=["hi1", "hi2"],
+        req_id_to_index={"hi1": 0, "hi2": 1},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    lo_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],  # Lower priority than every runner.
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["lo"],
+    )[0]
+    scheduler.add_request(lo_req)
+
+    output = scheduler.schedule()
+    assert "lo" not in output.num_scheduled_tokens
+    assert scheduler.requests["lo"].status == RequestStatus.WAITING
+    assert {req.request_id for req in scheduler.running} == {"hi1", "hi2"}
+
+
+def test_priority_waiting_equal_priority_no_preemption():
+    """An equal-priority waiting request must NOT preempt a running request,
+    even if the waiting request has an earlier arrival time.
+
+    Using the Request.__lt__ tiebreak (priority, arrival_time) would let the
+    earlier-arrived waiting request preempt, while the preempted request
+    keeps its earlier arrival time and would reclaim the slot on the next
+    step -- preemption ping-pong. Only a strictly higher priority
+    (numerically lower value) may preempt.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+    )
+
+    running_reqs = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[2.0, 3.0],
+        num_tokens=10,
+        req_ids=["r1", "r2"],
+    )
+    for req in running_reqs:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+
+    # A waiting request with the SAME priority (5) but an EARLIER arrival
+    # time (1.0 < 2.0).
+    waiting_req = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=10,
+        req_ids=["w1"],
+    )[0]
+    scheduler.add_request(waiting_req)
+
+    # Run several steps: no preemption must ever fire (no churn/ping-pong).
+    for _ in range(3):
+        output = scheduler.schedule()
+        model_output = ModelRunnerOutput(
+            req_ids=["r1", "r2"],
+            req_id_to_index={"r1": 0, "r2": 1},
+            sampled_token_ids=[[99], [98]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+        scheduler.update_from_output(output, model_output)
+
+        assert "w1" not in output.num_scheduled_tokens
+        assert scheduler.requests["r1"].status == RequestStatus.RUNNING
+        assert scheduler.requests["r2"].status == RequestStatus.RUNNING
+        assert scheduler.requests["w1"].status == RequestStatus.WAITING
+        assert len(scheduler.running) == 2
+        assert len(scheduler.waiting) == 1
+
+
+def _attach_lora(requests, lora_int_ids):
+    for request, lora_int_id in zip(requests, lora_int_ids, strict=True):
+        request.lora_request = LoRARequest(
+            lora_name=f"lora{lora_int_id}",
+            lora_int_id=lora_int_id,
+            lora_path=f"/tmp/lora{lora_int_id}",
+        )
+
+
+def test_priority_waiting_preemption_keeps_shared_lora():
+    """Preempting a running request must NOT discard its LoRA ID from the
+    step's accounting while another request scheduled this step still uses
+    it (issue #40004 review feedback).
+
+    Scenario: max_num_seqs = 2, max_loras = 1.
+    - Y (priority 7, LoRA 1) is running.
+    - hi (0, LoRA 1), mid (1, LoRA 2), x (6, LoRA 1) are waiting.
+    Step: hi is admitted (slot is free). The queue is then full, so x
+    preempts Y. Y's LoRA 1 must stay accounted for: hi -- admitted this
+    same step -- still uses it, so mid (LoRA 2) must remain excluded by the
+    max_loras constraint rather than preempting anyone.
+    """
+    lora_config = LoRAConfig(max_loras=1, max_lora_rank=8)
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+        lora_config=lora_config,
+    )
+
+    req_y = create_requests_with_priority(
+        num_requests=1,
+        priorities=[7],
+        arrival_times=[0.0],
+        num_tokens=10,
+        req_ids=["y"],
+    )
+    _attach_lora(req_y, [1])
+    scheduler.add_request(req_y[0])
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+    model_output = ModelRunnerOutput(
+        req_ids=["y"],
+        req_id_to_index={"y": 0},
+        sampled_token_ids=[[99]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    waiters = create_requests_with_priority(
+        num_requests=3,
+        priorities=[0, 1, 6],
+        arrival_times=[1.0, 2.0, 3.0],
+        num_tokens=10,
+        req_ids=["hi", "mid", "x"],
+    )
+    _attach_lora(waiters, [1, 2, 1])
+    for req in waiters:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+
+    # hi fills the free slot; x preempts y; mid (LoRA 2) stays out.
+    scheduled_ids = set(output.num_scheduled_tokens)
+    assert {"hi", "x"} <= scheduled_ids
+    assert "mid" not in scheduled_ids
+    assert "y" not in scheduled_ids
+    assert scheduler.requests["y"].status == RequestStatus.PREEMPTED
+    assert scheduler.requests["mid"].status == RequestStatus.WAITING
+    assert {req.request_id for req in scheduler.running} == {"hi", "x"}
+
+
+def test_priority_waiting_preemption_discards_unused_lora():
+    """Preempting a running request DOES free its LoRA slot when no other
+    request scheduled this step uses it.
+
+    Scenario: max_num_seqs = 2, max_loras = 2.
+    - A (priority 7, LoRA 1) and B (priority 8, LoRA 2) are running.
+    - hi (0, LoRA 1) and mid (1, LoRA 3) are waiting.
+    Step: hi preempts B, freeing LoRA 2 from the step's accounting. That
+    leaves LoRA capacity for mid (LoRA 3), which preempts A. Without the
+    discard, mid would be (wrongly) excluded by the max_loras constraint.
+    """
+    lora_config = LoRAConfig(max_loras=2, max_lora_rank=8)
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+        lora_config=lora_config,
+    )
+
+    runners = create_requests_with_priority(
+        num_requests=2,
+        priorities=[7, 8],
+        arrival_times=[0.0, 1.0],
+        num_tokens=10,
+        req_ids=["a", "b"],
+    )
+    _attach_lora(runners, [1, 2])
+    for req in runners:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    model_output = ModelRunnerOutput(
+        req_ids=["a", "b"],
+        req_id_to_index={"a": 0, "b": 1},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    waiters = create_requests_with_priority(
+        num_requests=2,
+        priorities=[0, 1],
+        arrival_times=[2.0, 3.0],
+        num_tokens=10,
+        req_ids=["hi", "mid"],
+    )
+    _attach_lora(waiters, [1, 3])
+    for req in waiters:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+
+    # hi preempts b; discarding b's now-unused LoRA leaves room for mid,
+    # which preempts a.
+    scheduled_ids = set(output.num_scheduled_tokens)
+    assert {"hi", "mid"} <= scheduled_ids
+    assert "a" not in scheduled_ids
+    assert "b" not in scheduled_ids
+    assert scheduler.requests["a"].status == RequestStatus.PREEMPTED
+    assert scheduler.requests["b"].status == RequestStatus.PREEMPTED
+    assert len(scheduler.waiting) == 2
+    assert {req.request_id for req in scheduler.running} == {"hi", "mid"}
+
+
+def test_waiting_no_preemption_at_max_num_seqs_fcfs():
+    """Queue-full preemption is exclusive to the priority scheduling policy;
+    FCFS never preempts (issue #40004)."""
+    scheduler = create_scheduler(
+        max_num_seqs=2,
+        max_num_batched_tokens=200,
+        num_blocks=100,
+    )
+
+    fcfs_requests = create_requests(
+        num_requests=2,
+        num_tokens=10,
+        req_ids=["f1", "f2"],
+    )
+    for req in fcfs_requests:
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 2
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id for req in fcfs_requests],
+        req_id_to_index={req.request_id: i for i, req in enumerate(fcfs_requests)},
+        sampled_token_ids=[[99], [98]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    waiting_request = create_requests(num_requests=1, num_tokens=10, req_ids=["f3"])[0]
+    waiting_request.priority = 0  # Irrelevant under FCFS.
+    scheduler.add_request(waiting_request)
+
+    output = scheduler.schedule()
+    assert waiting_request.request_id not in output.num_scheduled_tokens
+    assert waiting_request.status == RequestStatus.WAITING
+    assert len(scheduler.running) == 2
+    assert len(scheduler.waiting) == 1
 
 
 def test_schedule_skip_tokenizer_init():

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -771,6 +771,89 @@ class Scheduler(SchedulerInterface):
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
+        def _preempt_lowest_priority_runner(request: Request) -> bool:
+            """Evict the lowest-priority running request so that a
+            higher-priority waiting request can take its slot once the
+            running queue has reached max_num_seqs.
+
+            Returns True iff a victim was preempted. Uses a strict
+            priority-only comparison (numerically lower `priority` value
+            wins): never Request.__lt__, whose arrival-time tiebreak would
+            let equal-priority requests preempt each other — a preempted
+            request keeps its earlier arrival_time and would immediately
+            reclaim the slot on the next step, ping-ponging forever.
+            """
+            nonlocal token_budget, input_budget, encoder_compute_budget
+            if not self.running:
+                return False
+            # Consistent with the KV-pressure preemption above: the victim
+            # is the lowest-priority, latest-arrived running request.
+            preempted_req = max(
+                self.running,
+                key=lambda r: (r.priority, r.arrival_time),
+            )
+            if request.priority >= preempted_req.priority:
+                # No strictly-lower-priority runner to evict.
+                return False
+
+            preempted_req_id = preempted_req.request_id
+            self.running.remove(preempted_req)
+
+            # Undo any scheduling already done for the victim in this step.
+            # The victim may come from the running-queue pass above or may
+            # have been admitted from the waiting queue earlier in this same
+            # step.
+            scheduled_this_step = False
+            for scheduled_list in (
+                scheduled_running_reqs,
+                scheduled_new_reqs,
+                scheduled_resumed_reqs,
+            ):
+                if preempted_req in scheduled_list:
+                    scheduled_list.remove(preempted_req)
+                    scheduled_this_step = True
+                    break
+            if scheduled_this_step:
+                restored = num_scheduled_tokens.pop(preempted_req_id)
+                token_budget += restored
+                input_budget += restored + draft_slots
+                req_to_new_blocks.pop(preempted_req_id)
+                scheduled_spec_decode_tokens.pop(preempted_req_id, None)
+                preempted_encoder_inputs = scheduled_encoder_inputs.pop(
+                    preempted_req_id, None
+                )
+                if preempted_encoder_inputs:
+                    # Restore encoder compute budget if the preempted request
+                    # had encoder inputs scheduled in this step.
+                    encoder_compute_budget += sum(
+                        preempted_req.get_num_encoder_embeds(i)
+                        for i in preempted_encoder_inputs
+                    )
+                # Discard the victim's LoRA from this step's accounting only
+                # if no still-scheduled request (including requests admitted
+                # from the waiting queue earlier in this step) uses it.
+                if self.lora_config and preempted_req.lora_request:
+                    lora_id = preempted_req.lora_request.lora_int_id
+                    still_used = any(
+                        req.lora_request is not None
+                        and req.lora_request.lora_int_id == lora_id
+                        for req in itertools.chain(
+                            scheduled_running_reqs,
+                            scheduled_new_reqs,
+                            scheduled_resumed_reqs,
+                        )
+                    )
+                    if not still_used:
+                        scheduled_loras.discard(lora_id)
+
+            self._preempt_request(
+                preempted_req,
+                scheduled_timestamp,
+                drop_stale_output=self.requires_kv_delivery,
+            )
+            preempted_reqs.append(preempted_req)
+            return True
+
         # Next, schedule the WAITING requests.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
@@ -781,7 +864,8 @@ class Scheduler(SchedulerInterface):
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
                 # in `running` but still hold a model-runner request slot.
                 num_running = len(self.running) + self.num_waiting_for_streaming_input
-                if num_running >= self.max_num_running_reqs:
+                queue_full = num_running >= self.max_num_running_reqs
+                if queue_full and self.policy != SchedulingPolicy.PRIORITY:
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
@@ -827,6 +911,19 @@ class Scheduler(SchedulerInterface):
                     # Scheduling would exceed max_loras, skip.
                     request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
+                    continue
+
+                if queue_full:
+                    # The running queue is full. Under priority scheduling,
+                    # evict a strictly-lower-priority runner so this request
+                    # can be admitted. This is attempted only here — after
+                    # every other admission check above has passed — so a
+                    # runner is never evicted for a request that is blocked
+                    # by something else this step anyway.
+                    if not _preempt_lowest_priority_runner(request):
+                        break
+                    # A running slot was freed; loop back and schedule the
+                    # same request.
                     continue
 
                 num_external_computed_tokens = 0


### PR DESCRIPTION
## Purpose

Closes #40004. Supersedes #45558 (stale since June; incorporates its review feedback).

Under `--scheduling-policy priority`, preemption only considered priorities under KV-cache pressure. When the running queue was full (`max_num_seqs`), a high-priority WAITING request could never displace a lower-priority RUNNING request — the waiting loop simply broke on `num_running >= max_num_seqs`, so low-priority requests could hold slots indefinitely while higher-priority ones starved.

### Design

When the waiting-queue pass would stop *solely* because the running queue is full, the scheduler now evicts the lowest-priority runner if and only if the waiting request has a strictly higher priority:

1. **Strict priority-only comparison** — `waiting.priority < victim.priority` numerically, never `Request.__lt__`. The `__lt__` arrival-time tiebreak causes equal-priority ping-pong: a preempted request keeps its earlier `arrival_time` and would immediately reclaim the slot next step.
2. **Placement** — preemption is attempted only after the waiting request passes that iteration's other admission checks (blocked status promotion, in-flight stale output, `max_loras`), so a runner is never evicted for a request that cannot be admitted this step anyway.
3. **Same-step rollback** — the victim's scheduling done earlier in this step (running-queue pass *or* a waiting-queue admission from this same step, reachable because the preempted victim is re-prepended mid-loop) is fully rolled back: token/input budgets, `req_to_new_blocks`, spec-decode tokens, encoder inputs/compute budget.
4. **LoRA accounting** — the victim's LoRA ID is dropped from this step's `scheduled_loras` only when no still-scheduled request uses it, counting requests admitted from the waiting queue in this same step (`scheduled_new_reqs`/`scheduled_resumed_reqs`), not just `scheduled_running_reqs`.

The victim re-enters the waiting queue through the existing `_preempt_request` mechanics, identical to KV-pressure preemption. FCFS is untouched (the original full-queue break still fires before any peeking). KV-pressure preemption for waiting requests (block-allocation failure path) from #45558 is intentionally left out of this PR to keep it reviewable; happy to split it into a follow-up if wanted.

## Test Plan

`pytest tests/v1/core/test_scheduler.py -k priority` and the full file, plus `test_priority_preemption_bug.py` / `test_priority_scheduler_random.py` / `test_async_scheduler.py`. New tests cover: preemption fires when a strictly-higher-priority waiter meets a full queue (incl. same-step rollback of the victim and later resumption of the preempted request, v1 and v2 model runner outputs); no preemption for equal priority (earlier arrival; multi-step no-ping-pong) and lower priority; LoRA accounting both ways (shared LoRA kept, unused LoRA freed enabling a second preemption in the same step); FCFS unaffected.

## Test Result

- `tests/v1/core/test_scheduler.py`: 163 passed (full file); `-k priority`: 27 passed
- `test_priority_preemption_bug.py` + `test_priority_scheduler_random.py`: 13 passed
- `test_async_scheduler.py`: 17 passed
- ruff check/format clean

---
<details>
<summary>Essential change sketch</summary>

waiting loop: `queue_full = num_running >= self.max_num_running_reqs`; break early only for non-priority policies; after the blocked-status/stale-output/max_loras admission checks, `if queue_full: if not _preempt_lowest_priority_runner(request): break; continue`. The helper picks `max(self.running, key=(priority, arrival_time))`, refuses unless `request.priority < victim.priority`, rolls back this-step scheduling for the victim (all three scheduled lists), conditionally discards the victim's LoRA, and delegates to `_preempt_request`.

</details>
