### PR TITLE
[Tests][ROCm] Give AITER combos a 0/1 expert_mask in the modular-kernel sweep

### DIFF
--- a/tests/kernels/moe/modular_kernel_tools/common.py
+++ b/tests/kernels/moe/modular_kernel_tools/common.py
@@ -492,12 +492,24 @@ class RankTensors:
 
         expert_map = None
         if config.world_size > 1:
-            expert_map = torch.full(
-                (global_num_experts,), fill_value=-1, dtype=torch.int32
-            )
             s = pgi.rank * num_local_experts
             e = s + num_local_experts
-            expert_map[s:e] = torch.tensor(list(range(num_local_experts)))
+            if config.fused_experts_type.consumes_expert_mask:
+                # Mirror determine_expert_map(..., return_expert_mask=True):
+                # ROCm AITER kernels read expert_map as a 0/1 local-expert
+                # mask (plus a trailing zero sentinel), not the canonical
+                # -1/local-slot index map every other backend expects. Real
+                # serving picks the right one per FusedMoEExperts.consumes_
+                # expert_mask (see RoutedExperts.expert_map); this harness
+                # has no RoutedExperts layer, so it must gate the same way
+                # or AITER reads local ids as a mask and walks out of bounds.
+                expert_map = torch.zeros((global_num_experts + 1,), dtype=torch.int32)
+                expert_map[s:e] = 1
+            else:
+                expert_map = torch.full(
+                    (global_num_experts,), fill_value=-1, dtype=torch.int32
+                )
+                expert_map[s:e] = torch.tensor(list(range(num_local_experts)))
             expert_map = expert_map.to(device=device, dtype=torch.int32)
 
         return RankTensors(


### PR DESCRIPTION
`RankTensors.make()` builds one generic `-1`/local-slot index-map `expert_map` for every `FusedMoEExperts` backend under test, unconditionally. That is wrong for ROCm AITER kernels: they read `expert_map` as a 0/1 local-expert mask (plus a trailing zero sentinel) derived via an exclusive prefix sum over the mask, not an index map -- values above 1 walk past the local weights and read out of bounds.

Real serving already gets this right: `RoutedExperts.expert_map` (`routed_experts.py`) hands AITER-consuming backends the correct 0/1 `ExpertMapManager.expert_mask` instead of the index map, gated on `FusedMoEExperts.consumes_expert_mask` (a flag `AiterExperts` already declares). This test harness has no `RoutedExperts` layer, so it never applied that gate -- every AITER combination in `test_modular_kernel_combinations.py` got the wrong tensor shape and semantics.

Gate the harness the same way, using the already-declared class attribute (no live experts instance needed). Builds the identical 0/1 mask `determine_expert_map(..., return_expert_mask=True)` would for a real model. No production code touched.

## Test plan

Verified on MI350X (gfx950): all four previously-faulting `DeepEPV2PrepareAndFinalize x AiterExperts` cases (dtype10/18/23/30) that used to fault with a GPU memory access fault on the base `m=32, topk=4` case now pass that case cleanly (`max_diff=0.055`, within the `0.12` FP8 tolerance), with zero changes outside this test file.