### PR TITLE
[Feature][Spec Decode] MTP with separate (possibly quantized) lm head for nemotron

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1780,9 +1780,7 @@ class SpeculativeConfig:
 
         if not self.use_heterogeneous_vocab:
             self.verify_equal_vocab_size_if_draft_model()
-        
         return self
-        
 
     def verify_equal_vocab_size_if_draft_model(self):
         if (

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -617,20 +617,18 @@ class SpeculativeConfig:
             "extract_hidden_states",
             "dflash",
             "dspark",
-            "mtp",
         )
         factors.append(uses_aux_hidden_states)
 
-        if uses_aux_hidden_states and self.draft_model_config is not None:
-            factors.append(self.draft_model_config.compute_hash())
-
+        if self.draft_model_config is not None:
+            factors.append(self.draft_model_config.compute_hash())            
             # The specific layers used also affect the computation graph.
             layer_ids = getattr(
                 self.draft_model_config.hf_config,
                 "eagle_aux_hidden_state_layer_ids",
                 None,
             )
-            if layer_ids is not None:
+            if layer_ids is not None and uses_aux_hidden_states:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -617,7 +617,7 @@ class SpeculativeConfig:
             "extract_hidden_states",
             "dflash",
             "dspark",
-            "mtp" 
+            "mtp",
         )
         factors.append(uses_aux_hidden_states)
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -621,7 +621,7 @@ class SpeculativeConfig:
         factors.append(uses_aux_hidden_states)
 
         if self.draft_model_config is not None:
