### PR TITLE
[Bugfix][Offloader] Prioritize sparse MoE experts in UVA CPU offloading

### DIFF
--- a/tests/model_executor/offloader/test_uva_offload_priority.py
+++ b/tests/model_executor/offloader/test_uva_offload_priority.py
@@ -32,6 +32,34 @@ def _make_mock_param(tensor: torch.Tensor) -> nn.Parameter:
     return MockParam(tensor.clone())
 
 
+class TrackedParam(nn.Parameter):
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda:0")
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "_vllm_is_uva_offloaded" and value is True:
+            tracker = getattr(self, "_tracker", None)
+            layer_idx = getattr(self, "_layer_idx", "unknown")
+            param_name = getattr(self, "_param_name", "unknown")
+            if tracker is not None:
+                tracker.append(f"offload_layer_{layer_idx}_{param_name}")
+        super().__setattr__(name, value)
+
+
+def _make_tracked_param(
+    tensor: torch.Tensor,
+    layer_idx: int,
+    param_name: str,
+    tracker: list[str],
+) -> nn.Parameter:
+    p = TrackedParam(tensor.clone())
+    p._layer_idx = layer_idx
+    p._param_name = param_name
+    p._tracker = tracker
+    return p
+
+
 class MockAttention(nn.Module):
     def __init__(self, dim: int = 128):
         super().__init__()
@@ -88,6 +116,37 @@ class MockDenseLayer(nn.Module):
         self.mlp_w2.weight = _make_mock_param(self.mlp_w2.weight)
 
 
