### PR TITLE
[Bugfix][Frontend] Truncate the assistant tokens mask with the prompt

### DIFF
--- a/tests/entrypoints/scale_out/render/test_render.py
+++ b/tests/entrypoints/scale_out/render/test_render.py
@@ -532,6 +532,52 @@ async def test_chat_completion_render_assistant_tokens_mask_with_generation_tags
 
 
 @pytest.mark.asyncio
+async def test_chat_render_assistant_tokens_mask_follows_truncation(client):
+    """The assistant mask must be truncated with the prompt it describes.
+
+    `assistant_tokens_mask` is positional: entry i labels token i. Truncating
+    `token_ids` from the left without truncating the mask leaves the two
+    describing different positions, and the mask ends up marking whichever
+    tokens happen to sit at the old offsets.
+    """
+    messages = [
+        # Deliberately lopsided: a long leading user turn and a short trailing
+        # one, so keeping the head of the mask is distinguishable from keeping
+        # its tail.
+        {"role": "user", "content": "Hello hello hello hello hello hello"},
+        {"role": "assistant", "content": "Hi!"},
+        {"role": "user", "content": "Bye"},
+    ]
+    body = {
+        "model": MODEL_NAME,
+        "messages": messages,
+        "chat_template": _TEMPLATE_WITH_GENERATION,
+        "return_assistant_tokens_mask": True,
+    }
+
+    full = await client.post("/v1/chat/completions/render", json=body)
+    assert full.status_code == 200
+    full_token_ids = full.json()["token_ids"]
+    full_mask = full.json()["assistant_tokens_mask"]
+    assert sum(full_mask) > 0
+
+    keep = len(full_token_ids) - 4
+    # Precondition: with this prompt the head and tail slices of the mask
+    # really do differ, so the assertion below can tell them apart.
+    assert full_mask[-keep:] != full_mask[:keep]
+
+    truncated = await client.post(
+        "/v1/chat/completions/render",
+        json={**body, "truncate_prompt_tokens": keep, "truncation_side": "left"},
+    )
+    assert truncated.status_code == 200
+    data = truncated.json()
+
+    assert data["token_ids"] == full_token_ids[-keep:]
+    assert data["assistant_tokens_mask"] == full_mask[-keep:]
+
+
+@pytest.mark.asyncio
 async def test_messages_render_basic(client):
     """Test basic Anthropic Messages render endpoint."""
     response = await client.post(

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -24,6 +24,18 @@ logger = init_logger(__name__)
 
 _S = TypeVar("_S", list[int], "torch.Tensor")
 
+# Prompt keys whose entry i describes token i of the prompt, so they must be
+# reduced with the same slice as the prompt tokens themselves. Anything added
+# here is truncated by `TokenizeParams.apply_post_tokenization`.
+# `_assistant_tokens_mask` is renderer-internal: `HfRenderer.render_messages`
+# stashes it on the prompt so `_process_tokens` can move it onto the engine
+# input.
+_PARALLEL_TO_PROMPT_TOKENS = (
+    "prompt_token_offsets",
+    "prompt_is_token_ids",
+    "_assistant_tokens_mask",
+)
+
 
 def merge_kwargs(
     defaults: dict[str, Any] | None,
@@ -420,8 +432,8 @@ class TokenizeParams:
         """The slice truncation applies to a sequence of `length` tokens.
 
         `None` means no truncation. Anything parallel to the prompt tokens
-        (see `prompt_token_offsets` and `prompt_is_token_ids`) must be reduced
-        with this same slice to stay aligned with them.
+        must be reduced with this same slice to stay aligned with them; list
+        such keys in `_PARALLEL_TO_PROMPT_TOKENS`.
         """
         max_length = self.truncate_prompt_tokens
         if max_length is not None and max_length < 0:
@@ -511,15 +523,13 @@ class TokenizeParams:
                 tokenizer,
                 prompt["prompt_embeds"],  # type: ignore[typeddict-item]
             )
-        offsets = cast(TokensPrompt, prompt).get("prompt_token_offsets")
-        if offsets is not None:
-            truncation = self._truncation_slice(tokenizer, len(offsets))
+        prompt_dict = cast(dict, prompt)
+        for key in _PARALLEL_TO_PROMPT_TOKENS:
+            parallel = prompt_dict.get(key)
+            if parallel is None:
+                continue
+            truncation = self._truncation_slice(tokenizer, len(parallel))
             if truncation is not None:
-                prompt["prompt_token_offsets"] = offsets[truncation]  # type: ignore[typeddict-unknown-key]
-        is_token_ids = cast(EmbedsPrompt, prompt).get("prompt_is_token_ids")
-        if is_token_ids is not None:
-            truncation = self._truncation_slice(tokenizer, len(is_token_ids))
-            if truncation is not None:
-                prompt["prompt_is_token_ids"] = is_token_ids[truncation]  # type: ignore[typeddict-unknown-key]
+                prompt_dict[key] = parallel[truncation]
 
         return prompt


### PR DESCRIPTION
Follow-up to #54407 and #54509 (both merged), which fixed the same class of
defect for `prompt_token_offsets` and `prompt_is_token_ids`. This is the last
array that has to stay parallel to the prompt. Rebased onto #54509.

## The bug

`assistant_tokens_mask` is positional: entry `i` labels token `i` of the
rendered prompt, and `/v1/chat/completions/render` returns it next to
`token_ids`. `HfRenderer.render_messages` stashes it on the prompt as
`_assistant_tokens_mask` (`vllm/renderers/hf.py:1025`, `:1150`) and
`_process_tokens` later moves it onto the engine input (`:1193`, `:1221`).

In between, `TokenizeParams.apply_post_tokenization` truncates
`prompt_token_ids` and never touches the mask, so with
`truncate_prompt_tokens` the two describe different positions.

## The symptom is silently wrong data, not an error

The render server already notices the length mismatch
(`vllm/entrypoints/scale_out/render/serving.py:126-142`). It logs

```
assistant_tokens_mask length (%d) != token_ids length (%d); this can happen
with multimodal inputs where placeholder expansion changes the token count.
The mask may be positionally misaligned.
```

and then reconciles by slicing `assistant_tokens_mask[: len(token_ids)]` --
from the **right**, regardless of `truncation_side`. With
`truncation_side="left"` the prompt keeps its last N tokens while the mask
keeps its first N, so the response labels the wrong tokens. The warning also
misattributes the cause: here it is truncation, not placeholder expansion.

`truncate_prompt_tokens`, `truncation_side` and `return_assistant_tokens_mask`
are all public fields on `ChatCompletionRequest`, and the schema documents that
the render response carries the mask, so this is wrong data in a documented
response field.

## Reachability

Against the render server (no GPU needed), with a chat template containing
`{% generation %}` so the mask is actually produced:

```bash
curl -X POST http://localhost:8000/v1/chat/completions/render \
  -H 'Content-Type: application/json' \
  -d '{
        "model": "<model>",
        "messages": [
          {"role": "user", "content": "Hello hello hello hello hello hello"},
          {"role": "assistant", "content": "Hi!"},
          {"role": "user", "content": "Bye"}
        ],
        "chat_template": "<template with {% generation %}>",
        "return_assistant_tokens_mask": true,
        "truncate_prompt_tokens": 8,
        "truncation_side": "left"
      }'
```

## The fix

Reduce the mask with the same `_truncation_slice` the prompt uses.

The mask is still parallel to `prompt_token_ids` at that point -- multi-modal
placeholder expansion happens later, in `_process_tokens` -- so the downstream
reconciliation still covers the expansion case it was written for, and only
stops firing for the truncation case.

Right-side truncation was already correct by accident, because slicing the mask
from the right is what that path happens to need; it stays correct, now without
relying on the fallback.

## Not a duplicate

Searched open PRs for `assistant_tokens_mask in:body`,
`return_assistant_tokens_mask in:body` and `render_chat_request in:body`.
Nothing touches this.

## Tests

New test:
`tests/entrypoints/scale_out/render/test_render.py::test_chat_render_assistant_tokens_mask_follows_truncation`.
It extends the existing `_TEMPLATE_WITH_GENERATION` render test: render once
normally, then again with `truncate_prompt_tokens` + `truncation_side: "left"`,
and require the mask to equal the tail slice of the full mask. It asserts up
front that the head and tail slices actually differ, so the test cannot pass
by coincidence on a symmetric mask.

This is a real HTTP round trip against the render server, which needs no GPU,
so I was able to run it end to end on a CPU runner on my fork. Against `main`
the request returns **200 OK with the wrong mask**:

```
>       assert data["assistant_tokens_mask"] == full_mask[-keep:]
E       assert [0, 0, 0, 0, 0, 0, ...] == [0, 0, 0, 0, 0, 1, ...]
E         At index 5 diff: 0 != 1
E         Full diff:
E           [
E         +     0,
E         +     0,
E         +     0,
E         +     0,
E               0, 0, 0, 0, 0,
E               1, 1, 1, 1, 1, 1,
E               0,
E         -     0,
E         -     0,
E         -     0,
E         -     0,
E           ]

1 failed, 23 deselected
```

The shape of that diff is the bug: the mask is the **head** slice where the
prompt kept its **tail**, so the assistant span is reported four positions too
late. Note the preceding assertion, `data["token_ids"] == full_token_ids[-keep:]`,
passes on `main` -- the tokens are right and only their labels are wrong, which
is why nothing downstream notices.

With the fix, the whole file passes:

```
24 passed in 39.33s
```

Lint: `ruff check`, `ruff format --diff`, `typos`, the SPDX pre-commit hook and
`mypy` (3.12) all pass on the changed files.

AI assistance was used to research and draft this change. I have reviewed every
changed line and run the tests above.

## Update: bundled the cleanup that closes this class of bug

Per review, the per-key blocks in `apply_post_tokenization` are now one loop
over a module-level `_PARALLEL_TO_PROMPT_TOKENS` tuple, and
`_truncation_slice`'s docstring points at it. Adding a future parallel key is a
name in that tuple rather than another copy of the slice.

The set of positionally parallel prompt fields is closed. Every field of the
renderer prompt types in `vllm/inputs/llm.py`:

| field | status |
| --- | --- |
| `TokensPrompt.prompt_token_ids`, `EmbedsPrompt.prompt_embeds` | the prompts themselves, `_validate_tokens` |
| `TokensPrompt.prompt_token_offsets` | #54407 (merged) |
| `EmbedsPrompt.prompt_is_token_ids` | #54509 (merged) |
| `TokensPrompt.token_type_ids` | the renderer never populates it; the only producer is the pooling scoring path, which keeps its own truncate/pad copy in `_apply_post_tokenization_to_token_type_ids`, fixed in #54364 (merged) |
| `_assistant_tokens_mask` | this PR |
| `prompt`, `multi_modal_data`, `mm_processor_kwargs`, `multi_modal_uuids`, `cache_salt` | not positional |

## Re-verified on the refactored diff

Fork CI run 33431485650, against current `main`. BEFORE is unchanged by the
refactor -- still 200 OK with the head slice of the mask where the prompt kept
its tail:

```
        assert data["token_ids"] == full_token_ids[-keep:]
>       assert data["assistant_tokens_mask"] == full_mask[-keep:]
E       assert [0, 0, 0, 0, 0, 0, ...] == [0, 0, 0, 0, 0, 1, ...]
E         At index 5 diff: 0 != 1

1 failed, 23 deselected, 14 warnings in 36.53s
```

AFTER (whole file): `24 passed, 14 warnings in 35.52s`.

`ruff check`, `ruff format --diff` and `mypy` (3.12) pass on
`vllm/renderers/params.py`.
