### PR TITLE
[CI] Read the CRCR report token from a Buildkite secret

### DIFF
--- a/.buildkite/scripts/crcr-report.sh
+++ b/.buildkite/scripts/crcr-report.sh
@@ -37,9 +37,16 @@ fi
 
 # read_builds only. Needed because a job cannot see its siblings' outcomes:
 # the agent exposes only its own step, so the job list comes from the REST API.
+TOKEN_SECRET_KEY="${CRCR_BUILDKITE_TOKEN_SECRET_KEY:-crcr_buildkite_api_token}"
 BK_TOKEN="${BUILDKITE_API_TOKEN:-}"
+if [[ -z "${BK_TOKEN}" ]] && command -v buildkite-agent >/dev/null 2>&1; then
+    # Not in the job environment, so read it from a Buildkite secret. The agent
+    # redacts values fetched this way from the log.
+    BK_TOKEN="$(buildkite-agent secret get "${TOKEN_SECRET_KEY}" 2>/dev/null)" || BK_TOKEN=""
+fi
 if [[ -z "${BK_TOKEN}" ]]; then
-    echo "BUILDKITE_API_TOKEN unset -- skipping report"
+    echo "no Buildkite API token (env BUILDKITE_API_TOKEN or secret" \
+        "'${TOKEN_SECRET_KEY}') -- skipping report"
     exit 0
 fi
 

--- a/.buildkite/scripts/crcr-report.sh
+++ b/.buildkite/scripts/crcr-report.sh
@@ -37,7 +37,7 @@ fi
 
 # read_builds only. Needed because a job cannot see its siblings' outcomes:
 # the agent exposes only its own step, so the job list comes from the REST API.
-TOKEN_SECRET_KEY="${CRCR_BUILDKITE_TOKEN_SECRET_KEY:-crcr_buildkite_api_token}"
+TOKEN_SECRET_KEY="${CRCR_BUILDKITE_TOKEN_SECRET_KEY:-CRCR_BUILDKITE_API_TOKEN}"
 BK_TOKEN="${BUILDKITE_API_TOKEN:-}"
 if [[ -z "${BK_TOKEN}" ]] && command -v buildkite-agent >/dev/null 2>&1; then
     # Not in the job environment, so read it from a Buildkite secret. The agent


### PR DESCRIPTION
## Purpose

The nightly CRCR report step has been a silent no-op since it landed. `BUILDKITE_API_TOKEN` is not in the job environment, so the script takes its early-exit path:

```
+++ :test_tube: Command (1/1): bash /vllm-workspace/.buildkite/scripts/crcr-report.sh
BUILDKITE_API_TOKEN unset -- skipping report
```

Reporting is best-effort and the step is `soft_fail`, so the job exits 0 and the build looks green while nothing reaches the relay. Seen on every torch-nightly build, e.g. [build 85962](https://buildkite.com/vllm/ci/builds/85962#01a047d1-4ec6-4626-ab91-fe4cbfbcddde) (`main`, `TORCH_NIGHTLY=1`) — job passed, report skipped.

The token is needed only to list this build's sibling jobs (`read_builds`): an agent can see its own step but not the outcomes of the others, so the job list has to come from the REST API.

## Changes

Fall back to `buildkite-agent secret get` when the environment variable is absent:

```bash
TOKEN_SECRET_KEY="${CRCR_BUILDKITE_TOKEN_SECRET_KEY:-CRCR_BUILDKITE_API_TOKEN}"
BK_TOKEN="${BUILDKITE_API_TOKEN:-}"
if [[ -z "${BK_TOKEN}" ]] && command -v buildkite-agent >/dev/null 2>&1; then
    BK_TOKEN="$(buildkite-agent secret get "${TOKEN_SECRET_KEY}" 2>/dev/null)" || BK_TOKEN=""
fi
```

- An explicit `BUILDKITE_API_TOKEN` still wins, so nothing changes for an environment that already sets it.
- The secret key is overridable via `CRCR_BUILDKITE_TOKEN_SECRET_KEY`, defaulting to `CRCR_BUILDKITE_API_TOKEN`.
- Guarded on `command -v buildkite-agent` so the script still degrades cleanly off-agent.
- Values read through `buildkite-agent secret get` are redacted from the log by the agent.
- The remaining skip message now names both sources rather than only the env var.

Every failure path still exits 0 — reporting stays best-effort and cannot fail a nightly.

## Follow-up required outside this PR

A secret named `CRCR_BUILDKITE_API_TOKEN` holding a **`read_builds`-only** API token must be created in the CI cluster's [secrets](https://buildkite.com/organizations/vllm/clusters/9cecc6b1-94cd-43d1-a256-ab438083f4f5/secrets). The key follows the convention already used there (`INGEST_BEARER_TOKEN`, `CODECOV_TOKEN`), and it is worth attaching a pipeline-scoped policy the way `INGEST_BEARER_TOKEN` does. Until the secret exists the step behaves exactly as it does today (logs and exits 0).

## Test Plan / Test Result

`bash -n` passes. Exercised all three paths locally with a stub `buildkite-agent`:

| Case | Result |
|---|---|
| No env var, secret present | token obtained, proceeds to the API call |
| `BUILDKITE_API_TOKEN` set | proceeds; secret never consulted |
| Neither, no agent on PATH | `no Buildkite API token (env BUILDKITE_API_TOKEN or secret 'CRCR_BUILDKITE_API_TOKEN') -- skipping report`, exit 0 |

Gating is unchanged: still `TORCH_NIGHTLY=1` and `BUILDKITE_BRANCH=main` only.
