### PR TITLE
[Bugfix][Frontend] Keep is_embed when round-tripping rendered placeholders

### DIFF
--- a/tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py
@@ -400,3 +400,19 @@ def test_placeholder_without_is_embed_roundtrips_as_none():
     (placeholder,) = rebuild_mm_placeholders(features.mm_placeholders)["image"]
     assert placeholder.is_embed is None
     assert placeholder.get_num_embeds() == 3
+
+
+def test_placeholder_rejects_a_mask_shorter_than_the_span():
+    """The wire format has to check what ``PlaceholderRange`` does not.
+
+    ``is_embed`` is documented as a mask of shape ``(length,)`` and the
+    frozen dataclass never validates it, so a client-supplied short mask
+    would reach ``get_embeds_indices_in_range`` and slice the wrong rows
+    out of the encoder output.
+    """
+    try:
+        PlaceholderRangeInfo(offset=0, length=4, is_embed=[True])
+    except ValidationError as exc:
+        assert "is_embed has 1 entries" in str(exc)
+        return
+    raise AssertionError("expected a mask shorter than the span to fail")

--- a/tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py
+++ b/tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py
@@ -28,6 +28,7 @@ from vllm.multimodal.inputs import (
     MultiModalFieldElem,
     MultiModalFlatField,
     MultiModalKwargsItem,
+    MultiModalKwargsItems,
     MultiModalSharedField,
     PlaceholderRange,
 )
@@ -326,3 +327,76 @@ def test_metadata_can_replace_or_extend_full_mm_data():
     merged = merge_mm_kwargs_items(full_item, metadata_item)
     assert merged is not None
     assert set(merged) == {"pixel_values", "image_grid_thw"}
+
+
+def test_render_features_preserve_is_embed():
+    """A sparse `is_embed` mask must reach the generate side intact.
+
+    The model runner branches on `PlaceholderRange.is_embed`: with a mask a
+    span consumes only `is_embed.sum()` rows of encoder output and only those
+    positions are marked as embeddings; without one it consumes the whole span
+    and every position in it is overwritten. Dropping the mask on the wire
+    therefore corrupts the prompt for models that use sparse placeholders
+    (Gemma 3, Phi-3-V, the Qwen omni thinkers).
+    """
+    is_embed = torch.tensor([True, False, True, True], dtype=torch.bool)
+    engine_input = mm_input(
+        prompt_token_ids=[1, 2, 3, 4, 5],
+        mm_kwargs=MultiModalKwargsItems({}),
+        mm_hashes={"image": ["hash-0"]},
+        mm_placeholders={
+            "image": [PlaceholderRange(offset=1, length=4, is_embed=is_embed)]
+        },
+    )
+
+    features = extract_mm_features(engine_input)
+    assert features is not None
+
+    # Assert on the serialized form: this is what actually crosses the wire
+    # to the generate service.
+    dumped = features.model_dump()["mm_placeholders"]["image"][0]
+    assert dumped.get("is_embed") == [True, False, True, True]
+
+
+def test_rebuild_mm_placeholders_restores_is_embed():
+    from vllm.entrypoints.scale_out.token_in_token_out.mm_features import (
+        rebuild_mm_placeholders,
+    )
+
+    is_embed = [True, False, True, True]
+    features = MultiModalFeatures(
+        mm_hashes={"image": ["hash-0"]},
+        mm_placeholders={
+            "image": [PlaceholderRangeInfo(offset=1, length=4, is_embed=is_embed)]
+        },
+    )
+    features = MultiModalFeatures.model_validate(features.model_dump())
+
+    (placeholder,) = rebuild_mm_placeholders(features.mm_placeholders)["image"]
+    assert placeholder.offset == 1
+    assert placeholder.length == 4
+    assert placeholder.is_embed is not None
+    assert torch.equal(placeholder.is_embed, torch.tensor(is_embed, dtype=torch.bool))
+    # The row count the model runner slices the encoder output by.
+    assert placeholder.get_num_embeds() == 3
+
+
+def test_placeholder_without_is_embed_roundtrips_as_none():
+    from vllm.entrypoints.scale_out.token_in_token_out.mm_features import (
+        rebuild_mm_placeholders,
+    )
+
+    engine_input = mm_input(
+        prompt_token_ids=[1, 2, 3],
+        mm_kwargs=MultiModalKwargsItems({}),
+        mm_hashes={"image": ["hash-0"]},
+        mm_placeholders={"image": [PlaceholderRange(offset=0, length=3)]},
+    )
+
+    features = extract_mm_features(engine_input)
+    assert features is not None
+    assert features.mm_placeholders["image"][0].is_embed is None
+
+    (placeholder,) = rebuild_mm_placeholders(features.mm_placeholders)["image"]
+    assert placeholder.is_embed is None
+    assert placeholder.get_num_embeds() == 3

