### PR TITLE
[Perf] Add exact distributed MRV2 prompt logprobs

### DIFF
--- a/tests/v1/sample/test_prompt_logprob_local.py
+++ b/tests/v1/sample/test_prompt_logprob_local.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU coverage for GLM-only TP-local target prompt logprobs."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed
+import torch.multiprocessing
+
+from vllm.model_executor.layers.logits_processor import LocalLogits
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbeddingShardIndices,
+)
+from vllm.v1.worker.gpu.model_runner import _get_prompt_logprobs_local_logits_fn
+from vllm.v1.worker.gpu.sample import prompt_logprob
+
+
+class _SingleRankTPGroup:
+    world_size = 1
+    device_group = None
+
+    @staticmethod
+    def all_reduce(values: torch.Tensor) -> torch.Tensor:
+        return values
+
+
+class _GlooTPGroup:
+    world_size = 2
+    device_group = torch.distributed.group.WORLD
+
+    @staticmethod
+    def all_reduce(values: torch.Tensor) -> torch.Tensor:
+        torch.distributed.all_reduce(values, group=torch.distributed.group.WORLD)
+        return values
+
+
+def _local_logits(
+    logits: torch.Tensor, start: int = 0, org_width: int | None = None
+) -> LocalLogits:
+    org_width = logits.shape[-1] if org_width is None else org_width
+    return LocalLogits(
+        logits=logits,
+        shard_indices=VocabParallelEmbeddingShardIndices(
+            padded_org_vocab_start_index=start,
+            padded_org_vocab_end_index=start + logits.shape[-1],
+            padded_added_vocab_start_index=start + logits.shape[-1],
+            padded_added_vocab_end_index=start + logits.shape[-1],
+            org_vocab_start_index=start,
+            org_vocab_end_index=start + org_width,
+            added_vocab_start_index=start + org_width,
+            added_vocab_end_index=start + org_width,
+        ),
+    )
+
+
+def test_target_only_matches_one_rank_log_softmax(monkeypatch):
+    monkeypatch.setattr(prompt_logprob, "get_tp_group", _SingleRankTPGroup)
+    logits = torch.tensor([[1.0, -2.0, 3.0], [0.5, 2.0, -1.0]])
+    target_ids = torch.tensor([2, 0])
+
+    result = prompt_logprob.compute_distributed_token_logprobs(
+        _local_logits(logits), target_ids
+    )
+
+    expected = torch.log_softmax(logits, -1)[torch.arange(2), target_ids]
+    torch.testing.assert_close(result.logprobs[:, 0], expected)
+    assert result.logprob_token_ids.tolist() == [[2], [0]]
+    assert result.selected_token_ranks.tolist() == [1, 2]
+    assert result.selected_token_ranks.dtype == torch.int64
+
+
+def test_target_only_excludes_dominant_padded_and_added_tail(monkeypatch):
+    monkeypatch.setattr(prompt_logprob, "get_tp_group", _SingleRankTPGroup)
+    local = LocalLogits(
+        logits=torch.tensor([[1.0, 2.0, -float("inf"), -float("inf"), 1e6]]),
+        shard_indices=VocabParallelEmbeddingShardIndices(
+            padded_org_vocab_start_index=4,
+            padded_org_vocab_end_index=8,
+            padded_added_vocab_start_index=6,
+            padded_added_vocab_end_index=7,
+            org_vocab_start_index=4,
+            org_vocab_end_index=6,
+            added_vocab_start_index=6,
+            added_vocab_end_index=7,
+        ),
+    )
+
+    result = prompt_logprob.compute_distributed_token_logprobs(local, torch.tensor([5]))
+
+    torch.testing.assert_close(
+        result.logprobs[:, 0], torch.log_softmax(torch.tensor([[1.0, 2.0]]), -1)[:, 1]
+    )
+    assert result.selected_token_ranks.tolist() == [1]
+
+
+def _chunking_fallback_test(monkeypatch, num_prompt_logprobs: int) -> None:
+    calls = SimpleNamespace(gathered=0, local=0)
+    logits = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+    def gathered(hidden_states: torch.Tensor) -> torch.Tensor:
+        calls.gathered += 1
+        return logits[: hidden_states.shape[0]]
+
+    def local(_: torch.Tensor) -> LocalLogits:
+        calls.local += 1
+        raise AssertionError(
+            "gathered prompt-logprob requests must not project locally"
+        )
+
+    def fake_topk(
+        prompt_logits: torch.Tensor,
+        requested_num: int,
+        _: torch.Tensor,
+        **__: object,
+    ) -> prompt_logprob.LogprobsTensors:
+        assert requested_num == (
+            prompt_logits.shape[-1]
+            if num_prompt_logprobs == -1
+            else num_prompt_logprobs
+        )
+        return prompt_logprob.LogprobsTensors(
+            logprob_token_ids=torch.zeros(
+                prompt_logits.shape[0], requested_num + 1, dtype=torch.int64
+            ),
+            logprobs=torch.zeros(prompt_logits.shape[0], requested_num + 1),
+            selected_token_ranks=torch.ones(prompt_logits.shape[0], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(prompt_logprob, "compute_topk_scores", fake_topk)
+    prompt_logprob.compute_prompt_logprobs_with_chunking(
+        torch.tensor([1, 0]),
+        torch.empty(2, 1),
+        gathered,
+        local,
+        num_prompt_logprobs,
+    )
+    assert calls.gathered == 1
+    assert calls.local == 0
+
+
+def test_chunking_gathers_for_prompt_topn(monkeypatch):
+    _chunking_fallback_test(monkeypatch, num_prompt_logprobs=1)
+
+
+def test_chunking_gathers_for_full_prompt_logprobs_minus_one(monkeypatch):
+    """``prompt_logprobs=-1`` never invokes the local target-only route."""
+    _chunking_fallback_test(monkeypatch, num_prompt_logprobs=-1)
+
+
+@pytest.mark.parametrize("logprobs_mode", ["raw_logits", "raw_logprobs"])
+def test_chunking_uses_local_target_only_at_minimum_row_count(
+    monkeypatch, logprobs_mode
+):
+    calls = SimpleNamespace(gathered=0, local=0, distributed=0)
+
+    def gathered(hidden_states: torch.Tensor) -> torch.Tensor:
+        calls.gathered += 1
+        return torch.zeros(hidden_states.shape[0], 2)
+
+    def local(hidden_states: torch.Tensor) -> LocalLogits:
+        calls.local += 1
+        return _local_logits(torch.zeros(hidden_states.shape[0], 2))
+
+    def distributed(
+        _: LocalLogits, token_ids: torch.Tensor, mode: object
+    ) -> prompt_logprob.LogprobsTensors:
+        assert mode == logprobs_mode
+        calls.distributed += 1
+        return prompt_logprob.LogprobsTensors(
+            logprob_token_ids=token_ids[:, None],
+            logprobs=torch.zeros(token_ids.shape[0], 1),
+            selected_token_ranks=torch.ones(token_ids.shape[0], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(
+        prompt_logprob, "compute_distributed_token_logprobs", distributed
+    )
+    prompt_logprob.compute_prompt_logprobs_with_chunking(
+        torch.zeros(prompt_logprob.MIN_LOCAL_PROMPT_LOGPROB_ROWS, dtype=torch.int64),
+        torch.empty(prompt_logprob.MIN_LOCAL_PROMPT_LOGPROB_ROWS, 1),
+        gathered,
+        local,
+        num_prompt_logprobs=0,
+        logprobs_mode=logprobs_mode,
+    )
+
+    assert calls.gathered == 0
+    assert calls.local == calls.distributed == 1
+
+
+@pytest.mark.parametrize("logprobs_mode", ["raw_logits", "raw_logprobs"])
+def test_chunking_gathers_below_minimum_without_local_projection(
+    monkeypatch, logprobs_mode
+):
+    calls = SimpleNamespace(gathered=0, local=0)
+    logged: list[str] = []
+    rows = prompt_logprob.MIN_LOCAL_PROMPT_LOGPROB_ROWS - 1
+
+    class Logger:
+        @staticmethod
+        def info_once(message: str, *args: object) -> None:
+            logged.append(message % args)
+
+    def gathered(hidden_states: torch.Tensor) -> torch.Tensor:
+        calls.gathered += 1
+        return torch.zeros(hidden_states.shape[0], 2)
+
+    def local(_: torch.Tensor) -> LocalLogits:
+        calls.local += 1
+        raise AssertionError("short chunks must not project local logits")
+
+    def fake_topk(
+        prompt_logits: torch.Tensor, _: int, token_ids: torch.Tensor, **kwargs: object
+    ) -> prompt_logprob.LogprobsTensors:
+        assert kwargs["logits_mode"] == (logprobs_mode == "raw_logits")
+        return prompt_logprob.LogprobsTensors(
+            logprob_token_ids=token_ids[:, None],
+            logprobs=torch.zeros(prompt_logits.shape[0], 1),
+            selected_token_ranks=torch.ones(prompt_logits.shape[0], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(prompt_logprob, "logger", Logger())
+    monkeypatch.setattr(prompt_logprob, "compute_topk_scores", fake_topk)
+    prompt_logprob.compute_prompt_logprobs_with_chunking(
+        torch.zeros(rows, dtype=torch.int64),
+        torch.empty(rows, 1),
+        gathered,
+        local,
+        num_prompt_logprobs=0,
+        logprobs_mode=logprobs_mode,
+    )
+
+    assert calls.gathered == 1
+    assert calls.local == 0
+    assert logged == [
+        (
+            f"{prompt_logprob.SHORT_CHUNK_GATHERED_MARKER} rows={rows} "
+            f"threshold={prompt_logprob.MIN_LOCAL_PROMPT_LOGPROB_ROWS}"
+        )
+    ]
+
+
+def test_chunking_mixed_1025_rows_uses_local_prefix_and_gathered_tail(monkeypatch):
+    calls = SimpleNamespace(gathered_rows=[], local_rows=[], distributed_rows=[])
+    rows = 1025
+
+    def gathered(hidden_states: torch.Tensor) -> torch.Tensor:
+        calls.gathered_rows.append(hidden_states.shape[0])
+        return torch.zeros(hidden_states.shape[0], 2)
+
+    def local(hidden_states: torch.Tensor) -> LocalLogits:
+        calls.local_rows.append(hidden_states.shape[0])
+        return _local_logits(torch.zeros(hidden_states.shape[0], 2))
+
+    def distributed(
+        _: LocalLogits, token_ids: torch.Tensor, __: object
+    ) -> prompt_logprob.LogprobsTensors:
+        calls.distributed_rows.append(token_ids.shape[0])
+        return prompt_logprob.LogprobsTensors(
+            logprob_token_ids=token_ids[:, None],
+            logprobs=torch.zeros(token_ids.shape[0], 1),
+            selected_token_ranks=torch.ones(token_ids.shape[0], dtype=torch.int64),
+        )
+
+    def fake_topk(
+        prompt_logits: torch.Tensor, _: int, token_ids: torch.Tensor, **__: object
+    ) -> prompt_logprob.LogprobsTensors:
+        return prompt_logprob.LogprobsTensors(
+            logprob_token_ids=token_ids[:, None],
+            logprobs=torch.zeros(prompt_logits.shape[0], 1),
+            selected_token_ranks=torch.ones(prompt_logits.shape[0], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(
+        prompt_logprob, "compute_distributed_token_logprobs", distributed
+    )
+    monkeypatch.setattr(prompt_logprob, "compute_topk_scores", fake_topk)
+    prompt_logprob.compute_prompt_logprobs_with_chunking(
+        torch.zeros(rows, dtype=torch.int64),
+        torch.empty(rows, 1),
+        gathered,
+        local,
+        num_prompt_logprobs=0,
+    )
+
+    assert calls.local_rows == calls.distributed_rows == [1024]
+    assert calls.gathered_rows == [1]
+
+
+def _tp2_asymmetric_worker(rank: int, init_method: str, queue) -> None:
+    torch.distributed.init_process_group(
+        backend="gloo", init_method=init_method, world_size=2, rank=rank
+    )
+    try:
+        prompt_logprob.get_tp_group = lambda: _GlooTPGroup
+        full = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0], [5.0, 4.0, 3.0, 2.0, 1.0]])
+        if rank == 0:
+            org = full[:, :4]
+            indices = VocabParallelEmbeddingShardIndices(
+                padded_org_vocab_start_index=0,
+                padded_org_vocab_end_index=4,
+                padded_added_vocab_start_index=5,
+                padded_added_vocab_end_index=9,
+                org_vocab_start_index=0,
+                org_vocab_end_index=4,
+                added_vocab_start_index=5,
+                added_vocab_end_index=7,
+            )
+            tail_width = 4
+        else:
+            org = full[:, 4:]
+            indices = VocabParallelEmbeddingShardIndices(
+                padded_org_vocab_start_index=4,
+                padded_org_vocab_end_index=8,
+                padded_added_vocab_start_index=9,
+                padded_added_vocab_end_index=13,
+                org_vocab_start_index=4,
+                org_vocab_end_index=5,
+                added_vocab_start_index=7,
+                added_vocab_end_index=7,
+            )
+            tail_width = 7
+        local = torch.cat((org, torch.full((2, tail_width), 1e6)), dim=-1)
+        result = prompt_logprob.compute_distributed_token_logprobs(
+            LocalLogits(local, indices), torch.tensor([4, 1])
+        )
+        queue.put(
+            (rank, result.logprobs[:, 0].tolist(), result.selected_token_ranks.tolist())
+        )
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def test_tp2_asymmetric_org_shards_exclude_padded_and_added_tails(tmp_path):
+    context = torch.multiprocessing.get_context("spawn")
+    queue = context.SimpleQueue()
+    torch.multiprocessing.spawn(
+        _tp2_asymmetric_worker,
+        args=(f"file://{tmp_path / 'tp2-asymmetric-tail'}", queue),
+        nprocs=2,
+        join=True,
+    )
+    full = torch.tensor([[1.0, 2.0, 3.0, 4.0, 5.0], [5.0, 4.0, 3.0, 2.0, 1.0]])
+    targets = torch.tensor([4, 1])
+    expected_scores = torch.log_softmax(full, -1)[torch.arange(2), targets]
+    expected_ranks = (full >= full[torch.arange(2), targets, None]).sum(-1)
+    for _, scores, ranks in sorted(queue.get() for _ in range(2)):
+        torch.testing.assert_close(torch.tensor(scores), expected_scores)
+        assert ranks == expected_ranks.tolist()
+
+
+def test_nvidia_dsa_local_logits_is_glm_only():
+    from vllm.models.deepseek_v32.nvidia.model import DeepseekV32ForCausalLM
+
+    class Processor:
+        def __init__(self):
+            self.calls = 0
+
+        def get_local_logits(self, _: object, __: torch.Tensor) -> LocalLogits:
+            self.calls += 1
+            return _local_logits(torch.zeros(1, 2))
+
+    processor = Processor()
+    glm = SimpleNamespace(
+        config=SimpleNamespace(model_type="glm_moe_dsa"),
+        logits_processor=processor,
+        lm_head=object(),
+    )
+    other = SimpleNamespace(
+        config=SimpleNamespace(model_type="deepseek_v32"),
+        logits_processor=processor,
+        lm_head=object(),
+    )
+    assert DeepseekV32ForCausalLM.compute_local_logits(glm, torch.empty(1, 1))
+    assert DeepseekV32ForCausalLM.compute_local_logits(other, torch.empty(1, 1)) is None
+    assert processor.calls == 1
+
+
+def test_dcp_falls_back_from_local_logits():
+    class GLM:
+        config = SimpleNamespace(model_type="glm_moe_dsa")
+
+        @staticmethod
+        def compute_local_logits(hidden_states: torch.Tensor) -> LocalLogits:
+            return _local_logits(hidden_states)
+
+    assert _get_prompt_logprobs_local_logits_fn(GLM(), dcp_size=1) is not None
+    assert _get_prompt_logprobs_local_logits_fn(GLM(), dcp_size=4) is None

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -3,6 +3,7 @@
 """A layer that compute logits from hidden_stats."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from functools import cache
 
 import torch
@@ -19,6 +20,7 @@ from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     UnquantizedEmbeddingMethod,
     VocabParallelEmbedding,
+    VocabParallelEmbeddingShardIndices,
 )
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
@@ -51,6 +53,14 @@ def _topk(scores: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
     if impl is None or not scores.is_cuda:
         return torch.topk(scores, k, dim=-1)
     return impl(scores, k, sorted=True, deterministic=True)
+
+
+@dataclass(frozen=True)
+class LocalLogits:
+    """Vocabulary-sharded logits and the layout needed to interpret them."""
+
+    logits: torch.Tensor
+    shard_indices: VocabParallelEmbeddingShardIndices
 
 
 # --8<-- [start:logits_processor]
@@ -132,6 +142,36 @@ class LogitsProcessor(PluggableLayer):
             # None may be returned for rank > 0
             logits = tensor_model_parallel_gather(logits)
         return logits
+
+    def get_local_logits(
+        self,
+        lm_head: VocabParallelEmbedding,
+        hidden_states: torch.Tensor,
+        embedding_bias: torch.Tensor | None = None,
+    ) -> LocalLogits | None:
+        """Return post-processed logits before TP vocabulary gathering.
+
+        ``logits_as_input`` has no vocabulary-shard layout, so callers must
+        retain the regular gathered path in that case.
+        """
+        if self.logits_as_input:
+            return None
+
+        logits = self._apply_head(lm_head, hidden_states, embedding_bias)
+        if self.soft_cap is not None:
+            logits = torch.tanh(logits / self.soft_cap) * self.soft_cap
+        if self.scale != 1.0:
+            logits *= self.scale
+
+        shard_indices = lm_head.shard_indices
+        org_end = shard_indices.num_org_elements
+        added_start = shard_indices.num_org_elements_padded
+        added_end = added_start + shard_indices.num_added_elements
+        if org_end < added_start:
+            logits[..., org_end:added_start] = -float("inf")
+        if added_end < logits.shape[-1]:
+            logits[..., added_end:] = -float("inf")
+        return LocalLogits(logits, shard_indices)
 
     def _apply_head(
         self,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -71,7 +71,7 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
     RowParallelLinear,
 )
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.logits_processor import LocalLogits, LogitsProcessor
 from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttentionWrapper
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
@@ -1980,4 +1980,5 @@ class DeepseekV3ForCausalLM(DeepseekV2ForCausalLM):
 
 
 class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
-    pass
+    def compute_local_logits(self, hidden_states: torch.Tensor) -> LocalLogits | None:
+        return self.logits_processor.get_local_logits(self.lm_head, hidden_states)

--- a/vllm/model_executor/models/interfaces_base.py
+++ b/vllm/model_executor/models/interfaces_base.py
@@ -122,6 +122,15 @@ class VllmModelForTextGeneration(VllmModel[T], Protocol[T]):
         ...
 
 
+@runtime_checkable
+class SupportsLocalLogits(Protocol):
+    """Optional capability to return post-processed, TP-local logits."""
+
+    def compute_local_logits(self, hidden_states: torch.Tensor) -> Any | None:
+        """Return local logits plus their vocabulary-shard layout."""
+        ...
+
+
 @overload
 def is_text_generation_model(
     model: type[object],

--- a/vllm/models/deepseek_v32/nvidia/model.py
+++ b/vllm/models/deepseek_v32/nvidia/model.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.logits_processor import LocalLogits
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
@@ -424,6 +425,11 @@ class DeepseekV32ForCausalLM(DeepseekV2ForCausalLM):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         if self.config.model_type == "glm_moe_dsa":
             enable_glm52_low_latency_gemm(self, vllm_config.model_config.dtype)
+
+    def compute_local_logits(self, hidden_states: torch.Tensor) -> LocalLogits | None:
+        if self.config.model_type != "glm_moe_dsa":
+            return None
+        return self.logits_processor.get_local_logits(self.lm_head, hidden_states)
 
     def set_moe_parameters(self):
         # Same as the base, but keyed on the MoE block type rather than the

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -20,6 +20,7 @@ instead of embedding feature-specific logic directly.
 import functools
 import gc
 import time
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from copy import deepcopy
 from typing import Any, NamedTuple
@@ -43,11 +44,13 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
     RoutedExpertsCapturer,
     bind_routed_experts_capturer,
 )
+from vllm.model_executor.layers.logits_processor import LocalLogits
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.models.interfaces import requires_raw_input_tokens
+from vllm.model_executor.models.interfaces_base import SupportsLocalLogits
 from vllm.model_executor.offloader import (
     create_offloader,
     get_offloader,
@@ -168,6 +171,23 @@ from vllm.v1.worker.utils import (
 from vllm.v1.worker.workspace import use_workspace_lane
 
 logger = init_logger(__name__)
+
+
+def _get_prompt_logprobs_local_logits_fn(
+    model: nn.Module, dcp_size: int
+) -> Callable[[torch.Tensor], LocalLogits | None] | None:
+    """Return the narrow GLM local-logits capability for V2 prompt scores."""
+    if dcp_size != 1:
+        return None
+    local_logits_fn = getattr(model, "compute_local_logits", None)
+    if not callable(local_logits_fn):
+        return None
+    if isinstance(model, SupportsLocalLogits):
+        return local_logits_fn
+    config = getattr(model, "config", None)
+    if getattr(config, "model_type", None) == "glm_moe_dsa":
+        return local_logits_fn
+    return None
 
 
 class GPUModelRunner(LoRAModelRunnerMixin):
@@ -1872,8 +1892,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
 
         assert self.prompt_logprobs_worker is not None
+        model = self.get_model()
+        local_logits_fn = _get_prompt_logprobs_local_logits_fn(model, self.dcp_size)
         prompt_logprobs_dict = self.prompt_logprobs_worker.compute_prompt_logprobs(
-            self.model.compute_logits,
+            model.compute_logits,
+            local_logits_fn,
             hidden_states,
             input_batch,
             self.req_states.all_token_ids.gpu,

--- a/vllm/v1/worker/gpu/sample/prompt_logprob.py
+++ b/vllm/v1/worker/gpu/sample/prompt_logprob.py
@@ -6,11 +6,24 @@ import numpy as np
 import torch
 
 from vllm.config.model import LogprobsMode
+from vllm.distributed import get_tp_group
+from vllm.logger import init_logger
+from vllm.model_executor.layers.logits_processor import LocalLogits
 from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.sample.logprob import compute_topk_scores
+
+logger = init_logger(__name__)
+
+# The TP-local target-only route removes the full-vocabulary gather, but its
+# collectives are not worthwhile for short MRV2 prompt chunks. This is applied
+# to each actual chunk below, not to a request-wide prompt length.
+MIN_LOCAL_PROMPT_LOGPROB_ROWS = 512
+SHORT_CHUNK_GATHERED_MARKER = (
+    "MRV2_PROMPT_LOGPROBS_SHORT_CHUNK_FALLBACK route=gathered reason=rows_lt_512"
+)
 
 
 class PromptLogprobsWorker:
@@ -36,6 +49,7 @@ class PromptLogprobsWorker:
     def compute_prompt_logprobs(
         self,
         logits_fn: Callable[[torch.Tensor], torch.Tensor],
+        local_logits_fn: Callable[[torch.Tensor], LocalLogits | None] | None,
         hidden_states: torch.Tensor,
         input_batch: InputBatch,
         # [max_num_reqs, max_model_len]
@@ -83,6 +97,7 @@ class PromptLogprobsWorker:
                 prompt_logprobs_token_ids,
                 hidden_states[: input_batch.num_tokens],
                 logits_fn,
+                local_logits_fn,
                 max_num_prompt_logprobs,
                 self.logprobs_mode,
             )
@@ -200,6 +215,7 @@ def compute_prompt_logprobs_with_chunking(
     prompt_token_ids: torch.Tensor,
     prompt_hidden_states: torch.Tensor,
     logits_fn: Callable[[torch.Tensor], torch.Tensor],
+    local_logits_fn: Callable[[torch.Tensor], LocalLogits | None] | None,
     num_prompt_logprobs: int,
     logprobs_mode: LogprobsMode = "raw_logprobs",
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -213,8 +229,35 @@ def compute_prompt_logprobs_with_chunking(
     prompt_token_ids = prompt_token_ids.to(torch.int64)
     for start_idx in range(0, prompt_token_ids.shape[0], CHUNK_SIZE):
         end_idx = start_idx + CHUNK_SIZE
+        chunk_hidden_states = prompt_hidden_states[start_idx:end_idx]
+        chunk_token_ids = prompt_token_ids[start_idx:end_idx]
+        if num_prompt_logprobs == 0 and local_logits_fn is not None:
+            if chunk_hidden_states.shape[0] >= MIN_LOCAL_PROMPT_LOGPROB_ROWS:
+                local_logits = local_logits_fn(chunk_hidden_states)
+                if local_logits is not None:
+                    logger.info_once(
+                        "MRV2 prompt_logprobs=0 is using TP-local target-only "
+                        "logits (no full-vocabulary gather)."
+                    )
+                    result = compute_distributed_token_logprobs(
+                        local_logits, chunk_token_ids, logprobs_mode
+                    )
+                    token_ids.append(result.logprob_token_ids)
+                    scores.append(result.logprobs)
+                    ranks.append(result.selected_token_ranks)
+                    continue
+            else:
+                # Preserve the gathered fallback without even projecting local
+                # logits. A request can thus distribute a full-sized prefix
+                # while gathering only its short final chunk.
+                logger.info_once(
+                    "%s rows=%d threshold=%d",
+                    SHORT_CHUNK_GATHERED_MARKER,
+                    chunk_hidden_states.shape[0],
+                    MIN_LOCAL_PROMPT_LOGPROB_ROWS,
+                )
         # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
-        prompt_logits = logits_fn(prompt_hidden_states[start_idx:end_idx])
+        prompt_logits = logits_fn(chunk_hidden_states)
         requested_num = (
             prompt_logits.shape[-1]
             if num_prompt_logprobs == -1
@@ -223,7 +266,7 @@ def compute_prompt_logprobs_with_chunking(
         result = compute_topk_scores(
             prompt_logits,
             requested_num,
-            prompt_token_ids[start_idx:end_idx],
+            chunk_token_ids,
             logits_mode=logits_mode,
         )
         token_ids.append(result.logprob_token_ids)
@@ -234,3 +277,58 @@ def compute_prompt_logprobs_with_chunking(
     scores = torch.cat(scores, dim=0) if len(scores) > 1 else scores[0]
     ranks = torch.cat(ranks, dim=0) if len(ranks) > 1 else ranks[0]
     return token_ids, scores, ranks
+
+
+def _local_token_indices(
+    token_ids: torch.Tensor, local_logits: LocalLogits
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Map global token ids to this rank's original vocabulary shard."""
+    indices = local_logits.shard_indices
+    owned = (token_ids >= indices.org_vocab_start_index) & (
+        token_ids < indices.org_vocab_end_index
+    )
+    return token_ids - indices.org_vocab_start_index, owned
+
+
+def _all_reduce_max(values: torch.Tensor) -> torch.Tensor:
+    tp_group = get_tp_group()
+    if tp_group.world_size > 1:
+        torch.distributed.all_reduce(
+            values, op=torch.distributed.ReduceOp.MAX, group=tp_group.device_group
+        )
+    return values
+
+
+def compute_distributed_token_logprobs(
+    local_logits: LocalLogits,
+    token_ids: torch.Tensor,
+    logprobs_mode: LogprobsMode = "raw_logprobs",
+) -> LogprobsTensors:
+    """Compute exact target scores from TP-local original-vocabulary logits."""
+    logits = local_logits.logits[..., : local_logits.shard_indices.num_org_elements]
+    local_token_ids, owned = _local_token_indices(token_ids, local_logits)
+    row_ids = torch.arange(token_ids.numel(), device=token_ids.device)
+    selected_scores = torch.zeros(
+        token_ids.numel(), dtype=torch.float32, device=logits.device
+    )
+    selected_scores[owned] = logits[row_ids[owned], local_token_ids[owned]].float()
+    selected_scores = get_tp_group().all_reduce(selected_scores)
+
+    # vLLM's custom GPU all-reduce accepts floating-point tensors, not int64.
+    # Vocabulary ranks are exactly representable in fp32 at supported sizes.
+    selected_ranks = (logits >= selected_scores[:, None]).sum(
+        dim=-1, dtype=torch.float32
+    )
+    selected_ranks = get_tp_group().all_reduce(selected_ranks).to(torch.int64)
+
+    if logprobs_mode not in ("raw_logits", "processed_logits"):
+        row_max = _all_reduce_max(logits.float().amax(dim=-1))
+        local_exp_sum = torch.exp(logits.float() - row_max[:, None]).sum(dim=-1)
+        exp_sum = get_tp_group().all_reduce(local_exp_sum)
+        selected_scores -= row_max + torch.log(exp_sum)
+
+    return LogprobsTensors(
+        logprob_token_ids=token_ids.unsqueeze(-1),
+        logprobs=selected_scores.unsqueeze(-1),
+        selected_token_ranks=selected_ranks,
+    )


### PR DESCRIPTION
# MRV2: exact target-only prompt logprobs without a TP vocab gather

## Summary

This change adds an exact target-token path for V2/MRV2 GLM
`prompt_logprobs=0`. Production commit `7f727ac0ce` is a single commit atop
upstream `c5d840ff6a`. It avoids gathering a full TP vocabulary and avoids
materializing `[rows, vocab]` logits for eligible chunks, while preserving the
existing gathered behavior everywhere else.

## Dataflow

AS-IS:

```text
hidden states -> per-TP-rank vocabulary logits -> TP vocabulary gather or
all-gather -> full [rows, vocab] logits -> target score, rank, and logsumexp
```

PR (eligible GLM target-only chunk):

```text
hidden states -> per-TP-rank local vocabulary logits -> owner target SUM,
row MAX/SUM normalizer, and rank-count SUM -> exact target score and rank
```

Only original-vocabulary entries participate in ownership, rank, and
normalization. Padded and added-vocabulary tails are excluded.

## Scope and fallback

- Opt-in is limited to GLM `GlmMoeDsaForCausalLM` and the NVIDIA DSA GLM path.
- DCP must be one. Non-GLM models and DCP greater than one retain gathering.
- Only `prompt_logprobs=0` is local. Prompt top-N and `prompt_logprobs=-1`
  always use the existing gathered computation.
- Dispatch is per actual MRV2 chunk. Chunks below 512 rows gather before local
  projection, so a 1050-token prompt uses local scoring for 1024 rows and
  gathering for the 26-row tail.

## Validation

CPU validation on this replayed source:

```text
PYTHONPATH=$PWD .venv/bin/python -m pytest \
  tests/v1/sample/test_prompt_logprob_local.py -q
# 12 passed

.venv/bin/python -m ruff check <seven changed Python files>
.venv/bin/python -m ruff format --check <seven changed Python files>
git diff --check
git commit -s ...
# repository pre-commit suite passed, including Python mypy and DCO
```

Coverage includes one-rank exactness; TP2 Gloo cross-owner selection; an
asymmetric original-vocabulary layout with a dominant padded/added tail;
raw-logit and raw-logprob dispatch at 511 and 512 rows; 1025 mixed
local-prefix/gathered-tail accounting; GLM and DCP eligibility; and gathered
prompt top-N and `-1` fallbacks.

Historical operator-only evidence on the prior accepted current-main replay
selected the 512-row guard using TP4, vocabulary 154880, and 20 warmups plus
100 samples per cell. It is not a performance claim for `c5d840ff6a` and must
be rerun before making an upstream performance claim. Historical GLM public
model validation and same-projection oracle work are validation-only and are
intentionally excluded from this production commit; the current-main model
route should be rerun before relying on it as a model-evaluation result.

## Duplicate-work and review

Open PR #44106 is a prompt-token-ID race fix and retains the vocabulary gather;
this change is materially different because it supplies an exact TP-local
target-only computation. No other open prompt-logprob or local-logits PR was
found in the required duplicate-work searches. The human submitter should
coordinate with #44106 if its target-ID API changes before this is proposed.

AI assistance was used for investigation, implementation, testing, and this
draft. A human must review every changed line and run the required model
evaluation before publication.
