### PR TITLE
[Kernel][Helion] support use_variant_config Helion register_kernel

### DIFF
--- a/scripts/autotune_helion_kernels.py
+++ b/scripts/autotune_helion_kernels.py
@@ -38,7 +38,10 @@ try:
         get_registered_kernels,
     )
     from vllm.kernels.helion.ops import import_all_kernels
-    from vllm.kernels.helion.utils import get_canonical_gpu_name
+    from vllm.kernels.helion.utils import (
+        get_config_gpu_name,
+        get_gpu_name,
+    )
     from vllm.logger import init_logger
     from vllm.utils.import_utils import has_helion
 except ImportError as e:
@@ -88,7 +91,6 @@ def check_requirements() -> bool:
 
 def autotune_kernel(
     kernel_name: str,
-    platform: str,
     config_manager: ConfigManager,
     force: bool = False,
     autotune_effort: str = "quick",
@@ -109,6 +111,8 @@ def autotune_kernel(
             failed=0,
             configs={},
         )
+
+    platform = get_config_gpu_name(kernel_wrapper.use_variant_config)
 
     try:
         with FakeTensorMode():
@@ -402,7 +406,7 @@ def main():
     if not check_requirements():
         sys.exit(1)
 
-    platform = get_canonical_gpu_name()
+    platform = get_gpu_name()
     logger.info("Detected GPU platform: %s", platform)
 
     config_manager = (
@@ -427,7 +431,7 @@ def main():
     results = {}
     for kernel_name in kernels_to_autotune:
         result = autotune_kernel(
-            kernel_name, platform, config_manager, args.force, args.autotune_effort
+            kernel_name, config_manager, args.force, args.autotune_effort
         )
         results[kernel_name] = result
 

--- a/tests/kernels/helion/helpers.py
+++ b/tests/kernels/helion/helpers.py
@@ -14,9 +14,9 @@ import helion
 from vllm.kernels.helion.case_key import CaseKey
 from vllm.kernels.helion.config_manager import ConfigManager
 from vllm.kernels.helion.register import register_kernel
-from vllm.kernels.helion.utils import get_canonical_gpu_name
+from vllm.kernels.helion.utils import get_config_gpu_name
 
-GPU_PLATFORM = get_canonical_gpu_name()
+GPU_PLATFORM = get_config_gpu_name(False)
 
 DEFAULT_CONFIGS: dict[CaseKey, helion.Config] = {
     CaseKey.default(): helion.Config(block_sizes=[32]),

--- a/tests/kernels/helion/test_pattern_matching.py
+++ b/tests/kernels/helion/test_pattern_matching.py
@@ -56,7 +56,7 @@ def _helion_mock_context():
             return_value=mock_config_manager,
         ),
         patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
+            "vllm.kernels.helion.utils.get_config_gpu_name",
             return_value="nvidia_h200",
         ),
     ):

--- a/tests/kernels/helion/test_register.py
+++ b/tests/kernels/helion/test_register.py
@@ -110,7 +110,7 @@ def configured_kernel(sample_kernel, sample_configs, config_manager_with_test_co
             return_value=config_manager_with_test_configs,
         ),
         patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
+            "vllm.kernels.helion.utils.get_config_gpu_name",
             return_value="nvidia_h200",
         ),
         patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -177,7 +177,7 @@ def create_configured_kernel_with_configs(
             return_value=mock_config_manager,
         ),
         patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
+            "vllm.kernels.helion.utils.get_config_gpu_name",
             return_value=platform,
         ),
         patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -210,7 +210,7 @@ class TestConfiguredHelionKernel:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             pytest.raises(RuntimeError, match="No config picker registered"),
@@ -287,7 +287,7 @@ class TestConfiguredHelionKernel:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
         ):
@@ -331,7 +331,7 @@ class TestConfiguredHelionKernel:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
         ):
