### PR TITLE
[Bugfix][CPU] Only enable ARM GELU LUT ops for models using GELU activations

### DIFF
--- a/tests/platforms/test_cpu.py
+++ b/tests/platforms/test_cpu.py
@@ -150,3 +150,42 @@ def test_cpu_accelerated_gdn_dtype_policy(
 
     CpuPlatform.check_and_update_config(config)
     assert cache_config.mamba_ssm_cache_dtype == expected_dtype
+
+
+@pytest.mark.parametrize(
+    ("model_config", "expected"),
+    [
+        pytest.param(None, True, id="no-model-config"),
+        pytest.param(
+            SimpleNamespace(hf_text_config=SimpleNamespace(hidden_act="silu")),
+            False,
+            id="silu",
+        ),
+        pytest.param(
+            SimpleNamespace(hf_text_config=SimpleNamespace(hidden_act="gelu")),
+            True,
+            id="gelu",
+        ),
+        pytest.param(
+            SimpleNamespace(
+                hf_text_config=SimpleNamespace(hidden_activation="gelu_pytorch_tanh")
+            ),
+            True,
+            id="gelu-tanh-via-hidden-activation",
+        ),
+        pytest.param(
+            SimpleNamespace(
+                hf_text_config=SimpleNamespace(activation_function="gelu_new")
+            ),
+            True,
+            id="gelu-new-via-activation-function",
+        ),
+        pytest.param(
+            SimpleNamespace(hf_text_config=SimpleNamespace()),
+            True,
+            id="unknown-activation-defaults-on",
+        ),
+    ],
+)
+def test_uses_gelu_activation(model_config, expected) -> None:
+    assert CpuPlatform._uses_gelu_activation(model_config) is expected

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -195,6 +195,29 @@ class CpuPlatform(Platform):
         return torch.no_grad()
 
     @classmethod
+    def _uses_gelu_activation(cls, model_config) -> bool:
+        """Best-effort check whether the model uses a GELU-family activation.
+
+        Falls back to True when the activation cannot be determined, so the
+        ARM GELU LUT ops are never withheld from a model that may need them.
+        """
+        if model_config is None:
+            return True
+        hf_config = getattr(model_config, "hf_text_config", None) or getattr(
+            model_config, "hf_config", None
+        )
+        if hf_config is None:
+            return True
+        acts = [
+            getattr(hf_config, attr, None)
+            for attr in ("hidden_act", "hidden_activation", "activation_function")
+        ]
+        known = [a for a in acts if isinstance(a, str)]
+        if not known:
+            return True
+        return any("gelu" in a.lower() for a in known)
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         model_config = vllm_config.model_config
 
@@ -317,24 +340,19 @@ class CpuPlatform(Platform):
         if vllm_config.lora_config is not None:
             compilation_config.mode = CompilationMode.NONE
 
-        if (
-            cls.get_cpu_architecture() == CpuArchEnum.ARM
-            and "+gelu" not in compilation_config.custom_ops
-            and "-gelu" not in compilation_config.custom_ops
+        # Enable the ARM GELU LUT ops only for models that actually use a
+        # GELU-family activation; unconditionally appending them makes
+        # check_enabled_custom_ops() warn "has no effect" for every other
+        # model (e.g. SiLU-based ones) on every ARM CPU startup.
+        if cls.get_cpu_architecture() == CpuArchEnum.ARM and cls._uses_gelu_activation(
+            vllm_config.model_config
         ):
-            compilation_config.custom_ops.append("+gelu")
-        if (
-            cls.get_cpu_architecture() == CpuArchEnum.ARM
-            and "+gelu_tanh" not in compilation_config.custom_ops
-            and "-gelu_tanh" not in compilation_config.custom_ops
-        ):
-            compilation_config.custom_ops.append("+gelu_tanh")
-        if (
-            cls.get_cpu_architecture() == CpuArchEnum.ARM
-            and "+gelu_and_mul" not in compilation_config.custom_ops
-            and "-gelu_and_mul" not in compilation_config.custom_ops
-        ):
-            compilation_config.custom_ops.append("+gelu_and_mul")
+            for gelu_op in ("gelu", "gelu_tanh", "gelu_and_mul"):
+                if (
+                    f"+{gelu_op}" not in compilation_config.custom_ops
+                    and f"-{gelu_op}" not in compilation_config.custom_ops
+                ):
+                    compilation_config.custom_ops.append(f"+{gelu_op}")
 
         vllm_config.profiler_config.torch_profiler_dump_cuda_time_total = False
 


### PR DESCRIPTION
## Purpose

On ARM CPUs, `CpuPlatform.check_and_update_config` unconditionally appends `+gelu`, `+gelu_tanh`, and `+gelu_and_mul` to `compilation_config.custom_ops` (introduced with the ARM GELU LUT work, #37469 / #44639).

Most current models use SiLU-family activations, so every engine start on ARM (e.g. any macOS Apple Silicon user following the CPU install docs, running Qwen/Llama) logs three spurious warnings:

```
WARNING [compilation.py:1354] Op 'gelu' not present in model, enabling with '+gelu' has no effect
WARNING [compilation.py:1354] Op 'gelu_tanh' not present in model, enabling with '+gelu_tanh' has no effect
WARNING [compilation.py:1354] Op 'gelu_and_mul' not present in model, enabling with '+gelu_and_mul' has no effect
```

This PR gates the injection on the model's configured activation (`hidden_act` / `hidden_activation` / `activation_function` on the HF text config): the ops are appended only when the activation is GELU-family. If the activation cannot be determined, we keep the previous behavior and append them, so the LUT path is never withheld from a model that may need it. The three copy-pasted blocks are also folded into a loop.

Note: a GELU model still warns for the family members it doesn't use (e.g. `EleutherAI/pythia-70m` uses plain `gelu` and warns for `gelu_tanh`/`gelu_and_mul`). That residual warning is accurate, and mapping each op to the exact activation variant would need model-internals knowledge the platform hook doesn't have.

## Test Plan

- New parametrized unit test `test_uses_gelu_activation` in `tests/platforms/test_cpu.py`.
- Manual on macOS arm64 (M4 Pro, source build of current main, commit 399247cc8):
  - `Qwen/Qwen2.5-0.5B-Instruct` (SiLU): before = 3 warnings per engine start; after = 0 warnings, `custom_ops == ['all']`, generation unchanged.
  - `EleutherAI/pythia-70m` (GELU): ops still injected (`['all', '+gelu', '+gelu_tanh', '+gelu_and_mul']`), generation unchanged.

## Test Result

- `pytest tests/platforms/test_cpu.py` → 14 passed.
- `ruff check` / `ruff format --check` clean on both files.

---

<sub>Prepared with AI assistance (Claude); reviewed and tested by the author on real hardware.</sub>
