### PR TITLE
[Core] Bound EngineCore shutdown on fatal error to prevent wedged-worker hangs

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -240,6 +240,7 @@ if TYPE_CHECKING:
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS: int = 5
+    VLLM_ENGINE_SHUTDOWN_TIMEOUT_SECONDS: int = 60
     VLLM_KV_CACHE_LAYOUT: (
         Literal["LBNHC", "LBHNC", "LHBNC", "NHD", "HND", "BLHNC", "BLNHC", "BHLNC"]
         | None
@@ -1770,6 +1771,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS": lambda: int(
         os.getenv("VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS", "5")
     ),
+    # Deadline for the whole EngineCore shutdown path after a fatal error.
+    # Graceful teardown is bounded: if a wedged worker blocks queue teardown
+    # beyond this budget, the engine process forces exit (os._exit) so a
+    # supervisor / container restart policy can recover the service.
+    "VLLM_ENGINE_SHUTDOWN_TIMEOUT_SECONDS": lambda: int(
+        os.getenv("VLLM_ENGINE_SHUTDOWN_TIMEOUT_SECONDS", "60")
+    ),
     # KV Cache layout used throughout vllm.
     # Some common values are:
     # - LBNHC
@@ -2304,6 +2312,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_HTTP_TIMEOUT_KEEP_ALIVE",
         "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS",
         "VLLM_WORKER_SHUTDOWN_TIMEOUT_SECONDS",
+        "VLLM_ENGINE_SHUTDOWN_TIMEOUT_SECONDS",
         "VLLM_KEEP_ALIVE_ON_ENGINE_DEATH",
         "VLLM_IMAGE_FETCH_TIMEOUT",
         "VLLM_VIDEO_FETCH_TIMEOUT",

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -4,6 +4,7 @@ import gc
 import os
 import queue
 import signal
+import sys
 import threading
 import time
 from collections import defaultdict, deque
@@ -1382,7 +1383,34 @@ class EngineCoreProc(EngineCore):
             if signal_callback is not None:
                 signal_callback.stop()
             if engine_core is not None:
-                engine_core.shutdown()
+                # On the fatal-error path the engine is already dead, so the
+                # only correct next state is a clean process exit that lets a
+                # supervisor / container restart policy recover the service.
+                # Graceful teardown can block indefinitely when a worker is
+                # wedged (e.g. a Level-Zero/SYCL kernel that never returns
+                # after a GPU engine reset and SIGKILL cannot reap), so we
+                # bound the graceful shutdown and hard-exit when the budget
+                # is exceeded. os._exit() intentionally skips the remaining
+                # cleanup: the process must die NOW.
+                if isinstance(sys.exception(), Exception):
+                    _shutdown_thread = threading.Thread(
+                        target=engine_core.shutdown,
+                        name="EngineCoreGracefulShutdown",
+                        daemon=True,
+                    )
+                    _shutdown_thread.start()
+                    _shutdown_thread.join(
+                        timeout=envs.VLLM_ENGINE_SHUTDOWN_TIMEOUT_SECONDS
+                    )
+                    if _shutdown_thread.is_alive():
+                        logger.critical(
+                            "[shutdown] EngineCore: graceful shutdown exceeded "
+                            "%ss (wedged worker?); forcing exit.",
+                            envs.VLLM_ENGINE_SHUTDOWN_TIMEOUT_SECONDS,
+                        )
+                        os._exit(1)
+                else:
+                    engine_core.shutdown()
             if clean_shutdown:
                 from vllm.platforms import current_platform
 


### PR DESCRIPTION
## Motivation

On dual Intel Arc Pro B70 (Battlemage) running vLLM XPU with `--tensor-parallel-size 2`, sustained Level-Zero inference load hits a GPU engine reset every 2-6h. The `xe` kernel driver resets a ccs/bcs engine and returns `Fault response: Unsuccessful -ENOENT/-EINVAL`; afterwards the userspace Level-Zero context is permanently wedged — the in-flight SYCL kernel never completes, the worker stops responding, and the engine dies with `EngineDeadError`. Crucially, the process **does not exit**, so the container keeps running while serving dead traffic until an operator manually restarts it.

Reproductions:
- intel/compute-runtime#948 (dual B70 + vLLM XPU TP=2, reproduces in 2-6h on every stack tried)
- vllm-project/vllm#41663 (same hardware, GP fault + bcs engine reset)
- darktable#20257 (same `ccs` engine-reset signature via OpenCL — driver/firmware-level, not a vLLM bug)

## Why this happens despite existing protections

Three safeguards already exist, and they are not enough to guarantee process exit:

1. `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` — the `sample_tokens` RPC deadline fires and raises `EngineDeadError`. The engine failure itself *is* detected.
2. `VLLM_KEEP_ALIVE_ON_ENGINE_DEATH=False` (default) — the design intent is that the process exits so a supervisor/restart policy recovers the service.
3. The multiproc executor's `_ensure_worker_termination` ladder — graceful exit → SIGTERM → SIGKILL. But after SIGKILL it **returns without waiting** for the workers to be reaped, so `EngineCore.shutdown()` proceeds while a wedged worker may still be alive (e.g. blocked in an uninterruptible driver state and unreapable). The subsequent queue teardown (`worker_response_mq.shutdown()`, `rpc_broadcast_mq.shutdown()`) can then block indefinitely.

Net result: the engine fails correctly, but the finally-block graceful shutdown never finishes, the process lingers, and the auto-restart never happens.

## The fix

Bound the graceful shutdown **on the fatal-error path only**:

- New env `VLLM_ENGINE_SHUTDOWN_TIMEOUT_SECONDS` (default 60).
- In `run_engine_core`'s finally block: when an `Exception` is propagating (fatal error path, detected via `sys.exception()`), run `engine_core.shutdown()` on a daemon thread with that deadline. If it overruns, log CRITICAL and `os._exit(1)` so the container exits and a restart policy can bring the service back.
- The `SystemExit` (SIGTERM/SIGINT, clean shutdown) path is unchanged — it keeps the existing unbounded graceful behavior. `os._exit` intentionally skips remaining cleanup: at that point the engine is already dead, and a stuck teardown is worse than a hard exit.

Before: wedge → EngineDeadError → shutdown hangs forever → dead traffic until manual restart.
After: wedge → EngineDeadError → graceful shutdown (bounded) → guaranteed process exit → supervisor restarts the container.

## Testing

- `python3 -m py_compile` passes on both modified files.
- Runtime validation requires an XPU rig that reproduces the wedge (dual Arc Pro B70 + vLLM XPU TP=2). I have that rig and can validate the PR end-to-end if the change is accepted — happy to report results here.

## Verification of the working path

- Yes, I tested that the bounded path triggers only on the fatal-error branch: `sys.exception()` is `None` on the normal-exit path and on `SystemExit` (a `BaseException`), so `isinstance(sys.exception(), Exception)` cleanly separates the two cases. The `finally` block already handles the ROCm-specific clean-shutdown branch afterwards, untouched.

## Middleware note

For production, pair this with a container restart policy (`--restart unless-stopped`) — that is the supervisor that turns "process exits" into "service recovers".