@@ -383,7 +383,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -418,7 +418,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -453,7 +453,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -491,7 +491,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -530,7 +530,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -575,7 +575,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,
@@ -600,7 +600,7 @@ class TestHelionKernelWrapper:
     def test_init_eagerly_initializes_hop_path(self):
         """Test that register_kernel eagerly builds the configured kernel
         on the HOP path (no custom op registration needed)."""
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
         configs: dict[CaseKey, helion.Config] = {
             CaseKey.default(): helion.Config(block_sizes=[4, 4])
@@ -608,8 +608,8 @@ class TestHelionKernelWrapper:
         with (
             dummy_kernel_registry(configs=configs) as register,
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
-                wraps=get_canonical_gpu_name,
+                "vllm.kernels.helion.utils.get_config_gpu_name",
+                wraps=get_config_gpu_name,
             ) as mock_gpu,
         ):
             wrapper = register(
@@ -620,8 +620,8 @@ class TestHelionKernelWrapper:
             assert wrapper._configured_kernel is not None
 
         with patch(
-            "vllm.kernels.helion.utils.get_canonical_gpu_name",
-            side_effect=AssertionError("get_canonical_gpu_name called during __call__"),
+            "vllm.kernels.helion.utils.get_config_gpu_name",
+            side_effect=AssertionError("get_config_gpu_name called during __call__"),
         ):
             x = torch.randn(4, 4, device="cuda")
             y = torch.randn(4, 4, device="cuda")
@@ -635,13 +635,13 @@ class TestHelionKernelWrapper:
     def test_init_eagerly_initializes(self):
         """Test that register_kernel eagerly loads configs and detects GPU
         during construction so __call__ needs no further initialization."""
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
         with (
             dummy_kernel_registry() as register,
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
-                wraps=get_canonical_gpu_name,
+                "vllm.kernels.helion.utils.get_config_gpu_name",
+                wraps=get_config_gpu_name,
             ) as mock_gpu,
         ):
             wrapper = register(
@@ -678,7 +678,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch.object(torch.ops, "vllm_helion", mock_namespace),
@@ -732,7 +732,7 @@ class TestHelionKernelWrapper:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch.object(torch.ops, "vllm_helion", mock_namespace),
@@ -937,7 +937,7 @@ class TestKernelRegistry:
                 return_value=mock_config_manager,
             ),
             patch(
-                "vllm.kernels.helion.utils.get_canonical_gpu_name",
+                "vllm.kernels.helion.utils.get_config_gpu_name",
                 return_value="nvidia_h200",
             ),
             patch("vllm.kernels.helion.register.helion.kernel") as mock_kernel,

--- a/tests/kernels/helion/test_silu_mul_fp8.py
+++ b/tests/kernels/helion/test_silu_mul_fp8.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from tests.kernels.helion.utils import skip_if_platform_unsupported
 from vllm.utils.import_utils import has_helion
 
 if not has_helion():
@@ -21,28 +22,6 @@ from vllm.kernels.helion.ops.silu_mul_fp8 import (
     silu_mul_fp8,
     silu_mul_fp8_baseline,
 )
-
-
-def skip_if_platform_unsupported():
-    try:
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
-
-        if not torch.cuda.is_available():
-            pytest.skip("CUDA not available")
-
-        platform = get_canonical_gpu_name()
-
-        try:
-            config_manager = ConfigManager.get_instance()
-        except RuntimeError:
-            config_manager = ConfigManager()
-
-        configs = config_manager.get_platform_configs("silu_mul_fp8", platform)
-        if len(configs) == 0:
-            pytest.skip("Current GPU platform not supported for silu_mul_fp8 kernel")
-
-    except (ImportError, RuntimeError, KeyError):
-        pytest.skip("Error detecting platform support for silu_mul_fp8 kernel")
 
 
 @pytest.fixture(autouse=True)
