### PR TITLE
[CI] Add gated smoke test for local source builds (pip install -e .)

### DIFF
--- a/.buildkite/hardware_tests/cpu.yaml
+++ b/.buildkite/hardware_tests/cpu.yaml
@@ -44,6 +44,27 @@ steps:
       pytest -x -v -s tests/kernels/mamba/test_causal_conv1d.py
       pytest -x -v -s tests/kernels/mamba/test_mamba_ssm.py
       pytest -x -v -s tests/v1/sample/test_topk_topp_sampler.py::TestTritonTopkTopp"
+# Smoke test for the developer local-build workflow (`pip install -e .`):
+# the wheel-based vllm-test image used above never exercises an editable
+# source build, so build system regressions that only break local builds
+# are caught here instead (#9129).
+- label: CPU-Source Build Test
+  key: cpu-source-build-test
+  depends_on: []
+  device: intel_cpu
+  no_plugin: true
+  source_file_dependencies:
+  - CMakeLists.txt
+  - cmake/
+  - csrc/
+  - setup.py
+  - pyproject.toml
+  - requirements/
+  - .buildkite/hardware_tests/cpu.yaml
+  - .buildkite/scripts/hardware_ci/run-cpu-source-build-test.sh
+  commands:
+    - |
+      bash .buildkite/scripts/hardware_ci/run-cpu-source-build-test.sh
 
 # Note: SDE can't be downloaded from CI host because of AWS WAF
 # - label: CPU-Compatibility Tests

--- a/.buildkite/scripts/hardware_ci/run-cpu-source-build-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-source-build-test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script builds the CPU source docker image (the vllm-src stage of
+# docker/Dockerfile.cpu: full source tree plus build dependencies, but no
+# prebuilt vLLM wheel) and verifies that a local source build,
+# `pip install -e .`, succeeds inside it, followed by an import /
+# `vllm serve --help` smoke check.
+#
+# It guards the developer local-build workflow (#9129), which the prebuilt
+# wheel-based vllm-test image used by the other CPU test steps cannot catch.
+set -euox pipefail
+
+# allow to bind to different cores
+CORE_RANGE=${CORE_RANGE:-48-95}
+NUMA_NODE=${NUMA_NODE:-1}
+AGENT_SLOT=${AGENT_SLOT:-}
+IMAGE_NAME="cpu-src-build-${NUMA_NODE}${AGENT_SLOT:+-${AGENT_SLOT}}"
+TIMEOUT_VAL=${TIMEOUT_VAL:-90m}
+
+cleanup() {
+    docker image rm -f "$IMAGE_NAME" || true
+}
+trap cleanup EXIT
+
+# Building the docker image. Layers up to and including vllm-src are shared
+# with the regular cpu-test image build, so base/build-dependency layers are
+# usually served from the BuildKit cache and only the source copy is new.
+echo "--- :docker: Building Docker image (vllm-src stage)"
+docker build --progress plain --tag "$IMAGE_NAME" --target vllm-src -f docker/Dockerfile.cpu .
+
+# Run the editable source build and smoke checks inside the image.
+docker run --rm --cpuset-cpus="$CORE_RANGE" --cpuset-mems="$NUMA_NODE" --shm-size=4g "$IMAGE_NAME" \
+    timeout "$TIMEOUT_VAL" bash -c '
+        set -euox pipefail
+        cd /vllm-workspace
+        echo "--- :hammer_and_wrench: pip install -e . (VLLM_TARGET_DEVICE=cpu)"
+        VLLM_TARGET_DEVICE=cpu uv pip install --no-build-isolation -e .
+        # Import from outside the source tree so the editable install itself is exercised.
+        cd /
+        echo "--- :mag: Smoke test: import vllm"
+        python3 -c "import vllm; print(f\"vLLM version: {vllm.__version__}\")"
+        echo "--- :mag: Smoke test: vllm serve --help"
+        vllm serve --help > /dev/null
+    '


### PR DESCRIPTION
## Summary

Part of #9129. Per @ProExpertProg's guidance (2025-12-23): add a smoke test of local builds (`pip install -e .`) guarded on changes to csrc & build files.

### Gap

Today nothing in PR CI exercises the developer local-build path:

- The Buildkite CPU test steps (`hardware_tests/cpu.yaml`) build the `vllm-test` target of `docker/Dockerfile.cpu`, in which vLLM is installed from a **prebuilt wheel** (`setup.py bdist_wheel` in the `vllm-build` stage) and the full source tree isn't even present.
- `.github/workflows/macos-smoke-test.yml` does run `uv pip install -e .`, but only on a daily cron / manual dispatch, never on PRs, and macOS-only.
- `ci_config.yaml` `run_all_patterns` covers `CMakeLists.txt`, `cmake/`, `csrc/`, `setup.py` by running the full pipeline, but explicitly **excludes** the CPU-only build inputs (`csrc/cpu/`, `cmake/cpu_extension.cmake`) and doesn't cover `pyproject.toml` or the CPU requirements files — precisely the files a local CPU build depends on.

A regression in the editable source build therefore still reaches contributors as a silent local breakage.

### Change

- New step `CPU-Source Build Test` in `.buildkite/hardware_tests/cpu.yaml` (device `intel_cpu`, `no_plugin`, same shape as the existing CPU steps), gated via the existing `source_file_dependencies` mechanism on:
  - `CMakeLists.txt`, `cmake/`, `csrc/`, `setup.py`, `pyproject.toml`, `requirements/`
  - the step's own definition files (`hardware_tests/cpu.yaml`, the new script)
- New helper `.buildkite/scripts/hardware_ci/run-cpu-source-build-test.sh`, modeled on `run-cpu-test.sh`: builds the existing `vllm-src` stage (full source tree + build deps, **no** prebuilt wheel; all base layers are shared with the regular cpu-test image so the incremental cost is one source `COPY`), then inside the container runs:
  1. `VLLM_TARGET_DEVICE=cpu uv pip install --no-build-isolation -e .` — the exact editable-install path a developer uses locally,
  2. `import vllm` **from outside** the source tree (exercises the editable install, not cwd import),
  3. `vllm serve --help` as a CLI smoke check.

Wrapped in a 90m timeout (overridable via `TIMEOUT_VAL`) with an image cleanup trap, matching the other hardware CI scripts. No new CI concepts, no changes to Dockerfiles or production code.

### Verification

YAML files parse cleanly (including duplicate-key check) and the script passes `bash -n`. Docker/runtime verification requires the Buildkite `intel_cpu` agents; this PR's own run will exercise the step end to end since it changes files under the gate.

## Test Plan

- CI: the new step triggers on this PR itself (it modifies `requirements`-adjacent CI files listed in its own `source_file_dependencies` — at minimum `.buildkite/hardware_tests/cpu.yaml`).
