### PR TITLE
feat(tpu): support single-host pipeline parallelism execution and scheduling

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -585,6 +585,10 @@ class VllmConfig:
         # PP requires PP-size concurrent batches to fill the pipeline.
         # Async scheduling requires 2 concurrent batches to overlap.
         pp_size = self.parallel_config.pipeline_parallel_size
+        # For TPU V1 runner with PP, execute synchronously (1 batch in flight)
+        # so that each decode step receives the previous step's sampled token.
+        if pp_size > 1 and not self.use_v2_model_runner:
+            return 1
         if self.scheduler_config.async_scheduling:
             if self.use_v2_model_runner:
                 return pp_size + 1
@@ -1271,6 +1275,10 @@ class VllmConfig:
                     "high-throughput DBO because that combination can corrupt "
                     "DP+EP generation accuracy."
                 )
+                self.scheduler_config.async_scheduling = False
+            elif self.parallel_config.pipeline_parallel_size > 1 and not getattr(
+                self, "use_v2_model_runner", False
+            ):
                 self.scheduler_config.async_scheduling = False
             else:
                 self.scheduler_config.async_scheduling = True

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1496,7 +1496,7 @@ class Scheduler(SchedulerInterface):
             # NOTE: In PP+async scheduling, we consume token ids via a direct GPU
             # broadcast path (`input_batch.prev_sampled_token_ids`), so we can
             # omit this payload.
-            if self.use_pp and not self.scheduler_config.async_scheduling:
+            if self.use_pp:
                 # When using PP, the scheduler sends the sampled tokens back,
                 # because there's no direct communication between the first-
                 # stage worker and the last-stage worker. Otherwise, we don't


### PR DESCRIPTION
Configures `max_concurrent_batches=1` for TPU PP V1 runner, disables async scheduling, and handles `use_pp` token output in scheduler.

Part of the TPU Pipeline Parallelism stack (corresponds to tpu-inference#3496).