### PR TITLE
[Bugfix] Support Sentence Transformers 5.4+ serialized configs

### DIFF
--- a/docs/models/pooling_models/README.md
+++ b/docs/models/pooling_models/README.md
@@ -292,12 +292,12 @@ classification activation is applied.
 
 | Field | Source precedence | How to override |
 | ----- | ----------------- | --------------- |
-| Pooling method (`pooling_type`) | `--pooler-config` > boolean `pooling_mode_*` fields in the Pooling module referenced by Sentence Transformers `modules.json` > architecture default (`LAST` for sequence pooling and `ALL` for token pooling unless the architecture overrides it) | Set `{"pooling_type": "CLS"}`, or set `seq_pooling_type` / `tok_pooling_type` explicitly. |
+| Pooling method (`pooling_type`) | `--pooler-config` > compact `pooling_mode` or legacy boolean `pooling_mode_*` fields in the Pooling module referenced by Sentence Transformers `modules.json` > architecture default (`LAST` for sequence pooling and `ALL` for token pooling unless the architecture overrides it) | Set `{"pooling_type": "CLS"}`, or set `seq_pooling_type` / `tok_pooling_type` explicitly. |
 | Embedding normalization (`use_activation`) | `--pooler-config` > Sentence Transformers modules (`true` when a Normalize module is present, otherwise `false`) > pooling-task default (`true`) when no Sentence Transformers Pooling module is found | Set `{"use_activation": false}` to return unnormalized embeddings. |
 | Classification activation function | Hugging Face `problem_type` > Sentence Transformers activation metadata > sigmoid or softmax selected from the label count | The function cannot be selected through `--pooler-config`; set `{"use_activation": false}` to return logits instead. |
 
