### PR TITLE
feat(tpu): propagate worker IPs for multi-host Ray PP on TPU

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -585,6 +585,10 @@ class VllmConfig:
         # PP requires PP-size concurrent batches to fill the pipeline.
         # Async scheduling requires 2 concurrent batches to overlap.
         pp_size = self.parallel_config.pipeline_parallel_size
+        # For TPU V1 runner with PP, execute synchronously (1 batch in flight)
+        # so that each decode step receives the previous step's sampled token.
+        if pp_size > 1 and not self.use_v2_model_runner:
+            return 1
         if self.scheduler_config.async_scheduling:
             if self.use_v2_model_runner:
                 return pp_size + 1
@@ -1271,6 +1275,10 @@ class VllmConfig:
                     "high-throughput DBO because that combination can corrupt "
                     "DP+EP generation accuracy."
                 )
+                self.scheduler_config.async_scheduling = False
+            elif self.parallel_config.pipeline_parallel_size > 1 and not getattr(
+                self, "use_v2_model_runner", False
+            ):
                 self.scheduler_config.async_scheduling = False
             else:
                 self.scheduler_config.async_scheduling = True

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -182,3 +182,5 @@ class SharedExperts(torch.nn.Module):
             self._output[self._output_idx] = self._layer(shared_experts_input)
 
         assert self._output[self._output_idx] is not None
+
+        return None

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1496,7 +1496,7 @@ class Scheduler(SchedulerInterface):
             # NOTE: In PP+async scheduling, we consume token ids via a direct GPU
             # broadcast path (`input_batch.prev_sampled_token_ids`), so we can
             # omit this payload.
-            if self.use_pp and not self.scheduler_config.async_scheduling:
+            if self.use_pp:
                 # When using PP, the scheduler sends the sampled tokens back,
                 # because there's no direct communication between the first-
                 # stage worker and the last-stage worker. Otherwise, we don't

--- a/vllm/v1/executor/ray_executor_v2.py
+++ b/vllm/v1/executor/ray_executor_v2.py
@@ -428,7 +428,13 @@ class RayExecutorV2(MultiprocExecutor):
         for i, (node_id, _) in enumerate(worker_node_and_physical_gpu_ids):
             local_rank = node_workers[node_id].index(i)
             assigned_physical_gpu_ids = sorted(node_physical_gpu_ids[node_id])
-            worker_env_vars: dict[str, str] = {}
+            worker_env_vars: dict[str, str] = {
+                "TPU_PP_WORKER_IP": bundle_assignments[i]["node_ip"]
+            }
+            if i > 0:
+                worker_env_vars["TPU_PP_PREV_WORKER_IP"] = bundle_assignments[i - 1][
+                    "node_ip"
+                ]
             self.ray_worker_handles[i].local_rank = local_rank
             init_worker_refs.append(
                 self.ray_worker_handles[i].actor.initialize_worker.remote(


### PR DESCRIPTION
Propagates `TPU_PP_WORKER_IP` and `TPU_PP_PREV_WORKER_IP` environment variables in `RayDistributedExecutorV2` for TPU workers.

**Stacked PR**: Depends on #54544 (corresponds to tpu-inference#3498).