### PR TITLE
[Sampling] Add Mirostat v2 sampling

### DIFF
--- a/tests/v1/sample/test_mirostat.py
+++ b/tests/v1/sample/test_mirostat.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Mirostat v2 sampling (state holder + SamplingParams validation)."""
+
+import math
+
+import pytest
+import torch
+
+from vllm.exceptions import VLLMValidationError
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor.interface import BatchUpdate, MoveDirectionality
+from vllm.v1.sample.mirostat_state import MirostatStateHolder
+
+
+def _batch_update(added=(), removed=(), moved=(), batch_size=8) -> BatchUpdate:
+    return BatchUpdate(
+        batch_size=batch_size,
+        removed=list(removed),
+        added=list(added),
+        moved=list(moved),
+    )
+
+
+def _mirostat_params(mode=2, tau=5.0, eta=0.1) -> SamplingParams:
+    return SamplingParams(
+        temperature=1.0,
+        top_k=0,
+        top_p=1.0,
+        mirostat_mode=mode,
+        mirostat_tau=tau,
+        mirostat_eta=eta,
+    )
+
+
+def _holder(max_num_reqs=8) -> MirostatStateHolder:
+    return MirostatStateHolder(max_num_reqs=max_num_reqs, device="cpu")
+
+
+# ---------------------------------------------------------------------------
+# SamplingParams validation
+# ---------------------------------------------------------------------------
+
+
+def test_default_disabled_is_noop():
+    sp = SamplingParams()
+    assert sp.mirostat_mode == 0
+    assert sp.mirostat_tau == 5.0
+    assert sp.mirostat_eta == 0.1
+
+
+def test_valid_mirostat_v2_params():
+    sp = _mirostat_params()
+    assert sp.mirostat_mode == 2
+
+
+def test_invalid_mode_rejected():
+    with pytest.raises(VLLMValidationError):
+        SamplingParams(mirostat_mode=1, temperature=1.0)
+
+
+def test_mirostat_requires_positive_temperature():
+    with pytest.raises(VLLMValidationError):
+        SamplingParams(mirostat_mode=2, temperature=0.0)
+
+
+def test_mirostat_requires_topk_disabled():
+    with pytest.raises(VLLMValidationError):
+        SamplingParams(mirostat_mode=2, temperature=1.0, top_k=50)
+
+
+def test_mirostat_requires_topp_disabled():
+    with pytest.raises(VLLMValidationError):
+        SamplingParams(mirostat_mode=2, temperature=1.0, top_p=0.9)
+
+
+def test_mirostat_rejects_nonpositive_tau_eta():
+    with pytest.raises(VLLMValidationError):
+        SamplingParams(mirostat_mode=2, temperature=1.0, mirostat_tau=0.0)
+    with pytest.raises(VLLMValidationError):
+        SamplingParams(mirostat_mode=2, temperature=1.0, mirostat_eta=0.0)
+
+
+# ---------------------------------------------------------------------------
+# MirostatStateHolder batch bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_sync_batch_add_remove():
+    holder = _holder()
+    assert not holder.has_tracked_requests()
+
+    holder.sync_batch(_batch_update(added=[(0, _mirostat_params(tau=4.0), None, [])]))
+    assert holder.has_tracked_requests()
+    # mu initialized to 2*tau.
+    assert holder.mu[0].item() == pytest.approx(8.0)
+    assert holder.tau[0].item() == pytest.approx(4.0)
+
+    holder.sync_batch(_batch_update(removed=[0]))
+    assert not holder.has_tracked_requests()
+    assert math.isinf(holder.mu[0].item())
+
+
+def test_sync_batch_non_mirostat_not_tracked():
+    holder = _holder()
+    holder.sync_batch(
+        _batch_update(added=[(0, SamplingParams(temperature=1.0), None, [])])
+    )
+    assert not holder.has_tracked_requests()
+    assert math.isinf(holder.mu[0].item())
+
+
+def test_sync_batch_move_and_swap():
+    holder = _holder()
+    holder.sync_batch(
+        _batch_update(
+            added=[
+                (0, _mirostat_params(tau=3.0), None, []),
+                (1, _mirostat_params(tau=6.0), None, []),
+            ]
+        )
+    )
+    # Swap 0 and 1.
+    holder.sync_batch(_batch_update(moved=[(0, 1, MoveDirectionality.SWAP)]))
+    assert holder.tau[0].item() == pytest.approx(6.0)
+    assert holder.tau[1].item() == pytest.approx(3.0)
+    assert holder.has_tracked_requests()
+
+    # Unidirectional move 1 -> 2.
+    holder.sync_batch(_batch_update(moved=[(1, 2, MoveDirectionality.UNIDIRECTIONAL)]))
+    assert 1 not in holder._active
+    assert math.isinf(holder.mu[1].item())
+    assert holder.tau[2].item() == pytest.approx(3.0)
+
+
+# ---------------------------------------------------------------------------
+# Truncation (apply_to_logits) and mu update
+# ---------------------------------------------------------------------------
+
+
+def test_apply_to_logits_truncates_high_surprise_but_keeps_argmax():
+    holder = _holder()
+    # Small mu -> aggressive truncation, on slot 0 only.
+    holder._set_active(0, tau=5.0, eta=0.1)
+    holder.mu[0] = 0.5
+
+    logits = torch.tensor(
+        [[10.0, 9.9, 1.0, -5.0], [1.0, 2.0, 3.0, 4.0]], dtype=torch.float32
+    )
+    original_row1 = logits[1].clone()
+    out = holder.apply_to_logits(logits)
+
+    # Argmax token of row 0 must survive.
+    assert torch.isfinite(out[0, 0])
+    # The very low-probability token should be truncated to -inf.
+    assert out[0, 3] == float("-inf")
+    # Untracked row is untouched.
+    assert torch.equal(out[1], original_row1)
+
+
+def test_apply_to_logits_noop_when_empty():
+    holder = _holder()
+    logits = torch.randn(3, 16)
+    out = holder.apply_to_logits(logits.clone())
+    assert torch.equal(out, logits)
+
+
+def test_update_mu_moves_toward_target():
+    holder = _holder()
+    tau, eta = 5.0, 0.1
+    holder._set_active(0, tau=tau, eta=eta)  # mu = 2*tau = 10
+
+    # Uniform distribution over V tokens -> surprise = log2(V) for any token.
+    vocab = 1024
+    logits = torch.zeros(1, vocab, dtype=torch.float32)
+    sampled = torch.tensor([0])
+
+    expected_surprise = math.log2(vocab)  # 10.0 bits
+    mu_before = holder.mu[0].item()
+    holder.apply_to_logits(logits)
+    holder.update_mu(sampled)
+    mu_after = holder.mu[0].item()
+
+    # surprise (10) > tau (5) -> mu should decrease by eta*(surprise - tau).
+    assert mu_after == pytest.approx(mu_before - eta * (expected_surprise - tau))
+    assert mu_after < mu_before
+
+
+def test_update_mu_increases_when_confident():
+    holder = _holder()
+    tau, eta = 5.0, 0.1
+    holder._set_active(0, tau=tau, eta=eta)  # mu = 2*tau = 10
+
+    # Highly peaked distribution -> tiny surprise for the top token.
+    logits = torch.full((1, 512), -50.0, dtype=torch.float32)
+    logits[0, 0] = 50.0
+    sampled = torch.tensor([0])
+
+    mu_before = holder.mu[0].item()
+    holder.apply_to_logits(logits)
+    holder.update_mu(sampled)
+    # surprise ~ 0 < tau -> mu increases (loosens truncation, escapes loops).
+    assert holder.mu[0].item() > mu_before

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -266,6 +266,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
     use_beam_search: bool = False
     top_k: int | None = None
     min_p: float | None = None
+    mirostat_mode: int = 0
+    mirostat_tau: float = 5.0
+    mirostat_eta: float = 0.1
     repetition_penalty: float | None = None
     length_penalty: float = 1.0
     stop_token_ids: list[int] | None = []
@@ -718,6 +721,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             top_p=top_p,
             top_k=top_k,
             min_p=min_p,
+            mirostat_mode=self.mirostat_mode,
+            mirostat_tau=self.mirostat_tau,
+            mirostat_eta=self.mirostat_eta,
             seed=self.seed,
             stop=self.stop,
             stop_token_ids=stop_token_ids,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -74,6 +74,9 @@ class CompletionRequest(OpenAIBaseModel):
     use_beam_search: bool = False
     top_k: int | None = None
     min_p: float | None = None
+    mirostat_mode: int = 0
+    mirostat_tau: float = 5.0
+    mirostat_eta: float = 0.1
     repetition_penalty: float | None = None
     length_penalty: float = 1.0
     stop_token_ids: list[int] | None = []
@@ -375,6 +378,9 @@ class CompletionRequest(OpenAIBaseModel):
             top_p=top_p,
             top_k=top_k,
             min_p=min_p,
+            mirostat_mode=self.mirostat_mode,
+            mirostat_tau=self.mirostat_tau,
+            mirostat_eta=self.mirostat_eta,
             seed=self.seed,
             stop=self.stop,
             stop_token_ids=stop_token_ids,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -263,6 +263,23 @@ class SamplingParams(
     """Represents the minimum probability for a token to be considered,
     relative to the probability of the most likely token. Must be in [0, 1].
     Set to 0 to disable this."""
+    mirostat_mode: int = 0
+    """Mirostat sampling mode. 0 disables Mirostat (default); 2 selects
+    Mirostat v2. When enabled, Mirostat replaces top-k/top-p truncation by
+    keeping the per-token surprise near ``mirostat_tau`` via a feedback
+    controller, which helps prevent runaway repetition. Requires
+    ``temperature > 0`` and ``top_k`` in {0, -1} and ``top_p == 1.0``.
+    Temperature is applied before Mirostat, so ``temperature`` close to 1.0 is
+    recommended; a much lower temperature sharpens the distribution, drives the
+    observed surprise toward 0, and makes Mirostat approach greedy sampling
+    (reintroducing the repetition it is meant to prevent)."""
+    mirostat_tau: float = 5.0
+    """Mirostat target surprise (per-token cross-entropy in bits). Lower values
+    make the output more focused, higher values more diverse. Only used when
+    ``mirostat_mode != 0``."""
+    mirostat_eta: float = 0.1
+    """Mirostat learning rate for the ``mu`` update. Only used when
+    ``mirostat_mode != 0``."""
     seed: int | None = None
     """Random seed to use for the generation."""
     stop: str | list[str] | None = None
@@ -388,6 +405,9 @@ class SamplingParams(
         top_p: float | None = 1.0,
         top_k: int = 0,
         min_p: float = 0.0,
+        mirostat_mode: int = 0,
+        mirostat_tau: float = 5.0,
+        mirostat_eta: float = 0.1,
         seed: int | None = None,
         stop: str | list[str] | None = None,
         stop_token_ids: list[int] | None = None,
@@ -453,6 +473,9 @@ class SamplingParams(
             top_p=1.0 if top_p is None else top_p,
             top_k=top_k,
             min_p=min_p,
+            mirostat_mode=mirostat_mode,
+            mirostat_tau=mirostat_tau,
+            mirostat_eta=mirostat_eta,
             seed=seed,
             stop=stop,
             stop_token_ids=stop_token_ids,
@@ -597,6 +620,39 @@ class SamplingParams(
             )
         if not 0.0 <= self.min_p <= 1.0:
             raise VLLMValidationError(f"min_p must be in [0, 1], got {self.min_p}.")
+        if self.mirostat_mode not in (0, 2):
+            raise VLLMValidationError(
+                "mirostat_mode must be 0 (disabled) or 2 (Mirostat v2), got "
+                f"{self.mirostat_mode}.",
+                parameter="mirostat_mode",
+                value=self.mirostat_mode,
+            )
+        if self.mirostat_mode != 0:
+            if self.temperature < _SAMPLING_EPS:
+                raise VLLMValidationError(
+                    "Mirostat sampling requires temperature > 0, got "
+                    f"{self.temperature}."
+                )
+            if self.top_k not in (0, -1):
+                raise VLLMValidationError(
+                    "Mirostat sampling requires top_k to be disabled (0 or -1), "
+                    f"got {self.top_k}. Mirostat replaces top-k/top-p truncation."
+                )
+            if self.top_p != 1.0:
+                raise VLLMValidationError(
+                    "Mirostat sampling requires top_p == 1.0 (disabled), got "
+                    f"{self.top_p}. Mirostat replaces top-k/top-p truncation."
+                )
+            if not math.isfinite(self.mirostat_tau) or self.mirostat_tau <= 0.0:
+                raise VLLMValidationError(
+                    "mirostat_tau must be a finite number greater than zero, got "
+                    f"{self.mirostat_tau}."
+                )
+            if not math.isfinite(self.mirostat_eta) or self.mirostat_eta <= 0.0:
+                raise VLLMValidationError(
+                    "mirostat_eta must be a finite number greater than zero, got "
+                    f"{self.mirostat_eta}."
+                )
         if self.max_tokens is not None and self.max_tokens < 1:
             raise VLLMValidationError(
                 f"max_tokens must be at least 1, got {self.max_tokens}.",
@@ -1206,6 +1262,9 @@ class SamplingParams(
             f"top_p={self.top_p}, "
             f"top_k={self.top_k}, "
             f"min_p={self.min_p}, "
+            f"mirostat_mode={self.mirostat_mode}, "
+            f"mirostat_tau={self.mirostat_tau}, "
+            f"mirostat_eta={self.mirostat_eta}, "
             f"seed={self.seed}, "
             f"stop={self.stop}, "
             f"stop_token_ids={self.stop_token_ids}, "

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import torch
 
 from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.mirostat_state import MirostatStateHolder
 from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
 
 
@@ -53,3 +54,8 @@ class SamplingMetadata:
     # When non-None, use ``holder.has_tracked_requests()`` to see if this batch applies
     # thinking-token-budget logits (holder may exist with an empty tracking set).
     thinking_budget_state_holder: ThinkingBudgetStateHolder | None = None
+
+    # Mirostat v2 per-request state; ``holder.has_tracked_requests()`` reports
+    # whether any request in this batch uses Mirostat (holder is always present
+    # but a no-op with an empty tracking set).
+    mirostat_state_holder: MirostatStateHolder | None = None

--- a/vllm/v1/sample/mirostat_state.py
+++ b/vllm/v1/sample/mirostat_state.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-batch Mirostat v2 sampling state.
+
+Mirostat (Basu et al., 2020, https://arxiv.org/abs/2007.14966) is a feedback
+controller over the *surprise* (``-log2(p)``, i.e. per-token cross-entropy in
+bits) of the sampled token. It keeps the running surprise near a target ``tau``
+by maintaining a per-request threshold ``mu`` that is updated after every step:
+
+    mu <- mu - eta * (observed_surprise - tau)
+
+This resists both degeneration into repetition (surprise collapses toward 0)
+and incoherence (surprise spikes), which is why it is effective against the
+"infinite repetition" failure mode.
+
+Only Mirostat v2 is implemented (``mirostat_mode == 2``): at each step every
+token whose surprise exceeds ``mu`` is truncated (its logit set to ``-inf``),
+then a token is sampled from the remaining distribution, then ``mu`` is updated
+from the sampled token's surprise. The truncation only removes low-probability
+tokens and always keeps the argmax, so it is argmax-invariant and composes with
+the rest of the (random) sampling pipeline.
+
+Performance: all per-step math runs on-device and the ``mu`` state persists as a
+GPU tensor, so decoding never forces a host<->device synchronization (the naive
+approach of reading surprise back to Python each step serializes the CPU/GPU
+pipeline and drops decode throughput). Inactive rows carry ``mu = +inf`` and
+``eta = 0``, which makes truncation a no-op (threshold ``-inf`` keeps every
+token) and the ``mu`` update a no-op (delta scaled by ``eta = 0``), so a single
+vectorized path covers the whole batch without per-request gathers -- this also
+keeps shapes static for CUDA graph capture. The state is consumed inside
+:class:`~vllm.v1.sample.sampler.Sampler` rather than as a ``LogitsProcessor``
+because the ``mu`` update needs the sampled token, which only exists after
+sampling. This mirrors
+:class:`~vllm.v1.sample.thinking_budget_state.ThinkingBudgetStateHolder`.
+"""
+
+import math
+
+import torch
+
+from vllm.v1.sample.logits_processor.interface import BatchUpdate, MoveDirectionality
+
+# ``mirostat_mode`` value that selects Mirostat v2.
+MIROSTAT_V2 = 2
+
+_LN2 = math.log(2.0)
+
+
+class MirostatStateHolder:
+    """Tracks per-request Mirostat v2 ``mu`` state across decoding steps.
+
+    ``mu``/``tau``/``eta`` are kept as device tensors indexed by batch-slot and
+    stay in sync with the running batch via :meth:`sync_batch`. Inactive slots
+    hold ``mu = +inf`` / ``eta = 0`` so the per-step math is a no-op for them.
+    A holder with no tracked requests is a no-op, so a single instance can be
+    created unconditionally per :class:`InputBatch`.
+    """
+
+    def __init__(self, max_num_reqs: int = 1, device: torch.device | str | None = None):
+        self.device = (
+            torch.device(device) if device is not None else torch.device("cpu")
+        )
+        self.max_num_reqs = max_num_reqs
+        # Slot state (device tensors). Inactive slot: mu=+inf, tau=0, eta=0.
+        self.mu = torch.full(
+            (max_num_reqs,), float("inf"), dtype=torch.float32, device=self.device
+        )
+        self.tau = torch.zeros((max_num_reqs,), dtype=torch.float32, device=self.device)
+        self.eta = torch.zeros((max_num_reqs,), dtype=torch.float32, device=self.device)
+        # CPU-side set of active slots: the gate + move bookkeeping never touch
+        # the device (no sync).
+        self._active: set[int] = set()
+        # log-probs of the pre-truncation distribution, cached by
+        # ``apply_to_logits`` and consumed by ``update_mu`` in the same step.
+        self._cached_logprobs: torch.Tensor | None = None
+
+    def has_tracked_requests(self) -> bool:
+        """True when at least one request in the batch uses Mirostat."""
+        return bool(self._active)
+
+    def _set_inactive(self, index: int) -> None:
+        self.mu[index] = float("inf")
+        self.tau[index] = 0.0
+        self.eta[index] = 0.0
+        self._active.discard(index)
+
+    def _set_active(self, index: int, tau: float, eta: float) -> None:
+        self.tau[index] = tau
+        self.eta[index] = eta
+        # Initialize mu to 2*tau, as in the reference implementation.
+        self.mu[index] = 2.0 * tau
+        self._active.add(index)
+
+    def sync_batch(self, batch_update: BatchUpdate | None) -> None:
+        """Add/remove/move per-request ``mu`` state to match the batch."""
+        if not batch_update:
+            return
+
+        for index in batch_update.removed:
+            self._set_inactive(index)
+
+        for index, params, _prompt_tok_ids, _output_tok_ids in batch_update.added:
+            mode = getattr(params, "mirostat_mode", 0) or 0
+            if mode == MIROSTAT_V2:
+                self._set_active(
+                    index, float(params.mirostat_tau), float(params.mirostat_eta)
+                )
+            else:
+                self._set_inactive(index)
+
+        for i1, i2, direction in batch_update.moved:
+            a1 = i1 in self._active
+            if direction == MoveDirectionality.SWAP:
+                a2 = i2 in self._active
+                for t in (self.mu, self.tau, self.eta):
+                    tmp = t[i1].clone()
+                    t[i1] = t[i2]
+                    t[i2] = tmp
+                self._active.discard(i1)
+                self._active.discard(i2)
+                if a2:
+                    self._active.add(i1)
+                if a1:
+                    self._active.add(i2)
+            else:
+                self.mu[i2] = self.mu[i1]
+                self.tau[i2] = self.tau[i1]
+                self.eta[i2] = self.eta[i1]
+                self._active.discard(i2)
+                if a1:
+                    self._active.add(i2)
+                self._set_inactive(i1)
+
+    def apply_to_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Truncate tokens with surprise greater than ``mu`` (Mirostat v2 step).
+
+        For every tracked request tokens whose surprise ``-log2(p)`` exceeds that
+        request's ``mu`` have their logit set to ``-inf``; the argmax is always
+        kept so at least one token survives and the transform stays
+        argmax-invariant. The pre-truncation log-probs are cached for
+        :meth:`update_mu` so the surprise is only computed once per step.
+
+        Args:
+            logits: ``[num_rows, vocab_size]`` float logits (modified in place).
+
+        Returns:
+            The same ``logits`` tensor.
+        """
+        if not self._active:
+            return logits
+
+        n = logits.shape[0]
+        logprobs = torch.log_softmax(logits, dim=-1)
+        self._cached_logprobs = logprobs
+        # Keep tokens with surprise <= mu, i.e. logprob >= -mu*ln2. Inactive rows
+        # have mu=+inf -> threshold -inf -> keep everything (untouched).
+        threshold = (-self.mu[:n] * _LN2).unsqueeze(-1)
+        keep = logprobs >= threshold
+        argmax = logits.argmax(dim=-1, keepdim=True)
+        keep.scatter_(-1, argmax, True)
+        logits.masked_fill_(~keep, float("-inf"))
+        return logits
+
+    def update_mu(self, sampled: torch.Tensor) -> None:
+        """Update each request's ``mu`` from the sampled token's surprise.
+
+        Fully on-device (no host sync). Uses the log-probs cached by
+        :meth:`apply_to_logits`. Inactive rows have ``eta = 0`` so their update
+        is a no-op and ``mu`` stays ``+inf``.
+
+        Args:
+            sampled: ``[num_rows]`` sampled token ids.
+        """
+        if not self._active or self._cached_logprobs is None:
+            return
+        logprobs = self._cached_logprobs
+        n = logprobs.shape[0]
+        tok = sampled[:n].long().unsqueeze(-1)
+        sampled_logprob = logprobs.gather(-1, tok).squeeze(-1)
+        # observed surprise in bits = -logprob / ln2.
+        surprise = -sampled_logprob / _LN2
+        self.mu[:n] = self.mu[:n] - self.eta[:n] * (surprise - self.tau[:n])
+        self._cached_logprobs = None

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -283,6 +283,15 @@ class Sampler(nn.Module):
         for processor in sampling_metadata.logitsprocs.argmax_invariant:
             logits = processor.apply(logits)
 
+        # Mirostat v2 truncation (argmax-invariant): drop tokens whose surprise
+        # exceeds the per-request ``mu``. Requests using Mirostat disable
+        # top_k/top_p, so ``logits`` for those rows is unchanged by the sampler
+        # below and can be reused to update ``mu`` from the sampled token.
+        mirostat = sampling_metadata.mirostat_state_holder
+        mirostat_active = mirostat is not None and mirostat.has_tracked_requests()
+        if mirostat_active:
+            logits = mirostat.apply_to_logits(logits)
+
         # Apply top_k and/or top_p.
         random_sampled, processed_logprobs = self.topk_topp_sampler(
             logits,
@@ -290,6 +299,9 @@ class Sampler(nn.Module):
             sampling_metadata.top_k,
             sampling_metadata.top_p,
         )
+
+        if mirostat_active:
+            mirostat.update_mu(random_sampled)
 
         if greedy_sampled is None:
             return random_sampled, processed_logprobs

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -24,6 +24,7 @@ from vllm.v1.sample.logits_processor import (
     MoveDirectionality,
 )
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.mirostat_state import MirostatStateHolder
 from vllm.v1.sample.thinking_budget_state import (
     maybe_create_thinking_budget_state_holder,
 )
@@ -109,6 +110,10 @@ class InputBatch:
         use_replayssm: bool = False,
         slot_mapping_modes: list[SlotMappingMode] | None = None,
     ):
+        # Always created; a no-op unless a request sets mirostat_mode != 0.
+        self.mirostat_state_holder = MirostatStateHolder(
+            max_num_reqs=max_num_reqs, device=device
+        )
         self.thinking_budget_state_holder = maybe_create_thinking_budget_state_holder(
             reasoning_config,
             max_num_reqs,
@@ -848,6 +853,8 @@ class InputBatch:
         # reset batch update tracking.
         # Update sampling metadata if batch state is changed.
         batch_update = self.batch_update_builder.get_and_reset(self.num_reqs)
+        if batch_update:
+            self.mirostat_state_holder.sync_batch(batch_update)
         if self.thinking_budget_state_holder is not None and batch_update:
             self.thinking_budget_state_holder.sync_batch(batch_update)
         for logit_proc in self.logitsprocs.all:
@@ -958,6 +965,7 @@ class InputBatch:
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,
             thinking_budget_state_holder=self.thinking_budget_state_holder,
+            mirostat_state_holder=self.mirostat_state_holder,
         )
 
     def get_pooling_params(self) -> list[PoolingParams]:


### PR DESCRIPTION
## Purpose

Add opt-in **Mirostat v2** sampling (`mirostat_mode` / `mirostat_tau` /
`mirostat_eta`) to the V1 sampler. Mirostat (Basu et al., 2020,
https://arxiv.org/abs/2007.14966) is a feedback controller that keeps the
per-token *surprise* (`-log2 p`, i.e. per-token cross-entropy in bits) near a
target `tau` by maintaining a per-request threshold `mu` updated every step:

```
mu <- mu - eta * (observed_surprise - tau)
```

This bounds the per-token surprise from above, which keeps decoding out of the
*confusion trap* — the incoherent, non-terminating output that plain
temperature/top-p sampling falls into at high temperature. Measured on
DeepSeek-V4-Flash at `temperature=1.8-2.0`, it cuts the share of requests that
run all the way to `max_tokens` by ~85% and halves generated tokens (numbers in
[Model evaluation](#model-evaluation)). At `temperature <= 1.5` it is inert by
design and leaves well-behaved decoding untouched.

**Default `mirostat_mode=0` is a no-op**, so existing behavior is unchanged.

Usage:

```python
SamplingParams(mirostat_mode=2, mirostat_tau=5.0, mirostat_eta=0.1,
               temperature=1.0, top_k=0, top_p=1.0)
```

Also exposed on the OpenAI `/v1/completions` and `/v1/chat/completions` request
bodies as `mirostat_mode` / `mirostat_tau` / `mirostat_eta`.

Closes the long-standing request in #5209 (Mirostat), which was auto-closed for
inactivity, not rejected.

## Not a duplicate

Searched open PRs/issues (`gh pr list --search "mirostat"`, `gh search issues
mirostat`). No open PR implements Mirostat. #5209 is a stale-closed feature
request with no implementation; this PR implements Mirostat v2 for the V1
sampler.

## Design notes (for reviewers)

- **State lives in the `Sampler`, not a `LogitsProcessor`.** The `mu` update
  needs the probability of the *sampled* token, which only exists after
  sampling; a pre-sampling logits processor cannot see it. This mirrors the
  existing `ThinkingBudgetStateHolder` pattern. `MirostatStateHolder`
  (`vllm/v1/sample/mirostat_state.py`) is created per `InputBatch`, synced via
  `BatchUpdate` (add/remove/move), attached to `SamplingMetadata`, and consumed
  in `Sampler.sample()`.
- **Truncation is argmax-invariant.** Mirostat v2 sets the logit of any token
  with surprise `> mu` to `-inf` and always keeps the argmax, so it composes
  with the rest of the random-sampling pipeline. It runs after temperature and
  the argmax-invariant logits processors (e.g. min_p), before top-k/top-p.
- **Decode throughput is unaffected (GPU-resident state).** `mu`/`tau`/`eta`
  are persistent device tensors; the per-step math (truncate + `mu` update) is
  fully on-device with **no host<->device sync**. Inactive rows carry
  `mu = +inf` / `eta = 0`, making the per-step math a masked no-op for them, so
  a single vectorized path covers the whole batch with static shapes (CUDA
  graph friendly). When no request uses Mirostat the holder short-circuits, so
  there is zero overhead on the common path.
- **Validation.** `mirostat_mode` must be `0` or `2`. When enabled it requires
  `temperature > 0`, `top_k in {0, -1}`, `top_p == 1.0` (Mirostat replaces
  top-k/top-p truncation), and finite `tau`/`eta > 0`. Because temperature is
  applied before Mirostat, the `mirostat_mode` docstring recommends
  `temperature ~= 1.0` (a much lower temperature drives surprise toward 0 and
  makes Mirostat approach greedy).

## Tests

- `pytest tests/v1/sample/test_mirostat.py -v` → **14/14 passed** (parameter
  validation; holder add/remove/swap/move bookkeeping; truncation keeps the
  argmax; `mu` updates in both directions).
- `ruff check` and `ruff format --check` clean on all changed files (ruff
  0.14.0, the pinned CI version).

## Model evaluation

Measured on DeepSeek-V4-Flash (8xH20, TP=8).

**Repetition / degeneration** (HumanEval/132 `is_nested`, `think`-high,
N=20/config, `max_tokens=8192`; a "loop" = `finish_reason==length` with high
tail-repetition):

| config | loop rate |
| --- | --- |
| greedy (`temperature=0`) | 35% |
| plain sampling (`temperature=1.0`, `top_p=1.0`) | 0% |
| Mirostat v2 (`mode=2`, `tau=5`, `temperature=1.0`) | 0% |

Any `temperature > 0` already breaks the greedy repetition attractor, so
Mirostat is not what fixes greedy loops here. Being explicit about the scope:
with a fixed `seed`, Mirostat (`tau=5`) at `temperature <= 1.5` produces
**byte-identical** output to plain sampling. `tau=5` bits targets perplexity
`2^5 = 32`; below that temperature the observed surprise stays under `tau`, so
`mu` grows monotonically and the truncation is inert. That is the intended
behavior — Mirostat should not perturb well-behaved decoding. Its measurable
benefit shows up once the distribution is hot enough to enter the *confusion
trap*.

**High-temperature stability (confusion trap)** — this is the regime where
Mirostat is not substitutable by temperature tuning. Full HumanEval (164
problems, `think`-high, `top_p=1.0`, `max_tokens=8192`, 30 concurrent):

| temperature | config | pass@1 | truncated at `max_tokens` | mean out tokens | total out tokens |
| --- | --- | --- | --- | --- | --- |
| 1.8 | baseline | 4.9% (8/164) | 135/164 (82%) | 7217 | 1.18M |
| 1.8 | Mirostat v2 (`tau=5`) | **12.2%** (20/164) | **20/164 (12%)** | **3018** | **0.49M** |
| 2.0 | baseline | 0.6% (1/164) | 146/164 (89%) | 7718 | 1.27M |
| 2.0 | Mirostat v2 (`tau=5`) | **1.2%** (2/164) | **24/164 (15%)** | **3335** | **0.55M** |

At `temperature >= 1.8` plain sampling degenerates into incoherence and burns the
entire budget — the *median* request hits `max_tokens`. Mirostat cuts the
truncation rate by ~85% (82% -> 12% and 89% -> 15%), reduces total generated
tokens by ~57%, and raises pass@1 by 2.5x / 2x respectively. End-to-end
wall-clock for the two sweeps dropped 43% and 46%.

Scope of the win, stated plainly: this is damage mitigation, not recovery.
`temperature=1.8` + Mirostat (12.2%) is still far below `temperature=1.0` plain
sampling (99.4% pass@1 on the same harness). The value is that workloads which
*must* run hot (diversity / creative sampling) get a bounded-surprise safety net
instead of unbounded degeneration, at roughly half the tokens.

**Decode throughput — lossless** (same engine, 30 concurrent, `max_tokens=3000`,
non-think, measured from `vllm:generation_tokens_total`):

| config | decode tok/s |
| --- | --- |
| baseline (no Mirostat) | 1902.3 |
| Mirostat v2 (enabled) | **1895.1** |

Δ = **-0.4%, within noise**. An earlier host-syncing prototype regressed decode
by ~16% at 30 concurrency; moving the `mu` state fully GPU-resident (no per-step
`.tolist()`/D2H) removed the regression.

## Limitations / follow-ups

- Only Mirostat **v2** is implemented (the common variant). v1 (which estimates
  the Zipf exponent per step) can be added later.
- Not validated with speculative decoding; the `mu` update assumes one sampled
  token per request per step. Recommend not combining with spec decode for now.
- Mirostat v2 cannot break a **high-confidence** repetition loop, and should not
  be advertised as a general anti-repetition fix. The repeated token is the
  argmax, which the truncation always keeps, and its surprise is near 0, which
  drives `mu` *upward* and loosens truncation further. The controller bounds
  surprise from above (confusion trap), not from below. For greedy-style loops,
  raise `temperature` or use a repetition penalty.

## Note

AI assistance was used to prepare this change. The submitter has reviewed every
line and is responsible for the change and its tests/evaluations.

