### PR TITLE
[Docs] Fill Apache LICENSE copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright contributors to the vLLM project
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Purpose

The Apache-2.0 LICENSE appendix still had the `Copyright [yyyy] [name of copyright owner]` placeholder, so the licensor was not identified.

This fills that line with `Copyright contributors to the vLLM project`, matching the SPDX headers used in the source (`SPDX-FileCopyrightText: Copyright contributors to the vLLM project`).

Closes https://github.com/vllm-project/vllm/issues/54550

## Test Plan

- [x] Confirmed the appendix placeholder is replaced and the rest of the LICENSE text is unchanged