### PR TITLE
[Bugfix] create the weight lock directory itself

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -89,7 +89,7 @@ class DisabledTqdm(tqdm):
 def get_lock(model_name_or_path: str | Path, cache_dir: str | None = None):
     lock_dir = cache_dir or temp_dir
     model_name_or_path = str(model_name_or_path)
-    os.makedirs(os.path.dirname(lock_dir), exist_ok=True)
+    os.makedirs(lock_dir, exist_ok=True)
     model_name = model_name_or_path.replace("/", "-")
     hash_name = hashlib.sha256(model_name.encode()).hexdigest()
     # add hash to avoid conflict with old users' lock files


### PR DESCRIPTION
## Summary
- `get_lock` called `makedirs(dirname(lock_dir))`, so a missing `cache_dir` was never created before `FileLock` opened a file inside it.
- Create `lock_dir` directly.

## Test plan
- [ ] get_lock with a fresh cache_dir path
- [ ] Default temp_dir path still works