+class TrackedMoELayer(nn.Module):
+    def __init__(
+        self,
+        layer_idx: int,
+        tracker: list[str],
+        dim: int = 128,
+        num_experts: int = 4,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        tracker.append(f"construct_layer_{layer_idx}")
+        self.input_layernorm = nn.LayerNorm(dim)
+        self.input_layernorm.weight = _make_tracked_param(
+            self.input_layernorm.weight, layer_idx, "input_layernorm", tracker
+        )
+        self.qkv_proj = nn.Linear(dim, dim * 3, bias=False)
+        self.qkv_proj.weight = _make_tracked_param(
+            self.qkv_proj.weight, layer_idx, "qkv_proj", tracker
+        )
+        self.gate = nn.Linear(dim, num_experts, bias=False)
+        self.gate.weight = _make_tracked_param(
+            self.gate.weight, layer_idx, "gate", tracker
+        )
+        self.experts = _make_tracked_param(
+            torch.randn(num_experts, dim, dim * 2),
+            layer_idx,
+            "experts",
+            tracker,
+        )
+
+
 @pytest.fixture(autouse=True)
 def mock_uva_runtime(monkeypatch):
     monkeypatch.setattr(
@@ -135,7 +194,7 @@ def test_moe_expert_priority_offloading_single_layer():
 
     # Allocate budget sufficient only for expert parameters
     offloader = UVAOffloader(cpu_offload_max_bytes=expert_bytes)
-    offloader.wrap_modules([layer], prefix="model.layers.0")
+    offloader.wrap_modules((m for m in [layer]), prefix="model.layers.0")
 
     # Experts MUST be offloaded
     assert _is_offloaded(layer.mlp.experts)
@@ -161,7 +220,7 @@ def test_moe_expert_priority_multi_layer_global_ordering():
     # Budget covers exactly 2 layers of experts
     budget = expert_bytes_per_layer * 2
     offloader = UVAOffloader(cpu_offload_max_bytes=budget)
-    offloader.wrap_modules([layer0, layer1], prefix="model.layers")
+    offloader.wrap_modules((m for m in [layer0, layer1]), prefix="model.layers")
 
     # Both layers' experts MUST be offloaded
     assert _is_offloaded(layer0.mlp.experts)
@@ -174,51 +233,79 @@ def test_moe_expert_priority_multi_layer_global_ordering():
     assert not _is_offloaded(layer1.input_layernorm.weight)
 
 
-def test_lazy_generator_incremental_offload():
-    """Verify that wrap_modules offloads sparse experts incrementally as layers
-    are yielded by the generator, rather than eagerly materializing all layers.
+def test_lazy_generator_temporal_ordering():
+    """Verify that each layer's priority-0 offloading happens BEFORE the next
+    layer is constructed by the generator.
+
+    Guards directly against eager materialization: list(modules_generator).
     """
     events: list[str] = []
 
-    class TrackedMoELayer(MockMoELayer):
-        def __init__(self, idx: int, dim: int = 128):
-            super().__init__(dim=dim)
-            self.idx = idx
-            events.append(f"construct_layer_{idx}")
-
     def layer_generator(count: int) -> Generator[nn.Module, None, None]:
         for i in range(count):
-            layer = TrackedMoELayer(i)
-            yield layer
+            yield TrackedMoELayer(i, tracker=events)
 
-    layer_sample = MockMoELayer(dim=128)
-    expert_bytes = (
-        layer_sample.mlp.experts.numel() * layer_sample.mlp.experts.element_size()
-    )
+    sample = TrackedMoELayer(999, tracker=[])
+    expert_bytes = sample.experts.numel() * sample.experts.element_size()
 
     # Budget covers 2 layers of experts
     offloader = UVAOffloader(cpu_offload_max_bytes=expert_bytes * 2)
+    events.clear()
 
-    created_layers: list[TrackedMoELayer] = []
+    modules = offloader.wrap_modules(layer_generator(3), prefix="model.layers")
 
-    def wrapped_gen() -> Generator[nn.Module, None, None]:
-        for layer in layer_generator(3):
-            created_layers.append(layer)
-            yield layer
+    # Temporal invariant: construction of layer i+1 MUST occur AFTER
+    # offloading of layer i experts.
+    expected_sequence = [
+        "construct_layer_0",
+        "offload_layer_0_experts",
+        "construct_layer_1",
+        "offload_layer_1_experts",
+        "construct_layer_2",
+    ]
+    assert events == expected_sequence
+    assert len(modules) == 3
 
-    # Subclass to record offload timing
-    modules = offloader.wrap_modules(wrapped_gen(), prefix="model.layers")
 
-    # Layer 0 experts offloaded immediately during pass 1
-    assert _is_offloaded(modules[0].mlp.experts)
-    # Layer 1 experts offloaded during pass 1
-    assert _is_offloaded(modules[1].mlp.experts)
-    # Layer 2 experts untouched (budget exhausted)
-    assert not _is_offloaded(modules[2].mlp.experts)
-    # None of the dense layers offloaded
-    assert not _is_offloaded(modules[0].self_attn.qkv_proj.weight)
-    assert not _is_offloaded(modules[1].self_attn.qkv_proj.weight)
-    assert not _is_offloaded(modules[2].self_attn.qkv_proj.weight)
+def test_constrained_budget_incremental_expert_then_dense():
+    """Verify that when budget exceeds total experts across multiple layers,
+    sparse experts are offloaded incrementally in Pass 1, and dense parameters
+    consume the remainder in Pass 2 in declaration order.
+    """
+    events: list[str] = []
+
+    def layer_generator(count: int) -> Generator[nn.Module, None, None]:
+        for i in range(count):
+            yield TrackedMoELayer(i, tracker=events)
+
+    sample = TrackedMoELayer(999, tracker=[])
+    expert_bytes = sample.experts.numel() * sample.experts.element_size()
+    ln_bytes = (
+        sample.input_layernorm.weight.numel()
+        * sample.input_layernorm.weight.element_size()
+    )
+    qkv_bytes = sample.qkv_proj.weight.numel() * sample.qkv_proj.weight.element_size()
+
+    # Budget covers exactly 2 layers of experts + Layer 0 layernorm + Layer 0 qkv_proj
+    total_budget = (expert_bytes * 2) + ln_bytes + qkv_bytes
+    offloader = UVAOffloader(cpu_offload_max_bytes=total_budget)
+    events.clear()
+
+    modules = offloader.wrap_modules(layer_generator(2), prefix="model.layers")
+
+    # In Pass 1: experts offloaded incrementally
+    # In Pass 2: remaining budget offloads Layer 0 layernorm and qkv
+    expected_sequence = [
+        "construct_layer_0",
+        "offload_layer_0_experts",
+        "construct_layer_1",
+        "offload_layer_1_experts",
+        "offload_layer_0_input_layernorm",
+        "offload_layer_0_qkv_proj",
+    ]
+    assert events == expected_sequence
+    assert offloader.cpu_offload_bytes == total_budget
+    assert len(modules) == 2
 
 
 def test_budget_spillover_to_dense():
@@ -235,7 +322,7 @@ def test_budget_spillover_to_dense():
     # Budget covers all experts + layernorm + qkv_proj
     budget = expert_bytes + qkv_bytes + 1024
     offloader = UVAOffloader(cpu_offload_max_bytes=budget)
-    offloader.wrap_modules([layer], prefix="model.layers.0")
+    offloader.wrap_modules((m for m in [layer]), prefix="model.layers.0")
 
     # Experts offloaded first
     assert _is_offloaded(layer.mlp.experts)
@@ -252,7 +339,7 @@ def test_explicit_params_filter_overrides_heuristic():
         cpu_offload_max_bytes=10 * 1024 * 1024,
         cpu_offload_params={"self_attn"},
     )
-    offloader.wrap_modules([layer], prefix="model.layers.0")
+    offloader.wrap_modules((m for m in [layer]), prefix="model.layers.0")
 
     # Only self_attn matches explicit filter
     assert _is_offloaded(layer.self_attn.qkv_proj.weight)
@@ -269,9 +356,39 @@ def test_dense_model_offload():
     )
 
     offloader = UVAOffloader(cpu_offload_max_bytes=qkv_bytes + 512)
-    offloader.wrap_modules([layer], prefix="model.layers.0")
+    offloader.wrap_modules((m for m in [layer]), prefix="model.layers.0")
 
     # Layernorm and QKV offloaded in declaration order
     assert _is_offloaded(layer.input_layernorm.weight)
     assert _is_offloaded(layer.self_attn.qkv_proj.weight)
     assert not _is_offloaded(layer.self_attn.o_proj.weight)
+
+
+def test_non_uva_single_wrap_protection(monkeypatch):
+    """Verify non-UVA fallback does not double-wrap forward when a module
+    participates in both Pass 1 and Pass 2 offloading.
+    """
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.is_uva_available", lambda: False
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.should_pin_memory", lambda: False
+    )
+
+    layer = MockMoELayer(dim=128)
+    expert_bytes = layer.mlp.experts.numel() * layer.mlp.experts.element_size()
+    ln_bytes = (
+        layer.input_layernorm.weight.numel()
+        * layer.input_layernorm.weight.element_size()
+    )
+
+    # Budget covers experts (Pass 1) and layernorm (Pass 2)
+    offloader = UVAOffloader(cpu_offload_max_bytes=expert_bytes + ln_bytes)
+
+    def gen() -> Generator[nn.Module, None, None]:
+        yield layer
+
+    offloader.wrap_modules(gen(), prefix="model.layers.0")
+
+    # Module forward must be marked as wrapped exactly once
+    assert getattr(layer, "_vllm_non_uva_wrapped", False) is True

--- a/tests/model_executor/offloader/test_uva_offload_priority.py
+++ b/tests/model_executor/offloader/test_uva_offload_priority.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.model_executor.offloader.uva import (
+    UVAOffloader,
+    _is_sparse_expert_param,
+)
+
+
+@pytest.fixture
+def should_do_global_cleanup_after_test():
+    return False
+
+
+def _is_offloaded(p: nn.Parameter) -> bool:
+    return getattr(p, "_vllm_is_uva_offloaded", False)
+
+
+class MockParam(nn.Parameter):
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda:0")
+
+
+def _make_mock_param(tensor: torch.Tensor) -> nn.Parameter:
+    return MockParam(tensor.clone())
+
+
+class MockAttention(nn.Module):
+    def __init__(self, dim: int = 128):
+        super().__init__()
+        self.qkv_proj = nn.Linear(dim, dim * 3, bias=False)
+        self.o_proj = nn.Linear(dim, dim, bias=False)
+        self.qkv_proj.weight = _make_mock_param(self.qkv_proj.weight)
+        self.o_proj.weight = _make_mock_param(self.o_proj.weight)
+
+
+class MockSparseMoE(nn.Module):
+    def __init__(self, dim: int = 128, num_experts: int = 4):
+        super().__init__()
+        self.gate = nn.Linear(dim, num_experts, bias=False)
+        self.gate.weight = _make_mock_param(self.gate.weight)
+        self.shared_expert = nn.Linear(dim, dim * 2, bias=False)
+        self.shared_expert.weight = _make_mock_param(self.shared_expert.weight)
+        self.experts = _make_mock_param(torch.randn(num_experts, dim, dim * 2))
+
+
+class MockMoELayer(nn.Module):
+    def __init__(self, dim: int = 128):
+        super().__init__()
+        self.input_layernorm = nn.LayerNorm(dim)
+        self.input_layernorm.weight = _make_mock_param(self.input_layernorm.weight)
+        self.input_layernorm.bias = _make_mock_param(self.input_layernorm.bias)
+        self.self_attn = MockAttention(dim)
+        self.post_attention_layernorm = nn.LayerNorm(dim)
+        self.post_attention_layernorm.weight = _make_mock_param(
+            self.post_attention_layernorm.weight
+        )
+        self.post_attention_layernorm.bias = _make_mock_param(
+            self.post_attention_layernorm.bias
+        )
+        self.mlp = MockSparseMoE(dim)
+
+
+class MockDenseLayer(nn.Module):
+    def __init__(self, dim: int = 128):
+        super().__init__()
+        self.input_layernorm = nn.LayerNorm(dim)
+        self.input_layernorm.weight = _make_mock_param(self.input_layernorm.weight)
+        self.input_layernorm.bias = _make_mock_param(self.input_layernorm.bias)
+        self.self_attn = MockAttention(dim)
+        self.post_attention_layernorm = nn.LayerNorm(dim)
+        self.post_attention_layernorm.weight = _make_mock_param(
+            self.post_attention_layernorm.weight
+        )
+        self.post_attention_layernorm.bias = _make_mock_param(
+            self.post_attention_layernorm.bias
+        )
+        self.mlp_w1 = nn.Linear(dim, dim * 4, bias=False)
+        self.mlp_w1.weight = _make_mock_param(self.mlp_w1.weight)
+        self.mlp_w2 = nn.Linear(dim * 4, dim, bias=False)
+        self.mlp_w2.weight = _make_mock_param(self.mlp_w2.weight)
+
+
+@pytest.fixture(autouse=True)
+def mock_uva_runtime(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.is_uva_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.should_pin_memory", lambda: False
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.offloader.uva.get_accelerator_view_from_cpu_tensor",
+        lambda x: x,
+    )
+
+
+def test_sparse_expert_param_classification():
+    """Verify classification of sparse vs dense parameters."""
+    # Real MoE sparse expert patterns
+    assert _is_sparse_expert_param("model.layers.0.mlp.experts.w13_weight")
+    assert _is_sparse_expert_param("model.layers.0.mlp.experts.w2_weight")
+    assert _is_sparse_expert_param("model.layers.0.block_sparse_moe.experts.0")
+    assert _is_sparse_expert_param("model.layers.0.mlp.fused_moe.w13_weight")
+    assert _is_sparse_expert_param("model.layers.0.mlp.switch_mlp.w13_weight")
+    assert _is_sparse_expert_param("model.layers.0.mlp.moe_experts.w13_weight")
+
+    # Dense weights must NOT be classified as sparse experts
+    assert not _is_sparse_expert_param("model.layers.0.self_attn.qkv_proj.weight")
+    assert not _is_sparse_expert_param("model.layers.0.self_attn.o_proj.weight")
+    assert not _is_sparse_expert_param("model.layers.0.input_layernorm.weight")
+    assert not _is_sparse_expert_param("model.layers.0.mlp.gate.weight")
+    assert not _is_sparse_expert_param("model.layers.0.mlp.shared_expert.weight")
+    assert not _is_sparse_expert_param("model.layers.0.mlp.shared_experts.w1.weight")
+    assert not _is_sparse_expert_param("model.layers.0.mlp.share_expert.weight")
+
+    # Edge cases with misleading substrings
+    assert not _is_sparse_expert_param("model.layers.0.mlp.expert_gate.weight")
+    assert not _is_sparse_expert_param("model.layers.0.mlp.router_logits.weight")
+    assert not _is_sparse_expert_param("visual.transformer.resblocks.0.expert_mode")
+    assert not _is_sparse_expert_param("language_model.model.embed_tokens.weight")
+
+
+def test_moe_expert_priority_offloading_single_layer():
+    """Verify sparse experts are offloaded before dense attention/norm weights."""
+    layer = MockMoELayer(dim=128)
+    expert_bytes = layer.mlp.experts.numel() * layer.mlp.experts.element_size()
+
+    # Allocate budget sufficient only for expert parameters
+    offloader = UVAOffloader(cpu_offload_max_bytes=expert_bytes)
+    offloader.wrap_modules([layer], prefix="model.layers.0")
+
+    # Experts MUST be offloaded
+    assert _is_offloaded(layer.mlp.experts)
+
+    # Dense attention, router, and layernorms MUST NOT be offloaded
+    assert not _is_offloaded(layer.self_attn.qkv_proj.weight)
+    assert not _is_offloaded(layer.self_attn.o_proj.weight)
+    assert not _is_offloaded(layer.input_layernorm.weight)
+    assert not _is_offloaded(layer.post_attention_layernorm.weight)
+    assert not _is_offloaded(layer.mlp.gate.weight)
+    assert not _is_offloaded(layer.mlp.shared_expert.weight)
+
+
+def test_moe_expert_priority_multi_layer_global_ordering():
+    """Verify global expert prioritization across multiple layers."""
+    layer0 = MockMoELayer(dim=128)
+    layer1 = MockMoELayer(dim=128)
+
+    expert_bytes_per_layer = (
+        layer0.mlp.experts.numel() * layer0.mlp.experts.element_size()
+    )
+
+    # Budget covers exactly 2 layers of experts
+    budget = expert_bytes_per_layer * 2
+    offloader = UVAOffloader(cpu_offload_max_bytes=budget)
+    offloader.wrap_modules([layer0, layer1], prefix="model.layers")
+
+    # Both layers' experts MUST be offloaded
+    assert _is_offloaded(layer0.mlp.experts)
+    assert _is_offloaded(layer1.mlp.experts)
+
+    # Neither layer's dense attention/norm should be offloaded
+    assert not _is_offloaded(layer0.self_attn.qkv_proj.weight)
+    assert not _is_offloaded(layer1.self_attn.qkv_proj.weight)
+    assert not _is_offloaded(layer0.input_layernorm.weight)
+    assert not _is_offloaded(layer1.input_layernorm.weight)
+
+
+def test_budget_spillover_to_dense():
+    """Verify that if budget exceeds total experts, dense parameters
+    are also offloaded in declaration order.
+    """
+    layer = MockMoELayer(dim=128)
+    expert_bytes = layer.mlp.experts.numel() * layer.mlp.experts.element_size()
+    qkv_bytes = (
+        layer.self_attn.qkv_proj.weight.numel()
+        * layer.self_attn.qkv_proj.weight.element_size()
+    )
+
+    # Budget covers all experts + layernorm + qkv_proj
+    budget = expert_bytes + qkv_bytes + 1024
+    offloader = UVAOffloader(cpu_offload_max_bytes=budget)
+    offloader.wrap_modules([layer], prefix="model.layers.0")
+
+    # Experts offloaded first
+    assert _is_offloaded(layer.mlp.experts)
+    # Dense parameters consume remaining budget in declaration order
+    assert _is_offloaded(layer.input_layernorm.weight)
+    assert _is_offloaded(layer.self_attn.qkv_proj.weight)
+    assert not _is_offloaded(layer.self_attn.o_proj.weight)
+
+
+def test_explicit_params_filter_overrides_heuristic():
+    """Verify explicit cpu_offload_params overrides the default heuristic."""
+    layer = MockMoELayer(dim=128)
+    offloader = UVAOffloader(
+        cpu_offload_max_bytes=10 * 1024 * 1024,
+        cpu_offload_params={"self_attn"},
+    )
+    offloader.wrap_modules([layer], prefix="model.layers.0")
+
+    # Only self_attn matches explicit filter
+    assert _is_offloaded(layer.self_attn.qkv_proj.weight)
+    assert _is_offloaded(layer.self_attn.o_proj.weight)
+    assert not _is_offloaded(layer.mlp.experts)
+
+
+def test_dense_model_offload():
+    """Verify dense models continue offloading in standard order."""
+    layer = MockDenseLayer(dim=128)
+    qkv_bytes = (
+        layer.self_attn.qkv_proj.weight.numel()
+        * layer.self_attn.qkv_proj.weight.element_size()
+    )
+
+    offloader = UVAOffloader(cpu_offload_max_bytes=qkv_bytes + 512)
+    offloader.wrap_modules([layer], prefix="model.layers.0")
+
+    # Layernorm and QKV offloaded in declaration order
+    assert _is_offloaded(layer.input_layernorm.weight)
+    assert _is_offloaded(layer.self_attn.qkv_proj.weight)
+    assert not _is_offloaded(layer.self_attn.o_proj.weight)

--- a/tests/model_executor/offloader/test_uva_offload_priority.py
+++ b/tests/model_executor/offloader/test_uva_offload_priority.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Generator
+
 import pytest
 import torch
 import torch.nn as nn
@@ -170,6 +172,53 @@ def test_moe_expert_priority_multi_layer_global_ordering():
     assert not _is_offloaded(layer1.self_attn.qkv_proj.weight)
     assert not _is_offloaded(layer0.input_layernorm.weight)
     assert not _is_offloaded(layer1.input_layernorm.weight)
+
+
+def test_lazy_generator_incremental_offload():
+    """Verify that wrap_modules offloads sparse experts incrementally as layers
+    are yielded by the generator, rather than eagerly materializing all layers.
+    """
+    events: list[str] = []
+
+    class TrackedMoELayer(MockMoELayer):
+        def __init__(self, idx: int, dim: int = 128):
+            super().__init__(dim=dim)
+            self.idx = idx
+            events.append(f"construct_layer_{idx}")
+
+    def layer_generator(count: int) -> Generator[nn.Module, None, None]:
+        for i in range(count):
+            layer = TrackedMoELayer(i)
+            yield layer
+
+    layer_sample = MockMoELayer(dim=128)
+    expert_bytes = (
+        layer_sample.mlp.experts.numel() * layer_sample.mlp.experts.element_size()
+    )
+
+    # Budget covers 2 layers of experts
+    offloader = UVAOffloader(cpu_offload_max_bytes=expert_bytes * 2)
+
+    created_layers: list[TrackedMoELayer] = []
+
+    def wrapped_gen() -> Generator[nn.Module, None, None]:
+        for layer in layer_generator(3):
+            created_layers.append(layer)
+            yield layer
+
+    # Subclass to record offload timing
+    modules = offloader.wrap_modules(wrapped_gen(), prefix="model.layers")
+
+    # Layer 0 experts offloaded immediately during pass 1
+    assert _is_offloaded(modules[0].mlp.experts)
+    # Layer 1 experts offloaded during pass 1
+    assert _is_offloaded(modules[1].mlp.experts)
+    # Layer 2 experts untouched (budget exhausted)
+    assert not _is_offloaded(modules[2].mlp.experts)
+    # None of the dense layers offloaded
+    assert not _is_offloaded(modules[0].self_attn.qkv_proj.weight)
+    assert not _is_offloaded(modules[1].self_attn.qkv_proj.weight)
+    assert not _is_offloaded(modules[2].self_attn.qkv_proj.weight)
 
 
 def test_budget_spillover_to_dense():

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -20,6 +20,46 @@ from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
 logger = init_logger(__name__)
 
 
+def _is_sparse_expert_param(full_name: str) -> bool:
+    """Check whether a parameter belongs to sparse MoE experts.
+
+    Uses dot-delimited segment matching to avoid false positives on
+    parameters such as 'shared_experts', router gates, or attention weights.
+    """
+    segments = full_name.lower().split(".")
+
+    # Shared experts and router gates are dense (read on 100% of tokens).
+    if any(
+        seg in ("shared_expert", "shared_experts", "share_expert") for seg in segments
+    ):
+        return False
+    if any(
+        seg
+        in (
+            "gate",
+            "router",
+            "shared_expert_gate",
+            "router_logits",
+            "expert_gate",
+        )
+        for seg in segments
+    ):
+        return False
+
+    # Sparse expert modules
+    return any(
+        seg
+        in (
+            "experts",
+            "block_sparse_moe",
+            "fused_moe",
+            "switch_mlp",
+            "moe_experts",
+        )
+        for seg in segments
+    )
+
+
 class UVAOffloader(BaseOffloader):
     """Offloader using Unified Virtual Addressing (UVA) for zero-copy access.
 
@@ -60,9 +100,8 @@ class UVAOffloader(BaseOffloader):
         """Wrap modules with UVA offloading."""
         if prefix:
             prefix = f"{prefix}."
-        modules = [
-            self._maybe_offload_to_cpu(module, prefix) for module in modules_generator
-        ]
+        modules = list(modules_generator)
+        self._offload_modules(modules, prefix)
         if self.cpu_offload_bytes > 0:
             logger.info(
                 "Total CPU offloaded parameters: %s",
@@ -72,43 +111,57 @@ class UVAOffloader(BaseOffloader):
 
     def _maybe_offload_to_cpu(self, module: nn.Module, prefix: str = "") -> nn.Module:
         """Offload module parameters to CPU using UVA if budget allows."""
-        if (params := next(module.parameters(), None)) is None:
-            return module
+        self._offload_modules([module], prefix)
+        return module
 
-        device = params.device
-
-        if device == torch.device("cpu"):
-            return module
-
+    def _offload_modules(
+        self,
+        modules: list[nn.Module],
+        prefix: str = "",
+    ) -> None:
+        """Offload parameters from modules to CPU using UVA if budget allows."""
         if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
-            return module
+            return
 
-        # offload parameters to CPU
-        # use pin_memory if possible, which helps cudagraph capture speed
-        offloaded_parameters = False
-        for name, p in module.named_parameters():
-            if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
-                # we use per-parameter offloading
-                # one module might have some parameters offloaded and some not
-                break
-
-            # Skip parameters an earlier wrap_modules call already offloaded.
-            # The UVA path leaves p.device as the accelerator (a view of CPU
-            # memory), so the marker is the only way to recognize those.
-            if p.device.type == "cpu" or getattr(p, "_vllm_is_uva_offloaded", False):
+        candidates: list[tuple[int, nn.Module, str, nn.Parameter, str]] = []
+        module_devices: dict[nn.Module, torch.device] = {}
+        for module in modules:
+            params = next(module.parameters(), None)
+            if params is None or params.device == torch.device("cpu"):
                 continue
+            module_devices[module] = params.device
 
-            if self.cpu_offload_params:
-                # Check if parameter belongs to the offloading set
-                # Add dots here to ensure we match full segments only
-                # e.g., "experts.w2_weight" matches "mlp.experts.w2_weight"
-                # but not "mlp.experts.w2_weight_scale"
-                should_offload = any(
-                    f".{param}." in f".{prefix}{name}."
-                    for param in self.cpu_offload_params
-                )
-                if not should_offload:
+            for name, p in module.named_parameters():
+                if p.device.type == "cpu" or getattr(
+                    p, "_vllm_is_uva_offloaded", False
+                ):
                     continue
+
+                full_name = f"{prefix}{name}"
+                if self.cpu_offload_params:
+                    # Segment match
+                    should_offload = any(
+                        f".{param}." in f".{full_name}."
+                        for param in self.cpu_offload_params
+                    )
+                    if not should_offload:
+                        continue
+                    priority = 0
+                else:
+                    # Sparse expert weights are prioritized over dense weights
+                    priority = 0 if _is_sparse_expert_param(full_name) else 1
+
+                candidates.append((priority, module, name, p, full_name))
+
+        # Stable sort by priority tier while preserving relative declaration order
+        candidates.sort(key=lambda item: item[0])
+
+        offloaded_modules: set[nn.Module] = set()
+        dense_offloaded = False
+
+        for priority, module, name, p, full_name in candidates:
+            if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
+                break
 
             cpu_data = p.data.to(device="cpu")
             if self.pin_memory:
@@ -121,34 +174,50 @@ class UVAOffloader(BaseOffloader):
                 p._vllm_is_uva_offloaded = True
 
             self.cpu_offload_bytes += p.data.numel() * p.data.element_size()
-            offloaded_parameters = True
+            offloaded_modules.add(module)
+            if priority == 1:
+                dense_offloaded = True
 
-        if offloaded_parameters and not self.uva_offloading:
-            original_forward = module.forward
+        if dense_offloaded and not self.cpu_offload_params:
+            logger.info_once(
+                "Dense parameters were offloaded to CPU because the offload "
+                "budget exceeded sparse expert weights or all parameters were "
+                "eligible. This may increase PCIe memory traffic."
+            )
 
-            def forward(*args, **kwargs):
-                module.forward = original_forward
-                with nullcontext() if self.pin_memory else gpu_sync_allowed():
-                    device_state = {
-                        # here we blindly call `to(device)`
-                        # if the parameter is already on the device,
-                        # it will be a no-op
-                        k: v.to(device, non_blocking=True)
-                        for k, v in module.state_dict().items()
-                    }
+        if not self.uva_offloading:
+            for module in offloaded_modules:
+                self._wrap_non_uva_forward(module, module_devices[module])
 
-                # set `tie_weights=False` as tied weights in original model
-                # become untied when calling .to(device) individually
-                output = functional_call(
-                    module,
-                    device_state,
-                    args=args,
-                    kwargs=kwargs,
-                    tie_weights=False,
-                )
-                module.forward = forward
-                return output
+    def _wrap_non_uva_forward(
+        self,
+        module: nn.Module,
+        device: torch.device,
+    ) -> None:
+        """Wrap module with functional_call for non-UVA CPU offloading."""
+        original_forward = module.forward
 
+        def forward(*args, **kwargs):
+            module.forward = original_forward
+            with nullcontext() if self.pin_memory else gpu_sync_allowed():
+                device_state = {
+                    # here we blindly call `to(device)`
+                    # if the parameter is already on the device,
+                    # it will be a no-op
+                    k: v.to(device, non_blocking=True)
+                    for k, v in module.state_dict().items()
+                }
+
+            # set `tie_weights=False` as tied weights in original model
+            # become untied when calling .to(device) individually
+            output = functional_call(
+                module,
+                device_state,
+                args=args,
+                kwargs=kwargs,
+                tie_weights=False,
+            )
             module.forward = forward
+            return output
 
-        return module
+        module.forward = forward

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -100,8 +100,14 @@ class UVAOffloader(BaseOffloader):
         """Wrap modules with UVA offloading."""
         if prefix:
             prefix = f"{prefix}."
-        modules = list(modules_generator)
-        self._offload_modules(modules, prefix)
+        modules: list[nn.Module] = []
+        for module in modules_generator:
+            self._offload_modules([module], prefix, only_priority=0)
+            modules.append(module)
+
+        if self.cpu_offload_bytes < self.cpu_offload_max_bytes:
+            self._offload_modules(modules, prefix, only_priority=1)
+
         if self.cpu_offload_bytes > 0:
             logger.info(
                 "Total CPU offloaded parameters: %s",
@@ -118,6 +124,7 @@ class UVAOffloader(BaseOffloader):
         self,
         modules: list[nn.Module],
         prefix: str = "",
+        only_priority: int | None = None,
     ) -> None:
         """Offload parameters from modules to CPU using UVA if budget allows."""
         if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
@@ -150,6 +157,9 @@ class UVAOffloader(BaseOffloader):
                 else:
                     # Sparse expert weights are prioritized over dense weights
                     priority = 0 if _is_sparse_expert_param(full_name) else 1
+
+                if only_priority is not None and priority != only_priority:
+                    continue
 
                 candidates.append((priority, module, name, p, full_name))
 
@@ -195,6 +205,10 @@ class UVAOffloader(BaseOffloader):
         device: torch.device,
     ) -> None:
         """Wrap module with functional_call for non-UVA CPU offloading."""
+        if getattr(module, "_vllm_non_uva_wrapped", False):
+            return
+        module._vllm_non_uva_wrapped = True
+
         original_forward = module.forward
 
         def forward(*args, **kwargs):


### PR DESCRIPTION
## Description

Fixes #54593.

`UVAOffloader` currently processes model parameters in Python declaration order when `--cpu-offload-params` is not explicitly specified. For Transformer MoE architectures, this can cause dense parameters such as attention projections, layer norms, and router gates to be offloaded before sparse expert weights.

Dense parameters are accessed on every forward pass, whereas sparse expert weights are accessed only for the experts selected by the router. Offloading dense parameters first can therefore introduce significantly more PCIe traffic and degrade inference throughput, as demonstrated in #54593.

### Changes

* **Workload-aware parameter prioritization**

  * When `--cpu-offload-params` is not specified, prioritize sparse MoE expert parameters for CPU offloading.
  * Dense parameters are considered only after the available expert weights have been exhausted.

* **Robust sparse-expert classification**

  * Use dot-delimited parameter-name segments to identify sparse expert parameters.
  * Explicitly avoid classifying shared experts, router/gate parameters, and unrelated parameters as sparse experts.

* **Global multi-layer prioritization**

  * Evaluate candidates across all modules passed to `wrap_modules()`.
  * This prevents dense parameters in earlier layers from consuming the offload budget before sparse experts in later layers are considered.

* **Preserve existing behavior**

  * Explicit `--cpu-offload-params` selections continue to take precedence over the default heuristic.
  * Dense-only models retain their existing declaration-order offloading behavior.
  * If the offload budget exceeds the total sparse-expert weight size, remaining capacity is used for dense parameters in declaration order.
  * An informational message is emitted when dense parameters are also offloaded under the default heuristic.

### Tests

Added `tests/model_executor/offloader/test_uva_offload_priority.py` covering:

* Sparse-expert parameter classification and false-positive cases
* Sparse-expert prioritization within a single MoE layer
* Global expert prioritization across multiple layers
* Spillover from expert to dense parameters when the budget allows
* Explicit `--cpu-offload-params` behavior
* Preservation of declaration-order behavior for dense models

### Verification

```bash
pytest tests/model_executor/offloader/test_uva_offload_priority.py -v
```

**Result:** `6 passed in 0.06s`

```bash
ruff check vllm/model_executor/offloader/uva.py \
    tests/model_executor/offloader/test_uva_offload_priority.py
```

**Result:** All checks passed.

### AI Assistance

AI assistance (Google Antigravity) was used during diagnosis, implementation, and test development. The parameter traversal behavior, prioritization logic, and regression tests were reviewed and verified locally.