-Sentence Transformers configurations using the newer compact `pooling_mode`
-string are not currently parsed; see [issue #45995](https://github.com/vllm-project/vllm/issues/45995).
+Both compact `pooling_mode` values written by Sentence Transformers 5.4+ and
+legacy boolean `pooling_mode_*` fields are supported.
 
 For converted models and predefined models using the standard DispatchPooler
 adapters, `embed` and `token_embed` construct an L2-normalization head, while

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 import logging
 import os
 from dataclasses import MISSING, Field, asdict, dataclass, field
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
@@ -39,9 +41,18 @@ from vllm.config.speculative import _validate_qwen3_omni_dspark
 from vllm.config.utils import get_field
 from vllm.config.vllm import OPTIMIZATION_LEVEL_TO_CONFIG, OptimizationLevel
 from vllm.platforms import current_platform
+from vllm.transformers_utils.config import (
+    get_pooling_config,
+    try_get_dense_modules,
+)
 from vllm.v1.attention.backend import AttentionCGSupport
 
 DEVICE_TYPE = current_platform.device_type
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
 
 
 def test_kda_recoverssm_derivation_is_revalidated():
@@ -1026,6 +1037,103 @@ def test_get_pooling_config():
     assert model_config.pooler_config.use_activation
     assert model_config.pooler_config.seq_pooling_type == "MEAN"
     assert model_config.pooler_config.tok_pooling_type == "ALL"
+
+
+@pytest.mark.parametrize(
+    ("pooling_module_type", "normalize_module_type", "pooling_config", "expected"),
+    [
+        (
+            "sentence_transformers.models.Pooling",
+            "sentence_transformers.models.Normalize",
+            {"pooling_mode_mean_tokens": True},
+            {"use_activation": True, "seq_pooling_type": "MEAN"},
+        ),
+        (
+            "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+            "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
+            {"pooling_mode": "lasttoken"},
+            {"use_activation": True, "seq_pooling_type": "LAST"},
+        ),
+        (
+            "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+            "sentence_transformers.base.modules.normalize.Normalize",
+            {"pooling_mode": "mean"},
+            {"use_activation": True, "seq_pooling_type": "MEAN"},
+        ),
+    ],
+)
+def test_get_pooling_config_supports_sentence_transformers_schemas(
+    tmp_path,
+    caplog,
+    pooling_module_type,
+    normalize_module_type,
+    pooling_config,
+    expected,
+):
+    modules = [
+        {"idx": 1, "name": "1", "path": "1_Pooling", "type": pooling_module_type},
+        {
+            "idx": 2,
+            "name": "2",
+            "path": "2_Normalize",
+            "type": normalize_module_type,
+        },
+    ]
+    _write_json(tmp_path / "modules.json", modules)
+    _write_json(tmp_path / "1_Pooling" / "config.json", pooling_config)
+
+    with caplog.at_level(logging.WARNING):
+        config = get_pooling_config(str(tmp_path))
+
+    assert config == expected
+    assert "Unable to determine Sentence Transformers pooling type" not in caplog.text
+
+
+def test_get_pooling_config_warns_when_pooling_mode_is_unknown(tmp_path, caplog):
+    modules = [
+        {
+            "idx": 1,
+            "name": "1",
+            "path": "1_Pooling",
+            "type": "sentence_transformers.models.Pooling",
+        }
+    ]
+    _write_json(tmp_path / "modules.json", modules)
+    _write_json(
+        tmp_path / "1_Pooling" / "config.json",
+        {"pooling_mode": "unsupported"},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        config = get_pooling_config(str(tmp_path))
+
+    assert config == {"use_activation": False}
+    assert "Unable to determine Sentence Transformers pooling type" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "dense_module_type",
+    [
+        "sentence_transformers.models.Dense",
+        "sentence_transformers.base.modules.dense.Dense",
+    ],
+)
+def test_get_dense_modules_supports_sentence_transformers_schemas(
+    tmp_path, dense_module_type
+):
+    modules = [{"idx": 2, "name": "2", "path": "2_Dense", "type": dense_module_type}]
+    dense_config = {
+        "in_features": 768,
+        "out_features": 3072,
+        "bias": False,
+        "activation_function": "torch.nn.modules.linear.Identity",
+    }
+    _write_json(tmp_path / "modules.json", modules)
+    _write_json(tmp_path / "2_Dense" / "config.json", dense_config)
+
+    assert try_get_dense_modules(str(tmp_path)) == [
+        {**dense_config, "folder": "2_Dense"}
+    ]
 
 
 @pytest.mark.skipif(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -52,6 +52,21 @@ MISTRAL_CONFIG_NAME = "params.json"
 
 logger = init_logger(__name__)
 
+_ST_POOLING_MODULE_TYPES = {
+    "sentence_transformers.models.Pooling",
+    "sentence_transformers.sentence_transformer.modules.pooling.Pooling",
+}
+_ST_NORMALIZE_MODULE_TYPES = {
+    "sentence_transformers.models.Normalize",
+    "sentence_transformers.base.modules.normalize.Normalize",
+    "sentence_transformers.sentence_transformer.modules.normalize.Normalize",
+}
+_DENSE_MODULE_TYPES = {
+    "sentence_transformers.models.Dense",
+    "sentence_transformers.base.modules.dense.Dense",
+    "pylate.models.Dense.Dense",
+}
+
 if Version(version("transformers")) < Version("5.0.0"):
     raise ImportError(
         "Support for Transformers v4 is deprecated and was removed in vLLM v0.24.0. "
@@ -852,11 +867,7 @@ def get_pooling_config(
     logger.info("Found sentence-transformers modules configuration.")
 
     pooling = next(
-        (
-            item
-            for item in modules_dict
-            if item["type"] == "sentence_transformers.models.Pooling"
-        ),
+        (item for item in modules_dict if item["type"] in _ST_POOLING_MODULE_TYPES),
         None,
     )
     normalize = bool(
@@ -864,7 +875,7 @@ def get_pooling_config(
             (
                 item
                 for item in modules_dict
-                if item["type"] == "sentence_transformers.models.Normalize"
+                if item["type"] in _ST_NORMALIZE_MODULE_TYPES
             ),
             False,
         )
@@ -880,14 +891,28 @@ def get_pooling_config(
 
         config: dict[str, Any] = {"use_activation": normalize}
         for key, val in pooling_dict.items():
-            if val is True:
-                pooling_type = parse_pooling_type(key)
-                if pooling_type in SEQ_POOLING_TYPES:
-                    config["seq_pooling_type"] = pooling_type
-                elif pooling_type in TOK_POOLING_TYPES:
-                    config["tok_pooling_type"] = pooling_type
-                else:
-                    logger.debug("Skipping unrelated field: %r=%r", key, val)
+            if key == "pooling_mode" and isinstance(val, str):
+                pooling_name = val
+            elif val is True:
+                pooling_name = key
+            else:
+                continue
+
+            pooling_type = parse_pooling_type(pooling_name)
+            if pooling_type in SEQ_POOLING_TYPES:
+                config["seq_pooling_type"] = pooling_type
+            elif pooling_type in TOK_POOLING_TYPES:
+                config["tok_pooling_type"] = pooling_type
+            else:
+                logger.debug("Skipping unrelated field: %r=%r", key, val)
+
+        if not {"seq_pooling_type", "tok_pooling_type"} & config.keys():
+            logger.warning(
+                "Unable to determine Sentence Transformers pooling type from %s; "
+                "unless configured explicitly, vLLM will fall back to the model "
+                "architecture default.",
+                pooling_file_name,
+            )
 
         return config
 
@@ -1151,10 +1176,6 @@ def try_get_dense_modules(
         if isinstance(modules, dict):
             modules = modules.get("modules", [])
 
-        _DENSE_MODULE_TYPES = {
-            "sentence_transformers.models.Dense",
-            "pylate.models.Dense.Dense",
-        }
         dense_modules = [m for m in modules if m.get("type") in _DENSE_MODULE_TYPES]
         if not dense_modules:
             return None


### PR DESCRIPTION
## Purpose

Fixes #45995.

Sentence Transformers 5.4+ changed both the Pooling configuration schema and
the fully qualified type paths written to `modules.json`.

In addition to the legacy `sentence_transformers.models.*` paths, serialized
artifacts can contain:

- `sentence_transformers.sentence_transformer.modules.pooling.Pooling`
- `sentence_transformers.sentence_transformer.modules.normalize.Normalize`
- `sentence_transformers.base.modules.normalize.Normalize`
- `sentence_transformers.base.modules.dense.Dense`

Pooling configurations can also use the compact string form:

```json
{
  "pooling_mode": "mean"
}
```

vLLM currently recognizes only the legacy module paths and boolean
`pooling_mode_*` fields. For re-serialized artifacts, this can cause vLLM to
ignore the Sentence Transformers metadata and silently use the architecture
default. Dense projector modules written with the new type path are likewise
not discovered.

This PR:

1. recognizes both legacy and modern Pooling, Normalize, and Dense paths;
2. parses compact `pooling_mode` strings while preserving legacy boolean fields;
3. warns when a Pooling module is present but no supported pooling type can be
   determined;
4. adds offline regression tests for legacy, ST 5.4, and ST 6.0 schemas; and
5. updates the pooling documentation to remove the resolved limitation.

### Relationship to existing PRs

#46010 and #46211 address compact `pooling_mode` parsing using the legacy
Pooling module path. This PR consolidates and extends that work to cover the
fully qualified paths emitted by actual Sentence Transformers 5.4+ artifacts,
including Normalize and Dense projector modules.

Thank you to @Anai-Guo and @GodlyDonuts for the investigation and implementation
in those PRs.

## Test Plan

Run the focused offline config tests:

```bash
.venv/bin/python -m pytest tests/test_config.py \
  -k 'get_pooling_config or get_dense_modules' -q
```

Run all applicable pre-commit hooks:

```bash
.venv/bin/python -m pre_commit run --files \
  vllm/transformers_utils/config.py \
  tests/test_config.py \
  docs/models/pooling_models/README.md
```

Validate numerical parity on Linux ARM64 CPU using artifacts re-serialized by
modern Sentence Transformers:

- `sentence-transformers/all-MiniLM-L6-v2`, re-serialized with ST 6.0.1;
- `google/embeddinggemma-300m`, re-serialized with ST 5.6.0 and loaded with
  ST 6.0.1.

Both artifacts were evaluated in float32 against vLLM with this branch's parser.

## Test Result

Focused unit tests:

```text
8 passed, 230 deselected
```

All applicable pre-commit hooks passed, including Ruff, mypy, markdownlint, and
repository-specific checks.

Numerical parity:

| Model | Resolved configuration | Output shape | Minimum cosine | Mean cosine |
| --- | --- | --- | ---: | ---: |
| all-MiniLM-L6-v2 | MEAN + Normalize | `(3, 384)` | 0.9999999845 | 1.0000000297 |
| embeddinggemma-300m | MEAN + Dense 768→3072→768 + Normalize | `(2, 768)` | 0.9999999766 | 1.0000000052 |

For embeddinggemma, vLLM discovered both Dense modules and resolved the final
embedding size to 768.

AI assistance was used to investigate, implement, and test this change. I
reviewed every changed line and validated the behavior and test results before
submission.