@@ -155,7 +134,7 @@ class TestSiluMulFp8Correctness:
     @pytest.mark.parametrize("intermediate_size", [2048, 3000, 3500, 4096, 5000])
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_silu_mul_fp8_correctness(self, batch_size, intermediate_size, dtype):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_size = 2 * intermediate_size
         input_tensor = torch.randn(batch_size, input_size, dtype=dtype, device="cuda")
@@ -181,7 +160,7 @@ class TestSiluMulFp8Correctness:
         )
 
     def test_silu_mul_fp8_shape_inference(self):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
         batch_size, input_size = 32, 8192
         intermediate_size = input_size // 2
 
@@ -197,7 +176,7 @@ class TestSiluMulFp8Correctness:
         assert output.dtype == torch.float8_e4m3fn
 
     def test_silu_mul_fp8_scale_variations(self):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
         batch_size, input_size = 16, 4096
 
         input_tensor = torch.randn(
@@ -235,7 +214,7 @@ class TestSiluMulFp8Correctness:
         ],
     )
     def test_silu_mul_fp8_various_shapes(self, shape):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_tensor = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
         scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
@@ -276,7 +255,7 @@ class TestSiluMulFp8PytorchReference:
     @pytest.mark.parametrize("intermediate_size", [1024, 2048, 4096])
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_silu_mul_fp8_vs_pytorch(self, batch_size, intermediate_size, dtype):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_tensor = torch.randn(
             batch_size, 2 * intermediate_size, dtype=dtype, device="cuda"
@@ -313,7 +292,7 @@ class TestSiluMulFp8PytorchReference:
         ],
     )
     def test_silu_mul_fp8_multidim_vs_pytorch(self, shape):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
 
         input_tensor = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
         scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
@@ -347,7 +326,7 @@ class TestSiluMulFp8Integration:
         assert kernel_wrapper._config_picker is not None
 
     def test_fake_impl_functionality(self):
-        skip_if_platform_unsupported()
+        skip_if_platform_unsupported("silu_mul_fp8")
         from vllm.kernels.helion.register import get_registered_kernels
 
         input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")

