### PR TITLE
[Bugfix] Pass quant config to Phi embeddings

### DIFF
--- a/tests/model_executor/test_phi_quantization.py
+++ b/tests/model_executor/test_phi_quantization.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 
 def test_phi_embedding_receives_quant_config():
+    from vllm.config import CompilationMode
     from vllm.model_executor.models.phi import PhiModel
 
     quant_config = Mock()
@@ -16,6 +17,7 @@ def test_phi_embedding_receives_quant_config():
     vllm_config.model_config.hf_config = config
     vllm_config.cache_config = Mock()
     vllm_config.quant_config = quant_config
+    vllm_config.compilation_config.mode = CompilationMode.NONE
 
     with (
         patch("vllm.model_executor.models.phi.VocabParallelEmbedding") as embedding,

--- a/tests/model_executor/test_phi_quantization.py
+++ b/tests/model_executor/test_phi_quantization.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock, patch
+
+
+def test_phi_embedding_receives_quant_config():
+    from vllm.model_executor.models.phi import PhiModel
+
+    quant_config = Mock()
+
+    config = Mock()
+    config.vocab_size = 128
+    config.hidden_size = 64
+    config.num_hidden_layers = 0
+    config.layer_norm_eps = 1e-5
+
+    vllm_config = Mock()
+    vllm_config.model_config.hf_config = config
+    vllm_config.cache_config = Mock()
+    vllm_config.quant_config = quant_config
+
+    with (
+        patch("vllm.model_executor.models.phi.VocabParallelEmbedding") as embedding,
+        patch(
+            "vllm.model_executor.models.phi.make_layers",
+            return_value=(0, 0, []),
+        ),
+        patch(
+            "vllm.model_executor.models.phi.make_empty_intermediate_tensors_factory",
+            return_value=Mock(),
+        ),
+    ):
+        PhiModel(vllm_config=vllm_config, prefix="model")
+
+    embedding.assert_called_once_with(
+        config.vocab_size,
+        config.hidden_size,
+        quant_config=quant_config,
+        prefix="model.embed_tokens",
+    )

--- a/vllm/model_executor/models/phi.py
+++ b/vllm/model_executor/models/phi.py
@@ -214,7 +214,10 @@ class PhiModel(nn.Module):
         self.config = config
         self.quant_config = quant_config
         self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size, config.hidden_size
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,


### PR DESCRIPTION
## Purpose

Pass `quant_config` and the embedding prefix to Phi input embeddings so quantized embedding weights load correctly. Part of #54304.

This is specific to Phi; it does not duplicate #45994, which covers Qwen3Next/Qwen3.5. This PR supersedes the closed #54464 with corrected DCO signatures.

## Test Plan

`.venv/bin/python -m pytest tests/model_executor/test_phi_quantization.py -v`

## Test Result

The regression test passes on the updated branch. The change only wires quantization metadata into the embedding constructor and does not alter the forward path. No model evaluation was needed.

AI assistance was used to identify and prepare the patch. I reviewed every changed line and ran the test.
