### PR TITLE
[ROCm] Optimize HY V4 graph inference on gfx942 and gfx950

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""ROCm custom op schema test for AITER MLA decode.
+"""ROCm custom op schema tests for AITER MLA decode.
 
-A single ``opcheck`` call on ``torch.ops.vllm.rocm_aiter_mla_decode_fwd``
-verifies that the custom op is registered and that its schema and fake
-implementation are consistent with the real kernel: fake-tensor support for
-torch.compile tracing and the ``mutates_args=["o"]`` in-place output aliasing.
+``opcheck`` verifies that the decode ops are registered and that their schemas
+and fake implementations are consistent with the real kernels: fake-tensor
+support for torch.compile tracing and ``mutates_args=["o"]`` in-place output
+aliasing.
 """
 
 import pytest
@@ -75,5 +75,36 @@ def test_mla_decode_fwd_op_schema() -> None:
             "reduce_indptr": None,
             "reduce_final_map": None,
             "reduce_partial_map": None,
+        },
+    )
+
+
+@torch.inference_mode()
+def test_mla_decode_fwd_lse_op_schema() -> None:
+    """Validate graph registration and mutation schema for LSE decode."""
+    _require_aiter()
+    # Import ensures the custom op is registered.
+    from vllm._aiter_ops import rocm_aiter_ops  # noqa: F401
+
+    batch_size, nhead = 2, 16
+    q = torch.randn(batch_size, nhead, Q_HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    kv_buffer = torch.randn(32, 1, 1, Q_HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    o = torch.zeros(batch_size, nhead, V_HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device="cuda")
+    kv_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * 16
+    kv_indices = torch.arange(32, dtype=torch.int32, device="cuda")
+    kv_last_page_lens = torch.ones(batch_size, dtype=torch.int32, device="cuda")
+
+    opcheck(
+        torch.ops.vllm.rocm_aiter_mla_decode_fwd_lse,
+        (q, kv_buffer, o, qo_indptr, 1),
+        {
+            "kv_indptr": kv_indptr,
+            "kv_indices": kv_indices,
+            "kv_last_page_lens": kv_last_page_lens,
+            "sm_scale": Q_HEAD_DIM**-0.5,
+            "logit_cap": 0.0,
+            "q_scale": None,
+            "kv_scale": None,
         },
     )

--- a/tests/kernels/attention/test_rocm_aiter_mla_sink.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sink.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for ROCm AITER sparse MLA attention sinks."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+_SKIP_NON_MI3XX = True
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import on_mi3xx
+
+    _SKIP_NON_MI3XX = not on_mi3xx()
+
+pytestmark = [
+    pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific tests"),
+    pytest.mark.skipif(_SKIP_NON_MI3XX, reason="MI300/MI350 ROCm only"),
+]
+
+Q_HEAD_DIM = 576
+V_HEAD_DIM = 512
+SM_SCALE = Q_HEAD_DIM**-0.5
+
+
+def _require_aiter() -> None:
+    from vllm._aiter_ops import is_aiter_found_and_supported
+
+    if not is_aiter_found_and_supported():
+        pytest.skip("aiter is required on supported ROCm hardware for this test")
+
+
+@pytest.mark.parametrize(
+    ("real_heads", "cache_kind"),
+    [
+        (1, "bf16"),
+        (4, "bf16"),
+        (8, "bf16"),
+        (8, "fp8"),
+        (12, "bf16"),
+        (16, "bf16"),
+        (24, "bf16"),
+        (32, "bf16"),
+    ],
+)
+@torch.inference_mode()
+def test_sparse_mla_sink_matches_ragged_reference(
+    real_heads: int, cache_kind: str
+) -> None:
+    """Exercise ragged sink decode, head padding, and FP8 scale forwarding."""
+    _require_aiter()
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAHelper
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+        ROCMAiterMLASparseImpl,
+    )
+
+    torch.manual_seed(real_heads * 17 + (cache_kind == "fp8"))
+    device = torch.device("cuda")
+    seq_lens = [1, 5, 23, 17]
+    batch_size = len(seq_lens)
+
+    q_source = torch.randn(batch_size, real_heads, Q_HEAD_DIM, device=device) * 0.2
+
+    pool_size = sum(seq_lens) + 52
+    kv_source = torch.randn(pool_size, 1, Q_HEAD_DIM, device=device) * 0.2
+    if cache_kind == "fp8":
+        fp8_dtype = current_platform.fp8_dtype()
+        q_scale = torch.tensor(0.5, dtype=torch.float32, device=device)
+        kv_scale = torch.tensor(0.25, dtype=torch.float32, device=device)
+        q_real = (q_source / q_scale).to(fp8_dtype)
+        kv = (kv_source / kv_scale).to(fp8_dtype)
+        q_ref = q_real.float() * q_scale
+        kv_ref = kv.float() * kv_scale
+    else:
+        q_scale = kv_scale = None
+        q_real = q_source.to(torch.bfloat16)
+        kv = kv_source.to(torch.bfloat16)
+        q_ref = q_real.float()
+        kv_ref = kv.float()
+    q = AiterMLAHelper.get_mla_padded_q(real_heads, q_real)
+
+    indices = torch.randperm(pool_size, device=device)[: sum(seq_lens)].to(torch.int32)
+    kv_indptr = torch.tensor(
+        [0] + [sum(seq_lens[:i]) for i in range(1, len(seq_lens) + 1)],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    # Non-None garbage proves the sink path cannot accidentally select the
+    # gfx942 persistent kernel, which has no return-LSE code object.
+    metadata = SimpleNamespace(
+        attn_out_dtype=torch.bfloat16,
+        qo_indptr=torch.arange(batch_size + 1, dtype=torch.int32, device=device),
+        paged_kv_indptr=kv_indptr,
+        paged_kv_indices=indices,
+        paged_kv_last_page_len=torch.ones(batch_size, dtype=torch.int32, device=device),
+        work_meta_data=torch.tensor([123], dtype=torch.int32),
+        work_indptr=None,
+        work_info_set=None,
+        reduce_indptr=None,
+        reduce_final_map=None,
+        reduce_partial_map=None,
+    )
+    sinks = torch.linspace(-2.0, 6.0, real_heads, device=device)
+
+    impl = object.__new__(ROCMAiterMLASparseImpl)
+    impl.num_heads = real_heads
+    impl.kv_lora_rank = V_HEAD_DIM
+    impl.scale = SM_SCALE
+    impl.sinks = sinks
+
+    output, lse = impl._forward_mla(
+        SimpleNamespace(_q_scale=q_scale, _k_scale=kv_scale), q, kv, metadata
+    )
+    assert lse is not None
+
+    kv_flat = kv_ref[:, 0]
+    ref_outputs = []
+    ref_lses = []
+    start = 0
+    for batch_idx, seq_len in enumerate(seq_lens):
+        rows = kv_flat[indices[start : start + seq_len].long()].float()
+        scores = q_ref[batch_idx] @ rows.T * SM_SCALE
+        ref_outputs.append(torch.softmax(scores, dim=-1) @ rows[:, :V_HEAD_DIM])
+        ref_lses.append(torch.logsumexp(scores, dim=-1))
+        start += seq_len
+
+    ref_output = torch.stack(ref_outputs)
+    ref_lse = torch.stack(ref_lses)
+    expected_lse = torch.logaddexp(ref_lse, sinks)
+    expected_output = ref_output * torch.exp(ref_lse - expected_lse).unsqueeze(-1)
+
+    assert output.dtype == torch.bfloat16
+    assert lse.dtype == torch.float32
+    torch.testing.assert_close(lse, expected_lse, atol=2e-4, rtol=2e-4)
+    output_atol = 1e-2 if cache_kind == "fp8" else 2e-3
+    output_rtol = 3e-2 if cache_kind == "fp8" else 2e-2
+    torch.testing.assert_close(
+        output.float(), expected_output, atol=output_atol, rtol=output_rtol
+    )
+
+
+def _make_noncontiguous_sink() -> torch.Tensor:
+    return torch.empty(8, dtype=torch.float32)[::2]
+
+
+@pytest.mark.parametrize(
+    ("sinks", "match"),
+    [
+        (torch.empty(4, dtype=torch.bfloat16), "must be float32"),
+        (torch.empty(2, 2, dtype=torch.float32), "must have shape"),
+        (_make_noncontiguous_sink(), "must be contiguous"),
+    ],
+)
+def test_sparse_mla_sink_validation(sinks: torch.Tensor, match: str) -> None:
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+        ROCMAiterMLASparseImpl,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        ROCMAiterMLASparseImpl(
+            num_heads=4,
+            head_size=Q_HEAD_DIM,
+            scale=SM_SCALE,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="bfloat16",
+            logits_soft_cap=None,
+            attn_type="decoder",
+            kv_sharing_target_layer_name=None,
+            sinks=sinks,
+            kv_lora_rank=V_HEAD_DIM,
+        )
+
+
+def test_sparse_mla_sink_rejects_unsupported_gfx942_h64_at_runtime() -> None:
+    from vllm.platforms.rocm import on_gfx942
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+        ROCMAiterMLASparseImpl,
+    )
+
+    if not on_gfx942():
+        pytest.skip("This AITER head-count constraint is gfx942-specific")
+
+    device = torch.device("cuda")
+    impl = object.__new__(ROCMAiterMLASparseImpl)
+    impl.num_heads = 64
+    impl.kv_lora_rank = V_HEAD_DIM
+    impl.scale = SM_SCALE
+    impl.sinks = torch.zeros(64, dtype=torch.float32, device=device)
+    metadata = SimpleNamespace(attn_out_dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="increase tensor_parallel_size"):
+        impl._forward_mla(
+            SimpleNamespace(_q_scale=None, _k_scale=None),
+            torch.empty(1, 64, Q_HEAD_DIM, dtype=torch.bfloat16, device=device),
+            torch.empty(1, 1, Q_HEAD_DIM, dtype=torch.bfloat16, device=device),
+            metadata,
+        )
+
+
+def test_sparse_mla_backend_advertises_sink_support() -> None:
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+        ROCMAiterMLASparseBackend,
+    )
+
+    assert ROCMAiterMLASparseBackend.supports_sink()
+
+
+def test_sparse_mla_backend_rejects_dcp() -> None:
+    from vllm.platforms.rocm import RocmPlatform
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+    from vllm.v1.attention.selector import AttentionSelectorConfig
+
+    selector_config = AttentionSelectorConfig(
+        head_size=Q_HEAD_DIM,
+        dtype=torch.bfloat16,
+        kv_cache_dtype="bfloat16",
+        block_size=16,
+        use_mla=True,
+        has_sink=True,
+        use_sparse=True,
+        use_mm_prefix=False,
+        use_per_head_quant_scales=False,
+        attn_type="decoder",
+        use_dcp=True,
+    )
+
+    with pytest.raises(ValueError, match="DCP not supported"):
+        RocmPlatform.get_attn_backend_cls(
+            selected_backend=AttentionBackendEnum.ROCM_AITER_MLA_SPARSE,
+            attn_selector_config=selector_config,
+        )

--- a/tests/kernels/attention/test_rocm_aiter_mla_sink.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sink.py
@@ -8,17 +8,17 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
 
-_SKIP_NON_MI3XX = True
+_SKIP_UNSUPPORTED_AITER_MLA = True
 if current_platform.is_rocm():
     from vllm.platforms.rocm import on_mi3xx
 
-    _SKIP_NON_MI3XX = not on_mi3xx()
+    _SKIP_UNSUPPORTED_AITER_MLA = not on_mi3xx()
 
-pytestmark = [
-    pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm-specific tests"),
-    pytest.mark.skipif(_SKIP_NON_MI3XX, reason="MI300/MI350 ROCm only"),
-]
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(), reason="ROCm-specific tests"
+)
 
 Q_HEAD_DIM = 576
 V_HEAD_DIM = 512
@@ -39,12 +39,18 @@ def _require_aiter() -> None:
         (4, "bf16"),
         (8, "bf16"),
         (8, "fp8"),
+        (32, "fp8"),
+        (64, "fp8"),
         (12, "bf16"),
         (16, "bf16"),
         (24, "bf16"),
         (32, "bf16"),
+        (48, "bf16"),
+        (64, "bf16"),
+        (80, "bf16"),
     ],
 )
+@pytest.mark.skipif(_SKIP_UNSUPPORTED_AITER_MLA, reason="MI300/MI350 AITER MLA only")
 @torch.inference_mode()
 def test_sparse_mla_sink_matches_ragged_reference(
     real_heads: int, cache_kind: str
@@ -56,7 +62,13 @@ def test_sparse_mla_sink_matches_ragged_reference(
         ROCMAiterMLASparseImpl,
     )
 
-    torch.manual_seed(real_heads * 17 + (cache_kind == "fp8"))
+    if cache_kind == "bf16" and real_heads in (48, 64):
+        from vllm.platforms.rocm import on_gfx942
+
+        if on_gfx942():
+            pytest.skip("This shape maps to gfx942's unsupported BF16 H64 kernel")
+
+    set_random_seed(real_heads * 17 + (cache_kind == "fp8"))
     device = torch.device("cuda")
     seq_lens = [1, 5, 23, 17]
     batch_size = len(seq_lens)
@@ -176,8 +188,12 @@ def test_sparse_mla_sink_validation(sinks: torch.Tensor, match: str) -> None:
         )
 
 
-def test_sparse_mla_sink_rejects_unsupported_gfx942_h64_at_runtime() -> None:
+@pytest.mark.parametrize("real_heads", [48, 64])
+def test_sparse_mla_sink_rejects_unsupported_gfx942_h64_at_runtime(
+    real_heads: int,
+) -> None:
     from vllm.platforms.rocm import on_gfx942
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLAHelper
     from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
         ROCMAiterMLASparseImpl,
     )
@@ -187,27 +203,35 @@ def test_sparse_mla_sink_rejects_unsupported_gfx942_h64_at_runtime() -> None:
 
     device = torch.device("cuda")
     impl = object.__new__(ROCMAiterMLASparseImpl)
-    impl.num_heads = 64
+    impl.num_heads = real_heads
     impl.kv_lora_rank = V_HEAD_DIM
     impl.scale = SM_SCALE
-    impl.sinks = torch.zeros(64, dtype=torch.float32, device=device)
+    impl.sinks = torch.zeros(real_heads, dtype=torch.float32, device=device)
     metadata = SimpleNamespace(attn_out_dtype=torch.bfloat16)
+    padded_heads = AiterMLAHelper.get_actual_mla_num_heads(real_heads)
 
     with pytest.raises(ValueError, match="increase tensor_parallel_size"):
         impl._forward_mla(
             SimpleNamespace(_q_scale=None, _k_scale=None),
-            torch.empty(1, 64, Q_HEAD_DIM, dtype=torch.bfloat16, device=device),
+            torch.empty(
+                1,
+                padded_heads,
+                Q_HEAD_DIM,
+                dtype=torch.bfloat16,
+                device=device,
+            ),
             torch.empty(1, 1, Q_HEAD_DIM, dtype=torch.bfloat16, device=device),
             metadata,
         )
 
 
-def test_sparse_mla_backend_advertises_sink_support() -> None:
+def test_sparse_mla_backend_reports_sink_support_for_current_hardware() -> None:
+    from vllm.platforms.rocm import on_mi3xx
     from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
         ROCMAiterMLASparseBackend,
     )
 
-    assert ROCMAiterMLASparseBackend.supports_sink()
+    assert ROCMAiterMLASparseBackend.supports_sink() == on_mi3xx()
 
 
 def test_sparse_mla_backend_rejects_dcp() -> None:

--- a/tests/kernels/attention/test_rocm_aiter_mla_sink.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sink.py
@@ -32,6 +32,95 @@ def _require_aiter() -> None:
         pytest.skip("aiter is required on supported ROCm hardware for this test")
 
 
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float32])
+def test_apply_attention_sink_matches_reference(output_dtype: torch.dtype) -> None:
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+        apply_attention_sink,
+    )
+
+    set_random_seed(20260902)
+    device = torch.device("cuda")
+    output_storage = torch.randn(3, 8, 17, device=device, dtype=output_dtype)
+    lse_storage = torch.randn(3, 8, device=device, dtype=torch.float32)
+    output = output_storage[:, ::2]
+    lse = lse_storage[:, ::2]
+    sinks = torch.linspace(-2.0, 6.0, 4, device=device, dtype=torch.float32)
+
+    expected_lse = torch.logaddexp(lse, sinks)
+    expected_output = output.float() * torch.exp(lse - expected_lse).unsqueeze(-1)
+    output_ptr = output.data_ptr()
+    lse_ptr = lse.data_ptr()
+
+    actual_output, actual_lse = apply_attention_sink(output, lse, sinks)
+
+    assert actual_output.data_ptr() == output_ptr
+    assert actual_lse.data_ptr() == lse_ptr
+    torch.testing.assert_close(actual_lse, expected_lse)
+    torch.testing.assert_close(
+        actual_output.float(),
+        expected_output,
+        atol=2e-3 if output_dtype == torch.bfloat16 else 1e-6,
+        rtol=2e-3 if output_dtype == torch.bfloat16 else 1e-6,
+    )
+
+
+def test_apply_attention_sink_zeroes_empty_rows_during_graph_replay() -> None:
+    from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+        apply_attention_sink,
+    )
+
+    set_random_seed(20260905)
+    device = torch.device("cuda")
+    output_storage = torch.empty(4, 16, V_HEAD_DIM, dtype=torch.bfloat16, device=device)
+    lse_storage = torch.empty(4, 16, dtype=torch.float32, device=device)
+    output = output_storage[:, ::2]
+    lse = lse_storage[:, ::2]
+    sinks = torch.empty(8, dtype=torch.float32, device=device)
+    kv_indptr = torch.empty(5, dtype=torch.int32, device=device)
+
+    output.normal_()
+    lse.normal_()
+    sinks.normal_()
+    kv_indptr.copy_(torch.tensor([0, 5, 10, 15, 20], device=device))
+    apply_attention_sink(output, lse, sinks, kv_indptr)
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        apply_attention_sink(output, lse, sinks, kv_indptr)
+
+    for lengths in ([5, 5, 5, 5], [7, 0, 3, 0], [0, 2, 0, 9]):
+        output.normal_()
+        lse.normal_()
+        sinks.normal_()
+        indptr = torch.tensor(
+            [0] + list(torch.tensor(lengths).cumsum(0).tolist()),
+            dtype=torch.int32,
+            device=device,
+        )
+        kv_indptr.copy_(indptr)
+
+        active = (kv_indptr[1:] > kv_indptr[:-1]).view(-1, 1)
+        expected_lse = torch.logaddexp(lse, sinks)
+        expected_lse = torch.where(active, expected_lse, sinks)
+        expected_output = output.float() * torch.exp(lse - expected_lse).unsqueeze(-1)
+        expected_output = torch.where(
+            active.unsqueeze(-1),
+            expected_output,
+            torch.zeros_like(expected_output),
+        )
+
+        graph.replay()
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(
+            output,
+            expected_output.to(output.dtype),
+            atol=0,
+            rtol=0,
+        )
+        torch.testing.assert_close(lse, expected_lse, atol=2e-7, rtol=2e-7)
+
+
 @pytest.mark.parametrize(
     ("real_heads", "cache_kind"),
     [
@@ -73,10 +162,28 @@ def test_sparse_mla_sink_matches_ragged_reference(
     seq_lens = [1, 5, 23, 17]
     batch_size = len(seq_lens)
 
-    q_source = torch.randn(batch_size, real_heads, Q_HEAD_DIM, device=device) * 0.2
+    q_source = (
+        torch.randn(
+            batch_size,
+            real_heads,
+            Q_HEAD_DIM,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.2
+    )
 
     pool_size = sum(seq_lens) + 52
-    kv_source = torch.randn(pool_size, 1, Q_HEAD_DIM, device=device) * 0.2
+    kv_source = (
+        torch.randn(
+            pool_size,
+            1,
+            Q_HEAD_DIM,
+            device=device,
+            dtype=torch.float32,
+        )
+        * 0.2
+    )
     if cache_kind == "fp8":
         fp8_dtype = current_platform.fp8_dtype()
         q_scale = torch.tensor(0.5, dtype=torch.float32, device=device)
@@ -115,7 +222,13 @@ def test_sparse_mla_sink_matches_ragged_reference(
         reduce_final_map=None,
         reduce_partial_map=None,
     )
-    sinks = torch.linspace(-2.0, 6.0, real_heads, device=device)
+    sinks = torch.linspace(
+        -2.0,
+        6.0,
+        real_heads,
+        device=device,
+        dtype=torch.float32,
+    )
 
     impl = object.__new__(ROCMAiterMLASparseImpl)
     impl.num_heads = real_heads
@@ -166,6 +279,7 @@ def _make_noncontiguous_sink() -> torch.Tensor:
         (_make_noncontiguous_sink(), "must be contiguous"),
     ],
 )
+@pytest.mark.usefixtures("default_vllm_config")
 def test_sparse_mla_sink_validation(sinks: torch.Tensor, match: str) -> None:
     from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
         ROCMAiterMLASparseImpl,
@@ -186,6 +300,92 @@ def test_sparse_mla_sink_validation(sinks: torch.Tensor, match: str) -> None:
             sinks=sinks,
             kv_lora_rank=V_HEAD_DIM,
         )
+
+
+@pytest.mark.parametrize("real_heads", [48, 64])
+@pytest.mark.parametrize("kv_cache_dtype", ["auto", "bfloat16"])
+def test_sparse_mla_sink_rejects_unsupported_gfx942_h64_at_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    real_heads: int,
+    kv_cache_dtype: str,
+) -> None:
+    from vllm.platforms import rocm as rocm_platform
+    from vllm.v1.attention.backends.mla import rocm_aiter_mla_sparse
+
+    monkeypatch.setattr(rocm_platform, "on_mi3xx", lambda: True)
+    monkeypatch.setattr(rocm_platform, "on_gfx942", lambda: True)
+    monkeypatch.setattr(
+        rocm_aiter_mla_sparse,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
+    )
+
+    with pytest.raises(ValueError, match="increase tensor_parallel_size"):
+        rocm_aiter_mla_sparse.ROCMAiterMLASparseImpl(
+            num_heads=real_heads,
+            head_size=Q_HEAD_DIM,
+            scale=SM_SCALE,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype=kv_cache_dtype,
+            logits_soft_cap=None,
+            attn_type="decoder",
+            kv_sharing_target_layer_name=None,
+            sinks=torch.zeros(real_heads, dtype=torch.float32),
+            kv_lora_rank=V_HEAD_DIM,
+        )
+
+
+@pytest.mark.parametrize("real_heads", [48, 64])
+@pytest.mark.parametrize(
+    ("head_size", "kv_cache_dtype"),
+    [
+        (Q_HEAD_DIM, "fp8"),
+        (Q_HEAD_DIM, "fp8_e4m3"),
+    ],
+)
+def test_sparse_mla_sink_accepts_supported_gfx942_construction_routes(
+    monkeypatch: pytest.MonkeyPatch,
+    real_heads: int,
+    head_size: int,
+    kv_cache_dtype: str,
+) -> None:
+    from vllm.platforms import rocm as rocm_platform
+    from vllm.v1.attention.backends.mla import rocm_aiter_mla_sparse
+
+    monkeypatch.setattr(rocm_platform, "on_mi3xx", lambda: True)
+    monkeypatch.setattr(rocm_platform, "on_gfx942", lambda: True)
+    monkeypatch.setattr(
+        rocm_aiter_mla_sparse,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(
+            model_config=SimpleNamespace(dtype=torch.bfloat16),
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=1),
+        ),
+    )
+    monkeypatch.setattr(
+        rocm_aiter_mla_sparse,
+        "current_workspace_manager",
+        lambda: SimpleNamespace(get_simultaneous=lambda *_args: (torch.empty(0),)),
+    )
+
+    impl = rocm_aiter_mla_sparse.ROCMAiterMLASparseImpl(
+        num_heads=real_heads,
+        head_size=head_size,
+        scale=SM_SCALE,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype=kv_cache_dtype,
+        logits_soft_cap=None,
+        attn_type="decoder",
+        kv_sharing_target_layer_name=None,
+        sinks=torch.zeros(real_heads, dtype=torch.float32),
+        kv_lora_rank=V_HEAD_DIM,
+    )
+
+    assert impl.sinks is not None
 
 
 @pytest.mark.parametrize("real_heads", [48, 64])

