### PR TITLE
[Bugfix][Model] Fix Quark FP8 block scale loading for GLM-5.3 MXFP4

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -902,6 +902,15 @@ def _try_load_fp8_indexer_wk(
     return True
 
 
+def _maybe_remap_fp8_block_scale_name(name: str, params_dict: dict) -> str:
+    """Map Quark checkpoint .weight_scale tensors to vLLM block-FP8 params."""
+    if name in params_dict or not name.endswith(".weight_scale"):
+        return name
+    scale_inv_name = name[: -len(".weight_scale")] + ".weight_scale_inv"
+    if scale_inv_name in params_dict:
+        return scale_inv_name
+    return name
+
 def _min_latency_fused_qkv_a_proj_impl(
     input_: torch.Tensor,
     weight: torch.Tensor,
@@ -1661,6 +1670,9 @@ class DeepseekV2Model(nn.Module):
                 if is_fusion_moe_shared_experts_layer:
                     continue
                 name_mapped = name.replace(weight_name, param_name)
+                name_mapped = _maybe_remap_fp8_block_scale_name(
+                    name_mapped, params_dict
+                )
 
                 # QKV fusion is optional, fall back to normal
                 # weight loading if it's not enabled
@@ -1675,6 +1687,7 @@ class DeepseekV2Model(nn.Module):
                 if name.endswith(".bias") and name not in params_dict:
                     continue
 
+                name = _maybe_remap_fp8_block_scale_name(name, params_dict)
                 if is_pp_missing_parameter(name, self):
                     continue
 
@@ -1787,6 +1800,7 @@ class DeepseekV2Model(nn.Module):
                             continue
                         name = remapped_name
 
+                        name = _maybe_remap_fp8_block_scale_name(name, params_dict)
                         if is_pp_missing_parameter(name, self):
                             continue
 


### PR DESCRIPTION
Fix loading Quark-quantized GLM-5.3 MXFP4 checkpoints whose FP8 block scale tensors are stored as `.weight_scale`, while vLLM registers the corresponding block-FP8 parameters as `.weight_scale_inv`.

The change adds a narrow load-time remap in the DeepSeek/GLM weight loader. It only rewrites `.weight_scale` to `.weight_scale_inv` when the original parameter name is missing and the remapped parameter exists, preserving existing behavior for parameters that already match.

This prevents `KeyError` during GLM-5.3-MXFP4 loading for tensors such as `indexer.wq_b.weight_scale` and fused QKV-A scale tensors such as `kv_a_proj_with_mqa.weight_scale`.

For this model :https://huggingface.co/amd/GLM-5.3-Quark-MXFP4