### PR TITLE
[Bugfix] return False from is_moe_layer when no MoE base matches

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -45,5 +45,6 @@ def is_moe_layer(module: torch.nn.Module) -> bool:
         for b in cls.__bases__:
             if _check_bases(b):
                 return True
+        return False
 
     return _check_bases(module.__class__)


### PR DESCRIPTION
## Summary
- `_check_bases` fell through with `None` for non-MoE modules despite a `-> bool` annotation.
- Return `False` after the base walk.

## Test plan
- [ ] `is_moe_layer(nn.Linear(2,2)) is False`
- [ ] MoE modules still return True
