### PR TITLE
[Bugfix][Model] Read Eagle3 aux layer count from the top-level config key

### DIFF
--- a/tests/model_executor/test_llama_eagle3_config.py
+++ b/tests/model_executor/test_llama_eagle3_config.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Resolution of the Eagle3 aux-hidden-state count across config layouts."""
+
+from transformers import LlamaConfig
+
+from vllm.model_executor.models.llama_eagle3 import _resolve_num_aux_hidden_states
+
+
+def test_explicit_count_wins_over_layer_lists():
+    config = LlamaConfig(num_aux_hidden_states=5)
+    config.eagle_config = {"eagle_aux_hidden_state_layer_ids": [1, 2, 3, 4]}
+    assert _resolve_num_aux_hidden_states(config) == 5
+
+
+def test_nested_eagle_config_layout():
+    config = LlamaConfig()
+    config.eagle_config = {"eagle_aux_hidden_state_layer_ids": [0, 5, 11, 17]}
+    assert _resolve_num_aux_hidden_states(config) == 4
+
+
+def test_top_level_layer_ids_layout():
+    # What Speculators writes and what the speculators config loader carries
+    # through: the layer list sits at the top level of the draft config.
+    config = LlamaConfig(eagle_aux_hidden_state_layer_ids=[2, 8, 15, 22])
+    assert _resolve_num_aux_hidden_states(config) == 4
+
+
+def test_nested_layout_beats_top_level():
+    config = LlamaConfig(eagle_aux_hidden_state_layer_ids=[0, 1])
+    config.eagle_config = {"eagle_aux_hidden_state_layer_ids": [0, 1, 2]}
+    assert _resolve_num_aux_hidden_states(config) == 3
+
+
+def test_default_is_three():
+    assert _resolve_num_aux_hidden_states(LlamaConfig()) == 3

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -119,6 +119,25 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
         return hidden_states, residual
 
 
+def _resolve_num_aux_hidden_states(config: LlamaConfig) -> int:
+    """How many target hidden states the draft head concatenates.
+
+    Resolution order follows how configs actually carry it: an explicit
+    ``num_aux_hidden_states`` count, then nested ``eagle_config`` (the legacy
+    layout), then a top-level ``eagle_aux_hidden_state_layer_ids`` list, which
+    is what Speculators writes and what the speculators config loader carries
+    through. Falls back to the historical default of 3.
+    """
+    num_aux = getattr(config, "num_aux_hidden_states", None)
+    if num_aux is not None:
+        return num_aux
+    eagle_config = getattr(config, "eagle_config", None) or {}
+    layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
+    if layer_ids is None:
+        layer_ids = getattr(config, "eagle_aux_hidden_state_layer_ids", None)
+    return len(layer_ids) if layer_ids else 3
+
+
 @support_torch_compile(
     dynamic_arg_dims={
         "input_ids": 0,
@@ -173,13 +192,7 @@ class LlamaModel(nn.Module):
             ]
         )
         if self.use_aux_hidden_state:
-            self.num_aux_hidden_states = getattr(
-                self.config, "num_aux_hidden_states", None
-            )
-            if self.num_aux_hidden_states is None:
-                eagle_config = getattr(self.config, "eagle_config", None) or {}
-                layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
-                self.num_aux_hidden_states = len(layer_ids) if layer_ids else 3
+            self.num_aux_hidden_states = _resolve_num_aux_hidden_states(self.config)
 
             target_hidden_size = getattr(
                 self.config, "target_hidden_size", self.config.hidden_size


### PR DESCRIPTION
## Purpose

Fixes #54526.

Speculators-trained Eagle3 checkpoints declare their aux hidden layers as `eagle_aux_hidden_state_layer_ids` at the top level of the draft config, and vLLM's own speculators loader (`transformers_utils/configs/speculators/algos.py`) carries the key through unchanged. The fc width resolution in `LlamaModel.__init__` only looked at `num_aux_hidden_states` and the nested `eagle_config` layout, so any such checkpoint with a layer count other than 3 fell off the hard default of 3 and crashed on weight load: the reporter's head has 4 aux layers, the fc was built for 3, and the loader asserted on `4096x16384` vs `4096x12288`.

The fix reads the top-level key before defaulting, matching the precedence `_get_qwen3_dspark_value` in `config/speculative.py` already uses for the same pair of layouts (nested first, top-level as the modern fallback), and factors the resolution into a helper so the precedence is testable without a model init. Not a duplicate of #50170: that one warns about the aux-layer capture heuristic (silent acceptance collapse), this one is the fc width resolution (load-time crash).

## Test Plan

`tests/model_executor/test_llama_eagle3_config.py` covers all five branches: explicit `num_aux_hidden_states` wins, nested `eagle_config` layout, top-level Speculators layout, nested beats top-level, and the default of 3.

## Verification

- `.venv/bin/python -m pytest tests/model_executor/test_llama_eagle3_config.py -q` -> 5 passed (run against the real module import on current main `e0d2704`).
- `ruff check` and `ruff format --check` clean on both files.
- Not run: GPU/model loading with a real 4-layer Speculators checkpoint (no such checkpoint or GPU here); the config-resolution change is exercised only at the unit level above.

This change was prepared with AI assistance (Kimi K3); the mechanism was verified by reading the full config path (Speculators' own schema, vLLM's speculators loader, and the fc construction) before writing the fix.