--- a/tests/kernels/helion/test_utils.py
+++ b/tests/kernels/helion/test_utils.py
@@ -2,9 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for Helion utility functions."""
 
+from unittest.mock import patch
+
 import pytest
 
-from vllm.kernels.helion.utils import canonicalize_gpu_name
+from vllm.kernels.helion.utils import (
+    canonicalize_gpu_name,
+    get_config_gpu_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -31,3 +36,12 @@ def test_canonicalize_gpu_name_rejects_empty(invalid_name):
     """Test that empty or whitespace-only names are rejected."""
     with pytest.raises(ValueError, match="cannot be empty"):
         canonicalize_gpu_name(invalid_name)
+
+
+def test_get_config_gpu_name():
+    with patch(
+        "vllm.kernels.helion.utils.get_gpu_name",
+        return_value="NVIDIA H100 PCIe",
+    ):
+        assert get_config_gpu_name(True) == "nvidia_h100_pcie"
+        assert get_config_gpu_name(False) == "nvidia_h100"

--- a/tests/kernels/helion/utils.py
+++ b/tests/kernels/helion/utils.py
@@ -6,16 +6,18 @@ import pytest
 import torch
 
 from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.register import get_kernel_by_name
 
 
 def skip_if_platform_unsupported(op_name: str):
     try:
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
         if not torch.cuda.is_available():
             pytest.skip("CUDA not available")
 
-        platform = get_canonical_gpu_name()
+        kernel = get_kernel_by_name(op_name)
+        platform = get_config_gpu_name(kernel.use_variant_config)
 
         try:
             config_manager = ConfigManager.get_instance()

--- a/vllm/kernels/helion/__init__.py
+++ b/vllm/kernels/helion/__init__.py
@@ -16,7 +16,7 @@ from vllm.kernels.helion.register import (
     register_kernel,
     vllm_helion_lib,
 )
-from vllm.kernels.helion.utils import canonicalize_gpu_name, get_canonical_gpu_name
+from vllm.kernels.helion.utils import canonicalize_gpu_name, get_config_gpu_name
 
 __all__ = [
     # Config management
@@ -33,5 +33,5 @@ __all__ = [
     "vllm_helion_lib",
     # Utilities
     "canonicalize_gpu_name",
-    "get_canonical_gpu_name",
+    "get_config_gpu_name",
 ]

--- a/vllm/kernels/helion/register.py
+++ b/vllm/kernels/helion/register.py
@@ -152,11 +152,13 @@ class ConfiguredHelionKernel:
         config_picker: ConfigPicker | None,
         raw_kernel_func: Callable,
         helion_settings: helion.Settings | None = None,
+        use_variant_config: bool = False,
     ):
         self.op_name = op_name
         self.config_picker = config_picker
         self.raw_kernel_func = raw_kernel_func
         self.helion_settings = helion_settings
+        self.use_variant_config = use_variant_config
         self._decorated_kernel = self._create_decorated_kernel()
 
     def __call__(self, *args, **kwargs):
@@ -218,9 +220,9 @@ class ConfiguredHelionKernel:
 
     def _load_platform_configs(self) -> None:
         from vllm.kernels.helion.config_manager import ConfigManager
-        from vllm.kernels.helion.utils import get_canonical_gpu_name
+        from vllm.kernels.helion.utils import get_config_gpu_name
 
-        self.platform = get_canonical_gpu_name()
+        self.platform = get_config_gpu_name(self.use_variant_config)
         config_manager = ConfigManager()
         self.configs = config_manager.get_platform_configs(self.op_name, self.platform)
 
@@ -263,6 +265,7 @@ class HelionKernelWrapper:
         mutates_args: list[str] | None = None,
         helion_settings: helion.Settings | None = None,
         input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
+        use_variant_config: bool = False,
     ):
         # Validate helion_settings doesn't conflict with our custom autotuner
         validate_helion_settings(helion_settings, op_name)
@@ -274,6 +277,7 @@ class HelionKernelWrapper:
         self._config_picker = config_picker
         self._input_generator = input_generator
         self._mutates_args = mutates_args
+        self.use_variant_config = use_variant_config
         self._configured_kernel: ConfiguredHelionKernel | None = None
         # TODO(@gmagogsfm): Remove this disable flag once integrated with vLLM IR,
         # which handles op enablement/disablement.
@@ -346,6 +350,7 @@ class HelionKernelWrapper:
                 config_picker=self._config_picker,
                 raw_kernel_func=self.raw_kernel_func,
                 helion_settings=self.helion_settings,
+                use_variant_config=self.use_variant_config,
             )
         return self._configured_kernel
 
@@ -407,6 +412,7 @@ def register_kernel(
     mutates_args: list[str] | None = None,
     helion_settings: helion.Settings | None = None,
     input_generator: (Callable[[], dict[CaseKey, tuple[Any, ...]]] | None) = None,
+    use_variant_config: bool = False,
 ) -> Callable[[Callable], HelionKernelWrapper]:
     """Register a Helion kernel with pre-tuned config selection.
 
@@ -434,6 +440,12 @@ def register_kernel(
                         "4096": (torch.randn(4096, device="cuda"), 0.5),
                         "8192": (torch.randn(8192, device="cuda"), 0.5),
                     }
