### PR TITLE
[Bugfix] avoid IndexError for trailing dotted CLI args

### DIFF
--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -9,6 +9,7 @@ import textwrap
 from argparse import (
     Action,
     ArgumentDefaultsHelpFormatter,
+    ArgumentError,
     ArgumentParser,
     ArgumentTypeError,
     Namespace,
@@ -412,6 +413,10 @@ class FlexibleArgumentParser(ArgumentParser):
                         # False positive, '.' was only in the value
                         continue
                 else:
+                    if i + 1 >= len(processed_args):
+                        raise ArgumentError(
+                            None, f"expected value after {processed_arg}"
+                        )
                     value_str = processed_args[i + 1]
                     delete.add(i + 1)
 


### PR DESCRIPTION
## Summary
- `--config.field` with no following token indexed `processed_args[i+1]` and raised `IndexError`.
- Raise `ArgumentError` when the value is missing.

## Test plan
- [ ] trailing dotted arg without value → argparse error, not IndexError
- [ ] `--config.foo=1` and `--config.foo 1` still work
