### PR TITLE
[Docs] Document NIXL KV connector metrics aggregation semantics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -51,6 +51,21 @@ class KVConnectorStats:
 
 
 class KVConnectorLogging:
+    """Handles periodic logging and telemetry aggregation for KV connectors.
+
+    Pipeline Overview:
+    1. **observe()**: Periodically called when the connector syncs with the scheduler.
+       Receives raw transfer telemetry (`transfer_stats_data`) pre-aggregated across
+       all worker ranks, instantiates connector stats via `build_kv_connector_stats()`,
+       and accumulates them into `self.transfer_stats_accumulator` via `aggregate()`.
+    2. **aggregate()**: Accumulates observations across intervals by extending
+       telemetry lists in the stats container.
+    3. **reduce()**: Called by :meth:`log` to compute summary metrics (averages,
+       percentiles, throughput) over the accumulated observations.
+    4. **log()**: Periodically formats and logs the reduced summary metrics line,
+       then clears the accumulator for the next logging window.
+    """
+
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -23,7 +23,30 @@ if TYPE_CHECKING:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Container for transfer performance metrics in NIXL KV Cache transfers.
+
+    In multi-rank (tensor parallel, TP > 1) deployments, each TP rank
+    independently records its own per-transfer telemetry (such as
+    `transfer_duration`, `post_duration`, `bytes_transferred`, and
+    `num_descriptors`). When stats are collected:
+    - Stats from all ranks are concatenated via :meth:`aggregate`
+      (`list.extend`).
+    - :meth:`reduce` computes summary statistics over the combined pool
+      of observations from all ranks.
+
+    Metric aggregation semantics in multi-rank settings:
+    - **Num successful transfers**: Total count of transfers across all
+      TP ranks combined (not per-rank or per-engine).
+    - **Avg MB per transfer**: Mean bytes moved across all individual
+      rank-level transfers (`total_mb_all_ranks / num_transfers_all_ranks`),
+      not the total bytes moved for a single high-level KV transfer.
+    - **Throughput (MB/s)**: Aggregate bytes divided by total transfer
+      duration (`total_mb_all_ranks / total_time_all_ranks`), representing
+      the average per-rank throughput over the combined observation pool.
+    - **P90 xfer time (ms) / P90 post time (ms)**: 90th percentile computed
+      over the combined distribution of all ranks' transfer/post durations.
+    - **Avg number of descriptors**: Mean descriptors per rank-level transfer.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -84,7 +107,12 @@ class NixlKVConnectorStats(KVConnectorStats):
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        # Compute compact representative stats suitable for CLI logging
+        # Compute compact representative stats suitable for CLI logging.
+        # Note on multi-rank (TP > 1) semantics:
+        # Since stats arrive pre-aggregated across all ranks via aggregate(),
+        # total_mb and total_time_seconds reflect sums over all individual
+        # rank observations. throughput_mb_s is thus an average per-rank
+        # throughput over the combined pool (total_MB / total_time).
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in
             # the interval were unsuccessful, Prom will report failures stats instead.


### PR DESCRIPTION
#### Motivation & Context
Fixes #41230

In multi-rank (tensor parallel, TP > 1) deployments, the NIXL KV connector logs periodically aggregated transfer metrics (e.g., `Num successful transfers`, `Avg MB per transfer`, `Throughput (MB/s)`, percentiles). Because metrics arrive pre-aggregated across all worker ranks, the aggregation semantics across ranks can be counter-intuitive without explicit documentation.

#### Description of Changes
1. **`NixlKVConnectorStats` docstring**: Added documentation in `stats.py` explaining multi-rank semantics:
   - `Num successful transfers`: total transfers across all ranks combined.
   - `Avg MB per transfer`: mean MB across individual rank transfers.
   - `Throughput (MB/s)`: average per-rank throughput across the combined pool (`total_MB_all_ranks / total_time_all_ranks`).
   - `P90 xfer time (ms) / P90 post time (ms)`: percentile computed over the combined pool across all ranks.
2. **Inline comments in `reduce()`**: Clarified the multi-rank pool semantics in throughput and average calculations.
3. **`KVConnectorLogging` docstring**: Documented the full `observe()` → `aggregate()` → `reduce()` → `log()` pipeline in `metrics.py`.