### PR TITLE
[Bugfix] resolve bare paths in atomic_writer before mkstemp

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -119,7 +119,8 @@ def atomic_writer(
     """
     # Create a temporary file in the same directory as the target file
     # to ensure it's on the same filesystem for an atomic replace.
-    temp_dir = os.path.dirname(filepath)
+    # Bare filenames have an empty dirname; resolve so mkstemp gets a real dir.
+    temp_dir = os.path.dirname(os.path.abspath(filepath))
     temp_fd, temp_path = tempfile.mkstemp(dir=temp_dir)
 
     try:


### PR DESCRIPTION
## Summary
- `dirname` of a bare filename is empty, so `tempfile.mkstemp(dir="")` failed or wrote in the wrong place.
- Use `dirname(abspath(filepath))`.

## Test plan
- [ ] atomic_writer("out.json") in cwd
- [ ] Nested paths still replace atomically on the same filesystem