--- a/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
@@ -57,6 +57,7 @@ def _make_builder():
     builder.paged_kv_indptr = torch.zeros(
         max_num_batched_tokens + 1, dtype=torch.int32, device="cpu"
     )
+    builder._use_persistent_metadata = True
     builder._num_attention_heads = 16
     builder._num_compute_units = current_platform.num_compute_units()
     builder._mla_work_meta_data = torch.empty(1, dtype=torch.int32, device="cpu")
@@ -128,6 +129,7 @@ def _patch_build_deps(monkeypatch, events=None):
             synchronize=lambda: events.append("sync") if events is not None else None
         ),
     )
+    return fake_aiter
 
 
 def test_build_populates_decode_only_split_fields(monkeypatch):
@@ -161,6 +163,25 @@ def test_build_populates_mixed_split_fields(monkeypatch):
     assert md.num_decode_tokens == 1
     assert md.prefill_max_seq_len == 0
     assert md.prefill is None
+
+
+def test_sink_build_skips_persistent_metadata(monkeypatch):
+    builder = _make_builder()
+    builder._use_persistent_metadata = False
+    fake_aiter = _patch_build_deps(monkeypatch)
+
+    md = builder.build(
+        common_prefix_len=0, common_attn_metadata=_make_common_metadata()
+    )
+
+    fake_aiter.get_mla_metadata_v1.assert_not_called()
+    assert md.work_meta_data is None
+    assert md.work_indptr is None
+    assert md.work_info_set is None
+    assert md.reduce_indptr is None
+    assert md.reduce_final_map is None
+    assert md.reduce_partial_map is None
+    assert builder._prev_metadata_key is None
 
 
 def test_sparse_persistent_metadata_syncs_only_after_recompute(monkeypatch):

--- a/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py
@@ -57,6 +57,9 @@ def _make_builder():
     builder.paged_kv_indptr = torch.zeros(
         max_num_batched_tokens + 1, dtype=torch.int32, device="cpu"
     )
+    builder.sparse_seqlen_buffer = torch.zeros(
+        max_num_batched_tokens, dtype=torch.int32, device="cpu"
+    )
     builder._use_persistent_metadata = True
     builder._num_attention_heads = 16
     builder._num_compute_units = current_platform.num_compute_units()