-            factors.append(self.draft_model_config.compute_hash())            
+            factors.append(self.draft_model_config.compute_hash())
             # The specific layers used also affect the computation graph.
             layer_ids = getattr(
                 self.draft_model_config.hf_config,

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -610,8 +610,6 @@ class SpeculativeConfig:
         the final hidden states.
         """
         factors: list[Any] = []
-        if self.method == "mtp" and self.draft_model_config is not None:
-            factors.append(self.draft_model_config.compute_hash())
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
         uses_aux_hidden_states = self.method in (
@@ -619,6 +617,7 @@ class SpeculativeConfig:
             "extract_hidden_states",
             "dflash",
             "dspark",
+            "mtp" 
         )
         factors.append(uses_aux_hidden_states)
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -404,10 +404,6 @@ class SpeculativeConfig:
     """Quantization method that was used to quantize the draft model weights.
     If `None`, we assume the model weights are not quantized. Note that it only
     takes effect when using the draft model-based speculative method."""
-    mtp_share_lm_head: bool = True
-    """Share the target model LM head with an MTP draft model. Disable this
-    only when the MTP checkpoint owns a separate LM head, for example when the
-    target and draft heads use different quantization schemes."""
     moe_backend: MoEBackend | None = None
     """MoE backend to use for the draft model. When `None`, the draft model
     inherits the target model's `--moe-backend` setting. Useful when the
@@ -614,7 +610,8 @@ class SpeculativeConfig:
         the final hidden states.
         """
         factors: list[Any] = []
-        factors.append(self.mtp_share_lm_head)
+        if self.method == "mtp" and self.draft_model_config is not None:
+            factors.append(self.draft_model_config.compute_hash())
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
         uses_aux_hidden_states = self.method in (
@@ -1785,9 +1782,6 @@ class SpeculativeConfig:
         if not self.use_heterogeneous_vocab:
             self.verify_equal_vocab_size_if_draft_model()
         
-        if not self.mtp_share_lm_head and self.method != "mtp":
-            raise ValueError("mtp_share_lm_head=False is only supported for MTP.")
-
         return self
         
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -404,6 +404,10 @@ class SpeculativeConfig:
     """Quantization method that was used to quantize the draft model weights.
     If `None`, we assume the model weights are not quantized. Note that it only
     takes effect when using the draft model-based speculative method."""
+    mtp_share_lm_head: bool = True
+    """Share the target model LM head with an MTP draft model. Disable this
+    only when the MTP checkpoint owns a separate LM head, for example when the
+    target and draft heads use different quantization schemes."""
     moe_backend: MoEBackend | None = None
     """MoE backend to use for the draft model. When `None`, the draft model
     inherits the target model's `--moe-backend` setting. Useful when the
@@ -610,6 +614,7 @@ class SpeculativeConfig:
         the final hidden states.
         """
         factors: list[Any] = []
+        factors.append(self.mtp_share_lm_head)
         # Eagle3 and extract_hidden_states affect the computation graph because
         # they return intermediate hidden states in addition to the final hidden state.
         uses_aux_hidden_states = self.method in (
@@ -1779,7 +1784,12 @@ class SpeculativeConfig:
 
         if not self.use_heterogeneous_vocab:
             self.verify_equal_vocab_size_if_draft_model()
+        
+        if not self.mtp_share_lm_head and self.method != "mtp":
+            raise ValueError("mtp_share_lm_head=False is only supported for MTP.")
+
         return self
+        
 
     def verify_equal_vocab_size_if_draft_model(self):
         if (

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -592,6 +592,15 @@ class NemotronHMTP(nn.Module, SupportsPP):
         # checkpoints serialize every model-owned parameter, so enforce the
         # stronger invariant here to catch missed name mappings.
         missing_params = set(params_dict) - loaded_params
+
+        # Existing proposer behavior replaces the temporary draft embedding
+        # with the target embedding after checkpoint loading.
+        missing_params -= {
+            name
+            for name in missing_params
+            if name.startswith("model.embed_tokens.")
+        }
+
         runtime_owned_params = {
             name
             for name in missing_params

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -360,12 +360,12 @@ class NemotronHMTP(nn.Module, SupportsPP):
         )
 
         speculative_config = vllm_config.speculative_config
-        self.use_private_lm_head = (
+        self.has_own_lm_head = (
             speculative_config is not None
             and speculative_config.method == "mtp"
             and not speculative_config.mtp_share_lm_head
         )
-        lm_head_quant_config = self.quant_config if self.use_private_lm_head else None
+        lm_head_quant_config = self.quant_config if self.has_own_lm_head else None
 
         # The proposer replaces a shared temporary head with the target head.
         # A private head stays draft-owned and must therefore be constructed
@@ -376,7 +376,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
             quant_config=lm_head_quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if self.use_private_lm_head:
+        if self.has_own_lm_head:
             quant_name = (
                 self.quant_config.get_name()
                 if self.quant_config is not None
@@ -460,14 +460,14 @@ class NemotronHMTP(nn.Module, SupportsPP):
             # Full checkpoints contain an lm_head even when MTP will share the
             # already-loaded target head. Skip that representation unless this
             # draft explicitly owns a private head.
-            if "lm_head" in name and not self.use_private_lm_head:
+            if "lm_head" in name and not self.has_own_lm_head:
                 continue
             # Only process MTP weights - skip all non-MTP weights
             if (
                 not name.startswith("mtp.")
                 and "embeddings" not in name
                 and not (
-                    self.use_private_lm_head and name.startswith("lm_head.")
+                    self.has_own_lm_head and name.startswith("lm_head.")
                 )
             ):
                 continue
@@ -566,7 +566,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
             weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
-        if self.use_private_lm_head:
+        if self.has_own_lm_head:
             loaded_lm_head_params = {
                 name for name in loaded_params if name.startswith("lm_head.")
             }

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -446,7 +446,8 @@ class NemotronHMTP(nn.Module, SupportsPP):
             is_lm_head_weight = name.startswith("lm_head.")
             if is_lm_head_weight:
                 self.has_own_lm_head = True
-            # Only process MTP and LM head weights - skip all non-MTP and non-LM head weights
+            # Only process MTP and LM head weights - 
+            # skip all non-MTP and non-LM head weights
             if (
                 not name.startswith("mtp.")
                 and "embeddings" not in name

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -466,7 +466,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
                 if name.startswith("backbone."):
                     name = name.replace("backbone.", "model.")
 
-            if "scale" in name or "zero_point" in name:
+            if "scale" in name:
                 # ModelOpt serializes KV-cache scales next to k_proj/v_proj,
                 # while vLLM registers them on the Attention module.
                 name = maybe_remap_kv_scale_name(name, params_dict)

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -223,7 +223,7 @@ class NemotronHMultiTokenPredictor(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
 
         self.config = config
         self.vocab_size = config.vocab_size
@@ -364,10 +364,6 @@ class NemotronHMTP(nn.Module, SupportsPP):
             speculative_config is not None
             and speculative_config.method == "mtp"
             and not speculative_config.mtp_share_lm_head
-        )
-        parallel_config = vllm_config.parallel_config
-        self.share_target_embeddings = (
-            parallel_config is None or parallel_config.pipeline_parallel_size == 1
         )
         lm_head_quant_config = self.quant_config if self.use_private_lm_head else None
 
@@ -590,14 +586,6 @@ class NemotronHMTP(nn.Module, SupportsPP):
                 name for name in params_dict if name.startswith("lm_head.")
             )
 
-        if self.share_target_embeddings:
-            # At PP=1 the target embedding replaces the draft embedding, so
-            # both full and MTP-only checkpoint layouts are valid.
-            loaded_params.update(
-                name
-                for name in params_dict
-                if name.startswith("model.embed_tokens.")
-            )
 
         # Quantized model loading disables the generic missing-weight check
         # because some quantizers synthesize parameters. These ModelOpt MTP

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -359,33 +359,17 @@ class NemotronHMTP(nn.Module, SupportsPP):
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
         )
 
-        speculative_config = vllm_config.speculative_config
-        self.has_own_lm_head = (
-            speculative_config is not None
-            and speculative_config.method == "mtp"
-            and not speculative_config.mtp_share_lm_head
-        )
-        lm_head_quant_config = self.quant_config if self.has_own_lm_head else None
+        self.has_own_lm_head = False
 
-        # The proposer replaces a shared temporary head with the target head.
-        # A private head stays draft-owned and must therefore be constructed
-        # from the draft checkpoint's quantization configuration.
+        # Construct from the draft checkpoint's quantization configuration.
+        # Weight loading below determines whether the checkpoint owns this head;
+        # otherwise, the proposer replaces it with the target head.
         self.lm_head = ParallelLMHead(
             self.config.vocab_size,
             self.config.hidden_size,
-            quant_config=lm_head_quant_config,
+            quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if self.has_own_lm_head:
-            quant_name = (
-                self.quant_config.get_name()
-                if self.quant_config is not None
-                else "unquantized"
-            )
-            logger.info(
-                "Constructed Nemotron MTP draft-owned lm_head with %s quantization.",
-                quant_name,
-            )
 
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
 
@@ -457,18 +441,14 @@ class NemotronHMTP(nn.Module, SupportsPP):
             # MTP weights are nested in "language_model."
             # in Multimodal Nemotron-H checkpoints.
             name = name.removeprefix("language_model.")
-            # Full checkpoints contain an lm_head even when MTP will share the
-            # already-loaded target head. Skip that representation unless this
-            # draft explicitly owns a private head.
-            if "lm_head" in name and not self.has_own_lm_head:
-                continue
+            is_lm_head_weight = name.startswith("lm_head.")
+            if is_lm_head_weight:
+                self.has_own_lm_head = True
             # Only process MTP weights - skip all non-MTP weights
             if (
                 not name.startswith("mtp.")
                 and "embeddings" not in name
-                and not (
-                    self.has_own_lm_head and name.startswith("lm_head.")
-                )
+                and not is_lm_head_weight
             ):
                 continue
             # Skip rotary embeddings (computed, not loaded)
@@ -572,11 +552,12 @@ class NemotronHMTP(nn.Module, SupportsPP):
             }
             if not loaded_lm_head_params:
                 raise ValueError(
-                    "mtp_share_lm_head=False requires lm_head weights in the "
-                    "external MTP checkpoint."
+                    "Nemotron MTP detected an owned lm_head but did not load any "
+                    "lm_head parameters from the checkpoint."
                 )
             logger.info(
-                "Loaded %d private MTP lm_head tensors from the draft checkpoint.",
+                "Detected and loaded %d Nemotron MTP lm_head tensors from the "
+                "draft checkpoint.",
                 len(loaded_lm_head_params),
             )
         else:

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -29,6 +29,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.models.utils import (
     WeightsMapper,
+    get_draft_quant_config,
     make_empty_intermediate_tensors_factory,
     maybe_prefix,
 )
@@ -223,7 +224,12 @@ class NemotronHMultiTokenPredictor(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
-        config = vllm_config.model_config.hf_config.get_text_config()
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        draft_model_config = speculative_config.draft_model_config
+        assert draft_model_config is not None
+        config = draft_model_config.hf_config.get_text_config()
+        quant_config = get_draft_quant_config(vllm_config)
 
         self.config = config
         self.vocab_size = config.vocab_size
@@ -263,9 +269,9 @@ class NemotronHMultiTokenPredictor(nn.Module):
             common_kwargs = dict(
                 config=config,
                 layer_idx=self.mtp_start_layer_idx + i,
-                model_config=vllm_config.model_config,
+                model_config=draft_model_config,
                 cache_config=vllm_config.cache_config,
-                quant_config=vllm_config.quant_config,
+                quant_config=quant_config,
                 parallel_config=vllm_config.parallel_config,
                 prefix=layer_prefix,
                 has_start_projections=is_start_of_step,
@@ -339,10 +345,14 @@ class NemotronHMTP(nn.Module, SupportsPP):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        config = vllm_config.model_config.hf_config.get_text_config()
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        draft_model_config = speculative_config.draft_model_config
+        assert draft_model_config is not None
+        config = draft_model_config.hf_config.get_text_config()
         self.vllm_config = vllm_config
         self.config = config
-        self.quant_config = vllm_config.quant_config
+        self.quant_config = get_draft_quant_config(vllm_config)
 
         # Needed for load_weights mapping
         self.mtp_start_layer_idx = config.num_hidden_layers

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -11,7 +11,6 @@ import torch.nn as nn
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.config.parallel import ParallelConfig
-from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
@@ -41,9 +40,6 @@ from .nemotron_h import (
     NemotronHAttentionDecoderLayer,
     NemotronHMoEDecoderLayer,
 )
-
-logger = init_logger(__name__)
-
 
 class NemotronHMTPAttentionDecoderLayer(NemotronHAttentionDecoderLayer):
     def __init__(
@@ -444,8 +440,6 @@ class NemotronHMTP(nn.Module, SupportsPP):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
-        loaded_stacked_shards: dict[str, set[str]] = {}
-        loaded_expert_slices: dict[str, set[int]] = {}
 
         for name, loaded_weight in weights:
             # MTP weights are nested in "language_model."
@@ -503,9 +497,6 @@ class NemotronHMTP(nn.Module, SupportsPP):
                 if weight_loader is not None:
                     weight_loader(param, loaded_weight, shard_id)
                     loaded_params.add(stacked_name)
-                    loaded_stacked_shards.setdefault(stacked_name, set()).add(
-                        shard_id
-                    )
                 break
 
             if is_stacked:
@@ -539,7 +530,6 @@ class NemotronHMTP(nn.Module, SupportsPP):
                 )
                 if success:
                     loaded_params.add(name_mapped)
-                    loaded_expert_slices.setdefault(name_mapped, set()).add(expert_id)
                 break
 
             if is_expert_weight:
@@ -556,88 +546,9 @@ class NemotronHMTP(nn.Module, SupportsPP):
             weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
-        if self.has_own_lm_head:
-            loaded_lm_head_params = {
-                name for name in loaded_params if name.startswith("lm_head.")
-            }
-            if not loaded_lm_head_params:
-                raise ValueError(
-                    "Nemotron MTP detected an owned lm_head but did not load any "
-                    "lm_head parameters from the checkpoint."
-                )
-            logger.info(
-                "Detected and loaded %d Nemotron MTP lm_head tensors from the "
-                "draft checkpoint.",
-                len(loaded_lm_head_params),
-            )
-        else:
-            # These temporary parameters are replaced by the target head after
-            # draft loading and may be absent from an MTP-only checkpoint.
+        if not self.has_own_lm_head:
             loaded_params.update(
                 name for name in params_dict if name.startswith("lm_head.")
             )
-
-
-        # Quantized model loading disables the generic missing-weight check
-        # because some quantizers synthesize parameters. These ModelOpt MTP
-        # checkpoints serialize every model-owned parameter, so enforce the
-        # stronger invariant here to catch missed name mappings.
-        missing_params = set(params_dict) - loaded_params
-
-        # Existing proposer behavior replaces the temporary draft embedding
-        # with the target embedding after checkpoint loading.
-        missing_params -= {
-            name
-            for name in missing_params
-            if name.startswith("model.embed_tokens.")
-        }
-
-        runtime_owned_params = {
-            name
-            for name in missing_params
-            if name.endswith((".attn.q_scale", ".attn.prob_scale"))
-            or name == "lm_head.input_scale"
-        }
-        missing_params -= runtime_owned_params
-        if missing_params:
-            missing_preview = ", ".join(sorted(missing_params)[:20])
-            raise ValueError(
-                "Nemotron MTP checkpoint did not initialize "
-                f"{len(missing_params)} parameter(s): {missing_preview}"
-            )
-
-        incomplete_stacked_params = [
-            f"{name} ({','.join(sorted(shards))}/k,q,v shards)"
-            for name, shards in sorted(loaded_stacked_shards.items())
-            if shards != {"q", "k", "v"}
-        ]
-        if incomplete_stacked_params:
-            raise ValueError(
-                "Nemotron MTP checkpoint incompletely initialized fused QKV "
-                "parameters: " + ", ".join(incomplete_stacked_params)
-            )
-
-        incomplete_expert_params: list[str] = []
-        for name, expert_ids in sorted(loaded_expert_slices.items()):
-            expected_slices = params_dict[name].shape[0]
-            if len(expert_ids) != expected_slices:
-                incomplete_expert_params.append(
-                    f"{name} ({len(expert_ids)}/{expected_slices} expert slices)"
-                )
-        if incomplete_expert_params:
-            raise ValueError(
-                "Nemotron MTP checkpoint incompletely initialized fused MoE "
-                "parameters: " + ", ".join(incomplete_expert_params)
-            )
-        if loaded_expert_slices:
-            logger.info(
-                "Verified complete expert-slice loading for %d fused MTP "
-                "parameter(s).",
-                len(loaded_expert_slices),
-            )
-        logger.info(
-            "Verified initialization of all %d Nemotron MTP parameters.",
-            len(params_dict),
-        )
 
         return loaded_params

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 from vllm.config.parallel import ParallelConfig
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
@@ -22,7 +23,10 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
 from vllm.model_executor.models.utils import (
     WeightsMapper,
     make_empty_intermediate_tensors_factory,
@@ -36,6 +40,8 @@ from .nemotron_h import (
     NemotronHAttentionDecoderLayer,
     NemotronHMoEDecoderLayer,
 )
+
+logger = init_logger(__name__)
 
 
 class NemotronHMTPAttentionDecoderLayer(NemotronHAttentionDecoderLayer):
@@ -217,7 +223,7 @@ class NemotronHMultiTokenPredictor(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
-        config = vllm_config.model_config.hf_config.get_text_config()
+        config = vllm_config.model_config.hf_config
 
         self.config = config
         self.vocab_size = config.vocab_size
@@ -333,7 +339,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        config = vllm_config.model_config.hf_config.get_text_config()
+        config = vllm_config.model_config.hf_config
         self.vllm_config = vllm_config
         self.config = config
         self.quant_config = vllm_config.quant_config
@@ -353,12 +359,37 @@ class NemotronHMTP(nn.Module, SupportsPP):
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
         )
 
-        # LM head for generating logits
+        speculative_config = vllm_config.speculative_config
+        self.use_private_lm_head = (
+            speculative_config is not None
+            and speculative_config.method == "mtp"
+            and not speculative_config.mtp_share_lm_head
+        )
+        parallel_config = vllm_config.parallel_config
+        self.share_target_embeddings = (
+            parallel_config is None or parallel_config.pipeline_parallel_size == 1
+        )
+        lm_head_quant_config = self.quant_config if self.use_private_lm_head else None
+
+        # The proposer replaces a shared temporary head with the target head.
+        # A private head stays draft-owned and must therefore be constructed
+        # from the draft checkpoint's quantization configuration.
         self.lm_head = ParallelLMHead(
             self.config.vocab_size,
             self.config.hidden_size,
+            quant_config=lm_head_quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
+        if self.use_private_lm_head:
+            quant_name = (
+                self.quant_config.get_name()
+                if self.quant_config is not None
+                else "unquantized"
+            )
+            logger.info(
+                "Constructed Nemotron MTP draft-owned lm_head with %s quantization.",
+                quant_name,
+            )
 
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
 
@@ -423,14 +454,26 @@ class NemotronHMTP(nn.Module, SupportsPP):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        loaded_stacked_shards: dict[str, set[str]] = {}
+        loaded_expert_slices: dict[str, set[int]] = {}
 
         for name, loaded_weight in weights:
             # MTP weights are nested in "language_model."
             # in Multimodal Nemotron-H checkpoints.
             name = name.removeprefix("language_model.")
-
+            # Full checkpoints contain an lm_head even when MTP will share the
+            # already-loaded target head. Skip that representation unless this
+            # draft explicitly owns a private head.
+            if "lm_head" in name and not self.use_private_lm_head:
+                continue
             # Only process MTP weights - skip all non-MTP weights
-            if not name.startswith("mtp.") and "embeddings" not in name:
+            if (
+                not name.startswith("mtp.")
+                and "embeddings" not in name
+                and not (
+                    self.use_private_lm_head and name.startswith("lm_head.")
+                )
+            ):
                 continue
             # Skip rotary embeddings (computed, not loaded)
             if "rotary_emb.inv_freq" in name:
@@ -442,6 +485,13 @@ class NemotronHMTP(nn.Module, SupportsPP):
                 name = name.replace("embeddings", "embed_tokens")
                 if name.startswith("backbone."):
                     name = name.replace("backbone.", "model.")
+
+            if "scale" in name or "zero_point" in name:
+                # ModelOpt serializes KV-cache scales next to k_proj/v_proj,
+                # while vLLM registers them on the Attention module.
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
 
             # Handle stacked parameters (qkv_proj) for attention layers
             is_stacked = False
@@ -467,6 +517,9 @@ class NemotronHMTP(nn.Module, SupportsPP):
                 if weight_loader is not None:
                     weight_loader(param, loaded_weight, shard_id)
                     loaded_params.add(stacked_name)
+                    loaded_stacked_shards.setdefault(stacked_name, set()).add(
+                        shard_id
+                    )
                 break
 
             if is_stacked:
@@ -500,6 +553,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
                 )
                 if success:
                     loaded_params.add(name_mapped)
+                    loaded_expert_slices.setdefault(name_mapped, set()).add(expert_id)
                 break
 
             if is_expert_weight:
@@ -515,5 +569,87 @@ class NemotronHMTP(nn.Module, SupportsPP):
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+        if self.use_private_lm_head:
+            loaded_lm_head_params = {
+                name for name in loaded_params if name.startswith("lm_head.")
+            }
+            if not loaded_lm_head_params:
+                raise ValueError(
+                    "mtp_share_lm_head=False requires lm_head weights in the "
+                    "external MTP checkpoint."
+                )
+            logger.info(
+                "Loaded %d private MTP lm_head tensors from the draft checkpoint.",
+                len(loaded_lm_head_params),
+            )
+        else:
+            # These temporary parameters are replaced by the target head after
+            # draft loading and may be absent from an MTP-only checkpoint.
+            loaded_params.update(
+                name for name in params_dict if name.startswith("lm_head.")
+            )
+
+        if self.share_target_embeddings:
+            # At PP=1 the target embedding replaces the draft embedding, so
+            # both full and MTP-only checkpoint layouts are valid.
+            loaded_params.update(
+                name
+                for name in params_dict
+                if name.startswith("model.embed_tokens.")
+            )
+
+        # Quantized model loading disables the generic missing-weight check
+        # because some quantizers synthesize parameters. These ModelOpt MTP
+        # checkpoints serialize every model-owned parameter, so enforce the
+        # stronger invariant here to catch missed name mappings.
+        missing_params = set(params_dict) - loaded_params
+        runtime_owned_params = {
+            name
+            for name in missing_params
+            if name.endswith((".attn.q_scale", ".attn.prob_scale"))
+            or name == "lm_head.input_scale"
+        }
+        missing_params -= runtime_owned_params
+        if missing_params:
+            missing_preview = ", ".join(sorted(missing_params)[:20])
+            raise ValueError(
+                "Nemotron MTP checkpoint did not initialize "
+                f"{len(missing_params)} parameter(s): {missing_preview}"
+            )
+
+        incomplete_stacked_params = [
+            f"{name} ({','.join(sorted(shards))}/k,q,v shards)"
+            for name, shards in sorted(loaded_stacked_shards.items())
+            if shards != {"q", "k", "v"}
+        ]
+        if incomplete_stacked_params:
+            raise ValueError(
+                "Nemotron MTP checkpoint incompletely initialized fused QKV "
+                "parameters: " + ", ".join(incomplete_stacked_params)
+            )
+
+        incomplete_expert_params: list[str] = []
+        for name, expert_ids in sorted(loaded_expert_slices.items()):
+            expected_slices = params_dict[name].shape[0]
+            if len(expert_ids) != expected_slices:
+                incomplete_expert_params.append(
+                    f"{name} ({len(expert_ids)}/{expected_slices} expert slices)"
+                )
+        if incomplete_expert_params:
+            raise ValueError(
+                "Nemotron MTP checkpoint incompletely initialized fused MoE "
+                "parameters: " + ", ".join(incomplete_expert_params)
+            )
+        if loaded_expert_slices:
+            logger.info(
+                "Verified complete expert-slice loading for %d fused MTP "
+                "parameter(s).",
+                len(loaded_expert_slices),
+            )
+        logger.info(
+            "Verified initialization of all %d Nemotron MTP parameters.",
+            len(params_dict),
+        )
 
         return loaded_params

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -41,6 +41,7 @@ from .nemotron_h import (
     NemotronHMoEDecoderLayer,
 )
 
+
 class NemotronHMTPAttentionDecoderLayer(NemotronHAttentionDecoderLayer):
     def __init__(
         self,
@@ -365,11 +366,8 @@ class NemotronHMTP(nn.Module, SupportsPP):
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
         )
 
+        # LM head for generating logits
         self.has_own_lm_head = False
-
-        # Construct from the draft checkpoint's quantization configuration.
-        # Weight loading below determines whether the checkpoint owns this head;
-        # otherwise, the proposer replaces it with the target head.
         self.lm_head = ParallelLMHead(
             self.config.vocab_size,
             self.config.hidden_size,
@@ -448,7 +446,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
             is_lm_head_weight = name.startswith("lm_head.")
             if is_lm_head_weight:
                 self.has_own_lm_head = True
-            # Only process MTP weights - skip all non-MTP weights
+            # Only process MTP and LM head weights - skip all non-MTP and non-LM head weights
             if (
                 not name.startswith("mtp.")
                 and "embeddings" not in name
@@ -467,8 +465,6 @@ class NemotronHMTP(nn.Module, SupportsPP):
                     name = name.replace("backbone.", "model.")
 
             if "scale" in name:
-                # ModelOpt serializes KV-cache scales next to k_proj/v_proj,
-                # while vLLM registers them on the Attention module.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -339,7 +339,7 @@ class NemotronHMTP(nn.Module, SupportsPP):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_config.get_text_config()
         self.vllm_config = vllm_config
         self.config = config
         self.quant_config = vllm_config.quant_config

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -453,7 +453,7 @@ class NemotronHMTP(nn.Module, SupportsPP, SupportsQuant):
             is_lm_head_weight = name.startswith("lm_head.")
             if is_lm_head_weight:
                 self.has_own_lm_head = True
-            # Only process MTP and LM head weights - 
+            # Only process MTP and LM head weights -
             # skip all non-MTP and non-LM head weights
             if (
                 not name.startswith("mtp.")

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -472,7 +472,7 @@ class NemotronHMTP(nn.Module, SupportsPP, SupportsQuant):
                 if name.startswith("backbone."):
                     name = name.replace("backbone.", "model.")
 
-            if "scale" in name:
+            if "scale" in name or "zero_point" in name:
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -218,7 +218,13 @@ class NemotronHMTPMoEDecoderLayer(NemotronHMoEDecoderLayer):
 class NemotronHMultiTokenPredictor(nn.Module):
     """MTP predictor with NemotronH layers."""
 
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
 
         speculative_config = vllm_config.speculative_config
@@ -226,7 +232,8 @@ class NemotronHMultiTokenPredictor(nn.Module):
         draft_model_config = speculative_config.draft_model_config
         assert draft_model_config is not None
         config = draft_model_config.hf_config.get_text_config()
-        quant_config = get_draft_quant_config(vllm_config)
+        if quant_config is None:
+            quant_config = get_draft_quant_config(vllm_config)
 
         self.config = config
         self.vocab_size = config.vocab_size
@@ -350,7 +357,13 @@ class NemotronHMTP(nn.Module, SupportsPP):
         self.vllm_config = vllm_config
         self.config = config
         self.quant_config = get_draft_quant_config(vllm_config)
-
+        if self.quant_config is not None:
+            self.quant_config.apply_vllm_mapper(
+                self.hf_to_vllm_mapper.get_rename_mapper()
+            )
+            self.quant_config.packed_modules_mapping.update(
+                self.packed_modules_mapping
+            )
         # Needed for load_weights mapping
         self.mtp_start_layer_idx = config.num_hidden_layers
 
@@ -363,7 +376,9 @@ class NemotronHMTP(nn.Module, SupportsPP):
 
         # MTP predictor
         self.model = NemotronHMultiTokenPredictor(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "mtp")
+            vllm_config=vllm_config,
+            quant_config=self.quant_config,
+            prefix=maybe_prefix(prefix, "mtp"),
         )
 
         # LM head for generating logits

--- a/vllm/model_executor/models/nemotron_h_mtp.py
+++ b/vllm/model_executor/models/nemotron_h_mtp.py
@@ -35,7 +35,7 @@ from vllm.model_executor.models.utils import (
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.nemotron_h import NemotronHConfig
 
-from .interfaces import SupportsPP
+from .interfaces import SupportsPP, SupportsQuant
 from .nemotron_h import (
     NemotronHAttentionDecoderLayer,
     NemotronHMoEDecoderLayer,
@@ -326,14 +326,9 @@ class NemotronHMultiTokenPredictor(nn.Module):
         return hidden_states
 
 
-class NemotronHMTP(nn.Module, SupportsPP):
+class NemotronHMTP(nn.Module, SupportsPP, SupportsQuant):
     """NemotronH MTP model."""
 
-    # Quant configs name modules in checkpoint space ("language_model.mtp.layers.0*"),
-    # but this draft is built under "mtp" (maybe_prefix below). SupportsQuant only
-    # re-roots exclude_modules when the model defines a mapper, so without one the
-    # exclusions never match and the MTP experts are wrongly quantized. Mirrors the
-    # prefix handling load_weights() already does by hand.
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={"language_model.": ""},
         orig_to_new_substr={"embeddings": "embed_tokens"},
@@ -356,14 +351,6 @@ class NemotronHMTP(nn.Module, SupportsPP):
         config = draft_model_config.hf_config.get_text_config()
         self.vllm_config = vllm_config
         self.config = config
-        self.quant_config = get_draft_quant_config(vllm_config)
-        if self.quant_config is not None:
-            self.quant_config.apply_vllm_mapper(
-                self.hf_to_vllm_mapper.get_rename_mapper()
-            )
-            self.quant_config.packed_modules_mapping.update(
-                self.packed_modules_mapping
-            )
         # Needed for load_weights mapping
         self.mtp_start_layer_idx = config.num_hidden_layers
 
@@ -395,6 +382,11 @@ class NemotronHMTP(nn.Module, SupportsPP):
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors
         )
+
+    @staticmethod
+    def _find_quant_config(*args, **kwargs) -> QuantizationConfig | None:
+        vllm_config = kwargs.get("vllm_config")
+        return get_draft_quant_config(vllm_config)
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1272,25 +1272,6 @@ class SpecDecodeBaseProposer:
         spec_cfg = self.speculative_config
         base = self.vllm_config
 
-        if self.method == "mtp":
-            # The engine config belongs to the target and therefore carries
-            # the target quantization object. MTP modules must be constructed
-            # with the external draft checkpoint's model and quantization
-            # metadata instead.
-            draft_load_config = spec_cfg.draft_load_config or base.load_config
-            draft_quant_config = VllmConfig._get_quantization_config(
-                spec_cfg.draft_model_config, draft_load_config
-            )
-            base = replace(
-                base,
-                model_config=spec_cfg.draft_model_config,
-                quant_config=draft_quant_config,
-            )
-            logger.info(
-                "Using the draft checkpoint quantization config for MTP modules; "
-                "target quantization is not inherited."
-            )
-
         if spec_cfg.moe_backend is not None:
             base = replace(
                 base,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1533,48 +1533,6 @@ class SpecDecodeBaseProposer:
         duplicate copy of the target model's LM head. In these cases, we share
         the target model's LM head with the draft model to save memory.
         """
-        if self.method == "mtp" and not self.speculative_config.mtp_share_lm_head:
-            draft_lm_head = getattr(self.model, "lm_head", None)
-            if draft_lm_head is None:
-                raise ValueError(
-                    "mtp_share_lm_head=False requires the MTP model to own an lm_head."
-                )
-            target_lm_head = getattr(target_language_model, "lm_head", None)
-            if draft_lm_head is target_lm_head:
-                raise RuntimeError(
-                    "Private MTP lm_head unexpectedly aliases the target lm_head."
-                )
-            draft_weight = getattr(draft_lm_head, "weight", None)
-            target_weight = getattr(target_lm_head, "weight", None)
-            if isinstance(draft_weight, torch.Tensor) and isinstance(
-                target_weight, torch.Tensor
-            ):
-                same_storage = (
-                    draft_weight.untyped_storage().data_ptr()
-                    == target_weight.untyped_storage().data_ptr()
-                )
-                if same_storage:
-                    raise RuntimeError(
-                        "Private MTP lm_head unexpectedly shares target weight storage."
-                    )
-            quant_method = getattr(draft_lm_head, "quant_method", None)
-            target_quant_method = getattr(target_lm_head, "quant_method", None)
-            target_quant_name = (
-                type(target_quant_method).__name__
-                if target_quant_method is not None
-                else "unquantized"
-            )
-            logger.info(
-                "Detected MTP model with mtp_share_lm_head=False. Keeping the "
-                "independently loaded draft-owned lm_head from %s "
-                "(quantization implementation: %s; no target alias). Target "
-                "lm_head quantization implementation: %s.",
-                self.speculative_config.draft_model_config.model,
-                type(quant_method).__name__ if quant_method is not None else "none",
-                target_quant_name,
-            )
-            return
-
         share_lm_head = False
         if hasattr(self.model, "has_own_lm_head"):
             # EAGLE model

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1272,6 +1272,25 @@ class SpecDecodeBaseProposer:
         spec_cfg = self.speculative_config
         base = self.vllm_config
 
+        if self.method == "mtp":
+            # The engine config belongs to the target and therefore carries
+            # the target quantization object. MTP modules must be constructed
+            # with the external draft checkpoint's model and quantization
+            # metadata instead.
+            draft_load_config = spec_cfg.draft_load_config or base.load_config
+            draft_quant_config = VllmConfig._get_quantization_config(
+                spec_cfg.draft_model_config, draft_load_config
+            )
+            base = replace(
+                base,
+                model_config=spec_cfg.draft_model_config,
+                quant_config=draft_quant_config,
+            )
+            logger.info(
+                "Using the draft checkpoint quantization config for MTP modules; "
+                "target quantization is not inherited."
+            )
+
         if spec_cfg.moe_backend is not None:
             base = replace(
                 base,
@@ -1514,6 +1533,48 @@ class SpecDecodeBaseProposer:
         duplicate copy of the target model's LM head. In these cases, we share
         the target model's LM head with the draft model to save memory.
         """
+        if self.method == "mtp" and not self.speculative_config.mtp_share_lm_head:
+            draft_lm_head = getattr(self.model, "lm_head", None)
+            if draft_lm_head is None:
+                raise ValueError(
+                    "mtp_share_lm_head=False requires the MTP model to own an lm_head."
+                )
+            target_lm_head = getattr(target_language_model, "lm_head", None)
+            if draft_lm_head is target_lm_head:
+                raise RuntimeError(
+                    "Private MTP lm_head unexpectedly aliases the target lm_head."
+                )
+            draft_weight = getattr(draft_lm_head, "weight", None)
+            target_weight = getattr(target_lm_head, "weight", None)
+            if isinstance(draft_weight, torch.Tensor) and isinstance(
+                target_weight, torch.Tensor
+            ):
+                same_storage = (
+                    draft_weight.untyped_storage().data_ptr()
+                    == target_weight.untyped_storage().data_ptr()
+                )
+                if same_storage:
+                    raise RuntimeError(
+                        "Private MTP lm_head unexpectedly shares target weight storage."
+                    )
+            quant_method = getattr(draft_lm_head, "quant_method", None)
+            target_quant_method = getattr(target_lm_head, "quant_method", None)
+            target_quant_name = (
+                type(target_quant_method).__name__
+                if target_quant_method is not None
+                else "unquantized"
+            )
+            logger.info(
+                "Detected MTP model with mtp_share_lm_head=False. Keeping the "
+                "independently loaded draft-owned lm_head from %s "
+                "(quantization implementation: %s; no target alias). Target "
+                "lm_head quantization implementation: %s.",
+                self.speculative_config.draft_model_config.model,
+                type(quant_method).__name__ if quant_method is not None else "none",
+                target_quant_name,
+            )
+            return
+
         share_lm_head = False
         if hasattr(self.model, "has_own_lm_head"):
             # EAGLE model


### PR DESCRIPTION



## Purpose
Enable nemotron_h_mtp to use a separate (possibly quantized) lm head, if one is provided in the MTP checkpoint
## Test Plan
Serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 with an mtp with the following configurations:
1. original checkpoint with native MTP
2. original checkpoint with external MTP nvidia/Nemotron-3-Super-120B-A12B-BF16-MTPv2 (using a shared lm head)
3. original checkpoint with external quantized MTP checkpoint, which includes a W4A16 quantized lm head
Ensure acceptance length is preserved for the first 2 settings, and that similar acceptance length is achieved in the third setting, using the SPEED-bench benchmark (qualitative split)
## Test Result
Existing ALs are preserved, for the third configuration there is a slight expected drop relative to the second configuration:
1. 3.462934 (upstream) ->  3.463326 (w/ feature)
2. 4.31106 (upstream -> 4.31565 (w/feature)
3. 4.28227 (with the new feature only)
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