--- a/vllm/entrypoints/scale_out/token_in_token_out/mm_features.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/mm_features.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from typing import cast
+
+import torch
 
 from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import (
     decode_mm_kwargs_item,
@@ -24,6 +26,7 @@ from vllm.inputs import (
 from vllm.multimodal.inputs import (
     MultiModalKwargsItem,
     MultiModalKwargsOptionalItems,
+    PlaceholderRange,
 )
 
 
@@ -117,6 +120,31 @@ def mm_kwargs_from_features(
     return mm_kwargs
 
 
+def rebuild_mm_placeholders(
+    mm_placeholders: Mapping[str, list[PlaceholderRangeInfo]],
+) -> dict[str, list[PlaceholderRange]]:
+    """Convert rendered `PlaceholderRangeInfo` back into `PlaceholderRange`.
+
+    `is_embed` has to survive the round trip: the model runner branches on it
+    to decide how much of the encoder output a span consumes and which
+    positions to overwrite, and it cannot be recomputed from offset and
+    length alone.
+    """
+    return {
+        modality: [
+            PlaceholderRange(
+                offset=p.offset,
+                length=p.length,
+                is_embed=None
+                if p.is_embed is None
+                else torch.tensor(p.is_embed, dtype=torch.bool),
+            )
+            for p in ranges
+        ]
+        for modality, ranges in mm_placeholders.items()
+    }
+
+
 def extract_mm_features(
     engine_input: EngineInput,
     *,
@@ -138,7 +166,12 @@ def extract_mm_features(
 
     mm_placeholders = {
         modality: [
-            PlaceholderRangeInfo(offset=p.offset, length=p.length) for p in ranges
+            PlaceholderRangeInfo(
+                offset=p.offset,
+                length=p.length,
+                is_embed=None if p.is_embed is None else p.is_embed.tolist(),
+            )
+            for p in ranges
         ]
         for modality, ranges in raw_placeholders.items()
     }

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -47,6 +47,15 @@ class PlaceholderRangeInfo(BaseModel):
     and the mask cannot be recomputed from offset and length alone.
     """
 
+    @model_validator(mode="after")
+    def _check_is_embed_length(self) -> "PlaceholderRangeInfo":
+        if self.is_embed is not None and len(self.is_embed) != self.length:
+            raise ValueError(
+                f"is_embed has {len(self.is_embed)} entries but the "
+                f"placeholder spans {self.length} tokens"
+            )
+        return self
+
 
 def _has_serialized_mm_items(
     payload: dict[str, list[str | None]] | None,

--- a/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/protocol.py
@@ -39,9 +39,13 @@ class PlaceholderRangeInfo(BaseModel):
     length: int = Field(gt=0)
     """Number of placeholder tokens."""
 
-    # TODO: add ``is_embed: list[bool] | None`` once the /generate side
-    # consumes features — some models (e.g. Qwen-VL) use sparse
-    # placeholder masks that cannot be recomputed from offset+length alone.
+    is_embed: list[bool] | None = None
+    """Which positions in the span actually receive embeddings.
+
+    ``None`` means every position does. Models with sparse placeholder
+    masks (Gemma 3, Phi-3-V, the Qwen omni thinkers) mark only a subset,
+    and the mask cannot be recomputed from offset and length alone.
+    """
 
 
 def _has_serialized_mm_items(

--- a/vllm/entrypoints/scale_out/token_in_token_out/serving.py
+++ b/vllm/entrypoints/scale_out/token_in_token_out/serving.py
@@ -36,7 +36,6 @@ from vllm.logger import init_logger
 from vllm.logprobs import Logprob
 from vllm.multimodal.inputs import (
     MultiModalKwargsItems,
-    PlaceholderRange,
 )
 from vllm.outputs import RequestOutput
 from vllm.renderers.online_renderer import OnlineRenderer
@@ -44,7 +43,7 @@ from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.utils.collection_utils import as_list
 from vllm.utils.serial_utils import numpy2base64
 
-from .mm_features import mm_kwargs_from_features
+from .mm_features import mm_kwargs_from_features, rebuild_mm_placeholders
 from .protocol import (
     GenerateRequest,
     GenerateResponse,
@@ -168,13 +167,7 @@ class ServingTokens(GenerateBaseServing):
                 [prompt]
             )
         elif features := request.features:
-            # Convert PlaceholderRangeInfo → PlaceholderRange per modality.
-            mm_placeholders: dict[str, list[PlaceholderRange]] = {
-                modality: [
-                    PlaceholderRange(offset=p.offset, length=p.length) for p in ranges
-                ]
-                for modality, ranges in features.mm_placeholders.items()
-            }
+            mm_placeholders = rebuild_mm_placeholders(features.mm_placeholders)
 
             # Deserialize full tensor data and optional metadata-only data.
             # Metadata-only items are valid when ec_transfer_params is set.


### PR DESCRIPTION
## The bug

`PlaceholderRange.is_embed` marks which positions inside a placeholder span
actually receive embeddings. The scale-out render path drops it: the render
response serializes only `offset` and `length`
(`vllm/entrypoints/scale_out/render/serving.py`), and the generate side rebuilds
`PlaceholderRange` from those two fields alone
(`vllm/entrypoints/scale_out/token_in_token_out/serving.py`).

`PlaceholderRangeInfo` already carried a TODO for this:

> TODO: add `is_embed: list[bool] | None` once the /generate side consumes
> features -- some models (e.g. Qwen-VL) use sparse placeholder masks that
> cannot be recomputed from offset+length alone.

The `/generate` side has consumed `features` since #51478 (2026-08-11), so the
condition is met.

## Why it matters

The model runner branches on the mask (`vllm/v1/worker/gpu_model_runner.py`,
and the same shape in `vllm/v1/worker/gpu/mm/encoder_runner.py`):

```python
if (is_embed := pos_info.is_embed) is not None:
    is_embed = is_embed[start_idx:end_idx]
    mm_embeds_item = encoder_output[curr_embeds_start:curr_embeds_end]
else:
    mm_embeds_item = encoder_output[start_idx:end_idx]
...
if is_embed is None:
    is_mm_embed[req_start_pos + start_idx : req_start_pos + end_idx] = True
else:
    is_mm_embed[req_start_pos + start_idx : req_start_pos + end_idx] |= is_embed
```

With the mask, a span consumes `is_embed.sum()` rows of encoder output and only
the masked positions are treated as embeddings. Without it, the span consumes
`length` rows and **every** position in it is overwritten. So losing the mask on
the wire is not a metadata nicety: it mis-slices the encoder output and clobbers
the real tokens interleaved inside the span.

Models that populate sparse placeholders, and are therefore affected: Gemma 3,
Gemma 3n, Phi-3-V, Qwen2.5-Omni, Qwen3-Omni, MiMo omni, Voxtral Realtime,
moss-audio, qwen3-asr-realtime, and the generic Transformers multi-modal
backend.

## The change

- `PlaceholderRangeInfo.is_embed: list[bool] | None`, replacing the TODO.
- The render side serializes `p.is_embed.tolist()` when present.
- The generate side rebuilds `torch.tensor(..., dtype=torch.bool)`.
- A `model_validator` rejects a mask whose length is not the placeholder's
  `length`, matching the bounds #51898 just added to `offset` and `length`.

The mask is only emitted when it is set, so requests for models with dense
placeholders are byte-for-byte unchanged on the wire.

I also lifted the generate-side conversion out of the middle of
`create_generate` into a module-level `rebuild_mm_placeholders()`. It was an
inline dict comprehension inside a long async handler with no way to test it;
the helper is what the round-trip test below exercises.

## Tests

Three tests in the existing serde round-trip file,
`tests/entrypoints/scale_out/token_in_token_out/test_mm_serde.py`. The headline
one builds an engine input whose placeholder carries
`is_embed=[True, False, True, True]`, runs the real
`ServingRender._extract_mm_features`, and asserts on the **serialized** form,
since that is what actually crosses the wire.

No GPU is needed, so I ran it on a CPU runner on my fork. Against `main`:

```
>       assert dumped.get("is_embed") == [True, False, True, True]
E       AssertionError: assert None == [True, False, True, True]
E        +  where None = <built-in method get of dict object>('is_embed')
E        +    where <...> = {'offset': 1, 'length': 4}.get

1 failed, 6 deselected
```

The `{'offset': 1, 'length': 4}` in that output is the whole bug: the mask is
simply not on the wire.

With the fix, the file passes:

```
7 passed in 2.52s
```

The other two tests pin the rebuild direction -- that a sparse mask comes back
as the right tensor with `get_num_embeds() == 3` (the row count the runner
slices the encoder output by), and that a dense placeholder still round-trips as
`None` with `get_num_embeds() == length`.

Whole-suite check, `pytest tests/entrypoints/scale_out/token_in_token_out` on
both revisions:

| | result |
| --- | --- |
| `main` | 23 passed, 15 errors |
| this branch | 26 passed, 15 errors |

The 15 errors are identical on both sides and environmental -- those cases start
a real model server, which the CPU runner cannot do ("Server exited
unexpectedly").

## Bounding the new field

CodeRabbit flagged that the new field was unbounded, and it was right.
`PlaceholderRange` is a frozen dataclass with no `__post_init__`: it documents
`is_embed` as a mask of shape `(length,)` and never checks it, so the wire
format is the only place that can. A client-supplied short mask reaches
`get_embeds_indices_in_range`, which indexes `embeds_cumsum` up to `length`, and
the runner slices the wrong rows out of the encoder output -- the same failure
this PR exists to prevent, arriving from the other direction.

#51898 landed a `model_validator` layer on these exact models a few days ago
(`offset >= 0`, `length > 0`, parallel-length and non-overlap checks) while
deliberately leaving the `is_embed` TODO that this PR replaces, so bounding
`is_embed` the same way completes that layer.

The server side cannot trip it: `PlaceholderFeaturesInfo.length` is
`len(self.tokens)` and `is_embed` is `content_is_embed(tokens)` over those same
tokens (`vllm/multimodal/processing/processor.py:595-606`), so the invariant
holds by construction and the validator only rejects a malformed client payload.

`test_placeholder_rejects_a_mask_shorter_than_the_span` covers it. BEFORE runs
against the previous branch head, where `is_embed` exists but is unvalidated:

```
    try:
        PlaceholderRangeInfo(offset=0, length=4, is_embed=[True])
    except ValidationError as exc:
        assert "is_embed has 1 entries" in str(exc)
        return
>   raise AssertionError("expected a mask shorter than the span to fail")
E   AssertionError: expected a mask shorter than the span to fail

1 failed, 15 deselected in 0.47s
```

AFTER, whole file: `16 passed in 4.73s`. Fork CI run 34183531905, which also
re-ran the round-trip test above against current `main` (`assert None ==
[True, False, True, True]` BEFORE, 16 passed AFTER) and the whole
`tests/entrypoints/scale_out/token_in_token_out` suite (`main` 34 passed,
this branch 38 passed, the same 15 environmental errors on both sides).

## Not a duplicate

Searched open PRs for `PlaceholderRangeInfo in:body`, `is_embed in:body` and
`mm_placeholders in:body`. #51898 has since merged; it validates client-supplied
features against the active model and explicitly left the `is_embed` TODO in
place. #43608 (open) adds `image_grid_thw` to `MultiModalFeatures` to shrink
payloads. Neither propagates `is_embed`.

## Lint

`ruff check`, `ruff format --diff`, `typos`, the SPDX hook,
`check_forbidden_imports`, `check_init_lazy_imports` and `mypy` (3.12) all pass
on the four changed files. The module-level `import torch` in
`token_in_token_out/serving.py` matches the sibling serving modules
(`vllm/entrypoints/pooling/base/serving.py`).

AI assistance was used to research and draft this change. I have reviewed every
changed line and run the tests above.