+
+        use_variant_config: Optional. When ``True``, configs are
+            looked up by the variant-specific GPU name (e.g.
+            ``nvidia_h100_pcie``) instead of the canonical name shared by all
+            variants (e.g. ``nvidia_h100``). Defaults to ``False``, which
+            preserves the canonical-name lookup used by most kernels.
     """
 
     def decorator(kernel_func: Callable) -> HelionKernelWrapper:
@@ -461,6 +473,7 @@ def register_kernel(
             mutates_args=mutates_args,
             helion_settings=helion_settings,
             input_generator=input_generator,
+            use_variant_config=use_variant_config,
         )
 
         _REGISTERED_KERNELS[final_op_name] = kernel_wrapper

--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -59,6 +59,19 @@ def get_gpu_name(device_id: int | None = None) -> str:
     return current_platform.get_device_name(device_id)
 
 
+def normalize_gpu_name(name: str) -> str:
+    """
+    Normalize a GPU name to lowercase underscore form, preserving variant
+    suffixes (i.e. without applying _GPU_NAME_ALIASES).
+
+    e.g., "NVIDIA H100 80GB HBM3" -> "nvidia_h100_80gb_hbm3"
+          "NVIDIA A100-SXM4-80GB" -> "nvidia_a100_sxm4_80gb"
+    """
+    if not name or not name.strip():
+        raise ValueError("GPU name cannot be empty")
+    return re.sub(r"[\s/-]+", "_", name.lower())
+
+
 def canonicalize_gpu_name(name: str) -> str:
     """
     Canonicalize GPU name for use as a platform identifier.
@@ -69,16 +82,15 @@ def canonicalize_gpu_name(name: str) -> str:
           "NVIDIA A100-SXM4-80GB" -> "nvidia_a100"
           "AMD Instinct MI300X"   -> "amd_instinct_mi300x"
     """
-    if not name or not name.strip():
-        raise ValueError("GPU name cannot be empty")
-    name = re.sub(r"[\s/-]+", "_", name.lower())
-    if name in _GPU_NAME_ALIASES:
-        return _GPU_NAME_ALIASES[name]
-    return name
+    name = normalize_gpu_name(name)
+    return _GPU_NAME_ALIASES.get(name, name)
 
 
-def get_canonical_gpu_name(device_id: int | None = None) -> str:
-    return canonicalize_gpu_name(get_gpu_name(device_id))
+def get_config_gpu_name(keep_variant: bool, device_id: int | None = None) -> str:
+    if keep_variant:
+        return normalize_gpu_name(get_gpu_name(device_id))
+    else:
+        return canonicalize_gpu_name(get_gpu_name(device_id))
 
 
 def get_fp8_dtype() -> torch.dtype:


### PR DESCRIPTION
## Purpose
Current Helion kernel config management framework treats different hardware variants as the same type and hence using the same config file. e.g., for H100, the following 3 variants
* NVIDIA H100 PCIE
* NVIDIA H100 SXM5
* NVIDIA H100 80GB HBM3 

will use the same config json file, **nvidia_h100.json**

The original intention of this design is to reduce the amount of the shipped pre-tuned configs and is based on the assumption that configs tuned on one variant is, in general, work well on other variants. 

For linear kernels, we need to do per-shape config tuning to compete with highly optimized libraries. We observed the configs tuned on one variant is not the best for a different variant. For those kernels, it is better to use variant-specific config file. 

This PR introduces a new flag ```use_variant_config``` for the Helion ```register_kernel``` decorator. It defaults to the current behavior that canonicalizes gpu name and uses the same config json file for different variants. So, this change does not impact the existing upstreamed kernels.

For the linear kernels, we will set ```use_variant_config``` to true. e.g.,
```
@register_kernel(
    config_picker=pick_config,
    input_generator=generate_inputs,
    use_variant_config=True,
    ...
    ),
)                                                                                                    
def scaled_mm(
...
```

After this change, the config json files used for H100 will become
* nvidia_h100_pcie.json
* nvidia_h100_sxm5.json
* nvidia_h100_80gb_hbm3.json

## Test Plan
* Add/Update unit tests to cover the changes
* Manually run autotune and benchmark to confirm it reads the right config file with and without setting ```use_variant_config``` flag

## Test Result
* Touched unit tests all passed
* Manually confirmed the expected behavior by autotuning and benchmarking Helion kernel with and without ```use_variant_config``` flag