### PR TITLE
[CI] Mark 1-GPU L4 test steps with device: l4 for EKS migration

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -20,6 +20,7 @@ steps:
 
 - label: ":nvidia: (L4) Sharded RDT Weight Transfer"
   key: sharded-rdt-weight-transfer
+  device: l4
   timeout_in_minutes: 20
   working_dir: "/vllm-workspace/tests"
   num_devices: 1

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -38,6 +38,8 @@ steps:
 
 - label: ":nvidia: (L4) V1 Engine"
   key: engine-1-gpu
+  device: l4
+  num_devices: 1
   timeout_in_minutes: 45
   source_file_dependencies:
     - vllm/v1/engine/

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -103,6 +103,8 @@ steps:
 
 - label: ":nvidia: (L4) Attention Kernels Shard %N"
   key: kernels-attention-test
+  device: l4
+  num_devices: 1
   timeout_in_minutes: 65
   source_file_dependencies:
   - csrc/attention/
@@ -164,6 +166,8 @@ steps:
 
 - label: ":nvidia: (L4) Quantization Kernels Shard %N"
   key: kernels-quantization-test
+  device: l4
+  num_devices: 1
   timeout_in_minutes: 60
   source_file_dependencies:
   - csrc/quantization/
@@ -193,6 +197,8 @@ steps:
 
 - label: ":nvidia: (L4) MoE Kernels Shard %N"
   key: kernels-moe-test
+  device: l4
+  num_devices: 1
   timeout_in_minutes: 50
   source_file_dependencies:
   - csrc/quantization/cutlass_w8a8/moe/

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -92,6 +92,8 @@ steps:
 # correctness test on L4 until its H200 output matches the Transformers reference.
 - label: ":nvidia: (L4) Granite Language Model Compatibility"
   key: language-models-tests-granite-l4-compatibility
+  device: l4
+  num_devices: 1
   timeout_in_minutes: 65
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -90,6 +90,8 @@ steps:
 
 - label: ":nvidia: (L4) PyTorch Compilation Passes"
   key: pytorch-compilation-passes-unit-tests
+  device: l4
+  num_devices: 1
   timeout_in_minutes: 45
   source_file_dependencies:
     - vllm/__init__.py
@@ -164,6 +166,8 @@ steps:
 # those SM90 cases skip while the architecture-compatible cases still run.
 - label: ":nvidia: (L4) PyTorch Fullgraph CUDAGraph Compatibility"
   key: pytorch-fullgraph-cudagraph-l4-compatibility
+  device: l4
+  num_devices: 1
   timeout_in_minutes: 60
   source_file_dependencies:
   - vllm/__init__.py


### PR DESCRIPTION
## Summary

Follow-up to #54326 (which moved the 2/4-GPU L4 steps to the EKS `l4-k8s` queue): mark the remaining 1-GPU L4 steps `device: l4` so they migrate too. The generator ([ci-infra#499](https://github.com/vllm-project/ci-infra/pull/499), merged) routes any `device: l4` step to `l4-k8s` with resources scaled by `num_devices` — no generator change needed.

Marked (8 steps): V1 Engine, Attention/Quantization/MoE kernel shard suites (each shard gets 1 GPU; `parallelism` unchanged), Granite compat, PyTorch compilation passes, PyTorch fullgraph cudagraph compat, Sharded RDT weight transfer.

Deliberately not marked: Torch Stable ABI Audit (restored to gpu_1_queue by #54468 — it must audit the CUDA wheel) and the 2-node step (multi-node stays on the ASG).

On EKS these pack 4-per-node (MostAllocated): the whole 1-GPU class occupies ~2-3 g6.12xlarge at typical concurrency vs 208 single-GPU ASG slots today.

## Notes for reviewers (per repo AI policy)

- **AI assistance**: prepared with AI assistance (Kimi Code); the migration design and two days of green soak on the 2/4-GPU class are on the cluster already.
- **Not a duplicate**: open-PR search for L4/EKS marking found none beyond #54326 (merged).
- **Tests run**: yaml parse check on all test_areas files; generated-pipeline verification with ci-infra main (`RUN_ALL=1`): 39 steps -> `l4-k8s`, torch-abi -> `gpu_1_queue`, 2-node -> `gpu_4_queue`, nothing else changed. Runtime evidence: the 2/4-GPU class has run this pod spec on the l4-ci cluster for 2 days (45/45 and 31/31 on validation builds, plus a day of main builds).