@@ -112,9 +115,18 @@ def _patch_build_deps(monkeypatch, events=None):
     on CPU."""
 
     def fake_generate_sparse_seqlen_triton(
-        query_lens, seq_lens, cu_query_lens, topk_token, num_tokens, max_query_len
+        seq_lens,
+        cu_query_lens,
+        topk_token,
+        num_tokens,
+        max_query_len,
+        out=None,
     ):
-        return torch.zeros(num_tokens, dtype=torch.int32, device="cpu")
+        result = torch.zeros(num_tokens, dtype=torch.int32, device="cpu")
+        if out is not None:
+            out[:num_tokens].copy_(result)
+            return out[:num_tokens]
+        return result
 
     fake_aiter = _FakeAiter("aiter")
     fake_aiter.get_mla_metadata_v1 = Mock(side_effect=lambda *a, **k: None)
@@ -221,3 +233,87 @@ def test_sparse_persistent_metadata_syncs_only_after_recompute(monkeypatch):
 
     assert events == []
     assert fake_get_mla_metadata_v1_mock.call_count == 1
+
+
+def test_nonpersistent_sparse_metadata_updates_decode_lengths(monkeypatch):
+    builder = _make_builder()
+    builder.use_persistent_mla_metadata = False
+    builder._use_persistent_metadata = False
+    builder.supports_draft_decode_metadata_update = True
+    common_metadata = _make_common_metadata()
+    common_metadata.seq_lens.copy_(torch.tensor([3, 2], dtype=torch.int32))
+
+    def fake_generate_sparse_seqlen_triton(
+        seq_lens,
+        cu_query_lens,
+        topk_token,
+        num_tokens,
+        max_query_len,
+        out=None,
+    ):
+        assert out is not None
+        out[:num_tokens].copy_(seq_lens[:num_tokens].clamp(max=topk_token))
+        return out[:num_tokens]
+
+    fake_aiter = _FakeAiter("aiter")
+    fake_aiter.get_mla_metadata_v1 = Mock(side_effect=AssertionError)
+    monkeypatch.setitem(sys.modules, "aiter", fake_aiter)
+    monkeypatch.setattr(
+        sparse_mod, "generate_sparse_seqlen_triton", fake_generate_sparse_seqlen_triton
+    )
+
+    metadata = builder.build(common_prefix_len=0, common_attn_metadata=common_metadata)
+    assert metadata.work_meta_data is None
+    assert metadata.paged_kv_indptr.tolist() == [0, 3, 5]
+
+    common_metadata.seq_lens.add_(1)
+    builder.update_draft_decode_metadata(metadata)
+
+    assert metadata.paged_kv_indptr.tolist() == [0, 4, 7]
+    assert fake_aiter.get_mla_metadata_v1.call_count == 0
+
+
+def test_sparse_mla_zero_initializes_graph_padding_output(monkeypatch):
+    impl = object.__new__(sparse_mod.ROCMAiterMLASparseImpl)
+    impl.num_heads = 2
+    impl.kv_lora_rank = 4
+    impl.scale = 1.0
+    impl.sinks = None
+
+    monkeypatch.setattr(
+        sparse_mod.AiterMLAHelper,
+        "get_actual_mla_num_heads",
+        lambda num_heads: num_heads,
+    )
+    monkeypatch.setattr(
+        sparse_mod.AiterMLAHelper,
+        "get_mla_unpadded_o",
+        lambda num_heads, output: output,
+    )
+
+    def fake_mla_decode_fwd(q, kv, output, *args, **kwargs):
+        assert torch.count_nonzero(output).item() == 0
+        output.fill_(1)
+
+    monkeypatch.setattr(
+        sparse_mod.rocm_aiter_ops,
+        "mla_decode_fwd",
+        fake_mla_decode_fwd,
+    )
+
+    metadata = SimpleNamespace(
+        attn_out_dtype=torch.float32,
+        qo_indptr=torch.tensor([0, 1, 2], dtype=torch.int32),
+        paged_kv_indptr=torch.tensor([0, 1, 2], dtype=torch.int32),
+        paged_kv_indices=torch.tensor([0, 1], dtype=torch.int32),
+        paged_kv_last_page_len=torch.ones(2, dtype=torch.int32),
+        work_meta_data=None,
+    )
+    layer = SimpleNamespace(_q_scale=None, _k_scale=None)
+    q = torch.empty((2, 2, 8), dtype=torch.float32)
+    kv = torch.empty((2, 1, 8), dtype=torch.float32)
+
+    output, lse = impl._forward_mla(layer, q, kv, metadata)
+
+    assert lse is None
+    assert torch.equal(output, torch.ones((2, 2, 4), dtype=torch.float32))

--- a/tests/kernels/moe/test_mxfp8_aiter_backend_selection.py
+++ b/tests/kernels/moe/test_mxfp8_aiter_backend_selection.py
@@ -51,18 +51,20 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (  # noqa:
 _AITER_MOD = "vllm.model_executor.layers.fused_moe.experts.aiter_mxfp8_moe"
 
 
-def _config(ep_size: int = 1):
-    # AiterMxfp8Experts hardcodes SwiGLU-OAI: match its required activation and
-    # alpha/beta so is_supported_config doesn't reject the config on those grounds.
+def _config(
+    ep_size: int = 1,
+    activation: MoEActivation = MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+):
     cfg = make_dummy_moe_config(
         num_experts=128,
         experts_per_token=4,
         hidden_dim=6144,
-        activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        activation=activation,
     )
-    cfg = dataclasses.replace(
-        cfg, swiglu_alpha=_AITER_SWIGLU_ALPHA, swiglu_beta=_AITER_SWIGLU_BETA
-    )
+    if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
+        cfg = dataclasses.replace(
+            cfg, swiglu_alpha=_AITER_SWIGLU_ALPHA, swiglu_beta=_AITER_SWIGLU_BETA
+        )
     if ep_size != 1:
         cfg = dataclasses.replace(
             cfg,
@@ -126,6 +128,26 @@ def test_is_supported_config(present, ep_size, supported, reason_substr):
     assert ok is supported
     if reason_substr is not None:
         assert reason_substr in reason
+
+
+@pytest.mark.parametrize(
+    "activation,supported",
+    [
+        (MoEActivation.SILU, True),
+        (MoEActivation.SWIGLUOAI_UNINTERLEAVE, True),
+        (MoEActivation.GELU, False),
+    ],
+)
+def test_supported_activations(activation, supported):
+    with _gfx950(), _flydsl_installed(True):
+        ok, _ = AiterMxfp8Experts.is_supported_config(
+            AiterMxfp8Experts,
+            _config(activation=activation),
+            kMxfp8Static,
+            kMxfp8Dynamic,
+            FusedMoEActivationFormat.Standard,
+        )
+    assert ok is supported
 
 
 def test_explicit_moe_backend_aiter():

--- a/tests/kernels/moe/test_rocm_aiter_topk.py
+++ b/tests/kernels/moe/test_rocm_aiter_topk.py
@@ -19,8 +19,10 @@ from vllm.platforms import current_platform
 if not current_platform.is_rocm():
     pytest.skip("This test can only run on ROCm.", allow_module_level=True)
 
-# this import statement is needed to ensure the ops are registered
-import vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe  # noqa: F401
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+    rocm_aiter_grouped_topk,
+)
 
 # need to import once to ensure the ops are registered
 # Check if aiter package is installed
@@ -46,6 +48,150 @@ def test_rocm_aiter_grouped_topk_custom_op_registration():
 
     # Check if the op is callable
     assert callable(torch.ops.vllm.rocm_aiter_grouped_topk)
+
+
+def test_rocm_aiter_topk_gating_custom_op_registration():
+    """Test that the custom op is correctly registered."""
+    assert hasattr(torch.ops.vllm, "rocm_aiter_topk_gating")
+    assert callable(torch.ops.vllm.rocm_aiter_topk_gating)
+
+
+def test_rocm_aiter_topk_gating_torch_compile_compatibility():
+    """Test biased sigmoid top-k through eager and compiled custom-op paths."""
+    torch.manual_seed(54594)
+    token = 4
+    expert = 256
+    topk = 8
+    scale_factor = 2.827
+    gating_output = torch.randn((token, expert), dtype=torch.float32, device="cuda")
+    correction_bias = torch.randn((expert,), dtype=torch.float32, device="cuda")
+
+    def allocate_outputs():
+        weights = torch.empty((token, topk + 1), dtype=torch.float32, device="cuda")[
+            :, :topk
+        ]
+        ids = torch.empty((token, topk + 1), dtype=torch.int32, device="cuda")[:, :topk]
+        assert not weights.is_contiguous()
+        assert not ids.is_contiguous()
+        return weights, ids
+
+    def topk_gating_fn(gating_output, correction_bias, topk_weights, topk_ids):
+        return torch.ops.vllm.rocm_aiter_topk_gating(
+            gating_output,
+            correction_bias,
+            topk_weights,
+            topk_ids,
+            True,
+            scale_factor,
+            "sigmoid",
+        )
+
+    opcheck_weights, opcheck_ids = allocate_outputs()
+    torch.library.opcheck(
+        torch.ops.vllm.rocm_aiter_topk_gating,
+        (gating_output, correction_bias, opcheck_weights, opcheck_ids),
+        kwargs={
+            "need_renorm": True,
+            "routed_scaling_factor": scale_factor,
+            "scoring_func": "sigmoid",
+        },
+        test_utils=("test_faketensor",),
+    )
+
+    eager_weights, eager_ids = allocate_outputs()
+    compiled_weights, compiled_ids = allocate_outputs()
+    topk_gating_fn(gating_output, correction_bias, eager_weights, eager_ids)
+    compiled_fn = torch.compile(
+        topk_gating_fn,
+        fullgraph=True,
+        backend="inductor",
+        mode="reduce-overhead",
+        dynamic=False,
+    )
+    compiled_fn(gating_output, correction_bias, compiled_weights, compiled_ids)
+
+    scores = gating_output.sigmoid()
+    expected_ids = torch.topk(scores + correction_bias, topk, dim=-1).indices
+    expected_weights = scores.gather(1, expected_ids)
+    expected_weights /= expected_weights.sum(dim=-1, keepdim=True)
+    expected_weights *= scale_factor
+
+    for actual_weights, actual_ids in (
+        (eager_weights, eager_ids),
+        (compiled_weights, compiled_ids),
+    ):
+        actual_ids, order = torch.sort(actual_ids)
+        actual_weights = torch.gather(actual_weights, 1, order)
+        expected_ids_sorted, expected_order = torch.sort(expected_ids.to(torch.int32))
+        expected_weights_sorted = torch.gather(expected_weights, 1, expected_order)
+        torch.testing.assert_close(actual_ids, expected_ids_sorted)
+        torch.testing.assert_close(
+            actual_weights, expected_weights_sorted, rtol=0.0, atol=1e-6
+        )
+
+
+def test_hy4_grouped_topk_dispatches_to_topk_gating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hidden_states = torch.empty((4, 6144), dtype=torch.bfloat16, device="cuda")
+    gating_output = torch.empty((4, 256), dtype=torch.float32, device="cuda")
+    correction_bias = torch.empty((256,), dtype=torch.float32, device="cuda")
+    calls = 0
+
+    def topk_gating(*args, **kwargs) -> None:
+        nonlocal calls
+        calls += 1
+
+    def fail_grouped_topk(*args, **kwargs) -> None:
+        raise AssertionError("Hy4 used biased_grouped_topk")
+
+    monkeypatch.setattr(rocm_aiter_ops, "topk_gating", topk_gating)
+    monkeypatch.setattr(rocm_aiter_ops, "biased_grouped_topk", fail_grouped_topk)
+    rocm_aiter_grouped_topk(
+        hidden_states,
+        gating_output,
+        topk=8,
+        renormalize=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="sigmoid",
+        routed_scaling_factor=2.827,
+        e_score_correction_bias=correction_bias,
+    )
+
+    assert calls == 1
+
+
+def test_non_hy4_grouped_topk_preserves_biased_grouped_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hidden_states = torch.empty((4, 6144), dtype=torch.bfloat16, device="cuda")
+    gating_output = torch.empty((4, 128), dtype=torch.float32, device="cuda")
+    correction_bias = torch.empty((128,), dtype=torch.float32, device="cuda")
+    calls = 0
+
+    def fail_topk_gating(*args, **kwargs) -> None:
+        raise AssertionError("non-Hy4 shape used topk_gating")
+
+    def biased_grouped_topk(*args, **kwargs) -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(rocm_aiter_ops, "topk_gating", fail_topk_gating)
+    monkeypatch.setattr(rocm_aiter_ops, "biased_grouped_topk", biased_grouped_topk)
+    rocm_aiter_grouped_topk(
+        hidden_states,
+        gating_output,
+        topk=8,
+        renormalize=True,
+        num_expert_group=1,
+        topk_group=1,
+        scoring_func="sigmoid",
+        routed_scaling_factor=2.827,
+        e_score_correction_bias=correction_bias,
+    )
+
+    assert calls == 1
 
 
 def test_rocm_aiter_biased_grouped_topk_torch_compile_compatibility():

--- a/tests/kernels/test_minimax_m3_amd_ops.py
+++ b/tests/kernels/test_minimax_m3_amd_ops.py
@@ -34,6 +34,9 @@ if not current_platform.is_rocm():
 if not torch.cuda.is_available():
     pytest.skip("Requires a GPU.", allow_module_level=True)
 
+from vllm.model_executor.layers.fused_moe.activation import (  # noqa: E402
+    MoEActivation,
+)
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (  # noqa: E402
     _mxfp8_e4m3_quantize_torch,
     _mxfp8_e4m3_quantize_triton,
@@ -186,6 +189,20 @@ def test_mxfp8_quant_triton_matches_torch(shape, dtype):
     deq_t = dequant_mxfp8_to_bf16(xq_t, s_t)
     deq_k = dequant_mxfp8_to_bf16(xq_k, s_k)
     assert _relerr(deq_k, deq_t) < 1e-2
+
+
+@pytest.mark.parametrize("shape", [(1, 2048), (64, 6144)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_mxfp8_quant_triton_zero_input(shape, dtype):
+    """Scale byte 0 must not make an all-zero activation block NaN."""
+    x = torch.zeros(*shape, device=DEVICE, dtype=dtype)
+    xq_ref, scale_ref = _mxfp8_e4m3_quantize_torch(x, is_sf_swizzled_layout=False)
+    xq, scale = _mxfp8_e4m3_quantize_triton(x)
+
+    torch.testing.assert_close(scale, scale_ref, rtol=0, atol=0)
+    torch.testing.assert_close(xq.float(), xq_ref.float(), rtol=0, atol=0)
+    assert torch.isfinite(xq.float()).all()
 
 
 # --------------------------------------------------------------------------- #
@@ -432,7 +449,12 @@ def test_mxfp8_linear_emulation_bf16_at_load(
 # forwards that mask to aiter unchanged (it no longer rebuilds it via
 # ``(expert_map >= 0)``, which collapsed an already-0/1 mask to all-ones and
 # produced EP garbage).
-def _capture_expert_mask(expert_mask, *, global_num_experts):
+def _capture_aiter_mxfp8_apply(
+    expert_mask,
+    *,
+    global_num_experts,
+    activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+):
     """Drive the real ``AiterMxfp8Experts.apply`` mask branch and capture the
     ``expert_mask`` it forwards to ``rocm_aiter_ops.fused_moe``."""
     from types import SimpleNamespace
@@ -452,6 +474,7 @@ def _capture_expert_mask(expert_mask, *, global_num_experts):
 
     def _fake_fused_moe(hidden_states, w1, w2, tw, ti, *, expert_mask, **kw):
         captured["expert_mask"] = expert_mask
+        captured.update(kw)
         return torch.zeros_like(hidden_states)
 
     w1 = torch.zeros(1, device=DEVICE)
@@ -469,7 +492,7 @@ def _capture_expert_mask(expert_mask, *, global_num_experts):
             w2=w2,
             topk_weights=tw,
             topk_ids=ti,
-            activation=None,
+            activation=activation,
             global_num_experts=global_num_experts,
             expert_map=expert_mask,
             a1q_scale=None,
@@ -479,7 +502,7 @@ def _capture_expert_mask(expert_mask, *, global_num_experts):
             expert_tokens_meta=None,
             apply_router_weight_on_input=False,
         )
-    return captured["expert_mask"]
+    return captured
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")
@@ -490,9 +513,31 @@ def test_aiter_mxfp8_apply_forwards_expert_mask_unchanged():
     ep_mask = torch.tensor(
         [1, 1, 1, 1, 0, 0, 0, 0, 0], dtype=torch.int32, device=DEVICE
     )
-    got = _capture_expert_mask(ep_mask, global_num_experts=8)
+    got = _capture_aiter_mxfp8_apply(ep_mask, global_num_experts=8)["expert_mask"]
     assert torch.equal(got.cpu().to(torch.int32), ep_mask.cpu().to(torch.int32))
     assert got.sum().item() == 4  # the 4 local experts, not all 9
+
+
+@pytest.mark.parametrize(
+    "activation,expected_activation,expected_gate_mode",
+    [
+        (MoEActivation.SILU, "Silu", "interleave"),
+        (MoEActivation.SWIGLUOAI_UNINTERLEAVE, "Swiglu", "interleave"),
+    ],
+)
+def test_aiter_mxfp8_apply_uses_matching_activation_and_layout(
+    activation, expected_activation, expected_gate_mode
+):
+    from aiter import ActivationType
+
+    captured = _capture_aiter_mxfp8_apply(
+        None, global_num_experts=8, activation=activation
+    )
+    assert (
+        captured["activation_method"]
+        == getattr(ActivationType, expected_activation).value
+    )
+    assert captured["gate_mode"] == expected_gate_mode
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")

--- a/tests/kernels/test_minimax_m3_amd_ops.py
+++ b/tests/kernels/test_minimax_m3_amd_ops.py
@@ -474,6 +474,8 @@ def _capture_aiter_mxfp8_apply(
 
     def _fake_fused_moe(hidden_states, w1, w2, tw, ti, *, expert_mask, **kw):
         captured["expert_mask"] = expert_mask
+        captured["topk_weights"] = tw
+        captured["topk_ids"] = ti
         captured.update(kw)
         return torch.zeros_like(hidden_states)
 
@@ -481,8 +483,10 @@ def _capture_aiter_mxfp8_apply(
     w2 = torch.zeros(1, device=DEVICE)
     out = torch.zeros(4, 8, device=DEVICE, dtype=torch.bfloat16)
     hidden = torch.zeros(4, 8, device=DEVICE, dtype=torch.bfloat16)
-    tw = torch.ones(4, 2, device=DEVICE)
-    ti = torch.zeros(4, 2, dtype=torch.int32, device=DEVICE)
+    tw = torch.ones(4, 4, device=DEVICE)[:, ::2]
+    ti = torch.zeros(4, 4, dtype=torch.int32, device=DEVICE)[:, ::2]
+    assert not tw.is_contiguous()
+    assert not ti.is_contiguous()
 
     with mock.patch.object(rocm_aiter_ops, "fused_moe", side_effect=_fake_fused_moe):
         experts.apply(
@@ -538,6 +542,8 @@ def test_aiter_mxfp8_apply_uses_matching_activation_and_layout(
         == getattr(ActivationType, expected_activation).value
     )
     assert captured["gate_mode"] == expected_gate_mode
+    assert captured["topk_weights"].is_contiguous()
+    assert captured["topk_ids"].is_contiguous()
 
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm only")

--- a/tests/model_executor/layers/test_fused_shared_expert.py
+++ b/tests/model_executor/layers/test_fused_shared_expert.py
@@ -16,6 +16,7 @@ from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.fused_moe import utils as fused_moe_utils
 from vllm.model_executor.layers.fused_moe.layer import determine_expert_counts
 from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.model_executor.layers.quantization.modelopt import ModelOptMxFp8Config
 from vllm.model_executor.layers.quantization.quark.quark import QuarkConfig
 from vllm.model_executor.layers.quantization.utils.config_utils import (
     is_shared_expert_quant_fse_compatible,
@@ -711,6 +712,38 @@ def test_non_quark_shared_expert_fse_is_incompatible() -> None:
     assert reason == (
         "shared-expert FSE quantization compatibility is not implemented for object"
     )
+
+
+@pytest.mark.parametrize(
+    ("exclude", "expected"),
+    [
+        ([], True),
+        (["model.layers.0.mlp.shared_experts.down_proj"], False),
+        (["model.layers.0.mlp.experts"], False),
+    ],
+)
+def test_modelopt_mxfp8_shared_expert_fse_compatibility(
+    exclude: list[str], expected: bool
+) -> None:
+    quant_config = ModelOptMxFp8Config(
+        is_checkpoint_mxfp8_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=exclude,
+    )
+    quant_config.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+
+    compatible, reason = is_shared_expert_quant_fse_compatible(
+        quant_config,
+        "model.layers.0.mlp.experts",
+        "model.layers.0.mlp.shared_experts",
+    )
+
+    assert compatible is expected
+    if expected:
+        assert reason is None
+    else:
+        assert reason is not None
+        assert "different quantization inclusion" in reason
 
 
 def _fp8_config(**kwargs: Any) -> Fp8Config:

--- a/tests/models/test_hy_v4_rocm.py
+++ b/tests/models/test_hy_v4_rocm.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+)
+from vllm.models.hy_v4.amd.attention import HYV4MLAAttention
+from vllm.models.hy_v4.amd.model import (
+    HYV4DecoderLayer,
+    HYV4ForCausalLM,
+    HYV4Model,
+)
+from vllm.models.hy_v4.amd.mtp import (
+    HYV4MTP,
+    HYV4MultiTokenPredictor,
+    HYV4MultiTokenPredictorLayer,
+)
+from vllm.models.hy_v4.amd.rocm import (
+    HYV4ROCMAiterMLASparseBackend,
+    HYV4ROCMAiterMLASparseImpl,
+)
+from vllm.models.hy_v4.nvidia.model import (
+    HYV4ForCausalLM as NvidiaHYV4ForCausalLM,
+)
+from vllm.models.hy_v4.nvidia.mtp import HYV4MTP as NvidiaHYV4MTP
+from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+    ROCMAiterMLASparseImpl,
+)
+
+
+class _FakeLmHead:
+    def __init__(self, weight: torch.Tensor):
+        self.weight = weight
+        self.quant_method = UnquantizedEmbeddingMethod()
+        self.shard_indices = type(
+            "ShardIndices",
+            (),
+            {"num_org_vocab_padding": 0, "org_vocab_start_index": 0},
+        )()
+        self.tp_size = 1
+
+
+class _FakeSharedHead(nn.Module):
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.head = _FakeLmHead(weight)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states
+
+
+class _FakeMTPPredictorLayer(nn.Module):
+    def __init__(self, weight: torch.Tensor):
+        super().__init__()
+        self.shared_head = _FakeSharedHead(weight)
+
+
+class _FakeLogitsProcessor(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.skip_gather_calls: list[bool] = []
+
+    def forward(
+        self,
+        lm_head: _FakeLmHead,
+        hidden_states: torch.Tensor,
+        embedding_bias: torch.Tensor | None = None,
+        skip_gather: bool = False,
+    ) -> torch.Tensor:
+        self.skip_gather_calls.append(skip_gather)
+        return torch.nn.functional.linear(
+            hidden_states,
+            lm_head.weight,
+            embedding_bias,
+        )
+
+    def get_top_tokens(
+        self, lm_head: _FakeLmHead, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        return self(lm_head, hidden_states).argmax(dim=-1)
+
+
+def _make_mtp_predictor(weights: list[torch.Tensor]) -> HYV4MultiTokenPredictor:
+    predictor = HYV4MultiTokenPredictor.__new__(HYV4MultiTokenPredictor)
+    nn.Module.__init__(predictor)
+    predictor.mtp_start_layer_idx = 80
+    predictor.num_mtp_layers = len(weights)
+    predictor.spec_step_idx = 0
+    predictor.layers = nn.ModuleDict(
+        {
+            str(predictor.mtp_start_layer_idx + idx): _FakeMTPPredictorLayer(weight)
+            for idx, weight in enumerate(weights)
+        }
+    )
+    predictor.logits_processor = _FakeLogitsProcessor()
+    return predictor
+
+
+def _make_mtp(weights: list[torch.Tensor]) -> HYV4MTP:
+    mtp = HYV4MTP.__new__(HYV4MTP)
+    nn.Module.__init__(mtp)
+    mtp.model = _make_mtp_predictor(weights)
+    return mtp
+
+
+def test_rocm_model_and_mtp_use_amd_attention() -> None:
+    assert HYV4DecoderLayer.attention_cls is HYV4MLAAttention
+    assert HYV4Model.decoder_layer_cls is HYV4DecoderLayer
+    assert HYV4ForCausalLM.model_cls is HYV4Model
+    assert HYV4MultiTokenPredictorLayer.decoder_layer_cls is HYV4DecoderLayer
+    assert HYV4MultiTokenPredictor.predictor_layer_cls is HYV4MultiTokenPredictorLayer
+    assert HYV4MTP.predictor_cls is HYV4MultiTokenPredictor
+
+
+@pytest.mark.parametrize("soft_cap", [None, 2.0])
+def test_rocm_target_local_logits_match_gathered_logits(
+    soft_cap: float | None,
+) -> None:
+    hidden_states = torch.tensor([[1.0, -2.0], [0.5, 3.0]])
+    weight = torch.tensor([[4.0, 0.0], [0.0, 3.0], [-1.0, -1.0]])
+    model = HYV4ForCausalLM.__new__(HYV4ForCausalLM)
+    nn.Module.__init__(model)
+    model.lm_head = _FakeLmHead(weight)
+    model.logits_processor = _FakeLogitsProcessor()
+    model.config = SimpleNamespace(
+        soft_logits_capping=soft_cap is not None,
+        soft_logits_capping_logits=soft_cap,
+    )
+
+    local_logits = model.compute_logits_local(hidden_states)
+    gathered_logits = model.compute_logits(hidden_states)
+
+    torch.testing.assert_close(local_logits, gathered_logits)
+    assert model.logits_processor.skip_gather_calls == [True, False]
+
+
+def test_rocm_target_exposes_local_logits_only_on_amd() -> None:
+    assert "compute_logits_local" in HYV4ForCausalLM.__dict__
+    assert "compute_logits_local" not in NvidiaHYV4ForCausalLM.__dict__
+
+
+def test_rocm_target_fused_shared_expert_rewrites_checkpoint_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = HYV4ForCausalLM.__new__(HYV4ForCausalLM)
+    nn.Module.__init__(model)
+    model.model = nn.Module()
+    model.model.is_fused_shared_expert_enabled = True
+    model.config = SimpleNamespace(n_routed_experts=2, n_shared_experts=1)
+    captured: list[tuple[str, torch.Tensor]] = []
+
+    def fake_load_weights(self, weights):
+        captured.extend(weights)
+        return {name for name, _ in captured}
+
+    monkeypatch.setattr(NvidiaHYV4ForCausalLM, "load_weights", fake_load_weights)
+    weight = torch.arange(6).view(2, 3)
+    loaded = model.load_weights(
+        iter(
+            [
+                (
+                    "model.layers.1.mlp.shared_experts.gate_proj.weight",
+                    weight,
+                )
+            ]
+        )
+    )
+
+    expected_name = "model.layers.1.mlp.experts.2.gate_proj.weight"
+    assert loaded == {expected_name}
+    assert len(captured) == 1
+    assert captured[0][0] == expected_name
+    assert torch.equal(captured[0][1], weight)
+
+
+def test_rocm_mtp_local_argmax_uses_current_layer(default_vllm_config) -> None:
+    hidden_states = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    weights = [
+        torch.tensor([[4.0, 0.0], [0.0, 3.0], [-1.0, -1.0]]),
+        torch.tensor([[0.0, 5.0], [6.0, 0.0], [-1.0, -1.0]]),
+    ]
+    mtp = _make_mtp(weights)
+
+    mtp.model.spec_step_idx = 0
+    step_zero = mtp.get_top_tokens(hidden_states)
+    expected_zero = mtp.model.compute_logits(hidden_states).argmax(dim=-1)
+
+    mtp.model.spec_step_idx = 1
+    step_one = mtp.get_top_tokens(hidden_states)
+    expected_one = mtp.model.compute_logits(hidden_states).argmax(dim=-1)
+
+    assert torch.equal(step_zero, expected_zero)
+    assert torch.equal(step_one, expected_one)
+    assert not torch.equal(step_zero, step_one)
+
+
+def test_rocm_mtp_exposes_local_argmax_only_on_amd() -> None:
+    assert "get_top_tokens" in HYV4MTP.__dict__
+    assert "get_top_tokens" not in NvidiaHYV4MTP.__dict__
+
+
+def test_rocm_mtp_fused_shared_expert_rewrites_checkpoint_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mtp = HYV4MTP.__new__(HYV4MTP)
+    nn.Module.__init__(mtp)
+    mtp.model = nn.Module()
+    mtp.model.is_fused_shared_expert_enabled = True
+    mtp.config = SimpleNamespace(n_routed_experts=2, n_shared_experts=1)
+    captured: list[tuple[str, torch.Tensor]] = []
+
+    def fake_load_weights(self, weights):
+        captured.extend(weights)
+        return {name for name, _ in captured}
+
+    monkeypatch.setattr(NvidiaHYV4MTP, "load_weights", fake_load_weights)
+    scale = torch.arange(3, dtype=torch.uint8).view(1, 3)
+    loaded = mtp.load_weights(
+        iter(
+            [
+                (
+                    "model.mtp_layers.0.mlp.shared_experts.down_proj.weight_scale",
+                    scale,
+                )
+            ]
+        )
+    )
+
+    expected_name = "model.mtp_layers.0.mlp.experts.2.down_proj.weight_scale"
+    assert loaded == {expected_name}
+    assert len(captured) == 1
+    assert captured[0][0] == expected_name
+    assert torch.equal(captured[0][1], scale)
+
+
+@pytest.mark.skipif(
+    getattr(torch.version, "hip", None) is None or not torch.accelerator.is_available(),
+    reason="requires ROCm",
+)
+def test_rocm_mtp_local_argmax_supports_graph_replay(default_vllm_config) -> None:
+    weights = [torch.randn(32, 16, device="cuda")]
+    mtp = _make_mtp(weights)
+    mtp.model.logits_processor = LogitsProcessor(weights[0].shape[0])
+    mtp.model.logits_processor.head_dtype = weights[0].dtype
+    hidden_states = torch.randn(4, 16, device="cuda")
+
+    mtp.get_top_tokens(hidden_states)
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_tokens = mtp.get_top_tokens(hidden_states)
+
+    hidden_states.copy_(torch.randn_like(hidden_states))
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    expected = mtp.model.compute_logits(hidden_states).argmax(dim=-1)
+    assert torch.equal(graph_tokens, expected)
+
+
+def test_rocm_sparse_backend_preserves_name_and_supports_sink() -> None:
+    assert HYV4ROCMAiterMLASparseBackend.get_name() == "ROCM_AITER_MLA_SPARSE"
+    assert HYV4ROCMAiterMLASparseBackend.supports_sink()
+    assert HYV4ROCMAiterMLASparseBackend.get_impl_cls() is HYV4ROCMAiterMLASparseImpl
+
+
+def test_rocm_sparse_impl_reuses_validated_base_initialization() -> None:
+    assert HYV4ROCMAiterMLASparseImpl.__init__ is ROCMAiterMLASparseImpl.__init__

--- a/tests/models/test_hy_v4_rocm.py
+++ b/tests/models/test_hy_v4_rocm.py
@@ -11,6 +11,7 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     UnquantizedEmbeddingMethod,
 )
+from vllm.models.hy_v4.amd import attention as amd_attention
 from vllm.models.hy_v4.amd.attention import HYV4MLAAttention
 from vllm.models.hy_v4.amd.model import (
     HYV4DecoderLayer,
@@ -25,6 +26,9 @@ from vllm.models.hy_v4.amd.mtp import (
 from vllm.models.hy_v4.amd.rocm import (
     HYV4ROCMAiterMLASparseBackend,
     HYV4ROCMAiterMLASparseImpl,
+)
+from vllm.models.hy_v4.nvidia.attention import (
+    HYV4MLAAttention as NvidiaHYV4MLAAttention,
 )
 from vllm.models.hy_v4.nvidia.model import (
     HYV4ForCausalLM as NvidiaHYV4ForCausalLM,
@@ -117,6 +121,57 @@ def test_rocm_model_and_mtp_use_amd_attention() -> None:
     assert HYV4MultiTokenPredictorLayer.decoder_layer_cls is HYV4DecoderLayer
     assert HYV4MultiTokenPredictor.predictor_layer_cls is HYV4MultiTokenPredictorLayer
     assert HYV4MTP.predictor_cls is HYV4MultiTokenPredictor
+
+
+def test_nvidia_mla_gate_hook_preserves_eager_semantics() -> None:
+    attention = NvidiaHYV4MLAAttention.__new__(NvidiaHYV4MLAAttention)
+    nn.Module.__init__(attention)
+    attn_out = torch.tensor([[1.0, -2.0, 0.5]], dtype=torch.bfloat16)
+    gate_score = torch.tensor([[-1.0, 0.0, 2.0]], dtype=torch.bfloat16)
+
+    actual = attention._apply_mla_gate(attn_out, gate_score)
+    expected = attn_out * torch.sigmoid(gate_score)
+
+    assert torch.equal(actual, expected)
+
+
+def test_rocm_mla_gate_falls_back_for_unsupported_inputs() -> None:
+    attention = HYV4MLAAttention.__new__(HYV4MLAAttention)
+    nn.Module.__init__(attention)
+    attention.config = SimpleNamespace(gating_type="elementwise")
+    attn_out = torch.tensor([[1.0, -2.0, 0.5]], dtype=torch.bfloat16)
+    gate_score = torch.tensor([[-1.0, 0.0, 2.0]], dtype=torch.bfloat16)
+
+    actual = attention._apply_mla_gate(attn_out, gate_score)
+    expected = attn_out * torch.sigmoid(gate_score)
+
+    assert torch.equal(actual, expected)
+
+
+def test_rocm_mla_gate_dispatches_fused_hook(monkeypatch: pytest.MonkeyPatch) -> None:
+    attention = HYV4MLAAttention.__new__(HYV4MLAAttention)
+    nn.Module.__init__(attention)
+    attn_out = torch.ones(1, 3)
+    gate_score = torch.zeros(1, 3)
+    sentinel = torch.full_like(attn_out, 7)
+    calls: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+    monkeypatch.setattr(
+        HYV4MLAAttention,
+        "_can_use_fused_mla_gate",
+        lambda self, output, gate: True,
+    )
+
+    def fake_fused(output: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        calls.append((output, gate))
+        return sentinel
+
+    monkeypatch.setattr(amd_attention, "hy4_rocm_bf16_sigmoid_mul", fake_fused)
+
+    actual = attention._apply_mla_gate(attn_out, gate_score)
+
+    assert actual is sentinel
+    assert calls == [(attn_out, gate_score)]
 
 
 @pytest.mark.parametrize("soft_cap", [None, 2.0])
@@ -264,6 +319,76 @@ def test_rocm_mtp_local_argmax_supports_graph_replay(default_vllm_config) -> Non
 
     expected = mtp.model.compute_logits(hidden_states).argmax(dim=-1)
     assert torch.equal(graph_tokens, expected)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4, 64])
+@pytest.mark.skipif(
+    getattr(torch.version, "hip", None) is None or not torch.accelerator.is_available(),
+    reason="requires ROCm",
+)
+def test_rocm_bf16_mla_gate_is_bitwise_equal(num_tokens: int) -> None:
+    torch.manual_seed(54594 + num_tokens)
+    attn_out = torch.randn(num_tokens, 2048, dtype=torch.bfloat16, device="cuda")
+    gate_score = torch.randn_like(attn_out)
+    gate_score.view(-1)[:7] = torch.tensor(
+        [float("-inf"), -20.0, -0.0, 0.0, 20.0, float("inf"), float("nan")],
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    expected = attn_out * torch.sigmoid(gate_score)
+    actual = amd_attention.hy4_rocm_bf16_sigmoid_mul(attn_out, gate_score)
+
+    expected_nan = torch.isnan(expected)
+    actual_nan = torch.isnan(actual)
+    assert torch.equal(actual_nan, expected_nan)
+    assert torch.equal(
+        actual.view(torch.int16)[~expected_nan],
+        expected.view(torch.int16)[~expected_nan],
+    )
+
+
+@pytest.mark.skipif(
+    getattr(torch.version, "hip", None) is None or not torch.accelerator.is_available(),
+    reason="requires ROCm",
+)
+def test_rocm_bf16_mla_gate_supports_graph_input_mutation() -> None:
+    torch.manual_seed(54594)
+    attn_out = torch.randn(4, 2048, dtype=torch.bfloat16, device="cuda")
+    gate_score = torch.randn_like(attn_out)
+    amd_attention.hy4_rocm_bf16_sigmoid_mul(attn_out, gate_score)
+    torch.accelerator.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = amd_attention.hy4_rocm_bf16_sigmoid_mul(attn_out, gate_score)
+
+    attn_out.copy_(torch.randn_like(attn_out))
+    gate_score.copy_(torch.randn_like(gate_score))
+    graph.replay()
+    torch.accelerator.synchronize()
+
+    expected = attn_out * torch.sigmoid(gate_score)
+    assert torch.equal(graph_output.view(torch.int16), expected.view(torch.int16))
+
+
+@pytest.mark.skipif(
+    getattr(torch.version, "hip", None) is None or not torch.accelerator.is_available(),
+    reason="requires ROCm",
+)
+def test_rocm_mla_gate_fusion_guard_matches_measured_shape() -> None:
+    attention = HYV4MLAAttention.__new__(HYV4MLAAttention)
+    nn.Module.__init__(attention)
+    attention.config = SimpleNamespace(gating_type="elementwise")
+    attn_out = torch.empty(4, 2048, dtype=torch.bfloat16, device="cuda")
+    gate_score = torch.empty_like(attn_out)
+
+    assert attention._can_use_fused_mla_gate(attn_out, gate_score)
+
+    attention.config.gating_type = "headwise"
+    assert not attention._can_use_fused_mla_gate(attn_out, gate_score)
+    attention.config.gating_type = "elementwise"
+    assert not attention._can_use_fused_mla_gate(attn_out[:, ::2], gate_score[:, ::2])
 
 
 def test_rocm_sparse_backend_preserves_name_and_supports_sink() -> None:

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -60,9 +60,9 @@ def test_registry_imports(model_arch):
         pytest.skip("Dots3 NOTE is only supported on CUDA")
 
     if model_arch in ("HYV4ForCausalLM", "HYV4MTPModel") and not (
-        current_platform.is_cuda()
+        current_platform.is_cuda() or current_platform.is_rocm()
     ):
-        pytest.skip("HY V4 is only supported on CUDA")
+        pytest.skip("HY V4 is only supported on CUDA and ROCm")
 
     # Ensure all model classes can be imported successfully
     model_cls = ModelRegistry._try_load_model_cls(model_arch)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -188,6 +188,48 @@ def test_rocm_keeps_compiled_deepseek_defaults(monkeypatch):
         default_breakable_cudagraph_architectures.cache_clear()
 
 
+def test_rocm_hyv4_defaults_to_mrv2_and_breakable_cudagraph(monkeypatch):
+    from vllm.compilation.breakable_cudagraph import (
+        is_breakable_cudagraph_enabled,
+    )
+    from vllm.config.vllm import (
+        ROCM_DEFAULT_MRV1_ARCHITECTURES,
+        default_breakable_cudagraph_architectures,
+    )
+    from vllm.platforms import current_platform
+
+    monkeypatch.delenv("VLLM_USE_BREAKABLE_CUDAGRAPH", raising=False)
+    monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+    monkeypatch.setattr(vllm_config_module, "HAS_TRITON", True)
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: True)
+    default_breakable_cudagraph_architectures.cache_clear()
+
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(architectures=["HYV4ForCausalLM"]),
+        compilation_config=CompilationConfig(
+            cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE
+        ),
+    )
+    config._get_v2_model_runner_unsupported_features = lambda: []
+    config._uses_breakable_cudagraph_by_default = lambda: (
+        VllmConfig._uses_breakable_cudagraph_by_default(config)
+    )
+
+    try:
+        assert "HYV4ForCausalLM" not in ROCM_DEFAULT_MRV1_ARCHITECTURES
+        assert {
+            "HYV4ForCausalLM",
+            "HYV4MTPModel",
+        } <= default_breakable_cudagraph_architectures()
+        assert VllmConfig.use_v2_model_runner.fget(config)
+        assert VllmConfig._maybe_enable_breakable_cudagraph(config)
+        assert is_breakable_cudagraph_enabled()
+        assert config.compilation_config.mode == CompilationMode.NONE
+    finally:
+        os.environ.pop("VLLM_USE_BREAKABLE_CUDAGRAPH", None)
+        default_breakable_cudagraph_architectures.cache_clear()
+
+
 @pytest.mark.parametrize(
     ("model", "architecture"),
     [

--- a/tests/v1/attention/test_indexer_native_next_n.py
+++ b/tests/v1/attention/test_indexer_native_next_n.py
@@ -8,10 +8,16 @@ the schedule metadata was sized for the matching slot count.
 """
 
 import pytest
+import torch
 
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import _paged_mqa_logits_schedule_slots
 from vllm.v1.attention.backends.mla import indexer
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepSeekV32IndexerDecodeMetadata,
+    DeepseekV32IndexerMetadata,
+    DeepseekV32IndexerMetadataBuilder,
+)
 
 NUM_SMS = 114  # H100 PCIe
 
@@ -66,6 +72,34 @@ def test_sm90_next_n_4_halves_the_schedule_slots(monkeypatch):
     assert _paged_mqa_logits_schedule_slots(NUM_SMS, 4) == NUM_SMS // 2
     for next_n in (1, 2, 3):
         assert _paged_mqa_logits_schedule_slots(NUM_SMS, next_n) == NUM_SMS
