### PR TITLE
[Bugfix][Env] Default VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE to enabled

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1945,7 +1945,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # DeepEP v2: enable two-tier NVLink+RDMA hybrid mode
     "VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE": lambda: bool(
-        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "0"))
+        int(os.getenv("VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE", "1"))
     ),
     # DeepEP v2: use fewer SMs at slight throughput cost
     "VLLM_DEEPEP_V2_PREFER_OVERLAP": lambda: bool(


### PR DESCRIPTION
Fixes #54281

## Summary
Default `VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE` to enabled for DeepEP v2 hybrid mode.

## Test plan
- [x] Env default matches expected runtime behavior