### PR TITLE
[Frontend][OpenAI] Forward thinking_token_budget to chat_template_kwargs in ChatCompletionRequest

### DIFF
--- a/tests/entrypoints/openai/test_reasoning_enable_thinking.py
+++ b/tests/entrypoints/openai/test_reasoning_enable_thinking.py
@@ -68,6 +68,28 @@ class TestChatCompletionReasoningEffort:
         assert params.chat_template_kwargs["reasoning_effort"] == "high"
 
 
+class TestChatCompletionThinkingTokenBudget:
+    """Chat Completions: thinking_token_budget -> chat_template_kwargs."""
+
+    def test_budget_forwarded_to_chat_template_kwargs(self):
+        request = _build_chat_request(thinking_token_budget=256)
+        params = request.build_chat_params(None, "auto")
+        assert params.chat_template_kwargs["thinking_token_budget"] == 256
+
+    def test_no_budget_does_not_inject(self):
+        request = _build_chat_request()
+        params = request.build_chat_params(None, "auto")
+        assert "thinking_token_budget" not in params.chat_template_kwargs
+
+    def test_explicit_user_kwarg_not_overridden(self):
+        request = _build_chat_request(
+            thinking_token_budget=256,
+            chat_template_kwargs={"thinking_token_budget": 100},
+        )
+        params = request.build_chat_params(None, "auto")
+        assert params.chat_template_kwargs["thinking_token_budget"] == 100
+
+
 class TestResponsesReasoningEffort:
     """Responses API: reasoning.effort -> enable_thinking."""
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -586,6 +586,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
         user_kwargs = self.chat_template_kwargs or {}
         if self.reasoning_effort is not None and "enable_thinking" not in user_kwargs:
             extra_kwargs["enable_thinking"] = self.reasoning_effort != "none"
+        if (
+            self.thinking_token_budget is not None
+            and "thinking_token_budget" not in user_kwargs
+        ):
+            extra_kwargs["thinking_token_budget"] = self.thinking_token_budget
 
         return ChatParams(
             chat_template=self.chat_template or default_template,


### PR DESCRIPTION
#### Motivation & Context
Models supporting reasoning budget configuration require `thinking_token_budget` to be passed into the chat template kwargs to properly enforce thinking token constraints during template rendering.

Currently, `ChatCompletionRequest` parses `thinking_token_budget`, but it is not automatically forwarded into `chat_template_kwargs` within `build_chat_params`. This PR forwards `thinking_token_budget` when set, following the same precedence pattern as `enable_thinking`.

#### Description of Changes
- Forward `thinking_token_budget` to `chat_template_kwargs` in `ChatCompletionRequest.build_chat_params()` when present and not explicitly overridden by user-supplied `chat_template_kwargs`.
- Add unit test coverage in `tests/entrypoints/openai/test_reasoning_enable_thinking.py` (`TestChatCompletionThinkingTokenBudget`).