+
+
+def test_update_flattened_draft_decode_seq_lens_in_place():
+    builder = object.__new__(DeepseekV32IndexerMetadataBuilder)
+    builder.supports_draft_decode_metadata_update = True
+
+    source_seq_lens = torch.tensor([17, 9, 0], dtype=torch.int32)
+    decode_seq_lens = torch.zeros((3, 1), dtype=torch.int32)
+    metadata = DeepseekV32IndexerMetadata(
+        seq_lens=source_seq_lens,
+        max_seq_len=17,
+        slot_mapping=torch.zeros(3, dtype=torch.int64),
+        num_decodes=3,
+        num_decode_tokens=3,
+        num_prefills=0,
+        num_prefill_tokens=0,
+        decode=DeepSeekV32IndexerDecodeMetadata(
+            block_table=torch.zeros((3, 1), dtype=torch.int32),
+            seq_lens=decode_seq_lens,
+            decode_lens=torch.ones(3, dtype=torch.int32),
+            requires_padding=False,
+            schedule_metadata=torch.empty(0, dtype=torch.int32),
+        ),
+    )
+
+    builder.update_draft_decode_metadata(metadata)
+
+    assert decode_seq_lens.tolist() == [[17], [9], [0]]
 
 
 @pytest.mark.parametrize("family", [10, 12])

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -637,6 +637,95 @@ def _rocm_aiter_mla_decode_fwd_fake(
     pass
 
 
+def _rocm_aiter_mla_decode_fwd_lse_impl(
+    q: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    o: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    max_seqlen_qo: int,
+    kv_indptr: torch.Tensor | None = None,
+    kv_indices: torch.Tensor | None = None,
+    kv_last_page_lens: torch.Tensor | None = None,
+    sm_scale: float = 1.0,
+    logit_cap: float = 0.0,
+    q_scale: torch.Tensor | None = None,
+    kv_scale: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run non-persistent AITER MLA decode and return natural-log LSE.
+
+    gfx942 persistent MLA kernels do not provide an LSE code object. Keeping
+    this as a separate op makes that constraint structural: callers that need
+    LSE cannot accidentally forward persistent work metadata.
+    """
+    from aiter.mla import get_meta_param, mla_decode_fwd
+
+    kwargs: dict[str, float | int | torch.Tensor | None | bool] = {
+        "sm_scale": sm_scale,
+        "logit_cap": logit_cap,
+        "return_lse": True,
+    }
+    if _check_aiter_mla_fp8_support():
+        kwargs["q_scale"] = q_scale
+        kwargs["kv_scale"] = kv_scale
+
+    if q.dtype == FP8_DTYPE:
+        assert kv_indices is not None
+        num_kv_splits, num_kv_splits_indptr = get_meta_param(
+            None,
+            qo_indptr.shape[0] - 1,
+            kv_indices.numel(),
+            q.shape[1],
+            max_seqlen_qo,
+            q.dtype,
+        )
+        if num_kv_splits == 1:
+            # gfx942's one-split FP8 asm writes the final output directly but
+            # does not write either LSE buffer. Force the normal split reducer,
+            # which produces both the same output and an accurate natural LSE.
+            num_kv_splits = 2
+            num_kv_splits_indptr = torch.arange(
+                0,
+                (qo_indptr.shape[0]) * num_kv_splits,
+                num_kv_splits,
+                dtype=torch.int32,
+                device=q.device,
+            )
+        kwargs["num_kv_splits"] = num_kv_splits
+        kwargs["num_kv_splits_indptr"] = num_kv_splits_indptr
+
+    _, final_lse = mla_decode_fwd(
+        q,
+        kv_buffer.view(-1, 1, 1, q.shape[-1]),
+        o,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_lens,
+        max_seqlen_qo,
+        **kwargs,
+    )
+    if final_lse is None:
+        raise RuntimeError("AITER MLA decode did not return the requested LSE")
+    return final_lse
+
+
+def _rocm_aiter_mla_decode_fwd_lse_fake(
+    q: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    o: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    max_seqlen_qo: int,
+    kv_indptr: torch.Tensor | None = None,
+    kv_indices: torch.Tensor | None = None,
+    kv_last_page_lens: torch.Tensor | None = None,
+    sm_scale: float = 1.0,
+    logit_cap: float = 0.0,
+    q_scale: torch.Tensor | None = None,
+    kv_scale: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.empty(q.shape[:-1], dtype=torch.float32, device=q.device)
+
+
 def _rocm_aiter_w8a8_gemm_impl(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -2172,6 +2261,13 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
+                op_name="rocm_aiter_mla_decode_fwd_lse",
+                op_func=_rocm_aiter_mla_decode_fwd_lse_impl,
+                mutates_args=["o"],
+                fake_impl=_rocm_aiter_mla_decode_fwd_lse_fake,
+            )
+
+            direct_register_custom_op(
                 op_name="rocm_aiter_w8a8_gemm",
                 op_func=_rocm_aiter_w8a8_gemm_impl,
                 fake_impl=_rocm_aiter_w8a8_gemm_fake,
@@ -2747,6 +2843,37 @@ class rocm_aiter_ops:
             reduce_indptr=reduce_indptr,
             reduce_final_map=reduce_final_map,
             reduce_partial_map=reduce_partial_map,
+        )
+
+    @staticmethod
+    def mla_decode_fwd_lse(
+        q: torch.Tensor,
+        kv_buffer: torch.Tensor,
+        o: torch.Tensor,
+        sm_scale: float,
+        qo_indptr: torch.Tensor,
+        max_seqlen_qo: int,
+        kv_indptr: torch.Tensor | None = None,
+        kv_indices: torch.Tensor | None = None,
+        kv_last_page_lens: torch.Tensor | None = None,
+        logit_cap: float = 0.0,
+        q_scale: torch.Tensor | None = None,
+        kv_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run MLA decode without persistent metadata and return its LSE."""
+        return torch.ops.vllm.rocm_aiter_mla_decode_fwd_lse(
+            q,
+            kv_buffer.view(-1, 1, 1, q.shape[-1]),
+            o,
+            qo_indptr,
+            max_seqlen_qo,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_lens,
+            sm_scale=sm_scale,
+            logit_cap=logit_cap,
+            q_scale=q_scale,
+            kv_scale=kv_scale,
         )
 
     @staticmethod

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -668,6 +668,21 @@ def _rocm_aiter_mla_decode_fwd_lse_impl(
         kwargs["q_scale"] = q_scale
         kwargs["kv_scale"] = kv_scale
 
+    if (
+        q.dtype == torch.bfloat16
+        and kv_buffer.dtype == torch.bfloat16
+        and q.shape[1] == 32
+    ):
+        from vllm.platforms.rocm import on_gfx950
+
+        if on_gfx950():
+            # The gfx950 H32 BF16 kernel mishandles ragged tails with split KV.
+            # Its single-split path returns correct output and natural-log LSE.
+            kwargs["num_kv_splits"] = 1
+            kwargs["num_kv_splits_indptr"] = torch.arange(
+                qo_indptr.shape[0], dtype=torch.int32, device=q.device
+            )
+
     if q.dtype == FP8_DTYPE:
         assert kv_indices is not None
         num_kv_splits, num_kv_splits_indptr = get_meta_param(

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -413,6 +413,40 @@ def _rocm_aiter_topk_sigmoid_fake(
     pass
 
 
+def _rocm_aiter_topk_gating_impl(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    need_renorm: bool,
+    routed_scaling_factor: float = 1.0,
+    scoring_func: str = "sigmoid",
+) -> None:
+    from aiter.ops.topk import topk_gating
+
+    topk_gating(
+        topk_weights,
+        topk_ids,
+        gating_output,
+        correction_bias,
+        need_renorm,
+        routed_scaling_factor,
+        scoring_func,
+    )
+
+
+def _rocm_aiter_topk_gating_fake(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    need_renorm: bool,
+    routed_scaling_factor: float = 1.0,
+    scoring_func: str = "sigmoid",
+) -> None:
+    pass
+
+
 def _rocm_aiter_biased_grouped_topk_impl(
     gating_output: torch.Tensor,
     correction_bias: torch.Tensor,
@@ -2245,6 +2279,14 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
+                op_name="rocm_aiter_topk_gating",
+                op_func=_rocm_aiter_topk_gating_impl,
+                mutates_args=["topk_weights", "topk_ids"],
+                fake_impl=_rocm_aiter_topk_gating_fake,
+                dispatch_key=current_platform.dispatch_key,
+            )
+
+            direct_register_custom_op(
                 op_name="rocm_aiter_biased_grouped_topk",
                 op_func=_rocm_aiter_biased_grouped_topk_impl,
                 mutates_args=["topk_weights", "topk_ids"],
@@ -2785,6 +2827,26 @@ class rocm_aiter_ops:
             topk_group,
             need_renorm,
             routed_scaling_factor,
+        )
+
+    @staticmethod
+    def topk_gating(
+        gating_output: torch.Tensor,
+        correction_bias: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        need_renorm: bool,
+        routed_scaling_factor: float = 1.0,
+        scoring_func: str = "sigmoid",
+    ) -> None:
+        torch.ops.vllm.rocm_aiter_topk_gating(
+            gating_output,
+            correction_bias,
+            topk_weights,
+            topk_ids,
+            need_renorm,
+            routed_scaling_factor,
+            scoring_func,
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp8_moe.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""MXFP8 (1x32 block, E8M0) MoE via AITER's FlyDSL two-stage grouped GEMM
-(gfx950); alternative to ``Mxfp8NativeTritonExperts``. Routes through
-``aiter.fused_moe`` (per_1x32, gate_mode=INTERLEAVE); weights are preshuffled in
-``convert_to_fp8_moe_kernel_format``.
-"""
+"""MXFP8 (1x32 block, E8M0) MoE via AITER's FlyDSL grouped GEMM."""
 
 import math
 
@@ -101,20 +97,24 @@ class AiterMxfp8Experts(Mxfp8TritonExpertsBase):
             return False, (
                 "kernel requires the aiter flydsl package, which is not installed"
             )
+        supported_activations = {
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        }
+        if is_supported and moe_config.activation not in supported_activations:
+            return False, (
+                "kernel supports only standard SiLU or uninterleaved "
+                f"SwiGLU-OAI; got activation={moe_config.activation.value}"
+            )
         if (
             is_supported
-            and moe_config.activation != MoEActivation.SWIGLUOAI_UNINTERLEAVE
-        ):
-            return False, (
-                "kernel hardcodes SwiGLU-OAI activation and requires "
-                f"activation={MoEActivation.SWIGLUOAI_UNINTERLEAVE.value}; "
-                f"got activation={moe_config.activation.value}"
+            and moe_config.activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
+            and (
+                moe_config.swiglu_alpha is None
+                or not math.isclose(float(moe_config.swiglu_alpha), _AITER_SWIGLU_ALPHA)
+                or moe_config.swiglu_beta is None
+                or not math.isclose(float(moe_config.swiglu_beta), _AITER_SWIGLU_BETA)
             )
-        if is_supported and (
-            moe_config.swiglu_alpha is None
-            or not math.isclose(float(moe_config.swiglu_alpha), _AITER_SWIGLU_ALPHA)
-            or moe_config.swiglu_beta is None
-            or not math.isclose(float(moe_config.swiglu_beta), _AITER_SWIGLU_BETA)
         ):
             return False, (
                 "kernel hardcodes SwiGLU-OAI with "
@@ -147,8 +147,17 @@ class AiterMxfp8Experts(Mxfp8TritonExpertsBase):
 
         from vllm._aiter_ops import rocm_aiter_ops
 
-        limit = self.quant_config.gemm1_clamp_limit
-        swiglu_limit = 0.0 if limit is None else float(limit)
+        if activation == MoEActivation.SILU:
+            activation_method = ActivationType.Silu.value
+            gate_mode = GateMode.INTERLEAVE.value
+            swiglu_limit = 0.0
+        elif activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
+            activation_method = ActivationType.Swiglu.value
+            gate_mode = GateMode.INTERLEAVE.value
+            limit = self.quant_config.gemm1_clamp_limit
+            swiglu_limit = 0.0 if limit is None else float(limit)
+        else:
+            raise ValueError(f"Unsupported AITER MXFP8 activation: {activation}")
 
         # RoutedExperts.expert_map hands AITER experts the precomputed 0/1
         # expert_mask (with trailing sentinel) instead of the vLLM expert_map.
@@ -165,14 +174,14 @@ class AiterMxfp8Experts(Mxfp8TritonExpertsBase):
             topk_weights.to(torch.float32),
             topk_ids.to(torch.int32),
             expert_mask=expert_mask,
-            activation_method=ActivationType.Swiglu.value,
+            activation_method=activation_method,
             quant_method=QuantType.per_1x32.value,
             doweight_stage1=apply_router_weight_on_input,
             w1_scale=self.w1_scale_val,
             w2_scale=self.w2_scale_val,
             a1_scale=None,
             a2_scale=None,
-            gate_mode=GateMode.INTERLEAVE.value,
+            gate_mode=gate_mode,
             swiglu_limit=swiglu_limit,
             output_dtype=output.dtype,
         )

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp8_moe.py
@@ -164,15 +164,16 @@ class AiterMxfp8Experts(Mxfp8TritonExpertsBase):
         expert_mask = expert_map
 
         # Route through the graph-safe ``rocm_aiter_fused_moe`` custom op so the
-        # call is captured under HIP graphs / torch.compile (a direct
-        # ``aiter.fused_moe`` is opaque to the dispatcher). aiter requires FP32
-        # routing weights / INT32 ids.
+        # call is captured under HIP graphs / torch.compile. AITER's sorting
+        # kernels consume the routing buffers as packed arrays and do not honor
+        # a strided column slice. ``Tensor.to`` is a no-op when the dtype already
+        # matches, so make both buffers explicitly contiguous here.
         out = rocm_aiter_ops.fused_moe(
             hidden_states,
             w1,
             w2,
-            topk_weights.to(torch.float32),
-            topk_ids.to(torch.int32),
+            topk_weights.to(torch.float32).contiguous(),
+            topk_ids.to(torch.int32).contiguous(),
             expert_mask=expert_mask,
             activation_method=activation_method,
             quant_method=QuantType.per_1x32.value,

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -412,6 +412,11 @@ def rocm_aiter_fused_experts(
             bias1=quant_config.w1_bias if quant_config.use_mxfp4_w4a16 else None,
             bias2=quant_config.w2_bias if quant_config.use_mxfp4_w4a16 else None,
             moe_sorting_dispatch_policy=moe_sorting_dispatch_policy,
+            swiglu_limit=(
+                0.0
+                if moe_config.swiglu_limit is None
+                else float(moe_config.swiglu_limit)
+            ),
             beta=moe_config.activation_situ_beta,
             linear_beta=moe_config.activation_situ_linear_beta,
         )

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -199,7 +199,28 @@ def rocm_aiter_grouped_topk(
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
 
-    if e_score_correction_bias is not None:
+    # HY V4 has one expert group, so group selection is a no-op. Use AITER's
+    # fused biased sigmoid top-k instead of paying for grouped routing.
+    use_hy4_topk_gating = (
+        e_score_correction_bias is not None
+        and hidden_states.shape[-1] == 6144
+        and gating_output.shape[-1] == 256
+        and topk == 8
+        and num_expert_group == 1
+        and topk_group == 1
+        and scoring_func == "sigmoid"
+    )
+    if use_hy4_topk_gating:
+        rocm_aiter_ops.topk_gating(
+            gating_output,
+            e_score_correction_bias,
+            topk_weights,
+            topk_ids,
+            renormalize,
+            routed_scaling_factor,
+            scoring_func,
+        )
+    elif e_score_correction_bias is not None:
         rocm_aiter_ops.biased_grouped_topk(
             gating_output,
             e_score_correction_bias,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -11,6 +11,10 @@ import vllm.envs as envs
 from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear import (
+    AiterFp8BlockScaledMMKernel,
+    Fp8BlockScaledMMLinearKernel,
+    FP8ScaledMMLinearKernel,
+    Mxfp8LinearKernel,
     init_fp8_linear_kernel,
     init_mxfp8_linear_kernel,
     init_nvfp4_linear_kernel,
@@ -65,21 +69,27 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
     get_marlin_input_dtype,
 )
 from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    FP8_BLOCK_SIZE,
     MXFP8_BLOCK_SIZE,
     MXFP8_SCALE_DTYPE,
     MXFP8_VALUE_DTYPE,
+    convert_mxfp8_moe_weights_to_block_fp8,
+    convert_mxfp8_weight_to_block_fp8,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     create_fp8_quant_key,
     is_layer_skipped,
+    kFp8Dynamic128Sym,
     kFp8DynamicTokenSym,
+    kFp8Static128BlockSym,
     kFp8StaticTensorSym,
     kFp8StaticTokenSym,
     kNvfp4Dynamic,
     kNvfp4Static,
 )
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
+    normalize_e4m3fn_to_e4m3fnuz,
     requantize_with_max_scale,
 )
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
@@ -91,6 +101,7 @@ from vllm.model_executor.parameter import (
     PerTensorScaleParameter,
 )
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.platforms import current_platform
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.utils import WeightsMapper
@@ -1795,7 +1806,25 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
                 "Dynamic quantization is not supported."
             )
 
-        self.kernel = init_mxfp8_linear_kernel()
+        vllm_config = get_current_vllm_config()
+        self.input_dtype = vllm_config.model_config.dtype
+        self.out_dtype = vllm_config.model_config.dtype
+        linear_backend = vllm_config.kernel_config.linear_backend
+        self.convert_mxfp8_to_block_fp8 = False
+        consider_aiter_block_fp8 = (
+            current_platform.is_rocm()
+            and not current_platform.supports_mx()
+            and linear_backend in ("auto", "aiter")
+        )
+        if consider_aiter_block_fp8:
+            aiter_supported, _ = AiterFp8BlockScaledMMKernel.is_supported()
+            self.convert_mxfp8_to_block_fp8 = aiter_supported
+        self.kernel: (
+            Mxfp8LinearKernel
+            | FP8ScaledMMLinearKernel
+            | Fp8BlockScaledMMLinearKernel
+            | None
+        ) = None if self.convert_mxfp8_to_block_fp8 else init_mxfp8_linear_kernel()
 
     def create_weights(
         self,
@@ -1853,11 +1882,30 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
         )
         layer.register_parameter("weight_scale", weight_scale)
 
+        if self.convert_mxfp8_to_block_fp8:
+            self.kernel = init_fp8_linear_kernel(
+                activation_quant_key=kFp8Dynamic128Sym,
+                weight_quant_key=kFp8Static128BlockSym,
+                weight_shape=layer.weight.shape,
+                input_dtype=self.input_dtype,
+                out_dtype=self.out_dtype,
+                module_name=self.__class__.__name__,
+            )
+            if not isinstance(self.kernel, AiterFp8BlockScaledMMKernel):
+                raise RuntimeError(
+                    "MXFP8 block conversion selected a non-AITER linear kernel: "
+                    f"{type(self.kernel).__name__}."
+                )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if getattr(layer, "_mxfp8_processed", False):
+            return
+
         # Idempotent: the emulation kernel may dequant the weight to BF16 at load
         # time (>=2-byte). If already converted, there is nothing left to do --
         # avoid re-running the MXFP8-only validation/conversion below.
         if layer.weight.element_size() >= 2:
+            layer._mxfp8_processed = True
             return
 
         # Validate weight tensor
@@ -1883,7 +1931,26 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
             f" got {layer.weight_scale.dtype}"
         )
 
+        assert self.kernel is not None
+        if self.convert_mxfp8_to_block_fp8:
+            weight, weight_scale = convert_mxfp8_weight_to_block_fp8(
+                layer.weight.data,
+                layer.weight_scale.data,
+                block_size=FP8_BLOCK_SIZE,
+            )
+            if current_platform.is_fp8_fnuz():
+                weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                    weight, weight_scale
+                )
+            replace_parameter(layer, "weight", weight)
+            replace_parameter(layer, "weight_scale", weight_scale)
+            layer.weight_block_size = [FP8_BLOCK_SIZE, FP8_BLOCK_SIZE]
+            logger.info_once(
+                "Converted MXFP8 dense weights to 128x128 block FP8 for AITER GEMM."
+            )
+
         self.kernel.process_weights_after_loading(layer)
+        layer._mxfp8_processed = True
 
     def apply(
         self,
@@ -1891,6 +1958,7 @@ class ModelOptMxFp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        assert self.kernel is not None
         return self.kernel.apply_weights(layer, x, bias)
 
 
@@ -1906,8 +1974,34 @@ class ModelOptMxFp8FusedMoE(FusedMoEMethodBase):
         self.weight_block_size = [1, MXFP8_BLOCK_SIZE]
         self.quant_config = quant_config
         assert self.quant_config.is_checkpoint_mxfp8_serialized
+        self.convert_mxfp8_to_block_fp8 = False
+        self.mxfp8_backend: Fp8MoeBackend
 
-        self.mxfp8_backend, self.experts_cls = select_mxfp8_moe_backend(config=self.moe)
+        if (
+            current_platform.is_rocm()
+            and not current_platform.supports_mx()
+            and self.moe.moe_backend in ("auto", "aiter")
+        ):
+            try:
+                block_backend, block_experts_cls = select_fp8_moe_backend(
+                    config=self.moe,
+                    weight_key=kFp8Static128BlockSym,
+                    activation_key=kFp8Dynamic128Sym,
+                )
+            except (NotImplementedError, ValueError):
+                if self.moe.moe_backend == "aiter":
+                    raise
+            else:
+                if block_backend == Fp8MoeBackend.AITER:
+                    self.convert_mxfp8_to_block_fp8 = True
+                    self.weight_block_size = [FP8_BLOCK_SIZE, FP8_BLOCK_SIZE]
+                    self.mxfp8_backend = block_backend
+                    self.experts_cls = block_experts_cls
+
+        if not self.convert_mxfp8_to_block_fp8:
+            self.mxfp8_backend, self.experts_cls = select_mxfp8_moe_backend(
+                config=self.moe
+            )
 
     def create_weights(
         self,
@@ -2056,6 +2150,26 @@ class ModelOptMxFp8FusedMoE(FusedMoEMethodBase):
             num_experts,
         )
 
+    @staticmethod
+    def _convert_mxfp8_weights_to_block_fp8(layer: RoutedExperts) -> None:
+        def convert(weight: torch.Tensor, scale: torch.Tensor):
+            quantized, block_scale = convert_mxfp8_moe_weights_to_block_fp8(
+                weight, scale, block_size=FP8_BLOCK_SIZE
+            )
+            if current_platform.is_fp8_fnuz():
+                quantized, block_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                    quantized, block_scale
+                )
+            return quantized, block_scale
+
+        w13, w13_scale = convert(layer.w13_weight.data, layer.w13_weight_scale.data)
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+
+        w2, w2_scale = convert(layer.w2_weight.data, layer.w2_weight_scale.data)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
+
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         # TODO(bnell): why is this required only for mxfp8?
         if getattr(layer, "_already_called_process_weights_after_loading", False):
@@ -2063,6 +2177,12 @@ class ModelOptMxFp8FusedMoE(FusedMoEMethodBase):
         layer._already_called_process_weights_after_loading = True
 
         self._check_weight_dtypes(layer)
+
+        if self.convert_mxfp8_to_block_fp8:
+            self._convert_mxfp8_weights_to_block_fp8(layer)
+            logger.info_once(
+                "Converted MXFP8 MoE weights to 128x128 block FP8 for AITER fused MoE."
+            )
 
         layer.weight_block_size = self.weight_block_size
 

--- a/vllm/model_executor/layers/quantization/utils/config_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/config_utils.py
@@ -144,17 +144,21 @@ def is_shared_expert_quant_fse_compatible(
             return True, None
         return (
             False,
-            "Quark uses different quantization configurations for routed and "
-            f"shared experts at {shared_expert_prefix}",
+            (
+                "Quark uses different quantization configurations for routed and "
+                f"shared experts at {shared_expert_prefix}"
+            ),
         )
 
     if isinstance(quant_config, Fp8Config):
         if quant_config.store_dtype is not None:
             return (
                 False,
-                f"FP8 stores routed experts as {quant_config.store_dtype}, which "
-                f"is not supported for fused shared experts at "
-                f"{shared_expert_prefix}",
+                (
+                    f"FP8 stores routed experts as {quant_config.store_dtype}, which "
+                    "is not supported for fused shared experts at "
+                    f"{shared_expert_prefix}"
+                ),
             )
 
         # Serialized per-tensor checkpoints store 0-D or size-1 scales, which
@@ -163,8 +167,10 @@ def is_shared_expert_quant_fse_compatible(
         if quant_config.weight_block_size is None:
             return (
                 False,
-                "FP8 shared-expert FSE is only implemented for block-quantized "
-                "checkpoints",
+                (
+                    "FP8 shared-expert FSE is only implemented for block-quantized "
+                    "checkpoints"
+                ),
             )
 
         def is_ignored(layer_name: str) -> bool:
@@ -182,11 +188,37 @@ def is_shared_expert_quant_fse_compatible(
         ):
             return (
                 False,
-                "FP8 ignores routed and shared experts inconsistently at "
-                f"{shared_expert_prefix}",
+                (
+                    "FP8 ignores routed and shared experts inconsistently at "
+                    f"{shared_expert_prefix}"
+                ),
             )
 
         return True, None
+
+    # ModelOpt MXFP8 uses one global scheme plus an exclusion list. Fusing is
+    # safe only when the routed container and every shared-expert projection
+    # resolve to the same included/excluded state.
+    from vllm.model_executor.layers.quantization.modelopt import ModelOptMxFp8Config
+
+    if isinstance(quant_config, ModelOptMxFp8Config):
+        if not quant_config.is_checkpoint_mxfp8_serialized:
+            return False, "ModelOpt MXFP8 shared-expert FSE requires serialized weights"
+
+        expert_is_excluded = quant_config.is_layer_excluded(expert_prefix)
+        shared_projection_states = [
+            quant_config.is_layer_excluded(f"{shared_expert_prefix}.{projection_name}")
+            for projection_name in projection_names
+        ]
+        if all(state == expert_is_excluded for state in shared_projection_states):
+            return True, None
+        return (
+            False,
+            (
+                "ModelOpt MXFP8 uses different quantization inclusion for routed and "
+                f"shared experts at {shared_expert_prefix}"
+            ),
+        )
 
     # TODO: Extend FSE support detection to other quantization methods. Typically,
     # one would check that the experts and shared_experts use the same
@@ -194,6 +226,8 @@ def is_shared_expert_quant_fse_compatible(
 
     return (
         False,
-        "shared-expert FSE quantization compatibility is not implemented for "
-        f"{type(quant_config).__name__}",
+        (
+            "shared-expert FSE quantization compatibility is not implemented for "
+            f"{type(quant_config).__name__}"
+        ),
     )

--- a/vllm/model_executor/layers/quantization/utils/mxfp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp8_utils.py
@@ -9,6 +9,7 @@ from vllm.utils.torch_utils import direct_register_custom_op
 MXFP8_VALUE_DTYPE = torch.float8_e4m3fn
 MXFP8_SCALE_DTYPE = torch.uint8
 MXFP8_BLOCK_SIZE = 32
+FP8_BLOCK_SIZE = 128
 
 
 def swizzle_mxfp8_scale(sf: torch.Tensor, M: int, K: int) -> torch.Tensor:
@@ -126,8 +127,16 @@ def _mxfp8_quant_triton_kernel():
         amax = tl.maximum(tl.max(tl.abs(x), axis=1), TINY)  # [BLOCK_M]
         sb = tl.ceil(tl.log2(amax / FP8_MAX)) + 127.0
         sb = tl.minimum(tl.maximum(sb, 0.0), 254.0)
-        descale = tl.exp2(sb - 127.0)
-        xq = (x / descale[:, None]).to(xq_ptr.dtype.element_ty)
+        # Avoid materializing subnormal inverse scales.  In particular, an
+        # all-zero block uses the valid E8M0 scale byte 0 (2^-127); that value
+        # may flush to zero on AMD when computed as ``exp2(-127)``, turning
+        # ``0 / 0`` into NaN.  Apply the power of two in the direction whose
+        # exponent is non-negative instead.  This preserves scale byte 0 and
+        # also handles non-zero values that legitimately select a small scale.
+        scaled_up = x * tl.exp2(127.0 - sb[:, None])
+        scaled_down = x / tl.exp2(sb[:, None] - 127.0)
+        x_scaled = tl.where(sb[:, None] <= 127.0, scaled_up, scaled_down)
+        xq = x_scaled.to(xq_ptr.dtype.element_ty)
         tl.store(
             xq_ptr + offs_m[:, None] * sqm + offs_k[None, :] * sqk,
             xq,
@@ -223,6 +232,18 @@ def mxfp8_e4m3_quantize(
 
 def dequant_mxfp8_to_bf16(x: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
     """Dequantize MXFP8 tensor to BF16."""
+    if x.shape[-1] % MXFP8_BLOCK_SIZE != 0:
+        raise ValueError(
+            f"MXFP8 weight K={x.shape[-1]} must be divisible by {MXFP8_BLOCK_SIZE}."
+        )
+    expected_scale_shape = (*x.shape[:-1], x.shape[-1] // MXFP8_BLOCK_SIZE)
+    if tuple(scales.shape) != expected_scale_shape:
+        raise ValueError(
+            "MXFP8 scale shape must match the weight leading dimensions and "
+            f"have K/{MXFP8_BLOCK_SIZE} columns: expected "
+            f"{expected_scale_shape}, got {tuple(scales.shape)}."
+        )
+
     x_float = x.to(torch.float32)
 
     num_blocks = x.shape[-1] // MXFP8_BLOCK_SIZE
@@ -235,6 +256,86 @@ def dequant_mxfp8_to_bf16(x: torch.Tensor, scales: torch.Tensor) -> torch.Tensor
     dequantized = dequantized.view(*x.shape)
 
     return dequantized.to(torch.bfloat16)
+
+
+def quantize_bf16_to_block_fp8(
+    weight: torch.Tensor,
+    block_size: int = FP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a 2D weight to E4M3FN with square FP32 block scales."""
+    if weight.ndim != 2:
+        raise ValueError(
+            f"Block FP8 conversion requires a 2D weight, got {weight.ndim}D."
+        )
+
+    n, k = weight.shape
+    padded_n = ((n + block_size - 1) // block_size) * block_size
+    padded_k = ((k + block_size - 1) // block_size) * block_size
+    padded = torch.zeros(
+        (padded_n, padded_k), dtype=torch.float32, device=weight.device
+    )
+    padded[:n, :k] = weight.to(torch.float32)
+
+    blocked = padded.view(
+        padded_n // block_size,
+        block_size,
+        padded_k // block_size,
+        block_size,
+    )
+    amax = blocked.abs().amax(dim=(1, 3), keepdim=True).clamp(min=1e-4)
+    scale = amax / torch.finfo(MXFP8_VALUE_DTYPE).max
+    quantized = (blocked / scale).to(MXFP8_VALUE_DTYPE)
+
+    return (
+        quantized.view(padded_n, padded_k)[:n, :k].contiguous(),
+        scale.view(padded_n // block_size, padded_k // block_size).contiguous(),
+    )
+
+
+def convert_mxfp8_weight_to_block_fp8(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = FP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert a 2D MXFP8 weight to conventional block-scaled FP8."""
+    if weight.ndim != 2 or scale.ndim != 2:
+        raise ValueError("MXFP8-to-block-FP8 conversion requires 2D tensors.")
+    return quantize_bf16_to_block_fp8(
+        dequant_mxfp8_to_bf16(weight, scale), block_size=block_size
+    )
+
+
+def convert_mxfp8_moe_weights_to_block_fp8(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = FP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert expert weights one expert at a time to bound peak memory."""
+    if weight.ndim != 3 or scale.ndim != 3:
+        raise ValueError("MXFP8 MoE conversion requires 3D weight and scale tensors.")
+    if weight.shape[0] != scale.shape[0]:
+        raise ValueError(
+            "MXFP8 MoE weight and scale tensors must have the same expert count."
+        )
+
+    num_experts, n, k = weight.shape
+    quantized = torch.empty_like(weight)
+    block_scales = torch.empty(
+        (
+            num_experts,
+            (n + block_size - 1) // block_size,
+            (k + block_size - 1) // block_size,
+        ),
+        dtype=torch.float32,
+        device=weight.device,
+    )
+    for expert_id in range(num_experts):
+        expert_weight, expert_scale = convert_mxfp8_weight_to_block_fp8(
+            weight[expert_id], scale[expert_id], block_size=block_size
+        )
+        quantized[expert_id].copy_(expert_weight)
+        block_scales[expert_id].copy_(expert_scale)
+    return quantized, block_scales
 
 
 def mxfp8_e4m3_quantize_fake(

--- a/vllm/models/hy_v4/__init__.py
+++ b/vllm/models/hy_v4/__init__.py
@@ -14,19 +14,18 @@ The package is organized like `vllm.models.deepseek_v32`: this module is the
 only public entry point and dispatches on the current platform, so registry
 entries never reach into a platform subpackage.
 
-Only NVIDIA is supported for now. The port also drops the reference
+NVIDIA and ROCm are supported. The port also drops the reference
 implementation's HPC/TPCP fusion paths, which depend on infrastructure that
 does not exist in this tree.
 """
 
 from vllm.platforms import current_platform
 
-if current_platform.is_rocm():
-    raise NotImplementedError("hy_v4 does not yet support ROCm.")
-elif current_platform.is_xpu():
+if current_platform.is_xpu():
     raise NotImplementedError("hy_v4 does not yet support XPU.")
 else:
-    # Covers Blackwell (sm100) and all other CUDA devices.
+    # The implementation is shared by CUDA and ROCm; platform-specific
+    # attention behavior is selected by the normal attention backend router.
     from .nvidia.model import HYV4ForCausalLM
     from .nvidia.mtp import HYV4MTP
 

--- a/vllm/models/hy_v4/__init__.py
+++ b/vllm/models/hy_v4/__init__.py
@@ -21,11 +21,12 @@ does not exist in this tree.
 
 from vllm.platforms import current_platform
 
-if current_platform.is_xpu():
+if current_platform.is_rocm():
+    from .amd.model import HYV4ForCausalLM  # type: ignore[assignment]
+    from .amd.mtp import HYV4MTP  # type: ignore[assignment]
+elif current_platform.is_xpu():
     raise NotImplementedError("hy_v4 does not yet support XPU.")
 else:
-    # The implementation is shared by CUDA and ROCm; platform-specific
-    # attention behavior is selected by the normal attention backend router.
     from .nvidia.model import HYV4ForCausalLM
     from .nvidia.mtp import HYV4MTP
 

--- a/vllm/models/hy_v4/amd/__init__.py
+++ b/vllm/models/hy_v4/amd/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/hy_v4/amd/attention.py
+++ b/vllm/models/hy_v4/amd/attention.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.models.hy_v4.nvidia.attention import HYV4MLAAttention as BaseAttention
+
+from .rocm import HYV4ROCMAiterMLASparseBackend
+
+
+class HYV4MLAAttention(BaseAttention):
+    """HY V4 MLA attention using the sink-capable ROCm AITER backend."""
+
+    def _resolve_sink_backend(self, kv_cache_dtype: str):
+        return HYV4ROCMAiterMLASparseBackend

--- a/vllm/models/hy_v4/amd/attention.py
+++ b/vllm/models/hy_v4/amd/attention.py
@@ -1,13 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import torch
+
 from vllm.models.hy_v4.nvidia.attention import HYV4MLAAttention as BaseAttention
 
+from .ops import hy4_rocm_bf16_sigmoid_mul
 from .rocm import HYV4ROCMAiterMLASparseBackend
 
 
 class HYV4MLAAttention(BaseAttention):
     """HY V4 MLA attention using the sink-capable ROCm AITER backend."""
+
+    def _can_use_fused_mla_gate(
+        self, attn_out: torch.Tensor, gate_score: torch.Tensor
+    ) -> bool:
+        return (
+            self.config.gating_type == "elementwise"
+            and attn_out.device.type == "cuda"
+            and gate_score.device == attn_out.device
+            and attn_out.dtype == torch.bfloat16
+            and gate_score.dtype == torch.bfloat16
+            and attn_out.ndim == 2
+            and attn_out.shape == gate_score.shape
+            and attn_out.shape[-1] == 2048
+            and attn_out.is_contiguous()
+            and gate_score.is_contiguous()
+        )
+
+    def _apply_mla_gate(
+        self, attn_out: torch.Tensor, gate_score: torch.Tensor
+    ) -> torch.Tensor:
+        if self._can_use_fused_mla_gate(attn_out, gate_score):
+            return hy4_rocm_bf16_sigmoid_mul(attn_out, gate_score)
+        return super()._apply_mla_gate(attn_out, gate_score)
 
     def _resolve_sink_backend(self, kv_cache_dtype: str):
         return HYV4ROCMAiterMLASparseBackend

--- a/vllm/models/hy_v4/amd/ihc.py
+++ b/vllm/models/hy_v4/amd/ihc.py
@@ -1,0 +1,378 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ROCm Triton kernels for HY V4 independent Hyper-Connections."""
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from vllm.models.hy_v4.nvidia.hc import (
+    HYV4HCPostLayer as BaseHCPostLayer,
+)
+from vllm.models.hy_v4.nvidia.hc import (
+    HYV4HCPreLayer as BaseHCPreLayer,
+)
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _hy4_ihc_pre_stage1(
+    x_ptr,
+    fn_ptr,
+    partial_ptr,
+    K_TOTAL: tl.constexpr,
+    HC_MULT: tl.constexpr,
+    HC_POW2: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    PARTIAL_STRIDE: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    split_idx = tl.program_id(1)
+    hc_idx = tl.arange(0, HC_POW2)
+    hc_mask = hc_idx < HC_MULT
+
+    k_offsets = split_idx * BLOCK_K + tl.arange(0, BLOCK_K)
+    k_mask = k_offsets < K_TOTAL
+    x_tile = tl.load(
+        x_ptr + token_idx * K_TOTAL + k_offsets, mask=k_mask, other=0.0
+    ).to(tl.float32)
+
+    fn_offsets = hc_idx[:, None] * K_TOTAL + k_offsets[None, :]
+    fn_mask = hc_mask[:, None] & k_mask[None, :]
+    mix_pre = tl.sum(
+        tl.load(fn_ptr + fn_offsets, mask=fn_mask, other=0.0) * x_tile[None, :],
+        axis=1,
+    )
+    mix_post = tl.sum(
+        tl.load(
+            fn_ptr + HC_MULT * K_TOTAL + fn_offsets,
+            mask=fn_mask,
+            other=0.0,
+        )
+        * x_tile[None, :],
+        axis=1,
+    )
+
+    partial = partial_ptr + (token_idx * NUM_SPLITS + split_idx) * PARTIAL_STRIDE
+    tl.store(partial, tl.sum(x_tile * x_tile, axis=0))
+    tl.store(partial + 1 + hc_idx, mix_pre, mask=hc_mask)
+    tl.store(partial + 1 + HC_POW2 + hc_idx, mix_post, mask=hc_mask)
+
+
+@triton.jit
+def _hy4_ihc_pre_stage2(
+    x_ptr,
+    partial_ptr,
+    scale_ptr,
+    base_ptr,
+    output_ptr,
+    post_ptr,
+    HIDDEN_SIZE: tl.constexpr,
+    K_TOTAL: tl.constexpr,
+    HC_MULT: tl.constexpr,
+    HC_POW2: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    PARTIAL_STRIDE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    MAGNITUDE: tl.constexpr,
+    NORM_EPS: tl.constexpr,
+    HC_EPS: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    block_idx = tl.program_id(1)
+    hc_idx = tl.arange(0, HC_POW2)
+    hc_mask = hc_idx < HC_MULT
+
+    partial = partial_ptr + token_idx * NUM_SPLITS * PARTIAL_STRIDE
+    sumsq = tl.zeros((), dtype=tl.float32)
+    mix_pre = tl.zeros((HC_POW2,), dtype=tl.float32)
+    mix_post = tl.zeros((HC_POW2,), dtype=tl.float32)
+    for split_idx in tl.static_range(NUM_SPLITS):
+        split = partial + split_idx * PARTIAL_STRIDE
+        sumsq += tl.load(split)
+        mix_pre += tl.load(split + 1 + hc_idx, mask=hc_mask, other=0.0)
+        mix_post += tl.load(split + 1 + HC_POW2 + hc_idx, mask=hc_mask, other=0.0)
+
+    inv_rms = tl.rsqrt(sumsq / K_TOTAL + NORM_EPS)
+    pre = (
+        tl.sigmoid(
+            mix_pre * inv_rms * tl.load(scale_ptr)
+            + tl.load(base_ptr + hc_idx, mask=hc_mask, other=0.0)
+        )
+        + HC_EPS
+    )
+    if block_idx == 0:
+        post = (
+            MAGNITUDE
+            * tl.sigmoid(
+                mix_post * inv_rms * tl.load(scale_ptr + 1)
+                + tl.load(base_ptr + HC_MULT + hc_idx, mask=hc_mask, other=0.0)
+            )
+            + HC_EPS
+        )
+        tl.store(post_ptr + token_idx * HC_MULT + hc_idx, post, mask=hc_mask)
+
+    d_offsets = block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
+    d_mask = d_offsets < HIDDEN_SIZE
+    x_row = x_ptr + token_idx * K_TOTAL
+    output = tl.zeros((BLOCK_D,), dtype=tl.float32)
+    for channel_idx in tl.static_range(HC_MULT):
+        channel = tl.load(
+            x_row + channel_idx * HIDDEN_SIZE + d_offsets,
+            mask=d_mask,
+            other=0.0,
+        )
+        gate = tl.sum(tl.where(hc_idx == channel_idx, pre, 0.0), axis=0)
+        output += gate * channel.to(tl.float32)
+    tl.store(
+        output_ptr + token_idx * HIDDEN_SIZE + d_offsets,
+        output.to(output_ptr.dtype.element_ty),
+        mask=d_mask,
+    )
+
+
+@triton.jit
+def _hy4_ihc_post_kernel(
+    output_ptr,
+    residual_ptr,
+    post_ptr,
+    result_ptr,
+    HIDDEN_SIZE: tl.constexpr,
+    HC_MULT: tl.constexpr,
+    HC_POW2: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token_idx = tl.program_id(0).to(tl.int64)
+    block_idx = tl.program_id(1)
+    hc_idx = tl.arange(0, HC_POW2)
+    hc_mask = hc_idx < HC_MULT
+    post = tl.load(post_ptr + token_idx * HC_MULT + hc_idx, mask=hc_mask, other=0.0)
+
+    d_offsets = block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
+    d_mask = d_offsets < HIDDEN_SIZE
+    output = tl.load(
+        output_ptr + token_idx * HIDDEN_SIZE + d_offsets,
+        mask=d_mask,
+        other=0.0,
+    ).to(tl.float32)
+    residual_row = residual_ptr + token_idx * HC_MULT * HIDDEN_SIZE
+    result_row = result_ptr + token_idx * HC_MULT * HIDDEN_SIZE
+    for channel_idx in tl.static_range(HC_MULT):
+        residual = tl.load(
+            residual_row + channel_idx * HIDDEN_SIZE + d_offsets,
+            mask=d_mask,
+            other=0.0,
+        )
+        gate = tl.sum(tl.where(hc_idx == channel_idx, post, 0.0), axis=0)
+        result = gate * output + residual.to(tl.float32)
+        tl.store(
+            result_row + channel_idx * HIDDEN_SIZE + d_offsets,
+            result.to(result_ptr.dtype.element_ty),
+            mask=d_mask,
+        )
+
+
+def fused_hy4_ihc_pre(
+    x: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    magnitude: float,
+    norm_eps: float,
+    hc_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Execute HY V4 iHC pre-processing in two fused Triton stages."""
+    assert x.dim() == 3
+    assert hc_fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+
+    x = x.contiguous()
+    hc_fn = hc_fn.contiguous()
+    num_tokens, hc_mult, hidden_size = x.shape
+    k_total = hc_mult * hidden_size
+    assert hc_fn.shape == (2 * hc_mult, k_total)
+    assert hc_scale.shape == (2,)
+    assert hc_base.shape == (2 * hc_mult,)
+
+    output = torch.empty((num_tokens, hidden_size), dtype=x.dtype, device=x.device)
+    post = torch.empty((num_tokens, hc_mult), dtype=torch.float32, device=x.device)
+    if num_tokens == 0:
+        return output, post
+
+    block_k = 1024
+    block_d = 1024
+    hc_pow2 = triton.next_power_of_2(hc_mult)
+    num_splits = triton.cdiv(k_total, block_k)
+    partial_stride = 1 + 2 * hc_pow2
+    partial = torch.empty(
+        (num_tokens, num_splits, partial_stride),
+        dtype=torch.float32,
+        device=x.device,
+    )
+
+    _hy4_ihc_pre_stage1[(num_tokens, num_splits)](
+        x,
+        hc_fn,
+        partial,
+        K_TOTAL=k_total,
+        HC_MULT=hc_mult,
+        HC_POW2=hc_pow2,
+        NUM_SPLITS=num_splits,
+        BLOCK_K=block_k,
+        PARTIAL_STRIDE=partial_stride,
+        num_warps=8,
+        enable_fp_fusion=False,
+    )
+    _hy4_ihc_pre_stage2[(num_tokens, triton.cdiv(hidden_size, block_d))](
+        x,
+        partial,
+        hc_scale,
+        hc_base,
+        output,
+        post,
+        HIDDEN_SIZE=hidden_size,
+        K_TOTAL=k_total,
+        HC_MULT=hc_mult,
+        HC_POW2=hc_pow2,
+        NUM_SPLITS=num_splits,
+        PARTIAL_STRIDE=partial_stride,
+        BLOCK_D=block_d,
+        MAGNITUDE=magnitude,
+        NORM_EPS=norm_eps,
+        HC_EPS=hc_eps,
+        num_warps=4,
+        enable_fp_fusion=False,
+    )
+    return output, post
+
+
+def fused_hy4_ihc_post(
+    output: torch.Tensor,
+    residual: torch.Tensor,
+    post: torch.Tensor,
+) -> torch.Tensor:
+    """Execute HY V4 iHC post-processing in one fused Triton kernel."""
+    assert output.dim() == 2
+    assert post.dtype == torch.float32
+
+    output = output.contiguous()
+    residual = residual.contiguous()
+    post = post.contiguous()
+    num_tokens, hidden_size = output.shape
+    hc_mult = post.shape[-1]
+    assert residual.shape == (num_tokens, hc_mult, hidden_size)
+    assert post.shape == (num_tokens, hc_mult)
+
+    result = torch.empty(
+        (num_tokens, hc_mult, hidden_size), dtype=output.dtype, device=output.device
+    )
+    if num_tokens == 0:
+        return result
+
+    block_d = 1024
+    _hy4_ihc_post_kernel[(num_tokens, triton.cdiv(hidden_size, block_d))](
+        output,
+        residual,
+        post,
+        result,
+        HIDDEN_SIZE=hidden_size,
+        HC_MULT=hc_mult,
+        HC_POW2=triton.next_power_of_2(hc_mult),
+        BLOCK_D=block_d,
+        num_warps=4,
+        enable_fp_fusion=False,
+    )
+    return result
+
+
+class HYV4HCPreLayer(BaseHCPreLayer):
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return fused_hy4_ihc_pre(
+            x,
+            self.hc_fn.weight,
+            self.hc_scale,
+            self.hc_base,
+            self.magnitude,
+            self.layernorm_epsilon,
+            self.hc_eps,
+        )
+
+
+class HYV4HCPostLayer(BaseHCPostLayer):
+    def forward(
+        self, x: torch.Tensor, residual: torch.Tensor, post: torch.Tensor
+    ) -> torch.Tensor:
+        return fused_hy4_ihc_post(x, residual, post)
+
+
+class HYV4HCLayer(nn.Module):
+    """HY V4 iHC boundary backed by ROCm Triton kernels."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_idx: int,
+        init_std: float = 6e-3,
+        base_noise_std: float = 0.0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.enable_ihc = getattr(config, "enable_ihc", False)
+        if self.enable_ihc:
+            self.hc_pre = HYV4HCPreLayer(
+                config,
+                config.hidden_size,
+                config.hc_mult,
+                config.hc_magnitude,
+                init_std,
+                base_noise_std,
+                config.hc_eps,
+                config.rms_norm_eps,
+                prefix=f"{prefix}.hc_pre",
+            )
+            self.hc_post = HYV4HCPostLayer(config)
+
+    def prepare_input(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if not self.enable_ihc:
+            return hidden_states
+        if hidden_states.dim() == 3:
+            return hidden_states
+        if hidden_states.dim() != 2:
+            raise RuntimeError(
+                f"HC expects a 2D/3D tensor, got shape={tuple(hidden_states.shape)}"
+            )
+
+        num_tokens, width = hidden_states.shape
+        hidden_size = self.config.hidden_size
+        hc_mult = self.config.hc_mult
+        if width == hidden_size:
+            return hidden_states.unsqueeze(1).repeat(1, hc_mult, 1)
+        if width == hc_mult * hidden_size:
+            return hidden_states.reshape(num_tokens, hc_mult, hidden_size)
+        raise RuntimeError(
+            f"HC expects last dim to be hidden_size ({hidden_size}) or "
+            f"hc_mult*hidden_size ({hc_mult * hidden_size}), got {width}."
+        )
+
+    def pre(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+        if not self.enable_ihc:
+            return hidden_states, None, hidden_states
+        reduced, post_gates = self.hc_pre(hidden_states)
+        return reduced, post_gates, hidden_states
+
+    def post(
+        self,
+        output_with_bias: torch.Tensor,
+        residual: torch.Tensor,
+        post_gates: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if not self.enable_ihc:
+            return output_with_bias + residual
+        assert post_gates is not None
+        return self.hc_post(output_with_bias, residual, post_gates)

--- a/vllm/models/hy_v4/amd/model.py
+++ b/vllm/models/hy_v4/amd/model.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.fused_moe.utils import (
+    is_model_fused_shared_expert_compatible,
+)
+from vllm.model_executor.models.utils import maybe_fuse_shared_experts
+from vllm.models.hy_v4.nvidia.model import (
+    HYV4DecoderLayer as BaseDecoderLayer,
+)
+from vllm.models.hy_v4.nvidia.model import HYV4ForCausalLM as BaseForCausalLM
+from vllm.models.hy_v4.nvidia.model import HYV4Model as BaseModel
+
+from .attention import HYV4MLAAttention
+from .ihc import HYV4HCLayer
+from .moe import HYV4MoEFused
+
+
+class HYV4DecoderLayer(BaseDecoderLayer):
+    attention_cls = HYV4MLAAttention
+    hc_layer_cls = HYV4HCLayer
+    moe_cls = HYV4MoEFused
+
+
+@support_torch_compile
+class HYV4Model(BaseModel):
+    decoder_layer_cls = HYV4DecoderLayer
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
+            self.layers,
+            HYV4MoEFused,
+            "mlp",
+        )
+        self.num_fused_shared_experts = (
+            self.config.num_shared_experts if self.is_fused_shared_expert_enabled else 0
+        )
+
+
+class HYV4ForCausalLM(BaseForCausalLM):
+    model_cls = HYV4Model
+
+    def load_weights(self, weights):
+        if self.model.is_fused_shared_expert_enabled:
+            weights = maybe_fuse_shared_experts(
+                weights,
+                n_routed_experts=self.config.n_routed_experts,
+                n_shared_experts=self.config.n_shared_experts,
+                ckpt_prefix="mlp.shared_experts",
+                enabled=True,
+            )
+        loaded_params = super().load_weights(weights)
+
+        from vllm.model_executor.layers.quantization.kv_cache import (
+            KVCacheScaleParameter,
+        )
+
+        unassigned = sorted(
+            name
+            for name, param in self.named_parameters()
+            if name not in loaded_params
+            and not isinstance(param, KVCacheScaleParameter)
+        )
+        if unassigned:
+            raise ValueError(
+                "HYV4 ROCm target model has parameters with no checkpoint value: "
+                + ", ".join(unassigned)
+            )
+        return loaded_params
+
+    def compute_logits_local(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        logits = self.logits_processor(
+            self.lm_head,
+            hidden_states,
+            skip_gather=True,
+        )
+        if getattr(self.config, "soft_logits_capping", False):
+            soft_cap = self.config.soft_logits_capping_logits
+            logits = soft_cap * torch.nn.functional.tanh(logits / soft_cap)
+        return logits

--- a/vllm/models/hy_v4/amd/moe.py
+++ b/vllm/models/hy_v4/amd/moe.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from transformers import PretrainedConfig
+
+from vllm.model_executor.layers.fused_moe.utils import (
+    resolve_layer_fused_shared_expert,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.models.hy_v4.nvidia.moe import HYV4MoEFused as BaseMoEFused
+
+
+class HYV4MoEFused(BaseMoEFused):
+    """HY V4 MoE with compatible routed/shared-expert fusion."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        enable_eplb: bool = False,
+    ) -> None:
+        fuse_shared_experts = False
+        if config.num_shared_experts > 0:
+            fuse_shared_experts = resolve_layer_fused_shared_expert(
+                quant_config,
+                prefix,
+            )
+        super().__init__(
+            config=config,
+            quant_config=quant_config,
+            prefix=prefix,
+            enable_eplb=enable_eplb,
+            fuse_shared_experts=fuse_shared_experts,
+        )

--- a/vllm/models/hy_v4/amd/mtp.py
+++ b/vllm/models/hy_v4/amd/mtp.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.fused_moe.utils import (
+    is_model_fused_shared_expert_compatible,
+)
+from vllm.model_executor.models.utils import maybe_fuse_shared_experts
+from vllm.models.hy_v4.nvidia.mtp import HYV4MTP as BaseMTP
+from vllm.models.hy_v4.nvidia.mtp import (
+    HYV4MultiTokenPredictor as BaseMultiTokenPredictor,
+)
+from vllm.models.hy_v4.nvidia.mtp import (
+    HYV4MultiTokenPredictorLayer as BaseMultiTokenPredictorLayer,
+)
+
+from .model import HYV4DecoderLayer
+from .moe import HYV4MoEFused
+
+
+class HYV4MultiTokenPredictorLayer(BaseMultiTokenPredictorLayer):
+    decoder_layer_cls = HYV4DecoderLayer
+
+
+class HYV4MultiTokenPredictor(BaseMultiTokenPredictor):
+    predictor_layer_cls = HYV4MultiTokenPredictorLayer
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        self.is_fused_shared_expert_enabled = is_model_fused_shared_expert_compatible(
+            self.layers.values(),
+            HYV4MoEFused,
+            "mtp_block.mlp",
+        )
+        first_layer = next(iter(self.layers.values()), None)
+        self.num_fused_shared_experts = (
+            first_layer.mtp_block.config.num_shared_experts
+            if self.is_fused_shared_expert_enabled and first_layer is not None
+            else 0
+        )
+
+    def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        current_step_idx = self.spec_step_idx % self.num_mtp_layers
+        mtp_layer = self.layers[str(self.mtp_start_layer_idx + current_step_idx)]
+        proj_input = mtp_layer.shared_head(hidden_states)
+        return self.logits_processor.get_top_tokens(
+            mtp_layer.shared_head.head, proj_input
+        )
+
+
+@support_torch_compile
+class HYV4MTP(BaseMTP):
+    predictor_cls = HYV4MultiTokenPredictor
+
+    def load_weights(self, weights):
+        if self.model.is_fused_shared_expert_enabled:
+            weights = maybe_fuse_shared_experts(
+                weights,
+                n_routed_experts=self.config.n_routed_experts,
+                n_shared_experts=self.config.n_shared_experts,
+                ckpt_prefix="mlp.shared_experts",
+                enabled=True,
+            )
+        return super().load_weights(weights)
+
+    def get_top_tokens(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.model.get_top_tokens(hidden_states)

--- a/vllm/models/hy_v4/amd/ops/__init__.py
+++ b/vllm/models/hy_v4/amd/ops/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from .gated_mla import hy4_rocm_bf16_sigmoid_mul
+
+__all__ = ["hy4_rocm_bf16_sigmoid_mul"]

--- a/vllm/models/hy_v4/amd/ops/gated_mla.py
+++ b/vllm/models/hy_v4/amd/ops/gated_mla.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ROCm output-gating kernel for HY V4 MLA."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_BLOCK_SIZE = 2048
+
+
+@triton.jit
+def _bf16_sigmoid_mul_kernel(
+    attention_ptr,
+    gate_ptr,
+    output_ptr,
+    num_elements,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_elements
+    attention = tl.load(attention_ptr + offsets, mask=mask)
+    gate = tl.load(gate_ptr + offsets, mask=mask).to(tl.float32)
+
+    # torch.sigmoid preserves its BF16 input dtype. Reproduce that intermediate
+    # rounding boundary before the multiply so this remains bitwise equivalent
+    # to ``attention * torch.sigmoid(gate)``.
+    sigmoid_bf16 = tl.sigmoid(gate).to(tl.bfloat16)
+    output = attention.to(tl.float32) * sigmoid_bf16.to(tl.float32)
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+
+def _hy4_rocm_bf16_sigmoid_mul_impl(
+    attention: torch.Tensor, gate: torch.Tensor
+) -> torch.Tensor:
+    assert attention.dtype == gate.dtype == torch.bfloat16
+    assert attention.shape == gate.shape
+    assert attention.is_contiguous() and gate.is_contiguous()
+
+    output = torch.empty_like(attention)
+    num_elements = attention.numel()
+    if num_elements == 0:
+        return output
+    _bf16_sigmoid_mul_kernel[(triton.cdiv(num_elements, _BLOCK_SIZE),)](
+        attention,
+        gate,
+        output,
+        num_elements,
+        BLOCK_SIZE=_BLOCK_SIZE,
+        num_warps=8,
+        num_stages=1,
+    )
+    return output
+
+
+def _hy4_rocm_bf16_sigmoid_mul_fake(
+    attention: torch.Tensor, gate: torch.Tensor
+) -> torch.Tensor:
+    del gate
+    return torch.empty_like(attention)
+
+
+direct_register_custom_op(
+    op_name="hy4_rocm_bf16_sigmoid_mul",
+    op_func=_hy4_rocm_bf16_sigmoid_mul_impl,
+    fake_impl=_hy4_rocm_bf16_sigmoid_mul_fake,
+)
+
+
+def hy4_rocm_bf16_sigmoid_mul(
+    attention: torch.Tensor, gate: torch.Tensor
+) -> torch.Tensor:
+    return torch.ops.vllm.hy4_rocm_bf16_sigmoid_mul(attention, gate)

--- a/vllm/models/hy_v4/amd/rocm.py
+++ b/vllm/models/hy_v4/amd/rocm.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.v1.attention.backends.mla.rocm_aiter_mla_sparse import (
+    ROCMAiterMLASparseBackend,
+    ROCMAiterMLASparseImpl,
+    ROCMAiterMLASparseMetadataBuilder,
+)
+
+
+class HYV4ROCMAiterMLASparseImpl(ROCMAiterMLASparseImpl):
+    """Use the generic sink-capable AITER implementation with HY V4 metadata."""
+
+
+class HYV4ROCMAiterMLASparseMetadataBuilder(ROCMAiterMLASparseMetadataBuilder):
+    supports_draft_decode_metadata_update = True
+    use_persistent_mla_metadata = False
+
+
+class HYV4ROCMAiterMLASparseBackend(ROCMAiterMLASparseBackend):
+    @staticmethod
+    def get_builder_cls() -> type[HYV4ROCMAiterMLASparseMetadataBuilder]:
+        return HYV4ROCMAiterMLASparseMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> type[HYV4ROCMAiterMLASparseImpl]:
+        return HYV4ROCMAiterMLASparseImpl
+
+    @classmethod
+    def supports_sink(cls) -> bool:
+        return True

--- a/vllm/models/hy_v4/nvidia/attention.py
+++ b/vllm/models/hy_v4/nvidia/attention.py
@@ -655,6 +655,16 @@ class HYV4MLAAttention(nn.Module):
             "as the dense MLA prefill backends cannot apply sinks."
         )
 
+    def _apply_mla_gate(
+        self, attn_out: torch.Tensor, gate_score: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply the architecture's output gate.
+
+        Platform subclasses may override this hook with a semantically
+        equivalent fused implementation.
+        """
+        return attn_out * torch.sigmoid(gate_score)
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -725,10 +735,10 @@ class HYV4MLAAttention(nn.Module):
                     attn_out = attn_out.reshape(
                         *attn_out.shape[:-1], -1, self.v_head_dim
                     )
-                    attn_out = attn_out * torch.sigmoid(gate_score)
+                    attn_out = self._apply_mla_gate(attn_out, gate_score)
                     attn_out = attn_out.reshape(*attn_out.shape[:-2], -1)
                 else:
-                    attn_out = attn_out * torch.sigmoid(gate_score)
+                    attn_out = self._apply_mla_gate(attn_out, gate_score)
 
         out, _ = self.o_proj(attn_out)
         return out

--- a/vllm/models/hy_v4/nvidia/model.py
+++ b/vllm/models/hy_v4/nvidia/model.py
@@ -92,6 +92,10 @@ class HYV4DecoderLayer(nn.Module):
     otherwise it uses the standard single-stream residual.
     """
 
+    attention_cls = HYV4MLAAttention
+    hc_layer_cls = HYV4HCLayer
+    moe_cls: type[nn.Module] = HYV4MoEFused
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -109,7 +113,7 @@ class HYV4DecoderLayer(nn.Module):
         self.layer_idx = layer_idx
 
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
-        self.self_attn = HYV4MLAAttention(
+        self.self_attn = self.attention_cls(
             vllm_config=vllm_config,
             config=config,
             hidden_size=self.hidden_size,
@@ -137,15 +141,15 @@ class HYV4DecoderLayer(nn.Module):
             )
             self.block_type = "feedforward"
         else:
-            self.mlp = HYV4MoEFused(
+            self.mlp = self.moe_cls(
                 config=config, quant_config=quant_config, prefix=f"{prefix}.mlp"
             )
             self.block_type = "moe"
         self.post_attention_layernorm = RMSNorm(config.hidden_size, config.rms_norm_eps)
-        self.hc_attn_layer = HYV4HCLayer(
+        self.hc_attn_layer = self.hc_layer_cls(
             config, layer_idx, prefix=f"{prefix}.hc_attn_layer"
         )
-        self.hc_mlp_layer = HYV4HCLayer(
+        self.hc_mlp_layer = self.hc_layer_cls(
             config, layer_idx, prefix=f"{prefix}.hc_mlp_layer"
         )
 
@@ -212,6 +216,8 @@ class HYV4DecoderLayer(nn.Module):
 class HYV4Model(nn.Module):
     """HY V4 backbone."""
 
+    decoder_layer_cls = HYV4DecoderLayer
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -248,7 +254,7 @@ class HYV4Model(nn.Module):
             self.embed_tokens = PPMissingLayer()
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
-            lambda prefix: HYV4DecoderLayer(
+            lambda prefix: self.decoder_layer_cls(
                 config=config,
                 vllm_config=vllm_config,
                 cache_config=cache_config,
@@ -430,7 +436,16 @@ class HYV4Model(nn.Module):
         # MoE) and make a later reload target orphaned tensors.
         params_dict = dict(self.named_parameters())
         # Split per-expert mapping (V3 style): experts.0.gate_proj.weight
-        split_expert_params_mapping = self.get_expert_mapping()
+        num_experts = getattr(self.config, "num_experts", 0)
+        num_fused_shared_experts = getattr(self, "num_fused_shared_experts", 0)
+        split_expert_params_mapping = fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=num_experts + num_fused_shared_experts,
+            num_redundant_experts=self.num_redundant_experts,
+        )
         loaded_params: set[str] = set()
 
         # Sink weights are sharded like the q/k/v linears.
@@ -450,7 +465,6 @@ class HYV4Model(nn.Module):
             (f"{fused_expert_prefix}w13_weight", ".experts.gate_up_proj", 0, "w1"),
             (f"{fused_expert_prefix}w2_weight", ".experts.down_proj", 0, "w2"),
         ]
-        num_experts = getattr(self.config, "num_experts", 0)
 
         def _should_skip_missing_param(param_name: str) -> bool:
             # Sparse checkpoints may contain indexer weights for layers that
@@ -618,6 +632,8 @@ class HYV4Model(nn.Module):
 
 
 class HYV4ForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
+    model_cls = HYV4Model
+
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_stacked={
             ".q_a_proj": (".fused_qkv_a_proj", 0),
@@ -650,7 +666,7 @@ class HYV4ForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
         eplb_config = parallel_config.eplb_config
         self.num_redundant_experts = eplb_config.num_redundant_experts
 
-        self.model = HYV4Model(
+        self.model = self.model_cls(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
         if get_pp_group().is_last_rank:

--- a/vllm/models/hy_v4/nvidia/moe.py
+++ b/vllm/models/hy_v4/nvidia/moe.py
@@ -91,6 +91,7 @@ class HYV4MoEFused(nn.Module):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         enable_eplb: bool = False,
+        fuse_shared_experts: bool = False,
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
@@ -128,8 +129,11 @@ class HYV4MoEFused(nn.Module):
             prefix=f"{prefix}.gate",
         )
 
+        self.is_fused_shared_expert_enabled = bool(
+            fuse_shared_experts and config.num_shared_experts > 0
+        )
         self.shared_experts: HYV4FeedForward | None
-        if config.num_shared_experts > 0:
+        if config.num_shared_experts > 0 and not self.is_fused_shared_expert_enabled:
             self.shared_experts = HYV4FeedForward(
                 hidden_size=config.hidden_size,
                 intermediate_size=config.expert_hidden_dim * config.num_shared_experts,
@@ -167,6 +171,12 @@ class HYV4MoEFused(nn.Module):
             e_score_correction_bias=self.expert_bias,
             shared_experts=self.shared_experts,
             swiglu_limit=moe_swiglu_limit,
+            n_shared_experts=(
+                config.num_shared_experts
+                if self.is_fused_shared_expert_enabled
+                else None
+            ),
+            fuse_shared_experts=self.is_fused_shared_expert_enabled,
         )
         self.prefix = prefix
         if use_swiglu_clamp:

--- a/vllm/models/hy_v4/nvidia/mtp.py
+++ b/vllm/models/hy_v4/nvidia/mtp.py
@@ -324,6 +324,8 @@ class HYV4SharedHead(nn.Module):
 class HYV4MultiTokenPredictorLayer(nn.Module):
     """A single MTP draft block."""
 
+    decoder_layer_cls = HYV4DecoderLayer
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -356,7 +358,7 @@ class HYV4MultiTokenPredictorLayer(nn.Module):
             getattr(mtp_config, "mlp_layer_types", None), layer_idx, "sparse"
         )
 
-        self.mtp_block = HYV4DecoderLayer(
+        self.mtp_block = self.decoder_layer_cls(
             config=mtp_config,
             vllm_config=vllm_config,
             cache_config=cache_config,
@@ -402,6 +404,8 @@ def _extend_layer_types(
 class HYV4MultiTokenPredictor(nn.Module):
     """Owns the MTP draft blocks and their shared embedding / logits path."""
 
+    predictor_layer_cls = HYV4MultiTokenPredictorLayer
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         target_config = vllm_config.model_config.hf_config
@@ -440,7 +444,7 @@ class HYV4MultiTokenPredictor(nn.Module):
 
         self.layers = nn.ModuleDict(
             {
-                str(idx): HYV4MultiTokenPredictorLayer(
+                str(idx): self.predictor_layer_cls(
                     config,
                     f"{prefix}.layers.{idx}",
                     vllm_config=vllm_config,
@@ -525,6 +529,8 @@ class HYV4MTP(nn.Module):
     matching `DeepseekV32MTP` / `KimiK3MTP` / `HYV3MTP`.
     """
 
+    predictor_cls = HYV4MultiTokenPredictor
+
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
         # MLA runs both latent down-projections as one GEMM.
@@ -536,7 +542,7 @@ class HYV4MTP(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config
-        self.model = HYV4MultiTokenPredictor(
+        self.model = self.predictor_cls(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
         self.quant_config = self.model.quant_config
@@ -752,12 +758,13 @@ class HYV4MTP(nn.Module):
         # The split layout is resolved through the shared EPLB helper so the
         # target param names stay in sync with the RoutedExperts module layout;
         # the fused layout is resolved from the live parameter names.
+        num_fused_shared_experts = getattr(self.model, "num_fused_shared_experts", 0)
         split_expert_params_mapping = fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=num_experts,
+            num_experts=num_experts + num_fused_shared_experts,
         )
         fused_expert_param_names: dict[tuple[str, str], str] = {}
         for param_name in params_dict:

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -227,6 +227,13 @@ class AttentionBackend(ABC):
             return False
 
     @classmethod
+    def supports_dcp(cls) -> bool:
+        try:
+            return cls.get_impl_cls().supports_dcp
+        except NotImplementedError:
+            return False
+
+    @classmethod
     def supports_non_causal_dcp(cls) -> bool:
         builder_cls = cls.get_builder_cls()
         return bool(getattr(builder_cls, "supports_non_causal_multi_token_dcp", False))
@@ -324,6 +331,8 @@ class AttentionBackend(ABC):
             invalid_reasons.append("KV connector not supported")
         if use_pcp and not cls.supports_pcp():
             invalid_reasons.append("PCP not supported")
+        if use_dcp and not cls.supports_dcp():
+            invalid_reasons.append("DCP not supported")
         if (
             use_adaptive_verification
             and not cls.supports_device_cpu_query_lens_mismatch()

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -632,6 +632,14 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 f"(compress_ratio={self.compress_ratio})."
             )
 
+        self.supports_draft_decode_metadata_update = (
+            current_platform.is_rocm()
+            and self.dcp_world_size == 1
+            and self.compress_ratio == 1
+            and self.use_flattening
+            and not self.supports_varlen
+        )
+
         # Pre-allocate buffers for CUDA graph compatibility when
         if self.compress_ratio > 1:
             # compress_ratio > 1 (DeepseekV4)
@@ -1070,6 +1078,22 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         )
 
         return attn_metadata
+
+    def update_draft_decode_metadata(
+        self, metadata: DeepseekV32IndexerMetadata
+    ) -> None:
+        assert self.supports_draft_decode_metadata_update
+        assert metadata.decode is not None
+        assert metadata.num_prefills == 0
+        assert metadata.num_decode_tokens == metadata.num_decodes
+
+        decode_seq_lens = metadata.decode.seq_lens
+        if decode_seq_lens.ndim == 2:
+            assert decode_seq_lens.shape[1] == 1
+            decode_seq_lens = decode_seq_lens[:, 0]
+        decode_seq_lens.copy_(
+            metadata.seq_lens[: metadata.num_decode_tokens], non_blocking=True
+        )
 
 
 def build_prefill_chunk_metadata(

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -302,6 +302,10 @@ class ROCMAiterMLASparseBackend(AttentionBackend):
     def is_sparse(cls) -> bool:
         return True
 
+    @classmethod
+    def supports_sink(cls) -> bool:
+        return True
+
 
 @dataclass
 class ROCMAiterMLASparseMetadata(AttentionMetadata):
@@ -369,6 +373,14 @@ class ROCMAiterMLASparseMetadataBuilder(
         self.num_heads = self.model_config.get_num_attention_heads(parallel_config)
         self.mla_dims = get_mla_dims(self.model_config)
         self.topk_tokens = vllm_config.model_config.hf_config.index_topk
+        attention_context = vllm_config.compilation_config.static_forward_context
+        # Sink decode must use AITER's nonpersistent path. In particular,
+        # gfx942 has no persistent+LSE kernel, and its metadata heuristic
+        # terminates for HY-V4's TP1 H64 shape.
+        self._use_persistent_metadata = all(
+            getattr(attention_context[name].impl, "sinks", None) is None
+            for name in layer_names
+        )
         # Bounds the KV-split heuristic (see `_sparse_decode_max_split`).
         self._num_compute_units = current_platform.num_compute_units()
         self.max_model_len_tensor = torch.tensor(
@@ -567,7 +579,7 @@ class ROCMAiterMLASparseMetadataBuilder(
             clamped_context_lens.tobytes(),
             seg_lengths.tobytes(),
         )
-        if metadata_key != self._prev_metadata_key:
+        if self._use_persistent_metadata and metadata_key != self._prev_metadata_key:
             from aiter import get_mla_metadata_v1
 
             max_split_per_batch = self._sparse_decode_max_split(
@@ -617,12 +629,24 @@ class ROCMAiterMLASparseMetadataBuilder(
             paged_kv_last_page_len=paged_kv_last_page_len,
             paged_kv_indices=paged_kv_indices,
             paged_kv_indptr=paged_kv_indptr,
-            work_meta_data=self._mla_work_meta_data,
-            work_indptr=self._mla_work_indptr,
-            work_info_set=self._mla_work_info_set,
-            reduce_indptr=self._mla_reduce_indptr,
-            reduce_final_map=self._mla_reduce_final_map,
-            reduce_partial_map=self._mla_reduce_partial_map,
+            work_meta_data=(
+                self._mla_work_meta_data if self._use_persistent_metadata else None
+            ),
+            work_indptr=(
+                self._mla_work_indptr if self._use_persistent_metadata else None
+            ),
+            work_info_set=(
+                self._mla_work_info_set if self._use_persistent_metadata else None
+            ),
+            reduce_indptr=(
+                self._mla_reduce_indptr if self._use_persistent_metadata else None
+            ),
+            reduce_final_map=(
+                self._mla_reduce_final_map if self._use_persistent_metadata else None
+            ),
+            reduce_partial_map=(
+                self._mla_reduce_partial_map if self._use_persistent_metadata else None
+            ),
         )
         return metadata
 
@@ -659,6 +683,7 @@ def reference_mla_sparse_prefill(
 class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
     is_sparse = True
     supports_dense_mha_prefill = False
+    supports_dcp = False
 
     def __init__(
         self,
@@ -683,6 +708,20 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         self.head_size = head_size
         self.scale = float(scale)
         self.num_kv_heads = num_kv_heads
+        sinks = mla_args.pop("sinks", None)
+        if sinks is not None:
+            if sinks.dtype != torch.float32:
+                raise ValueError(
+                    f"ROCm AITER MLA sinks must be float32, got {sinks.dtype}"
+                )
+            if sinks.ndim != 1 or sinks.numel() != num_heads:
+                raise ValueError(
+                    "ROCm AITER MLA sinks must have shape "
+                    f"({num_heads},), got {tuple(sinks.shape)}"
+                )
+            if not sinks.is_contiguous():
+                raise ValueError("ROCm AITER MLA sinks must be contiguous")
+        self.sinks: torch.Tensor | None = sinks
         self.kv_cache_dtype = kv_cache_dtype
         self.kv_lora_rank: int = mla_args["kv_lora_rank"]
         self.softmax_scale = scale
@@ -706,46 +745,92 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         q: torch.Tensor,  # [sq, heads, d_qk]
         kv_c_and_k_pe_cache: torch.Tensor,  # [blocks, heads, d_qk]
         attn_metadata: ROCMAiterMLASparseMetadata,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         num_tokens = q.shape[0]
         mla_num_heads = AiterMLAHelper.get_actual_mla_num_heads(self.num_heads)
+        need_lse = self.sinks is not None
+        if (
+            need_lse
+            and q.dtype == torch.bfloat16
+            and kv_c_and_k_pe_cache.dtype == torch.bfloat16
+            and mla_num_heads == 64
+        ):
+            from vllm.platforms.rocm import on_gfx942
+
+            if on_gfx942():
+                raise ValueError(
+                    "ROCm AITER MLA attention sinks do not support BF16 "
+                    "query/KV with 64 padded local heads on gfx942; increase "
+                    "tensor_parallel_size"
+                )
         output = torch.empty(
             [num_tokens, mla_num_heads, self.kv_lora_rank],
             dtype=attn_metadata.attn_out_dtype,
             device=q.device,
         )
 
-        # Build kwargs and forward the persistent MLA metadata when it has
-        # been computed. The aiter mla_decode_fwd switches to its
-        # work-stealing persistent kernel path when work_meta_data is given.
-        mla_kwargs: dict = dict(
-            q_scale=layer._q_scale,
-            kv_scale=layer._k_scale,
-        )
-        if attn_metadata.work_meta_data is not None:
-            mla_kwargs.update(
-                work_meta_data=attn_metadata.work_meta_data,
-                work_indptr=attn_metadata.work_indptr,
-                work_info_set=attn_metadata.work_info_set,
-                reduce_indptr=attn_metadata.reduce_indptr,
-                reduce_final_map=attn_metadata.reduce_final_map,
-                reduce_partial_map=attn_metadata.reduce_partial_map,
+        if need_lse:
+            # gfx942 has no persistent MLA code object that writes final LSE.
+            # The split-KV path consumes the same ragged indices and is exact.
+            lse = rocm_aiter_ops.mla_decode_fwd_lse(
+                q,
+                kv_c_and_k_pe_cache,
+                output,
+                self.scale,
+                attn_metadata.qo_indptr,
+                1,
+                attn_metadata.paged_kv_indptr,
+                attn_metadata.paged_kv_indices,
+                attn_metadata.paged_kv_last_page_len,
+                q_scale=layer._q_scale,
+                kv_scale=layer._k_scale,
             )
+        else:
+            # Preserve the persistent work-stealing fast path for models that
+            # do not use sinks.
+            mla_kwargs: dict = dict(
+                q_scale=layer._q_scale,
+                kv_scale=layer._k_scale,
+            )
+            if attn_metadata.work_meta_data is not None:
+                mla_kwargs.update(
+                    work_meta_data=attn_metadata.work_meta_data,
+                    work_indptr=attn_metadata.work_indptr,
+                    work_info_set=attn_metadata.work_info_set,
+                    reduce_indptr=attn_metadata.reduce_indptr,
+                    reduce_final_map=attn_metadata.reduce_final_map,
+                    reduce_partial_map=attn_metadata.reduce_partial_map,
+                )
 
-        rocm_aiter_ops.mla_decode_fwd(
-            q,
-            kv_c_and_k_pe_cache,
-            output,
-            self.scale,
-            attn_metadata.qo_indptr,
-            1,
-            attn_metadata.paged_kv_indptr,
-            attn_metadata.paged_kv_indices,
-            attn_metadata.paged_kv_last_page_len,
-            **mla_kwargs,
-        )
+            rocm_aiter_ops.mla_decode_fwd(
+                q,
+                kv_c_and_k_pe_cache,
+                output,
+                self.scale,
+                attn_metadata.qo_indptr,
+                1,
+                attn_metadata.paged_kv_indptr,
+                attn_metadata.paged_kv_indices,
+                attn_metadata.paged_kv_last_page_len,
+                **mla_kwargs,
+            )
+            lse = None
 
-        return AiterMLAHelper.get_mla_unpadded_o(self.num_heads, output)
+        output = AiterMLAHelper.get_mla_unpadded_o(self.num_heads, output)
+        if lse is not None:
+            lse = AiterMLAHelper.get_mla_unpadded_o(
+                self.num_heads, lse.unsqueeze(-1)
+            ).squeeze(-1)
+
+        if self.sinks is not None:
+            assert lse is not None
+            sink = self.sinks
+            sink_lse = torch.logaddexp(lse, sink)
+            sink_scale = torch.exp(lse - sink_lse)
+            output = (output.float() * sink_scale.unsqueeze(-1)).to(output.dtype)
+            lse = sink_lse
+
+        return output, lse
 
     def forward_mqa(
         self,
@@ -792,8 +877,6 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
                 q, _ = ops.scaled_fp8_quant(q.view(q.shape[0], -1), layer._q_scale)
                 q = q.view(original_q_shape)
         mla_padded_q = AiterMLAHelper.get_mla_padded_q(self.num_heads, q)
-        attn_out = self._forward_mla(
+        return self._forward_mla(
             layer, mla_padded_q, kv_c_and_k_pe_cache, attn_metadata
         )
-
-        return attn_out, None

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -304,7 +304,9 @@ class ROCMAiterMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supports_sink(cls) -> bool:
-        return True
+        from vllm.platforms.rocm import on_mi3xx
+
+        return on_mi3xx()
 
 
 @dataclass
@@ -747,8 +749,49 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         attn_metadata: ROCMAiterMLASparseMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         num_tokens = q.shape[0]
-        mla_num_heads = AiterMLAHelper.get_actual_mla_num_heads(self.num_heads)
+        base_mla_num_heads = AiterMLAHelper.get_actual_mla_num_heads(self.num_heads)
+        mla_num_heads = base_mla_num_heads
         need_lse = self.sinks is not None
+        # AITER's nonpersistent return-LSE dispatch has discrete head kernels.
+        supported_head_buckets: tuple[int, ...] | None = None
+        head_dtype_name = ""
+        if need_lse:
+            if (
+                q.dtype == torch.bfloat16
+                and kv_c_and_k_pe_cache.dtype == torch.bfloat16
+            ):
+                supported_head_buckets = (16, 32, 64, 128)
+                head_dtype_name = "BF16"
+            elif (
+                q.dtype == current_platform.fp8_dtype()
+                and kv_c_and_k_pe_cache.dtype == current_platform.fp8_dtype()
+            ):
+                supported_head_buckets = (16, 128)
+                head_dtype_name = "FP8"
+
+        if supported_head_buckets is not None:
+            from vllm.platforms.rocm import on_mi3xx
+
+            if on_mi3xx():
+                supported_heads = next(
+                    (
+                        heads
+                        for heads in supported_head_buckets
+                        if heads >= mla_num_heads
+                    ),
+                    None,
+                )
+                if supported_heads is None:
+                    raise ValueError(
+                        "ROCm AITER MLA attention sinks support at most 128 "
+                        f"padded local {head_dtype_name} heads; increase "
+                        "tensor_parallel_size"
+                    )
+                if supported_heads != mla_num_heads:
+                    q = AiterMLAHelper.get_mla_padded_q(
+                        mla_num_heads, q, supported_heads
+                    )
+                    mla_num_heads = supported_heads
         if (
             need_lse
             and q.dtype == torch.bfloat16
@@ -815,6 +858,17 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
                 **mla_kwargs,
             )
             lse = None
+
+        if mla_num_heads != base_mla_num_heads:
+            if mla_num_heads % base_mla_num_heads == 0:
+                head_stride = mla_num_heads // base_mla_num_heads
+                output = output[:, ::head_stride]
+                if lse is not None:
+                    lse = lse[:, ::head_stride]
+            else:
+                output = output[:, :base_mla_num_heads]
+                if lse is not None:
+                    lse = lse[:, :base_mla_num_heads]
 
         output = AiterMLAHelper.get_mla_unpadded_o(self.num_heads, output)
         if lse is not None:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -196,16 +196,20 @@ def generate_sparse_seqlen_kernel(
 
 
 def generate_sparse_seqlen_triton(
-    query_lens: torch.Tensor,
     seq_lens: torch.Tensor,
     cu_query_lens: torch.Tensor,
     topk_token: int,
     num_tokens: int,
     max_query_len: int,
+    out: torch.Tensor | None = None,
 ):
-    num_seqs = query_lens.size(0)
-    # zero initialize the tensor to make sure invalid positions will be zero
-    out = torch.zeros([num_tokens], dtype=torch.int32, device=query_lens.device)
+    num_seqs = seq_lens.size(0)
+    if out is None:
+        out = torch.empty([num_tokens], dtype=torch.int32, device=seq_lens.device)
+    else:
+        out = out[:num_tokens]
+    # Zero initialize the tensor to make sure invalid positions will be zero.
+    out.zero_()
     block_size = 64
     num_block_per_row = triton.cdiv(max_query_len, block_size)
     grid = (
@@ -317,6 +321,7 @@ class ROCMAiterMLASparseMetadata(AttentionMetadata):
 
     num_actual_tokens: int  # Number of tokens excluding padding.
     query_start_loc: torch.Tensor
+    seq_lens: torch.Tensor
     slot_mapping: torch.Tensor
 
     block_table: torch.Tensor
@@ -354,6 +359,7 @@ class ROCMAiterMLASparseMetadataBuilder(
     AttentionMetadataBuilder[ROCMAiterMLASparseMetadata]
 ):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    use_persistent_mla_metadata: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -379,7 +385,7 @@ class ROCMAiterMLASparseMetadataBuilder(
         # Sink decode must use AITER's nonpersistent path. In particular,
         # gfx942 has no persistent+LSE kernel, and its metadata heuristic
         # terminates for HY-V4's TP1 H64 shape.
-        self._use_persistent_metadata = all(
+        self._use_persistent_metadata = self.use_persistent_mla_metadata and all(
             getattr(attention_context[name].impl, "sinks", None) is None
             for name in layer_names
         )
@@ -414,6 +420,9 @@ class ROCMAiterMLASparseMetadataBuilder(
         )
         self.paged_kv_indptr = torch.zeros(
             [max_num_batched_tokens + 1], dtype=torch.int32, device=device
+        )
+        self.sparse_seqlen_buffer = torch.zeros(
+            [max_num_batched_tokens], dtype=torch.int32, device=device
         )
 
         # ----- Persistent MLA metadata buffers -----
@@ -532,18 +541,14 @@ class ROCMAiterMLASparseMetadataBuilder(
         self.req_id_per_token_buffer[:new_req_extent].copy_(
             np_to_pinned_tensor(req_id_per_token), non_blocking=True
         )
-        query_lens = (
-            common_attn_metadata.query_start_loc[1:]
-            - common_attn_metadata.query_start_loc[:-1]
-        )
         seq_lens = common_attn_metadata.seq_lens
         sparse_seqlen = generate_sparse_seqlen_triton(
-            query_lens,
             seq_lens,
             common_attn_metadata.query_start_loc,
             self.topk_tokens,
             num_tokens,
             common_attn_metadata.max_query_len,
+            out=self.sparse_seqlen_buffer,
         )
 
         torch.cumsum(sparse_seqlen, dim=0, out=self.paged_kv_indptr[1 : num_tokens + 1])
@@ -557,60 +562,57 @@ class ROCMAiterMLASparseMetadataBuilder(
 
         # ----- Compute persistent MLA metadata -----
         # The aiter sparse decode kernel uses qseqlen=1 (each query token is
-        # treated as its own batch entry), so persistent metadata can always
-        # be precomputed here. The kernel switches to the persistent
-        # work-stealing path automatically when work_meta_data is non-None.
-        # The output is a deterministic function of the per-request query and
-        # context lengths (both clamped to topk_tokens, past which per-token KV
-        # length saturates) and num_heads; fingerprint those CPU-side and skip
-        # the launch when nothing changed.
-        num_reqs = common_attn_metadata.num_reqs
-        clamped_seq_lens = np.minimum(
-            common_attn_metadata.seq_lens_cpu[:num_reqs].numpy(),
-            self.topk_tokens,
-        )
-        clamped_context_lens = np.minimum(
-            common_attn_metadata.seq_lens_cpu[:num_reqs].numpy() - seg_lengths,
-            self.topk_tokens,
-        )
-        metadata_key = (
-            num_tokens,
-            int(common_attn_metadata.max_query_len),
-            self._num_attention_heads,
-            clamped_seq_lens.tobytes(),
-            clamped_context_lens.tobytes(),
-            seg_lengths.tobytes(),
-        )
-        if self._use_persistent_metadata and metadata_key != self._prev_metadata_key:
-            from aiter import get_mla_metadata_v1
-
-            max_split_per_batch = self._sparse_decode_max_split(
-                int(common_attn_metadata.max_seq_len)
+        # treated as its own batch entry). The output is a deterministic
+        # function of the per-request query and context lengths and num_heads;
+        # fingerprint those CPU-side and skip the launch when nothing changed.
+        if self._use_persistent_metadata:
+            num_reqs = common_attn_metadata.num_reqs
+            clamped_seq_lens = np.minimum(
+                common_attn_metadata.seq_lens_cpu[:num_reqs].numpy(),
+                self.topk_tokens,
             )
-            get_mla_metadata_v1(
-                qo_indptr,
-                paged_kv_indptr,
-                paged_kv_last_page_len,
+            clamped_context_lens = np.minimum(
+                common_attn_metadata.seq_lens_cpu[:num_reqs].numpy() - seg_lengths,
+                self.topk_tokens,
+            )
+            metadata_key = (
+                num_tokens,
+                int(common_attn_metadata.max_query_len),
                 self._num_attention_heads,
-                1,
-                True,
-                self._mla_work_meta_data,
-                self._mla_work_info_set,
-                self._mla_work_indptr,
-                self._mla_reduce_indptr,
-                self._mla_reduce_final_map,
-                self._mla_reduce_partial_map,
-                page_size=1,
-                kv_granularity=16,
-                max_seqlen_qo=1,
-                uni_seqlen_qo=1,
-                fast_mode=True,
-                max_split_per_batch=max_split_per_batch,
+                clamped_seq_lens.tobytes(),
+                clamped_context_lens.tobytes(),
+                seg_lengths.tobytes(),
             )
-            # The persistent metadata buffers are read by graph replay. Order
-            # the async metadata write before the graph-captured decode kernel.
-            torch.cuda.current_stream(self.device).synchronize()
-            self._prev_metadata_key = metadata_key
+            if metadata_key != self._prev_metadata_key:
+                from aiter import get_mla_metadata_v1
+
+                max_split_per_batch = self._sparse_decode_max_split(
+                    int(common_attn_metadata.max_seq_len)
+                )
+                get_mla_metadata_v1(
+                    qo_indptr,
+                    paged_kv_indptr,
+                    paged_kv_last_page_len,
+                    self._num_attention_heads,
+                    1,
+                    True,
+                    self._mla_work_meta_data,
+                    self._mla_work_info_set,
+                    self._mla_work_indptr,
+                    self._mla_reduce_indptr,
+                    self._mla_reduce_final_map,
+                    self._mla_reduce_partial_map,
+                    page_size=1,
+                    kv_granularity=16,
+                    max_seqlen_qo=1,
+                    uni_seqlen_qo=1,
+                    fast_mode=True,
+                    max_split_per_batch=max_split_per_batch,
+                )
+                # The persistent metadata buffers are read by graph replay. Order
+                # the async metadata write before the graph-captured decode kernel.
+                torch.cuda.current_stream(self.device).synchronize()
+                self._prev_metadata_key = metadata_key
 
         metadata = ROCMAiterMLASparseMetadata(
             num_reqs=common_attn_metadata.num_reqs,
@@ -618,6 +620,7 @@ class ROCMAiterMLASparseMetadataBuilder(
             max_seq_len=common_attn_metadata.max_seq_len,
             num_actual_tokens=common_attn_metadata.num_actual_tokens,
             query_start_loc=common_attn_metadata.query_start_loc,
+            seq_lens=seq_lens,
             slot_mapping=common_attn_metadata.slot_mapping,
             block_table=common_attn_metadata.block_table_tensor,
             req_id_per_token=req_id_per_token,
@@ -651,6 +654,26 @@ class ROCMAiterMLASparseMetadataBuilder(
             ),
         )
         return metadata
+
+    def update_draft_decode_metadata(
+        self, metadata: ROCMAiterMLASparseMetadata
+    ) -> None:
+        assert self.supports_draft_decode_metadata_update
+        assert not self.use_persistent_mla_metadata
+        sparse_seqlen = generate_sparse_seqlen_triton(
+            metadata.seq_lens,
+            metadata.query_start_loc,
+            metadata.topk_tokens,
+            metadata.num_actual_tokens,
+            metadata.max_query_len,
+            out=self.sparse_seqlen_buffer,
+        )
+        metadata.paged_kv_indptr[0].zero_()
+        torch.cumsum(
+            sparse_seqlen,
+            dim=0,
+            out=metadata.paged_kv_indptr[1:],
+        )
 
 
 # Take from
@@ -806,7 +829,10 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
                     "query/KV with 64 padded local heads on gfx942; increase "
                     "tensor_parallel_size"
                 )
-        output = torch.empty(
+        # Graph-padded rows are not guaranteed to be written by every AITER
+        # kernel variant. Record the zero-fill in the graph so an inactive row
+        # cannot retain values from an earlier replay.
+        output = torch.zeros(
             [num_tokens, mla_num_heads, self.kv_lora_rank],
             dtype=attn_metadata.attn_out_dtype,
             device=q.device,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -17,7 +17,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.utils.torch_utils import np_to_pinned_tensor
+from vllm.utils.torch_utils import get_kv_cache_torch_dtype, np_to_pinned_tensor
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -38,6 +38,159 @@ from vllm.v1.worker.workspace import current_workspace_manager
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
 logger = init_logger(__name__)
+
+
+def _get_aiter_sink_num_heads(
+    num_heads: int,
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+) -> int:
+    """Validate an AITER sink configuration and return its kernel head count."""
+    if q_dtype == torch.bfloat16 and kv_dtype == torch.bfloat16:
+        supported_head_buckets: tuple[int, ...] = (16, 32, 64, 128)
+        head_dtype_name = "BF16"
+    elif (
+        q_dtype == current_platform.fp8_dtype()
+        and kv_dtype == current_platform.fp8_dtype()
+    ):
+        supported_head_buckets = (16, 128)
+        head_dtype_name = "FP8"
+    else:
+        raise ValueError(
+            "ROCm AITER MLA attention sinks require query and KV to "
+            "both use BF16 or both use FP8, got "
+            f"query={q_dtype}, KV={kv_dtype}"
+        )
+
+    from vllm.platforms.rocm import on_gfx942, on_mi3xx
+
+    if not on_mi3xx():
+        return num_heads
+
+    padded_heads = next(
+        (heads for heads in supported_head_buckets if heads >= num_heads),
+        None,
+    )
+    if padded_heads is None:
+        raise ValueError(
+            "ROCm AITER MLA attention sinks support at most 128 "
+            f"padded local {head_dtype_name} heads; increase tensor_parallel_size"
+        )
+    if on_gfx942() and q_dtype == torch.bfloat16 and padded_heads == 64:
+        raise ValueError(
+            "ROCm AITER MLA attention sinks do not support BF16 "
+            "query/KV with 64 padded local heads on gfx942; increase "
+            "tensor_parallel_size"
+        )
+    return padded_heads
+
+
+@triton.jit
+def _apply_attention_sink_kernel(
+    output_ptr,
+    lse_ptr,
+    sink_ptr,
+    kv_indptr_ptr,
+    num_heads: tl.constexpr,
+    head_size: tl.constexpr,
+    output_stride_token,
+    output_stride_head,
+    output_stride_dim,
+    lse_stride_token,
+    lse_stride_head,
+    sink_stride,
+    HAS_KV_INDPTR: tl.constexpr,
+    HEADS_PER_PROGRAM: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    group_count: tl.constexpr = tl.cdiv(num_heads, HEADS_PER_PROGRAM)
+    program_idx = tl.program_id(0)
+    token_idx = program_idx // group_count
+    head_group = program_idx % group_count
+
+    head_offsets = head_group * HEADS_PER_PROGRAM + tl.arange(0, HEADS_PER_PROGRAM)
+    head_mask = head_offsets < num_heads
+    row_active = True
+    if HAS_KV_INDPTR:
+        row_active = tl.load(kv_indptr_ptr + token_idx + 1) > tl.load(
+            kv_indptr_ptr + token_idx
+        )
+
+    lse_offsets = token_idx * lse_stride_token + head_offsets * lse_stride_head
+    lse = tl.load(lse_ptr + lse_offsets, mask=head_mask).to(tl.float32)
+    sink = tl.load(sink_ptr + head_offsets * sink_stride, mask=head_mask).to(tl.float32)
+    safe_lse = tl.where(row_active, lse, float("-inf"))
+    maximum = tl.maximum(safe_lse, sink)
+    sink_lse = maximum + tl.log(tl.exp(safe_lse - maximum) + tl.exp(sink - maximum))
+    scale = tl.exp(safe_lse - sink_lse)
+
+    dim_offsets = tl.arange(0, BLOCK_SIZE)
+    dim_mask = dim_offsets < head_size
+    output_offsets = (
+        token_idx * output_stride_token
+        + head_offsets[:, None] * output_stride_head
+        + dim_offsets[None, :] * output_stride_dim
+    )
+    output_mask = head_mask[:, None] & dim_mask[None, :]
+    value = tl.load(
+        output_ptr + output_offsets,
+        mask=output_mask & row_active,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(
+        output_ptr + output_offsets,
+        value * scale[:, None],
+        mask=output_mask,
+    )
+    tl.store(lse_ptr + lse_offsets, sink_lse, mask=head_mask)
+
+
+def apply_attention_sink(
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    sinks: torch.Tensor,
+    kv_indptr: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply attention sinks and zero empty ragged rows in place."""
+    assert output.ndim == 3
+    assert lse.shape == output.shape[:2]
+    assert sinks.shape == (output.shape[1],)
+    assert lse.dtype == torch.float32
+    assert sinks.dtype == torch.float32
+    if kv_indptr is not None:
+        assert kv_indptr.ndim == 1
+        assert kv_indptr.shape[0] >= output.shape[0] + 1
+        assert kv_indptr.dtype == torch.int32
+        assert kv_indptr.device == output.device
+
+    num_tokens, num_heads, head_size = output.shape
+    if num_tokens == 0:
+        return output, lse
+
+    # HY V4 TP8 exposes eight real heads after AITER's H16 padding. Grouping
+    # those heads amortizes the empty-row check and is faster on gfx950.
+    heads_per_program = 8 if num_heads == 8 and head_size == 512 else 1
+    num_warps = 8 if heads_per_program == 8 else 4
+    group_count = triton.cdiv(num_heads, heads_per_program)
+    _apply_attention_sink_kernel[(num_tokens * group_count,)](
+        output,
+        lse,
+        sinks,
+        kv_indptr if kv_indptr is not None else lse,
+        num_heads=num_heads,
+        head_size=head_size,
+        output_stride_token=output.stride(0),
+        output_stride_head=output.stride(1),
+        output_stride_dim=output.stride(2),
+        lse_stride_token=lse.stride(0),
+        lse_stride_head=lse.stride(1),
+        sink_stride=sinks.stride(0),
+        HAS_KV_INDPTR=kv_indptr is not None,
+        HEADS_PER_PROGRAM=heads_per_program,
+        BLOCK_SIZE=triton.next_power_of_2(head_size),
+        num_warps=num_warps,
+    )
+    return output, lse
 
 
 @triton.jit
@@ -733,6 +886,9 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         self.head_size = head_size
         self.scale = float(scale)
         self.num_kv_heads = num_kv_heads
+        self.kv_cache_dtype = kv_cache_dtype
+        self.kv_lora_rank: int = mla_args["kv_lora_rank"]
+        vllm_config = get_current_vllm_config()
         sinks = mla_args.pop("sinks", None)
         if sinks is not None:
             if sinks.dtype != torch.float32:
@@ -746,9 +902,20 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
                 )
             if not sinks.is_contiguous():
                 raise ValueError("ROCm AITER MLA sinks must be contiguous")
+            # Reject unsupported AITER sink layouts during construction rather
+            # than deferring the failure until the first real request.
+            model_dtype = vllm_config.model_config.dtype
+            if kv_cache_dtype.startswith("fp8"):
+                q_dtype = kv_dtype = current_platform.fp8_dtype()
+            else:
+                q_dtype = model_dtype
+                kv_dtype = get_kv_cache_torch_dtype(kv_cache_dtype, model_dtype)
+            _get_aiter_sink_num_heads(
+                AiterMLAHelper.get_actual_mla_num_heads(num_heads),
+                q_dtype,
+                kv_dtype,
+            )
         self.sinks: torch.Tensor | None = sinks
-        self.kv_cache_dtype = kv_cache_dtype
-        self.kv_lora_rank: int = mla_args["kv_lora_rank"]
         self.softmax_scale = scale
         # The indexer carries the shared buffer for normal layers and tests;
         # the explicitly-passed buffer covers backbone skip layers, whose
@@ -757,7 +924,6 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
             indexer.topk_indices_buffer if indexer is not None else topk_indices_buffer
         )
 
-        vllm_config = get_current_vllm_config()
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         q_concat_shape = (max_tokens, num_heads, head_size)
         (self.q_concat_buffer,) = current_workspace_manager().get_simultaneous(
@@ -775,63 +941,19 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         base_mla_num_heads = AiterMLAHelper.get_actual_mla_num_heads(self.num_heads)
         mla_num_heads = base_mla_num_heads
         need_lse = self.sinks is not None
-        # AITER's nonpersistent return-LSE dispatch has discrete head kernels.
-        supported_head_buckets: tuple[int, ...] | None = None
-        head_dtype_name = ""
         if need_lse:
-            if (
-                q.dtype == torch.bfloat16
-                and kv_c_and_k_pe_cache.dtype == torch.bfloat16
-            ):
-                supported_head_buckets = (16, 32, 64, 128)
-                head_dtype_name = "BF16"
-            elif (
-                q.dtype == current_platform.fp8_dtype()
-                and kv_c_and_k_pe_cache.dtype == current_platform.fp8_dtype()
-            ):
-                supported_head_buckets = (16, 128)
-                head_dtype_name = "FP8"
-
-        if supported_head_buckets is not None:
-            from vllm.platforms.rocm import on_mi3xx
-
-            if on_mi3xx():
-                supported_heads = next(
-                    (
-                        heads
-                        for heads in supported_head_buckets
-                        if heads >= mla_num_heads
-                    ),
-                    None,
-                )
-                if supported_heads is None:
-                    raise ValueError(
-                        "ROCm AITER MLA attention sinks support at most 128 "
-                        f"padded local {head_dtype_name} heads; increase "
-                        "tensor_parallel_size"
-                    )
-                if supported_heads != mla_num_heads:
-                    q = AiterMLAHelper.get_mla_padded_q(
-                        mla_num_heads, q, supported_heads
-                    )
-                    mla_num_heads = supported_heads
-        if (
-            need_lse
-            and q.dtype == torch.bfloat16
-            and kv_c_and_k_pe_cache.dtype == torch.bfloat16
-            and mla_num_heads == 64
-        ):
-            from vllm.platforms.rocm import on_gfx942
-
-            if on_gfx942():
-                raise ValueError(
-                    "ROCm AITER MLA attention sinks do not support BF16 "
-                    "query/KV with 64 padded local heads on gfx942; increase "
-                    "tensor_parallel_size"
-                )
-        # Graph-padded rows are not guaranteed to be written by every AITER
-        # kernel variant. Record the zero-fill in the graph so an inactive row
-        # cannot retain values from an earlier replay.
+            supported_heads = _get_aiter_sink_num_heads(
+                mla_num_heads,
+                q.dtype,
+                kv_c_and_k_pe_cache.dtype,
+            )
+            if supported_heads != mla_num_heads:
+                q = AiterMLAHelper.get_mla_padded_q(mla_num_heads, q, supported_heads)
+                mla_num_heads = supported_heads
+        # Retain the graph-recorded zero-fill. Some AITER kernels do not write
+        # every graph-padded row, and leaving those rows uninitialized can make
+        # subsequent graph replays pathologically slow. The sink kernel below
+        # still repairs empty-row LSE values and preserves zero outputs.
         output = torch.zeros(
             [num_tokens, mla_num_heads, self.kv_lora_rank],
             dtype=attn_metadata.attn_out_dtype,
@@ -904,11 +1026,12 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
 
         if self.sinks is not None:
             assert lse is not None
-            sink = self.sinks
-            sink_lse = torch.logaddexp(lse, sink)
-            sink_scale = torch.exp(lse - sink_lse)
-            output = (output.float() * sink_scale.unsqueeze(-1)).to(output.dtype)
-            lse = sink_lse
+            output, lse = apply_attention_sink(
+                output,
+                lse,
+                self.sinks,
+                attn_metadata.paged_kv_indptr,
+            )
 
         return output, lse
 


### PR DESCRIPTION
# [ROCm] Optimize HY V4 graph inference on gfx942 and gfx950

## Purpose

This PR remains stacked on #54405 (and therefore #54404). This update adds four
targeted changes to the HY V4 ROCm graph-mode serving path:

- use AITER's fused biased sigmoid top-k for HY V4's one-group routing shape;
- make the AITER MXFP8 routing buffers contiguous before fused MoE consumes
  them;
- fuse the BF16 elementwise MLA output gate into one graph-safe Triton op; and
- apply attention sinks with a grouped, graph-safe kernel that also repairs
  empty graph-padded rows.

Unsupported AITER sink layouts are now rejected during construction instead of
on the first request. The shared NVIDIA attention path retains the same eager
gate expression through a small subclass hook.

## Platform isolation

- The direct top-k route is guarded by the one-group sigmoid routing
  configuration and HY V4's measured hidden/expert/top-k shape.
- The fused MLA gate is in the ROCm subclass and requires matching contiguous
  BF16 CUDA tensors with the measured width; all other inputs use the existing
  eager expression.
- The attention-sink kernel remains inside the ROCm AITER sparse-MLA backend.
- NVIDIA still executes `attn_out * torch.sigmoid(gate_score)`.
- Model-class dispatch remains capability/platform based. The only gfx-specific
  branch in this update is the AITER sink compatibility check that rejects the
  unsupported gfx942 BF16 64-head bucket.

## Exact candidate and runtime

- Published optimization commit:
  `53abd3cac3e06993a8afae86b3246fa27d0ab1b1`
- Published commit tree: `93b4fced3bf3dfaf67cf9d5f6217240189ba67f1`
- Optimization binary-patch SHA-256:
  `bf8b13d562587b6b5a4437f4822985d74e6d350091afffedaf1c1440a0638657`
- MI350X source manifest SHA-256:
  `b33a8fa5bc83e646f67dfe4c23ec3bec8395c3de4e8ecca0ff0678f409ec0a13`
- MI350X extension manifest SHA-256:
  `a22a8a03367f53d095a541b79d25a469a48d77aeda75d2c99beaa43acea7430b`
- MI350X generated-runtime manifest SHA-256:
  `d1875bc16df989dd514620ed24575f8e2fdc6e0a6838f391563be69c003fdc67`
- MI350X runtime image:
  `sha256:03f385c0cdc48a0031aba05e1d3d7b6fa0b51a6744f9b69e6c8cd7cd4de4b49b`
- MI350X runtime parent image:
  `sha256:40e19c756e3dc9ffc9117770904d40376c7d3bf529cc76ddc379cde7ac4dae2d`
- gfx942 source/extension/generated-runtime manifest SHA-256 values:
  `6711d26262846e35aad24d1540985c3b9aceea51dbde3dfe36eba72ce4fc023b`,
  `83aaee20d27b06931a18f639ba0aadcea268e2262077ffc53dcb2b055abea9e1`,
  and `d719add875735eefb97258888a92393a48bf0d5bcdcaf6dd89bab6bb09928214`.
- gfx942 runtime image:
  `sha256:8908b8ab5ba28c3b81f9f42bb72e2421f06a180e001c67c4f10ff7f127c5690b`
- Performance-runtime prerequisite: open ROCm/aiter#5148 at
  `f8500b8543949ec5c856a9395956fb4927948211`
- FlyDSL: `0.2.4`, wheel SHA-256
  `3ba78e6c1cec37c99b83d71a34c1ed50f1058231bcab1a352a1b431082fb2c4f`
- AITER FMoE tuning file SHA-256:
  `1f05eadfb3654b7d4adb059f069fe1d0de7d4ce24d9e8cb3e1b6f23699b92534`
- Model revision: `4215ec29de873a998e849cee902654490c7ff4d1`
- GSM8K dataset SHA-256:
  `67e9046d913470477dfb321814d4e3240240a397cfc19c6c610af02dd2cb6456`
- `sgl-eval` revision: `a231b7a439b235090ff7baa30778fa2b514309ae`

## Validation

Static and exact-tree correctness:

- Touched-file pre-commit: passed.
- MI350X gfx950 r163: `221 passed, 2 skipped`; source/runtime postflight,
  external-user, kernel-error, and clean teardown checks passed. Artifact
  manifest SHA-256:
  `b435d4213b0a0d8baef5b34cf271271a7e9f325eca20de473855bd30ec506514`.
- gfx942 r155: `210 passed, 13 skipped`; source/runtime postflight,
  external-user, kernel-error, and clean teardown checks passed. Artifact
  manifest SHA-256:
  `abae83e91b3304206906c2f37dae0fb6105856728457761a5b62c5beac88f381`.

Authoritative MI350X TP8/C1 performance used three fresh-process repeats per
arm, exactly 128 input and 256 output tokens per request, and a maximum allowed
within-arm spread of `0.250 ms`:

| arm | repeat mean ITL values (ms) | mean (ms) | spread (ms) |
| --- | --- | ---: | ---: |
| control before, r178 | 20.376864, 20.386123, 20.413625 | 20.392204 | 0.036761 |
| candidate, r179 | 18.980972, 18.986528, 19.003041 | **18.990180** | 0.022069 |
| control after, r183 | 20.340497, 20.360134, 20.358735 | 20.353122 | 0.019637 |

The candidate is `1.382483 ms` / `6.785971%` below the adjacent-control
average (`20.372663 ms`), below both controls, and `0.672820 ms` below the
`19.663 ms` acceptance target. r180 was rejected rather than averaged because
its `56.644377 ms` spread exceeded the stability limit. The sealed post-hoc
validator summary has SHA-256
`71398c1c1a74d19e847648cc37434c002800678225172f6effec411aeddbd19b`.
The post-hoc step was needed because the wrapper hit an `awk` newline-formatting
error only after r183 had sealed; the validator rechecked every immutable arm
artifact rather than rerunning or altering the measurements.

The sink-only precursor experiment was neutral to slightly slower, so the sink
kernel is retained for graph-replay correctness and is not presented as an
independent latency win.

Authoritative MI350X full GSM8K and route validation (r186) passed:

- 1,319/1,319 unique rows, zero malformed/duplicate/missing/unexpected IDs,
  zero request errors, zero empty generations, and zero missing grades;
- `1,232/1,319 = 93.4041%` symbolic accuracy;
- `1,203/1,227 = 98.0440%` normal-stop accuracy;
- 92 length truncations, 29 correct, and 43 missing extracted predictions;
- 2,166,076 completion tokens in 5,501.155 seconds, or 393.7493 output
  tokens/s; and
- health `200` before and after evaluation, all nine optimized-route checks,
  empty runtime/kernel-fault scans, source postflight, and the full 300-second
  exclusive-idle teardown passed.

The pinned workload used TP8, native MTP with three speculative tokens,
full/piecewise graphs, AITER sparse MLA and MXFP8 MoE, explicit fused shared
experts, disabled prefix caching, all 1,319 examples, four request threads,
temperature 0.9, top-p 1.0, and seed 0. The r186 artifact manifest SHA-256 is
`c3ba616f12615bc34a55d60d941f77dbe0c9133ddf7c8b53aaae2b86a2d3e284`.

Supplementary MI355X r173 completed 1,319/1,319 unique requests with zero
request errors, 93.9348% accuracy (`1,239/1,319`), 78 length truncations, and
407.3702 output tokens/s. Its artifact manifest SHA-256 is
`7c75b7c2624127c12ed796229d38b541eee683b327fd0f938dec9a1ad16da284`.
This confirms a second gfx950 execution lane but is not used for the MI350X
performance acceptance claim.

## Test plan

```bash
pre-commit run --files \
  $(git diff --name-only 4be7ce114bc8fcf5a7ff8175b57f80d3db5418a4..HEAD)

.venv/bin/python -m pytest -q -p no:cacheprovider \
  tests/compile/passes/test_fuse_mla_dual_rms_norm.py \
  tests/kernels/attention/test_rocm_aiter_mla_sink.py \
  tests/kernels/attention/test_rocm_aiter_mla_sparse_metadata_sync.py \
  tests/kernels/moe/test_mxfp8_aiter_backend_selection.py \
  tests/kernels/moe/test_rocm_aiter_moe.py \
  tests/kernels/moe/test_rocm_aiter_topk.py \
  tests/kernels/test_minimax_m3_amd_ops.py \
  tests/model_executor/layers/test_fused_shared_expert.py \
  tests/models/test_hy_v4_rocm.py \
  tests/test_config.py::test_rocm_hyv4_defaults_to_mrv2_and_breakable_cudagraph \
  tests/v1/attention/test_indexer_native_next_n.py
```

The hardware suites also cover the surrounding ROCm AITER MoE, sparse-MLA,
MTP, graph-replay, fused-shared-expert, and model-loading paths rather than only
the newly added unit tests.

## Related work and stack

- #54404 supplies the AITER sparse-MLA sink prerequisite; #54405 supplies the
  initial HY V4 ROCm enablement and is this PR's immediate base.
- #54432 is a separate overlapping gfx950 HY V4 enablement draft. Its fixes and
  this stack must be coordinated before merge rather than landed twice.
- #45726 overlaps the gfx942 MXFP8 conversion mechanics; this candidate adds
  graph/MTP integration and native-gfx950 behavior around that route.
- #55154 adds fused Triton iHC pre/post/head kernels in the NVIDIA path. It is
  adjacent rather than duplicative; this update's new kernels and routing
  changes are ROCm-specific.
- #37682, #45324, #46763, #39168, #49263, #49755, #51309, #53492, #43804,
  and #46172 remain open changes around ROCm sparse MLA or its lower-level
  kernels. Their independent fixes must be preserved through landing order or
  a later rebase.

#54594 is based on #54405 at
`29c7fa2027700f0bbbb26fae07868f308d26780b`. #54404 has independently advanced
to `1059697b5316c6de3afe3cde3c8c70613e94fbaf`; this update does not rewrite the
other contributor's parent branch. Any parent refresh or conflict resolution
changes the effective tree and invalidates this source-dependent validation.

## AI assistance

AI assistance was used to investigate, implement, test, and prepare this
change. Before commit and publication, the human submitter reviewed every
changed line in tree `93b4fced3bf3dfaf67cf9d5f6217240189ba67f1`,
confirmed end-to-end understanding, and explicitly approved the DCO signoff.
Commit `53abd3cac3e06993a8afae86b3246fa27d0ab1b1` records both the human
`Signed-off-by` trailer and the Codex `Co-authored-by` trailer.
