### PR TITLE
[Kernel] Enable Kimi-K3 SiTU on the CuteDSL MoE backend and the SM107 low-latency GEMM plan

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
@@ -62,6 +62,8 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
         self.gemm1_alpha = quant_config.gemm1_alpha
         self.gemm1_beta = quant_config.gemm1_beta
         self.gemm1_clamp_limit = quant_config.gemm1_clamp_limit
+        self.situ_beta = moe_config.activation_situ_beta
+        self.situ_linear_beta = moe_config.activation_situ_linear_beta
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
@@ -101,6 +103,7 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
             MoEActivation.RELU2_NO_MUL,
+            MoEActivation.SITU,
         )
 
     @staticmethod
@@ -171,6 +174,19 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
                 "swiglu_beta": self.gemm1_beta,
                 "swiglu_limit": self.gemm1_clamp_limit,
             }
+        elif activation == MoEActivation.SITU:
+            # The cute_dsl kernel keys SiTU on situ_beta and requires
+            # activation_type to stay a base type (ActivationType.Situ is
+            # rejected by normalize_cute_dsl_moe_activation_type), so the
+            # Swiglu base type is passed below and SiTU rides the betas.
+            if self.situ_beta is None:
+                raise ValueError(
+                    "SITU activation requires moe_config.activation_situ_beta"
+                )
+            swiglu_params = {
+                "situ_beta": self.situ_beta,
+                "situ_linear_beta": self.situ_linear_beta,
+            }
         swiglu_kwargs = {k: v for k, v in swiglu_params.items() if v is not None}
 
         flashinfer_cute_dsl_fused_moe_nvfp4(
@@ -190,6 +206,8 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
             num_local_experts=self.local_num_experts,
             local_expert_offset=self.local_expert_offset,
             moe_output=output,
-            activation_type=activation_to_flashinfer_int(activation),
+            activation_type=activation_to_flashinfer_int(
+                MoEActivation.SILU if activation == MoEActivation.SITU else activation
+            ),
             **swiglu_kwargs,
         )

--- a/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
+++ b/vllm/models/kimi_k3/nvidia/low_latency_gemm.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Kimi-K3 decode GEMM selection for unquantized BF16 on SM90/SM100/SM103.
+"""Kimi-K3 decode GEMM selection for unquantized BF16 on SM90/SM100/SM103/SM107.
 
 Dispatch is purely by local ``(N, K)`` shape and token count ``M`` — the module
 name plays no role. Each measured shape maps to a :class:`ProjectionSpec`
@@ -12,7 +12,10 @@ The supported capabilities carry separate measured tables:
 :data:`KIMI_K3_PROJECTIONS` was tuned on B300 (SM103),
 :data:`KIMI_K3_PROJECTIONS_SM100` on B200 (SM100), and
 :data:`KIMI_K3_PROJECTIONS_SM90` on H200 (SM90). The per-(shape, M) winners
-genuinely differ between the parts, so the tables must not be merged.
+genuinely differ between the parts, so the tables must not be merged. SM107
+(Rubin) reuses the SM103 table: the plan was validated end-to-end on SM107
+hardware, but the per-M crossovers have not been re-measured there and may
+deserve their own table once retuned.
 """
 
 from __future__ import annotations
@@ -626,9 +629,14 @@ def _is_sm103() -> bool:
     return current_platform.is_device_capability((10, 3))
 
 
+def _is_sm107() -> bool:
+    return current_platform.is_device_capability((10, 7))
+
+
 def _low_latency_table() -> dict[tuple[int, int], ProjectionSpec] | None:
     """Measured dispatch table for the current device, or None if unsupported."""
-    if _is_sm103():
+    if _is_sm103() or _is_sm107():
+        # SM107 reuses the SM103 table; see the module docstring.
         return KIMI_K3_PROJECTIONS
     if current_platform.is_device_capability((10, 0)):
         return KIMI_K3_PROJECTIONS_SM100


### PR DESCRIPTION
## Summary

Two enablement changes for Kimi-K3, ported from a downstream fork where they were validated end-to-end on SM107 (Rubin) hardware:

1. **SiTU on the FlashInfer CuteDSL NVFP4 MoE backend** (`flashinfer_cutedsl_moe.py`): accept `MoEActivation.SITU` and plumb `situ_beta` / `situ_linear_beta` from `moe_config` into `flashinfer_cute_dsl_fused_moe_nvfp4`. The cute_dsl kernel keys SiTU on `situ_beta` and requires the base `Swiglu` activation type (`ActivationType.Situ` is rejected by `normalize_cute_dsl_moe_activation_type`), so the base type is passed and SiTU rides the betas — the contract FlashInfer 0.6.18 (the pinned version) exposes. This makes `--moe-backend flashinfer_cutedsl` usable for Kimi-K3.
2. **SM107 in the Kimi-K3 low-latency decode GEMM plan** (`low_latency_gemm.py`): `_low_latency_table()` now maps SM107 to the SM103 table, so the dsv3_fused_a / CuTe skinny-GEMM plan runs instead of falling back to cuBLASLt nvjet splitK + splitKreduce (two launches plus a reduce per GEMM). `dsv3_fused_a_gemm` only requires `__CUDA_ARCH__ >= 900`, and the CuTe skinny GEMM compiles for SM107 via CuteDSL (its PDL gate is `major >= 9`).

## Not duplicating existing PRs

Searched open PRs for `sm107`, `dsv3_fused_a`, `low_latency_gemm`, `situ`: #54565 relaxes dsv3 GEMM tensor-layout acceptance (complementary, different hunks of the same file); #52405 fixes SiTU output scale on the TRTLLM backend (not CuteDSL). No open PR adds SITU to the CuteDSL backend or SM107 to the low-latency plan.

## Testing

Validated on `nvidia/Kimi-K3-NVFP4`, TP8 across 8x SM107 GPUs, 8K ISL / 1K OSL random serving (`vllm bench serve --random-input-len 8192 --random-output-len 1024 --num-prompts 8 --max-concurrency 4 --ignore-eos`), `--moe-backend flashinfer_cutedsl --quantization modelopt_mixed --kv-cache-dtype fp8`:

- **Numerics:** greedy factual prompts correct, matching the `flashinfer_trtllm` reference backend on the same build.
- **Kernel dispatch** (torch-profiler kineto inventory, per rank): `fused_a_gemm_kernel` replaces the nvjet splitK + splitKreduce pairs on all three live decode shapes — ~40% fewer launches for those projections and better per-call time on every replaced shape; the CuTe skinny GEMM compiles and fires at its table-selected token counts.
- **End-to-end:** output throughput and TPOT at parity or slightly better than the pre-change baseline, within run-to-run variance. (Absolute pre-release-hardware numbers intentionally omitted.)
- **No behavior change off SM107:** the gate change is pure widening; SM90/SM100/SM103 tables and dispatch are untouched. Lint not run locally (no tooling on the validation cluster); relying on CI.

## Known follow-ups

- `KIMI_K3_PROJECTIONS` winners were measured on B300 (SM103); the SM107 per-M crossovers have not been re-measured and may deserve their own table (noted in the module docstring).
- FlashInfer 0.6.18's cute_dsl gather GEMM applies the SiTU soft-caps on Blackwell, but its SM107 kernels do not yet plumb `situ_beta` (the epilogue falls back to plain SwiGLU there) — tracked on the FlashInfer side.

## AI assistance disclosure

AI-assisted (Claude Code, see commit trailers); the submitter reviewed every changed line and ran the hardware validation above.
