### PR TITLE
[Frontend][Performance] Resolve async media across modalities concurrently

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2797,9 +2797,61 @@ def test_postprocess_messages_null_arguments_string():
 
 
 @pytest.mark.asyncio
+async def test_resolve_items_runs_modalities_concurrently_and_preserves_order():
+    """Media fetches overlap while modality and item order are preserved."""
+
+    active_fetches = 0
+    max_active_fetches = 0
+
+    async def _fetch(name: str, delay: float):
+        nonlocal active_fetches, max_active_fetches
+        active_fetches += 1
+        max_active_fetches = max(max_active_fetches, active_fetches)
+        try:
+            await asyncio.sleep(delay)
+            return name, f"{name}-uuid"
+        finally:
+            active_fetches -= 1
+
+    tracker = AsyncMultiModalItemTracker(MagicMock())
+    tracker._model_config.is_multimodal_model = True
+    tracker.__dict__["mm_processor"] = MagicMock()
+    tracker._items_by_modality["video"] = [
+        lambda: _fetch("video-0", 0.02),
+        lambda: _fetch("video-1", 0.01),
+    ]
+    tracker._items_by_modality["image"] = [
+        lambda: _fetch("image-0", 0.02),
+        lambda: _fetch("image-1", 0.01),
+    ]
+    tracker._items_by_modality["audio"] = [
+        lambda: _fetch("audio-0", 0.02),
+        lambda: _fetch("audio-1", 0.01),
+    ]
+
+    mm_data, mm_uuids = await tracker.resolve_items()
+
+    assert mm_data is not None
+    assert mm_uuids is not None
+    assert max_active_fetches == 6
+    assert list(mm_data) == ["image", "audio", "video"]
+    assert list(mm_uuids) == ["image", "audio", "video"]
+    assert mm_data == {
+        "image": ["image-0", "image-1"],
+        "audio": ["audio-0", "audio-1"],
+        "video": ["video-0", "video-1"],
+    }
+    assert mm_uuids == {
+        "image": ["image-0-uuid", "image-1-uuid"],
+        "audio": ["audio-0-uuid", "audio-1-uuid"],
+        "video": ["video-0-uuid", "video-1-uuid"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
     """Regression test: one failing media fetch must not abandon the other
-    still-in-flight fetches in the same modality batch.
+    still-in-flight fetches across modality batches.
 
     Before the fix, `resolve_items` gathered per-modality fetches with plain
     `asyncio.gather`, so the first exception propagated immediately while
@@ -2820,6 +2872,8 @@ async def test_resolve_items_does_not_leak_tasks_on_partial_failure():
         lambda: _fetch(False, 0.2),
         lambda: _fetch(False, 0.2),
     ]
+    tracker._items_by_modality["audio"] = [lambda: _fetch(False, 0.2)]
+    tracker._items_by_modality["video"] = [lambda: _fetch(False, 0.2)]
 
     tasks_before = asyncio.all_tasks()
     with pytest.raises(ValueError, match="simulated fetch failure"):

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -840,19 +840,30 @@ class AsyncMultiModalItemTracker(BaseMultiModalItemTracker[_AsyncMultiModalItem]
         if not self._items_by_modality:
             return None, None
 
+        # Fetch all modalities together. Each tracked item is already an
+        # independent awaitable, and the async connector offloads blocking
+        # decode work, so waiting for one modality before starting the next
+        # needlessly adds their latency.
+        # Keep the original group and item order when rebuilding the result.
+        item_groups = list(self._items_by_modality.items())
+        items = [item for _, group in item_groups for item in group]
+        results = await asyncio.gather(
+            *(item() for item in items), return_exceptions=True
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                # Gathering with return_exceptions=True lets every task finish
+                # (or itself fail) before we raise, instead of abandoning
+                # still-in-flight fetches (real network/thread-pool work) the
+                # moment the first one fails.
+                raise result
+
         resolved_items_by_modality: dict[str, list[Any]] = {}
-        for modality, items in self._items_by_modality.items():
-            results = await asyncio.gather(
-                *(item() for item in items), return_exceptions=True
-            )
-            for result in results:
-                if isinstance(result, BaseException):
-                    # Gathering with return_exceptions=True lets every task in
-                    # this modality finish (or itself fail) before we raise,
-                    # instead of abandoning still-in-flight fetches (real
-                    # network/thread-pool work) the moment the first one fails.
-                    raise result
-            resolved_items_by_modality[modality] = results
+        result_idx = 0
+        for modality, group in item_groups:
+            next_result_idx = result_idx + len(group)
+            resolved_items_by_modality[modality] = results[result_idx:next_result_idx]
+            result_idx = next_result_idx
 
         mm_processor = (
             self.mm_processor if self._model_config.is_multimodal_model else None


### PR DESCRIPTION
## Purpose

`parse_chat_messages_async` records asynchronous media work in
`AsyncMultiModalItemTracker`, grouped by modality. `resolve_items` currently
waits for one complete modality group before it starts the next group. For a
request containing image, audio, and video inputs, this makes independent
fetch/decode work run one modality group at a time, for example:

```text
image group -> audio group -> video group
```

The asynchronous media connector already moves blocking I/O and decode work
off the event loop. The per-modality loop therefore adds avoidable wall-clock
latency to mixed-modality requests, even though items within each individual
modality are already gathered concurrently.

This change gathers all tracked asynchronous media items in one
`asyncio.gather` call. It then slices the returned list back into the original
modality groups before calling the existing result materialization code. The
flatten/slice step preserves both the modality mapping and the order of items
within each modality. `return_exceptions=True` is retained so that every
in-flight fetch settles before an exception is re-raised.

The scope is intentionally limited to scheduling already tracked asynchronous
items. It does not inspect private connector state, change MediaConnector
cache behavior, or promise single-flight/deduplication for identical URLs.

### Duplicate-work check

Searches of open vLLM pull requests and issues for
`AsyncMultiModalItemTracker`, `resolve_items` modality concurrency, and
`parse_chat_messages_async` media concurrency found no contribution that
implements this change. The nearby multimodal preprocessing reports concern
HF processor work later in the input pipeline, rather than the per-modality
media-resolution loop changed here, so this PR does not duplicate them.

## Test Plan

### Automated tests

```bash
uv run --active --no-sync python -m pytest -q tests/entrypoints/unit_tests/test_chat_utils.py
uv run --active --no-sync ruff check vllm/entrypoints/chat_utils.py tests/entrypoints/unit_tests/test_chat_utils.py
uv run --active --no-sync ruff format --check vllm/entrypoints/chat_utils.py tests/entrypoints/unit_tests/test_chat_utils.py
uv run --active --no-sync pre-commit run --files vllm/entrypoints/chat_utils.py tests/entrypoints/unit_tests/test_chat_utils.py
git diff --check
```

The unit tests cover:

- six simultaneous fetches spanning image, audio, and video, with delayed
  completions to prove overlap;
- the order of modality keys and the order of two items within every modality;
- distinct result values and UUIDs, so an incorrect flatten/slice boundary is
  detected rather than only checking item counts;
- a failure in one modality while fetches in the other modalities are still in
  flight, verifying that no tasks are left running after the exception.

### Real-media parser matrix

The unmodified `HEAD` and the patched implementation were run with the same
`Qwen2.5-Omni-3B` model configuration and the same reproducible image, audio,
and video assets through `parse_chat_messages_async`. The media connector used
the same video decoding settings on both versions. The workload matrix was:

- one image, one audio, and one video;
- one image + one audio + one video, in multiple input orders;
- two and four items per modality for image/video and image/audio/video mixes;
- 1, 2, 4, and 8 concurrent requests, each containing four images and four
  videos;
- all six permutations of the image/audio/video input order.

For each case, one warm-up run was discarded. Cases with at most three media
items used five timed trials; larger cases used three timed trials. The table
reports the median wall-clock time from entering `parse_chat_messages_async`
until `mm_data` and `mm_uuids` were materialized.

This is a GPU-less render-path benchmark of asynchronous media fetching and
decoding. It is not a GPU inference-throughput benchmark: model execution,
multimodal processor tensorization, token generation, and HTTP response
serialization are outside the measured interval and are unchanged by this
PR. A separate HTTP-connector check used the same assets behind reproducible
HTTP URLs to verify that the optimization also applies to the normal download
path.

For every matrix case, the two versions were also compared using a fingerprint
over the rendered conversation, modality/UUID lists, original media bytes,
decoded array shapes/dtypes, and decoded media bytes.

### GPU output equivalence

1. Run the same image-plus-video render request against the unmodified and
   patched implementations.
2. Compare prompt token IDs, modality hashes, placeholder ranges, decoded
   media tensor shapes/dtypes, and decoded media values.
3. Feed both rendered inputs to the same A100 `bfloat16` eager vLLM inference
   engine with seed `123` and temperature `0`.
4. Compare the complete generated token sequences, including the stop token,
   and repeat the same input to distinguish implementation changes from
   inference nondeterminism.

## Test Result

### Automated tests

- `tests/entrypoints/unit_tests/test_chat_utils.py`: **78 passed**
- `ruff check`: passed
- `ruff format --check`: passed
- `pre-commit` on both changed files: passed
- `git diff --check`: passed

### Real-media parser matrix

The following are median parser-resolution times in milliseconds. `Change` is
`(patched / unmodified - 1)`, so a negative value is an improvement.

| Workload | Unmodified | Patched | Change |
| --- | ---: | ---: | ---: |
| 1 image | 19.276 | 19.002 | -1.4% |
| 1 audio | 9.436 | 8.209 | -13.0% |
| 1 video | 73.799 | 76.708 | +3.9% |
| 1 audio + 1 video | 79.620 | 75.621 | -5.0% |
| 1 image + 1 audio + 1 video | 99.885 | 77.744 | **-22.2%** |
| 2 images + 2 videos | 109.205 | 95.420 | **-12.6%** |
| 2 images + 2 audio + 2 videos | 113.366 | 94.906 | **-16.3%** |
| 4 images + 4 videos | 138.712 | 127.054 | **-8.4%** |
| 4 images + 4 audio + 4 videos | 153.845 | 136.230 | **-11.4%** |
| 1 concurrent 4-image/4-video request | 145.474 | 127.326 | **-12.5%** |
| 2 concurrent 4-image/4-video requests | 213.488 | 194.697 | **-8.8%** |
| 4 concurrent 4-image/4-video requests | 379.047 | 336.314 | **-11.3%** |
| 8 concurrent 4-image/4-video requests | 693.728 | 677.679 | -2.3% |

The single-modality controls show no systematic regression (the largest
absolute difference is 2.9 ms); the largest and most consistent improvements
appear when a request contains independent modalities. The 8-request point is
close to saturation because the shared decode/thread-pool resources become the
bottleneck, so it is not presented as the headline result.

The six image/audio/video input-order permutations produced identical
conversation, UUID, and decoded-media fingerprints between the two versions.
The ten single-request matrix cases and four concurrency cases likewise
produced identical fingerprints.

### HTTP connector check

These are median times for the same parser workloads when the media was
served through the normal HTTP connector. Each result used five trials for the
one-item-per-modality case and three trials for the larger cases:

| Workload | Unmodified | Patched | Change |
| --- | ---: | ---: | ---: |
| 1 image + 1 audio + 1 video | 119.491 ms | 96.985 ms | **-18.8%** |
| 4 images + 4 videos | 182.158 ms | 155.293 ms | **-14.7%** |
| 4 images + 4 audio + 4 videos | 205.741 ms | 169.751 ms | **-17.5%** |

The HTTP check is a connector-path confirmation; the primary performance
comparison uses file-backed reproducible inputs to avoid network jitter.

### GPU output equivalence

Using the same A100, `bfloat16` eager vLLM inference engine, seed `123`, and
temperature `0`, both versions produced 2,733 prompt token IDs, identical
modality hashes, identical placeholder ranges, and identical decoded media
tensor values. The canonical semantic engine-input digest was identical:

`71fe0f7b9ead20501757fd72b65d3d8bb56cdeab920cc8446e16cf9b13c5be`

Both rendered inputs generated exactly the same 77 output token IDs,
including the stop token. Repeating the same input also returned the same
sequence. Thus the performance result is from overlapping media preparation;
the model output did not change.

### AI-assisted contribution

This contribution was developed with AI assistance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] No documentation update is needed because this only changes internal
  scheduling and adds no user-facing API or configuration.
</details>

